### PR TITLE
Ensuring switches’ inputs it's still hidden when [disabled].

### DIFF
--- a/src/components/form/switch/_switch.scss
+++ b/src/components/form/switch/_switch.scss
@@ -12,8 +12,10 @@
 
   /**
    * 1. The input is "hidden" but still focusable.
+   * 2. Make sure it's still hidden when [disabled].
    */
-  .euiSwitch__input {
+  .euiSwitch__input,
+  .euiSwitch__input[disabled] /* 2 */ {
     position: absolute;
     opacity: 0; /* 1 */
     width: 100%;


### PR DESCRIPTION
Fixes a bug where Kibana's `input[type="checkbox"][disabled] { opacity: .8 }` was overriding the `opacity: 0` of the input for switches.

## Before

<img width="498" alt="screen shot 2018-05-04 at 16 20 51 pm" src="https://user-images.githubusercontent.com/549577/39651184-e9aba2ee-4fb8-11e8-89c6-ff43ff81cef4.png">


## After

<img width="507" alt="screen shot 2018-05-04 at 16 32 28 pm" src="https://user-images.githubusercontent.com/549577/39651178-e60bd76c-4fb8-11e8-8f36-ffbd761e0ac8.png">


cc @ppisljar 