### PR TITLE
Allow EuiFieldNumber to take empty string in value prop

### DIFF
--- a/src-docs/src/views/form/form_controls.js
+++ b/src-docs/src/views/form/form_controls.js
@@ -49,6 +49,7 @@ export default class extends Component {
         label: 'Option three',
       }],
       radioIdSelected: `${idPrefix}5`,
+      numberInputValue: '',
     };
   }
 
@@ -71,6 +72,16 @@ export default class extends Component {
   onRadioChange = optionId => {
     this.setState({
       radioIdSelected: optionId,
+    });
+  }
+
+  onNumberInputChange = (evt) => {
+    let value = parseFloat(evt.target.value);
+    if (isNaN(value)) {
+      value = '';
+    }
+    this.setState({
+      numberInputValue: value,
     });
   }
 
@@ -98,6 +109,17 @@ export default class extends Component {
         <EuiFieldNumber
           defaultValue="23"
           icon="user"
+        />
+
+        <br />
+        <br />
+
+        <p>
+          Number input with no initial value. Input value: {this.state.numberInputValue}
+        </p>
+        <EuiFieldNumber
+          value={this.state.numberInputValue}
+          onChange={this.onNumberInputChange}
         />
 
         <br />

--- a/src-docs/src/views/form/form_controls.js
+++ b/src-docs/src/views/form/form_controls.js
@@ -101,7 +101,10 @@ export default class extends Component {
         <br />
         <br />
 
-        <EuiFieldNumber defaultValue="23" />
+        <EuiFieldNumber
+          value={this.state.numberInputValue}
+          onChange={this.onNumberInputChange}
+        />
 
         <br />
         <br />
@@ -109,17 +112,6 @@ export default class extends Component {
         <EuiFieldNumber
           defaultValue="23"
           icon="user"
-        />
-
-        <br />
-        <br />
-
-        <p>
-          Number input with no initial value. Input value: {this.state.numberInputValue}
-        </p>
-        <EuiFieldNumber
-          value={this.state.numberInputValue}
-          onChange={this.onNumberInputChange}
         />
 
         <br />

--- a/src/components/form/field_number/__snapshots__/field_number.test.js.snap
+++ b/src/components/form/field_number/__snapshots__/field_number.test.js.snap
@@ -66,3 +66,33 @@ exports[`EuiFieldNumber props isLoading is rendered 1`] = `
   </eui-validatable-control>
 </eui-form-control-layout>
 `;
+
+exports[`EuiFieldNumber props value no initial value 1`] = `
+<eui-form-control-layout
+  fullwidth="false"
+  isloading="false"
+>
+  <eui-validatable-control>
+    <input
+      class="euiFieldNumber"
+      type="number"
+      value=""
+    />
+  </eui-validatable-control>
+</eui-form-control-layout>
+`;
+
+exports[`EuiFieldNumber props value value is number 1`] = `
+<eui-form-control-layout
+  fullwidth="false"
+  isloading="false"
+>
+  <eui-validatable-control>
+    <input
+      class="euiFieldNumber"
+      type="number"
+      value="0"
+    />
+  </eui-validatable-control>
+</eui-form-control-layout>
+`;

--- a/src/components/form/field_number/field_number.js
+++ b/src/components/form/field_number/field_number.js
@@ -53,13 +53,28 @@ export const EuiFieldNumber = ({
   );
 };
 
+function numberOrEmptyString(props, propName, componentName) {
+  componentName = componentName || 'ANONYMOUS';
+
+  if (props[propName]) {
+    const value = props[propName];
+    if (typeof value === 'string' && value !== '') {
+      return new Error(`Invalid prop '${propName}' of type 'string' supplied to '${componentName}',` +
+      ` expected empty string or type 'number', you supplied a string with the contents '${value}'`);
+    }
+  }
+
+  // assume all ok
+  return null;
+}
+
 EuiFieldNumber.propTypes = {
   id: PropTypes.string,
   name: PropTypes.string,
   min: PropTypes.number,
   max: PropTypes.number,
   step: PropTypes.number,
-  value: PropTypes.number,
+  value: numberOrEmptyString,
   icon: PropTypes.string,
   isInvalid: PropTypes.bool,
   fullWidth: PropTypes.bool,

--- a/src/components/form/field_number/field_number.js
+++ b/src/components/form/field_number/field_number.js
@@ -60,7 +60,10 @@ function numberOrEmptyString(props, propName, componentName) {
     const value = props[propName];
     if (typeof value === 'string' && value !== '') {
       return new Error(`Invalid prop '${propName}' of type 'string' supplied to '${componentName}',` +
-      ` expected empty string or type 'number', you supplied a string with the contents '${value}'`);
+      ` expected empty string or type 'number', you supplied a string with the contents '${value}'.`);
+    } else if (typeof value !== 'number') {
+      return new Error(`Invalid prop '${propName}' of type '${typeof value}' supplied to '${componentName}',` +
+      ` expected empty string or type 'number'.`);
     }
   }
 

--- a/src/components/form/field_number/field_number.test.js
+++ b/src/components/form/field_number/field_number.test.js
@@ -60,5 +60,40 @@ describe('EuiFieldNumber', () => {
       expect(component)
         .toMatchSnapshot();
     });
+
+    describe('value', () => {
+      let value = 0;
+      const onChange = (evt) => {
+        value = parseFloat(evt.target.value);
+        if (isNaN(value)) {
+          value = '';
+        }
+      };
+
+      test(`value is number`, () => {
+        const component = render(
+          <EuiFieldNumber
+            value={value}
+            onChange={onChange}
+          />
+        );
+        expect(component)
+          .toMatchSnapshot();
+      });
+
+      test(`no initial value`, () => {
+        value = '';
+        const component = render(
+          <EuiFieldNumber
+            value={value}
+            onChange={onChange}
+          />
+        );
+        expect(component)
+          .toMatchSnapshot();
+      });
+
+    });
+
   });
 });

--- a/src/components/form/field_number/field_number.test.js
+++ b/src/components/form/field_number/field_number.test.js
@@ -62,19 +62,11 @@ describe('EuiFieldNumber', () => {
     });
 
     describe('value', () => {
-      let value = 0;
-      const onChange = (evt) => {
-        value = parseFloat(evt.target.value);
-        if (isNaN(value)) {
-          value = '';
-        }
-      };
-
       test(`value is number`, () => {
         const component = render(
           <EuiFieldNumber
-            value={value}
-            onChange={onChange}
+            value={0}
+            onChange={() => {}}
           />
         );
         expect(component)
@@ -82,11 +74,10 @@ describe('EuiFieldNumber', () => {
       });
 
       test(`no initial value`, () => {
-        value = '';
         const component = render(
           <EuiFieldNumber
-            value={value}
-            onChange={onChange}
+            value={''}
+            onChange={() => {}}
           />
         );
         expect(component)


### PR DESCRIPTION
There needs to be a way to create an EuiFieldNumber with no initial value. You can not pass `undefined` in because when switching from `undefined` to numbers react throws the error `A component is changing an uncontrolled input of type number to be controlled. Input elements should not switch from uncontrolled to controlled`. The recommended react way to have an input with no value is to pass an empty string as discussed [here](https://github.com/facebook/react/issues/6222#issuecomment-194061477).

This PR updates the EuiFieldNumber component to accept an empty string or a number 