### PR TITLE
refactored EuiSearchBox and EuiPopover to use React 16.3 lifecycle

### DIFF
--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -32,6 +32,28 @@ const anchorPositionToClassNameMap = {
 export const ANCHOR_POSITIONS = Object.keys(anchorPositionToClassNameMap);
 
 export class EuiPopover extends Component {
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (prevState.prevProps.isOpen && !nextProps.isOpen) {
+      return {
+        prevProps: {
+          isOpen: nextProps.isOpen
+        },
+        isClosing: true,
+        isOpening: false,
+      };
+    }
+
+    if (prevState.prevProps.isOpen !== nextProps.isOpen) {
+      return {
+        prevProps: {
+          isOpen: nextProps.isOpen
+        }
+      };
+    }
+
+    return null;
+  }
+  
   constructor(props) {
     super(props);
 
@@ -103,28 +125,6 @@ export class EuiPopover extends Component {
     }
 
     this.updateFocus();
-  }
-
-  static getDerivedStateFromProps(nextProps, prevState) {
-    if (prevState.prevProps.isOpen && !nextProps.isOpen) {
-      return {
-        prevProps: {
-          isOpen: nextProps.isOpen
-        },
-        isClosing: true,
-        isOpening: false,
-      };
-    }
-
-    if (prevState.prevProps.isOpen !== nextProps.isOpen) {
-      return {
-        prevProps: {
-          isOpen: nextProps.isOpen
-        }
-      };
-    }
-
-    return null;
   }
 
   componentWillUnmount() {

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -38,6 +38,9 @@ export class EuiPopover extends Component {
     this.closingTransitionTimeout = undefined;
 
     this.state = {
+      prevProps: {
+        isOpen: props.isOpen
+      },
       isClosing: false,
       isOpening: false,
     };
@@ -75,10 +78,9 @@ export class EuiPopover extends Component {
     this.updateFocus();
   }
 
-  // TODO: React 16.3 - componentDidUpdate
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     // The popover is being opened.
-    if (!this.props.isOpen && nextProps.isOpen) {
+    if (!prevProps.isOpen && this.props.isOpen) {
       clearTimeout(this.closingTransitionTimeout);
       // We need to set this state a beat after the render takes place, so that the CSS
       // transition can take effect.
@@ -90,24 +92,39 @@ export class EuiPopover extends Component {
     }
 
     // The popover is being closed.
-    if (this.props.isOpen && !nextProps.isOpen) {
+    if (prevProps.isOpen && !this.props.isOpen) {
       // If the user has just closed the popover, queue up the removal of the content after the
       // transition is complete.
-      this.setState({
-        isClosing: true,
-        isOpening: false,
-      });
-
       this.closingTransitionTimeout = setTimeout(() => {
         this.setState({
           isClosing: false,
         });
       }, 250);
     }
+
+    this.updateFocus();
   }
 
-  componentDidUpdate() {
-    this.updateFocus();
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (prevState.prevProps.isOpen && !nextProps.isOpen) {
+      return {
+        prevProps: {
+          isOpen: nextProps.isOpen
+        },
+        isClosing: true,
+        isOpening: false,
+      };
+    }
+
+    if (prevState.prevProps.isOpen !== nextProps.isOpen) {
+      return {
+        prevProps: {
+          isOpen: nextProps.isOpen
+        }
+      };
+    }
+
+    return null;
   }
 
   componentWillUnmount() {

--- a/src/components/search_bar/search_box.js
+++ b/src/components/search_bar/search_box.js
@@ -33,11 +33,8 @@ export class EuiSearchBox extends Component {
     super(props);
   }
 
-  // TODO: React 16.3 - shouldn't `query` be passed to EuiFieldSearch's value?
-  // (and possibly remove `inputRef` from EuiFieldSearch)
-  // if that doesn't work, componentDidUpdate
-  componentWillUpdate(nextProps) {
-    this.inputElement.value = nextProps.query;
+  componentDidUpdate() {
+    this.inputElement.value = this.props.query;
   }
 
   render() {


### PR DESCRIPTION
Part of #763 

- changed `EuiSearchBox`'s `componentWillUpdate` to `componentDidUpdate`.
- merged `EuiPopOver`'s `componentWillUpdate` into its existing `componentDidUpdate` and split some of it out into `getDerivedStateFromProps` (mostly because the no-setstate-in-componentdidupdate lint rule which is hilariously skirted around by the rest of this `componentDidUpdate`).