### PR TITLE
Fix import paths for EuiTable, EuiHealth, and EuiPopover.

### DIFF
--- a/src/components/health/health.js
+++ b/src/components/health/health.js
@@ -6,7 +6,7 @@ import {
   EuiIcon,
   EuiFlexGroup,
   EuiFlexItem,
-} from '../../components';
+} from '../';
 
 export const EuiHealth = ({
   children,

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -11,7 +11,7 @@ import { cascadingMenuKeyCodes } from '../../services';
 
 import { EuiOutsideClickDetector } from '../outside_click_detector';
 
-import { EuiPanel, SIZES } from '../../components/panel';
+import { EuiPanel, SIZES } from '../panel';
 
 const anchorPositionToClassNameMap = {
   'upCenter': 'euiPopover--anchorUpCenter',

--- a/src/components/table/table_pagination/table_pagination.js
+++ b/src/components/table/table_pagination/table_pagination.js
@@ -11,7 +11,7 @@ import {
   EuiFlexItem,
   EuiPagination,
   EuiPopover,
-} from '../../../../src/components';
+} from '../../';
 
 export class EuiTablePagination extends Component {
   constructor(props) {


### PR DESCRIPTION
This causes a bug when this dependency is consumed because files in ES5 `lib` will try to import the ES6 files in `src`. We should guard against this in the future by using something like [create-react-app's ModuleScopePlugin](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-dev-utils/ModuleScopePlugin.js) ([docs](https://github.com/facebookincubator/create-react-app/blob/e8a3e4b2995f4c6e49c0a7ed653a1646a7b5e515/packages/react-dev-utils/README.md#new-modulescopepluginappsrc-string-allowedfiles-string)).