### PR TITLE
remove getDOMNode function call from findTestSubject

### DIFF
--- a/src/components/code_editor/code_editor.test.js
+++ b/src/components/code_editor/code_editor.test.js
@@ -38,21 +38,21 @@ describe('EuiCodeEditor', () => {
 
     describe('hint element', () => {
       test('should be tabable', () => {
-        const hint = findTestSubject(component, 'codeEditorHint');
+        const hint = findTestSubject(component, 'codeEditorHint').getDOMNode();
         expect(hint).toMatchSnapshot();
       });
 
       test('should be disabled when the ui ace box gains focus', () => {
-        const hint = findTestSubject(component, 'codeEditorHint', false);
+        const hint = findTestSubject(component, 'codeEditorHint');
         hint.simulate('keyup', { keyCode: keyCodes.ENTER });
-        expect(findTestSubject(component, 'codeEditorHint')).toMatchSnapshot();
+        expect(findTestSubject(component, 'codeEditorHint').getDOMNode()).toMatchSnapshot();
       });
 
       test('should be enabled when the ui ace box loses focus', () => {
-        const hint = findTestSubject(component, 'codeEditorHint', false);
+        const hint = findTestSubject(component, 'codeEditorHint');
         hint.simulate('keyup', { keyCode: keyCodes.ENTER });
         component.instance().onBlurAce();
-        expect(findTestSubject(component, 'codeEditorHint')).toMatchSnapshot();
+        expect(findTestSubject(component, 'codeEditorHint').getDOMNode()).toMatchSnapshot();
       });
     });
 
@@ -70,7 +70,7 @@ describe('EuiCodeEditor', () => {
           stopPropagation: () => {},
           keyCode: keyCodes.ESCAPE,
         });
-        const hint = findTestSubject(component, 'codeEditorHint');
+        const hint = findTestSubject(component, 'codeEditorHint').getDOMNode();
         expect(hint).toBe(document.activeElement);
       });
     });

--- a/src/components/context_menu/context_menu_panel.test.js
+++ b/src/components/context_menu/context_menu_panel.test.js
@@ -170,7 +170,7 @@ describe('EuiContextMenuPanel', () => {
           />
         );
 
-        expect(findTestSubject(component, 'itemB')).toBe(document.activeElement);
+        expect(findTestSubject(component, 'itemB').getDOMNode()).toBe(document.activeElement);
       });
     });
 
@@ -276,7 +276,7 @@ describe('EuiContextMenuPanel', () => {
           </EuiContextMenuPanel>
         );
 
-        expect(findTestSubject(component, 'button')).toBe(document.activeElement);
+        expect(findTestSubject(component, 'button').getDOMNode()).toBe(document.activeElement);
       });
 
       it('is not set on anything if hasFocus is false', () => {
@@ -286,7 +286,7 @@ describe('EuiContextMenuPanel', () => {
           </EuiContextMenuPanel>
         );
 
-        expect(findTestSubject(component, 'button')).not.toBe(document.activeElement);
+        expect(findTestSubject(component, 'button').getDOMNode()).not.toBe(document.activeElement);
       });
     });
 
@@ -315,41 +315,41 @@ describe('EuiContextMenuPanel', () => {
       it('down arrow key focuses the first menu item', () => {
         component.simulate('keydown', { keyCode: keyCodes.DOWN });
 
-        expect(findTestSubject(component, 'itemA')).toBe(document.activeElement);
+        expect(findTestSubject(component, 'itemA').getDOMNode()).toBe(document.activeElement);
       });
 
       it('subsequently, down arrow key focuses the next menu item', () => {
         component.simulate('keydown', { keyCode: keyCodes.DOWN });
         component.simulate('keydown', { keyCode: keyCodes.DOWN });
 
-        expect(findTestSubject(component, 'itemB')).toBe(document.activeElement);
+        expect(findTestSubject(component, 'itemB').getDOMNode()).toBe(document.activeElement);
       });
 
       it('down arrow key wraps to first menu item', () => {
         component.simulate('keydown', { keyCode: keyCodes.UP });
         component.simulate('keydown', { keyCode: keyCodes.DOWN });
 
-        expect(findTestSubject(component, 'itemA')).toBe(document.activeElement);
+        expect(findTestSubject(component, 'itemA').getDOMNode()).toBe(document.activeElement);
       });
 
       it('up arrow key focuses the last menu item', () => {
         component.simulate('keydown', { keyCode: keyCodes.UP });
 
-        expect(findTestSubject(component, 'itemC')).toBe(document.activeElement);
+        expect(findTestSubject(component, 'itemC').getDOMNode()).toBe(document.activeElement);
       });
 
       it('subsequently, up arrow key focuses the previous menu item', () => {
         component.simulate('keydown', { keyCode: keyCodes.UP });
         component.simulate('keydown', { keyCode: keyCodes.UP });
 
-        expect(findTestSubject(component, 'itemB')).toBe(document.activeElement);
+        expect(findTestSubject(component, 'itemB').getDOMNode()).toBe(document.activeElement);
       });
 
       it('up arrow key wraps to last menu item', () => {
         component.simulate('keydown', { keyCode: keyCodes.DOWN });
         component.simulate('keydown', { keyCode: keyCodes.UP });
 
-        expect(findTestSubject(component, 'itemC')).toBe(document.activeElement);
+        expect(findTestSubject(component, 'itemC').getDOMNode()).toBe(document.activeElement);
       });
 
       it(`right arrow key shows next panel with focused item's index`, () => {

--- a/src/components/modal/confirm_modal.test.js
+++ b/src/components/modal/confirm_modal.test.js
@@ -43,7 +43,7 @@ test('onConfirm', () => {
     />
   );
 
-  findTestSubject(component, 'confirmModalConfirmButton', false).simulate('click');
+  findTestSubject(component, 'confirmModalConfirmButton').simulate('click');
   sinon.assert.calledOnce(onConfirm);
   sinon.assert.notCalled(onCancel);
 });
@@ -59,7 +59,7 @@ describe('onCancel', () => {
       />
     );
 
-    findTestSubject(component, 'confirmModalCancelButton', false).simulate('click');
+    findTestSubject(component, 'confirmModalCancelButton').simulate('click');
     sinon.assert.notCalled(onConfirm);
     sinon.assert.calledOnce(onCancel);
   });
@@ -75,7 +75,7 @@ describe('onCancel', () => {
       />
     );
 
-    findTestSubject(component, 'modal', false).simulate('keydown', { keyCode: keyCodes.ESCAPE });
+    findTestSubject(component, 'modal').simulate('keydown', { keyCode: keyCodes.ESCAPE });
     sinon.assert.notCalled(onConfirm);
     sinon.assert.calledOnce(onCancel);
   });
@@ -93,7 +93,7 @@ describe('defaultFocusedButton', () => {
       />
     );
 
-    const button = findTestSubject(component, 'confirmModalCancelButton');
+    const button = findTestSubject(component, 'confirmModalCancelButton').getDOMNode();
     expect(document.activeElement).toEqual(button);
   });
 
@@ -108,7 +108,7 @@ describe('defaultFocusedButton', () => {
       />
     );
 
-    const button = findTestSubject(component, 'confirmModalConfirmButton');
+    const button = findTestSubject(component, 'confirmModalConfirmButton').getDOMNode();
     expect(document.activeElement).toEqual(button);
   });
 

--- a/src/test/find_test_subject.js
+++ b/src/test/find_test_subject.js
@@ -1,10 +1,13 @@
-// Extract the DOM node which matches a specific test subject selector.
-export const findTestSubject = (mountedComponent, testSubjectSelector, isDOMNode = true) => {
+/**
+ * Find node which matches a specific test subject selector. Returns ReactWrappers around DOM element,
+ * https://github.com/airbnb/enzyme/tree/master/docs/api/ReactWrapper.
+ * Typically call simulate on ReactWrapper or call getDOMNode to get underlying DOM node.
+ */
+export const findTestSubject = (mountedComponent, testSubjectSelector) => {
   const testSubject = mountedComponent.find(`[data-test-subj="${testSubjectSelector}"]`);
 
-  if (isDOMNode) {
-    return testSubject.hostNodes().getDOMNode();
-  }
-
+  // restore enzyme 2 default find behavior of only returning ReactWrappers around DOM element
+  // where as enzyme 3 returns both 1) ReactWrappers around DOM element and 2) react component.
+  // https://github.com/airbnb/enzyme/issues/1174
   return testSubject.hostNodes();
 };

--- a/src/test/find_test_subject.js
+++ b/src/test/find_test_subject.js
@@ -1,13 +1,13 @@
 /**
  * Find node which matches a specific test subject selector. Returns ReactWrappers around DOM element,
  * https://github.com/airbnb/enzyme/tree/master/docs/api/ReactWrapper.
- * Typically call simulate on ReactWrapper or call getDOMNode to get underlying DOM node.
+ * Common use cases include calling simulate or getDOMNode on the returned ReactWrapper.
  */
 export const findTestSubject = (mountedComponent, testSubjectSelector) => {
   const testSubject = mountedComponent.find(`[data-test-subj="${testSubjectSelector}"]`);
 
-  // restore enzyme 2 default find behavior of only returning ReactWrappers around DOM element
-  // where as enzyme 3 returns both 1) ReactWrappers around DOM element and 2) react component.
+  // Restores Enzyme 2's find behavior, which was to only return ReactWrappers around DOM elements.
+  // Enzyme 3 returns ReactWrappers around both DOM elements and React components.
   // https://github.com/airbnb/enzyme/issues/1174
   return testSubject.hostNodes();
 };

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -88,8 +88,8 @@ describe('YourComponent', () => {
         <YourComponent />
       );
 
-      expect(findTestSubject(component, 'button')).toBe(document.activeElement);
-    }); 
+      expect(findTestSubject(component, 'button').getDOMNode()).toBe(document.activeElement);
+    });
   });
 });
 


### PR DESCRIPTION
During a review of findTestSubject in https://github.com/elastic/kibana, it was suggested that getDOMNode be removed from findTestSubject.