### PR TITLE
add disabled prop to EuiComboBoxOption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `0.0.40`.
+- add disabled prop to `EuiComboBoxOption` ([#650](https://github.com/elastic/eui/pull/650))
 
 # [`0.0.40`](https://github.com/elastic/eui/tree/v0.0.40)
 

--- a/src-docs/src/views/combo_box/combo_box.js
+++ b/src-docs/src/views/combo_box/combo_box.js
@@ -12,7 +12,7 @@ export default class extends Component {
       label: 'Titan',
       'data-test-subj': 'titanOption',
     }, {
-      label: 'Enceladus',
+      label: 'Enceladus is disabled',
       disabled: true,
     }, {
       label: 'Mimas',

--- a/src-docs/src/views/combo_box/combo_box.js
+++ b/src-docs/src/views/combo_box/combo_box.js
@@ -13,6 +13,7 @@ export default class extends Component {
       'data-test-subj': 'titanOption',
     }, {
       label: 'Enceladus',
+      disabled: true,
     }, {
       label: 'Mimas',
     }, {

--- a/src/components/combo_box/combo_box_options_list/_combo_box_option.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_option.scss
@@ -16,4 +16,8 @@
     color: $euiColorPrimary;
     background-color: $euiFocusBackgroundColor;
   }
+  &:disabled {
+    color: $euiColorMediumShade;
+    cursor: not-allowed;
+  }
 }

--- a/src/components/combo_box/combo_box_options_list/_combo_box_option.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_option.scss
@@ -19,5 +19,8 @@
   &:disabled {
     color: $euiColorMediumShade;
     cursor: not-allowed;
+    &:hover {
+      text-decoration: none;
+    }
   }
 }

--- a/src/components/combo_box/combo_box_options_list/combo_box_option.js
+++ b/src/components/combo_box/combo_box_options_list/combo_box_option.js
@@ -14,6 +14,7 @@ export class EuiComboBoxOption extends Component {
     optionRef: PropTypes.func,
     onClick: PropTypes.func.isRequired,
     onEnterKey: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
   }
 
   onClick = () => {

--- a/src/components/combo_box/combo_box_options_list/combo_box_option.js
+++ b/src/components/combo_box/combo_box_options_list/combo_box_option.js
@@ -38,6 +38,7 @@ export class EuiComboBoxOption extends Component {
       option, // eslint-disable-line no-unused-vars
       onClick, // eslint-disable-line no-unused-vars
       onEnterKey, // eslint-disable-line no-unused-vars
+      disabled,
       ...rest
     } = this.props;
 
@@ -54,6 +55,7 @@ export class EuiComboBoxOption extends Component {
         onKeyDown={this.onKeyDown}
         ref={optionRef}
         tabIndex="-1"
+        disabled={disabled}
         {...rest}
       >
         {children}


### PR DESCRIPTION
I am looking into the feasibility of replacing react-select with EuiComboBox in Kibana Visual Builder. One missing feature is the ability to disable options.

<img width="866" alt="screen shot 2018-04-10 at 1 54 03 pm" src="https://user-images.githubusercontent.com/373691/38580386-091fa986-3cc7-11e8-9470-7c0f6cba66a6.png">

This PR just adds a disabled prop to `EuiComboBoxOption`
