### PR TITLE
Fix nested flexitems in IE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Bug fixes**
 
 - Adjust toast z-index to show over modals [(#296)](https://github.com/elastic/eui/pull/296)
+- Fix nested `<EuiFlexItem>` collapse issue in IE [(#308)](https://github.com/elastic/eui/pull/308)
 
 # [`0.0.12`](https://github.com/elastic/eui/tree/v0.0.12)
 

--- a/src/components/flex/_flex_group.scss
+++ b/src/components/flex/_flex_group.scss
@@ -4,7 +4,7 @@
 
   .euiFlexItem {
     flex-grow: 1;
-    flex-basis: 0;
+    flex-basis: 0%;
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/286

IE has an issue with flex-basis when a % value isn't used.

![kib_eui](https://user-images.githubusercontent.com/324519/35010855-1c55c800-fab9-11e7-8cae-bae3f97c070a.PNG)
![ie_kib](https://user-images.githubusercontent.com/324519/35010856-1c720c4a-fab9-11e7-97e2-9a2720d148a3.PNG)
