### PR TITLE
 Fix inherited line-height of inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `0.0.43`.
+**Bug fixes**
+
+- Fix inherited `line-height` of inputs and buttons ([#702](https://github.com/elastic/eui/pull/702))
 
 ## [`0.0.43`](https://github.com/elastic/eui/tree/v0.0.43)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Bug fixes**
 
-- Fix inherited `line-height` of inputs and buttons ([#702](https://github.com/elastic/eui/pull/702))
+- Fixed inherited `line-height` of inputs and buttons ([#702](https://github.com/elastic/eui/pull/702))
 
 ## [`0.0.43`](https://github.com/elastic/eui/tree/v0.0.43)
 

--- a/src/components/form/_mixins.scss
+++ b/src/components/form/_mixins.scss
@@ -75,7 +75,6 @@
   border: none;
   font-size: $euiFontSizeS;
   font-family: $euiFontFamily;
-  line-height: normal;
   padding: $euiSizeM;
   color: $euiTextColor;
   background: $euiFormBackgroundColor;

--- a/src/components/form/_mixins.scss
+++ b/src/components/form/_mixins.scss
@@ -75,6 +75,7 @@
   border: none;
   font-size: $euiFontSizeS;
   font-family: $euiFontFamily;
+  line-height: normal;
   padding: $euiSizeM;
   color: $euiTextColor;
   background: $euiFormBackgroundColor;

--- a/src/global_styling/reset/_reset.scss
+++ b/src/global_styling/reset/_reset.scss
@@ -21,7 +21,6 @@ small, strike, strong, sub, sup, tt, var,
 b, u, i, center,
 dl, dt, dd, ol, ul, li,
 fieldset, form, label, legend,
-input, textarea, select, button,
 table, caption, tbody, tfoot, thead, tr, th, td,
 article, aside, canvas, details, embed,
 figure, figcaption, footer, header, hgroup,
@@ -33,6 +32,10 @@ time, mark, audio, video {
   font: inherit; /* 1 */
   font-family: inherit; /* 1 */
   vertical-align: baseline;
+}
+
+input, textarea, select, button {
+  font-family: inherit; /* 1 */
 }
 
 em {


### PR DESCRIPTION
`line-height: inherited` from reset.scss was making inputs get their line-height from their container, which we really only want it to remain “normal”

Before: 
<img width="448" alt="screen shot 2018-04-25 at 14 26 13 pm" src="https://user-images.githubusercontent.com/549577/39272030-c244d124-48a8-11e8-92fd-47df2ec0a45a.png">

After: 
<img width="434" alt="screen shot 2018-04-25 at 16 50 42 pm" src="https://user-images.githubusercontent.com/549577/39272059-d1a59586-48a8-11e8-95e7-da1fd7f86e11.png">
