### PR TITLE
Fix bug with EuiPageSideBar width.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Fixed bug where screen-reader styles weren't being imported [(#103)](https://github.com/elastic/eui/pull/103)
 - Fixed a bug where `<progress>` wasn't being rendered under `block` display [(#166)](https://github.com/elastic/eui/pull/166)
+- Fixed a bug that caused `<EuiPageSideBar>` width to change when the width of its content changed [(#181)](https://github.com/elastic/eui/pull/181)
 
 **Breaking**
 

--- a/src/components/page/page_side_bar/_page_side_bar.scss
+++ b/src/components/page/page_side_bar/_page_side_bar.scss
@@ -1,5 +1,9 @@
+/**
+ * 1. Prevent side bar width from changing when content width changes.
+ */
 .euiPageSideBar {
-  width: $euiSize * 12;
+  min-width: $euiSize * 12; /* 1 */
+  flex: 0 0 0; /* 1 */
   margin-right: $euiSizeL;
 }
 


### PR DESCRIPTION
Originally the width would change as you navigate from page to page. Now it stays fixed. Seems related to https://github.com/philipwalton/flexbugs#flexbug-1.

CC @snide 