### PR TITLE
Card theme title parity and margin fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug fixes**
 
 - Fixed inherited `line-height` of inputs and buttons ([#702](https://github.com/elastic/eui/pull/702))
+- Fixed card title sizing in K6 theme. ([#704](https://github.com/elastic/eui/pull/704))
 
 ## [`0.0.43`](https://github.com/elastic/eui/tree/v0.0.43)
 

--- a/src/components/card/__snapshots__/card.test.js.snap
+++ b/src/components/card/__snapshots__/card.test.js.snap
@@ -127,9 +127,6 @@ exports[`EuiCard is rendered 1`] = `
   data-test-subj="test subject string"
 >
   <span
-    class="euiCard__top"
-  />
-  <span
     class="euiCard__content"
   >
     <span

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -2,6 +2,7 @@
 @import "../panel/mixins";
 
 $euiCardSpacing: map-get($euiPanelPaddingModifiers, "paddingMedium");
+$euiCardTitleSize: 18px; // Hardcoded pixel value for theme parity.
 
 // Start with a base of EuiPanel styles
 @include euiPanel($selector: 'euiCard');
@@ -52,6 +53,7 @@ $euiCardSpacing: map-get($euiPanelPaddingModifiers, "paddingMedium");
 
 /**
  * 1. Footer is always at the bottom.
+ * 2. Footer is always at the bottom.
  */
 
 .euiCard__top {
@@ -79,14 +81,18 @@ $euiCardSpacing: map-get($euiPanelPaddingModifiers, "paddingMedium");
   }
 }
 
+// If an icon or image exists, add some space
+.euiCard__top + .euiCard__content {
+  margin-top: $euiSize;
+}
+
 .euiCard__content {
   flex-grow: 1; /* 1 */
 
   .euiCard__title {
     display: block;
-    margin-top: $euiCardSpacing;
-    @include euiTitle($euiFontSizeM);
-    font-weight: $euiFontWeightRegular;
+    @include euiTitle($euiCardTitleSize);
+    font-weight: $euiFontWeightMedium;
   }
 
   .euiCard__description {

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -53,7 +53,6 @@ $euiCardTitleSize: 18px; // Hardcoded pixel value for theme parity.
 
 /**
  * 1. Footer is always at the bottom.
- * 2. Footer is always at the bottom.
  */
 
 .euiCard__top {
@@ -83,7 +82,7 @@ $euiCardTitleSize: 18px; // Hardcoded pixel value for theme parity.
 
 // If an icon or image exists, add some space
 .euiCard__top + .euiCard__content {
-  margin-top: $euiSize;
+  margin-top: $euiCardSpacing;
 }
 
 .euiCard__content {

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -57,6 +57,16 @@ export const EuiCard = ({
     OuterElement = 'button';
   }
 
+  let optionalCardTop;
+  if (image || icon) {
+    optionalCardTop = (
+      <span className="euiCard__top">
+        {imageNode}
+        {iconNode}
+      </span>
+    );
+  }
+
   return (
     <OuterElement
       onClick={onClick}
@@ -64,10 +74,8 @@ export const EuiCard = ({
       href={href}
       {...rest}
     >
-      <span className="euiCard__top">
-        {imageNode}
-        {iconNode}
-      </span>
+
+      {optionalCardTop}
 
       <span className="euiCard__content">
         <EuiTitle className="euiCard__title">


### PR DESCRIPTION
This also fixes an issue with margins when no icon is used.

## before

![image](https://user-images.githubusercontent.com/324519/39275050-be7be18c-4898-11e8-820f-f24417d306a1.png)

## after

![image](https://user-images.githubusercontent.com/324519/39275059-c3a59928-4898-11e8-9a0c-417b30cc9eb6.png)
