### PR TITLE
Misc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `0.0.26`.
+- Don't propagate a null `onClick` on EuiPanels ([#473](https://github.com/elastic/eui/pull/473))
+- Use 1.1px for the default horizontal line height, in order to work around strange Chrome height calculations ([#473](https://github.com/elastic/eui/pull/473))
 
 # [`0.0.26`](https://github.com/elastic/eui/tree/v0.0.26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
 - Don't propagate a null `onClick` on EuiPanels ([#473](https://github.com/elastic/eui/pull/473))
-- Use 1.1px for the default horizontal line height, in order to work around strange Chrome height calculations ([#473](https://github.com/elastic/eui/pull/473))
+- Use 1.1px for the `EuiHorizontalRule` height, in order to work around strange Chrome height calculations ([#473](https://github.com/elastic/eui/pull/473))
 
 # [`0.0.26`](https://github.com/elastic/eui/tree/v0.0.26)
 

--- a/src/components/horizontal_rule/_horizontal_rule.scss
+++ b/src/components/horizontal_rule/_horizontal_rule.scss
@@ -1,6 +1,8 @@
 .euiHorizontalRule {
   border: none;
-  height: 1px;
+  // Sometimes Chrome "calculates" an element height of e.g. 0.990px, which it
+  // rounds down, thereby hiding the element.
+  height: 1.1px;
   background-color: $euiBorderColor;
 
   &.euiHorizontalRule--full {

--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -35,13 +35,19 @@ export const EuiPanel = ({
 
   const PanelTag = onClick ? 'button' : 'div';
 
+  const props = {
+    ref: panelRef,
+    className: classes
+  }
+
+  // Avoid passing down this props if is hasn't been supplied, in order to
+  // avoid noise in snapshots.
+  if (onClick != null) {
+    props.onClick = onClick
+  }
+
   return (
-    <PanelTag
-      onClick={onClick}
-      ref={panelRef}
-      className={classes}
-      {...rest}
-    >
+    <PanelTag {...props} {...rest}>
       {children}
     </PanelTag>
   );

--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -40,8 +40,8 @@ export const EuiPanel = ({
     className: classes
   }
 
-  // Avoid passing down this props if is hasn't been supplied, in order to
-  // avoid noise in snapshots.
+  // Avoid passing down this prop if it hasn't been supplied, in order to
+  // avoid noise in react-test-renderer snapshots.
   if (onClick != null) {
     props.onClick = onClick
   }


### PR DESCRIPTION
- Don't propagate a null `onClick` on EuiPanels. This helps avoid noise in Jest snapshots.
- Use 1.1px for the default horizontal line height, in order to work around strange Chrome height calculations.