### PR TITLE
Refactor EuiFlexGroup and EuiFlexItem to apply the classes to the children directly instead of to a wrapper, by default.

### DIFF
--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -57,18 +57,10 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   }
 }
 
-.guideDemo__highlightGrid {
-  .euiFlexItem {
-    background: transparentize(#0096CC, .9);
-    padding: 16px;
-  }
-}
-
-.guideDemo__highlightGridWrap {
-  .euiFlexItem div {
-    background: transparentize(#0096CC, .9);
-    padding: 16px;
-  }
+.guideDemo__highlightGrid .euiFlexItem,
+.guideDemo__highlightGridWrap .euiFlexItem {
+  background: transparentize(#0096CC, .9);
+  padding: 16px;
 }
 
 .guideDemo__textLines {

--- a/src-docs/src/views/accordion/accordion_form.js
+++ b/src-docs/src/views/accordion/accordion_form.js
@@ -19,7 +19,7 @@ import {
 
 const repeatableForm = (
   <EuiForm>
-    <EuiFlexGroup>
+    <EuiFlexGroup alignItems="center">
       <EuiFlexItem>
         <EuiFormRow label="Username">
           <EuiFieldText icon="user" placeholder="John" />

--- a/src-docs/src/views/flex/component_span.js
+++ b/src-docs/src/views/flex/component_span.js
@@ -7,13 +7,17 @@ import {
 
 export default () => (
   <button onClick={() => { window.alert('click'); }}>
-    <EuiFlexGroup component="span">
-      <EuiFlexItem component="span">
-        These items are within a button
+    <EuiFlexGroup>
+      <EuiFlexItem>
+        <span>
+          These items are within a button
+        </span>
       </EuiFlexItem>
 
-      <EuiFlexItem component="span">
-        So they all specify component=&ldquo;span&rdquo;
+      <EuiFlexItem>
+        <span>
+          So they are both wrapped in &lt;span&gt; elements
+        </span>
       </EuiFlexItem>
     </EuiFlexGroup>
   </button>

--- a/src-docs/src/views/flex/flex_item_panel.js
+++ b/src-docs/src/views/flex/flex_item_panel.js
@@ -25,10 +25,12 @@ export default () => (
     </EuiFlexItem>
 
     <EuiFlexItem>
-      <EuiPanel grow={false}>
-        Another <EuiCode>EuiPanel</EuiCode>,
-        with <EuiCode>grow=&#123;false&#125;</EuiCode>.
-      </EuiPanel>
+      <div>
+        <EuiPanel grow={false}>
+          Another <EuiCode>EuiPanel</EuiCode>,
+          with <EuiCode>grow=&#123;false&#125;</EuiCode>.
+        </EuiPanel>
+      </div>
     </EuiFlexItem>
   </EuiFlexGroup>
 );

--- a/src-docs/src/views/pagination/centered_pagination.js
+++ b/src-docs/src/views/pagination/centered_pagination.js
@@ -28,13 +28,15 @@ export default class extends Component {
   render() {
     return (
       <EuiFlexGroup justifyContent="spaceAround">
-        <EuiFlexItem grow={false}>
-          <EuiPagination
-            pageCount={this.PAGE_COUNT}
-            activePage={this.state.activePage}
-            onPageClick={this.goToPage}
-          />
-        </EuiFlexItem>
+        <div>
+          <EuiFlexItem grow={false}>
+            <EuiPagination
+              pageCount={this.PAGE_COUNT}
+              activePage={this.state.activePage}
+              onPageClick={this.goToPage}
+            />
+          </EuiFlexItem>
+        </div>
       </EuiFlexGroup>
     );
   }

--- a/src/components/accordion/__snapshots__/accordion.test.js.snap
+++ b/src/components/accordion/__snapshots__/accordion.test.js.snap
@@ -10,7 +10,6 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
   >
     <EuiFlexGroup
       alignItems="center"
-      component="div"
       gutterSize="none"
       justifyContent="flexStart"
       responsive={true}
@@ -20,85 +19,74 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
         className="euiFlexGroup euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
       >
         <EuiFlexItem
-          component="div"
           grow={true}
         >
-          <div
+          <button
+            aria-controls="6"
+            aria-expanded={false}
             className="euiFlexItem"
+            onClick={[Function]}
           >
-            <button
-              aria-controls="6"
-              aria-expanded={false}
-              className="euiAccordion__button"
-              onClick={[Function]}
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="s"
+              justifyContent="flexStart"
+              responsive={true}
+              wrap={false}
             >
-              <EuiFlexGroup
-                alignItems="center"
-                component="div"
-                gutterSize="s"
-                justifyContent="flexStart"
-                responsive={true}
-                wrap={false}
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
               >
-                <div
-                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
+                <EuiFlexItem
+                  grow={false}
                 >
-                  <EuiFlexItem
-                    component="div"
-                    grow={false}
+                  <EuiIcon
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                    size="m"
+                    type="arrowRight"
                   >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    <arrowRight
+                      className="euiIcon euiFlexItem euiFlexItem--flexGrowZero euiIcon--medium"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
                     >
-                      <EuiIcon
-                        size="m"
-                        type="arrowRight"
+                      <svg
+                        className="euiIcon euiFlexItem euiFlexItem--flexGrowZero euiIcon--medium"
+                        height="16"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                        xmlnsXlink="http://www.w3.org/1999/xlink"
                       >
-                        <arrowRight
-                          className="euiIcon euiIcon--medium"
-                          height="16"
-                          viewBox="0 0 16 16"
-                          width="16"
-                          xmlns="http://www.w3.org/2000/svg"
-                          xmlnsXlink="http://www.w3.org/1999/xlink"
-                        >
-                          <svg
-                            className="euiIcon euiIcon--medium"
-                            height="16"
-                            viewBox="0 0 16 16"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                            xmlnsXlink="http://www.w3.org/1999/xlink"
-                          >
-                            <defs>
-                              <path
-                                d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
-                                id="arrow_right-a"
-                              />
-                            </defs>
-                            <use
-                              fillRule="nonzero"
-                              transform="matrix(0 1 1 0 0 0)"
-                              xlinkHref="#arrow_right-a"
-                            />
-                          </svg>
-                        </arrowRight>
-                      </EuiIcon>
-                    </div>
-                  </EuiFlexItem>
-                  <EuiFlexItem
-                    className="euiAccordion__buttonContent"
-                    component="div"
-                    grow={true}
-                  >
-                    <div
-                      className="euiFlexItem euiAccordion__buttonContent"
-                    />
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-            </button>
-          </div>
+                        <defs>
+                          <path
+                            d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+                            id="arrow_right-a"
+                          />
+                        </defs>
+                        <use
+                          fillRule="nonzero"
+                          transform="matrix(0 1 1 0 0 0)"
+                          xlinkHref="#arrow_right-a"
+                        />
+                      </svg>
+                    </arrowRight>
+                  </EuiIcon>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  className="euiAccordion__buttonContent"
+                  grow={true}
+                >
+                  <div
+                    className="euiFlexItem euiAccordion__buttonContent"
+                  />
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+          </button>
         </EuiFlexItem>
       </div>
     </EuiFlexGroup>
@@ -122,7 +110,6 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
   >
     <EuiFlexGroup
       alignItems="center"
-      component="div"
       gutterSize="none"
       justifyContent="flexStart"
       responsive={true}
@@ -132,84 +119,73 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
         className="euiFlexGroup euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
       >
         <EuiFlexItem
-          component="div"
           grow={true}
         >
-          <div
+          <button
+            aria-controls="5"
+            aria-expanded={true}
             className="euiFlexItem"
+            onClick={[Function]}
           >
-            <button
-              aria-controls="5"
-              aria-expanded={true}
-              className="euiAccordion__button"
-              onClick={[Function]}
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="s"
+              justifyContent="flexStart"
+              responsive={true}
+              wrap={false}
             >
-              <EuiFlexGroup
-                alignItems="center"
-                component="div"
-                gutterSize="s"
-                justifyContent="flexStart"
-                responsive={true}
-                wrap={false}
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
               >
-                <div
-                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
+                <EuiFlexItem
+                  grow={false}
                 >
-                  <EuiFlexItem
-                    component="div"
-                    grow={false}
+                  <EuiIcon
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                    size="m"
+                    type="arrowDown"
                   >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    <arrowDown
+                      className="euiIcon euiFlexItem euiFlexItem--flexGrowZero euiIcon--medium"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlnsXlink="http://www.w3.org/1999/xlink"
                     >
-                      <EuiIcon
-                        size="m"
-                        type="arrowDown"
+                      <svg
+                        className="euiIcon euiFlexItem euiFlexItem--flexGrowZero euiIcon--medium"
+                        height="16"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                        xmlnsXlink="http://www.w3.org/1999/xlink"
                       >
-                        <arrowDown
-                          className="euiIcon euiIcon--medium"
-                          height="16"
-                          viewBox="0 0 16 16"
-                          width="16"
-                          xmlns="http://www.w3.org/2000/svg"
-                          xmlnsXlink="http://www.w3.org/1999/xlink"
-                        >
-                          <svg
-                            className="euiIcon euiIcon--medium"
-                            height="16"
-                            viewBox="0 0 16 16"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                            xmlnsXlink="http://www.w3.org/1999/xlink"
-                          >
-                            <defs>
-                              <path
-                                d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
-                                id="arrow_down-a"
-                              />
-                            </defs>
-                            <use
-                              fillRule="nonzero"
-                              xlinkHref="#arrow_down-a"
-                            />
-                          </svg>
-                        </arrowDown>
-                      </EuiIcon>
-                    </div>
-                  </EuiFlexItem>
-                  <EuiFlexItem
-                    className="euiAccordion__buttonContent"
-                    component="div"
-                    grow={true}
-                  >
-                    <div
-                      className="euiFlexItem euiAccordion__buttonContent"
-                    />
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-            </button>
-          </div>
+                        <defs>
+                          <path
+                            d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+                            id="arrow_down-a"
+                          />
+                        </defs>
+                        <use
+                          fillRule="nonzero"
+                          xlinkHref="#arrow_down-a"
+                        />
+                      </svg>
+                    </arrowDown>
+                  </EuiIcon>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  className="euiAccordion__buttonContent"
+                  grow={true}
+                >
+                  <div
+                    className="euiFlexItem euiAccordion__buttonContent"
+                  />
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+          </button>
         </EuiFlexItem>
       </div>
     </EuiFlexGroup>
@@ -232,47 +208,39 @@ exports[`EuiAccordion is rendered 1`] = `
   <div
     class="euiFlexGroup euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
   >
-    <div
+    <button
+      aria-controls="0"
+      aria-expanded="false"
       class="euiFlexItem"
     >
-      <button
-        aria-controls="0"
-        aria-expanded="false"
-        class="euiAccordion__button"
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
       >
-        <div
-          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
+        <svg
+          class="euiIcon euiFlexItem euiFlexItem--flexGrowZero euiIcon--medium"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <div
-            class="euiFlexItem euiFlexItem--flexGrowZero"
-          >
-            <svg
-              class="euiIcon euiIcon--medium"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xlink="http://www.w3.org/1999/xlink"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <defs>
-                <path
-                  d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
-                  id="arrow_right-a"
-                />
-              </defs>
-              <use
-                fill-rule="nonzero"
-                href="#arrow_right-a"
-                transform="matrix(0 1 1 0 0 0)"
-              />
-            </svg>
-          </div>
-          <div
-            class="euiFlexItem euiAccordion__buttonContent"
+          <defs>
+            <path
+              d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+              id="arrow_right-a"
+            />
+          </defs>
+          <use
+            fill-rule="nonzero"
+            href="#arrow_right-a"
+            transform="matrix(0 1 1 0 0 0)"
           />
-        </div>
-      </button>
-    </div>
+        </svg>
+        <div
+          class="euiFlexItem euiAccordion__buttonContent"
+        />
+      </div>
+    </button>
   </div>
   <div
     class="euiAccordion__childWrapper"
@@ -290,51 +258,41 @@ exports[`EuiAccordion props buttonContent is rendered 1`] = `
   <div
     class="euiFlexGroup euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
   >
-    <div
+    <button
+      aria-controls="2"
+      aria-expanded="false"
       class="euiFlexItem"
     >
-      <button
-        aria-controls="2"
-        aria-expanded="false"
-        class="euiAccordion__button"
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
       >
-        <div
-          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
+        <svg
+          class="euiIcon euiFlexItem euiFlexItem--flexGrowZero euiIcon--medium"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <div
-            class="euiFlexItem euiFlexItem--flexGrowZero"
-          >
-            <svg
-              class="euiIcon euiIcon--medium"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xlink="http://www.w3.org/1999/xlink"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <defs>
-                <path
-                  d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
-                  id="arrow_right-a"
-                />
-              </defs>
-              <use
-                fill-rule="nonzero"
-                href="#arrow_right-a"
-                transform="matrix(0 1 1 0 0 0)"
-              />
-            </svg>
-          </div>
-          <div
-            class="euiFlexItem euiAccordion__buttonContent"
-          >
-            <div>
-              Button content
-            </div>
-          </div>
+          <defs>
+            <path
+              d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+              id="arrow_right-a"
+            />
+          </defs>
+          <use
+            fill-rule="nonzero"
+            href="#arrow_right-a"
+            transform="matrix(0 1 1 0 0 0)"
+          />
+        </svg>
+        <div
+          class="euiFlexItem euiAccordion__buttonContent"
+        >
+          Button content
         </div>
-      </button>
-    </div>
+      </div>
+    </button>
   </div>
   <div
     class="euiAccordion__childWrapper"
@@ -352,47 +310,39 @@ exports[`EuiAccordion props buttonContentClassName is rendered 1`] = `
   <div
     class="euiFlexGroup euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
   >
-    <div
+    <button
+      aria-controls="1"
+      aria-expanded="false"
       class="euiFlexItem"
     >
-      <button
-        aria-controls="1"
-        aria-expanded="false"
-        class="euiAccordion__button"
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
       >
-        <div
-          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
+        <svg
+          class="euiIcon euiFlexItem euiFlexItem--flexGrowZero euiIcon--medium"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <div
-            class="euiFlexItem euiFlexItem--flexGrowZero"
-          >
-            <svg
-              class="euiIcon euiIcon--medium"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xlink="http://www.w3.org/1999/xlink"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <defs>
-                <path
-                  d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
-                  id="arrow_right-a"
-                />
-              </defs>
-              <use
-                fill-rule="nonzero"
-                href="#arrow_right-a"
-                transform="matrix(0 1 1 0 0 0)"
-              />
-            </svg>
-          </div>
-          <div
-            class="euiFlexItem euiAccordion__buttonContent button content class name"
+          <defs>
+            <path
+              d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+              id="arrow_right-a"
+            />
+          </defs>
+          <use
+            fill-rule="nonzero"
+            href="#arrow_right-a"
+            transform="matrix(0 1 1 0 0 0)"
           />
-        </div>
-      </button>
-    </div>
+        </svg>
+        <div
+          class="euiFlexItem euiAccordion__buttonContent button content class name"
+        />
+      </div>
+    </button>
   </div>
   <div
     class="euiAccordion__childWrapper"
@@ -410,54 +360,44 @@ exports[`EuiAccordion props extraAction is rendered 1`] = `
   <div
     class="euiFlexGroup euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
   >
-    <div
+    <button
+      aria-controls="3"
+      aria-expanded="false"
       class="euiFlexItem"
     >
-      <button
-        aria-controls="3"
-        aria-expanded="false"
-        class="euiAccordion__button"
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
       >
-        <div
-          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
+        <svg
+          class="euiIcon euiFlexItem euiFlexItem--flexGrowZero euiIcon--medium"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <div
-            class="euiFlexItem euiFlexItem--flexGrowZero"
-          >
-            <svg
-              class="euiIcon euiIcon--medium"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xlink="http://www.w3.org/1999/xlink"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <defs>
-                <path
-                  d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
-                  id="arrow_right-a"
-                />
-              </defs>
-              <use
-                fill-rule="nonzero"
-                href="#arrow_right-a"
-                transform="matrix(0 1 1 0 0 0)"
-              />
-            </svg>
-          </div>
-          <div
-            class="euiFlexItem euiAccordion__buttonContent"
+          <defs>
+            <path
+              d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+              id="arrow_right-a"
+            />
+          </defs>
+          <use
+            fill-rule="nonzero"
+            href="#arrow_right-a"
+            transform="matrix(0 1 1 0 0 0)"
           />
-        </div>
-      </button>
-    </div>
-    <div
+        </svg>
+        <div
+          class="euiFlexItem euiAccordion__buttonContent"
+        />
+      </div>
+    </button>
+    <button
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
-      <button>
-        Extra action
-      </button>
-    </div>
+      Extra action
+    </button>
   </div>
   <div
     class="euiAccordion__childWrapper"
@@ -475,46 +415,38 @@ exports[`EuiAccordion props initialIsOpen is rendered 1`] = `
   <div
     class="euiFlexGroup euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
   >
-    <div
+    <button
+      aria-controls="4"
+      aria-expanded="true"
       class="euiFlexItem"
     >
-      <button
-        aria-controls="4"
-        aria-expanded="true"
-        class="euiAccordion__button"
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
       >
-        <div
-          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
+        <svg
+          class="euiIcon euiFlexItem euiFlexItem--flexGrowZero euiIcon--medium"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <div
-            class="euiFlexItem euiFlexItem--flexGrowZero"
-          >
-            <svg
-              class="euiIcon euiIcon--medium"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xlink="http://www.w3.org/1999/xlink"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <defs>
-                <path
-                  d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
-                  id="arrow_down-a"
-                />
-              </defs>
-              <use
-                fill-rule="nonzero"
-                href="#arrow_down-a"
-              />
-            </svg>
-          </div>
-          <div
-            class="euiFlexItem euiAccordion__buttonContent"
+          <defs>
+            <path
+              d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+              id="arrow_down-a"
+            />
+          </defs>
+          <use
+            fill-rule="nonzero"
+            href="#arrow_down-a"
           />
-        </div>
-      </button>
-    </div>
+        </svg>
+        <div
+          class="euiFlexItem euiAccordion__buttonContent"
+        />
+      </div>
+    </button>
   </div>
   <div
     class="euiAccordion__childWrapper"

--- a/src/components/accordion/__snapshots__/accordion.test.js.snap
+++ b/src/components/accordion/__snapshots__/accordion.test.js.snap
@@ -24,7 +24,7 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
           <button
             aria-controls="6"
             aria-expanded={false}
-            className="euiFlexItem"
+            className="euiFlexItem euiAccordion__button"
             onClick={[Function]}
           >
             <EuiFlexGroup
@@ -124,7 +124,7 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
           <button
             aria-controls="5"
             aria-expanded={true}
-            className="euiFlexItem"
+            className="euiFlexItem euiAccordion__button"
             onClick={[Function]}
           >
             <EuiFlexGroup
@@ -211,7 +211,7 @@ exports[`EuiAccordion is rendered 1`] = `
     <button
       aria-controls="0"
       aria-expanded="false"
-      class="euiFlexItem"
+      class="euiFlexItem euiAccordion__button"
     >
       <div
         class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
@@ -261,7 +261,7 @@ exports[`EuiAccordion props buttonContent is rendered 1`] = `
     <button
       aria-controls="2"
       aria-expanded="false"
-      class="euiFlexItem"
+      class="euiFlexItem euiAccordion__button"
     >
       <div
         class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
@@ -313,7 +313,7 @@ exports[`EuiAccordion props buttonContentClassName is rendered 1`] = `
     <button
       aria-controls="1"
       aria-expanded="false"
-      class="euiFlexItem"
+      class="euiFlexItem euiAccordion__button"
     >
       <div
         class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
@@ -363,7 +363,7 @@ exports[`EuiAccordion props extraAction is rendered 1`] = `
     <button
       aria-controls="3"
       aria-expanded="false"
-      class="euiFlexItem"
+      class="euiFlexItem euiAccordion__button"
     >
       <div
         class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
@@ -418,7 +418,7 @@ exports[`EuiAccordion props initialIsOpen is rendered 1`] = `
     <button
       aria-controls="4"
       aria-expanded="true"
-      class="euiFlexItem"
+      class="euiFlexItem euiAccordion__button"
     >
       <div
         class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"

--- a/src/components/filter_group/__snapshots__/filter_select_item.test.js.snap
+++ b/src/components/filter_group/__snapshots__/filter_select_item.test.js.snap
@@ -7,23 +7,20 @@ exports[`EuiFilterSelectItem is rendered 1`] = `
   data-test-subj="test subject string"
   type="button"
 >
-  <span
+  <div
     class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
+    component="span"
   >
-    <div
-      class="euiFlexItem euiFlexItem--flexGrowZero"
-    >
-      <svg
-        class="euiIcon euiIcon--medium"
-        height="16"
-        viewBox="0 0 16 16"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
-      />
-    </div>
+    <svg
+      class="euiIcon euiFlexItem euiFlexItem--flexGrowZero euiIcon--medium"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    />
     <div
       class="euiFlexItem"
     />
-  </span>
+  </div>
 </button>
 `;

--- a/src/components/flex/__snapshots__/flex_group.test.js.snap
+++ b/src/components/flex/__snapshots__/flex_group.test.js.snap
@@ -1,15 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiFlexGroup is rendered 1`] = `
-<div
+<h2
   aria-label="aria-label"
   class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--responsive testClass1 testClass2"
   data-test-subj="test subject string"
 >
-  <h2>
-    My Child
-  </h2>
-</div>
+  My Child
+</h2>
 `;
 
 exports[`EuiFlexGroup props alignItems center is rendered 1`] = `
@@ -32,18 +30,6 @@ exports[`EuiFlexGroup props alignItems flexStart is rendered 1`] = `
 
 exports[`EuiFlexGroup props alignItems stretch is rendered 1`] = `
 <div
-  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--responsive"
-/>
-`;
-
-exports[`EuiFlexGroup props component div is rendered 1`] = `
-<div
-  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--responsive"
-/>
-`;
-
-exports[`EuiFlexGroup props component span is rendered 1`] = `
-<span
   class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--responsive"
 />
 `;

--- a/src/components/flex/__snapshots__/flex_item.test.js.snap
+++ b/src/components/flex/__snapshots__/flex_item.test.js.snap
@@ -1,17 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiFlexItem component div is rendered 1`] = `
-<div
-  class="euiFlexItem"
-/>
-`;
-
-exports[`EuiFlexItem component span is rendered 1`] = `
-<span
-  class="euiFlexItem"
-/>
-`;
-
 exports[`EuiFlexItem grow 1 is rendered 1`] = `
 <div
   class="euiFlexItem euiFlexItem--flexGrow1"

--- a/src/components/flex/_flex_item.scss
+++ b/src/components/flex/_flex_item.scss
@@ -2,9 +2,6 @@
  * 1. Allow EuiPanels to expand to fill the item.
  */
 .euiFlexItem {
-  display: flex; /* 1 */
-  flex-direction: column; /* 1 */
-
   /*
    * 1. We need the extra specificity here to override the FlexGroup > FlexItem styles.
    * 2. FlexItem can be manually set to not grow if needed.

--- a/src/components/flex/flex_group.js
+++ b/src/components/flex/flex_group.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -41,7 +41,6 @@ export const EuiFlexGroup = ({
   responsive,
   justifyContent,
   wrap,
-  component: Component,
   ...rest,
 }) => {
   const classes = classNames(
@@ -56,14 +55,20 @@ export const EuiFlexGroup = ({
     className
   );
 
-  return (
-    <Component
-      className={classes}
-      {...rest}
-    >
-      {children}
-    </Component>
-  );
+  let originalChildren;
+
+  if (typeof children === 'string' || Array.isArray(children) || typeof children === 'undefined') {
+    originalChildren = (
+      <div>{children}</div>
+    );
+  } else {
+    originalChildren = children;
+  }
+
+  return cloneElement(originalChildren, {
+    className: classes,
+    ...rest
+  });
 };
 
 EuiFlexGroup.propTypes = {
@@ -73,7 +78,6 @@ EuiFlexGroup.propTypes = {
   gutterSize: PropTypes.oneOf(GUTTER_SIZES),
   alignItems: PropTypes.oneOf(ALIGN_ITEMS),
   justifyContent: PropTypes.oneOf(JUSTIFY_CONTENTS),
-  component: PropTypes.oneOf(['div', 'span']),
   wrap: PropTypes.bool,
 };
 
@@ -82,6 +86,5 @@ EuiFlexGroup.defaultProps = {
   alignItems: 'stretch',
   responsive: true,
   justifyContent: 'flexStart',
-  component: 'div',
   wrap: false,
 };

--- a/src/components/flex/flex_group.js
+++ b/src/components/flex/flex_group.js
@@ -66,7 +66,7 @@ export const EuiFlexGroup = ({
   }
 
   return cloneElement(originalChildren, {
-    className: classes,
+    className: classNames(classes, originalChildren.props.className),
     ...rest
   });
 };

--- a/src/components/flex/flex_group.test.js
+++ b/src/components/flex/flex_group.test.js
@@ -81,27 +81,6 @@ describe('EuiFlexGroup', () => {
       });
     });
 
-    describe('component', () => {
-      ['div', 'span'].forEach(value => {
-        test(`${value} is rendered`, () => {
-          const component = render(
-            <EuiFlexGroup component={value} />
-          );
-
-          expect(component)
-            .toMatchSnapshot();
-        });
-      });
-
-      ['h2'].forEach(value => {
-        test(`${value} is not rendered`, () => {
-          expect(() => render(
-            <EuiFlexGroup component={value} />
-          )).toThrow();
-        });
-      });
-    });
-
     describe('wrap', () => {
       [true, false].forEach(value => {
         test(`${value} is rendered`, () => {

--- a/src/components/flex/flex_item.js
+++ b/src/components/flex/flex_item.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -8,7 +8,6 @@ export const EuiFlexItem = ({
   children,
   className,
   grow,
-  component: Component,
   ...rest,
 }) => {
   const classes = classNames(
@@ -20,20 +19,20 @@ export const EuiFlexItem = ({
     className
   );
 
-  return (
-    <Component
-      className={classes}
-      {...rest}
-    >
-      {children}
-    </Component>
-  );
-};
+  let originalChildren;
 
-EuiFlexItem.propTypes = {
-  children: PropTypes.node,
-  grow: growPropType,
-  component: PropTypes.oneOf(['div', 'span']),
+  if (typeof children === 'string' || Array.isArray(children) || typeof children === 'undefined') {
+    originalChildren = (
+      <div>{children}</div>
+    );
+  } else {
+    originalChildren = children;
+  }
+
+  return cloneElement(originalChildren, {
+    className: classes,
+    ...rest
+  });
 };
 
 function growPropType(props, propName, componentName) {
@@ -52,7 +51,12 @@ function growPropType(props, propName, componentName) {
   }
 }
 
+EuiFlexItem.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  grow: growPropType,
+};
+
 EuiFlexItem.defaultProps = {
   grow: true,
-  component: 'div',
 };

--- a/src/components/flex/flex_item.js
+++ b/src/components/flex/flex_item.js
@@ -30,7 +30,7 @@ export const EuiFlexItem = ({
   }
 
   return cloneElement(originalChildren, {
-    className: classes,
+    className: classNames(classes, originalChildren.props.className),
     ...rest
   });
 };

--- a/src/components/flex/flex_item.test.js
+++ b/src/components/flex/flex_item.test.js
@@ -50,25 +50,4 @@ describe('EuiFlexItem', () => {
       });
     });
   });
-
-  describe('component', () => {
-    ['div', 'span'].forEach(value => {
-      test(`${value} is rendered`, () => {
-        const component = render(
-          <EuiFlexItem component={value} />
-        );
-
-        expect(component)
-          .toMatchSnapshot();
-      });
-    });
-
-    ['h2'].forEach(value => {
-      test(`${value} is not rendered`, () => {
-        expect(() => render(
-          <EuiFlexItem component={value} />
-        )).toThrow();
-      });
-    });
-  });
 });

--- a/src/components/form/field_number/field_number.js
+++ b/src/components/form/field_number/field_number.js
@@ -24,7 +24,7 @@ export const EuiFieldNumber = ({
   isLoading,
   ...rest
 }) => {
-  const classes = classNames('euiFieldNumber', className, {
+  const classes = classNames('euiFieldNumber', {
     'euiFieldNumber--withIcon': icon,
     'euiFieldNumber--fullWidth': fullWidth,
     'euiFieldNumber-isLoading': isLoading,
@@ -35,6 +35,7 @@ export const EuiFieldNumber = ({
       icon={icon}
       fullWidth={fullWidth}
       isLoading={isLoading}
+      className={className}
     >
       <EuiValidatableControl isInvalid={isInvalid}>
         <input

--- a/src/components/form/field_password/field_password.js
+++ b/src/components/form/field_password/field_password.js
@@ -27,7 +27,6 @@ export const EuiFieldPassword = ({
       'euiFieldPassword--fullWidth': fullWidth,
       'euiFieldPassword-isLoading': isLoading,
     },
-    className
   );
 
   return (
@@ -35,6 +34,7 @@ export const EuiFieldPassword = ({
       icon="lock"
       fullWidth={fullWidth}
       isLoading={isLoading}
+      className={className}
     >
       <EuiValidatableControl isInvalid={isInvalid}>
         <input

--- a/src/components/form/field_search/__snapshots__/field_search.test.js.snap
+++ b/src/components/form/field_search/__snapshots__/field_search.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`EuiFieldSearch is rendered 1`] = `
 <eui-form-control-layout
+  classname="testClass1 testClass2"
   fullwidth="false"
   icon="search"
   isloading="false"
@@ -9,7 +10,7 @@ exports[`EuiFieldSearch is rendered 1`] = `
   <eui-validatable-control>
     <input
       aria-label="aria-label"
-      class="euiFieldSearch testClass1 testClass2"
+      class="euiFieldSearch"
       data-test-subj="test subject string"
       id="1"
       name="elastic"

--- a/src/components/form/field_search/field_search.js
+++ b/src/components/form/field_search/field_search.js
@@ -12,7 +12,6 @@ import {
   EuiValidatableControl,
 } from '../validatable_control';
 
-
 const propTypes = {
   name: PropTypes.string,
   id: PropTypes.string,
@@ -95,7 +94,6 @@ export class EuiFieldSearch extends Component {
         'euiFieldSearch--fullWidth': fullWidth,
         'euiFieldSearch-isLoading': isLoading,
       },
-      className
     );
 
     const ref = (inputElement) => {
@@ -111,6 +109,7 @@ export class EuiFieldSearch extends Component {
         icon="search"
         fullWidth={fullWidth}
         isLoading={isLoading}
+        className={className}
       >
         <EuiValidatableControl isInvalid={isInvalid}>
           <input

--- a/src/components/form/field_text/__snapshots__/field_text.test.js.snap
+++ b/src/components/form/field_text/__snapshots__/field_text.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`EuiFieldText is rendered 1`] = `
 <eui-form-control-layout
+  classname="testClass1 testClass2"
   fullwidth="false"
   icon="foo"
   isloading="false"
@@ -9,7 +10,7 @@ exports[`EuiFieldText is rendered 1`] = `
   <eui-validatable-control>
     <input
       aria-label="aria-label"
-      class="euiFieldText testClass1 testClass2 euiFieldText--withIcon"
+      class="euiFieldText euiFieldText--withIcon"
       data-test-subj="test subject string"
       id="1"
       name="elastic"

--- a/src/components/form/field_text/field_text.js
+++ b/src/components/form/field_text/field_text.js
@@ -23,7 +23,7 @@ export const EuiFieldText = ({
   isLoading,
   ...rest
 }) => {
-  const classes = classNames('euiFieldText', className, {
+  const classes = classNames('euiFieldText', {
     'euiFieldText--withIcon': icon,
     'euiFieldText--fullWidth': fullWidth,
     'euiFieldText-isLoading': isLoading,
@@ -34,6 +34,7 @@ export const EuiFieldText = ({
       icon={icon}
       fullWidth={fullWidth}
       isLoading={isLoading}
+      className={className}
     >
       <EuiValidatableControl
         isInvalid={isInvalid}

--- a/src/components/form/select/__snapshots__/select.test.js.snap
+++ b/src/components/form/select/__snapshots__/select.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`EuiSelect is rendered 1`] = `
 <eui-form-control-layout
+  classname="testClass1 testClass2"
   fullwidth="false"
   icon="arrowDown"
   iconside="right"
@@ -10,7 +11,7 @@ exports[`EuiSelect is rendered 1`] = `
   <eui-validatable-control>
     <select
       aria-label="aria-label"
-      class="euiSelect testClass1 testClass2"
+      class="euiSelect"
       data-test-subj="test subject string"
       id="id"
       name="name"

--- a/src/components/form/select/select.js
+++ b/src/components/form/select/select.js
@@ -29,7 +29,6 @@ export const EuiSelect = ({
       'euiSelect--fullWidth': fullWidth,
       'euiSelect-isLoading': isLoading,
     },
-    className
   );
 
   let emptyOptionNode;
@@ -45,6 +44,7 @@ export const EuiSelect = ({
       iconSide="right"
       fullWidth={fullWidth}
       isLoading={isLoading}
+      className={className}
     >
       <EuiValidatableControl isInvalid={isInvalid}>
         <select

--- a/src/components/header/header_alert/__snapshots__/header_alert.test.js.snap
+++ b/src/components/header/header_alert/__snapshots__/header_alert.test.js.snap
@@ -44,10 +44,10 @@ exports[`EuiHeaderAlert is rendered 1`] = `
     class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--responsive"
   >
     <div
-      class="euiFlexItem euiFlexItem--flexGrowZero"
+      class="euiFlexItem euiFlexItem--flexGrowZero euiHeaderAlert__action euiLink"
     />
     <div
-      class="euiFlexItem euiFlexItem--flexGrowZero"
+      class="euiFlexItem euiFlexItem--flexGrowZero euiHeaderAlert__date"
     >
       date
     </div>

--- a/src/components/header/header_alert/__snapshots__/header_alert.test.js.snap
+++ b/src/components/header/header_alert/__snapshots__/header_alert.test.js.snap
@@ -45,19 +45,11 @@ exports[`EuiHeaderAlert is rendered 1`] = `
   >
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
-    >
-      <div
-        class="euiHeaderAlert__action euiLink"
-      />
-    </div>
+    />
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
-      <div
-        class="euiHeaderAlert__date"
-      >
-        date
-      </div>
+      date
     </div>
   </div>
 </div>

--- a/src/components/health/__snapshots__/health.test.js.snap
+++ b/src/components/health/__snapshots__/health.test.js.snap
@@ -9,30 +9,26 @@ exports[`EuiHealth is rendered 1`] = `
   <div
     class="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
   >
-    <div
-      class="euiFlexItem euiFlexItem--flexGrowZero"
+    <svg
+      class="euiIcon euiFlexItem euiFlexItem--flexGrowZero euiIcon--medium"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xlink="http://www.w3.org/1999/xlink"
+      xmlns="http://www.w3.org/2000/svg"
     >
-      <svg
-        class="euiIcon euiIcon--medium"
-        height="16"
-        viewBox="0 0 16 16"
-        width="16"
-        xlink="http://www.w3.org/1999/xlink"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <defs>
-          <circle
-            cx="8"
-            cy="8"
-            id="dot-a"
-            r="4"
-          />
-        </defs>
-        <use
-          href="#dot-a"
+      <defs>
+        <circle
+          cx="8"
+          cy="8"
+          id="dot-a"
+          r="4"
         />
-      </svg>
-    </div>
+      </defs>
+      <use
+        href="#dot-a"
+      />
+    </svg>
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
     />

--- a/src/components/panel/_mixins.scss
+++ b/src/components/panel/_mixins.scss
@@ -8,12 +8,11 @@
   }
   @else {
     .#{$selector} {
-
       @include euiBottomShadowSmall;
       background-color: $euiColorEmptyShade;
       border: $euiBorderThin;
       border-radius: $euiBorderRadius;
-      flex-grow: 1;
+
       &.#{$selector}--flexGrowZero {
         flex-grow: 0;
       }

--- a/src/components/search_bar/__snapshots__/search_bar.test.js.snap
+++ b/src/components/search_bar/__snapshots__/search_bar.test.js.snap
@@ -3,14 +3,12 @@
 exports[`SearchBar render - no config, no query 1`] = `
 <EuiFlexGroup
   alignItems="center"
-  component="div"
   gutterSize="m"
   justifyContent="flexStart"
   responsive={true}
   wrap={false}
 >
   <EuiFlexItem
-    component="div"
     grow={true}
   >
     <EuiSearchBox
@@ -27,14 +25,12 @@ exports[`SearchBar render - no config, no query 1`] = `
 exports[`SearchBar render - no query, custom box placeholder and incremental 1`] = `
 <EuiFlexGroup
   alignItems="center"
-  component="div"
   gutterSize="m"
   justifyContent="flexStart"
   responsive={true}
   wrap={false}
 >
   <EuiFlexItem
-    component="div"
     grow={true}
   >
     <EuiSearchBox
@@ -51,14 +47,12 @@ exports[`SearchBar render - no query, custom box placeholder and incremental 1`]
 exports[`SearchBar render - provided query, filters 1`] = `
 <EuiFlexGroup
   alignItems="center"
-  component="div"
   gutterSize="m"
   justifyContent="flexStart"
   responsive={true}
   wrap={false}
 >
   <EuiFlexItem
-    component="div"
     grow={true}
   >
     <EuiSearchBox
@@ -70,7 +64,6 @@ exports[`SearchBar render - provided query, filters 1`] = `
     />
   </EuiFlexItem>
   <EuiFlexItem
-    component="div"
     grow={false}
   >
     <EuiSearchFilters

--- a/src/components/table/table_pagination/__snapshots__/table_pagination.test.js.snap
+++ b/src/components/table/table_pagination/__snapshots__/table_pagination.test.js.snap
@@ -5,51 +5,43 @@ exports[`EuiTablePagination is rendered 1`] = `
   class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--responsive"
 >
   <div
-    class="euiFlexItem euiFlexItem--flexGrowZero"
+    class="euiPopover euiPopover--anchorUpRight euiFlexItem euiFlexItem--flexGrowZero euiPopover--withTitle"
   >
-    <div
-      class="euiPopover euiPopover--anchorUpRight euiPopover--withTitle"
+    <button
+      aria-controls="customizablePagination"
+      aria-expanded="false"
+      class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--iconRight"
+      type="button"
     >
-      <button
-        aria-controls="customizablePagination"
-        aria-expanded="false"
-        class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--iconRight"
-        type="button"
+      <span
+        class="euiButtonEmpty__content"
       >
-        <span
-          class="euiButtonEmpty__content"
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiButtonEmpty__icon euiIcon--medium"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            aria-hidden="true"
-            class="euiIcon euiButtonEmpty__icon euiIcon--medium"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
-            xlink="http://www.w3.org/1999/xlink"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <defs>
-              <path
-                d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
-                id="arrow_down-a"
-              />
-            </defs>
-            <use
-              fill-rule="nonzero"
-              href="#arrow_down-a"
+          <defs>
+            <path
+              d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+              id="arrow_down-a"
             />
-          </svg>
-          <span>
-            Rows per page: 50
-          </span>
+          </defs>
+          <use
+            fill-rule="nonzero"
+            href="#arrow_down-a"
+          />
+        </svg>
+        <span>
+          Rows per page: 50
         </span>
-      </button>
-    </div>
+      </span>
+    </button>
   </div>
-  <div
-    class="euiFlexItem euiFlexItem--flexGrowZero"
-  >
-    <span />
-  </div>
+  <span />
 </div>
 `;


### PR DESCRIPTION
Flexbox layout is very tightly coupled to the DOM structure. So creating wrapper elements by default can introduce problems with nested layouts or applying flexbox rules to children. By applying the classes to the children directly by default, we support common use cases like stretching the children vertically to fill the flexbox container
  
**To-do:**

- [ ] Tests
- [ ] CHANGELOG