### PR TITLE
Update EuiSearchBar to React 16.3 lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 **Breaking changes**
 
-- `EuiSearchBar` no longer has an `onParse` callback, and now passes an object to `onChange` with the shape `{ query, queryText, error }` ([#863](https://github.com/elastic/eui/pull/863)) 
+- `EuiSearchBar` no longer has an `onParse` callback, and now passes an object to `onChange` with the shape `{ query, queryText, error }` ([#863](https://github.com/elastic/eui/pull/863))
+- `EuiInMemoryTable`'s `search.onChange` callback now passes an object with `{ query, queryText, error }` instead of only the query ([#863](https://github.com/elastic/eui/pull/863))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- When using `EuiSearchBar` as a controlled input, the `onParse` and `onChange` callbacks will now fire
+**Breaking changes**
+
+- `EuiSearchBar` no longer has an `onParse` callback, and now passes an object to `onChange` with the shape `{ query, queryText, error }` ([#863](https://github.com/elastic/eui/pull/863)) 
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- When using `EuiSearchBar` as a controlled input, the `onParse` and `onChange` callbacks will now fire
+
 **Bug fixes**
 
 - `EuiButton`, `EuiButtonEmpty`, and `EuiButtonIcon` now look and behave disabled when `isDisabled={true}` ([#862](https://github.com/elastic/eui/pull/862))

--- a/src-docs/src/views/search_bar/controlled_search_bar.js
+++ b/src-docs/src/views/search_bar/controlled_search_bar.js
@@ -7,11 +7,10 @@ import {
   EuiSpacer,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiCodeBlock,
-  EuiTitle,
   EuiSwitch,
   EuiBasicTable,
   EuiSearchBar,
+  EuiButton,
 } from '../../../../src/components';
 
 const random = new Random();
@@ -65,7 +64,7 @@ const loadTags = () => {
 
 const initialQuery = EuiSearchBar.Query.MATCH_ALL;
 
-export class SearchBar extends Component {
+export class ControlledSearchBar extends Component {
 
   constructor(props) {
     super(props);
@@ -92,6 +91,28 @@ export class SearchBar extends Component {
   toggleIncremental = () => {
     this.setState(prevState => ({ incremental: !prevState.incremental }));
   };
+
+  setQuery = query => {
+    this.setState({ query });
+  }
+
+  renderBookmarks() {
+    return (
+      <Fragment>
+        <p>Enter a query, or select one from a bookmark</p>
+        <EuiSpacer size="s"/>
+        <EuiFlexGroup>
+          <EuiFlexItem grow={false}>
+            <EuiButton size="s" onClick={() => this.setQuery('status:open owner:dewey')}>mine, open</EuiButton>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton size="s" onClick={() => this.setQuery('status:closed owner:dewey')}>mine, closed</EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiSpacer size="m"/>
+      </Fragment>
+    );
+  }
 
   renderSearch() {
     const { incremental } = this.state;
@@ -170,7 +191,7 @@ export class SearchBar extends Component {
 
     return (
       <EuiSearchBar
-        defaultQuery={initialQuery}
+        query={this.state.query}
         box={{
           placeholder: 'e.g. type:visualization -is:active joe',
           incremental,
@@ -253,43 +274,11 @@ export class SearchBar extends Component {
   render() {
     const {
       incremental,
-      query,
     } = this.state;
-
-    const esQueryDsl = EuiSearchBar.Query.toESQuery(query);
-    const esQueryString = EuiSearchBar.Query.toESQueryString(query);
 
     const content = this.renderError() || (
       <EuiFlexGroup>
-        <EuiFlexItem grow={4}>
-
-          <EuiTitle size="s">
-            <h3>Elasticsearch Query String</h3>
-          </EuiTitle>
-          <EuiSpacer size="s"/>
-          <EuiCodeBlock language="js">
-            {esQueryString ? esQueryString : ''}
-          </EuiCodeBlock>
-
-          <EuiSpacer size="l"/>
-
-          <EuiTitle size="s">
-            <h3>Elasticsearch Query DSL</h3>
-          </EuiTitle>
-          <EuiSpacer size="s"/>
-          <EuiCodeBlock language="js">
-            {esQueryDsl ? JSON.stringify(esQueryDsl, null, 2) : ''}
-          </EuiCodeBlock>
-
-        </EuiFlexItem>
-
         <EuiFlexItem grow={6}>
-          <EuiTitle size="s">
-            <h3>JS execution</h3>
-          </EuiTitle>
-
-          <EuiSpacer size="s"/>
-
           {this.renderTable()}
         </EuiFlexItem>
       </EuiFlexGroup>
@@ -297,6 +286,11 @@ export class SearchBar extends Component {
 
     return (
       <Fragment>
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            {this.renderBookmarks()}
+          </EuiFlexItem>
+        </EuiFlexGroup>
         <EuiFlexGroup alignItems="center">
           <EuiFlexItem>
             {this.renderSearch()}

--- a/src-docs/src/views/search_bar/props_info.js
+++ b/src-docs/src/views/search_bar/props_info.js
@@ -4,15 +4,10 @@ export const propsInfo = {
     __docgenInfo: {
       props: {
         onChange: {
-          description: 'Called every time the query behind the search bar changes',
-          required: true,
-          type: { name: '(query: #Query) => void' }
-        },
-        onParse: {
           description: 'Called every time the text query in the search box is parsed. When parsing is successful ' +
                        'the callback will receive both the query text and the parsed query. When it fails ' +
                        'the callback ill receive the query text and an error object (holding the error message)',
-          required: false,
+          required: true,
           type: { name: '({ query?: #Query, queryText: string, error?: { message: string } }) => void' }
         },
         query: {

--- a/src-docs/src/views/search_bar/search_bar_example.js
+++ b/src-docs/src/views/search_bar/search_bar_example.js
@@ -12,9 +12,13 @@ import {
 } from '../../../../src/components';
 
 import { SearchBar } from './search_bar';
+import { ControlledSearchBar } from './controlled_search_bar';
 
 const searchBarSource = require('!!raw-loader!./search_bar');
 const searchBarHtml = renderToHtml(SearchBar);
+
+const controlledSearchBarSource = require('!!raw-loader!./controlled_search_bar');
+const controlledSearchBarHtml = renderToHtml(ControlledSearchBar);
 
 export const SearchBarExample = {
   title: 'Search Bar',
@@ -89,6 +93,26 @@ export const SearchBarExample = {
       ),
       props: propsInfo,
       demo: <SearchBar/>
+    },
+    {
+      title: 'Controlled Search Bar',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: controlledSearchBarSource,
+        }, {
+          type: GuideSectionTypes.HTML,
+          code: controlledSearchBarHtml,
+        }
+      ],
+      text: (
+        <div>
+          <p>
+            A <EuiCode>EuiSearchBar</EuiCode> can have its query controlled by a parent component by passing the `query` prop. Changes to the query will be passed back up through the <EuiCode>onChange</EuiCode> callback where the new Query must be stored in state and passed back into the search bar.
+          </p>
+        </div>
+      ),
+      demo: <ControlledSearchBar/>
     }
   ],
 };

--- a/src-docs/src/views/search_bar/search_bar_example.js
+++ b/src-docs/src/views/search_bar/search_bar_example.js
@@ -108,7 +108,7 @@ export const SearchBarExample = {
       text: (
         <div>
           <p>
-            A <EuiCode>EuiSearchBar</EuiCode> can have its query controlled by a parent component by passing the `query` prop. Changes to the query will be passed back up through the <EuiCode>onChange</EuiCode> callback where the new Query must be stored in state and passed back into the search bar.
+            A <EuiCode>EuiSearchBar</EuiCode> can have its query controlled by a parent component by passing the <EuiCode>query</EuiCode> prop. Changes to the query will be passed back up through the <EuiCode>onChange</EuiCode> callback where the new Query must be stored in state and passed back into the search bar.
           </p>
         </div>
       ),

--- a/src-docs/src/views/tables/in_memory/in_memory_search_callback.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_search_callback.js
@@ -44,7 +44,7 @@ export class Table extends React.Component {
     };
   }
 
-  onQueryChange = query => {
+  onQueryChange = ({ query }) => {
     clearTimeout(debounceTimeoutId);
     clearTimeout(requestTimeoutId);
 

--- a/src/components/basic_table/in_memory_table.js
+++ b/src/components/basic_table/in_memory_table.js
@@ -159,9 +159,9 @@ export class EuiInMemoryTable extends Component {
     });
   };
 
-  onQueryChange = ({ query }) => {
+  onQueryChange = ({ query, queryText, error }) => {
     if (this.props.search.onChange) {
-      const shouldQueryInMemory = this.props.search.onChange(query);
+      const shouldQueryInMemory = this.props.search.onChange({ query, queryText, error });
       if (!shouldQueryInMemory) {
         return;
       }

--- a/src/components/basic_table/in_memory_table.js
+++ b/src/components/basic_table/in_memory_table.js
@@ -159,7 +159,7 @@ export class EuiInMemoryTable extends Component {
     });
   };
 
-  onQueryChange = (query) => {
+  onQueryChange = ({ query }) => {
     if (this.props.search.onChange) {
       const shouldQueryInMemory = this.props.search.onChange(query);
       if (!shouldQueryInMemory) {

--- a/src/components/search_bar/search_bar.js
+++ b/src/components/search_bar/search_bar.js
@@ -17,14 +17,9 @@ export const QueryType = PropTypes.oneOfType([ PropTypes.instanceOf(Query), Prop
 
 export const SearchBarPropTypes = {
   /**
-   * (query: Query) => void
-   */
-  onChange: PropTypes.func,
-
-  /**
    (query?: Query, queryText: string, error?: string) => void
    */
-  onParse: PropTypes.func,
+  onChange: PropTypes.func.isRequired,
 
   /**
    The initial query the bar will hold when first mounted
@@ -56,12 +51,18 @@ export const SearchBarPropTypes = {
   /**
    * Tools which go to the right of the search bar.
    */
-  toolsRight: PropTypes.node
+  toolsRight: PropTypes.node,
+
+  /**
+   * Date formatter to use when parsing date values
+   */
+  dateFormat: PropTypes.object
 };
 
 const parseQuery = (query, props) => {
   const schema = props.box ? props.box.schema : undefined;
-  const parseOptions = { schema };
+  const dateFormat = props.dateFormat;
+  const parseOptions = { schema, dateFormat };
   if (!query) {
     return Query.parse('', parseOptions);
   }
@@ -106,16 +107,7 @@ export class EuiSearchBar extends Component {
     const isErrorDifferent = oldError !== newError;
 
     if (isQueryDifferent || isErrorDifferent) {
-      if (this.props.onParse) {
-        this.props.onParse({ query, queryText, error });
-      }
-
-      // only fire onChange if there isn't an error
-      if (newError == null) {
-        if (this.props.onChange) {
-          this.props.onChange(query);
-        }
-      }
+      this.props.onChange({ query, queryText, error });
     }
   }
 
@@ -135,9 +127,6 @@ export class EuiSearchBar extends Component {
       queryText: query.text,
       error: null
     });
-    if (this.props.onChange) {
-      this.props.onChange(query);
-    }
   };
 
   renderTools(tools) {

--- a/src/components/search_bar/search_bar.js
+++ b/src/components/search_bar/search_bar.js
@@ -56,7 +56,7 @@ export const SearchBarPropTypes = {
   /**
    * Tools which go to the right of the search bar.
    */
-  toolsRight: PropTypes.node
+  toolsRight: PropTypes.node,
 };
 
 const parseQuery = (query, props) => {

--- a/src/components/search_bar/search_bar.js
+++ b/src/components/search_bar/search_bar.js
@@ -56,7 +56,7 @@ export const SearchBarPropTypes = {
   /**
    * Tools which go to the right of the search bar.
    */
-  toolsRight: PropTypes.node,
+  toolsRight: PropTypes.node
 };
 
 const parseQuery = (query, props) => {

--- a/src/components/search_bar/search_bar.test.js
+++ b/src/components/search_bar/search_bar.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-multi-comp */
-import React, { Component } from 'react';
+import React from 'react';
 import { requiredProps } from '../../test';
 import { mount, shallow } from 'enzyme';
 import { EuiSearchBar } from './search_bar';
@@ -79,74 +79,49 @@ describe('SearchBar', () => {
   });
 
   describe('controlled input', () => {
-    test('calls onParse callback when a new query is passed', () => {
-      const onParse = jest.fn();
+    test('calls onChange callback when a new query is passed', () => {
+      const onChange = jest.fn();
 
-      class Wrapper extends Component {
-        constructor(...args) {
-          super(...args);
-          this.state = { query: '' };
-        }
-
-        setQuery(query) {
-          this.setState({ query });
-        }
-
-        render() {
-          return (
-            <EuiSearchBar
-              {...requiredProps}
-              query={this.state.query}
-              onParse={onParse}
-            />
-          );
-        }
-      }
       const component = mount(
-        <Wrapper/>
+        <EuiSearchBar
+          {...requiredProps}
+          query=""
+          onChange={onChange}
+        />
       );
 
-      const wrapperInstance = component.instance();
-      wrapperInstance.setQuery('is:active');
+      component.setProps({
+        ...requiredProps,
+        query: 'is:active',
+        onChange
+      });
 
-      expect(onParse).toHaveBeenCalledTimes(1);
-      const [[{ query, queryText }]] = onParse.mock.calls;
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const [[{ query, queryText }]] = onChange.mock.calls;
       expect(query).toBeInstanceOf(Query);
       expect(queryText).toBe('is:active');
     });
 
-    test('does not call onParse when an unwatched prop changes', () => {
-      const onParse = jest.fn();
+    test('does not call onChange when an unwatched prop changes', () => {
+      const onChange = jest.fn();
 
-      class Wrapper extends Component {
-        constructor(...args) {
-          super(...args);
-          this.state = { isFoo: false };
-        }
-
-        setIsFoo(isFoo) {
-          this.setState({ isFoo });
-        }
-
-        render() {
-          return (
-            <EuiSearchBar
-              {...requiredProps}
-              query="is:active"
-              isFoo={this.state.isFoo}
-              onParse={onParse}
-            />
-          );
-        }
-      }
       const component = mount(
-        <Wrapper/>
+        <EuiSearchBar
+          {...requiredProps}
+          query="is:active"
+          isFoo={false}
+          onChange={onChange}
+        />
       );
 
-      const wrapperInstance = component.instance();
-      wrapperInstance.setIsFoo(true);
+      component.setProps({
+        ...requiredProps,
+        query: 'is:active',
+        isFoo: true,
+        onChange
+      });
 
-      expect(onParse).toHaveBeenCalledTimes(0);
+      expect(onChange).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/src/components/search_bar/search_bar.test.js
+++ b/src/components/search_bar/search_bar.test.js
@@ -1,7 +1,9 @@
-import React from 'react';
+/* eslint-disable react/no-multi-comp */
+import React, { Component } from 'react';
 import { requiredProps } from '../../test';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { EuiSearchBar } from './search_bar';
+import { Query } from './query';
 
 describe('SearchBar', () => {
   test('render - no config, no query', () => {
@@ -74,5 +76,77 @@ describe('SearchBar', () => {
     );
 
     expect(component).toMatchSnapshot();
+  });
+
+  describe('controlled input', () => {
+    test('calls onParse callback when a new query is passed', () => {
+      const onParse = jest.fn();
+
+      class Wrapper extends Component {
+        constructor(...args) {
+          super(...args);
+          this.state = { query: '' };
+        }
+
+        setQuery(query) {
+          this.setState({ query });
+        }
+
+        render() {
+          return (
+            <EuiSearchBar
+              {...requiredProps}
+              query={this.state.query}
+              onParse={onParse}
+            />
+          );
+        }
+      }
+      const component = mount(
+        <Wrapper/>
+      );
+
+      const wrapperInstance = component.instance();
+      wrapperInstance.setQuery('is:active');
+
+      expect(onParse).toHaveBeenCalledTimes(1);
+      const [[{ query, queryText }]] = onParse.mock.calls;
+      expect(query).toBeInstanceOf(Query);
+      expect(queryText).toBe('is:active');
+    });
+
+    test('does not call onParse when an unwatched prop changes', () => {
+      const onParse = jest.fn();
+
+      class Wrapper extends Component {
+        constructor(...args) {
+          super(...args);
+          this.state = { isFoo: false };
+        }
+
+        setIsFoo(isFoo) {
+          this.setState({ isFoo });
+        }
+
+        render() {
+          return (
+            <EuiSearchBar
+              {...requiredProps}
+              query="is:active"
+              isFoo={this.state.isFoo}
+              onParse={onParse}
+            />
+          );
+        }
+      }
+      const component = mount(
+        <Wrapper/>
+      );
+
+      const wrapperInstance = component.instance();
+      wrapperInstance.setIsFoo(true);
+
+      expect(onParse).toHaveBeenCalledTimes(0);
+    });
   });
 });

--- a/src/components/search_bar/search_bar.test.js
+++ b/src/components/search_bar/search_bar.test.js
@@ -84,17 +84,12 @@ describe('SearchBar', () => {
 
       const component = mount(
         <EuiSearchBar
-          {...requiredProps}
           query=""
           onChange={onChange}
         />
       );
 
-      component.setProps({
-        ...requiredProps,
-        query: 'is:active',
-        onChange
-      });
+      component.setProps({ query: 'is:active' });
 
       expect(onChange).toHaveBeenCalledTimes(1);
       const [[{ query, queryText }]] = onChange.mock.calls;
@@ -107,19 +102,13 @@ describe('SearchBar', () => {
 
       const component = mount(
         <EuiSearchBar
-          {...requiredProps}
           query="is:active"
           isFoo={false}
           onChange={onChange}
         />
       );
 
-      component.setProps({
-        ...requiredProps,
-        query: 'is:active',
-        isFoo: true,
-        onChange
-      });
+      component.setProps({ isFoo: true });
 
       expect(onChange).toHaveBeenCalledTimes(0);
     });


### PR DESCRIPTION
- fixed `EuiSearchBar`'s proptypes (had been changed to the wrong object at some point)
- refactored `componentWillUpdate` -> `getDerivedStateFromProps` / `componentDidUpdate` and updated support for externally-controlled query values
- corrected how the custom date parser property / parse option is passed
- `onChange` has changed from taking one argument, `queryText`, to taking an argument with the shape `{ query, queryText, error }`
- `onParse` has been removed
- added an example of a controlled search bar to the docs

![controlled searchbar example](https://d.pr/i/LkagCm.gif)