### PR TITLE
Add tooltips to context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added utility CSS classes for text and alignment concerns.  ([#774](https://github.com/elastic/eui/pull/774))
 - Added `compressed` versions of `EuiFormRow` and all form controls.  ([#800](https://github.com/elastic/eui/pull/800))
+- Added the ability to add tooltips to `EuiContextMenuItem`s.  ([#817](https://github.com/elastic/eui/pull/817))
 
 **Bug fixes**
 

--- a/src-docs/src/views/context_menu/context_menu.js
+++ b/src-docs/src/views/context_menu/context_menu.js
@@ -101,8 +101,10 @@ export default class extends Component {
         icon: 'user',
         onClick: () => { this.closePopover(); window.alert('Edit / add panels'); },
       }, {
-        name: 'Display options',
+        name: 'You can add a tooltip',
         icon: 'user',
+        toolTipTitle: 'Optional tooltip',
+        toolTipContent: 'Optional content for a tooltip',
         onClick: () => { this.closePopover(); window.alert('Display options'); },
       }, {
         name: 'Disabled option',

--- a/src-docs/src/views/context_menu/context_menu.js
+++ b/src-docs/src/views/context_menu/context_menu.js
@@ -105,6 +105,7 @@ export default class extends Component {
         icon: 'user',
         toolTipTitle: 'Optional tooltip',
         toolTipContent: 'Optional content for a tooltip',
+        toolTipPosition: 'right',
         onClick: () => { this.closePopover(); window.alert('Display options'); },
       }, {
         name: 'Disabled option',

--- a/src-docs/src/views/context_menu/context_menu_example.js
+++ b/src-docs/src/views/context_menu/context_menu_example.js
@@ -9,6 +9,8 @@ import {
 import {
   EuiCode,
   EuiContextMenu,
+  EuiContextMenuPanel,
+  EuiContextMenuItem,
 } from '../../../../src/components';
 
 import ContextMenu from './context_menu';
@@ -36,7 +38,7 @@ export const ContextMenuExample = {
         which itself can be wrapped around any component (like a button in this example).
       </p>
     ),
-    props: { EuiContextMenu },
+    props: { EuiContextMenu, EuiContextMenuPanel, EuiContextMenuItem },
     demo: <ContextMenu />,
   }, {
     title: `With single panel`,

--- a/src/components/basic_table/__snapshots__/collapsed_item_actions.test.js.snap
+++ b/src/components/basic_table/__snapshots__/collapsed_item_actions.test.js.snap
@@ -30,11 +30,13 @@ exports[`CollapsedItemActions render 1`] = `
           disabled={false}
           icon={undefined}
           onClick={[Function]}
+          toolTipPosition="right"
         >
           default1
         </EuiContextMenuItem>,
         <EuiContextMenuItem
           onClick={[Function]}
+          toolTipPosition="right"
         />,
       ]
     }

--- a/src/components/context_menu/__snapshots__/context_menu_panel.test.js.snap
+++ b/src/components/context_menu/__snapshots__/context_menu_panel.test.js.snap
@@ -115,7 +115,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
 "<EuiContextMenuPanel items={{...}} hasFocus={true}>
   <div className=\\"euiContextMenuPanel\\" onKeyDown={[Function]} tabIndex=\\"0\\" onAnimationEnd={[Function]}>
     <div>
-      <EuiContextMenuItem data-counter={0} buttonRef={[Function: bound ]}>
+      <EuiContextMenuItem data-counter={0} toolTipPosition=\\"right\\" buttonRef={[Function: bound ]}>
         <button className=\\"euiContextMenuItem\\" type=\\"button\\" disabled={[undefined]} data-counter={0}>
           <span className=\\"euiContextMenu__itemLayout\\">
             <span className=\\"euiContextMenuItem__text\\">
@@ -124,7 +124,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
           </span>
         </button>
       </EuiContextMenuItem>
-      <EuiContextMenuItem data-counter={1} buttonRef={[Function: bound ]}>
+      <EuiContextMenuItem data-counter={1} toolTipPosition=\\"right\\" buttonRef={[Function: bound ]}>
         <button className=\\"euiContextMenuItem\\" type=\\"button\\" disabled={[undefined]} data-counter={1}>
           <span className=\\"euiContextMenu__itemLayout\\">
             <span className=\\"euiContextMenuItem__text\\">
@@ -142,7 +142,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
 "<EuiContextMenuPanel items={{...}} hasFocus={true}>
   <div className=\\"euiContextMenuPanel\\" onKeyDown={[Function]} tabIndex=\\"0\\" onAnimationEnd={[Function]}>
     <div>
-      <EuiContextMenuItem data-counter={0} buttonRef={[Function: bound ]}>
+      <EuiContextMenuItem data-counter={0} toolTipPosition=\\"right\\" buttonRef={[Function: bound ]}>
         <button className=\\"euiContextMenuItem\\" type=\\"button\\" disabled={[undefined]} data-counter={0}>
           <span className=\\"euiContextMenu__itemLayout\\">
             <span className=\\"euiContextMenuItem__text\\">
@@ -151,7 +151,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
           </span>
         </button>
       </EuiContextMenuItem>
-      <EuiContextMenuItem data-counter={1} buttonRef={[Function: bound ]}>
+      <EuiContextMenuItem data-counter={1} toolTipPosition=\\"right\\" buttonRef={[Function: bound ]}>
         <button className=\\"euiContextMenuItem\\" type=\\"button\\" disabled={[undefined]} data-counter={1}>
           <span className=\\"euiContextMenu__itemLayout\\">
             <span className=\\"euiContextMenuItem__text\\">
@@ -189,7 +189,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
 "<EuiContextMenuPanel watchedItemProps={{...}} items={{...}} hasFocus={true}>
   <div className=\\"euiContextMenuPanel\\" onKeyDown={[Function]} tabIndex=\\"0\\" onAnimationEnd={[Function]}>
     <div>
-      <EuiContextMenuItem data-counter={0} buttonRef={[Function: bound ]}>
+      <EuiContextMenuItem data-counter={0} toolTipPosition=\\"right\\" buttonRef={[Function: bound ]}>
         <button className=\\"euiContextMenuItem\\" type=\\"button\\" disabled={[undefined]} data-counter={0}>
           <span className=\\"euiContextMenu__itemLayout\\">
             <span className=\\"euiContextMenuItem__text\\">
@@ -198,7 +198,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
           </span>
         </button>
       </EuiContextMenuItem>
-      <EuiContextMenuItem data-counter={1} buttonRef={[Function: bound ]}>
+      <EuiContextMenuItem data-counter={1} toolTipPosition=\\"right\\" buttonRef={[Function: bound ]}>
         <button className=\\"euiContextMenuItem\\" type=\\"button\\" disabled={[undefined]} data-counter={1}>
           <span className=\\"euiContextMenu__itemLayout\\">
             <span className=\\"euiContextMenuItem__text\\">
@@ -216,7 +216,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
 "<EuiContextMenuPanel watchedItemProps={{...}} items={{...}} hasFocus={true}>
   <div className=\\"euiContextMenuPanel\\" onKeyDown={[Function]} tabIndex=\\"0\\" onAnimationEnd={[Function]}>
     <div>
-      <EuiContextMenuItem data-counter={2} buttonRef={[Function: bound ]}>
+      <EuiContextMenuItem data-counter={2} toolTipPosition=\\"right\\" buttonRef={[Function: bound ]}>
         <button className=\\"euiContextMenuItem\\" type=\\"button\\" disabled={[undefined]} data-counter={2}>
           <span className=\\"euiContextMenu__itemLayout\\">
             <span className=\\"euiContextMenuItem__text\\">
@@ -225,7 +225,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
           </span>
         </button>
       </EuiContextMenuItem>
-      <EuiContextMenuItem data-counter={3} buttonRef={[Function: bound ]}>
+      <EuiContextMenuItem data-counter={3} toolTipPosition=\\"right\\" buttonRef={[Function: bound ]}>
         <button className=\\"euiContextMenuItem\\" type=\\"button\\" disabled={[undefined]} data-counter={3}>
           <span className=\\"euiContextMenu__itemLayout\\">
             <span className=\\"euiContextMenuItem__text\\">

--- a/src/components/context_menu/context_menu.js
+++ b/src/components/context_menu/context_menu.js
@@ -199,6 +199,8 @@ export class EuiContextMenu extends Component {
         name,
         icon,
         onClick,
+        toolTipTitle,
+        toolTipContent,
         ...rest
       } = item;
 
@@ -221,6 +223,8 @@ export class EuiContextMenu extends Component {
           icon={icon}
           onClick={onClickHandler}
           hasPanel={Boolean(panel)}
+          toolTipTitle={toolTipTitle}
+          toolTipContent={toolTipContent}
           {...rest}
         >
           {name}

--- a/src/components/context_menu/context_menu_item.js
+++ b/src/components/context_menu/context_menu_item.js
@@ -1,24 +1,42 @@
 import React, {
   cloneElement,
   Component,
+  Fragment,
 } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { EuiIcon } from '../icon';
+import { EuiToolTip } from '../tool_tip';
 
 export class EuiContextMenuItem extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
+    /**
+     * Icon used for the item
+     */
     icon: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
     onClick: PropTypes.func,
+    /**
+     * Whether the item leads to a new set of items
+     */
     hasPanel: PropTypes.bool,
     buttonRef: PropTypes.func,
     disabled: PropTypes.bool,
+    /**
+     * Optional if adding a tooltip. Add an optional tooltip on hover
+     */
+    toolTipTitle: PropTypes.node,
+    /**
+     * Required if using a tooltip. Add an optional tooltip on hover
+     */
+    toolTipContent: PropTypes.node,
   };
 
   render() {
+    console.log(this.props);
+
     const {
       children,
       className,
@@ -26,6 +44,8 @@ export class EuiContextMenuItem extends Component {
       icon,
       buttonRef,
       disabled,
+      toolTipTitle,
+      toolTipContent,
       ...rest
     } = this.props;
 
@@ -67,7 +87,7 @@ export class EuiContextMenuItem extends Component {
       'euiContextMenuItem-isDisabled': disabled,
     });
 
-    return (
+    const button = (
       <button
         className={classes}
         type="button"
@@ -84,5 +104,25 @@ export class EuiContextMenuItem extends Component {
         </span>
       </button>
     );
+
+    if (toolTipTitle || toolTipContent) {
+      return (
+        <EuiToolTip
+          title={toolTipTitle ? toolTipTitle : null}
+          content={toolTipContent ? toolTipContent : null}
+          anchorClassName="eui-displayBlock"
+          position="right"
+        >
+          {button}
+        </EuiToolTip>
+      );
+    } else {
+      return (
+        <Fragment>
+          {button}
+        </Fragment>
+      );
+    }
+
   }
 }

--- a/src/components/context_menu/context_menu_item.js
+++ b/src/components/context_menu/context_menu_item.js
@@ -1,7 +1,6 @@
 import React, {
   cloneElement,
   Component,
-  Fragment,
 } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -35,7 +34,7 @@ export class EuiContextMenuItem extends Component {
     /**
      * Dictates the position of the tooltip.
      */
-    toolTipPosition: PropTypes.node,
+    toolTipPosition: PropTypes.string,
   };
 
   render() {
@@ -122,9 +121,7 @@ export class EuiContextMenuItem extends Component {
       );
     } else {
       return (
-        <Fragment>
-          {button}
-        </Fragment>
+        button
       );
     }
 

--- a/src/components/context_menu/context_menu_item.js
+++ b/src/components/context_menu/context_menu_item.js
@@ -25,13 +25,13 @@ export class EuiContextMenuItem extends Component {
     buttonRef: PropTypes.func,
     disabled: PropTypes.bool,
     /**
-     * Optional if adding a tooltip. Add an optional tooltip on hover
-     */
-    toolTipTitle: PropTypes.node,
-    /**
      * Required if using a tooltip. Add an optional tooltip on hover
      */
     toolTipContent: PropTypes.node,
+    /**
+     * Optional title for the tooltip
+     */
+    toolTipTitle: PropTypes.node,
     /**
      * Dictates the position of the tooltip.
      */
@@ -110,11 +110,11 @@ export class EuiContextMenuItem extends Component {
       </button>
     );
 
-    if (toolTipTitle || toolTipContent) {
+    if (toolTipContent) {
       return (
         <EuiToolTip
           title={toolTipTitle ? toolTipTitle : null}
-          content={toolTipContent ? toolTipContent : null}
+          content={toolTipContent}
           anchorClassName="eui-displayBlock"
           position={toolTipPosition}
         >

--- a/src/components/context_menu/context_menu_item.js
+++ b/src/components/context_menu/context_menu_item.js
@@ -39,7 +39,6 @@ export class EuiContextMenuItem extends Component {
   };
 
   render() {
-    console.log(this.props);
 
     const {
       children,

--- a/src/components/context_menu/context_menu_item.js
+++ b/src/components/context_menu/context_menu_item.js
@@ -32,6 +32,10 @@ export class EuiContextMenuItem extends Component {
      * Required if using a tooltip. Add an optional tooltip on hover
      */
     toolTipContent: PropTypes.node,
+    /**
+     * Dictates the position of the tooltip.
+     */
+    toolTipPosition: PropTypes.node,
   };
 
   render() {
@@ -46,6 +50,7 @@ export class EuiContextMenuItem extends Component {
       disabled,
       toolTipTitle,
       toolTipContent,
+      toolTipPosition,
       ...rest
     } = this.props;
 
@@ -111,7 +116,7 @@ export class EuiContextMenuItem extends Component {
           title={toolTipTitle ? toolTipTitle : null}
           content={toolTipContent ? toolTipContent : null}
           anchorClassName="eui-displayBlock"
-          position="right"
+          position={toolTipPosition}
         >
           {button}
         </EuiToolTip>
@@ -126,3 +131,7 @@ export class EuiContextMenuItem extends Component {
 
   }
 }
+
+EuiContextMenuItem.defaultProps = {
+  toolTipPosition: "right",
+};

--- a/src/components/tool_tip/tool_tip.js
+++ b/src/components/tool_tip/tool_tip.js
@@ -88,6 +88,7 @@ export class EuiToolTip extends Component {
     const {
       children,
       className,
+      anchorClassName,
       content,
       title,
       ...rest
@@ -97,6 +98,11 @@ export class EuiToolTip extends Component {
       'euiToolTip',
       positionsToClassNameMap[this.state.calculatedPosition],
       className
+    );
+
+    const anchorClasses = classNames(
+      'euiToolTipAnchor',
+      anchorClassName,
     );
 
     let tooltip;
@@ -121,7 +127,7 @@ export class EuiToolTip extends Component {
     const anchor = (
       <span
         ref={anchor => this.anchor = anchor}
-        className="euiToolTipAnchor"
+        className={anchorClasses}
       >
         {cloneElement(children, {
           onFocus: this.showToolTip,


### PR DESCRIPTION
Fixed #808 

Context menus now allow a `toolTipTitle` and `toolTipContent` to apply a tooltip.

![](https://d3vv6lp55qjaqc.cloudfront.net/items/2V1m1Y2Q0J2t2Y223K2t/Screen%20Recording%202018-05-10%20at%2003.22%20PM.gif?X-CloudApp-Visitor-Id=59773&v=002f9bb3)