### PR TITLE
Update context menu components to React 16.3 lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ No public changes since 0.0.50
 
 **Bug fixes**
 
+- `EuiContextMenuPanel` now updates appropriately if its items are modified ([#887](https://github.com/elastic/eui/pull/887))
 - `EuiComboBox` is no longer a focus trap, the clear button is now keyboard-accessible, and the virtualized list no longer interferes with the tab order ([#866](https://github.com/elastic/eui/pull/866))
 - `EuiButton`, `EuiButtonEmpty`, and `EuiButtonIcon` now look and behave disabled when `isDisabled={true}` ([#862](https://github.com/elastic/eui/pull/862))
 - `EuiGlobalToastList` no longer triggers `Uncaught TypeError: _this.callback is not a function`  ([#865](https://github.com/elastic/eui/pull/865))

--- a/src-docs/src/views/context_menu/content_panel.js
+++ b/src-docs/src/views/context_menu/content_panel.js
@@ -1,0 +1,61 @@
+import React, {
+  Component,
+} from 'react';
+
+import {
+  EuiButton,
+  EuiContextMenuPanel,
+  EuiPopover,
+} from '../../../../src/components';
+
+export default class extends Component {
+  constructor(props) {
+    super(props);
+
+    this.interval = undefined;
+
+    this.state = {
+      isPopoverOpen: false,
+    };
+  }
+
+  onButtonClick = () => {
+    this.setState(prevState => ({
+      isPopoverOpen: !prevState.isPopoverOpen
+    }));
+  };
+
+  closePopover = () => {
+    this.setState({
+      isPopoverOpen: false,
+    });
+  };
+
+  render() {
+    const button = (
+      <EuiButton
+        size="s"
+        iconType="arrowDown"
+        iconSide="right"
+        onClick={this.onButtonClick}
+      >
+        Click to show some content
+      </EuiButton>
+    );
+
+    return (
+      <EuiPopover
+        id="contentPanel"
+        button={button}
+        isOpen={this.state.isPopoverOpen}
+        closePopover={this.closePopover}
+        panelPaddingSize="s"
+        anchorPosition="downLeft"
+      >
+        <EuiContextMenuPanel>
+            This context menu doesn&#39;t render items, it passes a child instead.
+        </EuiContextMenuPanel>
+      </EuiPopover>
+    );
+  }
+}

--- a/src-docs/src/views/context_menu/context_menu_example.js
+++ b/src-docs/src/views/context_menu/context_menu_example.js
@@ -21,6 +21,14 @@ import SinglePanel from './single_panel';
 const singlePanelSource = require('!!raw-loader!./single_panel');
 const singlePanelHtml = renderToHtml(SinglePanel);
 
+import ContentPanel from './content_panel';
+const contentPanelSource = require('!!raw-loader!./content_panel');
+const contentPanelHtml = renderToHtml(ContentPanel);
+
+import ContextMenuWithContent from './context_menu_with_content';
+const contextMenuWithContentSource = require('!!raw-loader!./context_menu_with_content');
+const contextMenuWithContentHtml = renderToHtml(ContextMenuWithContent);
+
 export const ContextMenuExample = {
   title: 'Context Menu',
   sections: [{
@@ -56,5 +64,38 @@ export const ContextMenuExample = {
       </p>
     ),
     demo: <SinglePanel />,
+  }, {
+    title: `Displaying custom elements`,
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: contentPanelSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: contentPanelHtml,
+    }],
+    text: (
+      <p>
+        If you have custom content to show instead of a list of options,
+        you can pass a React element as a child to <EuiCode>EuiContextMenuPanel</EuiCode>.
+      </p>
+    ),
+    demo: <ContentPanel />,
+  }, {
+    title: `Using panels with mixed items & content`,
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: contextMenuWithContentSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: contextMenuWithContentHtml,
+    }],
+    text: (
+      <p>
+        Context menu panels can be passed React elements through the
+        <EuiCode>content</EuiCode> prop instead of <EuiCode>items</EuiCode>. The panel
+        will display your custom content without modification.
+      </p>
+    ),
+    demo: <ContextMenuWithContent />,
   }],
 };

--- a/src-docs/src/views/context_menu/context_menu_with_content.js
+++ b/src-docs/src/views/context_menu/context_menu_with_content.js
@@ -1,0 +1,111 @@
+import React, {
+  Component,
+} from 'react';
+
+import {
+  EuiButton,
+  EuiContextMenu,
+  EuiIcon,
+  EuiPopover,
+  EuiPanel,
+  EuiCard
+} from '../../../../src/components';
+
+function flattenPanelTree(tree, array = []) {
+  array.push(tree);
+
+  if (tree.items) {
+    tree.items.forEach(item => {
+      if (item.panel) {
+        flattenPanelTree(item.panel, array);
+        item.panel = item.panel.id;
+      }
+    });
+  }
+
+  return array;
+}
+
+export default class extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isPopoverOpen: false,
+    };
+
+    const panelTree = {
+      id: 0,
+      title: 'View options',
+      items: [{
+        name: 'Show fullscreen',
+        icon: (
+          <EuiIcon
+            type="search"
+            size="m"
+          />
+        ),
+        onClick: () => { this.closePopover(); window.alert('Show fullscreen'); },
+      }, {
+        name: 'See more',
+        icon: 'plusInCircle',
+        panel: {
+          id: 1,
+          title: 'See more',
+          content: (
+            <EuiPanel>
+              <EuiCard
+                icon={<EuiIcon size="l" type="bolt" />}
+                title="More Details"
+                description="This menu demonstrates using panels that have items and panels with content."
+              />
+            </EuiPanel>
+          )
+        },
+      }],
+    };
+
+    this.panels = flattenPanelTree(panelTree);
+  }
+
+  onButtonClick = () => {
+    this.setState(prevState => ({
+      isPopoverOpen: !prevState.isPopoverOpen,
+    }));
+  };
+
+  closePopover = () => {
+    this.setState({
+      isPopoverOpen: false,
+    });
+  };
+
+  render() {
+    const button = (
+      <EuiButton
+        iconType="arrowDown"
+        iconSide="right"
+        onClick={this.onButtonClick}
+      >
+        Click me to load mixed content menu
+      </EuiButton>
+    );
+
+    return (
+      <EuiPopover
+        id="contextMenu"
+        button={button}
+        isOpen={this.state.isPopoverOpen}
+        closePopover={this.closePopover}
+        panelPaddingSize="none"
+        withTitle
+        anchorPosition="upLeft"
+      >
+        <EuiContextMenu
+          initialPanelId={0}
+          panels={this.panels}
+        />
+      </EuiPopover>
+    );
+  }
+}

--- a/src/components/context_menu/context_menu_panel.js
+++ b/src/components/context_menu/context_menu_panel.js
@@ -233,21 +233,6 @@ export class EuiContextMenuPanel extends Component {
     return null;
   }
 
-  // // TODO: React 16.3 - componentDidUpdate & getDerivedStateFromProps; alternatively refactor
-  // // this.menuItems into state and only use getDerivedStateFromProps
-  // componentWillReceiveProps(nextProps) {
-  //   // Clear refs to menuItems if we're getting new ones.
-  //   if (nextProps.items !== this.props.items) {
-  //     this.menuItems = [];
-  //   }
-  //
-  //   if (nextProps.transitionType) {
-  //     this.setState({
-  //       isTransitioning: true,
-  //     });
-  //   }
-  // }
-
   getWatchedPropsForItems(items) {
     // This lets us compare prevProps and nextProps among items so we can re-render if our items
     // have changed.


### PR DESCRIPTION
Associated with #763 

* Refactored `EuiContextMenu` and `EuiContextMenuPanel` to React 16.3's lifecycle. This moves computed values in both components off of instance members and into React's state.
* Added 2 more examples to context menu docs
* Fixed some lurking bugs around allowing dynamic content in the menu panels