### PR TITLE
Reverse description lists

### DIFF
--- a/src-docs/src/views/description_list/description_list_example.js
+++ b/src-docs/src/views/description_list/description_list_example.js
@@ -27,6 +27,10 @@ import DescriptionListInline from './description_list_inline';
 const descriptionListInlineSource = require('!!raw-loader!./description_list_inline');
 const descriptionListInlineHtml = renderToHtml(DescriptionListInline);
 
+import DescriptionListReverse from './description_list_reverse';
+const descriptionListReverseSource = require('!!raw-loader!./description_list_reverse');
+const descriptionListReverseHtml = renderToHtml(DescriptionListReverse);
+
 export const DescriptionListExample = {
   title: 'Description List',
   sections: [{
@@ -48,6 +52,28 @@ export const DescriptionListExample = {
     ),
     props: { EuiDescriptionList },
     demo: <DescriptionList />,
+  }, {
+    title: 'Reverse style',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: descriptionListReverseSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: descriptionListReverseHtml,
+    }],
+    text: (
+      <div>
+        <p>
+          Setting the <EuiCode>textStyle</EuiCode> prop to <EuiCode>reverse</EuiCode> will reverse
+          the text styles of the <EuiCode>title</EuiCode> and <EuiCode>description</EuiCode> elements
+          so that the description is more prominent. This works best for key/value type content.
+        </p>
+        <p>
+          Adding this property to the <EuiCode>inline</EuiCode> type will not change anything.
+        </p>
+      </div>
+    ),
+    demo: <DescriptionListReverse />,
   }, {
     title: 'As columns',
     source: [{

--- a/src-docs/src/views/description_list/description_list_reverse.js
+++ b/src-docs/src/views/description_list/description_list_reverse.js
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import {
+  EuiDescriptionList,
+} from '../../../../src/components';
+
+const favoriteVideoGame = [
+  {
+    title: 'Name',
+    description: 'The Elder Scrolls: Morrowind',
+  },
+  {
+    title: 'Video game style',
+    description: 'Open-world, fantasy, action role-playing',
+  },
+  {
+    title: 'Release date',
+    description: '2002',
+  },
+];
+
+export default () => (
+  <EuiDescriptionList textStyle="reverse" listItems={favoriteVideoGame} />
+);

--- a/src-docs/src/views/description_list/description_list_reverse.js
+++ b/src-docs/src/views/description_list/description_list_reverse.js
@@ -10,7 +10,7 @@ const favoriteVideoGame = [
     description: 'The Elder Scrolls: Morrowind',
   },
   {
-    title: 'Video game style',
+    title: 'Game style',
     description: 'Open-world, fantasy, action role-playing',
   },
   {

--- a/src-docs/src/views/text/text.js
+++ b/src-docs/src/views/text/text.js
@@ -124,6 +124,29 @@ export default () => (
           The game that made me drop out of college.
         </dd>
       </dl>
+
+      <EuiHorizontalRule />
+
+      <dl className="eui-definitionListReverse">
+        <dt>
+          Name
+        </dt>
+        <dd>
+          The Elder Scrolls: Morrowind
+        </dd>
+        <dt>
+          Game style
+        </dt>
+        <dd>
+          Open-world, fantasy, action role-playing
+        </dd>
+        <dt>
+          Release date
+        </dt>
+        <dd>
+          2002
+        </dd>
+      </dl>
     </EuiText>
   </div>
 );

--- a/src/components/description_list/_description_list.scss
+++ b/src/components/description_list/_description_list.scss
@@ -25,6 +25,18 @@
       text-align: right;
     }
 
+    // Reversed makes the description larger than the title
+    &.euiDescriptionList--reverse {
+      .euiDescriptionList__title {
+        @include euiText;
+        @include euiFontSizeS;
+      }
+
+      .euiDescriptionList__description {
+        @include euiTitle("xs");
+      }
+    }
+
     // Compressed gets smaller fonts.
     &.euiDescriptionList--compressed {
 
@@ -34,6 +46,17 @@
 
       .euiDescriptionList__description {
         @include euiFontSizeS;
+      }
+
+      &.euiDescriptionList--reverse {
+        .euiDescriptionList__title {
+          @include euiText;
+          @include euiFontSizeS;
+        }
+
+        .euiDescriptionList__description {
+          @include euiTitle("xxs");
+        }
       }
     }
   }
@@ -73,6 +96,17 @@
       }
     }
 
+    &.euiDescriptionList--reverse {
+      .euiDescriptionList__title {
+        @include euiText;
+        @include euiFontSize;
+      }
+
+      .euiDescriptionList__description {
+        @include euiTitle("xs");
+      }
+    }
+
     &.euiDescriptionList--compressed {
 
       .euiDescriptionList__title {
@@ -81,6 +115,17 @@
 
       .euiDescriptionList__description {
         @include euiFontSizeS;
+      }
+
+      &.euiDescriptionList--reverse {
+        .euiDescriptionList__title {
+          @include euiText;
+          @include euiFontSizeS;
+        }
+
+        .euiDescriptionList__description {
+          @include euiTitle("xxs");
+        }
       }
     }
   }

--- a/src/components/description_list/description_list.js
+++ b/src/components/description_list/description_list.js
@@ -25,12 +25,20 @@ const alignmentsToClassNameMap = {
 
 export const ALIGNMENTS = Object.keys(alignmentsToClassNameMap);
 
+const textStylesToClassNameMap = {
+  normal: '',
+  reverse: 'euiDescriptionList--reverse',
+};
+
+export const TEXT_STYLES = Object.keys(textStylesToClassNameMap);
+
 export const EuiDescriptionList = ({
   children,
   className,
   listItems,
   align,
   compressed,
+  textStyle,
   type,
   ...rest
 }) => {
@@ -38,6 +46,7 @@ export const EuiDescriptionList = ({
     'euiDescriptionList',
     typesToClassNameMap[type],
     alignmentsToClassNameMap[align],
+    textStylesToClassNameMap[textStyle],
     {
       'euiDescriptionList--compressed': compressed,
     },
@@ -74,19 +83,38 @@ export const EuiDescriptionList = ({
 };
 
 EuiDescriptionList.propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
   listItems: PropTypes.arrayOf(PropTypes.shape({
     title: PropTypes.node,
     description: PropTypes.node,
   })),
-  compressed: PropTypes.bool,
-  type: PropTypes.oneOf(TYPES),
+  children: PropTypes.node,
+  className: PropTypes.string,
+
+  /**
+   * Text alignment
+   */
   align: PropTypes.oneOf(ALIGNMENTS),
+
+  /**
+   * Smaller text and condensed spacing
+   */
+  compressed: PropTypes.bool,
+
+  /**
+   * How should the content be styled, by default
+   * this will emphasize the title
+   */
+  textStyle: PropTypes.oneOf(TEXT_STYLES),
+
+  /**
+   * How each item should be layed out
+   */
+  type: PropTypes.oneOf(TYPES),
 };
 
 EuiDescriptionList.defaultProps = {
-  type: 'row',
   align: 'left',
   compressed: false,
+  textStyle: 'normal',
+  type: 'row',
 };

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -7,7 +7,6 @@
   ul,
   ol,
   dl,
-  dd,
   blockquote,
   img,
   pre {
@@ -30,6 +29,10 @@
   h5,
   h6 {
     margin-bottom: convertToRem($baseLineHeightMultiplier * 1);
+  }
+
+  dd + dt {
+    margin-top: convertToRem($baseLineHeightMultiplier * 2);
   }
 
   * + h2,
@@ -56,8 +59,14 @@
   }
 
   h4,
-  dt {
+  dt,
+  dl.eui-definitionListReverse dd {
     font-size: convertToRem($baseFontSize * nth($euiTextScale, 5)); // skip level 4 on purpose
+  }
+
+  dl.eui-definitionListReverse dt {
+    font-size: convertToRem($baseFontSize * nth($euiTextScale, 7));
+    color: $euiTextColor;
   }
 
   h5 {


### PR DESCRIPTION
The default of `normal` will display as is now. The new option, `reverse`, will reverse the style of the title and description to emphasize the description.

I purposefully did not alter the inline description list to use this reverse style as it didn't make sense the way that one is laid out. It seems counter to what that style accomplishes.

I also added a `.eui-definitionListReverse` class for `dl`s in `EuiText`.

<img width="629" alt="screen shot 2018-05-25 at 18 09 31 pm" src="https://user-images.githubusercontent.com/549577/40568646-e087197c-6049-11e8-8f99-0d2713367d2c.png">
