### PR TITLE
fix combobox bugs introduced by isDisabled prop

### DIFF
--- a/src-docs/src/views/combo_box/single_selection.js
+++ b/src-docs/src/views/combo_box/single_selection.js
@@ -32,7 +32,7 @@ export default class extends Component {
     }];
 
     this.state = {
-      selectedOptions: undefined,
+      selectedOptions: [this.options[2]],
     };
   }
 
@@ -48,10 +48,11 @@ export default class extends Component {
     return (
       <EuiComboBox
         placeholder="Select a single option"
-        singleSelection
+        singleSelection={true}
         options={this.options}
         selectedOptions={selectedOptions}
         onChange={this.onChange}
+        isClearable={false}
       />
     );
   }

--- a/src/components/combo_box/__snapshots__/combo_box.test.js.snap
+++ b/src/components/combo_box/__snapshots__/combo_box.test.js.snap
@@ -28,3 +28,205 @@ exports[`EuiComboBox is rendered 1`] = `
   />
 </div>
 `;
+
+exports[`props isClearable is false with selectedOptions 1`] = `
+<div
+  aria-label="aria-label"
+  className="euiComboBox testClass1 testClass2"
+  data-test-subj="test subject string"
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+>
+  <EuiComboBoxInput
+    autoSizeInputRef={[Function]}
+    hasSelectedOptions={true}
+    inputRef={[Function]}
+    isListOpen={false}
+    onChange={[Function]}
+    onClick={[Function]}
+    onClose={[Function]}
+    onFocus={[Function]}
+    onOpen={[Function]}
+    onRemoveOption={[Function]}
+    searchValue=""
+    selectedOptions={
+      Array [
+        Object {
+          "label": "Mimas",
+        },
+        Object {
+          "label": "Iapetus",
+        },
+      ]
+    }
+    singleSelection={false}
+    updatePosition={[Function]}
+    value="Mimas, Iapetus"
+  />
+</div>
+`;
+
+exports[`props isClearable is false without selectedOptions 1`] = `
+<div
+  aria-label="aria-label"
+  className="euiComboBox testClass1 testClass2"
+  data-test-subj="test subject string"
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+>
+  <EuiComboBoxInput
+    autoSizeInputRef={[Function]}
+    hasSelectedOptions={false}
+    inputRef={[Function]}
+    isListOpen={false}
+    onChange={[Function]}
+    onClick={[Function]}
+    onClose={[Function]}
+    onFocus={[Function]}
+    onOpen={[Function]}
+    onRemoveOption={[Function]}
+    searchValue=""
+    selectedOptions={Array []}
+    singleSelection={false}
+    updatePosition={[Function]}
+    value=""
+  />
+</div>
+`;
+
+exports[`props isDisabled 1`] = `
+<div
+  aria-label="aria-label"
+  className="euiComboBox testClass1 testClass2 euiComboBox-isDisabled"
+  data-test-subj="test subject string"
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+>
+  <EuiComboBoxInput
+    autoSizeInputRef={[Function]}
+    hasSelectedOptions={true}
+    inputRef={[Function]}
+    isDisabled={true}
+    isListOpen={false}
+    onChange={[Function]}
+    onClick={[Function]}
+    onClose={[Function]}
+    onFocus={[Function]}
+    onOpen={[Function]}
+    onRemoveOption={[Function]}
+    searchValue=""
+    selectedOptions={
+      Array [
+        Object {
+          "label": "Mimas",
+        },
+      ]
+    }
+    singleSelection={false}
+    updatePosition={[Function]}
+    value="Mimas"
+  />
+</div>
+`;
+
+exports[`props options 1`] = `
+<div
+  aria-label="aria-label"
+  className="euiComboBox testClass1 testClass2"
+  data-test-subj="test subject string"
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+>
+  <EuiComboBoxInput
+    autoSizeInputRef={[Function]}
+    hasSelectedOptions={false}
+    inputRef={[Function]}
+    isListOpen={false}
+    onChange={[Function]}
+    onClear={[Function]}
+    onClick={[Function]}
+    onClose={[Function]}
+    onFocus={[Function]}
+    onOpen={[Function]}
+    onRemoveOption={[Function]}
+    searchValue=""
+    selectedOptions={Array []}
+    singleSelection={false}
+    updatePosition={[Function]}
+    value=""
+  />
+</div>
+`;
+
+exports[`props selectedOptions 1`] = `
+<div
+  aria-label="aria-label"
+  className="euiComboBox testClass1 testClass2"
+  data-test-subj="test subject string"
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+>
+  <EuiComboBoxInput
+    autoSizeInputRef={[Function]}
+    hasSelectedOptions={true}
+    inputRef={[Function]}
+    isListOpen={false}
+    onChange={[Function]}
+    onClear={[Function]}
+    onClick={[Function]}
+    onClose={[Function]}
+    onFocus={[Function]}
+    onOpen={[Function]}
+    onRemoveOption={[Function]}
+    searchValue=""
+    selectedOptions={
+      Array [
+        Object {
+          "label": "Mimas",
+        },
+        Object {
+          "label": "Iapetus",
+        },
+      ]
+    }
+    singleSelection={false}
+    updatePosition={[Function]}
+    value="Mimas, Iapetus"
+  />
+</div>
+`;
+
+exports[`props singleSelection 1`] = `
+<div
+  aria-label="aria-label"
+  className="euiComboBox testClass1 testClass2"
+  data-test-subj="test subject string"
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+>
+  <EuiComboBoxInput
+    autoSizeInputRef={[Function]}
+    hasSelectedOptions={true}
+    inputRef={[Function]}
+    isListOpen={false}
+    onChange={[Function]}
+    onClear={[Function]}
+    onClick={[Function]}
+    onClose={[Function]}
+    onFocus={[Function]}
+    onOpen={[Function]}
+    onRemoveOption={[Function]}
+    searchValue=""
+    selectedOptions={
+      Array [
+        Object {
+          "label": "Mimas",
+        },
+      ]
+    }
+    singleSelection={true}
+    updatePosition={[Function]}
+    value="Mimas"
+  />
+</div>
+`;

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -434,14 +434,6 @@ export class EuiComboBox extends Component {
     }
   };
 
-  onClear = () => {
-    if (this.props.isClearable && this.clearSelectedOptions && !this.props.isDisabled) {
-      return this.clearSelectedOptions();
-    } else {
-      return undefined;
-    }
-  }
-
   autoSizeInputRef = node => {
     this.autoSizeInput = node;
   };
@@ -524,7 +516,7 @@ export class EuiComboBox extends Component {
       async, // eslint-disable-line no-unused-vars
       isInvalid,
       rowHeight,
-      isClearable, // eslint-disable-line no-unused-vars
+      isClearable,
       ...rest
     } = this.props;
 
@@ -563,7 +555,6 @@ export class EuiComboBox extends Component {
             scrollToIndex={activeOptionIndex}
             onScroll={this.focusActiveOption}
             rowHeight={rowHeight}
-            isDisabled={isDisabled}
           />
         </EuiPortal>
       );
@@ -590,7 +581,7 @@ export class EuiComboBox extends Component {
           autoSizeInputRef={this.autoSizeInputRef}
           inputRef={this.searchInputRef}
           updatePosition={this.updateListPosition}
-          onClear={this.onClear}
+          onClear={isClearable && !isDisabled ? this.clearSelectedOptions : undefined}
           hasSelectedOptions={selectedOptions.length > 0}
           isListOpen={isListOpen}
           onOpen={this.openList}

--- a/src/components/combo_box/combo_box.test.js
+++ b/src/components/combo_box/combo_box.test.js
@@ -4,10 +4,111 @@ import { requiredProps } from '../../test';
 
 import { EuiComboBox } from './combo_box';
 
+const options = [{
+  label: 'Titan',
+  'data-test-subj': 'titanOption',
+}, {
+  label: 'Enceladus',
+}, {
+  label: 'Mimas',
+}, {
+  label: 'Dione',
+}, {
+  label: 'Iapetus',
+}, {
+  label: 'Phoebe',
+}, {
+  label: 'Rhea',
+}, {
+  label: 'Pandora is one of Saturn\'s moons, named for a Titaness of Greek mythology',
+}, {
+  label: 'Tethys',
+}, {
+  label: 'Hyperion',
+}];
+
 describe('EuiComboBox', () => {
   test('is rendered', () => {
     const component = shallow(
       <EuiComboBox {...requiredProps} />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+});
+
+describe('props', () => {
+  test('options', () => {
+    const component = shallow(
+      <EuiComboBox
+        options={options}
+        {...requiredProps}
+      />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
+  test('selectedOptions', () => {
+    const component = shallow(
+      <EuiComboBox
+        options={options}
+        selectedOptions={[options[2], options[4]]}
+        {...requiredProps}
+      />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
+  describe('isClearable is false', () => {
+    test('without selectedOptions', () => {
+      const component = shallow(
+        <EuiComboBox
+          options={options}
+          isClearable={false}
+          {...requiredProps}
+        />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
+    test('with selectedOptions', () => {
+      const component = shallow(
+        <EuiComboBox
+          options={options}
+          selectedOptions={[options[2], options[4]]}
+          isClearable={false}
+          {...requiredProps}
+        />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+  });
+
+  test('singleSelection', () => {
+    const component = shallow(
+      <EuiComboBox
+        options={options}
+        selectedOptions={[options[2]]}
+        singleSelection={true}
+        {...requiredProps}
+      />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
+  test('isDisabled', () => {
+    const component = shallow(
+      <EuiComboBox
+        options={options}
+        selectedOptions={[options[2]]}
+        isDisabled={true}
+        {...requiredProps}
+      />
     );
 
     expect(component).toMatchSnapshot();


### PR DESCRIPTION
PR https://github.com/elastic/eui/pull/829 introduced 2 bugs into EuiComboBox

1) Open the combo box displayed the console warning.
<img width="2047" alt="screen shot 2018-05-16 at 2 48 55 pm" src="https://user-images.githubusercontent.com/373691/40143381-7b1d6006-5918-11e8-96d5-32d1f00fb8ba.png">

2) Setting `isClearable` to false on  a combo box with `selectedOptions` still displayed the clear button

This PR fixes those bugs and adds some better snapshot testing.
