### PR TITLE
Fixed a bug with `EuiButtonEmpty` disabled state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed `EuiToolTip` bug which caused the tooltip to hide when moving the mouse around inside of the trigger element ([#557](https://github.com/elastic/eui/pull/557))
 - Added a `buttonColor` prop to `EuiConfirmModal` ([#546](https://github.com/elastic/eui/pull/546))
 - Added ‘baseline’ as option to `EuiFlexGroup`'s `alignItems` prop ([#546](https://github.com/elastic/eui/pull/546))
+- Fixed a bug where `EuiButtonEmpty` would offer a white background on hover when it was disabled, even when there was no such background transition on hover when the buttons are not disabled ([#561](https://github.com/elastic/eui/pull/561))
 
 # [`0.0.33`](https://github.com/elastic/eui/tree/v0.0.33)
 

--- a/src/components/button/button_empty/_button_empty.scss
+++ b/src/components/button/button_empty/_button_empty.scss
@@ -45,8 +45,11 @@
       fill: $euiButtonColorDisabled;
     }
 
+    &:focus {
+      background-color: transparent;
+    }
+
     &:hover, &:focus {
-      background-color: $euiColorEmptyShade;
       text-decoration: none;
     }
   }
@@ -75,8 +78,6 @@ $buttonTypes: (
     }
 
     &:hover {
-      background-color: transparent;
-
       @if ($name == 'disabled') {
         cursor: not-allowed;
       }


### PR DESCRIPTION
Fixed a bug where `EuiButtonEmpty` would offer a white background on hover when it was disabled, even when there was no such background transition on hover when the buttons are not disabled.