### PR TITLE
Fix timer callback triggering after timer is cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - `EuiButton`, `EuiButtonEmpty`, and `EuiButtonIcon` now look and behave disabled when `isDisabled={true}` ([#862](https://github.com/elastic/eui/pull/862))
+- `EuiGlobalToastList` no longer triggers `Uncaught TypeError: _this.callback is not a function`  ([#865](https://github.com/elastic/eui/pull/865))
 
 ## [`0.0.49`](https://github.com/elastic/eui/tree/v0.0.49)
 

--- a/src/services/time/timer.js
+++ b/src/services/time/timer.js
@@ -14,6 +14,7 @@ export class Timer {
 
   resume = () => {
     this.id = setTimeout(this.finish, this.timeRemaining);
+    this.finishTime = Date.now() + this.timeRemaining;
     this.timeRemaining = undefined;
   };
 
@@ -26,7 +27,9 @@ export class Timer {
   };
 
   finish = () => {
-    this.callback();
+    if (this.callback) {
+      this.callback();
+    }
     this.clear();
   };
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/19285

We could get fancy and fix this specific situation through more coordination, or we can be defensive and just not trigger the callback if it's been removed. I opted for the second because of its simplicity and it addresses any related bugs that may occur in the future.

This also fixes a second bug where the toast's countdown is not restarted for the correct amount of time after the second hover.

<details>
<summary>what causes the error</summary>
When a toast managed by `EuiGlobalToastList` reaches the end of its timer, the timer self-clears and triggers the callback, beginning the process of fading out the element. The toast fade-and-remove can be laid out as

- timer's timeout happens
  - timer.callback()
    - toast list tracks this toast as dismissed (it starts fading out)
    - toast list sets `timeout X`
  - timer.clear()
    - removes timer callback
- `timeout X` happens
  - toast dismissal callback happens, which removes toast from the list
  - toast's timer is cleared, to be safe (allowing dismissals outside of this flow)

The bug as described in the [kibana issue](https://github.com/elastic/kibana/issues/19285) can happen by a 3rd event triggering between the timer's timeout and `timeout X`: `EuiGlobalToastList`'s `onMouseLeave` handler cycles through the known timers and calls `resume`, re-creating their setTimeouts. The list of known timers at this point includes elements that are fading out, which have already completed their timers, and their callbacks have been removed.
</details>

