### PR TITLE
remove scripts directory from .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,8 +6,6 @@ wiki/
 generator-eui/
 test/
 src-docs/
-scripts/
-
 
 .DS_Store
 .eslintcache


### PR DESCRIPTION
Kibana `yarn kbn bootstrap` tries to run `postinstall` script but this generates an error because the scripts directory is not part of the published package.