### PR TITLE
[BasicTable] - allow noItemMessage to be node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 - `EuiInMemoryTable` pass items to BasicTable when message is provided ([#517](https://github.com/elastic/eui/pull/517)).
 - `EuiSearchBox` now passes unused props through to `EuiFieldSearch` ([#514](https://github.com/elastic/eui/pull/514))
-- `EuiBasicTable` `noItemsMessage` Allow typeof Node ([#516](https://github.com/elastic/eui/pull/516))
+- Change `EuiBasicTable` `noItemsMessage` and `EuiInMemoryTable` `messgae` propType to node
+instead of just string ([#516](https://github.com/elastic/eui/pull/516))
 
 # [`0.0.27`](https://github.com/elastic/eui/tree/v0.0.27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - `EuiInMemoryTable` pass items to BasicTable when message is provided ([#517](https://github.com/elastic/eui/pull/517)).
 - `EuiSearchBox` now passes unused props through to `EuiFieldSearch` ([#514](https://github.com/elastic/eui/pull/514))
+- `EuiBasicTable` `noItemsMessage` Allow typeof Node ([#516](https://github.com/elastic/eui/pull/516))
 
 # [`0.0.27`](https://github.com/elastic/eui/tree/v0.0.27)
 

--- a/src-docs/src/views/tables/in_memory/in_memory_selection.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_selection.js
@@ -48,7 +48,17 @@ export class Table extends Component {
     this.state = {
       loading: false,
       users: [],
-      message: 'No users, click "Load Users" to load some',
+      message: (
+        <div>
+          <span>Looks like you don't have any users. Let's create some!</span>
+          <EuiButton
+            key="loadUsers"
+            onClick={this.loadUsers.bind(this)}
+          >
+            Load Users
+          </EuiButton>
+        </div>
+      ),
       selection: []
     };
   }

--- a/src/components/basic_table/__snapshots__/basic_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.js.snap
@@ -33,6 +33,45 @@ exports[`EuiBasicTable basic - empty - custom message 1`] = `
 </div>
 `;
 
+exports[`EuiBasicTable basic - empty - custom message as node 1`] = `
+<div
+  className="euiBasicTable testClass1 testClass2"
+>
+  <EuiTable>
+    <EuiTableHeader>
+      <EuiTableHeaderCell
+        align="left"
+        isSortAscending={false}
+        isSorted={false}
+        key="_data_h_name_0"
+        scope="col"
+      >
+        Name
+      </EuiTableHeaderCell>
+    </EuiTableHeader>
+    <EuiTableBody>
+      <EuiTableRow>
+        <EuiTableRowCell
+          align="center"
+          colSpan={1}
+          textOnly={true}
+        >
+          <p>
+            no items, click 
+            <a
+              href={true}
+            >
+              here
+            </a>
+             to make some
+          </p>
+        </EuiTableRowCell>
+      </EuiTableRow>
+    </EuiTableBody>
+  </EuiTable>
+</div>
+`;
+
 exports[`EuiBasicTable basic - empty 1`] = `
 <div
   className="euiBasicTable testClass1 testClass2"

--- a/src/components/basic_table/__snapshots__/basic_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.js.snap
@@ -23,9 +23,7 @@ exports[`EuiBasicTable basic - empty - custom message 1`] = `
           colSpan={1}
           textOnly={true}
         >
-          <div>
-            where my items at?
-          </div>
+          where my items at?
         </EuiTableRowCell>
       </EuiTableRow>
     </EuiTableBody>
@@ -95,9 +93,7 @@ exports[`EuiBasicTable basic - empty 1`] = `
           colSpan={1}
           textOnly={true}
         >
-          <div>
-            No items found
-          </div>
+          No items found
         </EuiTableRowCell>
       </EuiTableRow>
     </EuiTableBody>

--- a/src/components/basic_table/basic_table.js
+++ b/src/components/basic_table/basic_table.js
@@ -120,6 +120,8 @@ export const SelectionType = PropTypes.shape({
   selectableMessage: PropTypes.func // (selectable, item) => boolean;
 });
 
+export const NoItemsMessageType = PropTypes.oneOfType([PropTypes.string, PropTypes.node]);
+
 const SortingType = PropTypes.shape({
   sort: PropertySortType
 });
@@ -133,7 +135,7 @@ const BasicTablePropTypes = {
   onChange: PropTypes.func,
   error: PropTypes.string,
   loading: PropTypes.bool,
-  noItemsMessage: PropTypes.string,
+  noItemsMessage: NoItemsMessageType,
   className: PropTypes.string
 };
 
@@ -421,11 +423,17 @@ export class EuiBasicTable extends Component {
 
   renderEmptyBody() {
     const colSpan = this.props.columns.length + (this.props.selection ? 1 : 0);
+    let message;
+    if (typeof this.props.noItemsMessage === 'string') {
+      message = (<div>{ this.props.noItemsMessage }</div>);
+    } else {
+      message = this.props.noItemsMessage;
+    }
     return (
       <EuiTableBody>
         <EuiTableRow>
           <EuiTableRowCell align="center" colSpan={colSpan}>
-            <div>{ this.props.noItemsMessage }</div>
+            {message}
           </EuiTableRowCell>
         </EuiTableRow>
       </EuiTableBody>

--- a/src/components/basic_table/basic_table.js
+++ b/src/components/basic_table/basic_table.js
@@ -120,8 +120,6 @@ export const SelectionType = PropTypes.shape({
   selectableMessage: PropTypes.func // (selectable, item) => boolean;
 });
 
-export const NoItemsMessageType = PropTypes.oneOfType([PropTypes.string, PropTypes.node]);
-
 const SortingType = PropTypes.shape({
   sort: PropertySortType
 });
@@ -135,7 +133,7 @@ const BasicTablePropTypes = {
   onChange: PropTypes.func,
   error: PropTypes.string,
   loading: PropTypes.bool,
-  noItemsMessage: NoItemsMessageType,
+  noItemsMessage: PropTypes.node,
   className: PropTypes.string
 };
 
@@ -422,18 +420,13 @@ export class EuiBasicTable extends Component {
   }
 
   renderEmptyBody() {
-    const colSpan = this.props.columns.length + (this.props.selection ? 1 : 0);
-    let message;
-    if (typeof this.props.noItemsMessage === 'string') {
-      message = (<div>{ this.props.noItemsMessage }</div>);
-    } else {
-      message = this.props.noItemsMessage;
-    }
+    const { columns, selection, noItemsMessage } = this.props;
+    const colSpan = columns.length + (selection ? 1 : 0);
     return (
       <EuiTableBody>
         <EuiTableRow>
           <EuiTableRowCell align="center" colSpan={colSpan}>
-            {message}
+            {noItemsMessage}
           </EuiTableRowCell>
         </EuiTableRow>
       </EuiTableBody>

--- a/src/components/basic_table/basic_table.test.js
+++ b/src/components/basic_table/basic_table.test.js
@@ -47,6 +47,27 @@ describe('EuiBasicTable', () => {
     expect(component).toMatchSnapshot();
   });
 
+  test('basic - empty - custom message as node', () => {
+
+    const props = {
+      ...requiredProps,
+      items: [],
+      columns: [
+        {
+          field: 'name',
+          name: 'Name',
+          description: 'description'
+        }
+      ],
+      noItemsMessage: (<p>no items, click <a href>here</a> to make some</p>)
+    };
+    const component = shallow(
+      <EuiBasicTable {...props} />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
   test('basic - with items', () => {
 
     const props = {

--- a/src/components/basic_table/in_memory_table.js
+++ b/src/components/basic_table/in_memory_table.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import {
   EuiBasicTable,
   ColumnType,
-  SelectionType
+  SelectionType,
+  NoItemsMessageType
 } from './basic_table';
 import {
   defaults as paginationBarDefaults
@@ -22,7 +23,7 @@ const InMemoryTablePropTypes = {
   columns: PropTypes.arrayOf(ColumnType).isRequired,
   items: PropTypes.array,
   loading: PropTypes.bool,
-  message: PropTypes.string,
+  message: NoItemsMessageType,
   error: PropTypes.string,
   search: PropTypes.oneOfType([PropTypes.bool, PropTypes.shape({
     defaultQuery: QueryType,

--- a/src/components/basic_table/in_memory_table.js
+++ b/src/components/basic_table/in_memory_table.js
@@ -4,7 +4,6 @@ import {
   EuiBasicTable,
   ColumnType,
   SelectionType,
-  NoItemsMessageType
 } from './basic_table';
 import {
   defaults as paginationBarDefaults
@@ -23,7 +22,7 @@ const InMemoryTablePropTypes = {
   columns: PropTypes.arrayOf(ColumnType).isRequired,
   items: PropTypes.array,
   loading: PropTypes.bool,
-  message: NoItemsMessageType,
+  message: PropTypes.node,
   error: PropTypes.string,
   search: PropTypes.oneOfType([PropTypes.bool, PropTypes.shape({
     defaultQuery: QueryType,


### PR DESCRIPTION
Kibana needs the ability to pass in html nodes for the `noItemsMessage` property for displaying nice messages that give users calls to action to create items when none exist.