### PR TITLE
Fixes for accessibility tickets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Ensure switches’ inputs are still hidden when `[disabled]` ([#778](https://github.com/elastic/eui/pull/778))
 - Made boolean matching in `EuiSearchBar` more exact so it doesn't match words starting with booleans, like "truest" or "offer" ([#776](https://github.com/elastic/eui/pull/776))
 - `EuiComboBox` do not setState or call refs once component is unmounted ([807](https://github.com/elastic/eui/pull/807) and [#813](https://github.com/elastic/eui/pull/813))
+- Added better accessibility labeling to `EuiPagination`, `EuiSideNav`, `EuiPopover`, `EuiBottomBar` and `EuiBasicTable`.  ([#821](https://github.com/elastic/eui/pull/821))
 
 ## [`0.0.46`](https://github.com/elastic/eui/tree/v0.0.46)
 

--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -93,7 +93,6 @@ export class GuidePageChrome extends Component {
   }
 
   renderSubSections = (subSections = []) => {
-    console.log(subSections);
 
     const subSectionsWithTitles = subSections.filter(item => (item.title));
 

--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -71,6 +71,7 @@ export class GuidePageChrome extends Component {
       <Link
         to="/"
         className="guideLogo"
+        aria-label="Go to home page"
       >
         <EuiIcon type="logoElastic" size="l" />
       </Link>

--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -93,11 +93,15 @@ export class GuidePageChrome extends Component {
   }
 
   renderSubSections = (subSections = []) => {
-    if (subSections.length <= 1) {
+    console.log(subSections);
+
+    const subSectionsWithTitles = subSections.filter(item => (item.title));
+
+    if (subSectionsWithTitles.length <= 1) {
       return;
     }
 
-    return subSections.map(({ title, id }) => ({
+    return subSectionsWithTitles.map(({ title, id }) => ({
       id: `subSection-${id}`,
       name: title,
       onClick: this.onClickLink.bind(this, id),

--- a/src-docs/src/components/guide_theme_selector/guide_theme_selector.js
+++ b/src-docs/src/components/guide_theme_selector/guide_theme_selector.js
@@ -37,6 +37,7 @@ export class GuideThemeSelector extends Component {
         iconType="arrowDown"
         iconSide="right"
         onClick={this.onThemeButtonClick}
+        aria-label="Select a visual theme"
       >
         <strong>Elastic UI</strong> <span className="guideSideNav__theme"> ~ {this.props.selectedTheme}</span>
       </EuiButtonEmpty>

--- a/src-docs/src/views/guidelines/button.js
+++ b/src-docs/src/views/guidelines/button.js
@@ -287,9 +287,9 @@ export default() => (
         frame="frame"
       >
         <div>
-          <EuiButtonIcon size="s" iconType="pencil" aria-label="Next"/>
+          <EuiButtonIcon size="s" iconType="pencil" aria-label="Edit"/>
           &nbsp;&nbsp;&nbsp;&nbsp;
-          <EuiButtonIcon size="s" iconType="expand" aria-label="Next"/>
+          <EuiButtonIcon size="s" iconType="expand" aria-label="Expand"/>
         </div>
       </GuideRuleExample>
       <GuideRuleExample
@@ -300,11 +300,11 @@ export default() => (
       >
         <div>
           <EuiButton>
-            <EuiIcon type="pencil"/>
+            <EuiIcon type="pencil" aria-label="Edit" />
           </EuiButton>
           &nbsp;&nbsp;&nbsp;&nbsp;
-          <EuiButton >
-            <EuiIcon type="expand"/>
+          <EuiButton>
+            <EuiIcon type="expand" aria-label="Expand" />
           </EuiButton>
         </div>
       </GuideRuleExample>

--- a/src-docs/src/views/popover/popover.js
+++ b/src-docs/src/views/popover/popover.js
@@ -42,7 +42,6 @@ export default class extends Component {
     return (
       <EuiPopover
         id="popover"
-        ownFocus
         button={button}
         isOpen={this.state.isPopoverOpen}
         closePopover={this.closePopover.bind(this)}

--- a/src/components/basic_table/__snapshots__/basic_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.js.snap
@@ -483,6 +483,7 @@ exports[`EuiBasicTable with pagination and selection 1`] = `
           width="24px"
         >
           <EuiCheckbox
+            aria-label="Select all rows"
             checked={false}
             compressed={false}
             data-test-subj="checkboxSelectAll"
@@ -511,6 +512,7 @@ exports[`EuiBasicTable with pagination and selection 1`] = `
               key="_selection_column_1"
             >
               <EuiCheckbox
+                aria-label="Select this row"
                 checked={false}
                 compressed={false}
                 data-test-subj="checkboxSelectRow-1"
@@ -540,6 +542,7 @@ exports[`EuiBasicTable with pagination and selection 1`] = `
               key="_selection_column_2"
             >
               <EuiCheckbox
+                aria-label="Select this row"
                 checked={false}
                 compressed={false}
                 data-test-subj="checkboxSelectRow-2"
@@ -569,6 +572,7 @@ exports[`EuiBasicTable with pagination and selection 1`] = `
               key="_selection_column_3"
             >
               <EuiCheckbox
+                aria-label="Select this row"
                 checked={false}
                 compressed={false}
                 data-test-subj="checkboxSelectRow-3"
@@ -635,6 +639,7 @@ exports[`EuiBasicTable with pagination, selection and sorting 1`] = `
           width="24px"
         >
           <EuiCheckbox
+            aria-label="Select all rows"
             checked={false}
             compressed={false}
             data-test-subj="checkboxSelectAll"
@@ -666,6 +671,7 @@ exports[`EuiBasicTable with pagination, selection and sorting 1`] = `
               key="_selection_column_1"
             >
               <EuiCheckbox
+                aria-label="Select this row"
                 checked={false}
                 compressed={false}
                 data-test-subj="checkboxSelectRow-1"
@@ -695,6 +701,7 @@ exports[`EuiBasicTable with pagination, selection and sorting 1`] = `
               key="_selection_column_2"
             >
               <EuiCheckbox
+                aria-label="Select this row"
                 checked={false}
                 compressed={false}
                 data-test-subj="checkboxSelectRow-2"
@@ -724,6 +731,7 @@ exports[`EuiBasicTable with pagination, selection and sorting 1`] = `
               key="_selection_column_3"
             >
               <EuiCheckbox
+                aria-label="Select this row"
                 checked={false}
                 compressed={false}
                 data-test-subj="checkboxSelectRow-3"
@@ -790,6 +798,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
           width="24px"
         >
           <EuiCheckbox
+            aria-label="Select all rows"
             checked={false}
             compressed={false}
             data-test-subj="checkboxSelectAll"
@@ -828,6 +837,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
               key="_selection_column_1"
             >
               <EuiCheckbox
+                aria-label="Select this row"
                 checked={false}
                 compressed={false}
                 data-test-subj="checkboxSelectRow-1"
@@ -885,6 +895,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
               key="_selection_column_2"
             >
               <EuiCheckbox
+                aria-label="Select this row"
                 checked={false}
                 compressed={false}
                 data-test-subj="checkboxSelectRow-2"
@@ -942,6 +953,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
               key="_selection_column_3"
             >
               <EuiCheckbox
+                aria-label="Select this row"
                 checked={false}
                 compressed={false}
                 data-test-subj="checkboxSelectRow-3"
@@ -1036,6 +1048,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and column dataType 1
           width="24px"
         >
           <EuiCheckbox
+            aria-label="Select all rows"
             checked={false}
             compressed={false}
             data-test-subj="checkboxSelectAll"
@@ -1067,6 +1080,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and column dataType 1
               key="_selection_column_1"
             >
               <EuiCheckbox
+                aria-label="Select this row"
                 checked={false}
                 compressed={false}
                 data-test-subj="checkboxSelectRow-1"
@@ -1096,6 +1110,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and column dataType 1
               key="_selection_column_2"
             >
               <EuiCheckbox
+                aria-label="Select this row"
                 checked={false}
                 compressed={false}
                 data-test-subj="checkboxSelectRow-2"
@@ -1125,6 +1140,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and column dataType 1
               key="_selection_column_3"
             >
               <EuiCheckbox
+                aria-label="Select this row"
                 checked={false}
                 compressed={false}
                 data-test-subj="checkboxSelectRow-3"
@@ -1191,6 +1207,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and column renderer 1
           width="24px"
         >
           <EuiCheckbox
+            aria-label="Select all rows"
             checked={false}
             compressed={false}
             data-test-subj="checkboxSelectAll"
@@ -1222,6 +1239,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and column renderer 1
               key="_selection_column_1"
             >
               <EuiCheckbox
+                aria-label="Select this row"
                 checked={false}
                 compressed={false}
                 data-test-subj="checkboxSelectRow-1"
@@ -1251,6 +1269,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and column renderer 1
               key="_selection_column_2"
             >
               <EuiCheckbox
+                aria-label="Select this row"
                 checked={false}
                 compressed={false}
                 data-test-subj="checkboxSelectRow-2"
@@ -1280,6 +1299,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and column renderer 1
               key="_selection_column_3"
             >
               <EuiCheckbox
+                aria-label="Select this row"
                 checked={false}
                 compressed={false}
                 data-test-subj="checkboxSelectRow-3"
@@ -1346,6 +1366,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
           width="24px"
         >
           <EuiCheckbox
+            aria-label="Select all rows"
             checked={false}
             compressed={false}
             data-test-subj="checkboxSelectAll"
@@ -1384,6 +1405,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
               key="_selection_column_1"
             >
               <EuiCheckbox
+                aria-label="Select this row"
                 checked={false}
                 compressed={false}
                 data-test-subj="checkboxSelectRow-1"
@@ -1439,6 +1461,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
               key="_selection_column_2"
             >
               <EuiCheckbox
+                aria-label="Select this row"
                 checked={false}
                 compressed={false}
                 data-test-subj="checkboxSelectRow-2"
@@ -1494,6 +1517,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
               key="_selection_column_3"
             >
               <EuiCheckbox
+                aria-label="Select this row"
                 checked={false}
                 compressed={false}
                 data-test-subj="checkboxSelectRow-3"
@@ -1586,6 +1610,7 @@ exports[`EuiBasicTable with pagination, selection, sorting, column renderer and 
           width="24px"
         >
           <EuiCheckbox
+            aria-label="Select all rows"
             checked={false}
             compressed={false}
             data-test-subj="checkboxSelectAll"
@@ -1617,6 +1642,7 @@ exports[`EuiBasicTable with pagination, selection, sorting, column renderer and 
               key="_selection_column_1"
             >
               <EuiCheckbox
+                aria-label="Select this row"
                 checked={false}
                 compressed={false}
                 data-test-subj="checkboxSelectRow-1"
@@ -1646,6 +1672,7 @@ exports[`EuiBasicTable with pagination, selection, sorting, column renderer and 
               key="_selection_column_2"
             >
               <EuiCheckbox
+                aria-label="Select this row"
                 checked={false}
                 compressed={false}
                 data-test-subj="checkboxSelectRow-2"
@@ -1675,6 +1702,7 @@ exports[`EuiBasicTable with pagination, selection, sorting, column renderer and 
               key="_selection_column_3"
             >
               <EuiCheckbox
+                aria-label="Select this row"
                 checked={false}
                 compressed={false}
                 data-test-subj="checkboxSelectRow-3"

--- a/src/components/basic_table/basic_table.js
+++ b/src/components/basic_table/basic_table.js
@@ -366,6 +366,7 @@ export class EuiBasicTable extends Component {
             disabled={disabled}
             onChange={onChange}
             data-test-subj="checkboxSelectAll"
+            aria-label="Select all rows"
           />
         </EuiTableHeaderCellCheckbox>
       );
@@ -562,6 +563,7 @@ export class EuiBasicTable extends Component {
           checked={checked}
           onChange={onChange}
           title={title}
+          aria-label="Select this row"
           data-test-subj={`checkboxSelectRow-${itemId}`}
         />
       </EuiTableRowCellCheckbox>

--- a/src/components/bottom_bar/__snapshots__/bottom_bar.test.js.snap
+++ b/src/components/bottom_bar/__snapshots__/bottom_bar.test.js.snap
@@ -1,35 +1,75 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiBottomBar is rendered 1`] = `
-<div
-  aria-label="aria-label"
-  class="euiBottomBar euiBottomBar--paddingMedium testClass1 testClass2"
-  data-test-subj="test subject string"
->
-  Content
-</div>
+Array [
+  <p
+    aria-live="assertive"
+    class="euiScreenReaderOnly"
+  >
+    There is a new menu opening with page level controls at the bottom of the document.
+  </p>,
+  <div
+    aria-label="aria-label"
+    class="euiBottomBar euiBottomBar--paddingMedium testClass1 testClass2"
+    data-test-subj="test subject string"
+  >
+    Content
+  </div>,
+]
 `;
 
 exports[`EuiBottomBar props paddingSize l is rendered 1`] = `
-<div
-  class="euiBottomBar euiBottomBar--paddingLarge"
-/>
+Array [
+  <p
+    aria-live="assertive"
+    class="euiScreenReaderOnly"
+  >
+    There is a new menu opening with page level controls at the bottom of the document.
+  </p>,
+  <div
+    class="euiBottomBar euiBottomBar--paddingLarge"
+  />,
+]
 `;
 
 exports[`EuiBottomBar props paddingSize m is rendered 1`] = `
-<div
-  class="euiBottomBar euiBottomBar--paddingMedium"
-/>
+Array [
+  <p
+    aria-live="assertive"
+    class="euiScreenReaderOnly"
+  >
+    There is a new menu opening with page level controls at the bottom of the document.
+  </p>,
+  <div
+    class="euiBottomBar euiBottomBar--paddingMedium"
+  />,
+]
 `;
 
 exports[`EuiBottomBar props paddingSize none is rendered 1`] = `
-<div
-  class="euiBottomBar"
-/>
+Array [
+  <p
+    aria-live="assertive"
+    class="euiScreenReaderOnly"
+  >
+    There is a new menu opening with page level controls at the bottom of the document.
+  </p>,
+  <div
+    class="euiBottomBar"
+  />,
+]
 `;
 
 exports[`EuiBottomBar props paddingSize s is rendered 1`] = `
-<div
-  class="euiBottomBar euiBottomBar--paddingSmall"
-/>
+Array [
+  <p
+    aria-live="assertive"
+    class="euiScreenReaderOnly"
+  >
+    There is a new menu opening with page level controls at the bottom of the document.
+  </p>,
+  <div
+    class="euiBottomBar euiBottomBar--paddingSmall"
+  />,
+]
 `;

--- a/src/components/bottom_bar/bottom_bar.js
+++ b/src/components/bottom_bar/bottom_bar.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { EuiPortal } from '../portal';
+import { EuiScreenReaderOnly } from '../accessibility';
 
 const paddingSizeToClassNameMap = {
   none: null,
@@ -32,6 +33,10 @@ export class EuiBottomBar extends Component {
     }
   }
 
+  handleScreenReaderFocus() {
+    this.bar.focus();
+  }
+
   render() {
     const {
       children,
@@ -50,6 +55,11 @@ export class EuiBottomBar extends Component {
 
     return (
       <EuiPortal>
+        <EuiScreenReaderOnly>
+          <p aria-live="assertive">
+            There is a new menu opening with page level controls at the bottom of the document.
+          </p>
+        </EuiScreenReaderOnly>
         <div
           className={classes}
           ref={node => { this.bar = node; }}

--- a/src/components/bottom_bar/bottom_bar.js
+++ b/src/components/bottom_bar/bottom_bar.js
@@ -33,10 +33,6 @@ export class EuiBottomBar extends Component {
     }
   }
 
-  handleScreenReaderFocus() {
-    this.bar.focus();
-  }
-
   render() {
     const {
       children,

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -102,7 +102,7 @@ export const EuiPagination = ({
     <EuiButtonIcon
       onClick={onPageClick.bind(null, activePage + 1)}
       iconType="arrowRight"
-      aria-label="Previous"
+      aria-label="Next"
       disabled={activePage === pageCount - 1}
       color="text"
     />

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -29,6 +29,7 @@ export const EuiPagination = ({
         key={index}
         onClick={onPageClick.bind(null, i)}
         hideOnMobile
+        aria-label={`Page ${i + 1} of ${lastPageInRange}`}
       >
         {i + 1}
       </EuiPaginationButton>
@@ -42,7 +43,7 @@ export const EuiPagination = ({
       iconType="arrowLeft"
       disabled={activePage === 0}
       color="text"
-      aria-label="Previous"
+      aria-label="Previous page"
     />
   );
 
@@ -54,6 +55,7 @@ export const EuiPagination = ({
         key="0"
         onClick={onPageClick.bind(null, 0)}
         hideOnMobile
+        aria-label={`Page 1 of ${lastPageInRange}`}
       >
         1
       </EuiPaginationButton>
@@ -65,6 +67,7 @@ export const EuiPagination = ({
           key="beginningEllipsis"
           isPlaceholder
           hideOnMobile
+          aria-hidden
         >
           <span>&hellip;</span>
         </EuiPaginationButton>
@@ -81,6 +84,7 @@ export const EuiPagination = ({
           key="endingEllipsis"
           isPlaceholder
           hideOnMobile
+          aria-hidden
         >
           <span>&hellip;</span>
         </EuiPaginationButton>
@@ -92,6 +96,7 @@ export const EuiPagination = ({
         key={pageCount - 1}
         onClick={onPageClick.bind(null, pageCount - 1)}
         hideOnMobile
+        aria-label={`Jump to the last page, number ${pageCount}`}
       >
         {pageCount}
       </EuiPaginationButton>
@@ -102,7 +107,7 @@ export const EuiPagination = ({
     <EuiButtonIcon
       onClick={onPageClick.bind(null, activePage + 1)}
       iconType="arrowRight"
-      aria-label="Next"
+      aria-label="Next page"
       disabled={activePage === pageCount - 1}
       color="text"
     />
@@ -124,6 +129,7 @@ export const EuiPagination = ({
       return (
         <div
           className={classes}
+          role="group"
           {...rest}
         >
           {previousButton}

--- a/src/components/popover/__snapshots__/popover.test.js.snap
+++ b/src/components/popover/__snapshots__/popover.test.js.snap
@@ -78,6 +78,7 @@ exports[`EuiPopover props isOpen renders true 1`] = `
   />
   <div>
     <div
+      aria-live="assertive"
       class="euiPanel euiPanel--paddingMedium euiPanel--shadow euiPopover__panel"
       id="8"
     />
@@ -95,6 +96,7 @@ exports[`EuiPopover props ownFocus defaults to false 1`] = `
   />
   <div>
     <div
+      aria-live="assertive"
       class="euiPanel euiPanel--paddingMedium euiPanel--shadow euiPopover__panel"
       id="9"
     />
@@ -112,6 +114,7 @@ exports[`EuiPopover props ownFocus renders true 1`] = `
   />
   <div>
     <div
+      aria-live="assertive"
       class="euiPanel euiPanel--paddingMedium euiPanel--shadow euiPopover__panel"
       id="10"
       tabindex="0"
@@ -130,6 +133,7 @@ exports[`EuiPopover props panelClassName is rendered 1`] = `
   />
   <div>
     <div
+      aria-live="assertive"
       class="euiPanel euiPanel--paddingMedium euiPanel--shadow euiPopover__panel test"
       id="11"
     />
@@ -147,6 +151,7 @@ exports[`EuiPopover props panelPaddingSize is rendered 1`] = `
   />
   <div>
     <div
+      aria-live="assertive"
       class="euiPanel euiPanel--paddingSmall euiPanel--shadow euiPopover__panel"
       id="12"
     />

--- a/src/components/popover/__snapshots__/popover.test.js.snap
+++ b/src/components/popover/__snapshots__/popover.test.js.snap
@@ -3,6 +3,7 @@
 exports[`EuiPopover children is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
+  id="1"
 >
   <button />
 </div>
@@ -13,6 +14,7 @@ exports[`EuiPopover is rendered 1`] = `
   aria-label="aria-label"
   class="euiPopover euiPopover--anchorDownCenter testClass1 testClass2"
   data-test-subj="test subject string"
+  id="0"
 >
   <button />
 </div>
@@ -21,6 +23,7 @@ exports[`EuiPopover is rendered 1`] = `
 exports[`EuiPopover props anchorPosition defaults to centerDown 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
+  id="4"
 >
   <button />
 </div>
@@ -29,6 +32,7 @@ exports[`EuiPopover props anchorPosition defaults to centerDown 1`] = `
 exports[`EuiPopover props anchorPosition downRight is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownRight"
+  id="6"
 >
   <button />
 </div>
@@ -37,6 +41,7 @@ exports[`EuiPopover props anchorPosition downRight is rendered 1`] = `
 exports[`EuiPopover props anchorPosition leftCenter is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorLeftCenter"
+  id="5"
 >
   <button />
 </div>
@@ -45,6 +50,7 @@ exports[`EuiPopover props anchorPosition leftCenter is rendered 1`] = `
 exports[`EuiPopover props isOpen defaults to false 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
+  id="7"
 >
   <button />
 </div>
@@ -53,6 +59,7 @@ exports[`EuiPopover props isOpen defaults to false 1`] = `
 exports[`EuiPopover props isOpen renders true 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
+  id="8"
 >
   <button />
   <div>
@@ -67,6 +74,7 @@ exports[`EuiPopover props isOpen renders true 1`] = `
 exports[`EuiPopover props ownFocus defaults to false 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
+  id="9"
 >
   <button />
   <div>
@@ -81,6 +89,7 @@ exports[`EuiPopover props ownFocus defaults to false 1`] = `
 exports[`EuiPopover props ownFocus renders true 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
+  id="10"
 >
   <button />
   <div>
@@ -96,6 +105,7 @@ exports[`EuiPopover props ownFocus renders true 1`] = `
 exports[`EuiPopover props panelClassName is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
+  id="11"
 >
   <button />
   <div>
@@ -110,6 +120,7 @@ exports[`EuiPopover props panelClassName is rendered 1`] = `
 exports[`EuiPopover props panelPaddingSize is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
+  id="12"
 >
   <button />
   <div>
@@ -124,6 +135,7 @@ exports[`EuiPopover props panelPaddingSize is rendered 1`] = `
 exports[`EuiPopover props withTitle is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter euiPopover--withTitle"
+  id="2"
 >
   <button />
 </div>

--- a/src/components/popover/__snapshots__/popover.test.js.snap
+++ b/src/components/popover/__snapshots__/popover.test.js.snap
@@ -4,10 +4,7 @@ exports[`EuiPopover children is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
 >
-  <button
-    aria-controls="1"
-    aria-expanded="false"
-  />
+  <button />
 </div>
 `;
 
@@ -17,10 +14,7 @@ exports[`EuiPopover is rendered 1`] = `
   class="euiPopover euiPopover--anchorDownCenter testClass1 testClass2"
   data-test-subj="test subject string"
 >
-  <button
-    aria-controls="0"
-    aria-expanded="false"
-  />
+  <button />
 </div>
 `;
 
@@ -28,10 +22,7 @@ exports[`EuiPopover props anchorPosition defaults to centerDown 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
 >
-  <button
-    aria-controls="4"
-    aria-expanded="false"
-  />
+  <button />
 </div>
 `;
 
@@ -39,10 +30,7 @@ exports[`EuiPopover props anchorPosition downRight is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownRight"
 >
-  <button
-    aria-controls="6"
-    aria-expanded="false"
-  />
+  <button />
 </div>
 `;
 
@@ -50,10 +38,7 @@ exports[`EuiPopover props anchorPosition leftCenter is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorLeftCenter"
 >
-  <button
-    aria-controls="5"
-    aria-expanded="false"
-  />
+  <button />
 </div>
 `;
 
@@ -61,10 +46,7 @@ exports[`EuiPopover props isOpen defaults to false 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
 >
-  <button
-    aria-controls="7"
-    aria-expanded="false"
-  />
+  <button />
 </div>
 `;
 
@@ -72,15 +54,11 @@ exports[`EuiPopover props isOpen renders true 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
 >
-  <button
-    aria-controls="8"
-    aria-expanded="true"
-  />
+  <button />
   <div>
     <div
       aria-live="assertive"
       class="euiPanel euiPanel--paddingMedium euiPanel--shadow euiPopover__panel"
-      id="8"
     />
   </div>
 </div>
@@ -90,15 +68,11 @@ exports[`EuiPopover props ownFocus defaults to false 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
 >
-  <button
-    aria-controls="9"
-    aria-expanded="true"
-  />
+  <button />
   <div>
     <div
       aria-live="assertive"
       class="euiPanel euiPanel--paddingMedium euiPanel--shadow euiPopover__panel"
-      id="9"
     />
   </div>
 </div>
@@ -108,15 +82,11 @@ exports[`EuiPopover props ownFocus renders true 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
 >
-  <button
-    aria-controls="10"
-    aria-expanded="true"
-  />
+  <button />
   <div>
     <div
-      aria-live="assertive"
+      aria-live="off"
       class="euiPanel euiPanel--paddingMedium euiPanel--shadow euiPopover__panel"
-      id="10"
       tabindex="0"
     />
   </div>
@@ -127,15 +97,11 @@ exports[`EuiPopover props panelClassName is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
 >
-  <button
-    aria-controls="11"
-    aria-expanded="true"
-  />
+  <button />
   <div>
     <div
       aria-live="assertive"
       class="euiPanel euiPanel--paddingMedium euiPanel--shadow euiPopover__panel test"
-      id="11"
     />
   </div>
 </div>
@@ -145,15 +111,11 @@ exports[`EuiPopover props panelPaddingSize is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
 >
-  <button
-    aria-controls="12"
-    aria-expanded="true"
-  />
+  <button />
   <div>
     <div
       aria-live="assertive"
       class="euiPanel euiPanel--paddingSmall euiPanel--shadow euiPopover__panel"
-      id="12"
     />
   </div>
 </div>
@@ -163,9 +125,6 @@ exports[`EuiPopover props withTitle is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter euiPopover--withTitle"
 >
-  <button
-    aria-controls="2"
-    aria-expanded="false"
-  />
+  <button />
 </div>
 `;

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -152,14 +152,20 @@ export class EuiPopover extends Component {
     if (isOpen || this.state.isClosing) {
       let tabIndex;
       let initialFocus;
+      let ariaLive;
 
       if (ownFocus) {
         tabIndex = '0';
+        ariaLive = 'off';
+
         initialFocus = () => this.panel;
+      } else {
+        ariaLive = 'assertive';
       }
 
       panel = (
         <FocusTrap
+          active={ownFocus}
           focusTrapOptions={{
             clickOutsideDeactivates: true,
             initialFocus,
@@ -171,8 +177,7 @@ export class EuiPopover extends Component {
             paddingSize={panelPaddingSize}
             tabIndex={tabIndex}
             hasShadow
-            id={id}
-            aria-live="assertive"
+            aria-live={ariaLive}
           >
             {children}
           </EuiPanel>
@@ -188,10 +193,7 @@ export class EuiPopover extends Component {
           ref={popoverRef}
           {...rest}
         >
-          {cloneElement(button, {
-            'aria-controls': id,
-            'aria-expanded': !!isOpen,
-          })}
+          {button}
           {panel}
         </div>
       </EuiOutsideClickDetector>

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -172,6 +172,7 @@ export class EuiPopover extends Component {
             tabIndex={tabIndex}
             hasShadow
             id={id}
+            aria-live="assertive"
           >
             {children}
           </EuiPanel>

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -1,5 +1,4 @@
 import React, {
-  cloneElement,
   Component,
 } from 'react';
 import PropTypes from 'prop-types';
@@ -126,7 +125,6 @@ export class EuiPopover extends Component {
       ownFocus,
       withTitle,
       children,
-      id,
       className,
       closePopover,
       panelClassName,
@@ -202,7 +200,6 @@ export class EuiPopover extends Component {
 }
 
 EuiPopover.propTypes = {
-  id: PropTypes.string.isRequired,
   isOpen: PropTypes.bool,
   ownFocus: PropTypes.bool,
   withTitle: PropTypes.bool,

--- a/src/components/side_nav/__snapshots__/side_nav.test.js.snap
+++ b/src/components/side_nav/__snapshots__/side_nav.test.js.snap
@@ -39,6 +39,7 @@ exports[`EuiSideNav is rendered 1`] = `
   </button>
   <div
     class="euiSideNav__content"
+    role="menubar"
   />
 </nav>
 `;
@@ -80,6 +81,7 @@ exports[`EuiSideNav props isOpenOnMobile defaults to false 1`] = `
   </button>
   <div
     class="euiSideNav__content"
+    role="menubar"
   />
 </nav>
 `;
@@ -121,6 +123,7 @@ exports[`EuiSideNav props isOpenOnMobile is rendered when specified as true 1`] 
   </button>
   <div
     class="euiSideNav__content"
+    role="menubar"
   />
 </nav>
 `;
@@ -162,11 +165,13 @@ exports[`EuiSideNav props items is rendered 1`] = `
   </button>
   <div
     class="euiSideNav__content"
+    role="menubar"
   >
     <div
       class="euiSideNavItem euiSideNavItem--root euiSideNavItem--hasChildItems"
     >
       <div
+        aria-label="[object Object]"
         class="euiSideNavItemButton"
       >
         <span
@@ -186,6 +191,7 @@ exports[`EuiSideNav props items is rendered 1`] = `
           class="euiSideNavItem euiSideNavItem--trunk"
         >
           <div
+            aria-label="[object Object]"
             class="euiSideNavItemButton"
           >
             <span
@@ -203,6 +209,7 @@ exports[`EuiSideNav props items is rendered 1`] = `
           class="euiSideNavItem euiSideNavItem--trunk"
         >
           <div
+            aria-label="[object Object]"
             class="euiSideNavItemButton"
           >
             <span
@@ -278,11 +285,13 @@ exports[`EuiSideNav props items renders items having { forceOpen: true } in open
   </button>
   <div
     class="euiSideNav__content"
+    role="menubar"
   >
     <div
       class="euiSideNavItem euiSideNavItem--root euiSideNavItem--hasChildItems"
     >
       <div
+        aria-label="[object Object]"
         class="euiSideNavItemButton"
       >
         <span
@@ -302,6 +311,7 @@ exports[`EuiSideNav props items renders items having { forceOpen: true } in open
           class="euiSideNavItem euiSideNavItem--trunk"
         >
           <div
+            aria-label="[object Object]"
             class="euiSideNavItemButton"
           >
             <span
@@ -319,6 +329,7 @@ exports[`EuiSideNav props items renders items having { forceOpen: true } in open
           class="euiSideNavItem euiSideNavItem--trunk euiSideNavItem--hasChildItems"
         >
           <div
+            aria-label="[object Object]"
             class="euiSideNavItemButton euiSideNavItemButton-isOpen"
           >
             <span
@@ -338,6 +349,7 @@ exports[`EuiSideNav props items renders items having { forceOpen: true } in open
               class="euiSideNavItem euiSideNavItem--branch euiSideNavItem--hasChildItems"
             >
               <div
+                aria-label="[object Object]"
                 class="euiSideNavItemButton euiSideNavItemButton-isOpen"
               >
                 <span
@@ -357,6 +369,7 @@ exports[`EuiSideNav props items renders items having { forceOpen: true } in open
                   class="euiSideNavItem euiSideNavItem--branch"
                 >
                   <div
+                    aria-label="[object Object]"
                     class="euiSideNavItemButton"
                   >
                     <span
@@ -417,6 +430,7 @@ exports[`EuiSideNav props items renders items using a specified callback 1`] = `
   </button>
   <div
     class="euiSideNav__content"
+    role="menubar"
   >
     <div
       class="euiSideNavItem euiSideNavItem--root euiSideNavItem--hasChildItems"
@@ -500,6 +514,7 @@ exports[`EuiSideNav props items renders items which are links 1`] = `
   </button>
   <div
     class="euiSideNav__content"
+    role="menubar"
   >
     <div
       class="euiSideNavItem euiSideNavItem--root euiSideNavItem--hasChildItems"
@@ -507,6 +522,7 @@ exports[`EuiSideNav props items renders items which are links 1`] = `
       <a
         class="euiSideNavItemButton euiSideNavItemButton--isClickable"
         href="http://www.elastic.co"
+        role="menuitem"
       >
         <span
           class="euiSideNavItemButton__content"
@@ -525,6 +541,7 @@ exports[`EuiSideNav props items renders items which are links 1`] = `
           class="euiSideNavItem euiSideNavItem--trunk"
         >
           <div
+            aria-label="[object Object]"
             class="euiSideNavItemButton"
           >
             <span
@@ -542,6 +559,7 @@ exports[`EuiSideNav props items renders items which are links 1`] = `
           class="euiSideNavItem euiSideNavItem--trunk"
         >
           <div
+            aria-label="[object Object]"
             class="euiSideNavItemButton"
           >
             <span
@@ -617,11 +635,13 @@ exports[`EuiSideNav props items renders selected item and automatically opens pa
   </button>
   <div
     class="euiSideNav__content"
+    role="menubar"
   >
     <div
       class="euiSideNavItem euiSideNavItem--root euiSideNavItem--hasChildItems"
     >
       <div
+        aria-label="[object Object]"
         class="euiSideNavItemButton"
       >
         <span
@@ -641,6 +661,7 @@ exports[`EuiSideNav props items renders selected item and automatically opens pa
           class="euiSideNavItem euiSideNavItem--trunk"
         >
           <div
+            aria-label="[object Object]"
             class="euiSideNavItemButton"
           >
             <span
@@ -658,6 +679,7 @@ exports[`EuiSideNav props items renders selected item and automatically opens pa
           class="euiSideNavItem euiSideNavItem--trunk euiSideNavItem--hasChildItems"
         >
           <div
+            aria-label="[object Object]"
             class="euiSideNavItemButton euiSideNavItemButton-isOpen"
           >
             <span
@@ -677,6 +699,7 @@ exports[`EuiSideNav props items renders selected item and automatically opens pa
               class="euiSideNavItem euiSideNavItem--branch"
             >
               <div
+                aria-label="[object Object]"
                 class="euiSideNavItemButton euiSideNavItemButton-isSelected"
               >
                 <span
@@ -694,6 +717,7 @@ exports[`EuiSideNav props items renders selected item and automatically opens pa
               class="euiSideNavItem euiSideNavItem--branch"
             >
               <div
+                aria-label="[object Object]"
                 class="euiSideNavItemButton"
               >
                 <span

--- a/src/components/side_nav/__snapshots__/side_nav_item.test.js.snap
+++ b/src/components/side_nav/__snapshots__/side_nav_item.test.js.snap
@@ -5,6 +5,7 @@ exports[`EuiSideNavItem is rendered 1`] = `
   class="euiSideNavItem"
 >
   <div
+    aria-label="[object Object]"
     class="euiSideNavItemButton"
   >
     <span
@@ -29,6 +30,7 @@ exports[`EuiSideNavItem isSelected defaults to false 1`] = `
   class="euiSideNavItem"
 >
   <div
+    aria-label="[object Object]"
     class="euiSideNavItemButton"
   >
     <span
@@ -49,6 +51,7 @@ exports[`EuiSideNavItem isSelected is rendered when specified as true 1`] = `
   class="euiSideNavItem"
 >
   <div
+    aria-label="[object Object]"
     class="euiSideNavItemButton euiSideNavItemButton-isSelected"
   >
     <span
@@ -69,6 +72,7 @@ exports[`EuiSideNavItem preserves child's classes 1`] = `
   class="euiSideNavItem"
 >
   <div
+    aria-label="[object Object]"
     class="euiSideNavItemButton"
   >
     <span

--- a/src/components/side_nav/side_nav.js
+++ b/src/components/side_nav/side_nav.js
@@ -123,7 +123,7 @@ export class EuiSideNav extends Component {
         </button>
 
         {/* Hidden from view in mobile, but toggled from the button above */}
-        <div className="euiSideNav__content">
+        <div className="euiSideNav__content" role="menubar">
           {nav}
         </div>
       </nav>

--- a/src/components/side_nav/side_nav_item.js
+++ b/src/components/side_nav/side_nav_item.js
@@ -15,6 +15,7 @@ const defaultRenderItem = ({ href, onClick, className, children, ...rest }) => {
         className={className}
         href={href}
         onClick={onClick}
+        role="menuitem"
         {...rest}
       >
         {children}
@@ -27,6 +28,7 @@ const defaultRenderItem = ({ href, onClick, className, children, ...rest }) => {
       <button
         className={className}
         onClick={onClick}
+        role="menuitem"
         {...rest}
       >
         {children}
@@ -37,6 +39,7 @@ const defaultRenderItem = ({ href, onClick, className, children, ...rest }) => {
   return (
     <div
       className={className}
+      aria-label={children}
       {...rest}
     >
       {children}

--- a/src/components/table/mobile/__snapshots__/table_sort_mobile.test.js.snap
+++ b/src/components/table/mobile/__snapshots__/table_sort_mobile.test.js.snap
@@ -10,8 +10,6 @@ exports[`EuiTableSortMobile is rendered 1`] = `
     data-test-subj="test subject string"
   >
     <button
-      aria-controls="sortPopover"
-      aria-expanded="false"
       class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--iconRight euiButtonEmpty--flushRight"
       type="button"
     >

--- a/src/components/table/mobile/__snapshots__/table_sort_mobile.test.js.snap
+++ b/src/components/table/mobile/__snapshots__/table_sort_mobile.test.js.snap
@@ -8,6 +8,7 @@ exports[`EuiTableSortMobile is rendered 1`] = `
     aria-label="aria-label"
     class="euiPopover euiPopover--anchorDownRight"
     data-test-subj="test subject string"
+    id="sortPopover"
   >
     <button
       class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--iconRight euiButtonEmpty--flushRight"

--- a/src/components/table/table_pagination/__snapshots__/table_pagination.test.js.snap
+++ b/src/components/table/table_pagination/__snapshots__/table_pagination.test.js.snap
@@ -9,6 +9,7 @@ exports[`EuiTablePagination is rendered 1`] = `
   >
     <div
       class="euiPopover euiPopover--anchorUpRight euiPopover--withTitle"
+      id="customizablePagination"
     >
       <button
         class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--iconRight"

--- a/src/components/table/table_pagination/__snapshots__/table_pagination.test.js.snap
+++ b/src/components/table/table_pagination/__snapshots__/table_pagination.test.js.snap
@@ -11,8 +11,6 @@ exports[`EuiTablePagination is rendered 1`] = `
       class="euiPopover euiPopover--anchorUpRight euiPopover--withTitle"
     >
       <button
-        aria-controls="customizablePagination"
-        aria-expanded="false"
         class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--iconRight"
         type="button"
       >


### PR DESCRIPTION
Fixes #733 
Fixes #734
Fixes #735 
Fixes #621 
Fixes #736
Fixes #728 
Fixes #729
Fixes #723 
Fixes #616 
Fixes #687 
Fixes #617 
Fixes #746 

Grab bag of accessibility fixes. The following changes were made.

* Fixed a bug in our documentation where sidenav submenus had empty buttons if we were excluding the title (which we usually do for the first one in the page).
* Made `EuiPagination` more friendly for screen readers.
* Made `EuiSideNav` use menubar labeling. Of all the options (nav / tree...etc) it was the most agreeable with our current formatting.
* Fixed an issue with `EuiPopover` where `ownFocs` was required if it didn't wrap a context menu. Made `EuiPopover` use an `aria-live` label to announce its contents if it isn't set (with the assumption that if it is, the SR will read what it focused).
* `EuiBottomBar` now has some hidden SR text to announce itself.
* `EuiBasicTable` now labels its checkboxes properly.
* Various aria labeling fixes for our own documentation, mostly around button labeling.
