### PR TITLE
Remove browser field

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "lib",
   "module": "src",
   "jsnext:main": "src",
-  "browser": "dist/eui.min.js",
   "scripts": {
     "start": "./build/scripts/docs-dev.sh",
     "build": "./build/scripts/compile-clean.sh && ./build/scripts/compile-scss.sh && ./build/scripts/compile-eui.sh",


### PR DESCRIPTION
This field breaks `npm link` consumption for Cloud UI, and I suspect it'd also break if this were consumed as an npm package as well.