### PR TITLE
Fix hover shadow on toasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `0.0.39`.
-
 **Bug fixes**
 
 - Fix visual shadow glitch on hover of `EuiToast` ([#632](https://github.com/elastic/eui/pull/632))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ No public interface changes since `0.0.39`.
 
 **Bug fixes**
 
+- Fix visual shadow glitch on hover of `EuiToast` ([#632](https://github.com/elastic/eui/pull/632))
 - Visual fix for the focus state of disabled `EuiButton` ([#603](https://github.com/elastic/eui/pull/603))
 - `EuiSelect` can pass any node as a value rather than just a string ([#603](https://github.com/elastic/eui/pull/603))
 - Fixed a typo in the flex TypeScript definition ([#629](https://github.com/elastic/eui/pull/629))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 No public interface changes since `0.0.39`.
 
+**Bug fixes**
+
+- Fix visual shadow glitch on hover of `EuiToast` ([#632](https://github.com/elastic/eui/pull/632))
+
 # [`0.0.39`](https://github.com/elastic/eui/tree/v0.0.39)
 
 **Bug fixes**
@@ -23,7 +27,6 @@ No public interface changes since `0.0.39`.
 
 **Bug fixes**
 
-- Fix visual shadow glitch on hover of `EuiToast` ([#632](https://github.com/elastic/eui/pull/632))
 - Visual fix for the focus state of disabled `EuiButton` ([#603](https://github.com/elastic/eui/pull/603))
 - `EuiSelect` can pass any node as a value rather than just a string ([#603](https://github.com/elastic/eui/pull/603))
 - Fixed a typo in the flex TypeScript definition ([#629](https://github.com/elastic/eui/pull/629))

--- a/src-docs/src/views/toast/toast_example.js
+++ b/src-docs/src/views/toast/toast_example.js
@@ -55,7 +55,7 @@ export const ToastExample = {
       EuiGlobalToastListItem,
     },
     demo: (
-      <div style={{ width: 320 }}>
+      <div style={{ maxWidth: 320 }}>
         <EuiButton onClick={addToast}>
           Add toast to global toast list
         </EuiButton>
@@ -89,7 +89,7 @@ export const ToastExample = {
       </div>
     ),
     demo: (
-      <div style={{ width: 320 }}>
+      <div style={{ maxWidth: 320 }}>
         <Default />
       </div>
     ),
@@ -108,7 +108,7 @@ export const ToastExample = {
       </p>
     ),
     demo: (
-      <div style={{ width: 320 }}>
+      <div style={{ maxWidth: 320 }}>
         <Info />
       </div>
     ),
@@ -127,7 +127,7 @@ export const ToastExample = {
       </p>
     ),
     demo: (
-      <div style={{ width: 320 }}>
+      <div style={{ maxWidth: 320 }}>
         <Success />
       </div>
     ),
@@ -146,7 +146,7 @@ export const ToastExample = {
       </p>
     ),
     demo: (
-      <div style={{ width: 320 }}>
+      <div style={{ maxWidth: 320 }}>
         <Warning />
       </div>
     ),
@@ -165,7 +165,7 @@ export const ToastExample = {
       </p>
     ),
     demo: (
-      <div style={{ width: 320 }}>
+      <div style={{ maxWidth: 320 }}>
         <Danger />
       </div>
     ),

--- a/src/components/toast/_global_toast_list.scss
+++ b/src/components/toast/_global_toast_list.scss
@@ -13,8 +13,9 @@
   z-index: $euiZToastList;
   bottom: 0;
   right: 0;
-  width: $euiToastWidth + $euiSize; /* 3 */
+  width: $euiToastWidth + $euiSize + $euiSizeXL; /* 3 */
   padding-right: $euiSize;
+  padding-left: $euiSizeXL;
   max-height: 100vh; /* 1 */
 
   &:hover {
@@ -64,4 +65,3 @@
     width: 100%; /* 1 */
   }
 }
-


### PR DESCRIPTION
With the new shadows, the toasts would look weird on hover because the overflow would cut them off. This adds some left padding so they will continue to show.

![](https://d3vv6lp55qjaqc.cloudfront.net/items/24080G0m1l293Y1Y2T0i/Screen%20Recording%202018-04-04%20at%2010.15%20AM.gif?X-CloudApp-Visitor-Id=59773&v=a4463c5e)