### PR TITLE
Make switch use a random id if none is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 No public interface changes since `3.1.0`.
 
+**Bug Fixes**
+
+- To make it more accessible, added a random id to `EuiSwitch`'s id prop if none is passed.  ([#779](https://github.com/elastic/eui/pull/779))
+
+
 ## [`3.1.0`](https://github.com/elastic/eui/tree/v3.1.0)
 
 - Added `EuiMutationObserver` to expose Mutation Observer API to React components ([#966](https://github.com/elastic/eui/pull/966))

--- a/src-docs/src/views/form_controls/switch.js
+++ b/src-docs/src/views/form_controls/switch.js
@@ -8,8 +8,6 @@ import {
   EuiSpacer,
 } from '../../../../src/components';
 
-import makeId from '../../../../src/components/form/form_row/make_id';
-
 export default class extends Component {
   constructor(props) {
     super(props);
@@ -29,7 +27,6 @@ export default class extends Component {
     return (
       <Fragment>
         <EuiSwitch
-          id={makeId()}
           label="I am a switch"
           checked={this.state.checked}
           onChange={this.onChange}
@@ -38,7 +35,6 @@ export default class extends Component {
         <EuiSpacer size="m" />
 
         <EuiSwitch
-          id={makeId()}
           label="I am a disabled switch"
           checked={this.state.checked}
           onChange={this.onChange}

--- a/src/components/form/switch/__snapshots__/switch.test.js.snap
+++ b/src/components/form/switch/__snapshots__/switch.test.js.snap
@@ -8,7 +8,6 @@ exports[`EuiSwitch is rendered 1`] = `
     aria-label="aria-label"
     class="euiSwitch__input"
     data-test-subj="test subject string"
-    id="test"
     type="checkbox"
   />
   <span

--- a/src/components/form/switch/__snapshots__/switch.test.js.snap
+++ b/src/components/form/switch/__snapshots__/switch.test.js.snap
@@ -8,7 +8,7 @@ exports[`EuiSwitch is rendered 1`] = `
     aria-label="aria-label"
     class="euiSwitch__input"
     data-test-subj="test subject string"
-    id="u9dcpoo5"
+    id="test"
     type="checkbox"
   />
   <span

--- a/src/components/form/switch/__snapshots__/switch.test.js.snap
+++ b/src/components/form/switch/__snapshots__/switch.test.js.snap
@@ -8,6 +8,7 @@ exports[`EuiSwitch is rendered 1`] = `
     aria-label="aria-label"
     class="euiSwitch__input"
     data-test-subj="test subject string"
+    id="u9dcpoo5"
     type="checkbox"
   />
   <span

--- a/src/components/form/switch/switch.js
+++ b/src/components/form/switch/switch.js
@@ -34,9 +34,9 @@ export class EuiSwitch extends Component {
 
     const classes = classNames(
       'euiSwitch',
-        {
-          'euiSwitch--compressed': compressed,
-        },
+      {
+        'euiSwitch--compressed': compressed,
+      },
       className
     );
 

--- a/src/components/form/switch/switch.js
+++ b/src/components/form/switch/switch.js
@@ -1,70 +1,87 @@
-import React from 'react';
+import React, {
+  Component,
+} from 'react';
+
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+import makeId from '../../form/form_row/make_id';
 import { EuiIcon } from '../../icon';
 
-export const EuiSwitch = ({
-  label,
-  id,
-  name,
-  checked,
-  disabled,
-  compressed,
-  onChange,
-  className,
-  ...rest
-}) => {
-  const classes = classNames(
-    'euiSwitch',
-    {
-      'euiSwitch--compressed': compressed,
-    },
-    className
-  );
+export class EuiSwitch extends Component {
+  constructor(props) {
+    super(props);
 
-  return (
-    <div className={classes}>
-      <input
-        className="euiSwitch__input"
-        name={name}
-        id={id}
-        type="checkbox"
-        checked={checked}
-        disabled={disabled}
-        onChange={onChange}
-        {...rest}
-      />
+    this.state = {
+      id: props.id || makeId(),
+    };
+  }
 
-      <span className="euiSwitch__body">
-        <span className="euiSwitch__thumb" />
-        <span className="euiSwitch__track">
-          <EuiIcon
-            type="cross"
-            size="m"
-            className="euiSwitch__icon"
-          />
+  render() {
+    const {
+      label,
+      id,
+      name,
+      checked,
+      disabled,
+      compressed,
+      onChange,
+      className,
+      ...rest
+    } = this.props;
 
-          <EuiIcon
-            type="check"
-            size="m"
-            className="euiSwitch__icon euiSwitch__icon--checked"
-          />
+    const { switchId } = this.state;
+
+    const classes = classNames(
+      'euiSwitch',
+        {
+          'euiSwitch--compressed': compressed,
+        },
+      className
+    );
+
+    return (
+      <div className={classes}>
+        <input
+          className="euiSwitch__input"
+          name={name}
+          id={switchId}
+          type="checkbox"
+          checked={checked}
+          disabled={disabled}
+          onChange={onChange}
+          {...rest}
+        />
+
+        <span className="euiSwitch__body">
+          <span className="euiSwitch__thumb" />
+          <span className="euiSwitch__track">
+            <EuiIcon
+              type="cross"
+              size="m"
+              className="euiSwitch__icon"
+            />
+
+            <EuiIcon
+              type="check"
+              size="m"
+              className="euiSwitch__icon euiSwitch__icon--checked"
+            />
+          </span>
         </span>
-      </span>
 
-      { label &&
-        <label
-          className="euiSwitch__label"
-          htmlFor={id}
-        >
-          {label}
-        </label>
-      }
-
-    </div>
-  );
-};
+        { label &&
+          <label
+            className="euiSwitch__label"
+            htmlFor={id}
+          >
+            {label}
+          </label>
+        }
+      </div>
+    );
+  }
+}
 
 EuiSwitch.propTypes = {
   name: PropTypes.string,

--- a/src/components/form/switch/switch.test.js
+++ b/src/components/form/switch/switch.test.js
@@ -7,7 +7,7 @@ import { EuiSwitch } from './switch';
 describe('EuiSwitch', () => {
   test('is rendered', () => {
     const component = render(
-      <EuiSwitch {...requiredProps} />
+      <EuiSwitch id="test" {...requiredProps} />
     );
 
     expect(component)


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/748
Fixes https://github.com/elastic/eui/issues/1027

Switches now generate a random id if none are passed (similar to how we do it in `EuiFormRow`. This should only happen when used on their own, since most other situations will usually generate one.

This seemed like the best solution since I could not require ids to be provided, otherwise it would spit out errors when `EuiFormRow` cloned ids down.