### PR TITLE
Using the same `--inList` styles for checkboxes and radios without labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Made `EuiIconTip` screen reader accessible ([#534](https://github.com/elastic/eui/pull/534))
+- Fix checkbox click for `EuiCheckbox` and `EuiRadio` without a label ([#541](https://github.com/elastic/eui/pull/541))
 
 # [`0.0.30`](https://github.com/elastic/eui/tree/v0.0.30)
 

--- a/src-docs/src/views/form/form_controls.js
+++ b/src-docs/src/views/form/form_controls.js
@@ -28,10 +28,8 @@ export default class extends Component {
       isSwitchChecked: false,
       checkboxes: [{
         id: `${idPrefix}0`,
-        label: 'Option one',
       }, {
         id: `${idPrefix}1`,
-        label: 'Option two is checked by default',
       }, {
         id: `${idPrefix}2`,
         label: 'Option three',
@@ -41,10 +39,8 @@ export default class extends Component {
       },
       radios: [{
         id: `${idPrefix}4`,
-        label: 'Option one',
       }, {
         id: `${idPrefix}5`,
-        label: 'Option two is selected by default',
       }, {
         id: `${idPrefix}6`,
         label: 'Option three',

--- a/src-docs/src/views/form/form_controls.js
+++ b/src-docs/src/views/form/form_controls.js
@@ -28,8 +28,10 @@ export default class extends Component {
       isSwitchChecked: false,
       checkboxes: [{
         id: `${idPrefix}0`,
+        label: 'Option one',
       }, {
         id: `${idPrefix}1`,
+        label: 'Option two is checked by default',
       }, {
         id: `${idPrefix}2`,
         label: 'Option three',
@@ -39,8 +41,10 @@ export default class extends Component {
       },
       radios: [{
         id: `${idPrefix}4`,
+        label: 'Option one',
       }, {
         id: `${idPrefix}5`,
+        label: 'Option two is selected by default',
       }, {
         id: `${idPrefix}6`,
         label: 'Option three',

--- a/src/components/form/checkbox/__snapshots__/checkbox.test.js.snap
+++ b/src/components/form/checkbox/__snapshots__/checkbox.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`EuiCheckbox is rendered 1`] = `
 <div
-  class="euiCheckbox testClass1 testClass2"
+  class="euiCheckbox euiCheckbox--noLabel testClass1 testClass2"
 >
   <input
     aria-label="aria-label"
@@ -19,7 +19,7 @@ exports[`EuiCheckbox is rendered 1`] = `
 
 exports[`EuiCheckbox props check is rendered 1`] = `
 <div
-  class="euiCheckbox"
+  class="euiCheckbox euiCheckbox--noLabel"
 >
   <input
     checked=""
@@ -35,7 +35,7 @@ exports[`EuiCheckbox props check is rendered 1`] = `
 
 exports[`EuiCheckbox props disabled disabled is rendered 1`] = `
 <div
-  class="euiCheckbox"
+  class="euiCheckbox euiCheckbox--noLabel"
 >
   <input
     class="euiCheckbox__input"
@@ -74,7 +74,7 @@ exports[`EuiCheckbox props label is rendered 1`] = `
 
 exports[`EuiCheckbox props type inList is rendered 1`] = `
 <div
-  class="euiCheckbox euiCheckbox--inList"
+  class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
 >
   <input
     class="euiCheckbox__input"

--- a/src/components/form/checkbox/_checkbox.scss
+++ b/src/components/form/checkbox/_checkbox.scss
@@ -72,7 +72,8 @@
    *    they actually click this input.
    */
 
-  &.euiCheckbox--inList {
+  &.euiCheckbox--inList,
+  &.euiCheckbox--noLabel {
     min-height: $euiCheckBoxSize;
     min-width: $euiCheckBoxSize;
 

--- a/src/components/form/checkbox/checkbox.js
+++ b/src/components/form/checkbox/checkbox.js
@@ -21,6 +21,9 @@ export const EuiCheckbox = ({
   const classes = classNames(
     'euiCheckbox',
     typeToClassNameMap[type],
+    {
+      'euiCheckbox--noLabel': !label
+    },
     className
   );
 

--- a/src/components/form/radio/__snapshots__/radio.test.js.snap
+++ b/src/components/form/radio/__snapshots__/radio.test.js.snap
@@ -3,7 +3,7 @@
 exports[`EuiRadio is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="euiRadio testClass1 testClass2"
+  class="euiRadio euiRadio--noLabel testClass1 testClass2"
   data-test-subj="test subject string"
 >
   <input
@@ -19,7 +19,7 @@ exports[`EuiRadio is rendered 1`] = `
 
 exports[`EuiRadio props checked is rendered 1`] = `
 <div
-  class="euiRadio"
+  class="euiRadio euiRadio--noLabel"
 >
   <input
     checked=""
@@ -35,7 +35,7 @@ exports[`EuiRadio props checked is rendered 1`] = `
 
 exports[`EuiRadio props disabled is rendered 1`] = `
 <div
-  class="euiRadio"
+  class="euiRadio euiRadio--noLabel"
 >
   <input
     class="euiRadio__input"

--- a/src/components/form/radio/_radio.scss
+++ b/src/components/form/radio/_radio.scss
@@ -60,7 +60,8 @@
    *    they actually click this input.
    */
 
-  &.euiRadio--inList {
+  &.euiRadio--inList,
+  &.euiRadio--noLabel {
     min-height: $euiRadioSize;
     min-width: $euiRadioSize;
 

--- a/src/components/form/radio/radio.js
+++ b/src/components/form/radio/radio.js
@@ -14,6 +14,9 @@ export const EuiRadio = ({
 }) => {
   const classes = classNames(
     'euiRadio',
+    {
+      'euiRadio--noLabel': !label
+    },
     className
   );
 


### PR DESCRIPTION
Fixes #541 

![screen capture on 2018-03-19 at 21-44-35](https://user-images.githubusercontent.com/549577/37631288-59ea7756-2bbf-11e8-8db4-241038ef1480.gif)

@arkwright: Basically using your solution here but just the opposite and appending a `--noLabel` selector to the `--inList` selector.