### PR TITLE
Gray out labels when disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Tweaked sizing, weights, color, line-heights, and added more levels to `EuiTitle` and `EuiText` ([#627](https://github.com/elastic/eui/pull/627))
 - Add TypeScript type defitions for `EuiPortal`, `EuiText` and `EuiTitle` as well as the `calculatePopoverPosition` service ([#638](https://github.com/elastic/eui/pull/638))
+- Grayed out labels for `disabled` controls ([#648])(https://github.com/elastic/eui/pull/648)
 
 **Bug fixes**
 

--- a/src/components/form/_mixins.scss
+++ b/src/components/form/_mixins.scss
@@ -58,6 +58,11 @@
   cursor: not-allowed;
   background: darken($euiColorLightestShade, 2%);
   box-shadow: 0 0 0 1px transparentize($euiColorFullShade, .92);
+  color: $euiColorMediumShade;
+
+  &::placeholder {
+    color: $euiColorMediumShade;
+  }
 }
 
 /**

--- a/src/components/form/checkbox/_checkbox.scss
+++ b/src/components/form/checkbox/_checkbox.scss
@@ -38,7 +38,7 @@
       cursor: not-allowed !important;
 
       ~ .euiCheckbox__label {
-        color: $euiColorDarkShade;
+        color: $euiColorMediumShade;
         cursor: not-allowed !important;
       }
 

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -23,6 +23,9 @@
     &:hover:disabled {
       cursor: not-allowed;
     }
+    &:disabled ~ .euiFilePicker__prompt {
+      color: $euiColorMediumShade;
+    }
   }
 
   .euiFilePicker__icon {

--- a/src/components/form/radio/_radio.scss
+++ b/src/components/form/radio/_radio.scss
@@ -32,7 +32,7 @@
       cursor: not-allowed !important;
 
       ~ .euiRadio__label {
-        color: $euiColorDarkShade;
+        color: $euiColorMediumShade;
         cursor: not-allowed !important;
       }
 

--- a/src/components/form/switch/_switch.scss
+++ b/src/components/form/switch/_switch.scss
@@ -108,7 +108,7 @@
     }
 
     + label {
-      color: $euiColorDarkShade;
+      color: $euiColorMediumShade;
     }
   }
 


### PR DESCRIPTION
This PR mostly grays out labels when components are disabled, so that it's a bit more obvious that they're disabled.

File Picker Before/After

<img alt="screen shot 2018-04-10 at 12 52 10" src="https://user-images.githubusercontent.com/934293/38568036-055ad108-3cbe-11e8-8a34-90c68c47b248.png">
<img alt="screen shot 2018-04-10 at 12 52 04" src="https://user-images.githubusercontent.com/934293/38568037-05841af4-3cbe-11e8-96bf-eb94fd303629.png">

Select Before/After

<img alt="screen shot 2018-04-10 at 12 53 08" src="https://user-images.githubusercontent.com/934293/38568084-296e5934-3cbe-11e8-89e6-f7e70ba8cd7d.png">
<img alt="screen shot 2018-04-10 at 12 53 12" src="https://user-images.githubusercontent.com/934293/38568085-29927fa8-3cbe-11e8-9868-14379d8c9d38.png">

Checkbox Before/After

<img alt="screen shot 2018-04-10 at 12 53 58" src="https://user-images.githubusercontent.com/934293/38568124-42906ce0-3cbe-11e8-9798-86e616edaaae.png"> 
<img alt="screen shot 2018-04-10 at 12 53 48" src="https://user-images.githubusercontent.com/934293/38568125-42b671ba-3cbe-11e8-8c67-78d50e2b2550.png">

Radio Before/After

<img alt="screen shot 2018-04-10 at 12 54 38" src="https://user-images.githubusercontent.com/934293/38568171-59a77590-3cbe-11e8-92d4-cba6eb63b179.png">
<img alt="screen shot 2018-04-10 at 12 54 33" src="https://user-images.githubusercontent.com/934293/38568169-597f01b4-3cbe-11e8-811e-5075f6dc8bba.png">

Switch Before/After

<img alt="screen shot 2018-04-10 at 12 56 02" src="https://user-images.githubusercontent.com/934293/38568240-92379d90-3cbe-11e8-8994-1d80107d4983.png">
<img alt="screen shot 2018-04-10 at 12 56 08" src="https://user-images.githubusercontent.com/934293/38568241-92615eaa-3cbe-11e8-807d-47869367f395.png">

Textarea Before/After

<img alt="screen shot 2018-04-10 at 13 02 23" src="https://user-images.githubusercontent.com/934293/38568620-7ad9c212-3cbf-11e8-8a9c-8bedb05665ab.png">
<img alt="screen shot 2018-04-10 at 13 02 18" src="https://user-images.githubusercontent.com/934293/38568619-7ab68d06-3cbf-11e8-82b1-0a26a02fbac6.png">

Password Before/After (all text fields change the same way)

<img alt="screen shot 2018-04-10 at 13 04 50" src="https://user-images.githubusercontent.com/934293/38568746-cd157576-3cbf-11e8-8cf4-6012ae4a7012.png">
<img alt="screen shot 2018-04-10 at 13 04 44" src="https://user-images.githubusercontent.com/934293/38568744-ccf0d61c-3cbf-11e8-9a0f-5a9792b74289.png">