### PR TITLE
remove unneeded class euiBody-hasToolTip

### DIFF
--- a/src/components/tool_tip/_tool_tip.scss
+++ b/src/components/tool_tip/_tool_tip.scss
@@ -1,10 +1,3 @@
-/**
- * 1. Relative / absolute positioning so they still work during scrolling.
- */
-.euiBody-hasToolTip {
-  position: relative; /* 1 */
-}
-
 .euiToolTip {
   @include euiBottomShadow;
   @include euiFontSizeS();

--- a/src/components/tool_tip/tool_tip_popover.js
+++ b/src/components/tool_tip/tool_tip_popover.js
@@ -19,8 +19,6 @@ export class EuiToolTipPopover extends Component {
   }
 
   componentDidMount() {
-    document.body.classList.add('euiBody-hasToolTip');
-
     this.updateDimensions();
     window.addEventListener('resize', this.updateDimensions);
   }
@@ -35,7 +33,6 @@ export class EuiToolTipPopover extends Component {
   }
 
   componentWillUnmount() {
-    document.body.classList.remove('euiBody-hasToolTip');
     window.removeEventListener('resize', this.updateDimensions);
   }
 


### PR DESCRIPTION
@cjcenizal and I were debugging page flicking caused by tooltips in https://github.com/elastic/kibana/pull/17227 and found that removing the class `euiBody-hasToolTip` resolved the problem. The comments stated that `euiBody-hasToolTip` was needed to preserve tooltip position while scrolling but the tooltip position works even when `euiBody-hasToolTip` class is removed.
 