### PR TITLE
[WIP] [POC] Docs Playground

### DIFF
--- a/src-docs/src/components/guide_rule/guide_rule_example.js
+++ b/src-docs/src/components/guide_rule/guide_rule_example.js
@@ -59,6 +59,7 @@ GuideRuleExample.propTypes = {
   type: PropTypes.string.isRequired,
   text: PropTypes.string,
   panel: PropTypes.bool,
+  frame: PropTypes.bool,
 };
 
 GuideRuleExample.defaultProps = {

--- a/src-docs/src/components/guide_section/_guide_section.scss
+++ b/src-docs/src/components/guide_section/_guide_section.scss
@@ -8,11 +8,3 @@
   height: $euiSizeL;
 }
 
-.guideSectionPropsTable {
-  width: auto;
-  min-width: 50%;
-
-  th, td {
-    max-width: none;
-  }
-}

--- a/src-docs/src/components/guide_section/_guide_section_playground.scss
+++ b/src-docs/src/components/guide_section/_guide_section_playground.scss
@@ -1,0 +1,17 @@
+.euiGuideSectionPlayground {
+  .euiTableCellContent__text {
+    flex-grow: 1;
+  }
+}
+
+.euiGuideSectionPlayground__table {
+  //@include euiFontSizeXS;
+}
+
+.euiGuideSectionPlayground__input {
+  padding: $euiSizeS;
+
+  + .euiFormControlLayout__icon {
+    top: $euiSizeS;
+  }
+}

--- a/src-docs/src/components/guide_section/_index.scss
+++ b/src-docs/src/components/guide_section/_index.scss
@@ -1,1 +1,2 @@
 @import "./guide_section";
+@import "./guide_section_playground";

--- a/src-docs/src/components/guide_section/guide_section.js
+++ b/src-docs/src/components/guide_section/guide_section.js
@@ -33,7 +33,7 @@ export class GuideSection extends Component {
 
     if (this.props.demo) {
       this.tabs.push({
-        name: this.props.playground ? 'Playground' : 'Demo',
+        name: 'Demo',
       });
     }
 
@@ -50,6 +50,12 @@ export class GuideSection extends Component {
     if (this.componentNames.length) {
       this.tabs.push({
         name: 'Props',
+      });
+    }
+
+    if (this.props.playground) {
+      this.tabs.push({
+        name: 'Playground',
       });
     }
 
@@ -137,6 +143,12 @@ export class GuideSection extends Component {
         (
           <EuiTableRowCell key="name">
             {humanizedName}
+            {descriptionMarkup ? (
+              <span>
+                <br />
+                {descriptionMarkup}
+              </span>
+            ) : undefined}
           </EuiTableRowCell>
         ), (
           <EuiTableRowCell key="type">
@@ -145,10 +157,6 @@ export class GuideSection extends Component {
         ), (
           <EuiTableRowCell key="defaultValue">
             {defaultValueMarkup}
-          </EuiTableRowCell>
-        ), (
-          <EuiTableRowCell key="description">
-            {descriptionMarkup}
           </EuiTableRowCell>
         )
       ];
@@ -183,7 +191,7 @@ export class GuideSection extends Component {
       table = (
         <EuiTable className="guideSectionPropsTable" compressed key={`propsTable-${componentName}`}>
           <EuiTableHeader>
-            <EuiTableHeaderCell>
+            <EuiTableHeaderCell style={{ width: '50%' }}>
               Prop
             </EuiTableHeaderCell>
 
@@ -193,10 +201,6 @@ export class GuideSection extends Component {
 
             <EuiTableHeaderCell>
               Default
-            </EuiTableHeaderCell>
-
-            <EuiTableHeaderCell>
-              Note
             </EuiTableHeaderCell>
           </EuiTableHeader>
 
@@ -299,11 +303,19 @@ export class GuideSection extends Component {
       );
     }
 
+    if (this.state.selectedTab.name === 'Playground') {
+      return (
+        <EuiErrorBoundary>
+          {this.props.playground}
+        </EuiErrorBoundary>
+      );
+    }
+
     return (
       <EuiErrorBoundary>
         <div>
           <div className="guideSection__space" />
-          {this.props.playground ? this.renderPlayground() : this.props.demo}
+          {this.props.demo}
         </div>
       </EuiErrorBoundary>
     );
@@ -330,7 +342,7 @@ GuideSection.propTypes = {
   theme: PropTypes.string.isRequired,
   routes: PropTypes.object.isRequired,
   props: PropTypes.object,
-  playground: PropTypes.func,
+  playground: PropTypes.object,
 };
 
 GuideSection.defaultProps = {

--- a/src-docs/src/components/guide_section/guide_section.js
+++ b/src-docs/src/components/guide_section/guide_section.js
@@ -18,85 +18,34 @@ import {
   EuiText,
   EuiTextColor,
   EuiTitle,
-  EuiLink
 } from '../../../../src/components';
 
-function markup(text) {
-  const regex = /(#[a-zA-Z]+)|(`[^`]+`)/g;
-  return text.split(regex).map((token, index) => {
-    if (!token) {
-      return '';
-    }
-    if (token.startsWith('#')) {
-      const id = token.substring(1);
-      const onClick = () => {
-        document.getElementById(id).scrollIntoView();
-      };
-      return <EuiLink key={`markup-${index}`} onClick={onClick}>{id}</EuiLink>;
-    }
-    if (token.startsWith('`')) {
-      const code = token.substring(1, token.length - 1);
-      return <EuiCode key={`markup-${index}`}>{code}</EuiCode>;
-    }
-    return token;
+import { markup, humanizeType } from '../../services/string/prop_types';
 
-  });
-}
-
-const humanizeType = type => {
-  if (!type) {
-    return '';
-  }
-
-  let humanizedType;
-
-  switch (type.name) {
-    case 'enum':
-      if (Array.isArray(type.value)) {
-        humanizedType = type.value.map(({ value }) => value).join(', ');
-        break;
-      }
-      humanizedType = type.value;
-      break;
-
-    case 'union':
-      if (Array.isArray(type.value)) {
-        const unionValues = type.value.map(({ name }) => name);
-        unionValues[unionValues.length - 1] = `or ${unionValues[unionValues.length - 1]}`;
-
-        if (unionValues.length > 2) {
-          humanizedType = unionValues.join(', ');
-        } else {
-          humanizedType = unionValues.join(' ');
-        }
-        break;
-      }
-      humanizedType = type.value;
-      break;
-
-    default:
-      humanizedType = type.name;
-  }
-
-  return humanizedType;
-};
-
+import { GuideSectionPlayground } from './guide_section_playground';
 
 export class GuideSection extends Component {
   constructor(props) {
     super(props);
 
     this.componentNames = Object.keys(props.props);
+    this.tabs = [];
 
-    this.tabs = [{
-      name: 'Demo',
-    }, {
-      name: 'JavaScript',
-      isCode: true,
-    }, {
-      name: 'HTML',
-      isCode: true,
-    }];
+    if (this.props.demo) {
+      this.tabs.push({
+        name: this.props.playground ? 'Playground' : 'Demo',
+      });
+    }
+
+    if (this.props.source) {
+      this.tabs.push( {
+        name: 'JavaScript',
+        isCode: true,
+      }, {
+        name: 'HTML',
+        isCode: true,
+      });
+    }
 
     if (this.componentNames.length) {
       this.tabs.push({
@@ -267,6 +216,12 @@ export class GuideSection extends Component {
     ];
   }
 
+  renderPlayground() {
+    return (
+      <GuideSectionPlayground component={this.props.playground} demo={this.props.demo} />
+    )
+  }
+
   renderProps() {
     const { props } = this.props;
     return flatten(
@@ -348,7 +303,7 @@ export class GuideSection extends Component {
       <EuiErrorBoundary>
         <div>
           <div className="guideSection__space" />
-          {this.props.demo}
+          {this.props.playground ? this.renderPlayground() : this.props.demo}
         </div>
       </EuiErrorBoundary>
     );
@@ -375,6 +330,7 @@ GuideSection.propTypes = {
   theme: PropTypes.string.isRequired,
   routes: PropTypes.object.isRequired,
   props: PropTypes.object,
+  playground: PropTypes.func,
 };
 
 GuideSection.defaultProps = {

--- a/src-docs/src/components/guide_section/guide_section_playground.js
+++ b/src-docs/src/components/guide_section/guide_section_playground.js
@@ -1,0 +1,290 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import {
+  EuiCode,
+  EuiSpacer,
+  EuiTable,
+  EuiTableBody,
+  EuiTableHeader,
+  EuiTableHeaderCell,
+  EuiTableRow,
+  EuiTableRowCell,
+  EuiTextColor,
+  EuiSwitch,
+  EuiSelect,
+  EuiFieldText,
+} from '../../../../src/components';
+
+import { unquote, markup, humanizeType } from '../../services/string/prop_types';
+
+export class GuideSectionPlayground extends Component {
+  static propTypes = {
+    className: PropTypes.string,
+    component: PropTypes.func,
+    demo: PropTypes.node,
+  }
+
+  constructor(props) {
+    super(props);
+
+    let allProps = undefined;
+    const compProps = {};
+
+    if (this.props.component.__docgenInfo) {
+      const docgenInfo = Array.isArray(this.props.component.__docgenInfo) ? this.props.component.__docgenInfo[0] : this.props.component.__docgenInfo;
+      const { props } = docgenInfo;
+      allProps = props ? props : undefined;
+
+      if (allProps) {
+        const propNames = Object.keys(allProps);
+        const addingValues = propNames.map(name => { // eslint-disable-line no-unused-vars
+          const value = allProps[name].defaultValue ? this.props.component.defaultProps[name] : undefined;
+          compProps[name] = value;
+        });
+      }
+    }
+
+    this.state = {
+      allProps: allProps,
+      compProps: compProps
+    }
+
+    //console.table(this.state.compProps);
+  }
+
+  onSwitchChange = e => {
+    const compProps = { ...this.state.compProps }
+    compProps[e.target.id] = e.target.checked;
+    this.setState({ compProps });
+  };
+
+  onSelectChange = e => {
+    const compProps = { ...this.state.compProps }
+    compProps[e.target.id] = e.target.value;
+    this.setState({ compProps });
+  };
+
+  onStringChange = e => {
+    const compProps = { ...this.state.compProps }
+    compProps[e.target.id] = e.target.value;
+    this.setState({ compProps });
+  };
+
+  controlType = (type, propName) => {
+    if (!type || (type.name === "node") || (type.name === "func")) {
+      return '';
+    }
+
+    let control;
+
+    switch (type.name) {
+      case 'bool':
+        control = (
+          <EuiSwitch
+            id={propName}
+            label={this.state.compProps[propName].toString()}
+            checked={this.state.compProps[propName]}
+            onChange={this.onSwitchChange}
+          />
+        );
+        break;
+
+      case 'enum':
+        if (Array.isArray(type.value)) {
+          const options = type.value.map(function(item) {
+            return {
+              value: unquote(item.value),
+              text: unquote(item.value),
+            }
+          });
+
+          control = (
+            <EuiSelect
+              className="euiGuideSectionPlayground__input"
+              id={propName}
+              options={options}
+              value={this.state.compProps[propName]}
+              onChange={this.onSelectChange}
+            />
+          )
+          break;
+        }
+        break;
+
+      case 'string':
+        control = (
+          <EuiFieldText
+            className="euiGuideSectionPlayground__input"
+            placeholder={propName}
+            id={propName}
+            value={this.state.compProps[propName]}
+            onChange={this.onStringChange}
+          />
+        )
+        break;
+
+      case 'union':
+        if (Array.isArray(type.value)) {
+          const unionValues = type.value.map(({ name }) => name);
+          unionValues[unionValues.length - 1] = `or ${unionValues[unionValues.length - 1]}`;
+
+          if (unionValues.length > 2) {
+            //humanizedType = unionValues.join(', ');
+          } else {
+            //humanizedType = unionValues.join(' ');
+          }
+          break;
+        }
+        control = "union";
+        break;
+
+      default:
+        control = type.name;
+    }
+
+    return control;
+  };
+
+  renderPropsForcomponent = () => {
+
+    const propNames = Object.keys(this.state.allProps);
+
+    const rows = propNames.map(propName => {
+      const {
+        description: propDescription,
+        required,
+        defaultValue,
+        type,
+      } = this.state.allProps[propName];
+
+      let humanizedName = (
+        <strong>{propName}</strong>
+      );
+
+      if (required) {
+        humanizedName = (
+          <span>
+            <strong>{humanizedName}</strong> <EuiTextColor color="danger">(required)</EuiTextColor>
+          </span>
+        );
+      }
+
+      const humanizedType = humanizeType(type);
+
+      let defaultValueMarkup = '';
+      if (defaultValue) {
+        defaultValueMarkup = [ <EuiCode key={`defaultValue-${propName}`}>{defaultValue.value}</EuiCode> ];
+        if (defaultValue.comment) {
+          defaultValueMarkup.push(`(${defaultValue.comment})`);
+        }
+      }
+
+      const cells = [
+        (
+          <EuiTableRowCell key="name">
+            {humanizedName}
+            {propDescription ? `<br>${markup(propDescription)}` : undefined}
+          </EuiTableRowCell>
+        ), (
+          <EuiTableRowCell key="type">
+            <EuiCode>{markup(humanizedType)}</EuiCode>
+          </EuiTableRowCell>
+        ), (
+          <EuiTableRowCell key="defaultValue">
+            {defaultValueMarkup}
+          </EuiTableRowCell>
+        ), (
+          <EuiTableRowCell key="edit">
+            {this.controlType(type, propName)}
+          </EuiTableRowCell>
+        )
+      ];
+
+      return (
+        <EuiTableRow key={propName}>
+          {cells}
+        </EuiTableRow>
+      );
+    });
+
+    let table;
+
+    if (rows.length) {
+      table = (
+        <EuiTable className="euiGuideSectionPlayground__table">
+          <EuiTableHeader>
+            <EuiTableHeaderCell>
+              Prop
+            </EuiTableHeaderCell>
+
+            <EuiTableHeaderCell>
+              Type
+            </EuiTableHeaderCell>
+
+            <EuiTableHeaderCell>
+              Default
+            </EuiTableHeaderCell>
+
+            <EuiTableHeaderCell>
+              Modify
+            </EuiTableHeaderCell>
+          </EuiTableHeader>
+
+          <EuiTableBody>
+            {rows}
+          </EuiTableBody>
+        </EuiTable>
+      );
+    }
+
+    return table;
+  }
+
+  render() {
+    const {
+      className,
+      component,  // eslint-disable-line no-unused-vars
+      demo,
+      ...rest
+    } = this.props;
+
+    const classes = classNames(
+      'euiGuideSectionPlayground',
+      'guideRule__example',
+      'guideRule__example--frame',
+      className
+    );
+
+    const newCompProps = {};
+    if (this.state.compProps) {
+      const propNames = Object.keys(this.state.compProps);
+      const addingValues = propNames.map(name => {  // eslint-disable-line no-unused-vars
+        newCompProps[name] = this.state.compProps[name];
+      });
+    }
+
+    const newElem = React.cloneElement(
+      demo,
+      newCompProps,
+      demo.props.children,
+    );
+
+    return (
+      <div
+        className={classes}
+        {...rest}
+      >
+
+        <div className="guideRule__example__panel">
+          {newElem}
+        </div>
+
+        <EuiSpacer />
+
+        {this.renderPropsForcomponent()}
+      </div>
+    );
+  }
+}

--- a/src-docs/src/components/guide_section/guide_section_playground.js
+++ b/src-docs/src/components/guide_section/guide_section_playground.js
@@ -281,7 +281,6 @@ export class GuideSectionPlayground extends Component {
       .filter(prop => this.state.compProps[prop] !== undefined)
       .filter(prop => !this.state.allProps[prop].defaultValue || unquote(this.state.allProps[prop].defaultValue.value) !== this.state.compProps[prop].toString())
       .map(prop => {
-        console.log(this.state.compProps[prop]);
         switch (typeof this.state.compProps[prop]) {
           case 'string':
             modifiedProps += `\n  ${prop}=${JSON.stringify(this.state.compProps[prop])}`;
@@ -292,7 +291,7 @@ export class GuideSectionPlayground extends Component {
         }
       });
 
-    if (this.state.allProps.children) {
+    if (this.props.demo.children) {
 
       if (modifiedProps) {
         modifiedProps = `${modifiedProps}\n>\n`

--- a/src-docs/src/components/guide_section/guide_section_playground.js
+++ b/src-docs/src/components/guide_section/guide_section_playground.js
@@ -52,7 +52,7 @@ export class GuideSectionPlayground extends Component {
       compProps: compProps
     }
 
-    if (this.state.allProps.onClick) {
+    if (this.allProps && this.allProps.onClick) {
       this.state.simulateOnClick === false;
     }
 
@@ -175,6 +175,9 @@ export class GuideSectionPlayground extends Component {
   };
 
   renderPropsForcomponent = () => {
+    if (!this.state.allProps) {
+      return;
+    }
 
     const propNames = Object.keys(this.state.allProps);
 

--- a/src-docs/src/components/guide_section/guide_section_playground.js
+++ b/src-docs/src/components/guide_section/guide_section_playground.js
@@ -38,10 +38,10 @@ export class GuideSectionPlayground extends Component {
       const { props } = docgenInfo;
       allProps = props ? props : undefined;
 
-      if (allProps) {
-        const propNames = Object.keys(allProps);
+      if (this.props.demo.props) {
+        const propNames = Object.keys(this.props.demo.props);
         const addingValues = propNames.map(name => { // eslint-disable-line no-unused-vars
-          const value = allProps[name].defaultValue ? this.props.component.defaultProps[name] : undefined;
+          const value = allProps[name].type.name !== 'node' ? this.props.demo.props[name] : undefined;
           compProps[name] = value;
         });
       }
@@ -294,7 +294,7 @@ export class GuideSectionPlayground extends Component {
         }
       });
 
-    if (this.props.demo.children) {
+    if (this.props.demo.props.children) {
 
       if (modifiedProps) {
         modifiedProps = `${modifiedProps}\n>\n`

--- a/src-docs/src/components/guide_section/index.js
+++ b/src-docs/src/components/guide_section/index.js
@@ -5,3 +5,7 @@ export {
 export {
   GuideSectionTypes,
 } from './guide_section_types';
+
+export {
+  GuideSectionPlayground,
+} from './guide_section_playground';

--- a/src-docs/src/components/index.js
+++ b/src-docs/src/components/index.js
@@ -13,4 +13,5 @@ export {
 export {
   GuideSection,
   GuideSectionTypes,
+  GuideSectionPlayground,
 } from './guide_section';

--- a/src-docs/src/services/string/prop_types.js
+++ b/src-docs/src/services/string/prop_types.js
@@ -6,6 +6,9 @@ import {
 } from '../../../../src/components';
 
 export function unquote(string) {
+  if (typeof string !== "string") {
+    return;
+  }
   const count = string.length - 1;
   const pair = string.charAt(0) + string.charAt(count);
   return (pair === '""' || pair === "''") ? string.slice(1, count) : string;

--- a/src-docs/src/services/string/prop_types.js
+++ b/src-docs/src/services/string/prop_types.js
@@ -1,0 +1,72 @@
+import React from 'react';
+
+import {
+  EuiCode,
+  EuiLink
+} from '../../../../src/components';
+
+export function unquote(string) {
+  const count = string.length - 1;
+  const pair = string.charAt(0) + string.charAt(count);
+  return (pair === '""' || pair === "''") ? string.slice(1, count) : string;
+}
+
+export function markup(text) {
+  const regex = /(#[a-zA-Z]+)|(`[^`]+`)/g;
+  return text.split(regex).map((token, index) => {
+    if (!token) {
+      return '';
+    }
+    if (token.startsWith('#')) {
+      const id = token.substring(1);
+      const onClick = () => {
+        document.getElementById(id).scrollIntoView();
+      };
+      return <EuiLink key={`markup-${index}`} onClick={onClick}>{id}</EuiLink>;
+    }
+    if (token.startsWith('`')) {
+      const code = token.substring(1, token.length - 1);
+      return <EuiCode key={`markup-${index}`}>{code}</EuiCode>;
+    }
+    return token;
+
+  });
+}
+
+export function humanizeType(type) {
+  if (!type) {
+    return '';
+  }
+
+  let humanizedType;
+
+  switch (type.name) {
+    case 'enum':
+      if (Array.isArray(type.value)) {
+        humanizedType = type.value.map(({ value }) => value).join(', ');
+        break;
+      }
+      humanizedType = type.value;
+      break;
+
+    case 'union':
+      if (Array.isArray(type.value)) {
+        const unionValues = type.value.map(({ name }) => name);
+        unionValues[unionValues.length - 1] = `or ${unionValues[unionValues.length - 1]}`;
+
+        if (unionValues.length > 2) {
+          humanizedType = unionValues.join(', ');
+        } else {
+          humanizedType = unionValues.join(' ');
+        }
+        break;
+      }
+      humanizedType = type.value;
+      break;
+
+    default:
+      humanizedType = type.name;
+  }
+
+  return humanizedType;
+}

--- a/src-docs/src/views/button/button_example.js
+++ b/src-docs/src/views/button/button_example.js
@@ -14,6 +14,7 @@ import {
 } from '../../../../src/components';
 
 import Button from './button';
+import ButtonPlayground from './button_playground';
 const buttonSource = require('!!raw-loader!./button');
 const buttonHtml = renderToHtml(Button);
 
@@ -57,6 +58,7 @@ export const ButtonExample = {
     }],
     props: { EuiButton },
     demo: <Button />,
+    playground: <ButtonPlayground />,
   }, {
     title: 'Buttons can also be links',
     source: [{

--- a/src-docs/src/views/button/button_playground.js
+++ b/src-docs/src/views/button/button_playground.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import {
+  EuiButton,
+} from '../../../../src/components';
+
+import { GuideSectionPlayground } from '../../components/guide_section/guide_section_playground';
+
+export default () => (
+  <GuideSectionPlayground
+    component={EuiButton}
+    demo={(
+      <EuiButton>Click me, I&apos;m a button</EuiButton>
+    )}
+    props={['fill', 'color', 'size', 'isDisabled', 'type']}
+  />
+);

--- a/src-docs/src/views/horizontal_rule/horizontal_rule.js
+++ b/src-docs/src/views/horizontal_rule/horizontal_rule.js
@@ -10,6 +10,7 @@ export default () => (
   <div>
     <EuiTitle size="s"><span>Sizes</span></EuiTitle>
     <EuiSpacer />
+
     <p>quarter</p>
     <EuiHorizontalRule size="quarter"/>
     <p>half</p>

--- a/src-docs/src/views/horizontal_rule/horizontal_rule.js
+++ b/src-docs/src/views/horizontal_rule/horizontal_rule.js
@@ -2,12 +2,36 @@ import React from 'react';
 
 import {
   EuiHorizontalRule,
+  EuiTitle,
+  EuiSpacer,
 } from '../../../../src/components';
 
 export default () => (
   <div>
+    <EuiTitle size="s"><span>Sizes</span></EuiTitle>
+    <EuiSpacer />
+    <p>quarter</p>
     <EuiHorizontalRule size="quarter"/>
+    <p>half</p>
     <EuiHorizontalRule size="half"/>
+    <p>full (default)</p>
     <EuiHorizontalRule />
+
+    <EuiSpacer />
+    <EuiTitle size="s"><span>Margins</span></EuiTitle>
+    <EuiSpacer />
+
+    <p>xs</p>
+    <EuiHorizontalRule margin="xs" />
+    <p>s</p>
+    <EuiHorizontalRule margin="s" />
+    <p>m</p>
+    <EuiHorizontalRule margin="m" />
+    <p>l (default)</p>
+    <EuiHorizontalRule margin="l" />
+    <p>xl</p>
+    <EuiHorizontalRule margin="xl" />
+    <p>xxl</p>
+    <EuiHorizontalRule margin="xxl" />
   </div>
 );

--- a/src-docs/src/views/horizontal_rule/horizontal_rule_example.js
+++ b/src-docs/src/views/horizontal_rule/horizontal_rule_example.js
@@ -1,56 +1,35 @@
 import React from 'react';
 
-import { renderToHtml } from '../../services';
+// import { renderToHtml } from '../../services';
 
-import {
-  GuideSectionTypes,
-} from '../../components';
+// import {
+//   GuideSectionTypes,
+// } from '../../components';
 
 import {
   EuiCode,
   EuiHorizontalRule,
 } from '../../../../src/components';
 
-import HorizontalRule from './horizontal_rule';
-const horizontalRuleSource = require('!!raw-loader!./horizontal_rule');
-const horizontalRuleHtml = renderToHtml(HorizontalRule);
+// import HorizontalRule from './horizontal_rule';
+// const horizontalRuleSource = require('!!raw-loader!./horizontal_rule');
+// const horizontalRuleHtml = renderToHtml(HorizontalRule);
 
-import HorizontalRuleMargin from './horizontal_rule_margin';
-const horizontalRuleMarginSource = require('!!raw-loader!./horizontal_rule_margin');
-const horizontalRuleMarginHtml = renderToHtml(HorizontalRuleMargin);
+// import HorizontalRuleMargin from './horizontal_rule_margin';
+// const horizontalRuleMarginSource = require('!!raw-loader!./horizontal_rule_margin');
+// const horizontalRuleMarginHtml = renderToHtml(HorizontalRuleMargin);
 
 export const HorizontalRuleExample = {
   title: 'Horizontal Rule',
   sections: [{
-    source: [{
-      type: GuideSectionTypes.JS,
-      code: horizontalRuleSource,
-    }, {
-      type: GuideSectionTypes.HTML,
-      code: horizontalRuleHtml,
-    }],
     text: (
       <p>
-        <EuiCode>HorizontalRule</EuiCode> can carry a size. By default it will be full.
+        <EuiCode>HorizontalRule</EuiCode> can carry a size. By default it will be
+        full. <EuiCode>HorizontalRule</EuiCode> margins can also be defined.
+        Don&rsquo;t forget that margins will collapse against items that proceed / follow.
       </p>
     ),
-    props: { EuiHorizontalRule },
-    demo: <HorizontalRule />,
-  }, {
-    title: 'Margins',
-    source: [{
-      type: GuideSectionTypes.JS,
-      code: horizontalRuleMarginSource,
-    }, {
-      type: GuideSectionTypes.HTML,
-      code: horizontalRuleMarginHtml,
-    }],
-    text: (
-      <p>
-        <EuiCode>HorizontalRule</EuiCode> margins can also be defined. Don&rsquo;t forget that
-        margins will collapse against items that proceed / follow.
-      </p>
-    ),
-    demo: <HorizontalRuleMargin />,
+    playground: EuiHorizontalRule,
+    demo: <EuiHorizontalRule />,
   }],
 };

--- a/src-docs/src/views/horizontal_rule/horizontal_rule_example.js
+++ b/src-docs/src/views/horizontal_rule/horizontal_rule_example.js
@@ -1,19 +1,20 @@
 import React from 'react';
 
-// import { renderToHtml } from '../../services';
+import { renderToHtml } from '../../services';
 
-// import {
-//   GuideSectionTypes,
-// } from '../../components';
+import {
+  GuideSectionTypes,
+} from '../../components';
 
 import {
   EuiCode,
   EuiHorizontalRule,
 } from '../../../../src/components';
 
-// import HorizontalRule from './horizontal_rule';
-// const horizontalRuleSource = require('!!raw-loader!./horizontal_rule');
-// const horizontalRuleHtml = renderToHtml(HorizontalRule);
+import HorizontalRule from './horizontal_rule';
+import HorizontalRulePlayground from './horizontal_rule_playground';
+const horizontalRuleSource = require('!!raw-loader!./horizontal_rule');
+const horizontalRuleHtml = renderToHtml(HorizontalRule);
 
 // import HorizontalRuleMargin from './horizontal_rule_margin';
 // const horizontalRuleMarginSource = require('!!raw-loader!./horizontal_rule_margin');
@@ -22,6 +23,13 @@ import {
 export const HorizontalRuleExample = {
   title: 'Horizontal Rule',
   sections: [{
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: horizontalRuleSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: horizontalRuleHtml,
+    }],
     text: (
       <p>
         <EuiCode>HorizontalRule</EuiCode> can carry a size. By default it will be
@@ -29,7 +37,8 @@ export const HorizontalRuleExample = {
         Don&rsquo;t forget that margins will collapse against items that proceed / follow.
       </p>
     ),
-    playground: EuiHorizontalRule,
-    demo: <EuiHorizontalRule />,
+    playground: <HorizontalRulePlayground />,
+    demo: <HorizontalRule />,
+    props: { EuiHorizontalRule }
   }],
 };

--- a/src-docs/src/views/horizontal_rule/horizontal_rule_playground.js
+++ b/src-docs/src/views/horizontal_rule/horizontal_rule_playground.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import {
+  EuiHorizontalRule,
+} from '../../../../src/components';
+
+import { GuideSectionPlayground } from '../../components/guide_section/guide_section_playground';
+
+export default () => (
+  <GuideSectionPlayground
+    component={EuiHorizontalRule}
+    demo={(
+      <EuiHorizontalRule />
+    )}
+  />
+);

--- a/src-docs/src/views/loading/loading_example.js
+++ b/src-docs/src/views/loading/loading_example.js
@@ -1,10 +1,10 @@
 import React from 'react';
 
-import { renderToHtml } from '../../services';
+// import { renderToHtml } from '../../services';
 
-import {
-  GuideSectionTypes,
-} from '../../components';
+// import {
+//   GuideSectionTypes,
+// } from '../../components';
 
 import {
   EuiLoadingKibana,
@@ -12,45 +12,31 @@ import {
   EuiLoadingChart,
 } from '../../../../src/components';
 
-import LoadingKibana from './loading_kibana';
-const loadingKibanaSource = require('!!raw-loader!./loading_kibana');
-const loadingKibanaHtml = renderToHtml(LoadingKibana);
+// import LoadingKibana from './loading_kibana';
+// const loadingKibanaSource = require('!!raw-loader!./loading_kibana');
+// const loadingKibanaHtml = renderToHtml(LoadingKibana);
 
-import LoadingChart from './loading_chart';
-const loadingChartSource = require('!!raw-loader!./loading_chart');
-const loadingChartHtml = renderToHtml(LoadingChart);
+// import LoadingChart from './loading_chart';
+// const loadingChartSource = require('!!raw-loader!./loading_chart');
+// const loadingChartHtml = renderToHtml(LoadingChart);
 
-import LoadingSpinner from './loading_spinner';
-const loadingSpinnerSource = require('!!raw-loader!./loading_spinner');
-const loadingSpinnerHtml = renderToHtml(LoadingSpinner);
+// import LoadingSpinner from './loading_spinner';
+// const loadingSpinnerSource = require('!!raw-loader!./loading_spinner');
+// const loadingSpinnerHtml = renderToHtml(LoadingSpinner);
 
 export const LoadingExample = {
   title: 'Loading',
   sections: [{
     title: 'Kibana',
-    source: [{
-      type: GuideSectionTypes.JS,
-      code: loadingKibanaSource,
-    }, {
-      type: GuideSectionTypes.HTML,
-      code: loadingKibanaHtml,
-    }],
     text: (
       <p>
         Logo based load. Should only be used in very large panels, like bootup screens.
       </p>
     ),
-    props: { EuiLoadingKibana },
-    demo: <LoadingKibana />,
+    playground: EuiLoadingKibana,
+    demo: <EuiLoadingKibana size="m" />,
   }, {
     title: 'Chart',
-    source: [{
-      type: GuideSectionTypes.JS,
-      code: loadingChartSource,
-    }, {
-      type: GuideSectionTypes.HTML,
-      code: loadingChartHtml,
-    }],
     text: (
       <p>
         Loader for the loading of chart or dashboard and visualization elements.
@@ -59,23 +45,16 @@ export const LoadingExample = {
         mono versions should be used.
       </p>
     ),
-    props: { EuiLoadingChart },
-    demo: <LoadingChart />,
+    playground: EuiLoadingChart,
+    demo: <EuiLoadingChart size="m" />,
   }, {
     title: 'Spinner',
-    source: [{
-      type: GuideSectionTypes.JS,
-      code: loadingSpinnerSource,
-    }, {
-      type: GuideSectionTypes.HTML,
-      code: loadingSpinnerHtml,
-    }],
     text: (
       <p>
         A simple spinner for most loading applications.
       </p>
     ),
-    props: { EuiLoadingSpinner },
-    demo: <LoadingSpinner />,
+    playground: EuiLoadingSpinner,
+    demo: <EuiLoadingSpinner size="m" />,
   }],
 };

--- a/src-docs/src/views/panel/panel.js
+++ b/src-docs/src/views/panel/panel.js
@@ -35,5 +35,11 @@ export default () => (
     <EuiPanel paddingSize="l" hasShadow>
       <EuiCode>paddingSize=&quot;l&quot;</EuiCode>, <EuiCode>hasShadow</EuiCode>
     </EuiPanel>
+
+    <EuiSpacer size="l"/>
+
+    <EuiPanel onClick={() => window.alert('Panel clicked')}>
+      <p>Hover me to see my hover state.</p>
+    </EuiPanel>
   </div>
 );

--- a/src-docs/src/views/panel/panel_example.js
+++ b/src-docs/src/views/panel/panel_example.js
@@ -2,11 +2,11 @@ import React from 'react';
 
 import { Link } from 'react-router';
 
-import { renderToHtml } from '../../services';
+// import { renderToHtml } from '../../services';
 
-import {
-  GuideSectionTypes,
-} from '../../components';
+// import {
+//   GuideSectionTypes,
+// } from '../../components';
 
 import {
   EuiCode,
@@ -17,9 +17,9 @@ import {
 // const panelSource = require('!!raw-loader!./panel');
 // const panelHtml = renderToHtml(Panel);
 
-import PanelHover from './panel_hover';
-const panelHoverSource = require('!!raw-loader!./panel_hover');
-const panelHoverHtml = renderToHtml(PanelHover);
+// import PanelHover from './panel_hover';
+// const panelHoverSource = require('!!raw-loader!./panel_hover');
+// const panelHoverHtml = renderToHtml(PanelHover);
 
 export const PanelExample = {
   title: 'Panel',
@@ -33,21 +33,5 @@ export const PanelExample = {
     ),
     playground: EuiPanel,
     demo: <EuiPanel>This is a panel. Use wisely. 🤪</EuiPanel>,
-  }, {
-    title: 'Panel can be hoverable',
-    source: [{
-      type: GuideSectionTypes.JS,
-      code: panelHoverSource,
-    }, {
-      type: GuideSectionTypes.HTML,
-      code: panelHoverHtml,
-    }],
-    text: (
-      <p>
-        Adding an <EuiCode>onClick</EuiCode> handler to the <EuiCode>EuiPanel</EuiCode> will
-        turn the wrapping element into a button to allow for interaction.
-      </p>
-    ),
-    demo: <PanelHover />,
   }],
 };

--- a/src-docs/src/views/panel/panel_example.js
+++ b/src-docs/src/views/panel/panel_example.js
@@ -13,9 +13,9 @@ import {
   EuiPanel,
 } from '../../../../src/components';
 
-import Panel from './panel';
-const panelSource = require('!!raw-loader!./panel');
-const panelHtml = renderToHtml(Panel);
+// import Panel from './panel';
+// const panelSource = require('!!raw-loader!./panel');
+// const panelHtml = renderToHtml(Panel);
 
 import PanelHover from './panel_hover';
 const panelHoverSource = require('!!raw-loader!./panel_hover');
@@ -24,13 +24,6 @@ const panelHoverHtml = renderToHtml(PanelHover);
 export const PanelExample = {
   title: 'Panel',
   sections: [{
-    source: [{
-      type: GuideSectionTypes.JS,
-      code: panelSource,
-    }, {
-      type: GuideSectionTypes.HTML,
-      code: panelHtml,
-    }],
     text: (
       <p>
         <EuiCode>Panel</EuiCode> is a simple wrapper component to add
@@ -38,8 +31,8 @@ export const PanelExample = {
         other larger components like <Link to="/layout/page">Page</Link> and <Link to="/layout/popover">Popover</Link>.
       </p>
     ),
-    props: { EuiPanel },
-    demo: <Panel />,
+    playground: EuiPanel,
+    demo: <EuiPanel>This is a panel. Use wisely. 🤪</EuiPanel>,
   }, {
     title: 'Panel can be hoverable',
     source: [{

--- a/src-docs/src/views/panel/panel_example.js
+++ b/src-docs/src/views/panel/panel_example.js
@@ -2,20 +2,21 @@ import React from 'react';
 
 import { Link } from 'react-router';
 
-// import { renderToHtml } from '../../services';
+import { renderToHtml } from '../../services';
 
-// import {
-//   GuideSectionTypes,
-// } from '../../components';
+import {
+  GuideSectionTypes,
+} from '../../components';
 
 import {
   EuiCode,
   EuiPanel,
 } from '../../../../src/components';
 
-// import Panel from './panel';
-// const panelSource = require('!!raw-loader!./panel');
-// const panelHtml = renderToHtml(Panel);
+import Panel from './panel';
+import PanelPlayground from './panel_playground';
+const panelSource = require('!!raw-loader!./panel');
+const panelHtml = renderToHtml(Panel);
 
 // import PanelHover from './panel_hover';
 // const panelHoverSource = require('!!raw-loader!./panel_hover');
@@ -24,6 +25,13 @@ import {
 export const PanelExample = {
   title: 'Panel',
   sections: [{
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: panelSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: panelHtml,
+    }],
     text: (
       <p>
         <EuiCode>Panel</EuiCode> is a simple wrapper component to add
@@ -31,7 +39,8 @@ export const PanelExample = {
         other larger components like <Link to="/layout/page">Page</Link> and <Link to="/layout/popover">Popover</Link>.
       </p>
     ),
-    playground: EuiPanel,
-    demo: <EuiPanel>This is a panel. Use wisely. 🤪</EuiPanel>,
+    props: { EuiPanel },
+    playground: <PanelPlayground />,
+    demo: <Panel />,
   }],
 };

--- a/src-docs/src/views/panel/panel_playground.js
+++ b/src-docs/src/views/panel/panel_playground.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import {
+  EuiPanel,
+} from '../../../../src/components';
+
+import { GuideSectionPlayground } from '../../components/guide_section/guide_section_playground';
+
+export default () => (
+  <GuideSectionPlayground
+    component={EuiPanel}
+    demo={(
+      <EuiPanel>This is a panel. Use wisely.</EuiPanel>
+    )}
+  />
+);

--- a/src-docs/src/views/title/title_example.js
+++ b/src-docs/src/views/title/title_example.js
@@ -1,30 +1,23 @@
 import React from 'react';
 
-import { renderToHtml } from '../../services';
+// import { renderToHtml } from '../../services';
 
-import {
-  GuideSectionTypes,
-} from '../../components';
+// import {
+//   GuideSectionTypes,
+// } from '../../components';
 
 import {
   EuiCode,
   EuiTitle,
 } from '../../../../src/components';
 
-import Title from './title';
-const titleSource = require('!!raw-loader!./title');
-const titleHtml = renderToHtml(Title);
+// import Title from './title';
+// const titleSource = require('!!raw-loader!./title');
+// const titleHtml = renderToHtml(Title);
 
 export const TitleExample = {
   title: 'Title',
   sections: [{
-    source: [{
-      type: GuideSectionTypes.JS,
-      code: titleSource,
-    }, {
-      type: GuideSectionTypes.HTML,
-      code: titleHtml,
-    }],
     text: (
       <p>
         <EuiCode>EuiTitle</EuiCode> style the page, section and content
@@ -33,7 +26,7 @@ export const TitleExample = {
         they are margin neutral and more suitable for general layout design.
       </p>
     ),
-    props: { EuiTitle },
-    demo: <Title />,
+    playground: EuiTitle,
+    demo: <EuiTitle><span>Titles are markup agnostic, they only confer style</span></EuiTitle>,
   }],
 };

--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -57,10 +57,22 @@ export const EuiPanel = ({
 EuiPanel.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
+
+  /**
+   * Increases the visual depth of the panel
+   */
   hasShadow: PropTypes.bool,
   paddingSize: PropTypes.oneOf(SIZES),
+
+  /**
+   * Disallows it from extending it's containers width & height
+   */
   grow: PropTypes.bool,
   panelRef: PropTypes.func,
+
+  /**
+   * Turns the wrapping element into a button to allow for interaction
+   */
   onClick: PropTypes.func,
 };
 


### PR DESCRIPTION
Utilizing some of the same auto-gen docs prop stuff, I was able to create a `GuideSectionPlayground` component that displays a single component and a table of all it's props including a way to modify it on the fly. It also spits out the raw component JSX in a code block.

This is just a proof of concept that I wanted to play around with. In order to make it live we would still need a few things, some of which are:

- [ ] Check how it works with all the different prop types
- [ ] A way to copy the JSX code - though I think we need to create a built in copy button to the `EuiCodeBlock` comp
- [ ] A way to display the rendered HTML
- [ ] A way to wrap the demo in a custom container
- [ ] Possibly allow multiple demos to be rendered (I'd say this is only for items that look better as a repeatable and therefore will still only show one component's JSX code and the modified props will apply to all instances).

Demo: 
![screen capture on 2018-04-02 at 01-32-13 2](https://user-images.githubusercontent.com/549577/38184653-18520522-3617-11e8-93f0-0fd857a5db3c.gif)

