### PR TITLE
[EuiSearchBar] relaxed syntax around hyphens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `0.0.35`.
+- Relaxed query syntax of `EuiSearchBar` to allow usage of hyphens without escaping ([#581](https://github.com/elastic/eui/pull/581))
 
 # [`0.0.35`](https://github.com/elastic/eui/tree/v0.0.35)
 
-- Modified `link` and all buttons to support both href and onClick ([554](https://github.com/elastic/eui/pull/554))
-- Added `color` prop to `EuiIconTip` ([580](https://github.com/elastic/eui/pull/580))
+- Modified `link` and all buttons to support both href and onClick ([#554](https://github.com/elastic/eui/pull/554))
+- Added `color` prop to `EuiIconTip` ([#580](https://github.com/elastic/eui/pull/580))
 
 # [`0.0.34`](https://github.com/elastic/eui/tree/v0.0.34)
 

--- a/src/components/search_bar/query/default_syntax.js
+++ b/src/components/search_bar/query/default_syntax.js
@@ -54,6 +54,7 @@ fieldName "field name"
 
 fieldChar
   = alnum
+  / [-]
   / escapedChar
 
 fieldValue "field value"
@@ -80,13 +81,14 @@ word
 
 valueChar
   = alnum
+  / [-]
   / escapedChar
 
 escapedChar
   = "\\\\" reservedChar
 
 reservedChar
-  = [:\\-\\\\]
+  = [\-:\\\\]
 
 alnum "alpha numeric"
   = [a-zA-Z0-9]

--- a/src/components/search_bar/query/default_syntax.test.js
+++ b/src/components/search_bar/query/default_syntax.test.js
@@ -15,21 +15,63 @@ describe('defaultSyntax', () => {
     expect(printedQuery).toBe(query);
   });
 
-  test('escaped chars as default clauses', () => {
-    const query = '\\- -\\: \\\\';
+  test('hyphen fields and values', () => {
+    const query = 'name-1:dash-1 -name-2:dash-2 \\-name-3:dash-3 term-1 -term-2 \\-term-3';
     const ast = defaultSyntax.parse(query);
 
     expect(ast).toBeDefined();
     expect(ast.clauses).toBeDefined();
-    expect(ast.clauses).toHaveLength(3);
+    expect(ast.clauses).toHaveLength(6);
 
-    let clause = ast.getTermClause('-');
+    let clause = ast.getTermClause('term-1');
     expect(clause).toBeDefined();
     expect(AST.Term.isInstance(clause)).toBe(true);
     expect(AST.Match.isMustClause(clause)).toBe(true);
-    expect(clause.value).toBe('-');
+    expect(clause.value).toBe('term-1');
 
-    clause = ast.getTermClause(':');
+    clause = ast.getTermClause('term-2');
+    expect(clause).toBeDefined();
+    expect(AST.Term.isInstance(clause)).toBe(true);
+    expect(AST.Match.isMustClause(clause)).toBe(false);
+    expect(clause.value).toBe('term-2');
+
+    clause = ast.getTermClause('-term-3');
+    expect(clause).toBeDefined();
+    expect(AST.Term.isInstance(clause)).toBe(true);
+    expect(AST.Match.isMustClause(clause)).toBe(true);
+    expect(clause.value).toBe('-term-3');
+
+    clause = ast.getSimpleFieldClause('name-1', 'dash-1');
+    expect(clause).toBeDefined();
+    expect(AST.Field.isInstance(clause)).toBe(true);
+    expect(AST.Match.isMustClause(clause)).toBe(true);
+    expect(clause.field).toBe('name-1');
+    expect(clause.value).toBe('dash-1');
+
+    clause = ast.getSimpleFieldClause('name-2', 'dash-2');
+    expect(clause).toBeDefined();
+    expect(AST.Field.isInstance(clause)).toBe(true);
+    expect(AST.Match.isMustClause(clause)).toBe(false);
+    expect(clause.field).toBe('name-2');
+    expect(clause.value).toBe('dash-2');
+
+    clause = ast.getSimpleFieldClause('-name-3', 'dash-3');
+    expect(clause).toBeDefined();
+    expect(AST.Field.isInstance(clause)).toBe(true);
+    expect(AST.Match.isMustClause(clause)).toBe(true);
+    expect(clause.field).toBe('-name-3');
+    expect(clause.value).toBe('dash-3');
+  });
+
+  test('escaped chars as default clauses', () => {
+    const query = '-\\: \\\\';
+    const ast = defaultSyntax.parse(query);
+
+    expect(ast).toBeDefined();
+    expect(ast.clauses).toBeDefined();
+    expect(ast.clauses).toHaveLength(2);
+
+    let clause = ast.getTermClause(':');
     expect(clause).toBeDefined();
     expect(AST.Term.isInstance(clause)).toBe(true);
     expect(AST.Match.isMustClause(clause)).toBe(false);


### PR DESCRIPTION
Due to their commonality in object names, made it possible to use hyphens without escaping. The only caveat here is that a search term or a field name starts with a hyphen, then it'll have to be escaped with `\`.

Fixes: #577