### PR TITLE
Remove secondary color from active states

### DIFF
--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -25,7 +25,7 @@
 
   &.euiTab-isSelected {
     cursor: default;
-    color: $euiColorSecondary;
+    color: $euiColorPrimary;
 
     &:after {
       position: absolute;
@@ -34,7 +34,7 @@
       content: ' ';
       width: 100%;
       height: $euiBorderWidthThick;
-      background-color: $euiColorSecondary;
+      background-color: $euiColorPrimary;
       animation: euiTab $euiAnimSpeedFast $euiAnimSlightResistance;
     }
   }


### PR DESCRIPTION
After the sidenav, only tabs had the teal active state. It's now set to the primary coloring. Hat tip @cjcenizal for calling this one out.

![image](https://user-images.githubusercontent.com/324519/32522481-4e9b9c50-c3cc-11e7-94f7-13c0dffd5886.png)
