### PR TITLE
Fix checkbox click for checkboxes without a label.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Bug fixes**
 
+- Fix checkbox click for `EuiCheckbox` without a label ([#540](https://github.com/elastic/eui/pull/540))
 - Made `EuiIconTip` screen reader accessible ([#534](https://github.com/elastic/eui/pull/534))
 - Fixed a sorting issue in `EuiInMemoryTable` ([#453](https://github.com/elastic/eui/pull/453))
 

--- a/src/components/form/checkbox/__snapshots__/checkbox.test.js.snap
+++ b/src/components/form/checkbox/__snapshots__/checkbox.test.js.snap
@@ -51,7 +51,7 @@ exports[`EuiCheckbox props disabled disabled is rendered 1`] = `
 
 exports[`EuiCheckbox props label is rendered 1`] = `
 <div
-  class="euiCheckbox"
+  class="euiCheckbox euiCheckbox--withLabel"
 >
   <input
     class="euiCheckbox__input"

--- a/src/components/form/checkbox/_checkbox.scss
+++ b/src/components/form/checkbox/_checkbox.scss
@@ -1,8 +1,17 @@
 .euiCheckbox {
   position: relative;
+  min-width: $euiCheckBoxSize;
+  min-height: $euiCheckBoxSize;
 
   .euiCheckbox__input {
-    @include euiScreenReaderOnly;
+    opacity: 0;
+    overflow: hidden;
+    position: absolute;
+    z-index: 1;
+    top: 0;
+    width: $euiCheckBoxSize;
+    height: $euiCheckBoxSize;
+    cursor: pointer;
 
     ~ .euiCheckbox__label {
       display: block;
@@ -17,8 +26,9 @@
     + .euiCheckbox__square {
       display: inline-block;
       position: absolute;
+      z-index: 0;
       left: 0;
-      top: ($euiSizeL - $euiCheckBoxSize)/2;
+      top: 0;
       @include euiCustomControl($type: 'square', $size: $euiCheckBoxSize);
     }
 
@@ -88,6 +98,16 @@
       margin: 0; /* 1 */
       left: 0; /* 1 */
       cursor: pointer;
+    }
+  }
+
+  &.euiCheckbox--withLabel {
+    .euiCheckbox__input {
+      top: ($euiSizeL - $euiCheckBoxSize)/2;
+
+      + .euiCheckbox__square {
+        top: ($euiSizeL - $euiCheckBoxSize)/2;
+      }
     }
   }
 }

--- a/src/components/form/checkbox/checkbox.js
+++ b/src/components/form/checkbox/checkbox.js
@@ -20,6 +20,9 @@ export const EuiCheckbox = ({
 }) => {
   const classes = classNames(
     'euiCheckbox',
+    {
+      'euiCheckbox--withLabel': !!label
+    },
     typeToClassNameMap[type],
     className
   );


### PR DESCRIPTION
Unfortunately #407 broke checkboxes without labels — they aren't clickable using a mouse. This fixes that.

Currently the `<input>` is rendered offscreen, a `<div>` is used visually in its place, and a `<label>` is overlayed on top of the `<div>` to receive mouse clicks.

This PR brings the `<input>` back onscreen and visually it using `opacity:0`. I also added `cursor:pointer` for consistency with the `<label>`. I should note that some consider this to be a [usability antipattern](https://medium.com/simple-human/buttons-shouldnt-have-a-hand-cursor-b11e99ca374b).