### PR TITLE
Update release scripts to push to upstream instead of origin.

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,6 +8,6 @@ npm test
 npm run build
 npm run sync-docs
 npm version $BUMP
-git push --tags
-git push
+git push upstream --tags
+git push upstream
 npm publish


### PR DESCRIPTION
I think our common set up is to fork a repo and have the `origin` remote pointing to the fork and `upstream` pointing to the original. The way the script is currently written results in a divergence between the fork and the original because the new release only gets pushed to the fork, but it should be pushed to the original.