### PR TITLE
WIP: Refactor color picker to be accessible and match our styles

### DIFF
--- a/src-docs/src/views/color_picker/color_picker_clear.js
+++ b/src-docs/src/views/color_picker/color_picker_clear.js
@@ -6,6 +6,8 @@ import {
   EuiColorPicker,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiButtonEmpty,
+  EuiFormRow,
   EuiKeyboardAccessible,
 } from '../../../../src/components';
 
@@ -27,28 +29,22 @@ export class ColorPickerLabelAndClear extends Component {
 
   render() {
     return (
-      <EuiFlexGroup alignItems="center">
+      <EuiFlexGroup alignItems="center" gutterSize="s">
         <EuiFlexItem grow={false}>
-          <label className="kuiLabel">
-            Background color
-          </label>
+          <EuiFormRow label="Pick a color">
+            <EuiColorPicker
+              onChange={this.handleChange}
+              color={this.state.color}
+            />
+          </EuiFormRow>
         </EuiFlexItem>
 
         <EuiFlexItem grow={false}>
-          <EuiColorPicker
-            onChange={this.handleChange}
-            color={this.state.color}
-          />
-        </EuiFlexItem>
-
-        <EuiFlexItem grow={false}>
-          <p className="kuiText">
-            <EuiKeyboardAccessible>
-              <a className="kuiLink" onClick={this.resetColor}>
-                Reset
-              </a>
-            </EuiKeyboardAccessible>
-          </p>
+          <EuiFormRow hasEmptyLabelSpace>
+            <EuiButtonEmpty onClick={this.resetColor}>
+              Reset
+            </EuiButtonEmpty>
+          </EuiFormRow>
         </EuiFlexItem>
       </EuiFlexGroup>
     );

--- a/src/components/color_picker/_color_picker.scss
+++ b/src/components/color_picker/_color_picker.scss
@@ -1,10 +1,15 @@
 .euiColorPicker {
   cursor: pointer;
+
+  .block-picker, .sketch-picker {
+    box-shadow: none !important;
+  }
 }
 
   .euiColorPicker__preview {
     display: flex;
     align-items: center;
+    width: 100%;
   }
 
   .euiColorPicker__swatch {
@@ -13,6 +18,7 @@
     border-radius: $euiBorderRadius;
     box-shadow: inset 0 0 0 1px rgba(#000, 0.2);
     display: inline-block;
+    position: relative;
   }
 
   .euiColorPicker__emptySwatch {
@@ -20,6 +26,8 @@
       position: absolute;
       width: $colorPickerSize;
       height: $colorPickerSize;
+      left: 0;
+      top: 0;
     }
 
     svg line {
@@ -29,15 +37,20 @@
   }
 
   .euiColorPicker__label {
-    font-size: $euiFontSize;
-    line-height: $euiLineHeight;
-    margin-left: 10px;
+    margin-left: $euiSizeS;
     display: inline-block;
     vertical-align: middle;
   }
 
-.euiColorPickerPopUp {
-  position: absolute;
-  z-index: 10;
+.twitter-picker {
+  box-shadow: none !important;
+
+  > div {
+    padding: 0 !important;
+  }
 }
 
+.euiColorPickerPopUp {
+  position: absolute;
+  z-index: $euiZContentMenu;
+}

--- a/src/components/color_picker/_index.scss
+++ b/src/components/color_picker/_index.scss
@@ -1,3 +1,3 @@
-$colorPickerSize: 20px;
+$colorPickerSize: 16px;
 
 @import "color_picker";

--- a/src/components/color_picker/color_picker.js
+++ b/src/components/color_picker/color_picker.js
@@ -3,17 +3,26 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { ChromePicker } from 'react-color';
+import { rgbToHex } from '../../../src/services'
+
+import makeId from '../form/form_row/make_id';
+
+import lightColors from '!!sass-vars-to-js-loader!../../../src/global_styling/variables/_colors.scss'
+
+import { SketchPicker } from 'react-color';
 
 import { EuiOutsideClickDetector } from '../outside_click_detector';
 
 import { EuiColorPickerSwatch } from './color_picker_swatch';
+
+import { EuiPopover } from '../popover';
 
 export class EuiColorPicker extends Component {
   constructor(props) {
     super(props);
     this.state = {
       showColorSelector: false,
+      id: this.props.id || makeId(),
     };
   }
 
@@ -31,44 +40,76 @@ export class EuiColorPicker extends Component {
 
   getColorLabel() {
     const { color } = this.props;
-    const colorValue = color === null ? '(transparent)' : color;
+    const colorValue = color === null ? '(transparent)' : color.toUpperCase();
     return (
-      <div
+      <span
         className="euiColorPicker__label"
         aria-label={`Color selection is ${ colorValue }`}
       >
         { colorValue }
-      </div>
+      </span>
     );
   }
 
   render() {
     const { color, className, showColorLabel } = this.props;
     const classes = classNames('euiColorPicker', className);
+
+    const allowedColors = [
+      'euiColorVis0',
+      'euiColorVis1',
+      'euiColorVis2',
+      'euiColorVis3',
+      'euiColorVis4',
+      'euiColorVis5',
+      'euiColorVis6',
+      'euiColorVis7',
+      'euiColorVis8',
+      'euiColorVis9',
+    ]
+
+    let colorSwatches = [];
+
+    allowedColors.map(function(color, index) {
+      colorSwatches.push(rgbToHex(lightColors[color].rgba))
+    });
+
+    const button = (
+      <button
+        className="euiColorPicker__preview euiFieldText"
+        onClick={this.toggleColorSelector}
+      >
+        <EuiColorPickerSwatch color={color} aria-label={this.props['aria-label']} />
+        { showColorLabel ? this.getColorLabel() : null }
+      </button>
+    );
+
     return (
       <EuiOutsideClickDetector onOutsideClick={this.closeColorSelector}>
         <div
           className={classes}
           data-test-subj={this.props['data-test-subj']}
         >
-          <div
-            className="euiColorPicker__preview"
-            onClick={this.toggleColorSelector}
+          <EuiPopover
+            id={this.state.id}
+            data-test-subj="colorPickerPopup"
+            button={button}
+            isOpen={this.state.showColorSelector}
+            closePopover={this.closeColorSelector}
+            anchorPosition="downLeft"
+            panelPaddingSize="none"
+            ownFocus
           >
-            <EuiColorPickerSwatch color={color} aria-label={this.props['aria-label']} />
-            { showColorLabel ? this.getColorLabel() : null }
-          </div>
-          {
-            this.state.showColorSelector ?
-              <div className="euiColorPickerPopUp" data-test-subj="colorPickerPopup">
-                <ChromePicker
-                  color={color ? color : '#ffffff'}
-                  disableAlpha={true}
-                  onChange={this.handleColorSelection}
-                />
-              </div>
-              : null
-          }
+            <SketchPicker
+              triangle="hide"
+              color={color ? color : '#ffffff'}
+              disableAlpha={true}
+              onChange={this.handleColorSelection}
+              presetColors={colorSwatches}
+              role="dialog"
+              aria-labelledby={this.state.id}
+            />
+          </EuiPopover>
         </div>
       </EuiOutsideClickDetector>
     );

--- a/src/components/color_picker/color_picker_swatch.js
+++ b/src/components/color_picker/color_picker_swatch.js
@@ -20,14 +20,14 @@ export const EuiColorPickerSwatch = ({
   }
 
   return (
-    <div
+    <span
       className={classes}
       data-test-subj="colorSwatch"
       style={{ background: color ? color : '' }}
       {...rest}
     >
       {children}
-    </div>
+    </span>
   );
 };
 


### PR DESCRIPTION
This is a WIP. Still a bit to do.

Fixes https://github.com/elastic/eui/issues/333

Aiming to do the following.

1. Match our styling.
2. Provide some default swatches that make sense and work for colorblind / accessibility.
3. Fix accessibility problems with current color picker.