### PR TITLE
Add TypeScript types for portal, text, title components, popover service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
 - Tweaked sizing, weights, color, line-heights, and added more levels to `EuiTitle` and `EuiText` ([#627](https://github.com/elastic/eui/pull/627))
+- Add TypeScript type defitions for `EuiPortal`, `EuiText` and `EuiTitle` as well as the `calculatePopoverPosition` service ([#638](https://github.com/elastic/eui/pull/638))
 
 **Bug fixes**
 

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -13,3 +13,6 @@
 /// <reference path="./link/index.d.ts" />
 /// <reference path="./loading/index.d.ts" />
 /// <reference path="./progress/index.d.ts" />
+/// <reference path="./portal/index.d.ts" />
+/// <reference path="./title/index.d.ts" />
+/// <reference path="./text/index.d.ts" />

--- a/src/components/portal/index.d.ts
+++ b/src/components/portal/index.d.ts
@@ -1,0 +1,14 @@
+declare module '@elastic/eui' {
+  import { SFC } from 'react';
+
+  /**
+   * portal type defs
+   *
+   * @see './portal.js'
+   */
+  type EuiPortalProps = {
+    children: React.ReactNode;
+  };
+
+  export const EuiPortal: SFC<EuiPortalProps>;
+}

--- a/src/components/text/index.d.ts
+++ b/src/components/text/index.d.ts
@@ -1,0 +1,30 @@
+/// <reference path="../common.d.ts" />
+
+declare module '@elastic/eui' {
+  import { SFC, HTMLAttributes } from 'react';
+
+  /**
+   * text type defs
+   *
+   * @see './text.js'
+   * @see './text_color.js'
+   */
+  type EuiTextSize = 's' | 'xs';
+
+  type EuiTextColor =
+    | 'default'
+    | 'subdued'
+    | 'secondary'
+    | 'accent'
+    | 'danger'
+    | 'warning'
+    | 'ghost';
+
+  type EuiTextProps = CommonProps &
+    HTMLAttributes<HTMLDivElement> & {
+      size?: EuiTextSize;
+      color?: EuiTextColor;
+    };
+
+  export const EuiText: SFC<EuiTextProps>;
+}

--- a/src/components/title/index.d.ts
+++ b/src/components/title/index.d.ts
@@ -1,0 +1,22 @@
+/// <reference path="../common.d.ts" />
+
+declare module '@elastic/eui' {
+  import { SFC } from 'react';
+
+  /**
+   * title type defs
+   *
+   * @see './title.js'
+   */
+
+  type EuiTitleSize = 'xxxs' | 'xxs' | 'xs' | 's' | 'm' | 'l';
+
+  type EuiTitleTextTransform = 'uppercase';
+
+  type EuiTitleProps = CommonProps & {
+    size?: EuiTitleSize;
+    textTransform?: EuiTitleTextTransform;
+  };
+
+  export const EuiTitle: SFC<EuiTitleProps>;
+}

--- a/src/services/index.d.ts
+++ b/src/services/index.d.ts
@@ -1,1 +1,2 @@
 /// <reference path="./alignment.d.ts" />
+/// <reference path="./popover/index.d.ts" />

--- a/src/services/popover/index.d.ts
+++ b/src/services/popover/index.d.ts
@@ -1,0 +1,29 @@
+declare module '@elastic/eui' {
+  type EuiToolTipPosition = 'top' | 'right' | 'bottom' | 'left';
+
+  type EuiPopoverAnchorRect = {
+    top: number;
+    left: number;
+    width: number;
+    height: number;
+  };
+
+  type EuiPopoverDimensions = {
+    width: number;
+    height: number;
+  };
+
+  export const calculatePopoverPosition: (
+    anchorBounds: EuiPopoverAnchorRect,
+    popoverBounds: EuiPopoverDimensions,
+    requestedPosition: EuiToolTipPosition,
+    buffer?: number,
+    positions?: EuiToolTipPosition[]
+  ) => {
+    top: number;
+    left: number;
+    width: number;
+    height: number;
+    position: EuiToolTipPosition;
+  };
+}


### PR DESCRIPTION
This adds type definitions for the components

* `<EuiPortal>`
* `<EuiText>`
* `<EuiTitle>`

and the service

* `calculatePopoverPosition`