### PR TITLE
Add ability to force open EuiSideNav items.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `0.0.29`.
+- Add ability to force `EuiSideNav` items open by setting `item.forceOpen`. ([#515](https://github.com/elastic/eui/pull/515))
 
 # [`0.0.29`](https://github.com/elastic/eui/tree/v0.0.29)
 

--- a/src-docs/src/views/side_nav/side_nav_example.js
+++ b/src-docs/src/views/side_nav/side_nav_example.js
@@ -19,6 +19,10 @@ import SideNavComplex from './side_nav_complex';
 const sideNavComplexSource = require('!!raw-loader!./side_nav_complex');
 const sideNavComplexHtml = renderToHtml(SideNavComplex);
 
+import SideNavForceOpen from './side_nav_force_open';
+const sideNavForceOpenSource = require('!!raw-loader!./side_nav_force_open');
+const sideNavForceOpenHtml = renderToHtml(SideNavForceOpen);
+
 export const SideNavExample = {
   title: 'Side Nav',
   sections: [{
@@ -33,13 +37,13 @@ export const SideNavExample = {
       <div>
         <p>
           <EuiCode>SideNav</EuiCode> is a responsive menu system that usually sits on the left side of a page layout.
-          It will exapand to the width of its container. This is the menu that is used on the left side of the
-          page you are looking at.
+          It will expand to the width of its container. This is the menu that is used on the left side of the
+          page you are currently looking at.
         </p>
 
         <p>
           Configure the content of a <EuiCode>SideNav</EuiCode> by passing in an <EuiCode>items</EuiCode> prop.
-          Referring to the source code for an example of this data structure&rsquo;s anatomy.
+          Refer to the source code for an example of this data structure&rsquo;s anatomy.
         </p>
       </div>
     ),
@@ -60,5 +64,20 @@ export const SideNavExample = {
       </p>
     ),
     demo: <SideNavComplex />,
+  }, {
+    title: 'Forced open side nav',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: sideNavForceOpenSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: sideNavForceOpenHtml,
+    }],
+    text: (
+      <p>
+        <EuiCode>SideNav</EuiCode> items can be forced open by setting <EuiCode>items[n].forceOpen = true</EuiCode>
+      </p>
+    ),
+    demo: <SideNavForceOpen />,
   }],
 };

--- a/src-docs/src/views/side_nav/side_nav_force_open.js
+++ b/src-docs/src/views/side_nav/side_nav_force_open.js
@@ -1,0 +1,94 @@
+import React, {
+  Component,
+} from 'react';
+
+import {
+  EuiIcon,
+  EuiSideNav,
+} from '../../../../src/components';
+
+export default class extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isSideNavOpenOnMobile: false,
+      selectedItemName: null,
+    };
+  }
+
+  toggleOpenOnMobile = () => {
+    this.setState({
+      isSideNavOpenOnMobile: !this.state.isSideNavOpenOnMobile,
+    });
+  };
+
+  selectItem = name => {
+    this.setState({
+      selectedItemName: name,
+    });
+  };
+
+  createItem = (name, data = {}) => {
+    // NOTE: Duplicate `name` values will cause `id` collisions.
+    return {
+      ...data,
+      id: name,
+      name,
+      isSelected: this.state.selectedItemName === name,
+      onClick: () => this.selectItem(name),
+    };
+  };
+
+  render() {
+    const sideNav = [
+      this.createItem('Kibana', {
+        icon: <EuiIcon type="logoKibana" />,
+        items: [
+          this.createItem('Has normal children', {
+            items: [
+              this.createItem('Without forceOpen', {
+                items: [
+                  this.createItem('Child 1'),
+                  this.createItem('Child 2'),
+                ],
+              }),
+            ],
+          }),
+          this.createItem('Normally not open', {
+            items: [
+              this.createItem('Has forceOpen:true', {
+                forceOpen: true,
+                items: [
+                  this.createItem('Child 3'),
+                  this.createItem('Child 4'),
+                ],
+              }),
+            ],
+          }),
+          this.createItem('With forceOpen:true', {
+            forceOpen: true,
+            items: [
+              this.createItem('Normal child', {
+                items: [
+                  this.createItem('Child 5'),
+                  this.createItem('Child 6'),
+                ],
+              }),
+            ],
+          }),
+        ],
+      }),
+    ];
+
+    return (
+      <EuiSideNav
+        mobileTitle="Navigate within $APP_NAME"
+        toggleOpenOnMobile={this.toggleOpenOnMobile}
+        isOpenOnMobile={this.state.isSideNavOpenOnMobile}
+        items={sideNav}
+        style={{ width: 192 }}
+      />
+    );
+  }
+}

--- a/src/components/side_nav/__snapshots__/side_nav.test.js.snap
+++ b/src/components/side_nav/__snapshots__/side_nav.test.js.snap
@@ -43,7 +43,7 @@ exports[`EuiSideNav is rendered 1`] = `
 </nav>
 `;
 
-exports[`EuiSideNav isOpenOnMobile defaults to false 1`] = `
+exports[`EuiSideNav props isOpenOnMobile defaults to false 1`] = `
 <nav
   class="euiSideNav"
 >
@@ -84,7 +84,7 @@ exports[`EuiSideNav isOpenOnMobile defaults to false 1`] = `
 </nav>
 `;
 
-exports[`EuiSideNav isOpenOnMobile is rendered when specified as true 1`] = `
+exports[`EuiSideNav props isOpenOnMobile is rendered when specified as true 1`] = `
 <nav
   class="euiSideNav euiSideNav-isOpenMobile"
 >
@@ -125,7 +125,7 @@ exports[`EuiSideNav isOpenOnMobile is rendered when specified as true 1`] = `
 </nav>
 `;
 
-exports[`EuiSideNav items is rendered 1`] = `
+exports[`EuiSideNav props items is rendered 1`] = `
 <nav
   class="euiSideNav"
 >
@@ -164,7 +164,7 @@ exports[`EuiSideNav items is rendered 1`] = `
     class="euiSideNav__content"
   >
     <div
-      class="euiSideNavItem euiSideNavItem--root"
+      class="euiSideNavItem euiSideNavItem--root euiSideNavItem--hasChildItems"
     >
       <div
         class="euiSideNavItemButton"
@@ -241,7 +241,7 @@ exports[`EuiSideNav items is rendered 1`] = `
 </nav>
 `;
 
-exports[`EuiSideNav items renders items using a specified callback 1`] = `
+exports[`EuiSideNav props items renders items having { forceOpen: true } in open state, and automatically opens parent items 1`] = `
 <nav
   class="euiSideNav"
 >
@@ -280,7 +280,146 @@ exports[`EuiSideNav items renders items using a specified callback 1`] = `
     class="euiSideNav__content"
   >
     <div
-      class="euiSideNavItem euiSideNavItem--root"
+      class="euiSideNavItem euiSideNavItem--root euiSideNavItem--hasChildItems"
+    >
+      <div
+        class="euiSideNavItemButton"
+      >
+        <span
+          class="euiSideNavItemButton__content"
+        >
+          <span
+            class="euiSideNavItemButton__label"
+          >
+            A
+          </span>
+        </span>
+      </div>
+      <div
+        class="euiSideNavItem__items"
+      >
+        <div
+          class="euiSideNavItem euiSideNavItem--trunk"
+        >
+          <div
+            class="euiSideNavItemButton"
+          >
+            <span
+              class="euiSideNavItemButton__content"
+            >
+              <span
+                class="euiSideNavItemButton__label"
+              >
+                B
+              </span>
+            </span>
+          </div>
+        </div>
+        <div
+          class="euiSideNavItem euiSideNavItem--trunk euiSideNavItem--hasChildItems"
+        >
+          <div
+            class="euiSideNavItemButton euiSideNavItemButton-isOpen"
+          >
+            <span
+              class="euiSideNavItemButton__content"
+            >
+              <span
+                class="euiSideNavItemButton__label"
+              >
+                C
+              </span>
+            </span>
+          </div>
+          <div
+            class="euiSideNavItem__items"
+          >
+            <div
+              class="euiSideNavItem euiSideNavItem--branch euiSideNavItem--hasChildItems"
+            >
+              <div
+                class="euiSideNavItemButton euiSideNavItemButton-isOpen"
+              >
+                <span
+                  class="euiSideNavItemButton__content"
+                >
+                  <span
+                    class="euiSideNavItemButton__label"
+                  >
+                    D
+                  </span>
+                </span>
+              </div>
+              <div
+                class="euiSideNavItem__items"
+              >
+                <div
+                  class="euiSideNavItem euiSideNavItem--branch"
+                >
+                  <div
+                    class="euiSideNavItemButton"
+                  >
+                    <span
+                      class="euiSideNavItemButton__content"
+                    >
+                      <span
+                        class="euiSideNavItemButton__label"
+                      >
+                        E
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</nav>
+`;
+
+exports[`EuiSideNav props items renders items using a specified callback 1`] = `
+<nav
+  class="euiSideNav"
+>
+  <button
+    class="euiSideNav__mobileToggle euiLink"
+    type="button"
+  >
+    <span
+      class="euiSideNav__mobileWrap"
+    >
+      <span
+        class="euiSideNav__mobileTitle"
+      />
+      <svg
+        aria-hidden="true"
+        class="euiIcon euiSideNav__mobileIcon euiIcon--medium"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xlink="http://www.w3.org/1999/xlink"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <defs>
+          <path
+            d="M2 4V2h2v2H2zm5 0V2h2v2H7zm5 0V2h2v2h-2zM2 9V7h2v2H2zm5 0V7h2v2H7zm5 0V7h2v2h-2zM2 14v-2h2v2H2zm5 0v-2h2v2H7zm5 0v-2h2v2h-2z"
+            id="apps-a"
+          />
+        </defs>
+        <use
+          href="#apps-a"
+        />
+      </svg>
+    </span>
+  </button>
+  <div
+    class="euiSideNav__content"
+  >
+    <div
+      class="euiSideNavItem euiSideNavItem--root euiSideNavItem--hasChildItems"
     >
       <a
         class="euiSideNavItemButton euiSideNavItemButton--isClickable"
@@ -324,7 +463,7 @@ exports[`EuiSideNav items renders items using a specified callback 1`] = `
 </nav>
 `;
 
-exports[`EuiSideNav items renders items which are links 1`] = `
+exports[`EuiSideNav props items renders items which are links 1`] = `
 <nav
   class="euiSideNav"
 >
@@ -363,7 +502,7 @@ exports[`EuiSideNav items renders items which are links 1`] = `
     class="euiSideNav__content"
   >
     <div
-      class="euiSideNavItem euiSideNavItem--root"
+      class="euiSideNavItem euiSideNavItem--root euiSideNavItem--hasChildItems"
     >
       <a
         class="euiSideNavItemButton euiSideNavItemButton--isClickable"
@@ -441,7 +580,7 @@ exports[`EuiSideNav items renders items which are links 1`] = `
 </nav>
 `;
 
-exports[`EuiSideNav items renders selected item and automatically opens parent items 1`] = `
+exports[`EuiSideNav props items renders selected item and automatically opens parent items 1`] = `
 <nav
   class="euiSideNav"
 >
@@ -480,7 +619,7 @@ exports[`EuiSideNav items renders selected item and automatically opens parent i
     class="euiSideNav__content"
   >
     <div
-      class="euiSideNavItem euiSideNavItem--root"
+      class="euiSideNavItem euiSideNavItem--root euiSideNavItem--hasChildItems"
     >
       <div
         class="euiSideNavItemButton"
@@ -516,7 +655,7 @@ exports[`EuiSideNav items renders selected item and automatically opens parent i
           </div>
         </div>
         <div
-          class="euiSideNavItem euiSideNavItem--trunk"
+          class="euiSideNavItem euiSideNavItem--trunk euiSideNavItem--hasChildItems"
         >
           <div
             class="euiSideNavItemButton euiSideNavItemButton-isOpen"
@@ -550,9 +689,6 @@ exports[`EuiSideNav items renders selected item and automatically opens parent i
                   </span>
                 </span>
               </div>
-              <div
-                class="euiSideNavItem__items"
-              />
             </div>
             <div
               class="euiSideNavItem euiSideNavItem--branch"

--- a/src/components/side_nav/_side_nav_item.scss
+++ b/src/components/side_nav/_side_nav_item.scss
@@ -22,12 +22,6 @@
     }
   }
 
-  &.euiSideNavItemButton-isOpen {
-    .euiSideNavItemButton__label {
-      color: $euiColorFullShade;
-    }
-  }
-
   &.euiSideNavItemButton-isSelected {
     .euiSideNavItemButton__label {
       color: $euiColorPrimary;
@@ -159,5 +153,13 @@
 
   & > .euiSideNavItem__items {
     margin-left: $euiSize;
+  }
+}
+
+.euiSideNavItem--hasChildItems {
+  & > .euiSideNavItemButton-isOpen {
+    .euiSideNavItemButton__label {
+      color: $euiColorFullShade;
+    }
   }
 }

--- a/src/components/side_nav/side_nav.js
+++ b/src/components/side_nav/side_nav.js
@@ -14,6 +14,11 @@ import {
 
 export class EuiSideNav extends Component {
   isItemOpen = item => {
+    // The developer can force the item to be open.
+    if (item.forceOpen) {
+      return true;
+    }
+
     // Of course a selected item is open.
     if (item.isSelected) {
       return true;
@@ -37,6 +42,7 @@ export class EuiSideNav extends Component {
         icon,
         onClick,
         href,
+        forceOpen, // eslint-disable-line no-unused-vars
         ...rest
       } = item;
 
@@ -126,12 +132,42 @@ export class EuiSideNav extends Component {
 }
 
 EuiSideNav.propTypes = {
+  /**
+   * `children` are not rendered. Use `items` to specify navigation items instead.
+   */
   children: PropTypes.node,
+  /**
+   * Class names to be merged into the final `className` property.
+   */
   className: PropTypes.string,
+  /**
+   * When called, toggles visibility of the navigation menu at mobile responsive widths. The callback should set the `isOpenOnMobile` prop to actually toggle navigation visibility.
+   */
   toggleOpenOnMobile: PropTypes.func,
+  /**
+   * If `true`, the navigation menu will be open at mobile device widths. Use in conjunction with the `toggleOpenOnMobile` prop.
+   */
   isOpenOnMobile: PropTypes.bool,
+  /**
+   * A React node to render at mobile responsive widths, representing the title of this navigation menu.
+   */
   mobileTitle: PropTypes.node,
+  /**
+   * `items` is an array of objects (navigation menu `item`s).
+   * Each `item` may contain the following properties (this is an incomplete list):
+   * `item.forceOpen` is an optional boolean; if set to true it will force the item to display in an "open" state at all times.
+   * `item.href` is an optional string to be passed as the navigaiton item's `href` prop, and by default it will force rendering of the item as an `<a>`.
+   * `item.icon` is an optional React node which will be rendered as a small icon to the left of the navigation item text.
+   * `item.isSelected` is an optional boolean; if set to true it will render the item in a visible "selected" state, and will force all ancestor navigation items to render in an "open" state.
+   * `item.items` is an optional array containing additional item objects, representing nested children of this navigation item.
+   * `item.name` is a required React node representing the text to render for this item (usually a string will suffice).
+   * `item.onClick` is an optional callback function to be passed as the navigaiton item's `onClick` prop, and by default it will force rendering of the item as a `<button>` instead of a link.
+   * `item.renderItem` is an optional function overriding default rendering for this navigation item — when called, it should return a React node representing a replacement navigation item.
+   */
   items: PropTypes.array,
+  /**
+   * Overrides default navigation menu item rendering. When called, it should return a React node representing a replacement navigation item.
+   */
   renderItem: PropTypes.func,
 };
 

--- a/src/components/side_nav/side_nav.test.js
+++ b/src/components/side_nav/side_nav.test.js
@@ -14,135 +14,167 @@ describe('EuiSideNav', () => {
       .toMatchSnapshot();
   });
 
-  describe('isOpenOnMobile', () => {
-    test('defaults to false', () => {
-      const component = render(
-        <EuiSideNav />
-      );
+  describe('props', () => {
+    describe('isOpenOnMobile', () => {
+      test('defaults to false', () => {
+        const component = render(
+          <EuiSideNav />
+        );
 
-      expect(component)
-        .toMatchSnapshot();
+        expect(component)
+          .toMatchSnapshot();
+      });
+
+      test('is rendered when specified as true', () => {
+        const component = render(
+          <EuiSideNav isOpenOnMobile />
+        );
+
+        expect(component)
+          .toMatchSnapshot();
+      });
     });
 
-    test('is rendered when specified as true', () => {
-      const component = render(
-        <EuiSideNav isOpenOnMobile />
-      );
-
-      expect(component)
-        .toMatchSnapshot();
-    });
-  });
-
-  describe('items', () => {
-    test('is rendered', () => {
-      const sideNav = [{
-        name: 'A',
-        id: 0,
-        items: [{
-          name: 'B',
-          id: 1,
-        }, {
-          name: 'C',
-          id: 2,
+    describe('items', () => {
+      test('is rendered', () => {
+        const sideNav = [{
+          name: 'A',
+          id: 0,
           items: [{
-            name: 'D',
-            id: 3,
+            name: 'B',
+            id: 1,
           }, {
-            name: 'E',
-            id: 4,
+            name: 'C',
+            id: 2,
+            items: [{
+              name: 'D',
+              id: 3,
+            }, {
+              name: 'E',
+              id: 4,
+            }],
           }],
-        }],
-      }];
+        }];
 
-      const component = render(
-        <EuiSideNav items={sideNav} />
-      );
+        const component = render(
+          <EuiSideNav items={sideNav} />
+        );
 
-      expect(component)
-        .toMatchSnapshot();
-    });
+        expect(component)
+          .toMatchSnapshot();
+      });
 
-    test('renders items which are links', () => {
-      const sideNav = [{
-        name: 'A',
-        id: 0,
-        href: 'http://www.elastic.co',
-        items: [{
-          name: 'B',
-          id: 1,
-        }, {
-          name: 'C',
-          id: 2,
+      test('renders items which are links', () => {
+        const sideNav = [{
+          name: 'A',
+          id: 0,
+          href: 'http://www.elastic.co',
           items: [{
-            name: 'D',
-            id: 3,
+            name: 'B',
+            id: 1,
           }, {
-            name: 'E',
-            id: 4,
+            name: 'C',
+            id: 2,
+            items: [{
+              name: 'D',
+              id: 3,
+            }, {
+              name: 'E',
+              id: 4,
+            }],
           }],
-        }],
-      }];
+        }];
 
-      const component = render(
-        <EuiSideNav items={sideNav} />
-      );
+        const component = render(
+          <EuiSideNav items={sideNav} />
+        );
 
-      expect(component)
-        .toMatchSnapshot();
-    });
+        expect(component)
+          .toMatchSnapshot();
+      });
 
-    test('renders items using a specified callback', () => {
-      const sideNav = [{
-        name: 'A',
-        id: 0,
-        href: 'http://www.elastic.co',
-        items: [{
-          name: 'B',
-          id: 1,
-        }],
-      }];
-
-      const renderItem = ({ href, className, children }) => (
-        <a data-test-id="my-custom-element" href={href} className={className}>
-          {children}
-        </a>);
-
-      const component = render(
-        <EuiSideNav items={sideNav} renderItem={renderItem} />
-      );
-
-      expect(component)
-        .toMatchSnapshot();
-    });
-
-    test('renders selected item and automatically opens parent items', () => {
-      const sideNav = [{
-        name: 'A',
-        id: 0,
-        items: [{
-          name: 'B',
-          id: 1,
-        }, {
-          name: 'C',
-          id: 2,
+      test('renders items using a specified callback', () => {
+        const sideNav = [{
+          name: 'A',
+          id: 0,
+          href: 'http://www.elastic.co',
           items: [{
-            name: 'D',
-            id: 3,
-            isSelected: true,
-          }, {
-            name: 'E',
-            id: 4,
+            name: 'B',
+            id: 1,
           }],
-        }],
-      }];
+        }];
 
-      const component = render(
-        <EuiSideNav items={sideNav} />
-      );
+        const renderItem = ({ href, className, children }) => (
+          <a data-test-id="my-custom-element" href={href} className={className}>
+            {children}
+          </a>);
 
-      expect(component)
-        .toMatchSnapshot();
+        const component = render(
+          <EuiSideNav items={sideNav} renderItem={renderItem} />
+        );
+
+        expect(component)
+          .toMatchSnapshot();
+      });
+
+      test('renders selected item and automatically opens parent items', () => {
+        const sideNav = [{
+          name: 'A',
+          id: 0,
+          items: [{
+            name: 'B',
+            id: 1,
+          }, {
+            name: 'C',
+            id: 2,
+            items: [{
+              name: 'D',
+              id: 3,
+              isSelected: true,
+            }, {
+              name: 'E',
+              id: 4,
+            }],
+          }],
+        }];
+
+        const component = render(
+          <EuiSideNav items={sideNav} />
+        );
+
+        expect(component)
+          .toMatchSnapshot();
+      });
+
+      test('renders items having { forceOpen: true } in open state, and automatically opens parent items', () => {
+        const sideNav = [{
+          name: 'A',
+          id: 0,
+          items: [{
+            name: 'B',
+            id: 1,
+          }, {
+            name: 'C',
+            id: 2,
+            items: [{
+              name: 'D',
+              id: 3,
+              forceOpen: true,
+              items: [{
+                name: 'E',
+                id: 4,
+              }],
+            }],
+          }],
+        }];
+
+        const component = render(
+          <EuiSideNav items={sideNav} />
+        );
+
+        expect(component)
+          .toMatchSnapshot();
+      });
     });
   });
 });

--- a/src/components/side_nav/side_nav_item.js
+++ b/src/components/side_nav/side_nav_item.js
@@ -58,7 +58,7 @@ export const EuiSideNavItem = ({
 }) => {
   let childItems;
 
-  if (isOpen) {
+  if (items && isOpen) {
     childItems = (
       <div className="euiSideNavItem__items">
         {items}
@@ -79,6 +79,7 @@ export const EuiSideNavItem = ({
     'euiSideNavItem--rootIcon': depth === 0 && icon,
     'euiSideNavItem--trunk': depth === 1,
     'euiSideNavItem--branch': depth > 1,
+    'euiSideNavItem--hasChildItems': !!childItems
   });
 
   const buttonClasses = classNames('euiSideNavItemButton', {


### PR DESCRIPTION
Fixes #497.

`items` passed to `EuiSideNav` can now receive an `item.forceOpen` boolean property, which forces that particular nav item (and all of its parents) to render in the "open" state. `.forceOpen` can be selectively applied to individual items, or can be applied to every item in the tree to force the entire tree to be open. This allows us to draw attention and convenience to certain navigation levels so that they are more easily discoverable by the user.

I chose the name `forceOpen` because my first choice, `isOpen`, when set to `undefined`, shadows the `isOpen` prop passed to `EuiSideNavItem`, which ironically can force the entire navigation tree closed. For example, if you use a `createItem()` function to create individual navigation items, it might include a line like this:

```
const createItem = (name, data = {}) => {
  return {
    ...data,
    id: name,
    name,
    isOpen: name === 'specific item to force open' : true : undefined,
  };
};
```

It is impossible to set `isOpen` in the example above using the ternary pattern — all items which do not match will be forced shut, even when selected. Using the property `forceOpen` avoids this problem, and enables the ternary pattern.

### Testing

If you want to test this work manually, I added a convenient demo at the bottom of the "Side Nav" living style guide page.