### PR TITLE
Fixed alignment of breadcrumb slashes when truncating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Added FF/IE fallback for `.eui-textBreakWord` ([#864](https://github.com/elastic/eui/pull/864))
 - Fixed `EuiCard` description text color when used in/as an anchor tag ([#864](https://github.com/elastic/eui/pull/864))
 - Fixed `EuiCard` IE bugs ([#864](https://github.com/elastic/eui/pull/864))
+- Fixed `EuiBreadcrumb` slash alignment when truncating ([#878](https://github.com/elastic/eui/pull/878))
 
 ## [`0.0.49`](https://github.com/elastic/eui/tree/v0.0.49)
 

--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -70,5 +70,6 @@
     max-width: 150px;
     text-overflow: ellipsis;
     overflow: hidden;
+    vertical-align: top; // overflow hidden causes misalignment of links and slashes, this fixes that
   }
 }


### PR DESCRIPTION
Before and after:

<img src="https://d.pr/free/i/tZi5FK+" />