### PR TITLE
K6 back to open sans font stack

### DIFF
--- a/src-docs/src/index.html
+++ b/src-docs/src/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
   </head>
   <body class="guideBody">
     <div id="guide" style="height: 100%"></div>

--- a/src/global_styling/variables/_typography.scss
+++ b/src/global_styling/variables/_typography.scss
@@ -18,8 +18,8 @@
 
 // Families
 
-$euiFontFamily: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-$euiCodeFontFamily: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+$euiFontFamily: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
+$euiCodeFontFamily: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace !default;
 
 // Font sizes
 

--- a/src/themes/k6/k6_globals.scss
+++ b/src/themes/k6/k6_globals.scss
@@ -1,5 +1,8 @@
-$euiFontSize:       14px;
+// Font families
+$euiFontFamily: 'Open Sans', Helvetica, Arial, sans-serif;
 
+// Font Sizes
+$euiFontSize:       14px;
 $euiFontSizeXS:     12px;
 $euiFontSizeS:      14px;
 $euiFontSizeM:      16px;


### PR DESCRIPTION
Relevant to https://github.com/elastic/kibana/issues/15814

Makes the K6 EUI theme use Open Sans. The other themes remain unaffected.

Kibana can't move over to system fonts because of issues that arise around dashboards and pdf reports (and somewhat our testing strategy). Briefly, variable fonts can cause the computed heights to get a little wobbly in repeatable elements like tables. While this isn't something we can fix 100% ever, using a singular font helps minimize the problem.

The reason we decided to go back to Open Sans is mainly for current consumer ease of use. Keeping the same font means Kibana dashboard items should retain their same computed height values as they were in 6.1.

The plan is that when we move to v7, we'll be allowed to make a more "breaking" change to these heights (since the layouts themselves should also shift). At that time we'll likely move to Roboto or some to be decided more modern font.

cc @elastic/eui-design 