### PR TITLE
Indeterminate checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Updated `euiPopover` to propagate `panelPaddingSize` padding values to content only (title does inherit horizontal values) via CSS. [(#229)](https://github.com/elastic/eui/pull/229)
 - Updated `<EuiErrorBoundary>` to preserve newlines in error. [(#238)[https://github.com/elastic/eui/pull/238]]
 - Added `EuiFlyout` component. [(#227)](https://github.com/elastic/eui/pull/227)
+- Added `indeterminate` prop and styling to checkboxes. [(#245)](https://github.com/elastic/eui/pull/245)
 
 **Breaking changes**
 

--- a/src-docs/src/views/form/form_controls.js
+++ b/src-docs/src/views/form/form_controls.js
@@ -30,7 +30,7 @@ export default class extends Component {
       isSwitchChecked: false,
       checkboxes: [{
         id: `${idPrefix}0`,
-        label: 'Option one',
+        label: 'Option one is an indeterminate checkbox',
       }, {
         id: `${idPrefix}1`,
         label: 'Option two is checked by default',
@@ -40,6 +40,9 @@ export default class extends Component {
       }],
       checkboxIdToSelectedMap: {
         [`${idPrefix}1`]: true,
+      },
+      checkboxIdToIndeterminateMap: {
+        [`${idPrefix}0`]: true,
       },
       radios: [{
         id: `${idPrefix}4`,
@@ -148,6 +151,7 @@ export default class extends Component {
 
         <EuiCheckboxGroup
           options={this.state.checkboxes}
+          idToIndeterminateMap={this.state.checkboxIdToIndeterminateMap}
           idToSelectedMap={this.state.checkboxIdToSelectedMap}
           onChange={this.onCheckboxChange}
         />

--- a/src/components/form/checkbox/_checkbox.scss
+++ b/src/components/form/checkbox/_checkbox.scss
@@ -52,6 +52,7 @@
     &:disabled:not(:checked) ~ .euiCheckbox__square {
       background-color: $euiColorLightestShade;
     }
+
   }
 
   .euiCheckbox__square {
@@ -92,5 +93,9 @@
       height: $euiSize;
       width: $euiSize;
     }
+  }
+
+  &.euiCheckbox--indeterminate  .euiCheckbox__square {
+    background: linear-gradient(to right bottom, $euiFormBackgroundColor 50%, $euiColorPrimary 50%);
   }
 }

--- a/src/components/form/checkbox/checkbox.js
+++ b/src/components/form/checkbox/checkbox.js
@@ -12,6 +12,7 @@ export const EuiCheckbox = ({
   className,
   id,
   checked,
+  indeterminate,
   label,
   onChange,
   type,
@@ -21,6 +22,9 @@ export const EuiCheckbox = ({
   const classes = classNames(
     'euiCheckbox',
     typeToClassNameMap[type],
+    {
+      'euiCheckbox--indeterminate': indeterminate,
+    },
     className
   );
 

--- a/src/components/form/checkbox/checkbox_group.js
+++ b/src/components/form/checkbox/checkbox_group.js
@@ -6,6 +6,7 @@ import { EuiCheckbox } from './checkbox';
 export const EuiCheckboxGroup = ({
   options,
   idToSelectedMap,
+  idToIndeterminateMap,
   onChange,
   className,
   disabled,
@@ -13,12 +14,18 @@ export const EuiCheckboxGroup = ({
 }) => (
   <div className={className} {...rest}>
     {options.map((option, index) => {
+      let optionalIndeterminateId;
+      if (idToIndeterminateMap) {
+        optionalIndeterminateId = idToIndeterminateMap[option.id];
+      }
+
       return (
         <EuiCheckbox
           className="euiCheckboxGroup__item"
           key={index}
           id={option.id}
           checked={idToSelectedMap[option.id]}
+          indeterminate={optionalIndeterminateId}
           label={option.label}
           disabled={disabled}
           onChange={onChange.bind(null, option.id)}


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/239

An [indeterminate state](https://css-tricks.com/indeterminate-checkboxes/) for checkboxes on request of @uboness. From what I've read on the subject this is a purely visual thing, and there is not an HTML attribute to correspond with it. I set it up as a prop on both checkbox group and checkbox. The "checked" state will overwrite it.

This would more than likely be used in the top of paginated tables to denote that some, but not all elements in a table are selected. Likely you will also want to spell that out as well... "3 things selected"...etc.

Also note that the styling of these things is different from browser to browser. I decided to stray from the "-" style, because I think with our styling it wouldn't read, and a half filled option gives a better "partial" read.

![image](https://user-images.githubusercontent.com/324519/34306862-3655b260-e6fa-11e7-844b-a9424b57992f.png)


