### PR TITLE
Handle environments where the HTML5 validation API is absent

### DIFF
--- a/src/components/form/validatable_control/validatable_control.js
+++ b/src/components/form/validatable_control/validatable_control.js
@@ -12,7 +12,7 @@ export class EuiValidatableControl extends Component {
 
   updateValidity() {
     if (this.control == null || typeof this.control.setCustomValidity !== 'function') {
-      return;
+      return; // jsdom doesn't polyfill this for the server-side
     }
 
     if (this.props.isInvalid) {


### PR DESCRIPTION
A test in Cloud UI is failing because JSDom doesn't yet implement the HTML5 validation API. I tried polyfilling the function in question but it didn't work, so now only call the validation function if it exists.