### PR TITLE
Fix FlexGrid responsiveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 **Bug fixes**
 
+- `EuiFlexGrid` now collapses down in mobile layouts properly. ([#515](https://github.com/elastic/eui/pull/515))
+- Made `EuiCard` proptypes more permission by changing strings to nodes. ([#515](https://github.com/elastic/eui/pull/515))
 - Fix `reponsive={false}` prop not working when flex groups were nested. ([#494](https://github.com/elastic/eui/pull/494))
 - `EuiBadge` wrapping element changed from a `div` to `span` so it can be nested in text blocks ([#494](https://github.com/elastic/eui/pull/494))
 

--- a/src-docs/src/views/home/home_view.js
+++ b/src-docs/src/views/home/home_view.js
@@ -94,7 +94,7 @@ export const HomeView = () => (
             image="https://i.imgur.com/uPtnXbv.png"
             isClickable
             icon={
-              <EuiFlexGroup style={{ marginLeft: 0 }}>
+              <EuiFlexGroup style={{ marginLeft: 0 }} responsive={false}>
                 <EuiFlexItem>
                   <EuiIcon size="xxl" type="check" color="ghost" />
                 </EuiFlexItem>

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -92,8 +92,8 @@ export const EuiCard = ({
 
 EuiCard.propTypes = {
   className: PropTypes.string,
-  title: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
+  title: PropTypes.node.isRequired,
+  description: PropTypes.node.isRequired,
 
   /**
    * Requires a <EuiIcon> node

--- a/src/components/flex/_flex_item.scss
+++ b/src/components/flex/_flex_item.scss
@@ -23,7 +23,8 @@
 
 // On mobile we force them to stack and act the same.
 @include screenXSmall {
-  .euiFlexGroup--responsive > .euiFlexItem {
+  .euiFlexGroup--responsive > .euiFlexItem,
+  .euiFlexGrid > .euiFlexItem {
     width: 100% !important;
     flex-basis: 100% !important;
     margin-left: 0 !important;


### PR DESCRIPTION
When we added the `responsive={false}` prop to `EuiFlexGroup` we indirectly broke responsiveness to `EuiFlexGrid` which should _always_ be responsive. Added some CSS to target it specifically so it now works on mobile how we'd expect.

Also threw in a small fix for @bmcconaghy where the proptypes on `EuiCard` were too strict.

### Before

![image](https://user-images.githubusercontent.com/324519/37429405-5cdef78e-278c-11e8-9ec7-66c5a91d3780.png)


### After

![image](https://user-images.githubusercontent.com/324519/37429399-528eb102-278c-11e8-834b-0246a0b630ed.png)
