### PR TITLE
Open Sans font-family for K6 theme

### DIFF
--- a/src-docs/src/index.html
+++ b/src-docs/src/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
   </head>
   <body class="guideBody">
     <div id="guide" style="height: 100%"></div>

--- a/src/components/code_editor/__snapshots__/code_editor.test.js.snap
+++ b/src/components/code_editor/__snapshots__/code_editor.test.js.snap
@@ -112,7 +112,6 @@ exports[`EuiCodeEditor is rendered 1`] = `
       wrap="off"
     />
     <div
-      aria-hidden="true"
       class="ace_gutter"
     >
       <div
@@ -226,7 +225,6 @@ exports[`EuiCodeEditor props isReadOnly renders alternate hint text 1`] = `
       wrap="off"
     />
     <div
-      aria-hidden="true"
       class="ace_gutter"
     >
       <div

--- a/src/components/form/form_row/__snapshots__/form_row.test.js.snap
+++ b/src/components/form/form_row/__snapshots__/form_row.test.js.snap
@@ -17,6 +17,7 @@ exports[`EuiFormRow behavior onBlur is called in child 1`] = `
     <EuiFormLabel
       htmlFor="generated-id"
       isFocused={false}
+      isInvalid={undefined}
     >
       <label
         className="euiFormLabel"
@@ -53,6 +54,7 @@ exports[`EuiFormRow behavior onBlur works in parent even if not in child 1`] = `
     <EuiFormLabel
       htmlFor="generated-id"
       isFocused={false}
+      isInvalid={undefined}
     >
       <label
         className="euiFormLabel"
@@ -89,6 +91,7 @@ exports[`EuiFormRow behavior onFocus is called in child 1`] = `
     <EuiFormLabel
       htmlFor="generated-id"
       isFocused={true}
+      isInvalid={undefined}
     >
       <label
         className="euiFormLabel euiFormLabel-isFocused"
@@ -125,6 +128,7 @@ exports[`EuiFormRow behavior onFocus works in parent even if not in child 1`] = 
     <EuiFormLabel
       htmlFor="generated-id"
       isFocused={true}
+      isInvalid={undefined}
     >
       <label
         className="euiFormLabel euiFormLabel-isFocused"

--- a/src/global_styling/variables/_typography.scss
+++ b/src/global_styling/variables/_typography.scss
@@ -18,8 +18,8 @@
 
 // Families
 
-$euiFontFamily: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-$euiCodeFontFamily: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+$euiFontFamily: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
+$euiCodeFontFamily: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace !default;
 
 // Font sizes
 

--- a/src/themes/k6/k6_globals.scss
+++ b/src/themes/k6/k6_globals.scss
@@ -1,5 +1,5 @@
 // Font families
-$euiFontFamily: 'Open Sans', sans-serif;
+$euiFontFamily: 'Open Sans', Helvetica, Arial, sans-serif;
 
 // Font Sizes
 $euiFontSize:       14px;

--- a/src/themes/k6/k6_globals.scss
+++ b/src/themes/k6/k6_globals.scss
@@ -1,5 +1,8 @@
-$euiFontSize:       14px;
+// Font families
+$euiFontFamily: 'Open Sans', sans-serif;
 
+// Font Sizes
+$euiFontSize:       14px;
 $euiFontSizeXS:     12px;
 $euiFontSizeS:      14px;
 $euiFontSizeM:      16px;


### PR DESCRIPTION
Relevant to https://github.com/elastic/kibana/issues/15814

Makes the K6 EUI theme use Open Sans. The other themes remain unaffected.

Kibana can't move over to system fonts because of issues that arise around dashboards and pdf reports (and somewhat our testing strategy). Briefly, variable fonts can cause the computed heights to get a little wobbly in repeatable elements like tables. While this isn't something we can fix 100% ever, using a singular font helps minimize the problem.

The reason we decided to go back to Open Sans is mainly for current consumer ease of use. Keeping the same font means Kibana dashboard items should retain their same computed height values as they were in 6.1.

The plan is that when we move to v7, we'll be allowed to make a more "breaking" change to these heights (since the layouts themselves should also shift). At that time we'll likely move to Roboto or some to be decided more modern font.

cc @elastic/eui-design 