### PR TITLE
Using tintOrShade for subStep background color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 **Bug fixes**
 
 - Wrap long lines of text within the body of `EuiToast` instead of letting text overflow ([#392](https://github.com/elastic/eui/pull/392))
+- Fix dark theme coloring of Substeps ([#396](https://github.com/elastic/eui/pull/396))
 
 # [`0.0.20`](https://github.com/elastic/eui/tree/v0.0.20)
 

--- a/src/components/steps/_sub_steps.scss
+++ b/src/components/steps/_sub_steps.scss
@@ -1,6 +1,6 @@
 .euiSubSteps {
   padding: $euiSize;
-  background-color: tint($euiColorPrimary, 93%);
+  background-color: tintOrShade(tint($euiColorPrimary, 55%), 83%, 78%);
   margin-bottom: $euiSize;
 
   > *:last-child {


### PR DESCRIPTION
Fixes #395

I see how those SASS functions work now.

<img width="632" alt="screen shot 2018-02-13 at 10 37 02 am" src="https://user-images.githubusercontent.com/549577/36158246-dcaccd46-10a9-11e8-9225-45ef74fa69f4.png">
<img width="524" alt="screen shot 2018-02-13 at 10 37 09 am" src="https://user-images.githubusercontent.com/549577/36158247-de1ffa04-10a9-11e8-84ea-4dcff9180cec.png">
