### PR TITLE
Comparators.property to support nested properties

### DIFF
--- a/src/services/sort/comparators.js
+++ b/src/services/sort/comparators.js
@@ -1,4 +1,5 @@
 import { SortDirection } from './sort_direction';
+import { get } from '../objects';
 
 export const Comparators = Object.freeze({
 
@@ -26,7 +27,7 @@ export const Comparators = Object.freeze({
   },
 
   property(prop, comparator = undefined) {
-    return this.value(value => value[prop], comparator);
+    return this.value(value => get(value, prop), comparator);
   },
 
 });

--- a/src/services/sort/comparators.test.js
+++ b/src/services/sort/comparators.test.js
@@ -27,12 +27,22 @@ describe('comparators - reverse', () => {
 });
 
 describe('comparators - property', () => {
-  const comparator = jest.fn();
   test('proper delegation to provided comparator', () => {
+    const comparator = jest.fn();
     const propComparator = Comparators.property('name', comparator);
     propComparator({ name: 'n1' }, { name: 'n2' });
     expect(comparator.mock.calls.length).toBe(1);
     expect(comparator.mock.calls[0][0]).toBe('n1');
     expect(comparator.mock.calls[0][1]).toBe('n2');
   });
+
+  test('resolving nested props', () => {
+    const comparator = jest.fn();
+    const propComparator = Comparators.property('person.name', comparator);
+    propComparator({ person: { name: 'n1' } }, { person: { name: 'n2' } });
+    expect(comparator.mock.calls.length).toBe(1);
+    expect(comparator.mock.calls[0][0]).toBe('n1');
+    expect(comparator.mock.calls[0][1]).toBe('n2');
+  });
 });
+


### PR DESCRIPTION
fixes https://github.com/elastic/eui/issues/442 by adding support for nested fields