### PR TITLE
Fix EuiTableOfRecords selection bug when selected items are deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `0.0.18`.
+**Bug fixes**
+
+- `EuiTableOfRecords` selection bugs ([#365](https://github.com/elastic/eui/pull/365))
+  - Deleting selected items now resets the select all checkbox to an unchecked state
+  - The select all checkbox only becomes checked when all selectable rows are checked, not just some of them
 
 # [`0.0.18`](https://github.com/elastic/eui/tree/v0.0.18)
 
@@ -12,7 +16,7 @@ No public interface changes since `0.0.18`.
 
 **Bug fixes**
 
-- Downgraded `lodash` version to `3.10.0` to align it with Kibana. ([#359]()https://github.com/elastic/eui/pull/359)
+- Downgraded `lodash` version to `3.10.0` to align it with Kibana. ([#359](https://github.com/elastic/eui/pull/359))
 
 # [`0.0.16`](https://github.com/elastic/eui/tree/v0.0.16)
 

--- a/src-docs/src/views/table_of_records/full_featured.js
+++ b/src-docs/src/views/table_of_records/full_featured.js
@@ -5,6 +5,7 @@ import uuid from 'uuid/v1';
 import { times } from 'lodash';
 
 import {
+  EuiButton,
   EuiTableOfRecords,
   EuiHealth,
   EuiSwitch,
@@ -62,6 +63,7 @@ export default class PeopleTable extends Component {
     super(props);
 
     this.state = {
+      selectedIds: [],
       features: {
         pagination: true,
         sorting: true,
@@ -96,17 +98,34 @@ export default class PeopleTable extends Component {
     };
   }
 
+  onSelectionChanged = selection => {
+    const selectedIds = selection.map(item => item.id);
+    this.setState({
+      selectedIds,
+    });
+  };
+
   onDataCriteriaChange(criteria) {
     this.setState(this.computeTableState(criteria));
   }
 
   deletePerson(personToDelete) {
     const i = people.findIndex((person) => person.id === personToDelete.id);
-    if (i >= 0) {
+    if (i !== -1) {
       people.splice(i, 1);
     }
     this.onDataCriteriaChange(this.state.criteria);
   }
+
+  deleteSelectedPeople = () => {
+    this.state.selectedIds.forEach(id => {
+      const i = people.findIndex((person) => person.id === id);
+      if (i !== -1) {
+        people.splice(i, 1);
+      }
+    });
+    this.onDataCriteriaChange(this.state.criteria);
+  };
 
   clonePerson(personToClone) {
     const i = people.findIndex((person) => person.id === personToClone.id);
@@ -235,13 +254,15 @@ export default class PeopleTable extends Component {
 
       selection: features.selection ? {
         selectable: (record) => record.online,
-        selectableMessage: person => !person.online ? `${person.firstName} is offline` : undefined
+        selectableMessage: person => !person.online ? `${person.firstName} is offline` : undefined,
+        onSelectionChanged: this.onSelectionChanged,
       } : undefined,
 
       onDataCriteriaChange: (criteria) => this.onDataCriteriaChange(criteria)
     };
 
     const {
+      selectedIds,
       data,
       criteria: {
         page,
@@ -257,9 +278,23 @@ export default class PeopleTable extends Component {
       },
     };
 
+    let deleteButton;
+
+    if (selectedIds.length) {
+      const label = selectedIds.length > 1 ? `Delete ${selectedIds.length} people` : `Delete 1 person`;
+      deleteButton = (
+        <EuiFlexItem grow={false}>
+          <EuiButton color="danger" onClick={this.deleteSelectedPeople}>
+            {label}
+          </EuiButton>
+        </EuiFlexItem>
+      );
+    }
+
     return (
       <div>
-        <EuiFlexGroup>
+        <EuiFlexGroup alignItems="center">
+          { deleteButton }
           <EuiFlexItem grow={false}>
             <EuiSwitch
               label="Pagination"

--- a/src/components/table_of_records/__snapshots__/table_of_records.test.js.snap
+++ b/src/components/table_of_records/__snapshots__/table_of_records.test.js.snap
@@ -308,6 +308,7 @@ exports[`EuiTableOfRecords with pagination and selection 1`] = `
       >
         <EuiCheckbox
           checked={false}
+          data-test-subj="checkboxSelectAll"
           disabled={false}
           id="_selection_column-checkbox"
           onChange={[Function]}
@@ -336,6 +337,7 @@ exports[`EuiTableOfRecords with pagination and selection 1`] = `
         >
           <EuiCheckbox
             checked={false}
+            data-test-subj="checkboxSelectRow-1"
             disabled={false}
             id="_selection_column_1-checkbox"
             onChange={[Function]}
@@ -361,6 +363,7 @@ exports[`EuiTableOfRecords with pagination and selection 1`] = `
         >
           <EuiCheckbox
             checked={false}
+            data-test-subj="checkboxSelectRow-2"
             disabled={false}
             id="_selection_column_2-checkbox"
             onChange={[Function]}
@@ -386,6 +389,7 @@ exports[`EuiTableOfRecords with pagination and selection 1`] = `
         >
           <EuiCheckbox
             checked={false}
+            data-test-subj="checkboxSelectRow-3"
             disabled={false}
             id="_selection_column_3-checkbox"
             onChange={[Function]}
@@ -468,6 +472,7 @@ exports[`EuiTableOfRecords with pagination, selection and sorting 1`] = `
       >
         <EuiCheckbox
           checked={false}
+          data-test-subj="checkboxSelectAll"
           disabled={false}
           id="_selection_column-checkbox"
           onChange={[Function]}
@@ -497,6 +502,7 @@ exports[`EuiTableOfRecords with pagination, selection and sorting 1`] = `
         >
           <EuiCheckbox
             checked={false}
+            data-test-subj="checkboxSelectRow-1"
             disabled={false}
             id="_selection_column_1-checkbox"
             onChange={[Function]}
@@ -522,6 +528,7 @@ exports[`EuiTableOfRecords with pagination, selection and sorting 1`] = `
         >
           <EuiCheckbox
             checked={false}
+            data-test-subj="checkboxSelectRow-2"
             disabled={false}
             id="_selection_column_2-checkbox"
             onChange={[Function]}
@@ -547,6 +554,7 @@ exports[`EuiTableOfRecords with pagination, selection and sorting 1`] = `
         >
           <EuiCheckbox
             checked={false}
+            data-test-subj="checkboxSelectRow-3"
             disabled={false}
             id="_selection_column_3-checkbox"
             onChange={[Function]}
@@ -630,6 +638,7 @@ exports[`EuiTableOfRecords with pagination, selection, sorting and a single reco
       >
         <EuiCheckbox
           checked={false}
+          data-test-subj="checkboxSelectAll"
           disabled={false}
           id="_selection_column-checkbox"
           onChange={[Function]}
@@ -664,6 +673,7 @@ exports[`EuiTableOfRecords with pagination, selection, sorting and a single reco
         >
           <EuiCheckbox
             checked={false}
+            data-test-subj="checkboxSelectRow-1"
             disabled={false}
             id="_selection_column_1-checkbox"
             onChange={[Function]}
@@ -743,6 +753,7 @@ exports[`EuiTableOfRecords with pagination, selection, sorting and a single reco
         >
           <EuiCheckbox
             checked={false}
+            data-test-subj="checkboxSelectRow-2"
             disabled={false}
             id="_selection_column_2-checkbox"
             onChange={[Function]}
@@ -822,6 +833,7 @@ exports[`EuiTableOfRecords with pagination, selection, sorting and a single reco
         >
           <EuiCheckbox
             checked={false}
+            data-test-subj="checkboxSelectRow-3"
             disabled={false}
             id="_selection_column_3-checkbox"
             onChange={[Function]}
@@ -969,6 +981,7 @@ exports[`EuiTableOfRecords with pagination, selection, sorting and column dataTy
       >
         <EuiCheckbox
           checked={false}
+          data-test-subj="checkboxSelectAll"
           disabled={false}
           id="_selection_column-checkbox"
           onChange={[Function]}
@@ -998,6 +1011,7 @@ exports[`EuiTableOfRecords with pagination, selection, sorting and column dataTy
         >
           <EuiCheckbox
             checked={false}
+            data-test-subj="checkboxSelectRow-1"
             disabled={false}
             id="_selection_column_1-checkbox"
             onChange={[Function]}
@@ -1023,6 +1037,7 @@ exports[`EuiTableOfRecords with pagination, selection, sorting and column dataTy
         >
           <EuiCheckbox
             checked={false}
+            data-test-subj="checkboxSelectRow-2"
             disabled={false}
             id="_selection_column_2-checkbox"
             onChange={[Function]}
@@ -1048,6 +1063,7 @@ exports[`EuiTableOfRecords with pagination, selection, sorting and column dataTy
         >
           <EuiCheckbox
             checked={false}
+            data-test-subj="checkboxSelectRow-3"
             disabled={false}
             id="_selection_column_3-checkbox"
             onChange={[Function]}
@@ -1132,6 +1148,7 @@ exports[`EuiTableOfRecords with pagination, selection, sorting and column render
       >
         <EuiCheckbox
           checked={false}
+          data-test-subj="checkboxSelectAll"
           disabled={false}
           id="_selection_column-checkbox"
           onChange={[Function]}
@@ -1161,6 +1178,7 @@ exports[`EuiTableOfRecords with pagination, selection, sorting and column render
         >
           <EuiCheckbox
             checked={false}
+            data-test-subj="checkboxSelectRow-1"
             disabled={false}
             id="_selection_column_1-checkbox"
             onChange={[Function]}
@@ -1186,6 +1204,7 @@ exports[`EuiTableOfRecords with pagination, selection, sorting and column render
         >
           <EuiCheckbox
             checked={false}
+            data-test-subj="checkboxSelectRow-2"
             disabled={false}
             id="_selection_column_2-checkbox"
             onChange={[Function]}
@@ -1211,6 +1230,7 @@ exports[`EuiTableOfRecords with pagination, selection, sorting and column render
         >
           <EuiCheckbox
             checked={false}
+            data-test-subj="checkboxSelectRow-3"
             disabled={false}
             id="_selection_column_3-checkbox"
             onChange={[Function]}
@@ -1295,6 +1315,7 @@ exports[`EuiTableOfRecords with pagination, selection, sorting and multiple reco
       >
         <EuiCheckbox
           checked={false}
+          data-test-subj="checkboxSelectAll"
           disabled={false}
           id="_selection_column-checkbox"
           onChange={[Function]}
@@ -1329,6 +1350,7 @@ exports[`EuiTableOfRecords with pagination, selection, sorting and multiple reco
         >
           <EuiCheckbox
             checked={false}
+            data-test-subj="checkboxSelectRow-1"
             disabled={false}
             id="_selection_column_1-checkbox"
             onChange={[Function]}
@@ -1406,6 +1428,7 @@ exports[`EuiTableOfRecords with pagination, selection, sorting and multiple reco
         >
           <EuiCheckbox
             checked={false}
+            data-test-subj="checkboxSelectRow-2"
             disabled={false}
             id="_selection_column_2-checkbox"
             onChange={[Function]}
@@ -1483,6 +1506,7 @@ exports[`EuiTableOfRecords with pagination, selection, sorting and multiple reco
         >
           <EuiCheckbox
             checked={false}
+            data-test-subj="checkboxSelectRow-3"
             disabled={false}
             id="_selection_column_3-checkbox"
             onChange={[Function]}
@@ -1634,6 +1658,7 @@ exports[`EuiTableOfRecords with pagination, selection, sorting, column renderer 
       >
         <EuiCheckbox
           checked={false}
+          data-test-subj="checkboxSelectAll"
           disabled={false}
           id="_selection_column-checkbox"
           onChange={[Function]}
@@ -1663,6 +1688,7 @@ exports[`EuiTableOfRecords with pagination, selection, sorting, column renderer 
         >
           <EuiCheckbox
             checked={false}
+            data-test-subj="checkboxSelectRow-1"
             disabled={false}
             id="_selection_column_1-checkbox"
             onChange={[Function]}
@@ -1688,6 +1714,7 @@ exports[`EuiTableOfRecords with pagination, selection, sorting, column renderer 
         >
           <EuiCheckbox
             checked={false}
+            data-test-subj="checkboxSelectRow-2"
             disabled={false}
             id="_selection_column_2-checkbox"
             onChange={[Function]}
@@ -1713,6 +1740,7 @@ exports[`EuiTableOfRecords with pagination, selection, sorting, column renderer 
         >
           <EuiCheckbox
             checked={false}
+            data-test-subj="checkboxSelectRow-3"
             disabled={false}
             id="_selection_column_3-checkbox"
             onChange={[Function]}

--- a/src/components/table_of_records/table_of_records.behavior.test.js
+++ b/src/components/table_of_records/table_of_records.behavior.test.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { findTestSubject } from '../../test';
+
+import { EuiTableOfRecords } from './table_of_records';
+
+describe('EuiTableOfRecords', () => {
+  describe('behavior', () => {
+    describe('selected items', () => {
+      let props;
+      let component;
+
+      beforeEach(() => {
+        props = {
+          config: {
+            recordId: 'id',
+            columns: [
+              {
+                field: 'name',
+                name: 'Name',
+                description: 'description'
+              }
+            ],
+            selection: {
+              onSelectionChanged: () => {}
+            },
+            onDataCriteriaChange: () => {}
+          },
+          model: {
+            data: {
+              records: [
+                { id: '1', name: 'name1' },
+                { id: '2', name: 'name2' }
+              ],
+            },
+          }
+        };
+
+        component = mount(<EuiTableOfRecords {...props} />);
+      });
+
+      test('check the select all checkbox when all are selected', () => {
+        findTestSubject(component, 'checkboxSelectRow-1').simulate('change', { target: { checked: true } });
+        findTestSubject(component, 'checkboxSelectRow-2').simulate('change', { target: { checked: true } });
+        expect(findTestSubject(component, 'checkboxSelectAll').prop('checked')).toBe(true);
+      });
+
+      test('uncheck the select all checkbox when some are selected', () => {
+        findTestSubject(component, 'checkboxSelectRow-1').simulate('change', { target: { checked: true } });
+        expect(findTestSubject(component, 'checkboxSelectAll').prop('checked')).toBe(false);
+      });
+
+      test('are all selected when the select all checkbox is checked', () => {
+        findTestSubject(component, 'checkboxSelectAll').simulate('change', { target: { checked: true } });
+        expect(findTestSubject(component, 'checkboxSelectRow-1').prop('checked')).toBe(true);
+        expect(findTestSubject(component, 'checkboxSelectRow-2').prop('checked')).toBe(true);
+      });
+
+      test('select all checkbox becomes unchecked when selected items are deleted', () => {
+        findTestSubject(component, 'checkboxSelectAll').simulate('change', { target: { checked: true } });
+        props.model.data.records = [];
+        component.setProps(...props);
+        expect(findTestSubject(component, 'checkboxSelectAll').prop('checked')).toBe(false);
+      });
+    });
+  });
+});

--- a/src/components/table_of_records/table_of_records.js
+++ b/src/components/table_of_records/table_of_records.js
@@ -237,7 +237,8 @@ export class EuiTableOfRecords extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     // Don't call changeSelection here or else we can get into an infinite loop:
-    // changeSelection calls owner -> owner sets its state -> we receive new props -> ad infinitum
+    // changeSelection calls props.onSelectionChanged on owner ->
+    // owner sets its state -> we receive new props, calling componentWillReceiveProps -> ad infinitum
     if (!this.props.config.selection) {
       return;
     }

--- a/src/components/table_of_records/table_of_records.js
+++ b/src/components/table_of_records/table_of_records.js
@@ -235,6 +235,25 @@ export class EuiTableOfRecords extends React.Component {
     this.setState({ hoverRecordId: null });
   }
 
+  componentWillReceiveProps(nextProps) {
+    // Don't call changeSelection here or else we can get into an infinite loop:
+    // changeSelection calls owner -> owner sets its state -> we receive new props -> ad infinitum
+    if (!this.props.config.selection) {
+      return;
+    }
+
+    this.setState(prevState => {
+      // Remove any records which don't exist any more.
+      const newSelection = prevState.selection.filter(selectedRecord => (
+        nextProps.model.data.records.findIndex(record => record.id === selectedRecord.id) !== -1
+      ));
+
+      return {
+        selection: newSelection,
+      };
+    });
+  }
+
   render() {
     const { className, config, model, ...rest } = this.props;
 
@@ -261,20 +280,25 @@ export class EuiTableOfRecords extends React.Component {
   }
 
   renderTableHead(config, model) {
-
     const headers = [];
 
     if (config.selection) {
-      const checked = this.state.selection && this.state.selection.length > 0;
+      const selectableRecords = model.data.records.filter((record) =>
+        !config.selection.selectable || config.selection.selectable(record, model));
+
+      const checked =
+        this.state.selection
+        && (selectableRecords.length !== 0)
+        && (this.state.selection.length === selectableRecords.length);
+
       const onChange = (event) => {
         if (event.target.checked) {
-          const selectableRecords = model.data.records.filter((record) =>
-            !config.selection.selectable || config.selection.selectable(record, model));
           this.changeSelection(selectableRecords);
         } else {
           this.changeSelection([]);
         }
       };
+
       headers.push(
         <EuiTableHeaderCellCheckbox key="_selection_column_h" width="24px">
           <EuiCheckbox
@@ -282,13 +306,13 @@ export class EuiTableOfRecords extends React.Component {
             type="inList"
             checked={checked}
             onChange={onChange}
+            data-test-subj="checkboxSelectAll"
           />
         </EuiTableHeaderCellCheckbox>
       );
     }
 
     config.columns.forEach((column, index) => {
-
       // actions column
       if (column.actions) {
         headers.push(
@@ -479,13 +503,13 @@ export class EuiTableOfRecords extends React.Component {
           checked={checked}
           onChange={onChange}
           title={title}
+          data-test-subj={`checkboxSelectRow-${recordId}`}
         />
       </EuiTableRowCellCheckbox>
     );
   }
 
   renderTableRecordActionsCell(recordId, record, actions, config, model, columnIndex) {
-
     const visible = this.state.hoverRecordId === recordId;
 
     const actionEnabled = (action) =>


### PR DESCRIPTION
Fixed two bugs:

1. Deleting selected items now resets the select all checkbox to an unchecked state
2. The select all checkbox only becomes checked when all selectable rows are checked, not just some of them