### PR TITLE
Tweaking Documentation styles

### DIFF
--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -87,7 +87,7 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   color: shadeOrTint($euiTextColor, .3, .1);
 
   p, ul, ol {
-    max-width: 36rem;
+    // max-width: 36rem;
   }
 }
 

--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -80,6 +80,16 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   margin-left: 240px;
 }
 
+.guideSection__text.euiText,
+.guideSection__text .euiText {
+  @include euiFontSizeS;
+  font-weight: $euiFontWeightLight;
+  color: shadeOrTint($euiTextColor, .3, .1);
+
+  p, ul, ol {
+    max-width: 36rem;
+  }
+}
 
 .guideDemo__highlightLayout {
   div {

--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -83,11 +83,11 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
 .guideSection__text.euiText,
 .guideSection__text .euiText {
   @include euiFontSizeS;
-  font-weight: $euiFontWeightLight;
+  //font-weight: $euiFontWeightLight;
   color: shadeOrTint($euiTextColor, .3, .1);
 
   p, ul, ol {
-    // max-width: 36rem;
+    max-width: 36rem;
   }
 }
 

--- a/src-docs/src/components/guide_rule/_guide_rule.scss
+++ b/src-docs/src/components/guide_rule/_guide_rule.scss
@@ -1,15 +1,31 @@
 .guideRule {
-  margin-bottom: $euiSizeXXL * 2;
+  margin-top: $euiSizeXXL;
 
-  &.guideRule--hasHeading {
-    margin-top: $euiSizeXXL * 2;
+  + .guideRule {
+    margin-top: $euiSizeL;
+
+    &.guideRule--hasDescription {
+      margin-top: $euiSizeXXL*1.5;
+    }
+
+    &.guideRule--hasHeading {
+      margin-top: $euiSizeXXL*2;
+    }
   }
 
-  & + .guideRule:not(.guideRule--hasHeading) {
-    margin-top: $euiSizeXXL * -2;
-  }
-
-  .guideRule__title + &.guideRule--hasHeading {
-    margin-top: $euiSizeXXL;
+  .guideRule__title + &:not(.guideRule--hasHeading) {
+    margin-top: 0;
   }
 }
+
+.guideRule__goToButton {
+  margin-bottom: $euiSizeM;
+
+  @include screenSmallMediumLarge {
+    position: absolute;
+    margin-top: -$euiSizeXL*2 - 6px;
+    right: $euiSizeL;
+  }
+}
+
+

--- a/src-docs/src/components/guide_rule/_guide_rule_description.scss
+++ b/src-docs/src/components/guide_rule/_guide_rule_description.scss
@@ -1,5 +1,5 @@
 .guideRule__description {
-  margin-top: $euiSizeXL;
   margin-bottom: $euiSizeXL;
-  max-width: 36rem;
+
+  @extend .guideSection__text;
 }

--- a/src-docs/src/components/guide_rule/_guide_rule_title.scss
+++ b/src-docs/src/components/guide_rule/_guide_rule_title.scss
@@ -1,3 +1,6 @@
 .guideRule__title {
   margin-top: $euiSizeXXL;
+  border-top: 1px solid $euiBorderColor;
+  padding-top: $euiSizeXXL;
+  margin-bottom: $euiSizeS;
 }

--- a/src-docs/src/components/guide_rule/guide_rule.js
+++ b/src-docs/src/components/guide_rule/guide_rule.js
@@ -19,7 +19,8 @@ export const GuideRule = ({
   const classes = classNames(
     'guideRule',
     {
-      'guideRule--hasHeading': description
+      'guideRule--hasHeading': heading,
+      'guideRule--hasDescription': description
     },
     className,
   );

--- a/src-docs/src/components/guide_section/_guide_section.scss
+++ b/src-docs/src/components/guide_section/_guide_section.scss
@@ -1,6 +1,6 @@
 .guideSection {
   & + .guideSection {
-    margin-top: 64px;
+    margin-top: $euiSizeXL*2;
   }
 }
 

--- a/src-docs/src/views/guidelines/button.js
+++ b/src-docs/src/views/guidelines/button.js
@@ -36,18 +36,18 @@ import imageButtonPlacement from '../../images/button_placement.png';
 
 export default() => (
   <GuidePage title="Button guidelines">
-    <EuiText>
+
+    <Link to="/navigation/button">
+      <EuiButton className="guideRule__goToButton">
+        View component code
+      </EuiButton>
+    </Link>
+
+    <EuiText className="guideSection__text">
       <p>
         This page documents patterns for button design, including types, placement, color, and size.
       </p>
-      <Link to="/navigation/button">
-        <EuiButton>
-          View component code
-        </EuiButton>
-      </Link>
     </EuiText>
-
-    <EuiHorizontalRule/>
 
     <GuideRuleTitle>Button types</GuideRuleTitle>
 
@@ -64,7 +64,7 @@ export default() => (
       </EuiFlexItem>
 
       <EuiFlexItem>
-        <EuiText>
+        <EuiText className="guideSection__text">
           <h4>
             <strong>Filled buttons are for the primary action</strong>
           </h4>
@@ -85,7 +85,7 @@ export default() => (
       </EuiFlexItem>
 
       <EuiFlexItem>
-        <EuiText>
+        <EuiText className="guideSection__text">
           <h4>
             <strong>Standard buttons are for secondary actions</strong>
           </h4>
@@ -107,7 +107,7 @@ export default() => (
       </EuiFlexItem>
 
       <EuiFlexItem>
-        <EuiText>
+        <EuiText className="guideSection__text">
           <h4>
             <strong>Empty buttons are for complimentary, UI-specific actions</strong>
           </h4>
@@ -135,7 +135,7 @@ export default() => (
       </EuiFlexItem>
 
       <EuiFlexItem>
-        <EuiText>
+        <EuiText className="guideSection__text">
           <h4>
             <strong>Icon buttons are for saving space</strong>
           </h4>
@@ -148,13 +148,10 @@ export default() => (
       </EuiFlexItem>
     </EuiFlexGroup>
 
-    <EuiHorizontalRule/>
-
     <GuideRuleTitle>Placement and order</GuideRuleTitle>
-
-    <GuideRule
-      description="Button placement and order should follow the user path."
-    />
+    <EuiText className="guideSection__text">
+      <p>Button placement and order should follow the user path.</p>
+    </EuiText>
 
     <GuideRule
       heading="Put buttons on the right in containers with a restricted width"
@@ -257,7 +254,7 @@ export default() => (
       </GuideRuleExample>
     </GuideRule>
 
-    <EuiHorizontalRule />
+    <EuiSpacer size="xl" />
 
     <GuideRuleTitle>One primary button per layout</GuideRuleTitle>
 
@@ -288,12 +285,9 @@ export default() => (
       </GuideRuleExample>
     </GuideRule>
 
-    <EuiHorizontalRule />
-
     <GuideRuleTitle>Icons in buttons either stand on their own or add context</GuideRuleTitle>
 
     <GuideRule
-      heading=""
       description="Icon buttons can save space.
         Limit icon buttons to groups of two&mdash;otherwise they lose meaning."
     >
@@ -367,8 +361,6 @@ export default() => (
       </GuideRuleExample>
     </GuideRule>
 
-    <EuiHorizontalRule />
-
     <GuideRuleTitle>Minimize the mixing of color, size, and type</GuideRuleTitle>
 
     <GuideRule description="When in doubt, use a blue button in the default size. Never put more than two
@@ -424,8 +416,6 @@ export default() => (
       </GuideRuleExample>
     </GuideRule>
 
-    <EuiHorizontalRule />
-
     <GuideRuleTitle>Stack action sets into one button</GuideRuleTitle>
 
     <GuideRule
@@ -469,23 +459,21 @@ export default() => (
       </GuideRuleExample>
     </GuideRule>
 
-    <EuiHorizontalRule />
-
     <GuideRuleTitle>Labels that say what the button does</GuideRuleTitle>
 
-    <GuideRule
-      heading=""
-      description="Labels should provide a clear indication of
+    <EuiText className="guideSection__text">
+      <p>
+        Labels should provide a clear indication of
         that action that occurs when the user clicks the button.
-        Prefer action words, and include an object when it's not clear from the context,
+        Prefer action words, and include an object when it is not clear from the context,
         for example, Add dashboard. Labels should be three words or less.
-        If your label requries more words, consider using a text link instead."
-    />
+        If your label requries more words, consider using a text link instead.
+      </p>
 
-    <EuiText >
       <h3>Preferred words in buttons</h3>
-      <EuiSpacer/>
     </EuiText>
+
+    <EuiSpacer/>
 
     <EuiTable>
       <EuiTableHeader>
@@ -586,11 +574,13 @@ export default() => (
         </EuiTableRow>
       </EuiTableBody>
     </EuiTable>
-    <EuiSpacer size="l"/>
 
-    <EuiText>
+    <EuiSpacer size="xl"/>
+
+    <EuiText className="guideSection__text">
       <h3>Avoid these words in buttons</h3>
     </EuiText>
+
     <EuiSpacer/>
 
     <EuiTable>

--- a/src-docs/src/views/guidelines/button.js
+++ b/src-docs/src/views/guidelines/button.js
@@ -361,6 +361,8 @@ export default() => (
       </GuideRuleExample>
     </GuideRule>
 
+    <EuiSpacer size="l" />
+
     <GuideRuleTitle>Minimize the mixing of color, size, and type</GuideRuleTitle>
 
     <GuideRule description="When in doubt, use a blue button in the default size. Never put more than two

--- a/src-docs/src/views/guidelines/colors.js
+++ b/src-docs/src/views/guidelines/colors.js
@@ -85,7 +85,7 @@ export default() => (
 
     <EuiSpacer size="xl" />
 
-    <EuiText>
+    <EuiText className="guideSection__text">
       <h2>Core palette</h2>
       <p>
         Elastic UI builds with a very limited palette. We use a core set of three colors,
@@ -105,7 +105,7 @@ export default() => (
 
     <EuiSpacer size="xxl" />
 
-    <EuiText>
+    <EuiText className="guideSection__text">
       <h2>Qualitative visualization palette</h2>
       <p>
         The following colors are color-blind safe and should be used in
@@ -125,7 +125,7 @@ export default() => (
 
     <EuiSpacer size="xxl" />
 
-    <EuiText>
+    <EuiText className="guideSection__text">
       <h2>Accessible text contrast</h2>
       <p>
         <EuiLink href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html">

--- a/src-docs/src/views/guidelines/modals.js
+++ b/src-docs/src/views/guidelines/modals.js
@@ -26,17 +26,17 @@ import {
 export default () => (
   <GuidePage title="Modals">
 
-    <EuiText>
+    <Link to="/layout/modal">
+      <EuiButton className="guideRule__goToButton">
+        View component code
+      </EuiButton>
+    </Link>
+
+    <EuiText className="guideSection__text">
       <p>
         A modal says “pay attention to me and nothing else.”  They work best for focusing users&apos; attention on a short
         amount of content and getting them to make a decision.
       </p>
-
-      <Link to="/layout/modal">
-        <EuiButton>
-          View component code
-        </EuiButton>
-      </Link>
     </EuiText>
 
     <EuiHorizontalRule/>
@@ -60,7 +60,7 @@ export default () => (
       </EuiFlexItem>
 
       <EuiFlexItem >
-        <EuiText>
+        <EuiText className="guideSection__text">
           <h4><strong>The header sets the context</strong></h4>
           <p>Short and sentence-case, it lets the user know the task that needs to get done.</p>
           <h4><strong>The body supports a single task</strong></h4>
@@ -311,9 +311,9 @@ export default () => (
     <EuiSpacer size="xxl" />
 
     <EuiFlexGroup wrap={true}>
-      <EuiFlexItem style={{ minWidth: 300 }}>
+      <EuiFlexItem style={{ minWidth: 240 }}>
         <EuiPanel paddingSize="l">
-          <EuiText>
+          <EuiText className="guideSection__text">
             <h3>Scrolling</h3>
             <p>
               Modal content should fit in a single screen.
@@ -325,10 +325,10 @@ export default () => (
         </EuiPanel>
       </EuiFlexItem>
 
-      <EuiFlexItem style={{ minWidth: 300 }}>
+      <EuiFlexItem style={{ minWidth: 240 }}>
 
         <EuiPanel paddingSize="l">
-          <EuiText>
+          <EuiText className="guideSection__text">
             <h3>Launching a modal from a modal</h3>
             <p>
               Using a modal on top of a modal typically means your workflow is
@@ -342,9 +342,9 @@ export default () => (
         </EuiPanel>
       </EuiFlexItem>
 
-      <EuiFlexItem style={{ minWidth: 300 }}>
+      <EuiFlexItem style={{ minWidth: 240 }}>
         <EuiPanel paddingSize="l">
-          <EuiText>
+          <EuiText className="guideSection__text">
             <h3>Opening a modal from a toolbar</h3>
             <p> Users don&apos;t expect a toolbar button to open a modal.</p>
           </EuiText>
@@ -353,9 +353,9 @@ export default () => (
     </EuiFlexGroup>
 
     <EuiFlexGroup wrap={true}>
-      <EuiFlexItem style={{ minWidth: 300 }}>
+      <EuiFlexItem style={{ minWidth: 240 }}>
         <EuiPanel paddingSize="l">
-          <EuiText>
+          <EuiText className="guideSection__text">
             <h3>Use modals sparingly</h3>
             <p>
               Modals pull users out of their current context.
@@ -366,10 +366,10 @@ export default () => (
         </EuiPanel>
       </EuiFlexItem>
 
-      <EuiFlexItem style={{ minWidth: 300 }}>
+      <EuiFlexItem style={{ minWidth: 240 }}>
 
         <EuiPanel paddingSize="l">
-          <EuiText>
+          <EuiText className="guideSection__text">
             <h3>Keep content clean & simple</h3>
             <p>
               A modal should be a short, direct conversation with the user.
@@ -380,9 +380,9 @@ export default () => (
         </EuiPanel>
       </EuiFlexItem>
 
-      <EuiFlexItem style={{ minWidth: 300 }}>
+      <EuiFlexItem style={{ minWidth: 240 }}>
         <EuiPanel paddingSize="l">
-          <EuiText>
+          <EuiText className="guideSection__text">
             <h3>Open on a user action</h3>
             <p>
               Don&apos;t just pop open a modal. Let a user action,

--- a/src-docs/src/views/guidelines/toasts.js
+++ b/src-docs/src/views/guidelines/toasts.js
@@ -292,6 +292,8 @@ export default () => (
       </GuideRuleExample>
     </GuideRule>
 
+    <EuiSpacer size="l" />
+
     <GuideRuleTitle>Icons should emphasize actions</GuideRuleTitle>
 
     <GuideRule

--- a/src-docs/src/views/guidelines/toasts.js
+++ b/src-docs/src/views/guidelines/toasts.js
@@ -23,21 +23,21 @@ import {
 
 export default () => (
   <GuidePage title="Toast guidelines">
-    <EuiText>
+
+    <Link to="/display/toast">
+      <EuiButton className="guideRule__goToButton">
+        View component code
+      </EuiButton>
+    </Link>
+
+    <EuiText className="guideSection__text">
       <p>
         This page documents patterns for using toasts, short messages that
         appears on the lower right corner and time out after a few seconds.
         They are a popular design choice because they don&apos;t need to
         fit in a layout and don&apos;t disrupt the user.
       </p>
-      <Link to="/display/toast">
-        <EuiButton>
-          View component code
-        </EuiButton>
-      </Link>
     </EuiText>
-
-    <EuiHorizontalRule/>
 
     <GuideRuleTitle>Toast types</GuideRuleTitle>
 
@@ -53,7 +53,7 @@ export default () => (
       </EuiFlexItem>
 
       <EuiFlexItem>
-        <EuiText>
+        <EuiText className="guideSection__text">
           <h4>
             <strong>Success toasts indicate that everything worked out</strong>
           </h4>
@@ -76,7 +76,7 @@ export default () => (
       </EuiFlexItem>
 
       <EuiFlexItem>
-        <EuiText>
+        <EuiText className="guideSection__text">
           <h4>
             <strong>Warning toasts direct user attention to a potential problem</strong>
           </h4>
@@ -100,7 +100,7 @@ export default () => (
       </EuiFlexItem>
 
       <EuiFlexItem>
-        <EuiText>
+        <EuiText className="guideSection__text">
           <h4>
             <strong>Error toasts report a problem</strong>
           </h4>
@@ -125,7 +125,7 @@ export default () => (
       </EuiFlexItem>
 
       <EuiFlexItem>
-        <EuiText>
+        <EuiText className="guideSection__text">
           <h4>
             <strong>Info toasts relay neutral information</strong>
           </h4>
@@ -138,10 +138,7 @@ export default () => (
 
     <EuiSpacer/>
 
-    <EuiHorizontalRule/>
-
     <GuideRuleTitle>Use a toast for a timely message</GuideRuleTitle>
-
 
     <GuideRule
       description="Toasts are appropriate for short feedback related to a user action.
@@ -177,8 +174,6 @@ export default () => (
       </GuideRuleExample>
 
     </GuideRule>
-
-    <EuiHorizontalRule/>
 
     <GuideRuleTitle>Most often, it&apos;s a single line of text</GuideRuleTitle>
 
@@ -221,7 +216,7 @@ export default () => (
             title="Your form has errors"
             color="danger"
           >
-            <EuiText>
+            <EuiText className="guideSection__text">
               <ul>
                 <li>
                   Username is a required field.
@@ -239,8 +234,6 @@ export default () => (
       </GuideRuleExample>
 
     </GuideRule>
-
-    <EuiHorizontalRule/>
 
     <GuideRuleTitle>Toasts should only contain a single action</GuideRuleTitle>
 
@@ -299,8 +292,6 @@ export default () => (
       </GuideRuleExample>
     </GuideRule>
 
-    <EuiHorizontalRule/>
-
     <GuideRuleTitle>Icons should emphasize actions</GuideRuleTitle>
 
     <GuideRule
@@ -351,8 +342,6 @@ export default () => (
 
     </GuideRule>
 
-    <EuiHorizontalRule/>
-
     <GuideRuleTitle>Display one toast at a time</GuideRuleTitle>
 
     <GuideRule
@@ -401,8 +390,6 @@ export default () => (
 
       </GuideRuleExample>
     </GuideRule>
-
-    <EuiHorizontalRule/>
 
     <GuideRuleTitle>Keep messages as short as possible</GuideRuleTitle>
 

--- a/src-docs/src/views/guidelines/writing.js
+++ b/src-docs/src/views/guidelines/writing.js
@@ -48,7 +48,7 @@ const GuideRuleWriting = ({
 
 export default () => (
   <GuidePage title="Writing guidelines">
-    <EuiText>
+    <EuiText className="guideSection__text">
       <p>
         You can have the most beautiful UI,
         but without <b>consistent, easy-to-understand text</b>,
@@ -61,19 +61,19 @@ export default () => (
     <EuiSpacer size="xxl" />
 
     <EuiFlexGroup wrap={true}>
-      <EuiFlexItem style={{ minWidth: 300 }}>
+      <EuiFlexItem style={{ minWidth: 240 }}>
         <EuiPanel paddingSize="l">
-          <EuiText>
+          <EuiText className="guideSection__text">
             <h3>Clear and concise</h3>
             <p>Get straight to the point&mdash;in a way that your users understand.  Make every word contribute to meaning.</p>
           </EuiText>
         </EuiPanel>
       </EuiFlexItem>
 
-      <EuiFlexItem style={{ minWidth: 300 }}>
+      <EuiFlexItem style={{ minWidth: 240 }}>
 
         <EuiPanel paddingSize="l">
-          <EuiText>
+          <EuiText className="guideSection__text">
             <h3>Consistent</h3>
             <p>Use the same terminology to mean the same thing. Make sure spelling, capitalization,
               punctuation, labels, and use of abbreviations are all consistent.
@@ -82,9 +82,9 @@ export default () => (
         </EuiPanel>
       </EuiFlexItem>
 
-      <EuiFlexItem style={{ minWidth: 300 }}>
+      <EuiFlexItem style={{ minWidth: 240 }}>
         <EuiPanel paddingSize="l">
-          <EuiText>
+          <EuiText className="guideSection__text">
             <h3>Conversational</h3>
             <p>Write as a professional in the field would talk&mdash;not as
             a professor lecturing students. Use words that the user would use.
@@ -570,28 +570,28 @@ export default () => (
     <EuiSpacer size="xxl" />
 
     <EuiFlexGroup wrap={true}>
-      <EuiFlexItem style={{ minWidth: 300 }}>
+      <EuiFlexItem style={{ minWidth: 240 }}>
         <EuiPanel paddingSize="l">
-          <EuiText>
+          <EuiText className="guideSection__text">
             <h3>Work with a writer on your text</h3>
             <p>A writer can help determine where you need text and what it should say.</p>
           </EuiText>
         </EuiPanel>
       </EuiFlexItem>
 
-      <EuiFlexItem style={{ minWidth: 300 }}>
+      <EuiFlexItem style={{ minWidth: 240 }}>
 
         <EuiPanel paddingSize="l">
-          <EuiText>
+          <EuiText className="guideSection__text">
             <h3>Word flow has a natural feel to it</h3>
             <p>Read your text out loud, make changes, and then repeat until the flow of your text feels just right.</p>
           </EuiText>
         </EuiPanel>
       </EuiFlexItem>
 
-      <EuiFlexItem style={{ minWidth: 300 }}>
+      <EuiFlexItem style={{ minWidth: 240 }}>
         <EuiPanel paddingSize="l">
-          <EuiText>
+          <EuiText className="guideSection__text">
             <h3>Use spell check</h3>
             <p>Run your text through a spelling and grammar checker.</p>
           </EuiText>

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -93,6 +93,9 @@
 
   h3 {
     font-size: 112.5%;
+  }
+
+  h3, h4, h5 {
     font-weight: $euiFontWeightMedium;
   }
 


### PR DESCRIPTION
- Smaller and lighter instruction text
- Better spacing on guide rules/examples
- Abs positioning on "go to component" button

_I'm on the fence about keeping the max-width on paragraphs in since we are now max-width-ing the entire page (so I left that in the css just commented for now). While I do think a shorter line length is more readable, it seemed like we were adding arbitrary stops at too many points._

_If we decide to un-max-width the entire page (#571) then we can just uncomment that line and all the line lengths should be good._

### Before

<img width="967" alt="screen shot 2018-03-26 at 10 55 57 am" src="https://user-images.githubusercontent.com/549577/37914070-5af35c74-30e4-11e8-9e7b-c8b77a81ca12.png">

### After

<img width="967" alt="screen shot 2018-03-26 at 10 56 07 am" src="https://user-images.githubusercontent.com/549577/37914083-62fd2d96-30e4-11e8-8d01-51c234a11b6e.png">
