### PR TITLE
update webpack config to exclude react-dom and moment from the bundle

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -40,8 +40,10 @@ module.exports = {
 
   // Specify where these libraries should be found
   externals: {
+    'moment': 'window.moment',
+    'prop-types': 'window.PropTypes',
     'react': 'window.React',
-    'prop-types': 'window.PropTypes'
+    'react-dom': 'window.ReactDOM'
   },
 
   module: {


### PR DESCRIPTION
Fixes #828 by adding `react-dom` and `moment` to webpack's `externals`. This only impacts the bundle published to npm, which is provided only for potential use by apps which pull scripts in from a CDN (like jsbin).