### PR TITLE
table-layout: fixed. Remove 20px max-width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 **Bug fixes**
 
+- Tables now default to `table-layout: fixed` to avoid some collapsing cell problems. [#398](https://github.com/elastic/eui/pull/398)
 - Wrap long lines of text within the body of `EuiToast` instead of letting text overflow ([#392](https://github.com/elastic/eui/pull/392))
 - Fix dark theme coloring of Substeps ([#396](https://github.com/elastic/eui/pull/396))
 - Reorder selectors to fix fixed progress bar in Firefox ([#404](https://github.com/elastic/eui/pull/404))

--- a/src/components/table/_index.scss
+++ b/src/components/table/_index.scss
@@ -1,8 +1,4 @@
-/**
- * 1. Prevent cells from expanding based on content size. This substitutes for table-layout: fixed.
- */
 @mixin euiTableCell {
-  max-width: 20px; /* 1 */
   vertical-align: middle;
 }
 

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -6,6 +6,7 @@
   @include euiFontSizeS;
 
   width: 100%;
+  table-layout: fixed;
   border: none;
   border-collapse: collapse;
   background-color: $euiColorEmptyShade;


### PR DESCRIPTION
Closes https://github.com/elastic/eui/issues/389

This removes some finicky code that tried to make tables widths a bit prettier, but came with some bad drawbacks.

Moving to table-layout: fixed seems to solve most of our problems, though it might require people to hand touch cell widths a bit more (which I think is fine).