### PR TITLE
Make full screen code block use the same font-size on the original code block

### DIFF
--- a/src/components/code/_code_block.js
+++ b/src/components/code/_code_block.js
@@ -162,7 +162,7 @@ export class EuiCodeBlockImpl extends Component {
       */}
       const fullScreenClasses = classNames(
         'euiCodeBlock',
-        'euiCodeBlock--fontLarge',
+        fontSizeToClassNameMap[fontSize],
         'euiCodeBlock-paddingLarge',
         'euiCodeBlock-isFullScreen',
       );


### PR DESCRIPTION
The large font size was driving me a little nuts because I kept trying to expand the code block to see more code, but the larger font-size meant I just ended up seeing the same amount of code, only larger!