### PR TITLE
Extract items and search from EuiInMemoryTable's ...rest prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No changes since 0.0.48.
+**Bug fixes**
+- `EuiInMemoryTable` now applies its search filter ([#851](https://github.com/elastic/eui/pull/851))
 
 ## [`0.0.48`](https://github.com/elastic/eui/tree/v0.0.48)
 

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
@@ -249,10 +249,6 @@ exports[`EuiInMemoryTable with pagination 1`] = `
         "id": "2",
         "name": "name2",
       },
-      Object {
-        "id": "3",
-        "name": "name3",
-      },
     ]
   }
   noItemsMessage="No items found"
@@ -541,7 +537,6 @@ exports[`EuiInMemoryTable with pagination, selection, sorting  and simple search
       }
     }
     responsive={true}
-    search={true}
     selection={
       Object {
         "onSelectionChanged": [Function],
@@ -654,10 +649,6 @@ exports[`EuiInMemoryTable with pagination, selection, sorting and column rendere
         "id": "2",
         "name": "name2",
       },
-      Object {
-        "id": "3",
-        "name": "name3",
-      },
     ]
   }
   noItemsMessage="No items found"
@@ -748,14 +739,6 @@ exports[`EuiInMemoryTable with pagination, selection, sorting and configured sea
           "id": "1",
           "name": "name1",
         },
-        Object {
-          "id": "2",
-          "name": "name2",
-        },
-        Object {
-          "id": "3",
-          "name": "name3",
-        },
       ]
     }
     noItemsMessage="No items found"
@@ -773,26 +756,6 @@ exports[`EuiInMemoryTable with pagination, selection, sorting and configured sea
       }
     }
     responsive={true}
-    search={
-      Object {
-        "box": Object {
-          "aria-label": "aria-label",
-          "className": "testClass1 testClass2",
-          "data-test-subj": "test subject string",
-          "incremental": true,
-        },
-        "defaultQuery": "name:name1",
-        "filters": Array [
-          Object {
-            "field": "name",
-            "name": "Name1",
-            "negatedName": "Not Name1",
-            "type": "field_value_toggle",
-            "value": "name1",
-          },
-        ],
-      }
-    }
     selection={
       Object {
         "onSelectionChanged": [Function],

--- a/src/components/basic_table/in_memory_table.js
+++ b/src/components/basic_table/in_memory_table.js
@@ -264,6 +264,8 @@ export class EuiInMemoryTable extends Component {
       sorting: hasSorting,
       itemIdToExpandedRowMap,
       itemId,
+      items: _unuseditems, // eslint-disable-line no-unused-vars
+      search, // eslint-disable-line no-unused-vars
       ...rest
     } = this.props;
 

--- a/src/components/basic_table/in_memory_table.test.js
+++ b/src/components/basic_table/in_memory_table.test.js
@@ -1,8 +1,9 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { requiredProps } from '../../test';
 
 import { EuiInMemoryTable } from './in_memory_table';
+import { ENTER } from '../../services/key_codes';
 
 describe('EuiInMemoryTable', () => {
 
@@ -522,4 +523,74 @@ describe('EuiInMemoryTable', () => {
     expect(component).toMatchSnapshot();
   });
 
+  describe('search interaction & functionality', () => {
+    it('updates the results as based on the entered query', () => {
+      const items = [
+        {
+          active: true,
+          name: 'Kansas'
+        },
+        {
+          active: true,
+          name: 'North Dakota'
+        },
+        {
+          active: false,
+          name: 'Florida'
+        },
+      ];
+
+      const columns = [
+        {
+          field: 'active',
+          name: 'Is Active'
+        },
+        {
+          field: 'name',
+          name: 'Name'
+        }
+      ];
+
+      const search = {};
+
+      const props = { items, columns, search, className: 'testTable' };
+
+      const component = mount(
+        <EuiInMemoryTable {...props}/>
+      );
+
+      // should render with all three results visible
+      expect(component.find('.testTable EuiTableRow').length).toBe(3);
+
+      const searchField = component.find('EuiFieldSearch input[type="search"]');
+
+      searchField.simulate(
+        'keyUp',
+        {
+          target: {
+            value: 'is:active',
+          },
+          keyCode: ENTER
+        }
+      );
+      component.update();
+
+      // should render with the two active results
+      expect(component.find('.testTable EuiTableRow').length).toBe(2);
+
+      searchField.simulate(
+        'keyUp',
+        {
+          target: {
+            value: 'active:false',
+          },
+          keyCode: ENTER
+        }
+      );
+      component.update();
+
+      // should render with the one inactive result
+      expect(component.find('.testTable EuiTableRow').length).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #850 by extracting `items` from the rest prop instead of passing it through to `EuiBasicTable`. Also extracts `search` prop as that is meant to be consumed by `EuiInMemoryTable`. Added a unit test to prevent future regressions.