### PR TITLE
Pass itemIdToExpandedRowMap prop from EuiInMemoryTable to EuiBasicTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Fixed `EuiTableRowCell` from overwriting its child element's `className` [#709](https://github.com/elastic/eui/pull/709)
 - Allow `EuiContextMenuPanel`s to update when their `children` changes ([#710](https://github.com/elastic/eui/pull/710))
-- `EuiInMemoryTable` now passes `itemIdToExpandedRowMap` prop to `EuiBasicTable`
+- `EuiInMemoryTable` now passes `itemIdToExpandedRowMap` prop to `EuiBasicTable` ([#759](https://github.com/elastic/eui/pull/759))
 
 ## [`0.0.44`](https://github.com/elastic/eui/tree/v0.0.44)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed `EuiTableRowCell` from overwriting its child element's `className` [#709](https://github.com/elastic/eui/pull/709)
 - Allow `EuiContextMenuPanel`s to update when their `children` changes ([#710](https://github.com/elastic/eui/pull/710))
+- `EuiInMemoryTable` now passes `itemIdToExpandedRowMap` prop to `EuiBasicTable`
 
 ## [`0.0.44`](https://github.com/elastic/eui/tree/v0.0.44)
 

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
@@ -96,6 +96,46 @@ exports[`EuiInMemoryTable with items 1`] = `
 />
 `;
 
+exports[`EuiInMemoryTable with items and expanded item 1`] = `
+<EuiBasicTable
+  columns={
+    Array [
+      Object {
+        "description": "description",
+        "field": "name",
+        "name": "Name",
+      },
+    ]
+  }
+  itemIdToExpandedRowMap={
+    Object {
+      "1": <div>
+        expanded row content
+      </div>,
+    }
+  }
+  items={
+    Array [
+      Object {
+        "id": "1",
+        "name": "name1",
+      },
+      Object {
+        "id": "2",
+        "name": "name2",
+      },
+      Object {
+        "id": "3",
+        "name": "name3",
+      },
+    ]
+  }
+  noItemsMessage="No items found"
+  onChange={[Function]}
+  responsive={true}
+/>
+`;
+
 exports[`EuiInMemoryTable with items and message - expecting to show the items 1`] = `
 <EuiBasicTable
   columns={

--- a/src/components/basic_table/in_memory_table.js
+++ b/src/components/basic_table/in_memory_table.js
@@ -259,6 +259,7 @@ export class EuiInMemoryTable extends Component {
       compressed,
       pagination: hasPagination,
       sorting: hasSorting,
+      itemIdToExpandedRowMap,
     } = this.props;
 
     const {
@@ -305,6 +306,7 @@ export class EuiInMemoryTable extends Component {
         loading={loading}
         noItemsMessage={message}
         compressed={compressed}
+        itemIdToExpandedRowMap={itemIdToExpandedRowMap}
       />
     );
 

--- a/src/components/basic_table/in_memory_table.test.js
+++ b/src/components/basic_table/in_memory_table.test.js
@@ -93,6 +93,33 @@ describe('EuiInMemoryTable', () => {
     expect(component).toMatchSnapshot();
   });
 
+  test('with items and expanded item', () => {
+
+    const props = {
+      ...requiredProps,
+      items: [
+        { id: '1', name: 'name1' },
+        { id: '2', name: 'name2' },
+        { id: '3', name: 'name3' }
+      ],
+      columns: [
+        {
+          field: 'name',
+          name: 'Name',
+          description: 'description'
+        }
+      ],
+      itemIdToExpandedRowMap: {
+        '1': <div>expanded row content</div>
+      }
+    };
+    const component = shallow(
+      <EuiInMemoryTable {...props} />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
   test('with items and message - expecting to show the items', () => {
 
     const props = {


### PR DESCRIPTION
Fixes #690 by passing the `itemIdToExpandedRowMap` prop down from `EuiInMemoryTable` to `EuiBasicTable`.