### PR TITLE
Make EuiPageSideBar sticky and scrollable.

### DIFF
--- a/src-docs/src/views/app_view.js
+++ b/src-docs/src/views/app_view.js
@@ -87,22 +87,22 @@ export class AppView extends Component {
 
       return (
         <EuiPage>
-          <EuiPageBody>
-            <EuiErrorBoundary>
-              <EuiPageSideBar>
-                <GuidePageChrome
-                  currentRouteName={currentRoute.name}
-                  onToggleTheme={toggleTheme}
-                  selectedTheme={theme}
-                  guidelines={guidelines}
-                  services={services}
-                  components={components}
-                  patterns={patterns}
-                  sandboxes={sandboxes}
-                />
-              </EuiPageSideBar>
-            </EuiErrorBoundary>
+          <EuiErrorBoundary>
+            <EuiPageSideBar>
+              <GuidePageChrome
+                currentRouteName={currentRoute.name}
+                onToggleTheme={toggleTheme}
+                selectedTheme={theme}
+                guidelines={guidelines}
+                services={services}
+                components={components}
+                patterns={patterns}
+                sandboxes={sandboxes}
+              />
+            </EuiPageSideBar>
+          </EuiErrorBoundary>
 
+          <EuiPageBody>
             <EuiPageContent>
               <EuiPageContentBody>
                 {children}

--- a/src/components/page/_index.scss
+++ b/src/components/page/_index.scss
@@ -1,3 +1,5 @@
+$euiPagePadding: $euiSize;
+
 @import 'page';
 @import 'page_body/index';
 @import 'page_content/index';

--- a/src/components/page/_page.scss
+++ b/src/components/page/_page.scss
@@ -1,3 +1,3 @@
 .euiPage {
-  padding: $euiSize;
+  display: flex;
 }

--- a/src/components/page/page_body/_page_body.scss
+++ b/src/components/page/page_body/_page_body.scss
@@ -1,8 +1,10 @@
 .euiPageBody {
   display: flex;
   flex-direction: row;
+  flex: 1 1 auto;
   align-items: stretch;
   min-height: 400px; // Temporary till we have a better doc system.
+  padding: $euiPagePadding;
 }
 
 @include screenXSmall {

--- a/src/components/page/page_side_bar/_page_side_bar.scss
+++ b/src/components/page/page_side_bar/_page_side_bar.scss
@@ -2,9 +2,13 @@
  * 1. Prevent side bar width from changing when content width changes.
  */
 .euiPageSideBar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow: auto;
   min-width: $euiSize * 12; /* 1 */
-  flex: 0 0 0; /* 1 */
-  margin-right: $euiSizeL;
+  flex: 1 1 auto; /* 1 */
+  padding: $euiPagePadding $euiSizeL $euiPagePadding $euiPagePadding;
 }
 
 @include screenXSmall {


### PR DESCRIPTION
Now the side bar and the content can scroll independently, making for a much improved UX when either the side bar and/or the content is very tall. If everyone likes this direction, I'll update the EuiPage examples too, because this change required changing the relationship of the EuiPageSideBar and EuiPageBody in the DOM.

![image](https://user-images.githubusercontent.com/1238659/35493989-3bb39d28-046c-11e8-8143-2dc9bb7bc086.png)
