### PR TITLE
Fix EuiPageContent centering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `0.0.28`.
+**Bug fixes**
+
+- Fix `EuiPageContent` centering within `EuiPage` issue ([#527](https://github.com/elastic/eui/pull/527))
 
 # [`0.0.28`](https://github.com/elastic/eui/tree/v0.0.28)
 

--- a/src/components/page/page_content/_page_content.scss
+++ b/src/components/page/page_content/_page_content.scss
@@ -8,7 +8,7 @@
   &.euiPageContent--horizontalCenter {
     width: auto;
     margin: auto;
-    flex-grow: 0; // Offsets the properties of .euiPanel
+    flex-grow: 0; // Offsets the properties of .euiPanel within flexboxes
   }
 }
 

--- a/src/components/page/page_content/_page_content.scss
+++ b/src/components/page/page_content/_page_content.scss
@@ -1,15 +1,17 @@
 .euiPageContent {
   width: 100%;
+
+  &.euiPageContent--verticalCenter {
+    align-self: center;
+  }
+
+  &.euiPageContent--horizontalCenter {
+    width: auto;
+    margin: auto;
+    flex-grow: 0; // Offsets the properties of .euiPanel
+  }
 }
 
-.euiPageContent--verticalCenter {
-  align-self: center;
-}
-
-.euiPageContent--horizontalCenter {
-  width: auto;
-  margin: auto;
-}
 
 @include screenXSmall {
   .euiPageContent {


### PR DESCRIPTION
This fixes a very old bug introduced when `EuiPanel` took on flex abilities based upon if it was placed in a flex item. That change broke a couple instances of positioning in `EuiPage`, where panels nest inside of flex layouts.

This change sets the grow to 0 for `EuiPageCOntent`, which itself is an `EuiPanel`.  The specificity is changed so we don't need to resort to !important tags.

### Before

![image](https://user-images.githubusercontent.com/324519/37495061-dd0936a4-2868-11e8-920c-880eed07e590.png)


### After

![image](https://user-images.githubusercontent.com/324519/37495073-f226f40e-2868-11e8-86fd-27b5ab453b48.png)
