### PR TITLE
Only show error messages if the form row is invalid

### DIFF
--- a/src/components/form/form_row/__snapshots__/form_row.test.js.snap
+++ b/src/components/form/form_row/__snapshots__/form_row.test.js.snap
@@ -196,6 +196,16 @@ exports[`EuiFormRow props error as string is rendered 1`] = `
 </div>
 `;
 
+exports[`EuiFormRow props error is not rendered if isInvalid is false 1`] = `
+<div
+  class="euiFormRow"
+>
+  <input
+    id="generated-id"
+  />
+</div>
+`;
+
 exports[`EuiFormRow props fullWidth is rendered 1`] = `
 <div
   class="euiFormRow euiFormRow--fullWidth"

--- a/src/components/form/form_row/form_row.js
+++ b/src/components/form/form_row/form_row.js
@@ -86,7 +86,7 @@ export class EuiFormRow extends Component {
 
     let optionalErrors;
 
-    if (error) {
+    if (error && isInvalid) {
       const errorTexts = Array.isArray(error) ? error : [error];
       optionalErrors = errorTexts.map((error, i) => (
         <EuiFormErrorText key={error} id={`${id}-error-${i}`} className="euiFormRow__text">

--- a/src/components/form/form_row/form_row.test.js
+++ b/src/components/form/form_row/form_row.test.js
@@ -23,6 +23,7 @@ describe('EuiFormRow', () => {
     const props = {
       label: `Label`,
       helpText: `Help text`,
+      isInvalid: true,
       error: [
         `Error one`,
         `Error two`
@@ -83,7 +84,7 @@ describe('EuiFormRow', () => {
 
     test('error as string is rendered', () => {
       const component = render(
-        <EuiFormRow error="Error">
+        <EuiFormRow error="Error" isInvalid={true}>
           <input/>
         </EuiFormRow>
       );
@@ -94,7 +95,7 @@ describe('EuiFormRow', () => {
 
     test('error as array is rendered', () => {
       const component = render(
-        <EuiFormRow error={['Error', 'Error2']}>
+        <EuiFormRow error={['Error', 'Error2']} isInvalid={true}>
           <input/>
         </EuiFormRow>
       );

--- a/src/components/form/form_row/form_row.test.js
+++ b/src/components/form/form_row/form_row.test.js
@@ -104,6 +104,17 @@ describe('EuiFormRow', () => {
         .toMatchSnapshot();
     });
 
+    test('error is not rendered if isInvalid is false', () => {
+      const component = render(
+        <EuiFormRow error={['Error']} isInvalid={false}>
+          <input/>
+        </EuiFormRow>
+      );
+
+      expect(component)
+        .toMatchSnapshot();
+    });
+
     test('helpText is rendered', () => {
       const component = render(
         <EuiFormRow helpText={<span>This is help text.</span>}>


### PR DESCRIPTION
This PR ensures we only show form row errors if `isInvalid:true`. Right now, they show all the time.