### PR TITLE
Fixes to code blocks

### DIFF
--- a/src/components/code/_code_block.scss
+++ b/src/components/code/_code_block.scss
@@ -5,7 +5,7 @@
     white-space: pre-wrap;
   }
 
-  .hljs {
+  .euiCodeBlock__code {
     display: block;
     line-height: $euiLineHeight;
     font-family: $euiCodeFontFamily;

--- a/src/components/code/code_block.js
+++ b/src/components/code/code_block.js
@@ -40,7 +40,11 @@ export class EuiCodeBlock extends Component {
   }
 
   componentDidMount() {
-    hljs.highlightBlock(this.code);
+    this.highlight();
+  }
+
+  componentDidUpdate() {
+    this.highlight();
   }
 
   render() {
@@ -52,7 +56,7 @@ export class EuiCodeBlock extends Component {
       fontSize,
       paddingSize,
       overflowHeight,
-      ...rest
+      ...otherProps
     } = this.props;
 
     const classes = classNames(
@@ -62,6 +66,8 @@ export class EuiCodeBlock extends Component {
       paddingSizeToClassNameMap[paddingSize],
       className
     );
+
+    const codeClasses = classNames('euiCodeBlock__code', language);
 
     let optionalOverflowHeight = 'auto';
 
@@ -77,14 +83,20 @@ export class EuiCodeBlock extends Component {
         <pre className="euiCodeBlock__pre">
           <code
             ref={ref => { this.code = ref; }}
-            className={language}
-            {...rest}
+            className={codeClasses}
+            {...otherProps}
           >
             {children}
           </code>
         </pre>
       </div>
     );
+  }
+
+  highlight() {
+    if (this.props.language) {
+      hljs.highlightBlock(this.code);
+    }
   }
 }
 


### PR DESCRIPTION
- Turns `language` into an optional prop
- Moves styles to own class so that we don't couple ourselves with `hljs` too much
- Re-executes highlighter when props get updated