### PR TITLE
Apply more specificity to fix disabled states

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -63,6 +63,8 @@
     }
 
     &:hover, &:focus {
+      @include euiSlightShadow;
+      
       text-decoration: none;
     }
   }

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -36,8 +36,10 @@
     @include euiSlightShadowActive;
   }
 
-  &:hover, &:focus {
-    background-color: transparentize($euiColorPrimary, .9);
+  &:enabled {
+    &:hover, &:focus {
+      background-color: transparentize($euiColorPrimary, .9);
+    }
   }
 
   &:disabled {
@@ -95,9 +97,11 @@ $buttonTypes: (
 
       color: $textColor;
 
-      &:hover, &:focus {
-        background-color: darken($color, 5%);
-        border-color: darken($color, 5%);
+      &:enabled {
+        &:hover, &:focus {
+          background-color: darken($color, 5%);
+          border-color: darken($color, 5%);
+        }
       }
 
       &:disabled .euiButton__spinner {
@@ -105,11 +109,13 @@ $buttonTypes: (
       }
     }
 
-    &:hover, &:focus {
-      background-color: transparentize($color, .9);
+    &:enabled {
+      &:hover, &:focus {
+        background-color: transparentize($color, .9);
 
-      @if ($name == 'disabled') {
-        cursor: not-allowed;
+        @if ($name == 'disabled') {
+          cursor: not-allowed;
+        }
       }
     }
   }


### PR DESCRIPTION
I busted hover states for disabled buttons in https://github.com/elastic/eui/pull/603

This adds the appropriate level of specificity to make sure disabled buttons don't get backgrounds regardless of their variation.

The black background just shows that it's hollow and not a transparent white.

![image](https://user-images.githubusercontent.com/324519/38154790-edae569e-3428-11e8-9cea-ac36d46c2e30.png)
