### PR TITLE
Give help / error text proper line-height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ No public interface changes since `0.0.8`.
 **Bug fixes**
 
 - Fix button vertical alignment. [(#232)](https://github.com/elastic/eui/pull/232)
+- Give help / error text proper line-height. [(#234)](https://github.com/elastic/eui/pull/234)
 
 # [`0.0.7`](https://github.com/elastic/eui/tree/v0.0.7)
 

--- a/src/components/form/form_error_text/_form_error_text.scss
+++ b/src/components/form/form_error_text/_form_error_text.scss
@@ -1,5 +1,5 @@
 .euiFormErrorText {
-  font-size: $euiFontSizeXS;
+  @include euiFontSizeXS;
   padding: $euiSizeS 0;
   color: $euiColorDanger;
 }

--- a/src/components/form/form_help_text/_form_help_text.scss
+++ b/src/components/form/form_help_text/_form_help_text.scss
@@ -1,5 +1,5 @@
 .euiFormHelpText {
-  font-size: $euiFontSizeXS;
+  @include euiFontSizeXS;
   padding: $euiSizeS 0;
   color: $euiColorDarkShade;
 }


### PR DESCRIPTION
Use the mixins to generate help / error text in forms so that they have proper line-height.