### PR TITLE
 Use a regex to swap out EUI import statements in code examples so that they look like they're importing from the EUI node module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 **Bug fixes**
 
-- `EuiTableOfRecords` selection bugs ([#365](https://github.com/elastic/eui/pull/365))
+- **Note: This is deprecated in 0.0.21.** `EuiTableOfRecords` selection bugs ([#365](https://github.com/elastic/eui/pull/365))
   - Deleting selected items now resets the select all checkbox to an unchecked state
   - The select all checkbox only becomes checked when all selectable rows are checked, not just some of them
 
@@ -44,7 +44,7 @@
 
 - `EuiRadio` now supports the `input` tag's `name` attribute. `EuiRadioGroup` accepts a `name` prop that will propagate to its `EuiRadio`s. ([#348](https://github.com/elastic/eui/pull/348))
 - Added Machine Learning create jobs icon set. ([#338](https://github.com/elastic/eui/pull/338))
-- Added `EuiTableOfRecords`, a higher level table component to take away all your table listings frustrations. ([#250](https://github.com/elastic/eui/pull/250))
+- **Note: This is deprecated in 0.0.21.** Added `EuiTableOfRecords`, a higher level table component to take away all your table listings frustrations. ([#250](https://github.com/elastic/eui/pull/250))
 
 **Bug fixes**
 

--- a/src-docs/src/components/guide_section/guide_section.js
+++ b/src-docs/src/components/guide_section/guide_section.js
@@ -230,7 +230,7 @@ export class GuideSection extends Component {
 
     const title = _euiObjectType === 'type' ?
       <EuiCode id={componentName}>{componentName}</EuiCode> :
-      <EuiText color="accent">{componentName}</EuiText>;
+      <EuiText>{componentName}</EuiText>;
 
     let descriptionElement;
 
@@ -336,7 +336,10 @@ export class GuideSection extends Component {
     };
 
     const codeClass = nameToCodeClassMap[name];
-    const source = this.props.source.find(sourceObject => sourceObject.type === name);
+    const { code } = this.props.source.find(sourceObject => sourceObject.type === name);
+    const npmImports = code
+      .replace(/(from )'(..\/)+src\/components(\/?';)/, `from '@elastic/eui';`)
+      .replace(/(from )'(..\/)+src\/services(\/?';)/, `from '@elastic/eui/services';`);
 
     return (
       <div key={name} ref={name}>
@@ -344,7 +347,7 @@ export class GuideSection extends Component {
           language={codeClass}
           overflowHeight={400}
         >
-          {source.code}
+          {npmImports}
         </EuiCodeBlock>
       </div>
     );

--- a/src-docs/src/views/tables/actions/actions.js
+++ b/src-docs/src/views/tables/actions/actions.js
@@ -1,14 +1,17 @@
 import React, { Component } from 'react';
 import { formatDate } from '../../../../../src/services/format';
 import { createDataStore } from '../data_store';
-import { EuiBasicTable } from '../../../../../src/components/basic_table';
-import { EuiLink } from '../../../../../src/components/link/link';
-import { EuiHealth } from '../../../../../src/components/health';
-import { EuiButton } from '../../../../../src/components/button/button';
-import { EuiFlexGroup } from '../../../../../src/components/flex/flex_group';
-import { EuiFlexItem } from '../../../../../src/components/flex/flex_item';
-import { EuiSwitch } from '../../../../../src/components/form/switch/switch';
-import { EuiSpacer } from '../../../../../src/components/spacer/spacer';
+
+import {
+  EuiBasicTable,
+  EuiLink,
+  EuiHealth,
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSwitch,
+  EuiSpacer,
+} from '../../../../../src/components';
 
 /*
 Example user object:

--- a/src-docs/src/views/tables/basic/basic.js
+++ b/src-docs/src/views/tables/basic/basic.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import { formatDate } from '../../../../../src/services/format';
 import { createDataStore } from '../data_store';
-import { EuiBasicTable } from '../../../../../src/components/basic_table';
-import { EuiHealth } from '../../../../../src/components/health';
-import { EuiLink } from '../../../../../src/components/link/link';
+
+import {
+  EuiBasicTable,
+  EuiLink,
+  EuiHealth,
+} from '../../../../../src/components';
 
 /*
 Example user object:

--- a/src-docs/src/views/tables/paginated/paginated.js
+++ b/src-docs/src/views/tables/paginated/paginated.js
@@ -3,9 +3,12 @@ import React, {
 } from 'react';
 import { formatDate } from '../../../../../src/services/format';
 import { createDataStore } from '../data_store';
-import { EuiBasicTable } from '../../../../../src/components/basic_table';
-import { EuiLink } from '../../../../../src/components/link/link';
-import { EuiHealth } from '../../../../../src/components/health';
+
+import {
+  EuiBasicTable,
+  EuiLink,
+  EuiHealth,
+} from '../../../../../src/components';
 
 /*
 Example user object:

--- a/src-docs/src/views/tables/selection/selection.js
+++ b/src-docs/src/views/tables/selection/selection.js
@@ -3,10 +3,13 @@ import React, {
 } from 'react';
 import { formatDate } from '../../../../../src/services/format';
 import { createDataStore } from '../data_store';
-import { EuiBasicTable } from '../../../../../src/components/basic_table';
-import { EuiLink } from '../../../../../src/components/link/link';
-import { EuiHealth } from '../../../../../src/components/health';
-import { EuiButton } from '../../../../../src/components/button/button';
+
+import {
+  EuiBasicTable,
+  EuiLink,
+  EuiHealth,
+  EuiButton,
+} from '../../../../../src/components';
 
 /*
 Example user object:

--- a/src-docs/src/views/tables/sorting/sorting.js
+++ b/src-docs/src/views/tables/sorting/sorting.js
@@ -3,9 +3,12 @@ import React, {
 } from 'react';
 import { formatDate } from '../../../../../src/services/format';
 import { createDataStore } from '../data_store';
-import { EuiBasicTable } from '../../../../../src/components/basic_table';
-import { EuiLink } from '../../../../../src/components/link/link';
-import { EuiHealth } from '../../../../../src/components/health';
+
+import {
+  EuiBasicTable,
+  EuiLink,
+  EuiHealth,
+} from '../../../../../src/components';
 
 /*
 Example user object:


### PR DESCRIPTION
This will make it easier for people to copy/paste examples.

![image](https://user-images.githubusercontent.com/1238659/36226488-de6b8738-1182-11e8-85d8-4cc7f10ee8d5.png)
