### PR TITLE
Bug/773 search bar boolean matching

### DIFF
--- a/src/components/search_bar/query/default_syntax.js
+++ b/src/components/search_bar/query/default_syntax.js
@@ -176,9 +176,7 @@ const Exp = {
   date: (expression, location) => ({ type: 'date', expression, location }),
   number: (expression, location) => ({ type: 'number', expression, location }),
   string: (expression, location) => ({ type: 'string', expression, location }),
-  boolean: (expression, location) => {
-    return { type: 'boolean', expression, location };
-  }
+  boolean: (expression, location) => ({ type: 'boolean', expression, location })
 };
 
 const validateFlag = (flag, location, ctx) => {

--- a/src/components/search_bar/query/default_syntax.js
+++ b/src/components/search_bar/query/default_syntax.js
@@ -113,7 +113,7 @@ rangeValue
 containsValue
   = number
   / date
-  / boolean
+  / booleanWord
   / word
   / phrase
 
@@ -135,6 +135,11 @@ escapedChar
 
 reservedChar
   = [\-:\\\\]
+
+// only match booleans followed by whitespace or end of input
+booleanWord
+  = bool:boolean &space { return bool; }
+  / bool:boolean !. { return bool; }
 
 boolean
   = [tT][rR][uU][eE] { return Exp.boolean(text(), location()); }
@@ -171,7 +176,9 @@ const Exp = {
   date: (expression, location) => ({ type: 'date', expression, location }),
   number: (expression, location) => ({ type: 'number', expression, location }),
   string: (expression, location) => ({ type: 'string', expression, location }),
-  boolean: (expression, location) => ({ type: 'boolean', expression, location })
+  boolean: (expression, location) => {
+    return { type: 'boolean', expression, location };
+  }
 };
 
 const validateFlag = (flag, location, ctx) => {

--- a/src/components/search_bar/search_bar.js
+++ b/src/components/search_bar/search_bar.js
@@ -102,7 +102,6 @@ export class EuiSearchBar extends Component {
   onSearch = (queryText) => {
     try {
       const query = parseQuery(queryText, this.props);
-      console.log(query);
       if (this.props.onParse) {
         this.props.onParse({ query, queryText });
       }

--- a/src/components/search_bar/search_bar.js
+++ b/src/components/search_bar/search_bar.js
@@ -102,6 +102,7 @@ export class EuiSearchBar extends Component {
   onSearch = (queryText) => {
     try {
       const query = parseQuery(queryText, this.props);
+      console.log(query);
       if (this.props.onParse) {
         this.props.onParse({ query, queryText });
       }


### PR DESCRIPTION
The search bar's grammar greedily prefers `boolean` fragments over `word` fragments, but did not verify that the boolean text it matched again didn't exist within a larger word structure.

e.g. `true` `truest` `off` and `offer` all match the `boolean` type because they start with a valid boolean expression.

This PR modifies the `containsValue` expression to look for `boolean` followed by whitespace or End Of Input, otherwise `containsValue` continues to match against `word`.

`true`, `off` match as `boolean`
`truest`, `offer` match as `word`