### PR TITLE
Clear search, reset nav display on nav item clicks

### DIFF
--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import $ from 'jquery';
+import {hashHistory} from 'react-router';
 
 import {
   Link,
@@ -57,6 +58,16 @@ export class GuidePageChrome extends Component {
       search: '',
       isSideNavOpenOnMobile: false,
     });
+  };
+
+  onClickRoute = path => {
+
+    this.setState({
+      search: '',
+      isSideNavOpenOnMobile: false,
+    });
+
+    hashHistory.push(path);
   };
 
   renderIdentity() {
@@ -116,7 +127,7 @@ export class GuidePageChrome extends Component {
         return {
           id: `${section.type}-${path}`,
           name,
-          href: `#/${path}`,
+          onClick: this.onClickRoute.bind(this, path),
           items: this.renderSubSections(sections),
           isSelected: name === this.props.currentRouteName,
         };


### PR DESCRIPTION
Clicking a nav item in the side nav will now clear the search and toggle off the mobile menu. This also works in desktop rez as well.

Makes the mobile menu and search in general muuuuuch more usable.

![](https://d3vv6lp55qjaqc.cloudfront.net/items/3c1Q2w0c2g0T0K3h0A2z/Screen%20Recording%202018-03-09%20at%2007.11%20PM.gif?X-CloudApp-Visitor-Id=59773&v=b719b29c)