### PR TITLE
Accordion needs a height calculation on mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 **Bug fixes**
 
+- Fixes height calculation error on `EuiAccordion` when it starts loads in an open state. ([#816](https://github.com/elastic/eui/pull/816))
 - Added aria-invalid labeling on `EuiFormRow` ([#777](https://github.com/elastic/eui/pull/799))
 - Added aria-live labeling for `EuiToasts` ([#777](https://github.com/elastic/eui/pull/777))
 - Added aria labeling requirements for `EuiBadge` , as well as a generic prop_type function `requiresAriaLabel` in `utils` to check for it. ([#777](https://github.com/elastic/eui/pull/777)) ([#802](https://github.com/elastic/eui/pull/802))

--- a/src-docs/src/index.html
+++ b/src-docs/src/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel="stylesheet">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/tota11y/0.1.6/tota11y.min.js"></script>
   </head>
   <body class="guideBody">
     <div id="guide" style="height: 100%"></div>

--- a/src-docs/src/index.html
+++ b/src-docs/src/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel="stylesheet">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/tota11y/0.1.6/tota11y.min.js"></script>
   </head>
   <body class="guideBody">
     <div id="guide" style="height: 100%"></div>

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -2,14 +2,20 @@
   text-align: left;
   width: 100%;
 
-  &:hover, &:focus {
+  &:hover {
     text-decoration: underline;
     cursor: pointer;
   }
 
   &:focus {
-    background-color: $euiFocusBackgroundColor;
+    .euiAccordion__iconWrapper {
+      @include euiFocusRing;
+
+      color: $euiColorPrimary;
+      border-radius: $euiBorderRadius;
+    }
   }
+
 }
 
 .euiAccordion__childWrapper {
@@ -23,6 +29,7 @@
     opacity $euiAnimSpeedNormal $euiAnimSlightResistance
   ;
 }
+
 
 $paddingSizes: (
   xs: $euiSizeXS,

--- a/src/components/accordion/_accordion_form.scss
+++ b/src/components/accordion/_accordion_form.scss
@@ -21,17 +21,6 @@
       text-decoration: underline;
     }
   }
-
-  &:focus {
-    text-decoration: none;
-    background-color: transparent;
-
-    .euiAccordionForm__title {
-      text-decoration: underline;
-      background-color: $euiFocusBackgroundColor;
-      outline: solid $euiSizeXS / 2 $euiFocusBackgroundColor;
-    }
-  }
 }
 .euiAccordionForm {
   border-top: $euiBorderThin;

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -121,7 +121,7 @@ export class EuiAccordion extends Component {
               className={buttonClasses}
             >
               <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-                <EuiFlexItem grow={false}>
+                <EuiFlexItem grow={false} className="euiAccordion__iconWrapper">
                   {icon}
                 </EuiFlexItem>
 

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -35,10 +35,19 @@ export class EuiAccordion extends Component {
     this.onToggle = this.onToggle.bind(this);
   }
 
-  componentDidUpdate() {
-    const height = this.state.isOpen ? this.childContent.clientHeight: 0;
+  setChildContentHeight = () => {
+    requestAnimationFrame(() => {
+      const height = this.state.isOpen ? this.childContent.clientHeight: 0;
+      this.childWrapper.setAttribute('style', `height: ${height}px`);
+    });
+  }
 
-    this.childWrapper.setAttribute('style', `height: ${height}px`);
+  componentDidMount() {
+    this.setChildContentHeight();
+  }
+
+  componentDidUpdate() {
+    this.setChildContentHeight();
   }
 
   onToggle() {


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/805

Makes sure that the child content of an accordion gets a height if its set to be initially open.

![image](https://user-images.githubusercontent.com/324519/39893022-59935618-5457-11e8-8929-a629feeba99b.png)

cc @ppisljar and @timroes who ran into this issue in https://github.com/elastic/kibana/pull/18579
