### PR TITLE
Add Changelog view and fix routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ No public interface changes since `0.0.40`.
 
 - Tweaked sizing, weights, color, line-heights, and added more levels to `EuiTitle` and `EuiText` ([#627](https://github.com/elastic/eui/pull/627))
 - Add TypeScript type defitions for `EuiPortal`, `EuiText` and `EuiTitle` as well as the `calculatePopoverPosition` service ([#638](https://github.com/elastic/eui/pull/638))
-- Grayed out labels for `disabled` controls ([#648])(https://github.com/elastic/eui/pull/648)
+- Grayed out labels for `disabled` controls ([#648](https://github.com/elastic/eui/pull/648))
 
 **Bug fixes**
 
@@ -102,7 +102,7 @@ No public interface changes since `0.0.40`.
 
 **Bug fixes**
 
-- Fixed `EuiToolTip` smart positioning to prevent tooltip from being clipped by the window where possible ([#550]https://github.com/elastic/eui/pull/550)
+- Fixed `EuiToolTip` smart positioning to prevent tooltip from being clipped by the window where possible ([#550](https://github.com/elastic/eui/pull/550))
 
 # [`0.0.31`](https://github.com/elastic/eui/tree/v0.0.31)
 
@@ -358,10 +358,10 @@ instead of just string ([#516](https://github.com/elastic/eui/pull/516))
 
 **Bug fixes**
 
-- Disabled tab styling. [(#258)[https://github.com/elastic/eui/pull/258]]
-- Proper classname for flexGroup alignItems prop. [(#257)[https://github.com/elastic/eui/pull/257]]
-- Clicking the downArrow icon in `EuiSelect` now triggers selection. [(#255)[https://github.com/elastic/eui/pull/255]]
-- Fixed `euiFormRow` id's from being the same as the containing input and label. [(#251)[https://github.com/elastic/eui/pull/251]]
+- Disabled tab styling. ([#258](https://github.com/elastic/eui/pull/258))
+- Proper classname for flexGroup alignItems prop. ([#257](https://github.com/elastic/eui/pull/257))
+- Clicking the downArrow icon in `EuiSelect` now triggers selection. ([#255](https://github.com/elastic/eui/pull/255))
+- Fixed `euiFormRow` id's from being the same as the containing input and label. ([#251](https://github.com/elastic/eui/pull/251))
 
 **Breaking changes**
 
@@ -370,7 +370,7 @@ instead of just string ([#516](https://github.com/elastic/eui/pull/516))
 # [`0.0.10`](https://github.com/elastic/eui/tree/v0.0.10)
 
 - Updated `euiPopover` to propagate `panelPaddingSize` padding values to content only (title does inherit horizontal values) via CSS. [(#229)](https://github.com/elastic/eui/pull/229)
-- Updated `EuiErrorBoundary` to preserve newlines in error. [(#238)[https://github.com/elastic/eui/pull/238]]
+- Updated `EuiErrorBoundary` to preserve newlines in error. ([#238](https://github.com/elastic/eui/pull/238))
 - Added more icons and fixed a few for dark mode [(#228)](https://github.com/elastic/eui/pull/228)
 - Added `EuiFlyout` component. [(#227)](https://github.com/elastic/eui/pull/227)
 
@@ -380,8 +380,8 @@ instead of just string ([#516](https://github.com/elastic/eui/pull/516))
 
 **Bug fixes**
 
-- Fixed bug in `Pager` service which occurred when there were no items. [(#237)[https://github.com/elastic/eui/pull/237]]
-- Added `isPageable` method to `Pager` service and set first and last page index to -1 when there are no pages. [(#242)[https://github.com/elastic/eui/pull/242]]
+- Fixed bug in `Pager` service which occurred when there were no items. ([#237](https://github.com/elastic/eui/pull/237))
+- Added `isPageable` method to `Pager` service and set first and last page index to -1 when there are no pages. ([#242](https://github.com/elastic/eui/pull/242))
 
 # [`0.0.9`](https://github.com/elastic/eui/tree/v0.0.9)
 

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "html-webpack-plugin": "^2.30.1",
     "jest": "^22.0.6",
     "jest-cli": "^22.0.6",
+    "markdown-it": "8.4.1",
     "moment": "^2.20.1",
     "node-sass": "^4.5.3",
     "npm-run": "^4.1.2",

--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -194,7 +194,7 @@ export class GuidePageChrome extends Component {
 }
 
 GuidePageChrome.propTypes = {
-  currentRouteName: PropTypes.string.isRequired,
+  currentRouteName: PropTypes.string,
   onToggleTheme: PropTypes.func.isRequired,
   selectedTheme: PropTypes.string.isRequired,
   navigation: PropTypes.array.isRequired,

--- a/src-docs/src/routes.js
+++ b/src-docs/src/routes.js
@@ -191,6 +191,9 @@ import { ToastExample }
 import { ToolTipExample }
   from './views/tool_tip/tool_tip_example';
 
+import { Changelog }
+  from './views/package/changelog';
+
 /**
  * Lowercases input and replaces spaces with hyphens:
  * e.g. 'GridView Example' -> 'gridview-example'
@@ -326,6 +329,11 @@ const navigation = [{
     OutsideClickDetectorExample,
     PortalExample,
   ].map(example => createExample(example)),
+}, {
+  name: 'Package',
+  items: [
+    Changelog
+  ]
 }].map(({ name, items, ...rest }) => ({
   name,
   type: slugify(name),

--- a/src-docs/src/views/app_view.js
+++ b/src-docs/src/views/app_view.js
@@ -31,34 +31,13 @@ export class AppView extends Component {
   }
 
   componentDidMount() {
-    const {
-      routes,
-    } = this.props;
-
     this.updateTheme();
 
-    document.addEventListener('keydown', e => {
-      if (e.target !== document.body) {
-        return;
-      }
+    document.addEventListener('keydown', this.onKeydown);
+  }
 
-      let route;
-
-      switch (e.keyCode) {
-        case keyCodes.LEFT:
-          route = routes.getPreviousRoute(this.props.currentRoute.name);
-          break;
-        case keyCodes.RIGHT:
-          route = routes.getNextRoute(this.props.currentRoute.name);
-          break;
-        default:
-          break;
-      }
-
-      if (route) {
-        routes.history.push(route.path);
-      }
-    });
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.onKeydown);
   }
 
   renderContent() {
@@ -98,6 +77,38 @@ export class AppView extends Component {
         {this.renderContent()}
       </div>
     );
+  }
+
+  onKeydown = e => {
+    if (e.target !== document.body) {
+      return;
+    }
+
+    if (e.metaKey) {
+      return;
+    }
+
+    const {
+      routes,
+      currentRoute,
+    } = this.props;
+
+    if (e.keyCode === keyCodes.LEFT) {
+      pushRoute(routes.getPreviousRoute);
+      return;
+    }
+
+    if (e.keyCode === keyCodes.RIGHT) {
+      pushRoute(routes.getNextRoute);
+    }
+
+    function pushRoute(getRoute) {
+      const route = getRoute(currentRoute.name);
+
+      if (route) {
+        routes.history.push(route.path);
+      }
+    }
   }
 }
 

--- a/src-docs/src/views/home/home_view.js
+++ b/src-docs/src/views/home/home_view.js
@@ -41,13 +41,15 @@ export const HomeView = () => (
           <EuiFlexItem grow={false}>
             <p>
               Version:{' '}
-              <EuiLink href="https://github.com/elastic/eui">
-                <strong>{ pkg.version }</strong>
+              <EuiLink href="#/package/changelog">
+                <strong>v{ pkg.version }</strong>
               </EuiLink>
             </p>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiIcon type="logoGithub" />
+            <EuiLink href="https://github.com/elastic/eui">
+              <EuiIcon type="logoGithub" />
+            </EuiLink>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>

--- a/src-docs/src/views/package/changelog.js
+++ b/src-docs/src/views/package/changelog.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import MarkdownIt from 'markdown-it';
+
+import { EuiText } from '../../../..'
+import { GuidePage } from '../../components/guide_page'
+
+const changelogSource = require('!!raw-loader!../../../../CHANGELOG.md');
+const md = new MarkdownIt();
+const changelog = md.render(changelogSource);
+
+export const Changelog = {
+  name: 'Changelog',
+  component: () => (
+    <GuidePage title="Changelog">
+      <EuiText dangerouslySetInnerHTML={{ __html: changelog }} />
+    </GuidePage>
+  ),
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5198,6 +5198,12 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+linkify-it@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.0.3.tgz#d94a4648f9b1c179d64fa97291268bdb6ce9434f"
+  dependencies:
+    uc.micro "^1.0.1"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -5471,6 +5477,16 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-it@8.4.1:
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.1.tgz#206fe59b0e4e1b78a7c73250af9b34a4ad0aaf44"
+  dependencies:
+    argparse "^1.0.7"
+    entities "~1.1.1"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
 material-colors@^1.2.1:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.5.tgz#5292593e6754cb1bcc2b98030e4e0d6a3afc9ea1"
@@ -5485,6 +5501,10 @@ md5.js@^1.3.4:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -8713,6 +8733,10 @@ typedarray@^0.0.6:
 ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
+
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.5.tgz#0c65f15f815aa08b560a61ce8b4db7ffc3f45376"
 
 uglify-js@3.3.x:
   version "3.3.8"


### PR DESCRIPTION
Only affects `docs` site:

- Adds a `Changelog` view at `/#/package/changelog`
- Adds a `Package` section with a link to this `Changelog` view
- Changes the version link to point to this changelog route
- Fixes lots of changelog links that were malformed
- Fixes a bug where we were preventing the user from using <kbd>⌘</kbd> + <kbd>←</kbd> or <kbd>⌘</kbd> + <kbd>→</kbd> to navigate history, resulting in a broken experience

<img width="1552" alt="screen shot 2018-04-10 at 14 18 05" src="https://user-images.githubusercontent.com/934293/38572750-61af1638-3cca-11e8-9091-c03bbf91d85d.png">
