### PR TITLE
Use more complete implementation of Omit in TypeScript definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 **Bug fixes**
 
 - Set `EuiFlexGroup` to `flex-grow: 1` to be more friendly with IE11 [(#315)](https://github.com/elastic/eui/pull/315)
+- Fix TypeScript definitions such that optional and readonly properties survive being passed through `Omit` [(#322)](https://github.com/elastic/eui/pull/322)
 
 # [`0.0.13`](https://github.com/elastic/eui/tree/v0.0.13)
 

--- a/src/components/common.d.ts
+++ b/src/components/common.d.ts
@@ -18,5 +18,5 @@ declare module '@elastic/eui' {
   type Diff<T extends string, U extends string> = ({ [P in T]: P } &
     { [P in U]: never } & { [x: string]: never })[T];
 
-  type Omit<T, K extends keyof T> = { [P in Diff<keyof T, K>]: T[P] };
+  type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
 }

--- a/src/components/context_menu/index.d.ts
+++ b/src/components/context_menu/index.d.ts
@@ -75,13 +75,12 @@ declare module '@elastic/eui' {
 
   export type EuiContextMenuPanelId = string | number;
 
-  export type EuiContextMenuPanelItemDescriptor = Omit<
-    EuiContextMenuItemProps,
-    'hasPanel'
-  > & {
+  export interface EuiContextMenuPanelItemDescriptor
+    extends EuiContextMenuItemProps {
+    hasPanel?: never;
     name: string;
     panel?: EuiContextMenuPanelId;
-  };
+  }
 
   interface EuiContextMenuPanelDescriptor {
     id: EuiContextMenuPanelId;
@@ -96,7 +95,6 @@ declare module '@elastic/eui' {
   }
 
   export const EuiContextMenu: SFC<
-    Omit<HTMLAttributes<HTMLDivElement>, 'className' | 'style'> &
-      EuiContextMenuProps
+    CommonProps & HTMLAttributes<HTMLDivElement> & EuiContextMenuProps
   >;
 }

--- a/src/components/context_menu/index.d.ts
+++ b/src/components/context_menu/index.d.ts
@@ -75,12 +75,13 @@ declare module '@elastic/eui' {
 
   export type EuiContextMenuPanelId = string | number;
 
-  export interface EuiContextMenuPanelItemDescriptor
-    extends EuiContextMenuItemProps {
-    hasPanel?: never;
+  export type EuiContextMenuPanelItemDescriptor = Omit<
+    EuiContextMenuItemProps,
+    'hasPanel'
+  > & {
     name: string;
     panel?: EuiContextMenuPanelId;
-  }
+  };
 
   interface EuiContextMenuPanelDescriptor {
     id: EuiContextMenuPanelId;
@@ -89,12 +90,11 @@ declare module '@elastic/eui' {
     content?: React.ReactNode;
   }
 
-  export interface EuiContextMenuProps {
-    panels?: EuiContextMenuPanelDescriptor[];
-    initialPanelId?: EuiContextMenuPanelId;
-  }
+  export type EuiContextMenuProps = CommonProps &
+    Omit<HTMLAttributes<HTMLDivElement>, 'style'> & {
+      panels?: EuiContextMenuPanelDescriptor[];
+      initialPanelId?: EuiContextMenuPanelId;
+    };
 
-  export const EuiContextMenu: SFC<
-    CommonProps & HTMLAttributes<HTMLDivElement> & EuiContextMenuProps
-  >;
+  export const EuiContextMenu: SFC<EuiContextMenuProps>;
 }


### PR DESCRIPTION
The TypeScript definitions for EuiContextMenu caused errors that seemed to result from usage of the `Omit<>` helper. It might be fixed with https://github.com/Microsoft/TypeScript/issues/21148, which is expected to be included in 2.7.1.