### PR TITLE
fixed typo from 'labe' to 'label'  Misspelling #356

### DIFF
--- a/src-docs/src/views/color_picker/color_picker_example.js
+++ b/src-docs/src/views/color_picker/color_picker_example.js
@@ -41,7 +41,7 @@ export const ColorPickerExample = {
     }],
     demo: <ColorPickerLabelAndClear />,
   }, {
-    title: 'Color Picker without a color labe',
+    title: 'Color Picker without a color label',
     source: [{
       type: GuideSectionTypes.JS,
       code: colorPickerNoColorLabelSource,


### PR DESCRIPTION
eui/src-docs/src/views/color_picker/color_picker_example.js
Line 44 in c19a9b6
 title: 'Color Picker without a color labe', 

"labe" instead of "label"

Misspelling #356