### PR TITLE
Add viewBox attribute to icon snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,17 @@
 - Added Apache, Nginx, MySQL logos [(#270)](https://github.com/elastic/eui/pull/270)
 - Added small version of `EuiCallOut` [(#269)](https://github.com/elastic/eui/pull/269)
 - Added first batch of TypeScript type definitions for components and services [(#252)](https://github.com/elastic/eui/pull/252)
+- Added button for expanding `<EuiCodeBlock>` instances to be full-screen. [(#259)](https://github.com/elastic/eui/pull/259)
 
 **Bug fixes**
 
-- Remove padding on `<EuiPage>` mobile breakpoint. [(#282)](https://github.com/elastic/eui/pull/282)
+- Removed padding on `<EuiPage>` mobile breakpoint. [(#282)](https://github.com/elastic/eui/pull/282)
 - Fixed some `<EuiIcon>` `type`s not setting their `viewBox` attribute, which caused them to not honor the `size` properly. [(#277)](https://github.com/elastic/eui/pull/277)
 - Fixed `<EuiContextMenu>` to pass the `event` argument to a `<EuiContextMenuItem>`'s `onClick` handler even when a panel is defined. [(#265)](https://github.com/elastic/eui/pull/265)
 
 **Breaking changes**
 
-- Removed `color` prop from `<EuiCodeBlock>`. This component's highlighting now matches whichever theme is currently active. [(#259)](https://github.com/elastic/eui/pull/259)
+- Removed `color` prop from `<EuiCodeBlock>`. This component's highlighting now matches whichever theme is currently active. See PR for details on SCSS breaking changes. [(#259)](https://github.com/elastic/eui/pull/259)
 
 # [`0.0.11`](https://github.com/elastic/eui/tree/v0.0.11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
+- All NPM dependencies now use ^ to install the latest minor version.
 - Added Apache, Nginx, MySQL logos [(#270)](https://github.com/elastic/eui/pull/270)
 - Added small version of `EuiCallOut` [(#269)](https://github.com/elastic/eui/pull/269)
 - Added first batch of TypeScript type definitions for components and services [(#252)](https://github.com/elastic/eui/pull/252)

--- a/src/components/code/__snapshots__/_code_block.test.js.snap
+++ b/src/components/code/__snapshots__/_code_block.test.js.snap
@@ -20,6 +20,7 @@ exports[`EuiCodeBlockImpl block highlights javascript code, adding "js" class 1`
       aria-hidden="true"
       class="euiIcon euiButtonIcon__icon euiIcon--medium"
       height="16"
+      viewBox="0 0 16 16"
       width="16"
       xmlns="http://www.w3.org/2000/svg"
     >
@@ -57,6 +58,7 @@ console.log(some);
       aria-hidden="true"
       class="euiIcon euiButtonIcon__icon euiIcon--medium"
       height="16"
+      viewBox="0 0 16 16"
       width="16"
       xmlns="http://www.w3.org/2000/svg"
     >
@@ -89,6 +91,7 @@ exports[`EuiCodeBlockImpl block renders with transparent background 1`] = `
       aria-hidden="true"
       class="euiIcon euiButtonIcon__icon euiIcon--medium"
       height="16"
+      viewBox="0 0 16 16"
       width="16"
       xmlns="http://www.w3.org/2000/svg"
     >

--- a/src/components/code/__snapshots__/code_block.test.js.snap
+++ b/src/components/code/__snapshots__/code_block.test.js.snap
@@ -25,6 +25,7 @@ console.log(some);
       aria-hidden="true"
       class="euiIcon euiButtonIcon__icon euiIcon--medium"
       height="16"
+      viewBox="0 0 16 16"
       width="16"
       xmlns="http://www.w3.org/2000/svg"
     >

--- a/src/components/icon/__snapshots__/icon.test.js.snap
+++ b/src/components/icon/__snapshots__/icon.test.js.snap
@@ -454,6 +454,7 @@ exports[`EuiIcon renders type asterisk 1`] = `
 <svg
   class="euiIcon euiIcon--medium"
   height="16"
+  viewBox="0 0 16 16"
   width="16"
   xmlns="http://www.w3.org/2000/svg"
 >
@@ -572,6 +573,7 @@ exports[`EuiIcon renders type calendar 1`] = `
 <svg
   class="euiIcon euiIcon--medium"
   height="16"
+  viewBox="0 0 16 16"
   width="16"
   xmlns="http://www.w3.org/2000/svg"
 >
@@ -607,6 +609,7 @@ exports[`EuiIcon renders type checkInCircleFilled 1`] = `
 <svg
   class="euiIcon euiIcon--medium"
   height="16"
+  viewBox="0 0 16 16"
   width="16"
   xmlns="http://www.w3.org/2000/svg"
 >
@@ -963,6 +966,7 @@ exports[`EuiIcon renders type exit 1`] = `
 <svg
   class="euiIcon euiIcon--medium"
   height="16"
+  viewBox="0 0 16 16"
   width="16"
   xmlns="http://www.w3.org/2000/svg"
 >
@@ -977,6 +981,7 @@ exports[`EuiIcon renders type expand 1`] = `
 <svg
   class="euiIcon euiIcon--medium"
   height="16"
+  viewBox="0 0 16 16"
   width="16"
   xmlns="http://www.w3.org/2000/svg"
 >
@@ -1005,6 +1010,7 @@ exports[`EuiIcon renders type faceNeutral 1`] = `
 <svg
   class="euiIcon euiIcon--medium"
   height="16"
+  viewBox="0 0 16 16"
   width="16"
   xmlns="http://www.w3.org/2000/svg"
 >
@@ -1170,6 +1176,7 @@ exports[`EuiIcon renders type iInCircle 1`] = `
 <svg
   class="euiIcon euiIcon--medium"
   height="16"
+  viewBox="0 0 16 16"
   width="16"
   xmlns="http://www.w3.org/2000/svg"
 >
@@ -2117,6 +2124,7 @@ exports[`EuiIcon renders type number 1`] = `
 <svg
   class="euiIcon euiIcon--medium"
   height="16"
+  viewBox="0 0 16 16"
   width="16"
   xmlns="http://www.w3.org/2000/svg"
 >
@@ -2131,6 +2139,7 @@ exports[`EuiIcon renders type pause 1`] = `
 <svg
   class="euiIcon euiIcon--medium"
   height="16"
+  viewBox="0 0 16 16"
   width="16"
   xmlns="http://www.w3.org/2000/svg"
 >
@@ -2239,6 +2248,7 @@ exports[`EuiIcon renders type play 1`] = `
 <svg
   class="euiIcon euiIcon--medium"
   height="16"
+  viewBox="0 0 16 16"
   width="16"
   xmlns="http://www.w3.org/2000/svg"
 >
@@ -2273,6 +2283,7 @@ exports[`EuiIcon renders type popout 1`] = `
 <svg
   class="euiIcon euiIcon--medium"
   height="16"
+  viewBox="0 0 16 16"
   width="16"
   xmlns="http://www.w3.org/2000/svg"
 >
@@ -2304,6 +2315,7 @@ exports[`EuiIcon renders type refresh 1`] = `
 <svg
   class="euiIcon euiIcon--medium"
   height="16"
+  viewBox="0 0 16 16"
   width="16"
   xmlns="http://www.w3.org/2000/svg"
 >
@@ -2394,6 +2406,7 @@ exports[`EuiIcon renders type scale 1`] = `
 <svg
   class="euiIcon euiIcon--medium"
   height="16"
+  viewBox="0 0 16 16"
   width="16"
   xmlns="http://www.w3.org/2000/svg"
 >
@@ -2496,6 +2509,7 @@ exports[`EuiIcon renders type share 1`] = `
 <svg
   class="euiIcon euiIcon--medium"
   height="16"
+  viewBox="0 0 16 16"
   width="16"
   xmlns="http://www.w3.org/2000/svg"
 >
@@ -2532,6 +2546,7 @@ exports[`EuiIcon renders type sortLeft 1`] = `
 <svg
   class="euiIcon euiIcon--medium"
   height="16"
+  viewBox="0 0 16 16"
   width="16"
   xmlns="http://www.w3.org/2000/svg"
 >
@@ -2545,6 +2560,7 @@ exports[`EuiIcon renders type sortRight 1`] = `
 <svg
   class="euiIcon euiIcon--medium"
   height="16"
+  viewBox="0 0 16 16"
   width="16"
   xmlns="http://www.w3.org/2000/svg"
 >
@@ -2601,6 +2617,7 @@ exports[`EuiIcon renders type starPlusFilled 1`] = `
 <svg
   class="euiIcon euiIcon--medium"
   height="16"
+  viewBox="0 0 16 16"
   width="16"
   xmlns="http://www.w3.org/2000/svg"
 >
@@ -2615,6 +2632,7 @@ exports[`EuiIcon renders type string 1`] = `
 <svg
   class="euiIcon euiIcon--medium"
   height="16"
+  viewBox="0 0 16 16"
   width="16"
   xmlns="http://www.w3.org/2000/svg"
 >
@@ -2629,6 +2647,7 @@ exports[`EuiIcon renders type tableOfContents 1`] = `
 <svg
   class="euiIcon euiIcon--medium"
   height="16"
+  viewBox="0 0 16 16"
   width="16"
   xmlns="http://www.w3.org/2000/svg"
 >


### PR DESCRIPTION
This fixes some test failures caused by https://github.com/elastic/eui/pull/283, which were in turn caused by an outdated Jest cache.