### PR TITLE
Font weight fix for k6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Added support for range queries in `EuiSearchBar` (works for numeric and date values) ([#485](https://github.com/elastic/eui/pull/485))
 - Add support for expandable rows to `EuiBasicTable` ([#585](https://github.com/elastic/eui/pull/585))
 
+**Bug fixes**
+- Fix font-weight issue in K6 theme ([#596](https://github.com/elastic/eui/pull/596))
+
 # [`0.0.35`](https://github.com/elastic/eui/tree/v0.0.35)
 
 - Modified `link` and all buttons to support both href and onClick ([#554](https://github.com/elastic/eui/pull/554))

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel="stylesheet">
   <link rel="shortcut icon" href="favicon.ico"></head>
   <body class="guideBody">
     <div id="guide" style="height: 100%"></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,600,700" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel="stylesheet">
   <link rel="shortcut icon" href="favicon.ico"></head>
   <body class="guideBody">
     <div id="guide" style="height: 100%"></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,600,700" rel="stylesheet">
   <link rel="shortcut icon" href="favicon.ico"></head>
   <body class="guideBody">
     <div id="guide" style="height: 100%"></div>

--- a/src-docs/src/index.html
+++ b/src-docs/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel="stylesheet">
   </head>
   <body class="guideBody">
     <div id="guide" style="height: 100%"></div>

--- a/src-docs/src/index.html
+++ b/src-docs/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,600,700" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel="stylesheet">
   </head>
   <body class="guideBody">
     <div id="guide" style="height: 100%"></div>

--- a/src-docs/src/index.html
+++ b/src-docs/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,600,700" rel="stylesheet">
   </head>
   <body class="guideBody">
     <div id="guide" style="height: 100%"></div>

--- a/src/global_styling/variables/_typography.scss
+++ b/src/global_styling/variables/_typography.scss
@@ -41,5 +41,5 @@ $euiLineHeight:     1.5;
 
 $euiFontWeightLight:    300 !default;
 $euiFontWeightRegular:  400 !default;
-$euiFontWeightMedium:   500 !default;
+$euiFontWeightMedium:   600 !default;
 $euiFontWeightBold:     700 !default;

--- a/src/themes/k6/k6_globals.scss
+++ b/src/themes/k6/k6_globals.scss
@@ -11,4 +11,4 @@ $euiFontSizeXL:     24px;
 $euiFontSizeXXL:    32px;
 
 // Make titles bold.
-$euiFontWeightLight: 500;
+$euiFontWeightLight: 600;

--- a/src/themes/k6/k6_globals.scss
+++ b/src/themes/k6/k6_globals.scss
@@ -12,5 +12,3 @@ $euiFontSizeXXL:    32px;
 
 // Make titles bold.
 $euiFontWeightLight: 500;
-$euiFontWeightMedium: 600;
-$euiFontWeightBold: 700;

--- a/src/themes/k6/k6_globals.scss
+++ b/src/themes/k6/k6_globals.scss
@@ -12,3 +12,5 @@ $euiFontSizeXXL:    32px;
 
 // Make titles bold.
 $euiFontWeightLight: 500;
+$euiFontWeightMedium: 600;
+$euiFontWeightBold: 700;


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/568 on the EUI side. Will also require a Kibana PR.

Goes along with https://github.com/elastic/kibana/pull/17467 on the Kibana side.

cc @jen-huang, @cchaos 

This was only happening in the K6 theme. In EUI it was happening because we weren't pulling the weights we needed down. In Kibana, the weights are delivered with Kibana, so will need to be manually added. I'll add a separate PR for that.

@cchaos I also upped the medium weight to 600 because ~~500 wasn't strong enough for the labels~~ 500 isn't available in Open Sans, and the 700 was a little too bold. This seemed to be the most consistent value across our themes.

EUI native

![image](https://user-images.githubusercontent.com/324519/38123334-66306d4a-338f-11e8-81ae-f588ee53b89b.png)

EUI K6

![image](https://user-images.githubusercontent.com/324519/38123374-8c77c534-338f-11e8-9c87-bb82957183d4.png)

