### PR TITLE
Improve HTML snippets created for EuiText docs.

### DIFF
--- a/src-docs/src/views/text/text.js
+++ b/src-docs/src/views/text/text.js
@@ -5,60 +5,62 @@ import {
 } from '../../../../src/components';
 
 export default () => (
-  <EuiText>
-    <h1>This is Heading One</h1>
-    <p>
-      Far out in the uncharted backwaters of the unfashionable end of
-      the western spiral arm of the Galaxy lies a small unregarded
-      yellow sun.
-    </p>
+  <div>
+    <EuiText>
+      <h1>This is Heading One</h1>
+      <p>
+        Far out in the uncharted backwaters of the unfashionable end of
+        the western spiral arm of the Galaxy lies a small unregarded
+        yellow sun.
+      </p>
 
-    <p>
-      Orbiting this at a distance of roughly ninety-two million miles
-      is an utterly insignificant little blue green planet whose ape-
-      descended life forms are so amazingly primitive that they still
-      think digital watches are a pretty neat idea.
-    </p>
+      <p>
+        Orbiting this at a distance of roughly ninety-two million miles
+        is an utterly insignificant little blue green planet whose ape-
+        descended life forms are so amazingly primitive that they still
+        think digital watches are a pretty neat idea.
+      </p>
 
-    <ul>
-      <li>List item one</li>
-      <li>List item two</li>
-      <li>Dolphins</li>
-    </ul>
+      <ul>
+        <li>List item one</li>
+        <li>List item two</li>
+        <li>Dolphins</li>
+      </ul>
 
-    <p>
-      This planet has - or rather had - a problem, which was this: most
-      of the people living on it were unhappy for pretty much of the time.
-      Many solutions were suggested for this problem, but most of these
-      were largely concerned with the movements of small green pieces
-      of paper, which is odd because on the whole it was not the small
-      green pieces of paper that were unhappy.
-    </p>
+      <p>
+        This planet has - or rather had - a problem, which was this: most
+        of the people living on it were unhappy for pretty much of the time.
+        Many solutions were suggested for this problem, but most of these
+        were largely concerned with the movements of small green pieces
+        of paper, which is odd because on the whole it was not the small
+        green pieces of paper that were unhappy.
+      </p>
 
-    <h2>This is Heading Two</h2>
+      <h2>This is Heading Two</h2>
 
-    <ol>
-      <li>Number one</li>
-      <li>Number two</li>
-      <li>Dolphins again</li>
-    </ol>
+      <ol>
+        <li>Number one</li>
+        <li>Number two</li>
+        <li>Dolphins again</li>
+      </ol>
 
-    <p>
-      But the dog wasn&rsquo;t lazy, it was just
-      practicing mindfulness, so it had a greater sense of
-      life-satisfaction than that fox with all its silly jumping.
-    </p>
+      <p>
+        But the dog wasn&rsquo;t lazy, it was just
+        practicing mindfulness, so it had a greater sense of
+        life-satisfaction than that fox with all its silly jumping.
+      </p>
 
-    <p>
-      And from the fox&rsquo;s perspective, life was full of hoops to jump <em>through</em>, low-hanging
-      fruit to jump <em>for</em>, and dead car batteries to jump-<em>start</em>.
-    </p>
+      <p>
+        And from the fox&rsquo;s perspective, life was full of hoops to jump <em>through</em>, low-hanging
+        fruit to jump <em>for</em>, and dead car batteries to jump-<em>start</em>.
+      </p>
 
-    <h3>This is Heading Three</h3>
+      <h3>This is Heading Three</h3>
 
-    <p>
-      So it thought the dog was making a poor life choice by focusing so much on mindfulness.
-      What if its car broke down?
-    </p>
-  </EuiText>
+      <p>
+        So it thought the dog was making a poor life choice by focusing so much on mindfulness.
+        What if its car broke down?
+      </p>
+    </EuiText>
+  </div>
 );

--- a/src-docs/src/views/text/text_color.js
+++ b/src-docs/src/views/text/text_color.js
@@ -9,7 +9,6 @@ import {
 
 export default () => (
   <div>
-
     <EuiTitle>
       <h2>
         <EuiTextColor color="default">You </EuiTextColor>

--- a/src-docs/src/views/text/text_example.js
+++ b/src-docs/src/views/text/text_example.js
@@ -16,7 +16,7 @@ const textHtml = renderToHtml(Text);
 
 import TextSmall from './text_small';
 const textSmallSource = require('!!raw-loader!./text_small');
-const textSmallHtml = renderToHtml(Text);
+const textSmallHtml = renderToHtml(TextSmall);
 
 import TextColor from './text_color';
 const textColorSource = require('!!raw-loader!./text_color');


### PR DESCRIPTION
This is just a bandaid for the underlying problem, which is that the `renderToHtml()` service uses `render` instead of `mount` to render the code snippet. Unfortunately, `mount` causes memory consumption to balloon and significantly degrade the performance of the doc site. I couldn't figure out how to free up memory using either Enzyme's `detach` and/or `unmount` methods or React's `unmountComponentAtNode` method (per [the way material-ui does it](https://github.com/mui-org/material-ui/blob/v1-beta/src/test-utils/createMount.js)). Seems related to https://github.com/airbnb/enzyme/issues/1055.