### PR TITLE
<EuiButton> ability to render into an <a> and not always <button>

### DIFF
--- a/docs/src/views/button/button.js
+++ b/docs/src/views/button/button.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {
   EuiButton,
+  EuiSpacer,
 } from '../../../../src/components/';
 
 export default () => (
@@ -200,5 +201,15 @@ export default () => (
       small and filled
     </EuiButton>
 
+    <EuiSpacer size="m" />
+
+    <div>
+      <EuiButton
+        size="small"
+        href="/"
+      >
+        Button that renders as a link pointing at home
+      </EuiButton>
+    </div>
   </div>
 );

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -41,6 +41,7 @@ export const EuiButton = ({
   size,
   fill,
   isDisabled,
+  href,
   ...rest,
 }) => {
 
@@ -69,17 +70,20 @@ export const EuiButton = ({
     );
   }
 
+  const ButtonTag = href ? 'a' : 'button'
+
   return (
-    <button
+    <ButtonTag
       disabled={isDisabled}
       className={classes}
+      href={href}
       {...rest}
     >
       <span className="euiButton__content">
         {buttonIcon}
         <span>{children}</span>
       </span>
-    </button>
+    </ButtonTag>
   );
 };
 


### PR DESCRIPTION
This solves problems like when we want to render a proper link but style it as a button for prominent actions, which we usually do in Cloud UI.

We can now do `<EuiButton href='/create'>Create</EuiButton>` and end up with an anchor styled like a button.

Closes #24 