### PR TITLE
Creating a standard links list for `EuiHeader`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added aria labeling requirements for `EuiBadge` , as well as a generic prop_type function `requiresAriaLabel` in `utils` to check for it. ([#777](https://github.com/elastic/eui/pull/777))
 - Ensure switches’ inputs are still hidden when `[disabled]` ([#778](https://github.com/elastic/eui/pull/778))
 - Made boolean matching in `EuiSearchBar` more exact so it doesn't match words starting with booleans, like "truest" or "offer" ([#776](https://github.com/elastic/eui/pull/776))
+- Adjusted coloring of active breadcrumb in `EuiHeader` for dark theme. ([#804](https://github.com/elastic/eui/pull/804))
 
 ## [`0.0.46`](https://github.com/elastic/eui/tree/v0.0.46)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added utility CSS classes for text and alignment concerns.  ([#774](https://github.com/elastic/eui/pull/774))
+- Added standard links list for `EuiHeader`. ([#804](https://github.com/elastic/eui/pull/804))
 
 **Bug fixes**
 

--- a/src-docs/src/views/header/header_example.js
+++ b/src-docs/src/views/header/header_example.js
@@ -15,11 +15,18 @@ import {
   EuiHeaderSectionItem,
   EuiHeaderSectionItemButton,
   EuiHeaderLogo,
+  EuiCode,
+  EuiHeaderLinks,
+  EuiHeaderLink,
 } from '../../../../src/components';
 
 import Header from './header';
 const headerSource = require('!!raw-loader!./header');
 const headerHtml = renderToHtml(Header);
+
+import HeaderLinks from './header_links';
+const headerLinksSource = require('!!raw-loader!./header_links');
+const headerLinksHtml = renderToHtml(HeaderLinks);
 
 export const HeaderExample = {
   title: 'Header',
@@ -47,5 +54,26 @@ export const HeaderExample = {
       EuiHeaderLogo,
     },
     demo: <Header />,
+  },{
+    title: "Links",
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: headerLinksSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: headerLinksHtml,
+    }],
+    text: (
+      <p>
+        Kibana should and will eventually always use the breadcrumb style of header.
+        However, in some rare cases where EUI is being used as a one-off site or page,
+        you can use <EuiCode>EuiHeaderLinks</EuiCode>, <EuiCode>EuiHeaderLink</EuiCode>s instead of breadcrumbs.
+      </p>
+    ),
+    props: {
+      EuiHeaderLinks,
+      EuiHeaderLink
+    },
+    demo: <HeaderLinks />,
   }],
 };

--- a/src-docs/src/views/header/header_links.js
+++ b/src-docs/src/views/header/header_links.js
@@ -1,0 +1,49 @@
+import React, {
+  Component,
+} from 'react';
+
+import {
+  EuiHeader,
+  EuiHeaderSectionItem,
+  EuiHeaderLogo,
+  EuiHeaderLinks,
+  EuiHeaderLink,
+} from '../../../../src/components';
+
+export default class extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isAppMenuOpen: false,
+    };
+  }
+
+  render() {
+    return (
+      <EuiHeader>
+
+        <EuiHeaderSectionItem border="none">
+          <EuiHeaderLogo href="#">
+            Elastic
+          </EuiHeaderLogo>
+        </EuiHeaderSectionItem>
+
+        <EuiHeaderLinks>
+          <EuiHeaderLink href="#" isActive>
+            Products
+          </EuiHeaderLink>
+
+          <EuiHeaderLink href="#">
+            Licenses
+          </EuiHeaderLink>
+
+          <EuiHeaderLink href="#">
+            Usage
+          </EuiHeaderLink>
+        </EuiHeaderLinks>
+
+      </EuiHeader>
+    );
+  }
+}

--- a/src/components/header/_header_logo.scss
+++ b/src/components/header/_header_logo.scss
@@ -5,13 +5,31 @@
 
   position: relative;
   height: $euiHeaderChildSize;
+  line-height: $euiSizeXL;
   padding: $euiSize $euiSizeL;
   display: inline-block;
   vertical-align: middle;
+  white-space: nowrap;
+
+  &:focus,
+  &:hover {
+    text-decoration: none;
+  }
 }
 
   .euiHeaderLogo__icon {
     height: $euiSizeXL;
     width: $euiSizeL;
     opacity: 1;
+  }
+
+  .euiHeaderLogo__text {
+    @include euiTitle("s");
+    padding-left: $euiSize;
+    font-weight: $euiFontWeightLight;
+
+    @include screenXSmall() {
+      @include euiTitle("xxs");
+      font-weight: $euiFontWeightLight;
+    }
   }

--- a/src/components/header/_index.scss
+++ b/src/components/header/_index.scss
@@ -10,6 +10,7 @@ $euiHeaderChildSize: $euiSizeXXL + $euiSizeL;
 @import 'header';
 @import 'header_popover';
 @import 'header_profile';
+@import 'header_links/index';
 @import 'header_logo';
 @import 'header_notification';
 @import 'header_alert/index';

--- a/src/components/header/header_breadcrumbs/_header_breadcrumbs.scss
+++ b/src/components/header/header_breadcrumbs/_header_breadcrumbs.scss
@@ -31,7 +31,7 @@
   }
 
   &.euiHeaderBreadcrumb-isActive {
-    color: $euiColorMediumShade;
+    color: makeHighContrastColor($euiColorMediumShade, $euiHeaderBackgroundColor);
   }
 }
 
@@ -44,7 +44,7 @@
   }
 
 .euiHeaderBreadcrumb--collapsed {
-  color: $euiColorLightShade;
+  color: makeHighContrastColor($euiColorMediumShade, $euiHeaderBackgroundColor);
 }
 
 // Laptop

--- a/src/components/header/header_links/__snapshots__/header_link.test.js.snap
+++ b/src/components/header/header_links/__snapshots__/header_link.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiHeaderLink is rendered 1`] = `
+<li
+  aria-label="aria-label"
+  class="euiHeaderLink testClass1 testClass2"
+  data-test-subj="test subject string"
+>
+  <a
+    class="euiHeaderLink__link"
+  >
+    <span
+      class="euiHeaderLink__text"
+    />
+  </a>
+</li>
+`;

--- a/src/components/header/header_links/__snapshots__/header_links.test.js.snap
+++ b/src/components/header/header_links/__snapshots__/header_links.test.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiHeaderLinks is rendered 1`] = `
+<div
+  aria-label="aria-label"
+  class="euiHeaderLinks testClass1 testClass2"
+  data-test-subj="test subject string"
+>
+  <ul
+    class="euiHeaderLinks__list"
+  />
+  <div
+    class="euiPopover euiPopover--anchorDownRight euiHeaderLinks__mobile"
+  >
+    <button
+      aria-controls="headerListMenu"
+      aria-expanded="false"
+      class="euiHeaderSectionItem__button"
+      type="button"
+    >
+      <svg
+        class="euiIcon euiIcon--medium"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xlink="http://www.w3.org/1999/xlink"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <defs>
+          <path
+            d="M2 4V3h2v1H2zm4 0V3h8v1H6zm0 3V6h8v1H6zm0 3V9h8v1H6zM2 7V6h2v1H2zm0 3V9h2v1H2zm4 3v-1h8v1H6zm-4 0v-1h2v1H2z"
+            id="list-a"
+          />
+        </defs>
+        <use
+          fill-rule="nonzero"
+          href="#list-a"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;

--- a/src/components/header/header_links/_header_link.scss
+++ b/src/components/header/header_links/_header_link.scss
@@ -1,0 +1,31 @@
+
+
+.euiHeaderLink {
+  display: inline-block;
+
+  .euiHeaderLink__link {
+    display: block;
+    height: $euiHeaderChildSize;
+    line-height: $euiHeaderChildSize;
+    padding: 0 $euiSize;
+    color: $euiHeaderBreadcrumbColor;
+    @include euiLink;
+  }
+
+  &.euiHeaderLink-isActive .euiHeaderLink__link {
+    color: $euiColorPrimary;
+  }
+}
+
+.euiHeaderLinks__mobile {
+  .euiHeaderLink {
+    display: block;
+    width: auto;
+
+    .euiHeaderLink__link {
+      height: auto;
+      line-height: $euiLineHeight;
+      padding: $euiSizeS;
+    }
+  }
+}

--- a/src/components/header/header_links/_header_links.scss
+++ b/src/components/header/header_links/_header_links.scss
@@ -1,0 +1,27 @@
+@import '../../link/mixins';
+
+.euiHeaderLinks {
+  display: flex;
+  justify-content: space-between;
+  position: relative;
+  flex-grow: 1;
+}
+
+.euiHeaderLinks__list {
+  white-space: nowrap;
+  overflow: hidden;
+
+  @include screenXSmall(){
+    display: none;
+  }
+}
+
+.euiHeaderLinks__mobile {
+  display: none !important; // override popover inline-block
+  position: absolute !important; // override popover relative
+  right: 0;
+
+  @include screenXSmall(){
+    display: block !important;
+  }
+}

--- a/src/components/header/header_links/_index.scss
+++ b/src/components/header/header_links/_index.scss
@@ -1,0 +1,2 @@
+@import 'header_links';
+@import 'header_link';

--- a/src/components/header/header_links/header_link.js
+++ b/src/components/header/header_links/header_link.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+export const EuiHeaderLink = ({
+  href,
+  isActive,
+  children,
+  className,
+  ...rest,
+}) => {
+  const classes = classNames('euiHeaderLink', className, {
+    'euiHeaderLink-isActive': isActive,
+  });
+
+  return (
+    <li className={classes} {...rest}>
+      <a className="euiHeaderLink__link" href={href}>
+        <span className="euiHeaderLink__text">{children}</span>
+      </a>
+    </li>
+  );
+};
+
+EuiHeaderLink.propTypes = {
+  href: PropTypes.string,
+  children: PropTypes.node,
+  isActive: PropTypes.bool,
+};

--- a/src/components/header/header_links/header_link.test.js
+++ b/src/components/header/header_links/header_link.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from 'enzyme';
+import { requiredProps } from '../../../test';
+
+import { EuiHeaderLink } from './header_link';
+
+describe('EuiHeaderLink', () => {
+  test('is rendered', () => {
+    const component = render(
+      <EuiHeaderLink {...requiredProps} />
+    );
+
+    expect(component)
+      .toMatchSnapshot();
+  });
+});

--- a/src/components/header/header_links/header_links.js
+++ b/src/components/header/header_links/header_links.js
@@ -1,0 +1,81 @@
+
+import React, {
+  Component,
+} from 'react';
+
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import { EuiIcon } from '../../icon';
+import { EuiPopover } from '../../popover';
+import { EuiHeaderSectionItemButton } from '../header_section';
+
+export class EuiHeaderLinks extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isOpen: false,
+    };
+  }
+
+  onMenuButtonClick = () => {
+    this.setState({
+      isOpen: !this.state.isOpen,
+    });
+  };
+
+  closeMenu = () => {
+    this.setState({
+      isOpen: false,
+    });
+  };
+
+  render() {
+    const {
+      children,
+      className,
+      ...rest
+    } = this.props;
+
+    const classes = classNames('euiHeaderLinks', className);
+
+    const button = (
+      <EuiHeaderSectionItemButton onClick={this.onMenuButtonClick}>
+        <EuiIcon type="list" size="m" />
+      </EuiHeaderSectionItemButton>
+    );
+
+    return (
+      <div
+        className={classes}
+        {...rest}
+      >
+
+        <ul className="euiHeaderLinks__list">
+          {children}
+        </ul>
+
+
+        <EuiPopover
+          className="euiHeaderLinks__mobile"
+          id="headerListMenu"
+          ownFocus
+          button={button}
+          isOpen={this.state.isOpen}
+          anchorPosition="downRight"
+          closePopover={this.closeMenu}
+          panelClassName="euiHeaderPopover"
+        >
+          {children}
+        </EuiPopover>
+
+      </div>
+    );
+  }
+}
+
+EuiHeaderLinks.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};

--- a/src/components/header/header_links/header_links.test.js
+++ b/src/components/header/header_links/header_links.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from 'enzyme';
+import { requiredProps } from '../../../test';
+
+import { EuiHeaderLinks } from './header_links';
+
+describe('EuiHeaderLinks', () => {
+  test('is rendered', () => {
+    const component = render(
+      <EuiHeaderLinks {...requiredProps} />
+    );
+
+    expect(component)
+      .toMatchSnapshot();
+  });
+});

--- a/src/components/header/header_links/index.js
+++ b/src/components/header/header_links/index.js
@@ -1,0 +1,7 @@
+export {
+  EuiHeaderLink,
+} from './header_link';
+
+export {
+  EuiHeaderLinks,
+} from './header_links';

--- a/src/components/header/header_logo.js
+++ b/src/components/header/header_logo.js
@@ -6,7 +6,7 @@ import {
   EuiIcon,
 } from '../icon';
 
-export const EuiHeaderLogo = ({ iconType, iconTitle, href, className, ...rest }) => {
+export const EuiHeaderLogo = ({ iconType, iconTitle, href, children, className, ...rest }) => {
   const classes = classNames('euiHeaderLogo', className);
 
   return (
@@ -17,12 +17,17 @@ export const EuiHeaderLogo = ({ iconType, iconTitle, href, className, ...rest })
         type={iconType}
         title={iconTitle}
       />
+
+      {children &&
+        <span className="euiHeaderLogo__text">{children}</span>
+      }
     </a>
   );
 };
 
 EuiHeaderLogo.propTypes = {
   href: PropTypes.string,
+  children: PropTypes.node,
 };
 
 EuiHeaderLogo.defaultProps = {

--- a/src/components/header/header_section/__snapshots__/header_section_item.test.js.snap
+++ b/src/components/header/header_section/__snapshots__/header_section_item.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`EuiHeaderSectionItem border defaults to left 1`] = `
 <div
-  class="euiHeaderSectionItem"
+  class="euiHeaderSectionItem euiHeaderSectionItem--borderLeft"
 />
 `;
 
@@ -15,14 +15,14 @@ exports[`EuiHeaderSectionItem border renders right 1`] = `
 exports[`EuiHeaderSectionItem is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="euiHeaderSectionItem testClass1 testClass2"
+  class="euiHeaderSectionItem euiHeaderSectionItem--borderLeft testClass1 testClass2"
   data-test-subj="test subject string"
 />
 `;
 
 exports[`EuiHeaderSectionItem renders children 1`] = `
 <div
-  class="euiHeaderSectionItem"
+  class="euiHeaderSectionItem euiHeaderSectionItem--borderLeft"
 >
   <span>
     Call me Ishmael.

--- a/src/components/header/header_section/_header_section_item.scss
+++ b/src/components/header/header_section/_header_section_item.scss
@@ -10,7 +10,6 @@
   &:after {
     position: absolute;
     content: "";
-    width: 1px;
     top: $euiSize;
     bottom: 0;
     background: $euiBorderColor;
@@ -28,8 +27,16 @@
     }
   }
 
+.euiHeaderSectionItem--borderLeft {
+  &:after {
+    left: 0;
+    width: 1px;
+  }
+}
+
 .euiHeaderSectionItem--borderRight {
   &:after {
+    width: 1px;
     left: auto;
     right: 0;
   }

--- a/src/components/header/header_section/header_section_item.js
+++ b/src/components/header/header_section/header_section_item.js
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 const borderToClassNameMap = {
-  left: undefined,
+  left: 'euiHeaderSectionItem--borderLeft',
   right: 'euiHeaderSectionItem--borderRight',
+  none: undefined,
 };
 
 const BORDERS = Object.keys(borderToClassNameMap);

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -13,6 +13,11 @@ export {
 } from './header_breadcrumbs';
 
 export {
+  EuiHeaderLink,
+  EuiHeaderLinks,
+} from './header_links';
+
+export {
   EuiHeaderLogo,
 } from './header_logo';
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -134,6 +134,8 @@ export {
   EuiHeaderBreadcrumb,
   EuiHeaderBreadcrumbCollapsed,
   EuiHeaderBreadcrumbs,
+  EuiHeaderLink,
+  EuiHeaderLinks,
   EuiHeaderLogo,
   EuiHeaderNotification,
   EuiHeaderSection,


### PR DESCRIPTION
Also made the following modifications to existing comps:
- `EuiHeaderLogo` now accepts text (children) as well
- `EuiHeaderSectionItem` can have “none” as the border but still defaults to “left”

<img width="760" alt="screen shot 2018-05-08 at 10 08 36 am" src="https://user-images.githubusercontent.com/549577/39762173-f9e4b74e-52a7-11e8-8c4a-2b03157b5709.png">
<img width="362" alt="screen shot 2018-05-08 at 10 08 50 am" src="https://user-images.githubusercontent.com/549577/39762174-f9f08b64-52a7-11e8-90c9-8c4b1238c27e.png">

cc @thomasneirynck 

## Also

Fixes #801 : Adjusted coloring of active breadcrumb in `EuiHeader` for dark theme.

<img width="743" alt="screen shot 2018-05-08 at 11 22 41 am" src="https://user-images.githubusercontent.com/549577/39766447-5687383c-52b2-11e8-948a-671d0cab8425.png">
<img width="755" alt="screen shot 2018-05-08 at 11 22 46 am" src="https://user-images.githubusercontent.com/549577/39766448-569beb4c-52b2-11e8-9207-fbdd08fbd18b.png">
