### PR TITLE
Reformat / fix clipboard icon

### DIFF
--- a/src/components/icon/assets/copy_clipboard.svg
+++ b/src/components/icon/assets/copy_clipboard.svg
@@ -1,1 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41421;"><g id="Page-1"><path id="Fill-1" d="M1,2.729l0,-0.729c0,-0.552 0.448,-1 1,-1l2,0l0,1l-2,0l0,12l4,0l0,1l-4,0c-0.552,0 -1,-0.448 -1,-1l0,-5l0,-6.271Zm12,2.271l0,-3c0,-0.552 -0.448,-1 -1,-1l-2,0l0,1l2,0l0,3l1,0Z" style="fill:#404040;"/><path id="Fill-3" d="M12,6l2,0l0,9l-1,0l-6,0l0,-5l0,-0.542l0,-3.458l5,0l0,-1l-5,0c-0.552,0 -1,0.448 -1,1l0,9c0,0.552 0.448,1 1,1l7,0c0.552,0 1,-0.448 1,-1l0,-9c0,-0.552 -0.448,-1 -1,-1l-2,0l0,1Z" style="fill:#404040;"/><path id="Fill-5" d="M8,10l5,0l0,-1l-5,0l0,1Z" style="fill:#404040;"/><path id="Fill-7" d="M8,8l5,0l0,-1l-5,0l0,1Z" style="fill:#404040;"/><path id="Fill-8" d="M8,12l5,0l0,-1l-5,0l0,1Z" style="fill:#404040;"/><path id="Fill-9" d="M8,14l5,0l0,-1l-5,0l0,1Z" style="fill:#404040;"/><path id="Fill-10" d="M10,2l0,-1c0,-0.552 -0.448,-1 -1,-1l-4,0c-0.552,0 -1,0.448 -1,1l0,1l1,0l0,-1l4,0l0,1l1,0Z" style="fill:#404040;"/><path id="Fill-11" d="M4,3l6,0l0,-1l-6,0l0,1Z" style="fill:#404040;"/></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <g>
+    <path d="M0 2.729L0 2C0 1.448.448 1 1 1L3 1 3 2 1 2 1 14 5 14 5 15 1 15C.448 15 0 14.552 0 14L0 9 0 2.729zM12 5L12 2C12 1.448 11.552 1 11 1L9 1 9 2 11 2 11 5 12 5zM11 6L13 6 13 15 12 15 6 15 6 10 6 9.458 6 6 11 6 11 5 6 5C5.448 5 5 5.448 5 6L5 15C5 15.552 5.448 16 6 16L13 16C13.552 16 14 15.552 14 15L14 6C14 5.448 13.552 5 13 5L11 5 11 6z"/>
+    <polygon points="7 10 12 10 12 9 7 9"/>
+    <polygon points="7 8 12 8 12 7 7 7"/>
+    <polygon points="7 12 12 12 12 11 7 11"/>
+    <polygon points="7 14 12 14 12 13 7 13"/>
+    <path d="M9,2 L9,1 C9,0.448 8.552,0 8,0 L4,0 C3.448,0 3,0.448 3,1 L3,2 L4,2 L4,1 L8,1 L8,2 L9,2 Z"/>
+    <polygon points="3 3 9 3 9 2 3 2"/>
+  </g>
+</svg>


### PR DESCRIPTION
cc @gjones

Small tip for icons. Run them through SVGO (there's a sketch plugin). Usually past that you'll also need to remove any fills in the actual code of the SVG (this means you can't use strokes, just paths / shapes).

This allows them to be colored by CSS / work with our theming system. Otherwise they'll only have the one color no matter what we try to do to it (in example below the clipboard should have been white).

![image](https://user-images.githubusercontent.com/324519/32529813-6f358bec-c3ef-11e7-8f39-ec224606ccc7.png)
