### PR TITLE
Appending '-row' to form-row id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Clicking the downArrow icon in `EuiSelect` now triggers selection. [(#237)[https://github.com/elastic/eui/pull/255]]
+- Fixed `euiFormRow` id's from being the same as the containing input and label. [(#251)[https://github.com/elastic/eui/pull/251]]
 
 **Breaking changes**
 
@@ -23,7 +24,6 @@
 
 - Fix bug in `Pager` service which occurred when there were no items. [(#237)[https://github.com/elastic/eui/pull/237]]
 - Add `isPageable` method to `Pager` service and set first and last page index to -1 when there are no pages. [(#242)[https://github.com/elastic/eui/pull/242]]
-- Fixed `euiFormRow` id's from being the same as the containing input and label. [(#251)[https://github.com/elastic/eui/pull/251]]
 
 # [`0.0.9`](https://github.com/elastic/eui/tree/v0.0.9)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 - Fix bug in `Pager` service which occurred when there were no items. [(#237)[https://github.com/elastic/eui/pull/237]]
 - Add `isPageable` method to `Pager` service and set first and last page index to -1 when there are no pages. [(#242)[https://github.com/elastic/eui/pull/242]]
+- Fixed `euiFormRow` id's from being the same as the containing input and label. [(#251)[https://github.com/elastic/eui/pull/251]]
 
 # [`0.0.9`](https://github.com/elastic/eui/tree/v0.0.9)
 

--- a/src-docs/src/views/accordion/accordion_form.js
+++ b/src-docs/src/views/accordion/accordion_form.js
@@ -17,21 +17,17 @@ import {
   EuiButtonIcon,
 } from '../../../../src/components';
 
-function makeId() {
-  return Math.random().toString(36).substr(2, 5);
-}
-
 const repeatableForm = (
   <EuiForm>
     <EuiFlexGroup>
       <EuiFlexItem>
-        <EuiFormRow label="Username"  id={makeId()}>
+        <EuiFormRow label="Username">
           <EuiFieldText icon="user" placeholder="John" />
         </EuiFormRow>
       </EuiFlexItem>
 
       <EuiFlexItem>
-        <EuiFormRow label="Password" id={makeId()} helpText="Must include one number and one symbol">
+        <EuiFormRow label="Password" helpText="Must include one number and one symbol">
           <EuiFieldPassword icon="lock" />
         </EuiFormRow>
       </EuiFlexItem>
@@ -39,7 +35,7 @@ const repeatableForm = (
 
     <EuiSpacer size="m" />
 
-    <EuiFormRow label="Body" id={makeId()}>
+    <EuiFormRow label="Body">
       <EuiTextArea placeholder="I am a textarea, put some content in me!" />
     </EuiFormRow>
   </EuiForm>

--- a/src-docs/src/views/form/disabled.js
+++ b/src-docs/src/views/form/disabled.js
@@ -15,10 +15,7 @@ import {
   EuiTextArea,
 } from '../../../../src/components';
 
-// Don't use this, make proper ids instead. This is just for the example.
-function makeId() {
-  return Math.random().toString(36).substr(2, 5);
-}
+import makeId from '../../../../src/components/form/form_row/make_id';
 
 export default class extends Component {
   constructor(props) {

--- a/src-docs/src/views/form/form_controls.js
+++ b/src-docs/src/views/form/form_controls.js
@@ -15,10 +15,7 @@ import {
   EuiTextArea,
 } from '../../../../src/components';
 
-// Don't use this, make proper ids instead. This is just for the example.
-function makeId() {
-  return Math.random().toString(36).substr(2, 5);
-}
+import makeId from '../../../../src/components/form/form_row/make_id';
 
 export default class extends Component {
   constructor(props) {

--- a/src-docs/src/views/form/form_full_width.js
+++ b/src-docs/src/views/form/form_full_width.js
@@ -11,11 +11,6 @@ import {
   EuiButton,
 } from '../../../../src/components';
 
-// Don't use this, make proper ids instead. This is just for the example.
-function makeId() {
-  return Math.random().toString(36).substr(2, 5);
-}
-
 export default () => (
   <div>
     <EuiFlexGroup>
@@ -30,7 +25,6 @@ export default () => (
     <EuiSpacer size="l" />
 
     <EuiFormRow
-      id={makeId()}
       label="Works on form rows too"
       fullWidth
       helpText="Note that fullWidth prop is passed to both the row and the child in this example"
@@ -43,7 +37,6 @@ export default () => (
       />
     </EuiFormRow>
     <EuiFormRow
-      id={makeId()}
       label="Often useful for text areas"
       fullWidth
       helpText="Again, passed to both the row and the textarea."

--- a/src-docs/src/views/form/form_popover.js
+++ b/src-docs/src/views/form/form_popover.js
@@ -12,9 +12,7 @@ import {
   EuiFieldText,
 } from '../../../../src/components';
 
-function makeId() {
-  return Math.random().toString(36).substr(2, 5);
-}
+import makeId from '../../../../src/components/form/form_row/make_id';
 
 export default class extends Component {
   constructor(props) {
@@ -69,14 +67,12 @@ export default class extends Component {
         </EuiFormRow>
 
         <EuiFormRow
-          id={makeId()}
           label="A text field"
         >
           <EuiFieldText name="popfirst" />
         </EuiFormRow>
 
         <EuiFormRow
-          id={makeId()}
           label="Range"
           helpText="Some help text for the range"
         >

--- a/src-docs/src/views/form/form_rows.js
+++ b/src-docs/src/views/form/form_rows.js
@@ -17,10 +17,7 @@ import {
   EuiTextArea,
 } from '../../../../src/components';
 
-// Don't use this, make proper ids instead. This is just for the example.
-function makeId() {
-  return Math.random().toString(36).substr(2, 5);
-}
+import makeId from '../../../../src/components/form/form_row/make_id';
 
 export default class extends Component {
   constructor(props) {
@@ -83,7 +80,6 @@ export default class extends Component {
     return (
       <EuiForm>
         <EuiFormRow
-          id={makeId()}
           label="Text field"
           helpText="I am some friendly help text."
         >
@@ -91,7 +87,6 @@ export default class extends Component {
         </EuiFormRow>
 
         <EuiFormRow
-          id={makeId()}
           label="Text field with icon"
         >
           <EuiFieldText
@@ -101,7 +96,6 @@ export default class extends Component {
         </EuiFormRow>
 
         <EuiFormRow
-          id={makeId()}
           label="Number field"
           helpText="Any number between 1 and 5"
         >
@@ -113,14 +107,12 @@ export default class extends Component {
         </EuiFormRow>
 
         <EuiFormRow
-          id={makeId()}
           label="Password"
         >
           <EuiFieldPassword defaultValue="password" />
         </EuiFormRow>
 
         <EuiFormRow
-          id={makeId()}
           label="Search"
         >
           <EuiFieldSearch />
@@ -128,14 +120,12 @@ export default class extends Component {
 
         <EuiFormRow
           label="Text area"
-          id={makeId()}
         >
           <EuiTextArea name="textarea"/>
         </EuiFormRow>
 
         <EuiFormRow
           label="Select"
-          id={makeId()}
         >
           <EuiSelect
             options={[
@@ -147,7 +137,6 @@ export default class extends Component {
         </EuiFormRow>
 
         <EuiFormRow
-          id={makeId()}
           label="Range"
         >
           <EuiRange
@@ -163,7 +152,7 @@ export default class extends Component {
         >
           <EuiSwitch
             name="switch"
-            id={makeId()}
+
             label="Should we do this?"
             checked={this.state.isSwitchChecked}
             onChange={this.onSwitchChange}
@@ -171,7 +160,6 @@ export default class extends Component {
         </EuiFormRow>
 
         <EuiFormRow
-          id={makeId()}
           label="Checkboxes"
         >
           <EuiCheckboxGroup

--- a/src-docs/src/views/form/inline_form.js
+++ b/src-docs/src/views/form/inline_form.js
@@ -8,21 +8,15 @@ import {
   EuiFieldText,
 } from '../../../../src/components/';
 
-function makeId() {
-  return Math.random().toString(36).substr(2, 5);
-}
-
-const idPrefix = makeId();
-
 export default () => (
   <EuiFlexGroup style={{ maxWidth: 600 }}>
     <EuiFlexItem>
-      <EuiFormRow label="First name"  id={idPrefix} helpText="I am helpful help text!">
+      <EuiFormRow label="First name" helpText="I am helpful help text!">
         <EuiFieldText />
       </EuiFormRow>
     </EuiFlexItem>
     <EuiFlexItem>
-      <EuiFormRow label="Last name" id={idPrefix}>
+      <EuiFormRow label="Last name">
         <EuiFieldText />
       </EuiFormRow>
     </EuiFlexItem>

--- a/src-docs/src/views/form/inline_form_popover.js
+++ b/src-docs/src/views/form/inline_form_popover.js
@@ -14,12 +14,6 @@ import {
 
 } from '../../../../src/components';
 
-function makeId() {
-  return Math.random().toString(36).substr(2, 5);
-}
-
-const idPrefix = makeId();
-
 export default class extends Component {
   constructor(props) {
     super(props);
@@ -64,12 +58,12 @@ export default class extends Component {
       <EuiForm>
         <EuiFlexGroup>
           <EuiFlexItem grow={false} style={{ width: 100 }}>
-            <EuiFormRow label="Age"  id={idPrefix}>
+            <EuiFormRow label="Age">
               <EuiFieldNumber max={10} placeholder={42} />
             </EuiFormRow>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiFormRow label="Full name" id={idPrefix}>
+            <EuiFormRow label="Full name">
               <EuiFieldText icon="user" placeholder="John Doe" />
             </EuiFormRow>
           </EuiFlexItem>

--- a/src-docs/src/views/form/inline_form_sizing.js
+++ b/src-docs/src/views/form/inline_form_sizing.js
@@ -9,21 +9,15 @@ import {
   EuiFieldNumber,
 } from '../../../../src/components/';
 
-function makeId() {
-  return Math.random().toString(36).substr(2, 5);
-}
-
-const idPrefix = makeId();
-
 export default () => (
   <EuiFlexGroup style={{ maxWidth: 600 }}>
     <EuiFlexItem grow={false} style={{ width: 100 }}>
-      <EuiFormRow label="Age"  id={idPrefix}>
+      <EuiFormRow label="Age">
         <EuiFieldNumber max={10} placeholder={42} />
       </EuiFormRow>
     </EuiFlexItem>
     <EuiFlexItem>
-      <EuiFormRow label="Full name" id={idPrefix}>
+      <EuiFormRow label="Full name">
         <EuiFieldText icon="user" placeholder="John Doe" />
       </EuiFormRow>
     </EuiFlexItem>

--- a/src-docs/src/views/form/validation.js
+++ b/src-docs/src/views/form/validation.js
@@ -11,10 +11,6 @@ import {
   EuiFieldText,
 } from '../../../../src/components';
 
-function makeId() {
-  return Math.random().toString(36).substr(2, 5);
-}
-
 export default class extends Component {
   constructor(props) {
     super(props);
@@ -53,7 +49,6 @@ export default class extends Component {
           error={errors}
         >
           <EuiFormRow
-            id={makeId()}
             label="Validation only"
             isInvalid={this.state.showErrors}
           >
@@ -64,7 +59,6 @@ export default class extends Component {
           </EuiFormRow>
 
           <EuiFormRow
-            id={makeId()}
             label="Validation with help text and errors"
             helpText="I am some friendly help text."
             isInvalid={this.state.showErrors}
@@ -77,7 +71,6 @@ export default class extends Component {
           </EuiFormRow>
 
           <EuiFormRow
-            id={makeId()}
             label="Text area"
             isInvalid={this.state.showErrors}
           >

--- a/src-docs/src/views/modal/modal.js
+++ b/src-docs/src/views/modal/modal.js
@@ -18,9 +18,7 @@ import {
   EuiSwitch,
 } from '../../../../src/components';
 
-function makeId() {
-  return Math.random().toString(36).substr(2, 5);
-}
+import makeId from '../../../../src/components/form/form_row/make_id';
 
 export class Modal extends Component {
   constructor(props) {
@@ -63,14 +61,12 @@ export class Modal extends Component {
         </EuiFormRow>
 
         <EuiFormRow
-          id={makeId()}
           label="A text field"
         >
           <EuiFieldText name="popfirst" />
         </EuiFormRow>
 
         <EuiFormRow
-          id={makeId()}
           label="Range"
           helpText="Some help text for the range"
         >

--- a/src/components/form/form_row/__snapshots__/form_row.test.js.snap
+++ b/src/components/form/form_row/__snapshots__/form_row.test.js.snap
@@ -12,6 +12,7 @@ exports[`EuiFormRow behavior onBlur is called in child 1`] = `
 >
   <div
     className="euiFormRow"
+    id="generated-id-row"
   >
     <EuiFormLabel
       htmlFor="generated-id"
@@ -48,6 +49,7 @@ exports[`EuiFormRow behavior onBlur works in parent even if not in child 1`] = `
 >
   <div
     className="euiFormRow"
+    id="generated-id-row"
   >
     <EuiFormLabel
       htmlFor="generated-id"
@@ -84,6 +86,7 @@ exports[`EuiFormRow behavior onFocus is called in child 1`] = `
 >
   <div
     className="euiFormRow"
+    id="generated-id-row"
   >
     <EuiFormLabel
       htmlFor="generated-id"
@@ -120,6 +123,7 @@ exports[`EuiFormRow behavior onFocus works in parent even if not in child 1`] = 
 >
   <div
     className="euiFormRow"
+    id="generated-id-row"
   >
     <EuiFormLabel
       htmlFor="generated-id"
@@ -149,6 +153,7 @@ exports[`EuiFormRow is rendered 1`] = `
   aria-label="aria-label"
   class="euiFormRow testClass1 testClass2"
   data-test-subj="test subject string"
+  id="generated-id-row"
 >
   <input
     id="generated-id"
@@ -159,6 +164,7 @@ exports[`EuiFormRow is rendered 1`] = `
 exports[`EuiFormRow props error as array is rendered 1`] = `
 <div
   class="euiFormRow"
+  id="generated-id-row"
 >
   <input
     aria-describedby="generated-id-error-0 generated-id-error-1"
@@ -182,6 +188,7 @@ exports[`EuiFormRow props error as array is rendered 1`] = `
 exports[`EuiFormRow props error as string is rendered 1`] = `
 <div
   class="euiFormRow"
+  id="generated-id-row"
 >
   <input
     aria-describedby="generated-id-error-0"
@@ -199,6 +206,7 @@ exports[`EuiFormRow props error as string is rendered 1`] = `
 exports[`EuiFormRow props error is not rendered if isInvalid is false 1`] = `
 <div
   class="euiFormRow"
+  id="generated-id-row"
 >
   <input
     id="generated-id"
@@ -209,6 +217,7 @@ exports[`EuiFormRow props error is not rendered if isInvalid is false 1`] = `
 exports[`EuiFormRow props fullWidth is rendered 1`] = `
 <div
   class="euiFormRow euiFormRow--fullWidth"
+  id="generated-id-row"
 >
   <input
     id="generated-id"
@@ -219,6 +228,7 @@ exports[`EuiFormRow props fullWidth is rendered 1`] = `
 exports[`EuiFormRow props hasEmptyLabelSpace is rendered 1`] = `
 <div
   class="euiFormRow euiFormRow--hasEmptyLabelSpace"
+  id="generated-id-row"
 >
   <input
     id="generated-id"
@@ -229,6 +239,7 @@ exports[`EuiFormRow props hasEmptyLabelSpace is rendered 1`] = `
 exports[`EuiFormRow props helpText is rendered 1`] = `
 <div
   class="euiFormRow"
+  id="generated-id-row"
 >
   <input
     aria-describedby="generated-id-help"
@@ -248,7 +259,7 @@ exports[`EuiFormRow props helpText is rendered 1`] = `
 exports[`EuiFormRow props id is rendered 1`] = `
 <div
   class="euiFormRow"
-  id="id"
+  id="id-row"
 >
   <input
     id="id"
@@ -259,6 +270,7 @@ exports[`EuiFormRow props id is rendered 1`] = `
 exports[`EuiFormRow props isInvalid is rendered 1`] = `
 <div
   class="euiFormRow"
+  id="generated-id-row"
 >
   <label
     class="euiFormLabel euiFormLabel-isInvalid"
@@ -275,6 +287,7 @@ exports[`EuiFormRow props isInvalid is rendered 1`] = `
 exports[`EuiFormRow props label is rendered 1`] = `
 <div
   className="euiFormRow"
+  id="generated-id-row"
 >
   <EuiFormLabel
     htmlFor="generated-id"

--- a/src/components/form/form_row/form_row.js
+++ b/src/components/form/form_row/form_row.js
@@ -133,6 +133,7 @@ export class EuiFormRow extends Component {
       <div
         className={classes}
         {...rest}
+        id={`${id}-row`}
       >
         {optionalLabel}
         {field}


### PR DESCRIPTION
### Fixes #224 

<img width="753" alt="screen shot 2017-12-22 at 15 42 03 pm" src="https://user-images.githubusercontent.com/549577/34311994-e8891dda-e72e-11e7-81a9-a8012014abac.png">

### Also updated form examples to:
- remove any duplicative `makeId()` function constructors
- remove `makeId()` from form-row id’s as form-rows will automatically use that function to create id’s
- made sure to import the `makeId` function if needed (like when creating id’s for radio/checkbox groups)