### PR TITLE
Fixed search bar query parser

### DIFF
--- a/src/components/search_bar/query/default_syntax.js
+++ b/src/components/search_bar/query/default_syntax.js
@@ -62,15 +62,15 @@ fieldValue "field value"
 
 fieldValues
   = "(" space? head:value tail:(
-  	space ([oO][rR]) space value:value space	{ return value; }
-  )+ space? ")" { return [ head, ...tail ] }
+  	space ([oO][rR]) space value:value { return value; }
+  )* space? ")" { return [ head, ...tail ] }
 
 termValue "term"
   = value
 
 value
   = word
-  / '"' phrase:phrase '"' { return phrase; }
+  / '"' space? phrase:phrase space?'"' { return phrase; }
 
 phrase
   = word (space word)* { return unescapeValue(text()); }
@@ -89,10 +89,10 @@ reservedChar
   = [:\\-\\\\]
 
 alnum "alpha numeric"
-  = [a-zA-Z0-9]+
+  = [a-zA-Z0-9]
 
 space "whitespace"
-  = [ \\t\\n\\r]*
+  = [ \\t\\n\\r]+
 `;
 
 const printValue = (value) => {

--- a/src/components/search_bar/query/default_syntax.test.js
+++ b/src/components/search_bar/query/default_syntax.test.js
@@ -411,4 +411,43 @@ describe('defaultSyntax', () => {
     expect(printedQuery).toBe(query);
   });
 
+  test('relaxed phrases with spaces', () => {
+
+    const query = `f:" this is a relaxed phrase \t"`;
+    const ast = defaultSyntax.parse(query);
+
+    expect(ast).toBeDefined();
+    expect(ast.clauses).toHaveLength(1);
+
+    const clause = ast.getSimpleFieldClause('f');
+    expect(clause).toBeDefined();
+    expect(AST.Field.isInstance(clause)).toBe(true);
+    expect(AST.Match.isMustClause(clause)).toBe(true);
+    expect(clause.field).toBe('f');
+    expect(clause.value).toBe('this is a relaxed phrase');
+
+    const printedQuery = defaultSyntax.print(ast);
+    expect(printedQuery).toBe(`f:"this is a relaxed phrase"`);
+  });
+
+  test('single term or expression', () => {
+
+    const query = `f:(foo)`;
+    const ast = defaultSyntax.parse(query);
+
+    expect(ast).toBeDefined();
+    expect(ast.clauses).toHaveLength(1);
+
+    const clause = ast.getOrFieldClause('f');
+    expect(clause).toBeDefined();
+    expect(AST.Field.isInstance(clause)).toBe(true);
+    expect(AST.Match.isMustClause(clause)).toBe(true);
+    expect(clause.field).toBe('f');
+    expect(clause.value).toHaveLength(1);
+    expect(clause.value).toContain('foo');
+
+    const printedQuery = defaultSyntax.print(ast);
+    expect(printedQuery).toBe(query);
+  });
+
 });


### PR DESCRIPTION
- relaxed the support for phrases - we now accept spaces anywhere in the phrase as long as it contains at least one term - the phrases are trimmed
- it's now possible to have a single term OR clause