### PR TITLE
Fix all table rows showing on page 1 for paginated table examples

### DIFF
--- a/src-docs/src/views/tables/data_store.js
+++ b/src-docs/src/views/tables/data_store.js
@@ -64,7 +64,7 @@ export const createDataStore = () => {
 
       let pageOfItems;
 
-      if (!pageIndex) {
+      if (!pageIndex && !pageSize) {
         pageOfItems = items;
       } else {
         const startIndex = pageIndex * pageSize;


### PR DESCRIPTION
All rows are currently showing for paginated basic table examples, when on page 1 (broke from #449).