### PR TITLE
Flyout alterations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 - `EuiComboBox` is now decorated with `data-test-subj` selectors for the search input (`comboxBoxSearchInput`), toggle button (`comboBoxToggleListButton`), and clear button (`comboBoxClearButton`) ([#918](https://github.com/elastic/eui/pull/918))
 - `EuiComboBox` now gives focus to the search input when the user clicks the clear button, to prevent focus from defaulting to the body ([#918](https://github.com/elastic/eui/pull/918))
 
+**Non-breaking major changes**
+
+- Added close (`cross`) button as default way to close to `EuiFlyout` when `onClose` is provided ([#925](https://github.com/elastic/eui/pull/925))
+- Fleshed out `EuiFlyoutHeader` for consistency (see docs) ([#925](https://github.com/elastic/eui/pull/925))
+
 **Bug fixes**
 
 - Added `role="dialog"` to `EuiFlyout` to improve screen reader accessibility ([#916](https://github.com/elastic/eui/pull/916))

--- a/src-docs/src/views/flyout/flyout.js
+++ b/src-docs/src/views/flyout/flyout.js
@@ -5,8 +5,11 @@ import React, {
 import {
   EuiFlyout,
   EuiFlyoutBody,
+  EuiFlyoutHeader,
   EuiButton,
   EuiText,
+  EuiTitle,
+  EuiCodeBlock,
 } from '../../../../src/components';
 
 export class Flyout extends Component {
@@ -39,29 +42,41 @@ export class Flyout extends Component {
   render() {
     let flyout;
 
+    const htmlCode = `<EuiFlyout ...>
+  <EuiFlyoutHeader hasBorder>
+    <EuiTitle size="m">
+      <h1></h1>
+    </EuiTitle>
+  </EuiFlyoutHeader>
+  <EuiFlyoutBody>
+    ...
+  </EuiFlyoutBody>
+</EuiFlyout>
+`;
+
     if (this.state.isFlyoutVisible) {
       flyout = (
         <EuiFlyout
           onClose={this.closeFlyout}
           aria-labelledby="flyoutTitle"
         >
+          <EuiFlyoutHeader hasBorder>
+            <EuiTitle size="m">
+              <h1 id="flyoutTitle">
+                A typical flyout
+              </h1>
+            </EuiTitle>
+          </EuiFlyoutHeader>
           <EuiFlyoutBody>
             <EuiText>
-              <h3 id="flyoutTitle">
-                A flyout
-              </h3>
-
               <p>
-                You can use ESC to close this panel, but we could also pass in a close button like so.
+                For consistency across the many flyouts, please utilize the following code for
+                implementing the flyout with a header.
               </p>
-
-              <EuiButton
-                iconType="cross"
-                onClick={this.closeFlyout}
-              >
-                Close me
-              </EuiButton>
             </EuiText>
+            <EuiCodeBlock language="html">
+              {htmlCode}
+            </EuiCodeBlock>
           </EuiFlyoutBody>
         </EuiFlyout>
       );

--- a/src-docs/src/views/flyout/flyout_complicated.js
+++ b/src-docs/src/views/flyout/flyout_complicated.js
@@ -5,18 +5,18 @@ import React, {
 import {
   EuiButton,
   EuiButtonEmpty,
+  EuiCodeBlock,
+  EuiFlexGroup,
+  EuiFlexItem,
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
-  EuiTitle,
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiSpacer,
-  EuiTabs,
   EuiTab,
+  EuiTabs,
   EuiText,
-  EuiTextColor,
+  EuiTitle,
 } from '../../../../src/components';
 
 export class FlyoutComplicated extends Component {
@@ -132,6 +132,11 @@ export class FlyoutComplicated extends Component {
       </EuiText>
     );
 
+    const htmlCode = `<!--I'm an example of HTML-->
+<div>
+  asdf
+</div>
+`;
 
     let flyout;
 
@@ -139,27 +144,28 @@ export class FlyoutComplicated extends Component {
       flyout = (
         <EuiFlyout
           onClose={this.closeFlyout}
+          hideCloseButton
           aria-labelledby="flyoutComplicatedTitle"
         >
-          <EuiFlyoutHeader>
-            <EuiTitle>
-              <h2 id="flyoutComplicatedTitle">
+          <EuiFlyoutHeader hasBorder>
+            <EuiTitle size="m">
+              <h1 id="flyoutComplicatedTitle">
                 Flyout header
-              </h2>
+              </h1>
             </EuiTitle>
             <EuiSpacer size="s" />
-            <EuiTextColor color="subdued">
-              <EuiText>
-                <p>Put navigation items in the header, and cross tab actions in a footer.</p>
-              </EuiText>
-            </EuiTextColor>
-            <EuiSpacer size="s" />
-            <EuiTabs>
+            <EuiText color="subdued">
+              <p>Put navigation items in the header, and cross tab actions in a footer.</p>
+            </EuiText>
+            <EuiTabs style={{ marginBottom: "-25px" }}>
               {this.renderTabs()}
             </EuiTabs>
           </EuiFlyoutHeader>
           <EuiFlyoutBody>
             {flyoutContent}
+            <EuiCodeBlock language="html">
+              {htmlCode}
+            </EuiCodeBlock>
           </EuiFlyoutBody>
           <EuiFlyoutFooter>
             <EuiFlexGroup justifyContent="spaceBetween">

--- a/src-docs/src/views/flyout/flyout_example.js
+++ b/src-docs/src/views/flyout/flyout_example.js
@@ -9,6 +9,8 @@ import {
 import {
   EuiCode,
   EuiFlyout,
+  EuiFlyoutHeader,
+  EuiFlyoutFooter,
 } from '../../../../src/components';
 
 import { Flyout } from './flyout';
@@ -55,12 +57,12 @@ export const FlyoutExample = {
           </ul>
 
           <p>
-            Notice how these examples use <EuiCode>aria-labelledby</EuiCode> and <EuiCode>aria-describedby</EuiCode> to
+            Notice how these examples use <EuiCode>aria-labelledby</EuiCode> to
             announce the flyout to screen readers when the user opens it.
           </p>
         </div>
       ),
-      props: { EuiFlyout },
+      props: { EuiFlyout, EuiFlyoutHeader },
       demo: <Flyout />,
     },
     {
@@ -80,6 +82,7 @@ export const FlyoutExample = {
           within <EuiCode>EuiContentBody</EuiCode> will automatcially overflow.
         </p>
       ),
+      props: { EuiFlyoutFooter },
       demo: <FlyoutComplicated />,
     },
     {
@@ -94,7 +97,7 @@ export const FlyoutExample = {
       text: (
         <p>
           In this example, we set <EuiCode>size</EuiCode> to <EuiCode>s</EuiCode> and
-          aply the <EuiCode>ownFocus</EuiCode> prop. The later not only traps the
+          apply the <EuiCode>ownFocus</EuiCode> prop. The latter not only traps the
           focus of our flyout, but also adds background overlay to reinforce your
           boundries.
         </p>

--- a/src-docs/src/views/flyout/flyout_size.js
+++ b/src-docs/src/views/flyout/flyout_size.js
@@ -4,9 +4,11 @@ import React, {
 
 import {
   EuiFlyout,
+  EuiFlyoutHeader,
   EuiFlyoutBody,
   EuiButton,
   EuiText,
+  EuiTitle,
 } from '../../../../src/components';
 
 export class FlyoutSize extends Component {
@@ -47,22 +49,18 @@ export class FlyoutSize extends Component {
           size="s"
           aria-labelledby="flyoutSizeTitle"
         >
+          <EuiFlyoutHeader hasBorder>
+            <EuiTitle size="s">
+              <h1 id="flyoutSizeTitle">
+                A small flyout
+              </h1>
+            </EuiTitle>
+          </EuiFlyoutHeader>
           <EuiFlyoutBody>
             <EuiText>
-              <h3 id="flyoutSizeTitle">
-                A flyout
-              </h3>
-
               <p>
-                You can use ESC to close this panel, but we could also pass in a close button like so.
+                In small flyouts, it is ok to reduce the header size to <code>s</code>.
               </p>
-
-              <EuiButton
-                iconType="cross"
-                onClick={this.closeFlyout}
-              >
-                Close me
-              </EuiButton>
             </EuiText>
           </EuiFlyoutBody>
         </EuiFlyout>

--- a/src/components/flyout/__snapshots__/flyout.test.js.snap
+++ b/src/components/flyout/__snapshots__/flyout.test.js.snap
@@ -9,7 +9,167 @@ exports[`EuiFlyout is rendered 1`] = `
       data-test-subj="test subject string"
       role="dialog"
       tabindex="0"
+    >
+      <button
+        aria-label="Closes this dialog"
+        class="euiButtonIcon euiButtonIcon--text euiFlyout__closeButton"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiButtonIcon__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <defs>
+            <path
+              d="M7.293 8l-4.147 4.146a.5.5 0 0 0 .708.708L8 8.707l4.146 4.147a.5.5 0 0 0 .708-.708L8.707 8l4.147-4.146a.5.5 0 0 0-.708-.708L8 7.293 3.854 3.146a.5.5 0 1 0-.708.708L7.293 8z"
+              id="cross-a"
+            />
+          </defs>
+          <use
+            fill-rule="nonzero"
+            href="#cross-a"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</span>
+`;
+
+exports[`EuiFlyout props close button is not rendered 1`] = `
+<span>
+  <div>
+    <div
+      class="euiFlyout euiFlyout--medium"
+      role="dialog"
+      tabindex="0"
     />
+  </div>
+</span>
+`;
+
+exports[`EuiFlyout size l is rendered 1`] = `
+<span>
+  <div>
+    <div
+      class="euiFlyout euiFlyout--large"
+      role="dialog"
+      tabindex="0"
+    >
+      <button
+        aria-label="Closes this dialog"
+        class="euiButtonIcon euiButtonIcon--text euiFlyout__closeButton"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiButtonIcon__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <defs>
+            <path
+              d="M7.293 8l-4.147 4.146a.5.5 0 0 0 .708.708L8 8.707l4.146 4.147a.5.5 0 0 0 .708-.708L8.707 8l4.147-4.146a.5.5 0 0 0-.708-.708L8 7.293 3.854 3.146a.5.5 0 1 0-.708.708L7.293 8z"
+              id="cross-a"
+            />
+          </defs>
+          <use
+            fill-rule="nonzero"
+            href="#cross-a"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</span>
+`;
+
+exports[`EuiFlyout size m is rendered 1`] = `
+<span>
+  <div>
+    <div
+      class="euiFlyout euiFlyout--medium"
+      role="dialog"
+      tabindex="0"
+    >
+      <button
+        aria-label="Closes this dialog"
+        class="euiButtonIcon euiButtonIcon--text euiFlyout__closeButton"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiButtonIcon__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <defs>
+            <path
+              d="M7.293 8l-4.147 4.146a.5.5 0 0 0 .708.708L8 8.707l4.146 4.147a.5.5 0 0 0 .708-.708L8.707 8l4.147-4.146a.5.5 0 0 0-.708-.708L8 7.293 3.854 3.146a.5.5 0 1 0-.708.708L7.293 8z"
+              id="cross-a"
+            />
+          </defs>
+          <use
+            fill-rule="nonzero"
+            href="#cross-a"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</span>
+`;
+
+exports[`EuiFlyout size s is rendered 1`] = `
+<span>
+  <div>
+    <div
+      class="euiFlyout euiFlyout--small"
+      role="dialog"
+      tabindex="0"
+    >
+      <button
+        aria-label="Closes this dialog"
+        class="euiButtonIcon euiButtonIcon--text euiFlyout__closeButton"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiButtonIcon__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <defs>
+            <path
+              d="M7.293 8l-4.147 4.146a.5.5 0 0 0 .708.708L8 8.707l4.146 4.147a.5.5 0 0 0 .708-.708L8.707 8l4.147-4.146a.5.5 0 0 0-.708-.708L8 7.293 3.854 3.146a.5.5 0 1 0-.708.708L7.293 8z"
+              id="cross-a"
+            />
+          </defs>
+          <use
+            fill-rule="nonzero"
+            href="#cross-a"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </span>
 `;

--- a/src/components/flyout/__snapshots__/flyout_header.test.js.snap
+++ b/src/components/flyout/__snapshots__/flyout_header.test.js.snap
@@ -7,3 +7,9 @@ exports[`EuiFlyoutHeader is rendered 1`] = `
   data-test-subj="test subject string"
 />
 `;
+
+exports[`EuiFlyoutHeader props border is rendered 1`] = `
+<div
+  class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
+/>
+`;

--- a/src/components/flyout/_flyout.scss
+++ b/src/components/flyout/_flyout.scss
@@ -15,6 +15,16 @@ $euiFlyoutBorderColor: tintOrShade($euiShadowColorLarge, 50%, 0%) !default; // m
   align-items: stretch;
 }
 
+// The actual size of the X button in pixels is a bit fuzzy because of all the
+// button padding so there is some pixel pushing here.
+.euiFlyout__closeButton {
+  background-color: transparentize($euiColorEmptyShade, .1);
+  position: absolute;
+  right: $euiSizeL - 7px;
+  top: $euiSizeL - 7px;
+  z-index: 3;
+}
+
 /**
   * 1. Calculating the minimum width based on the screen takover breakpoint
   * 2. Only small flyouts should NOT takover the entire screen

--- a/src/components/flyout/_flyout_footer.scss
+++ b/src/components/flyout/_flyout_footer.scss
@@ -2,4 +2,5 @@
   background: $euiColorLightestShade;
   flex-grow: 0;
   padding: $euiSize $euiSizeL;
+  @include euiOverflowShadowTop;
 }

--- a/src/components/flyout/_flyout_header.scss
+++ b/src/components/flyout/_flyout_header.scss
@@ -1,6 +1,10 @@
 .euiFlyoutHeader {
   flex-grow: 0;
-  padding: $euiSizeL;
-  padding-bottom: 0;
+  padding: $euiSizeL $euiSizeXXL 0 $euiSizeL;
   @include euiOverflowShadowBottom;
+}
+
+.euiFlyoutHeader--hasBorder {
+  padding-bottom: $euiSizeL;
+  border-bottom: $euiBorderThin;
 }

--- a/src/components/flyout/flyout.js
+++ b/src/components/flyout/flyout.js
@@ -115,4 +115,6 @@ EuiFlyout.propTypes = {
 
 EuiFlyout.defaultProps = {
   size: 'm',
+  hideCloseButton: false,
+  ownFocus: false,
 };

--- a/src/components/flyout/flyout.js
+++ b/src/components/flyout/flyout.js
@@ -7,9 +7,8 @@ import FocusTrap from 'focus-trap-react';
 
 import { keyCodes } from '../../services';
 
-import {
-  EuiOverlayMask,
-} from '../overlay_mask';
+import { EuiOverlayMask } from '../overlay_mask';
+import { EuiButtonIcon } from '../button';
 
 const sizeToClassNameMap = {
   s: 'euiFlyout--small',
@@ -32,6 +31,7 @@ export class EuiFlyout extends Component {
     const {
       className,
       children,
+      hideCloseButton,
       onClose,
       ownFocus,
       size,
@@ -44,6 +44,19 @@ export class EuiFlyout extends Component {
       className
     );
 
+    let closeButton;
+    if (onClose && !hideCloseButton) {
+      closeButton = (
+        <EuiButtonIcon
+          className="euiFlyout__closeButton"
+          iconType="cross"
+          color="text"
+          aria-label="Closes this dialog"
+          onClick={onClose}
+        />
+      );
+    }
+
     const flyoutContent = (
       <div
         role="dialog"
@@ -53,6 +66,7 @@ export class EuiFlyout extends Component {
         onKeyDown={this.onKeyDown}
         {...rest}
       >
+        {closeButton}
         {children}
       </div>
     );
@@ -89,6 +103,14 @@ EuiFlyout.propTypes = {
   children: PropTypes.node,
   onClose: PropTypes.func.isRequired,
   size: PropTypes.oneOf(SIZES),
+  /**
+   * Hides the default close button. You must provide another close button somewhere within the flyout.
+   */
+  hideCloseButton: PropTypes.bool,
+  /**
+   * Locks the mouse / keyboard focus to within the flyout
+   */
+  ownFocus: PropTypes.bool,
 };
 
 EuiFlyout.defaultProps = {

--- a/src/components/flyout/flyout.test.js
+++ b/src/components/flyout/flyout.test.js
@@ -2,7 +2,10 @@ import React from 'react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../test';
 
-import { EuiFlyout } from './flyout';
+import {
+  EuiFlyout,
+  SIZES,
+} from './flyout';
 
 describe('EuiFlyout', () => {
   test('is rendered', () => {
@@ -15,5 +18,35 @@ describe('EuiFlyout', () => {
 
     expect(component)
       .toMatchSnapshot();
+  });
+
+  describe('props', () => {
+    test('close button is not rendered', () => {
+      const component = render(
+        <EuiFlyout
+          onClose={() => {}}
+          hideCloseButton
+        />
+      );
+
+      expect(component)
+        .toMatchSnapshot();
+    });
+  });
+
+  describe('size', () => {
+    SIZES.forEach(size => {
+      it(`${size} is rendered`, () => {
+        const component = render(
+          <EuiFlyout
+            onClose={() => {}}
+            size={size}
+          />
+        );
+
+        expect(component)
+          .toMatchSnapshot();
+      });
+    });
   });
 });

--- a/src/components/flyout/flyout_header.js
+++ b/src/components/flyout/flyout_header.js
@@ -5,9 +5,16 @@ import classNames from 'classnames';
 export const EuiFlyoutHeader = ({
   children,
   className,
+  hasBorder,
   ...rest,
 }) => {
-  const classes = classNames('euiFlyoutHeader', className);
+  const classes = classNames(
+    'euiFlyoutHeader',
+    {
+      'euiFlyoutHeader--hasBorder': hasBorder,
+    },
+    className
+  );
 
   return (
     <div
@@ -22,4 +29,8 @@ export const EuiFlyoutHeader = ({
 EuiFlyoutHeader.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
+  /**
+   * Adds a bottom border to the header to divide header from body
+   */
+  hasBorder: PropTypes.bool,
 };

--- a/src/components/flyout/flyout_header.js
+++ b/src/components/flyout/flyout_header.js
@@ -34,3 +34,7 @@ EuiFlyoutHeader.propTypes = {
    */
   hasBorder: PropTypes.bool,
 };
+
+EuiFlyoutHeader.defaultProps = {
+  hasBorder: false,
+};

--- a/src/components/flyout/flyout_header.test.js
+++ b/src/components/flyout/flyout_header.test.js
@@ -13,4 +13,17 @@ describe('EuiFlyoutHeader', () => {
     expect(component)
       .toMatchSnapshot();
   });
+
+  describe('props', () => {
+    test('border is rendered', () => {
+      const component = render(
+        <EuiFlyoutHeader
+          hasBorder
+        />
+      );
+
+      expect(component)
+        .toMatchSnapshot();
+    });
+  });
 });

--- a/src/components/flyout/index.js
+++ b/src/components/flyout/index.js
@@ -1,5 +1,6 @@
 export {
   EuiFlyout,
+  SIZES,
 } from './flyout';
 
 export {


### PR DESCRIPTION
- Added “cross” close button to top right as default if (“onClose”) is present
- Added option for a border below header
- Altered doc examples to represent how we **want** the flyouts to display consistently

<img width="771" alt="screen shot 2018-06-13 at 15 09 31 pm" src="https://user-images.githubusercontent.com/549577/41373231-b69fe868-6f1d-11e8-91ae-0c586967c8d5.png">

@snide I made some design decisions on the header, let me know if you think otherwise.