### PR TITLE
Set FlexGroup to grow: 1 to be more friendly with IE11

### DIFF
--- a/src-docs/src/views/flex/flex_nest.js
+++ b/src-docs/src/views/flex/flex_nest.js
@@ -10,9 +10,16 @@ import {
 export default () => (
   <div>
     <EuiFlexGroup>
-      <EuiFlexItem grow={false}>Group One</EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <div>Group Two</div>
+        <div>Flex Group</div>
+        <EuiSpacer />
+        <EuiFlexGroup>
+          <EuiFlexItem>Nested Grid One</EuiFlexItem>
+          <EuiFlexItem>Nested Grid Two</EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <div>Flex Grid</div>
         <EuiSpacer />
         <EuiFlexGrid columns={3}>
           <EuiFlexItem>Nested Grid One</EuiFlexItem>

--- a/src/components/flex/_flex_group.scss
+++ b/src/components/flex/_flex_group.scss
@@ -1,10 +1,16 @@
+/**
+ * 1. Not always needed, but fixes an IE11 issue when flex-groups are nested under display: flex elements.
+ * 2. IE requires a unit to grow.
+ */
+
 .euiFlexGroup {
   display: flex;
   align-items: stretch;
+  flex-grow: 1; /* 1 */
 
   .euiFlexItem {
     flex-grow: 1;
-    flex-basis: 0%;
+    flex-basis: 0%; /* 1 */
   }
 }
 


### PR DESCRIPTION
This is more a bug that popped up in Kibana, then an EUI bug, but this makes usage a little more fault tolerant. IE11 has trouble with nesting flex groups. The 0% fix from https://github.com/elastic/eui/pull/308 actually works as it should, but Kibana was using a wrapping `display: flex` element (to provide an href) around `EuiFlexItems` which caused the groups to not size correctly when nested.

Applying a `flex-grow: 1` to groups themselves fixes that issue and causes no harm to the functionality of our system. For IE11, it'll act as you'd expect, even if you happen to add some flexy wrappers around our components.

I've tested this in every browser and also updated our docs to use a more rigorous nesting scenario (mostly wanted to make sure the bugfix didn't force growth against `<FlexItem>` parents that had `grow={false}`

![](https://d3vv6lp55qjaqc.cloudfront.net/items/2T3H1p1N093G2b2a2y0S/Screen%20Recording%202018-01-17%20at%2011.50%20AM.gif?X-CloudApp-Visitor-Id=59773&v=9dbb6297)