### PR TITLE
Remove styling from hover state of empty buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
-- Equivalent to `0.0.1`
+- Changed the hover states of `EuiButtonEmpty` to look more like links.
 
 # [`0.0.1`](https://github.com/elastic/eui/tree/v0.0.1) Initial Release
 

--- a/src/components/button/button_empty/_button_empty.scss
+++ b/src/components/button/button_empty/_button_empty.scss
@@ -1,9 +1,15 @@
+/**
+ * 1. We don't want any of the animations that come inherited from the mixin.
+ *    These should act like normal links instead.
+ */
 .euiButtonEmpty {
   @include euiButton;
 
   border-color: transparent;
   background-color: transparent;
   box-shadow: none;
+  transform: none !important; // 1
+  animation: none !important; // 1
 
   .euiButtonEmpty__content {
     @include euiButtonContent;
@@ -73,11 +79,7 @@ $buttonTypes: (
     }
 
     &:hover {
-      @if ($name == 'text') {
-        background-color: transparent;
-      } @else {
-        background-color: transparentize($color, .9);
-      }
+      background-color: transparent;
 
       @if ($name == 'disabled') {
         cursor: not-allowed;


### PR DESCRIPTION
Closes https://github.com/elastic/eui/issues/134 at the request of @zinckiwi

For the moment, I'm keeping it on EmptyButtonIcon. I can't really underline the icons, so this solution doesn't work well for them. Likely I'll think up a better way to handle those then doing the background, but that can be a later PR.

![](https://d3vv6lp55qjaqc.cloudfront.net/items/2w2c3i0h201Z2h051l17/Screen%20Recording%202017-11-09%20at%2002.30%20PM.gif?X-CloudApp-Visitor-Id=59773&v=176f058c)