### PR TITLE
Add support for nodes as a proptype for errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added `status` prop to `EuiStep` for additional styling ([#673](https://github.com/elastic/eui/pull/673))
+- Add support for node as a proptype for EuiForm and EuiFormRow errors. ([#685](https://github.com/elastic/eui/pull/685))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added `status` prop to `EuiStep` for additional styling ([#673](https://github.com/elastic/eui/pull/673))
-- Add support for node as a proptype for EuiForm and EuiFormRow errors. ([#685](https://github.com/elastic/eui/pull/685))
+- `EuiForm` and `EuiFormRow` now accept nodes for `errors` prop ([#685](https://github.com/elastic/eui/pull/685))
 
 **Bug fixes**
 

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -54,5 +54,5 @@ export const EuiForm = ({
 
 EuiForm.propTypes = {
   isInvalid: PropTypes.bool,
-  error: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  error: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string), PropTypes.node]),
 };

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -54,5 +54,5 @@ export const EuiForm = ({
 
 EuiForm.propTypes = {
   isInvalid: PropTypes.bool,
-  error: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string), PropTypes.node]),
+  error: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
 };

--- a/src/components/form/form_row/form_row.js
+++ b/src/components/form/form_row/form_row.js
@@ -150,7 +150,7 @@ EuiFormRow.propTypes = {
   label: PropTypes.node,
   id: PropTypes.string,
   isInvalid: PropTypes.bool,
-  error: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string), PropTypes.node]),
+  error: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   helpText: PropTypes.node,
   hasEmptyLabelSpace: PropTypes.bool,
   fullWidth: PropTypes.bool,

--- a/src/components/form/form_row/form_row.js
+++ b/src/components/form/form_row/form_row.js
@@ -150,7 +150,7 @@ EuiFormRow.propTypes = {
   label: PropTypes.node,
   id: PropTypes.string,
   isInvalid: PropTypes.bool,
-  error: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  error: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string), PropTypes.node]),
   helpText: PropTypes.node,
   hasEmptyLabelSpace: PropTypes.bool,
   fullWidth: PropTypes.bool,


### PR DESCRIPTION
I've been getting a few of these warnings while running tests in Cloud. 

![screen shot 2018-04-18 at 11 28 19 am](https://user-images.githubusercontent.com/305167/38945574-dca57d1a-4304-11e8-9068-76ed1fa0fc9d.png)

They're being caused because the error passed is a node (rather than the currently accepted string or array of strings. I spoke to @pugnascotia and @cjcenizal who agreed that we should allow node as a PropType too. 