### PR TITLE
Always pull the latest docker image (node:8) before running the tests in docker

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "module": "src",
   "types": "src/index.d.ts",
   "jsnext:main": "src",
+  "docker_image": "node:8",
   "scripts": {
     "start": "webpack-dev-server --port 8030 --inline --hot --config=src-docs/webpack.config.js",
-    "test-docker": "docker run --rm -i --user=$(id -u):$(id -g) -e HOME=/tmp -v $(pwd):/app -w /app node:8 bash -c 'npm config set spin false && yarn && npm run test'",
+    "test-docker": "docker pull $npm_package_docker_image && docker run --rm -i --user=$(id -u):$(id -g) -e HOME=/tmp -v $(pwd):/app -w /app $npm_package_docker_image bash -c 'npm config set spin false && yarn && npm run test'",
     "sync-docs": "node ./scripts/docs-sync.js",
     "build-docs": "webpack --config=src-docs/webpack.config.js",
     "build": "node ./scripts/compile-clean.js && node ./scripts/compile-eui.js && node ./scripts/compile-scss.js",


### PR DESCRIPTION
By default docker will use whatever image is available locally if the node:8 image already exists. This meant that different versions of npm/node were being run depending on which jenkins worker picked up the job.