### PR TITLE
DO NOT MERGE: Add K6 overrides to light theme.

### DIFF
--- a/src/global_styling/k6/_colors.scss
+++ b/src/global_styling/k6/_colors.scss
@@ -1,0 +1,1 @@
+$euiTextColor: #2D2D2D;

--- a/src/global_styling/k6/_index.scss
+++ b/src/global_styling/k6/_index.scss
@@ -1,0 +1,6 @@
+@import 'size';
+@import 'colors';
+@import 'typography';
+// @import 'borders';
+// @import 'shadows';
+// @import 'z_index';

--- a/src/global_styling/k6/_size.scss
+++ b/src/global_styling/k6/_size.scss
@@ -1,0 +1,7 @@
+$euiSizeXS:   4px;
+$euiSizeS:    8px;
+$euiSizeM:    11px;
+$euiSize:     14px;
+$euiSizeL:    18px;
+$euiSizeXL:   22px;
+$euiSizeXXL:  26px;

--- a/src/global_styling/k6/_typography.scss
+++ b/src/global_styling/k6/_typography.scss
@@ -1,0 +1,7 @@
+$euiFontSizeXS:     10px;
+$euiFontSizeS:      12px;
+$euiFontSizeM:      14px;
+$euiFontSize:       14px;
+$euiFontSizeL:      18px;
+$euiFontSizeXL:     22px;
+$euiFontSizeXXL:    28px;

--- a/src/global_styling/theme_light_variables.scss
+++ b/src/global_styling/theme_light_variables.scss
@@ -1,2 +1,5 @@
+// K6 custom values
+@import 'k6/index';
+
 // Configuration
 @import 'variables/index';

--- a/src/global_styling/variables/_size.scss
+++ b/src/global_styling/variables/_size.scss
@@ -1,10 +1,10 @@
-$euiSize:     16px;
+$euiSize:     16px !default;
 
-$euiSizeXS:   $euiSize * .25;
-$euiSizeS:    $euiSize * .5;
-$euiSizeM:    $euiSize * .75;
-$euiSizeL:    $euiSize * 1.5;
-$euiSizeXL:   $euiSize * 2;
-$euiSizeXXL:  $euiSize * 2.5;
+$euiSizeXS:   $euiSize * .25 !default;
+$euiSizeS:    $euiSize * .5 !default;
+$euiSizeM:    $euiSize * .75 !default;
+$euiSizeL:    $euiSize * 1.5 !default;
+$euiSizeXL:   $euiSize * 2 !default;
+$euiSizeXXL:  $euiSize * 2.5 !default;
 
-$euiButtonMinWidth: $euiSize * 7;
+$euiButtonMinWidth: $euiSize * 7 !default;

--- a/src/global_styling/variables/_typography.scss
+++ b/src/global_styling/variables/_typography.scss
@@ -23,14 +23,14 @@ $euiCodeFontFamily: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courie
 
 // Font sizes
 
-$euiFontSize:       $euiSize;
+$euiFontSize:       $euiSize !default;
 
-$euiFontSizeXS:     $euiFontSize * .75;
-$euiFontSizeS:      $euiFontSize * .875;
-$euiFontSizeM:      $euiFontSize;
-$euiFontSizeL:      $euiFontSize * 1.5;
-$euiFontSizeXL:     $euiFontSize * 2;
-$euiFontSizeXXL:    $euiFontSize * 3;
+$euiFontSizeXS:     $euiFontSize * .75 !default;
+$euiFontSizeS:      $euiFontSize * .875 !default;
+$euiFontSizeM:      $euiFontSize !default;
+$euiFontSizeL:      $euiFontSize * 1.5 !default;
+$euiFontSizeXL:     $euiFontSize * 2 !default;
+$euiFontSizeXXL:    $euiFontSize * 3 !default;
 
 // Line height
 


### PR DESCRIPTION
# DO NOT MERGE.

☠️  ☠️  ☠️ 

This branch is intended to be consumed by Kibana 6.x. By providing a K6 theme over the K7 components, we're hoping to enable Kibana engineers to consume this framework today, while retaining a consistent look-and-feel in the Kibana UI.

## Guidelines

1. Only override SCSS variables.
2. If necessary, abstract parts of KUI behind variables and mixins to enable #1.
3. Avoid overriding selectors and styles directly as much as possible. Only do this as a last resort.

## K6 theme

The K6 theme consists of:

1. Changing colors to match the palette.
2. Changing font-size to match.
3. Changing some spacing to match, which generally just means making spacing tighter.