### PR TITLE
Styling of required props in docs

### DIFF
--- a/src-docs/src/components/guide_section/guide_section.js
+++ b/src-docs/src/components/guide_section/guide_section.js
@@ -156,13 +156,13 @@ export class GuideSection extends Component {
       } = props[propName];
 
       let humanizedName = (
-        <EuiTextColor color="secondary"><strong>{propName}</strong></EuiTextColor>
+        <strong>{propName}</strong>
       );
 
       if (required) {
         humanizedName = (
           <span>
-            {humanizedName} <EuiTextColor color="subdued">(required)</EuiTextColor>
+            <strong>{humanizedName}</strong> <EuiTextColor color="danger">(required)</EuiTextColor>
           </span>
         );
       }


### PR DESCRIPTION
Red for required, back to strong in default color for prop.

![image](https://user-images.githubusercontent.com/324519/35240817-854d9dba-ff69-11e7-8615-0d73a765be4f.png)
