### PR TITLE
Z-index for toasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Bug fixes**
 
+- Adjust toast z-index to show over modals [(#296)](https://github.com/elastic/eui/pull/296)
 - Removed padding on `<EuiPage>` mobile breakpoint. [(#282)](https://github.com/elastic/eui/pull/282)
 - Fixed some `<EuiIcon>` `type`s not setting their `viewBox` attribute, which caused them to not honor the `size` properly. [(#277)](https://github.com/elastic/eui/pull/277)
 - Fixed `<EuiContextMenu>` to pass the `event` argument to a `<EuiContextMenuItem>`'s `onClick` handler even when a panel is defined. [(#265)](https://github.com/elastic/eui/pull/265)

--- a/src/components/toast/_toast.scss
+++ b/src/components/toast/_toast.scss
@@ -6,6 +6,7 @@
   background-color: $euiColorEmptyShade;
   border: $euiBorderThin;
   width: 100%;
+  z-index: $euiZToast;
 
   &:hover .euiToast__closeButton,
   &:focus .euiToast__closeButton, {

--- a/src/components/toast/_toast.scss
+++ b/src/components/toast/_toast.scss
@@ -6,7 +6,6 @@
   background-color: $euiColorEmptyShade;
   border: $euiBorderThin;
   width: 100%;
-  z-index: $euiZToast;
 
   &:hover .euiToast__closeButton,
   &:focus .euiToast__closeButton, {

--- a/src/global_styling/variables/_z_index.scss
+++ b/src/global_styling/variables/_z_index.scss
@@ -17,3 +17,4 @@ $euiZNavigation:      $euiZLevel4;
 $euiZToastList:       $euiZLevel5;
 $euiZMask:            $euiZLevel6;
 $euiZModal:           $euiZLevel8;
+$euiZToast:           $euiZLevel9;

--- a/src/global_styling/variables/_z_index.scss
+++ b/src/global_styling/variables/_z_index.scss
@@ -14,7 +14,6 @@ $euiZLevel9:          9000;
 $euiZContent:         $euiZLevel0;
 $euiZContentMenu:     $euiZLevel2;
 $euiZNavigation:      $euiZLevel4;
-$euiZToastList:       $euiZLevel5;
 $euiZMask:            $euiZLevel6;
 $euiZModal:           $euiZLevel8;
-$euiZToast:           $euiZLevel9;
+$euiZToastList:       $euiZLevel9;


### PR DESCRIPTION
This sets a z-index for toasts so they will appear above things like modals. cc @bmcconaghy 

TODO

- [ ] Use react portal to move node to body.