### PR TITLE
Include the postinstall.js script when building the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,8 +6,9 @@ wiki/
 generator-eui/
 test/
 src-docs/
-scripts/
 
+# ignore everything in `scripts` except postinstall.js
+scripts/!(postinstall.js)
 
 .DS_Store
 .eslintcache


### PR DESCRIPTION
This keeps everything in `scripts` out of the npm package except `postinstall.js` 