### PR TITLE
Fix table re-rendering by showing/hiding actions column via CSS instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 **Bug fixes**
 
-- Fixed `EuiBasicTable` re-rendering on hover of table rows
+- Fixed `EuiBasicTable` re-rendering on hover of table rows ([#665](https://github.com/elastic/eui/pull/665))
 
 **Breaking changes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Wrap `EuiHorizontalStep` text instead of truncating it ([#653](https://github.com/elastic/eui/pull/653))
 - Fixed a bug where `EuiSideNavItem` wouldn't pass an `onClick` handler down to `<a>` tags if they also had an `href`. ([#664](https://github.com/elastic/eui/pull/664))
 
+**Bug fixes**
+
+- Fixed `EuiBasicTable` re-rendering on hover of table rows
+
 **Breaking changes**
 
 - `EuiHorizontalSteps` now requires an `onClick` prop be provided for each step configuration object ([#653](https://github.com/elastic/eui/pull/653))

--- a/src-docs/src/views/tables/actions/actions.js
+++ b/src-docs/src/views/tables/actions/actions.js
@@ -11,6 +11,7 @@ import {
   EuiFlexItem,
   EuiSwitch,
   EuiSpacer,
+  EuiText,
 } from '../../../../../src/components';
 
 /*
@@ -47,7 +48,8 @@ export class Table extends Component {
       sortField: 'firstName',
       sortDirection: 'asc',
       selectedItems: [],
-      multiAction: false
+      multiAction: false,
+      customAction: false,
     };
   }
 
@@ -79,6 +81,10 @@ export class Table extends Component {
     });
   };
 
+  onSelectionChange = (selectedItems) => {
+    this.setState({ selectedItems });
+  };
+
   renderDeleteButton() {
     const { selectedItems } = this.state;
 
@@ -101,6 +107,10 @@ export class Table extends Component {
     this.setState(prevState => ({ multiAction: !prevState.multiAction }));
   };
 
+  toggleCustomAction = () => {
+    this.setState(prevState => ({ customAction: !prevState.customAction }));
+  };
+
   deleteUser = user => {
     store.deleteUsers(user.id);
     this.setState({ selectedItems: [] });
@@ -117,6 +127,8 @@ export class Table extends Component {
       pageSize,
       sortField,
       sortDirection,
+      multiAction,
+      customAction,
     } = this.state;
 
     const {
@@ -125,6 +137,63 @@ export class Table extends Component {
     } = store.findUsers(pageIndex, pageSize, sortField, sortDirection);
 
     const deleteButton = this.renderDeleteButton();
+
+    let actions = null;
+
+    if(multiAction) {
+      actions = customAction
+        ? [{
+          render: (item) => {
+            return (
+              <EuiText color="secondary" onClick={() => this.cloneUser(item)}>
+                Clone
+              </EuiText>
+            );
+          }
+        }, {
+          render: (item) => {
+            return (
+              <EuiText color="danger" onClick={() => this.deleteUser(item)}>
+                Delete
+              </EuiText>
+            );
+          }
+        }]
+        : [{
+          name: 'Clone',
+          description: 'Clone this person',
+          icon: 'copy',
+          onClick: this.cloneUser
+        }, {
+          name: 'Delete',
+          description: 'Delete this person',
+          icon: 'trash',
+          color: 'danger',
+          onClick: this.deleteUser
+        }];
+    } else {
+      actions = customAction
+        ? [{
+          render: (item) => {
+            return (
+              <EuiLink
+                onClick={() => this.deleteUser(item)}
+                color="danger"
+              >
+                Delete
+              </EuiLink>
+            );
+          }
+        }]
+        : [{
+          name: 'Delete',
+          description: 'Delete this person',
+          icon: 'trash',
+          color: 'danger',
+          type: 'icon',
+          onClick: this.deleteUser
+        }];
+    }
 
     const columns = [{
       field: 'firstName',
@@ -166,25 +235,7 @@ export class Table extends Component {
       sortable: true
     }, {
       name: 'Actions',
-      actions: this.state.multiAction ? [{
-        name: 'Clone',
-        description: 'Clone this person',
-        icon: 'copy',
-        onClick: this.cloneUser
-      }, {
-        name: 'Delete',
-        description: 'Delete this person',
-        icon: 'trash',
-        color: 'danger',
-        onClick: this.deleteUser
-      }] : [{
-        name: 'Delete',
-        type: 'icon',
-        description: 'Delete this person',
-        icon: 'trash',
-        color: 'danger',
-        onClick: this.deleteUser
-      }]
+      actions
     }];
 
     const pagination = {
@@ -217,6 +268,13 @@ export class Table extends Component {
               label="Multiple Actions"
               checked={this.state.multiAction}
               onChange={this.toggleMultiAction}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiSwitch
+              label="Custom Actions"
+              checked={this.state.customAction}
+              onChange={this.toggleCustomAction}
             />
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/src/components/basic_table/__snapshots__/basic_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.js.snap
@@ -116,8 +116,6 @@ exports[`EuiBasicTable basic - with items 1`] = `
         <EuiTableRow
           aria-owns="row_0_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCell
             align="left"
@@ -134,8 +132,6 @@ exports[`EuiBasicTable basic - with items 1`] = `
         <EuiTableRow
           aria-owns="row_1_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCell
             align="left"
@@ -152,8 +148,6 @@ exports[`EuiBasicTable basic - with items 1`] = `
         <EuiTableRow
           aria-owns="row_2_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCell
             align="left"
@@ -190,8 +184,6 @@ exports[`EuiBasicTable itemIdToExpandedRowMap renders an expanded row 1`] = `
         <EuiTableRow
           aria-owns="row_0_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCell
             align="left"
@@ -208,8 +200,6 @@ exports[`EuiBasicTable itemIdToExpandedRowMap renders an expanded row 1`] = `
         <EuiTableRow
           aria-owns="row_1_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCell
             align="left"
@@ -240,8 +230,6 @@ exports[`EuiBasicTable itemIdToExpandedRowMap renders an expanded row 1`] = `
         <EuiTableRow
           aria-owns="row_2_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCell
             align="left"
@@ -278,8 +266,6 @@ exports[`EuiBasicTable with pagination - 2nd page 1`] = `
         <EuiTableRow
           aria-owns="row_0_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCell
             align="left"
@@ -296,8 +282,6 @@ exports[`EuiBasicTable with pagination - 2nd page 1`] = `
         <EuiTableRow
           aria-owns="row_1_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCell
             align="left"
@@ -345,8 +329,6 @@ exports[`EuiBasicTable with pagination 1`] = `
         <EuiTableRow
           aria-owns="row_0_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCell
             align="left"
@@ -363,8 +345,6 @@ exports[`EuiBasicTable with pagination 1`] = `
         <EuiTableRow
           aria-owns="row_1_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCell
             align="left"
@@ -381,8 +361,6 @@ exports[`EuiBasicTable with pagination 1`] = `
         <EuiTableRow
           aria-owns="row_2_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCell
             align="left"
@@ -479,8 +457,6 @@ exports[`EuiBasicTable with pagination and selection 1`] = `
         <EuiTableRow
           aria-owns="row_1_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCellCheckbox
             key="_selection_column_1"
@@ -509,8 +485,6 @@ exports[`EuiBasicTable with pagination and selection 1`] = `
         <EuiTableRow
           aria-owns="row_2_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCellCheckbox
             key="_selection_column_2"
@@ -539,8 +513,6 @@ exports[`EuiBasicTable with pagination and selection 1`] = `
         <EuiTableRow
           aria-owns="row_3_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCellCheckbox
             key="_selection_column_3"
@@ -617,8 +589,6 @@ exports[`EuiBasicTable with pagination, selection and sorting 1`] = `
         <EuiTableRow
           aria-owns="row_1_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCellCheckbox
             key="_selection_column_1"
@@ -647,8 +617,6 @@ exports[`EuiBasicTable with pagination, selection and sorting 1`] = `
         <EuiTableRow
           aria-owns="row_2_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCellCheckbox
             key="_selection_column_2"
@@ -677,8 +645,6 @@ exports[`EuiBasicTable with pagination, selection and sorting 1`] = `
         <EuiTableRow
           aria-owns="row_3_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCellCheckbox
             key="_selection_column_3"
@@ -762,8 +728,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
         <EuiTableRow
           aria-owns="row_1_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCellCheckbox
             key="_selection_column_1"
@@ -787,6 +751,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
           <EuiTableRowCell
             align="right"
             key="record_actions_1_1"
+            showOnHover={true}
             textOnly={false}
           >
             <ExpandedItemActions
@@ -808,7 +773,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
                 }
               }
               itemId="1"
-              visible={false}
             />
           </EuiTableRowCell>
         </EuiTableRow>
@@ -819,8 +783,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
         <EuiTableRow
           aria-owns="row_2_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCellCheckbox
             key="_selection_column_2"
@@ -844,6 +806,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
           <EuiTableRowCell
             align="right"
             key="record_actions_2_1"
+            showOnHover={true}
             textOnly={false}
           >
             <ExpandedItemActions
@@ -865,7 +828,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
                 }
               }
               itemId="2"
-              visible={false}
             />
           </EuiTableRowCell>
         </EuiTableRow>
@@ -876,8 +838,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
         <EuiTableRow
           aria-owns="row_3_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCellCheckbox
             key="_selection_column_3"
@@ -901,6 +861,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
           <EuiTableRowCell
             align="right"
             key="record_actions_3_1"
+            showOnHover={true}
             textOnly={false}
           >
             <ExpandedItemActions
@@ -922,7 +883,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
                 }
               }
               itemId="3"
-              visible={false}
             />
           </EuiTableRowCell>
         </EuiTableRow>
@@ -981,8 +941,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and column dataType 1
         <EuiTableRow
           aria-owns="row_1_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCellCheckbox
             key="_selection_column_1"
@@ -1011,8 +969,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and column dataType 1
         <EuiTableRow
           aria-owns="row_2_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCellCheckbox
             key="_selection_column_2"
@@ -1041,8 +997,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and column dataType 1
         <EuiTableRow
           aria-owns="row_3_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCellCheckbox
             key="_selection_column_3"
@@ -1119,8 +1073,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and column renderer 1
         <EuiTableRow
           aria-owns="row_1_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCellCheckbox
             key="_selection_column_1"
@@ -1149,8 +1101,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and column renderer 1
         <EuiTableRow
           aria-owns="row_2_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCellCheckbox
             key="_selection_column_2"
@@ -1179,8 +1129,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and column renderer 1
         <EuiTableRow
           aria-owns="row_3_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCellCheckbox
             key="_selection_column_3"
@@ -1264,8 +1212,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
         <EuiTableRow
           aria-owns="row_1_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCellCheckbox
             key="_selection_column_1"
@@ -1289,6 +1235,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
           <EuiTableRowCell
             align="right"
             key="record_actions_1_1"
+            showOnHover={true}
             textOnly={false}
           >
             <ExpandedItemActions
@@ -1308,7 +1255,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
                 }
               }
               itemId="1"
-              visible={false}
             />
           </EuiTableRowCell>
         </EuiTableRow>
@@ -1319,8 +1265,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
         <EuiTableRow
           aria-owns="row_2_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCellCheckbox
             key="_selection_column_2"
@@ -1344,6 +1288,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
           <EuiTableRowCell
             align="right"
             key="record_actions_2_1"
+            showOnHover={true}
             textOnly={false}
           >
             <ExpandedItemActions
@@ -1363,7 +1308,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
                 }
               }
               itemId="2"
-              visible={false}
             />
           </EuiTableRowCell>
         </EuiTableRow>
@@ -1374,8 +1318,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
         <EuiTableRow
           aria-owns="row_3_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCellCheckbox
             key="_selection_column_3"
@@ -1399,6 +1341,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
           <EuiTableRowCell
             align="right"
             key="record_actions_3_1"
+            showOnHover={true}
             textOnly={false}
           >
             <ExpandedItemActions
@@ -1418,7 +1361,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
                 }
               }
               itemId="3"
-              visible={false}
             />
           </EuiTableRowCell>
         </EuiTableRow>
@@ -1477,8 +1419,6 @@ exports[`EuiBasicTable with pagination, selection, sorting, column renderer and 
         <EuiTableRow
           aria-owns="row_1_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCellCheckbox
             key="_selection_column_1"
@@ -1507,8 +1447,6 @@ exports[`EuiBasicTable with pagination, selection, sorting, column renderer and 
         <EuiTableRow
           aria-owns="row_2_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCellCheckbox
             key="_selection_column_2"
@@ -1537,8 +1475,6 @@ exports[`EuiBasicTable with pagination, selection, sorting, column renderer and 
         <EuiTableRow
           aria-owns="row_3_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCellCheckbox
             key="_selection_column_3"
@@ -1598,8 +1534,6 @@ exports[`EuiBasicTable with sortable columns and sorting disabled 1`] = `
         <EuiTableRow
           aria-owns="row_0_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCell
             align="left"
@@ -1616,8 +1550,6 @@ exports[`EuiBasicTable with sortable columns and sorting disabled 1`] = `
         <EuiTableRow
           aria-owns="row_1_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCell
             align="left"
@@ -1634,8 +1566,6 @@ exports[`EuiBasicTable with sortable columns and sorting disabled 1`] = `
         <EuiTableRow
           aria-owns="row_2_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCell
             align="left"
@@ -1675,8 +1605,6 @@ exports[`EuiBasicTable with sorting 1`] = `
         <EuiTableRow
           aria-owns="row_0_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCell
             align="left"
@@ -1693,8 +1621,6 @@ exports[`EuiBasicTable with sorting 1`] = `
         <EuiTableRow
           aria-owns="row_1_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCell
             align="left"
@@ -1711,8 +1637,6 @@ exports[`EuiBasicTable with sorting 1`] = `
         <EuiTableRow
           aria-owns="row_2_expansion"
           isSelected={false}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
         >
           <EuiTableRowCell
             align="left"

--- a/src/components/basic_table/__snapshots__/collapsed_item_actions.test.js.snap
+++ b/src/components/basic_table/__snapshots__/collapsed_item_actions.test.js.snap
@@ -6,6 +6,7 @@ exports[`CollapsedItemActions render 1`] = `
   button={
     <EuiButtonIcon
       aria-label="actions"
+      className={undefined}
       color="text"
       iconType="gear"
       isDisabled={false}
@@ -32,7 +33,9 @@ exports[`CollapsedItemActions render 1`] = `
         >
           default1
         </EuiContextMenuItem>,
-        <EuiContextMenuItem />,
+        <EuiContextMenuItem
+          onClick={[Function]}
+        />,
       ]
     }
   />

--- a/src/components/basic_table/__snapshots__/custom_item_action.test.js.snap
+++ b/src/components/basic_table/__snapshots__/custom_item_action.test.js.snap
@@ -2,10 +2,6 @@
 
 exports[`CustomItemAction render 1`] = `
 <div
-  style={
-    Object {
-      "opacity": 1,
-    }
-  }
+  style={null}
 />
 `;

--- a/src/components/basic_table/__snapshots__/default_item_action.test.js.snap
+++ b/src/components/basic_table/__snapshots__/default_item_action.test.js.snap
@@ -10,11 +10,7 @@ exports[`DefaultItemAction render - button 1`] = `
   onClick={[Function]}
   onFocus={[Function]}
   size="s"
-  style={
-    Object {
-      "opacity": 1,
-    }
-  }
+  style={null}
   title="action 1"
   type="button"
 >
@@ -31,11 +27,7 @@ exports[`DefaultItemAction render - icon 1`] = `
   onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
-  style={
-    Object {
-      "opacity": 1,
-    }
-  }
+  style={null}
   title="action 1"
   type="button"
 />

--- a/src/components/basic_table/__snapshots__/default_item_action.test.js.snap
+++ b/src/components/basic_table/__snapshots__/default_item_action.test.js.snap
@@ -6,11 +6,8 @@ exports[`DefaultItemAction render - button 1`] = `
   fill={false}
   iconSide="left"
   isDisabled={false}
-  onBlur={[Function]}
   onClick={[Function]}
-  onFocus={[Function]}
   size="s"
-  style={null}
   title="action 1"
   type="button"
 >
@@ -24,10 +21,7 @@ exports[`DefaultItemAction render - icon 1`] = `
   color="primary"
   iconType="trash"
   isDisabled={false}
-  onBlur={[Function]}
   onClick={[Function]}
-  onFocus={[Function]}
-  style={null}
   title="action 1"
   type="button"
 />

--- a/src/components/basic_table/__snapshots__/expanded_item_actions.test.js.snap
+++ b/src/components/basic_table/__snapshots__/expanded_item_actions.test.js.snap
@@ -19,7 +19,6 @@ Array [
     }
     itemId="xyz"
     key="item_action_xyz_0"
-    visible={true}
   />,
   <CustomItemAction
     action={
@@ -38,7 +37,6 @@ Array [
     }
     itemId="xyz"
     key="item_action_xyz_1"
-    visible={true}
   />,
 ]
 `;

--- a/src/components/basic_table/basic_table.js
+++ b/src/components/basic_table/basic_table.js
@@ -149,7 +149,6 @@ export class EuiBasicTable extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      hoverRow: null,
       selection: []
     };
   }
@@ -238,14 +237,6 @@ export class EuiBasicTable extends Component {
       }
     };
     this.props.onChange(criteria);
-  }
-
-  onRowHover(row) {
-    this.setState({ hoverRow: row });
-  }
-
-  clearRowHover() {
-    this.setState({ hoverRow: null });
   }
 
   componentWillReceiveProps(nextProps) {
@@ -460,9 +451,6 @@ export class EuiBasicTable extends Component {
       }
     });
 
-    const onMouseOver = () => this.onRowHover(rowIndex);
-    const onMouseOut = () => this.clearRowHover();
-
     // Occupy full width of table, taking checkbox column into account.
     const expandedRowColSpan = selection ? columns.length + 1 : columns.length;
     // We'll use the ID to associate the expanded row with the original.
@@ -480,8 +468,6 @@ export class EuiBasicTable extends Component {
         <EuiTableRow
           aria-owns={expandedRowId}
           isSelected={selected}
-          onMouseOver={onMouseOver}
-          onMouseOut={onMouseOut}
         >
           {cells}
         </EuiTableRow>
@@ -523,9 +509,7 @@ export class EuiBasicTable extends Component {
     );
   }
 
-  renderItemActionsCell(itemId, item, column, columnIndex, rowIndex) {
-    const visible = this.state.hoverRow === rowIndex;
-
+  renderItemActionsCell(itemId, item, column, columnIndex) {
     const actionEnabled = (action) =>
       this.state.selection.length === 0 && (!action.enabled || action.enabled(item));
 
@@ -545,7 +529,6 @@ export class EuiBasicTable extends Component {
             return (
               <CollapsedItemActions
                 actions={column.actions}
-                visible={visible}
                 itemId={itemId}
                 item={item}
                 actionEnabled={actionEnabled}
@@ -559,7 +542,6 @@ export class EuiBasicTable extends Component {
     const tools = (
       <ExpandedItemActions
         actions={actualActions}
-        visible={visible}
         itemId={itemId}
         item={item}
         actionEnabled={actionEnabled}
@@ -568,7 +550,7 @@ export class EuiBasicTable extends Component {
 
     const key = `record_actions_${itemId}_${columnIndex}`;
     return (
-      <EuiTableRowCell key={key} align="right" textOnly={false}>
+      <EuiTableRowCell showOnHover={true} key={key} align="right" textOnly={false}>
         {tools}
       </EuiTableRowCell>
     );

--- a/src/components/basic_table/collapsed_item_actions.js
+++ b/src/components/basic_table/collapsed_item_actions.js
@@ -45,7 +45,7 @@ export class CollapsedItemActions extends Component {
 
   render() {
 
-    const { actions, itemId, item, actionEnabled, onFocus } = this.props;
+    const { actions, itemId, item, actionEnabled, onFocus, className } = this.props;
 
     const isOpen = this.state.popoverOpen;
 
@@ -60,8 +60,9 @@ export class CollapsedItemActions extends Component {
       allDisabled = allDisabled && !enabled;
       if (action.render) {
         const actionControl = action.render(item, enabled);
+        const actionControlOnClick = actionControl && actionControl.props && actionControl.props.onClick;
         controls.push(
-          <EuiContextMenuItem key={key}>
+          <EuiContextMenuItem key={key} onClick={actionControlOnClick ? actionControlOnClick.bind(null, item) : () => {}}>
             {actionControl}
           </EuiContextMenuItem>
         );
@@ -82,6 +83,7 @@ export class CollapsedItemActions extends Component {
 
     const popoverButton = (
       <EuiButtonIcon
+        className={className}
         aria-label="actions"
         iconType="gear"
         color="text"
@@ -93,6 +95,7 @@ export class CollapsedItemActions extends Component {
 
     return (
       <EuiPopover
+        className={className}
         popoverRef={this.registerPopoverDiv}
         id={`${itemId}-actions`}
         isOpen={isOpen}

--- a/src/components/basic_table/collapsed_item_actions.test.js
+++ b/src/components/basic_table/collapsed_item_actions.test.js
@@ -21,7 +21,6 @@ describe('CollapsedItemActions', () => {
           }
         }
       ],
-      visible: true,
       itemId: 'id',
       item: { id: 'xyz' },
       actionEnabled: () => true,

--- a/src/components/basic_table/custom_item_action.js
+++ b/src/components/basic_table/custom_item_action.js
@@ -41,12 +41,12 @@ export class CustomItemAction extends Component {
   };
 
   render() {
-    const { action, enabled, item } = this.props;
+    const { action, enabled, item, className } = this.props;
     const tool = action.render(item, enabled);
     const clonedTool = cloneElement(tool, { onFocus: this.onFocus, onBlur: this.onBlur });
     const style = this.hasFocus() ? { opacity: 1 } : null;
     return (
-      <div style={style}>
+      <div style={style} className={className}>
         {clonedTool}
       </div>
     );

--- a/src/components/basic_table/custom_item_action.js
+++ b/src/components/basic_table/custom_item_action.js
@@ -41,10 +41,10 @@ export class CustomItemAction extends Component {
   };
 
   render() {
-    const { action, enabled, visible, item } = this.props;
+    const { action, enabled, item } = this.props;
     const tool = action.render(item, enabled);
     const clonedTool = cloneElement(tool, { onFocus: this.onFocus, onBlur: this.onBlur });
-    const style = this.hasFocus() || visible ? { opacity: 1 } : { opacity: 0 };
+    const style = this.hasFocus() ? { opacity: 1 } : null;
     return (
       <div style={style}>
         {clonedTool}

--- a/src/components/basic_table/custom_item_action.test.js
+++ b/src/components/basic_table/custom_item_action.test.js
@@ -13,7 +13,6 @@ describe('CustomItemAction', () => {
         render: () => 'test'
       },
       enabled: true,
-      visible: true,
       item: { id: 'xyz' }
     };
 

--- a/src/components/basic_table/default_item_action.js
+++ b/src/components/basic_table/default_item_action.js
@@ -10,41 +10,7 @@ export class DefaultItemAction extends Component {
 
   constructor(props) {
     super(props);
-    this.state = { hasFocus: false };
-
-    // while generally considered an anti-pattern, here we require
-    // to do that as the onFocus/onBlur events of the action controls
-    // may trigger while this component is unmounted. An alternative
-    // (at least the workarounds suggested by react is to unregister
-    // the onFocus/onBlur listeners from the action controls... this
-    // unfortunately will lead to unecessarily complex code... so we'll
-    // stick to this approach for now)
-    this.mounted = false;
   }
-
-  componentWillMount() {
-    this.mounted = true;
-  }
-
-  componentWillUnmount() {
-    this.mounted = false;
-  }
-
-  onFocus = () => {
-    if (this.mounted) {
-      this.setState({ hasFocus: true });
-    }
-  };
-
-  onBlur = () => {
-    if (this.mounted) {
-      this.setState({ hasFocus: false });
-    }
-  };
-
-  hasFocus = () => {
-    return this.state.hasFocus;
-  };
 
   render() {
     const { action, enabled, item } = this.props;
@@ -55,7 +21,6 @@ export class DefaultItemAction extends Component {
     const onClick = () => action.onClick(item);
     const color = this.resolveActionColor();
     const icon = this.resolveActionIcon();
-    const style = this.hasFocus() ? { opacity: 1 } : null;
     if (action.type === 'icon') {
       if (!icon) {
         throw new Error(`Cannot render item action [${action.name}]. It is configured to render as an icon but no
@@ -68,10 +33,7 @@ export class DefaultItemAction extends Component {
           color={color}
           iconType={icon}
           title={action.description}
-          style={style}
           onClick={onClick}
-          onFocus={this.onFocus}
-          onBlur={this.onBlur}
         />
       );
     }
@@ -84,10 +46,7 @@ export class DefaultItemAction extends Component {
         iconType={icon}
         fill={false}
         title={action.description}
-        style={style}
         onClick={onClick}
-        onFocus={this.onFocus}
-        onBlur={this.onBlur}
       >
         {action.name}
       </EuiButton>

--- a/src/components/basic_table/default_item_action.js
+++ b/src/components/basic_table/default_item_action.js
@@ -13,7 +13,7 @@ export class DefaultItemAction extends Component {
   }
 
   render() {
-    const { action, enabled, item } = this.props;
+    const { action, enabled, item, className } = this.props;
     if (!action.onClick) {
       throw new Error(`Cannot render item action [${action.name}]. Missing required 'onClick' callback. If you want
       to provide a custom action control, make sure to define the 'render' callback`);
@@ -28,6 +28,7 @@ export class DefaultItemAction extends Component {
       }
       return (
         <EuiButtonIcon
+          className={className}
           aria-label={action.name}
           isDisabled={!enabled}
           color={color}
@@ -40,6 +41,7 @@ export class DefaultItemAction extends Component {
 
     return (
       <EuiButton
+        className={className}
         size="s"
         isDisabled={!enabled}
         color={color}

--- a/src/components/basic_table/default_item_action.js
+++ b/src/components/basic_table/default_item_action.js
@@ -47,7 +47,7 @@ export class DefaultItemAction extends Component {
   };
 
   render() {
-    const { action, enabled, visible, item } = this.props;
+    const { action, enabled, item } = this.props;
     if (!action.onClick) {
       throw new Error(`Cannot render item action [${action.name}]. Missing required 'onClick' callback. If you want
       to provide a custom action control, make sure to define the 'render' callback`);
@@ -55,7 +55,7 @@ export class DefaultItemAction extends Component {
     const onClick = () => action.onClick(item);
     const color = this.resolveActionColor();
     const icon = this.resolveActionIcon();
-    const style = this.hasFocus() || visible ? { opacity: 1 } : { opacity: 0 };
+    const style = this.hasFocus() ? { opacity: 1 } : null;
     if (action.type === 'icon') {
       if (!icon) {
         throw new Error(`Cannot render item action [${action.name}]. It is configured to render as an icon but no

--- a/src/components/basic_table/default_item_action.test.js
+++ b/src/components/basic_table/default_item_action.test.js
@@ -17,7 +17,6 @@ describe('DefaultItemAction', () => {
         onClick: () => {}
       },
       enabled: true,
-      visible: true,
       item: { id: 'xyz' }
     };
 
@@ -40,7 +39,6 @@ describe('DefaultItemAction', () => {
         onClick: () => {}
       },
       enabled: true,
-      visible: true,
       item: { id: 'xyz' }
     };
 

--- a/src/components/basic_table/expanded_item_actions.js
+++ b/src/components/basic_table/expanded_item_actions.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { DefaultItemAction } from './default_item_action';
 import { CustomItemAction } from './custom_item_action';
 
-export const ExpandedItemActions = ({ actions, visible, itemId, item, actionEnabled }) => {
+export const ExpandedItemActions = ({ actions, itemId, item, actionEnabled }) => {
 
   return actions.reduce((tools, action, index) => {
     const available = action.available ? action.available(item) : true;
@@ -19,7 +19,6 @@ export const ExpandedItemActions = ({ actions, visible, itemId, item, actionEnab
           index={index}
           action={action}
           enabled={enabled}
-          visible={visible}
           itemId={itemId}
           item={item}
         />
@@ -31,7 +30,6 @@ export const ExpandedItemActions = ({ actions, visible, itemId, item, actionEnab
           index={index}
           action={action}
           enabled={enabled}
-          visible={visible}
           itemId={itemId}
           item={item}
         />

--- a/src/components/basic_table/expanded_item_actions.js
+++ b/src/components/basic_table/expanded_item_actions.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { DefaultItemAction } from './default_item_action';
 import { CustomItemAction } from './custom_item_action';
 
-export const ExpandedItemActions = ({ actions, itemId, item, actionEnabled }) => {
+export const ExpandedItemActions = ({ actions, itemId, item, actionEnabled, className }) => {
 
   return actions.reduce((tools, action, index) => {
     const available = action.available ? action.available(item) : true;
@@ -16,6 +16,7 @@ export const ExpandedItemActions = ({ actions, itemId, item, actionEnabled }) =>
       tools.push(
         <CustomItemAction
           key={key}
+          className={className}
           index={index}
           action={action}
           enabled={enabled}
@@ -27,6 +28,7 @@ export const ExpandedItemActions = ({ actions, itemId, item, actionEnabled }) =>
       tools.push(
         <DefaultItemAction
           key={key}
+          className={className}
           index={index}
           action={action}
           enabled={enabled}

--- a/src/components/basic_table/expanded_item_actions.test.js
+++ b/src/components/basic_table/expanded_item_actions.test.js
@@ -21,7 +21,6 @@ describe('ExpandedItemActions', () => {
           }
         }
       ],
-      visible: true,
       itemId: 'xyz',
       item: { id: 'xyz' },
       actionEnabled: () => true

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -149,7 +149,7 @@
   .euiTableCellContent__hoverItem {
     opacity: 0;
 
-    .euiTableRow:hover > .euiTableRowCell > &,
+    .euiTableRow:hover &,
     &:hover, &:focus {
       opacity: 1;
     }

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -144,3 +144,16 @@
     overflow: visible; /* 1 */
   }
 }
+
+.euiTableCellContent--showOnHover {
+  > * {
+    opacity: 0;
+  }
+
+  .euiTableRow:hover > .euiTableRowCell > &,
+  &:hover, &:focus {
+    > * {
+      opacity: 1;
+    }
+  }
+}

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -148,11 +148,9 @@
 .euiTableCellContent--showOnHover {
   > * {
     opacity: 0;
-  }
 
-  .euiTableRow:hover > .euiTableRowCell > &,
-  &:hover, &:focus {
-    > * {
+    .euiTableRow:hover > .euiTableRowCell > &,
+    &:hover, &:focus {
       opacity: 1;
     }
   }

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -146,7 +146,7 @@
 }
 
 .euiTableCellContent--showOnHover {
-  > * {
+  .euiTableCellContent__hoverItem {
     opacity: 0;
 
     .euiTableRow:hover > .euiTableRowCell > &,

--- a/src/components/table/table_row_cell.js
+++ b/src/components/table/table_row_cell.js
@@ -19,6 +19,7 @@ export const EuiTableRowCell = ({
   children,
   className,
   truncateText,
+  showOnHover,
   textOnly,
   colSpan,
   ...rest
@@ -26,6 +27,7 @@ export const EuiTableRowCell = ({
   const contentClasses = classNames('euiTableCellContent', className, {
     'euiTableCellContent--alignRight': align === RIGHT_ALIGNMENT,
     'euiTableCellContent--alignCenter': align === CENTER_ALIGNMENT,
+    'euiTableCellContent--showOnHover': showOnHover,
     'euiTableCellContent--truncateText': truncateText,
     // We're doing this rigamarole instead of creating `euiTableCellContent--textOnly` for BWC
     // purposes for the time-being.
@@ -47,6 +49,7 @@ export const EuiTableRowCell = ({
 
 EuiTableRowCell.propTypes = {
   align: PropTypes.oneOf(ALIGNMENT),
+  showOnHover: PropTypes.bool,
   truncateText: PropTypes.bool,
   children: PropTypes.node,
   className: PropTypes.string,

--- a/src/components/table/table_row_cell.js
+++ b/src/components/table/table_row_cell.js
@@ -31,17 +31,26 @@ export const EuiTableRowCell = ({
     'euiTableCellContent--truncateText': truncateText,
     // We're doing this rigamarole instead of creating `euiTableCellContent--textOnly` for BWC
     // purposes for the time-being.
-    'euiTableCellContent--overflowingContent': !textOnly,
+    'euiTableCellContent--overflowingContent': textOnly !== true,
   });
+
+  const childClasses = classNames({
+    'euiTableCellContent__text': textOnly === true,
+    'euiTableCellContent__hoverItem': showOnHover,
+  });
+
+  let modifiedChildren = children;
+
+  if(textOnly === true) {
+    modifiedChildren = <span className={childClasses}>{children}</span>;
+  } else if(React.isValidElement(modifiedChildren)) {
+    modifiedChildren = React.Children.map(children, child => React.cloneElement(child, { className: childClasses }));
+  }
 
   return (
     <td className="euiTableRowCell" colSpan={colSpan}>
       <div className={contentClasses} {...rest}>
-        {
-          textOnly === true
-            ? <span className="euiTableCellContent__text">{children}</span>
-            : children
-        }
+        {modifiedChildren}
       </div>
     </td>
   );


### PR DESCRIPTION
Fixes #441 

This PR fixes unnecessary re-rendering of the entire `EuiBasicTable` component upon hovering over table rows by:
* removing `hoverRow` state on `EuiBasicTable`
* adding the class `.euiTableCellContent--showOnHover` to `EuiTableRowCell` when prop `showOnHover` is true

The `.euiTableCellContent--showOnHover` class has styling rules to hide its content by default and show it when its parent `.euiTableRow` is hovered.

Normal/keyboard navigation for single and multiple action column remains the same (no functionality changes).