### PR TITLE
Improve screen-reader-accessibility of Accordion, ButtonIcon, and Popover

### DIFF
--- a/docs/src/views/accordion/accordion.js
+++ b/docs/src/views/accordion/accordion.js
@@ -11,6 +11,7 @@ import {
 export default () => (
   <div>
     <EuiAccordion
+      id="accordion1"
       buttonContent="Click me to toggle open / close"
     >
       <EuiText>
@@ -21,6 +22,7 @@ export default () => (
     <EuiSpacer size="l" />
 
     <EuiAccordion
+      id="accordion2"
       buttonContent="You can click me as well"
     >
       <EuiText>

--- a/docs/src/views/accordion/accordion_extra.js
+++ b/docs/src/views/accordion/accordion_extra.js
@@ -7,6 +7,7 @@ import {
 
 export default () => (
   <EuiAccordion
+    id="accordionExtra"
     buttonContent="Click to open"
     extraAction={<EuiButton size="s">Extra action!</EuiButton>}
   >

--- a/docs/src/views/accordion/accordion_form.js
+++ b/docs/src/views/accordion/accordion_form.js
@@ -29,13 +29,16 @@ const repeatableForm = (
           <EuiFieldText icon="user" placeholder="John" />
         </EuiFormRow>
       </EuiFlexItem>
+
       <EuiFlexItem>
         <EuiFormRow label="Password" id={makeId()} helpText="Must include one number and one symbol">
           <EuiFieldPassword icon="lock" />
         </EuiFormRow>
       </EuiFlexItem>
     </EuiFlexGroup>
+
     <EuiSpacer size="m" />
+
     <EuiFormRow label="Body" id={makeId()}>
       <EuiTextArea placeholder="I am a textarea, put some content in me!" />
     </EuiFormRow>
@@ -48,12 +51,14 @@ const buttonContent = (
       <EuiFlexItem grow={false}>
         <EuiIcon type="logoWebhook" size="m" />
       </EuiFlexItem>
+
       <EuiFlexItem>
         <EuiTitle size="s" className="euiAccordionForm__title">
           <h6>Webhook</h6>
         </EuiTitle>
       </EuiFlexItem>
     </EuiFlexGroup>
+
     <EuiText size="s">
       <p>
         <EuiTextColor color="subdued">
@@ -65,7 +70,12 @@ const buttonContent = (
 );
 
 const extraAction = (
-  <EuiButtonIcon iconType="cross" color="danger" className="euiAccordionForm__extraAction" />
+  <EuiButtonIcon
+    iconType="cross"
+    color="danger"
+    className="euiAccordionForm__extraAction"
+    aria-label="Delete"
+  />
 );
 
 export default () => (
@@ -73,8 +83,11 @@ export default () => (
     <EuiTitle size="s">
       <h3>I am a complicated, highly styled, repeatable form!</h3>
     </EuiTitle>
+
     <EuiSpacer size="l" />
+
     <EuiAccordion
+      id="accordionForm1"
       className="euiAccordionForm"
       buttonClassName="euiAccordionForm__button"
       buttonContent={buttonContent}
@@ -84,7 +97,9 @@ export default () => (
         {repeatableForm}
       </div>
     </EuiAccordion>
+
     <EuiAccordion
+      id="accordionForm2"
       className="euiAccordionForm"
       buttonClassName="euiAccordionForm__button"
       buttonContent={buttonContent}

--- a/docs/src/views/button/button_ghost.js
+++ b/docs/src/views/button/button_ghost.js
@@ -44,6 +44,7 @@ export default () => (
       color="ghost"
       iconType="user"
       onClick={() => window.alert('Button clicked')}
+      aria-label="Your account"
     />
   </div>
 );

--- a/docs/src/views/button/button_icon.js
+++ b/docs/src/views/button/button_icon.js
@@ -9,6 +9,7 @@ export default () => (
     <EuiButtonIcon
       onClick={() => window.alert('Button clicked')}
       iconType="arrowRight"
+      aria-label="Next"
     />
 
     <EuiButtonIcon
@@ -16,6 +17,7 @@ export default () => (
       color="danger"
       onClick={() => window.alert('Button clicked')}
       iconType="arrowRight"
+      aria-label="Next"
     />
 
     <EuiButtonIcon
@@ -23,6 +25,7 @@ export default () => (
       color="disabled"
       onClick={() => window.alert('Button clicked')}
       iconType="arrowRight"
+      aria-label="Next"
     />
   </div>
 );

--- a/docs/src/views/context_menu/context_menu.js
+++ b/docs/src/views/context_menu/context_menu.js
@@ -135,6 +135,7 @@ export default class extends Component {
 
     return (
       <EuiPopover
+        id="contextMenu"
         button={button}
         isOpen={this.state.isPopoverOpen}
         closePopover={this.closePopover}

--- a/docs/src/views/context_menu/single_panel.js
+++ b/docs/src/views/context_menu/single_panel.js
@@ -79,6 +79,7 @@ export default class extends Component {
 
     return (
       <EuiPopover
+        id="singlePanel"
         button={button}
         isOpen={this.state.isPopoverOpen}
         closePopover={this.closePopover}

--- a/docs/src/views/form/form_example.js
+++ b/docs/src/views/form/form_example.js
@@ -60,11 +60,19 @@ export default props => (
         code: formControlsHtml,
       }]}
       text={
-        <p>
-          These are the base inputs without their labels. If you need labels
-          then use the <EuiCode>FormRow</EuiCode> wrapper as explained
-          in the next example.
-        </p>
+        <div>
+          <p>
+            These are the base inputs without their labels. If you need labels
+            then use the <EuiCode>FormRow</EuiCode> wrapper as explained
+            in the next example.
+          </p>
+          <p>
+            Never forget to label every input element. You can either
+            use a <EuiCode>label</EuiCode> element with a <EuiCode>for</EuiCode> attribute
+            referencing the <EuiCode>id</EuiCode> of the input field, wrap the <EuiCode>input</EuiCode> field
+            within the <EuiCode>label</EuiCode> element or use <EuiCode>aria-label</EuiCode> or <EuiCode>aria-labelledby</EuiCode>.
+          </p>
+        </div>
       }
       demo={
         <FormControls />

--- a/docs/src/views/form/form_popover.js
+++ b/docs/src/views/form/form_popover.js
@@ -92,6 +92,7 @@ export default class extends Component {
     return (
       <div>
         <EuiPopover
+          id="formPopover"
           ownFocus
           button={button}
           isOpen={this.state.isPopoverOpen}

--- a/docs/src/views/form/inline_form_popover.js
+++ b/docs/src/views/form/inline_form_popover.js
@@ -84,6 +84,7 @@ export default class extends Component {
 
     return (
       <EuiPopover
+        id="inlineFormPopover"
         ownFocus
         button={button}
         isOpen={this.state.isPopoverOpen}

--- a/docs/src/views/header/header_app_menu.js
+++ b/docs/src/views/header/header_app_menu.js
@@ -40,6 +40,7 @@ export default class extends Component {
 
     return (
       <EuiPopover
+        id="headerAppMenu"
         ownFocus
         button={button}
         isOpen={this.state.isOpen}

--- a/docs/src/views/header/header_user_menu.js
+++ b/docs/src/views/header/header_user_menu.js
@@ -52,6 +52,7 @@ export default class extends Component {
 
     return (
       <EuiPopover
+        id="headerUserMenu"
         ownFocus
         button={button}
         isOpen={this.state.isOpen}

--- a/docs/src/views/kibana/watches.js
+++ b/docs/src/views/kibana/watches.js
@@ -103,6 +103,7 @@ export default class extends Component {
 
     return (
       <EuiPopover
+        id="watches"
         button={button}
         isOpen={this.state.isPopoverOpen}
         closePopover={this.closePopover}

--- a/docs/src/views/pagination/customizable_pagination.js
+++ b/docs/src/views/pagination/customizable_pagination.js
@@ -87,6 +87,7 @@ export default class extends Component {
       <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
         <EuiFlexItem grow={false}>
           <EuiPopover
+            id="customizablePagination"
             button={button}
             isOpen={this.state.isPopoverOpen}
             closePopover={this.closePopover.bind(this)}

--- a/docs/src/views/popover/popover.js
+++ b/docs/src/views/popover/popover.js
@@ -41,6 +41,7 @@ export default class extends Component {
 
     return (
       <EuiPopover
+        id="popover"
         ownFocus
         button={button}
         isOpen={this.state.isPopoverOpen}

--- a/docs/src/views/popover/popover_anchor_position.js
+++ b/docs/src/views/popover/popover_anchor_position.js
@@ -176,6 +176,7 @@ export default class extends Component {
         <EuiFlexGroup>
           <EuiFlexItem grow={false}>
             <EuiPopover
+              id="downLeft"
               ownFocus
               button={(
                 <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick1.bind(this)}>
@@ -189,8 +190,10 @@ export default class extends Component {
               Popover content
             </EuiPopover>
           </EuiFlexItem>
+
           <EuiFlexItem grow={false}>
             <EuiPopover
+              id="downCenter"
               ownFocus
               button={(
                 <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick2.bind(this)}>
@@ -204,8 +207,10 @@ export default class extends Component {
               Popover content
             </EuiPopover>
           </EuiFlexItem>
+
           <EuiFlexItem grow={false}>
             <EuiPopover
+              id="downRight"
               ownFocus
               button={(
                 <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick3.bind(this)}>
@@ -226,6 +231,7 @@ export default class extends Component {
         <EuiFlexGroup>
           <EuiFlexItem grow={false}>
             <EuiPopover
+              id="upLeft"
               ownFocus
               button={(
                 <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick4.bind(this)}>
@@ -239,8 +245,10 @@ export default class extends Component {
               Popover content
             </EuiPopover>
           </EuiFlexItem>
+
           <EuiFlexItem grow={false}>
             <EuiPopover
+              id="upCenter"
               ownFocus
               button={(
                 <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick5.bind(this)}>
@@ -254,8 +262,10 @@ export default class extends Component {
               Popover content
             </EuiPopover>
           </EuiFlexItem>
+
           <EuiFlexItem grow={false}>
             <EuiPopover
+              id="upRight"
               ownFocus
               button={(
                 <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick6.bind(this)}>
@@ -276,6 +286,7 @@ export default class extends Component {
         <EuiFlexGroup>
           <EuiFlexItem grow={false}>
             <EuiPopover
+              id="leftUp"
               ownFocus
               button={(
                 <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick7.bind(this)}>
@@ -294,8 +305,10 @@ export default class extends Component {
               </EuiText>
             </EuiPopover>
           </EuiFlexItem>
+
           <EuiFlexItem grow={false}>
             <EuiPopover
+              id="leftCenter"
               ownFocus
               button={(
                 <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick8.bind(this)}>
@@ -309,8 +322,10 @@ export default class extends Component {
               Popover content
             </EuiPopover>
           </EuiFlexItem>
+
           <EuiFlexItem grow={false}>
             <EuiPopover
+              id="leftDown"
               ownFocus
               button={(
                 <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick9.bind(this)}>
@@ -336,6 +351,7 @@ export default class extends Component {
         <EuiFlexGroup>
           <EuiFlexItem grow={false}>
             <EuiPopover
+              id="rightUp"
               ownFocus
               button={(
                 <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick10.bind(this)}>
@@ -354,8 +370,10 @@ export default class extends Component {
               </EuiText>
             </EuiPopover>
           </EuiFlexItem>
+
           <EuiFlexItem grow={false}>
             <EuiPopover
+              id="rightCenter"
               ownFocus
               button={(
                 <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick11.bind(this)}>
@@ -369,8 +387,10 @@ export default class extends Component {
               Popover content
             </EuiPopover>
           </EuiFlexItem>
+
           <EuiFlexItem grow={false}>
             <EuiPopover
+              id="rightDown"
               ownFocus
               button={(
                 <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick12.bind(this)}>

--- a/docs/src/views/popover/popover_panel_class_name.js
+++ b/docs/src/views/popover/popover_panel_class_name.js
@@ -31,6 +31,7 @@ export default class extends Component {
   render() {
     return (
       <EuiPopover
+        id="popoverPanelClassName"
         ownFocus
         button={(
           <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick.bind(this)}>

--- a/docs/src/views/popover/popover_with_title.js
+++ b/docs/src/views/popover/popover_with_title.js
@@ -61,6 +61,7 @@ export default class extends Component {
       <EuiFlexGroup>
         <EuiFlexItem grow={false}>
           <EuiPopover
+            id="downCenterWithTitle"
             ownFocus
             button={(
               <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick1.bind(this)}>
@@ -83,8 +84,10 @@ export default class extends Component {
             </div>
           </EuiPopover>
         </EuiFlexItem>
+
         <EuiFlexItem grow={false}>
           <EuiPopover
+            id="upCenterWithTitle"
             ownFocus
             button={(
               <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick2.bind(this)}>
@@ -107,8 +110,10 @@ export default class extends Component {
             </div>
           </EuiPopover>
         </EuiFlexItem>
+
         <EuiFlexItem grow={false}>
           <EuiPopover
+            id="rightUpWithTitle"
             ownFocus
             button={(
               <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick3.bind(this)}>

--- a/docs/src/views/popover/trap_focus.js
+++ b/docs/src/views/popover/trap_focus.js
@@ -43,6 +43,7 @@ export default class extends Component {
 
     return (
       <EuiPopover
+        id="trapFocus"
         ownFocus
         button={button}
         isOpen={this.state.isPopoverOpen}
@@ -57,6 +58,7 @@ export default class extends Component {
             label="Snapshot data"
           />
         </EuiFormRow>
+
         <EuiFormRow
           label="Include the following in the embed"
         >
@@ -66,7 +68,8 @@ export default class extends Component {
             label="Current time range"
           />
         </EuiFormRow>
-        <EuiButton fill>Copy iFrame code</EuiButton>
+
+        <EuiButton fill>Copy IFRAME code</EuiButton>
       </EuiPopover>
     );
   }

--- a/src/components/accordion/__snapshots__/accordion.test.js.snap
+++ b/src/components/accordion/__snapshots__/accordion.test.js.snap
@@ -12,10 +12,10 @@ exports[`EuiAccordion is rendered 1`] = `
     <div
       class="euiFlexItem"
     >
-      <div
+      <button
+        aria-controls="0"
+        aria-expanded="false"
         class="euiAccordion__button"
-        role="button"
-        tabindex="0"
       >
         <div
           class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter"
@@ -38,11 +38,12 @@ exports[`EuiAccordion is rendered 1`] = `
             class="euiFlexItem euiAccordion__buttonContent"
           />
         </div>
-      </div>
+      </button>
     </div>
   </div>
   <div
     class="euiAccordion__childWrapper"
+    id="0"
   >
     <div />
   </div>

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import {
-  EuiKeyboardAccessible,
   EuiIcon,
   EuiFlexGroup,
   EuiFlexItem,
@@ -46,6 +45,7 @@ export class EuiAccordion extends Component {
       children,
       buttonContent,
       className,
+      id,
       buttonClassName,
       buttonContentClassName,
       extraAction,
@@ -91,23 +91,32 @@ export class EuiAccordion extends Component {
       >
         <EuiFlexGroup gutterSize="none" alignItems="center">
           <EuiFlexItem>
-            <EuiKeyboardAccessible>
-              <div onClick={this.onToggleOpen} className={buttonClasses}>
-                <EuiFlexGroup gutterSize="s" alignItems="center">
-                  <EuiFlexItem grow={false}>
-                    {icon}
-                  </EuiFlexItem>
-                  <EuiFlexItem className={buttonContentClasses}>
-                    {buttonContent}
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </div>
-            </EuiKeyboardAccessible>
+            <button
+              aria-controls={id}
+              aria-expanded={!!this.state.isOpen}
+              onClick={this.onToggleOpen}
+              className={buttonClasses}
+            >
+              <EuiFlexGroup gutterSize="s" alignItems="center">
+                <EuiFlexItem grow={false}>
+                  {icon}
+                </EuiFlexItem>
+
+                <EuiFlexItem className={buttonContentClasses}>
+                  {buttonContent}
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </button>
           </EuiFlexItem>
+
           {optionalAction}
         </EuiFlexGroup>
 
-        <div className="euiAccordion__childWrapper"  ref={node => { this.childWrapper = node; }}>
+        <div
+          className="euiAccordion__childWrapper"
+          ref={node => { this.childWrapper = node; }}
+          id={id}
+        >
           <div ref={node => { this.childContent = node; }}>
             {children}
           </div>
@@ -119,6 +128,7 @@ export class EuiAccordion extends Component {
 
 EuiAccordion.propTypes = {
   children: PropTypes.node,
+  id: PropTypes.string.isRequired,
   className: PropTypes.string,
   buttonContentClassName: PropTypes.string,
   buttonContent: PropTypes.node,

--- a/src/components/accordion/accordion.test.js
+++ b/src/components/accordion/accordion.test.js
@@ -4,10 +4,16 @@ import { requiredProps } from '../../test/required_props';
 
 import { EuiAccordion } from './accordion';
 
+let id = 0;
+const getId = () => (`${id++}`);
+
 describe('EuiAccordion', () => {
   test('is rendered', () => {
     const component = render(
-      <EuiAccordion {...requiredProps} />
+      <EuiAccordion
+        id={getId()}
+        {...requiredProps}
+      />
     );
 
     expect(component)

--- a/src/components/button/button_icon/button_icon.js
+++ b/src/components/button/button_icon/button_icon.js
@@ -7,6 +7,21 @@ import {
   EuiIcon,
 } from '../../icon';
 
+const accessibleButtonIcon = (props, propName, componentName) => {
+  if (props['aria-label']) {
+    return;
+  }
+
+  if (props['aria-labelledby']) {
+    return;
+  }
+
+  throw new Error(
+    `${componentName} requires aria-label or aria-labelledby to be specified because icon-only
+    buttons are screen-reader-inaccessible without them.`
+  );
+};
+
 const colorToClassNameMap = {
   primary: 'euiButtonIcon--primary',
   danger: 'euiButtonIcon--danger',
@@ -61,6 +76,7 @@ EuiButtonIcon.propTypes = {
   iconType: PropTypes.oneOf(ICON_TYPES),
   color: PropTypes.oneOf(COLORS),
   isDisabled: PropTypes.bool,
+  'aria-label': accessibleButtonIcon,
 };
 
 EuiButtonIcon.defaultProps = {

--- a/src/components/button/button_icon/button_icon.test.js
+++ b/src/components/button/button_icon/button_icon.test.js
@@ -7,7 +7,7 @@ import { EuiButtonIcon } from './button_icon';
 describe('EuiButtonIcon', () => {
   test('is rendered', () => {
     const component = render(
-      <EuiButtonIcon {...requiredProps} />
+      <EuiButtonIcon aria-label="ariaLabel" {...requiredProps} />
     );
 
     expect(component)

--- a/src/components/description_list/description_list.js
+++ b/src/components/description_list/description_list.js
@@ -44,10 +44,15 @@ export const EuiDescriptionList = ({
   let childrenOrListItems = null;
   if (listItems) {
     childrenOrListItems = (
-      listItems.map((item) => {
+      listItems.map((item, index) => {
         return [
-          <EuiDescriptionListTitle>{item.title}</EuiDescriptionListTitle>,
-          <EuiDescriptionListDescription>{item.description}</EuiDescriptionListDescription>
+          <EuiDescriptionListTitle key={`title-${index}`}>
+            {item.title}
+          </EuiDescriptionListTitle>,
+
+          <EuiDescriptionListDescription key={`description-${index}`}>
+            {item.description}
+          </EuiDescriptionListDescription>
         ];
       })
     );

--- a/src/components/header/header_alert/__snapshots__/header_alert.test.js.snap
+++ b/src/components/header/header_alert/__snapshots__/header_alert.test.js.snap
@@ -7,6 +7,7 @@ exports[`EuiHeaderAlert is rendered 1`] = `
   data-test-subj="test subject string"
 >
   <button
+    aria-label="Dismiss"
     class="euiButtonIcon euiButtonIcon--primary euiHeaderAlert__dismiss"
     type="button"
   >

--- a/src/components/header/header_alert/header_alert.js
+++ b/src/components/header/header_alert/header_alert.js
@@ -22,13 +22,22 @@ export const EuiHeaderAlert = ({
       className={classes}
       {...rest}
     >
-      <EuiButtonIcon iconType="cross" size="s" className="euiHeaderAlert__dismiss" />
+      <EuiButtonIcon
+        aria-label="Dismiss"
+        iconType="cross"
+        size="s"
+        className="euiHeaderAlert__dismiss"
+      />
+
       <p className="euiHeaderAlert__title">{title}</p>
+
       <p className="euiHeaderAlert__text">{text}</p>
+
       <EuiFlexGroup justifyContent="spaceBetween">
         <EuiFlexItem grow={false}>
           <div className="euiHeaderAlert__action euiLink">{action}</div>
         </EuiFlexItem>
+
         <EuiFlexItem grow={false}>
           <div className="euiHeaderAlert__date">
             {date}

--- a/src/components/popover/__snapshots__/popover.test.js.snap
+++ b/src/components/popover/__snapshots__/popover.test.js.snap
@@ -4,7 +4,10 @@ exports[`EuiPopover children is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
 >
-  <button />
+  <button
+    aria-controls="1"
+    aria-expanded="false"
+  />
 </div>
 `;
 
@@ -14,7 +17,10 @@ exports[`EuiPopover is rendered 1`] = `
   class="euiPopover euiPopover--anchorDownCenter testClass1 testClass2"
   data-test-subj="test subject string"
 >
-  <button />
+  <button
+    aria-controls="0"
+    aria-expanded="false"
+  />
 </div>
 `;
 
@@ -22,7 +28,10 @@ exports[`EuiPopover props anchorPosition defaults to centerDown 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
 >
-  <button />
+  <button
+    aria-controls="4"
+    aria-expanded="false"
+  />
 </div>
 `;
 
@@ -30,7 +39,10 @@ exports[`EuiPopover props anchorPosition downRight is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownRight"
 >
-  <button />
+  <button
+    aria-controls="6"
+    aria-expanded="false"
+  />
 </div>
 `;
 
@@ -38,7 +50,10 @@ exports[`EuiPopover props anchorPosition leftCenter is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorLeftCenter"
 >
-  <button />
+  <button
+    aria-controls="5"
+    aria-expanded="false"
+  />
 </div>
 `;
 
@@ -46,7 +61,10 @@ exports[`EuiPopover props isOpen defaults to false 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
 >
-  <button />
+  <button
+    aria-controls="7"
+    aria-expanded="false"
+  />
 </div>
 `;
 
@@ -54,10 +72,14 @@ exports[`EuiPopover props isOpen renders true 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
 >
-  <button />
+  <button
+    aria-controls="8"
+    aria-expanded="true"
+  />
   <div>
     <div
       class="euiPanel euiPanel--paddingMedium euiPanel--shadow euiPopover__panel"
+      id="8"
     />
   </div>
 </div>
@@ -67,10 +89,14 @@ exports[`EuiPopover props ownFocus defaults to false 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
 >
-  <button />
+  <button
+    aria-controls="9"
+    aria-expanded="true"
+  />
   <div>
     <div
       class="euiPanel euiPanel--paddingMedium euiPanel--shadow euiPopover__panel"
+      id="9"
     />
   </div>
 </div>
@@ -80,10 +106,14 @@ exports[`EuiPopover props ownFocus renders true 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
 >
-  <button />
+  <button
+    aria-controls="10"
+    aria-expanded="true"
+  />
   <div>
     <div
       class="euiPanel euiPanel--paddingMedium euiPanel--shadow euiPopover__panel"
+      id="10"
       tabindex="0"
     />
   </div>
@@ -94,10 +124,14 @@ exports[`EuiPopover props panelClassName is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
 >
-  <button />
+  <button
+    aria-controls="11"
+    aria-expanded="true"
+  />
   <div>
     <div
       class="euiPanel euiPanel--paddingMedium euiPanel--shadow euiPopover__panel test"
+      id="11"
     />
   </div>
 </div>
@@ -107,10 +141,14 @@ exports[`EuiPopover props panelPaddingSize is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
 >
-  <button />
+  <button
+    aria-controls="12"
+    aria-expanded="true"
+  />
   <div>
     <div
       class="euiPanel euiPanel--paddingSmall euiPanel--shadow euiPopover__panel"
+      id="12"
     />
   </div>
 </div>
@@ -120,6 +158,9 @@ exports[`EuiPopover props withTitle is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter euiPopover--withTitle"
 >
-  <button />
+  <button
+    aria-controls="2"
+    aria-expanded="false"
+  />
 </div>
 `;

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -1,4 +1,5 @@
 import React, {
+  cloneElement,
   Component,
 } from 'react';
 import PropTypes from 'prop-types';
@@ -123,6 +124,7 @@ export class EuiPopover extends Component {
       ownFocus,
       withTitle,
       children,
+      id,
       className,
       closePopover,
       panelClassName,
@@ -166,6 +168,7 @@ export class EuiPopover extends Component {
             paddingSize={panelPaddingSize}
             tabIndex={tabIndex}
             hasShadow
+            id={id}
           >
             {children}
           </EuiPanel>
@@ -180,7 +183,10 @@ export class EuiPopover extends Component {
           onKeyDown={this.onKeyDown}
           {...rest}
         >
-          {button}
+          {cloneElement(button, {
+            'aria-controls': id,
+            'aria-expanded': !!isOpen,
+          })}
           {panel}
         </div>
       </EuiOutsideClickDetector>
@@ -189,6 +195,7 @@ export class EuiPopover extends Component {
 }
 
 EuiPopover.propTypes = {
+  id: PropTypes.string.isRequired,
   isOpen: PropTypes.bool,
   ownFocus: PropTypes.bool,
   withTitle: PropTypes.bool,

--- a/src/components/popover/popover.test.js
+++ b/src/components/popover/popover.test.js
@@ -7,10 +7,14 @@ import { EuiPopover } from './popover';
 
 import { keyCodes } from '../../services';
 
+let id = 0;
+const getId = () => (`${id++}`);
+
 describe('EuiPopover', () => {
   test('is rendered', () => {
     const component = render(
       <EuiPopover
+        id={getId()}
         button={<button />}
         closePopover={() => {}}
         {...requiredProps}
@@ -24,6 +28,7 @@ describe('EuiPopover', () => {
   test('children is rendered', () => {
     const component = render(
       <EuiPopover
+        id={getId()}
         button={<button />}
         closePopover={() => {}}
       >
@@ -40,6 +45,7 @@ describe('EuiPopover', () => {
       test('is rendered', () => {
         const component = render(
           <EuiPopover
+            id={getId()}
             withTitle
             button={<button />}
             closePopover={() => {}}
@@ -57,6 +63,7 @@ describe('EuiPopover', () => {
 
         const component = mount(
           <EuiPopover
+            id={getId()}
             withTitle
             button={<button />}
             closePopover={closePopoverHandler}
@@ -72,6 +79,7 @@ describe('EuiPopover', () => {
       test('defaults to centerDown', () => {
         const component = render(
           <EuiPopover
+            id={getId()}
             button={<button />}
             closePopover={() => {}}
           />
@@ -84,6 +92,7 @@ describe('EuiPopover', () => {
       test('leftCenter is rendered', () => {
         const component = render(
           <EuiPopover
+            id={getId()}
             button={<button />}
             closePopover={() => {}}
             anchorPosition="leftCenter"
@@ -97,6 +106,7 @@ describe('EuiPopover', () => {
       test('downRight is rendered', () => {
         const component = render(
           <EuiPopover
+            id={getId()}
             button={<button />}
             closePopover={() => {}}
             anchorPosition="downRight"
@@ -112,6 +122,7 @@ describe('EuiPopover', () => {
       test('defaults to false', () => {
         const component = render(
           <EuiPopover
+            id={getId()}
             button={<button />}
             closePopover={() => {}}
           />
@@ -124,6 +135,7 @@ describe('EuiPopover', () => {
       test('renders true', () => {
         const component = render(
           <EuiPopover
+            id={getId()}
             button={<button />}
             closePopover={() => {}}
             isOpen
@@ -139,6 +151,7 @@ describe('EuiPopover', () => {
       test('defaults to false', () => {
         const component = render(
           <EuiPopover
+            id={getId()}
             isOpen
             button={<button />}
             closePopover={() => {}}
@@ -152,6 +165,7 @@ describe('EuiPopover', () => {
       test('renders true', () => {
         const component = render(
           <EuiPopover
+            id={getId()}
             isOpen
             ownFocus
             button={<button />}
@@ -168,6 +182,7 @@ describe('EuiPopover', () => {
       test('is rendered', () => {
         const component = render(
           <EuiPopover
+            id={getId()}
             button={<button />}
             closePopover={() => {}}
             panelClassName="test"
@@ -184,6 +199,7 @@ describe('EuiPopover', () => {
       test('is rendered', () => {
         const component = render(
           <EuiPopover
+            id={getId()}
             button={<button />}
             closePopover={() => {}}
             panelPaddingSize="s"

--- a/src/components/tabs/__snapshots__/tab.test.js.snap
+++ b/src/components/tabs/__snapshots__/tab.test.js.snap
@@ -3,8 +3,10 @@
 exports[`EuiTab renders 1`] = `
 <button
   aria-label="aria-label"
+  aria-selected="false"
   class="euiTab testClass1 testClass2"
   data-test-subj="test subject string"
+  role="tab"
   type="button"
 >
   <span
@@ -18,8 +20,10 @@ exports[`EuiTab renders 1`] = `
 exports[`EuiTab renders isSelected 1`] = `
 <button
   aria-label="aria-label"
+  aria-selected="true"
   class="euiTab testClass1 testClass2 euiTab-isSelected"
   data-test-subj="test subject string"
+  role="tab"
   type="button"
 >
   <span

--- a/src/components/tabs/__snapshots__/tabs.test.js.snap
+++ b/src/components/tabs/__snapshots__/tabs.test.js.snap
@@ -5,5 +5,6 @@ exports[`EuiTabs renders 1`] = `
   aria-label="aria-label"
   class="euiTabs testClass1 testClass2"
   data-test-subj="test subject string"
+  role="tablist"
 />
 `;

--- a/src/components/tabs/tab.js
+++ b/src/components/tabs/tab.js
@@ -2,13 +2,21 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-export const EuiTab = ({ isSelected, onClick, children, className, ...rest }) => {
+export const EuiTab = ({
+  isSelected,
+  onClick,
+  children,
+  className,
+  ...rest
+}) => {
   const classes = classNames('euiTab', className, {
     'euiTab-isSelected': isSelected
   });
 
   return (
     <button
+      role="tab"
+      aria-selected={!!isSelected}
       type="button"
       className={classes}
       onClick={onClick}

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -11,6 +11,7 @@ export const EuiTabs = ({
 
   return (
     <div
+      role="tablist"
       className={classes}
       {...rest}
     >


### PR DESCRIPTION
Ports applicable improvements from https://github.com/elastic/kibana/pull/14073

- Associate Accordion button with content using id, aria-expanded, and aria-controls.
- Do the same thing with Popovers.
- Required aria-label or aria-labelledby on ButtonIcon.