### PR TITLE
Remove loose and in flex group

### DIFF
--- a/src/components/flex/_flex_group.scss
+++ b/src/components/flex/_flex_group.scss
@@ -26,7 +26,7 @@ $gutterTypes: (
 @each $gutterName, $gutterSize in $gutterTypes {
   $halfGutterSize: $gutterSize * 0.5;
 
-  &.euiFlexGroup--#{$gutterName} {
+  .euiFlexGroup--#{$gutterName} {
     margin: -$halfGutterSize;
 
     & > .euiFlexItem {


### PR DESCRIPTION
The `&` used in the flex group sass didn't have a parent. Apparently this was causing problems with @zumwalt's libsass compile. This should be an overall non-change.