### PR TITLE
do not set both value and defaultValue on select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Bug fixes**
 
-- `EuiSelect` do not set `defaultValue` property when `value` property is provided.
+- `EuiSelect` do not set `defaultValue` property when `value` property is provided ([#504](https://github.com/elastic/eui/pull/504)).
 - `EuiBottomBar` now uses `EuiPortal` to avoid zindex conflicts ([#487](https://github.com/elastic/eui/pull/487))
 - Upped dark theme contrast on disabled buttons  ([#487](https://github.com/elastic/eui/pull/487))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Bug fixes**
 
+- `EuiSelect` do not set `defaultValue` property when `value` property is provided.
 - `EuiBottomBar` now uses `EuiPortal` to avoid zindex conflicts ([#487](https://github.com/elastic/eui/pull/487))
 - Upped dark theme contrast on disabled buttons  ([#487](https://github.com/elastic/eui/pull/487))
 

--- a/src/components/form/select/__snapshots__/select.test.js.snap
+++ b/src/components/form/select/__snapshots__/select.test.js.snap
@@ -118,3 +118,30 @@ exports[`EuiSelect props options are rendered 1`] = `
   </eui-validatable-control>
 </eui-form-control-layout>
 `;
+
+exports[`EuiSelect props value option is rendered 1`] = `
+<eui-form-control-layout
+  fullwidth="false"
+  icon="arrowDown"
+  iconside="right"
+  isloading="false"
+>
+  <eui-validatable-control>
+    <select
+      class="euiSelect"
+    >
+      <option
+        selected=""
+        value="1"
+      >
+        Option #1
+      </option>
+      <option
+        value="2"
+      >
+        Option #2
+      </option>
+    </select>
+  </eui-validatable-control>
+</eui-form-control-layout>
+`;

--- a/src/components/form/select/select.js
+++ b/src/components/form/select/select.js
@@ -21,6 +21,7 @@ export const EuiSelect = ({
   isLoading,
   hasNoInitialSelection,
   defaultValue,
+  value,
   ...rest
 }) => {
   const classes = classNames(
@@ -39,6 +40,13 @@ export const EuiSelect = ({
     );
   }
 
+  // React HTML input can not have both value and defaultValue properties.
+  // https://reactjs.org/docs/uncontrolled-components.html#default-values
+  let selectDefaultValue;
+  if (!value) {
+    selectDefaultValue = defaultValue || '';
+  }
+
   return (
     <EuiFormControlLayout
       icon="arrowDown"
@@ -52,7 +60,8 @@ export const EuiSelect = ({
           name={name}
           className={classes}
           ref={inputRef}
-          defaultValue={defaultValue || ''}
+          defaultValue={selectDefaultValue}
+          value={value}
           {...rest}
         >
           {emptyOptionNode}

--- a/src/components/form/select/select.test.js
+++ b/src/components/form/select/select.test.js
@@ -76,5 +76,21 @@ describe('EuiSelect', () => {
       expect(component)
         .toMatchSnapshot();
     });
+
+    test('value option is rendered', () => {
+      const component = render(
+        <EuiSelect
+          options={[
+            { value: '1', text: 'Option #1' },
+            { value: '2', text: 'Option #2' }
+          ]}
+          value={'1'}
+          onChange={() => {}}
+        />
+      );
+
+      expect(component)
+        .toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
```
Warning: Select elements must be either controlled or uncontrolled (specify either the value prop, or the defaultValue prop, but not both). Decide between using a controlled or uncontrolled select element and remove one of these props.
```

React throws the above if an `Input` element contains both `value` and `defaultValue` property. 

This PR updates EuiSelect to ensure `defaultValue` is never set when `value` is provided.