### PR TITLE
Preserve contextMenuItem onClick event handler argument

### DIFF
--- a/src/components/context_menu/context_menu.js
+++ b/src/components/context_menu/context_menu.js
@@ -176,11 +176,14 @@ export class EuiContextMenu extends Component {
       } = item;
 
       const onClickHandler = panel
-        ? () => {
+        ? (event) => {
+          if (onClick && event) {
+            event.persist();
+          }
           // This component is commonly wrapped in a EuiOutsideClickDetector, which means we'll
           // need to wait for that logic to complete before re-rendering the DOM via showPanel.
           window.requestAnimationFrame(() => {
-            if (onClick) onClick();
+            if (onClick) onClick(event);
             this.showNextPanel(index);
           });
         } : onClick;


### PR DESCRIPTION
This change preserves the `onClick` handler's signature of `<T>(event: React.MouseEvent<T>) => void` even if a `panel` is given. Additionally, the event will be removed from the React event pooling system due to the async nature of the `requestAnimationFrame` callback.
  