### PR TITLE
Adds paddingSize prop to EuiAccordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Added support for text alignment with `EuiTextAlign` ([#683](https://github.com/elastic/eui/pull/683))
 - `EuiBasicTable` added the `compressed` prop to allow for tables with smaller fonts and padding.  ([#687](https://github.com/elastic/eui/pull/687))
 
+**Bug fixes**
+
+- Added a `paddingSize` prop to `EuiAccordion` to better mitigate situations where a nested `EuiFlexGroup` causes scrollbars ([#701](https://github.com/elastic/eui/pull/701))
+
 **Breaking changes**
 
 - Added responsive support for tables. This isn't technically a breaking change, but you will need to apply some new props (`hasActions`, `isSelectable`) for certain tables to make them look their best in mobile. **Responsive table views are on by default.**  ([#584](https://github.com/elastic/eui/pull/584))

--- a/src-docs/src/views/accordion/accordion.js
+++ b/src-docs/src/views/accordion/accordion.js
@@ -23,7 +23,8 @@ export default () => (
 
     <EuiAccordion
       id="accordion2"
-      buttonContent="You can click me as well"
+      buttonContent="An accordion with some padding applied through props"
+      paddingSize="l"
     >
       <EuiText>
         <p>The content inside can be of any height.</p>

--- a/src-docs/src/views/accordion/accordion_example.js
+++ b/src-docs/src/views/accordion/accordion_example.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 
 import { renderToHtml } from '../../services';
 
@@ -9,6 +9,8 @@ import {
 import {
   EuiAccordion,
   EuiCode,
+  EuiCallOut,
+  EuiSpacer,
 } from '../../../../src/components';
 
 import Accordion from './accordion';
@@ -33,6 +35,23 @@ const accordionGrowHtml = renderToHtml(AccordionGrow);
 
 export const AccordionExample = {
   title: 'Accordion',
+  intro: (
+    <Fragment>
+      <EuiCallOut
+        title="Take care including flex group content within accordions"
+      >
+        <p>
+          <EuiCode>EuiFlexGroup</EuiCode>&apos;s negative margins can sometimes
+          create scrollbars within <EuiCode>EuiAccordion</EuiCode> because of
+          the overflow tricks the used to hide content. If you run into this issue make
+          sure your <EuiCode>paddingSize</EuiCode> prop is large enough to account for
+          the <EuiCode>gutterSize</EuiCode> of any nested flex groups.
+        </p>
+      </EuiCallOut>
+
+      <EuiSpacer size="l" />
+    </Fragment>
+  ),
   sections: [{
     title: 'Unstyled',
     source: [{

--- a/src-docs/src/views/accordion/accordion_extra.js
+++ b/src-docs/src/views/accordion/accordion_extra.js
@@ -10,6 +10,7 @@ export default () => (
     id="accordionExtra"
     buttonContent="Click to open"
     extraAction={<EuiButton size="s">Extra action!</EuiButton>}
+    paddingSize="l"
   >
     <div>Opened content.</div>
   </EuiAccordion>

--- a/src-docs/src/views/accordion/accordion_form.js
+++ b/src-docs/src/views/accordion/accordion_form.js
@@ -89,9 +89,7 @@ export default () => (
       buttonContent={buttonContent}
       extraAction={extraAction}
     >
-      <div className="euiAccordionForm__children">
-        {repeatableForm}
-      </div>
+      {repeatableForm}
     </EuiAccordion>
 
     <EuiAccordion
@@ -101,9 +99,7 @@ export default () => (
       buttonContent={buttonContent}
       extraAction={extraAction}
     >
-      <div className="euiAccordionForm__children">
-        {repeatableForm}
-      </div>
+      {repeatableForm}
     </EuiAccordion>
   </div>
 );

--- a/src-docs/src/views/accordion/accordion_form.js
+++ b/src-docs/src/views/accordion/accordion_form.js
@@ -88,6 +88,7 @@ export default () => (
       buttonClassName="euiAccordionForm__button"
       buttonContent={buttonContent}
       extraAction={extraAction}
+      paddingSize="l"
     >
       {repeatableForm}
     </EuiAccordion>
@@ -98,6 +99,7 @@ export default () => (
       buttonClassName="euiAccordionForm__button"
       buttonContent={buttonContent}
       extraAction={extraAction}
+      paddingSize="l"
     >
       {repeatableForm}
     </EuiAccordion>

--- a/src-docs/src/views/accordion/accordion_grow.js
+++ b/src-docs/src/views/accordion/accordion_grow.js
@@ -24,6 +24,7 @@ class AccordionGrow extends Component {
         id="accordion1"
         buttonContent="Click me to toggle close / open"
         initialIsOpen={true}
+        paddingSize="l"
       >
         <EuiText>
           <EuiSpacer size='s' />

--- a/src-docs/src/views/accordion/accordion_open.js
+++ b/src-docs/src/views/accordion/accordion_open.js
@@ -13,6 +13,7 @@ export default () => (
       id="accordion1"
       buttonContent="I am opened by default. Click me to toggle close / open"
       initialIsOpen={true}
+      paddingSize="l"
     >
       <EuiText>
         <p>Any content inside of <EuiCode>EuiAccordion</EuiCode> will appear here.</p>

--- a/src/components/accordion/__snapshots__/accordion.test.js.snap
+++ b/src/components/accordion/__snapshots__/accordion.test.js.snap
@@ -4,7 +4,7 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
 <EuiAccordion
   id="6"
   initialIsOpen={false}
-  paddingSize="l"
+  paddingSize="none"
 >
   <div
     className="euiAccordion"
@@ -119,7 +119,7 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
     >
       <div>
         <div
-          className="euiAccordion__padding--l"
+          className=""
         />
       </div>
     </div>
@@ -131,7 +131,7 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
 <EuiAccordion
   id="5"
   initialIsOpen={false}
-  paddingSize="l"
+  paddingSize="none"
 >
   <div
     className="euiAccordion euiAccordion-isOpen"
@@ -245,7 +245,7 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
     >
       <div>
         <div
-          className="euiAccordion__padding--l"
+          className=""
         />
       </div>
     </div>
@@ -310,7 +310,7 @@ exports[`EuiAccordion is rendered 1`] = `
   >
     <div>
       <div
-        class="euiAccordion__padding--l"
+        class=""
       />
     </div>
   </div>
@@ -376,7 +376,7 @@ exports[`EuiAccordion props buttonContent is rendered 1`] = `
   >
     <div>
       <div
-        class="euiAccordion__padding--l"
+        class=""
       />
     </div>
   </div>
@@ -438,7 +438,7 @@ exports[`EuiAccordion props buttonContentClassName is rendered 1`] = `
   >
     <div>
       <div
-        class="euiAccordion__padding--l"
+        class=""
       />
     </div>
   </div>
@@ -507,7 +507,7 @@ exports[`EuiAccordion props extraAction is rendered 1`] = `
   >
     <div>
       <div
-        class="euiAccordion__padding--l"
+        class=""
       />
     </div>
   </div>
@@ -568,7 +568,7 @@ exports[`EuiAccordion props initialIsOpen is rendered 1`] = `
   >
     <div>
       <div
-        class="euiAccordion__padding--l"
+        class=""
       >
         <p>
           You can see me.

--- a/src/components/accordion/__snapshots__/accordion.test.js.snap
+++ b/src/components/accordion/__snapshots__/accordion.test.js.snap
@@ -4,6 +4,7 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
 <EuiAccordion
   id="6"
   initialIsOpen={false}
+  paddingSize="l"
 >
   <div
     className="euiAccordion"
@@ -116,7 +117,11 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
       className="euiAccordion__childWrapper"
       id="6"
     >
-      <div />
+      <div>
+        <div
+          className="euiAccordion__padding--l"
+        />
+      </div>
     </div>
   </div>
 </EuiAccordion>
@@ -126,6 +131,7 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
 <EuiAccordion
   id="5"
   initialIsOpen={false}
+  paddingSize="l"
 >
   <div
     className="euiAccordion euiAccordion-isOpen"
@@ -237,7 +243,11 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
       className="euiAccordion__childWrapper"
       id="5"
     >
-      <div />
+      <div>
+        <div
+          className="euiAccordion__padding--l"
+        />
+      </div>
     </div>
   </div>
 </EuiAccordion>
@@ -298,7 +308,11 @@ exports[`EuiAccordion is rendered 1`] = `
     class="euiAccordion__childWrapper"
     id="0"
   >
-    <div />
+    <div>
+      <div
+        class="euiAccordion__padding--l"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -360,7 +374,11 @@ exports[`EuiAccordion props buttonContent is rendered 1`] = `
     class="euiAccordion__childWrapper"
     id="2"
   >
-    <div />
+    <div>
+      <div
+        class="euiAccordion__padding--l"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -418,7 +436,11 @@ exports[`EuiAccordion props buttonContentClassName is rendered 1`] = `
     class="euiAccordion__childWrapper"
     id="1"
   >
-    <div />
+    <div>
+      <div
+        class="euiAccordion__padding--l"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -483,7 +505,11 @@ exports[`EuiAccordion props extraAction is rendered 1`] = `
     class="euiAccordion__childWrapper"
     id="3"
   >
-    <div />
+    <div>
+      <div
+        class="euiAccordion__padding--l"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -541,9 +567,13 @@ exports[`EuiAccordion props initialIsOpen is rendered 1`] = `
     id="4"
   >
     <div>
-      <p>
-        You can see me.
-      </p>
+      <div
+        class="euiAccordion__padding--l"
+      >
+        <p>
+          You can see me.
+        </p>
+      </div>
     </div>
   </div>
 </div>

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -19,6 +19,7 @@
   overflow-y: hidden;
   transform: translatez(0);
   transition:
+    height $euiAnimSpeedNormal $euiAnimSlightResistance,
     opacity $euiAnimSpeedNormal $euiAnimSlightResistance
   ;
 }

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -19,9 +19,24 @@
   overflow-y: hidden;
   transform: translatez(0);
   transition:
-    height $euiAnimSpeedNormal $euiAnimSlightResistance,
     opacity $euiAnimSpeedNormal $euiAnimSlightResistance
   ;
+}
+
+$paddingSizes: (
+  xs: $euiSizeXS,
+  s: $euiSizeS,
+  m: $euiSize,
+  l: $euiSizeL,
+  xl: $euiSizeXL,
+);
+
+// Create button modifiders based upon the map.
+@each $name, $size in $paddingSizes {
+
+  .euiAccordion__padding--#{$name} {
+    padding: $size;
+  }
 }
 
 .euiAccordion.euiAccordion-isOpen {

--- a/src/components/accordion/_accordion_form.scss
+++ b/src/components/accordion/_accordion_form.scss
@@ -1,7 +1,3 @@
-.euiAccordionForm__children {
-  padding: $euiSizeL;
-}
-
 .euiAccordionForm__extraAction {
   opacity: 0;
   transition: opacity $euiAnimSpeedNormal $euiAnimSlightResistance;

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -161,7 +161,7 @@ EuiAccordion.propTypes = {
    */
   buttonContent: PropTypes.node,
   /**
-   * Will apear right aligned against the button. Useful for separate actions like deletions.
+   * Will appear right aligned against the button. Useful for separate actions like deletions.
    */
   extraAction: PropTypes.node,
   /**

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -171,7 +171,7 @@ EuiAccordion.propTypes = {
   /**
    * The padding around the exposed accordion content.
    */
-  paddingSize: PropTypes.string,
+  paddingSize: PropTypes.oneOf(PADDING_SIZES),
 };
 
 EuiAccordion.defaultProps = {

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -13,6 +13,17 @@ import {
   EuiFlexItem,
 } from '../flex';
 
+const paddingSizeToClassNameMap = {
+  none: null,
+  xs: 'euiAccordion__padding--xs',
+  s: 'euiAccordion__padding--s',
+  m: 'euiAccordion__padding--m',
+  l: 'euiAccordion__padding--l',
+  xl: 'euiAccordion__padding--xl',
+};
+
+export const PADDING_SIZES = Object.keys(paddingSizeToClassNameMap);
+
 export class EuiAccordion extends Component {
   constructor(props) {
     super(props);
@@ -45,16 +56,22 @@ export class EuiAccordion extends Component {
       buttonClassName,
       buttonContentClassName,
       extraAction,
+      paddingSize,
       initialIsOpen, // eslint-disable-line no-unused-vars
       ...rest
     } = this.props;
+
 
     const classes = classNames(
       'euiAccordion',
       {
         'euiAccordion-isOpen': this.state.isOpen,
       },
-      className
+      className,
+    );
+
+    const paddingClass = classNames(
+      paddingSizeToClassNameMap[paddingSize],
     );
 
     const buttonClasses = classNames(
@@ -115,7 +132,9 @@ export class EuiAccordion extends Component {
           id={id}
         >
           <div ref={node => { this.childContent = node; }}>
-            {children}
+            <div className={paddingClass}>
+              {children}
+            </div>
           </div>
         </div>
       </div>
@@ -124,15 +143,38 @@ export class EuiAccordion extends Component {
 }
 
 EuiAccordion.propTypes = {
+  /**
+   * The content of the exposed accordion.
+   */
   children: PropTypes.node,
   id: PropTypes.string.isRequired,
+  /**
+   * Class that will apply to the entire accordion.
+   */
   className: PropTypes.string,
+  /**
+   * Class that will apply to the trigger for the accordion.
+   */
   buttonContentClassName: PropTypes.string,
+  /**
+   * The content of the clickable trigger
+   */
   buttonContent: PropTypes.node,
+  /**
+   * Will apear right aligned against the button. Useful for separate actions like deletions.
+   */
   extraAction: PropTypes.node,
+  /**
+   * The accordion will start in the open state.
+   */
   initialIsOpen: PropTypes.bool,
+  /**
+   * The padding around the exposed accordion content.
+   */
+  paddingSize: PropTypes.string,
 };
 
 EuiAccordion.defaultProps = {
   initialIsOpen: false,
+  paddingSize: 'l',
 };

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -176,5 +176,5 @@ EuiAccordion.propTypes = {
 
 EuiAccordion.defaultProps = {
   initialIsOpen: false,
-  paddingSize: 'l',
+  paddingSize: 'none',
 };


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/695

This adds a new prop to `EuiAccordion` of `paddingSize` and accepts the usual array of named sizes. The issue @pugnascotia noticed happened because if you use a FlexGroup inside of an Accordion the negative margin will conflict with the accordions overflow attributes (which we use to hide the content). This causes a bunch of unnecessary scroll bars. Although I toyed with the idea of removing the negative margins from flexgroups entirely, they do have some really useful abilities that would be tough to replicate (wrapping an unknown amount of flexitems dynamically).

![image](https://user-images.githubusercontent.com/324519/39218650-9a8d17e6-47da-11e8-9cbc-e428a840beb5.png)

![image](https://user-images.githubusercontent.com/324519/39218730-f92cc788-47da-11e8-825c-507ce18b4192.png)
