### PR TITLE
Full range of button icon colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added multiple style-only adjustments to `EuiFormControlLayout` buttons/icons ([#894](https://github.com/elastic/eui/pull/894))
 - Shifted `readOnly` inputs to not have left padding unless it has an icon ([#894](https://github.com/elastic/eui/pull/894))
 - Added more customization options to `EuiAvatar` ([#903](https://github.com/elastic/eui/pull/903))
+- Added more color options to `EuiButtonIcon` ([#907](https://github.com/elastic/eui/pull/907))
 
 **Bug fixes**
 
@@ -19,6 +20,7 @@
 - Fixed responsive widths of `EuiDescribedFormGroup` ([#894](https://github.com/elastic/eui/pull/894))
 - Fixed descenders being cut off in `EuiSelect` ([#894](https://github.com/elastic/eui/pull/894))
 - Fixed extra spacing applied by Safari to `EuiFieldSearch` ([#894](https://github.com/elastic/eui/pull/894))
+- Fixed contrast issues in dark theming ([#907](https://github.com/elastic/eui/pull/907))
 
 ## [`0.0.51`](https://github.com/elastic/eui/tree/v0.0.51)
 

--- a/src-docs/src/views/button/button_example.js
+++ b/src-docs/src/views/button/button_example.js
@@ -164,7 +164,10 @@ export const ButtonExample = {
     }],
     text: (
       <p>
-        Button icons are buttons that only contain an icon (no text).
+        Button icons are buttons that only contain an icon
+        (no text). <strong>Note:</strong> the
+        the dark background on the <EuiCode>ghost</EuiCode> example is used
+        only for illustrative purposes.
       </p>
     ),
     props: { EuiButtonIcon },

--- a/src-docs/src/views/button/button_icon.js
+++ b/src-docs/src/views/button/button_icon.js
@@ -16,11 +16,6 @@ const colors = [
   'disabled',
 ];
 
-const ghostBackgroundStyle = {
-  background: '#000',
-  borderRadius: '4px',
-}
-
 export default () => (
   <EuiFlexGroup gutterSize="s" alignItems="center">
     {

--- a/src-docs/src/views/button/button_icon.js
+++ b/src-docs/src/views/button/button_icon.js
@@ -6,35 +6,32 @@ import {
   EuiFlexItem,
 } from '../../../../src/components';
 
+const colors = [
+  'primary',
+  'text',
+  'subdued',
+  'success',
+  'warning',
+  'danger',
+  'disabled',
+  'ghost',
+];
+
 export default () => (
   <EuiFlexGroup gutterSize="s" alignItems="center">
-    <EuiFlexItem grow={false}>
-      <EuiButtonIcon
-        onClick={() => window.alert('Button clicked')}
-        iconType="arrowRight"
-        aria-label="Next"
-      />
-    </EuiFlexItem>
-
-    <EuiFlexItem grow={false}>
-      <EuiButtonIcon
-        size="s"
-        color="danger"
-        onClick={() => window.alert('Button clicked')}
-        iconType="arrowRight"
-        aria-label="Next"
-      />
-    </EuiFlexItem>
-
-    <EuiFlexItem grow={false}>
-      <EuiButtonIcon
-        size="s"
-        color="disabled"
-        onClick={() => window.alert('Button clicked')}
-        iconType="arrowRight"
-        aria-label="Next"
-      />
-    </EuiFlexItem>
+    {
+      colors.map(color => (
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon
+            size="s"
+            color={color}
+            onClick={() => window.alert('Button clicked')}
+            iconType="arrowRight"
+            aria-label="Next"
+            disabled={color === "disabled" ? true : false}
+          />
+        </EuiFlexItem>
+      ))
+    }
   </EuiFlexGroup>
 );
-

--- a/src-docs/src/views/button/button_icon.js
+++ b/src-docs/src/views/button/button_icon.js
@@ -17,11 +17,16 @@ const colors = [
   'ghost',
 ];
 
+const ghostBackgroundStyle = {
+  background: '#000',
+  borderRadius: '4px',
+}
+
 export default () => (
   <EuiFlexGroup gutterSize="s" alignItems="center">
     {
       colors.map(color => (
-        <EuiFlexItem grow={false}>
+        <EuiFlexItem grow={false} style={color === "ghost" ? ghostBackgroundStyle : null}>
           <EuiButtonIcon
             size="s"
             color={color}

--- a/src-docs/src/views/button/button_icon.js
+++ b/src-docs/src/views/button/button_icon.js
@@ -14,7 +14,6 @@ const colors = [
   'warning',
   'danger',
   'disabled',
-  'ghost',
 ];
 
 const ghostBackgroundStyle = {
@@ -26,7 +25,7 @@ export default () => (
   <EuiFlexGroup gutterSize="s" alignItems="center">
     {
       colors.map(color => (
-        <EuiFlexItem grow={false} style={color === "ghost" ? ghostBackgroundStyle : null}>
+        <EuiFlexItem grow={false}>
           <EuiButtonIcon
             size="s"
             color={color}

--- a/src/components/button/button_icon/__snapshots__/button_icon.test.js.snap
+++ b/src/components/button/button_icon/__snapshots__/button_icon.test.js.snap
@@ -41,10 +41,34 @@ exports[`EuiButtonIcon props color primary is rendered 1`] = `
 />
 `;
 
+exports[`EuiButtonIcon props color subdued is rendered 1`] = `
+<button
+  aria-label="button"
+  class="euiButtonIcon euiButtonIcon--subdued"
+  type="button"
+/>
+`;
+
+exports[`EuiButtonIcon props color success is rendered 1`] = `
+<button
+  aria-label="button"
+  class="euiButtonIcon euiButtonIcon--success"
+  type="button"
+/>
+`;
+
 exports[`EuiButtonIcon props color text is rendered 1`] = `
 <button
   aria-label="button"
   class="euiButtonIcon euiButtonIcon--text"
+  type="button"
+/>
+`;
+
+exports[`EuiButtonIcon props color warning is rendered 1`] = `
+<button
+  aria-label="button"
+  class="euiButtonIcon euiButtonIcon--warning"
   type="button"
 />
 `;

--- a/src/components/button/button_icon/_button_icon.scss
+++ b/src/components/button/button_icon/_button_icon.scss
@@ -33,7 +33,7 @@
 // Modifier naming and colors.
 $buttonTypes: (
   danger: $euiColorDanger,
-  disabled: tintOrShade($euiTextColor, 70%, 80%),
+  disabled: $euiButtonColorDisabled,
   ghost: $euiColorGhost,
   primary: $euiColorPrimary,
   subdued: $euiColorDarkShade,

--- a/src/components/button/button_icon/_button_icon.scss
+++ b/src/components/button/button_icon/_button_icon.scss
@@ -32,11 +32,14 @@
 
 // Modifier naming and colors.
 $buttonTypes: (
-  primary: $euiColorPrimary,
   danger: $euiColorDanger,
   disabled: tintOrShade($euiTextColor, 70%, 80%),
   ghost: $euiColorGhost,
+  primary: $euiColorPrimary,
+  subdued: $euiColorDarkShade,
+  success: $euiColorSuccess,
   text: $euiTextColor,
+  warning: $euiColorWarning,
 );
 
 // Create button modifiders based upon the map.

--- a/src/components/button/button_icon/button_icon.js
+++ b/src/components/button/button_icon/button_icon.js
@@ -25,11 +25,14 @@ const accessibleButtonIcon = (props, propName, componentName) => {
 };
 
 const colorToClassNameMap = {
-  primary: 'euiButtonIcon--primary',
   danger: 'euiButtonIcon--danger',
   disabled: 'euiButtonIcon--disabled',
   ghost: 'euiButtonIcon--ghost',
+  primary: 'euiButtonIcon--primary',
+  subdued: 'euiButtonIcon--subdued',
+  success: 'euiButtonIcon--success',
   text: 'euiButtonIcon--text',
+  warning: 'euiButtonIcon--warning',
 };
 
 export const COLORS = Object.keys(colorToClassNameMap);

--- a/src/themes/eui/eui_colors_dark.scss
+++ b/src/themes/eui/eui_colors_dark.scss
@@ -4,7 +4,7 @@ $euiColorEmptyShade: #222;
 $euiColorLightestShade: #272727;
 $euiColorLightShade: #333;
 $euiColorMediumShade: #444;
-$euiColorDarkShade: #D9D9D9;
+$euiColorDarkShade: #999;
 $euiColorDarkestShade: #F5F5F5;
 $euiColorFullShade: #FFF;
 $euiColorSlightHue: #494E51;

--- a/src/themes/eui/eui_colors_dark.scss
+++ b/src/themes/eui/eui_colors_dark.scss
@@ -4,7 +4,7 @@ $euiColorEmptyShade: #222;
 $euiColorLightestShade: #272727;
 $euiColorLightShade: #333;
 $euiColorMediumShade: #444;
-$euiColorDarkShade: #888;
+$euiColorDarkShade: #8A8A8A;
 $euiColorDarkestShade: #F5F5F5;
 $euiColorFullShade: #FFF;
 $euiColorSlightHue: #494E51;

--- a/src/themes/eui/eui_colors_dark.scss
+++ b/src/themes/eui/eui_colors_dark.scss
@@ -1,7 +1,7 @@
 // Dark theme overides
 
 $euiColorEmptyShade: #222;
-$euiColorLightestShade: #272727;
+$euiColorLightestShade: #242424;
 $euiColorLightShade: #333;
 $euiColorMediumShade: #444;
 $euiColorDarkShade: #8A8A8A;

--- a/src/themes/eui/eui_colors_dark.scss
+++ b/src/themes/eui/eui_colors_dark.scss
@@ -4,7 +4,7 @@ $euiColorEmptyShade: #222;
 $euiColorLightestShade: #272727;
 $euiColorLightShade: #333;
 $euiColorMediumShade: #444;
-$euiColorDarkShade: #999;
+$euiColorDarkShade: #888;
 $euiColorDarkestShade: #F5F5F5;
 $euiColorFullShade: #FFF;
 $euiColorSlightHue: #494E51;

--- a/src/themes/k6/k6_colors_dark.scss
+++ b/src/themes/k6/k6_colors_dark.scss
@@ -4,10 +4,12 @@ $euiColorEmptyShade: #222;
 $euiColorLightestShade: #272727;
 $euiColorLightShade: #333;
 $euiColorMediumShade: #444;
-$euiColorDarkShade: #D9D9D9;
+$euiColorDarkShade: #999;
 $euiColorDarkestShade: #F5F5F5;
 $euiColorFullShade: #FFF;
+$euiColorSlightHue: #494E51;
 $euiColorPrimary: #4da1c0;
+$euiColorWarning: #c06c4c;
 $euiColorDanger: #bf4d4d;
 $euiTextColor: #DDD;
 

--- a/src/themes/k6/k6_colors_dark.scss
+++ b/src/themes/k6/k6_colors_dark.scss
@@ -4,7 +4,7 @@ $euiColorEmptyShade: #222;
 $euiColorLightestShade: #272727;
 $euiColorLightShade: #333;
 $euiColorMediumShade: #444;
-$euiColorDarkShade: #888;
+$euiColorDarkShade: #8A8A8A;
 $euiColorDarkestShade: #F5F5F5;
 $euiColorFullShade: #FFF;
 $euiColorSlightHue: #494E51;

--- a/src/themes/k6/k6_colors_dark.scss
+++ b/src/themes/k6/k6_colors_dark.scss
@@ -1,7 +1,7 @@
 // Dark theme overides
 
 $euiColorEmptyShade: #222;
-$euiColorLightestShade: #272727;
+$euiColorLightestShade: #242424;
 $euiColorLightShade: #333;
 $euiColorMediumShade: #444;
 $euiColorDarkShade: #8A8A8A;

--- a/src/themes/k6/k6_colors_dark.scss
+++ b/src/themes/k6/k6_colors_dark.scss
@@ -4,7 +4,7 @@ $euiColorEmptyShade: #222;
 $euiColorLightestShade: #272727;
 $euiColorLightShade: #333;
 $euiColorMediumShade: #444;
-$euiColorDarkShade: #999;
+$euiColorDarkShade: #888;
 $euiColorDarkestShade: #F5F5F5;
 $euiColorFullShade: #FFF;
 $euiColorSlightHue: #494E51;


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/907

FWIW the screen @timroes  pointed to was of a disabled state icon, which was purposely low contrast. I went ahead though and added the full range of coloring to `EuiButtonIcon` including a proper subdued state and our other core palette colors.

![image](https://user-images.githubusercontent.com/324519/41057240-763f01ca-697b-11e8-9902-f900dc93678c.png)

![image](https://user-images.githubusercontent.com/324519/41057325-a91358b2-697b-11e8-96a2-cb0490681148.png)



