### PR TITLE
Adjust hue for warning callouts specifically

### DIFF
--- a/src/components/call_out/_call_out.scss
+++ b/src/components/call_out/_call_out.scss
@@ -11,7 +11,7 @@
 $callOutTypes: (
   primary: $euiColorPrimary,
   success: $euiColorSecondary,
-  warning: $euiColorWarning,
+  warning: adjust-hue($euiColorWarning, 20%),
   danger: $euiColorDanger,
 );
 


### PR DESCRIPTION
The current warning color works in most places, but with lighter shading like callouts it gets too close to the red. This adjusts the hue for that specific section (and we might do something like this in other places as we need it). Screenshot to show that accessibility is still valid.

I'd rather do a math coloring than make a new variable because it gets easy to over tokenize stuff.

cc @timroes, @alexfrancoeur

![image](https://user-images.githubusercontent.com/324519/37785154-a7227d54-2db6-11e8-9fbd-794eae470c9c.png)

![image](https://user-images.githubusercontent.com/324519/37785171-b3e3386c-2db6-11e8-8bef-e81950b326a9.png)

![image](https://user-images.githubusercontent.com/324519/37785187-bcf3a8ec-2db6-11e8-9d1e-58e548b5c83f.png)
