### PR TITLE
added TODOs to the lifecycle methods deprecated in react 16.3

### DIFF
--- a/src/components/basic_table/basic_table.js
+++ b/src/components/basic_table/basic_table.js
@@ -248,7 +248,7 @@ export class EuiBasicTable extends Component {
     this.props.onChange(criteria);
   }
 
-  // @TODO: React 16.3 - getDerivedStateFromProps
+  // TODO: React 16.3 - getDerivedStateFromProps
   componentWillReceiveProps(nextProps) {
     // Don't call changeSelection here or else we can get into an infinite loop:
     // changeSelection calls props.onSelectionChanged on owner ->

--- a/src/components/basic_table/basic_table.js
+++ b/src/components/basic_table/basic_table.js
@@ -248,6 +248,7 @@ export class EuiBasicTable extends Component {
     this.props.onChange(criteria);
   }
 
+  // @TODO: React 16.3 - getDerivedStateFromProps
   componentWillReceiveProps(nextProps) {
     // Don't call changeSelection here or else we can get into an infinite loop:
     // changeSelection calls props.onSelectionChanged on owner ->

--- a/src/components/basic_table/custom_item_action.js
+++ b/src/components/basic_table/custom_item_action.js
@@ -16,7 +16,7 @@ export class CustomItemAction extends Component {
     this.mounted = false;
   }
 
-  // @TODO: React 16.3 - move this to componentDidMount
+  // TODO: React 16.3 - move this to componentDidMount
   componentWillMount() {
     this.mounted = true;
   }

--- a/src/components/basic_table/custom_item_action.js
+++ b/src/components/basic_table/custom_item_action.js
@@ -16,6 +16,7 @@ export class CustomItemAction extends Component {
     this.mounted = false;
   }
 
+  // @TODO: React 16.3 - move this to componentDidMount
   componentWillMount() {
     this.mounted = true;
   }

--- a/src/components/basic_table/in_memory_table.js
+++ b/src/components/basic_table/in_memory_table.js
@@ -240,6 +240,7 @@ export class EuiInMemoryTable extends Component {
     };
   }
 
+  // @TODO: React 16.3 - getDerivedStateFromProps
   componentWillReceiveProps(nextProps) {
     if (nextProps.items !== this.props.items) {
       // We have new items because an external search has completed, so reset pagination state.

--- a/src/components/basic_table/in_memory_table.js
+++ b/src/components/basic_table/in_memory_table.js
@@ -240,7 +240,7 @@ export class EuiInMemoryTable extends Component {
     };
   }
 
-  // @TODO: React 16.3 - getDerivedStateFromProps
+  // TODO: React 16.3 - getDerivedStateFromProps
   componentWillReceiveProps(nextProps) {
     if (nextProps.items !== this.props.items) {
       // We have new items because an external search has completed, so reset pagination state.

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -461,6 +461,8 @@ export class EuiComboBox extends Component {
     }, 100);
   }
 
+  // @TODO: React 16.3 - ideally refactor from class members into state
+  // and use getDerivedStateFromProps; otherwise componentDidUpdate
   componentWillUpdate(nextProps, nextState) {
     const { options, selectedOptions } = nextProps;
     const { searchValue } = nextState;

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -461,7 +461,7 @@ export class EuiComboBox extends Component {
     }, 100);
   }
 
-  // @TODO: React 16.3 - ideally refactor from class members into state
+  // TODO: React 16.3 - ideally refactor from class members into state
   // and use getDerivedStateFromProps; otherwise componentDidUpdate
   componentWillUpdate(nextProps, nextState) {
     const { options, selectedOptions } = nextProps;

--- a/src/components/combo_box/combo_box_input/combo_box_input.js
+++ b/src/components/combo_box/combo_box_input/combo_box_input.js
@@ -60,6 +60,7 @@ export class EuiComboBoxInput extends Component {
     });
   };
 
+  // @TODO: React 16.3 - componentDidUpdate
   componentWillUpdate(nextProps) {
     const { searchValue } = nextProps;
 

--- a/src/components/combo_box/combo_box_input/combo_box_input.js
+++ b/src/components/combo_box/combo_box_input/combo_box_input.js
@@ -60,7 +60,7 @@ export class EuiComboBoxInput extends Component {
     });
   };
 
-  // @TODO: React 16.3 - componentDidUpdate
+  // TODO: React 16.3 - componentDidUpdate
   componentWillUpdate(nextProps) {
     const { searchValue } = nextProps;
 

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
@@ -65,7 +65,7 @@ export class EuiComboBoxOptionsList extends Component {
     window.addEventListener('resize', this.updatePosition);
   }
 
-  // @TODO: React 16.3 - componentDidUpdate
+  // TODO: React 16.3 - componentDidUpdate
   componentWillUpdate(nextProps) {
     const { options, selectedOptions, searchValue } = nextProps;
 

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.js
@@ -65,6 +65,7 @@ export class EuiComboBoxOptionsList extends Component {
     window.addEventListener('resize', this.updatePosition);
   }
 
+  // @TODO: React 16.3 - componentDidUpdate
   componentWillUpdate(nextProps) {
     const { options, selectedOptions, searchValue } = nextProps;
 

--- a/src/components/context_menu/context_menu.js
+++ b/src/components/context_menu/context_menu.js
@@ -173,12 +173,12 @@ export class EuiContextMenu extends Component {
     this.mapIdsToRenderedItems(panels);
   }
 
-  // @TODO: React 16.3 - move this into constructor
+  // TODO: React 16.3 - move this into constructor
   componentWillMount() {
     this.updatePanelMaps(this.props.panels);
   }
 
-  // @TODO: React 16.3 - componentDidUpdate; alternatively refactor the panel mappings
+  // TODO: React 16.3 - componentDidUpdate; alternatively refactor the panel mappings
   // into state and use getDerivedStateFromProps
   componentWillReceiveProps(nextProps) {
     if (nextProps.panels !== this.props.panels) {

--- a/src/components/context_menu/context_menu.js
+++ b/src/components/context_menu/context_menu.js
@@ -173,10 +173,13 @@ export class EuiContextMenu extends Component {
     this.mapIdsToRenderedItems(panels);
   }
 
+  // @TODO: React 16.3 - move this into constructor
   componentWillMount() {
     this.updatePanelMaps(this.props.panels);
   }
 
+  // @TODO: React 16.3 - componentDidUpdate; alternatively refactor the panel mappings
+  // into state and use getDerivedStateFromProps
   componentWillReceiveProps(nextProps) {
     if (nextProps.panels !== this.props.panels) {
       this.updatePanelMaps(nextProps.panels);

--- a/src/components/context_menu/context_menu_panel.js
+++ b/src/components/context_menu/context_menu_panel.js
@@ -207,7 +207,7 @@ export class EuiContextMenuPanel extends Component {
     this.updateFocus();
   }
 
-  // @TODO: React 16.3 - componentDidUpdate & getDerivedStateFromProps; alternatively refactor
+  // TODO: React 16.3 - componentDidUpdate & getDerivedStateFromProps; alternatively refactor
   // this.menuItems into state and only use getDerivedStateFromProps
   componentWillReceiveProps(nextProps) {
     // Clear refs to menuItems if we're getting new ones.

--- a/src/components/context_menu/context_menu_panel.js
+++ b/src/components/context_menu/context_menu_panel.js
@@ -207,6 +207,8 @@ export class EuiContextMenuPanel extends Component {
     this.updateFocus();
   }
 
+  // @TODO: React 16.3 - componentDidUpdate & getDerivedStateFromProps; alternatively refactor
+  // this.menuItems into state and only use getDerivedStateFromProps
   componentWillReceiveProps(nextProps) {
     // Clear refs to menuItems if we're getting new ones.
     if (nextProps.items !== this.props.items) {

--- a/src/components/delay_hide/delay_hide.js
+++ b/src/components/delay_hide/delay_hide.js
@@ -28,7 +28,7 @@ export class EuiDelayHide extends Component {
     return minimumDuration - visibleDuration;
   }
 
-  // @TODO: React 16.3 - componentDidUpdate
+  // TODO: React 16.3 - componentDidUpdate
   componentWillReceiveProps(nextProps) {
     clearTimeout(this.timeout);
     const timeRemaining = this.getTimeRemaining(nextProps.minimumDuration);

--- a/src/components/delay_hide/delay_hide.js
+++ b/src/components/delay_hide/delay_hide.js
@@ -28,6 +28,7 @@ export class EuiDelayHide extends Component {
     return minimumDuration - visibleDuration;
   }
 
+  // @TODO: React 16.3 - componentDidUpdate
   componentWillReceiveProps(nextProps) {
     clearTimeout(this.timeout);
     const timeRemaining = this.getTimeRemaining(nextProps.minimumDuration);

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -73,6 +73,7 @@ export class EuiPopover extends Component {
     this.updateFocus();
   }
 
+  // @TODO: React 16.3 - componentDidUpdate
   componentWillReceiveProps(nextProps) {
     // The popover is being opened.
     if (!this.props.isOpen && nextProps.isOpen) {

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -73,7 +73,7 @@ export class EuiPopover extends Component {
     this.updateFocus();
   }
 
-  // @TODO: React 16.3 - componentDidUpdate
+  // TODO: React 16.3 - componentDidUpdate
   componentWillReceiveProps(nextProps) {
     // The popover is being opened.
     if (!this.props.isOpen && nextProps.isOpen) {

--- a/src/components/search_bar/search_bar.js
+++ b/src/components/search_bar/search_bar.js
@@ -88,7 +88,7 @@ export class EuiSearchBar extends Component {
     };
   }
 
-  // @TODO: React 16.3 - getDerivedStateFromProps
+  // TODO: React 16.3 - getDerivedStateFromProps
   componentWillReceiveProps(nextProps) {
     if (nextProps.query) {
       const query = parseQuery(nextProps.query, this.props);

--- a/src/components/search_bar/search_bar.js
+++ b/src/components/search_bar/search_bar.js
@@ -88,6 +88,7 @@ export class EuiSearchBar extends Component {
     };
   }
 
+  // @TODO: React 16.3 - getDerivedStateFromProps
   componentWillReceiveProps(nextProps) {
     if (nextProps.query) {
       const query = parseQuery(nextProps.query, this.props);

--- a/src/components/search_bar/search_box.js
+++ b/src/components/search_bar/search_box.js
@@ -33,7 +33,7 @@ export class EuiSearchBox extends Component {
     super(props);
   }
 
-  // @TODO: React 16.3 - shouldn't `query` be passed to EuiFieldSearch's value?
+  // TODO: React 16.3 - shouldn't `query` be passed to EuiFieldSearch's value?
   // (and possibly remove `inputRef` from EuiFieldSearch)
   // if that doesn't work, componentDidUpdate
   componentWillUpdate(nextProps) {

--- a/src/components/search_bar/search_box.js
+++ b/src/components/search_bar/search_box.js
@@ -33,6 +33,9 @@ export class EuiSearchBox extends Component {
     super(props);
   }
 
+  // @TODO: React 16.3 - shouldn't `query` be passed to EuiFieldSearch's value?
+  // (and possibly remove `inputRef` from EuiFieldSearch)
+  // if that doesn't work, componentDidUpdate
   componentWillUpdate(nextProps) {
     this.inputElement.value = nextProps.query;
   }


### PR DESCRIPTION
Completes the first step in #763 by adding TODOs to the locations where EUI uses the React lifecycle methods that were deprecated in 16.3. Each comment includes a suggestion for how to move that instance off the deprecated method.