### PR TITLE
move EuiFieldSearch's and EuiValidateControl's ref creation out of re…

### DIFF
--- a/src/components/form/field_search/field_search.js
+++ b/src/components/form/field_search/field_search.js
@@ -67,6 +67,13 @@ export class EuiFieldSearch extends Component {
     this.cleanups.forEach(cleanup => cleanup());
   }
 
+  setRef = inputElement => {
+    this.inputElement = inputElement;
+    if (this.props.inputRef) {
+      this.props.inputRef(inputElement);
+    }
+  };
+
   onKeyUp = (incremental, onSearch, event) => {
     if (this.props.onKeyUp) {
       this.props.onKeyUp(event);
@@ -89,7 +96,7 @@ export class EuiFieldSearch extends Component {
       isInvalid,
       fullWidth,
       isLoading,
-      inputRef,
+      inputRef, // eslint-disable-line no-unused-vars
       incremental,
       compressed,
       onSearch,
@@ -105,15 +112,7 @@ export class EuiFieldSearch extends Component {
       className
     );
 
-    const ref = (inputElement) => {
-      this.inputElement = inputElement;
-      if (inputRef) {
-        inputRef(inputElement);
-      }
-    };
-
     return (
-
       <EuiFormControlLayout
         icon="search"
         fullWidth={fullWidth}
@@ -129,7 +128,7 @@ export class EuiFieldSearch extends Component {
             className={classes}
             value={value}
             onKeyUp={this.onKeyUp.bind(this, incremental, onSearch)}
-            ref={ref}
+            ref={this.setRef}
             {...rest}
           />
         </EuiValidatableControl>

--- a/src/components/form/validatable_control/validatable_control.js
+++ b/src/components/form/validatable_control/validatable_control.js
@@ -30,17 +30,22 @@ export class EuiValidatableControl extends Component {
     this.updateValidity();
   }
 
-  render() {
-    return cloneElement(this.props.children, {
-      ref: node => {
-        this.control = node;
+  setRef = node => {
+    this.control = node;
 
-        // Call the original ref, if any
-        const { ref } = this.props.children;
-        if (typeof ref === 'function') {
-          ref(node);
-        }
-      },
-    });
+    // Call the original ref, if any
+    const { ref } = this.props.children;
+    if (typeof ref === 'function') {
+      ref(node);
+    }
+  }
+
+  render() {
+    return cloneElement(
+      this.props.children,
+      {
+        ref: this.setRef,
+      }
+    );
   }
 }


### PR DESCRIPTION
Fixes #877 

Turns out React calls a given `ref` function if it is a different function than the previous `ref`. This degrades developer experience and potentially app performance if the `ref` function is created in a component's render method. This behaviour was observed in in `EuiFieldSearch`, whose render path created new ref functions in two different places, I moved these to setRef class methods instead.