### PR TITLE
Add ability to specify default page size for EuiInMemoryTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `0.0.25`.
+- Added `initialPageSize` option to `EuiInMemoryTable` ([#477](https://github.com/elastic/eui/pull/477))
 
 # [`0.0.24`](https://github.com/elastic/eui/tree/v0.0.24)
 

--- a/src-docs/src/views/tables/in_memory/in_memory_selection.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_selection.js
@@ -146,7 +146,7 @@ export class Table extends Component {
     }];
 
     const pagination = {
-      defaultPageSize: 5,
+      initialPageSize: 5,
       pageSizeOptions: [3, 5, 8]
     };
 

--- a/src-docs/src/views/tables/in_memory/in_memory_selection.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_selection.js
@@ -146,6 +146,7 @@ export class Table extends Component {
     }];
 
     const pagination = {
+      defaultPageSize: 5,
       pageSizeOptions: [3, 5, 8]
     };
 

--- a/src-docs/src/views/tables/in_memory/props_info.js
+++ b/src-docs/src/views/tables/in_memory/props_info.js
@@ -57,7 +57,7 @@ export const propsInfo = {
     __docgenInfo: {
       _euiObjectType: 'type',
       props: {
-        defaultPageSize: {
+        initialPageSize: {
           description: 'Configures the default page size to show, must be one of "pageSizeOptions"',
           required: false,
           type: { name: 'number' }

--- a/src-docs/src/views/tables/in_memory/props_info.js
+++ b/src-docs/src/views/tables/in_memory/props_info.js
@@ -57,6 +57,11 @@ export const propsInfo = {
     __docgenInfo: {
       _euiObjectType: 'type',
       props: {
+        defaultPageSize: {
+          description: 'Configures the default page size to show, must be one of "pageSizeOptions"',
+          required: false,
+          type: { name: 'number' }
+        },
         pageSizeOptions: basicPropsInfo.Pagination.__docgenInfo.props.pageSizeOptions
       }
     }

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
@@ -141,7 +141,7 @@ exports[`EuiInMemoryTable with pagination 1`] = `
 />
 `;
 
-exports[`EuiInMemoryTable with pagination and error 1`] = `
+exports[`EuiInMemoryTable with pagination and default page size 1`] = `
 <EuiBasicTable
   columns={
     Array [
@@ -152,12 +152,19 @@ exports[`EuiInMemoryTable with pagination and error 1`] = `
       },
     ]
   }
-  error="ouch!"
   items={
     Array [
       Object {
         "id": "1",
         "name": "name1",
+      },
+      Object {
+        "id": "2",
+        "name": "name2",
+      },
+      Object {
+        "id": "3",
+        "name": "name3",
       },
     ]
   }
@@ -166,13 +173,13 @@ exports[`EuiInMemoryTable with pagination and error 1`] = `
   pagination={
     Object {
       "pageIndex": 0,
-      "pageSize": 2,
+      "pageSize": 4,
       "pageSizeOptions": Array [
         2,
         4,
         6,
       ],
-      "totalItemCount": 1,
+      "totalItemCount": 3,
     }
   }
 />
@@ -218,6 +225,43 @@ exports[`EuiInMemoryTable with pagination and selection 1`] = `
     Object {
       "itemId": "id",
       "onSelectionChanged": [Function],
+    }
+  }
+/>
+`;
+
+exports[`EuiInMemoryTable with pagination, default page size and error 1`] = `
+<EuiBasicTable
+  columns={
+    Array [
+      Object {
+        "description": "description",
+        "field": "name",
+        "name": "Name",
+      },
+    ]
+  }
+  error="ouch!"
+  items={
+    Array [
+      Object {
+        "id": "1",
+        "name": "name1",
+      },
+    ]
+  }
+  noItemsMessage="No items found"
+  onChange={[Function]}
+  pagination={
+    Object {
+      "pageIndex": 0,
+      "pageSize": 4,
+      "pageSizeOptions": Array [
+        2,
+        4,
+        6,
+      ],
+      "totalItemCount": 1,
     }
   }
 />

--- a/src/components/basic_table/in_memory_table.js
+++ b/src/components/basic_table/in_memory_table.js
@@ -34,6 +34,10 @@ const InMemoryTablePropTypes = {
     PropTypes.bool,
     PropTypes.shape({
       pageSizeOptions: PropTypes.arrayOf(PropTypes.number)
+    }),
+    PropTypes.shape({
+      defaultPageSize: PropTypes.number,
+      pageSizeOptions: PropTypes.arrayOf(PropTypes.number)
     })
   ]),
   sorting: PropTypes.bool,
@@ -54,7 +58,10 @@ const initialCriteria = (props) => {
   return {
     page: !pagination ? undefined : {
       index: 0,
-      size: pagination.pageSizeOptions ? pagination.pageSizeOptions[0] : paginationBarDefaults.pageSizeOptions[0]
+      size: pagination.pageSizeOptions ? (
+        pagination.defaultPageSize && pagination.pageSizeOptions.includes(pagination.defaultPageSize) ?
+          pagination.defaultPageSize : pagination.pageSizeOptions[0]
+      ) : paginationBarDefaults.pageSizeOptions[0]
     }
   };
 };
@@ -126,7 +133,9 @@ export class EuiInMemoryTable extends React.Component {
       pageIndex: criteria.page.index,
       pageSize: criteria.page.size,
       totalItemCount: totalCount,
-      ...(isBoolean(this.props.pagination) ? {} : this.props.pagination)
+      ...(isBoolean(this.props.pagination) ? {} : {
+        pageSizeOptions: this.props.pagination.pageSizeOptions
+      })
     };
     const sorting = !this.props.sorting ? undefined : {
       sort: criteria.sort

--- a/src/components/basic_table/in_memory_table.js
+++ b/src/components/basic_table/in_memory_table.js
@@ -36,7 +36,7 @@ const InMemoryTablePropTypes = {
       pageSizeOptions: PropTypes.arrayOf(PropTypes.number)
     }),
     PropTypes.shape({
-      defaultPageSize: PropTypes.number,
+      initialPageSize: PropTypes.number,
       pageSizeOptions: PropTypes.arrayOf(PropTypes.number)
     })
   ]),
@@ -54,14 +54,29 @@ const initialQuery = (props) => {
 };
 
 const initialCriteria = (props) => {
-  const { pagination } = props;
+  if (!props.pagination) {
+    return {
+      page: undefined,
+    };
+  }
+
+  const {
+    pagination: {
+      pageSizeOptions,
+      initialPageSize,
+    }
+  } = props;
+
+  if (initialPageSize && (!pageSizeOptions || !pageSizeOptions.includes(initialPageSize))) {
+    throw new Error(`EuiInMemoryTable received initialPageSize ${initialPageSize}, which wasn't provided within pageSizeOptions.`);
+  }
+
+  const defaultPageSize = pageSizeOptions ? pageSizeOptions[0] : paginationBarDefaults.pageSizeOptions[0];
+
   return {
-    page: !pagination ? undefined : {
+    page: {
       index: 0,
-      size: pagination.pageSizeOptions ? (
-        pagination.defaultPageSize && pagination.pageSizeOptions.includes(pagination.defaultPageSize) ?
-          pagination.defaultPageSize : pagination.pageSizeOptions[0]
-      ) : paginationBarDefaults.pageSizeOptions[0]
+      size: initialPageSize || defaultPageSize,
     }
   };
 };

--- a/src/components/basic_table/in_memory_table.test.js
+++ b/src/components/basic_table/in_memory_table.test.js
@@ -162,7 +162,7 @@ describe('EuiInMemoryTable', () => {
         }
       ],
       pagination: {
-        defaultPageSize: 4,
+        initialPageSize: 4,
         pageSizeOptions: [2, 4, 6]
       }
     };
@@ -189,7 +189,7 @@ describe('EuiInMemoryTable', () => {
         }
       ],
       pagination: {
-        defaultPageSize: 4,
+        initialPageSize: 4,
         pageSizeOptions: [2, 4, 6]
       }
     };

--- a/src/components/basic_table/in_memory_table.test.js
+++ b/src/components/basic_table/in_memory_table.test.js
@@ -145,7 +145,35 @@ describe('EuiInMemoryTable', () => {
     expect(component).toMatchSnapshot();
   });
 
-  test('with pagination and error', () => {
+  test('with pagination and default page size', () => {
+
+    const props = {
+      ...requiredProps,
+      items: [
+        { id: '1', name: 'name1' },
+        { id: '2', name: 'name2' },
+        { id: '3', name: 'name3' }
+      ],
+      columns: [
+        {
+          field: 'name',
+          name: 'Name',
+          description: 'description'
+        }
+      ],
+      pagination: {
+        defaultPageSize: 4,
+        pageSizeOptions: [2, 4, 6]
+      }
+    };
+    const component = shallow(
+      <EuiInMemoryTable {...props} />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
+  test('with pagination, default page size and error', () => {
 
     const props = {
       ...requiredProps,
@@ -161,6 +189,7 @@ describe('EuiInMemoryTable', () => {
         }
       ],
       pagination: {
+        defaultPageSize: 4,
         pageSizeOptions: [2, 4, 6]
       }
     };


### PR DESCRIPTION
Currently `EuiInMemoryTable` uses the first element in `pageSizeOptions` as the initial page size. This allows a different initial page size to be specified.