### PR TITLE
Add ability to specify initial sorting to EuiInMemoryTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `0.0.32`.
+- Added initial sorting option to `EuiInMemoryTable`
 
 # [`0.0.32`](https://github.com/elastic/eui/tree/v0.0.32)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
-- Added initial sorting option to `EuiInMemoryTable`
+- Added initial sorting option to `EuiInMemoryTable` ([#547](https://github.com/elastic/eui/pull/547))
 
 # [`0.0.32`](https://github.com/elastic/eui/tree/v0.0.32)
 

--- a/src-docs/src/views/tables/in_memory/in_memory.js
+++ b/src-docs/src/views/tables/in_memory/in_memory.js
@@ -70,12 +70,19 @@ export const Table = () => {
     sortable: true
   }];
 
+  const sorting = {
+    sort: {
+      field: 'dateOfBirth',
+      direction: 'desc',
+    }
+  };
+
   return (
     <EuiInMemoryTable
       items={store.users}
       columns={columns}
       pagination={true}
-      sorting={true}
+      sorting={sorting}
     />
   );
 };

--- a/src-docs/src/views/tables/in_memory/props_info.js
+++ b/src-docs/src/views/tables/in_memory/props_info.js
@@ -2,7 +2,7 @@ import { omit } from '../../../../../src/services/objects';
 import { propsInfo as basicPropsInfo } from '../basic/props_info';
 import { propsInfo as searchBarPropsInfo } from '../../search_bar/props_info';
 
-const basicTableProps = omit(basicPropsInfo, [ 'EuiBasicTable', 'Pagination', 'Sorting' ]);
+const basicTableProps = omit(basicPropsInfo, [ 'EuiBasicTable', 'Pagination' ]);
 const searchBarProps = omit(searchBarPropsInfo, [ 'EuiSearchBar' ]);
 
 export const propsInfo = {
@@ -39,9 +39,9 @@ export const propsInfo = {
           type: { name: 'boolean | #Pagination' }
         },
         sorting: {
-          description: 'Enables/disables sorting',
+          description: 'Enables/disables sorting. Can be an object that configures initial sorting when enabled',
           required: false,
-          type: { name: 'boolean' }
+          type: { name: 'boolean | #Sorting' }
         },
         search: {
           description: 'Configures a search bar for the table',

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
@@ -17,6 +17,47 @@ exports[`EuiInMemoryTable empty array 1`] = `
 />
 `;
 
+exports[`EuiInMemoryTable with initial sorting 1`] = `
+<EuiBasicTable
+  columns={
+    Array [
+      Object {
+        "description": "description",
+        "field": "name",
+        "name": "Name",
+        "sortable": true,
+      },
+    ]
+  }
+  items={
+    Array [
+      Object {
+        "id": "3",
+        "name": "name3",
+      },
+      Object {
+        "id": "2",
+        "name": "name2",
+      },
+      Object {
+        "id": "1",
+        "name": "name1",
+      },
+    ]
+  }
+  noItemsMessage="No items found"
+  onChange={[Function]}
+  sorting={
+    Object {
+      "sort": Object {
+        "direction": "desc",
+        "field": "name",
+      },
+    }
+  }
+/>
+`;
+
 exports[`EuiInMemoryTable with items 1`] = `
 <EuiBasicTable
   columns={

--- a/src/components/basic_table/in_memory_table.js
+++ b/src/components/basic_table/in_memory_table.js
@@ -9,7 +9,7 @@ import {
   defaults as paginationBarDefaults
 } from './pagination_bar';
 import { isBoolean, isString } from '../../services/predicate';
-import { Comparators } from '../../services/sort';
+import { Comparators, PropertySortType } from '../../services/sort';
 import {
   Query,
   QueryType,
@@ -40,7 +40,12 @@ const InMemoryTablePropTypes = {
       pageSizeOptions: PropTypes.arrayOf(PropTypes.number)
     })
   ]),
-  sorting: PropTypes.bool,
+  sorting: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.shape({
+      sort: PropertySortType
+    })
+  ]),
   selection: SelectionType
 };
 
@@ -81,7 +86,7 @@ const getInitialPagination = (pagination) => {
 };
 
 const getInitialSorting = (sorting) => {
-  if (!sorting) {
+  if (!sorting || !sorting.sort) {
     return {
       sortField: undefined,
       sortDirection: undefined,
@@ -91,7 +96,7 @@ const getInitialSorting = (sorting) => {
   const {
     field: sortField,
     direction: sortDirection,
-  } = sorting;
+  } = sorting.sort;
 
   return {
     sortField,

--- a/src/components/basic_table/in_memory_table.test.js
+++ b/src/components/basic_table/in_memory_table.test.js
@@ -226,6 +226,37 @@ describe('EuiInMemoryTable', () => {
     expect(component).toMatchSnapshot();
   });
 
+  test('with initial sorting', () => {
+
+    const props = {
+      ...requiredProps,
+      items: [
+        { id: '1', name: 'name1' },
+        { id: '2', name: 'name2' },
+        { id: '3', name: 'name3' }
+      ],
+      columns: [
+        {
+          field: 'name',
+          name: 'Name',
+          description: 'description',
+          sortable: true
+        }
+      ],
+      sorting: {
+        sort: {
+          field: 'name',
+          direction: 'desc'
+        }
+      }
+    };
+    const component = shallow(
+      <EuiInMemoryTable {...props} />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
   test('with pagination and selection', () => {
 
     const props = {


### PR DESCRIPTION
Fixes #464

Allows user to specify initial sorting by passing an object to the `sorting` prop. `sorting` will still take boolean values. Passing an object will enable sorting (same as using `sorting={true}`). The object shape is the same as the sorting prop for `EuiBasicTable`.