### PR TITLE
Fix focus state regression of icons in EuiFormControlLayout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 - Added `restrictWidth` to `EuiPage` ([#896](https://github.com/elastic/eui/pull/896))
 
 **Bug fixes**
+
 - Removed `.nvmrc` file from published npm package ([#892](https://github.com/elastic/eui/pull/892))
 - `EuiComboBox` no longer shows the _clear_ icon when it's a no-op ([#890](https://github.com/elastic/eui/pull/890))
 - `EuiIcon` no longer takes focus in Edge and IE unless `tabIndex` is defined as a value other than `"-1"` ([#900](https://github.com/elastic/eui/pull/900))
+- Fixed regression introduced in `0.0.50` in which the form control icons blocked users from clicking the control ([#898](https://github.com/elastic/eui/pull/898))
 
 ## [`0.0.51`](https://github.com/elastic/eui/tree/v0.0.51)
 
@@ -16,9 +18,11 @@
 
 **Bug fixes**
 
-- Moved `EuiFieldSearch`'s and `EuiValidateControl`'s ref out of render into setClass methods. ([#883](https://github.com/elastic/eui/pull/883))
+- Moved `EuiFieldSearch`'s and `EuiValidateControl`'s ref out of render into `setRef` methods. ([#883](https://github.com/elastic/eui/pull/883))
 
 ## [`0.0.50`](https://github.com/elastic/eui/tree/v0.0.50)
+
+**Note: this release creates a minor regression to form controls containing icons, in which the icon blocks the user from clicking the control.**
 
 - Created `EuiToggle`, `EuiButtonToggle`, and `EuiButtonGroup` ([#872](https://github.com/elastic/eui/pull/872))
 - `EuiBasicTable` and `EuiInMemoryTable` now accept `rowProps` and `cellProps` callbacks,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ## [`0.0.50`](https://github.com/elastic/eui/tree/v0.0.50)
 
-**Note: this release creates a minor regression to form controls containing icons, in which the icon blocks the user from clicking the control.**
+**Note: this release creates a minor regression to form controls containing icons, in which the icon blocks the user from clicking the control. This is fixed in `0.0.52`.**
 
 - Created `EuiToggle`, `EuiButtonToggle`, and `EuiButtonGroup` ([#872](https://github.com/elastic/eui/pull/872))
 - `EuiBasicTable` and `EuiInMemoryTable` now accept `rowProps` and `cellProps` callbacks,

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -110,7 +110,7 @@
         position: absolute;
         top: $euiSizeM/2;
         right: $euiSizeM;
-        @include euiFormControlLayout__clear('.euiFilePicker__clearIcon');
+        @include euiFormControlLayoutClearIcon('.euiFilePicker__clearIcon');
       }
     }
   }

--- a/src/components/form/form_control_layout/__snapshots__/form_control_layout.test.js.snap
+++ b/src/components/form/form_control_layout/__snapshots__/form_control_layout.test.js.snap
@@ -60,26 +60,30 @@ exports[`EuiFormControlLayout props icon is rendered as a string 1`] = `
   <div
     class="euiFormControlLayoutIcons"
   >
-    <svg
-      aria-hidden="true"
-      class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon"
-      focusable="false"
-      height="16"
-      viewBox="0 0 16 16"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
+    <span
+      class="euiFormControlLayoutCustomIcon"
     >
-      <g
-        fill-rule="evenodd"
+      <svg
+        aria-hidden="true"
+        class="euiIcon euiIcon--medium"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <path
-          d="M7.5 2.236L1.618 14h11.764L7.5 2.236zm.894-.447l5.882 11.764A1 1 0 0 1 13.382 15H1.618a1 1 0 0 1-.894-1.447L6.606 1.789a1 1 0 0 1 1.788 0z"
-        />
-        <path
-          d="M7 6h1v5H7zM7 12h1v1H7z"
-        />
-      </g>
-    </svg>
+        <g
+          fill-rule="evenodd"
+        >
+          <path
+            d="M7.5 2.236L1.618 14h11.764L7.5 2.236zm.894-.447l5.882 11.764A1 1 0 0 1 13.382 15H1.618a1 1 0 0 1-.894-1.447L6.606 1.789a1 1 0 0 1 1.788 0z"
+          />
+          <path
+            d="M7 6h1v5H7zM7 12h1v1H7z"
+          />
+        </g>
+      </svg>
+    </span>
   </div>
 </div>
 `;
@@ -91,27 +95,31 @@ exports[`EuiFormControlLayout props icon is rendered as an object 1`] = `
   <div
     class="euiFormControlLayoutIcons"
   >
-    <svg
-      aria-hidden="true"
-      class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon customClass"
+    <span
+      class="euiFormControlLayoutCustomIcon customClass"
       data-test-subj="myIcon"
-      focusable="false"
-      height="16"
-      viewBox="0 0 16 16"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
     >
-      <g
-        fill-rule="evenodd"
+      <svg
+        aria-hidden="true"
+        class="euiIcon euiIcon--medium"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <path
-          d="M7.5 2.236L1.618 14h11.764L7.5 2.236zm.894-.447l5.882 11.764A1 1 0 0 1 13.382 15H1.618a1 1 0 0 1-.894-1.447L6.606 1.789a1 1 0 0 1 1.788 0z"
-        />
-        <path
-          d="M7 6h1v5H7zM7 12h1v1H7z"
-        />
-      </g>
-    </svg>
+        <g
+          fill-rule="evenodd"
+        >
+          <path
+            d="M7.5 2.236L1.618 14h11.764L7.5 2.236zm.894-.447l5.882 11.764A1 1 0 0 1 13.382 15H1.618a1 1 0 0 1-.894-1.447L6.606 1.789a1 1 0 0 1 1.788 0z"
+          />
+          <path
+            d="M7 6h1v5H7zM7 12h1v1H7z"
+          />
+        </g>
+      </svg>
+    </span>
   </div>
 </div>
 `;
@@ -123,26 +131,30 @@ exports[`EuiFormControlLayout props icon side left is rendered 1`] = `
   <div
     class="euiFormControlLayoutIcons"
   >
-    <svg
-      aria-hidden="true"
-      class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon"
-      focusable="false"
-      height="16"
-      viewBox="0 0 16 16"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
+    <span
+      class="euiFormControlLayoutCustomIcon"
     >
-      <g
-        fill-rule="evenodd"
+      <svg
+        aria-hidden="true"
+        class="euiIcon euiIcon--medium"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <path
-          d="M7.5 2.236L1.618 14h11.764L7.5 2.236zm.894-.447l5.882 11.764A1 1 0 0 1 13.382 15H1.618a1 1 0 0 1-.894-1.447L6.606 1.789a1 1 0 0 1 1.788 0z"
-        />
-        <path
-          d="M7 6h1v5H7zM7 12h1v1H7z"
-        />
-      </g>
-    </svg>
+        <g
+          fill-rule="evenodd"
+        >
+          <path
+            d="M7.5 2.236L1.618 14h11.764L7.5 2.236zm.894-.447l5.882 11.764A1 1 0 0 1 13.382 15H1.618a1 1 0 0 1-.894-1.447L6.606 1.789a1 1 0 0 1 1.788 0z"
+          />
+          <path
+            d="M7 6h1v5H7zM7 12h1v1H7z"
+          />
+        </g>
+      </svg>
+    </span>
   </div>
 </div>
 `;
@@ -154,26 +166,30 @@ exports[`EuiFormControlLayout props icon side right is rendered 1`] = `
   <div
     class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
   >
-    <svg
-      aria-hidden="true"
-      class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon"
-      focusable="false"
-      height="16"
-      viewBox="0 0 16 16"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
+    <span
+      class="euiFormControlLayoutCustomIcon"
     >
-      <g
-        fill-rule="evenodd"
+      <svg
+        aria-hidden="true"
+        class="euiIcon euiIcon--medium"
+        focusable="false"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <path
-          d="M7.5 2.236L1.618 14h11.764L7.5 2.236zm.894-.447l5.882 11.764A1 1 0 0 1 13.382 15H1.618a1 1 0 0 1-.894-1.447L6.606 1.789a1 1 0 0 1 1.788 0z"
-        />
-        <path
-          d="M7 6h1v5H7zM7 12h1v1H7z"
-        />
-      </g>
-    </svg>
+        <g
+          fill-rule="evenodd"
+        >
+          <path
+            d="M7.5 2.236L1.618 14h11.764L7.5 2.236zm.894-.447l5.882 11.764A1 1 0 0 1 13.382 15H1.618a1 1 0 0 1-.894-1.447L6.606 1.789a1 1 0 0 1 1.788 0z"
+          />
+          <path
+            d="M7 6h1v5H7zM7 12h1v1H7z"
+          />
+        </g>
+      </svg>
+    </span>
   </div>
 </div>
 `;

--- a/src/components/form/form_control_layout/__snapshots__/form_control_layout.test.js.snap
+++ b/src/components/form/form_control_layout/__snapshots__/form_control_layout.test.js.snap
@@ -18,12 +18,12 @@ exports[`EuiFormControlLayout props clear onClick is rendered 1`] = `
     class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
   >
     <button
-      aria-label="Clear selections"
-      class="euiFormControlLayoutIcons__clearButton customClass"
+      aria-label="Clear input"
+      class="euiFormControlLayoutClearButton customClass"
       data-test-subj="clearButton"
     >
       <svg
-        class="euiIcon euiIcon--medium euiFormControlLayoutIcons__clearButtonIcon"
+        class="euiIcon euiIcon--medium euiFormControlLayoutClearButton__icon"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -62,7 +62,7 @@ exports[`EuiFormControlLayout props icon is rendered as a string 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="euiIcon euiIcon--medium euiFormControlLayoutIcons__customIcon"
+      class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -93,7 +93,7 @@ exports[`EuiFormControlLayout props icon is rendered as an object 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="euiIcon euiIcon--medium euiFormControlLayoutIcons__customIcon customClass"
+      class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon customClass"
       data-test-subj="myIcon"
       focusable="false"
       height="16"
@@ -125,7 +125,7 @@ exports[`EuiFormControlLayout props icon side left is rendered 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="euiIcon euiIcon--medium euiFormControlLayoutIcons__customIcon"
+      class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -156,7 +156,7 @@ exports[`EuiFormControlLayout props icon side right is rendered 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="euiIcon euiIcon--medium euiFormControlLayoutIcons__customIcon"
+      class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"

--- a/src/components/form/form_control_layout/__snapshots__/form_control_layout.test.js.snap
+++ b/src/components/form/form_control_layout/__snapshots__/form_control_layout.test.js.snap
@@ -15,15 +15,15 @@ exports[`EuiFormControlLayout props clear onClick is rendered 1`] = `
   class="euiFormControlLayout"
 >
   <div
-    class="euiFormControlLayout__icons euiFormControlLayout__icons--right"
+    class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
   >
     <button
       aria-label="Clear selections"
-      class="euiFormControlLayout__clear customClass"
+      class="euiFormControlLayoutIcons__clearButton customClass"
       data-test-subj="clearButton"
     >
       <svg
-        class="euiIcon euiIcon--medium euiFormControlLayout__clearIcon"
+        class="euiIcon euiIcon--medium euiFormControlLayoutIcons__clearButtonIcon"
         focusable="false"
         height="16"
         viewBox="0 0 16 16"
@@ -58,11 +58,11 @@ exports[`EuiFormControlLayout props icon is rendered as a string 1`] = `
   class="euiFormControlLayout"
 >
   <div
-    class="euiFormControlLayout__icons"
+    class="euiFormControlLayoutIcons"
   >
     <svg
       aria-hidden="true"
-      class="euiIcon euiIcon--medium euiFormControlLayout__icon"
+      class="euiIcon euiIcon--medium euiFormControlLayoutIcons__customIcon"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -89,11 +89,11 @@ exports[`EuiFormControlLayout props icon is rendered as an object 1`] = `
   class="euiFormControlLayout"
 >
   <div
-    class="euiFormControlLayout__icons"
+    class="euiFormControlLayoutIcons"
   >
     <svg
       aria-hidden="true"
-      class="euiIcon euiIcon--medium euiFormControlLayout__icon customClass"
+      class="euiIcon euiIcon--medium euiFormControlLayoutIcons__customIcon customClass"
       data-test-subj="myIcon"
       focusable="false"
       height="16"
@@ -121,11 +121,11 @@ exports[`EuiFormControlLayout props icon side left is rendered 1`] = `
   class="euiFormControlLayout"
 >
   <div
-    class="euiFormControlLayout__icons"
+    class="euiFormControlLayoutIcons"
   >
     <svg
       aria-hidden="true"
-      class="euiIcon euiIcon--medium euiFormControlLayout__icon"
+      class="euiIcon euiIcon--medium euiFormControlLayoutIcons__customIcon"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -152,11 +152,11 @@ exports[`EuiFormControlLayout props icon side right is rendered 1`] = `
   class="euiFormControlLayout"
 >
   <div
-    class="euiFormControlLayout__icons euiFormControlLayout__icons--right"
+    class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
   >
     <svg
       aria-hidden="true"
-      class="euiIcon euiIcon--medium euiFormControlLayout__icon"
+      class="euiIcon euiIcon--medium euiFormControlLayoutIcons__customIcon"
       focusable="false"
       height="16"
       viewBox="0 0 16 16"
@@ -183,7 +183,7 @@ exports[`EuiFormControlLayout props isLoading is rendered 1`] = `
   class="euiFormControlLayout"
 >
   <div
-    class="euiFormControlLayout__icons euiFormControlLayout__icons--right"
+    class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
   >
     <div
       class="euiLoadingSpinner euiLoadingSpinner--medium"

--- a/src/components/form/form_control_layout/_form_control_layout.scss
+++ b/src/components/form/form_control_layout/_form_control_layout.scss
@@ -6,53 +6,9 @@
 
   display: inline-block;
   position: relative;
+}
 
-  &.euiFormControlLayout--fullWidth {
-    width: 100%;
-    max-width: 100%;
-  }
-
-  .euiFormControlLayout__icon {
-    pointer-events: none;
-  }
-
-  .euiFormControlLayout__icon--button {
-    pointer-events: all;
-    height: $euiSize;
-    width: $euiSize;
-    @include size($euiSize);
-
-    .euiIcon {
-      vertical-align: baseline;
-    }
-
-    &:focus {
-      background: $euiColorPrimary;
-      border-radius: 100%;
-      color: $euiColorGhost;
-    }
-  }
-
-  .euiFormControlLayout__icons {
-    pointer-events: none;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: $euiFormControlPadding;
-    display: flex;
-    align-items: center;
-
-    > * + * {
-      margin-left: $euiFormControlPadding;
-    }
-  }
-
-  .euiFormControlLayout__icons--right {
-    left: auto;
-    right: $euiFormControlPadding;
-  }
-
-  .euiFormControlLayout__clear {
-    @include euiFormControlLayout__clear('.euiFormControlLayout__clearIcon');
-  }
+.euiFormControlLayout--fullWidth {
+  width: 100%;
+  max-width: 100%;
 }

--- a/src/components/form/form_control_layout/_form_control_layout.scss
+++ b/src/components/form/form_control_layout/_form_control_layout.scss
@@ -34,6 +34,7 @@
   }
 
   .euiFormControlLayout__icons {
+    pointer-events: none;
     position: absolute;
     top: 0;
     bottom: 0;

--- a/src/components/form/form_control_layout/_form_control_layout_clear_button.scss
+++ b/src/components/form/form_control_layout/_form_control_layout_clear_button.scss
@@ -1,0 +1,3 @@
+.euiFormControlLayoutClearButton {
+  @include euiFormControlLayoutClearIcon('.euiFormControlLayoutClearButton__icon');
+}

--- a/src/components/form/form_control_layout/_form_control_layout_custom_icon.scss
+++ b/src/components/form/form_control_layout/_form_control_layout_custom_icon.scss
@@ -1,0 +1,20 @@
+.euiFormControlLayoutCustomIcon {
+  pointer-events: none;
+}
+
+.euiFormControlLayoutCustomIcon--clickable {
+  pointer-events: all;
+  height: $euiSize;
+  width: $euiSize;
+  @include size($euiSize);
+
+  .euiFormControlLayoutCustomIcon__clickableIcon {
+    vertical-align: baseline;
+  }
+
+  &:focus {
+    background: $euiColorPrimary;
+    border-radius: 100%;
+    color: $euiColorGhost;
+  }
+}

--- a/src/components/form/form_control_layout/_form_control_layout_icons.scss
+++ b/src/components/form/form_control_layout/_form_control_layout_icons.scss
@@ -1,0 +1,43 @@
+.euiFormControlLayoutIcons {
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: $euiFormControlPadding;
+  display: flex;
+  align-items: center;
+
+  > * + * {
+    margin-left: $euiFormControlPadding;
+  }
+}
+
+.euiFormControlLayoutIcons--right {
+  left: auto;
+  right: $euiFormControlPadding;
+}
+
+  .euiFormControlLayoutIcons__clearButton {
+    @include euiFormControlLayoutClearIcon('.euiFormControlLayoutIcons__clearButtonIcon');
+  }
+
+  .euiFormControlLayoutIcons__customIcon {
+    pointer-events: none;
+  }
+
+  .euiFormControlLayoutIcons__customIcon--clickable {
+    pointer-events: all;
+    height: $euiSize;
+    width: $euiSize;
+    @include size($euiSize);
+
+    .euiIcon {
+      vertical-align: baseline;
+    }
+
+    &:focus {
+      background: $euiColorPrimary;
+      border-radius: 100%;
+      color: $euiColorGhost;
+    }
+  }

--- a/src/components/form/form_control_layout/_form_control_layout_icons.scss
+++ b/src/components/form/form_control_layout/_form_control_layout_icons.scss
@@ -16,28 +16,3 @@
   left: auto;
   right: $euiFormControlPadding;
 }
-
-  .euiFormControlLayoutIcons__clearButton {
-    @include euiFormControlLayoutClearIcon('.euiFormControlLayoutIcons__clearButtonIcon');
-  }
-
-  .euiFormControlLayoutIcons__customIcon {
-    pointer-events: none;
-  }
-
-  .euiFormControlLayoutIcons__customIcon--clickable {
-    pointer-events: all;
-    height: $euiSize;
-    width: $euiSize;
-    @include size($euiSize);
-
-    .euiIcon {
-      vertical-align: baseline;
-    }
-
-    &:focus {
-      background: $euiColorPrimary;
-      border-radius: 100%;
-      color: $euiColorGhost;
-    }
-  }

--- a/src/components/form/form_control_layout/_index.scss
+++ b/src/components/form/form_control_layout/_index.scss
@@ -1,2 +1,3 @@
 @import 'mixins';
 @import 'form_control_layout';
+@import 'form_control_layout_icons';

--- a/src/components/form/form_control_layout/_index.scss
+++ b/src/components/form/form_control_layout/_index.scss
@@ -1,3 +1,5 @@
 @import 'mixins';
 @import 'form_control_layout';
 @import 'form_control_layout_icons';
+@import 'form_control_layout_clear_button';
+@import 'form_control_layout_custom_icon';

--- a/src/components/form/form_control_layout/_mixins.scss
+++ b/src/components/form/form_control_layout/_mixins.scss
@@ -1,4 +1,4 @@
-@mixin euiFormControlLayout__clear($iconClass) {
+@mixin euiFormControlLayoutClearIcon($iconClass) {
   $clearSize: $euiSize;
   pointer-events: all;
 

--- a/src/components/form/form_control_layout/_mixins.scss
+++ b/src/components/form/form_control_layout/_mixins.scss
@@ -1,5 +1,6 @@
 @mixin euiFormControlLayout__clear($iconClass) {
   $clearSize: $euiSize;
+  pointer-events: all;
 
   @include size($clearSize);
   background-color: transparentize($euiColorMediumShade, .5);

--- a/src/components/form/form_control_layout/form_control_layout.js
+++ b/src/components/form/form_control_layout/form_control_layout.js
@@ -1,165 +1,42 @@
-import React, { Fragment, Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { EuiIcon } from '../../icon';
-import { EuiLoadingSpinner } from '../../loading';
+import { EuiFormControlLayoutIcons } from './form_control_layout_icons'
 
 export const ICON_SIDES = ['left', 'right'];
 
-export class EuiFormControlLayout extends Component {
-  render() {
-    const {
-      children,
-      icon, // eslint-disable-line no-unused-vars
-      clear, // eslint-disable-line no-unused-vars
-      fullWidth,
-      isLoading, // eslint-disable-line no-unused-vars
-      compressed,
-      className,
-      ...rest
-    } = this.props;
+export const EuiFormControlLayout = ({
+  children,
+  icon,
+  clear,
+  fullWidth,
+  isLoading,
+  compressed,
+  className,
+  ...rest
+}) => {
+  const classes = classNames(
+    'euiFormControlLayout',
+    {
+      'euiFormControlLayout--fullWidth': fullWidth,
+      'euiFormControlLayout--compressed': compressed,
+    },
+    className
+  );
 
-    const classes = classNames(
-      'euiFormControlLayout',
-      {
-        'euiFormControlLayout--fullWidth': fullWidth,
-        'euiFormControlLayout--compressed': compressed,
-      },
-      className
-    );
+  return (
+    <div className={classes} {...rest}>
+      {children}
 
-    return (
-      <div className={classes} {...rest}>
-        {children}
-        {this.renderIcons()}
-      </div>
-    );
-  }
-
-  renderIcons() {
-    const {
-      isLoading,
-      icon,
-      clear,
-    } = this.props;
-
-    let optionalLoader;
-    if (isLoading) {
-      optionalLoader = (
-        <EuiLoadingSpinner size="m" />
-      );
-    }
-
-    let optionalIconSide;
-    let optionalIcon;
-    if (icon) {
-      // Normalize the icon to an object if it's a string.
-      const iconProps = typeof icon === 'string' ? {
-        type: icon,
-      } : icon;
-
-      const {
-        className: iconClassName,
-        type: iconType,
-        side: iconSide = 'left',
-        onClick: onIconClick,
-        ref: iconRef,
-        ...iconRest
-      } = iconProps
-
-      optionalIconSide = iconSide
-
-      const iconClasses = classNames(
-        'euiFormControlLayout__icon',
-        iconClassName,
-        {
-          'euiFormControlLayout__icon--button': onIconClick,
-        },
-      );
-
-      if (onIconClick) {
-        optionalIcon = (
-          <button
-            className={iconClasses}
-            onClick={onIconClick}
-            ref={iconRef}
-            {...iconRest}
-          >
-            <EuiIcon
-              type={iconType}
-            />
-          </button>
-        )
-      } else {
-        optionalIcon = (
-          <EuiIcon
-            aria-hidden="true"
-            className={iconClasses}
-            type={iconType}
-            {...iconRest}
-          />
-        );
-      }
-    }
-
-    let optionalClear;
-    if (clear) {
-      const {
-        className: clearClassName,
-        onClick: onClearClick,
-        ...clearRest
-      } = clear;
-
-      const clearClasses = classNames('euiFormControlLayout__clear', clearClassName);
-
-      optionalClear = (
-        <button
-          className={clearClasses}
-          onClick={onClearClick}
-          aria-label="Clear selections"
-          {...clearRest}
-        >
-          <EuiIcon
-            className="euiFormControlLayout__clearIcon"
-            type="cross"
-          />
-        </button>
-      );
-    }
-
-    let leftIcons;
-
-    if ( optionalIconSide === 'left') {
-      leftIcons = (
-        <div className="euiFormControlLayout__icons">
-          {optionalIcon}
-        </div>
-      );
-    }
-
-    let rightIcons;
-
-    // If the icon is on the right, it should be placed after the clear button in the DOM.
-    if (optionalClear || optionalLoader || optionalIconSide === 'right') {
-      rightIcons = (
-        <div className="euiFormControlLayout__icons euiFormControlLayout__icons--right">
-          {optionalClear}
-          {optionalLoader}
-          {optionalIconSide === 'right' ? optionalIcon : undefined}
-        </div>
-      );
-    }
-
-
-    return (
-      <Fragment>
-        {leftIcons}
-        {rightIcons}
-      </Fragment>
-    );
-  }
-}
+      <EuiFormControlLayoutIcons
+        icon={icon}
+        clear={clear}
+        isLoading={isLoading}
+      />
+    </div>
+  );
+};
 
 EuiFormControlLayout.propTypes = {
   children: PropTypes.node,

--- a/src/components/form/form_control_layout/form_control_layout_clear_button.js
+++ b/src/components/form/form_control_layout/form_control_layout_clear_button.js
@@ -9,17 +9,17 @@ export const EuiFormControlLayoutClearButton = ({
   onClick,
   ...rest
 }) => {
-  const classes = classNames('euiFormControlLayoutIcons__clearButton', className);
+  const classes = classNames('euiFormControlLayoutClearButton', className);
 
   return (
     <button
       className={classes}
       onClick={onClick}
-      aria-label="Clear selections"
+      aria-label="Clear input"
       {...rest}
     >
       <EuiIcon
-        className="euiFormControlLayoutIcons__clearButtonIcon"
+        className="euiFormControlLayoutClearButton__icon"
         type="cross"
       />
     </button>

--- a/src/components/form/form_control_layout/form_control_layout_clear_button.js
+++ b/src/components/form/form_control_layout/form_control_layout_clear_button.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import { EuiIcon } from '../../icon';
+
+export const EuiFormControlLayoutClearButton = ({
+  className,
+  onClick,
+  ...rest
+}) => {
+  const classes = classNames('euiFormControlLayoutIcons__clearButton', className);
+
+  return (
+    <button
+      className={classes}
+      onClick={onClick}
+      aria-label="Clear selections"
+      {...rest}
+    >
+      <EuiIcon
+        className="euiFormControlLayoutIcons__clearButtonIcon"
+        type="cross"
+      />
+    </button>
+  );
+};
+
+EuiFormControlLayoutClearButton.propTypes = {
+  className: PropTypes.string,
+  onClick: PropTypes.func,
+};

--- a/src/components/form/form_control_layout/form_control_layout_custom_icon.js
+++ b/src/components/form/form_control_layout/form_control_layout_custom_icon.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import { EuiIcon } from '../../icon';
+
+export const EuiFormControlLayoutCustomIcon = ({
+  className,
+  onClick,
+  type,
+  iconRef,
+  ...rest
+}) => {
+  const classes = classNames(
+    'euiFormControlLayoutIcons__customIcon',
+    className,
+    {
+      'euiFormControlLayoutIcons__customIcon--clickable': onClick,
+    },
+  );
+
+  if (onClick) {
+    return (
+      <button
+        className={classes}
+        onClick={onClick}
+        ref={iconRef}
+        {...rest}
+      >
+        <EuiIcon
+          type={type}
+        />
+      </button>
+    );
+  }
+
+  return (
+    <EuiIcon
+      aria-hidden="true"
+      className={classes}
+      type={type}
+      {...rest}
+    />
+  );
+};
+
+EuiFormControlLayoutCustomIcon.propTypes = {
+  className: PropTypes.string,
+  onClick: PropTypes.func,
+  type: PropTypes.string,
+  iconRef: PropTypes.func,
+};

--- a/src/components/form/form_control_layout/form_control_layout_custom_icon.js
+++ b/src/components/form/form_control_layout/form_control_layout_custom_icon.js
@@ -12,10 +12,10 @@ export const EuiFormControlLayoutCustomIcon = ({
   ...rest
 }) => {
   const classes = classNames(
-    'euiFormControlLayoutIcons__customIcon',
+    'euiFormControlLayoutCustomIcon',
     className,
     {
-      'euiFormControlLayoutIcons__customIcon--clickable': onClick,
+      'euiFormControlLayoutCustomIcon--clickable': onClick,
     },
   );
 
@@ -28,6 +28,7 @@ export const EuiFormControlLayoutCustomIcon = ({
         {...rest}
       >
         <EuiIcon
+          className="euiFormControlLayoutCustomIcon__clickableIcon"
           type={type}
         />
       </button>

--- a/src/components/form/form_control_layout/form_control_layout_custom_icon.js
+++ b/src/components/form/form_control_layout/form_control_layout_custom_icon.js
@@ -22,13 +22,14 @@ export const EuiFormControlLayoutCustomIcon = ({
   if (onClick) {
     return (
       <button
-        className={classes}
         onClick={onClick}
+        className={classes}
         ref={iconRef}
         {...rest}
       >
         <EuiIcon
           className="euiFormControlLayoutCustomIcon__clickableIcon"
+          aria-hidden="true"
           type={type}
         />
       </button>
@@ -36,12 +37,16 @@ export const EuiFormControlLayoutCustomIcon = ({
   }
 
   return (
-    <EuiIcon
-      aria-hidden="true"
+    <span
       className={classes}
-      type={type}
+      ref={iconRef}
       {...rest}
-    />
+    >
+      <EuiIcon
+        aria-hidden="true"
+        type={type}
+      />
+    </span>
   );
 };
 

--- a/src/components/form/form_control_layout/form_control_layout_icons.js
+++ b/src/components/form/form_control_layout/form_control_layout_icons.js
@@ -63,7 +63,7 @@ export class EuiFormControlLayoutIcons extends Component {
       ref: iconRef,
       side, // eslint-disable-line no-unused-vars
       ...iconRest
-    } = iconProps
+    } = iconProps;
 
     return (
       <EuiFormControlLayoutCustomIcon
@@ -93,10 +93,7 @@ export class EuiFormControlLayoutIcons extends Component {
     }
 
     return (
-      <EuiFormControlLayoutClearButton
-        aria-label="Clear selections"
-        {...clear}
-      />
+      <EuiFormControlLayoutClearButton {...clear} />
     );
   }
 }

--- a/src/components/form/form_control_layout/form_control_layout_icons.js
+++ b/src/components/form/form_control_layout/form_control_layout_icons.js
@@ -1,0 +1,117 @@
+import React, { Fragment, Component } from 'react';
+import PropTypes from 'prop-types';
+
+import { EuiLoadingSpinner } from '../../loading';
+import { EuiFormControlLayoutClearButton } from './form_control_layout_clear_button';
+import { EuiFormControlLayoutCustomIcon } from './form_control_layout_custom_icon';
+
+export const ICON_SIDES = ['left', 'right'];
+
+export class EuiFormControlLayoutIcons extends Component {
+  render() {
+    const { icon } = this.props;
+
+    const iconSide = icon && icon.side ? icon.side : 'left';
+    const customIcon = this.renderCustomIcon();
+    const loadingSpinner = this.renderLoadingSpinner();
+    const clearButton = this.renderClearButton();
+
+    let leftIcons;
+
+    if (customIcon && iconSide === 'left') {
+      leftIcons = (
+        <div className="euiFormControlLayoutIcons">
+          {customIcon}
+        </div>
+      );
+    }
+
+    let rightIcons;
+
+    // If the icon is on the right, it should be placed after the clear button in the DOM.
+    if (clearButton || loadingSpinner || (customIcon && iconSide === 'right')) {
+      rightIcons = (
+        <div className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right">
+          {clearButton}
+          {loadingSpinner}
+          {iconSide === 'right' ? customIcon : undefined}
+        </div>
+      );
+    }
+
+    return (
+      <Fragment>
+        {leftIcons}
+        {rightIcons}
+      </Fragment>
+    );
+  }
+
+  renderCustomIcon() {
+    const { icon } = this.props;
+
+    if (!icon) {
+      return null;
+    }
+
+    // Normalize the icon to an object if it's a string.
+    const iconProps = typeof icon === 'string' ? {
+      type: icon,
+    } : icon;
+
+    const {
+      ref: iconRef,
+      side, // eslint-disable-line no-unused-vars
+      ...iconRest
+    } = iconProps
+
+    return (
+      <EuiFormControlLayoutCustomIcon
+        iconRef={iconRef}
+        {...iconRest}
+      />
+    );
+  }
+
+  renderLoadingSpinner() {
+    const { isLoading } = this.props;
+
+    if (!isLoading) {
+      return null;
+    }
+
+    return (
+      <EuiLoadingSpinner size="m" />
+    );
+  }
+
+  renderClearButton() {
+    const { clear } = this.props;
+
+    if (!clear) {
+      return null;
+    }
+
+    return (
+      <EuiFormControlLayoutClearButton
+        aria-label="Clear selections"
+        {...clear}
+      />
+    );
+  }
+}
+
+EuiFormControlLayoutIcons.propTypes = {
+  icon: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({
+      type: PropTypes.string,
+      side: PropTypes.oneOf(ICON_SIDES),
+      onClick: PropTypes.func,
+    }),
+  ]),
+  clear: PropTypes.shape({
+    onClick: PropTypes.func,
+  }),
+  isLoading: PropTypes.bool,
+};


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/893

Thanks for catching this @cchaos!

I tested the following scenarios:

* Clicking the icon in a EuiSelect now opens the select and gives it focus
* Clicking the icon in a EuiFieldPassword gives focus to the input
* Clicking both the clear and caret icons in EuiComboBox still has the original desired behavior of clearing/toggling the EuiComboBox

I also added a note to the CHANGELOG under 0.0.50 noting this regression.
