### PR TITLE
Fix responsive flex group margins

### DIFF
--- a/src/components/flex/_flex_group.scss
+++ b/src/components/flex/_flex_group.scss
@@ -70,5 +70,7 @@ $gutterTypes: (
 @include screenXSmall {
   .euiFlexGroup--responsive {
     flex-wrap: wrap;
+    margin-left: 0;
+    margin-right: 0;
   }
 }

--- a/src/components/flex/_flex_item.scss
+++ b/src/components/flex/_flex_item.scss
@@ -27,6 +27,7 @@
     width: 100% !important;
     flex-basis: 100% !important;
     margin-left: 0 !important;
+    margin-right: 0 !important;
     margin-bottom: $euiSize !important;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/247

Negative horizontal margins need to be cleared when flex groups become responsive.

![image](https://user-images.githubusercontent.com/324519/34309143-616c98be-e705-11e7-8e38-65e7e763e6bc.png)
