### PR TITLE
Add typescript definitions for more components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 - Added `EuiColorPicker`. ((328)[https://github.com/elastic/eui/pull/328])
 - `EuiCodeBlock` now only shows fullscreen icons if `overflowHeight` prop is set. Also forces large fonts and padding while expanded. [(#325)](https://github.com/elastic/eui/pull/325)
 - Exported `VISUALIZATION_COLORS` from services ((#329)[https://github.com/elastic/eui/pull/329])
+- Add typescript definitions for `<EuiFormRow>`, `<EuiRadioGroup>`, `<EuiSwitch>`, `<EuiLoadingSpinner>`, `<EuiLoadingChart>` and `<EuiProgress>`. [(#326)](https://github.com/elastic/eui/pull/326)
 
 **Breaking changes**
 
 - `EuiCodeBlock` now only shows fullscreen icons if `overflowHeight` prop is set. Also forces large fonts and padding while expanded. [(#325)](https://github.com/elastic/eui/pull/325)
 - React ^16.2 is now a peer dependency ([#264](https://github.com/elastic/eui/pull/264))
+- `<EuiProgress>` no longer accepts the `indeterminate` property, which never had any effect. [(#326)](https://github.com/elastic/eui/pull/326)
 
 **Bug fixes**
 

--- a/src/components/form/form_row/index.d.ts
+++ b/src/components/form/form_row/index.d.ts
@@ -1,0 +1,21 @@
+/// <reference path="../../common.d.ts" />
+
+import { SFC, ReactNode, HTMLAttributes } from 'react';
+
+declare module '@elastic/eui' {
+  /**
+   * @see './form_row.js'
+   */
+
+  export type EuiFormRowProps = CommonProps &
+    HTMLAttributes<HTMLDivElement> & {
+      error?: string | string[];
+      fullWidth?: boolean;
+      hasEmptyLabelSpace?: boolean;
+      helpText?: ReactNode;
+      isInvalid?: boolean;
+      label?: ReactNode;
+    };
+
+  export const EuiFormRow: SFC<EuiFormRowProps>;
+}

--- a/src/components/form/index.d.ts
+++ b/src/components/form/index.d.ts
@@ -1,2 +1,5 @@
 /// <reference path="./checkbox/index.d.ts" />
 /// <reference path="./field_search/index.d.ts" />
+/// <reference path="./form_row/index.d.ts" />
+/// <reference path="./radio/index.d.ts" />
+/// <reference path="./switch/index.d.ts" />

--- a/src/components/form/radio/index.d.ts
+++ b/src/components/form/radio/index.d.ts
@@ -1,0 +1,26 @@
+/// <reference path="../../common.d.ts" />
+
+import { SFC, HTMLAttributes, ReactNode } from 'react';
+
+declare module '@elastic/eui' {
+  /**
+   * @see './radio_group.js'
+   */
+  export interface EuiRadioGroupOption {
+    id: string;
+    label?: ReactNode;
+  }
+
+  export type EuiRadioGroupChangeCallback = (id: string) => void;
+
+  export type EuiRadioGroupProps = CommonProps &
+    Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> & {
+      options?: EuiRadioGroupOption[];
+      idSelected?: string;
+      onChange: (id: string) => void;
+    };
+
+  export type x = EuiRadioGroupProps['onChange'];
+
+  export const EuiRadioGroup: SFC<EuiRadioGroupProps>;
+}

--- a/src/components/form/radio/index.d.ts
+++ b/src/components/form/radio/index.d.ts
@@ -17,7 +17,7 @@ declare module '@elastic/eui' {
     Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> & {
       options?: EuiRadioGroupOption[];
       idSelected?: string;
-      onChange: (id: string) => void;
+      onChange: EuiRadioGroupChangeCallback;
     };
 
   export type x = EuiRadioGroupProps['onChange'];

--- a/src/components/form/switch/index.d.ts
+++ b/src/components/form/switch/index.d.ts
@@ -1,0 +1,18 @@
+/// <reference path="../../common.d.ts" />
+
+import { SFC, InputHTMLAttributes, ReactNode } from 'react';
+
+declare module '@elastic/eui' {
+  /**
+   * @see './switch.js'
+   */
+  export type EuiSwitchChangeCallback = (state: boolean) => void;
+
+  export type EuiSwitchProps = CommonProps &
+    Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange'> & {
+      label?: ReactNode;
+      onChange?: EuiSwitchChangeCallback;
+    };
+
+  export const EuiSwitch: SFC<EuiSwitchProps>;
+}

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -10,3 +10,5 @@
 /// <reference path="./spacer/index.d.ts" />
 /// <reference path="./pagination/index.d.ts" />
 /// <reference path="./link/index.d.ts" />
+/// <reference path="./loading/index.d.ts" />
+/// <reference path="./progress/index.d.ts" />

--- a/src/components/loading/index.d.ts
+++ b/src/components/loading/index.d.ts
@@ -1,0 +1,30 @@
+/// <reference path="../common.d.ts" />
+
+import { SFC, HTMLAttributes } from 'react';
+
+declare module '@elastic/eui' {
+  /**
+   * @see './loading_spinner.js'
+   */
+  export type EuiLoadingSpinnerSize = 's' | 'm' | 'l' | 'xl';
+
+  export type EuiLoadingSpinnerProps = CommonProps &
+    HTMLAttributes<HTMLDivElement> & {
+      size?: EuiLoadingSpinnerSize;
+    };
+
+  export const EuiLoadingSpinner: SFC<EuiLoadingSpinnerProps>;
+
+  /**
+   * @see './loading_chart.js'
+   */
+  export type EuiLoadingChartSize = 'm' | 'l' | 'xl';
+
+  export type EuiLoadingChartProps = CommonProps &
+    HTMLAttributes<HTMLDivElement> & {
+      mono?: boolean;
+      size?: EuiLoadingChartSize;
+    };
+
+  export const EuiLoadingChart: SFC<EuiLoadingChartProps>;
+}

--- a/src/components/loading/loading_chart.js
+++ b/src/components/loading/loading_chart.js
@@ -32,6 +32,10 @@ export const EuiLoadingChart = ({ size, mono, className, ...rest }) => {
 };
 
 EuiLoadingChart.propTypes = {
-  size: PropTypes.oneOf(SIZES),
+  mono: PropTypes.bool,
+  size: PropTypes.oneOf(SIZES)
 };
 
+EuiLoadingChart.defaultProps = {
+  mono: false
+};

--- a/src/components/progress/index.d.ts
+++ b/src/components/progress/index.d.ts
@@ -10,7 +10,7 @@ declare module '@elastic/eui' {
     | 'accent'
     | 'danger'
     | 'primary'
-    | 'secondar'
+    | 'secondary'
     | 'subdued';
 
   export type EuiProgressSize = 'xs' | 's' | 'm' | 'l';

--- a/src/components/progress/index.d.ts
+++ b/src/components/progress/index.d.ts
@@ -1,0 +1,29 @@
+/// <reference path="../common.d.ts" />
+
+import { SFC, HTMLAttributes } from 'react';
+
+declare module '@elastic/eui' {
+  /**
+   * @see './progress.js'
+   */
+  export type EuiProgressColor =
+    | 'accent'
+    | 'danger'
+    | 'primary'
+    | 'secondar'
+    | 'subdued';
+
+  export type EuiProgressSize = 'xs' | 's' | 'm' | 'l';
+
+  export type EuiProgressPosition = 'fixed' | 'absolute' | 'static';
+
+  export type EuiProgressProps = CommonProps &
+    HTMLAttributes<HTMLProgressElement> & {
+      size?: EuiProgressSize;
+      color?: EuiProgressColor;
+      position?: EuiProgressPosition;
+      max?: number;
+    };
+
+  export const EuiProgress: SFC<EuiProgressProps>;
+}

--- a/src/components/progress/progress.js
+++ b/src/components/progress/progress.js
@@ -74,7 +74,6 @@ EuiProgress.propTypes = {
   color: PropTypes.oneOf(COLORS),
   position: PropTypes.oneOf(POSITIONS),
   max: PropTypes.number,
-  indeterminate: PropTypes.bool,
 };
 
 EuiProgress.defaultProps = {


### PR DESCRIPTION
This adds type definitions for

* `<EuiFormRow>`
* `<EuiRadioGroup>`
* `<EuiSwitch>`
* `<EuiLoadingSpinner>`
* `<EuiLoadingChart>`
* `<EuiProgress>`