### PR TITLE
Toggle components

### DIFF
--- a/src-docs/src/routes.js
+++ b/src-docs/src/routes.js
@@ -204,6 +204,9 @@ import { ToastExample }
 import { ToolTipExample }
   from './views/tool_tip/tool_tip_example';
 
+import { ToggleExample }
+  from './views/toggle/toggle_example';
+
 import { Changelog }
   from './views/package/changelog';
 
@@ -344,6 +347,7 @@ const navigation = [{
     IsColorDarkExample,
     OutsideClickDetectorExample,
     PortalExample,
+    ToggleExample,
     UtilityClassesExample,
   ].map(example => createExample(example)),
 }, {

--- a/src-docs/src/views/button/button_example.js
+++ b/src-docs/src/views/button/button_example.js
@@ -217,7 +217,7 @@ export const ButtonExample = {
         ...
       </p>
     ),
-    demo: <ButtonToggle />,
+    demo: <ButtonGroup />,
     props: { EuiButtonGroup },
   }],
 };

--- a/src-docs/src/views/button/button_example.js
+++ b/src-docs/src/views/button/button_example.js
@@ -13,6 +13,7 @@ import {
   EuiCode,
   EuiButtonGroup,
   EuiButtonToggle,
+  EuiLink,
 } from '../../../../src/components';
 
 import Button from './button';
@@ -169,25 +170,6 @@ export const ButtonExample = {
     props: { EuiButtonIcon },
     demo: <ButtonIcon />,
   }, {
-    title: 'Ghost buttons for deep color backgrounds',
-    source: [{
-      type: GuideSectionTypes.JS,
-      code: buttonGhostSource,
-    }, {
-      type: GuideSectionTypes.HTML,
-      code: buttonGhostHtml,
-    }],
-    text: (
-      <p>
-        You can also pass <EuiCode>type=&apos;ghost&apos;</EuiCode> to any of the button
-        styles on this page. These should be used extremely rarely, and are
-        only for placing buttons on top of dark or image-based backgrounds.
-        A good example of their use is in
-        the <EuiCode>EuiBottomBar</EuiCode> component
-      </p>
-    ),
-    demo: <ButtonGhost />,
-  }, {
     title: 'Toggle buttons',
     source: [{
       type: GuideSectionTypes.JS,
@@ -197,9 +179,19 @@ export const ButtonExample = {
       code: buttonToggleHtml,
     }],
     text: (
-      <p>
-        ...
-      </p>
+      <div>
+        <p>
+          This is a specialized component that combines <EuiCode>EuiButton</EuiCode> and <EuiCode>EuiToggle</EuiCode> to
+          create a button with an on/off state. You can pass all the same parameters to it as you
+          can to <EuiCode>EuiButton</EuiCode>. The main difference is that, it does not accept any children,
+          but a <EuiCode>label</EuiCode> prop instead. This is for the handling of accessiblity with
+          the <EuiCode>EuiToggle</EuiCode>.
+        </p>
+        <p>
+          The <EuiCode>EuiButtonToggle</EuiCode> does not have any inherit visual state differences.
+          These you must apply in your implementation.
+        </p>
+      </div>
     ),
     demo: <ButtonToggle />,
     props: { EuiButtonToggle },
@@ -213,11 +205,40 @@ export const ButtonExample = {
       code: buttonGroupHtml,
     }],
     text: (
-      <p>
-        ...
-      </p>
+      <div>
+        <p>
+          Button groups are handled similarly to the way checkbox and radio groups are
+          handled but made to look like buttons. They group multiple <EuiCode>EuiButtonToggle</EuiCode>s
+          and utilize the <EuiCode>type=&quot;single&quot;</EuiCode> or <EuiCode>&quot;multi&quot;</EuiCode> prop
+          to determine whether multiple or only single selections are allowed per group.
+        </p>
+        <p>
+          Stylistically, all button groups are the size of small buttons, do not stretch to fill the container
+          and typically should only be <EuiCode>color=&quot;text&quot;</EuiCode> (default)
+          or <EuiCode>&quot;primary&quot;</EuiCode>.
+          If your just displaying a group of icons, add the prop <EuiCode>isIconOnly</EuiCode>.
+        </p>
+      </div>
     ),
     demo: <ButtonGroup />,
     props: { EuiButtonGroup },
+  }, {
+    title: 'Ghost',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: buttonGhostSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: buttonGhostHtml,
+    }],
+    text: (
+      <p>
+        For buttons on dark color backgrounds, you can pass <EuiCode>color=&apos;ghost&apos;</EuiCode> to
+        any of the button styles on this page. These should be used extremely rarely, and are
+        only for placing buttons on top of dark or image-based backgrounds.
+        A good example of their use is in the <EuiLink href="/#/layout/bottom-bar">EuiBottomBar</EuiLink> component.
+      </p>
+    ),
+    demo: <ButtonGhost />,
   }],
 };

--- a/src-docs/src/views/button/button_example.js
+++ b/src-docs/src/views/button/button_example.js
@@ -11,6 +11,8 @@ import {
   EuiButtonEmpty,
   EuiButtonIcon,
   EuiCode,
+  EuiButtonGroup,
+  EuiButtonToggle,
 } from '../../../../src/components';
 
 import Button from './button';
@@ -44,6 +46,14 @@ const buttonAsLinkHtml = renderToHtml(ButtonAsLink);
 import ButtonLoading from './button_loading';
 const buttonLoadingSource = require('!!raw-loader!./button_loading');
 const buttonLoadingHtml = renderToHtml(ButtonLoading);
+
+import ButtonToggle from './button_toggle';
+const buttonToggleSource = require('!!raw-loader!./button_toggle');
+const buttonToggleHtml = renderToHtml(ButtonToggle);
+
+import ButtonGroup from './button_group';
+const buttonGroupSource = require('!!raw-loader!./button_group');
+const buttonGroupHtml = renderToHtml(ButtonGroup);
 
 export const ButtonExample = {
   title: 'Button',
@@ -177,5 +187,37 @@ export const ButtonExample = {
       </p>
     ),
     demo: <ButtonGhost />,
+  }, {
+    title: 'Toggle buttons',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: buttonToggleSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: buttonToggleHtml,
+    }],
+    text: (
+      <p>
+        ...
+      </p>
+    ),
+    demo: <ButtonToggle />,
+    props: { EuiButtonToggle },
+  }, {
+    title: 'Groups',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: buttonGroupSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: buttonGroupHtml,
+    }],
+    text: (
+      <p>
+        ...
+      </p>
+    ),
+    demo: <ButtonToggle />,
+    props: { EuiButtonGroup },
   }],
 };

--- a/src-docs/src/views/button/button_ghost.js
+++ b/src-docs/src/views/button/button_ghost.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 
 import {
   EuiButton,
@@ -6,69 +6,95 @@ import {
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiButtonToggle,
 } from '../../../../src/components';
 
-export default () => (
-  <EuiFlexGroup gutterSize="s" alignItems="center" className="guideDemo__ghostBackground">
-    <EuiFlexItem grow={false}>
-      <EuiButton
-        color="ghost"
-        onClick={() => window.alert('Button clicked')}
-      >
-        Primary
-      </EuiButton>
-    </EuiFlexItem>
+export default class extends Component {
+  constructor(props) {
+    super(props);
 
-    <EuiFlexItem grow={false}>
-      <EuiButton
-        fill
-        color="ghost"
-        size="s"
-        iconType="check"
-        onClick={() => window.alert('Button clicked')}
-      >
-        Filled
-      </EuiButton>
-    </EuiFlexItem>
+    this.state = {
+      toggle0On: false,
+    };
+  }
 
-    <EuiFlexItem grow={false}>
-      <EuiButtonEmpty
-        size="s"
-        color="ghost"
-        onClick={() => window.alert('Button clicked')}
-      >
-        small
-      </EuiButtonEmpty>
-    </EuiFlexItem>
+  onToggle0Change = (e) => {
+    this.setState({ toggle0On: e.target.checked });
+  }
 
-    <EuiFlexItem grow={false}>
-      <EuiButtonIcon
-        size="s"
-        color="ghost"
-        iconType="user"
-        onClick={() => window.alert('Button clicked')}
-        aria-label="Your account"
-      />
-    </EuiFlexItem>
+  render() {
+    return (
+      <EuiFlexGroup wrap gutterSize="s" alignItems="center" className="guideDemo__ghostBackground">
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            color="ghost"
+            onClick={() => window.alert('Button clicked')}
+          >
+            Primary
+          </EuiButton>
+        </EuiFlexItem>
 
-    <EuiFlexItem grow={false}>
-      <EuiButton
-        color="ghost"
-        isLoading
-        fill
-        size="s"
-      >
-        Loading&hellip;
-      </EuiButton>
-    </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            fill
+            color="ghost"
+            size="s"
+            iconType="check"
+            onClick={() => window.alert('Button clicked')}
+          >
+            Filled
+          </EuiButton>
+        </EuiFlexItem>
 
-    <EuiFlexItem grow={false}>
-      <EuiButton
-        color="ghost"
-        isLoading
-      >
-        Loading&hellip;
-      </EuiButton>
-    </EuiFlexItem>
-  </EuiFlexGroup>
-);
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty
+            size="s"
+            color="ghost"
+            onClick={() => window.alert('Button clicked')}
+          >
+            small
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon
+            size="s"
+            color="ghost"
+            iconType="user"
+            onClick={() => window.alert('Button clicked')}
+            aria-label="Your account"
+          />
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            color="ghost"
+            isLoading
+            fill
+            size="s"
+          >
+            Loading&hellip;
+          </EuiButton>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            color="ghost"
+            isLoading
+          >
+            Loading&hellip;
+          </EuiButton>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButtonToggle
+            color="ghost"
+            label="Toggle Me"
+            fill={this.state.toggle0On}
+            onChange={this.onToggle0Change}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+}

--- a/src-docs/src/views/button/button_group.js
+++ b/src-docs/src/views/button/button_group.js
@@ -17,6 +17,7 @@ export default class extends Component {
 
     const idPrefix = makeId();
     const idPrefix2 = makeId();
+    const idPrefix3 = makeId();
 
     this.toggleButtons = [{
       id: `${idPrefix}0`,
@@ -40,11 +41,45 @@ export default class extends Component {
       label: 'Option 3',
     }];
 
+    this.toggleButtonsIcons = [{
+      id: `${idPrefix3}0`,
+      label: 'Align left',
+      iconType: 'editorAlignLeft',
+    }, {
+      id: `${idPrefix3}1`,
+      label: 'Align center',
+      iconType: 'editorAlignCenter',
+    }, {
+      id: `${idPrefix3}2`,
+      label: 'Align right',
+      iconType: 'editorAlignRight',
+    }];
+
+    this.toggleButtonsIconsMulti = [{
+      id: `${idPrefix3}3`,
+      label: 'Bold',
+      iconType: 'editorBold',
+    }, {
+      id: `${idPrefix3}4`,
+      label: 'Italic',
+      iconType: 'editorItalic',
+    }, {
+      id: `${idPrefix3}5`,
+      label: 'Underline',
+      iconType: 'editorUnderline',
+    }, {
+      id: `${idPrefix3}6`,
+      label: 'Strikethrough',
+      iconType: 'editorStrike',
+    }];
+
     this.state = {
       toggleIdSelected: `${idPrefix}1`,
       toggleIdToSelectedMap: {
         [`${idPrefix2}1`]: true,
       },
+      toggleIconIdSelected: `${idPrefix3}1`,
+      toggleIconIdToSelectedMap: {},
     };
   }
 
@@ -61,6 +96,22 @@ export default class extends Component {
 
     this.setState({
       toggleIdToSelectedMap: newToggleIdToSelectedMap,
+    });
+  };
+
+  onChangeIcons = optionId => {
+    this.setState({
+      toggleIconIdSelected: optionId,
+    });
+  };
+
+  onChangeIconsMulti = optionId => {
+    const newToggleIconIdToSelectedMap = ({ ...this.state.toggleIconIdToSelectedMap, ...{
+      [optionId]: !this.state.toggleIconIdToSelectedMap[optionId],
+    } });
+
+    this.setState({
+      toggleIconIdToSelectedMap: newToggleIconIdToSelectedMap,
     });
   };
 
@@ -99,6 +150,31 @@ export default class extends Component {
           onChange={this.onChange}
           isDisabled
           isFullWidth
+        />
+
+        <EuiSpacer size="m" />
+
+        <EuiTitle size="xxs"><h3>Icons only</h3></EuiTitle>
+
+        <EuiSpacer size="s" />
+
+        <EuiButtonGroup
+          className="eui-displayInlineBlock"
+          options={this.toggleButtonsIcons}
+          idSelected={this.state.toggleIconIdSelected}
+          onChange={this.onChangeIcons}
+          isIconOnly
+        />
+
+        &nbsp;&nbsp;
+
+        <EuiButtonGroup
+          className="eui-displayInlineBlock"
+          options={this.toggleButtonsIconsMulti}
+          idToSelectedMap={this.state.toggleIconIdToSelectedMap}
+          onChange={this.onChangeIconsMulti}
+          type="multi"
+          isIconOnly
         />
       </Fragment>
     );

--- a/src-docs/src/views/button/button_group.js
+++ b/src-docs/src/views/button/button_group.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import {
+  EuiButtonGroup,
+} from '../../../../src/components';
+
+export default () => (
+  <EuiButtonGroup />
+);

--- a/src-docs/src/views/button/button_group.js
+++ b/src-docs/src/views/button/button_group.js
@@ -16,29 +16,51 @@ export default class extends Component {
     super(props);
 
     const idPrefix = makeId();
+    const idPrefix2 = makeId();
 
     this.toggleButtons = [{
       id: `${idPrefix}0`,
       label: 'Option one',
-      content: 'Option one',
     }, {
       id: `${idPrefix}1`,
       label: 'Option two is selected by default',
-      content: 'Option two is selected by default',
     }, {
       id: `${idPrefix}2`,
       label: 'Option three',
-      content: 'Option three',
+    }];
+
+    this.toggleButtonsMulti = [{
+      id: `${idPrefix2}0`,
+      label: 'Option 1',
+    }, {
+      id: `${idPrefix2}1`,
+      label: 'Option 2 is selected by default',
+    }, {
+      id: `${idPrefix2}2`,
+      label: 'Option 3',
     }];
 
     this.state = {
       toggleIdSelected: `${idPrefix}1`,
+      toggleIdToSelectedMap: {
+        [`${idPrefix2}1`]: true,
+      },
     };
   }
 
   onChange = optionId => {
     this.setState({
       toggleIdSelected: optionId,
+    });
+  };
+
+  onChangeMulti = optionId => {
+    const newToggleIdToSelectedMap = ({ ...this.state.toggleIdToSelectedMap, ...{
+      [optionId]: !this.state.toggleIdToSelectedMap[optionId],
+    } });
+
+    this.setState({
+      toggleIdToSelectedMap: newToggleIdToSelectedMap,
     });
   };
 
@@ -53,20 +75,21 @@ export default class extends Component {
 
         <EuiSpacer size="m" />
 
-        <EuiTitle size="xxs"><h3>Primary</h3></EuiTitle>
+        <EuiTitle size="xxs"><h3>Primary &amp; multi select</h3></EuiTitle>
 
         <EuiSpacer size="s" />
 
         <EuiButtonGroup
-          options={this.toggleButtons}
-          idSelected={this.state.toggleIdSelected}
-          onChange={this.onChange}
+          options={this.toggleButtonsMulti}
+          idToSelectedMap={this.state.toggleIdToSelectedMap}
+          onChange={this.onChangeMulti}
           color="primary"
+          type="multi"
         />
 
         <EuiSpacer size="m" />
 
-        <EuiTitle size="xxs"><h3>Disabled</h3></EuiTitle>
+        <EuiTitle size="xxs"><h3>Disabled &amp; full width</h3></EuiTitle>
 
         <EuiSpacer size="s" />
 
@@ -74,7 +97,8 @@ export default class extends Component {
           options={this.toggleButtons}
           idSelected={this.state.toggleIdSelected}
           onChange={this.onChange}
-          disabled
+          isDisabled
+          isFullWidth
         />
       </Fragment>
     );

--- a/src-docs/src/views/button/button_group.js
+++ b/src-docs/src/views/button/button_group.js
@@ -119,6 +119,7 @@ export default class extends Component {
     return (
       <Fragment>
         <EuiButtonGroup
+          name="Basic"
           options={this.toggleButtons}
           idSelected={this.state.toggleIdSelected}
           onChange={this.onChange}
@@ -131,6 +132,7 @@ export default class extends Component {
         <EuiSpacer size="s" />
 
         <EuiButtonGroup
+          name="Primary"
           options={this.toggleButtonsMulti}
           idToSelectedMap={this.state.toggleIdToSelectedMap}
           onChange={this.onChangeMulti}
@@ -145,6 +147,7 @@ export default class extends Component {
         <EuiSpacer size="s" />
 
         <EuiButtonGroup
+          name="Disabled"
           options={this.toggleButtons}
           idSelected={this.state.toggleIdSelected}
           onChange={this.onChange}
@@ -159,6 +162,7 @@ export default class extends Component {
         <EuiSpacer size="s" />
 
         <EuiButtonGroup
+          name="Text align"
           className="eui-displayInlineBlock"
           options={this.toggleButtonsIcons}
           idSelected={this.state.toggleIconIdSelected}
@@ -169,6 +173,7 @@ export default class extends Component {
         &nbsp;&nbsp;
 
         <EuiButtonGroup
+          name="Text style"
           className="eui-displayInlineBlock"
           options={this.toggleButtonsIconsMulti}
           idToSelectedMap={this.state.toggleIconIdToSelectedMap}

--- a/src-docs/src/views/button/button_group.js
+++ b/src-docs/src/views/button/button_group.js
@@ -1,9 +1,82 @@
-import React from 'react';
+import React, {
+  Component,
+  Fragment,
+} from 'react';
 
 import {
   EuiButtonGroup,
+  EuiSpacer,
+  EuiTitle,
 } from '../../../../src/components';
 
-export default () => (
-  <EuiButtonGroup />
-);
+import makeId from '../../../../src/components/form/form_row/make_id';
+
+export default class extends Component {
+  constructor(props) {
+    super(props);
+
+    const idPrefix = makeId();
+
+    this.toggleButtons = [{
+      id: `${idPrefix}0`,
+      label: 'Option one',
+      content: 'Option one',
+    }, {
+      id: `${idPrefix}1`,
+      label: 'Option two is selected by default',
+      content: 'Option two is selected by default',
+    }, {
+      id: `${idPrefix}2`,
+      label: 'Option three',
+      content: 'Option three',
+    }];
+
+    this.state = {
+      toggleIdSelected: `${idPrefix}1`,
+    };
+  }
+
+  onChange = optionId => {
+    this.setState({
+      toggleIdSelected: optionId,
+    });
+  };
+
+  render() {
+    return (
+      <Fragment>
+        <EuiButtonGroup
+          options={this.toggleButtons}
+          idSelected={this.state.toggleIdSelected}
+          onChange={this.onChange}
+        />
+
+        <EuiSpacer size="m" />
+
+        <EuiTitle size="xxs"><h3>Primary</h3></EuiTitle>
+
+        <EuiSpacer size="s" />
+
+        <EuiButtonGroup
+          options={this.toggleButtons}
+          idSelected={this.state.toggleIdSelected}
+          onChange={this.onChange}
+          color="primary"
+        />
+
+        <EuiSpacer size="m" />
+
+        <EuiTitle size="xxs"><h3>Disabled</h3></EuiTitle>
+
+        <EuiSpacer size="s" />
+
+        <EuiButtonGroup
+          options={this.toggleButtons}
+          idSelected={this.state.toggleIdSelected}
+          onChange={this.onChange}
+          disabled
+        />
+      </Fragment>
+    );
+  }
+}

--- a/src-docs/src/views/button/button_toggle.js
+++ b/src-docs/src/views/button/button_toggle.js
@@ -27,22 +27,41 @@ export default class extends Component {
   render() {
     return (
       <div>
-        <EuiButtonToggle label="Toggle Me" isSelected={this.state.toggle0On} onChange={this.onToggle0Change} />
+        <EuiButtonToggle
+          label="Toggle Me"
+          iconType={this.state.toggle0On ? 'eye' : 'eyeClosed'}
+          onChange={this.onToggle0Change}
+        />
 
         <br />
         <br />
 
-        <EuiButtonToggle color="primary" label="I'm a primary toggle" isSelected={this.state.toggle1On} onChange={this.onToggle1Change} />
+        <EuiButtonToggle
+          color="primary"
+          label={this.state.toggle1On ? "I'm a filled toggle" : "I'm a primary toggle"}
+          fill={this.state.toggle1On}
+          onChange={this.onToggle1Change}
+        />
 
         <br />
         <br />
 
-        <EuiButtonToggle color="primary" isDisabled label="Can't toggle this" isSelected={this.state.toggle2On} />
+        <EuiButtonToggle
+          color="primary"
+          isDisabled
+          label="Can't toggle this"
+          fill={this.state.toggle2On}
+        />
 
         <br />
         <br />
 
-        <EuiButtonToggle color="primary" isDisabled label="Can't toggle this either" isSelected={this.state.toggle3On} />
+        <EuiButtonToggle
+          color="primary"
+          isDisabled
+          label="Can't toggle this either"
+          fill={this.state.toggle3On}
+        />
       </div>
     );
   }

--- a/src-docs/src/views/button/button_toggle.js
+++ b/src-docs/src/views/button/button_toggle.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import {
+  EuiButtonToggle,
+} from '../../../../src/components';
+
+export default () => (
+  <EuiButtonToggle>
+    Toggle Me
+  </EuiButtonToggle>
+);

--- a/src-docs/src/views/button/button_toggle.js
+++ b/src-docs/src/views/button/button_toggle.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react';
 
 import {
   EuiButtonToggle,
+  EuiSpacer,
+  EuiTitle,
 } from '../../../../src/components';
 
 export default class extends Component {
@@ -13,6 +15,7 @@ export default class extends Component {
       toggle1On: false,
       toggle2On: false,
       toggle3On: true,
+      toggle4On: true,
     };
   }
 
@@ -24,40 +27,52 @@ export default class extends Component {
     this.setState({ toggle1On: e.target.checked });
   }
 
+  onToggle4Change = (e) => {
+    this.setState({ toggle4On: e.target.checked });
+  }
+
   render() {
     return (
       <div>
         <EuiButtonToggle
           label="Toggle Me"
-          iconType={this.state.toggle0On ? 'eye' : 'eyeClosed'}
+          iconType={this.state.toggle0On ? 'check' : 'cross'}
           onChange={this.onToggle0Change}
         />
 
-        <br />
-        <br />
+        &emsp;
 
         <EuiButtonToggle
-          color="primary"
           label={this.state.toggle1On ? "I'm a filled toggle" : "I'm a primary toggle"}
           fill={this.state.toggle1On}
           onChange={this.onToggle1Change}
         />
 
-        <br />
-        <br />
+        &emsp;
 
         <EuiButtonToggle
-          color="primary"
+          label="Toggle Me"
+          iconType={this.state.toggle4On ? 'eye' : 'eyeClosed'}
+          onChange={this.onToggle4Change}
+          isEmpty
+          isIconOnly
+        />
+
+        <EuiSpacer size="m" />
+
+        <EuiTitle size="xxs"><h3>Disabled</h3></EuiTitle>
+
+        <EuiSpacer size="s" />
+
+        <EuiButtonToggle
           isDisabled
           label="Can't toggle this"
           fill={this.state.toggle2On}
         />
 
-        <br />
-        <br />
+        &emsp;
 
         <EuiButtonToggle
-          color="primary"
           isDisabled
           label="Can't toggle this either"
           fill={this.state.toggle3On}

--- a/src-docs/src/views/button/button_toggle.js
+++ b/src-docs/src/views/button/button_toggle.js
@@ -6,29 +6,21 @@ import {
 
 export default () => (
   <div>
-    <EuiButtonToggle toggleLabel="Toggle Me">
-      Toggle Me
-    </EuiButtonToggle>
+    <EuiButtonToggle label="Toggle Me" />
 
     <br />
     <br />
 
-    <EuiButtonToggle color="primary" toggleLabel="I'm a primary toggle">
-      I&apos;m a primary toggle
-    </EuiButtonToggle>
+    <EuiButtonToggle color="primary" label="I'm a primary toggle" />
 
     <br />
     <br />
 
-    <EuiButtonToggle color="primary" isDisabled toggleLabel="Can't toggle this">
-      Can&apos;t toggle this
-    </EuiButtonToggle>
+    <EuiButtonToggle color="primary" isDisabled label="Can't toggle this" />
 
     <br />
     <br />
 
-    <EuiButtonToggle color="primary" selected isDisabled toggleLabel="Can't toggle this">
-      Can&apos;t toggle this either
-    </EuiButtonToggle>
+    <EuiButtonToggle color="primary" isSelected isDisabled label="Can't toggle this either" />
   </div>
 );

--- a/src-docs/src/views/button/button_toggle.js
+++ b/src-docs/src/views/button/button_toggle.js
@@ -1,26 +1,49 @@
-import React from 'react';
+import React, { Component } from 'react';
 
 import {
   EuiButtonToggle,
 } from '../../../../src/components';
 
-export default () => (
-  <div>
-    <EuiButtonToggle label="Toggle Me" />
+export default class extends Component {
+  constructor(props) {
+    super(props);
 
-    <br />
-    <br />
+    this.state = {
+      toggle0On: false,
+      toggle1On: false,
+      toggle2On: false,
+      toggle3On: true,
+    };
+  }
 
-    <EuiButtonToggle color="primary" label="I'm a primary toggle" />
+  onToggle0Change = (e) => {
+    this.setState({ toggle0On: e.target.checked });
+  }
 
-    <br />
-    <br />
+  onToggle1Change = (e) => {
+    this.setState({ toggle1On: e.target.checked });
+  }
 
-    <EuiButtonToggle color="primary" isDisabled label="Can't toggle this" />
+  render() {
+    return (
+      <div>
+        <EuiButtonToggle label="Toggle Me" isSelected={this.state.toggle0On} onChange={this.onToggle0Change} />
 
-    <br />
-    <br />
+        <br />
+        <br />
 
-    <EuiButtonToggle color="primary" isSelected isDisabled label="Can't toggle this either" />
-  </div>
-);
+        <EuiButtonToggle color="primary" label="I'm a primary toggle" isSelected={this.state.toggle1On} onChange={this.onToggle1Change} />
+
+        <br />
+        <br />
+
+        <EuiButtonToggle color="primary" isDisabled label="Can't toggle this" isSelected={this.state.toggle2On} />
+
+        <br />
+        <br />
+
+        <EuiButtonToggle color="primary" isDisabled label="Can't toggle this either" isSelected={this.state.toggle3On} />
+      </div>
+    );
+  }
+}

--- a/src-docs/src/views/button/button_toggle.js
+++ b/src-docs/src/views/button/button_toggle.js
@@ -5,7 +5,30 @@ import {
 } from '../../../../src/components';
 
 export default () => (
-  <EuiButtonToggle>
-    Toggle Me
-  </EuiButtonToggle>
+  <div>
+    <EuiButtonToggle toggleLabel="Toggle Me">
+      Toggle Me
+    </EuiButtonToggle>
+
+    <br />
+    <br />
+
+    <EuiButtonToggle color="primary" toggleLabel="I'm a primary toggle">
+      I&apos;m a primary toggle
+    </EuiButtonToggle>
+
+    <br />
+    <br />
+
+    <EuiButtonToggle color="primary" isDisabled toggleLabel="Can't toggle this">
+      Can&apos;t toggle this
+    </EuiButtonToggle>
+
+    <br />
+    <br />
+
+    <EuiButtonToggle color="primary" selected isDisabled toggleLabel="Can't toggle this">
+      Can&apos;t toggle this either
+    </EuiButtonToggle>
+  </div>
 );

--- a/src-docs/src/views/toggle/toggle.js
+++ b/src-docs/src/views/toggle/toggle.js
@@ -4,8 +4,6 @@ import React, {
 
 import {
   EuiToggle,
-  EuiButton,
-  EuiButtonIcon,
 } from '../../../../src/components';
 
 export default class extends Component {
@@ -13,49 +11,19 @@ export default class extends Component {
     super(props);
 
     this.state = {
-      toggle1On: false,
-      toggle2On: false,
-      toggle3On: false,
+      toggleOn: false,
     };
   }
 
   onToggleChange = (e) => {
-    this.setState({ toggle1On: e.target.checked });
-  }
-
-  onToggleChange2 = (e) => {
-    this.setState({ toggle2On: e.target.checked });
-  }
-
-  onToggleChange3 = (e) => {
-    this.setState({ toggle3On: e.target.checked });
+    this.setState({ toggleOn: e.target.checked });
   }
 
   render() {
     return (
       <div>
-        <EuiToggle id="toggle1" onChange={this.onToggleChange} label="Is toggle on?">
-          {this.state.toggle1On ? 'On' : 'Off'}
-        </EuiToggle>
-
-        &nbsp;
-
-        <EuiToggle id="toggle2" onChange={this.onToggleChange2} label="Visibility" containsButton>
-          {this.state.toggle2On ? (
-            <EuiButtonIcon iconType="eye" aria-labelledby="toggle2"/>
-          ) : (
-            <EuiButtonIcon iconType="eyeClosed" aria-labelledby="toggle2"/>
-          )}
-        </EuiToggle>
-
-        &nbsp;
-
-        <EuiToggle id="toggle3" onChange={this.onToggleChange3} label="Is toggle on?" containsButton>
-          {this.state.toggle3On ? (
-            <EuiButton fill>Toggle is on</EuiButton>
-          ) : (
-            <EuiButton>Toggle is off</EuiButton>
-          )}
+        <EuiToggle onChange={this.onToggleChange} label="Is toggle on?">
+          {this.state.toggleOn ? 'On' : 'Off'}
         </EuiToggle>
       </div>
     );

--- a/src-docs/src/views/toggle/toggle.js
+++ b/src-docs/src/views/toggle/toggle.js
@@ -1,0 +1,29 @@
+import React, {
+  Component,
+} from 'react';
+
+import {
+  EuiToggle,
+} from '../../../../src/components';
+
+export default class extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      toggleOn: false,
+    };
+  }
+
+  onToggleChange = (e) => {
+    this.setState({ toggleOn: e.target.checked });
+  }
+
+  render() {
+    return (
+      <EuiToggle onChange={this.onToggleChange}>
+        {this.state.toggleOn ? 'On' : 'Off'}
+      </EuiToggle>
+    );
+  }
+}

--- a/src-docs/src/views/toggle/toggle.js
+++ b/src-docs/src/views/toggle/toggle.js
@@ -4,6 +4,7 @@ import React, {
 
 import {
   EuiToggle,
+  EuiIcon,
 } from '../../../../src/components';
 
 export default class extends Component {
@@ -12,6 +13,7 @@ export default class extends Component {
 
     this.state = {
       toggleOn: false,
+      toggleOn2: false,
     };
   }
 
@@ -19,11 +21,27 @@ export default class extends Component {
     this.setState({ toggleOn: e.target.checked });
   }
 
+  onToggleChange2 = (e) => {
+    this.setState({ toggleOn2: e.target.checked });
+  }
+
   render() {
     return (
-      <EuiToggle onChange={this.onToggleChange}>
-        {this.state.toggleOn ? 'On' : 'Off'}
-      </EuiToggle>
+      <div>
+        <EuiToggle onChange={this.onToggleChange}>
+          {this.state.toggleOn ? 'On' : 'Off'}
+        </EuiToggle>
+
+        &nbsp;
+
+        <EuiToggle onChange={this.onToggleChange2}>
+          {this.state.toggleOn2 ? (
+            <EuiIcon type="eye" />
+          ) : (
+            <EuiIcon type="eyeClosed" />
+          )}
+        </EuiToggle>
+      </div>
     );
   }
 }

--- a/src-docs/src/views/toggle/toggle.js
+++ b/src-docs/src/views/toggle/toggle.js
@@ -4,6 +4,7 @@ import React, {
 
 import {
   EuiToggle,
+  EuiButton,
   EuiButtonIcon,
 } from '../../../../src/components';
 
@@ -12,33 +13,48 @@ export default class extends Component {
     super(props);
 
     this.state = {
-      toggleOn: false,
-      toggleOn2: false,
+      toggle1On: false,
+      toggle2On: false,
+      toggle3On: false,
     };
   }
 
   onToggleChange = (e) => {
-    this.setState({ toggleOn: e.target.checked });
+    this.setState({ toggle1On: e.target.checked });
   }
 
   onToggleChange2 = (e) => {
-    this.setState({ toggleOn2: e.target.checked });
+    this.setState({ toggle2On: e.target.checked });
+  }
+
+  onToggleChange3 = (e) => {
+    this.setState({ toggle3On: e.target.checked });
   }
 
   render() {
     return (
       <div>
-        <EuiToggle onChange={this.onToggleChange} label="Is toggle on?">
-          {this.state.toggleOn ? 'On' : 'Off'}
+        <EuiToggle id="toggle1" onChange={this.onToggleChange} label="Is toggle on?">
+          {this.state.toggle1On ? 'On' : 'Off'}
         </EuiToggle>
 
         &nbsp;
 
-        <EuiToggle onChange={this.onToggleChange2} label="Visibility">
-          {this.state.toggleOn2 ? (
-            <EuiButtonIcon iconType="eye" aria-label="visible"/>
+        <EuiToggle id="toggle2" onChange={this.onToggleChange2} label="Visibility" containsButton>
+          {this.state.toggle2On ? (
+            <EuiButtonIcon iconType="eye" aria-labelledby="toggle2"/>
           ) : (
-            <EuiButtonIcon iconType="eyeClosed" aria-label="not visible"/>
+            <EuiButtonIcon iconType="eyeClosed" aria-labelledby="toggle2"/>
+          )}
+        </EuiToggle>
+
+        &nbsp;
+
+        <EuiToggle id="toggle3" onChange={this.onToggleChange3} label="Is toggle on?" containsButton>
+          {this.state.toggle3On ? (
+            <EuiButton fill>Toggle is on</EuiButton>
+          ) : (
+            <EuiButton>Toggle is off</EuiButton>
           )}
         </EuiToggle>
       </div>

--- a/src-docs/src/views/toggle/toggle.js
+++ b/src-docs/src/views/toggle/toggle.js
@@ -4,7 +4,7 @@ import React, {
 
 import {
   EuiToggle,
-  EuiIcon,
+  EuiButtonIcon,
 } from '../../../../src/components';
 
 export default class extends Component {
@@ -36,9 +36,9 @@ export default class extends Component {
 
         <EuiToggle onChange={this.onToggleChange2}>
           {this.state.toggleOn2 ? (
-            <EuiIcon type="eye" />
+            <EuiButtonIcon iconType="eye" aria-label="s"/>
           ) : (
-            <EuiIcon type="eyeClosed" />
+            <EuiButtonIcon iconType="eyeClosed" aria-label="s"/>
           )}
         </EuiToggle>
       </div>

--- a/src-docs/src/views/toggle/toggle.js
+++ b/src-docs/src/views/toggle/toggle.js
@@ -28,17 +28,17 @@ export default class extends Component {
   render() {
     return (
       <div>
-        <EuiToggle onChange={this.onToggleChange}>
+        <EuiToggle onChange={this.onToggleChange} label="Is toggle on?">
           {this.state.toggleOn ? 'On' : 'Off'}
         </EuiToggle>
 
         &nbsp;
 
-        <EuiToggle onChange={this.onToggleChange2}>
+        <EuiToggle onChange={this.onToggleChange2} label="Visibility">
           {this.state.toggleOn2 ? (
-            <EuiButtonIcon iconType="eye" aria-label="s"/>
+            <EuiButtonIcon iconType="eye" aria-label="visible"/>
           ) : (
-            <EuiButtonIcon iconType="eyeClosed" aria-label="s"/>
+            <EuiButtonIcon iconType="eyeClosed" aria-label="not visible"/>
           )}
         </EuiToggle>
       </div>

--- a/src-docs/src/views/toggle/toggle_example.js
+++ b/src-docs/src/views/toggle/toggle_example.js
@@ -9,6 +9,7 @@ import {
 import {
   EuiCode,
   EuiToggle,
+  EuiLink,
 } from '../../../../src/components';
 
 import Toggle from './toggle';
@@ -26,11 +27,17 @@ export const ToggleExample = {
       code: toggleHtml,
     }],
     text: (
-      <p>
-        The <EuiCode>EuiToggle</EuiCode> component is a very simplified utility for creating
-        toggle-able elements. There is only an on/off (checked/unchecked) state. All this creates is
-        a visibly hidden input (checkbox or radio) overtop of the children provided.
-      </p>
+      <div>
+        <p>
+          The <EuiCode>EuiToggle</EuiCode> component is a very simplified utility for creating
+          toggle-able elements. There is only an on/off (checked/unchecked) state. All this creates is
+          a visibly hidden input (checkbox or radio) overtop of the children provided.
+        </p>
+        <p>
+          By default, the children will be wrapped in a block element. To change the display you can
+          simply use one of the <EuiLink href="/#/utilities/css-utility-classes">utility classes</EuiLink> like <EuiCode>.eui-displayInlineBlock</EuiCode>.
+        </p>
+      </div>
     ),
     components: { EuiToggle },
     demo: <Toggle />,

--- a/src-docs/src/views/toggle/toggle_example.js
+++ b/src-docs/src/views/toggle/toggle_example.js
@@ -18,7 +18,6 @@ const toggleHtml = renderToHtml(Toggle);
 export const ToggleExample = {
   title: 'Toggle',
   sections: [{
-    title: 'Toggle',
     source: [{
       type: GuideSectionTypes.JS,
       code: toggleSource,
@@ -28,10 +27,13 @@ export const ToggleExample = {
     }],
     text: (
       <p>
-        Description needed: how to use the <EuiCode>EuiToggle</EuiCode> component.
+        The <EuiCode>EuiToggle</EuiCode> component is a very simplified utility for creating
+        toggle-able elements. There is only an on/off (checked/unchecked) state. All this creates is
+        a visibly hidden input (checkbox or radio) overtop of the children provided.
       </p>
     ),
     components: { EuiToggle },
     demo: <Toggle />,
+    props: { EuiToggle },
   }],
 };

--- a/src-docs/src/views/toggle/toggle_example.js
+++ b/src-docs/src/views/toggle/toggle_example.js
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import { renderToHtml } from '../../services';
+
+import {
+  GuideSectionTypes,
+} from '../../components';
+
+import {
+  EuiCode,
+  EuiToggle,
+} from '../../../../src/components';
+
+import Toggle from './toggle';
+const toggleSource = require('!!raw-loader!./toggle');
+const toggleHtml = renderToHtml(Toggle);
+
+export const ToggleExample = {
+  title: 'Toggle',
+  sections: [{
+    title: 'Toggle',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: toggleSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: toggleHtml,
+    }],
+    text: (
+      <p>
+        Description needed: how to use the <EuiCode>EuiToggle</EuiCode> component.
+      </p>
+    ),
+    components: { EuiToggle },
+    demo: <Toggle />,
+  }],
+};

--- a/src/components/button/__snapshots__/button.test.js.snap
+++ b/src/components/button/__snapshots__/button.test.js.snap
@@ -79,6 +79,21 @@ exports[`EuiButton props color secondary is rendered 1`] = `
 </button>
 `;
 
+exports[`EuiButton props color text is rendered 1`] = `
+<button
+  class="euiButton euiButton--text"
+  type="button"
+>
+  <span
+    class="euiButton__content"
+  >
+    <span
+      class="euiButton__text"
+    />
+  </span>
+</button>
+`;
+
 exports[`EuiButton props color warning is rendered 1`] = `
 <button
   class="euiButton euiButton--warning"

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -20,6 +20,7 @@
 
   &.euiButton--small {
     height: $euiButtonHeightSmall;
+    line-height: $euiButtonHeightSmall; // prevents descenders from getting cut off
   }
 
   &.euiButton--iconRight {
@@ -73,6 +74,7 @@ $buttonTypes: (
   warning: $euiColorWarning,
   danger: $euiColorDanger,
   ghost: $euiColorGhost, // Ghost is special, and does not care about theming.
+  text: $euiColorDarkShade, // Reserved for special use cases
 );
 
 // Create button modifiders based upon the map.
@@ -82,6 +84,9 @@ $buttonTypes: (
     @if ($name == 'ghost') {
       // Ghost is unique and ALWAYS sits against a dark background.
       color: $color;
+    } @else if ($name == 'text') {
+      // The default color is lighter than the normal text color, make the it the text color
+      color: $euiTextColor;
     } @else {
       // Other colors need to check their contrast against the page background color.
       color: makeHighContrastColor($color, $euiColorEmptyShade);

--- a/src/components/button/_index.scss
+++ b/src/components/button/_index.scss
@@ -1,71 +1,8 @@
-$euiButtonHeightSmall: $euiSizeXL;
-$euiButtonColorDisabled: tintOrShade($euiTextColor, 70%, 70%);
-
-@mixin euiButton {
-
-  display: inline-block;
-  appearance: none;
-  cursor: pointer;
-  height: $euiSizeXXL;
-  text-decoration: none;
-  border: solid 1px transparent;
-  text-align: center;
-  font-family: $euiFontFamily;
-  transition: all $euiAnimSpeedNormal $euiAnimSlightBounce;
-  white-space: nowrap;
-  max-width: 100%;
-  vertical-align: middle;
-
-  &:hover:not(:disabled) {
-    transform: translateY(-1px);
-  }
-
-  &:hover:not(:disabled), &:focus {
-    text-decoration: underline;
-  }
-
-  &:focus {
-    animation: euiButtonActive $euiAnimSpeedNormal $euiAnimSlightBounce;
-  }
-
-  &:active:not(:disabled) {
-    transform: translateY(1px);
-  }
-}
-
-/**
- * 1. Apply margin to all but last item in the flex.
- * 2. Margin gets flipped because of the row-reverse.
- */
-@mixin euiButtonContent($isReverse: false) {
-  height: 100%;
-  width: 100%;
-  vertical-align: middle;
-
-  @if ($isReverse) {
-    flex-direction: row-reverse;
-
-    > * + * {
-      margin-left: 0; /* 1 */
-      margin-right: $euiSizeS; /* 1 */
-    }
-  } @else {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
-    > * + * {
-      margin-left: $euiSizeS; /* 1 */
-    }
-  }
-}
-
-@keyframes euiButtonActive {
-  50% {
-    transform: translateY(1px);
-  }
-}
+@import 'variables';
+@import 'mixins';
 
 @import 'button';
 @import 'button_empty/index';
 @import 'button_icon/index';
+@import 'button_toggle/index';
+@import 'button_group/index';

--- a/src/components/button/_mixins.scss
+++ b/src/components/button/_mixins.scss
@@ -63,3 +63,16 @@
     transform: translateY(1px);
   }
 }
+
+// BUTTON TOGGLES
+// Pointer events and interactions are handled by the input (checkbox/radio)
+// and not the button, this mixin helps to target that element for states
+@mixin euiButtonToggleStates(){
+  @at-root {
+    .euiButtonToggle__input:enabled:hover + #{&},
+    .euiButtonToggle__input:enabled:focus + #{&},
+    .euiButtonToggle__input:enabled:active + #{&} {
+      @content;
+    }
+  }
+}

--- a/src/components/button/_mixins.scss
+++ b/src/components/button/_mixins.scss
@@ -1,0 +1,64 @@
+@mixin euiButton {
+
+  display: inline-block;
+  appearance: none;
+  cursor: pointer;
+  height: $euiSizeXXL;
+  text-decoration: none;
+  border: solid 1px transparent;
+  text-align: center;
+  font-family: $euiFontFamily;
+  transition: all $euiAnimSpeedNormal $euiAnimSlightBounce;
+  white-space: nowrap;
+  max-width: 100%;
+  vertical-align: middle;
+
+  &:hover:not(:disabled) {
+    transform: translateY(-1px);
+  }
+
+  &:hover:not(:disabled), &:focus {
+    text-decoration: underline;
+  }
+
+  &:focus {
+    animation: euiButtonActive $euiAnimSpeedNormal $euiAnimSlightBounce;
+  }
+
+  &:active:not(:disabled) {
+    transform: translateY(1px);
+  }
+}
+
+/**
+ * 1. Apply margin to all but last item in the flex.
+ * 2. Margin gets flipped because of the row-reverse.
+ */
+@mixin euiButtonContent($isReverse: false) {
+  height: 100%;
+  width: 100%;
+  vertical-align: middle;
+
+  @if ($isReverse) {
+    flex-direction: row-reverse;
+
+    > * + * {
+      margin-left: 0; /* 1 */
+      margin-right: $euiSizeS; /* 1 */
+    }
+  } @else {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    > * + * {
+      margin-left: $euiSizeS; /* 1 */
+    }
+  }
+}
+
+@keyframes euiButtonActive {
+  50% {
+    transform: translateY(1px);
+  }
+}

--- a/src/components/button/_mixins.scss
+++ b/src/components/button/_mixins.scss
@@ -4,6 +4,7 @@
   appearance: none;
   cursor: pointer;
   height: $euiSizeXXL;
+  line-height: $euiSizeXXL; // prevents descenders from getting cut off
   text-decoration: none;
   border: solid 1px transparent;
   text-align: center;

--- a/src/components/button/_variables.scss
+++ b/src/components/button/_variables.scss
@@ -1,2 +1,3 @@
 $euiButtonHeightSmall: $euiSizeXL;
 $euiButtonColorDisabled: tintOrShade($euiTextColor, 70%, 70%);
+$euiButtonToggleBorderColor: $euiColorLightShade;

--- a/src/components/button/_variables.scss
+++ b/src/components/button/_variables.scss
@@ -1,0 +1,2 @@
+$euiButtonHeightSmall: $euiSizeXL;
+$euiButtonColorDisabled: tintOrShade($euiTextColor, 70%, 70%);

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -19,6 +19,7 @@ const colorToClassNameMap = {
   warning: 'euiButton--warning',
   danger: 'euiButton--danger',
   ghost: 'euiButton--ghost',
+  text: 'euiButton--text',
 };
 
 export const COLORS = Object.keys(colorToClassNameMap);

--- a/src/components/button/button_group/__snapshots__/button_group.test.js.snap
+++ b/src/components/button/button_group/__snapshots__/button_group.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiButtonGroup is rendered 1`] = `
+<div
+  aria-label="aria-label"
+  class="euiButtonGroup testClass1 testClass2"
+  data-test-subj="test subject string"
+/>
+`;

--- a/src/components/button/button_group/__snapshots__/button_group.test.js.snap
+++ b/src/components/button/button_group/__snapshots__/button_group.test.js.snap
@@ -3,7 +3,7 @@
 exports[`EuiButtonGroup is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="euiButtonGroup testClass1 testClass2"
+  class="testClass1 testClass2"
   data-test-subj="test subject string"
 />
 `;

--- a/src/components/button/button_group/__snapshots__/button_group.test.js.snap
+++ b/src/components/button/button_group/__snapshots__/button_group.test.js.snap
@@ -3,7 +3,7 @@
 exports[`EuiButtonGroup is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="testClass1 testClass2"
+  class="euiButtonGroup testClass1 testClass2"
   data-test-subj="test subject string"
 />
 `;

--- a/src/components/button/button_group/_button_group.scss
+++ b/src/components/button/button_group/_button_group.scss
@@ -1,5 +1,16 @@
 .euiButtonGroup {
+  max-width: 100%;
+  display: flex;
+}
 
+.euiButtonGroup--fullWidth {
+  .euiButtonGroup__item {
+    flex: 1;
+
+    .euiButtonToggle {
+      width: 100%;
+    }
+  }
 }
 
 .euiButtonGroup__item {

--- a/src/components/button/button_group/_button_group.scss
+++ b/src/components/button/button_group/_button_group.scss
@@ -4,18 +4,23 @@
 }
 
 .euiButtonGroup--fullWidth {
-  .euiButtonGroup__item {
+  .euiButtonGroup__toggle {
     flex: 1;
 
-    .euiButtonToggle {
+    .euiButtonGroup__button {
       width: 100%;
     }
   }
 }
 
-.euiButtonGroup__item {
+.euiButtonGroup__toggle {
   margin-left: -1px;
   z-index: 1;
+
+  // DO NOT Transform
+  transition: none !important;
+  transform: none !important;
+  animation: none !important;
 
   &[class*="checked"] {
     z-index: 2; // Raise it above the simply bordered versions for crisper lines
@@ -26,20 +31,34 @@
     }
   }
 
-  .euiButtonToggle {
+  .euiButtonGroup__button {
     border-radius: 0;
+
+    // always the same border color unless it's selected
+    &:not([class*="fill"]) {
+      border-color: $euiButtonToggleBorderColor;
+    }
+
+    // don't colorize the shadows
+    &:enabled {
+      @include euiSlightShadow;
+    }
+
+    @include euiButtonToggleStates() {
+      @include euiSlightShadowHover;
+    }
   }
 
   &:first-child {
     margin-left: 0;
 
-    .euiButtonToggle {
+    .euiButtonGroup__button {
       border-top-left-radius: $euiBorderRadius;
       border-bottom-left-radius: $euiBorderRadius;
     }
   }
 
-  &:last-child .euiButtonToggle {
+  &:last-child .euiButtonGroup__button {
     border-top-right-radius: $euiBorderRadius;
     border-bottom-right-radius: $euiBorderRadius;
   }

--- a/src/components/button/button_group/_button_group.scss
+++ b/src/components/button/button_group/_button_group.scss
@@ -4,19 +4,19 @@
 
 .euiButtonGroup__item {
   margin-left: -1px;
+  z-index: 1;
+
+  &[class*="checked"] {
+    z-index: 2; // Raise it above the simply bordered versions for crisper lines
+
+    // add a slight divider if two selected items are next to each other
+    + [class*="checked"] {
+      box-shadow: -1px 0 0 transparentize($euiColorEmptyShade, .9);
+    }
+  }
 
   .euiButtonToggle {
     border-radius: 0;
-    position: relative;
-    z-index: 1;
-  }
-
-  .euiButtonToggle--fill {
-    z-index: 2; // Raise it above the simply bordered versions for crisper lines
-  }
-
-  .euiToggle__input {
-    z-index: 3; // but make sure the input is on top
   }
 
   &:first-child {

--- a/src/components/button/button_group/_button_group.scss
+++ b/src/components/button/button_group/_button_group.scss
@@ -7,6 +7,16 @@
 
   .euiButtonToggle {
     border-radius: 0;
+    position: relative;
+    z-index: 1;
+  }
+
+  .euiButtonToggle--fill {
+    z-index: 2; // Raise it above the simply bordered versions for crisper lines
+  }
+
+  .euiToggle__input {
+    z-index: 3; // but make sure the input is on top
   }
 
   &:first-child {

--- a/src/components/button/button_group/_button_group.scss
+++ b/src/components/button/button_group/_button_group.scss
@@ -1,3 +1,25 @@
 .euiButtonGroup {
 
 }
+
+.euiButtonGroup__item {
+  margin-left: -1px;
+
+  .euiButtonToggle {
+    border-radius: 0;
+  }
+
+  &:first-child {
+    margin-left: 0;
+
+    .euiButtonToggle {
+      border-top-left-radius: $euiBorderRadius;
+      border-bottom-left-radius: $euiBorderRadius;
+    }
+  }
+
+  &:last-child .euiButtonToggle {
+    border-top-right-radius: $euiBorderRadius;
+    border-bottom-right-radius: $euiBorderRadius;
+  }
+}

--- a/src/components/button/button_group/_button_group.scss
+++ b/src/components/button/button_group/_button_group.scss
@@ -1,0 +1,3 @@
+.euiButtonGroup {
+
+}

--- a/src/components/button/button_group/_index.scss
+++ b/src/components/button/button_group/_index.scss
@@ -1,0 +1,1 @@
+@import 'button_group';

--- a/src/components/button/button_group/button_group.js
+++ b/src/components/button/button_group/button_group.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { EuiButtonToggle } from '../button_toggle';
+import { TOGGLE_TYPES } from '../../toggle';
 
 export const EuiButtonGroup = ({
   options,
@@ -10,30 +11,46 @@ export const EuiButtonGroup = ({
   onChange,
   name,
   className,
-  disabled,
+  isDisabled,
   color,
+  isFullWidth,
+  idToSelectedMap,
+  type,
   ...rest
 }) => {
 
   const classes = classNames(
     'euiButtonGroup',
+    {
+      'euiButtonGroup--fullWidth': isFullWidth,
+    },
     className,
   );
 
   return (
     <div className={classes} {...rest}>
       {options.map((option, index) => {
+
+        let isSelectedState;
+        if (type === 'multi') {
+          isSelectedState = idToSelectedMap[option.id];
+        } else {
+          isSelectedState = option.id === idSelected;
+        }
+
         return (
           <EuiButtonToggle
             className="euiButtonGroup__item"
             key={index}
             id={option.id}
+            isSelected={isSelectedState}
             name={name}
-            isSelected={option.id === idSelected}
             label={option.label}
-            isDisabled={disabled}
-            onChange={onChange.bind(null, option.id, option.label)}
+            value={option.value}
+            isDisabled={isDisabled}
+            onChange={onChange.bind(null, option.id, option.value)}
             color={color}
+            type={type}
           />
         );
       })}
@@ -48,10 +65,18 @@ EuiButtonGroup.propTypes = {
       label: PropTypes.string.isRequired
     }),
   ).isRequired,
-  idSelected: PropTypes.string,
   onChange: PropTypes.func.isRequired,
+  isDisabled: PropTypes.bool,
+  isFullWidth: PropTypes.bool,
+  color: PropTypes.string,
+  type: PropTypes.oneOf(TOGGLE_TYPES),
+  idSelected: PropTypes.string,
+  idToSelectedMap: PropTypes.objectOf(PropTypes.bool),
 };
 
 EuiButtonGroup.defaultProps = {
   options: [],
+  idToSelectedMap: {},
+  color: 'text',
+  type: 'single',
 };

--- a/src/components/button/button_group/button_group.js
+++ b/src/components/button/button_group/button_group.js
@@ -1,15 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 import { EuiButtonToggle } from '../button_toggle';
-
-const colorToClassNameMap = {
-  default: '',
-  primary: 'euiButtonToggle--primary',
-  ghost: 'euiButtonToggle--ghost',
-};
-
-export const COLORS = Object.keys(colorToClassNameMap);
 
 export const EuiButtonGroup = ({
   options,
@@ -20,39 +13,43 @@ export const EuiButtonGroup = ({
   disabled,
   color,
   ...rest
-}) => (
-  <div className={className} {...rest}>
-    {options.map((option, index) => {
-      return (
-        <EuiButtonToggle
-          className="euiButtonGroup__item"
-          key={index}
-          id={option.id}
-          name={name}
-          selected={option.id === idSelected}
-          label={option.label}
-          isDisabled={disabled}
-          onChange={onChange.bind(null, option.id, option.label)}
-          color={color}
-        >
-          {option.content}
-        </EuiButtonToggle>
-      );
-    })}
-  </div>
-);
+}) => {
+
+  const classes = classNames(
+    'euiButtonGroup',
+    className,
+  );
+
+  return (
+    <div className={classes} {...rest}>
+      {options.map((option, index) => {
+        return (
+          <EuiButtonToggle
+            className="euiButtonGroup__item"
+            key={index}
+            id={option.id}
+            name={name}
+            isSelected={option.id === idSelected}
+            label={option.label}
+            isDisabled={disabled}
+            onChange={onChange.bind(null, option.id, option.label)}
+            color={color}
+          />
+        );
+      })}
+    </div>
+  )
+};
 
 EuiButtonGroup.propTypes = {
   options: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
-      label: PropTypes.string,
-      content: PropTypes.node,
+      label: PropTypes.string.isRequired
     }),
   ).isRequired,
   idSelected: PropTypes.string,
   onChange: PropTypes.func.isRequired,
-  color: PropTypes.oneOf(COLORS),
 };
 
 EuiButtonGroup.defaultProps = {

--- a/src/components/button/button_group/button_group.js
+++ b/src/components/button/button_group/button_group.js
@@ -34,7 +34,7 @@ export const EuiButtonGroup = ({
 
         let isSelectedState;
         if (type === 'multi') {
-          isSelectedState = idToSelectedMap[option.id];
+          isSelectedState = idToSelectedMap[option.id] || false;
         } else {
           isSelectedState = option.id === idSelected;
         }

--- a/src/components/button/button_group/button_group.js
+++ b/src/components/button/button_group/button_group.js
@@ -6,17 +6,17 @@ import { EuiButtonToggle } from '../button_toggle';
 import { TOGGLE_TYPES } from '../../toggle';
 
 export const EuiButtonGroup = ({
-  options,
-  idSelected,
-  onChange,
-  name,
   className,
-  isDisabled,
   color,
-  isFullWidth,
+  idSelected,
   idToSelectedMap,
-  type,
+  isDisabled,
+  isFullWidth,
   isIconOnly,
+  name,
+  onChange,
+  options,
+  type,
   ...rest
 }) => {
 
@@ -41,23 +41,23 @@ export const EuiButtonGroup = ({
 
         return (
           <EuiButtonToggle
-            toggleClassName="euiButtonGroup__toggle"
             className="euiButtonGroup__button"
-            key={index}
-            id={option.id}
-            isSelected={isSelectedState}
-            fill={isSelectedState}
-            name={name}
-            label={option.label}
-            value={option.value}
-            iconType={option.iconType}
-            iconSide={option.iconSide}
-            isDisabled={isDisabled}
-            onChange={onChange.bind(null, option.id, option.value)}
             color={color}
-            type={type}
+            fill={isSelectedState}
+            iconSide={option.iconSide}
+            iconType={option.iconType}
+            id={option.id}
+            isDisabled={isDisabled}
             isIconOnly={isIconOnly}
+            isSelected={isSelectedState}
+            key={index}
+            label={option.label}
+            name={name}
+            onChange={onChange.bind(null, option.id, option.value)}
             size="s" // force small for button groups
+            toggleClassName="euiButtonGroup__toggle"
+            type={type}
+            value={option.value}
           />
         );
       })}

--- a/src/components/button/button_group/button_group.js
+++ b/src/components/button/button_group/button_group.js
@@ -1,40 +1,60 @@
-import React, {
-  Component,
-} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 
-export class EuiButtonGroup extends Component {
-  static propTypes = {
-    children: PropTypes.node,
-    className: PropTypes.string,
-  }
+import { EuiButtonToggle } from '../button_toggle';
 
-  constructor(props) {
-    super(props);
+const colorToClassNameMap = {
+  default: '',
+  primary: 'euiButtonToggle--primary',
+  ghost: 'euiButtonToggle--ghost',
+};
 
-    this.state = {};
-  }
+export const COLORS = Object.keys(colorToClassNameMap);
 
-  render() {
-    const {
-      children,
-      className,
-      ...rest
-    } = this.props;
+export const EuiButtonGroup = ({
+  options,
+  idSelected,
+  onChange,
+  name,
+  className,
+  disabled,
+  color,
+  ...rest
+}) => (
+  <div className={className} {...rest}>
+    {options.map((option, index) => {
+      return (
+        <EuiButtonToggle
+          className="euiButtonGroup__item"
+          key={index}
+          id={option.id}
+          name={name}
+          selected={option.id === idSelected}
+          label={option.label}
+          isDisabled={disabled}
+          onChange={onChange.bind(null, option.id, option.label)}
+          color={color}
+        >
+          {option.content}
+        </EuiButtonToggle>
+      );
+    })}
+  </div>
+);
 
-    const classes = classNames(
-      'euiButtonGroup',
-      className
-    );
+EuiButtonGroup.propTypes = {
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      label: PropTypes.string,
+      content: PropTypes.node,
+    }),
+  ).isRequired,
+  idSelected: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  color: PropTypes.oneOf(COLORS),
+};
 
-    return (
-      <div
-        className={classes}
-        {...rest}
-      >
-        {children}
-      </div>
-    );
-  }
-}
+EuiButtonGroup.defaultProps = {
+  options: [],
+};

--- a/src/components/button/button_group/button_group.js
+++ b/src/components/button/button_group/button_group.js
@@ -1,0 +1,40 @@
+import React, {
+  Component,
+} from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+export class EuiButtonGroup extends Component {
+  static propTypes = {
+    children: PropTypes.node,
+    className: PropTypes.string,
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.state = {};
+  }
+
+  render() {
+    const {
+      children,
+      className,
+      ...rest
+    } = this.props;
+
+    const classes = classNames(
+      'euiButtonGroup',
+      className
+    );
+
+    return (
+      <div
+        className={classes}
+        {...rest}
+      >
+        {children}
+      </div>
+    );
+  }
+}

--- a/src/components/button/button_group/button_group.js
+++ b/src/components/button/button_group/button_group.js
@@ -16,6 +16,7 @@ export const EuiButtonGroup = ({
   isFullWidth,
   idToSelectedMap,
   type,
+  isIconOnly,
   ...rest
 }) => {
 
@@ -47,10 +48,13 @@ export const EuiButtonGroup = ({
             name={name}
             label={option.label}
             value={option.value}
+            iconType={option.iconType}
+            iconSide={option.iconSide}
             isDisabled={isDisabled}
             onChange={onChange.bind(null, option.id, option.value)}
             color={color}
             type={type}
+            isIconOnly={isIconOnly}
           />
         );
       })}
@@ -72,6 +76,7 @@ EuiButtonGroup.propTypes = {
   type: PropTypes.oneOf(TOGGLE_TYPES),
   idSelected: PropTypes.string,
   idToSelectedMap: PropTypes.objectOf(PropTypes.bool),
+  isIconOnly: PropTypes.bool,
 };
 
 EuiButtonGroup.defaultProps = {

--- a/src/components/button/button_group/button_group.js
+++ b/src/components/button/button_group/button_group.js
@@ -41,10 +41,12 @@ export const EuiButtonGroup = ({
 
         return (
           <EuiButtonToggle
-            className="euiButtonGroup__item"
+            toggleClassName="euiButtonGroup__toggle"
+            className="euiButtonGroup__button"
             key={index}
             id={option.id}
             isSelected={isSelectedState}
+            fill={isSelectedState}
             name={name}
             label={option.label}
             value={option.value}
@@ -55,6 +57,7 @@ export const EuiButtonGroup = ({
             color={color}
             type={type}
             isIconOnly={isIconOnly}
+            size="s" // force small for button groups
           />
         );
       })}
@@ -70,13 +73,37 @@ EuiButtonGroup.propTypes = {
     }),
   ).isRequired,
   onChange: PropTypes.func.isRequired,
-  isDisabled: PropTypes.bool,
-  isFullWidth: PropTypes.bool,
+
+  /**
+   * See `EuiButton`
+   */
   color: PropTypes.string,
-  type: PropTypes.oneOf(TOGGLE_TYPES),
-  idSelected: PropTypes.string,
-  idToSelectedMap: PropTypes.objectOf(PropTypes.bool),
+
+  /**
+   * Hides the label from the button content and only displays the icon
+   */
   isIconOnly: PropTypes.bool,
+  isDisabled: PropTypes.bool,
+
+  /**
+   * Makes the whole group 100% of it's parent
+   */
+  isFullWidth: PropTypes.bool,
+
+  /**
+   * Can only a "single" option be selected or "multi"ple?
+   */
+  type: PropTypes.oneOf(TOGGLE_TYPES),
+
+  /**
+   * Id of selected option for `type="single"`
+   */
+  idSelected: PropTypes.string,
+
+  /**
+   * Map of ids of selected options for `type="multi"`
+   */
+  idToSelectedMap: PropTypes.objectOf(PropTypes.bool),
 };
 
 EuiButtonGroup.defaultProps = {

--- a/src/components/button/button_group/button_group.test.js
+++ b/src/components/button/button_group/button_group.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from 'enzyme';
+import { requiredProps } from '../../../test';
+
+import { EuiButtonGroup } from './button_group';
+
+describe('EuiButtonGroup', () => {
+  test('is rendered', () => {
+    const component = render(
+      <EuiButtonGroup {...requiredProps} />
+    );
+
+    expect(component)
+      .toMatchSnapshot();
+  });
+});

--- a/src/components/button/button_group/button_group.test.js
+++ b/src/components/button/button_group/button_group.test.js
@@ -7,7 +7,7 @@ import { EuiButtonGroup } from './button_group';
 describe('EuiButtonGroup', () => {
   test('is rendered', () => {
     const component = render(
-      <EuiButtonGroup {...requiredProps} />
+      <EuiButtonGroup onChange={() => {}} {...requiredProps} />
     );
 
     expect(component)

--- a/src/components/button/button_group/index.js
+++ b/src/components/button/button_group/index.js
@@ -1,0 +1,3 @@
+export {
+  EuiButtonGroup,
+} from './button_group';

--- a/src/components/button/button_toggle/__snapshots__/button_toggle.test.js.snap
+++ b/src/components/button/button_toggle/__snapshots__/button_toggle.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiButtonToggle is rendered 1`] = `
+<div
+  aria-label="aria-label"
+  class="euiButtonToggle testClass1 testClass2"
+  data-test-subj="test subject string"
+/>
+`;

--- a/src/components/button/button_toggle/__snapshots__/button_toggle.test.js.snap
+++ b/src/components/button/button_toggle/__snapshots__/button_toggle.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`EuiButtonToggle is rendered 1`] = `
 <div
-  class="euiToggle euiButtonToggle__wrapper testClass1 testClass2"
+  class="euiToggle euiButtonToggle__wrapper"
 >
   <input
     aria-label="Label me"
@@ -11,7 +11,7 @@ exports[`EuiButtonToggle is rendered 1`] = `
   />
   <button
     aria-label="aria-label"
-    class="euiButton euiButton--text euiButton--small euiButtonToggle"
+    class="euiButton euiButton--primary euiButtonToggle testClass1 testClass2"
     data-test-subj="test subject string"
     tabindex="-1"
     type="button"

--- a/src/components/button/button_toggle/__snapshots__/button_toggle.test.js.snap
+++ b/src/components/button/button_toggle/__snapshots__/button_toggle.test.js.snap
@@ -5,6 +5,7 @@ exports[`EuiButtonToggle is rendered 1`] = `
   class="euiToggle euiButtonToggle__wrapper testClass1 testClass2"
 >
   <input
+    aria-label="Lable me"
     class="euiToggle__input"
     type="checkbox"
   />

--- a/src/components/button/button_toggle/__snapshots__/button_toggle.test.js.snap
+++ b/src/components/button/button_toggle/__snapshots__/button_toggle.test.js.snap
@@ -5,22 +5,26 @@ exports[`EuiButtonToggle is rendered 1`] = `
   class="euiToggle euiButtonToggle__wrapper testClass1 testClass2"
 >
   <input
-    aria-label="Lable me"
-    class="euiToggle__input"
+    aria-label="Label me"
+    class="euiToggle__input euiButtonToggle__input"
     type="checkbox"
   />
-  <div
+  <button
     aria-label="aria-label"
-    class="euiButtonToggle"
+    class="euiButton euiButton--text euiButton--small euiButtonToggle"
     data-test-subj="test subject string"
+    tabindex="-1"
+    type="button"
   >
     <span
-      class="euiButtonToggle__content"
+      class="euiButton__content"
     >
       <span
-        class="euiButtonToggle__text"
-      />
+        class="euiButton__text"
+      >
+        Label me
+      </span>
     </span>
-  </div>
+  </button>
 </div>
 `;

--- a/src/components/button/button_toggle/__snapshots__/button_toggle.test.js.snap
+++ b/src/components/button/button_toggle/__snapshots__/button_toggle.test.js.snap
@@ -2,8 +2,24 @@
 
 exports[`EuiButtonToggle is rendered 1`] = `
 <div
-  aria-label="aria-label"
-  class="euiButtonToggle testClass1 testClass2"
-  data-test-subj="test subject string"
-/>
+  class="euiToggle euiButtonToggle__wrapper testClass1 testClass2"
+>
+  <input
+    class="euiToggle__input"
+    type="checkbox"
+  />
+  <div
+    aria-label="aria-label"
+    class="euiButtonToggle"
+    data-test-subj="test subject string"
+  >
+    <span
+      class="euiButtonToggle__content"
+    >
+      <span
+        class="euiButtonToggle__text"
+      />
+    </span>
+  </div>
+</div>
 `;

--- a/src/components/button/button_toggle/_button_toggle.scss
+++ b/src/components/button/button_toggle/_button_toggle.scss
@@ -1,0 +1,3 @@
+.euiButtonToggle {
+
+}

--- a/src/components/button/button_toggle/_button_toggle.scss
+++ b/src/components/button/button_toggle/_button_toggle.scss
@@ -36,26 +36,28 @@
   }
 }
 
-// // Default color
-// .euiButtonToggle:not([class*="primary"]):not([class*="ghost"]) {
-//   @include euiButtonToggleStates() {
-//     background-color: transparentize($euiColorDarkShade, .9);
-//   }
+// Modifier naming and colors.
+$buttonTypes: (
+  primary: $euiColorPrimary,
+  secondary: $euiColorSecondary,
+  warning: $euiColorWarning,
+  danger: $euiColorDanger,
+  ghost: $euiColorGhost, // Ghost is special, and does not care about theming.
+  text: $euiColorDarkShade, // Reserved for special use cases
+);
 
-//   &[class*="--fill"] {
-//     background-color: $euiColorDarkShade;
-//     border-color: $euiColorDarkShade;
-//     color: $euiColorEmptyShade;
+// Create button modifiders based upon the map.
+@each $name, $color in $buttonTypes {
+  .euiButtonToggle[class*="#{$name}"] {
+    @include euiButtonToggleStates() {
+      background-color: transparentize($color, .9);
+    }
 
-//     @include euiButtonToggleStates() {
-//       background-color: darken($euiColorDarkShade, 5%);
-//       border-color: darken($euiColorDarkShade, 5%);
-//     }
-
-//     &:disabled {
-//       background-color: $euiButtonColorDisabled;
-//       border-color: $euiButtonToggleBorderColor;
-//     }
-//   }
-// }
-
+    &[class*="fill"] {
+      @include euiButtonToggleStates() {
+        background-color: darken($color, 5%);
+        border-color: darken($color, 5%);
+      }
+    }
+  }
+}

--- a/src/components/button/button_toggle/_button_toggle.scss
+++ b/src/components/button/button_toggle/_button_toggle.scss
@@ -1,155 +1,61 @@
-// Our base button
-.euiButtonToggle {
-  @include euiButton;
-  @include euiSlightShadow;
+// Pointer events and interactions are handled by the input (checkbox/radio)
+// and not the button, this mixin helps to target that element for states
+@mixin euiButtonToggleStates(){
+  @at-root {
+    .euiButtonToggle__input:enabled:hover + #{&},
+    .euiButtonToggle__input:enabled:focus + #{&},
+    .euiButtonToggle__input:enabled:active + #{&} {
+      @content;
+    }
+  }
+}
 
-  border-color: $euiColorLightShade;
-  border-radius: $euiBorderRadius;
-  min-width: $euiButtonMinWidth;
-  height: $euiButtonHeightSmall;
+.euiButtonToggle__wrapper {
+  display: inline-block;
+}
+
+.euiButtonToggle {
+  // always the same border color unless it's selected
+  border-color: $euiButtonToggleBorderColor;
+
+  &:enabled {
+    @include euiSlightShadow; // don't colorize the shadow
+  }
 
   .euiButtonToggle__content {
-    @include euiButtonContent;
-    padding: 0 ($euiSize - $euiSizeXS);
+    padding: 0 $euiSizeS;
   }
 
-  .euiButtonToggle__text {
-    text-overflow: ellipsis;
-    overflow: hidden;
-    line-height: $euiButtonHeightSmall;
+  @include euiButtonToggleStates() {
+    @include euiSlightShadowHover;
+    text-decoration: underline;
   }
 
-  &.euiButtonToggle--iconRight {
-    .euiButtonToggle__content {
-      @include euiButtonContent($isReverse: true);
-    }
-  }
-
-  @at-root {
-    .euiButtonToggle__wrapper .euiToggle__input:hover + #{&},
-    .euiButtonToggle__wrapper .euiToggle__input:focus + #{&},
-    .euiButtonToggle__wrapper .euiToggle__input:active + #{&} {
-      @include euiSlightShadowHover;
-      background-color: transparentize($euiColorDarkShade, .9);
-      text-decoration: underline;
-    }
-  }
-
-  &.euiButtonToggle--fill {
-    background-color: $euiColorDarkShade;
-    border-color: $euiColorDarkShade;
-    color: $euiColorEmptyShade;
-
-    @at-root {
-      .euiButtonToggle__wrapper .euiToggle__input:hover + #{&},
-      .euiButtonToggle__wrapper .euiToggle__input:focus + #{&},
-      .euiButtonToggle__wrapper .euiToggle__input:active + #{&} {
-        background-color: darken($euiColorDarkShade, 5%);
-        border-color: darken($euiColorDarkShade, 5%);
-        text-decoration: underline;
-      }
-    }
-  }
-
-  &.euiButtonToggle--isDisabled {
-    color: $euiButtonColorDisabled;
-    border-color: $euiButtonColorDisabled;
-    pointer-events: none;
-
-    .euiButtonToggle__content {
-      pointer-events: auto;
-      cursor: not-allowed;
-    }
-
-    &.euiButtonToggle--fill {
-      color: $euiColorEmptyShade;
-      background-color: $euiButtonColorDisabled;
-      border-color: $euiButtonColorDisabled;
-
-      @at-root {
-        .euiButtonToggle__wrapper .euiToggle__input:hover + #{&},
-        .euiButtonToggle__wrapper .euiToggle__input:focus + #{&},
-        .euiButtonToggle__wrapper .euiToggle__input:active + #{&} {
-          background-color: $euiButtonColorDisabled;
-          border-color: $euiButtonColorDisabled;
-        }
-      }
-    }
-
-    @at-root {
-      .euiButtonToggle__wrapper .euiToggle__input:hover + #{&},
-      .euiButtonToggle__wrapper .euiToggle__input:focus + #{&},
-      .euiButtonToggle__wrapper .euiToggle__input:active + #{&} {
-        @include euiSlightShadow;
-        background-color: transparent;
-        text-decoration: none;
-      }
-    }
+  &:disabled {
+    border-color: $euiButtonToggleBorderColor;
   }
 }
 
-// Modifier naming and colors.
-$buttonTypes: (
-  primary: $euiColorPrimary,
-  ghost: $euiColorGhost, // Ghost is special, and does not care about theming.
-);
+// // Default color
+// .euiButtonToggle:not([class*="primary"]):not([class*="ghost"]) {
+//   @include euiButtonToggleStates() {
+//     background-color: transparentize($euiColorDarkShade, .9);
+//   }
 
-// Create button modifiders based upon the map.
-@each $name, $color in $buttonTypes {
-  .euiButtonToggle--#{$name} {
+//   &[class*="--fill"] {
+//     background-color: $euiColorDarkShade;
+//     border-color: $euiColorDarkShade;
+//     color: $euiColorEmptyShade;
 
-    @if ($name == 'ghost') {
-      // Ghost is unique and ALWAYS sits against a dark background.
-      border-color: $color;
-    }
+//     @include euiButtonToggleStates() {
+//       background-color: darken($euiColorDarkShade, 5%);
+//       border-color: darken($euiColorDarkShade, 5%);
+//     }
 
-    color: $color;
+//     &:disabled {
+//       background-color: $euiButtonColorDisabled;
+//       border-color: $euiButtonToggleBorderColor;
+//     }
+//   }
+// }
 
-    &.euiButtonToggle--fill {
-      background-color: $color;
-      border-color: $color;
-
-      $fillTextColor: chooseLightOrDarkText($color, #FFF, #000);
-
-      color: $fillTextColor;
-
-      @at-root {
-        .euiButtonToggle__wrapper .euiToggle__input:hover + #{&},
-        .euiButtonToggle__wrapper .euiToggle__input:focus + #{&},
-        .euiButtonToggle__wrapper .euiToggle__input:active + #{&} {
-          background-color: darken($color, 5%);
-          border-color: darken($color, 5%);
-        }
-      }
-    }
-
-    $shadowColor: $euiShadowColor;
-    @if ($name == 'ghost') {
-      $shadowColor: #000;
-    } @else if (lightness($euiTextColor) < 50) {
-      // Only if this is the light theme do we use the button variant color to colorize the shadow
-      $shadowColor: desaturate($color, 60%);
-    }
-
-    @at-root {
-      .euiButtonToggle__wrapper .euiToggle__input:enabled:hover + #{&},
-      .euiButtonToggle__wrapper .euiToggle__input:enabled:focus + #{&},
-      .euiButtonToggle__wrapper .euiToggle__input:enabled:active + #{&} {
-        @if ($name == 'disabled') {
-          cursor: not-allowed;
-        }
-      }
-    }
-
-    @at-root {
-      .euiButtonToggle__wrapper .euiToggle__input:disabled + #{&},
-      .euiButtonToggle__wrapper .euiToggle__input:disabled:hover + #{&},
-      .euiButtonToggle__wrapper .euiToggle__input:disabled:focus + #{&},
-      .euiButtonToggle__wrapper .euiToggle__input:disabled:active + #{&} {
-        @if ($name == 'ghost') {
-          @include euiSlightShadow(#000);
-        }
-      }
-    }
-  }
-}

--- a/src/components/button/button_toggle/_button_toggle.scss
+++ b/src/components/button/button_toggle/_button_toggle.scss
@@ -22,10 +22,6 @@
     @include euiSlightShadow; // don't colorize the shadow
   }
 
-  .euiButtonToggle__content {
-    padding: 0 $euiSizeS;
-  }
-
   @include euiButtonToggleStates() {
     @include euiSlightShadowHover;
     text-decoration: underline;
@@ -33,6 +29,18 @@
 
   &:disabled {
     border-color: $euiButtonToggleBorderColor;
+  }
+
+  &.euiButtonToggle--isIconOnly {
+    min-width: 0;
+
+    .euiButton__content {
+      padding: 0 $euiSizeS;
+    }
+
+    .euiButton__text:empty {
+      display: none;
+    }
   }
 }
 

--- a/src/components/button/button_toggle/_button_toggle.scss
+++ b/src/components/button/button_toggle/_button_toggle.scss
@@ -1,3 +1,155 @@
+// Our base button
 .euiButtonToggle {
+  @include euiButton;
+  @include euiSlightShadow;
 
+  border-color: $euiColorLightShade;
+  border-radius: $euiBorderRadius;
+  min-width: $euiButtonMinWidth;
+  height: $euiButtonHeightSmall;
+
+  .euiButtonToggle__content {
+    @include euiButtonContent;
+    padding: 0 ($euiSize - $euiSizeXS);
+  }
+
+  .euiButtonToggle__text {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    line-height: $euiButtonHeightSmall;
+  }
+
+  &.euiButtonToggle--iconRight {
+    .euiButtonToggle__content {
+      @include euiButtonContent($isReverse: true);
+    }
+  }
+
+  @at-root {
+    .euiButtonToggle__wrapper .euiToggle__input:hover + #{&},
+    .euiButtonToggle__wrapper .euiToggle__input:focus + #{&},
+    .euiButtonToggle__wrapper .euiToggle__input:active + #{&} {
+      @include euiSlightShadowHover;
+      background-color: transparentize($euiColorDarkShade, .9);
+      text-decoration: underline;
+    }
+  }
+
+  &.euiButtonToggle--fill {
+    background-color: $euiColorDarkShade;
+    border-color: $euiColorDarkShade;
+    color: $euiColorEmptyShade;
+
+    @at-root {
+      .euiButtonToggle__wrapper .euiToggle__input:hover + #{&},
+      .euiButtonToggle__wrapper .euiToggle__input:focus + #{&},
+      .euiButtonToggle__wrapper .euiToggle__input:active + #{&} {
+        background-color: darken($euiColorDarkShade, 5%);
+        border-color: darken($euiColorDarkShade, 5%);
+        text-decoration: underline;
+      }
+    }
+  }
+
+  &.euiButtonToggle--isDisabled {
+    color: $euiButtonColorDisabled;
+    border-color: $euiButtonColorDisabled;
+    pointer-events: none;
+
+    .euiButtonToggle__content {
+      pointer-events: auto;
+      cursor: not-allowed;
+    }
+
+    &.euiButtonToggle--fill {
+      color: $euiColorEmptyShade;
+      background-color: $euiButtonColorDisabled;
+      border-color: $euiButtonColorDisabled;
+
+      @at-root {
+        .euiButtonToggle__wrapper .euiToggle__input:hover + #{&},
+        .euiButtonToggle__wrapper .euiToggle__input:focus + #{&},
+        .euiButtonToggle__wrapper .euiToggle__input:active + #{&} {
+          background-color: $euiButtonColorDisabled;
+          border-color: $euiButtonColorDisabled;
+        }
+      }
+    }
+
+    @at-root {
+      .euiButtonToggle__wrapper .euiToggle__input:hover + #{&},
+      .euiButtonToggle__wrapper .euiToggle__input:focus + #{&},
+      .euiButtonToggle__wrapper .euiToggle__input:active + #{&} {
+        @include euiSlightShadow;
+        background-color: transparent;
+        text-decoration: none;
+      }
+    }
+  }
+}
+
+// Modifier naming and colors.
+$buttonTypes: (
+  primary: $euiColorPrimary,
+  ghost: $euiColorGhost, // Ghost is special, and does not care about theming.
+);
+
+// Create button modifiders based upon the map.
+@each $name, $color in $buttonTypes {
+  .euiButtonToggle--#{$name} {
+
+    @if ($name == 'ghost') {
+      // Ghost is unique and ALWAYS sits against a dark background.
+      border-color: $color;
+    }
+
+    color: $color;
+
+    &.euiButtonToggle--fill {
+      background-color: $color;
+      border-color: $color;
+
+      $fillTextColor: chooseLightOrDarkText($color, #FFF, #000);
+
+      color: $fillTextColor;
+
+      @at-root {
+        .euiButtonToggle__wrapper .euiToggle__input:hover + #{&},
+        .euiButtonToggle__wrapper .euiToggle__input:focus + #{&},
+        .euiButtonToggle__wrapper .euiToggle__input:active + #{&} {
+          background-color: darken($color, 5%);
+          border-color: darken($color, 5%);
+        }
+      }
+    }
+
+    $shadowColor: $euiShadowColor;
+    @if ($name == 'ghost') {
+      $shadowColor: #000;
+    } @else if (lightness($euiTextColor) < 50) {
+      // Only if this is the light theme do we use the button variant color to colorize the shadow
+      $shadowColor: desaturate($color, 60%);
+    }
+
+    @at-root {
+      .euiButtonToggle__wrapper .euiToggle__input:enabled:hover + #{&},
+      .euiButtonToggle__wrapper .euiToggle__input:enabled:focus + #{&},
+      .euiButtonToggle__wrapper .euiToggle__input:enabled:active + #{&} {
+        @if ($name == 'disabled') {
+          cursor: not-allowed;
+        }
+      }
+    }
+
+    @at-root {
+      .euiButtonToggle__wrapper .euiToggle__input:disabled + #{&},
+      .euiButtonToggle__wrapper .euiToggle__input:disabled:hover + #{&},
+      .euiButtonToggle__wrapper .euiToggle__input:disabled:focus + #{&},
+      .euiButtonToggle__wrapper .euiToggle__input:disabled:active + #{&} {
+        @if ($name == 'ghost') {
+          @include euiSlightShadow(#000);
+        }
+      }
+    }
+  }
 }

--- a/src/components/button/button_toggle/_button_toggle.scss
+++ b/src/components/button/button_toggle/_button_toggle.scss
@@ -26,10 +26,6 @@
     text-decoration: underline;
   }
 
-  // &:disabled {
-  //   border-color: $euiButtonToggleBorderColor;
-  // }
-
   &.euiButtonToggle--isIconOnly {
     min-width: 0;
 
@@ -40,6 +36,12 @@
     .euiButton__text:empty {
       display: none;
     }
+  }
+
+  &.euiButtonToggle--isEmpty {
+    border-color: transparent;
+    background-color: transparent;
+    box-shadow: none;
   }
 }
 

--- a/src/components/button/button_toggle/_button_toggle.scss
+++ b/src/components/button/button_toggle/_button_toggle.scss
@@ -1,35 +1,34 @@
-// Pointer events and interactions are handled by the input (checkbox/radio)
-// and not the button, this mixin helps to target that element for states
-@mixin euiButtonToggleStates(){
-  @at-root {
-    .euiButtonToggle__input:enabled:hover + #{&},
-    .euiButtonToggle__input:enabled:focus + #{&},
-    .euiButtonToggle__input:enabled:active + #{&} {
-      @content;
+
+.euiButtonToggle__wrapper {
+  display: inline-block;
+
+  // Transform the whole thing so that the button doesn't
+  // steal pointer events from input
+  &:not(.euiButtonToggle--isDisabled) {
+    transition: transform $euiAnimSpeedNormal $euiAnimSlightBounce;
+
+    &:hover {
+      transform: translateY(-1px);
+    }
+
+    &:focus {
+      animation: euiButtonActive $euiAnimSpeedNormal $euiAnimSlightBounce;
+    }
+
+    &:active {
+      transform: translateY(1px);
     }
   }
 }
 
-.euiButtonToggle__wrapper {
-  display: inline-block;
-}
-
 .euiButtonToggle {
-  // always the same border color unless it's selected
-  border-color: $euiButtonToggleBorderColor;
-
-  &:enabled {
-    @include euiSlightShadow; // don't colorize the shadow
-  }
-
   @include euiButtonToggleStates() {
-    @include euiSlightShadowHover;
     text-decoration: underline;
   }
 
-  &:disabled {
-    border-color: $euiButtonToggleBorderColor;
-  }
+  // &:disabled {
+  //   border-color: $euiButtonToggleBorderColor;
+  // }
 
   &.euiButtonToggle--isIconOnly {
     min-width: 0;
@@ -54,7 +53,7 @@ $buttonTypes: (
   text: $euiColorDarkShade, // Reserved for special use cases
 );
 
-// Create button modifiders based upon the map.
+// Add hover states based on input state
 @each $name, $color in $buttonTypes {
   .euiButtonToggle[class*="#{$name}"] {
     @include euiButtonToggleStates() {
@@ -69,3 +68,4 @@ $buttonTypes: (
     }
   }
 }
+

--- a/src/components/button/button_toggle/_index.scss
+++ b/src/components/button/button_toggle/_index.scss
@@ -1,0 +1,1 @@
+@import 'button_toggle';

--- a/src/components/button/button_toggle/button_toggle.js
+++ b/src/components/button/button_toggle/button_toggle.js
@@ -1,0 +1,40 @@
+import React, {
+  Component,
+} from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+export class EuiButtonToggle extends Component {
+  static propTypes = {
+    children: PropTypes.node,
+    className: PropTypes.string,
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.state = {};
+  }
+
+  render() {
+    const {
+      children,
+      className,
+      ...rest
+    } = this.props;
+
+    const classes = classNames(
+      'euiButtonToggle',
+      className
+    );
+
+    return (
+      <div
+        className={classes}
+        {...rest}
+      >
+        {children}
+      </div>
+    );
+  }
+}

--- a/src/components/button/button_toggle/button_toggle.js
+++ b/src/components/button/button_toggle/button_toggle.js
@@ -14,13 +14,15 @@ export const EuiButtonToggle = ({
   label,
   type,
   isIconOnly,
+  toggleClassName,
   ...rest,
 }) => {
   const classes = classNames(
     'euiButtonToggle',
     {
       'euiButtonToggle--isIconOnly': isIconOnly,
-    }
+    },
+    className,
   );
 
   const wrapperClasses = classNames(
@@ -28,27 +30,25 @@ export const EuiButtonToggle = ({
     {
       'euiButtonToggle--isDisabled': isDisabled,
     },
-    className
+    toggleClassName
   );
 
-  //const WrappingElement = isIconOnly ? EuiButtonIcon : EuiButton;
   const buttonContent = isIconOnly ? '' : label;
 
   return (
     <EuiToggle
       className={wrapperClasses}
+      inputClassName="euiButtonToggle__input"
       isDisabled={isDisabled}
       label={label}
       checked={isSelected}
       onChange={onChange}
-      inputClassName="euiButtonToggle__input"
       type={type}
     >
       <EuiButton
         tabIndex="-1" // prevents double focus from input to button
         className={classes}
-        size="s"
-        fill={isSelected}
+        size={isIconOnly ? 's' : undefined} // only force small if it's the icon only version
         disabled={isDisabled}
         color={color}
         {...rest}
@@ -65,27 +65,32 @@ EuiButtonToggle.propTypes = {
   onChange: PropTypes.func,
 
   /**
-   * See EuiButton
+   * See `EuiButton`
    */
   color: PropTypes.string,
 
   /**
-   * Button label, which is also passed to EuiToggle as the input's label
+   * Button label, which is also passed to `EuiToggle` as the input's label
    */
   label: PropTypes.string.isRequired,
 
   /**
-   * Starting state of toggle
+   * Is the button a single action or part of a group (multi)?
+   * Used primarily for `EuiButtonGroup`
    */
-  isSelected: PropTypes.bool,
   type: PropTypes.oneOf(TOGGLE_TYPES),
 
   /**
    * Hides the label from the button content and only displays the icon
    */
   isIconOnly: PropTypes.bool,
+
+  /**
+   * Classnames to add to `EuiToggle` instead of the `EuiButton`
+   */
+  toggleClassName: PropTypes.string,
 };
 
 EuiButtonToggle.defaultProps = {
-  color: 'text',
+  color: 'primary',
 };

--- a/src/components/button/button_toggle/button_toggle.js
+++ b/src/components/button/button_toggle/button_toggle.js
@@ -1,76 +1,61 @@
-import React, {
-  Component,
-} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { EuiToggle } from '../../toggle';
+import { EuiToggle, TOGGLE_TYPES } from '../../toggle';
 import { EuiButton } from '../button';
 
-export class EuiButtonToggle extends Component {
-  constructor(props) {
-    super(props);
+export const EuiButtonToggle = ({
+  className,
+  color,
+  isDisabled,
+  isSelected,
+  onChange,
+  label,
+  type,
+  ...rest,
+}) => {
+  const classes = classNames(
+    'euiButtonToggle',
+  );
 
-    this.state = {
-      isSelected: this.props.isSelected || false,
-    };
-  }
+  const wrapperClasses = classNames(
+    'euiButtonToggle__wrapper',
+    {
+      'euiButtonToggle--isDisabled': isDisabled,
+    },
+    className
+  );
 
-  onToggleChange = (e) => {
-    this.setState({ isSelected: e.target.checked });
-    this.props.onClick;
-  }
-
-  render() {
-    const {
-      className,
-      color,
-      isDisabled,
-      label,
-      ...rest
-    } = this.props;
-
-    const classes = classNames(
-      'euiButtonToggle',
-    );
-
-    const wrapperClasses = classNames(
-      'euiButtonToggle__wrapper',
-      {
-        'euiButtonToggle--isDisabled': isDisabled,
-      },
-      className
-    );
-
-    return (
-      <EuiToggle
-        className={wrapperClasses}
-        onChange={this.onToggleChange}
-        isDisabled={isDisabled}
-        checked={this.state.isSelected}
-        label={label}
-        inputClassName="euiButtonToggle__input"
+  return (
+    <EuiToggle
+      className={wrapperClasses}
+      isDisabled={isDisabled}
+      label={label}
+      checked={isSelected}
+      onChange={onChange}
+      inputClassName="euiButtonToggle__input"
+      type={type}
+    >
+      <EuiButton
+        tabIndex="-1" // prevents double focus from input to button
+        className={classes}
+        size="s"
+        fill={isSelected}
+        disabled={isDisabled}
+        color={color}
+        {...rest}
       >
-        <EuiButton
-          tabIndex="-1" // prevents double focus from input to button
-          className={classes}
-          size="s"
-          fill={this.state.isSelected}
-          disabled={isDisabled}
-          color={color}
-          {...rest}
-        >
-          {label}
-        </EuiButton>
-      </EuiToggle>
-    );
-  }
-}
+        {label}
+      </EuiButton>
+    </EuiToggle>
+  );
+};
 
 EuiButtonToggle.propTypes = {
   className: PropTypes.string,
   isDisabled: PropTypes.bool,
-  onClick: PropTypes.func,
+  onChange: PropTypes.func,
 
   /**
    * See EuiButton
@@ -86,6 +71,7 @@ EuiButtonToggle.propTypes = {
    * Starting state of toggle
    */
   isSelected: PropTypes.bool,
+  type: PropTypes.oneOf(TOGGLE_TYPES),
 };
 
 EuiButtonToggle.defaultProps = {

--- a/src/components/button/button_toggle/button_toggle.js
+++ b/src/components/button/button_toggle/button_toggle.js
@@ -5,33 +5,14 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { EuiToggle } from '../../toggle';
-
-import {
-  ICON_TYPES,
-  EuiIcon,
-} from '../../icon';
-
-const colorToClassNameMap = {
-  default: '',
-  primary: 'euiButtonToggle--primary',
-  ghost: 'euiButtonToggle--ghost',
-};
-
-export const COLORS = Object.keys(colorToClassNameMap);
-
-const iconSideToClassNameMap = {
-  left: null,
-  right: 'euiButtonToggle--iconRight',
-};
-
-export const ICON_SIDES = Object.keys(iconSideToClassNameMap);
+import { EuiButton } from '../button';
 
 export class EuiButtonToggle extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      isSelected: this.props.selected || false,
+      isSelected: this.props.isSelected || false,
     };
   }
 
@@ -42,94 +23,71 @@ export class EuiButtonToggle extends Component {
 
   render() {
     const {
-      children,
       className,
-      iconType,
-      iconSide,
       color,
       isDisabled,
-      buttonRef,
-      toggleLabel,
+      label,
       ...rest
     } = this.props;
 
     const classes = classNames(
       'euiButtonToggle',
-      colorToClassNameMap[color],
-      iconSideToClassNameMap[iconSide],
-      {
-        'euiButtonToggle--isDisabled': isDisabled,
-        'euiButtonToggle--fill': this.state.isSelected,
-      }
     );
 
     const wrapperClasses = classNames(
       'euiButtonToggle__wrapper',
+      {
+        'euiButtonToggle--isDisabled': isDisabled,
+      },
       className
     );
-
-    // Add an icon to the button if one exists.
-    let buttonIcon;
-
-    if (iconType) {
-      buttonIcon = (
-        <EuiIcon
-          className="euiButtonToggle__icon"
-          type={iconType}
-          size="m"
-          aria-hidden="true"
-        />
-      );
-    }
 
     return (
       <EuiToggle
         className={wrapperClasses}
         onChange={this.onToggleChange}
-        disabled={isDisabled}
-        label={toggleLabel}
+        isDisabled={isDisabled}
+        checked={this.state.isSelected}
+        label={label}
+        inputClassName="euiButtonToggle__input"
       >
-        <div
+        <EuiButton
+          tabIndex="-1" // prevents double focus from input to button
           className={classes}
-          ref={buttonRef}
+          size="s"
+          fill={this.state.isSelected}
+          disabled={isDisabled}
+          color={color}
           {...rest}
         >
-          <span className="euiButtonToggle__content">
-            {buttonIcon}
-            <span className="euiButtonToggle__text">{children}</span>
-          </span>
-        </div>
+          {label}
+        </EuiButton>
       </EuiToggle>
     );
   }
 }
 
 EuiButtonToggle.propTypes = {
-  children: PropTypes.node,
   className: PropTypes.string,
-
-  /**
-   * See EuiIcon
-   */
-  iconType: PropTypes.oneOf(ICON_TYPES),
-  iconSide: PropTypes.oneOf(ICON_SIDES),
-
-  /**
-   * Define the color of the button
-   */
-  color: PropTypes.oneOf(COLORS),
   isDisabled: PropTypes.bool,
   onClick: PropTypes.func,
-  buttonRef: PropTypes.func,
-  toggleLabel: PropTypes.string.isRequired,
+
+  /**
+   * See EuiButton
+   */
+  color: PropTypes.string,
+
+  /**
+   * Button label, which is also passed to EuiToggle as the input's label
+   */
+  label: PropTypes.string.isRequired,
 
   /**
    * Starting state of toggle
    */
-  selected: PropTypes.bool,
+  isSelected: PropTypes.bool,
 };
 
 EuiButtonToggle.defaultProps = {
-  iconSide: 'left',
-  color: 'default',
+  color: 'text',
 };

--- a/src/components/button/button_toggle/button_toggle.js
+++ b/src/components/button/button_toggle/button_toggle.js
@@ -121,7 +121,7 @@ EuiButtonToggle.propTypes = {
   isDisabled: PropTypes.bool,
   onClick: PropTypes.func,
   buttonRef: PropTypes.func,
-  toggleLabel: PropTypes.string,
+  toggleLabel: PropTypes.string.isRequired,
 
   /**
    * Starting state of toggle

--- a/src/components/button/button_toggle/button_toggle.js
+++ b/src/components/button/button_toggle/button_toggle.js
@@ -13,10 +13,14 @@ export const EuiButtonToggle = ({
   onChange,
   label,
   type,
+  isIconOnly,
   ...rest,
 }) => {
   const classes = classNames(
     'euiButtonToggle',
+    {
+      'euiButtonToggle--isIconOnly': isIconOnly,
+    }
   );
 
   const wrapperClasses = classNames(
@@ -26,6 +30,9 @@ export const EuiButtonToggle = ({
     },
     className
   );
+
+  //const WrappingElement = isIconOnly ? EuiButtonIcon : EuiButton;
+  const buttonContent = isIconOnly ? '' : label;
 
   return (
     <EuiToggle
@@ -46,7 +53,7 @@ export const EuiButtonToggle = ({
         color={color}
         {...rest}
       >
-        {label}
+        {buttonContent}
       </EuiButton>
     </EuiToggle>
   );
@@ -72,6 +79,11 @@ EuiButtonToggle.propTypes = {
    */
   isSelected: PropTypes.bool,
   type: PropTypes.oneOf(TOGGLE_TYPES),
+
+  /**
+   * Hides the label from the button content and only displays the icon
+   */
+  isIconOnly: PropTypes.bool,
 };
 
 EuiButtonToggle.defaultProps = {

--- a/src/components/button/button_toggle/button_toggle.js
+++ b/src/components/button/button_toggle/button_toggle.js
@@ -4,37 +4,132 @@ import React, {
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-export class EuiButtonToggle extends Component {
-  static propTypes = {
-    children: PropTypes.node,
-    className: PropTypes.string,
-  }
+import { EuiToggle } from '../../toggle';
 
+import {
+  ICON_TYPES,
+  EuiIcon,
+} from '../../icon';
+
+const colorToClassNameMap = {
+  default: '',
+  primary: 'euiButtonToggle--primary',
+  ghost: 'euiButtonToggle--ghost',
+};
+
+export const COLORS = Object.keys(colorToClassNameMap);
+
+const iconSideToClassNameMap = {
+  left: null,
+  right: 'euiButtonToggle--iconRight',
+};
+
+export const ICON_SIDES = Object.keys(iconSideToClassNameMap);
+
+export class EuiButtonToggle extends Component {
   constructor(props) {
     super(props);
 
-    this.state = {};
+    this.state = {
+      isSelected: this.props.selected || false,
+    };
+  }
+
+  onToggleChange = (e) => {
+    this.setState({ isSelected: e.target.checked });
+    this.props.onClick;
   }
 
   render() {
     const {
       children,
       className,
+      iconType,
+      iconSide,
+      color,
+      isDisabled,
+      buttonRef,
+      toggleLabel,
       ...rest
     } = this.props;
 
     const classes = classNames(
       'euiButtonToggle',
+      colorToClassNameMap[color],
+      iconSideToClassNameMap[iconSide],
+      {
+        'euiButtonToggle--isDisabled': isDisabled,
+        'euiButtonToggle--fill': this.state.isSelected,
+      }
+    );
+
+    const wrapperClasses = classNames(
+      'euiButtonToggle__wrapper',
       className
     );
 
+    // Add an icon to the button if one exists.
+    let buttonIcon;
+
+    if (iconType) {
+      buttonIcon = (
+        <EuiIcon
+          className="euiButtonToggle__icon"
+          type={iconType}
+          size="m"
+          aria-hidden="true"
+        />
+      );
+    }
+
     return (
-      <div
-        className={classes}
-        {...rest}
+      <EuiToggle
+        className={wrapperClasses}
+        onChange={this.onToggleChange}
+        disabled={isDisabled}
+        label={toggleLabel}
       >
-        {children}
-      </div>
+        <div
+          className={classes}
+          ref={buttonRef}
+          {...rest}
+        >
+          <span className="euiButtonToggle__content">
+            {buttonIcon}
+            <span className="euiButtonToggle__text">{children}</span>
+          </span>
+        </div>
+      </EuiToggle>
     );
   }
 }
+
+EuiButtonToggle.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+
+  /**
+   * See EuiIcon
+   */
+  iconType: PropTypes.oneOf(ICON_TYPES),
+  iconSide: PropTypes.oneOf(ICON_SIDES),
+
+  /**
+   * Define the color of the button
+   */
+  color: PropTypes.oneOf(COLORS),
+  isDisabled: PropTypes.bool,
+  onClick: PropTypes.func,
+  buttonRef: PropTypes.func,
+  toggleLabel: PropTypes.string,
+
+  /**
+   * Starting state of toggle
+   */
+  selected: PropTypes.bool,
+};
+
+EuiButtonToggle.defaultProps = {
+  iconSide: 'left',
+  color: 'default',
+};

--- a/src/components/button/button_toggle/button_toggle.js
+++ b/src/components/button/button_toggle/button_toggle.js
@@ -9,18 +9,22 @@ export const EuiButtonToggle = ({
   className,
   color,
   isDisabled,
-  isSelected,
-  onChange,
-  label,
-  type,
+  isEmpty,
   isIconOnly,
+  isSelected,
+  label,
+  name,
+  onChange,
   toggleClassName,
+  type,
+  value,
   ...rest,
 }) => {
   const classes = classNames(
     'euiButtonToggle',
     {
       'euiButtonToggle--isIconOnly': isIconOnly,
+      'euiButtonToggle--isEmpty': isEmpty,
     },
     className,
   );
@@ -39,18 +43,20 @@ export const EuiButtonToggle = ({
     <EuiToggle
       className={wrapperClasses}
       inputClassName="euiButtonToggle__input"
+      checked={isSelected}
       isDisabled={isDisabled}
       label={label}
-      checked={isSelected}
+      name={name}
       onChange={onChange}
       type={type}
+      value={value}
     >
       <EuiButton
         tabIndex="-1" // prevents double focus from input to button
         className={classes}
-        size={isIconOnly ? 's' : undefined} // only force small if it's the icon only version
-        disabled={isDisabled}
         color={color}
+        disabled={isDisabled}
+        size={isIconOnly ? 's' : undefined} // only force small if it's the icon only version
         {...rest}
       >
         {buttonContent}
@@ -61,24 +67,18 @@ export const EuiButtonToggle = ({
 
 EuiButtonToggle.propTypes = {
   className: PropTypes.string,
-  isDisabled: PropTypes.bool,
+
+  /**
+   * Button label, which is also passed to `EuiToggle` as the input's label
+   */
+  label: PropTypes.string.isRequired,
   onChange: PropTypes.func,
 
   /**
    * See `EuiButton`
    */
   color: PropTypes.string,
-
-  /**
-   * Button label, which is also passed to `EuiToggle` as the input's label
-   */
-  label: PropTypes.string.isRequired,
-
-  /**
-   * Is the button a single action or part of a group (multi)?
-   * Used primarily for `EuiButtonGroup`
-   */
-  type: PropTypes.oneOf(TOGGLE_TYPES),
+  isDisabled: PropTypes.bool,
 
   /**
    * Hides the label from the button content and only displays the icon
@@ -86,9 +86,20 @@ EuiButtonToggle.propTypes = {
   isIconOnly: PropTypes.bool,
 
   /**
+   * Simulates a `EuiButtonEmpty`
+   */
+  isEmpty: PropTypes.bool,
+
+  /**
    * Classnames to add to `EuiToggle` instead of the `EuiButton`
    */
   toggleClassName: PropTypes.string,
+
+  /**
+   * Is the button a single action or part of a group (multi)?
+   * Used primarily for `EuiButtonGroup`
+   */
+  type: PropTypes.oneOf(TOGGLE_TYPES),
 };
 
 EuiButtonToggle.defaultProps = {

--- a/src/components/button/button_toggle/button_toggle.test.js
+++ b/src/components/button/button_toggle/button_toggle.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from 'enzyme';
+import { requiredProps } from '../../../test';
+
+import { EuiButtonToggle } from './button_toggle';
+
+describe('EuiButtonToggle', () => {
+  test('is rendered', () => {
+    const component = render(
+      <EuiButtonToggle {...requiredProps} />
+    );
+
+    expect(component)
+      .toMatchSnapshot();
+  });
+});

--- a/src/components/button/button_toggle/button_toggle.test.js
+++ b/src/components/button/button_toggle/button_toggle.test.js
@@ -7,7 +7,7 @@ import { EuiButtonToggle } from './button_toggle';
 describe('EuiButtonToggle', () => {
   test('is rendered', () => {
     const component = render(
-      <EuiButtonToggle {...requiredProps} />
+      <EuiButtonToggle {...requiredProps} toggleLabel="Lable me" />
     );
 
     expect(component)

--- a/src/components/button/button_toggle/button_toggle.test.js
+++ b/src/components/button/button_toggle/button_toggle.test.js
@@ -7,7 +7,7 @@ import { EuiButtonToggle } from './button_toggle';
 describe('EuiButtonToggle', () => {
   test('is rendered', () => {
     const component = render(
-      <EuiButtonToggle {...requiredProps} toggleLabel="Lable me" />
+      <EuiButtonToggle {...requiredProps} label="Label me" />
     );
 
     expect(component)

--- a/src/components/button/button_toggle/index.js
+++ b/src/components/button/button_toggle/index.js
@@ -1,0 +1,3 @@
+export {
+  EuiButtonToggle,
+} from './button_toggle';

--- a/src/components/button/index.js
+++ b/src/components/button/index.js
@@ -7,3 +7,11 @@ export {
 export {
   EuiButtonIcon,
 } from './button_icon';
+
+export {
+  EuiButtonToggle,
+} from './button_toggle';
+
+export {
+  EuiButtonGroup,
+} from './button_group';

--- a/src/components/form/switch/_mixins.scss
+++ b/src/components/form/switch/_mixins.scss
@@ -1,0 +1,7 @@
+@mixin euiHiddenSelectableInput(){
+  position: absolute;
+  opacity: 0; /* 1 */
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -28,6 +28,8 @@ export {
   EuiButton,
   EuiButtonEmpty,
   EuiButtonIcon,
+  EuiButtonToggle,
+  EuiButtonGroup,
 } from './button';
 
 export {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -298,6 +298,10 @@ export {
 } from './toast';
 
 export {
+  EuiToggle,
+} from './toggle';
+
+export {
   EuiIconTip,
   EuiToolTip,
 } from './tool_tip';

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -49,5 +49,6 @@
 @import 'tabs/index';
 @import 'title/index';
 @import 'toast/index';
+@import 'toggle/index';
 @import 'tool_tip/index';
 @import 'text/index';

--- a/src/components/toggle/__snapshots__/toggle.test.js.snap
+++ b/src/components/toggle/__snapshots__/toggle.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiToggle is rendered 1`] = `
-<span
+<div
   aria-label="aria-label"
   class="euiToggle testClass1 testClass2"
   data-test-subj="test subject string"
@@ -11,5 +11,5 @@ exports[`EuiToggle is rendered 1`] = `
     class="euiToggle__input"
     type="checkbox"
   />
-</span>
+</div>
 `;

--- a/src/components/toggle/__snapshots__/toggle.test.js.snap
+++ b/src/components/toggle/__snapshots__/toggle.test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiToggle is rendered 1`] = `
+<div
+  class="euiToggle testClass1 testClass2"
+>
+  <input
+    class="euiToggle__input"
+    type="checkbox"
+  />
+</div>
+`;

--- a/src/components/toggle/__snapshots__/toggle.test.js.snap
+++ b/src/components/toggle/__snapshots__/toggle.test.js.snap
@@ -2,9 +2,12 @@
 
 exports[`EuiToggle is rendered 1`] = `
 <span
+  aria-label="aria-label"
   class="euiToggle testClass1 testClass2"
+  data-test-subj="test subject string"
 >
   <input
+    aria-label="Is toggle on?"
     class="euiToggle__input"
     type="checkbox"
   />

--- a/src/components/toggle/__snapshots__/toggle.test.js.snap
+++ b/src/components/toggle/__snapshots__/toggle.test.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiToggle is rendered 1`] = `
-<div
+<span
   class="euiToggle testClass1 testClass2"
 >
   <input
     class="euiToggle__input"
     type="checkbox"
   />
-</div>
+</span>
 `;

--- a/src/components/toggle/_index.scss
+++ b/src/components/toggle/_index.scss
@@ -1,0 +1,1 @@
+@import 'toggle';

--- a/src/components/toggle/_toggle.scss
+++ b/src/components/toggle/_toggle.scss
@@ -1,7 +1,6 @@
 @import '../form/switch/mixins';
 
 .euiToggle {
-  display: inline-block;
   position: relative;
 
   .euiToggle__input {

--- a/src/components/toggle/_toggle.scss
+++ b/src/components/toggle/_toggle.scss
@@ -1,0 +1,9 @@
+@import '../form/switch/mixins';
+
+.euiToggle {
+  display: inline-block;
+  position: relative;
+  .euiToggle__input {
+    @include euiHiddenSelectableInput;
+  }
+}

--- a/src/components/toggle/_toggle.scss
+++ b/src/components/toggle/_toggle.scss
@@ -6,9 +6,5 @@
 
   .euiToggle__input {
     @include euiHiddenSelectableInput;
-
-    + * {
-      pointer-events: none;
-    }
   }
 }

--- a/src/components/toggle/_toggle.scss
+++ b/src/components/toggle/_toggle.scss
@@ -6,5 +6,9 @@
 
   .euiToggle__input {
     @include euiHiddenSelectableInput;
+
+    &:disabled {
+      cursor: not-allowed;
+    }
   }
 }

--- a/src/components/toggle/_toggle.scss
+++ b/src/components/toggle/_toggle.scss
@@ -3,7 +3,12 @@
 .euiToggle {
   display: inline-block;
   position: relative;
+
   .euiToggle__input {
     @include euiHiddenSelectableInput;
+
+    + * {
+      pointer-events: none;
+    }
   }
 }

--- a/src/components/toggle/index.js
+++ b/src/components/toggle/index.js
@@ -1,0 +1,3 @@
+export {
+  EuiToggle,
+} from './toggle';

--- a/src/components/toggle/index.js
+++ b/src/components/toggle/index.js
@@ -1,3 +1,4 @@
 export {
   EuiToggle,
+  TYPES as TOGGLE_TYPES,
 } from './toggle';

--- a/src/components/toggle/toggle.js
+++ b/src/components/toggle/toggle.js
@@ -13,20 +13,27 @@ export const EuiToggle = ({
   id,
   label,
   checked,
-  disabled,
+  isDisabled,
   onChange,
   children,
   type,
+  name,
+  value,
   className,
+  inputClassName,
   ...rest,
 }) => {
   const classes = classNames(
     'euiToggle',
     {
-      'euiToggle--disabled': disabled,
       'euiToggle--checked': checked,
     },
     className
+  );
+
+  const inputClasses = classNames(
+    'euiToggle__input',
+    inputClassName,
   );
 
   return (
@@ -35,11 +42,13 @@ export const EuiToggle = ({
       {...rest}
     >
       <input
-        className="euiToggle__input"
+        className={inputClasses}
         id={id}
+        name={name}
+        value={value}
         type={typeToInputTypeMap[type]}
         checked={checked}
-        disabled={disabled}
+        disabled={isDisabled}
         onChange={onChange}
         aria-label={label}
       />
@@ -62,7 +71,7 @@ EuiToggle.propTypes = {
    * For handling the onChange event of the input
    */
   onChange: PropTypes.func,
-  disabled: PropTypes.bool,
+  isDisabled: PropTypes.bool,
 
   /**
    * Use your own logic to pass the child you want according to
@@ -78,7 +87,8 @@ EuiToggle.propTypes = {
   /**
    * What would typically be the input's label. Required for accessibility.
    */
-  label: PropTypes.string,
+  label: PropTypes.string.isRequired,
+  inputClassName: PropTypes.string,
 };
 
 EuiToggle.defaultProps = {

--- a/src/components/toggle/toggle.js
+++ b/src/components/toggle/toggle.js
@@ -78,7 +78,7 @@ EuiToggle.propTypes = {
   /**
    * What would typically be the input's label. Required for accessibility.
    */
-  label: PropTypes.string.isRequired,
+  label: PropTypes.string,
 };
 
 EuiToggle.defaultProps = {

--- a/src/components/toggle/toggle.js
+++ b/src/components/toggle/toggle.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 const typeToInputTypeMap = {
-  'single': 'checkbox',
-  'multi': 'radio',
+  'single': 'radio',
+  'multi': 'checkbox',
 };
 
 export const TYPES = Object.keys(typeToInputTypeMap);;
@@ -92,5 +92,5 @@ EuiToggle.propTypes = {
 };
 
 EuiToggle.defaultProps = {
-  type: 'single',
+  type: 'multi',
 };

--- a/src/components/toggle/toggle.js
+++ b/src/components/toggle/toggle.js
@@ -11,16 +11,16 @@ export const TYPES = Object.keys(typeToInputTypeMap);;
 
 export const EuiToggle = ({
   id,
-  label,
-  checked,
-  isDisabled,
-  onChange,
-  children,
-  type,
-  name,
-  value,
   className,
+  checked,
+  children,
   inputClassName,
+  isDisabled,
+  label,
+  name,
+  onChange,
+  type,
+  value,
   ...rest,
 }) => {
   const classes = classNames(
@@ -42,15 +42,15 @@ export const EuiToggle = ({
       {...rest}
     >
       <input
-        className={inputClasses}
         id={id}
-        name={name}
-        value={value}
-        type={typeToInputTypeMap[type]}
+        className={inputClasses}
+        aria-label={label}
         checked={checked}
         disabled={isDisabled}
+        name={name}
         onChange={onChange}
-        aria-label={label}
+        type={typeToInputTypeMap[type]}
+        value={value}
       />
 
       {children}
@@ -75,12 +75,12 @@ EuiToggle.propTypes = {
 
   /**
    * Use your own logic to pass the child you want according to
-   * the checked state of your component.
+   * the checked state of your component
    */
   children: PropTypes.node,
 
   /**
-   * Determines the input type based on multiple or single item(s).
+   * Determines the input type based on multiple or single item(s)
    */
   type: PropTypes.oneOf(TYPES),
 
@@ -88,6 +88,10 @@ EuiToggle.propTypes = {
    * What would typically be the input's label. Required for accessibility.
    */
   label: PropTypes.string.isRequired,
+
+  /**
+   * Additional classNames for the input itself
+   */
   inputClassName: PropTypes.string,
 };
 

--- a/src/components/toggle/toggle.js
+++ b/src/components/toggle/toggle.js
@@ -21,7 +21,7 @@ export const EuiToggle = ({
   );
 
   return (
-    <div className={classes}>
+    <span className={classes}>
       <input
         className="euiToggle__input"
         name={name}
@@ -33,7 +33,7 @@ export const EuiToggle = ({
       />
 
       {children}
-    </div>
+    </span>
   );
 };
 

--- a/src/components/toggle/toggle.js
+++ b/src/components/toggle/toggle.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+export const EuiToggle = ({
+  id,
+  name,
+  checked,
+  disabled,
+  onChange,
+  children,
+  className
+}) => {
+  const classes = classNames(
+    'euiToggle',
+    {
+      'euiToggle--disabled': disabled,
+      'euiToggle--checked': checked,
+    },
+    className
+  );
+
+  return (
+    <div className={classes}>
+      <input
+        className="euiToggle__input"
+        name={name}
+        id={id}
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={onChange}
+      />
+
+      {children}
+    </div>
+  );
+};
+
+EuiToggle.propTypes = {
+  name: PropTypes.string,
+  id: PropTypes.string,
+  checked: PropTypes.bool,
+  onChange: PropTypes.func,
+  disabled: PropTypes.bool,
+  children: PropTypes.node,
+};

--- a/src/components/toggle/toggle.js
+++ b/src/components/toggle/toggle.js
@@ -4,12 +4,13 @@ import classNames from 'classnames';
 
 export const EuiToggle = ({
   id,
-  name,
+  label,
   checked,
   disabled,
   onChange,
   children,
-  className
+  className,
+  ...rest,
 }) => {
   const classes = classNames(
     'euiToggle',
@@ -21,27 +22,40 @@ export const EuiToggle = ({
   );
 
   return (
-    <span className={classes}>
+    <span
+      className={classes}
+      {...rest}
+    >
       <input
         className="euiToggle__input"
-        name={name}
         id={id}
         type="checkbox"
         checked={checked}
         disabled={disabled}
         onChange={onChange}
+        aria-label={label}
       />
 
       {children}
+
     </span>
   );
 };
 
 EuiToggle.propTypes = {
-  name: PropTypes.string,
   id: PropTypes.string,
   checked: PropTypes.bool,
   onChange: PropTypes.func,
   disabled: PropTypes.bool,
+
+  /**
+   * Use your own logic to pass the child you want according to
+   * the checked state of your component.
+   */
   children: PropTypes.node,
+
+  /**
+   * Required for accessibility.
+   */
+  label: PropTypes.string.isRequired,
 };

--- a/src/components/toggle/toggle.js
+++ b/src/components/toggle/toggle.js
@@ -2,6 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+const typeToInputTypeMap = {
+  'single': 'checkbox',
+  'multi': 'radio',
+};
+
+export const TYPES = Object.keys(typeToInputTypeMap);;
+
 export const EuiToggle = ({
   id,
   label,
@@ -9,7 +16,7 @@ export const EuiToggle = ({
   disabled,
   onChange,
   children,
-  containsButton,
+  type,
   className,
   ...rest,
 }) => {
@@ -18,37 +25,42 @@ export const EuiToggle = ({
     {
       'euiToggle--disabled': disabled,
       'euiToggle--checked': checked,
-      'euiToggle--containsButton': containsButton,
     },
     className
   );
 
-  const childrenNode = containsButton ? React.cloneElement(children, { tabIndex: -1 }) : children;
-
   return (
-    <span
+    <div
       className={classes}
       {...rest}
     >
       <input
         className="euiToggle__input"
         id={id}
-        type="checkbox"
+        type={typeToInputTypeMap[type]}
         checked={checked}
         disabled={disabled}
         onChange={onChange}
         aria-label={label}
       />
 
-      {childrenNode}
+      {children}
 
-    </span>
+    </div>
   );
 };
 
 EuiToggle.propTypes = {
   id: PropTypes.string,
+
+  /**
+   * Initial state of the toggle
+   */
   checked: PropTypes.bool,
+
+  /**
+   * For handling the onChange event of the input
+   */
   onChange: PropTypes.func,
   disabled: PropTypes.bool,
 
@@ -56,16 +68,19 @@ EuiToggle.propTypes = {
    * Use your own logic to pass the child you want according to
    * the checked state of your component.
    */
-  children: PropTypes.node,
+  children: PropTypes.element,
 
   /**
-   * Use your own logic to pass the child you want according to
-   * the checked state of your component.
+   * Determines the input type based on multiple or single item(s).
    */
-  containsButton: PropTypes.bool,
+  type: PropTypes.oneOf(TYPES),
 
   /**
-   * Required for accessibility.
+   * What would typically be the input's label. Required for accessibility.
    */
   label: PropTypes.string.isRequired,
+};
+
+EuiToggle.defaultProps = {
+  type: 'single',
 };

--- a/src/components/toggle/toggle.js
+++ b/src/components/toggle/toggle.js
@@ -68,7 +68,7 @@ EuiToggle.propTypes = {
    * Use your own logic to pass the child you want according to
    * the checked state of your component.
    */
-  children: PropTypes.element,
+  children: PropTypes.node,
 
   /**
    * Determines the input type based on multiple or single item(s).

--- a/src/components/toggle/toggle.js
+++ b/src/components/toggle/toggle.js
@@ -9,6 +9,7 @@ export const EuiToggle = ({
   disabled,
   onChange,
   children,
+  containsButton,
   className,
   ...rest,
 }) => {
@@ -17,9 +18,12 @@ export const EuiToggle = ({
     {
       'euiToggle--disabled': disabled,
       'euiToggle--checked': checked,
+      'euiToggle--containsButton': containsButton,
     },
     className
   );
+
+  const childrenNode = containsButton ? React.cloneElement(children, { tabIndex: -1 }) : children;
 
   return (
     <span
@@ -36,7 +40,7 @@ export const EuiToggle = ({
         aria-label={label}
       />
 
-      {children}
+      {childrenNode}
 
     </span>
   );
@@ -53,6 +57,12 @@ EuiToggle.propTypes = {
    * the checked state of your component.
    */
   children: PropTypes.node,
+
+  /**
+   * Use your own logic to pass the child you want according to
+   * the checked state of your component.
+   */
+  containsButton: PropTypes.bool,
 
   /**
    * Required for accessibility.

--- a/src/components/toggle/toggle.test.js
+++ b/src/components/toggle/toggle.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from 'enzyme';
+import { requiredProps } from '../../test';
+
+import { EuiToggle } from './toggle';
+
+describe('EuiToggle', () => {
+  test('is rendered', () => {
+    const component = render(
+      <EuiToggle {...requiredProps} />
+    );
+
+    expect(component)
+      .toMatchSnapshot();
+  });
+});

--- a/src/components/toggle/toggle.test.js
+++ b/src/components/toggle/toggle.test.js
@@ -7,7 +7,7 @@ import { EuiToggle } from './toggle';
 describe('EuiToggle', () => {
   test('is rendered', () => {
     const component = render(
-      <EuiToggle {...requiredProps} />
+      <EuiToggle label="Is toggle on?" {...requiredProps} />
     );
 
     expect(component)


### PR DESCRIPTION
This PR creates three different components:

1. `EuiToggle`: A generic toggling component that just overlays a checkbox (or radio) on top of the child supplied and listens for changes on this input.
2. `EuiButtonToggle`: Since supplying a standard `EuiButton` to the `EuiToggle` component doesn't allow for pointer events on the actual button, this component adds some extra styles to simulate the same behavior but based on the pointer events on the input instead.
<img src="https://d.pr/free/i/Vg5wTQ+" />

3. `EuiButtonGroup`: A group of `EuiButtonToggle`s that can either allow only one selection or multiple. It also has some extra specific styles as well.
<img src="https://d.pr/free/i/2Vwf7N+" />

### Accessibility
Since each toggle is essentially just a checkbox (or radio), it requires a `label` which is added to the input via `aria-label` and this is what is read by the voiceover.

I also had to add `tabIndex="-1"` to the `<button>` element so that tabbing doesn't jump from input to button which doubles up on label reading.

### Browser checks
- [ ] Mac ,Chrome
- [ ] Mac, FF
- [ ] Mac, Safari
- [ ] Windows 8, Edge 

Fixes #293 #841 
