### PR TITLE
Callouts can be title only

### DIFF
--- a/docs/src/views/call_out/info.js
+++ b/docs/src/views/call_out/info.js
@@ -3,19 +3,29 @@ import React from 'react';
 import {
   KuiCallOut,
   KuiLink,
+  KuiSpacer,
 } from '../../../../src/components';
 
 export default () => (
-  <KuiCallOut
-    title="Check it out, here's a really long title that will wrap within a narrower browser"
-    iconType="search"
-  >
-    <p>
-      Here&rsquo;s some stuff that you need to know. We can make this text really long so that,
-      when viewed within a browser that&rsquo;s fairly narrow, it will wrap, too.
-    </p>
-    <p>
-      And some other stuff on another line, just for kicks. And <KuiLink href="#">here&rsquo;s a link</KuiLink>.
-    </p>
-  </KuiCallOut>
+  <div>
+    <KuiCallOut
+      title="Check it out, here's a really long title that will wrap within a narrower browser"
+      iconType="search"
+    >
+      <p>
+        Here&rsquo;s some stuff that you need to know. We can make this text really long so that,
+        when viewed within a browser that&rsquo;s fairly narrow, it will wrap, too.
+      </p>
+      <p>
+        And some other stuff on another line, just for kicks. And <KuiLink href="#">here&rsquo;s a link</KuiLink>.
+      </p>
+    </KuiCallOut>
+
+    <KuiSpacer size="m" />
+
+    <KuiCallOut
+      title="Callouts can exist as just a title. Simply omit the child content."
+      iconType="gear"
+    />
+  </div>
 );

--- a/src/components/call_out/call_out.js
+++ b/src/components/call_out/call_out.js
@@ -37,6 +37,15 @@ export const KuiCallOut = ({ title, type, iconType, children, className, ...rest
     );
   }
 
+  let optionalChildren;
+  if (children) {
+    optionalChildren = (
+      <KuiText size="s">
+        {children}
+      </KuiText>
+    );
+  }
+
   return (
     <div
       className={classes}
@@ -50,9 +59,7 @@ export const KuiCallOut = ({ title, type, iconType, children, className, ...rest
         </span>
       </div>
 
-      <KuiText size="s">
-        {children}
-      </KuiText>
+      {optionalChildren}
     </div>
   );
 };


### PR DESCRIPTION
Closes https://github.com/elastic/eui/issues/9

If no child content is present, don't use the `KuiText` wrapper.

![image](https://user-images.githubusercontent.com/324519/31906944-46da385a-b7e7-11e7-9eb9-0e25707b32c1.png)
