### PR TITLE
Fix EuiToolTip bug which caused the tooltip to hide when moving the mouse around inside of the trigger element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `0.0.33`.
+**Bug fixes**
+
+- Fixed `EuiToolTip` bug which caused the tooltip to hide when moving the mouse around inside of the trigger element ([#557](https://github.com/elastic/eui/pull/557))
 
 # [`0.0.33`](https://github.com/elastic/eui/tree/v0.0.33)
 

--- a/src/components/tool_tip/tool_tip.js
+++ b/src/components/tool_tip/tool_tip.js
@@ -74,7 +74,12 @@ export class EuiToolTip extends Component {
     this.hideToolTip();
   };
 
-  onMouseOut = () => {
+  onMouseOut = (e) => {
+    if (e.target !== e.currentTarget) {
+      // We've moused out of a child element, but we haven't yet left the root trigger element.
+      return;
+    }
+
     if (!this.state.hasFocus) {
       this.hideToolTip();
     }


### PR DESCRIPTION
![tooltip_mouseout_bug](https://user-images.githubusercontent.com/1238659/37742662-c63748e8-2d23-11e8-97da-fd5a2a195e7f.gif)
