### PR TITLE
Changing the way EuiCard inherits EuiPanel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix appearance of checked checkeboxes and radios in IE ([#407](https://github.com/elastic/eui/pull/407))
 - Fix disabled vs enabled appearance of checked checkeboxes and radios ([#407](https://github.com/elastic/eui/pull/407))
 - Fix disabled & checked state of switches ([#407](https://github.com/elastic/eui/pull/407))
+- Fix EuiCard content alignment when content is short. ([#415](https://github.com/elastic/eui/pull/415))
 
 # [`0.0.21`](https://github.com/elastic/eui/tree/v0.0.21)
 
@@ -21,7 +22,7 @@
 - Added importAction and exportAction icons ([#394](https://github.com/elastic/eui/pull/394))
 - Added `EuiCard` for UI patterns that need an icon/image, title and description with some sort of action. ([#380](https://github.com/elastic/eui/pull/380))
 - Add TypeScript definitions for the `<EuiHealth>` component. ([#403](https://github.com/elastic/eui/pull/403))
-- Added `SearchBar` component - introduces a simple yet rich query language to search for objects + search box and filter controls to construct/manipulate it. ([#379](https://github.com/elastic/eui/pull/379))  
+- Added `SearchBar` component - introduces a simple yet rich query language to search for objects + search box and filter controls to construct/manipulate it. ([#379](https://github.com/elastic/eui/pull/379))
 
 **Bug fixes**
 

--- a/src-docs/src/views/card/card.js
+++ b/src-docs/src/views/card/card.js
@@ -15,7 +15,7 @@ const cardNodes = icons.map(function (item, index) {
       <EuiCard
         icon={<EuiIcon size="xxl" type={`logo${item}`} />}
         title={`Elastic ${item}`}
-        description="Example of a card's description. Stick to one or two sentences."
+        description="Example of a card."
         onClick={() => window.alert('Card clicked')}
       />
     </EuiFlexItem>

--- a/src-docs/src/views/card/card.js
+++ b/src-docs/src/views/card/card.js
@@ -15,7 +15,7 @@ const cardNodes = icons.map(function (item, index) {
       <EuiCard
         icon={<EuiIcon size="xxl" type={`logo${item}`} />}
         title={`Elastic ${item}`}
-        description="Example of a card."
+        description="Example of a card's description. Stick to one or two sentences."
         onClick={() => window.alert('Card clicked')}
       />
     </EuiFlexItem>

--- a/src-docs/src/views/panel/panel.js
+++ b/src-docs/src/views/panel/panel.js
@@ -9,31 +9,31 @@ import {
 export default () => (
   <div>
     <EuiPanel paddingSize="none">
-      <EuiCode>sizePadding=&quot;none&quot;</EuiCode>
+      <EuiCode>paddingSize=&quot;none&quot;</EuiCode>
     </EuiPanel>
 
     <EuiSpacer size="l"/>
 
     <EuiPanel paddingSize="s">
-      <EuiCode>sizePadding=&quot;s&quot;</EuiCode>
+      <EuiCode>paddingSize=&quot;s&quot;</EuiCode>
     </EuiPanel>
 
     <EuiSpacer size="l"/>
 
     <EuiPanel paddingSize="m">
-      <EuiCode>sizePadding=&quot;m&quot;</EuiCode>
+      <EuiCode>paddingSize=&quot;m&quot;</EuiCode>
     </EuiPanel>
 
     <EuiSpacer size="l"/>
 
     <EuiPanel paddingSize="l">
-      <EuiCode>sizePadding=&quot;l&quot;</EuiCode>
+      <EuiCode>paddingSize=&quot;l&quot;</EuiCode>
     </EuiPanel>
 
     <EuiSpacer size="l"/>
 
     <EuiPanel paddingSize="l" hasShadow>
-      <EuiCode>sizePadding=&quot;l&quot;</EuiCode>, <EuiCode>hasShadow</EuiCode>
+      <EuiCode>paddingSize=&quot;l&quot;</EuiCode>, <EuiCode>hasShadow</EuiCode>
     </EuiPanel>
   </div>
 );

--- a/src/components/card/__snapshots__/card.test.js.snap
+++ b/src/components/card/__snapshots__/card.test.js.snap
@@ -2,31 +2,35 @@
 
 exports[`EuiCard is rendered 1`] = `
 <div
-  aria-label="aria-label"
-  class="euiPanel euiPanel--paddingMedium euiCard euiCard--centerAligned euiCard--textAlign testClass1 testClass2"
-  data-test-subj="test subject string"
+  class="euiPanel"
 >
   <div
-    class="euiCard__top"
-  />
-  <div
-    class="euiCard__content"
+    aria-label="aria-label"
+    class="euiCard euiCard--centerAligned testClass1 testClass2"
+    data-test-subj="test subject string"
   >
-    <span
-      class="euiTitle euiTitle--small euiCard__title"
-    >
-      Card title
-    </span>
     <div
-      class="euiText euiText--small euiCard__description"
+      class="euiCard__top"
+    />
+    <div
+      class="euiCard__content"
     >
-      <p>
-        Card description
-      </p>
+      <span
+        class="euiTitle euiTitle--small euiCard__title"
+      >
+        Card title
+      </span>
+      <div
+        class="euiText euiText--small euiCard__description"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
+    <div
+      class="euiCard__footer"
+    />
   </div>
-  <div
-    class="euiCard__footer"
-  />
 </div>
 `;

--- a/src/components/card/__snapshots__/card.test.js.snap
+++ b/src/components/card/__snapshots__/card.test.js.snap
@@ -3,7 +3,7 @@
 exports[`EuiCard is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="euiPanel euiPanel--paddingMedium euiCard euiCard--centerAligned euiCard--textAlign testClass1 testClass2"
+  class="euiCard euiCard--centerAligned testClass1 testClass2"
   data-test-subj="test subject string"
 >
   <div

--- a/src/components/card/__snapshots__/card.test.js.snap
+++ b/src/components/card/__snapshots__/card.test.js.snap
@@ -6,10 +6,10 @@ exports[`EuiCard is rendered 1`] = `
   class="euiCard euiCard--centerAligned testClass1 testClass2"
   data-test-subj="test subject string"
 >
-  <div
+  <span
     class="euiCard__top"
   />
-  <div
+  <span
     class="euiCard__content"
   >
     <span
@@ -24,8 +24,8 @@ exports[`EuiCard is rendered 1`] = `
         Card description
       </p>
     </div>
-  </div>
-  <div
+  </span>
+  <span
     class="euiCard__footer"
   />
 </div>

--- a/src/components/card/__snapshots__/card.test.js.snap
+++ b/src/components/card/__snapshots__/card.test.js.snap
@@ -2,35 +2,31 @@
 
 exports[`EuiCard is rendered 1`] = `
 <div
-  class="euiPanel"
+  aria-label="aria-label"
+  class="euiPanel euiPanel--paddingMedium euiCard euiCard--centerAligned euiCard--textAlign testClass1 testClass2"
+  data-test-subj="test subject string"
 >
   <div
-    aria-label="aria-label"
-    class="euiCard euiCard--centerAligned testClass1 testClass2"
-    data-test-subj="test subject string"
+    class="euiCard__top"
+  />
+  <div
+    class="euiCard__content"
   >
-    <div
-      class="euiCard__top"
-    />
-    <div
-      class="euiCard__content"
+    <span
+      class="euiTitle euiTitle--small euiCard__title"
     >
-      <span
-        class="euiTitle euiTitle--small euiCard__title"
-      >
-        Card title
-      </span>
-      <div
-        class="euiText euiText--small euiCard__description"
-      >
-        <p>
-          Card description
-        </p>
-      </div>
-    </div>
+      Card title
+    </span>
     <div
-      class="euiCard__footer"
-    />
+      class="euiText euiText--small euiCard__description"
+    >
+      <p>
+        Card description
+      </p>
+    </div>
   </div>
+  <div
+    class="euiCard__footer"
+  />
 </div>
 `;

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -13,7 +13,9 @@ $euiCardSpacing: map-get($euiPanelPaddingModifiers, "paddingMedium");
   overflow: hidden;
   padding: $euiCardSpacing;
 
-  > * {
+  .euiCard__top,
+  .euiCard__content,
+  .euiCard__footer {
     display: block;
     width: 100%;
   }
@@ -52,19 +54,6 @@ $euiCardSpacing: map-get($euiPanelPaddingModifiers, "paddingMedium");
  * 1. Footer is always at the bottom.
  */
 
-.euiCard__content {
-  flex-grow: 1; /* 1 */
-
-  .euiCard__title {
-    display: block;
-    margin-top: $euiCardSpacing;
-  }
-
-  .euiCard__description {
-    margin-top: $euiCardSpacing/2;
-  }
-}
-
 .euiCard__top {
   flex-grow: 0; /* 1 */
   position: relative;
@@ -87,6 +76,19 @@ $euiCardSpacing: map-get($euiPanelPaddingModifiers, "paddingMedium");
       left: 50%;
       transform: translate(-50%, calc(-50% + #{$euiCardSpacing * -1}));
     }
+  }
+}
+
+.euiCard__content {
+  flex-grow: 1; /* 1 */
+
+  .euiCard__title {
+    display: block;
+    margin-top: $euiCardSpacing;
+  }
+
+  .euiCard__description {
+    margin-top: $euiCardSpacing/2;
   }
 }
 

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -1,28 +1,44 @@
 @import "../panel/variables";
+@import "../panel/mixins";
 
 $euiCardSpacing: map-get($euiPanelPaddingModifiers, "paddingMedium");
 
+// Start with a base of EuiPanel styles
+@include euiPanel($selector: 'euiCard');
+
+// EuiCard specific
 .euiCard {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  padding: $euiCardSpacing;
+
+  > * {
+    display: block;
+    width: 100%;
+  }
 
   &.euiCard--leftAligned,
   &.euiCard--isClickable.euiCard--leftAligned {
     text-align: left;
+    align-items: flex-start;
   }
 
   &.euiCard--centerAligned,
   &.euiCard--isClickable.euiCard--centerAligned {
     text-align: center;
+    align-items: center;
   }
 
   &.euiCard--rightAligned,
   &.euiCard--isClickable.euiCard--rightAligned {
     text-align: right;
+    align-items: flex-end;
   }
 
   &.euiCard--isClickable {
+    display: flex;
+
     &:focus,
     &:hover {
       .euiCard__title {

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -6,7 +6,6 @@ $euiCardSpacing: map-get($euiPanelPaddingModifiers, "paddingMedium");
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  padding: $euiCardSpacing;
 
   &.euiCard--leftAligned,
   &.euiCard--isClickable.euiCard--leftAligned {
@@ -24,8 +23,6 @@ $euiCardSpacing: map-get($euiPanelPaddingModifiers, "paddingMedium");
   }
 
   &.euiCard--isClickable {
-    display: flex; // override panel
-
     &:focus,
     &:hover {
       .euiCard__title {

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -6,6 +6,7 @@ $euiCardSpacing: map-get($euiPanelPaddingModifiers, "paddingMedium");
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  padding: $euiCardSpacing;
 
   &.euiCard--leftAligned,
   &.euiCard--isClickable.euiCard--leftAligned {
@@ -23,6 +24,8 @@ $euiCardSpacing: map-get($euiPanelPaddingModifiers, "paddingMedium");
   }
 
   &.euiCard--isClickable {
+    display: flex; // override panel
+
     &:focus,
     &:hover {
       .euiCard__title {

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -30,6 +30,7 @@ export const EuiCard = ({
     textAlignToClassNameMap[textAlign],
     {
       'euiCard--isClickable': onClick,
+      'euiCard--textAlign': textAlign,
     },
     className,
   );
@@ -49,36 +50,30 @@ export const EuiCard = ({
     );
   }
 
-  const InnerElement = onClick ? 'span' : 'div';
-
   return (
     <EuiPanel
       onClick={onClick}
-      paddingSize="none"
+      className={classes}
+      {...rest}
     >
-      <InnerElement
-        className={classes}
-        {...rest}
-      >
-        <InnerElement className="euiCard__top">
-          {imageNode}
-          {iconNode}
-        </InnerElement>
+      <div className="euiCard__top">
+        {imageNode}
+        {iconNode}
+      </div>
 
-        <InnerElement className="euiCard__content">
-          <EuiTitle size="s" className="euiCard__title">
-            <span>{title}</span>
-          </EuiTitle>
+      <div className="euiCard__content">
+        <EuiTitle size="s" className="euiCard__title">
+          <span>{title}</span>
+        </EuiTitle>
 
-          <EuiText size="s" className="euiCard__description">
-            <p>{description}</p>
-          </EuiText>
-        </InnerElement>
+        <EuiText size="s" className="euiCard__description">
+          <p>{description}</p>
+        </EuiText>
+      </div>
 
-        <InnerElement className="euiCard__footer">
-          {footer}
-        </InnerElement>
-      </InnerElement>
+      <div className="euiCard__footer">
+        {footer}
+      </div>
     </EuiPanel>
   );
 };

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -30,7 +30,6 @@ export const EuiCard = ({
     textAlignToClassNameMap[textAlign],
     {
       'euiCard--isClickable': onClick,
-      'euiCard--textAlign': textAlign,
     },
     className,
   );
@@ -50,30 +49,36 @@ export const EuiCard = ({
     );
   }
 
+  const InnerElement = onClick ? 'span' : 'div';
+
   return (
     <EuiPanel
       onClick={onClick}
-      className={classes}
-      {...rest}
+      paddingSize="none"
     >
-      <div className="euiCard__top">
-        {imageNode}
-        {iconNode}
-      </div>
+      <InnerElement
+        className={classes}
+        {...rest}
+      >
+        <InnerElement className="euiCard__top">
+          {imageNode}
+          {iconNode}
+        </InnerElement>
 
-      <div className="euiCard__content">
-        <EuiTitle size="s" className="euiCard__title">
-          <span>{title}</span>
-        </EuiTitle>
+        <InnerElement className="euiCard__content">
+          <EuiTitle size="s" className="euiCard__title">
+            <span>{title}</span>
+          </EuiTitle>
 
-        <EuiText size="s" className="euiCard__description">
-          <p>{description}</p>
-        </EuiText>
-      </div>
+          <EuiText size="s" className="euiCard__description">
+            <p>{description}</p>
+          </EuiText>
+        </InnerElement>
 
-      <div className="euiCard__footer">
-        {footer}
-      </div>
+        <InnerElement className="euiCard__footer">
+          {footer}
+        </InnerElement>
+      </InnerElement>
     </EuiPanel>
   );
 };

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -49,7 +49,6 @@ export const EuiCard = ({
   }
 
   const OuterElement = onClick ? 'button' : 'div';
-  const InnerElement = onClick ? 'span' : 'div';
 
   return (
     <OuterElement
@@ -57,12 +56,12 @@ export const EuiCard = ({
       className={classes}
       {...rest}
     >
-      <InnerElement className="euiCard__top">
+      <span className="euiCard__top">
         {imageNode}
         {iconNode}
-      </InnerElement>
+      </span>
 
-      <InnerElement className="euiCard__content">
+      <span className="euiCard__content">
         <EuiTitle size="s" className="euiCard__title">
           <span>{title}</span>
         </EuiTitle>
@@ -70,11 +69,11 @@ export const EuiCard = ({
         <EuiText size="s" className="euiCard__description">
           <p>{description}</p>
         </EuiText>
-      </InnerElement>
+      </span>
 
-      <InnerElement className="euiCard__footer">
+      <span className="euiCard__footer">
         {footer}
-      </InnerElement>
+      </span>
     </OuterElement>
   );
 };

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { EuiPanel } from '../panel';
 import { EuiText } from '../text';
 import { EuiTitle } from '../title';
 
@@ -30,7 +29,6 @@ export const EuiCard = ({
     textAlignToClassNameMap[textAlign],
     {
       'euiCard--isClickable': onClick,
-      'euiCard--textAlign': textAlign,
     },
     className,
   );
@@ -50,18 +48,21 @@ export const EuiCard = ({
     );
   }
 
+  const OuterElement = onClick ? 'button' : 'div';
+  const InnerElement = onClick ? 'span' : 'div';
+
   return (
-    <EuiPanel
+    <OuterElement
       onClick={onClick}
       className={classes}
       {...rest}
     >
-      <div className="euiCard__top">
+      <InnerElement className="euiCard__top">
         {imageNode}
         {iconNode}
-      </div>
+      </InnerElement>
 
-      <div className="euiCard__content">
+      <InnerElement className="euiCard__content">
         <EuiTitle size="s" className="euiCard__title">
           <span>{title}</span>
         </EuiTitle>
@@ -69,22 +70,38 @@ export const EuiCard = ({
         <EuiText size="s" className="euiCard__description">
           <p>{description}</p>
         </EuiText>
-      </div>
+      </InnerElement>
 
-      <div className="euiCard__footer">
+      <InnerElement className="euiCard__footer">
         {footer}
-      </div>
-    </EuiPanel>
+      </InnerElement>
+    </OuterElement>
   );
 };
 
 EuiCard.propTypes = {
   className: PropTypes.string,
-  description: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+
+  /**
+   * Requires a <EuiIcon> node
+   */
   icon: PropTypes.node,
+
+  /**
+   * Accepts a url in string form
+   */
   image: PropTypes.string,
+
+  /**
+   * Accepts any combination of elements
+   */
   footer: PropTypes.node,
+
+  /**
+   * Use only if you want to forego a button in the footer and make the whole card clickable
+   */
   onClick: PropTypes.func,
   textAlign: PropTypes.oneOf(ALIGNMENTS),
 };

--- a/src/components/panel/_index.scss
+++ b/src/components/panel/_index.scss
@@ -1,2 +1,3 @@
 @import 'variables';
+@import 'mixins';
 @import 'panel';

--- a/src/components/panel/_mixins.scss
+++ b/src/components/panel/_mixins.scss
@@ -1,0 +1,48 @@
+/**
+ *  Mixin for use in:
+ *  - EuiCard
+*/
+@mixin euiPanel($selector){
+  @if variable-exists(selector) == false {
+    @error "A $selector must be provided.";
+  }
+  @else {
+    .#{$selector} {
+
+      @include euiBottomShadowSmall;
+      background-color: $euiColorEmptyShade;
+      border: $euiBorderThin;
+      border-radius: $euiBorderRadius;
+      flex-grow: 1;
+      &.#{$selector}--flexGrowZero {
+        flex-grow: 0;
+      }
+
+      &.#{$selector}--isClickable {
+        // in case of button wrapper which inherently is inline-block and no width
+        display: block;
+        width: 100%;
+        text-align: left;
+
+        // transition the shadow
+        @include euiSlightShadow;
+        transition: all $euiAnimSpeedFast $euiAnimSlightResistance;
+
+        &:hover,
+        &:focus {
+          @include euiSlightShadowHover;
+          transform: translateY(-2px);
+          cursor: pointer;
+        }
+      }
+
+      &.#{$selector}--shadow {
+        &,
+        &:hover,
+        &:focus {
+          @include euiBottomShadow;
+        }
+      }
+    }
+  }
+}

--- a/src/components/panel/_mixins.scss
+++ b/src/components/panel/_mixins.scss
@@ -4,7 +4,7 @@
 */
 @mixin euiPanel($selector){
   @if variable-exists(selector) == false {
-    @error "A $selector must be provided.";
+    @error "A $selector must be provided to @mixin euiPanel().";
   }
   @else {
     .#{$selector} {

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -1,39 +1,9 @@
-.euiPanel {
-  @include euiBottomShadowSmall;
-  background-color: $euiColorEmptyShade;
-  border: $euiBorderThin;
-  border-radius: $euiBorderRadius;
-  flex-grow: 1;
+// Export basic class & modifiers
+@include euiPanel($selector: 'euiPanel');
 
-  @each $modifier, $amount in $euiPanelPaddingModifiers {
-    &.euiPanel--#{$modifier} {
-      padding: $amount;
-    }
-  }
-
-  &.euiPanel--shadow {
-    @include euiBottomShadow;
-  }
-
-  &.euiPanel--flexGrowZero {
-    flex-grow: 0;
-  }
-
-  &.euiPanel--isClickable {
-    // in case of button wrapper which inherently is inline-block and no width
-    display: block;
-    width: 100%;
-    text-align: left;
-
-    // transition the shadow
-    @include euiSlightShadow;
-    transition: all $euiAnimSpeedFast $euiAnimSlightResistance;
-
-    &:hover,
-    &:focus {
-      @include euiSlightShadowHover;
-      transform: translateY(-2px);
-      cursor: pointer;
-    }
+// Specific
+@each $modifier, $amount in $euiPanelPaddingModifiers {
+  .euiPanel.euiPanel--#{$modifier} {
+    padding: $amount;
   }
 }


### PR DESCRIPTION
EuiPanel now has a mixin that can be used by any component. EuiCard uses this mixin to inherit the styles of EuiPanel but doesn’t have specificity/order issues.

Fixes #408 
<img width="863" alt="screen shot 2018-02-15 at 15 52 20 pm" src="https://user-images.githubusercontent.com/549577/36280441-47202140-1268-11e8-8c68-32766ec3a259.png">
