### PR TITLE
Adjust table selection / hover states

### DIFF
--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -66,13 +66,16 @@
 }
 
 .euiTableRow {
-  transition: background-color $euiAnimSpeedFast $euiAnimSlightResistance;
   &:hover {
     background-color: tintOrShade($euiColorLightestShade, 50%, 20%);
   }
 
   &.euiTableRow-isSelected {
-    background-color: transparentize($euiColorPrimary, .95);
+    background-color: tintOrShade($euiFocusBackgroundColor, 30%, 0%);
+
+    &:hover {
+      background-color: tintOrShade($euiFocusBackgroundColor, 0, 10%);
+    }
   }
 }
 

--- a/src/global_styling/theme_dark_variables.scss
+++ b/src/global_styling/theme_dark_variables.scss
@@ -11,5 +11,7 @@ $euiColorPrimary: #4da1c0;
 $euiColorDanger: #bf4d4d;
 $euiTextColor: #DDD;
 
+$euiFocusBackgroundColor: #191919;
+
 // Configuration
 @import 'variables/index';


### PR DESCRIPTION
Tables didn't have a hover state when they were also selected. I also went ahead and adjusted some of the dark theme coloring around this as well.

![image](https://user-images.githubusercontent.com/324519/32521845-ed236112-c3c9-11e7-93f7-19ef18e73238.png)

![image](https://user-images.githubusercontent.com/324519/32521859-f7c28418-c3c9-11e7-9fd7-33e74783ee02.png)
