### PR TITLE
Add syncify test helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added small version of `EuiCallOut` [(#269)](https://github.com/elastic/eui/pull/269)
 - Added first batch of TypeScript type definitions for components and services [(#252)](https://github.com/elastic/eui/pull/252)
 - Added button for expanding `<EuiCodeBlock>` instances to be full-screen. [(#259)](https://github.com/elastic/eui/pull/259)
+- Add test helper for async functions that throw exceptions [#301](https://github.com/elastic/eui/pull/301)
 
 **Bug fixes**
 

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -2,3 +2,4 @@ export { requiredProps } from './required_props';
 export { takeMountedSnapshot } from './take_mounted_snapshot';
 export { findTestSubject } from './find_test_subject';
 export { startThrowingReactWarnings, stopThrowingReactWarnings } from './react_warnings';
+export { syncify } from './syncify';

--- a/src/test/syncify.js
+++ b/src/test/syncify.js
@@ -1,4 +1,7 @@
 // Helper designed to help test async/await functions that throw exceptions
+// Example usage:
+// const fn = await syncify(() => asyncFn());
+// expect(fn).toThrow();
 // https://github.com/facebook/jest/issues/1377
 export const syncify = async (fn) => {
   try {

--- a/src/test/syncify.js
+++ b/src/test/syncify.js
@@ -1,0 +1,10 @@
+// Helper designed to help test async/await functions that throw exceptions
+// https://github.com/facebook/jest/issues/1377
+export const syncify = async (fn) => {
+  try {
+    const result = await fn();
+    return () => { return result; };
+  } catch (e) {
+    return () => { throw e; };
+  }
+};


### PR DESCRIPTION
@cjcenizal recommended adding this from [this discussion](https://github.com/elastic/kibana/pull/15936#discussion_r160832170)

This helper allows you to properly test async functions that throw exceptions.

Here is working code using the helper:
```
const fn = await syncify(() => asyncFn());
expect(fn).toThrow();
```