### PR TITLE
Some random fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,16 @@
 **Bug fixes**
 
 - Fixed `EuiToolTip` bug which caused the tooltip to hide when moving the mouse around inside of the trigger element ([#557](https://github.com/elastic/eui/pull/557))
+- Added a `buttonColor` prop to `EuiConfirmModal` ([#546](https://github.com/elastic/eui/pull/546))
+- Added ‘baseline’ as option to `EuiFlexGroup`'s `alignItems` prop ([#546](https://github.com/elastic/eui/pull/546))
 
 # [`0.0.33`](https://github.com/elastic/eui/tree/v0.0.33)
 
 - Added initial sorting option to `EuiInMemoryTable` ([#547](https://github.com/elastic/eui/pull/547))
+- Horizontally scrolling `EuiTabs` ([#546](https://github.com/elastic/eui/pull/546))
+- Remove padding from both sides of `EuiEmptyButton` ([#546](https://github.com/elastic/eui/pull/546))
+- Added `disabled` prop to placeholder (ellipses) button in pagination ([#546](https://github.com/elastic/eui/pull/546))
+- Converted `.euiHeader__notification` into `EuiHeaderNotification` ([#546](https://github.com/elastic/eui/pull/546))
 
 **Bug fixes**
 

--- a/src-docs/src/views/header/header_user_menu.js
+++ b/src-docs/src/views/header/header_user_menu.js
@@ -8,6 +8,7 @@ import {
   EuiFlexItem,
   EuiHeaderAlert,
   EuiHeaderSectionItemButton,
+  EuiHeaderNotification,
   EuiIcon,
   EuiLink,
   EuiText,
@@ -44,9 +45,7 @@ export default class extends Component {
           size="m"
         />
 
-        <span className="euiHeader__notification">
-          3
-        </span>
+        <EuiHeaderNotification>3</EuiHeaderNotification>
       </EuiHeaderSectionItemButton>
     );
 

--- a/src-docs/src/views/modal/confirm_modal.js
+++ b/src-docs/src/views/modal/confirm_modal.js
@@ -73,7 +73,7 @@ export class ConfirmModal extends Component {
             onConfirm={this.closeDestroyModal}
             cancelButtonText="No, don't do it"
             confirmButtonText="Yes, do it"
-            buttonColor="danger"
+            type="destroy"
             defaultFocusedButton={EUI_MODAL_CONFIRM_BUTTON}
           >
             <p>You&rsquo;re about to destroy something.</p>
@@ -92,7 +92,7 @@ export class ConfirmModal extends Component {
         &nbsp;
 
         <EuiButton onClick={this.showDestroyModal}>
-          Show dangerous ConfirmModal
+          Show destroy type of ConfirmModal
         </EuiButton>
 
         {modal}

--- a/src-docs/src/views/modal/confirm_modal.js
+++ b/src-docs/src/views/modal/confirm_modal.js
@@ -15,10 +15,14 @@ export class ConfirmModal extends Component {
 
     this.state = {
       isModalVisible: false,
+      isDestroyModalVisible: false,
     };
 
     this.closeModal = this.closeModal.bind(this);
     this.showModal = this.showModal.bind(this);
+
+    this.closeDestroyModal = this.closeDestroyModal.bind(this);
+    this.showDestroyModal = this.showDestroyModal.bind(this);
   }
 
   closeModal() {
@@ -27,6 +31,14 @@ export class ConfirmModal extends Component {
 
   showModal() {
     this.setState({ isModalVisible: true });
+  }
+
+  closeDestroyModal() {
+    this.setState({ isDestroyModalVisible: false });
+  }
+
+  showDestroyModal() {
+    this.setState({ isDestroyModalVisible: true });
   }
 
   render() {
@@ -50,13 +62,41 @@ export class ConfirmModal extends Component {
       );
     }
 
+    let destroyModal;
+
+    if (this.state.isDestroyModalVisible) {
+      destroyModal = (
+        <EuiOverlayMask>
+          <EuiConfirmModal
+            title="Do this destructive thing"
+            onCancel={this.closeDestroyModal}
+            onConfirm={this.closeDestroyModal}
+            cancelButtonText="No, don't do it"
+            confirmButtonText="Yes, do it"
+            type="destroy"
+            defaultFocusedButton={EUI_MODAL_CONFIRM_BUTTON}
+          >
+            <p>You&rsquo;re about to destroy something.</p>
+            <p>Are you sure you want to do this?</p>
+          </EuiConfirmModal>
+        </EuiOverlayMask>
+      );
+    }
+
     return (
       <div>
         <EuiButton onClick={this.showModal}>
           Show ConfirmModal
         </EuiButton>
 
+        &nbsp;
+
+        <EuiButton onClick={this.showDestroyModal}>
+          Show destroy type of ConfirmModal
+        </EuiButton>
+
         {modal}
+        {destroyModal}
       </div>
     );
   }

--- a/src-docs/src/views/modal/confirm_modal.js
+++ b/src-docs/src/views/modal/confirm_modal.js
@@ -73,7 +73,7 @@ export class ConfirmModal extends Component {
             onConfirm={this.closeDestroyModal}
             cancelButtonText="No, don't do it"
             confirmButtonText="Yes, do it"
-            type="destroy"
+            buttonColor="danger"
             defaultFocusedButton={EUI_MODAL_CONFIRM_BUTTON}
           >
             <p>You&rsquo;re about to destroy something.</p>
@@ -92,7 +92,7 @@ export class ConfirmModal extends Component {
         &nbsp;
 
         <EuiButton onClick={this.showDestroyModal}>
-          Show destroy type of ConfirmModal
+          Show dangerous ConfirmModal
         </EuiButton>
 
         {modal}

--- a/src-docs/src/views/modal/modal.js
+++ b/src-docs/src/views/modal/modal.js
@@ -102,14 +102,12 @@ export class Modal extends Component {
             <EuiModalFooter>
               <EuiButtonEmpty
                 onClick={this.closeModal}
-                size="s"
               >
                 Cancel
               </EuiButtonEmpty>
 
               <EuiButton
                 onClick={this.closeModal}
-                size="s"
                 fill
               >
                 Save

--- a/src-docs/src/views/modal/modal_example.js
+++ b/src-docs/src/views/modal/modal_example.js
@@ -54,27 +54,28 @@ export const ModalExample = {
     }],
     text: (
       <p>
-        Use the <EuiCode>EuiConfirmModal</EuiCode> to ask the user to confirm a decision,
-        typically one which is destructive and potentially regrettable.
+        Use the <EuiCode>EuiConfirmModal</EuiCode> to ask the user to confirm a decision.
+        The default type is a positive or neutral confirmation. Change the <EuiCode>type</EuiCode>
+        property to <EuiCode>&quot;destroy&quot;</EuiCode> for those that are destructive and potentially regrettable.
       </p>
     ),
     props: { EuiConfirmModal },
     demo: <ConfirmModal />,
+  }, {
+    title: 'Overflow overflow test',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: overflowTestSource,
     }, {
-      title: 'Overflow overflow test',
-      source: [{
-        type: GuideSectionTypes.JS,
-        code: overflowTestSource,
-      }, {
-        type: GuideSectionTypes.HTML,
-        code: overflowTestHtml,
-      }],
-      text: (
-        <p>
+      type: GuideSectionTypes.HTML,
+      code: overflowTestHtml,
+    }],
+    text: (
+      <p>
           This demo is to test long overflowing body content.
-        </p>
-      ),
-      props: { EuiConfirmModal },
-      demo: <OverflowTest />,
+      </p>
+    ),
+    props: { EuiConfirmModal },
+    demo: <OverflowTest />,
   }],
 };

--- a/src-docs/src/views/modal/modal_example.js
+++ b/src-docs/src/views/modal/modal_example.js
@@ -55,8 +55,8 @@ export const ModalExample = {
     text: (
       <p>
         Use the <EuiCode>EuiConfirmModal</EuiCode> to ask the user to confirm a decision.
-        The default type is a positive or neutral confirmation. To change the main button color
-        change the the <EuiCode>buttonColor</EuiCode> property to any of the button color options.
+        The default type is a positive or neutral confirmation. Change the <EuiCode>type</EuiCode>
+        property to <EuiCode>&quot;destroy&quot;</EuiCode> for those that are destructive and potentially regrettable.
       </p>
     ),
     props: { EuiConfirmModal },

--- a/src-docs/src/views/modal/modal_example.js
+++ b/src-docs/src/views/modal/modal_example.js
@@ -55,8 +55,8 @@ export const ModalExample = {
     text: (
       <p>
         Use the <EuiCode>EuiConfirmModal</EuiCode> to ask the user to confirm a decision.
-        The default type is a positive or neutral confirmation. Change the <EuiCode>type</EuiCode>
-        property to <EuiCode>&quot;destroy&quot;</EuiCode> for those that are destructive and potentially regrettable.
+        The default type is a positive or neutral confirmation. To change the main button color
+        change the the <EuiCode>buttonColor</EuiCode> property to any of the button color options.
       </p>
     ),
     props: { EuiConfirmModal },

--- a/src-docs/src/views/modal/overflow_test.js
+++ b/src-docs/src/views/modal/overflow_test.js
@@ -125,14 +125,12 @@ export class OverflowTest extends Component {
             <EuiModalFooter>
               <EuiButtonEmpty
                 onClick={this.closeModal}
-                size="s"
               >
                 Cancel
               </EuiButtonEmpty>
 
               <EuiButton
                 onClick={this.closeModal}
-                size="s"
                 fill
               >
                 Save

--- a/src/components/button/button_empty/_button_empty.scss
+++ b/src/components/button/button_empty/_button_empty.scss
@@ -85,15 +85,21 @@ $buttonTypes: (
 }
 
 .euiButtonEmpty--flushLeft {
+  margin-right: $euiSizeS;
+
   .euiButtonEmpty__content {
     border-left: none;
     padding-left: 0;
+    padding-right: 0;
   }
 }
 
 .euiButtonEmpty--flushRight {
+  margin-left: $euiSizeS;
+
   .euiButtonEmpty__content {
     border-right: none;
+    padding-left: 0;
     padding-right: 0;
   }
 }

--- a/src/components/flex/__snapshots__/flex_group.test.js.snap
+++ b/src/components/flex/__snapshots__/flex_group.test.js.snap
@@ -12,6 +12,12 @@ exports[`EuiFlexGroup is rendered 1`] = `
 </div>
 `;
 
+exports[`EuiFlexGroup props alignItems baseline is rendered 1`] = `
+<div
+  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--responsive"
+/>
+`;
+
 exports[`EuiFlexGroup props alignItems center is rendered 1`] = `
 <div
   class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--responsive"

--- a/src/components/flex/_flex_group.scss
+++ b/src/components/flex/_flex_group.scss
@@ -69,6 +69,11 @@ $gutterTypes: (
   align-items: flex-end;
 }
 
+.euiFlexGroup--alignItemsBaseline {
+  align-items: baseline;
+}
+
+// Wrap
 .euiFlexGroup--wrap {
   flex-wrap: wrap;
 }

--- a/src/components/flex/flex_group.js
+++ b/src/components/flex/flex_group.js
@@ -18,6 +18,7 @@ const alignItemsToClassNameMap = {
   flexStart: 'euiFlexGroup--alignItemsFlexStart',
   flexEnd: 'euiFlexGroup--alignItemsFlexEnd',
   center: 'euiFlexGroup--alignItemsCenter',
+  baseline: 'euiFlexGroup--alignItemsBaseline',
 };
 
 export const ALIGN_ITEMS = Object.keys(alignItemsToClassNameMap);

--- a/src/components/flyout/_flyout_header.scss
+++ b/src/components/flyout/_flyout_header.scss
@@ -2,6 +2,5 @@
   flex-grow: 0;
   padding: $euiSizeL;
   padding-bottom: 0;
-  box-shadow: 0 $euiSize $euiSize (-$euiSize / 2) $euiColorEmptyShade;
-  z-index: 2;
+  @include euiOverflowShadowBottom;
 }

--- a/src/components/form/switch/_switch.scss
+++ b/src/components/form/switch/_switch.scss
@@ -7,6 +7,7 @@
     padding-left: $euiSizeS;
     line-height: $euiSwitchHeight;
     font-size: $euiFontSizeS;
+    vertical-align: middle;
   }
 
   /**

--- a/src/components/header/__snapshots__/header_notification.test.js.snap
+++ b/src/components/header/__snapshots__/header_notification.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiHeaderNotification is rendered 1`] = `
+<span
+  aria-label="aria-label"
+  class="euiHeaderNotification testClass1 testClass2"
+  data-test-subj="test subject string"
+>
+  Content
+</span>
+`;

--- a/src/components/header/_header_notification.scss
+++ b/src/components/header/_header_notification.scss
@@ -1,0 +1,12 @@
+
+.euiHeaderNotification {
+  display: inline-block;
+  border-radius: $euiBorderRadius;
+  background: $euiHeaderNotificationBackgroundColor;
+  color: $euiColorEmptyShade;
+  font-size: $euiFontSizeXS;
+  line-height: $euiSize;
+  height: $euiSize;
+  min-width: $euiSize;
+  vertical-align: middle;
+}

--- a/src/components/header/_index.scss
+++ b/src/components/header/_index.scss
@@ -11,6 +11,7 @@ $euiHeaderChildSize: $euiSizeXXL + $euiSizeL;
 @import 'header_popover';
 @import 'header_profile';
 @import 'header_logo';
+@import 'header_notification';
 @import 'header_alert/index';
 @import 'header_breadcrumbs/index';
 @import 'header_section/index';

--- a/src/components/header/header_notification.js
+++ b/src/components/header/header_notification.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import classNames from 'classnames';
+
+export const EuiHeaderNotification = ({ children, className, ...rest }) => {
+  const classes = classNames('euiHeaderNotification', className);
+
+  return (
+    <span
+      className={classes}
+      {...rest}
+    >
+      {children}
+    </span>
+  );
+};

--- a/src/components/header/header_notification.test.js
+++ b/src/components/header/header_notification.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render } from 'enzyme';
+import { requiredProps } from '../../test/required_props';
+
+import { EuiHeaderNotification } from './header_notification';
+
+describe('EuiHeaderNotification', () => {
+  test('is rendered', () => {
+    const component = render(
+      <EuiHeaderNotification {...requiredProps}>
+        Content
+      </EuiHeaderNotification>
+    );
+
+    expect(component)
+      .toMatchSnapshot();
+  });
+});

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -17,6 +17,10 @@ export {
 } from './header_logo';
 
 export {
+  EuiHeaderNotification,
+} from './header_notification';
+
+export {
   EuiHeaderSection,
   EuiHeaderSectionItem,
   EuiHeaderSectionItemButton,

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -121,6 +121,7 @@ export {
   EuiHeaderBreadcrumbCollapsed,
   EuiHeaderBreadcrumbs,
   EuiHeaderLogo,
+  EuiHeaderNotification,
   EuiHeaderSection,
   EuiHeaderSectionItem,
   EuiHeaderSectionItemButton,

--- a/src/components/modal/__snapshots__/confirm_modal.test.js.snap
+++ b/src/components/modal/__snapshots__/confirm_modal.test.js.snap
@@ -60,7 +60,7 @@ exports[`renders EuiConfirmModal 1`] = `
       class="euiModalFooter"
     >
       <button
-        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
+        class="euiButtonEmpty euiButtonEmpty--primary"
         data-test-subj="confirmModalCancelButton"
         type="button"
       >
@@ -73,7 +73,7 @@ exports[`renders EuiConfirmModal 1`] = `
         </span>
       </button>
       <button
-        class="euiButton euiButton--primary euiButton--small euiButton--fill"
+        class="euiButton euiButton--primary euiButton--fill"
         data-test-subj="confirmModalConfirmButton"
         type="button"
       >

--- a/src/components/modal/__snapshots__/confirm_modal.test.js.snap
+++ b/src/components/modal/__snapshots__/confirm_modal.test.js.snap
@@ -60,9 +60,9 @@ exports[`renders EuiConfirmModal 1`] = `
       class="euiModalFooter"
     >
       <button
-        class="euiButtonEmpty euiButtonEmpty--primary"
+        class="euiButtonEmpty"
         data-test-subj="confirmModalCancelButton"
-        type="button"
+        type="confirm"
       >
         <span
           class="euiButtonEmpty__content"

--- a/src/components/modal/__snapshots__/confirm_modal.test.js.snap
+++ b/src/components/modal/__snapshots__/confirm_modal.test.js.snap
@@ -60,9 +60,9 @@ exports[`renders EuiConfirmModal 1`] = `
       class="euiModalFooter"
     >
       <button
-        class="euiButtonEmpty"
+        class="euiButtonEmpty euiButtonEmpty--primary"
         data-test-subj="confirmModalCancelButton"
-        type="confirm"
+        type="button"
       >
         <span
           class="euiButtonEmpty__content"

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -22,10 +22,10 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: $euiSizeL;
-  padding-bottom: 0;
+  padding: $euiSizeL $euiSizeXXL $euiSizeM $euiSizeL;
   flex-grow: 0;
-  padding-bottom: $euiSizeL;
+  flex-shrink: 0;
+  @include euiOverflowShadowBottom;
 }
 
   .euiModalHeader__title {
@@ -43,8 +43,10 @@
 .euiModalFooter {
   display: flex;
   justify-content: flex-end;
-  padding: $euiSizeL;
+  padding: $euiSizeM $euiSizeL;
   flex-grow: 0;
+  flex-shrink: 0; // ensure the height of the footer is based off it's contents and doesn't squish
+  @include euiOverflowShadowTop;
 
   > * + * {
     margin-left: $euiSize;
@@ -54,13 +56,15 @@
 // When both a header and body exist, drop the top padding so the overflow on
 // the body is spaced correctly.
 .euiModalHeader + .euiModalBody {
-  padding-top: 0;
+  padding-top: $euiSizeM;
 }
 
 .euiModal__closeIcon {
+  background-color: transparentize($euiColorEmptyShade, .1);
   position: absolute;
-  right: $euiSizeL;
-  top: $euiSizeL;
+  right: $euiSizeM;
+  top: $euiSizeL + 4px;
+  z-index: 3;
 }
 
 @keyframes euiModal {
@@ -78,13 +82,14 @@
 @include screenXSmall {
   .euiModal {
     position: fixed;
-    width: 100vw;
+    width: calc(100vw + 2px);
     max-height: 100vh;
     left: 0;
     right: 0;
-    top: 0;
     bottom: 0;
-    box-shadow: none;
+    top: 0;
+    border-radius: 0;
+    box-shadow: 0 -8px 16px -8px rgba(0, 0, 0, 0.1);
     border: none;
   }
 
@@ -95,6 +100,15 @@
   .euiModalFooter {
     background: $euiColorLightestShade;
     width: 100vw;
+    justify-content: stretch;
+
+    > * {
+      flex: 1;
+
+      + * {
+        margin-left: 0;
+      }
+    }
   }
 
   .euiModal__closeIcon {

--- a/src/components/modal/confirm_modal.js
+++ b/src/components/modal/confirm_modal.js
@@ -25,13 +25,6 @@ const CONFIRM_MODAL_BUTTONS = [
   CANCEL_BUTTON,
 ];
 
-const typeToButtonColorMap = {
-  'confirm': 'primary',
-  'destroy': 'danger',
-};
-
-export const MODAL_TYPES = Object.keys(typeToButtonColorMap);
-
 export class EuiConfirmModal extends Component {
   componentDidMount() {
     // We have to do this instead of using `autoFocus` because React's polyfill for auto-focusing
@@ -61,7 +54,7 @@ export class EuiConfirmModal extends Component {
       cancelButtonText,
       confirmButtonText,
       className,
-      type,
+      buttonColor,
       defaultFocusedButton, // eslint-disable-line no-unused-vars
       ...rest
     } = this.props;
@@ -116,7 +109,7 @@ export class EuiConfirmModal extends Component {
             onClick={onConfirm}
             fill
             buttonRef={this.confirmRef}
-            color={typeToButtonColorMap[type]}
+            color={buttonColor}
           >
             {confirmButtonText}
           </EuiButton>
@@ -135,9 +128,9 @@ EuiConfirmModal.propTypes = {
   onConfirm: PropTypes.func,
   className: PropTypes.string,
   defaultFocusedButton: PropTypes.oneOf(CONFIRM_MODAL_BUTTONS),
-  type: PropTypes.oneOf(MODAL_TYPES),
+  buttonColor: PropTypes.string,
 };
 
 EuiConfirmModal.defaultProps = {
-  type: 'confirm',
+  buttonColor: 'primary',
 };

--- a/src/components/modal/confirm_modal.js
+++ b/src/components/modal/confirm_modal.js
@@ -25,6 +25,13 @@ const CONFIRM_MODAL_BUTTONS = [
   CANCEL_BUTTON,
 ];
 
+const typeToButtonColorMap = {
+  'confirm': 'primary',
+  'destroy': 'danger',
+};
+
+export const MODAL_TYPES = Object.keys(typeToButtonColorMap);
+
 export class EuiConfirmModal extends Component {
   componentDidMount() {
     // We have to do this instead of using `autoFocus` because React's polyfill for auto-focusing
@@ -54,7 +61,7 @@ export class EuiConfirmModal extends Component {
       cancelButtonText,
       confirmButtonText,
       className,
-      buttonColor,
+      type,
       defaultFocusedButton, // eslint-disable-line no-unused-vars
       ...rest
     } = this.props;
@@ -109,7 +116,7 @@ export class EuiConfirmModal extends Component {
             onClick={onConfirm}
             fill
             buttonRef={this.confirmRef}
-            color={buttonColor}
+            color={typeToButtonColorMap[type]}
           >
             {confirmButtonText}
           </EuiButton>
@@ -128,9 +135,9 @@ EuiConfirmModal.propTypes = {
   onConfirm: PropTypes.func,
   className: PropTypes.string,
   defaultFocusedButton: PropTypes.oneOf(CONFIRM_MODAL_BUTTONS),
-  buttonColor: PropTypes.string,
+  type: PropTypes.oneOf(MODAL_TYPES),
 };
 
 EuiConfirmModal.defaultProps = {
-  buttonColor: 'primary',
+  type: 'confirm',
 };

--- a/src/components/modal/confirm_modal.js
+++ b/src/components/modal/confirm_modal.js
@@ -25,6 +25,13 @@ const CONFIRM_MODAL_BUTTONS = [
   CANCEL_BUTTON,
 ];
 
+const typeToButtonColorMap = {
+  'confirm': 'primary',
+  'destroy': 'danger',
+};
+
+export const MODAL_TYPES = Object.keys(typeToButtonColorMap);
+
 export class EuiConfirmModal extends Component {
   componentDidMount() {
     // We have to do this instead of using `autoFocus` because React's polyfill for auto-focusing
@@ -54,6 +61,7 @@ export class EuiConfirmModal extends Component {
       cancelButtonText,
       confirmButtonText,
       className,
+      type,
       defaultFocusedButton, // eslint-disable-line no-unused-vars
       ...rest
     } = this.props;
@@ -108,6 +116,7 @@ export class EuiConfirmModal extends Component {
             onClick={onConfirm}
             fill
             buttonRef={this.confirmRef}
+            color={typeToButtonColorMap[type]}
           >
             {confirmButtonText}
           </EuiButton>
@@ -125,5 +134,10 @@ EuiConfirmModal.propTypes = {
   onCancel: PropTypes.func,
   onConfirm: PropTypes.func,
   className: PropTypes.string,
-  defaultFocusedButton: PropTypes.oneOf(CONFIRM_MODAL_BUTTONS)
+  defaultFocusedButton: PropTypes.oneOf(CONFIRM_MODAL_BUTTONS),
+  type: PropTypes.oneOf(MODAL_TYPES),
+};
+
+EuiButtonEmpty.defaultProps = {
+  type: 'confirm',
 };

--- a/src/components/modal/confirm_modal.js
+++ b/src/components/modal/confirm_modal.js
@@ -138,6 +138,6 @@ EuiConfirmModal.propTypes = {
   type: PropTypes.oneOf(MODAL_TYPES),
 };
 
-EuiButtonEmpty.defaultProps = {
+EuiConfirmModal.defaultProps = {
   type: 'confirm',
 };

--- a/src/components/modal/confirm_modal.js
+++ b/src/components/modal/confirm_modal.js
@@ -98,7 +98,6 @@ export class EuiConfirmModal extends Component {
           <EuiButtonEmpty
             data-test-subj="confirmModalCancelButton"
             onClick={onCancel}
-            size="s"
             buttonRef={this.cancelRef}
           >
             {cancelButtonText}
@@ -107,7 +106,6 @@ export class EuiConfirmModal extends Component {
           <EuiButton
             data-test-subj="confirmModalConfirmButton"
             onClick={onConfirm}
-            size="s"
             fill
             buttonRef={this.confirmRef}
           >

--- a/src/components/overlay_mask/_overlay_mask.scss
+++ b/src/components/overlay_mask/_overlay_mask.scss
@@ -6,11 +6,18 @@
   right: 0;
   bottom: 0;
   display: flex;
-  background: transparentize($euiColorEmptyShade, .2);
   align-items: center;
   justify-content: center;
   padding-bottom: 10vh;
   animation: euiAnimFadeIn $euiAnimSpeedFast ease-in;
+
+  $backgroundColor: $euiColorEmptyShade;
+
+  @if (lightness($euiTextColor) > 50) {
+    $backgroundColor: $euiColorLightShade;
+  }
+
+  background: transparentize($backgroundColor, .2);
 }
 
 .euiBody-hasOverlayMask {

--- a/src/components/pagination/_pagination_button.scss
+++ b/src/components/pagination/_pagination_button.scss
@@ -12,9 +12,9 @@
   font-weight: $euiFontWeightBold;
 }
 
-.euiPaginationButton-isPlaceholder {
-  pointer-events: none;
-  color: $euiColorMediumShade;
+.euiPaginationButton-isPlaceholder:disabled .euiButtonEmpty__content {
+  // needs specifity to override regular disabled button
+  cursor: default;
 }
 
 @include screenXSmall {

--- a/src/components/pagination/pagination_button.js
+++ b/src/components/pagination/pagination_button.js
@@ -25,6 +25,7 @@ export const EuiPaginationButton = ({
       className={classes}
       size="xs"
       color="text"
+      disabled={isPlaceholder}
       {...rest}
     >
       {children}

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -1,6 +1,9 @@
 .euiTabs {
   display: flex;
   border-bottom: $euiBorderThin;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden; // don't scroll vertically when scrolling horizontally
 
   &.euiTabs--small {
     .euiTab {

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -4,6 +4,12 @@
   max-width: 100%;
   overflow-x: auto;
   overflow-y: hidden; // don't scroll vertically when scrolling horizontally
+  @include euiScrollBar;
+
+  // Changing height of scrollbar so it sits flush with border
+  &::-webkit-scrollbar {
+    height: 3px;
+  }
 
   &.euiTabs--small {
     .euiTab {
@@ -65,6 +71,9 @@
 
   .euiTab__content {
     display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     transition: transform $euiAnimSpeedFast $euiAnimSlightBounce;
     transform: translateY(0);
   }

--- a/src/global_styling/mixins/_shadow.scss
+++ b/src/global_styling/mixins/_shadow.scss
@@ -24,3 +24,13 @@
   box-shadow:
     0 1px 1px 0px rgba(0, 0, 0, 0.2),
 }
+
+@mixin euiOverflowShadowTop {
+  box-shadow: 0 ($euiSize *-1) $euiSize (-$euiSize / 2) $euiColorEmptyShade;
+  z-index: 2;
+}
+
+@mixin euiOverflowShadowBottom {
+  box-shadow: 0 $euiSize $euiSize (-$euiSize / 2) $euiColorEmptyShade;
+  z-index: 2;
+}


### PR DESCRIPTION
## Modals

1. Adjusting modals for mobile

    - Added drop shadows for overflows
    - Added padding to header to accomodate close button
    - Modal buttons should be normal size (not small) (docs only)

<img width="412" alt="screen shot 2018-03-20 at 15 18 14 pm" src="https://user-images.githubusercontent.com/549577/37677635-f4fc392c-2c51-11e8-93e0-d48a87bc1192.png">


2. Fixes #334 - Lightening overlay color in dark theme

<img width="881" alt="screen shot 2018-03-20 at 15 17 22 pm" src="https://user-images.githubusercontent.com/549577/37677580-d0fe7a62-2c51-11e8-9ed8-59af58ee067a.png">

3. Fixes #520 Added a type prop to `EuiConfirmModal`

    - Defaults to ‘confirm’ (positive/neutral), but can be ‘destroy’.

<img width="662" alt="screen shot 2018-03-20 at 15 26 42 pm" src="https://user-images.githubusercontent.com/549577/37677992-1bda357a-2c53-11e8-9029-9a146bc38883.png">


## Non-issues

1. Overflowing tabs now scroll horizontally


## Issues

1. Fixes #537 - Removing padding from *both* sides of `EuiEmptyButton` when flush
<img width="203" alt="screen shot 2018-03-20 at 15 25 45 pm" src="https://user-images.githubusercontent.com/549577/37677964-ff6ebf46-2c52-11e8-85bb-17886ca3ddea.png">

2. Fixes #474 - Added disabled prop to placeholder (ellipses) pagination

3. Fixes #423 - Added ‘baseline’ as option to `EuiFlexGroup`’s `alignItems` prop

    - _’normal’ doesn’t do anything_

4. Fixes #87 - Converted `.euiHeader__notification` into `EuiHeaderNotification`