### PR TITLE
Fix CommonJS exports

### DIFF
--- a/build/scripts/compile-eui.sh
+++ b/build/scripts/compile-eui.sh
@@ -16,7 +16,7 @@ compile_lib() {
   babel \
     --quiet \
     --out-dir=lib \
-    --ignore "**/test/*.js,**/webpack.config.js,**/*.test.js" \
+    --ignore "**/webpack.config.js,**/test/*.js,**/*.test.js" \
     src
   tput rc
   echo -e "${color_green}✔ Finished compiling src/ to lib/${color_reset}" >&2

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "@elastic/eui",
   "description": "Elastic UI Component Library",
   "version": "0.0.1",
-  "main": "lib/index.js",
-  "module": "src/index.js",
-  "jsnext:main": "src/index.js",
+  "main": "lib",
+  "module": "src",
+  "jsnext:main": "src",
   "browser": "dist/eui.min.js",
   "scripts": {
     "start": "./build/scripts/docs-dev.sh",


### PR DESCRIPTION
In #8, the build process was updated to cover CommonJS and browser bundle outputs, however it didn't manage to transpile over `src/index.js`. Fix that so that services are again exported by the package entrypoints, and also fix the entrypoints.