### PR TITLE
Single page pagination, button reset, table header sorting, codeblock styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
+- Minor style-only changes to `EuiPagination`, button reset, `EuiTableHeaderCell`, and `EuiCodeBlock`  [(#298)](https://github.com/elastic/eui/pull/298)
 - All NPM dependencies now use ^ to install the latest minor version.
 - Added Apache, Nginx, MySQL logos [(#270)](https://github.com/elastic/eui/pull/270)
 - Added small version of `EuiCallOut` [(#269)](https://github.com/elastic/eui/pull/269)

--- a/src/components/code/_code_block.scss
+++ b/src/components/code/_code_block.scss
@@ -75,7 +75,8 @@
     display: inline-block;
     white-space: pre;
     color: $euiTextColor;
-    font-size: 75%; // 1
+    font-size: 90%; // 1
+    padding: 0 $euiSizeS;
     background: $euiColorLightestShade;
 
     .euiCodeBlock__pre {

--- a/src/components/code/_code_block.scss
+++ b/src/components/code/_code_block.scss
@@ -71,7 +71,6 @@
   ** 1. Size the code against the text its embedded within.
   **/
   &.euiCodeBlock--inline {
-    vertical-align: middle;
     display: inline-block;
     white-space: pre;
     color: $euiTextColor;

--- a/src/components/form/switch/switch.js
+++ b/src/components/form/switch/switch.js
@@ -63,7 +63,3 @@ EuiSwitch.propTypes = {
   checked: PropTypes.bool,
   onChange: PropTypes.func,
 };
-
-EuiSwitch.defaultProps = {
-  defaultChecked: false,
-};

--- a/src/components/link/_mixins.scss
+++ b/src/components/link/_mixins.scss
@@ -1,4 +1,6 @@
 @mixin euiLink {
+  text-align: left;
+  
   &:hover {
     text-decoration: underline;
   }

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -108,6 +108,11 @@ export const EuiPagination = ({
     );
   }
 
+  let selectablePages;
+  if (pages.length > 1) {
+    selectablePages = pages;
+  }
+
   return (
     <div
       className={classes}
@@ -115,7 +120,7 @@ export const EuiPagination = ({
     >
       {previousButton}
       {firstPageButtons}
-      {pages}
+      {selectablePages}
       {lastPageButtons}
       {nextButton}
     </div>

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -56,7 +56,6 @@
 
 .euiTableSortIcon {
   margin-left: $euiSizeXS;
-  fill: tintOrShade($euiTitleColor, 80%, 70%);
 
   .euiTableHeaderButton-isSorted & {
     fill: $euiTitleColor;

--- a/src/components/table/table_header_cell.js
+++ b/src/components/table/table_header_cell.js
@@ -34,13 +34,16 @@ export const EuiTableHeaderCell = ({
   });
 
   if (onSort) {
-    const sortIcon = (
-      <EuiIcon
-        className="euiTableSortIcon"
-        type={isSortAscending ? 'sortUp' : 'sortDown'}
-        size="m"
-      />
-    );
+    let sortIcon;
+    if (isSorted) {
+      sortIcon = (
+        <EuiIcon
+          className="euiTableSortIcon"
+          type={isSortAscending ? 'sortUp' : 'sortDown'}
+          size="m"
+        />
+      );
+    }
 
     const buttonClasses = classNames('euiTableHeaderButton', {
       'euiTableHeaderButton-isSorted': isSorted,

--- a/src/global_styling/reset/_reset.scss
+++ b/src/global_styling/reset/_reset.scss
@@ -99,6 +99,7 @@ button {
   color: inherit;
   font-size: inherit;
   border-radius: 0;
+  text-align: left;
 
   &:hover {
     cursor: pointer;

--- a/src/global_styling/reset/_reset.scss
+++ b/src/global_styling/reset/_reset.scss
@@ -99,7 +99,6 @@ button {
   color: inherit;
   font-size: inherit;
   border-radius: 0;
-  text-align: left;
 
   &:hover {
     cursor: pointer;


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/297, https://github.com/elastic/eui/issues/268 and https://github.com/elastic/eui/issues/289, https://github.com/elastic/eui/issues/300, https://github.com/elastic/eui/issues/299

Small stylistic changes.

Pagination no long shows a single item

![](https://d3vv6lp55qjaqc.cloudfront.net/items/1a1t1w2R0R353R0z2F2d/Screen%20Recording%202018-01-11%20at%2011.50%20PM.gif?X-CloudApp-Visitor-Id=59773&v=2d281c79)

Table heads no longer show vague "is sortable" state. Things just have hover states or not. Only one sort shows.

![](https://d3vv6lp55qjaqc.cloudfront.net/items/1O2p3z0U3x2l3Y3J0K3f/Screen%20Recording%202018-01-11%20at%2011.51%20PM.gif?X-CloudApp-Visitor-Id=59773&v=c6bd712f)

Codeblock sizing increasing with additional padding per feedback form designers

![image](https://user-images.githubusercontent.com/324519/34864745-9cbdedd4-f72a-11e7-8b3c-d01fd39fab9e.png)
