### PR TITLE
Reset border radius on buttons

### DIFF
--- a/src/global_styling/reset/_reset.scss
+++ b/src/global_styling/reset/_reset.scss
@@ -93,6 +93,7 @@ button {
   font-size: $euiFontSize;
   color: inherit;
   font-size: inherit;
+  border-radius: 0;
 
   &:hover {
     cursor: pointer;


### PR DESCRIPTION
https://www.chromestatus.com/features/5743649186906112

Chrome introduced some border radius on buttons for Mac. This resets it.
