### PR TITLE
Spacer should use the large size as default size prop

### DIFF
--- a/docs/src/views/spacer/spacer.js
+++ b/docs/src/views/spacer/spacer.js
@@ -24,8 +24,8 @@ export default () => (
     <br />
     <br />
 
-    <p>l: 24px</p>
-    <EuiSpacer size="l" />
+    <p>l: 24px (this is the default)</p>
+    <EuiSpacer />
 
     <br />
     <br />

--- a/docs/src/views/spacer/spacer_example.js
+++ b/docs/src/views/spacer/spacer_example.js
@@ -49,6 +49,8 @@ export default props => (
         <p>
           The <EuiCode>Spacer</EuiCode> component is a fancy break tag. Use
           it to add vertical space between items. Please do not stack them.
+          If passed without a <EuiCode>size</EuiCode> prop, it will default
+          to the large size, which matches the margins of <EuiCode>EuiFlex</EuiCode> elements.
         </p>
       }
       demo={

--- a/src/components/spacer/spacer.js
+++ b/src/components/spacer/spacer.js
@@ -35,4 +35,9 @@ export const EuiSpacer = ({
 EuiSpacer.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
+  size: PropTypes.oneOf(SIZES),
+};
+
+EuiSpacer.defaultProps = {
+  size: 'l',
 };


### PR DESCRIPTION
This matches the margins of `FlexGroup` and will result in the best "matches" when dealing with space.

Closes https://github.com/elastic/eui/issues/30