### PR TITLE
Remove font smoothing from reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
 - Make `<EuiProgress>` TypeScript types more specific ([#518](https://github.com/elastic/eui/pull/518))
+- Remove `font-smoothing` from our reset css for better text legibility ([#539](https://github.com/elastic/eui/pull/539))
 
 **Bug fixes**
 

--- a/src/global_styling/reset/_reset.scss
+++ b/src/global_styling/reset/_reset.scss
@@ -55,7 +55,6 @@ html {
   color: $euiTextColor;
   height: 100%;
   background-color: $euiColorLightestShade;
-  -webkit-font-smoothing: antialiased;
 }
 
 body {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/16662

This removes font-smoothing for webkit browsers as a base reset. @cchaos and I tend to prefer font-smoothing on, and it can be very subjective, but according to https://caniuse.com/#feat=font-smooth

> Though present in early (2002) drafts of CSS3 Fonts, font-smooth has been removed from this specification and is currently not on the standard track.

We should stick to standards when we can. cc @elastic/eui-design 