### PR TITLE
Close singleSelection EuiComboBox select list when item is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added `disabled` prop to `EuiComboBoxOption` ([#650](https://github.com/elastic/eui/pull/650))
 - Added support for `<pre>` and `<code>` tags to `<EuiText>` ([#654](https://github.com/elastic/eui/pull/654))
 - Added export of SASS theme variables in JSON format during compilation ([#642](https://github.com/elastic/eui/pull/642))
+- Close `EuiComboBox` `singleSelection` options list when option is choosen ([#645](https://github.com/elastic/eui/pull/645))
 
 ## [`0.0.40`](https://github.com/elastic/eui/tree/v0.0.40)
 

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -346,6 +346,10 @@ export class EuiComboBox extends Component {
   onAddOption = (addedOption) => {
     const { onChange, selectedOptions, singleSelection } = this.props;
     onChange(singleSelection ? [addedOption] : selectedOptions.concat(addedOption));
+    if (singleSelection) {
+      this.closeList();
+      return;
+    }
     this.clearSearchValue();
     this.focusSearchInput();
   };

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -346,11 +346,14 @@ export class EuiComboBox extends Component {
   onAddOption = (addedOption) => {
     const { onChange, selectedOptions, singleSelection } = this.props;
     onChange(singleSelection ? [addedOption] : selectedOptions.concat(addedOption));
+
+    this.clearSearchValue();
+
     if (singleSelection) {
       this.closeList();
       return;
     }
-    this.clearSearchValue();
+
     this.focusSearchInput();
   };
 


### PR DESCRIPTION
The combo box selection list should be automatically closed when an item is selected in `singleSelection` mode.