### PR TITLE
Creating new CSS class: euiFlexGroup--justifyContentSpaceEvenly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
 No public interface changes since `0.0.5`.
+- `justify` prop of `<EuiFlexGroup>` now accepts `spaceEvenly` [(#205)](https://github.com/elastic/eui/pull/205)
 
 # [`0.0.5`](https://github.com/elastic/eui/tree/v0.0.5)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `0.0.5`.
 - `justify` prop of `<EuiFlexGroup>` now accepts `spaceEvenly` [(#205)](https://github.com/elastic/eui/pull/205)
 
 # [`0.0.5`](https://github.com/elastic/eui/tree/v0.0.5)

--- a/src-docs/src/views/flex/flex_justify.js
+++ b/src-docs/src/views/flex/flex_justify.js
@@ -9,6 +9,13 @@ import {
 
 export default () => (
   <div>
+    <EuiFlexGroup justifyContent="spaceEvenly">
+      <EuiFlexItem grow={false}>One here on the left</EuiFlexItem>
+      <EuiFlexItem grow={false}>The other over here on the right.</EuiFlexItem>
+    </EuiFlexGroup>
+
+    <EuiSpacer />
+
     <EuiFlexGroup justifyContent="spaceBetween">
       <EuiFlexItem grow={false}>One here on the left</EuiFlexItem>
       <EuiFlexItem grow={false}>The other over here on the right.</EuiFlexItem>

--- a/src/components/flex/__snapshots__/flex_group.test.js.snap
+++ b/src/components/flex/__snapshots__/flex_group.test.js.snap
@@ -114,6 +114,12 @@ exports[`EuiFlexGroup props justifyContent spaceBetween is rendered 1`] = `
 />
 `;
 
+exports[`EuiFlexGroup props justifyContent spaceEvenly is rendered 1`] = `
+<div
+  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceEvenly euiFlexGroup--responsive"
+/>
+`;
+
 exports[`EuiFlexGroup props responsive false is rendered 1`] = `
 <div
   class="euiFlexGroup euiFlexGroup--gutterLarge"

--- a/src/components/flex/_flex_group.scss
+++ b/src/components/flex/_flex_group.scss
@@ -30,6 +30,10 @@ $gutterTypes: (
 }
 
 // Justify the grid
+.euiFlexGroup--justifyContentSpaceEvenly {
+  justify-content: space-evenly;
+}
+
 .euiFlexGroup--justifyContentSpaceBetween {
   justify-content: space-between;
 }

--- a/src/components/flex/flex_group.js
+++ b/src/components/flex/flex_group.js
@@ -28,6 +28,7 @@ const justifyContentToClassNameMap = {
   center: 'euiFlexGroup--justifyContentCenter',
   spaceBetween: 'euiFlexGroup--justifyContentSpaceBetween',
   spaceAround: 'euiFlexGroup--justifyContentSpaceAround',
+  spaceEvenly: 'euiFlexGroup--justifyContentSpaceEvenly',
 };
 
 export const JUSTIFY_CONTENTS = Object.keys(justifyContentToClassNameMap);


### PR DESCRIPTION
This PR:
* [x] Adds a new `euiFlexGroup--justifyContentSpaceEvenly` CSS class
* [x] Adds corresponding `spaceEvenly` option to `justifyContent` prop on the `EuiFlexGroup` component
* [x] Updates the corresponding Jest snapshot to cover the new option
* [x] Adds corresponding documentation
* [x] Adds CHANGELOG item
