### PR TITLE
use react-virtualized to virtualize EuiComboBox options list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added `status` prop to `EuiStep` for additional styling ([#673](https://github.com/elastic/eui/pull/673))
+- Virtualized `EuiComboBoxOptionsList` ([#670](https://github.com/elastic/eui/pull/670))
 
 **Bug fixes**
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-color": "^2.13.8",
     "react-datepicker": "v1.4.1",
     "react-input-autosize": "^2.2.1",
+    "react-virtualized": "^9.18.5",
     "serve": "^6.3.1",
     "tabbable": "^1.1.0",
     "uuid": "^3.1.0"

--- a/src-docs/src/views/combo_box/combo_box_example.js
+++ b/src-docs/src/views/combo_box/combo_box_example.js
@@ -54,6 +54,10 @@ import Async from './async';
 const asyncSource = require('!!raw-loader!./async');
 const asyncHtml = renderToHtml(Async);
 
+import Virtualized from './virtualized';
+const virtualizedSource = require('!!raw-loader!./virtualized');
+const virtualizedHtml = renderToHtml(Virtualized);
+
 export const ComboBoxExample = {
   title: 'Combo Box',
   intro: (
@@ -197,6 +201,22 @@ export const ComboBoxExample = {
     ),
     props: { EuiComboBox },
     demo: <DisallowCustomOptions />,
+  }, {
+    title: 'Virtualized',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: virtualizedSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: virtualizedHtml,
+    }],
+    text: (
+      <p>
+        Use virtualization to handle long lists
+      </p>
+    ),
+    props: { EuiComboBox },
+    demo: <Virtualized />,
   }, {
     title: 'Custom options only, with validation',
     source: [{

--- a/src-docs/src/views/combo_box/combo_box_example.js
+++ b/src-docs/src/views/combo_box/combo_box_example.js
@@ -109,8 +109,8 @@ export const ComboBoxExample = {
     }],
     text: (
       <p>
-        <EuiCode>EuiComboBoxList</EuiCode> uses <Link to="https://github.com/bvaughn/react-virtualized">react-virtualized</Link>
-        to only render visiable options to be super fast no matter how many options there are.
+        <EuiCode>EuiComboBoxList</EuiCode> uses <Link to="https://github.com/bvaughn/react-virtualized">react-virtualized</Link>{' '}
+        to only render visible options to be super fast no matter how many options there are.
       </p>
     ),
     props: { EuiComboBox },
@@ -163,8 +163,8 @@ export const ComboBoxExample = {
     text: (
       <Fragment>
         <p>
-          You can provide a <EuiCode>renderOption</EuiCode> prop which will accept <EuiCode>option</EuiCode>
-          and <EuiCode>searchValue</EuiCode> arguments. Use the <EuiCode>value</EuiCode> prop of the
+          You can provide a <EuiCode>renderOption</EuiCode> prop which will accept <EuiCode>option</EuiCode>{' '}
+          and <EuiCode>searchValue</EuiCode> arguments. Use the <EuiCode>value</EuiCode> prop of the{' '}
           <EuiCode>option</EuiCode> object to store metadata about the option for use in this callback.
         </p>
 

--- a/src-docs/src/views/combo_box/combo_box_example.js
+++ b/src-docs/src/views/combo_box/combo_box_example.js
@@ -99,6 +99,23 @@ export const ComboBoxExample = {
     props: { EuiComboBox },
     demo: <ComboBox />,
   }, {
+    title: 'Virtualized',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: virtualizedSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: virtualizedHtml,
+    }],
+    text: (
+      <p>
+        <EuiCode>EuiComboBoxList</EuiCode> uses <Link to="https://github.com/bvaughn/react-virtualized">react-virtualized</Link>
+        to only render visiable options to be super fast no matter how many options there are.
+      </p>
+    ),
+    props: { EuiComboBox },
+    demo: <Virtualized />,
+  }, {
     title: 'Containers',
     source: [{
       type: GuideSectionTypes.JS,
@@ -201,22 +218,6 @@ export const ComboBoxExample = {
     ),
     props: { EuiComboBox },
     demo: <DisallowCustomOptions />,
-  }, {
-    title: 'Virtualized',
-    source: [{
-      type: GuideSectionTypes.JS,
-      code: virtualizedSource,
-    }, {
-      type: GuideSectionTypes.HTML,
-      code: virtualizedHtml,
-    }],
-    text: (
-      <p>
-        Use virtualization to handle long lists
-      </p>
-    ),
-    props: { EuiComboBox },
-    demo: <Virtualized />,
   }, {
     title: 'Custom options only, with validation',
     source: [{

--- a/src-docs/src/views/combo_box/combo_box_example.js
+++ b/src-docs/src/views/combo_box/combo_box_example.js
@@ -161,11 +161,19 @@ export const ComboBoxExample = {
       code: renderOptionHtml,
     }],
     text: (
-      <p>
-        You can provide a <EuiCode>renderOption</EuiCode> prop which will accept <EuiCode>option</EuiCode>
-        and <EuiCode>searchValue</EuiCode> arguments. Use the <EuiCode>value</EuiCode> prop of the
-        <EuiCode>option</EuiCode> object to store metadata about the option for use in this callback.
-      </p>
+      <Fragment>
+        <p>
+          You can provide a <EuiCode>renderOption</EuiCode> prop which will accept <EuiCode>option</EuiCode>
+          and <EuiCode>searchValue</EuiCode> arguments. Use the <EuiCode>value</EuiCode> prop of the
+          <EuiCode>option</EuiCode> object to store metadata about the option for use in this callback.
+        </p>
+
+        <p>
+          <strong>Note:</strong> virtualization (above) requires that each option have the same height.
+          Ensure that you render the options so that wrapping text is truncated instead of causing
+          the height of the option to change.
+        </p>
+      </Fragment>
     ),
     props: { EuiComboBox },
     demo: <RenderOption />,

--- a/src-docs/src/views/combo_box/render_option.js
+++ b/src-docs/src/views/combo_box/render_option.js
@@ -110,11 +110,11 @@ export default class extends Component {
     }));
   };
 
-  renderOption = (option, searchValue) => {
+  renderOption = (option, searchValue, contentClassName) => {
     const { color, label, value } = option;
     return (
       <EuiHealth color={color}>
-        <span>
+        <span className={contentClassName}>
           <EuiHighlight search={searchValue}>
             {label}
           </EuiHighlight>

--- a/src-docs/src/views/combo_box/virtualized.js
+++ b/src-docs/src/views/combo_box/virtualized.js
@@ -9,8 +9,16 @@ export default class extends Component {
     super(props);
 
     this.options = [];
-    for (let i=0; i < 5000; i++) {
-      this.options.push({ label: `option${i}` });
+    let groupOptions = [];
+    for (let i=1; i < 5000; i++) {
+      groupOptions.push({ label: `option${i}` });
+      if (i % 25 === 0) {
+        this.options.push({
+          label: `Options ${i - (groupOptions.length - 1)} to ${i}`,
+          options: groupOptions
+        });
+        groupOptions = [];
+      }
     }
 
     this.state = {

--- a/src-docs/src/views/combo_box/virtualized.js
+++ b/src-docs/src/views/combo_box/virtualized.js
@@ -1,0 +1,38 @@
+import React, { Component } from 'react';
+
+import {
+  EuiComboBox,
+} from '../../../../src/components';
+
+export default class extends Component {
+  constructor(props) {
+    super(props);
+
+    this.options = [];
+    for (let i=0; i < 5000; i++) {
+      this.options.push({ label: `option${i}` });
+    }
+
+    this.state = {
+      selectedOptions: [],
+    };
+  }
+
+  onChange = (selectedOptions) => {
+    this.setState({
+      selectedOptions,
+    });
+  };
+
+  render() {
+    const { selectedOptions } = this.state;
+    return (
+      <EuiComboBox
+        placeholder="Select or create options"
+        options={this.options}
+        selectedOptions={selectedOptions}
+        onChange={this.onChange}
+      />
+    );
+  }
+}

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -26,10 +26,12 @@
    * 2. Force input height to expand tp fill this element.
    * 3. Reset appearance on Safari.
    * 4. Fix react-input-autosize appearance.
+   * 5. Prevent a lot of input from causing the react-input-autosize to overflow the container.
    */
   .euiComboBox__input {
     display: inline-flex !important; /* 1 */
     height: 32px; /* 2 */
+    overflow: hidden; /* 5 */
 
     > input {
       appearance: none; /* 3 */

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -490,7 +490,6 @@ export class EuiComboBox extends Component {
     let optionsList;
 
     if (!noSuggestions && isListOpen) {
-      console.log("width", width);
       optionsList = (
         <EuiPortal>
           <EuiComboBoxOptionsList

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -3,6 +3,7 @@
  * from the tab order with tabindex="-1" so that we can control the keyboard navigation interface.
  */
 
+import _ from 'lodash';
 import React, {
   Component,
 } from 'react';
@@ -149,7 +150,7 @@ export class EuiComboBox extends Component {
     tabbableItems[comboBoxIndex + amount].focus();
   };
 
-  incrementActiveOptionIndex = amount => {
+  incrementActiveOptionIndex = _.throttle(amount => {
     // If there are no options available, reset the focus.
     if (!this.matchingOptions.length) {
       this.clearActiveOption();
@@ -188,7 +189,7 @@ export class EuiComboBox extends Component {
     this.setState({
       activeOptionIndex: nextActiveOptionIndex,
     });
-  };
+  }, 200);
 
   hasActiveOption = () => {
     return this.state.activeOptionIndex !== undefined;

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -394,6 +394,10 @@ export class EuiComboBox extends Component {
 
   comboBoxRef = node => {
     this.comboBox = node;
+    const comboBoxBounds = this.comboBox.getBoundingClientRect();
+    this.setState({
+      width: comboBoxBounds.width,
+    });
   };
 
   autoSizeInputRef = node => {
@@ -487,6 +491,8 @@ export class EuiComboBox extends Component {
     let optionsList;
 
     if (!noSuggestions && isListOpen) {
+      console.log("width", width);
+      console.log("optionsListHeight", optionsListHeight);
       optionsList = (
         <EuiPortal>
           <EuiComboBoxOptionsList

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -393,10 +393,12 @@ export class EuiComboBox extends Component {
 
   comboBoxRef = node => {
     this.comboBox = node;
-    /*const comboBoxBounds = this.comboBox.getBoundingClientRect();
-    this.setState({
-      width: comboBoxBounds.width,
-    });*/
+    if (this.comboBox) {
+      const comboBoxBounds = this.comboBox.getBoundingClientRect();
+      this.setState({
+        width: comboBoxBounds.width,
+      });
+    }
   };
 
   autoSizeInputRef = node => {

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -175,10 +175,9 @@ export class EuiComboBox extends Component {
     }
 
     // Group titles are included in option list but are not selectable
-    // Skip group title options and disabled options
+    // Skip group title options
     const direction = amount > 0 ? 1 : -1;
-    while (this.matchingOptions[nextActiveOptionIndex].isGroupLabelOption
-      || this.matchingOptions[nextActiveOptionIndex].disabled) {
+    while (this.matchingOptions[nextActiveOptionIndex].isGroupLabelOption) {
       nextActiveOptionIndex = nextActiveOptionIndex + direction;
 
       if (nextActiveOptionIndex < 0) {

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -188,7 +188,6 @@ export class EuiComboBox extends Component {
     this.setState({
       activeOptionIndex: nextActiveOptionIndex,
     });
-    this.focusActiveOption();
   };
 
   hasActiveOption = () => {
@@ -196,7 +195,9 @@ export class EuiComboBox extends Component {
   };
 
   clearActiveOption = () => {
-    this.state.activeOptionIndex = undefined;
+    this.setState({
+      activeOptionIndex: undefined,
+    });
   };
 
   focusActiveOption = () => {
@@ -381,6 +382,8 @@ export class EuiComboBox extends Component {
   onComboBoxClick = () => {
     // When the user clicks anywhere on the box, enter the interaction state.
     this.searchInput.focus();
+    // If the user does this from a state in which an option has focus, then we need to clear it.
+    this.clearActiveOption();
   };
 
   onComboBoxFocus = (e) => {
@@ -459,7 +462,10 @@ export class EuiComboBox extends Component {
     this.matchingOptions = matchingOptions;
 
     if (!matchingOptions.length) {
-      this.clearActiveOption();
+      // Prevent endless setState -> componentWillUpdate -> setState loop.
+      if (nextState.hasActiveOption) {
+        this.clearActiveOption();
+      }
     }
   }
 

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -50,7 +50,7 @@ export class EuiComboBox extends Component {
 
     const initialSearchValue = '';
     const { options, selectedOptions } = props;
-    const { matchingOptions, optionToGroupMap } = this.getMatchingOptions(options, selectedOptions, initialSearchValue);
+    const matchingOptions = this.getMatchingOptions(options, selectedOptions, initialSearchValue);
 
     this.state = {
       searchValue: initialSearchValue,
@@ -60,7 +60,6 @@ export class EuiComboBox extends Component {
 
     // Cached derived state.
     this.matchingOptions = matchingOptions;
-    this.optionToGroupMap = optionToGroupMap;
     this.activeOptionIndex = undefined;
     this.listBounds = undefined;
 
@@ -394,10 +393,10 @@ export class EuiComboBox extends Component {
 
   comboBoxRef = node => {
     this.comboBox = node;
-    const comboBoxBounds = this.comboBox.getBoundingClientRect();
+    /*const comboBoxBounds = this.comboBox.getBoundingClientRect();
     this.setState({
       width: comboBoxBounds.width,
-    });
+    });*/
   };
 
   autoSizeInputRef = node => {
@@ -442,9 +441,8 @@ export class EuiComboBox extends Component {
 
     // Calculate and cache the options which match the searchValue, because we use this information
     // in multiple places and it would be expensive to calculate repeatedly.
-    const { matchingOptions, optionToGroupMap } = this.getMatchingOptions(options, selectedOptions, nextState.searchValue);
+    const matchingOptions = this.getMatchingOptions(options, selectedOptions, nextState.searchValue);
     this.matchingOptions = matchingOptions;
-    this.optionToGroupMap = optionToGroupMap;
 
     if (!matchingOptions.length) {
       this.clearActiveOption();
@@ -502,7 +500,6 @@ export class EuiComboBox extends Component {
             onCreateOption={onCreateOption}
             searchValue={searchValue}
             matchingOptions={this.matchingOptions}
-            optionToGroupMap={this.optionToGroupMap}
             listRef={this.optionsListRef}
             optionRef={this.optionRef}
             onOptionClick={this.onOptionClick}

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -39,6 +39,7 @@ export class EuiComboBox extends Component {
     onCreateOption: PropTypes.func,
     renderOption: PropTypes.func,
     isInvalid: PropTypes.bool,
+    rowHeight: PropTypes.number,
   }
 
   static defaultProps = {
@@ -495,6 +496,7 @@ export class EuiComboBox extends Component {
       onSearchChange, // eslint-disable-line no-unused-vars
       async, // eslint-disable-line no-unused-vars
       isInvalid,
+      rowHeight,
       ...rest
     } = this.props;
 
@@ -531,6 +533,7 @@ export class EuiComboBox extends Component {
             width={width}
             scrollToIndex={activeOptionIndex}
             onScroll={this.focusActiveOption}
+            rowHeight={rowHeight}
           />
         </EuiPortal>
       );

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -122,7 +122,6 @@ export class EuiComboBox extends Component {
 
     this.setState({
       width: comboBoxBounds.width,
-      optionsListHeight: listBounds.height,
       listPosition: position,
     });
   };
@@ -479,7 +478,7 @@ export class EuiComboBox extends Component {
       ...rest
     } = this.props;
 
-    const { searchValue, isListOpen, listPosition, width, optionsListHeight } = this.state;
+    const { searchValue, isListOpen, listPosition, width, } = this.state;
 
     const classes = classNames('euiComboBox', className, {
       'euiComboBox-isOpen': isListOpen,
@@ -492,7 +491,6 @@ export class EuiComboBox extends Component {
 
     if (!noSuggestions && isListOpen) {
       console.log("width", width);
-      console.log("optionsListHeight", optionsListHeight);
       optionsList = (
         <EuiPortal>
           <EuiComboBoxOptionsList
@@ -512,7 +510,6 @@ export class EuiComboBox extends Component {
             position={listPosition}
             renderOption={renderOption}
             width={width}
-            height={optionsListHeight}
           />
         </EuiPortal>
       );

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -122,6 +122,8 @@ export class EuiComboBox extends Component {
     this.optionsList.style.width = `${comboBoxBounds.width}px`;
 
     this.setState({
+      width: comboBoxBounds.width,
+      optionsListHeight: listBounds.height,
       listPosition: position,
     });
   };
@@ -473,7 +475,7 @@ export class EuiComboBox extends Component {
       ...rest
     } = this.props;
 
-    const { searchValue, isListOpen, listPosition } = this.state;
+    const { searchValue, isListOpen, listPosition, width, optionsListHeight } = this.state;
 
     const classes = classNames('euiComboBox', className, {
       'euiComboBox-isOpen': isListOpen,
@@ -504,6 +506,8 @@ export class EuiComboBox extends Component {
             updatePosition={this.updateListPosition}
             position={listPosition}
             renderOption={renderOption}
+            width={width}
+            height={optionsListHeight}
           />
         </EuiPortal>
       );

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -174,15 +174,15 @@ export class EuiComboBox extends Component {
 
     // Group titles are included in option list but are not selectable
     // Skip group title options
-    if (this.matchingOptions[nextActiveOptionIndex].isGroupLabelOption) {
-      const direction = amount > 0 ? 1 : -1;
+    const direction = amount > 0 ? 1 : -1;
+    while (this.matchingOptions[nextActiveOptionIndex].isGroupLabelOption) {
       nextActiveOptionIndex = nextActiveOptionIndex + direction;
-    }
 
-    if (nextActiveOptionIndex < 0) {
-      nextActiveOptionIndex = this.matchingOptions.length - 1;
-    } else if (nextActiveOptionIndex === this.matchingOptions.length) {
-      nextActiveOptionIndex = 0;
+      if (nextActiveOptionIndex < 0) {
+        nextActiveOptionIndex = this.matchingOptions.length - 1;
+      } else if (nextActiveOptionIndex === this.matchingOptions.length) {
+        nextActiveOptionIndex = 0;
+      }
     }
 
     this.setState({

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -3,7 +3,7 @@
  * from the tab order with tabindex="-1" so that we can control the keyboard navigation interface.
  */
 
-import _ from 'lodash';
+import { throttle } from 'lodash';
 import React, {
   Component,
 } from 'react';
@@ -151,7 +151,7 @@ export class EuiComboBox extends Component {
     tabbableItems[comboBoxIndex + amount].focus();
   };
 
-  incrementActiveOptionIndex = _.throttle(amount => {
+  incrementActiveOptionIndex = throttle(amount => {
     // If there are no options available, reset the focus.
     if (!this.matchingOptions.length) {
       this.clearActiveOption();

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -175,9 +175,10 @@ export class EuiComboBox extends Component {
     }
 
     // Group titles are included in option list but are not selectable
-    // Skip group title options
+    // Skip group title options and disabled options
     const direction = amount > 0 ? 1 : -1;
-    while (this.matchingOptions[nextActiveOptionIndex].isGroupLabelOption) {
+    while (this.matchingOptions[nextActiveOptionIndex].isGroupLabelOption
+      || this.matchingOptions[nextActiveOptionIndex].disabled) {
       nextActiveOptionIndex = nextActiveOptionIndex + direction;
 
       if (nextActiveOptionIndex < 0) {

--- a/src/components/combo_box/combo_box_options_list/_combo_box_option.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_option.scss
@@ -1,6 +1,6 @@
 .euiComboBoxOption {
   font-size: $euiFontSizeS;
-  padding: $euiSizeXS $euiSizeS;
+  padding: $euiSizeXS $euiSizeS $euiSizeXS #{$euiSizeM + $euiSizeXS};
   width: 100%;
   text-align: left;
   border: $euiBorderThin;
@@ -24,3 +24,9 @@
     }
   }
 }
+
+  .euiComboBoxOption__content {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }

--- a/src/components/combo_box/combo_box_options_list/_combo_box_option.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_option.scss
@@ -11,12 +11,14 @@
   &:hover {
     text-decoration: underline;
   }
+
   &:focus {
     cursor: pointer;
     color: $euiColorPrimary;
     background-color: $euiFocusBackgroundColor;
   }
-  &:disabled {
+
+  &.euiComboBoxOption-isDisabled {
     color: $euiColorMediumShade;
     cursor: not-allowed;
     &:hover {

--- a/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
@@ -30,9 +30,11 @@
   }
 
   .euiComboBoxOptionsList__rowWrap {
-    @include euiScrollBar;
-
-    padding: $euiSizeS;
+    padding: 0;
     max-height: 200px;
-    overflow-y: auto;
+    overflow: hidden;
+  }
+
+  .ReactVirtualized__List {
+    @include euiScrollBar;
   }

--- a/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
@@ -11,6 +11,10 @@
   z-index: $euiZComboBox;
   position: absolute; /* 2 */
   top: 0; /* 2 */
+
+  .ReactVirtualized__List {
+    @include euiScrollBar;
+  }
 }
 
 .euiComboBoxOptionsList--bottom {
@@ -33,8 +37,4 @@
     padding: 0;
     max-height: 200px;
     overflow: hidden;
-  }
-
-  .ReactVirtualized__List {
-    @include euiScrollBar;
   }

--- a/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
@@ -27,10 +27,14 @@
   box-shadow: none !important;
 }
 
+  /**
+   * 1. Prevent really long input from overflowing the container.
+   */
   .euiComboBoxOptionsList__empty {
     padding: $euiSizeS;
     text-align: center;
     color: $euiColorDarkShade;
+    word-wrap: break-word; /* 1 */
   }
 
   .euiComboBoxOptionsList__rowWrap {

--- a/src/components/combo_box/combo_box_options_list/_combo_box_title.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_title.scss
@@ -4,7 +4,7 @@
  */
 .euiComboBoxTitle {
   font-size: $euiFontSizeXS;
-  padding: ($euiSizeXS + $euiSizeS - 1px) $euiSizeS $euiSizeXS 0; /* 1 */
+  padding: ($euiSizeXS + $euiSizeS - 1px) $euiSizeS $euiSizeXS; /* 1 */
   width: 100%;
   font-weight: $euiFontWeightBold;
   color: $euiColorFullShade;

--- a/src/components/combo_box/combo_box_options_list/_combo_box_title.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_title.scss
@@ -1,11 +1,11 @@
+/**
+ * 1. Force each title to be the same height as an option, so that the virtualized scroll logic
+ *    works.
+ */
 .euiComboBoxTitle {
   font-size: $euiFontSizeXS;
-  padding: $euiSizeXS $euiSizeS $euiSizeXS 0;
+  padding: ($euiSizeXS + $euiSizeS - 1px) $euiSizeS $euiSizeXS 0; /* 1 */
   width: 100%;
   font-weight: $euiFontWeightBold;
   color: $euiColorFullShade;
-
-  .euiComboBoxOption + & {
-    margin-top: $euiSizeS;
-  }
 }

--- a/src/components/combo_box/combo_box_options_list/combo_box_option.js
+++ b/src/components/combo_box/combo_box_options_list/combo_box_option.js
@@ -36,7 +36,7 @@ export class EuiComboBoxOption extends Component {
       children,
       className,
       optionRef,
-      option, // eslint-disable-line no-unused-vars
+      option,
       onClick, // eslint-disable-line no-unused-vars
       onEnterKey, // eslint-disable-line no-unused-vars
       disabled,
@@ -48,6 +48,10 @@ export class EuiComboBoxOption extends Component {
       className
     );
 
+    const {
+      label,
+    } = option;
+
     return (
       <button
         role="option"
@@ -57,6 +61,7 @@ export class EuiComboBoxOption extends Component {
         ref={optionRef}
         tabIndex="-1"
         disabled={disabled}
+        title={label}
         {...rest}
       >
         {children}

--- a/src/components/combo_box/combo_box_options_list/combo_box_option.js
+++ b/src/components/combo_box/combo_box_options_list/combo_box_option.js
@@ -18,7 +18,12 @@ export class EuiComboBoxOption extends Component {
   }
 
   onClick = () => {
-    const { onClick, option } = this.props;
+    const { onClick, option, disabled } = this.props;
+
+    if (disabled) {
+      return;
+    }
+
     onClick(option);
   };
 
@@ -26,7 +31,12 @@ export class EuiComboBoxOption extends Component {
     if (e.keyCode === ENTER || e.keyCode === SPACE) {
       e.preventDefault();
       e.stopPropagation();
-      const { onEnterKey, option } = this.props;
+      const { onEnterKey, option, disabled } = this.props;
+
+      if (disabled) {
+        return;
+      }
+
       onEnterKey(option);
     }
   };
@@ -45,7 +55,10 @@ export class EuiComboBoxOption extends Component {
 
     const classes = classNames(
       'euiComboBoxOption',
-      className
+      className,
+      {
+        'euiComboBoxOption-isDisabled': disabled,
+      },
     );
 
     const {
@@ -55,12 +68,13 @@ export class EuiComboBoxOption extends Component {
     return (
       <button
         role="option"
+        type="button"
         className={classes}
         onClick={this.onClick}
         onKeyDown={this.onKeyDown}
         ref={optionRef}
         tabIndex="-1"
-        disabled={disabled}
+        aria-disabled={disabled}
         title={label}
         {...rest}
       >

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
@@ -37,11 +37,6 @@ export class EuiComboBoxOptionsList extends Component {
     listRef: PropTypes.func.isRequired,
     renderOption: PropTypes.func,
     width: PropTypes.number,
-    height: PropTypes.number
-  }
-
-  static defaultProps = {
-    height: 200,
   }
 
   updatePosition = () => {
@@ -102,7 +97,6 @@ export class EuiComboBoxOptionsList extends Component {
       listRef, // eslint-disable-line no-unused-vars
       updatePosition, // eslint-disable-line no-unused-vars
       width,
-      height,
       ...rest
     } = this.props;
 
@@ -151,12 +145,16 @@ export class EuiComboBoxOptionsList extends Component {
 
     const groupLabelToGroupMap = {};
 
+    const optionHeight = 27; // TODO dynamically figure this out
+    const numVisiableOptions = matchingOptions.length < 7 ? matchingOptions.length : 7;
+    const height = numVisiableOptions * optionHeight;
+
     const optionsList = (
       <List
-        width={384}
-        height={184}
+        width={width}
+        height={height}
         rowCount={matchingOptions.length}
-        rowHeight={27}
+        rowHeight={optionHeight}
         rowRenderer={({ key, index, style }) => {
           const option = matchingOptions[index];
           const {

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { List } from 'react-virtualized';
 
 import { EuiCode } from '../../code';
 import { EuiFlexGroup, EuiFlexItem } from '../../flex';
@@ -36,6 +37,7 @@ export class EuiComboBoxOptionsList extends Component {
     position: PropTypes.oneOf(POSITIONS),
     listRef: PropTypes.func.isRequired,
     renderOption: PropTypes.func,
+    width: PropTypes.number.isRequired,
   }
 
   updatePosition = () => {
@@ -96,6 +98,8 @@ export class EuiComboBoxOptionsList extends Component {
       renderOption,
       listRef, // eslint-disable-line no-unused-vars
       updatePosition, // eslint-disable-line no-unused-vars
+      width,
+      height,
       ...rest
     } = this.props;
 
@@ -143,43 +147,82 @@ export class EuiComboBoxOptionsList extends Component {
     ) : undefined;
 
     const groupLabelToGroupMap = {};
-    const optionsList = [];
 
-    matchingOptions.forEach((option, index) => {
-      const {
-        value, // eslint-disable-line no-unused-vars
-        label,
-        ...rest
-      } = option;
+    let optionsList;
 
-      const group = optionToGroupMap.get(option);
-
-      if (group && !groupLabelToGroupMap[group.label]) {
-        groupLabelToGroupMap[group.label] = true;
-        optionsList.push(
-          <EuiComboBoxTitle key={`group-${group.label}`}>
-            {group.label}
-          </EuiComboBoxTitle>
-        );
-      }
-
-      const renderedOption = (
-        <EuiComboBoxOption
-          option={option}
-          key={option.label.toLowerCase()}
-          onClick={onOptionClick}
-          onEnterKey={onOptionEnterKey}
-          optionRef={optionRef.bind(this, index)}
-          {...rest}
-        >
-          {renderOption ? renderOption(option, searchValue) : (
-            <EuiHighlight search={searchValue}>{label}</EuiHighlight>
-          )}
-        </EuiComboBoxOption>
+    console.log(matchingOptions.length);
+    if (matchingOptions.length > 10) {
+      optionsList = (
+        <List
+          width={400}
+          height={200}
+          rowCount={matchingOptions.length} // plus number of group labels
+          rowHeight={27}
+          rowRenderer={({ key, index, style }) => {
+            const option = matchingOptions[index];
+            const {
+              value, // eslint-disable-line no-unused-vars
+              label,
+              ...rest
+            } = option;
+            return (
+              <div key={key} style={style}>
+                <EuiComboBoxOption
+                  option={option}
+                  key={option.label.toLowerCase()}
+                  onClick={onOptionClick}
+                  onEnterKey={onOptionEnterKey}
+                  optionRef={optionRef.bind(this, index)}
+                  {...rest}
+                >
+                  {renderOption ? renderOption(option, searchValue) : (
+                    <EuiHighlight search={searchValue}>{label}</EuiHighlight>
+                  )}
+                </EuiComboBoxOption>
+              </div>
+            );
+          }}
+        />
       );
+    } else {
+      optionsList = [];
 
-      optionsList.push(renderedOption);
-    });
+      matchingOptions.forEach((option, index) => {
+        const {
+          value, // eslint-disable-line no-unused-vars
+          label,
+          ...rest
+        } = option;
+
+        const group = optionToGroupMap.get(option);
+
+        if (group && !groupLabelToGroupMap[group.label]) {
+          groupLabelToGroupMap[group.label] = true;
+          optionsList.push(
+            <EuiComboBoxTitle key={`group-${group.label}`}>
+              {group.label}
+            </EuiComboBoxTitle>
+          );
+        }
+
+        const renderedOption = (
+          <EuiComboBoxOption
+            option={option}
+            key={option.label.toLowerCase()}
+            onClick={onOptionClick}
+            onEnterKey={onOptionEnterKey}
+            optionRef={optionRef.bind(this, index)}
+            {...rest}
+          >
+            {renderOption ? renderOption(option, searchValue) : (
+              <EuiHighlight search={searchValue}>{label}</EuiHighlight>
+            )}
+          </EuiComboBoxOption>
+        );
+
+        optionsList.push(renderedOption);
+      });
+    }
 
     const classes = classNames('euiComboBoxOptionsList', positionToClassNameMap[position]);
 

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
@@ -41,6 +41,11 @@ export class EuiComboBoxOptionsList extends Component {
     width: PropTypes.number,
     scrollToIndex: PropTypes.number,
     onScroll: PropTypes.func,
+    rowHeight: PropTypes.number,
+  }
+
+  static defaultProps = {
+    rowHeight: 27, // row height of default option renderer
   }
 
   updatePosition = () => {
@@ -103,6 +108,7 @@ export class EuiComboBoxOptionsList extends Component {
       width,
       scrollToIndex,
       onScroll,
+      rowHeight,
       ...rest
     } = this.props;
 
@@ -149,7 +155,7 @@ export class EuiComboBoxOptionsList extends Component {
       </EuiText>
     ) : undefined;
 
-    const optionHeight = 27; // TODO dynamically figure this out
+    const optionHeight = rowHeight;
     const numVisibleOptions = matchingOptions.length < 7 ? matchingOptions.length : 7;
     const height = numVisibleOptions * optionHeight;
 

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
@@ -39,6 +39,8 @@ export class EuiComboBoxOptionsList extends Component {
     listRef: PropTypes.func.isRequired,
     renderOption: PropTypes.func,
     width: PropTypes.number,
+    scrollToIndex: PropTypes.number,
+    onScroll: PropTypes.func,
   }
 
   updatePosition = () => {
@@ -99,6 +101,8 @@ export class EuiComboBoxOptionsList extends Component {
       listRef, // eslint-disable-line no-unused-vars
       updatePosition, // eslint-disable-line no-unused-vars
       width,
+      scrollToIndex,
+      onScroll,
       ...rest
     } = this.props;
 
@@ -155,6 +159,8 @@ export class EuiComboBoxOptionsList extends Component {
         height={height}
         rowCount={matchingOptions.length}
         rowHeight={optionHeight}
+        scrollToIndex={scrollToIndex}
+        onScroll={onScroll}
         rowRenderer={({ key, index, style }) => {
           const option = matchingOptions[index];
           const {

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
@@ -27,7 +27,6 @@ export class EuiComboBoxOptionsList extends Component {
     onCreateOption: PropTypes.func,
     searchValue: PropTypes.string,
     matchingOptions: PropTypes.array,
-    optionToGroupMap: PropTypes.object,
     optionRef: PropTypes.func,
     onOptionClick: PropTypes.func,
     onOptionEnterKey: PropTypes.func,
@@ -93,7 +92,6 @@ export class EuiComboBoxOptionsList extends Component {
       onCreateOption,
       searchValue,
       matchingOptions,
-      optionToGroupMap,
       optionRef,
       onOptionClick,
       onOptionEnterKey,
@@ -155,79 +153,50 @@ export class EuiComboBoxOptionsList extends Component {
 
     let optionsList;
 
-    console.log(matchingOptions.length);
-    if (matchingOptions.length > 10) {
-      optionsList = (
-        <List
-          width={384}
-          height={184}
-          rowCount={matchingOptions.length} // plus number of group labels
-          rowHeight={27}
-          rowRenderer={({ key, index, style }) => {
-            const option = matchingOptions[index];
-            const {
-              value, // eslint-disable-line no-unused-vars
-              label,
-              ...rest
-            } = option;
+    optionsList = (
+      <List
+        width={384}
+        height={184}
+        rowCount={matchingOptions.length} // plus number of group labels
+        rowHeight={27}
+        rowRenderer={({ key, index, style }) => {
+          const option = matchingOptions[index];
+          const {
+            value, // eslint-disable-line no-unused-vars
+            label,
+            isGroupLabelOption,
+            ...rest
+          } = option;
+
+          if (isGroupLabelOption) {
             return (
               <div key={key} style={style}>
-                <EuiComboBoxOption
-                  option={option}
-                  key={option.label.toLowerCase()}
-                  onClick={onOptionClick}
-                  onEnterKey={onOptionEnterKey}
-                  optionRef={optionRef.bind(this, index)}
-                  {...rest}
-                >
-                  {renderOption ? renderOption(option, searchValue) : (
-                    <EuiHighlight search={searchValue}>{label}</EuiHighlight>
-                  )}
-                </EuiComboBoxOption>
+                <EuiComboBoxTitle>
+                  {label}
+                </EuiComboBoxTitle>
               </div>
             );
-          }}
-        />
-      );
-    } else {
-      optionsList = [];
+          }
 
-      matchingOptions.forEach((option, index) => {
-        const {
-          value, // eslint-disable-line no-unused-vars
-          label,
-          ...rest
-        } = option;
-
-        const group = optionToGroupMap.get(option);
-
-        if (group && !groupLabelToGroupMap[group.label]) {
-          groupLabelToGroupMap[group.label] = true;
-          optionsList.push(
-            <EuiComboBoxTitle key={`group-${group.label}`}>
-              {group.label}
-            </EuiComboBoxTitle>
+          return (
+            <div key={key} style={style}>
+              <EuiComboBoxOption
+                option={option}
+                key={option.label.toLowerCase()}
+                onClick={onOptionClick}
+                onEnterKey={onOptionEnterKey}
+                optionRef={optionRef.bind(this, index)}
+                {...rest}
+              >
+                {renderOption ? renderOption(option, searchValue) : (
+                  <EuiHighlight search={searchValue}>{label}</EuiHighlight>
+                )}
+              </EuiComboBoxOption>
+            </div>
           );
-        }
-
-        const renderedOption = (
-          <EuiComboBoxOption
-            option={option}
-            key={option.label.toLowerCase()}
-            onClick={onOptionClick}
-            onEnterKey={onOptionEnterKey}
-            optionRef={optionRef.bind(this, index)}
-            {...rest}
-          >
-            {renderOption ? renderOption(option, searchValue) : (
-              <EuiHighlight search={searchValue}>{label}</EuiHighlight>
-            )}
-          </EuiComboBoxOption>
-        );
-
-        optionsList.push(renderedOption);
-      });
-    }
+        }}
+      />
+    );
 
     const classes = classNames('euiComboBoxOptionsList', positionToClassNameMap[position]);
 

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
@@ -151,13 +151,11 @@ export class EuiComboBoxOptionsList extends Component {
 
     const groupLabelToGroupMap = {};
 
-    let optionsList;
-
-    optionsList = (
+    const optionsList = (
       <List
         width={384}
         height={184}
-        rowCount={matchingOptions.length} // plus number of group labels
+        rowCount={matchingOptions.length}
         rowHeight={27}
         rowRenderer={({ key, index, style }) => {
           const option = matchingOptions[index];

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
@@ -146,8 +146,8 @@ export class EuiComboBoxOptionsList extends Component {
     ) : undefined;
 
     const optionHeight = 27; // TODO dynamically figure this out
-    const numVisiableOptions = matchingOptions.length < 7 ? matchingOptions.length : 7;
-    const height = numVisiableOptions * optionHeight;
+    const numVisibleOptions = matchingOptions.length < 7 ? matchingOptions.length : 7;
+    const height = numVisibleOptions * optionHeight;
 
     const optionsList = (
       <List

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
@@ -37,7 +37,12 @@ export class EuiComboBoxOptionsList extends Component {
     position: PropTypes.oneOf(POSITIONS),
     listRef: PropTypes.func.isRequired,
     renderOption: PropTypes.func,
-    width: PropTypes.number.isRequired,
+    width: PropTypes.number,
+    height: PropTypes.number
+  }
+
+  static defaultProps = {
+    height: 200,
   }
 
   updatePosition = () => {
@@ -154,8 +159,8 @@ export class EuiComboBoxOptionsList extends Component {
     if (matchingOptions.length > 10) {
       optionsList = (
         <List
-          width={400}
-          height={200}
+          width={384}
+          height={184}
           rowCount={matchingOptions.length} // plus number of group labels
           rowHeight={27}
           rowRenderer={({ key, index, style }) => {

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
@@ -19,6 +19,8 @@ const positionToClassNameMap = {
 
 const POSITIONS = Object.keys(positionToClassNameMap);
 
+const OPTION_CONTENT_CLASSNAME = 'euiComboBoxOption__content';
+
 export class EuiComboBoxOptionsList extends Component {
   static propTypes = {
     options: PropTypes.array,
@@ -143,8 +145,6 @@ export class EuiComboBoxOptionsList extends Component {
       </EuiText>
     ) : undefined;
 
-    const groupLabelToGroupMap = {};
-
     const optionHeight = 27; // TODO dynamically figure this out
     const numVisiableOptions = matchingOptions.length < 7 ? matchingOptions.length : 7;
     const height = numVisiableOptions * optionHeight;
@@ -184,8 +184,8 @@ export class EuiComboBoxOptionsList extends Component {
                 optionRef={optionRef.bind(this, index)}
                 {...rest}
               >
-                {renderOption ? renderOption(option, searchValue) : (
-                  <EuiHighlight search={searchValue}>{label}</EuiHighlight>
+                {renderOption ? renderOption(option, searchValue, OPTION_CONTENT_CLASSNAME) : (
+                  <EuiHighlight search={searchValue} className={OPTION_CONTENT_CLASSNAME}>{label}</EuiHighlight>
                 )}
               </EuiComboBoxOption>
             </div>

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
@@ -155,16 +155,15 @@ export class EuiComboBoxOptionsList extends Component {
       </EuiText>
     ) : undefined;
 
-    const optionHeight = rowHeight;
     const numVisibleOptions = matchingOptions.length < 7 ? matchingOptions.length : 7;
-    const height = numVisibleOptions * optionHeight;
+    const height = numVisibleOptions * rowHeight;
 
     const optionsList = (
       <List
         width={width}
         height={height}
         rowCount={matchingOptions.length}
-        rowHeight={optionHeight}
+        rowHeight={rowHeight}
         scrollToIndex={scrollToIndex}
         onScroll={onScroll}
         rowRenderer={({ key, index, style }) => {

--- a/src/components/combo_box/matching_options.js
+++ b/src/components/combo_box/matching_options.js
@@ -40,18 +40,23 @@ const collectMatchingOption = (accumulator, option, selectedOptions, normalizedS
 
 export const getMatchingOptions = (options, selectedOptions, searchValue, isPreFiltered) => {
   const normalizedSearchValue = searchValue.trim().toLowerCase();
-  const optionToGroupMap = new Map();
   const matchingOptions = [];
 
   options.forEach(option => {
     if (option.options) {
+      const matchingOptionsForGroup = [];
       option.options.forEach(groupOption => {
-        optionToGroupMap.set(groupOption, option)
-        collectMatchingOption(matchingOptions, groupOption, selectedOptions, normalizedSearchValue, isPreFiltered);
-      })
+        collectMatchingOption(matchingOptionsForGroup, groupOption, selectedOptions, normalizedSearchValue, isPreFiltered);
+      });
+      if (matchingOptionsForGroup.length > 0) {
+        // Add option for group label
+        matchingOptions.push({ label: option.label, isGroupLabelOption: true });
+        // Add matching options for group
+        matchingOptions.push(...matchingOptionsForGroup);
+      }
     } else {
       collectMatchingOption(matchingOptions, option, selectedOptions, normalizedSearchValue, isPreFiltered);
     }
   });
-  return { optionToGroupMap, matchingOptions };
+  return matchingOptions;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1653,7 +1653,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5:
+classnames@^2.2.3, classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
@@ -2435,6 +2435,10 @@ dom-converter@~0.1:
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.1.4.tgz#a45ef5727b890c9bffe6d7c876e7b19cb0e17f3b"
   dependencies:
     utila "~0.3"
+
+"dom-helpers@^2.4.0 || ^3.0.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
 dom-serializer@0, dom-serializer@^0.1.0, dom-serializer@~0.1.0:
   version "0.1.0"
@@ -5429,7 +5433,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -7283,6 +7287,16 @@ react-test-renderer@^16.0.0-0, react-test-renderer@^16.2.0:
   dependencies:
     fbjs "^0.8.16"
     object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
+react-virtualized@^9.18.5:
+  version "9.18.5"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.18.5.tgz#42dd390ebaa7ea809bfcaf775d39872641679b89"
+  dependencies:
+    babel-runtime "^6.26.0"
+    classnames "^2.2.3"
+    dom-helpers "^2.4.0 || ^3.0.0"
+    loose-envify "^1.3.0"
     prop-types "^15.6.0"
 
 react@^16.2.0:


### PR DESCRIPTION
fixes https://github.com/elastic/eui/issues/651

paired with @cjcenizal to convert EuiComboBox rendering to use react-virtualized. 

Rendering long lists was really slow because each list item was added to the DOM. With virtualization, only the list items that are visible in the EuiComboBoxOptionsList panel are in the DOM and there is great performance for large lists.