### PR TITLE
Properly cancel keydown events after handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ No public interface changes since `0.0.15`.
 
 **Bug fixes**
 
-- Stop propagation and prevent default when closing components. [(#344)](https://github.com/elastic/eui/pull/344)
+- Stop propagation and prevent default when closing components. Otherwise the same Escape keypress could close the parent component(s) as well as the one you intend to close. [(#344)](https://github.com/elastic/eui/pull/344)
 
 # [`0.0.15`](https://github.com/elastic/eui/tree/v0.0.15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 No public interface changes since `0.0.15`.
 
+**Bug fixes**
+
+- Stop propagation and prevent default when closing components. [(#344)](https://github.com/elastic/eui/pull/344)
+
 # [`0.0.15`](https://github.com/elastic/eui/tree/v0.0.15)
 
 - Added `EuiColorPicker`. ((328)[https://github.com/elastic/eui/pull/328])

--- a/src/components/code/_code_block.js
+++ b/src/components/code/_code_block.js
@@ -58,6 +58,8 @@ export class EuiCodeBlockImpl extends Component {
 
   onKeyDown = event => {
     if (event.keyCode === keyCodes.ESCAPE) {
+      event.preventDefault();
+      event.stopPropagation();
       this.closeFullScreen();
     }
   };

--- a/src/components/context_menu/context_menu_panel.js
+++ b/src/components/context_menu/context_menu_panel.js
@@ -88,6 +88,8 @@ export class EuiContextMenuPanel extends Component {
     ) {
       if (e.keyCode === cascadingMenuKeyCodes.LEFT) {
         if (this.props.showPreviousPanel) {
+          e.preventDefault();
+          e.stopPropagation();
           this.props.showPreviousPanel();
 
           if (this.props.onUseKeyboardToNavigate) {

--- a/src/components/flyout/flyout.js
+++ b/src/components/flyout/flyout.js
@@ -22,6 +22,8 @@ export const SIZES = Object.keys(sizeToClassNameMap);
 export class EuiFlyout extends Component {
   onKeyDown = event => {
     if (event.keyCode === keyCodes.ESCAPE) {
+      event.preventDefault();
+      event.stopPropagation();
       this.props.onClose();
     }
   };

--- a/src/components/image/image.js
+++ b/src/components/image/image.js
@@ -42,6 +42,8 @@ export class EuiImage extends Component {
 
   onKeyDown = event => {
     if (event.keyCode === keyCodes.ESCAPE) {
+      event.preventDefault();
+      event.stopPropagation();
       this.closeFullScreen();
     }
   };

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -10,6 +10,8 @@ import { keyCodes } from '../../services';
 export class EuiModal extends Component {
   onKeyDown = event => {
     if (event.keyCode === keyCodes.ESCAPE) {
+      event.preventDefault();
+      event.stopPropagation();
       this.props.onClose();
     }
   };

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -44,6 +44,8 @@ export class EuiPopover extends Component {
 
   onKeyDown = e => {
     if (e.keyCode === cascadingMenuKeyCodes.ESCAPE) {
+      e.preventDefault();
+      e.stopPropagation();
       this.props.closePopover();
     }
   };


### PR DESCRIPTION
Whenever we handle a keydown event, we should properly prevent it's default behavior and also stop propagation to parent nodes. Otherwise the same Escape keypress could close multiple components.

I have the case where I have an `EuiCodeBlock` in an `EuiFlyout`. If you now open the code block fullscreen and press <kbd>Escape</kbd> both components will close, because the `EuiCodeBlock` doesn't stop propagation when handling its close event.

That same will be true for any of these components if you place them in something else, that tries to handle the same keypress. In general: if we handle a keyevent we should prevent it's default behavior and stop its propagation.