### PR TITLE
Add postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test-visual-tests": "node ./scripts/run-visual-tests.js",
     "start-test-server-and-visual-test": "start-server-and-test start-test-server http-get://localhost:9999 test-visual",
     "yo-doc": "yo ./generator-eui/app/documentation.js",
-    "release": "npm test && npm run build && npm version patch && git push upstream --tags && npm publish && npm run sync-docs"
+    "release": "npm test && npm run build && npm version patch && git push upstream --tags && npm publish && npm run sync-docs",
+    "postinstall": "node ./scripts/postinstall.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+const path = require('path');
+
+const targetFilePath = path.join(__dirname, '..', 'node_modules', 'nodegit', 'vendor', 'libgit2', 'tests', 'resources', 'status', '这');
+if (fs.existsSync(targetFilePath)) {
+  console.log(`removing ${targetFilePath}`);
+  fs.unlinkSync(targetFilePath);
+}

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
+// the jenkins CI job breaks when deleting the old workspace if it encounters the `这` file
 const targetFilePath = path.join(__dirname, '..', 'node_modules', 'nodegit', 'vendor', 'libgit2', 'tests', 'resources', 'status', '这');
 if (fs.existsSync(targetFilePath)) {
   console.log(`removing ${targetFilePath}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10142,9 +10142,9 @@ wdio-sync@0.7.1:
     fibers "~2.0.0"
     object.assign "^4.0.3"
 
-wdio-visual-regression-service@^0.9.0:
+wdio-visual-regression-service@silne30/wdio-visual-regression-service#Add_Filename_To_Result:
   version "0.9.0"
-  resolved "https://registry.yarnpkg.com/wdio-visual-regression-service/-/wdio-visual-regression-service-0.9.0.tgz#caca5507010f02a20a0b83d321f289e3ad565e5e"
+  resolved "https://codeload.github.com/silne30/wdio-visual-regression-service/tar.gz/2ac00b6d9fc4e742b59bc667d36fedfb0ba983e5"
   dependencies:
     babel-runtime "^6.9.0"
     debug "^2.2.0"


### PR DESCRIPTION
The CI job fails when Jenkins tries to clear the old workspace if it contains a filename with non-latin characters, such as `这` from the `nodegit` dependency. I consider this a short-term fix to make CI happy again and then work with infra to support having such files in the workspace.