### PR TITLE
Apply additional props to checkbox/switch inputs rather than wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Fix bug in `Pager` service which occurred when there were no items. [(#237)[https://github.com/elastic/eui/pull/237]]
 - Add `isPageable` method to `Pager` service and set first and last page index to -1 when there are no pages. [(#242)[https://github.com/elastic/eui/pull/242]]
+- Apply additional props to checkbox/switch inputs rather than wrappers. [(#246)](https://github.com/elastic/eui/pull/246)
 
 # [`0.0.9`](https://github.com/elastic/eui/tree/v0.0.9)
 

--- a/src/components/form/checkbox/__snapshots__/checkbox.test.js.snap
+++ b/src/components/form/checkbox/__snapshots__/checkbox.test.js.snap
@@ -2,12 +2,12 @@
 
 exports[`EuiCheckbox is rendered 1`] = `
 <div
-  aria-label="aria-label"
   class="euiCheckbox testClass1 testClass2"
-  data-test-subj="test subject string"
 >
   <input
+    aria-label="aria-label"
     class="euiCheckbox__input"
+    data-test-subj="test subject string"
     id="id"
     type="checkbox"
   />

--- a/src/components/form/checkbox/checkbox.js
+++ b/src/components/form/checkbox/checkbox.js
@@ -40,7 +40,6 @@ export const EuiCheckbox = ({
   return (
     <div
       className={classes}
-      {...rest}
     >
       <input
         className="euiCheckbox__input"
@@ -49,6 +48,7 @@ export const EuiCheckbox = ({
         checked={checked}
         onChange={onChange}
         disabled={disabled}
+        {...rest}
       />
 
       <div className="euiCheckbox__square">

--- a/src/components/form/switch/__snapshots__/switch.test.js.snap
+++ b/src/components/form/switch/__snapshots__/switch.test.js.snap
@@ -2,12 +2,12 @@
 
 exports[`EuiSwitch is rendered 1`] = `
 <div
-  aria-label="aria-label"
   class="euiSwitch testClass1 testClass2"
-  data-test-subj="test subject string"
 >
   <input
+    aria-label="aria-label"
     class="euiSwitch__input"
+    data-test-subj="test subject string"
     type="checkbox"
   />
   <span

--- a/src/components/form/switch/switch.js
+++ b/src/components/form/switch/switch.js
@@ -17,7 +17,7 @@ export const EuiSwitch = ({
   const classes = classNames('euiSwitch', className);
 
   return (
-    <div className={classes} {...rest}>
+    <div className={classes}>
       <input
         className="euiSwitch__input"
         name={name}
@@ -26,6 +26,7 @@ export const EuiSwitch = ({
         checked={checked}
         disabled={disabled}
         onChange={onChange}
+        {...rest}
       />
 
       <span className="euiSwitch__body">


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/225

Passes `{rest}` onto the inputs themselves rather than the wrappers. Ran some quick tests to make sure we weren't using those props against the wrappers. This is how we pass it to our text based inputs as well.