### PR TITLE
Beta Badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `0.0.44`.
+- Added `EuiBetaBadge` for non-GA labelling including options to add it to `EuiCard` and `EuiKeyPadMenuItem` ([#705](https://github.com/elastic/eui/pull/705))
+
 
 ## [`0.0.44`](https://github.com/elastic/eui/tree/v0.0.44)
 

--- a/src-docs/src/views/badge/badge_example.js
+++ b/src-docs/src/views/badge/badge_example.js
@@ -100,7 +100,7 @@ export const BadgeExample = {
         </p>
         <p>
           They can also be used in conjunction
-          with <EuiLink href="/#/display/card">EuiCards</EuiLink> and EuiKeyPadMenuItems.
+          with <EuiLink href="/#/display/card">EuiCards</EuiLink> and <EuiLink href="/#/navigation/key-pad-menu">EuiKeyPadMenuItems</EuiLink>.
         </p>
       </div>
     ),

--- a/src-docs/src/views/badge/badge_example.js
+++ b/src-docs/src/views/badge/badge_example.js
@@ -96,7 +96,14 @@ export const BadgeExample = {
         <p>
           The <EuiCode>EuiBetaBadge</EuiCode> was created specifically to call out
           modules that are not in GA. Generally the labels used are &quot;Beta&quot; or &quot;Lab&quot;.
-          They require an extra <EuiCode>description</EuiCode> that will be presented in a tooltip.
+          They require an extra <EuiCode>tooltipContent</EuiCode> to describe the purpose of the badge.
+          You can pass an optional <EuiCode>title</EuiCode> prop to populate the tooltip title or html title
+          attribute but by default it will use the <EuiCode>label</EuiCode>.
+        </p>
+        <p>
+          If you pass in an <EuiCode>iconType</EuiCode>, only the icon will be used in the badge itself and
+          the label will be applied as the title. Only use an icon when attaching the beta badge to small
+          components like the EuiKeyPadMenuItem.
         </p>
         <p>
           They can also be used in conjunction

--- a/src-docs/src/views/badge/badge_example.js
+++ b/src-docs/src/views/badge/badge_example.js
@@ -9,6 +9,8 @@ import {
 import {
   EuiBadge,
   EuiCode,
+  EuiBetaBadge,
+  EuiLink,
 } from '../../../../src/components';
 
 import Badge from './badge';
@@ -22,6 +24,10 @@ const badgeWithIconHtml = renderToHtml(BadgeWithIcon);
 import BadgeButton from './badge_button';
 const badgeButtonSource = require('!!raw-loader!./badge_button');
 const badgeButtonHtml = renderToHtml(BadgeButton);
+
+import BetaBadge from './beta_badge';
+const betaBadgeSource = require('!!raw-loader!./beta_badge');
+const betaBadgeHtml = renderToHtml(BetaBadge);
 
 export const BadgeExample = {
   title: 'Badge',
@@ -76,5 +82,29 @@ export const BadgeExample = {
       </p>
     ),
     demo: <BadgeButton />,
+  }, {
+    title: 'Beta badge type',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: betaBadgeSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: betaBadgeHtml,
+    }],
+    text: (
+      <div>
+        <p>
+          The <EuiCode>EuiBetaBadge</EuiCode> was created specifically to call out
+          modules that are not in GA. Generally the labels used are &quot;Beta&quot; or &quot;Lab&quot;.
+          They require an extra <EuiCode>description</EuiCode> that will be presented in a tooltip.
+        </p>
+        <p>
+          They can also be used in conjunction
+          with <EuiLink href="/#/display/card">EuiCards</EuiLink> and EuiKeyPadMenuItems.
+        </p>
+      </div>
+    ),
+    props: { EuiBetaBadge },
+    demo: <BetaBadge />,
   }],
 };

--- a/src-docs/src/views/badge/beta_badge.js
+++ b/src-docs/src/views/badge/beta_badge.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import {
+  EuiBetaBadge,
+} from '../../../../src/components';
+
+export default () => (
+  <div>
+    <EuiBetaBadge label="Beta" description="This module is not GA. Please help us by reporting any bugs." />
+    &emsp;
+    <EuiBetaBadge label="Lab" description="This module is not GA. Please help us by reporting any bugs." />
+  </div>
+);

--- a/src-docs/src/views/badge/beta_badge.js
+++ b/src-docs/src/views/badge/beta_badge.js
@@ -2,12 +2,21 @@ import React from 'react';
 
 import {
   EuiBetaBadge,
+  EuiSpacer,
+  EuiTitle,
 } from '../../../../src/components';
 
 export default () => (
   <div>
-    <EuiBetaBadge label="Beta" description="This module is not GA. Please help us by reporting any bugs." />
+    <EuiBetaBadge label="Beta" tooltipContent="This module is not GA. Please help us by reporting any bugs." />
     &emsp;
-    <EuiBetaBadge label="Lab" description="This module is not GA. Please help us by reporting any bugs." />
+    <EuiBetaBadge label="Lab" title="Laboratory" tooltipContent="This module is not GA. Please help us by reporting any bugs." />
+    &emsp;
+    <EuiBetaBadge label="Lightening" iconType="bolt" />
+
+    <EuiSpacer />
+    <EuiTitle>
+      <h3>Beta badges will also line up nicely with titles <EuiBetaBadge label="Lab" tooltipContent="This module is not GA. Please help us by reporting any bugs." /></h3>
+    </EuiTitle>
   </div>
 );

--- a/src-docs/src/views/card/card_beta.js
+++ b/src-docs/src/views/card/card_beta.js
@@ -17,8 +17,8 @@ const cardNodes = icons.map(function (item, index) {
         icon={<EuiIcon size="xxl" type={`${item}App`} />}
         title={`Kibana ${item}`}
         description="Example of a card's description. Stick to one or two sentences."
-        betaLabel={badges[index]}
-        betaDescription={badges[index] ? "This module is not GA. Please help us by reporting any bugs." : undefined}
+        betaBadgeLabel={badges[index]}
+        betaBadgeTooltipContent={badges[index] ? "This module is not GA. Please help us by reporting any bugs." : undefined}
         onClick={() => window.alert('Card clicked')}
       />
     </EuiFlexItem>

--- a/src-docs/src/views/card/card_beta.js
+++ b/src-docs/src/views/card/card_beta.js
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import {
+  EuiCard,
+  EuiIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+} from '../../../../src/components';
+
+const icons = ['dashboard', 'monitoring', 'watches'];
+const badges = [null, 'Beta', 'Lab'];
+
+const cardNodes = icons.map(function (item, index) {
+  return (
+    <EuiFlexItem key={index}>
+      <EuiCard
+        icon={<EuiIcon size="xxl" type={`${item}App`} />}
+        title={`Kibana ${item}`}
+        description="Example of a card's description. Stick to one or two sentences."
+        betaLabel={badges[index]}
+        betaDescription={badges[index] ? "This module is not GA. Please help us by reporting any bugs." : undefined}
+        onClick={() => window.alert('Card clicked')}
+      />
+    </EuiFlexItem>
+  );
+});
+
+export default () => (
+  <EuiFlexGroup gutterSize="l">
+    {cardNodes}
+  </EuiFlexGroup>
+);

--- a/src-docs/src/views/card/card_example.js
+++ b/src-docs/src/views/card/card_example.js
@@ -23,6 +23,10 @@ import CardFooter from './card_footer';
 const cardFooterSource = require('!!raw-loader!./card_footer');
 const cardFooterHtml = renderToHtml(CardFooter);
 
+import CardBeta from './card_beta';
+const cardBetaSource = require('!!raw-loader!./card_beta');
+const cardBetaHtml = renderToHtml(CardBeta);
+
 export const CardExample = {
   title: 'Card',
   sections: [{
@@ -91,5 +95,24 @@ export const CardExample = {
     ),
     components: { EuiCard },
     demo: <CardFooter />,
+  },
+  {
+    title: 'Beta badge',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: cardBetaSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: cardBetaHtml,
+    }],
+    text: (
+      <p>
+        If the card links to or references a module that is not GA (beta, lab, etc),
+        you can add a <EuiCode>betaLabel</EuiCode> and <EuiCode>betaDescription</EuiCode> to
+        the card and it will properly create and position an <EuiCode>EuiBetaBadge</EuiCode>.
+      </p>
+    ),
+    components: { EuiCard },
+    demo: <CardBeta />,
   }],
 };

--- a/src-docs/src/views/card/card_example.js
+++ b/src-docs/src/views/card/card_example.js
@@ -108,8 +108,9 @@ export const CardExample = {
     text: (
       <p>
         If the card links to or references a module that is not GA (beta, lab, etc),
-        you can add a <EuiCode>betaLabel</EuiCode> and <EuiCode>betaDescription</EuiCode> to
-        the card and it will properly create and position an <EuiCode>EuiBetaBadge</EuiCode>.
+        you can add a <EuiCode>betaBadgeLabel</EuiCode> and <EuiCode>betaBadgeTooltipContent</EuiCode> to
+        the card and it will properly create and position an <EuiCode>EuiBetaBadge</EuiCode>. If you want to
+        change the title of the tooltip, supply a <EuiCode>betaBadgeTitle</EuiCode> prop.
       </p>
     ),
     components: { EuiCard },

--- a/src-docs/src/views/key_pad_menu/key_pad_beta.js
+++ b/src-docs/src/views/key_pad_menu/key_pad_beta.js
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import {
+  EuiIcon,
+  EuiKeyPadMenu,
+  EuiKeyPadMenuItem,
+} from '../../../../src/components';
+
+export default () => (
+  <EuiKeyPadMenu>
+    <EuiKeyPadMenuItem
+      label="Dashboard"
+      href="#"
+    >
+      <EuiIcon type="dashboardApp" size="l" />
+    </EuiKeyPadMenuItem>
+
+    <EuiKeyPadMenuItem
+      label="Dashboard"
+      href="#"
+      betaLabel="Beta"
+      betaDescription="This module is not GA. Please help us by reporting any bugs."
+    >
+      <EuiIcon type="dashboardApp" size="l" />
+    </EuiKeyPadMenuItem>
+
+    <EuiKeyPadMenuItem
+      label="Dashboard"
+      href="#"
+      betaLabel="Lab"
+      betaDescription="This module is not GA. Please help us by reporting any bugs."
+    >
+      <EuiIcon type="dashboardApp" size="l" />
+    </EuiKeyPadMenuItem>
+  </EuiKeyPadMenu>
+);

--- a/src-docs/src/views/key_pad_menu/key_pad_beta.js
+++ b/src-docs/src/views/key_pad_menu/key_pad_beta.js
@@ -18,8 +18,8 @@ export default () => (
     <EuiKeyPadMenuItem
       label="Dashboard"
       href="#"
-      betaLabel="Beta"
-      betaDescription="This module is not GA. Please help us by reporting any bugs."
+      betaBadgeLabel="Beta"
+      betaBadgeTooltipContent="This module is not GA. Please help us by reporting any bugs."
     >
       <EuiIcon type="dashboardApp" size="l" />
     </EuiKeyPadMenuItem>
@@ -27,8 +27,9 @@ export default () => (
     <EuiKeyPadMenuItem
       label="Dashboard"
       href="#"
-      betaLabel="Lab"
-      betaDescription="This module is not GA. Please help us by reporting any bugs."
+      betaBadgeLabel="Lab"
+      betaBadgeTooltipContent="This module is not GA. Please help us by reporting any bugs."
+      betaBadgeIconType="bolt"
     >
       <EuiIcon type="dashboardApp" size="l" />
     </EuiKeyPadMenuItem>

--- a/src-docs/src/views/key_pad_menu/key_pad_menu_example.js
+++ b/src-docs/src/views/key_pad_menu/key_pad_menu_example.js
@@ -20,6 +20,10 @@ import KeyPadMenuItemButton from './key_pad_menu_item_button';
 const keyPadMenuItemButtonSource = require('!!raw-loader!./key_pad_menu_item_button');
 const keyPadMenuItemButtonHtml = renderToHtml(KeyPadMenuItemButton);
 
+import KeyPadBeta from './key_pad_beta';
+const keyPadBetaSource = require('!!raw-loader!./key_pad_beta');
+const keyPadBetaHtml = renderToHtml(KeyPadBeta);
+
 export const KeyPadMenuExample = {
   title: 'Key Pad Menu',
   sections: [{
@@ -54,5 +58,22 @@ export const KeyPadMenuExample = {
       </p>
     ),
     demo: <KeyPadMenuItemButton />,
+  }, {
+    title: 'Beta item',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: keyPadBetaSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: keyPadBetaHtml,
+    }],
+    text: (
+      <p>
+        If the item links to a module that is not GA (beta, lab, etc),
+        you can add a <EuiCode>betaLabel</EuiCode> and <EuiCode>betaDescription</EuiCode> to
+        the card and it will properly create and position an <EuiCode>EuiBetaBadge</EuiCode>.
+      </p>
+    ),
+    demo: <KeyPadBeta />,
   }],
 };

--- a/src-docs/src/views/key_pad_menu/key_pad_menu_example.js
+++ b/src-docs/src/views/key_pad_menu/key_pad_menu_example.js
@@ -68,11 +68,18 @@ export const KeyPadMenuExample = {
       code: keyPadBetaHtml,
     }],
     text: (
-      <p>
-        If the item links to a module that is not GA (beta, lab, etc),
-        you can add a <EuiCode>betaLabel</EuiCode> and <EuiCode>betaDescription</EuiCode> to
-        the card and it will properly create and position an <EuiCode>EuiBetaBadge</EuiCode>.
-      </p>
+      <div>
+        <p>
+          If the item links to a module that is not GA (beta, lab, etc),
+          you can add a <EuiCode>betaBadgeLabel</EuiCode> and <EuiCode>betaBadgeTooltipContent</EuiCode> to
+          the card and it will properly create and position an <EuiCode>EuiBetaBadge</EuiCode>.
+        </p>
+        <p>
+          Supplying just a label will only show the first letter in the badge and supply the full label
+          to the tooltip. You can also pass an <EuiCode>iconType</EuiCode> to replace the letter only badge
+          and the label will still become the title.
+        </p>
+      </div>
     ),
     demo: <KeyPadBeta />,
   }],

--- a/src/components/badge/_badge.scss
+++ b/src/components/badge/_badge.scss
@@ -2,7 +2,7 @@
  * 1. Accounts for the border
  */
 .euiBadge {
-  font-size: $euiSizeM;
+  font-size: $euiFontSizeXS;
   font-weight: $euiFontWeightMedium;
   line-height: $euiSize + 2px; /* 1 */
   display: inline-block;

--- a/src/components/badge/_index.scss
+++ b/src/components/badge/_index.scss
@@ -1,1 +1,2 @@
 @import 'badge';
+@import 'beta_badge/index';

--- a/src/components/badge/beta_badge/__snapshots__/beta_badge.test.js.snap
+++ b/src/components/badge/beta_badge/__snapshots__/beta_badge.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiBetaBadge is rendered 1`] = `
+<span
+  aria-label="aria-label"
+  class="euiBetaBadge testClass1 testClass2"
+  data-test-subj="test subject string"
+>
+  Beta
+</span>
+`;

--- a/src/components/badge/beta_badge/__snapshots__/beta_badge.test.js.snap
+++ b/src/components/badge/beta_badge/__snapshots__/beta_badge.test.js.snap
@@ -5,6 +5,7 @@ exports[`EuiBetaBadge is rendered 1`] = `
   aria-label="aria-label"
   class="euiBetaBadge testClass1 testClass2"
   data-test-subj="test subject string"
+  title="Beta"
 >
   Beta
 </span>

--- a/src/components/badge/beta_badge/_beta_badge.scss
+++ b/src/components/badge/beta_badge/_beta_badge.scss
@@ -1,0 +1,19 @@
+.euiBetaBadge {
+  display: inline-block;
+  padding: 0 $euiSizeL;
+  border-radius: $euiSizeL;
+  background-color: $euiColorAccent;
+  vertical-align: text-bottom; // if displayed inline with text
+  @include euiSlightShadowHover($euiColorAccent);
+
+  font-size: $euiSizeM;
+  font-weight: $euiFontWeightBold;
+  letter-spacing: .05em;
+  color: chooseLightOrDarkText($euiColorAccent, $euiColorEmptyShade, $euiColorFullShade);
+  text-transform: uppercase;
+  line-height: $euiSizeL;
+  text-align: center;
+  white-space: nowrap;
+
+  cursor: default;
+}

--- a/src/components/badge/beta_badge/_beta_badge.scss
+++ b/src/components/badge/beta_badge/_beta_badge.scss
@@ -3,17 +3,28 @@
   padding: 0 $euiSizeL;
   border-radius: $euiSizeL;
   background-color: $euiColorAccent;
-  vertical-align: text-bottom; // if displayed inline with text
+  vertical-align: super; // if displayed inline with text
   @include euiSlightShadowHover($euiColorAccent);
 
-  font-size: $euiSizeM;
+  font-size: $euiFontSizeXS;
   font-weight: $euiFontWeightBold;
+  text-transform: uppercase;
   letter-spacing: .05em;
   color: chooseLightOrDarkText($euiColorAccent, $euiColorEmptyShade, $euiColorFullShade);
-  text-transform: uppercase;
   line-height: $euiSizeL;
   text-align: center;
   white-space: nowrap;
 
   cursor: default;
+
+  // When it's just an icon, make it a circle
+  &.euiBetaBadge--iconOnly {
+    padding: 0;
+    width: $euiSizeL;
+
+    .euiBetaBadge__icon {
+      position: relative;
+      margin-top: -1px;
+    }
+  }
 }

--- a/src/components/badge/beta_badge/_index.scss
+++ b/src/components/badge/beta_badge/_index.scss
@@ -1,0 +1,1 @@
+@import 'beta_badge';

--- a/src/components/badge/beta_badge/beta_badge.js
+++ b/src/components/badge/beta_badge/beta_badge.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import { EuiToolTip } from '../../tool_tip';
+
+export const EuiBetaBadge = ({
+  className,
+  label,
+  description,
+  tooltipPosition,
+  title,
+  ...rest,
+}) => {
+
+  const classes = classNames(
+    'euiBetaBadge',
+    className
+  );
+
+  if (description) {
+    return (
+      <EuiToolTip
+        position={tooltipPosition}
+        content={description}
+        title={title}
+      >
+        <span
+          className={classes}
+          {...rest}
+        >
+          {label}
+        </span>
+      </EuiToolTip>
+    );
+  } else {
+    return (
+      <span
+        className={classes}
+        title={title}
+        {...rest}
+      >
+        {label}
+      </span>
+    )
+  }
+}
+
+EuiBetaBadge.propTypes = {
+  className: PropTypes.string,
+
+  /**
+   * One word label like "Beta" or "Lab"
+   */
+  label: PropTypes.string.isRequired,
+
+  /**
+   * Description for the tooltip
+   */
+  description: PropTypes.node,
+
+  /**
+   * Custom position of the tooltip
+   */
+  tooltipPosition: PropTypes.string,
+
+  /**
+   * Optional title will be supplied as tooltip title or title attribute
+   */
+  title: PropTypes.string,
+}
+
+EuiBetaBadge.defaultProps = {
+  tooltipPosition: 'top',
+};

--- a/src/components/badge/beta_badge/beta_badge.js
+++ b/src/components/badge/beta_badge/beta_badge.js
@@ -4,32 +4,53 @@ import classNames from 'classnames';
 
 import { EuiToolTip } from '../../tool_tip';
 
+import {
+  ICON_TYPES,
+  EuiIcon,
+} from '../../icon';
+
 export const EuiBetaBadge = ({
   className,
   label,
-  description,
+  tooltipContent,
   tooltipPosition,
   title,
+  iconType,
   ...rest,
 }) => {
 
   const classes = classNames(
     'euiBetaBadge',
+    {
+      'euiBetaBadge--iconOnly': iconType,
+    },
     className
   );
 
-  if (description) {
+  let icon;
+  if (iconType) {
+    icon = (
+      <EuiIcon
+        className="euiBetaBadge__icon"
+        type={iconType}
+        size="m"
+        aria-hidden="true"
+      />
+    );
+  }
+
+  if (tooltipContent) {
     return (
       <EuiToolTip
         position={tooltipPosition}
-        content={description}
-        title={title}
+        content={tooltipContent}
+        title={title || label}
       >
         <span
           className={classes}
           {...rest}
         >
-          {label}
+          {icon || label}
         </span>
       </EuiToolTip>
     );
@@ -37,10 +58,10 @@ export const EuiBetaBadge = ({
     return (
       <span
         className={classes}
-        title={title}
+        title={title || label}
         {...rest}
       >
-        {label}
+        {icon || label}
       </span>
     )
   }
@@ -52,12 +73,17 @@ EuiBetaBadge.propTypes = {
   /**
    * One word label like "Beta" or "Lab"
    */
-  label: PropTypes.string.isRequired,
+  label: PropTypes.node.isRequired,
 
   /**
-   * Description for the tooltip
+   * Supply an icon type if the badge should just be an icon
    */
-  description: PropTypes.node,
+  iconType: PropTypes.oneOf(ICON_TYPES),
+
+  /**
+   * Content for the tooltip
+   */
+  tooltipContent: PropTypes.node,
 
   /**
    * Custom position of the tooltip
@@ -65,7 +91,7 @@ EuiBetaBadge.propTypes = {
   tooltipPosition: PropTypes.string,
 
   /**
-   * Optional title will be supplied as tooltip title or title attribute
+   * Optional title will be supplied as tooltip title or title attribute otherwise the label will be used
    */
   title: PropTypes.string,
 }

--- a/src/components/badge/beta_badge/beta_badge.test.js
+++ b/src/components/badge/beta_badge/beta_badge.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from 'enzyme';
+import { requiredProps } from '../../../test';
+
+import { EuiBetaBadge } from './beta_badge';
+
+describe('EuiBetaBadge', () => {
+  test('is rendered', () => {
+    const component = render(
+      <EuiBetaBadge label="Beta" {...requiredProps} />
+    );
+
+    expect(component)
+      .toMatchSnapshot();
+  });
+});

--- a/src/components/badge/beta_badge/index.js
+++ b/src/components/badge/beta_badge/index.js
@@ -1,7 +1,3 @@
 export {
-  EuiBadge,
-} from './badge';
-
-export {
   EuiBetaBadge,
 } from './beta_badge';

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -28,10 +28,16 @@ $euiCardTitleSize: 18px; // Hardcoded pixel value for theme parity.
       transform: translateX(-50%);
       z-index: 3; // get above abs positioned image
       min-width: 40%; /* 2 */
+      max-width: calc(100% - #{$euiCardSpacing*2});
 
       .euiToolTipAnchor,
       .euiCard__betaBadge {
         width: 100%; /* 2 */
+      }
+
+      .euiCard__betaBadge {
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
     }
   }

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -7,12 +7,34 @@ $euiCardTitleSize: 18px; // Hardcoded pixel value for theme parity.
 // Start with a base of EuiPanel styles
 @include euiPanel($selector: 'euiCard');
 
+/**
+ * 1. Footer is always at the bottom.
+ * 2. Extend beta badges to at least 40% of the card's width
+ */
+
 // EuiCard specific
 .euiCard {
   display: flex;
   flex-direction: column;
-  overflow: hidden;
   padding: $euiCardSpacing;
+
+  &.euiCard--hasBetaBadge {
+    position: relative;
+
+    .euiCard__betaBadgeWrapper {
+      position: absolute;
+      top: $euiSizeL/-2;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 3; // get above abs positioned image
+      min-width: 40%; /* 2 */
+
+      .euiToolTipAnchor,
+      .euiCard__betaBadge {
+        width: 100%; /* 2 */
+      }
+    }
+  }
 
   .euiCard__top,
   .euiCard__content,
@@ -51,10 +73,6 @@ $euiCardTitleSize: 18px; // Hardcoded pixel value for theme parity.
   }
 }
 
-/**
- * 1. Footer is always at the bottom.
- */
-
 .euiCard__top {
   flex-grow: 0; /* 1 */
   position: relative;
@@ -69,6 +87,10 @@ $euiCardTitleSize: 18px; // Hardcoded pixel value for theme parity.
     left: $euiCardSpacing * -1;
     top: $euiCardSpacing * -1;
     margin-bottom: $euiCardSpacing * -1; // ensure the parent is only as tall as the image
+
+    // match border radius, minus 1px because it's inside a border
+    border-top-left-radius: $euiBorderRadius - 1px;
+    border-top-right-radius: $euiBorderRadius - 1px;
 
     // IF both exist, position the icon centered on top of image
     + .euiCard__icon {

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -25,8 +25,9 @@ export const EuiCard = ({
   href,
   textAlign,
   isClickable,
-  betaLabel,
-  betaDescription,
+  betaBadgeLabel,
+  betaBadgeTooltipContent,
+  betaBadgeTitle,
   ...rest,
 }) => {
   const classes = classNames(
@@ -34,7 +35,7 @@ export const EuiCard = ({
     textAlignToClassNameMap[textAlign],
     {
       'euiCard--isClickable': onClick || href || isClickable,
-      'euiCard--hasBetaBadge': betaLabel,
+      'euiCard--hasBetaBadge': betaBadgeLabel,
     },
     className,
   );
@@ -72,10 +73,10 @@ export const EuiCard = ({
   }
 
   let optionalBetaBadge;
-  if (betaLabel) {
+  if (betaBadgeLabel) {
     optionalBetaBadge = (
       <span className="euiCard__betaBadgeWrapper">
-        <EuiBetaBadge label={betaLabel} description={betaDescription} className="euiCard__betaBadge" />
+        <EuiBetaBadge label={betaBadgeLabel} title={betaBadgeTitle} tooltipContent={betaBadgeTooltipContent} className="euiCard__betaBadge" />
       </span>
     )
   }
@@ -138,12 +139,17 @@ EuiCard.propTypes = {
   /**
    * Add a badge to the card to label it as "Beta" or other non-GA state
    */
-  betaLabel: PropTypes.string,
+  betaBadgeLabel: PropTypes.string,
 
   /**
-   * Add a description to the beta label (will appear in a tooltip)
+   * Add a description to the beta badge (will appear in a tooltip)
    */
-  betaDescription: PropTypes.node,
+  betaBadgeTooltipContent: PropTypes.node,
+
+  /**
+   * Optional title will be supplied as tooltip title or title attribute otherwise the label will be used
+   */
+  betaBadgeTitle: PropTypes.string,
 };
 
 EuiCard.defaultProps = {

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 
 import { EuiText } from '../text';
 import { EuiTitle } from '../title';
+import { EuiBetaBadge } from '../badge/beta_badge';
 
 const textAlignToClassNameMap = {
   left: 'euiCard--leftAligned',
@@ -24,6 +25,8 @@ export const EuiCard = ({
   href,
   textAlign,
   isClickable,
+  betaLabel,
+  betaDescription,
   ...rest,
 }) => {
   const classes = classNames(
@@ -31,6 +34,7 @@ export const EuiCard = ({
     textAlignToClassNameMap[textAlign],
     {
       'euiCard--isClickable': onClick || href || isClickable,
+      'euiCard--hasBetaBadge': betaLabel,
     },
     className,
   );
@@ -67,6 +71,15 @@ export const EuiCard = ({
     );
   }
 
+  let optionalBetaBadge;
+  if (betaLabel) {
+    optionalBetaBadge = (
+      <span className="euiCard__betaBadgeWrapper">
+        <EuiBetaBadge label={betaLabel} description={betaDescription} className="euiCard__betaBadge" />
+      </span>
+    )
+  }
+
   return (
     <OuterElement
       onClick={onClick}
@@ -74,6 +87,7 @@ export const EuiCard = ({
       href={href}
       {...rest}
     >
+      {optionalBetaBadge}
 
       {optionalCardTop}
 
@@ -120,6 +134,16 @@ EuiCard.propTypes = {
   onClick: PropTypes.func,
   href: PropTypes.string,
   textAlign: PropTypes.oneOf(ALIGNMENTS),
+
+  /**
+   * Add a badge to the card to label it as "Beta" or other non-GA state
+   */
+  betaLabel: PropTypes.string,
+
+  /**
+   * Add a description to the beta label (will appear in a tooltip)
+   */
+  betaDescription: PropTypes.node,
 };
 
 EuiCard.defaultProps = {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -23,6 +23,7 @@ export {
 
 export {
   EuiBadge,
+  EuiBetaBadge,
 } from './badge';
 
 export {

--- a/src/components/key_pad_menu/_key_pad_menu.scss
+++ b/src/components/key_pad_menu/_key_pad_menu.scss
@@ -62,9 +62,9 @@
         right: $euiSizeM * -.5;
         z-index: 3;
 
-        .euiKeyPadMenuItem__betaBadge {
+        .euiKeyPadMenuItem__betaBadge:not(.euiBetaBadge--iconOnly) {
           width: $euiSizeL;
-          padding: 0 8px;  /* 2 */
+          padding: 0 ($euiSizeL - $euiFontSizeXS)/1.5;  /* 2 */
           overflow: hidden;  /* 2 */
           letter-spacing: 3rem;  /* 2 */
         }

--- a/src/components/key_pad_menu/_key_pad_menu.scss
+++ b/src/components/key_pad_menu/_key_pad_menu.scss
@@ -14,6 +14,7 @@
 
 /**
  * 1. If this class is applied to a button, we need to override the Chrome default font.
+ * 2. If it has a BetaBadge, make sure only the first letter shows
  */
 .euiKeyPadMenuItem {
   display: block;
@@ -51,6 +52,24 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
+
+    .euiKeyPadMenuItem--hasBetaBadge & {
+      position: relative;
+
+      .euiKeyPadMenuItem__betaBadgeWrapper {
+        position: absolute;
+        top: $euiSizeM * -.5;
+        right: $euiSizeM * -.5;
+        z-index: 3;
+
+        .euiKeyPadMenuItem__betaBadge {
+          width: $euiSizeL;
+          padding: 0 8px;  /* 2 */
+          overflow: hidden;  /* 2 */
+          letter-spacing: 3rem;  /* 2 */
+        }
+      }
+    }
   }
 
   .euiKeyPadMenuItem__icon {

--- a/src/components/key_pad_menu/key_pad_menu_item.js
+++ b/src/components/key_pad_menu/key_pad_menu_item.js
@@ -4,11 +4,20 @@ import classNames from 'classnames';
 
 import { EuiBetaBadge } from '../../components/badge/beta_badge';
 
-const renderContent = (children, label, betaLabel, betaDescription) => (
+import {
+  ICON_TYPES,
+} from '../icon';
+
+const renderContent = (children, label, betaBadgeLabel, betaBadgeTooltipContent, betaBadgeIconType) => (
   <div className="euiKeyPadMenuItem__inner">
-    {betaLabel &&
+    {betaBadgeLabel &&
       <span className="euiKeyPadMenuItem__betaBadgeWrapper">
-        <EuiBetaBadge label={betaLabel} title={betaLabel} description={betaDescription} className="euiKeyPadMenuItem__betaBadge" />
+        <EuiBetaBadge
+          className="euiKeyPadMenuItem__betaBadge"
+          label={betaBadgeLabel}
+          iconType={betaBadgeIconType}
+          tooltipContent={betaBadgeTooltipContent}
+        />
       </span>
     }
 
@@ -29,19 +38,24 @@ const commonPropTypes = {
   /**
    * Add a badge to the card to label it as "Beta" or other non-GA state
    */
-  betaLabel: PropTypes.string,
+  betaBadgeLabel: PropTypes.string,
 
   /**
-   * Add a description to the beta label (will appear in a tooltip)
+   * Supply an icon type if the badge should just be an icon
    */
-  betaDescription: PropTypes.node,
+  betaBadgeIconType: PropTypes.oneOf(ICON_TYPES),
+
+  /**
+   * Add a description to the beta badge (will appear in a tooltip)
+   */
+  betaBadgeTooltipContent: PropTypes.node,
 };
 
-export const EuiKeyPadMenuItem = ({ href, label, children, className, betaLabel, betaDescription, ...rest }) => {
+export const EuiKeyPadMenuItem = ({ href, label, children, className, betaBadgeLabel, betaBadgeTooltipContent, betaBadgeIconType, ...rest }) => {
   const classes = classNames(
     'euiKeyPadMenuItem',
     {
-      'euiKeyPadMenuItem--hasBetaBadge': betaLabel,
+      'euiKeyPadMenuItem--hasBetaBadge': betaBadgeLabel,
     },
     className
   );
@@ -52,7 +66,7 @@ export const EuiKeyPadMenuItem = ({ href, label, children, className, betaLabel,
       className={classes}
       {...rest}
     >
-      {renderContent(children, label, betaLabel, betaDescription)}
+      {renderContent(children, label, betaBadgeLabel, betaBadgeTooltipContent, betaBadgeIconType)}
     </a>
   );
 };
@@ -61,11 +75,11 @@ EuiKeyPadMenuItem.propTypes = ({ ...{
   href: PropTypes.string,
 }, ...commonPropTypes });
 
-export const EuiKeyPadMenuItemButton = ({ onClick, label, children, className, betaLabel, betaDescription, ...rest }) => {
+export const EuiKeyPadMenuItemButton = ({ onClick, label, children, className, betaBadgeLabel, betaBadgeTooltipContent, betaBadgeIconType, ...rest }) => {
   const classes = classNames(
     'euiKeyPadMenuItem',
     {
-      'euiKeyPadMenuItem--hasBetaBadge': betaLabel,
+      'euiKeyPadMenuItem--hasBetaBadge': betaBadgeLabel,
     },
     className
   );
@@ -77,7 +91,7 @@ export const EuiKeyPadMenuItemButton = ({ onClick, label, children, className, b
       className={classes}
       {...rest}
     >
-      {renderContent(children, label, betaLabel, betaDescription)}
+      {renderContent(children, label, betaBadgeLabel, betaBadgeTooltipContent, betaBadgeIconType)}
     </button>
   );
 };

--- a/src/components/key_pad_menu/key_pad_menu_item.js
+++ b/src/components/key_pad_menu/key_pad_menu_item.js
@@ -2,8 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-const renderContent = (children, label) => (
+import { EuiBetaBadge } from '../../components/badge/beta_badge';
+
+const renderContent = (children, label, betaLabel, betaDescription) => (
   <div className="euiKeyPadMenuItem__inner">
+    {betaLabel &&
+      <span className="euiKeyPadMenuItem__betaBadgeWrapper">
+        <EuiBetaBadge label={betaLabel} title={betaLabel} description={betaDescription} className="euiKeyPadMenuItem__betaBadge" />
+      </span>
+    }
+
     <div className="euiKeyPadMenuItem__icon">
       {children}
     </div>
@@ -17,10 +25,26 @@ const renderContent = (children, label) => (
 const commonPropTypes = {
   children: PropTypes.node.isRequired,
   label: PropTypes.node.isRequired,
+
+  /**
+   * Add a badge to the card to label it as "Beta" or other non-GA state
+   */
+  betaLabel: PropTypes.string,
+
+  /**
+   * Add a description to the beta label (will appear in a tooltip)
+   */
+  betaDescription: PropTypes.node,
 };
 
-export const EuiKeyPadMenuItem = ({ href, label, children, className, ...rest }) => {
-  const classes = classNames('euiKeyPadMenuItem', className);
+export const EuiKeyPadMenuItem = ({ href, label, children, className, betaLabel, betaDescription, ...rest }) => {
+  const classes = classNames(
+    'euiKeyPadMenuItem',
+    {
+      'euiKeyPadMenuItem--hasBetaBadge': betaLabel,
+    },
+    className
+  );
 
   return (
     <a
@@ -28,7 +52,7 @@ export const EuiKeyPadMenuItem = ({ href, label, children, className, ...rest })
       className={classes}
       {...rest}
     >
-      {renderContent(children, label)}
+      {renderContent(children, label, betaLabel, betaDescription)}
     </a>
   );
 };
@@ -37,8 +61,14 @@ EuiKeyPadMenuItem.propTypes = ({ ...{
   href: PropTypes.string,
 }, ...commonPropTypes });
 
-export const EuiKeyPadMenuItemButton = ({ onClick, label, children, className, ...rest }) => {
-  const classes = classNames('euiKeyPadMenuItem', className);
+export const EuiKeyPadMenuItemButton = ({ onClick, label, children, className, betaLabel, betaDescription, ...rest }) => {
+  const classes = classNames(
+    'euiKeyPadMenuItem',
+    {
+      'euiKeyPadMenuItem--hasBetaBadge': betaLabel,
+    },
+    className
+  );
 
   return (
     <button
@@ -47,7 +77,7 @@ export const EuiKeyPadMenuItemButton = ({ onClick, label, children, className, .
       className={classes}
       {...rest}
     >
-      {renderContent(children, label)}
+      {renderContent(children, label, betaLabel, betaDescription)}
     </button>
   );
 };


### PR DESCRIPTION
Fixes #682 

This adds a new component called `EuiBetaBadge` that only accepts a `label` and `description`. It will only add a tooltip if the `description` prop exists.

----

<img width="909" alt="screen shot 2018-04-26 at 10 59 54 am" src="https://user-images.githubusercontent.com/549577/39313968-3f148fbc-4941-11e8-82db-82e287d43ac9.png">

### Can be used on cards

<img width="900" alt="screen shot 2018-04-26 at 10 59 09 am" src="https://user-images.githubusercontent.com/549577/39314007-4b5ca728-4941-11e8-9f40-671ded7c0b5d.png">

### And Key Pad Menu Items

This will truncate to only one letter and ensure the full label is supplied to the tooltip as a title or if there is no tooltip (no description) it will add the title just as a norma `title` attribute.

<img width="910" alt="screen shot 2018-04-26 at 10 59 21 am" src="https://user-images.githubusercontent.com/549577/39314148-9f0efee8-4941-11e8-8147-dc3b3c199530.png">

cc @nreese 