### PR TITLE
Bottom bar padding and optional body class

### DIFF
--- a/src/components/bottom_bar/bottom_bar.js
+++ b/src/components/bottom_bar/bottom_bar.js
@@ -1,4 +1,6 @@
-import React from 'react';
+import React, {
+  Component,
+} from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -13,33 +15,66 @@ const paddingSizeToClassNameMap = {
 
 export const PADDING_SIZES = Object.keys(paddingSizeToClassNameMap);
 
-export const EuiBottomBar = ({
-  children,
-  className,
-  paddingSize,
-  ...rest
-}) => {
-  const classes = classNames(
-    'euiBottomBar',
-    paddingSizeToClassNameMap[paddingSize],
-    className
-  );
+export class EuiBottomBar extends Component {
 
-  return (
-    <EuiPortal>
-      <div
-        className={classes}
-        {...rest}
-      >
-        {children}
-      </div>
-    </EuiPortal>
-  );
-};
+  componentDidMount() {
+    const height = this.bar.clientHeight;
+    document.body.style.paddingBottom= `${height}px`;
+    if (this.props.bodyClassName) {
+      document.body.classList.add(this.props.bodyClassName);
+    }
+  }
+
+  componentWillUnmount() {
+    document.body.style.paddingBottom = null;
+    if (this.props.bodyClassName) {
+      document.body.classList.remove(this.props.bodyClassName);
+    }
+  }
+
+  render() {
+    const {
+      children,
+      className,
+      paddingSize,
+      // eslint-disable-next-line no-unused-vars
+      bodyClassName,
+      ...rest
+    } = this.props;
+
+    const classes = classNames(
+      'euiBottomBar',
+      paddingSizeToClassNameMap[paddingSize],
+      className
+    );
+
+    return (
+      <EuiPortal>
+        <div
+          className={classes}
+          ref={node => { this.bar = node; }}
+          {...rest}
+        >
+          {children}
+        </div>
+      </EuiPortal>
+    );
+  };
+}
 
 EuiBottomBar.propTypes = {
   children: PropTypes.node,
+  /**
+   * Optional class applied to the bar iteself
+   */
   className: PropTypes.string,
+  /**
+   * Optional class applied to the body class
+   */
+  bodyClassName: PropTypes.string,
+  /**
+   * Padding applied to the bar
+   */
   paddingSize: PropTypes.oneOf(PADDING_SIZES),
 };
 


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/663

`EuiBottomBar` will now apply a bottom padding to the body that is the size of the bar itself. Since a user might also have fixed controls (like the docs sidenav for example), I made it so you can also attach a `bodyClassName` to the body when it is mounted. This should allow people to make any sort of style adjustments they need when the bar pops up.