### PR TITLE
Reduced EuiToast title to “xs” title size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Reduced `EuiToast` title size ([#703](https://github.com/elastic/eui/pull/703))
+
 **Bug fixes**
 
 - Fixed inherited `line-height` of inputs and buttons ([#702](https://github.com/elastic/eui/pull/702))

--- a/src/components/toast/_toast.scss
+++ b/src/components/toast/_toast.scss
@@ -89,7 +89,7 @@ $toastTypes: (
   }
 
   .euiToastHeader__title {
-    @include euiTitle("s");
+    @include euiTitle("xs");
     font-weight: $euiFontWeightLight;
   }
 


### PR DESCRIPTION
Before:
<img width="434" alt="screen shot 2018-04-25 at 17 09 37 pm" src="https://user-images.githubusercontent.com/549577/39272962-7991bf52-48ab-11e8-83d2-e8236d6877a9.png">


After:
<img width="401" alt="screen shot 2018-04-25 at 17 09 28 pm" src="https://user-images.githubusercontent.com/549577/39272964-7abddaa0-48ab-11e8-8576-5ebb690f8dde.png">

