### PR TITLE
Adds utility CSS classes to EUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `0.0.46`.
+- Added utility CSS classes for text and alignment concerns.  ([#774](https://github.com/elastic/eui/pull/774))
 
 ## [`0.0.46`](https://github.com/elastic/eui/tree/v0.0.46)
 

--- a/src-docs/src/routes.js
+++ b/src-docs/src/routes.js
@@ -39,6 +39,10 @@ import WritingGuidelines
 import { IsColorDarkExample }
   from './views/is_color_dark/is_color_dark_example';
 
+
+import { UtilityClassesExample }
+  from './views/utility_classes/utility_classes_example';
+
 // Component examples
 
 import { AccessibilityExample }
@@ -336,6 +340,7 @@ const navigation = [{
     IsColorDarkExample,
     OutsideClickDetectorExample,
     PortalExample,
+    UtilityClassesExample,
   ].map(example => createExample(example)),
 }, {
   name: 'Package',

--- a/src-docs/src/views/utility_classes/utility_classes.js
+++ b/src-docs/src/views/utility_classes/utility_classes.js
@@ -54,44 +54,44 @@ export default () => (
     <EuiSpacer />
 
     <div>
-      <EuiIcon type="logoElasticStack" size="xxl" />
-      <EuiCode className="eui-alignTop">.eui-alignTop</EuiCode>
+      <EuiIcon type="logoElasticStack" size="xxl" className="eui-alignTop" />
+      <EuiCode>.eui-alignTop</EuiCode>
     </div>
 
     <EuiSpacer />
 
     <div>
-      <EuiIcon type="logoElasticStack" size="xxl" />
-      <EuiCode className="eui-alignMiddle">.eui-alignMiddle</EuiCode>
+      <EuiIcon type="logoElasticStack" size="xxl" className="eui-alignMiddle" />
+      <EuiCode>.eui-alignMiddle</EuiCode>
     </div>
 
     <EuiSpacer />
 
     <div>
-      <EuiIcon type="logoElasticStack" size="xxl" />
-      <EuiCode className="eui-alignBottom">.eui-alignBottom</EuiCode>
+      <EuiIcon type="logoElasticStack" size="xxl"  className="eui-alignBottom" />
+      <EuiCode>.eui-alignBottom</EuiCode>
     </div>
 
     <EuiSpacer />
 
     <div>
-      <EuiIcon type="logoElasticStack" size="xxl" />
-      <EuiCode className="eui-alignBaseline">.eui-alignBaseline</EuiCode>
+      <EuiIcon type="logoElasticStack" size="xxl" className="eui-alignBaseline" />
+      <EuiCode>.eui-alignBaseline</EuiCode>
     </div>
 
     <EuiSpacer />
 
     <h4>Display</h4>
 
-    <EuiCode className="eui-block">.eui-block</EuiCode>
+    <EuiCode className="eui-displayBlock">.eui-displayBlock</EuiCode>
 
     <EuiSpacer />
 
-    <EuiCode className="eui-inline">.eui-inline</EuiCode>
+    <EuiCode className="eui-displayInline">.eui-displayInline</EuiCode>
 
     <EuiSpacer />
 
-    <EuiCode className="eui-inlineBlock">.eui-inlineBlock</EuiCode>
+    <EuiCode className="eui-displayInlineBlock">.eui-displayInlineBlock</EuiCode>
 
   </EuiText>
 );

--- a/src-docs/src/views/utility_classes/utility_classes.js
+++ b/src-docs/src/views/utility_classes/utility_classes.js
@@ -1,0 +1,97 @@
+import React from 'react';
+
+import {
+  EuiText,
+  EuiCode,
+  EuiSpacer,
+  EuiIcon,
+} from '../../../../src/components';
+
+export default () => (
+  <EuiText>
+
+    <h4>Text</h4>
+
+    <EuiSpacer />
+
+    <div className="eui-textLeft">
+      <EuiCode>.eui-textLeft</EuiCode>
+    </div>
+
+    <div className="eui-textCenter">
+      <EuiCode>.eui-textCenter</EuiCode>
+    </div>
+    <div className="eui-textRight">
+      <EuiCode>.eui-textRight</EuiCode>
+    </div>
+
+    <EuiSpacer />
+
+    <div style={{ width: 300, padding: 16, background: 'rgba(254, 228, 181, 0.5)' }} className="eui-textNoWrap">
+      <EuiCode>.eui-textNoWrap</EuiCode> will force text not to wrap even in small containers.
+    </div>
+
+    <EuiSpacer />
+
+    <div style={{ width: 300, padding: 16, background: 'rgba(254, 228, 181, 0.5)' }} className="eui-textBreakAll">
+      <EuiCode>.eui-textBreakAll</EuiCode> will break up anything. It is useful for long urls like http://www.hithereimalongurl.com/dave_will_just_ramble_on_in_a_long_sentence_like_this/?ok=cool
+    </div>
+
+    <EuiSpacer />
+
+    <div style={{ width: 300, padding: 16, background: 'rgba(254, 228, 181, 0.5)' }} className="eui-textBreakWord">
+      <EuiCode>.eui-textBreakWord</EuiCode> will only break up at the end of words. Long urls will still break http://www.hithereimalongurl.com/dave_will_just_ramble_on_in_a_long_sentence_like_this/?ok=cool
+    </div>
+
+    <EuiSpacer />
+
+    <div style={{ width: 300, padding: 16, background: 'rgba(254, 228, 181, 0.5)' }} className="eui-textTruncate">
+      <EuiCode>.eui-textTruncate</EuiCode> will ellipsis after a certain point.
+    </div>
+
+    <h4>Vertical alignment</h4>
+
+    <EuiSpacer />
+
+    <div>
+      <EuiIcon type="logoElasticStack" size="xxl" />
+      <EuiCode className="eui-alignTop">.eui-alignTop</EuiCode>
+    </div>
+
+    <EuiSpacer />
+
+    <div>
+      <EuiIcon type="logoElasticStack" size="xxl" />
+      <EuiCode className="eui-alignMiddle">.eui-alignMiddle</EuiCode>
+    </div>
+
+    <EuiSpacer />
+
+    <div>
+      <EuiIcon type="logoElasticStack" size="xxl" />
+      <EuiCode className="eui-alignBottom">.eui-alignBottom</EuiCode>
+    </div>
+
+    <EuiSpacer />
+
+    <div>
+      <EuiIcon type="logoElasticStack" size="xxl" />
+      <EuiCode className="eui-alignBaseline">.eui-alignBaseline</EuiCode>
+    </div>
+
+    <EuiSpacer />
+
+    <h4>Display</h4>
+
+    <EuiCode className="eui-block">.eui-block</EuiCode>
+
+    <EuiSpacer />
+
+    <EuiCode className="eui-inline">.eui-inline</EuiCode>
+
+    <EuiSpacer />
+
+    <EuiCode className="eui-inlineBlock">.eui-inlineBlock</EuiCode>
+
+  </EuiText>
+);

--- a/src-docs/src/views/utility_classes/utility_classes_example.js
+++ b/src-docs/src/views/utility_classes/utility_classes_example.js
@@ -6,10 +6,6 @@ import {
   GuideSectionTypes,
 } from '../../components';
 
-import {
-  EuiCode,
-} from '../../../../src/components';
-
 import UtilityClasses from './utility_classes';
 const utilityClassesSource = require('!!raw-loader!./utility_classes');
 const utilityClassesHtml = renderToHtml(UtilityClasses);

--- a/src-docs/src/views/utility_classes/utility_classes_example.js
+++ b/src-docs/src/views/utility_classes/utility_classes_example.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { renderToHtml } from '../../services';
+
+import {
+  GuideSectionTypes,
+} from '../../components';
+
+import {
+  EuiCode,
+} from '../../../../src/components';
+
+import UtilityClasses from './utility_classes';
+const utilityClassesSource = require('!!raw-loader!./utility_classes');
+const utilityClassesHtml = renderToHtml(UtilityClasses);
+
+export const UtilityClassesExample = {
+  title: 'UtilityClasses',
+  sections: [{
+    title: 'UtilityClasses',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: utilityClassesSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: utilityClassesHtml,
+    }],
+    text: (
+      <p>
+        Description needed: how to use the <EuiCode>EuiUtilityClasses</EuiCode> component.
+      </p>
+    ),
+    demo: <UtilityClasses />,
+  }],
+};

--- a/src-docs/src/views/utility_classes/utility_classes_example.js
+++ b/src-docs/src/views/utility_classes/utility_classes_example.js
@@ -15,7 +15,7 @@ const utilityClassesSource = require('!!raw-loader!./utility_classes');
 const utilityClassesHtml = renderToHtml(UtilityClasses);
 
 export const UtilityClassesExample = {
-  title: 'UtilityClasses',
+  title: 'CSS utility classes',
   sections: [{
     source: [{
       type: GuideSectionTypes.JS,
@@ -27,7 +27,7 @@ export const UtilityClassesExample = {
     text: (
       <p>
         The following CSS-only classes are provided as helper utilities. They are
-        useful for making micro-adjustments to existing components.
+        useful for making micro-adjustments to existing React components.
       </p>
     ),
     demo: <UtilityClasses />,

--- a/src-docs/src/views/utility_classes/utility_classes_example.js
+++ b/src-docs/src/views/utility_classes/utility_classes_example.js
@@ -17,7 +17,6 @@ const utilityClassesHtml = renderToHtml(UtilityClasses);
 export const UtilityClassesExample = {
   title: 'UtilityClasses',
   sections: [{
-    title: 'UtilityClasses',
     source: [{
       type: GuideSectionTypes.JS,
       code: utilityClassesSource,
@@ -27,7 +26,8 @@ export const UtilityClassesExample = {
     }],
     text: (
       <p>
-        Description needed: how to use the <EuiCode>EuiUtilityClasses</EuiCode> component.
+        The following CSS-only classes are provided as helper utilities. They are
+        useful for making micro-adjustments to existing components.
       </p>
     ),
     demo: <UtilityClasses />,

--- a/src/global_styling/index.scss
+++ b/src/global_styling/index.scss
@@ -9,5 +9,8 @@
 // Mixins provide generic code expansion through helpers
 @import 'mixins/index';
 
+// Utility classes provide one-off selectors for common css problems
+@import 'utility/index';
+
 // The reset file makes use of variables and mixins
 @import 'reset/index';

--- a/src/global_styling/utility/_index.scss
+++ b/src/global_styling/utility/_index.scss
@@ -1,0 +1,1 @@
+@import 'utility';

--- a/src/global_styling/utility/_utility.scss
+++ b/src/global_styling/utility/_utility.scss
@@ -5,9 +5,9 @@
 .eui-alignTop { vertical-align: top !important; }
 
 // Display
-.eui-block {display: block !important;}
-.eui-inline {display: inline !important;}
-.eui-inlineBlock {display: inline-block !important;}
+.eui-displayBlock {display: block !important;}
+.eui-displayInline {display: inline !important;}
+.eui-displayInlineBlock {display: inline-block !important;}
 
 // Text
 .eui-textCenter {text-align: center !important;}

--- a/src/global_styling/utility/_utility.scss
+++ b/src/global_styling/utility/_utility.scss
@@ -1,0 +1,38 @@
+// Vertical alignment
+.eui-alignBaseline { vertical-align: baseline !important; }
+.eui-alignBottom { vertical-align: bottom !important; }
+.eui-alignMiddle { vertical-align: middle !important; }
+.eui-alignTop { vertical-align: top !important; }
+
+// Display
+.eui-block {display: block !important;}
+.eui-inline {display: inline !important;}
+.eui-inlineBlock {display: inline-block !important;}
+
+// Text
+.eui-textCenter {text-align: center !important;}
+.eui-textLeft {text-align: left !important;}
+.eui-textRight {text-align: right !important;}
+.eui-textBreakWord {word-break: break-word !important;}
+.eui-textBreakAll {word-break: break-all !important;}
+.eui-textNoWrap {white-space: nowrap !important;}
+.eui-textInheritColor {color: inherit !important;}
+
+/**
+ * Text truncation
+ *
+ * Prevent text from wrapping onto multiple lines, and truncate with an
+ * ellipsis.
+ *
+ * 1. Ensure that the node has a maximum width after which truncation can
+ *    occur.
+ * 2. Fix for IE 8/9 if `word-wrap: break-word` is in effect on ancestor
+ *    nodes.
+ */
+.eui-textTruncate {
+  max-width: 100%; /* 1 */
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  white-space: nowrap !important;
+  word-wrap: normal !important; /* 2 */
+}


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/758

After seeing separate instances of people wanting to deal with text wrapping issues we decided it best to provide some CSS utility classes for common situations. Otherwise we'd need to add lots of optional props to our React components that might not target the individual piece of content (like a heading in a tooltip) that we want.

More discussion can be found in the issue above.

I'm purposefully keeping this list very small to start. For example, keeping out flexs and floats since we already have components that do a decent job at this type of thing.

![image](https://user-images.githubusercontent.com/324519/39607691-422941d8-4ef1-11e8-98e4-7b7be61410b2.png)
