### PR TITLE
EuiText adds xs size, and lets you apply color directly

### DIFF
--- a/docs/src/views/text/text_color.js
+++ b/docs/src/views/text/text_color.js
@@ -9,6 +9,7 @@ import {
 
 export default () => (
   <div>
+
     <EuiTitle>
       <h2>
         <EuiTextColor color="default">You </EuiTextColor>
@@ -64,6 +65,17 @@ export default () => (
             Ghost text color is always white regardless of theme.
           </EuiTextColor>
         </span>
+      </p>
+    </EuiText>
+
+    <EuiSpacer />
+
+    <EuiText color="primary">
+      <h2>Works on EuiText as well.</h2>
+      <p>
+        Sometimes you need to color entire blocks of text, no matter what is in them.
+        You can always apply color directly (versus using the separated component) to
+        make it easy.
       </p>
     </EuiText>
   </div>

--- a/docs/src/views/text/text_example.js
+++ b/docs/src/views/text/text_example.js
@@ -50,7 +50,7 @@ export default props => (
     />
 
     <GuideSection
-      title="TextSmall"
+      title="Text can come in various sizes."
       source={[{
         type: GuideSectionTypes.JS,
         code: textSmallSource,
@@ -58,13 +58,19 @@ export default props => (
         type: GuideSectionTypes.HTML,
         code: textSmallHtml,
       }]}
+      text={
+        <p>
+          Using the <EuiCode>size</EuiCode> prop on <EuiCode>EuiText</EuiCode> you
+          can get smaller sizes of text then the default.
+        </p>
+      }
       demo={
         <TextSmall />
       }
     />
 
     <GuideSection
-      title="TextColor"
+      title="Coloring text"
       source={[{
         type: GuideSectionTypes.JS,
         code: textColorSource,
@@ -74,8 +80,12 @@ export default props => (
       }]}
       text={
         <p>
-          Any text element can be colored as needed. Wraps the element in a span
-          with the <EuiCode>!important</EuiCode> applied to the color.
+          There are two ways to color text. Either individually by
+          applying <EuiCode>EuiTextColor</EuiCode> on individual text objects, or
+          by passing the <EuiCode>color</EuiCode> prop directly on <EuiCode>EuiText</EuiCode> for
+          a blanket approach across the entirely of your text. Either solution wraps
+          the element in a span with the <EuiCode>!important</EuiCode> applied to the color.
+          It will override any other colors in use, so be careful.
         </p>
       }
       demo={

--- a/docs/src/views/text/text_small.js
+++ b/docs/src/views/text/text_small.js
@@ -2,10 +2,12 @@ import React from 'react';
 
 import {
   EuiText,
+  EuiFlexGroup,
+  EuiFlexItem,
 } from '../../../../src/components';
 
-export default () => (
-  <EuiText size="s">
+const exampleText = (
+  <div>
     <h1>This is Heading One</h1>
     <p>
       Far out in the uncharted backwaters of the unfashionable end of
@@ -60,5 +62,20 @@ export default () => (
       So it thought the dog was making a poor life choice by focusing so much on mindfulness.
       What if its car broke down?
     </p>
-  </EuiText>
+  </div>
+);
+
+export default () => (
+  <EuiFlexGroup>
+    <EuiFlexItem>
+      <EuiText size="s">
+        {exampleText}
+      </EuiText>
+    </EuiFlexItem>
+    <EuiFlexItem>
+      <EuiText size="xs">
+        {exampleText}
+      </EuiText>
+    </EuiFlexItem>
+  </EuiFlexGroup>
 );

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -86,6 +86,32 @@
     }
   }
 
+  &.euiText--extraSmall {
+    @include euiFontSizeXS;
+
+    * + h1,
+    * + h2,
+    * + h3,
+    * + h4,
+    * + h5,
+    * + h6 {
+      margin-top: $euiSizeM;
+    }
+
+    p,
+    ul,
+    ol,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    img {
+      margin-bottom: $euiFontSizeS;
+    }
+  }
+
   > :last-child {
     margin-bottom: 0 !important;
   }

--- a/src/components/text/_text_color.scss
+++ b/src/components/text/_text_color.scss
@@ -14,5 +14,10 @@ $textColors: (
 @each $name, $color in $textColors {
   .euiTextColor.euiTextColor--#{$name} {
     color: $color !important;
+
+    // We need a blanket approach for coloring. It should overule everything.
+    * {
+      color: $color !important;
+    }
   }
 }

--- a/src/components/text/text.js
+++ b/src/components/text/text.js
@@ -2,13 +2,19 @@ import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
+import {
+  COLORS,
+  EuiTextColor,
+} from './text_color';
+
 const textSizeToClassNameMap = {
   s: 'euiText--small',
+  xs: 'euiText--extraSmall',
 };
 
 export const TEXT_SIZES = Object.keys(textSizeToClassNameMap);
 
-export const EuiText = ({ size, children, className, ...rest }) => {
+export const EuiText = ({ size, color, children, className, ...rest }) => {
 
   const classes = classNames(
     'euiText',
@@ -16,9 +22,20 @@ export const EuiText = ({ size, children, className, ...rest }) => {
     className
   );
 
+  let optionallyColoredText;
+  if (color) {
+    optionallyColoredText = (
+      <EuiTextColor color={color}>
+        {children}
+      </EuiTextColor>
+    );
+  } else {
+    optionallyColoredText = children;
+  }
+
   return (
     <div className={classes} {...rest}>
-      {children}
+      {optionallyColoredText}
     </div>
   );
 };
@@ -27,4 +44,5 @@ EuiText.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   size: PropTypes.oneOf(TEXT_SIZES),
+  color: PropTypes.oneOf(COLORS),
 };


### PR DESCRIPTION
Closes https://github.com/elastic/eui/issues/80

### EuiText now has an "xs" size

Usage would be `<EuiText size="xs">`

![image](https://user-images.githubusercontent.com/324519/32194168-d1c7c6aa-bd76-11e7-8177-1b566714dc85.png)

### EuiText now accepts a color value directly

This just wraps `EuiTextColor` around the child if it's passed.

Usage is now more flexible. Example usage

```jsx
<EuiText size="s">
  <EuiTextColor color="danger"><h2>Some title in danger</h2></EuiTextColor>

  <p>This shows an example where the color might be mixed throughout a doc.</p>
</EuiText>

<EuiText size="xs" color="subdued">This is a one off</EuiText>
```

![image](https://user-images.githubusercontent.com/324519/32194206-ef0f6bfa-bd76-11e7-8134-3a6390b41b4b.png)

