### PR TITLE
Move `@types/react` to `dependencies`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 No public interface changes since `0.0.15`.
 
+**Bug fixes**
+
+- Move `@types/react` from `devDependencies` to `dependencies` to make typescript definitions usable. [(#345)](https://github.com/elastic/eui/345)
+
 # [`0.0.15`](https://github.com/elastic/eui/tree/v0.0.15)
 
 - Added `EuiColorPicker`. ((328)[https://github.com/elastic/eui/pull/328])

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "release": "./scripts/release.sh"
   },
   "dependencies": {
+    "@types/react": "^16.0.35",
     "brace": "^0.10.0",
     "classnames": "^2.2.5",
     "core-js": "^2.5.1",
@@ -37,7 +38,6 @@
   },
   "devDependencies": {
     "@elastic/eslint-config-kibana": "^0.15.0",
-    "@types/react": "^16.0.31",
     "autoprefixer": "^7.1.5",
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,9 +70,9 @@
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.3.0.tgz#3a129cda7c4e5df2409702626892cb4b96546dd5"
 
-"@types/react@^16.0.31":
-  version "16.0.34"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.34.tgz#7a8f795afd8a404a9c4af9539b24c75d3996914e"
+"@types/react@^16.0.35":
+  version "16.0.35"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.35.tgz#7ce8a83cad9690fd965551fc513217a74fc9e079"
 
 "@zeit/check-updates@1.0.5":
   version "1.0.5"


### PR DESCRIPTION
Since the typescript definitions import types from the `react` package, the `@types/react` package providing these must be installed as well when `@elastic/eui` is installed.