### PR TITLE
Fix bug with EuiInMemoryTable losing previous query state.

### DIFF
--- a/src/components/basic_table/in_memory_table.js
+++ b/src/components/basic_table/in_memory_table.js
@@ -85,7 +85,7 @@ export class EuiInMemoryTable extends React.Component {
     });
   }
 
-  computeData(items, criteria, query) {
+  computeData(items, criteria, query = (this.state && this.state.query)) {
     if (!items) {
       return { items: [], totalCount: 0 };
     }


### PR DESCRIPTION
To reproduce:

1. Create table with both filters and selection
2. Filter by Online users
3. Try to select a row
4. The Online filter state is lost in the table

![table_selection_bug](https://user-images.githubusercontent.com/1238659/36939359-4a0c22ae-1ee4-11e8-9ba6-59bb318d7eca.gif)
