### PR TITLE
add .nvmrc .idea .vscode to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,12 +6,15 @@ wiki/
 generator-eui/
 test/
 src-docs/
+.nvmrc
 
 # ignore everything in `scripts` except postinstall.js
 scripts/!(postinstall.js)
 
 .DS_Store
 .eslintcache
+.idea
+.vscode
 .yo-rc.json
 package-lock.json
 npm-debug.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public facing changes since `0.0.51`
+- Removed `.nvmrc` file from published npm package ([#892](https://github.com/elastic/eui/pull/892))
 
 ## [`0.0.51`](https://github.com/elastic/eui/tree/v0.0.51)
 


### PR DESCRIPTION
Fixes #891 by preventing the `.nvmrc` file from being included in the published npm package. I also added entries to keep `.idea` and `.vscode` configurations out of the package (they're already excluded in `.gitignore`)