### PR TITLE
[babel] use babel-runtime+transform-runtime to support async functions

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -29,6 +29,14 @@
           ]
         }
       }
+    ],
+    [
+      "transform-runtime",
+      {
+        "helpers": false,
+        "polyfill": false,
+        "regenerator": true,
+      }
     ]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "release": "./scripts/release.sh"
   },
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "brace": "^0.10.0",
     "classnames": "^2.2.5",
     "core-js": "^2.5.1",
@@ -48,6 +49,7 @@
     "babel-plugin-transform-async-generator-functions": "^6.24.1",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "chokidar": "^1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -972,6 +972,12 @@ babel-plugin-transform-regenerator@^6.22.0:
   dependencies:
     regenerator-transform "^0.10.0"
 
+babel-plugin-transform-runtime@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"


### PR DESCRIPTION
Using async functions and targeting runtimes that don't support generators means that eui must depend on regenerator. Without it the `test/syncify.js` helper throws `ReferenceError: regeneratorRuntime is not defined` when installed as a node modules.

This pr includes the `transform-runtime` babel plugin which will rewrite access to the `regeneratorRuntime` global with calls to `require("babel-runtime/regenerator")`, which is now listed as a dependency of eui. This does add a fairly sizable dependency for one async function, but since Kibana is also using regenerator it should only get included in the bundles once.

Alternatively we can disallow async functions in eslint config and convert the syncify helper to use standard promises.