### PR TITLE
Reorder selectors to fix fixed progress bar in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Wrap long lines of text within the body of `EuiToast` instead of letting text overflow ([#392](https://github.com/elastic/eui/pull/392))
 - Fix dark theme coloring of Substeps ([#396](https://github.com/elastic/eui/pull/396))
+- Reorder selectors to fix fixed progress bar in Firefox ([#404](https://github.com/elastic/eui/pull/404))
 
 # [`0.0.20`](https://github.com/elastic/eui/tree/v0.0.20)
 

--- a/src/components/progress/_progress.scss
+++ b/src/components/progress/_progress.scss
@@ -58,6 +58,33 @@ $euiProgressSizes: (
   }
 }
 
+// Progress bars can be set to fixed or absolute.
+.euiProgress--fixed {
+  position: fixed;
+}
+
+.euiProgress--absolute {
+  position: absolute;
+}
+
+.euiProgress--fixed,
+.euiProgress--absolute {
+  top: 0;
+  left: 0;
+  right: 0;
+  background-color: transparent;
+
+  &.euiProgress--native {
+    &::-webkit-progress-bar {
+      background-color: transparent;
+    }
+
+    &::-moz-progress-bar {
+      background-color: transparent;
+    }
+  }
+}
+
 // Progress bars come in different colors.
 $euiProgressColors: (
   primary: $euiColorPrimary,
@@ -83,33 +110,6 @@ $euiProgressColors: (
       &:before {
         background-color: $color;
       }
-    }
-  }
-}
-
-// Progress bars can be set to fixed or absolute.
-.euiProgress--fixed {
-  position: fixed;
-}
-
-.euiProgress--absolute {
-  position: absolute;
-}
-
-.euiProgress--fixed,
-.euiProgress--absolute {
-  top: 0;
-  left: 0;
-  right: 0;
-  background-color: transparent;
-
-  &.euiProgress--native {
-    &::-webkit-progress-bar {
-      background-color: transparent;
-    }
-
-    &::-moz-progress-bar {
-      background-color: transparent;
     }
   }
 }


### PR DESCRIPTION
Fixes #362 

Issue had to do with `background-color: transparent;` of fixed style taking precedence over color styles:

<img width="426" alt="screen shot 2018-02-14 at 11 09 17 am" src="https://user-images.githubusercontent.com/1965714/36223263-b390c0f0-1178-11e8-973b-ae17c30ecc2c.png">

Fix simply reorders the styles:

<img width="389" alt="screen shot 2018-02-14 at 11 14 14 am" src="https://user-images.githubusercontent.com/1965714/36223265-b5418240-1178-11e8-8881-d62889b7ed37.png">
