### PR TITLE
EuiHealth responsive fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Bug fixes**
 
+- `EuiHealth` no longer stacks flex items on small screens ([#530](https://github.com/elastic/eui/pull/530))
 - Fix `EuiPageContent` centering within `EuiPage` issue ([#527](https://github.com/elastic/eui/pull/527))
 
 # [`0.0.28`](https://github.com/elastic/eui/tree/v0.0.28)

--- a/src/components/health/__snapshots__/health.test.js.snap
+++ b/src/components/health/__snapshots__/health.test.js.snap
@@ -7,7 +7,7 @@ exports[`EuiHealth is rendered 1`] = `
   data-test-subj="test subject string"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"
+    class="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter"
   >
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/src/components/health/health.js
+++ b/src/components/health/health.js
@@ -24,7 +24,11 @@ export const EuiHealth = ({
       className={classes}
       {...rest}
     >
-      <EuiFlexGroup gutterSize="xs" alignItems="center">
+      <EuiFlexGroup
+        gutterSize="xs"
+        alignItems="center"
+        responsive={false}
+      >
         <EuiFlexItem grow={false}>
           <EuiIcon type="dot" color={color} />
         </EuiFlexItem>


### PR DESCRIPTION
Sets `responsive={false}` on the `EuiHealth` component.

### Before

![image](https://user-images.githubusercontent.com/324519/37501338-3688af30-288b-11e8-877c-3da0615d48de.png)

### After

![image](https://user-images.githubusercontent.com/324519/37501343-3b25eefe-288b-11e8-8229-151b4efa26ae.png)
