### PR TITLE
Fix flex group class name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `0.0.19`.
+- Rename class from `euiFlexGroup--alignItemsStart` to `euiFlexGroup--alignItemsFlexStart`
 
 # [`0.0.19`](https://github.com/elastic/eui/tree/v0.0.19)
 

--- a/src/components/flex/_flex_group.scss
+++ b/src/components/flex/_flex_group.scss
@@ -57,7 +57,7 @@ $gutterTypes: (
 }
 
 // Align Items
-.euiFlexGroup--alignItemsStart {
+.euiFlexGroup--alignItemsFlexStart {
   align-items: flex-start;
 }
 


### PR DESCRIPTION
One of the flex group classes was mis-named, so you couldn't actually set `align-items` to `flex-start.