### PR TITLE
New icon size of small, adjust coloring of sidenav arrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add `scope` prop to `<EuiTableHeaderCell>` and `<EuiTableHeaderCellCheckbox>` ([#171](https://github.com/elastic/eui/pull/171))
 - Add `disabled` prop to `<EuiContextMenuItem>` ([#172](https://github.com/elastic/eui/pull/172))
 - Add `<EuiTablePagination>` component and `Pager` service ([#178](https://github.com/elastic/eui/pull/178))
+- Icon size prop now accepts `s`. Adjusted coloring of sidenav arrows ([#178](https://github.com/elastic/eui/pull/197))
 
 **Bug fixes**
 

--- a/src-docs/src/views/icon/icon_sizes.js
+++ b/src-docs/src/views/icon/icon_sizes.js
@@ -9,6 +9,7 @@ import {
 } from '../../../../src/components';
 
 const iconSizes = [
+  's',
   'm',
   'l',
   'xl',

--- a/src/components/icon/__snapshots__/icon.test.js.snap
+++ b/src/components/icon/__snapshots__/icon.test.js.snap
@@ -86,6 +86,27 @@ exports[`EuiIcon renders size original 1`] = `
 </svg>
 `;
 
+exports[`EuiIcon renders size s 1`] = `
+<svg
+  class="euiIcon euiIcon--small"
+  height="16"
+  viewBox="0 0 16 16"
+  width="16"
+  xlink="http://www.w3.org/1999/xlink"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <defs>
+    <path
+      d="M11.271 11.978l3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738z"
+      id="search-a"
+    />
+  </defs>
+  <use
+    href="#search-a"
+  />
+</svg>
+`;
+
 exports[`EuiIcon renders size xl 1`] = `
 <svg
   class="euiIcon euiIcon--xLarge"

--- a/src/components/icon/_icon.scss
+++ b/src/components/icon/_icon.scss
@@ -41,6 +41,10 @@
   fill: $euiColorDanger;
 }
 
+.euiIcon--small {
+  @include size($euiSizeM);
+}
+
 .euiIcon--medium {
   @include size($euiSize);
 }

--- a/src/components/icon/icon.js
+++ b/src/components/icon/icon.js
@@ -194,6 +194,7 @@ export const COLORS = Object.keys(colorToClassMap);
 
 const sizeToClassNameMap = {
   original: null,
+  s: 'euiIcon--small',
   m: 'euiIcon--medium',
   l: 'euiIcon--large',
   xl: 'euiIcon--xLarge',

--- a/src/components/side_nav/__snapshots__/side_nav.test.js.snap
+++ b/src/components/side_nav/__snapshots__/side_nav.test.js.snap
@@ -214,7 +214,7 @@ exports[`EuiSideNav items is rendered 1`] = `
                 C
               </span>
               <svg
-                class="euiIcon euiIcon--medium"
+                class="euiIcon euiIcon--small euiIcon--subdued"
                 height="16"
                 viewBox="0 0 16 16"
                 width="16"
@@ -331,7 +331,7 @@ exports[`EuiSideNav items renders items with are links 1`] = `
                 C
               </span>
               <svg
-                class="euiIcon euiIcon--medium"
+                class="euiIcon euiIcon--small euiIcon--subdued"
                 height="16"
                 viewBox="0 0 16 16"
                 width="16"

--- a/src/components/side_nav/side_nav_item.js
+++ b/src/components/side_nav/side_nav_item.js
@@ -53,7 +53,7 @@ export const EuiSideNavItem = ({
   let caret;
 
   if (depth > 0 && isParent && !isOpen && !isSelected) {
-    caret = <EuiIcon type="arrowDown" />;
+    caret = <EuiIcon type="arrowDown" color="subdued" size="s" />;
   }
 
   const buttonContent = (


### PR DESCRIPTION
The arrows in the sidenav was pretty overbearing.

![image](https://user-images.githubusercontent.com/324519/33737252-4cc10218-db4a-11e7-9616-f05950ea560e.png)

![image](https://user-images.githubusercontent.com/324519/33737260-55816758-db4a-11e7-9bdd-818e7b499e63.png)
