### PR TITLE
Set GID to build users group id so that npm doesn't default to the root GID

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "jsnext:main": "src",
   "scripts": {
     "start": "webpack-dev-server --port 8030 --inline --hot --config=src-docs/webpack.config.js",
-    "test-docker": "docker run --rm -i --user=$UID -e HOME=/tmp -v $(pwd):/app -w /app node:8 bash -c 'npm config set spin false && yarn && npm run test'",
+    "test-docker": "docker run --rm -i --user=$UID -e GID=$(id -g) -e HOME=/tmp -v $(pwd):/app -w /app node:8 bash -c 'npm config set spin false && yarn && npm run test'",
     "sync-docs": "node ./scripts/docs-sync.js",
     "build-docs": "npm run build && webpack --config=src-docs/webpack.config.js",
     "build": "node ./scripts/compile-clean.js && node ./scripts/compile-eui.js && node ./scripts/compile-scss.js",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "jsnext:main": "src",
   "scripts": {
     "start": "webpack-dev-server --port 8030 --inline --hot --config=src-docs/webpack.config.js",
-    "test-docker": "docker run --rm -i --user=$UID -e GID=$(id -g) -e HOME=/tmp -v $(pwd):/app -w /app node:8 bash -c 'npm config set spin false && yarn && npm run test'",
+    "test-docker": "docker run --rm -i --user=$UID:$UID -e HOME=/tmp -v $(pwd):/app -w /app node:8 bash -c 'npm config set spin false && yarn && npm run test'",
     "sync-docs": "node ./scripts/docs-sync.js",
     "build-docs": "npm run build && webpack --config=src-docs/webpack.config.js",
     "build": "node ./scripts/compile-clean.js && node ./scripts/compile-eui.js && node ./scripts/compile-scss.js",


### PR DESCRIPTION
Without the `GID` being correctly set npm/yarn was setting the ownership of the `node_modules` directory to the root user. This was causing the build system to fail when attempting to clean up this directory. 
```
-rw-r--r--    1 jenkins jenkins 2.2K Feb 27 14:56 README.md
-rw-r--r--    1 jenkins jenkins  103 Feb 27 14:56 .npmignore
-rw-r--r--    1 jenkins jenkins    4 Feb 27 14:56 .node-version
-rw-r--r--    1 jenkins jenkins  553 Feb 27 14:56 LICENSE
-rw-r--r--    1 jenkins jenkins  113 Feb 27 14:56 .gitignore
-rw-r--r--    1 jenkins jenkins  266 Feb 27 14:56 .eslintrc.json
-rw-r--r--    1 jenkins jenkins 1.7K Feb 27 14:56 CONTRIBUTING.md
-rw-r--r--    1 jenkins jenkins  759 Feb 27 14:56 .babelrc
drwxr-xr-x    5 jenkins jenkins 4.0K Feb 27 14:56 generator-eui
drwxr-xr-x    2 jenkins jenkins 4.0K Feb 27 14:56 docs
-rw-r--r--    1 jenkins jenkins 553K Feb 27 14:56 package-lock.json
drwxr-xr-x    2 jenkins jenkins 4.0K Feb 27 14:56 wiki
drwxr-xr-x    8 jenkins jenkins 4.0K Feb 27 14:56 .git
drwxr-xr-x 1203 root    root     36K Feb 27 14:57 node_modules
-rw-r--r--    1 jenkins jenkins 1.1M Feb 27 14:58 .output.log
```