### PR TITLE
Allow custom components to be rendered in EuiSideNav

### DIFF
--- a/src/components/side_nav/__snapshots__/side_nav.test.js.snap
+++ b/src/components/side_nav/__snapshots__/side_nav.test.js.snap
@@ -241,7 +241,90 @@ exports[`EuiSideNav items is rendered 1`] = `
 </nav>
 `;
 
-exports[`EuiSideNav items renders items with are links 1`] = `
+exports[`EuiSideNav items renders items using a custom component 1`] = `
+<nav
+  class="euiSideNav"
+>
+  <button
+    class="euiSideNav__mobileToggle euiLink"
+    type="button"
+  >
+    <span
+      class="euiSideNav__mobileWrap"
+    >
+      <span
+        class="euiSideNav__mobileTitle"
+      />
+      <svg
+        aria-hidden="true"
+        class="euiIcon euiSideNav__mobileIcon euiIcon--medium"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xlink="http://www.w3.org/1999/xlink"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <defs>
+          <path
+            d="M2 4V2h2v2H2zm5 0V2h2v2H7zm5 0V2h2v2h-2zM2 9V7h2v2H2zm5 0V7h2v2H7zm5 0V7h2v2h-2zM2 14v-2h2v2H2zm5 0v-2h2v2H7zm5 0v-2h2v2h-2z"
+            id="apps-a"
+          />
+        </defs>
+        <use
+          href="#apps-a"
+        />
+      </svg>
+    </span>
+  </button>
+  <div
+    class="euiSideNav__content"
+  >
+    <div
+      class="euiSideNavItem euiSideNavItem--root"
+    >
+      <div
+        class="euiSideNavItemButton"
+        data-test-id="my-custom-element"
+        href="http://www.elastic.co"
+      >
+        <span
+          class="euiSideNavItemButton__content"
+        >
+          <span
+            class="euiSideNavItemButton__label"
+          >
+            A
+          </span>
+        </span>
+      </div>
+      <div
+        class="euiSideNavItem__items"
+      >
+        <div
+          class="euiSideNavItem euiSideNavItem--trunk"
+        >
+          <div
+            class="euiSideNavItemButton"
+            data-test-id="my-custom-element"
+          >
+            <span
+              class="euiSideNavItemButton__content"
+            >
+              <span
+                class="euiSideNavItemButton__label"
+              >
+                B
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</nav>
+`;
+
+exports[`EuiSideNav items renders items which are links 1`] = `
 <nav
   class="euiSideNav"
 >

--- a/src/components/side_nav/side_nav.js
+++ b/src/components/side_nav/side_nav.js
@@ -26,6 +26,8 @@ export class EuiSideNav extends Component {
   };
 
   renderTree = (items, depth = 0) => {
+    const { component } = this.props;
+
     return items.map((item) => {
       const {
         id,
@@ -35,6 +37,7 @@ export class EuiSideNav extends Component {
         icon,
         onClick,
         href,
+        ...rest
       } = item;
 
       // Root items are always open.
@@ -57,6 +60,8 @@ export class EuiSideNav extends Component {
           items={renderedItems}
           key={id}
           depth={depth}
+          component={component}
+          {...rest}
         >
           {name}
         </EuiSideNavItem>
@@ -71,6 +76,8 @@ export class EuiSideNav extends Component {
       toggleOpenOnMobile,
       isOpenOnMobile,
       mobileTitle,
+      // Extract this one out so it isn't passed to <nav>
+      component, // eslint-disable-line no-unused-vars
       ...rest
     } = this.props;
 
@@ -125,6 +132,7 @@ EuiSideNav.propTypes = {
   isOpenOnMobile: PropTypes.bool,
   mobileTitle: PropTypes.node,
   items: PropTypes.array,
+  component: PropTypes.func,
 };
 
 EuiSideNav.defaultProps = {

--- a/src/components/side_nav/side_nav.test.js
+++ b/src/components/side_nav/side_nav.test.js
@@ -63,7 +63,7 @@ describe('EuiSideNav', () => {
         .toMatchSnapshot();
     });
 
-    test('renders items with are links', () => {
+    test('renders items which are links', () => {
       const sideNav = [{
         name: 'A',
         id: 0,
@@ -86,6 +86,30 @@ describe('EuiSideNav', () => {
 
       const component = render(
         <EuiSideNav items={sideNav} />
+      );
+
+      expect(component)
+        .toMatchSnapshot();
+    });
+
+    test('renders items using a custom component', () => {
+      const sideNav = [{
+        name: 'A',
+        id: 0,
+        href: 'http://www.elastic.co',
+        items: [{
+          name: 'B',
+          id: 1,
+        }],
+      }];
+
+      const MyNavButton = ({ href, className, children }) => (
+        <div data-test-id="my-custom-element" href={href} className={className}>
+          {children}
+        </div>);
+
+      const component = render(
+        <EuiSideNav items={sideNav} component={MyNavButton} />
       );
 
       expect(component)

--- a/src/components/side_nav/side_nav_item.js
+++ b/src/components/side_nav/side_nav_item.js
@@ -8,6 +8,30 @@ import {
   EuiIcon,
 } from '../icon';
 
+const EuiSideNavButton = ({ href, onClick, className, children, ...rest }) => {
+  if (href) {
+    return (
+      <a
+        className={className}
+        href={href}
+        {...rest}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <button
+      className={className}
+      onClick={onClick}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+};
+
 export const EuiSideNavItem = ({
   isOpen,
   isSelected,
@@ -18,6 +42,7 @@ export const EuiSideNavItem = ({
   items,
   children,
   depth,
+  component: ButtonComponent = EuiSideNavButton,
   ...rest,
 }) => {
   let childItems;
@@ -60,9 +85,7 @@ export const EuiSideNavItem = ({
     <span className="euiSideNavItemButton__content">
       {buttonIcon}
 
-      <span
-        className="euiSideNavItemButton__label"
-      >
+      <span className="euiSideNavItemButton__label">
         {children}
       </span>
 
@@ -70,31 +93,11 @@ export const EuiSideNavItem = ({
     </span>
   );
 
-  let button;
-
-  if (href) {
-    button = (
-      <a
-        className={buttonClasses}
-        href={href}
-      >
-        {buttonContent}
-      </a>
-    );
-  } else {
-    button = (
-      <button
-        className={buttonClasses}
-        onClick={onClick}
-      >
-        {buttonContent}
-      </button>
-    );
-  }
-
   return (
-    <div className={classes} {...rest}>
-      {button}
+    <div className={classes}>
+      <ButtonComponent href={href} onClick={onClick} className={buttonClasses} {...rest}>
+        {buttonContent}
+      </ButtonComponent>
       {childItems}
     </div>
   );


### PR DESCRIPTION
In `EuiSideNav`, allow a component prop to be passed that will be used to render the individual items in the navigation. This makes interoperability with e.g. `react-router` easier. The current implementation is difficult to use in Cloud's UI. To make the implementation clean, I refactored the current link / button rendering into a component, and use it by default.

Other changes:

   * Fix test name typo in `side_nav.test.js`