### PR TITLE
Ensure DelayHide component disappears correctly

### DIFF
--- a/src/components/delay_hide/delay_hide.js
+++ b/src/components/delay_hide/delay_hide.js
@@ -1,23 +1,29 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 
+function isComponentBecomingVisible(prevHide, nextHide) {
+  return prevHide === true && nextHide === false;
+}
+
 export class EuiDelayHide extends Component {
   static propTypes = {
     hide: PropTypes.bool,
     minimumDuration: PropTypes.number,
-    render: PropTypes.func.isRequired
+    render: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
     hide: false,
-    minimumDuration: 1000
+    minimumDuration: 1000,
   };
 
   static getDerivedStateFromProps(nextProps, prevState) {
     // if the component should be visible (nextProps.hide === false)
     // but we're currently suppresing it, update state.countdownExpired
-    if (nextProps.hide === false && prevState.countdownExpired === true) {
+    const isBecomingVisible = isComponentBecomingVisible(prevState.prevHide, nextProps.hide);
+    if (isBecomingVisible && prevState.countdownExpired === true) {
       return {
+        prevHide: false,
         countdownExpired: false,
       };
     }
@@ -33,6 +39,7 @@ export class EuiDelayHide extends Component {
     this.state = {
       // start countdownExpired based on the hide prop
       countdownExpired: this.props.hide,
+      prevHide: this.props.hide,
     };
   }
 
@@ -44,8 +51,8 @@ export class EuiDelayHide extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const isComponentBecomingVisible = prevProps.hide === true && this.props.hide === false;
-    if (isComponentBecomingVisible) {
+    const isBecomingVisible = isComponentBecomingVisible(prevProps.hide, this.props.hide);
+    if (isBecomingVisible) {
       this.startCountdown();
     }
   }
@@ -61,12 +68,12 @@ export class EuiDelayHide extends Component {
     if (this.timeoutId == null) {
       this.timeoutId = setTimeout(this.finishCountdown, this.props.minimumDuration);
     }
-  }
+  };
 
   finishCountdown = () => {
     this.timeoutId = null;
     this.setState({ countdownExpired: true });
-  }
+  };
 
   render() {
     const shouldHideContent = this.props.hide === true && this.state.countdownExpired;

--- a/src/components/delay_hide/delay_hide.js
+++ b/src/components/delay_hide/delay_hide.js
@@ -18,10 +18,8 @@ export class EuiDelayHide extends Component {
   };
 
   static getDerivedStateFromProps(nextProps, prevState) {
-    // if the component should be visible (nextProps.hide === false)
-    // but we're currently suppresing it, update state.countdownExpired
     const isBecomingVisible = isComponentBecomingVisible(prevState.prevHide, nextProps.hide);
-    if (isBecomingVisible && prevState.countdownExpired === true) {
+    if (isBecomingVisible) {
       return {
         prevHide: false,
         countdownExpired: false,
@@ -31,17 +29,10 @@ export class EuiDelayHide extends Component {
     return null;
   }
 
-  constructor(...args) {
-    super(...args);
-
-    this.timeoutId = null; // track timeout so it can be referenced / cleared
-
-    this.state = {
-      // start countdownExpired based on the hide prop
-      countdownExpired: this.props.hide,
-      prevHide: this.props.hide,
-    };
-  }
+  state = {
+    countdownExpired: this.props.hide,
+    prevHide: this.props.hide,
+  };
 
   componentDidMount() {
     // if the component begins visible start counting

--- a/src/components/delay_hide/delay_hide.js
+++ b/src/components/delay_hide/delay_hide.js
@@ -19,14 +19,10 @@ export class EuiDelayHide extends Component {
 
   static getDerivedStateFromProps(nextProps, prevState) {
     const isBecomingVisible = isComponentBecomingVisible(prevState.prevHide, nextProps.hide);
-    if (isBecomingVisible) {
-      return {
-        prevHide: false,
-        countdownExpired: false,
-      };
-    }
-
-    return null;
+    return {
+      prevHide: nextProps.hide,
+      countdownExpired: isBecomingVisible ? false : prevState.countdownExpired
+    };
   }
 
   state = {

--- a/src/components/delay_hide/delay_hide.js
+++ b/src/components/delay_hide/delay_hide.js
@@ -18,16 +18,15 @@ export class EuiDelayHide extends Component {
   };
 
   static getDerivedStateFromProps(nextProps, prevState) {
-    const isBecomingVisible = isComponentBecomingVisible(prevState.prevHide, nextProps.hide);
+    const isBecomingVisible = isComponentBecomingVisible(prevState.hide, nextProps.hide);
     return {
-      prevHide: nextProps.hide,
+      hide: nextProps.hide,
       countdownExpired: isBecomingVisible ? false : prevState.countdownExpired
     };
   }
 
   state = {
     countdownExpired: this.props.hide,
-    prevHide: this.props.hide,
   };
 
   componentDidMount() {

--- a/src/components/delay_hide/delay_hide.test.js
+++ b/src/components/delay_hide/delay_hide.test.js
@@ -127,3 +127,28 @@ describe('when EuiDelayHide is visible initially and has a minimumDuration of 20
     expect(wrapper.html()).toEqual(null);
   });
 });
+
+describe('when EuiDelayHide has been visible and become hidden', () => {
+  it('should still be visible for the minimum duration the second time', () => {
+    jest.useFakeTimers();
+    const wrapper = mount(
+      <EuiDelayHide
+        hide={true}
+        render={() => <div>Hello World</div>}
+      />
+    );
+
+    wrapper.setProps({ hide: false });
+    jest.advanceTimersByTime(1100);
+    wrapper.setProps({ hide: true });
+    jest.advanceTimersByTime(100);
+    wrapper.setProps({ hide: false });
+    wrapper.setProps({ hide: true });
+
+    expect(wrapper.html()).toEqual('<div>Hello World</div>');
+
+    jest.advanceTimersByTime(1100);
+
+    expect(wrapper.html()).toEqual(null);
+  });
+});

--- a/src/components/delay_hide/delay_hide.test.js
+++ b/src/components/delay_hide/delay_hide.test.js
@@ -49,6 +49,26 @@ describe('when EuiDelayHide is visible initially', () => {
   });
 });
 
+describe('when EuiDelayHide parent updates', () => {
+  it('should still hide correctly', () => {
+    jest.useFakeTimers();
+    const wrapper = mount(
+      <EuiDelayHide
+        hide={true}
+        render={() => <div>Hello World</div>}
+      />
+    );
+
+    wrapper.setProps({ hide: false });
+    jest.advanceTimersByTime(1100);
+    wrapper.setProps(); // simulate parent component re-rendering
+    wrapper.setProps({ hide: true });
+    jest.advanceTimersByTime(1100);
+
+    expect(wrapper.html()).toEqual(null);
+  });
+});
+
 describe('when EuiDelayHide is hidden initially', () => {
   let wrapper;
   beforeEach(() => {


### PR DESCRIPTION
A regression was introduced in https://github.com/elastic/eui/pull/879 which causes the component to be displayed indefinitely even though the `hide` parameter is `true` and the timeout has passed.

I added a tests that reproduces this scenario, where an update to the parent component will cause `getDerivedStateFromProps` to be called again, which will corrupt the internal state.

There is a good blog post about this exact pitfall here: https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html

@chandlerprall I'm not sure the solution presented here is the best. If you have anything more elegant I'm all ears!

fixes elastic/kibana#19785