### PR TITLE
Keep using <pre> for code blocks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
-- Changed the hover states of `EuiButtonEmpty` to look more like links. [#135](https://github.com/elastic/eui/pull/135)
-- Added `transparentBackground` prop to `EuiCodeBlock`. Made light theme the default.
-`EuiCode` now just wraps `EuiCodeBlock` so you can do inline highlighting. [#138](https://github.com/elastic/eui/pull/138)
-- `EuiFormRow` generates its own unique `id` prop if none is provided. [(#130)](https://github.com/elastic/eui/pull/130)
-- `EuiFormRow` associates help text and errors with the field element via ARIA attributes. [(#130)](https://github.com/elastic/eui/pull/130)
+- Changed the hover states of `<EuiButtonEmpty>` to look more like links. [(#135)](https://github.com/elastic/eui/pull/135)
+- `<EuiCode>` now wraps `<EuiCodeBlock>`, so it can do everything `<EuiCodeBlock>` could [(#138)](https://github.com/elastic/eui/pull/138)
+- Added `transparentBackground` prop to `<EuiCodeBlock>` [(#138)](https://github.com/elastic/eui/pull/138)
+- `<EuiCodeBlock>` now uses the `light` theme by default [(#138)](https://github.com/elastic/eui/pull/138)
+- `<EuiFormRow>` generates its own unique `id` prop if none is provided. [(#130)](https://github.com/elastic/eui/pull/130)
+- `<EuiFormRow>` associates help text and errors with the field element via ARIA attributes. [(#130)](https://github.com/elastic/eui/pull/130)
 
 # [`0.0.1`](https://github.com/elastic/eui/tree/v0.0.1) Initial Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
 - Changed the hover states of `<EuiButtonEmpty>` to look more like links. [(#135)](https://github.com/elastic/eui/pull/135)
-- `<EuiCode>` now wraps `<EuiCodeBlock>`, so it can do everything `<EuiCodeBlock>` could [(#138)](https://github.com/elastic/eui/pull/138)
+- `<EuiCode>` now wraps `<EuiCodeBlock>`, so it can do everything `<EuiCodeBlock>` could, but inline [(#138)](https://github.com/elastic/eui/pull/138)
 - Added `transparentBackground` prop to `<EuiCodeBlock>` [(#138)](https://github.com/elastic/eui/pull/138)
 - `<EuiCodeBlock>` now uses the `light` theme by default [(#138)](https://github.com/elastic/eui/pull/138)
 - `<EuiFormRow>` generates its own unique `id` prop if none is provided. [(#130)](https://github.com/elastic/eui/pull/130)

--- a/src/components/code/__snapshots__/_code_block.test.js.snap
+++ b/src/components/code/__snapshots__/_code_block.test.js.snap
@@ -1,0 +1,145 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiCodeBlockImpl block highlights javascript code, adding "js" class 1`] = `
+<div
+  class="euiCodeBlock euiCodeBlock--light euiCodeBlock--fontSmall euiCodeBlock--paddingLarge testClass1 testClass2"
+  style="height:auto"
+>
+  <pre
+    class="euiCodeBlock__pre"
+  >
+    <code
+      aria-label="aria-label"
+      class="euiCodeBlock__code js"
+      data-test-subj="test subject string"
+    >
+      var some = 'code';
+console.log(some);
+    </code>
+  </pre>
+</div>
+`;
+
+exports[`EuiCodeBlockImpl block renders a pre block tag 1`] = `
+<div
+  class="euiCodeBlock euiCodeBlock--light euiCodeBlock--fontSmall euiCodeBlock--paddingLarge testClass1 testClass2"
+  style="height:auto"
+>
+  <pre
+    class="euiCodeBlock__pre"
+  >
+    <code
+      aria-label="aria-label"
+      class="euiCodeBlock__code"
+      data-test-subj="test subject string"
+    >
+      var some = 'code';
+console.log(some);
+    </code>
+  </pre>
+</div>
+`;
+
+exports[`EuiCodeBlockImpl block renders with dark theme 1`] = `
+<div
+  class="euiCodeBlock euiCodeBlock--dark euiCodeBlock--fontSmall euiCodeBlock--paddingLarge testClass1 testClass2"
+  style="height:auto"
+>
+  <pre
+    class="euiCodeBlock__pre"
+  >
+    <code
+      aria-label="aria-label"
+      class="euiCodeBlock__code"
+      data-test-subj="test subject string"
+    >
+      var some = 'code';
+console.log(some);
+    </code>
+  </pre>
+</div>
+`;
+
+exports[`EuiCodeBlockImpl block renders with transparent background 1`] = `
+<div
+  class="euiCodeBlock euiCodeBlock--light euiCodeBlock--fontSmall euiCodeBlock--paddingLarge euiCodeBlock--transparentBackground testClass1 testClass2"
+  style="height:auto"
+>
+  <pre
+    class="euiCodeBlock__pre"
+  >
+    <code
+      aria-label="aria-label"
+      class="euiCodeBlock__code"
+      data-test-subj="test subject string"
+    >
+      var some = 'code';
+console.log(some);
+    </code>
+  </pre>
+</div>
+`;
+
+exports[`EuiCodeBlockImpl inline highlights javascript code, adding "js" class 1`] = `
+<span
+  class="euiCodeBlock euiCodeBlock--light euiCodeBlock--fontSmall euiCodeBlock--paddingLarge euiCodeBlock--inline testClass1 testClass2"
+  style="height:auto"
+>
+  <code
+    aria-label="aria-label"
+    class="euiCodeBlock__code js"
+    data-test-subj="test subject string"
+  >
+    var some = 'code';
+console.log(some);
+  </code>
+</span>
+`;
+
+exports[`EuiCodeBlockImpl inline renders an inline code tag 1`] = `
+<span
+  class="euiCodeBlock euiCodeBlock--light euiCodeBlock--fontSmall euiCodeBlock--paddingLarge euiCodeBlock--inline testClass1 testClass2"
+  style="height:auto"
+>
+  <code
+    aria-label="aria-label"
+    class="euiCodeBlock__code"
+    data-test-subj="test subject string"
+  >
+    var some = 'code';
+console.log(some);
+  </code>
+</span>
+`;
+
+exports[`EuiCodeBlockImpl inline renders with dark theme 1`] = `
+<span
+  class="euiCodeBlock euiCodeBlock--dark euiCodeBlock--fontSmall euiCodeBlock--paddingLarge euiCodeBlock--inline testClass1 testClass2"
+  style="height:auto"
+>
+  <code
+    aria-label="aria-label"
+    class="euiCodeBlock__code"
+    data-test-subj="test subject string"
+  >
+    var some = 'code';
+console.log(some);
+  </code>
+</span>
+`;
+
+exports[`EuiCodeBlockImpl inline renders with transparent background 1`] = `
+<span
+  class="euiCodeBlock euiCodeBlock--light euiCodeBlock--fontSmall euiCodeBlock--paddingLarge euiCodeBlock--transparentBackground euiCodeBlock--inline testClass1 testClass2"
+  style="height:auto"
+>
+  <code
+    aria-label="aria-label"
+    class="euiCodeBlock__code"
+    data-test-subj="test subject string"
+  >
+    var some = 'code';
+console.log(some);
+  </code>
+</span>
+`;

--- a/src/components/code/__snapshots__/_code_block.test.js.snap
+++ b/src/components/code/__snapshots__/_code_block.test.js.snap
@@ -2,20 +2,15 @@
 
 exports[`EuiCodeBlockImpl block highlights javascript code, adding "js" class 1`] = `
 <div
-  class="euiCodeBlock euiCodeBlock--light euiCodeBlock--fontSmall euiCodeBlock--paddingLarge testClass1 testClass2"
+  class="euiCodeBlock euiCodeBlock--light euiCodeBlock--fontSmall euiCodeBlock--paddingLarge"
   style="height:auto"
 >
   <pre
     class="euiCodeBlock__pre"
   >
     <code
-      aria-label="aria-label"
       class="euiCodeBlock__code js"
-      data-test-subj="test subject string"
-    >
-      var some = 'code';
-console.log(some);
-    </code>
+    />
   </pre>
 </div>
 `;
@@ -42,57 +37,42 @@ console.log(some);
 
 exports[`EuiCodeBlockImpl block renders with dark theme 1`] = `
 <div
-  class="euiCodeBlock euiCodeBlock--dark euiCodeBlock--fontSmall euiCodeBlock--paddingLarge testClass1 testClass2"
+  class="euiCodeBlock euiCodeBlock--dark euiCodeBlock--fontSmall euiCodeBlock--paddingLarge"
   style="height:auto"
 >
   <pre
     class="euiCodeBlock__pre"
   >
     <code
-      aria-label="aria-label"
       class="euiCodeBlock__code"
-      data-test-subj="test subject string"
-    >
-      var some = 'code';
-console.log(some);
-    </code>
+    />
   </pre>
 </div>
 `;
 
 exports[`EuiCodeBlockImpl block renders with transparent background 1`] = `
 <div
-  class="euiCodeBlock euiCodeBlock--light euiCodeBlock--fontSmall euiCodeBlock--paddingLarge euiCodeBlock--transparentBackground testClass1 testClass2"
+  class="euiCodeBlock euiCodeBlock--light euiCodeBlock--fontSmall euiCodeBlock--paddingLarge euiCodeBlock--transparentBackground"
   style="height:auto"
 >
   <pre
     class="euiCodeBlock__pre"
   >
     <code
-      aria-label="aria-label"
       class="euiCodeBlock__code"
-      data-test-subj="test subject string"
-    >
-      var some = 'code';
-console.log(some);
-    </code>
+    />
   </pre>
 </div>
 `;
 
 exports[`EuiCodeBlockImpl inline highlights javascript code, adding "js" class 1`] = `
 <span
-  class="euiCodeBlock euiCodeBlock--light euiCodeBlock--fontSmall euiCodeBlock--paddingLarge euiCodeBlock--inline testClass1 testClass2"
+  class="euiCodeBlock euiCodeBlock--light euiCodeBlock--fontSmall euiCodeBlock--paddingLarge euiCodeBlock--inline"
   style="height:auto"
 >
   <code
-    aria-label="aria-label"
     class="euiCodeBlock__code js"
-    data-test-subj="test subject string"
-  >
-    var some = 'code';
-console.log(some);
-  </code>
+  />
 </span>
 `;
 
@@ -114,32 +94,22 @@ console.log(some);
 
 exports[`EuiCodeBlockImpl inline renders with dark theme 1`] = `
 <span
-  class="euiCodeBlock euiCodeBlock--dark euiCodeBlock--fontSmall euiCodeBlock--paddingLarge euiCodeBlock--inline testClass1 testClass2"
+  class="euiCodeBlock euiCodeBlock--dark euiCodeBlock--fontSmall euiCodeBlock--paddingLarge euiCodeBlock--inline"
   style="height:auto"
 >
   <code
-    aria-label="aria-label"
     class="euiCodeBlock__code"
-    data-test-subj="test subject string"
-  >
-    var some = 'code';
-console.log(some);
-  </code>
+  />
 </span>
 `;
 
 exports[`EuiCodeBlockImpl inline renders with transparent background 1`] = `
 <span
-  class="euiCodeBlock euiCodeBlock--light euiCodeBlock--fontSmall euiCodeBlock--paddingLarge euiCodeBlock--transparentBackground euiCodeBlock--inline testClass1 testClass2"
+  class="euiCodeBlock euiCodeBlock--light euiCodeBlock--fontSmall euiCodeBlock--paddingLarge euiCodeBlock--transparentBackground euiCodeBlock--inline"
   style="height:auto"
 >
   <code
-    aria-label="aria-label"
     class="euiCodeBlock__code"
-    data-test-subj="test subject string"
-  >
-    var some = 'code';
-console.log(some);
-  </code>
+  />
 </span>
 `;

--- a/src/components/code/__snapshots__/code.test.js.snap
+++ b/src/components/code/__snapshots__/code.test.js.snap
@@ -5,14 +5,10 @@ exports[`EuiCode is rendered 1`] = `
   class="euiCodeBlock euiCodeBlock--light euiCodeBlock--fontSmall euiCodeBlock--paddingLarge euiCodeBlock--inline testClass1 testClass2"
   style="height:auto"
 >
-  <span
-    class="euiCodeBlock__pre"
-  >
-    <code
-      aria-label="aria-label"
-      class="euiCodeBlock__code"
-      data-test-subj="test subject string"
-    />
-  </span>
+  <code
+    aria-label="aria-label"
+    class="euiCodeBlock__code"
+    data-test-subj="test subject string"
+  />
 </span>
 `;

--- a/src/components/code/__snapshots__/code.test.js.snap
+++ b/src/components/code/__snapshots__/code.test.js.snap
@@ -1,12 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiCode is rendered using EuiCodeBlockImpl 1`] = `
-<euicodeblockimpl
-  aria-label="aria-label"
-  class="testClass1 testClass2"
-  data-test-subj="test subject string"
+exports[`EuiCode renders a code snippet 1`] = `
+<span
+  class="euiCodeBlock euiCodeBlock--light euiCodeBlock--fontSmall euiCodeBlock--paddingLarge euiCodeBlock--inline testClass1 testClass2"
+  style="height:auto"
 >
-  var some = 'code';
+  <code
+    aria-label="aria-label"
+    class="euiCodeBlock__code"
+    data-test-subj="test subject string"
+  >
+    var some = 'code';
 console.log(some);
-</euicodeblockimpl>
+  </code>
+</span>
 `;

--- a/src/components/code/__snapshots__/code_block.test.js.snap
+++ b/src/components/code/__snapshots__/code_block.test.js.snap
@@ -1,12 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiCodeBlock is rendered 1`] = `
-<euicodeblockimpl
-  aria-label="aria-label"
-  class="testClass1 testClass2"
-  data-test-subj="test subject string"
+exports[`EuiCodeBlock renders a code block 1`] = `
+<div
+  class="euiCodeBlock euiCodeBlock--light euiCodeBlock--fontSmall euiCodeBlock--paddingLarge testClass1 testClass2"
+  style="height:auto"
 >
-  var some = 'code';
+  <pre
+    class="euiCodeBlock__pre"
+  >
+    <code
+      aria-label="aria-label"
+      class="euiCodeBlock__code"
+      data-test-subj="test subject string"
+    >
+      var some = 'code';
 console.log(some);
-</euicodeblockimpl>
+    </code>
+  </pre>
+</div>
 `;

--- a/src/components/code/__snapshots__/code_block.test.js.snap
+++ b/src/components/code/__snapshots__/code_block.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiCode is rendered using EuiCodeBlockImpl 1`] = `
+exports[`EuiCodeBlock is rendered 1`] = `
 <euicodeblockimpl
   aria-label="aria-label"
   class="testClass1 testClass2"

--- a/src/components/code/_code_block.js
+++ b/src/components/code/_code_block.js
@@ -127,7 +127,7 @@ EuiCodeBlockImpl.propTypes = {
   paddingSize: PropTypes.oneOf(PADDING_SIZES),
   fontSize: PropTypes.oneOf(FONT_SIZES),
   transparentBackground: PropTypes.bool,
-  inline: PropTypes.bool.isRequired,
+  inline: PropTypes.bool,
 };
 
 EuiCodeBlockImpl.defaultProps = {

--- a/src/components/code/_code_block.js
+++ b/src/components/code/_code_block.js
@@ -1,0 +1,138 @@
+import React, {
+  Component,
+} from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import hljs from 'highlight.js';
+
+const colorToClassNameMap = {
+  light: 'euiCodeBlock--light',
+  dark: 'euiCodeBlock--dark',
+};
+
+export const COLORS = Object.keys(colorToClassNameMap);
+
+const fontSizeToClassNameMap = {
+  s: 'euiCodeBlock--fontSmall',
+  m: 'euiCodeBlock--fontMedium',
+  l: 'euiCodeBlock--fontLarge',
+};
+
+export const FONT_SIZES = Object.keys(fontSizeToClassNameMap);
+
+const paddingSizeToClassNameMap = {
+  s: 'euiCodeBlock--paddingSmall',
+  m: 'euiCodeBlock--paddingMedium',
+  l: 'euiCodeBlock--paddingLarge',
+};
+
+export const PADDING_SIZES = Object.keys(paddingSizeToClassNameMap);
+
+export class EuiCodeBlockImpl extends Component {
+  static propTypes = {
+    children: PropTypes.node,
+    className: PropTypes.string,
+  }
+
+  constructor(props) {
+    super(props);
+  }
+
+  componentDidMount() {
+    this.highlight();
+  }
+
+  componentDidUpdate() {
+    this.highlight();
+  }
+
+  render() {
+    const {
+      inline,
+      children,
+      className,
+      color,
+      fontSize,
+      language,
+      overflowHeight,
+      paddingSize,
+      transparentBackground,
+      ...otherProps
+    } = this.props;
+
+    const classes = classNames(
+      'euiCodeBlock',
+      colorToClassNameMap[color],
+      fontSizeToClassNameMap[fontSize],
+      paddingSizeToClassNameMap[paddingSize],
+      {
+        'euiCodeBlock--transparentBackground': transparentBackground,
+        'euiCodeBlock--inline': inline,
+      },
+      className
+    );
+
+    const codeClasses = classNames('euiCodeBlock__code', language);
+
+    let optionalOverflowHeight = 'auto';
+
+    if (overflowHeight) {
+      optionalOverflowHeight = overflowHeight;
+    }
+
+    const codeSnippet = (
+      <code
+        ref={ref => { this.code = ref; }}
+        className={codeClasses}
+        {...otherProps}
+      >
+        {children}
+      </code>
+    );
+
+    const wrapperProps = {
+      className: classes,
+      style: { height: optionalOverflowHeight }
+    };
+
+    if (inline) {
+      return (
+        <span {...wrapperProps}>
+          {codeSnippet}
+        </span>
+      );
+    }
+
+    return (
+      <div {...wrapperProps}>
+        <pre className="euiCodeBlock__pre">
+          {codeSnippet}
+        </pre>
+      </div>
+    );
+  }
+
+  highlight() {
+    if (this.props.language) {
+      hljs.highlightBlock(this.code);
+    }
+  }
+}
+
+EuiCodeBlockImpl.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  color: PropTypes.string,
+  paddingSize: PropTypes.oneOf(PADDING_SIZES),
+  fontSize: PropTypes.oneOf(FONT_SIZES),
+  transparentBackground: PropTypes.bool,
+  inline: PropTypes.bool.isRequired,
+};
+
+EuiCodeBlockImpl.defaultProps = {
+  color: 'light',
+  transparentBackground: false,
+  paddingSize: 'l',
+  fontSize: 's',
+};

--- a/src/components/code/_code_block.scss
+++ b/src/components/code/_code_block.scss
@@ -50,7 +50,7 @@
     padding:  0 $euiSizeXS;
     background: $euiColorLightestShade;
 
-    .euiCodeBlock__pre, .euiCodeBlock__code {
+    .euiCodeBlock__code {
       display: inline;
       white-space: normal;
     }

--- a/src/components/code/_code_block.test.js
+++ b/src/components/code/_code_block.test.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render } from 'enzyme';
+import { requiredProps } from '../../test/required_props';
+
+import { EuiCodeBlockImpl } from './_code_block';
+
+const code = `var some = 'code';
+console.log(some);`;
+
+describe('EuiCodeBlockImpl', () => {
+  describe('inline', () => {
+    test('renders an inline code tag', () => {
+      const component = render(
+        <EuiCodeBlockImpl inline={true} {...requiredProps}>
+          {code}
+        </EuiCodeBlockImpl>
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
+    test('highlights javascript code, adding "js" class', () => {
+      const component = render(
+        <EuiCodeBlockImpl inline={true} language="js" {...requiredProps}>
+          {code}
+        </EuiCodeBlockImpl>
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
+    test('renders with transparent background', () => {
+      const component = render(
+        <EuiCodeBlockImpl inline={true} transparentBackground={true} {...requiredProps}>
+          {code}
+        </EuiCodeBlockImpl>
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
+    test('renders with dark theme', () => {
+      const component = render(
+        <EuiCodeBlockImpl inline={true} color="dark" {...requiredProps}>
+          {code}
+        </EuiCodeBlockImpl>
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+  });
+
+  describe('block', () => {
+    test('renders a pre block tag', () => {
+      const component = render(
+        <EuiCodeBlockImpl inline={false} {...requiredProps}>
+          {code}
+        </EuiCodeBlockImpl>
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
+    test('highlights javascript code, adding "js" class', () => {
+      const component = render(
+        <EuiCodeBlockImpl inline={false} language="js" {...requiredProps}>
+          {code}
+        </EuiCodeBlockImpl>
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
+    test('renders with transparent background', () => {
+      const component = render(
+        <EuiCodeBlockImpl inline={false} transparentBackground={true} {...requiredProps}>
+          {code}
+        </EuiCodeBlockImpl>
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
+    test('renders with dark theme', () => {
+      const component = render(
+        <EuiCodeBlockImpl inline={false} color="dark" {...requiredProps}>
+          {code}
+        </EuiCodeBlockImpl>
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/code/_code_block.test.js
+++ b/src/components/code/_code_block.test.js
@@ -21,9 +21,7 @@ describe('EuiCodeBlockImpl', () => {
 
     test('highlights javascript code, adding "js" class', () => {
       const component = render(
-        <EuiCodeBlockImpl inline={true} language="js" {...requiredProps}>
-          {code}
-        </EuiCodeBlockImpl>
+        <EuiCodeBlockImpl inline={true} language="js" />
       );
 
       expect(component).toMatchSnapshot();
@@ -31,9 +29,7 @@ describe('EuiCodeBlockImpl', () => {
 
     test('renders with transparent background', () => {
       const component = render(
-        <EuiCodeBlockImpl inline={true} transparentBackground={true} {...requiredProps}>
-          {code}
-        </EuiCodeBlockImpl>
+        <EuiCodeBlockImpl inline={true} transparentBackground={true} />
       );
 
       expect(component).toMatchSnapshot();
@@ -41,9 +37,7 @@ describe('EuiCodeBlockImpl', () => {
 
     test('renders with dark theme', () => {
       const component = render(
-        <EuiCodeBlockImpl inline={true} color="dark" {...requiredProps}>
-          {code}
-        </EuiCodeBlockImpl>
+        <EuiCodeBlockImpl inline={true} color="dark" />
       );
 
       expect(component).toMatchSnapshot();
@@ -63,9 +57,7 @@ describe('EuiCodeBlockImpl', () => {
 
     test('highlights javascript code, adding "js" class', () => {
       const component = render(
-        <EuiCodeBlockImpl inline={false} language="js" {...requiredProps}>
-          {code}
-        </EuiCodeBlockImpl>
+        <EuiCodeBlockImpl inline={false} language="js" />
       );
 
       expect(component).toMatchSnapshot();
@@ -73,9 +65,7 @@ describe('EuiCodeBlockImpl', () => {
 
     test('renders with transparent background', () => {
       const component = render(
-        <EuiCodeBlockImpl inline={false} transparentBackground={true} {...requiredProps}>
-          {code}
-        </EuiCodeBlockImpl>
+        <EuiCodeBlockImpl inline={false} transparentBackground={true} />
       );
 
       expect(component).toMatchSnapshot();
@@ -83,9 +73,7 @@ describe('EuiCodeBlockImpl', () => {
 
     test('renders with dark theme', () => {
       const component = render(
-        <EuiCodeBlockImpl inline={false} color="dark" {...requiredProps}>
-          {code}
-        </EuiCodeBlockImpl>
+        <EuiCodeBlockImpl inline={false} color="dark" />
       );
 
       expect(component).toMatchSnapshot();

--- a/src/components/code/code.js
+++ b/src/components/code/code.js
@@ -4,7 +4,10 @@ import {
   EuiCodeBlockImpl,
 } from './_code_block';
 
-export const EuiCode = ({ ...rest }) => {
+export const EuiCode = ({
+  inline, // eslint-disable-line
+  ...rest
+}) => {
   return (
     <EuiCodeBlockImpl
       inline={true}

--- a/src/components/code/code.js
+++ b/src/components/code/code.js
@@ -1,29 +1,14 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import classNames from 'classnames';
 
 import {
-  EuiCodeBlock,
-} from '../../components';
+  EuiCodeBlockImpl,
+} from './_code_block';
 
-export const EuiCode = ({
-  children,
-  className,
-  ...rest
-}) => {
-  const classes = classNames('euiCodeBlock--inline', className);
-
+export function EuiCode({ ...rest }) {
   return (
-    <EuiCodeBlock
-      className={classes}
+    <EuiCodeBlockImpl
+      inline={true}
       {...rest}
-    >
-      {children}
-    </EuiCodeBlock>
+    />
   );
-};
-
-EuiCode.propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-};
+}

--- a/src/components/code/code.js
+++ b/src/components/code/code.js
@@ -4,11 +4,15 @@ import {
   EuiCodeBlockImpl,
 } from './_code_block';
 
-export function EuiCode({ ...rest }) {
+export const EuiCode = ({ ...rest }) => {
   return (
     <EuiCodeBlockImpl
       inline={true}
       {...rest}
     />
   );
-}
+};
+
+EuiCode.propTypes = {
+  ...EuiCodeBlockImpl.propTypes
+};

--- a/src/components/code/code.test.js
+++ b/src/components/code/code.test.js
@@ -4,20 +4,17 @@ import { requiredProps } from '../../test/required_props';
 
 import { EuiCode } from './code';
 
-jest.mock('./_code_block', () => ({ EuiCodeBlockImpl: 'EuiCodeBlockImpl' }));
-
 const code = `var some = 'code';
 console.log(some);`;
 
 describe('EuiCode', () => {
-  test('is rendered using EuiCodeBlockImpl', () => {
+  test('renders a code snippet', () => {
     const component = render(
       <EuiCode {...requiredProps}>
         {code}
       </EuiCode>
     );
 
-    expect(component)
-      .toMatchSnapshot();
+    expect(component).toMatchSnapshot();
   });
 });

--- a/src/components/code/code_block.js
+++ b/src/components/code/code_block.js
@@ -4,7 +4,10 @@ import {
   EuiCodeBlockImpl,
 } from './_code_block';
 
-export const EuiCodeBlock = ({ ...rest }) => {
+export const EuiCodeBlock = ({
+  inline, // eslint-disable-line
+  ...rest
+}) => {
   return (
     <EuiCodeBlockImpl
       inline={false}

--- a/src/components/code/code_block.js
+++ b/src/components/code/code_block.js
@@ -4,11 +4,15 @@ import {
   EuiCodeBlockImpl,
 } from './_code_block';
 
-export function EuiCodeBlock({ ...rest }) {
+export const EuiCodeBlock = ({ ...rest }) => {
   return (
     <EuiCodeBlockImpl
       inline={false}
       {...rest}
     />
   );
-}
+};
+
+EuiCodeBlock.propTypes = {
+  ...EuiCodeBlockImpl.propTypes
+};

--- a/src/components/code/code_block.js
+++ b/src/components/code/code_block.js
@@ -1,121 +1,14 @@
-import React, {
-  Component,
-} from 'react';
-import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import React from 'react';
 
-import hljs from 'highlight.js';
+import {
+  EuiCodeBlockImpl,
+} from './_code_block';
 
-const colorToClassNameMap = {
-  light: 'euiCodeBlock--light',
-  dark: 'euiCodeBlock--dark',
-};
-
-export const COLORS = Object.keys(colorToClassNameMap);
-
-const fontSizeToClassNameMap = {
-  s: 'euiCodeBlock--fontSmall',
-  m: 'euiCodeBlock--fontMedium',
-  l: 'euiCodeBlock--fontLarge',
-};
-
-export const FONT_SIZES = Object.keys(fontSizeToClassNameMap);
-
-const paddingSizeToClassNameMap = {
-  s: 'euiCodeBlock--paddingSmall',
-  m: 'euiCodeBlock--paddingMedium',
-  l: 'euiCodeBlock--paddingLarge',
-};
-
-export const PADDING_SIZES = Object.keys(paddingSizeToClassNameMap);
-
-export class EuiCodeBlock extends Component {
-  static propTypes = {
-    children: PropTypes.node,
-    className: PropTypes.string,
-  }
-
-  constructor(props) {
-    super(props);
-  }
-
-  componentDidMount() {
-    this.highlight();
-  }
-
-  componentDidUpdate() {
-    this.highlight();
-  }
-
-  render() {
-    const {
-      children,
-      className,
-      color,
-      fontSize,
-      language,
-      overflowHeight,
-      paddingSize,
-      transparentBackground,
-      ...otherProps
-    } = this.props;
-
-    const classes = classNames(
-      'euiCodeBlock',
-      colorToClassNameMap[color],
-      fontSizeToClassNameMap[fontSize],
-      paddingSizeToClassNameMap[paddingSize],
-      {
-        'euiCodeBlock--transparentBackground': transparentBackground,
-      },
-      className
-    );
-
-    const codeClasses = classNames('euiCodeBlock__code', language);
-
-    let optionalOverflowHeight = 'auto';
-
-    if (overflowHeight) {
-      optionalOverflowHeight = overflowHeight;
-    }
-
-    return (
-      <span
-        className={classes}
-        style={{ height: optionalOverflowHeight }}
-      >
-        <span className="euiCodeBlock__pre">
-          <code
-            ref={ref => { this.code = ref; }}
-            className={codeClasses}
-            {...otherProps}
-          >
-            {children}
-          </code>
-        </span>
-      </span>
-    );
-  }
-
-  highlight() {
-    if (this.props.language) {
-      hljs.highlightBlock(this.code);
-    }
-  }
+export function EuiCodeBlock({ ...rest }) {
+  return (
+    <EuiCodeBlockImpl
+      inline={false}
+      {...rest}
+    />
+  );
 }
-
-EuiCodeBlock.propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  color: PropTypes.string,
-  paddingSize: PropTypes.oneOf(PADDING_SIZES),
-  fontSize: PropTypes.oneOf(FONT_SIZES),
-  transparentBackground: PropTypes.bool,
-};
-
-EuiCodeBlock.defaultProps = {
-  color: 'light',
-  transparentBackground: false,
-  paddingSize: 'l',
-  fontSize: 's',
-};

--- a/src/components/code/code_block.test.js
+++ b/src/components/code/code_block.test.js
@@ -4,20 +4,17 @@ import { requiredProps } from '../../test/required_props';
 
 import { EuiCodeBlock } from './code_block';
 
-jest.mock('./_code_block', () => ({ EuiCodeBlockImpl: 'EuiCodeBlockImpl' }));
-
 const code = `var some = 'code';
 console.log(some);`;
 
 describe('EuiCodeBlock', () => {
-  test('is rendered', () => {
+  test('renders a code block', () => {
     const component = render(
       <EuiCodeBlock {...requiredProps}>
         {code}
       </EuiCodeBlock>
     );
 
-    expect(component)
-      .toMatchSnapshot();
+    expect(component).toMatchSnapshot();
   });
 });

--- a/src/components/code/code_block.test.js
+++ b/src/components/code/code_block.test.js
@@ -2,19 +2,19 @@ import React from 'react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
 
-import { EuiCode } from './code';
+import { EuiCodeBlock } from './code_block';
 
 jest.mock('./_code_block', () => ({ EuiCodeBlockImpl: 'EuiCodeBlockImpl' }));
 
 const code = `var some = 'code';
 console.log(some);`;
 
-describe('EuiCode', () => {
-  test('is rendered using EuiCodeBlockImpl', () => {
+describe('EuiCodeBlock', () => {
+  test('is rendered', () => {
     const component = render(
-      <EuiCode {...requiredProps}>
+      <EuiCodeBlock {...requiredProps}>
         {code}
-      </EuiCode>
+      </EuiCodeBlock>
     );
 
     expect(component)


### PR DESCRIPTION
Block goes `<div><pre><code>`:

<img width="831" alt="screen shot 2017-11-10 at 17 06 24" src="https://user-images.githubusercontent.com/934293/32676632-17869ca4-c63a-11e7-8df0-646426186246.png">

Inline goes `<span><code>`:

<img width="932" alt="screen shot 2017-11-10 at 17 06 34" src="https://user-images.githubusercontent.com/934293/32676633-17aa635a-c63a-11e7-9e1b-c8d7f0400e8a.png">

Public interface left unchanged:

<img width="813" alt="screen shot 2017-11-10 at 17 06 40" src="https://user-images.githubusercontent.com/934293/32676634-17d04958-c63a-11e7-8944-86b9ec406782.png">

<img width="1174" alt="screen shot 2017-11-10 at 17 06 48" src="https://user-images.githubusercontent.com/934293/32676635-17f4c77e-c63a-11e7-84fb-e88f2bd2d413.png">
