### PR TITLE
Step status props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `0.0.42`.
+- Added `status` prop to `EuiStep` for additional styling ([#673](https://github.com/elastic/eui/pull/673))
 
 ## [`0.0.42`](https://github.com/elastic/eui/tree/v0.0.42)
 

--- a/src-docs/src/views/steps/status.js
+++ b/src-docs/src/views/steps/status.js
@@ -1,0 +1,69 @@
+
+import React, {
+  Component,
+  Fragment,
+} from 'react';
+
+import {
+  EuiSpacer,
+  EuiSteps,
+  EuiButton,
+} from '../../../../src/components';
+
+export default class extends Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      status: 'incomplete',
+    };
+
+    this.handleComplete = this.handleComplete.bind(this);
+  }
+
+  handleComplete() {
+    this.setState({
+      status: 'complete',
+    });
+  }
+
+  render() {
+
+    let button;
+    if (this.state.status === "incomplete") {
+      button = (
+        <EuiButton onClick={this.handleComplete}>You complete me</EuiButton>
+      );
+    }
+
+    const firstSetOfSteps = [
+      {
+        title: 'Normal step',
+        children: <p>Do this first</p>,
+      },
+      {
+        title: 'Push the button to complete this final step',
+        children: (
+          <Fragment>
+            <p>
+              I am a fancy button just waiting to be pushed!
+            </p>
+            <EuiSpacer />
+            {button}
+          </Fragment>
+        ),
+        status: this.state.status,
+      },
+    ];
+
+    return (
+      <div>
+        <EuiSteps
+          steps={firstSetOfSteps}
+        />
+
+      </div>
+    );
+  }
+}

--- a/src-docs/src/views/steps/steps_example.js
+++ b/src-docs/src/views/steps/steps_example.js
@@ -27,6 +27,10 @@ import StepsHorizontal from './steps_horizontal';
 const stepsHorizontalSource = require('!!raw-loader!./steps_horizontal');
 const stepsHorizontalHtml = renderToHtml(StepsHorizontal);
 
+import Status from './status';
+const statusSource = require('!!raw-loader!./status');
+const statusHtml = renderToHtml(Steps);
+
 export const StepsExample = {
   title: 'Steps',
   sections: [{
@@ -86,6 +90,24 @@ export const StepsExample = {
       </div>
     ),
     demo: <HeadingElementSteps />,
+  },
+  {
+    title: 'Steps status',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: statusSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: statusHtml,
+    }],
+    text: (
+      <p>
+        Steps can optionally include <EuiCode>status</EuiCode> prop with
+        a value of <EuiCode>complete</EuiCode> or <EuiCode>incomplete</EuiCode>. This
+        is used mostly as a final step when you need to make some sort of final check.
+      </p>
+    ),
+    demo: <Status />,
   },
   {
     title: 'Horizontal',

--- a/src-docs/src/views/steps/steps_example.js
+++ b/src-docs/src/views/steps/steps_example.js
@@ -9,6 +9,7 @@ import {
 import {
   EuiCode,
   EuiSteps,
+  EuiStep,
 } from '../../../../src/components';
 
 import Steps from './steps';
@@ -46,7 +47,7 @@ export const StepsExample = {
         Numbered steps
       </p>
     ),
-    props: { EuiSteps },
+    props: { EuiSteps, EuiStep },
     demo: <Steps />,
   },
   {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -234,6 +234,7 @@ export {
 } from './spacer';
 
 export {
+  EuiStep,
   EuiSteps,
   EuiSubSteps,
   EuiStepsHorizontal,

--- a/src/components/steps/__snapshots__/step.test.js.snap
+++ b/src/components/steps/__snapshots__/step.test.js.snap
@@ -11,9 +11,13 @@ exports[`EuiStep is rendered 1`] = `
   >
     Step
   </span>
+  <div
+    class="euiStep__circle"
+  >
+    1
+  </div>
   <h3
     class="euiTitle euiTitle--small euiStep__title"
-    data-step-num="1"
   >
     First step
   </h3>

--- a/src/components/steps/__snapshots__/steps.test.js.snap
+++ b/src/components/steps/__snapshots__/steps.test.js.snap
@@ -14,9 +14,13 @@ exports[`EuiSteps renders step title inside "headingElement" element 1`] = `
     >
       Step
     </span>
+    <div
+      class="euiStep__circle"
+    >
+      1
+    </div>
     <h2
       class="euiTitle euiTitle--small euiStep__title"
-      data-step-num="1"
     >
       first title
     </h2>
@@ -36,9 +40,13 @@ exports[`EuiSteps renders step title inside "headingElement" element 1`] = `
     >
       Step
     </span>
+    <div
+      class="euiStep__circle"
+    >
+      2
+    </div>
     <h2
       class="euiTitle euiTitle--small euiStep__title"
-      data-step-num="2"
     >
       second title
     </h2>
@@ -58,9 +66,13 @@ exports[`EuiSteps renders step title inside "headingElement" element 1`] = `
     >
       Step
     </span>
+    <div
+      class="euiStep__circle"
+    >
+      3
+    </div>
     <h2
       class="euiTitle euiTitle--small euiStep__title"
-      data-step-num="3"
     >
       third title
     </h2>
@@ -89,9 +101,13 @@ exports[`EuiSteps renders steps 1`] = `
     >
       Step
     </span>
+    <div
+      class="euiStep__circle"
+    >
+      1
+    </div>
     <p
       class="euiTitle euiTitle--small euiStep__title"
-      data-step-num="1"
     >
       first title
     </p>
@@ -111,9 +127,13 @@ exports[`EuiSteps renders steps 1`] = `
     >
       Step
     </span>
+    <div
+      class="euiStep__circle"
+    >
+      2
+    </div>
     <p
       class="euiTitle euiTitle--small euiStep__title"
-      data-step-num="2"
     >
       second title
     </p>
@@ -133,9 +153,13 @@ exports[`EuiSteps renders steps 1`] = `
     >
       Step
     </span>
+    <div
+      class="euiStep__circle"
+    >
+      3
+    </div>
     <p
       class="euiTitle euiTitle--small euiStep__title"
-      data-step-num="3"
     >
       third title
     </p>
@@ -164,9 +188,13 @@ exports[`EuiSteps renders steps with firstStepNumber 1`] = `
     >
       Step
     </span>
+    <div
+      class="euiStep__circle"
+    >
+      10
+    </div>
     <p
       class="euiTitle euiTitle--small euiStep__title"
-      data-step-num="10"
     >
       first title
     </p>
@@ -186,9 +214,13 @@ exports[`EuiSteps renders steps with firstStepNumber 1`] = `
     >
       Step
     </span>
+    <div
+      class="euiStep__circle"
+    >
+      11
+    </div>
     <p
       class="euiTitle euiTitle--small euiStep__title"
-      data-step-num="11"
     >
       second title
     </p>
@@ -208,9 +240,13 @@ exports[`EuiSteps renders steps with firstStepNumber 1`] = `
     >
       Step
     </span>
+    <div
+      class="euiStep__circle"
+    >
+      12
+    </div>
     <p
       class="euiTitle euiTitle--small euiStep__title"
-      data-step-num="12"
     >
       third title
     </p>

--- a/src/components/steps/_steps.scss
+++ b/src/components/steps/_steps.scss
@@ -25,7 +25,7 @@
     }
 
     &.euiStep__circle--complete {
-      animation: euiGrow $euiAnimSpeedFast ease-in;
+      animation: euiGrow $euiAnimSpeedFast $euiAnimSlightBounce;
     }
 
     .euiStep__circleIcon {

--- a/src/components/steps/_steps.scss
+++ b/src/components/steps/_steps.scss
@@ -12,16 +12,31 @@
     line-height: $euiStepNumberSize; /* 1 */
   }
 
+  .euiStep__circle {
+    @include createStepsNumber();
+
+    margin-right: $euiStepNumberMargin;
+    vertical-align: top; /* 1 */
+
+    &.euiStep__circle--incomplete {
+      background-color: transparent;
+      border: solid 2px $euiColorPrimary;
+      color: $euiColorDarkShade;
+    }
+
+    &.euiStep__circle--complete {
+      animation: euiGrow $euiAnimSpeedFast ease-in;
+    }
+
+    .euiStep__circleIcon {
+      position: relative;
+      top: -2px;
+    }
+  }
+
   .euiStep__title {
     font-weight: $euiFontWeightMedium;
-
-    &::before {
-      content: attr(data-step-num); // Get the number from the data attribute
-      @include createStepsNumber();
-
-      margin-right: $euiStepNumberMargin;
-      vertical-align: top; /* 1 */
-    }
+    display: inline-block;
   }
 
   .euiStep__content {
@@ -36,4 +51,3 @@
     margin-left: ($euiStepNumberSize/2) - 1px;
   }
 }
-

--- a/src/components/steps/index.js
+++ b/src/components/steps/index.js
@@ -1,4 +1,8 @@
 export {
+  EuiStep,
+} from './step';
+
+export {
   EuiSteps,
 } from './steps';
 

--- a/src/components/steps/step.js
+++ b/src/components/steps/step.js
@@ -10,15 +10,35 @@ import {
   EuiTitle,
 } from '../title';
 
+import {
+  EuiIcon,
+} from '../icon';
+
 export const EuiStep = ({
   className,
   children,
   headingElement,
   step,
   title,
+  status,
   ...rest
 }) => {
   const classes = classNames('euiStep', className);
+  const circleClasses = classNames(
+    'euiStep__circle',
+    {
+      'euiStep__circle--complete': (status === "complete"),
+      'euiStep__circle--incomplete': (status === "incomplete"),
+    }
+  );
+
+  let numberOrIcon;
+  if (status === "complete") {
+      numberOrIcon = <EuiIcon type="check" color="ghost" className="euiStep__circleIcon" />;
+  } else if (status !== "incomplete") {
+    numberOrIcon = step;
+  }
+
   return (
     <div
       className={classes}
@@ -27,7 +47,11 @@ export const EuiStep = ({
 
       <EuiScreenReaderOnly><span>Step</span></EuiScreenReaderOnly>
 
-      <EuiTitle size="s" className="euiStep__title" data-step-num={step}>
+      <div className={circleClasses}>
+        {numberOrIcon}
+      </div>
+
+      <EuiTitle size="s" className="euiStep__title">
         {React.createElement(headingElement, null, title)}
       </EuiTitle>
 

--- a/src/components/steps/step.js
+++ b/src/components/steps/step.js
@@ -65,8 +65,18 @@ export const EuiStep = ({
 
 EuiStep.propTypes = {
   children: PropTypes.node.isRequired,
+  /**
+   * Will replace the number provided in props.step with alternate styling
+   */
+  status: PropTypes.oneOf(['complete', 'incomplete']),
+  /**
+   * The number of the step in the list of steps
+   */
   step: PropTypes.number.isRequired,
   title: PropTypes.string.isRequired,
+  /**
+   * The HTML tag used for the title
+   */
   headingElement: PropTypes.string.isRequired,
 };
 

--- a/src/components/steps/steps.js
+++ b/src/components/steps/steps.js
@@ -9,6 +9,7 @@ function renderSteps(steps, firstStepNumber, headingElement) {
       className,
       children,
       title,
+      status,
       ...rest
     } = step;
 
@@ -19,6 +20,7 @@ function renderSteps(steps, firstStepNumber, headingElement) {
         headingElement={headingElement}
         step={firstStepNumber + index}
         title={title}
+        status={status}
         {...rest}
       >
         {children}

--- a/src/components/steps/steps.js
+++ b/src/components/steps/steps.js
@@ -55,8 +55,17 @@ const stepPropType = PropTypes.shape({
 
 EuiSteps.propTypes = {
   className: PropTypes.string,
+  /**
+   * The number the steps should begin from
+   */
   firstStepNumber: PropTypes.number,
+  /**
+   * The HTML tag used for the title
+   */
   headingElement: PropTypes.string,
+  /**
+   * An array of individal step objects
+   */
   steps: PropTypes.arrayOf(stepPropType).isRequired,
 };
 


### PR DESCRIPTION
Closes https://github.com/elastic/eui/issues/667

Adds a status prop from `EuiSteps` and `EuiStep`. This allows it to have some different styling for last item checks. Pretty sure this styling originally came from @formgeist so I kept it as is and just added a bit of animation.

@nreese if you're in a hurry with this, we can merge it, but expect @cchaos to possibly tweak the styling later.

![](https://d3vv6lp55qjaqc.cloudfront.net/items/3h201j0P0l1X1Z3C0a1u/Screen%20Recording%202018-04-13%20at%2003.54%20PM.gif?X-CloudApp-Visitor-Id=59773&v=064094c8)