### PR TITLE
Remove misplaced backtick

### DIFF
--- a/src-docs/src/views/search_bar/search_bar.js
+++ b/src-docs/src/views/search_bar/search_bar.js
@@ -276,7 +276,7 @@ export class SearchBar extends Component {
 
           <EuiTitle size="s">
             <h3>Elasticsearch Query DSL</h3>
-          </EuiTitle>`
+          </EuiTitle>
           <EuiSpacer size="s"/>
           <EuiCodeBlock language="js">
             {esQueryDsl ? JSON.stringify(esQueryDsl, null, 2) : ''}


### PR DESCRIPTION
Removing misplaced backtick from https://elastic.github.io/eui/#/forms/search-bar

<img width="396" alt="backtick" src="https://user-images.githubusercontent.com/3660049/39428465-bbdc80d8-4c87-11e8-8ceb-3f62e7d4c3b4.png">
