### PR TITLE
Proper classname for flexGroup alignItems prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Bug fixes**
 
-- Proper classname for flexGroup alignItems prop. [(#256)[https://github.com/elastic/eui/pull/256]]
+- Proper classname for flexGroup alignItems prop. [(#257)[https://github.com/elastic/eui/pull/257]]
 - Clicking the downArrow icon in `EuiSelect` now triggers selection. [(#255)[https://github.com/elastic/eui/pull/255]]
 - Fixed `euiFormRow` id's from being the same as the containing input and label. [(#251)[https://github.com/elastic/eui/pull/251]]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 **Bug fixes**
 
-- Clicking the downArrow icon in `EuiSelect` now triggers selection. [(#237)[https://github.com/elastic/eui/pull/255]]
+- Proper classname for flexGroup alignItems prop. [(#256)[https://github.com/elastic/eui/pull/256]]
+- Clicking the downArrow icon in `EuiSelect` now triggers selection. [(#255)[https://github.com/elastic/eui/pull/255]]
 - Fixed `euiFormRow` id's from being the same as the containing input and label. [(#251)[https://github.com/elastic/eui/pull/251]]
 
 **Breaking changes**

--- a/src/components/flex/__snapshots__/flex_group.test.js.snap
+++ b/src/components/flex/__snapshots__/flex_group.test.js.snap
@@ -20,13 +20,13 @@ exports[`EuiFlexGroup props alignItems center is rendered 1`] = `
 
 exports[`EuiFlexGroup props alignItems flexEnd is rendered 1`] = `
 <div
-  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsEnd euiFlexGroup--responsive"
+  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexEnd euiFlexGroup--responsive"
 />
 `;
 
 exports[`EuiFlexGroup props alignItems flexStart is rendered 1`] = `
 <div
-  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsStart euiFlexGroup--responsive"
+  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexStart euiFlexGroup--responsive"
 />
 `;
 

--- a/src/components/flex/flex_group.js
+++ b/src/components/flex/flex_group.js
@@ -15,8 +15,8 @@ export const GUTTER_SIZES = Object.keys(gutterSizeToClassNameMap);
 
 const alignItemsToClassNameMap = {
   stretch: null,
-  flexStart: 'euiFlexGroup--alignItemsStart',
-  flexEnd: 'euiFlexGroup--alignItemsEnd',
+  flexStart: 'euiFlexGroup--alignItemsFlexStart',
+  flexEnd: 'euiFlexGroup--alignItemsFlexEnd',
   center: 'euiFlexGroup--alignItemsCenter',
 };
 


### PR DESCRIPTION
The class being used in the component was not the one being used in the sass. This uses the proper one used in the sass. Since the css is not effected, this is a non-breaking change.