### PR TITLE
Some quick CSS fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `EuiButton`, `EuiButtonEmpty`, and `EuiButtonIcon` now look and behave disabled when `isDisabled={true}` ([#862](https://github.com/elastic/eui/pull/862))
 - Added FF/IE fallback for `.eui-textBreakWord` ([#864](https://github.com/elastic/eui/pull/864))
 - Fixed `EuiCard` description text color when used in/as an anchor tag ([#864](https://github.com/elastic/eui/pull/864))
+- Fixed `EuiCard` IE bugs ([#864](https://github.com/elastic/eui/pull/864))
 
 ## [`0.0.49`](https://github.com/elastic/eui/tree/v0.0.49)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 **Bug fixes**
 
 - `EuiButton`, `EuiButtonEmpty`, and `EuiButtonIcon` now look and behave disabled when `isDisabled={true}` ([#862](https://github.com/elastic/eui/pull/862))
+- Added FF/IE fallback for `.eui-textBreakWord` ([#864](https://github.com/elastic/eui/pull/864))
+- Fixed `EuiCard` description text color when used in/as an anchor tag ([#864](https://github.com/elastic/eui/pull/864))
 
 ## [`0.0.49`](https://github.com/elastic/eui/tree/v0.0.49)
 

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -10,6 +10,9 @@ $euiCardTitleSize: 18px; // Hardcoded pixel value for theme parity.
 /**
  * 1. Footer is always at the bottom.
  * 2. Extend beta badges to at least 40% of the card's width
+ * 3. Fix for IE to ensure badges are visible outside of a <button> tag
+ * 4. Fix for IE where the image correctly resizes in width but doesn't collapse it's height
+      (https://github.com/philipwalton/flexbugs/issues/75#issuecomment-134702421)
  */
 
 // EuiCard specific
@@ -17,6 +20,7 @@ $euiCardTitleSize: 18px; // Hardcoded pixel value for theme parity.
   display: flex;
   flex-direction: column;
   padding: $euiCardSpacing;
+  overflow: visible; /* 3 */
 
   &.euiCard--hasBetaBadge {
     position: relative;
@@ -82,6 +86,7 @@ $euiCardTitleSize: 18px; // Hardcoded pixel value for theme parity.
 .euiCard__top {
   flex-grow: 0; /* 1 */
   position: relative;
+  min-height: 1px; /* 4 */
 
   .euiCard__icon {
     margin-top: $euiCardSpacing/2;
@@ -103,6 +108,7 @@ $euiCardTitleSize: 18px; // Hardcoded pixel value for theme parity.
       position: absolute;
       top: 50%;
       left: 50%;
+      transform: translate(-50%, -75%); // Fallback for IE as it doesn't accept calcs in translates
       transform: translate(-50%, calc(-50% + #{$euiCardSpacing * -1}));
     }
   }

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -123,6 +123,7 @@ $euiCardTitleSize: 18px; // Hardcoded pixel value for theme parity.
   }
 
   .euiCard__description {
+    color: $euiTextColor; // Ensures regular text color if wrapped in an anchor tag
     margin-top: $euiCardSpacing/2;
   }
 }

--- a/src/components/form/form_control_layout/_form_control_layout.scss
+++ b/src/components/form/form_control_layout/_form_control_layout.scss
@@ -27,7 +27,11 @@
 
   .euiFormControlLayout__iconButton {
     pointer-events: all;
-    top: $euiFormControlPadding - 1px;
+    @include size($euiSize);
+
+    .euiIcon {
+      vertical-align: baseline;
+    }
 
     @at-root {
       .euiFormControlLayout--compressed#{&} {

--- a/src/global_styling/utility/_utility.scss
+++ b/src/global_styling/utility/_utility.scss
@@ -13,10 +13,14 @@
 .eui-textCenter {text-align: center !important;}
 .eui-textLeft {text-align: left !important;}
 .eui-textRight {text-align: right !important;}
-.eui-textBreakWord {word-break: break-word !important;}
-.eui-textBreakAll {word-break: break-all !important;}
 .eui-textNoWrap {white-space: nowrap !important;}
 .eui-textInheritColor {color: inherit !important;}
+
+.eui-textBreakAll {word-break: break-all !important;}
+.eui-textBreakWord {
+  word-break: break-all !important; // Fallback for FF and IE
+  word-break: break-word !important;
+}
 
 /**
  * Text truncation


### PR DESCRIPTION
- Fixes #855: Add fallback to just break-all in FF and IE
<img width="617" alt="screen shot 2018-05-22 at 16 54 40 pm" src="https://user-images.githubusercontent.com/549577/40389588-d8792bfa-5de0-11e8-87a4-e9735988efe4.png">

- Fixed text color of descriptions in cards
<img width="804" alt="screen shot 2018-05-22 at 16 55 17 pm" src="https://user-images.githubusercontent.com/549577/40389619-ebe9bc0e-5de0-11e8-9602-c9093132a3a1.png">

- Fixed vertical alignment of combo box arrow icon (it was a couple pixels too low)
- Fixed `EuiCard` IE bugs
    - `EuiBetaBadge` wasn't displying outside of card bounds
    - Image bounds weren’t being correctly calculated
    - IE doesn’t accept `calc` in transforms