### PR TITLE
Updating Popovers to use Panel Padding vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
+No public interface changes since `0.0.8`.
+
+# [`0.0.8`](https://github.com/elastic/eui/tree/v0.0.8)
+
 **Bug fixes**
 
 - Fix button vertical alignment. [(#232)](https://github.com/elastic/eui/pull/232)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `0.0.9`.
+- Updated `euiPopover` to propogate `panelPaddingSize` padding values to content only (title does inherit horizontal values) via CSS. [(#229)](https://github.com/elastic/eui/pull/229)
 
 # [`0.0.9`](https://github.com/elastic/eui/tree/v0.0.9)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
+No public interface changes since `0.0.9`.
+
+# [`0.0.9`](https://github.com/elastic/eui/tree/v0.0.9)
+
 **Breaking changes**
 
 - Renamed `euiFlexGroup--alignItemsEnd` class to `euiFlexGroup--alignItemsFlexEnd`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ No public interface changes since `0.0.8`.
 **Bug fixes**
 
 - Fix button vertical alignment. [(#232)](https://github.com/elastic/eui/pull/232)
+- Give help / error text proper line-height. [(#234)](https://github.com/elastic/eui/pull/234)
 
 # [`0.0.7`](https://github.com/elastic/eui/tree/v0.0.7)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `0.0.7`.
+**Bug fixes**
+
+- Fix button vertical alignment. [(#232)](https://github.com/elastic/eui/pull/232)
 
 # [`0.0.7`](https://github.com/elastic/eui/tree/v0.0.7)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,19 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `0.0.8`.
+**Breaking changes**
+
+- Renamed `euiFlexGroup--alignItemsEnd` class to `euiFlexGroup--alignItemsFlexEnd`.
+- Remove support for `primary` color from `<EuiTextColor>` because it looked too much like a link.
+
+**Bug fixes**
+
+- Give `<EuiFormErrorText>` and `<EuiFormHelpText>` proper line-height. [(#234)](https://github.com/elastic/eui/pull/234)
 
 # [`0.0.8`](https://github.com/elastic/eui/tree/v0.0.8)
 
 **Bug fixes**
 
 - Fix button vertical alignment. [(#232)](https://github.com/elastic/eui/pull/232)
-- Give help / error text proper line-height. [(#234)](https://github.com/elastic/eui/pull/234)
 
 # [`0.0.7`](https://github.com/elastic/eui/tree/v0.0.7)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/eui",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/eui",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elastic/eui",
   "description": "Elastic UI Component Library",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "main": "lib",
   "module": "src",
   "jsnext:main": "src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elastic/eui",
   "description": "Elastic UI Component Library",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "lib",
   "module": "src",
   "jsnext:main": "src",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,6 +8,6 @@ npm test
 npm run build
 npm run sync-docs
 npm version $BUMP
-git push --tags
-git push
+git push upstream --tags
+git push upstream
 npm publish

--- a/src-docs/src/components/guide_theme_selector/guide_theme_selector.js
+++ b/src-docs/src/components/guide_theme_selector/guide_theme_selector.js
@@ -75,7 +75,6 @@ export class GuideThemeSelector extends Component {
         isOpen={this.state.isThemePopoverOpen}
         closePopover={this.closeThemePopover}
         panelPaddingSize="none"
-        withTitle
         anchorPosition="downRight"
       >
         <EuiContextMenuPanel

--- a/src-docs/src/views/button/button.js
+++ b/src-docs/src/views/button/button.js
@@ -2,203 +2,216 @@ import React from 'react';
 
 import {
   EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
 } from '../../../../src/components/';
 
 export default () => (
   <div>
-    <EuiButton
-      onClick={() => window.alert('Button clicked')}
-    >
-      Primary
-    </EuiButton>
+    <EuiFlexGroup gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          onClick={() => window.alert('Button clicked')}
+        >
+          Primary
+        </EuiButton>
+      </EuiFlexItem>
 
-    &nbsp;&nbsp;
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          fill
+          onClick={() => window.alert('Button clicked')}
+        >
+          Filled
+        </EuiButton>
+      </EuiFlexItem>
 
-    <EuiButton
-      fill
-      onClick={() => window.alert('Button clicked')}
-    >
-      Filled
-    </EuiButton>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+        >
+          small
+        </EuiButton>
+      </EuiFlexItem>
 
-    &nbsp;&nbsp;
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          size="s"
+          fill
+          onClick={() => window.alert('Button clicked')}
+        >
+          small and filled
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
 
-    <EuiButton
-      size="s"
-      onClick={() => window.alert('Button clicked')}
-    >
-      small
-    </EuiButton>
+    <EuiFlexGroup gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          color="secondary"
+          onClick={() => window.alert('Button clicked')}
+        >
+          Secondary
+        </EuiButton>
+      </EuiFlexItem>
 
-    &nbsp;&nbsp;
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          color="secondary"
+          fill
+          onClick={() => window.alert('Button clicked')}
+        >
+          Filled
+        </EuiButton>
+      </EuiFlexItem>
 
-    <EuiButton
-      size="s"
-      fill
-      onClick={() => window.alert('Button clicked')}
-    >
-      small and filled
-    </EuiButton>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          color="secondary"
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+        >
+          small
+        </EuiButton>
+      </EuiFlexItem>
 
-    <br/><br/>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          color="secondary"
+          size="s"
+          fill
+          onClick={() => window.alert('Button clicked')}
+        >
+          small and filled
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
 
-    <EuiButton
-      color="secondary"
-      onClick={() => window.alert('Button clicked')}
-    >
-      Secondary
-    </EuiButton>
+    <EuiFlexGroup gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          color="warning"
+          onClick={() => window.alert('Button clicked')}
+        >
+          Warning
+        </EuiButton>
+      </EuiFlexItem>
 
-    &nbsp;&nbsp;
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          color="warning"
+          fill
+          onClick={() => window.alert('Button clicked')}
+        >
+          Filled
+        </EuiButton>
+      </EuiFlexItem>
 
-    <EuiButton
-      color="secondary"
-      fill
-      onClick={() => window.alert('Button clicked')}
-    >
-      Filled
-    </EuiButton>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          color="warning"
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+        >
+          small
+        </EuiButton>
+      </EuiFlexItem>
 
-    &nbsp;&nbsp;
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          color="warning"
+          size="s"
+          fill
+          onClick={() => window.alert('Button clicked')}
+        >
+          small and filled
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
 
-    <EuiButton
-      color="secondary"
-      size="s"
-      onClick={() => window.alert('Button clicked')}
-    >
-      small
-    </EuiButton>
+    <EuiFlexGroup gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          color="danger"
+          onClick={() => window.alert('Button clicked')}
+        >
+          Danger
+        </EuiButton>
+      </EuiFlexItem>
 
-    &nbsp;&nbsp;
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          color="danger"
+          fill
+          onClick={() => window.alert('Button clicked')}
+        >
+          Filled
+        </EuiButton>
+      </EuiFlexItem>
 
-    <EuiButton
-      color="secondary"
-      size="s"
-      fill
-      onClick={() => window.alert('Button clicked')}
-    >
-      small and filled
-    </EuiButton>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          color="danger"
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+        >
+          small
+        </EuiButton>
+      </EuiFlexItem>
 
-    <br/><br/>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          color="danger"
+          size="s"
+          fill
+          onClick={() => window.alert('Button clicked')}
+        >
+          small and filled
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
 
-    <EuiButton
-      color="warning"
-      onClick={() => window.alert('Button clicked')}
-    >
-      Warning
-    </EuiButton>
+    <EuiFlexGroup gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          isDisabled
+          onClick={() => window.alert('Button clicked')}
+        >
+          Disabled
+        </EuiButton>
+      </EuiFlexItem>
 
-    &nbsp;&nbsp;
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          isDisabled
+          fill
+          onClick={() => window.alert('Button clicked')}
+        >
+          Filled
+        </EuiButton>
+      </EuiFlexItem>
 
-    <EuiButton
-      color="warning"
-      fill
-      onClick={() => window.alert('Button clicked')}
-    >
-      Filled
-    </EuiButton>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          isDisabled
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+        >
+          small
+        </EuiButton>
+      </EuiFlexItem>
 
-    &nbsp;&nbsp;
-
-    <EuiButton
-      color="warning"
-      size="s"
-      onClick={() => window.alert('Button clicked')}
-    >
-      small
-    </EuiButton>
-
-    &nbsp;&nbsp;
-
-    <EuiButton
-      color="warning"
-      size="s"
-      fill
-      onClick={() => window.alert('Button clicked')}
-    >
-      small and filled
-    </EuiButton>
-
-    <br/><br/>
-
-    <EuiButton
-      color="danger"
-      onClick={() => window.alert('Button clicked')}
-    >
-      Danger
-    </EuiButton>
-
-    &nbsp;&nbsp;
-
-    <EuiButton
-      color="danger"
-      fill
-      onClick={() => window.alert('Button clicked')}
-    >
-      Filled
-    </EuiButton>
-
-    &nbsp;&nbsp;
-
-    <EuiButton
-      color="danger"
-      size="s"
-      onClick={() => window.alert('Button clicked')}
-    >
-      small
-    </EuiButton>
-
-    &nbsp;&nbsp;
-
-    <EuiButton
-      color="danger"
-      size="s"
-      fill
-      onClick={() => window.alert('Button clicked')}
-    >
-      small and filled
-    </EuiButton>
-
-    <br/><br/>
-
-    <EuiButton
-      isDisabled
-      onClick={() => window.alert('Button clicked')}
-    >
-      Disabled
-    </EuiButton>
-
-    &nbsp;&nbsp;
-
-    <EuiButton
-      isDisabled
-      fill
-      onClick={() => window.alert('Button clicked')}
-    >
-      Filled
-    </EuiButton>
-
-    &nbsp;&nbsp;
-
-    <EuiButton
-      isDisabled
-      size="s"
-      onClick={() => window.alert('Button clicked')}
-    >
-      small
-    </EuiButton>
-
-    &nbsp;&nbsp;
-
-    <EuiButton
-      isDisabled
-      size="s"
-      fill
-      onClick={() => window.alert('Button clicked')}
-    >
-      small and filled
-    </EuiButton>
-
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          isDisabled
+          size="s"
+          fill
+          onClick={() => window.alert('Button clicked')}
+        >
+          small and filled
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   </div>
 );

--- a/src-docs/src/views/button/button_empty.js
+++ b/src-docs/src/views/button/button_empty.js
@@ -2,298 +2,318 @@ import React from 'react';
 
 import {
   EuiButtonEmpty,
-} from '../../../../src/components';
+  EuiFlexGroup,
+  EuiFlexItem,
+} from '../../../../src/components/';
 
 export default () => (
   <div>
-    <EuiButtonEmpty
-      onClick={() => window.alert('Button clicked')}
-    >
-      Primary
-    </EuiButtonEmpty>
+    <EuiFlexGroup gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          onClick={() => window.alert('Button clicked')}
+        >
+          Primary
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-    &nbsp;&nbsp;
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+        >
+          small
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-    <EuiButtonEmpty
-      size="s"
-      onClick={() => window.alert('Button clicked')}
-    >
-      small
-    </EuiButtonEmpty>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          size="xs"
+          onClick={() => window.alert('Button clicked')}
+        >
+          extra small
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+    </EuiFlexGroup>
 
-    &nbsp;&nbsp;
+    <EuiFlexGroup gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowDown"
+        >
+          Primary
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-    <EuiButtonEmpty
-      size="xs"
-      onClick={() => window.alert('Button clicked')}
-    >
-      extra small
-    </EuiButtonEmpty>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowDown"
+        >
+          small
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-    <br/><br/>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowDown"
+          iconSide="right"
+        >
+          Primary
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-    <EuiButtonEmpty
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowDown"
-    >
-      Primary
-    </EuiButtonEmpty>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowDown"
+          iconSide="right"
+        >
+          small
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+    </EuiFlexGroup>
 
-    &nbsp;&nbsp;
+    <EuiFlexGroup gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="danger"
+          onClick={() => window.alert('Button clicked')}
+        >
+          Danger
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-    <EuiButtonEmpty
-      size="s"
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowDown"
-    >
-      small
-    </EuiButtonEmpty>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="danger"
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+        >
+          small
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-    &nbsp;&nbsp;
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="danger"
+          size="xs"
+          onClick={() => window.alert('Button clicked')}
+        >
+          extra small
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+    </EuiFlexGroup>
 
-    <EuiButtonEmpty
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowDown"
-      iconSide="right"
-    >
-      Primary
-    </EuiButtonEmpty>
+    <EuiFlexGroup gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="danger"
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowDown"
+        >
+          Danger
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-    &nbsp;&nbsp;
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="danger"
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowDown"
+        >
+          small
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-    <EuiButtonEmpty
-      size="s"
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowDown"
-      iconSide="right"
-    >
-      small
-    </EuiButtonEmpty>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="danger"
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowDown"
+          iconSide="right"
+        >
+          Danger
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-    <br/><br/>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="danger"
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowDown"
+          iconSide="right"
+        >
+          small
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+    </EuiFlexGroup>
 
-    <EuiButtonEmpty
-      color="danger"
-      onClick={() => window.alert('Button clicked')}
-    >
-      Danger
-    </EuiButtonEmpty>
+    <EuiFlexGroup gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="text"
+          onClick={() => window.alert('Button clicked')}
+        >
+          Text
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-    &nbsp;&nbsp;
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="text"
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+        >
+          small
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-    <EuiButtonEmpty
-      color="danger"
-      size="s"
-      onClick={() => window.alert('Button clicked')}
-    >
-      small
-    </EuiButtonEmpty>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="text"
+          size="xs"
+          onClick={() => window.alert('Button clicked')}
+        >
+          extra small
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+    </EuiFlexGroup>
 
-    &nbsp;&nbsp;
+    <EuiFlexGroup gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="text"
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowDown"
+        >
+          Text
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-    <EuiButtonEmpty
-      color="danger"
-      size="xs"
-      onClick={() => window.alert('Button clicked')}
-    >
-      extra small
-    </EuiButtonEmpty>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="text"
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowDown"
+        >
+          small
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-    <br/><br/>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="text"
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowDown"
+          iconSide="right"
+        >
+          Text
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-    <EuiButtonEmpty
-      color="danger"
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowDown"
-    >
-      Danger
-    </EuiButtonEmpty>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="text"
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowDown"
+          iconSide="right"
+        >
+          small
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+    </EuiFlexGroup>
 
-    &nbsp;&nbsp;
+    <EuiFlexGroup gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="danger"
+          onClick={() => window.alert('Button clicked')}
+          isDisabled
+        >
+          Disabled
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-    <EuiButtonEmpty
-      color="danger"
-      size="s"
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowDown"
-    >
-      small
-    </EuiButtonEmpty>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="danger"
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+          isDisabled
+        >
+          small
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-    &nbsp;&nbsp;
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="danger"
+          size="xs"
+          onClick={() => window.alert('Button clicked')}
+          isDisabled
+        >
+          extra small
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+    </EuiFlexGroup>
 
-    <EuiButtonEmpty
-      color="danger"
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowDown"
-      iconSide="right"
-    >
-      Danger
-    </EuiButtonEmpty>
+    <EuiFlexGroup gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="danger"
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowDown"
+          isDisabled
+        >
+          Disabled
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-    &nbsp;&nbsp;
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="danger"
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowDown"
+          isDisabled
+        >
+          small
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-    <EuiButtonEmpty
-      color="danger"
-      size="s"
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowDown"
-      iconSide="right"
-    >
-      small
-    </EuiButtonEmpty>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="danger"
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowDown"
+          iconSide="right"
+          isDisabled
+        >
+          Disabled
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-    <br/><br/>
-
-    <EuiButtonEmpty
-      color="text"
-      onClick={() => window.alert('Button clicked')}
-    >
-      Text
-    </EuiButtonEmpty>
-
-    &nbsp;&nbsp;
-
-    <EuiButtonEmpty
-      color="text"
-      size="s"
-      onClick={() => window.alert('Button clicked')}
-    >
-      small
-    </EuiButtonEmpty>
-
-    &nbsp;&nbsp;
-
-    <EuiButtonEmpty
-      color="text"
-      size="xs"
-      onClick={() => window.alert('Button clicked')}
-    >
-      extra small
-    </EuiButtonEmpty>
-
-    <br/><br/>
-
-    <EuiButtonEmpty
-      color="text"
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowDown"
-    >
-      Text
-    </EuiButtonEmpty>
-
-    &nbsp;&nbsp;
-
-    <EuiButtonEmpty
-      color="text"
-      size="s"
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowDown"
-    >
-      small
-    </EuiButtonEmpty>
-
-    &nbsp;&nbsp;
-
-    <EuiButtonEmpty
-      color="text"
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowDown"
-      iconSide="right"
-    >
-      Text
-    </EuiButtonEmpty>
-
-    &nbsp;&nbsp;
-
-    <EuiButtonEmpty
-      color="text"
-      size="s"
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowDown"
-      iconSide="right"
-    >
-      small
-    </EuiButtonEmpty>
-
-    <br/><br/>
-
-    <EuiButtonEmpty
-      color="danger"
-      onClick={() => window.alert('Button clicked')}
-      isDisabled
-    >
-      Disabled
-    </EuiButtonEmpty>
-
-    &nbsp;&nbsp;
-
-    <EuiButtonEmpty
-      color="danger"
-      size="s"
-      onClick={() => window.alert('Button clicked')}
-      isDisabled
-    >
-      small
-    </EuiButtonEmpty>
-
-    &nbsp;&nbsp;
-
-    <EuiButtonEmpty
-      color="danger"
-      size="xs"
-      onClick={() => window.alert('Button clicked')}
-      isDisabled
-    >
-      extra small
-    </EuiButtonEmpty>
-
-    <br/><br/>
-
-    <EuiButtonEmpty
-      color="danger"
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowDown"
-      isDisabled
-    >
-      Disabled
-    </EuiButtonEmpty>
-
-    &nbsp;&nbsp;
-
-    <EuiButtonEmpty
-      color="danger"
-      size="s"
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowDown"
-      isDisabled
-    >
-      small
-    </EuiButtonEmpty>
-
-    &nbsp;&nbsp;
-
-    <EuiButtonEmpty
-      color="danger"
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowDown"
-      iconSide="right"
-      isDisabled
-    >
-      Disabled
-    </EuiButtonEmpty>
-
-    &nbsp;&nbsp;
-
-    <EuiButtonEmpty
-      color="danger"
-      size="s"
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowDown"
-      iconSide="right"
-      isDisabled
-    >
-      small
-    </EuiButtonEmpty>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="danger"
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowDown"
+          iconSide="right"
+          isDisabled
+        >
+          small
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   </div>
 );

--- a/src-docs/src/views/button/button_empty_flush.js
+++ b/src-docs/src/views/button/button_empty_flush.js
@@ -2,16 +2,22 @@ import React from 'react';
 
 import {
   EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
 } from '../../../../src/components';
 
 export default () => (
-  <div>
-    <EuiButtonEmpty flush="left">
-      Flush left
-    </EuiButtonEmpty>
+  <EuiFlexGroup gutterSize="s" alignItems="center">
+    <EuiFlexItem grow={false}>
+      <EuiButtonEmpty flush="left">
+        Flush left
+      </EuiButtonEmpty>
+    </EuiFlexItem>
 
-    <EuiButtonEmpty flush="right">
-      Flush right
-    </EuiButtonEmpty>
-  </div>
+    <EuiFlexItem grow={false}>
+      <EuiButtonEmpty flush="right">
+        Flush right
+      </EuiButtonEmpty>
+    </EuiFlexItem>
+  </EuiFlexGroup>
 );

--- a/src-docs/src/views/button/button_ghost.js
+++ b/src-docs/src/views/button/button_ghost.js
@@ -4,47 +4,51 @@ import {
   EuiButton,
   EuiButtonEmpty,
   EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
 } from '../../../../src/components';
 
 export default () => (
-  <div className="guideDemo__ghostBackground">
-    <EuiButton
-      color="ghost"
-      onClick={() => window.alert('Button clicked')}
-    >
-      Primary
-    </EuiButton>
+  <EuiFlexGroup gutterSize="s" alignItems="center" className="guideDemo__ghostBackground">
+    <EuiFlexItem grow={false}>
+      <EuiButton
+        color="ghost"
+        onClick={() => window.alert('Button clicked')}
+      >
+        Primary
+      </EuiButton>
+    </EuiFlexItem>
 
-    &nbsp;&nbsp;
+    <EuiFlexItem grow={false}>
+      <EuiButton
+        fill
+        color="ghost"
+        size="s"
+        iconType="check"
+        onClick={() => window.alert('Button clicked')}
+      >
+        Filled
+      </EuiButton>
+    </EuiFlexItem>
 
-    <EuiButton
-      fill
-      color="ghost"
-      size="s"
-      iconType="check"
-      onClick={() => window.alert('Button clicked')}
-    >
-      Filled
-    </EuiButton>
+    <EuiFlexItem grow={false}>
+      <EuiButtonEmpty
+        size="s"
+        color="ghost"
+        onClick={() => window.alert('Button clicked')}
+      >
+        small
+      </EuiButtonEmpty>
+    </EuiFlexItem>
 
-    &nbsp;&nbsp;
-
-    <EuiButtonEmpty
-      size="s"
-      color="ghost"
-      onClick={() => window.alert('Button clicked')}
-    >
-      small
-    </EuiButtonEmpty>
-
-    &nbsp;&nbsp;
-
-    <EuiButtonIcon
-      size="s"
-      color="ghost"
-      iconType="user"
-      onClick={() => window.alert('Button clicked')}
-      aria-label="Your account"
-    />
-  </div>
+    <EuiFlexItem grow={false}>
+      <EuiButtonIcon
+        size="s"
+        color="ghost"
+        iconType="user"
+        onClick={() => window.alert('Button clicked')}
+        aria-label="Your account"
+      />
+    </EuiFlexItem>
+  </EuiFlexGroup>
 );

--- a/src-docs/src/views/button/button_icon.js
+++ b/src-docs/src/views/button/button_icon.js
@@ -2,31 +2,39 @@ import React from 'react';
 
 import {
   EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
 } from '../../../../src/components';
 
 export default () => (
-  <div>
-    <EuiButtonIcon
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowRight"
-      aria-label="Next"
-    />
+  <EuiFlexGroup gutterSize="s" alignItems="center">
+    <EuiFlexItem grow={false}>
+      <EuiButtonIcon
+        onClick={() => window.alert('Button clicked')}
+        iconType="arrowRight"
+        aria-label="Next"
+      />
+    </EuiFlexItem>
 
-    <EuiButtonIcon
-      size="s"
-      color="danger"
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowRight"
-      aria-label="Next"
-    />
+    <EuiFlexItem grow={false}>
+      <EuiButtonIcon
+        size="s"
+        color="danger"
+        onClick={() => window.alert('Button clicked')}
+        iconType="arrowRight"
+        aria-label="Next"
+      />
+    </EuiFlexItem>
 
-    <EuiButtonIcon
-      size="s"
-      color="disabled"
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowRight"
-      aria-label="Next"
-    />
-  </div>
+    <EuiFlexItem grow={false}>
+      <EuiButtonIcon
+        size="s"
+        color="disabled"
+        onClick={() => window.alert('Button clicked')}
+        iconType="arrowRight"
+        aria-label="Next"
+      />
+    </EuiFlexItem>
+  </EuiFlexGroup>
 );
 

--- a/src-docs/src/views/button/button_with_icon.js
+++ b/src-docs/src/views/button/button_with_icon.js
@@ -2,138 +2,148 @@ import React from 'react';
 
 import {
   EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
 } from '../../../../src/components';
 
 export default () => (
   <div>
-    <EuiButton
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowUp"
-    >
-      Primary
-    </EuiButton>
+    <EuiFlexGroup gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowUp"
+        >
+          Primary
+        </EuiButton>
+      </EuiFlexItem>
 
-    &nbsp;&nbsp;
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          fill
+          iconType="arrowDown"
+          onClick={() => window.alert('Button clicked')}
+        >
+          Filled
+        </EuiButton>
+      </EuiFlexItem>
 
-    <EuiButton
-      fill
-      iconType="arrowDown"
-      onClick={() => window.alert('Button clicked')}
-    >
-      Filled
-    </EuiButton>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          iconType="arrowLeft"
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+        >
+          small
+        </EuiButton>
+      </EuiFlexItem>
 
-    &nbsp;&nbsp;
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          iconType="arrowRight"
+          size="s"
+          fill
+          onClick={() => window.alert('Button clicked')}
+        >
+          small and filled
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
 
-    <EuiButton
-      iconType="arrowLeft"
-      size="s"
-      onClick={() => window.alert('Button clicked')}
-    >
-      small
-    </EuiButton>
+    <EuiFlexGroup gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          iconSide="right"
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowUp"
+        >
+          Primary
+        </EuiButton>
+      </EuiFlexItem>
 
-    &nbsp;&nbsp;
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          iconSide="right"
+          fill
+          iconType="arrowDown"
+          onClick={() => window.alert('Button clicked')}
+        >
+          Filled
+        </EuiButton>
+      </EuiFlexItem>
 
-    <EuiButton
-      iconType="arrowRight"
-      size="s"
-      fill
-      onClick={() => window.alert('Button clicked')}
-    >
-      small and filled
-    </EuiButton>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          iconSide="right"
+          iconType="arrowLeft"
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+        >
+          small
+        </EuiButton>
+      </EuiFlexItem>
 
-    <br/><br/>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          iconSide="right"
+          iconType="arrowRight"
+          size="s"
+          fill
+          onClick={() => window.alert('Button clicked')}
+        >
+          small and filled
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
 
-    <EuiButton
-      iconSide="right"
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowUp"
-    >
-      Primary
-    </EuiButton>
+    <EuiFlexGroup gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          iconSide="right"
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowUp"
+          isDisabled
+        >
+          Disabled
+        </EuiButton>
+      </EuiFlexItem>
 
-    &nbsp;&nbsp;
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          iconSide="right"
+          fill
+          iconType="arrowDown"
+          onClick={() => window.alert('Button clicked')}
+          isDisabled
+        >
+          Filled
+        </EuiButton>
+      </EuiFlexItem>
 
-    <EuiButton
-      iconSide="right"
-      fill
-      iconType="arrowDown"
-      onClick={() => window.alert('Button clicked')}
-    >
-      Filled
-    </EuiButton>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          iconSide="right"
+          iconType="arrowLeft"
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+          isDisabled
+        >
+          small
+        </EuiButton>
+      </EuiFlexItem>
 
-    &nbsp;&nbsp;
-
-    <EuiButton
-      iconSide="right"
-      iconType="arrowLeft"
-      size="s"
-      onClick={() => window.alert('Button clicked')}
-    >
-      small
-    </EuiButton>
-
-    &nbsp;&nbsp;
-
-    <EuiButton
-      iconSide="right"
-      iconType="arrowRight"
-      size="s"
-      fill
-      onClick={() => window.alert('Button clicked')}
-    >
-      small and filled
-    </EuiButton>
-
-    <br/><br/>
-
-    <EuiButton
-      iconSide="right"
-      onClick={() => window.alert('Button clicked')}
-      iconType="arrowUp"
-      isDisabled
-    >
-      Disabled
-    </EuiButton>
-
-    &nbsp;&nbsp;
-
-    <EuiButton
-      iconSide="right"
-      fill
-      iconType="arrowDown"
-      onClick={() => window.alert('Button clicked')}
-      isDisabled
-    >
-      Filled
-    </EuiButton>
-
-    &nbsp;&nbsp;
-
-    <EuiButton
-      iconSide="right"
-      iconType="arrowLeft"
-      size="s"
-      onClick={() => window.alert('Button clicked')}
-      isDisabled
-    >
-      small
-    </EuiButton>
-
-    &nbsp;&nbsp;
-
-    <EuiButton
-      iconSide="right"
-      iconType="arrowRight"
-      size="s"
-      fill
-      onClick={() => window.alert('Button clicked')}
-      isDisabled
-    >
-      small and filled
-    </EuiButton>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          iconSide="right"
+          iconType="arrowRight"
+          size="s"
+          fill
+          onClick={() => window.alert('Button clicked')}
+          isDisabled
+        >
+          small and filled
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   </div>
 );

--- a/src-docs/src/views/form/inline_form_popover.js
+++ b/src-docs/src/views/form/inline_form_popover.js
@@ -90,7 +90,7 @@ export default class extends Component {
         isOpen={this.state.isPopoverOpen}
         closePopover={this.closePopover.bind(this)}
       >
-        <div style={{ width: 500, padding: 16 }}>
+        <div style={{ width: 500 }}>
           {formSample}
         </div>
       </EuiPopover>

--- a/src-docs/src/views/popover/popover_example.js
+++ b/src-docs/src/views/popover/popover_example.js
@@ -30,6 +30,10 @@ import PopoverWithTitle from './popover_with_title';
 const popoverWithTitleSource = require('!!raw-loader!./popover_with_title');
 const popoverWithTitleHtml = renderToHtml(PopoverWithTitle);
 
+import PopoverWithTitlePadding from './popover_with_title_padding';
+const popoverWithTitlePaddingSource = require('!!raw-loader!./popover_with_title_padding');
+const popoverWithTitlePaddingHtml = renderToHtml(PopoverWithTitlePadding);
+
 export const PopoverExample = {
   title: 'Popover',
   sections: [{
@@ -112,11 +116,6 @@ export const PopoverExample = {
           <EuiCode>EuiPopoverTitle</EuiCode> nested somwhere in the child
           prop.
         </p>
-        <p>
-          Note that when using popover titles, you will need to
-          set <EuiCode>panelPaddingSize=&quot;none&quot;</EuiCode> and apply
-          some sort of padding around your content block itself.
-        </p>
       </div>
     ),
     demo: <PopoverWithTitle />,
@@ -137,5 +136,24 @@ export const PopoverExample = {
       </p>
     ),
     demo: <PopoverPanelClassName />,
+  }, {
+    title: 'Popover with title and padding size',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: popoverWithTitlePaddingSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: popoverWithTitlePaddingHtml,
+    }],
+    text: (
+      <div>
+        <p>
+          When using popover titles, you can still propogate the padding size
+          by using <EuiCode>panelPaddingSize</EuiCode>. This will only affect
+          the horizontal padding of the title and the overall padding of the content.
+        </p>
+      </div>
+    ),
+    demo: <PopoverWithTitlePadding />,
   }],
 };

--- a/src-docs/src/views/popover/popover_with_title.js
+++ b/src-docs/src/views/popover/popover_with_title.js
@@ -97,6 +97,7 @@ export default class extends Component {
             closePopover={this.closePopover2.bind(this)}
             anchorPosition="upCenter"
             withTitle
+            panelPaddingSize="l"
           >
             <EuiPopoverTitle>Hello, I&rsquo;m a popover title</EuiPopoverTitle>
             <div style={{ width: '300px' }}>
@@ -122,6 +123,7 @@ export default class extends Component {
             closePopover={this.closePopover3.bind(this)}
             anchorPosition="rightUp"
             withTitle
+            panelPaddingSize="none"
           >
             <EuiPopoverTitle>Hello, I&rsquo;m a popover title</EuiPopoverTitle>
             <div style={{ width: '300px' }}>

--- a/src-docs/src/views/popover/popover_with_title.js
+++ b/src-docs/src/views/popover/popover_with_title.js
@@ -77,7 +77,7 @@ export default class extends Component {
             <div style={{ width: '300px' }}>
               <EuiText>
                 <p>
-                  Popover content
+                  Popover content with default padding
                 </p>
               </EuiText>
             </div>
@@ -103,7 +103,7 @@ export default class extends Component {
             <div style={{ width: '300px' }}>
               <EuiText>
                 <p>
-                  Popover content
+                  Popover content with large padding
                 </p>
               </EuiText>
             </div>
@@ -129,7 +129,7 @@ export default class extends Component {
             <div style={{ width: '300px' }}>
               <EuiText>
                 <p>
-                  Popover content
+                  Popover content with no padding
                 </p>
               </EuiText>
             </div>

--- a/src-docs/src/views/popover/popover_with_title.js
+++ b/src-docs/src/views/popover/popover_with_title.js
@@ -72,10 +72,9 @@ export default class extends Component {
             closePopover={this.closePopover1.bind(this)}
             anchorPosition="downCenter"
             withTitle
-            panelPaddingSize="none"
           >
             <EuiPopoverTitle>Hello, I&rsquo;m a popover title</EuiPopoverTitle>
-            <div style={{ width: '300px', padding: 16 }}>
+            <div style={{ width: '300px' }}>
               <EuiText>
                 <p>
                   Popover content
@@ -98,10 +97,9 @@ export default class extends Component {
             closePopover={this.closePopover2.bind(this)}
             anchorPosition="upCenter"
             withTitle
-            panelPaddingSize="none"
           >
             <EuiPopoverTitle>Hello, I&rsquo;m a popover title</EuiPopoverTitle>
-            <div style={{ width: '300px', padding: 16 }}>
+            <div style={{ width: '300px' }}>
               <EuiText>
                 <p>
                   Popover content
@@ -124,10 +122,9 @@ export default class extends Component {
             closePopover={this.closePopover3.bind(this)}
             anchorPosition="rightUp"
             withTitle
-            panelPaddingSize="none"
           >
             <EuiPopoverTitle>Hello, I&rsquo;m a popover title</EuiPopoverTitle>
-            <div style={{ width: '300px', padding: 16 }}>
+            <div style={{ width: '300px' }}>
               <EuiText>
                 <p>
                   Popover content

--- a/src-docs/src/views/popover/popover_with_title.js
+++ b/src-docs/src/views/popover/popover_with_title.js
@@ -97,7 +97,6 @@ export default class extends Component {
             closePopover={this.closePopover2.bind(this)}
             anchorPosition="upCenter"
             withTitle
-            panelPaddingSize="l"
           >
             <EuiPopoverTitle>Hello, I&rsquo;m a popover title</EuiPopoverTitle>
             <div style={{ width: '300px' }}>
@@ -123,7 +122,6 @@ export default class extends Component {
             closePopover={this.closePopover3.bind(this)}
             anchorPosition="rightUp"
             withTitle
-            panelPaddingSize="none"
           >
             <EuiPopoverTitle>Hello, I&rsquo;m a popover title</EuiPopoverTitle>
             <div style={{ width: '300px' }}>

--- a/src-docs/src/views/popover/popover_with_title_padding.js
+++ b/src-docs/src/views/popover/popover_with_title_padding.js
@@ -1,0 +1,179 @@
+import React, {
+  Component,
+} from 'react';
+
+import {
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText
+} from '../../../../src/components';
+
+export default class extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isPopoverOpen: false,
+    };
+  }
+
+  onButtonClick1() {
+    this.setState({
+      isPopoverOpen1: !this.state.isPopoverOpen1,
+    });
+  }
+
+  closePopover1() {
+    this.setState({
+      isPopoverOpen1: false,
+    });
+  }
+
+  onButtonClick2() {
+    this.setState({
+      isPopoverOpen2: !this.state.isPopoverOpen2,
+    });
+  }
+
+  closePopover2() {
+    this.setState({
+      isPopoverOpen2: false,
+    });
+  }
+
+  onButtonClick3() {
+    this.setState({
+      isPopoverOpen3: !this.state.isPopoverOpen3,
+    });
+  }
+
+  closePopover3() {
+    this.setState({
+      isPopoverOpen3: false,
+    });
+  }
+
+  onButtonClick4() {
+    this.setState({
+      isPopoverOpen4: !this.state.isPopoverOpen4,
+    });
+  }
+
+  closePopover4() {
+    this.setState({
+      isPopoverOpen4: false,
+    });
+  }
+
+  render() {
+    return (
+      <EuiFlexGroup wrap={true}>
+        <EuiFlexItem grow={false}>
+          <EuiPopover
+            id="titleWithSmallPadding"
+            ownFocus
+            button={(
+              <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick2.bind(this)}>
+                Title and small padding
+              </EuiButton>
+            )}
+            isOpen={this.state.isPopoverOpen2}
+            closePopover={this.closePopover2.bind(this)}
+            anchorPosition="upCenter"
+            withTitle
+            panelPaddingSize="s"
+          >
+            <EuiPopoverTitle>Hello, I&rsquo;m a popover title</EuiPopoverTitle>
+            <div style={{ width: '300px' }}>
+              <EuiText>
+                <p>
+                  Popover content
+                </p>
+              </EuiText>
+            </div>
+          </EuiPopover>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiPopover
+            id="titleWithDefaultPadding"
+            ownFocus
+            button={(
+              <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick1.bind(this)}>
+                Title and default padding (m)
+              </EuiButton>
+            )}
+            isOpen={this.state.isPopoverOpen1}
+            closePopover={this.closePopover1.bind(this)}
+            anchorPosition="upCenter"
+            withTitle
+          >
+            <EuiPopoverTitle>Hello, I&rsquo;m a popover title</EuiPopoverTitle>
+            <div style={{ width: '300px' }}>
+              <EuiText>
+                <p>
+                  Popover content
+                </p>
+              </EuiText>
+            </div>
+          </EuiPopover>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiPopover
+            id="titleWithLargePadding"
+            ownFocus
+            button={(
+              <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick4.bind(this)}>
+                Title and large padding
+              </EuiButton>
+            )}
+            isOpen={this.state.isPopoverOpen4}
+            closePopover={this.closePopover4.bind(this)}
+            anchorPosition="upCenter"
+            withTitle
+            panelPaddingSize="l"
+          >
+            <EuiPopoverTitle>Hello, I&rsquo;m a popover title</EuiPopoverTitle>
+            <div style={{ width: '300px' }}>
+              <EuiText>
+                <p>
+                  Popover content
+                </p>
+              </EuiText>
+            </div>
+          </EuiPopover>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiPopover
+            id="titleWithNoPadding"
+            ownFocus
+            button={(
+              <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick3.bind(this)}>
+                Title and no padding
+              </EuiButton>
+            )}
+            isOpen={this.state.isPopoverOpen3}
+            closePopover={this.closePopover3.bind(this)}
+            anchorPosition="upCenter"
+            withTitle
+            panelPaddingSize="none"
+          >
+            <EuiPopoverTitle>As the title, I keep my padding</EuiPopoverTitle>
+            <div style={{ width: '300px' }}>
+              <EuiText>
+                <p>
+                  Popover content
+                </p>
+              </EuiText>
+            </div>
+          </EuiPopover>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+}

--- a/src-docs/src/views/text/text_color.js
+++ b/src-docs/src/views/text/text_color.js
@@ -13,7 +13,6 @@ export default () => (
     <EuiTitle>
       <h2>
         <EuiTextColor color="default">You </EuiTextColor>
-        <EuiTextColor color="primary">can </EuiTextColor>
         <EuiTextColor color="secondary">use </EuiTextColor>
         <EuiTextColor color="accent">it </EuiTextColor>
         <EuiTextColor color="warning">on </EuiTextColor>
@@ -32,11 +31,6 @@ export default () => (
       <p>
         <EuiTextColor color="subdued">
           Subdued text color
-        </EuiTextColor>
-      </p>
-      <p>
-        <EuiTextColor color="primary">
-          Primary text color
         </EuiTextColor>
       </p>
       <p>
@@ -70,7 +64,7 @@ export default () => (
 
     <EuiSpacer />
 
-    <EuiText color="primary">
+    <EuiText color="danger">
       <h2>Works on EuiText as well.</h2>
       <p>
         Sometimes you need to color entire blocks of text, no matter what is in them.

--- a/src/components/button/_index.scss
+++ b/src/components/button/_index.scss
@@ -16,6 +16,7 @@ $euiButtonColorDisabled: tintOrShade($euiTextColor, 70%, 80%);
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
+  vertical-align: middle;
 
   &:hover:not(:disabled) {
     transform: translateY(-1px);
@@ -41,6 +42,7 @@ $euiButtonColorDisabled: tintOrShade($euiTextColor, 70%, 80%);
 @mixin euiButtonContent($isReverse: false) {
   height: 100%;
   width: 100%;
+  vertical-align: middle;
 
   @if ($isReverse) {
     flex-direction: row-reverse;

--- a/src/components/flex/_flex_group.scss
+++ b/src/components/flex/_flex_group.scss
@@ -59,7 +59,7 @@ $gutterTypes: (
   align-items: center;
 }
 
-.euiFlexGroup--alignItemsEnd {
+.euiFlexGroup--alignItemsFlexEnd {
   align-items: flex-end;
 }
 

--- a/src/components/form/form_error_text/_form_error_text.scss
+++ b/src/components/form/form_error_text/_form_error_text.scss
@@ -1,5 +1,5 @@
 .euiFormErrorText {
-  font-size: $euiFontSizeXS;
+  @include euiFontSizeXS;
   padding: $euiSizeS 0;
   color: $euiColorDanger;
 }

--- a/src/components/form/form_help_text/_form_help_text.scss
+++ b/src/components/form/form_help_text/_form_help_text.scss
@@ -1,5 +1,5 @@
 .euiFormHelpText {
-  font-size: $euiFontSizeXS;
+  @include euiFontSizeXS;
   padding: $euiSizeS 0;
   color: $euiColorDarkShade;
 }

--- a/src/components/panel/_index.scss
+++ b/src/components/panel/_index.scss
@@ -1,1 +1,2 @@
+@import 'variables';
 @import 'panel';

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -1,14 +1,3 @@
-/**
- * Padding map referenced in:
- *  - Popover
-*/
-$euiPanelPaddingModifiers: (
-  "--paddingSmall": $euiSizeS,
-  "--paddingMedium": $euiSize,
-  "--paddingLarge": $euiSizeL
-) !default;
-
-
 .euiPanel {
   @include euiBottomShadowSmall;
 
@@ -18,7 +7,7 @@ $euiPanelPaddingModifiers: (
   flex-grow: 1;
 
   @each $modifier, $amount in $euiPanelPaddingModifiers {
-    &.euiPanel#{$modifier} {
+    &.euiPanel--#{$modifier} {
       padding: $amount;
     }
   }

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -17,17 +17,10 @@ $euiPanelPadding: (
   flex-grow: 1;
 
   @each $size, $amount in $euiPanelPadding {
-
     &.euiPanel--padding#{$size} {
       padding: $amount;
     }
-
   }
-
-
-
-
-
 
   &.euiPanel--shadow {
     @include euiBottomShadow;

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -1,3 +1,13 @@
+/** Padding map eferenced in:
+ *  - Popover
+*/
+$euiPanelPadding: (
+  "Small": $euiSizeS,
+  "Medium": $euiSize,
+  "Large": $euiSizeL
+) !default;
+
+
 .euiPanel {
   @include euiBottomShadowSmall;
 
@@ -6,17 +16,18 @@
   border-radius: $euiBorderRadius;
   flex-grow: 1;
 
-  &.euiPanel--paddingSmall {
-    padding: $euiSizeS;
+  @each $size, $amount in $euiPanelPadding {
+
+    &.euiPanel--padding#{$size} {
+      padding: $amount;
+    }
+
   }
 
-  &.euiPanel--paddingMedium {
-    padding: $euiSize;
-  }
 
-  &.euiPanel--paddingLarge {
-    padding: $euiSizeL;
-  }
+
+
+
 
   &.euiPanel--shadow {
     @include euiBottomShadow;

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -1,10 +1,11 @@
-/** Padding map eferenced in:
+/**
+ * Padding map referenced in:
  *  - Popover
 */
-$euiPanelPadding: (
-  "Small": $euiSizeS,
-  "Medium": $euiSize,
-  "Large": $euiSizeL
+$euiPanelPaddingModifiers: (
+  "--paddingSmall": $euiSizeS,
+  "--paddingMedium": $euiSize,
+  "--paddingLarge": $euiSizeL
 ) !default;
 
 
@@ -16,8 +17,8 @@ $euiPanelPadding: (
   border-radius: $euiBorderRadius;
   flex-grow: 1;
 
-  @each $size, $amount in $euiPanelPadding {
-    &.euiPanel--padding#{$size} {
+  @each $modifier, $amount in $euiPanelPaddingModifiers {
+    &.euiPanel#{$modifier} {
       padding: $amount;
     }
   }

--- a/src/components/panel/_variables.scss
+++ b/src/components/panel/_variables.scss
@@ -1,0 +1,9 @@
+/**
+ * Padding map referenced in:
+ *  - Popover
+*/
+$euiPanelPaddingModifiers: (
+  "paddingSmall": $euiSizeS,
+  "paddingMedium": $euiSize,
+  "paddingLarge": $euiSizeL
+) !default;

--- a/src/components/popover/_mixins.scss
+++ b/src/components/popover/_mixins.scss
@@ -2,4 +2,6 @@
   background-color: $euiColorLightestShade;
   border-bottom: $euiBorderThin;
   padding: $euiSizeM;
+  border-top-left-radius: $euiBorderRadius - 1;
+  border-top-right-radius: $euiBorderRadius - 1;
 }

--- a/src/components/popover/_mixins.scss
+++ b/src/components/popover/_mixins.scss
@@ -1,6 +1,5 @@
 @mixin euiPopoverTitle {
   background-color: $euiColorLightestShade;
-  border-bottom: $euiBorderThin;
   padding: $euiSizeM;
   border-top-left-radius: $euiBorderRadius - 1;
   border-top-right-radius: $euiBorderRadius - 1;

--- a/src/components/popover/_mixins.scss
+++ b/src/components/popover/_mixins.scss
@@ -1,6 +1,9 @@
 @mixin euiPopoverTitle {
   background-color: $euiColorLightestShade;
   padding: $euiSizeM;
-  border-top-left-radius: $euiBorderRadius - 1;
-  border-top-right-radius: $euiBorderRadius - 1;
+
+  // Subtract 1px from the border radius since it's inside another container that also has the border radius
+  // -- makes for better rounded corners
+  border-top-left-radius: $euiBorderRadius - 1px;
+  border-top-right-radius: $euiBorderRadius - 1px;
 }

--- a/src/components/popover/_popover_title.scss
+++ b/src/components/popover/_popover_title.scss
@@ -1,3 +1,5 @@
+@import '../panel/panel'; // grab the $euiPanelPaddingModifiers map
+
 .euiPopoverTitle {
   @include euiPopoverTitle;
 

--- a/src/components/popover/_popover_title.scss
+++ b/src/components/popover/_popover_title.scss
@@ -5,8 +5,8 @@
   // ensure the title expands to cover that padding and
   // take on the same amount of padding horizontally
 
-  @each $size, $amount in $euiPanelPadding {
-    .euiPopover__panel.euiPanel--padding#{$size} & {
+  @each $modifier, $amount in $euiPanelPaddingModifiers {
+    .euiPopover__panel.euiPanel#{$modifier} & {
       padding: $euiSizeM $amount;
       margin: ($amount * -1) ($amount * -1) $amount;
     }

--- a/src/components/popover/_popover_title.scss
+++ b/src/components/popover/_popover_title.scss
@@ -1,4 +1,4 @@
-@import '../panel/panel'; // grab the $euiPanelPaddingModifiers map
+@import '../panel/variables'; // grab the $euiPanelPaddingModifiers map
 
 .euiPopoverTitle {
   @include euiPopoverTitle;
@@ -8,7 +8,7 @@
   // take on the same amount of padding horizontally
 
   @each $modifier, $amount in $euiPanelPaddingModifiers {
-    .euiPopover__panel.euiPanel#{$modifier} & {
+    .euiPopover__panel.euiPanel--#{$modifier} & {
       padding: $euiSizeM $amount;
       margin: ($amount * -1) ($amount * -1) $amount;
     }

--- a/src/components/popover/_popover_title.scss
+++ b/src/components/popover/_popover_title.scss
@@ -1,3 +1,15 @@
 .euiPopoverTitle {
   @include euiPopoverTitle;
+
+  // If the popover's containing panel has padding applied,
+  // ensure the title expands to cover that padding and
+  // take on the same amount of padding horizontally
+
+  @each $size, $amount in $euiPanelPadding {
+    .euiPopover__panel.euiPanel--padding#{$size} & {
+      padding: $euiSizeM $amount;
+      margin: ($amount * -1) ($amount * -1) $amount;
+    }
+  }
+
 }

--- a/src/components/text/_text_color.scss
+++ b/src/components/text/_text_color.scss
@@ -2,7 +2,6 @@
 $textColors: (
   default: $euiTextColor,
   subdued: $euiColorDarkShade,
-  primary: $euiColorPrimary,
   secondary: $euiColorSecondary,
   accent: $euiColorAccent,
   warning: $euiColorWarning,

--- a/src/components/text/text_color.js
+++ b/src/components/text/text_color.js
@@ -5,7 +5,6 @@ import classNames from 'classnames';
 const colorsToClassNameMap = {
   'default': 'euiTextColor--default',
   'subdued': 'euiTextColor--subdued',
-  'primary': 'euiTextColor--primary',
   'secondary': 'euiTextColor--secondary',
   'accent': 'euiTextColor--accent',
   'danger': 'euiTextColor--danger',


### PR DESCRIPTION
## Takeaway ##
Popovers with titles no longer require padding to be manually added to the popover's child that follows the title.

## Solution ##
The panel's padding is still applied to the entire popover. Based on the panel padding class applied to the popover, ie `.euiPanel--paddingMedium`, the title has negative margins to expand  to cover that padding amount.

The popover's title also adjusts the horizontal padding to match so that the content and the title align horizontally.

The popover's title always has some padding and only the content's padding is affected by the "none" padding property on the panel.

## Design ##
I, personally, feel that borders around shading are duplicative and noisy, so I also removed the bottom border from the title. I can easily change back if others disagree.

## Screenshots ##
<img width="376" alt="screen shot 2017-12-20 at 19 25 37 pm" src="https://user-images.githubusercontent.com/549577/34234843-b9eb09b2-e5bb-11e7-8e0d-d6f658074aea.png">
<img width="377" alt="screen shot 2017-12-20 at 19 25 43 pm" src="https://user-images.githubusercontent.com/549577/34234844-b9f2cf8a-e5bb-11e7-9ed6-396dcd6456e0.png">
<img width="379" alt="screen shot 2017-12-20 at 19 25 47 pm" src="https://user-images.githubusercontent.com/549577/34234845-b9f9fa76-e5bb-11e7-8f3e-da3d7bffc351.png">
<img width="346" alt="screen shot 2017-12-20 at 19 25 51 pm" src="https://user-images.githubusercontent.com/549577/34234846-ba01f1fe-e5bb-11e7-9f92-3a9f215ccf93.png">

