### PR TITLE
do not call setState if combo box is no longer mounted

### DIFF
--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -74,8 +74,6 @@ export class EuiComboBox extends Component {
     this.searchInput = undefined;
     this.optionsList = undefined;
     this.options = [];
-
-    this._hasUnmounted = false;
   }
 
   getMatchingOptions = (options, selectedOptions, searchValue) => {
@@ -98,7 +96,7 @@ export class EuiComboBox extends Component {
   };
 
   updateListPosition = (listBounds = this.listBounds) => {
-    if (this._hasUnmounted) {
+    if (!this._isMounted) {
       return;
     }
 
@@ -452,6 +450,8 @@ export class EuiComboBox extends Component {
   };
 
   componentDidMount() {
+    this._isMounted = true;
+
     // TODO: This will need to be called once the actual stylesheet loads.
     setTimeout(() => {
       this.autoSizeInput.copyInputStyles();
@@ -490,7 +490,7 @@ export class EuiComboBox extends Component {
 
   componentWillUnmount() {
     this.incrementActiveOptionIndex.cancel();
-    this._hasUnmounted = true;
+    this._isMounted = false;
     document.removeEventListener('click', this.onDocumentFocusChange);
     document.removeEventListener('focusin', this.onDocumentFocusChange);
   }

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -489,7 +489,7 @@ export class EuiComboBox extends Component {
   }
 
   componentWillUnmount() {
-    this.incrementActiveOptionIndex.cancel;
+    this.incrementActiveOptionIndex.cancel();
     this._hasUnmounted = true;
     document.removeEventListener('click', this.onDocumentFocusChange);
     document.removeEventListener('focusin', this.onDocumentFocusChange);

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -74,6 +74,8 @@ export class EuiComboBox extends Component {
     this.searchInput = undefined;
     this.optionsList = undefined;
     this.options = [];
+
+    this._hasUnmounted = false;
   }
 
   getMatchingOptions = (options, selectedOptions, searchValue) => {
@@ -96,6 +98,10 @@ export class EuiComboBox extends Component {
   };
 
   updateListPosition = (listBounds = this.listBounds) => {
+    if (this._hasUnmounted) {
+      return;
+    }
+
     if (!this.state.isListOpen) {
       return;
     }
@@ -483,6 +489,8 @@ export class EuiComboBox extends Component {
   }
 
   componentWillUnmount() {
+    this.incrementActiveOptionIndex.cancel;
+    this._hasUnmounted = true;
     document.removeEventListener('click', this.onDocumentFocusChange);
     document.removeEventListener('focusin', this.onDocumentFocusChange);
   }


### PR DESCRIPTION
fixes https://github.com/elastic/eui/issues/794

I could not find a way to reproduce calling setState once the combo box component had been unmounted. This PR just avoids the potential of calling setState for 2 places where setState was called asynchronously. 

