### PR TITLE
Update EuiInMemoryTable's and EuiCustomItemAction lifecycle for React 16.3

### DIFF
--- a/src/components/basic_table/custom_item_action.js
+++ b/src/components/basic_table/custom_item_action.js
@@ -16,8 +16,7 @@ export class CustomItemAction extends Component {
     this.mounted = false;
   }
 
-  // TODO: React 16.3 - move this to componentDidMount
-  componentWillMount() {
+  componentDidMount() {
     this.mounted = true;
   }
 

--- a/src/components/basic_table/in_memory_table.js
+++ b/src/components/basic_table/in_memory_table.js
@@ -123,6 +123,20 @@ export class EuiInMemoryTable extends Component {
     responsive: true,
   };
 
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.items !== prevState.items) {
+      // We have new items because an external search has completed, so reset pagination state.
+      return {
+        props: {
+          items: nextProps.items,
+        },
+        pageIndex: 0,
+      };
+    } else {
+      return null;
+    }
+  }
+
   constructor(props) {
     super(props);
 
@@ -131,7 +145,9 @@ export class EuiInMemoryTable extends Component {
     const { sortField, sortDirection } = getInitialSorting(sorting);
 
     this.state = {
-      items: props.items,
+      props: {
+        items: props.items,
+      },
       query: getInitialQuery(search),
       pageIndex,
       pageSize,
@@ -208,7 +224,7 @@ export class EuiInMemoryTable extends Component {
   }
 
   getItems() {
-    const { items } = this.state;
+    const { props: { items } } = this.state;
 
     if (!items.length) {
       return {
@@ -239,18 +255,6 @@ export class EuiInMemoryTable extends Component {
       items: visibleItems,
       totalItemCount: matchingItems.length,
     };
-  }
-
-  static getDerivedStateFromProps(nextProps, prevState) {
-    if (nextProps.items !== prevState.items) {
-      // We have new items because an external search has completed, so reset pagination state.
-      return {
-        items: nextProps.items,
-        pageIndex: 0,
-      };
-    } else {
-      return null;
-    }
   }
 
   render() {

--- a/src/components/basic_table/in_memory_table.js
+++ b/src/components/basic_table/in_memory_table.js
@@ -131,6 +131,7 @@ export class EuiInMemoryTable extends Component {
     const { sortField, sortDirection } = getInitialSorting(sorting);
 
     this.state = {
+      items: props.items,
       query: getInitialQuery(search),
       pageIndex,
       pageSize,
@@ -207,7 +208,7 @@ export class EuiInMemoryTable extends Component {
   }
 
   getItems() {
-    const { items } = this.props;
+    const { items } = this.state;
 
     if (!items.length) {
       return {
@@ -240,13 +241,15 @@ export class EuiInMemoryTable extends Component {
     };
   }
 
-  // TODO: React 16.3 - getDerivedStateFromProps
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.items !== this.props.items) {
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.items !== prevState.items) {
       // We have new items because an external search has completed, so reset pagination state.
-      this.setState({
+      return {
+        items: nextProps.items,
         pageIndex: 0,
-      });
+      };
+    } else {
+      return null;
     }
   }
 

--- a/src/components/basic_table/in_memory_table.js
+++ b/src/components/basic_table/in_memory_table.js
@@ -127,7 +127,7 @@ export class EuiInMemoryTable extends Component {
     if (nextProps.items !== prevState.items) {
       // We have new items because an external search has completed, so reset pagination state.
       return {
-        props: {
+        prevProps: {
           items: nextProps.items,
         },
         pageIndex: 0,
@@ -145,7 +145,7 @@ export class EuiInMemoryTable extends Component {
     const { sortField, sortDirection } = getInitialSorting(sorting);
 
     this.state = {
-      props: {
+      prevProps: {
         items: props.items,
       },
       query: getInitialQuery(search),
@@ -224,7 +224,7 @@ export class EuiInMemoryTable extends Component {
   }
 
   getItems() {
-    const { props: { items } } = this.state;
+    const { prevProps: { items } } = this.state;
 
     if (!items.length) {
       return {


### PR DESCRIPTION
For #763 
* _EuiInMemoryTable_ implements `getDerivedStateFromProps` to replace `componentWillReceiveProps`. Moved `items` into component state instead of accessing it from props.
* _EuiCustomItemAction_ `componentWillMount` -> `componentDidMount`