### PR TITLE
Form fields now have a loading state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
 - `<EuiFlexItem>` now accepts integers between 1 and 10 for the `grow` prop. [(#144)](https://github.com/elastic/eui/pull/144)
+- Add `isLoading` prop to form inputs to allow for a loading state [(#150)](https://github.com/elastic/eui/pull/150)
 
 # [`0.0.2`](https://github.com/elastic/eui/tree/v0.0.2)
 

--- a/src-docs/src/views/form/form_controls_loading.js
+++ b/src-docs/src/views/form/form_controls_loading.js
@@ -3,16 +3,11 @@ import React, {
 } from 'react';
 
 import {
-  EuiCheckboxGroup,
   EuiFieldNumber,
   EuiFieldPassword,
   EuiFieldSearch,
   EuiFieldText,
-  EuiRange,
-  EuiRadioGroup,
   EuiSelect,
-  EuiSwitch,
-  EuiTextArea,
 } from '../../../../src/components';
 
 // Don't use this, make proper ids instead. This is just for the example.

--- a/src-docs/src/views/form/form_controls_loading.js
+++ b/src-docs/src/views/form/form_controls_loading.js
@@ -1,0 +1,87 @@
+import React, {
+  Component,
+} from 'react';
+
+import {
+  EuiCheckboxGroup,
+  EuiFieldNumber,
+  EuiFieldPassword,
+  EuiFieldSearch,
+  EuiFieldText,
+  EuiRange,
+  EuiRadioGroup,
+  EuiSelect,
+  EuiSwitch,
+  EuiTextArea,
+} from '../../../../src/components';
+
+// Don't use this, make proper ids instead. This is just for the example.
+function makeId() {
+  return Math.random().toString(36).substr(2, 5);
+}
+
+export default class extends Component {
+  constructor(props) {
+    super(props);
+
+    const idPrefix = makeId();
+  }
+
+  render() {
+    return (
+      <div>
+        <EuiFieldText
+          placeholder="Placeholder text"
+          isLoading
+        />
+
+        <br />
+        <br />
+
+        <EuiFieldText
+          defaultValue="Text field with customizable icon"
+          icon="user"
+          isLoading
+          disabled
+        />
+
+        <br />
+        <br />
+
+        <EuiFieldNumber
+          defaultValue="23"
+          isLoading
+        />
+
+        <br />
+        <br />
+
+        <EuiFieldPassword
+          defaultValue="password"
+          isLoading
+        />
+
+        <br />
+        <br />
+
+        <EuiFieldSearch
+          defaultValue="Search field"
+          isLoading
+        />
+
+        <br />
+        <br />
+
+        <EuiSelect
+          isLoading
+          options={[
+            { value: 'option_one', text: 'Option one' },
+            { value: 'option_two', text: 'Option two' },
+            { value: 'option_three', text: 'Option three' },
+          ]}
+        />
+
+      </div>
+    );
+  }
+}

--- a/src-docs/src/views/form/form_example.js
+++ b/src-docs/src/views/form/form_example.js
@@ -48,6 +48,10 @@ import Disabled from './disabled';
 const disabledSource = require('!!raw-loader!./disabled');
 const disabledHtml = renderToHtml(Disabled);
 
+import Loading from './form_controls_loading';
+const loadingSource = require('!!raw-loader!./form_controls_loading');
+const loadingHtml = renderToHtml(Loading);
+
 export default props => (
   <GuidePage title={props.route.name}>
     <GuideSection
@@ -136,6 +140,27 @@ export default props => (
       }
       demo={
         <Disabled />
+      }
+    />
+
+    <GuideSection
+      title="Fields can be in a loading state"
+      source={[{
+        type: GuideSectionTypes.JS,
+        code: loadingSource,
+      }, {
+        type: GuideSectionTypes.HTML,
+        code: loadingHtml,
+      }]}
+      text={
+        <p>
+          Pass <EuiCode>isLoading</EuiCode> onto any field level (text, number, search, select)
+          component to put it in a loading state. This can be in combination with any other
+          props you attach (like <EuiCode>disabled</EuiCode>).
+        </p>
+      }
+      demo={
+        <Loading />
       }
     />
 
@@ -245,5 +270,6 @@ export default props => (
         <InlineFormPopover />
       }
     />
+
   </GuidePage>
 );

--- a/src/components/form/_index.scss
+++ b/src/components/form/_index.scss
@@ -20,6 +20,19 @@ $euiFormBackgroundColor: tintOrShade($euiColorLightestShade, 60%, 25%);
   }
 }
 
+@mixin euiFormControlIsLoading($isNextToIcon: false) {
+
+  @at-root {
+    #{&}-isLoading {
+      @if ($isNextToIcon) {
+        padding-right: $euiSizeXXL + $euiSize;
+      } @else {
+        padding-right: $euiSizeXXL;
+      }
+    }
+  }
+}
+
 /**
  * 1. Override invalid state with focus state.
  */

--- a/src/components/form/field_number/__snapshots__/field_number.test.js.snap
+++ b/src/components/form/field_number/__snapshots__/field_number.test.js.snap
@@ -1,10 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiFieldNumber is rendered 1`] = `
-<input
-  aria-label="aria-label"
-  class="euiFieldNumber testClass1 testClass2"
-  data-test-subj="test subject string"
-  type="number"
-/>
+<div
+  class="euiFormControlLayout"
+>
+  <input
+    aria-label="aria-label"
+    class="euiFieldNumber testClass1 testClass2"
+    data-test-subj="test subject string"
+    type="number"
+  />
+</div>
 `;

--- a/src/components/form/field_number/_field_number.scss
+++ b/src/components/form/field_number/_field_number.scss
@@ -1,4 +1,5 @@
 .euiFieldNumber {
   @include euiFormControlStyle;
   @include euiFormControlWithIcon($isIconOptional: true);
+  @include euiFormControlIsLoading;
 }

--- a/src/components/form/field_number/field_number.js
+++ b/src/components/form/field_number/field_number.js
@@ -21,17 +21,20 @@ export const EuiFieldNumber = ({
   value,
   isInvalid,
   fullWidth,
+  isLoading,
   ...rest
 }) => {
   const classes = classNames('euiFieldNumber', className, {
     'euiFieldNumber--withIcon': icon,
     'euiFieldNumber--fullWidth': fullWidth,
+    'euiFieldNumber-isLoading': isLoading,
   });
 
   return (
     <EuiFormControlLayout
       icon={icon}
       fullWidth={fullWidth}
+      isLoading={isLoading}
     >
       <EuiValidatableControl isInvalid={isInvalid}>
         <input
@@ -60,9 +63,11 @@ EuiFieldNumber.propTypes = {
   icon: PropTypes.string,
   isInvalid: PropTypes.bool,
   fullWidth: PropTypes.bool,
+  isLoading: PropTypes.bool,
 };
 
 EuiFieldNumber.defaultProps = {
   value: undefined,
   fullWidth: false,
+  isLoading: false,
 };

--- a/src/components/form/field_password/_field_password.scss
+++ b/src/components/form/field_password/_field_password.scss
@@ -1,4 +1,5 @@
 .euiFieldPassword {
   @include euiFormControlStyle;
   @include euiFormControlWithIcon($isIconOptional: false);
+  @include euiFormControlIsLoading;
 }

--- a/src/components/form/field_password/field_password.js
+++ b/src/components/form/field_password/field_password.js
@@ -18,12 +18,14 @@ export const EuiFieldPassword = ({
   value,
   isInvalid,
   fullWidth,
+  isLoading,
   ...rest
 }) => {
   const classes = classNames(
     'euiFieldPassword',
     {
       'euiFieldPassword--fullWidth': fullWidth,
+      'euiFieldPassword-isLoading': isLoading,
     },
     className
   );
@@ -32,6 +34,7 @@ export const EuiFieldPassword = ({
     <EuiFormControlLayout
       icon="lock"
       fullWidth={fullWidth}
+      isLoading={isLoading}
     >
       <EuiValidatableControl isInvalid={isInvalid}>
         <input
@@ -55,9 +58,11 @@ EuiFieldPassword.propTypes = {
   value: PropTypes.string,
   isInvalid: PropTypes.bool,
   fullWidth: PropTypes.bool,
+  isLoading: PropTypes.bool,
 };
 
 EuiFieldPassword.defaultProps = {
   value: undefined,
   fullWidth: false,
+  isLoading: false,
 };

--- a/src/components/form/field_search/_field_search.scss
+++ b/src/components/form/field_search/_field_search.scss
@@ -1,6 +1,7 @@
 .euiFieldSearch {
   @include euiFormControlStyle;
   @include euiFormControlWithIcon($isIconOptional: false);
+  @include euiFormControlIsLoading;
   // This is a hack, since in Safari the search boxes were ignoring
   // padding. Get Dave Snider involved. It improves rendering significantly
   // although the padding still looks a bit off.

--- a/src/components/form/field_search/field_search.js
+++ b/src/components/form/field_search/field_search.js
@@ -18,12 +18,14 @@ export const EuiFieldSearch = ({
   value,
   isInvalid,
   fullWidth,
+  isLoading,
   ...rest
 }) => {
   const classes = classNames(
     'euiFieldSearch',
     {
       'euiFieldSearch--fullWidth': fullWidth,
+      'euiFieldSearch-isLoading': isLoading,
     },
     className
   );
@@ -32,6 +34,7 @@ export const EuiFieldSearch = ({
     <EuiFormControlLayout
       icon="search"
       fullWidth={fullWidth}
+      isLoading={isLoading}
     >
       <EuiValidatableControl isInvalid={isInvalid}>
         <input
@@ -55,9 +58,11 @@ EuiFieldSearch.propTypes = {
   value: PropTypes.string,
   isInvalid: PropTypes.bool,
   fullWidth: PropTypes.bool,
+  isLoading: PropTypes.bool,
 };
 
 EuiFieldSearch.defaultProps = {
   value: undefined,
   fullWidth: false,
+  isLoading: false,
 };

--- a/src/components/form/field_text/__snapshots__/field_text.test.js.snap
+++ b/src/components/form/field_text/__snapshots__/field_text.test.js.snap
@@ -1,10 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiFieldText is rendered 1`] = `
-<input
-  aria-label="aria-label"
-  class="euiFieldText testClass1 testClass2"
-  data-test-subj="test subject string"
-  type="text"
-/>
+<div
+  class="euiFormControlLayout"
+>
+  <input
+    aria-label="aria-label"
+    class="euiFieldText testClass1 testClass2"
+    data-test-subj="test subject string"
+    type="text"
+  />
+</div>
 `;

--- a/src/components/form/field_text/_field_text.scss
+++ b/src/components/form/field_text/_field_text.scss
@@ -1,4 +1,5 @@
 .euiFieldText {
   @include euiFormControlStyle;
   @include euiFormControlWithIcon($isIconOptional: true);
+  @include euiFormControlIsLoading;
 }

--- a/src/components/form/field_text/field_text.js
+++ b/src/components/form/field_text/field_text.js
@@ -20,17 +20,20 @@ export const EuiFieldText = ({
   isInvalid,
   inputRef,
   fullWidth,
+  isLoading,
   ...rest
 }) => {
   const classes = classNames('euiFieldText', className, {
     'euiFieldText--withIcon': icon,
     'euiFieldText--fullWidth': fullWidth,
+    'euiFieldText-isLoading': isLoading,
   });
 
   return (
     <EuiFormControlLayout
       icon={icon}
       fullWidth={fullWidth}
+      isLoading={isLoading}
     >
       <EuiValidatableControl
         isInvalid={isInvalid}
@@ -59,9 +62,11 @@ EuiFieldText.propTypes = {
   isInvalid: PropTypes.bool,
   inputRef: PropTypes.func,
   fullWidth: PropTypes.bool,
+  isLoading: PropTypes.bool,
 };
 
 EuiFieldText.defaultProps = {
   value: undefined,
   fullWidth: false,
+  isLoading: false,
 };

--- a/src/components/form/form_control_layout/__snapshots__/form_control_layout.test.js.snap
+++ b/src/components/form/form_control_layout/__snapshots__/form_control_layout.test.js.snap
@@ -1,3 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiFormControlLayout is rendered 1`] = `<input />`;
+exports[`EuiFormControlLayout is rendered 1`] = `
+<div
+  class="euiFormControlLayout"
+>
+  <input />
+</div>
+`;

--- a/src/components/form/form_control_layout/_form_control_layout.scss
+++ b/src/components/form/form_control_layout/_form_control_layout.scss
@@ -18,5 +18,16 @@
   .euiFormControlLayout__icon--right {
     left: auto;
     right: $euiSizeM;
+
+    // Loading spinner needs adjustment if icon also exists like selects.
+    ~ .euiFormControlLayout__loading {
+      right: $euiSizeXL;
+    }
+  }
+
+  .euiFormControlLayout__loading {
+    position: absolute;
+    top: $euiSizeM;
+    right: $euiSizeM;
   }
 }

--- a/src/components/form/form_control_layout/form_control_layout.js
+++ b/src/components/form/form_control_layout/form_control_layout.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { EuiIcon } from '../..';
+import { EuiIcon, EuiLoadingSpinner } from '../..';
 
 const iconSideToClassNameMap = {
   left: '',
@@ -11,7 +11,7 @@ const iconSideToClassNameMap = {
 
 export const ICON_SIDES = Object.keys(iconSideToClassNameMap);
 
-export const EuiFormControlLayout = ({ children, icon, fullWidth, iconSide, className }) => {
+export const EuiFormControlLayout = ({ children, icon, fullWidth, iconSide, isLoading, className }) => {
 
   const classes = classNames(
     'euiFormControlLayout',
@@ -21,34 +21,43 @@ export const EuiFormControlLayout = ({ children, icon, fullWidth, iconSide, clas
     className
   );
 
+  let optionalLoader;
+  if (isLoading) {
+    optionalLoader = (
+      <EuiLoadingSpinner size="m" className="euiFormControlLayout__loading" />
+    );
+  }
+
+  let optionalIcon;
   if (icon) {
     const iconClasses = classNames('euiFormControlLayout__icon', iconSideToClassNameMap[iconSide]);
 
-    const optionalIcon = (
+    optionalIcon = (
       <EuiIcon
         className={iconClasses}
         type={icon}
         size="m"
       />
     );
-
-    return (
-      <div className={classes}>
-        {children}
-        {optionalIcon}
-      </div>
-    );
   }
 
-  return children;
+  return (
+    <div className={classes}>
+      {children}
+      {optionalIcon}
+      {optionalLoader}
+    </div>
+  );
 };
 
 EuiFormControlLayout.propTypes = {
   children: PropTypes.node,
   icon: PropTypes.string,
   iconSide: PropTypes.oneOf(ICON_SIDES),
+  isLoading: PropTypes.bool,
 };
 
 EuiFormControlLayout.defaultProps = {
   iconSide: 'left',
+  isLoading: false,
 };

--- a/src/components/form/select/_select.scss
+++ b/src/components/form/select/_select.scss
@@ -3,6 +3,7 @@
  */
 .euiSelect {
   @include euiFormControlStyle;
+  @include euiFormControlIsLoading($isNextToIcon: true);
 
   padding-right: $euiSizeXXL; /* 1 */
   appearance: none;

--- a/src/components/form/select/select.js
+++ b/src/components/form/select/select.js
@@ -18,12 +18,14 @@ export const EuiSelect = ({
   inputRef,
   isInvalid,
   fullWidth,
+  isLoading,
   ...rest
 }) => {
   const classes = classNames(
     'euiSelect',
     {
       'euiSelect--fullWidth': fullWidth,
+      'euiSelect-isLoading': isLoading,
     },
     className
   );
@@ -33,6 +35,7 @@ export const EuiSelect = ({
       icon="arrowDown"
       iconSide="right"
       fullWidth={fullWidth}
+      isLoading={isLoading}
     >
       <EuiValidatableControl isInvalid={isInvalid}>
         <select
@@ -57,10 +60,12 @@ EuiSelect.propTypes = {
   options: PropTypes.arrayOf(PropTypes.object).isRequired,
   isInvalid: PropTypes.bool,
   fullWidth: PropTypes.bool,
+  isLoading: PropTypes.bool,
   inputRef: PropTypes.func,
 };
 
 EuiSelect.defaultProps = {
   options: [],
   fullWidth: false,
+  isLoading: false,
 };


### PR DESCRIPTION
Closes https://github.com/elastic/eui/issues/146

Add `isLoading` to any text based form field to signify the input is in a loading state. This can be provided in combo with props like `disabled` if needed.

![](https://d3vv6lp55qjaqc.cloudfront.net/items/0g0I2A3p3q3O2e2J432D/Screen%20Recording%202017-11-14%20at%2001.52%20PM.gif?X-CloudApp-Visitor-Id=59773&v=cac0d50e)
