### PR TITLE
WIP: Sidenav tree

### DIFF
--- a/docs/src/views/partials.js
+++ b/docs/src/views/partials.js
@@ -1,7 +1,7 @@
 export { default as KibanaChrome } from './kibana/kibana_chrome';
 export { default as KibanaHeader } from './header/header';
 export { default as TablePagination } from './pagination/customizable_pagination';
-export { default as ManagementSideNav } from './side_nav/side_nav';
+export { default as ManagementSideNav } from './side_nav/side_nav_complicated';
 export { default as Table } from './table/table';
 export {
   default as ToastList,

--- a/docs/src/views/side_nav/side_nav.js
+++ b/docs/src/views/side_nav/side_nav.js
@@ -35,53 +35,22 @@ export default class extends Component {
         style={{ width: 192 }}
       >
 
-        <EuiSideNavItem isSelected parent>
+        <EuiSideNavTitle>
+          Kibana
+        </EuiSideNavTitle>
+        <EuiSideNavItem>
           <button>
             Advanced settings
           </button>
         </EuiSideNavItem>
 
-        <div className="euiSideNavGroup">
-          <EuiSideNavItem>
-            <button>
-              General
-            </button>
-          </EuiSideNavItem>
-
-          <EuiSideNavItem isSelected parent>
-            <button>
-              Timelion
-            </button>
-          </EuiSideNavItem>
-
-          <div className="euiSideNavGroup">
-            <EuiSideNavItem>
-              <button>
-                Time stuff
-              </button>
-            </EuiSideNavItem>
-
-            <EuiSideNavItem isSelected>
-              <button>
-                Lion stuff
-              </button>
-            </EuiSideNavItem>
-          </div>
-
-          <EuiSideNavItem>
-            <button>
-              Visualizations
-            </button>
-          </EuiSideNavItem>
-        </div>
-
-        <EuiSideNavItem>
+        <EuiSideNavItem isSelected>
           <button>
             Index Patterns
           </button>
         </EuiSideNavItem>
 
-        <EuiSideNavItem parent>
+        <EuiSideNavItem>
           <button>
             Saved Objects
           </button>

--- a/docs/src/views/side_nav/side_nav.js
+++ b/docs/src/views/side_nav/side_nav.js
@@ -3,9 +3,12 @@ import React, {
 } from 'react';
 
 import {
+  EuiIcon,
   EuiSideNav,
   EuiSideNavItem,
   EuiSideNavTitle,
+  EuiFlexGroup,
+  EuiFlexItem,
 } from '../../../../src/components';
 
 export default class extends Component {
@@ -29,72 +32,48 @@ export default class extends Component {
         mobileTitle="Navigate within $APP_NAME"
         toggleOpenOnMobile={this.toggleOpenOnMobile}
         isOpenOnMobile={this.state.isSideNavOpenOnMobile}
+        style={{ width: 192 }}
       >
-        {/* Elasticsearch section */}
 
-        <EuiSideNavTitle>
-          Elasticsearch
-        </EuiSideNavTitle>
-
-        <EuiSideNavItem>
-          <button onClick={() => window.alert('Button clicked')}>
-            Data sources
-          </button>
-        </EuiSideNavItem>
-
-        <EuiSideNavItem>
-          <a href="http://www.elastic.co">
-            Users
-          </a>
-        </EuiSideNavItem>
-
-        <EuiSideNavItem>
-          <button>
-            Roles
-          </button>
-        </EuiSideNavItem>
-
-        <EuiSideNavItem>
-          <button>
-            Watches
-          </button>
-        </EuiSideNavItem>
-
-        <EuiSideNavItem>
-          <button>
-            Extremely long title will become truncated when the browser is narrow enough
-          </button>
-        </EuiSideNavItem>
-
-        {/* Kibana section */}
-
-        <EuiSideNavTitle>
-          Kibana
-        </EuiSideNavTitle>
-
-        <EuiSideNavItem isSelected>
+        <EuiSideNavItem isSelected parent>
           <button>
             Advanced settings
           </button>
         </EuiSideNavItem>
 
-        <EuiSideNavItem indent>
-          <button>
-            General
-          </button>
-        </EuiSideNavItem>
+        <div className="euiSideNavGroup">
+          <EuiSideNavItem>
+            <button>
+              General
+            </button>
+          </EuiSideNavItem>
 
-        <EuiSideNavItem indent isSelected>
-          <button>
-            Timelion
-          </button>
-        </EuiSideNavItem>
+          <EuiSideNavItem isSelected parent>
+            <button>
+              Timelion
+            </button>
+          </EuiSideNavItem>
 
-        <EuiSideNavItem indent>
-          <button>
-            Visualizations
-          </button>
-        </EuiSideNavItem>
+          <div className="euiSideNavGroup">
+            <EuiSideNavItem>
+              <button>
+                Time stuff
+              </button>
+            </EuiSideNavItem>
+
+            <EuiSideNavItem isSelected>
+              <button>
+                Lion stuff
+              </button>
+            </EuiSideNavItem>
+          </div>
+
+          <EuiSideNavItem>
+            <button>
+              Visualizations
+            </button>
+          </EuiSideNavItem>
+        </div>
 
         <EuiSideNavItem>
           <button>
@@ -102,7 +81,7 @@ export default class extends Component {
           </button>
         </EuiSideNavItem>
 
-        <EuiSideNavItem>
+        <EuiSideNavItem parent>
           <button>
             Saved Objects
           </button>
@@ -114,17 +93,6 @@ export default class extends Component {
           </button>
         </EuiSideNavItem>
 
-        {/* Logstash section */}
-
-        <EuiSideNavTitle>
-          Logstash
-        </EuiSideNavTitle>
-
-        <EuiSideNavItem>
-          <button>
-            Pipeline Viewer
-          </button>
-        </EuiSideNavItem>
       </EuiSideNav>
     );
   }

--- a/docs/src/views/side_nav/side_nav_complicated.js
+++ b/docs/src/views/side_nav/side_nav_complicated.js
@@ -48,7 +48,6 @@ export default class extends Component {
           </EuiFlexGroup>
         </EuiSideNavTitle>
 
-        <EuiSideNavGroup>
           <EuiSideNavItem>
             <button onClick={() => window.alert('Button clicked')}>
               Data sources
@@ -78,7 +77,6 @@ export default class extends Component {
               Extremely long title will become truncated when the browser is narrow enough
             </button>
           </EuiSideNavItem>
-        </EuiSideNavGroup>
 
         {/* Kibana section */}
 
@@ -93,7 +91,6 @@ export default class extends Component {
           </EuiFlexGroup>
         </EuiSideNavTitle>
 
-        <EuiSideNavGroup>
           <EuiSideNavItem isSelected parent>
             <button>
               Advanced settings
@@ -151,7 +148,6 @@ export default class extends Component {
               Reporting
             </button>
           </EuiSideNavItem>
-        </EuiSideNavGroup>
 
         {/* Logstash section */}
 
@@ -166,13 +162,11 @@ export default class extends Component {
           </EuiFlexGroup>
         </EuiSideNavTitle>
 
-        <EuiSideNavGroup>
           <EuiSideNavItem>
             <button>
               Pipeline Viewer
             </button>
           </EuiSideNavItem>
-        </EuiSideNavGroup>
       </EuiSideNav>
     );
   }

--- a/docs/src/views/side_nav/side_nav_complicated.js
+++ b/docs/src/views/side_nav/side_nav_complicated.js
@@ -1,0 +1,178 @@
+import React, {
+  Component,
+} from 'react';
+
+import {
+  EuiIcon,
+  EuiSideNav,
+  EuiSideNavItem,
+  EuiSideNavTitle,
+  EuiFlexGroup,
+  EuiFlexItem,
+} from '../../../../src/components';
+
+export default class extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isSideNavOpenOnMobile: false,
+    };
+  }
+
+  toggleOpenOnMobile = () => {
+    this.setState({
+      isSideNavOpenOnMobile: !this.state.isSideNavOpenOnMobile,
+    });
+  };
+
+  render() {
+    return (
+      <EuiSideNav
+        mobileTitle="Navigate within $APP_NAME"
+        toggleOpenOnMobile={this.toggleOpenOnMobile}
+        isOpenOnMobile={this.state.isSideNavOpenOnMobile}
+        style={{ width: 192 }}
+      >
+        {/* Elasticsearch section */}
+
+        <EuiSideNavTitle>
+          <EuiFlexGroup gutterSize="s" alignItems="center">
+            <EuiFlexItem grow={false}>
+              <EuiIcon type="logoElasticSearch" />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              Elasticsearch
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiSideNavTitle>
+
+        <div className="euiSideNavGroup">
+          <EuiSideNavItem>
+            <button onClick={() => window.alert('Button clicked')}>
+              Data sources
+            </button>
+          </EuiSideNavItem>
+
+          <EuiSideNavItem>
+            <a href="http://www.elastic.co">
+              Users
+            </a>
+          </EuiSideNavItem>
+
+          <EuiSideNavItem>
+            <button>
+              Roles
+            </button>
+          </EuiSideNavItem>
+
+          <EuiSideNavItem>
+            <button>
+              Watches
+            </button>
+          </EuiSideNavItem>
+
+          <EuiSideNavItem>
+            <button>
+              Extremely long title will become truncated when the browser is narrow enough
+            </button>
+          </EuiSideNavItem>
+        </div>
+
+        {/* Kibana section */}
+
+        <EuiSideNavTitle>
+          <EuiFlexGroup gutterSize="s" alignItems="center">
+            <EuiFlexItem grow={false}>
+              <EuiIcon type="logoKibana" />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              Kibana
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiSideNavTitle>
+
+        <div className="euiSideNavGroup">
+          <EuiSideNavItem isSelected parent>
+            <button>
+              Advanced settings
+            </button>
+          </EuiSideNavItem>
+
+          <div className="euiSideNavGroup">
+            <EuiSideNavItem>
+              <button>
+                General
+              </button>
+            </EuiSideNavItem>
+
+            <EuiSideNavItem isSelected parent>
+              <button>
+                Timelion
+              </button>
+            </EuiSideNavItem>
+
+            <div className="euiSideNavGroup">
+              <EuiSideNavItem>
+                <button>
+                  Time stuff
+                </button>
+              </EuiSideNavItem>
+
+              <EuiSideNavItem isSelected>
+                <button>
+                  Lion stuff
+                </button>
+              </EuiSideNavItem>
+            </div>
+
+            <EuiSideNavItem>
+              <button>
+                Visualizations
+              </button>
+            </EuiSideNavItem>
+          </div>
+
+          <EuiSideNavItem>
+            <button>
+              Index Patterns
+            </button>
+          </EuiSideNavItem>
+
+          <EuiSideNavItem parent>
+            <button>
+              Saved Objects
+            </button>
+          </EuiSideNavItem>
+
+          <EuiSideNavItem>
+            <button>
+              Reporting
+            </button>
+          </EuiSideNavItem>
+        </div>
+
+        {/* Logstash section */}
+
+        <EuiSideNavTitle>
+          <EuiFlexGroup gutterSize="s" alignItems="center">
+            <EuiFlexItem grow={false}>
+              <EuiIcon type="logoLogstash" />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              Logstash
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiSideNavTitle>
+
+        <div className="euiSideNavGroup">
+          <EuiSideNavItem>
+            <button>
+              Pipeline Viewer
+            </button>
+          </EuiSideNavItem>
+        </div>
+      </EuiSideNav>
+    );
+  }
+}

--- a/docs/src/views/side_nav/side_nav_complicated.js
+++ b/docs/src/views/side_nav/side_nav_complicated.js
@@ -5,6 +5,7 @@ import React, {
 import {
   EuiIcon,
   EuiSideNav,
+  EuiSideNavGroup,
   EuiSideNavItem,
   EuiSideNavTitle,
   EuiFlexGroup,
@@ -47,7 +48,7 @@ export default class extends Component {
           </EuiFlexGroup>
         </EuiSideNavTitle>
 
-        <div className="euiSideNavGroup">
+        <EuiSideNavGroup>
           <EuiSideNavItem>
             <button onClick={() => window.alert('Button clicked')}>
               Data sources
@@ -77,7 +78,7 @@ export default class extends Component {
               Extremely long title will become truncated when the browser is narrow enough
             </button>
           </EuiSideNavItem>
-        </div>
+        </EuiSideNavGroup>
 
         {/* Kibana section */}
 
@@ -92,14 +93,14 @@ export default class extends Component {
           </EuiFlexGroup>
         </EuiSideNavTitle>
 
-        <div className="euiSideNavGroup">
+        <EuiSideNavGroup>
           <EuiSideNavItem isSelected parent>
             <button>
               Advanced settings
             </button>
           </EuiSideNavItem>
 
-          <div className="euiSideNavGroup">
+          <EuiSideNavGroup>
             <EuiSideNavItem>
               <button>
                 General
@@ -112,7 +113,7 @@ export default class extends Component {
               </button>
             </EuiSideNavItem>
 
-            <div className="euiSideNavGroup">
+            <EuiSideNavGroup>
               <EuiSideNavItem>
                 <button>
                   Time stuff
@@ -124,14 +125,14 @@ export default class extends Component {
                   Lion stuff
                 </button>
               </EuiSideNavItem>
-            </div>
+            </EuiSideNavGroup>
 
             <EuiSideNavItem>
               <button>
                 Visualizations
               </button>
             </EuiSideNavItem>
-          </div>
+          </EuiSideNavGroup>
 
           <EuiSideNavItem>
             <button>
@@ -150,7 +151,7 @@ export default class extends Component {
               Reporting
             </button>
           </EuiSideNavItem>
-        </div>
+        </EuiSideNavGroup>
 
         {/* Logstash section */}
 
@@ -165,13 +166,13 @@ export default class extends Component {
           </EuiFlexGroup>
         </EuiSideNavTitle>
 
-        <div className="euiSideNavGroup">
+        <EuiSideNavGroup>
           <EuiSideNavItem>
             <button>
               Pipeline Viewer
             </button>
           </EuiSideNavItem>
-        </div>
+        </EuiSideNavGroup>
       </EuiSideNav>
     );
   }

--- a/docs/src/views/side_nav/side_nav_example.js
+++ b/docs/src/views/side_nav/side_nav_example.js
@@ -22,6 +22,10 @@ import SideNavInPanel from './side_nav_in_panel';
 const sideNavInPanelSource = require('!!raw-loader!./side_nav_in_panel');
 const sideNavInPanelHtml = renderToHtml(SideNavInPanel);
 
+import SideNavComplicated from './side_nav_complicated';
+const sideNavComplicatedSource = require('!!raw-loader!./side_nav_complicated');
+const sideNavComplicatedHtml = renderToHtml(SideNavComplicated);
+
 export default props => (
   <GuidePage title={props.route.name}>
     <GuideSection
@@ -42,6 +46,27 @@ export default props => (
       }
       demo={
         <SideNav />
+      }
+    />
+
+    <GuideSection
+      title="Complicated side nav"
+      source={[{
+        type: GuideSectionTypes.JS,
+        code: sideNavSource,
+      }, {
+        type: GuideSectionTypes.HTML,
+        code: sideNavHtml,
+      }]}
+      text={
+        <p>
+          <EuiCode>SideNav</EuiCode> is a responsive menu system that usually sits on the left side of a page layout.
+          It will exapand to the width of its container. This is the menu that is used on the left side of the
+          page you are looking at.
+        </p>
+      }
+      demo={
+        <SideNavComplicated />
       }
     />
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -184,6 +184,7 @@ export {
 
 export {
   EuiSideNav,
+  EuiSideNavGroup,
   EuiSideNavItem,
   EuiSideNavTitle,
 } from './side_nav';

--- a/src/components/side_nav/__snapshots__/side_nav_group.test.js.snap
+++ b/src/components/side_nav/__snapshots__/side_nav_group.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiSideNavTitle is rendered 1`] = `
+exports[`EuiSideNavGroup is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="euiSideNavTitle testClass1 testClass2"
+  class="euiSideNavGroup testClass1 testClass2"
   data-test-subj="test subject string"
 />
 `;

--- a/src/components/side_nav/__snapshots__/side_nav_title.test.js.snap
+++ b/src/components/side_nav/__snapshots__/side_nav_title.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiSideNavTitle is rendered 1`] = `
-<p
+<div
   aria-label="aria-label"
   class="euiTitle euiTitle--small euiSideNavTitle testClass1 testClass2"
   data-test-subj="test subject string"

--- a/src/components/side_nav/_index.scss
+++ b/src/components/side_nav/_index.scss
@@ -1,3 +1,4 @@
 @import 'side_nav';
 @import 'side_nav_item';
 @import 'side_nav_title';
+@import 'side_nav_group';

--- a/src/components/side_nav/_side_nav_group.scss
+++ b/src/components/side_nav/_side_nav_group.scss
@@ -6,7 +6,7 @@
     position: absolute;
     content: "";
     top: 0;
-    bottom: 12px;
+    bottom: $euiSizeM;
     width: 1px;
     background: $euiBorderColor;
     left: 0px;

--- a/src/components/side_nav/_side_nav_group.scss
+++ b/src/components/side_nav/_side_nav_group.scss
@@ -1,0 +1,27 @@
+.euiSideNavGroup {
+  position: relative;
+  margin-left: $euiSize;
+
+  &:after {
+    position: absolute;
+    content: "";
+    top: 0;
+    bottom: 12px;
+    width: 1px;
+    background: $euiBorderColor;
+    left: 0px;
+  }
+
+  .euiSideNavItem {
+
+    &:after {
+      position: absolute;
+      content: "";
+      top: 50%;
+      left: 0;
+      width: $euiSizeXS;
+      height: 1px;
+      background: $euiBorderColor;
+    }
+  }
+}

--- a/src/components/side_nav/_side_nav_item.scss
+++ b/src/components/side_nav/_side_nav_item.scss
@@ -15,11 +15,13 @@
 
   &.euiSideNavItem--parent:hover {
     background: svg-load('../src/components/icon/assets/arrow_down.svg') center right no-repeat;
+    background-size: $euiSizeM $euiSizeM;
   }
 
   &.euiSideNavItem--parent.euiSideNavItem-isSelected {
     color: $euiColorFullShade;
     background: svg-load('../src/components/icon/assets/arrow_down.svg') center right no-repeat;
+    background-size: $euiSizeM $euiSizeM;
   }
 
   &.euiSideNavItem-isSelected:not(.euiSideNavItem--parent) {

--- a/src/components/side_nav/_side_nav_item.scss
+++ b/src/components/side_nav/_side_nav_item.scss
@@ -2,39 +2,30 @@
   @include euiFontSizeS;
 
   display: block;
+  position: relative;
   width: 100%;
   text-align: left;
-  padding: $euiSizeXS $euiSizeS;
   color: $euiColorDarkShade;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  border: $euiBorderThin;
   border-color: transparent;
+  font-size: $euiFontSizeS;
+  padding: $euiSizeXS / 2 $euiSize $euiSizeXS / 2 $euiSizeS;
 
-  &.euiSideNavItem-isSelected {
-    @include euiBottomShadowSmall;
-
-    color: $euiColorSecondary;
-    border-left: $euiBorderThick;
-    border-left-color: $euiColorSecondary;
-    background-color: $euiColorEmptyShade;
+  &.euiSideNavItem--parent:hover {
+    background: svg-load('../src/components/icon/assets/arrow_down.svg') center right no-repeat;
   }
 
-  // We allow one level of nesting.
-  &.euiSideNavItem--indent {
-    margin-left: $euiSize;
-    font-size: $euiFontSizeS;
-    padding: $euiSizeXS / 2 $euiSizeS;
-    border-left: $euiBorderThin;
-    border-left-color: $euiBorderColor;
+  &.euiSideNavItem--parent.euiSideNavItem-isSelected {
+    color: $euiColorFullShade;
+    background: svg-load('../src/components/icon/assets/arrow_down.svg') center right no-repeat;
+  }
 
-    // When indented and selected, make it not so heavy.
-    &.euiSideNavItem-isSelected {
-      border-left-color: $euiColorSecondary;
-      background-color: transparent;
-      box-shadow: none;
-    }
+  &.euiSideNavItem-isSelected:not(.euiSideNavItem--parent) {
+    color: $euiColorPrimary;
+    font-weight: $euiFontWeightMedium;
+    text-decoration: underline;
   }
 
   &:hover {
@@ -44,9 +35,5 @@
   // Focus state background regardless of index/selected state.
   &:focus {
     background-color: $euiFocusBackgroundColor !important;
-  }
-
-  &:focus:not(.euiSideNavItem-isSelected) {
-    border: solid 1px darken($euiFocusBackgroundColor, 10%);
   }
 }

--- a/src/components/side_nav/_side_nav_title.scss
+++ b/src/components/side_nav/_side_nav_title.scss
@@ -3,7 +3,7 @@
 
   margin-top: $euiSizeXL;
   margin-bottom: $euiSizeS;
-  font-size: $euiSize + 2px !important;
+  font-size: $euiSize + 2px;
 
   /**
    * 1. Only want the first title to have margin. Since buttons exist in nav

--- a/src/components/side_nav/_side_nav_title.scss
+++ b/src/components/side_nav/_side_nav_title.scss
@@ -1,9 +1,6 @@
 .euiSideNavTitle {
-  @include euiFontSize;
-
-  font-weight: $euiFontWeightMedium;
-  margin-bottom: $euiSizeS;
   margin-top: $euiSize;
+  font-size: $euiSize + 2px !important;
 
   /**
    * 1. Only want the first title to have margin. Since buttons exist in nav

--- a/src/components/side_nav/_side_nav_title.scss
+++ b/src/components/side_nav/_side_nav_title.scss
@@ -1,5 +1,8 @@
 .euiSideNavTitle {
-  margin-top: $euiSize;
+  @include euiTitle;
+
+  margin-top: $euiSizeXL;
+  margin-bottom: $euiSizeS;
   font-size: $euiSize + 2px !important;
 
   /**

--- a/src/components/side_nav/index.js
+++ b/src/components/side_nav/index.js
@@ -1,3 +1,4 @@
 export { EuiSideNav } from './side_nav';
+export { EuiSideNavGroup } from './side_nav_group';
 export { EuiSideNavItem } from './side_nav_item';
 export { EuiSideNavTitle } from './side_nav_title';

--- a/src/components/side_nav/side_nav_group.js
+++ b/src/components/side_nav/side_nav_group.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+export const EuiSideNavGroup = ({
+  children,
+  className,
+  ...rest,
+}) => {
+  const classes = classNames('euiSideNavGroup', className);
+
+  return (
+    <div
+      className={classes}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+};
+
+EuiSideNavGroup.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};

--- a/src/components/side_nav/side_nav_group.test.js
+++ b/src/components/side_nav/side_nav_group.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from 'enzyme';
+import { requiredProps } from '../../test/required_props';
+
+import { EuiSideNavGroup } from './side_nav_group';
+
+describe('EuiSideNavGroup', () => {
+  test('is rendered', () => {
+    const component = render(
+      <EuiSideNavGroup {...requiredProps} />
+    );
+
+    expect(component)
+      .toMatchSnapshot();
+  });
+});

--- a/src/components/side_nav/side_nav_item.js
+++ b/src/components/side_nav/side_nav_item.js
@@ -5,7 +5,7 @@ import {
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-export const EuiSideNavItem = ({ children, indent, isSelected }) => {
+export const EuiSideNavItem = ({ children, parent, isSelected }) => {
   const child = Children.only(children);
 
   const classes = classNames(
@@ -13,7 +13,7 @@ export const EuiSideNavItem = ({ children, indent, isSelected }) => {
     'euiSideNavItem',
     {
       'euiSideNavItem-isSelected': isSelected,
-      'euiSideNavItem--indent': indent,
+      'euiSideNavItem--parent': parent,
     }
   );
 
@@ -24,5 +24,10 @@ export const EuiSideNavItem = ({ children, indent, isSelected }) => {
 
 EuiSideNavItem.propTypes = {
   isSelected: PropTypes.bool,
-  indent: PropTypes.bool,
+  parent: PropTypes.bool,
+};
+
+EuiSideNavItem.defaultProps = {
+  parent: false,
+  isSelected: false,
 };

--- a/src/components/side_nav/side_nav_title.js
+++ b/src/components/side_nav/side_nav_title.js
@@ -1,21 +1,16 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import {
-  EuiTitle,
-} from '..';
-
 export const EuiSideNavTitle = ({ children, className, ...rest }) => {
   const classes = classNames('euiSideNavTitle', className);
 
   return (
-    <EuiTitle
-      size="s"
+    <div
       className={classes}
       {...rest}
     >
-      <div>{children}</div>
-    </EuiTitle>
+      {children}
+    </div>
   );
 };
 

--- a/src/components/side_nav/side_nav_title.js
+++ b/src/components/side_nav/side_nav_title.js
@@ -14,7 +14,7 @@ export const EuiSideNavTitle = ({ children, className, ...rest }) => {
       className={classes}
       {...rest}
     >
-      <p>{children}</p>
+      <div>{children}</div>
     </EuiTitle>
   );
 };


### PR DESCRIPTION
Closes https://github.com/elastic/eui/issues/50

This is a WIP Sidenav exploration. It needs some work on the React side before we can merge it, assuming people are OK with the style.

### Changes the following:

- `EuiSideNavGroup` is a new component for nesting a group of `EuiSideNavItems`. It adds some borders and ticking to items underneath. It can be nested indefinitely (as space allows)
- `EuiSideNavItem` now has a `parent` prop. This will render some arrow carets and other styling.
- Removing the `EuiTitle` inheritance in `EuiSubNavTitle` and just applied those styles directly in the CSS. Make the component more flexible so you can include icons and the like.

### Stuff to do before merge

- [x] Play with focus state. It's a little weak.
- [x] Chat with CJ about how to pass icons in to the cloned `EuiSideNavItem` element.
- [x] Better document the new props / usage.
- [x] Fix sidenav in panel.

### Need help on the React side

- [ ] `EuiSideNavGroup` needs to wrap around subnav items in our actual documentation sidenav. I'll bug @cjcenizal about it, likely easy.
- [ ] With the nesting, my guess is it makes sense to make an all-in-one component where you just pass in a JSON tree and have it do all the component construction for you. That's probably beyond my "quick" abilities.

![image](https://user-images.githubusercontent.com/324519/32477496-827222ae-c333-11e7-89a4-da546969ba89.png)

![](https://d3vv6lp55qjaqc.cloudfront.net/items/2f1z3T381f291W3I0B0S/Screen%20Recording%202017-11-06%20at%2008.46%20PM.gif?X-CloudApp-Visitor-Id=59773&v=b910f0f5)