### PR TITLE
System level font stacks

### DIFF
--- a/src/global_styling/variables/_typography.scss
+++ b/src/global_styling/variables/_typography.scss
@@ -18,19 +18,19 @@
 
 // Families
 
-$euiFontFamily: "Roboto", Helvetica, Arial, sans-serif;
-$euiCodeFontFamily: "Roboto Mono", monospace;
+$euiFontFamily: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+$euiCodeFontFamily: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
 
 // Font sizes
 
 $euiFontSize:       $euiSize;
 
-$euiFontSizeXS:     12px;
-$euiFontSizeS:      14px;
+$euiFontSizeXS:     $euiFontSize * .75;
+$euiFontSizeS:      $euiFontSize * .875;
 $euiFontSizeM:      $euiFontSize;
-$euiFontSizeL:      24px;
-$euiFontSizeXL:     32px;
-$euiFontSizeXXL:    48px;
+$euiFontSizeL:      $euiFontSize * 1.5;
+$euiFontSizeXL:     $euiFontSize * 2;
+$euiFontSizeXXL:    $euiFontSize * 3;
 
 // Line height
 


### PR DESCRIPTION
Replaces https://github.com/elastic/eui/pull/127, closes https://github.com/elastic/eui/issues/124

Changes EUI to use system level fonts. After doing some research, although "system-ui" is a thing, it's can fail in certain languages, so it's better to write out the stack manually as below. I went with github's stack since they previously ran into the system-ui problem.

I also went ahead and made our font-sizing based on some reactive math to so that `$euiSize` cascade the values there as well (this was the problem @formgeist noticed in my Berlin demo).

### Mac various

* Chrome in master
* Chrome with changes
* Firefox
* Safari

![image](https://user-images.githubusercontent.com/324519/32578209-336d10ec-c491-11e7-8949-160873e7f94f.png)


### Edge windows

![snider localtunnel me_](https://user-images.githubusercontent.com/324519/32578143-fd7d1400-c490-11e7-9ba6-08a12a310eaa.png)
