### PR TITLE
Fix bug where users could tab away from EuiComboBox while navigating the options list

### DIFF
--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -134,7 +134,7 @@ export class EuiComboBox extends Component {
     }
 
     const tabbableItems = tabbable(document);
-    console.log('tabbableItems', tabbableItems)
+
     if (document.activeElement === this.searchInput) {
       const searchInputIndex = tabbableItems.indexOf(this.searchInput);
 

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -134,7 +134,7 @@ export class EuiComboBox extends Component {
     }
 
     const tabbableItems = tabbable(document);
-
+    console.log('tabbableItems', tabbableItems)
     if (document.activeElement === this.searchInput) {
       const searchInputIndex = tabbableItems.indexOf(this.searchInput);
 
@@ -362,6 +362,13 @@ export class EuiComboBox extends Component {
         break;
 
       case TAB:
+        // Disallow tabbing when the user is navigating the options.
+        if (this.hasActiveOption()) {
+          e.preventDefault();
+          e.stopPropagation();
+          break;
+        }
+
         const amount = e.shiftKey ? -1 : 1;
         if (this.tabAway(amount)) {
           e.preventDefault();

--- a/src/components/combo_box/combo_box.test.js
+++ b/src/components/combo_box/combo_box.test.js
@@ -138,7 +138,7 @@ describe('props', () => {
 
 describe('behavior', () => {
   describe('tabbing', () => {
-    test(`off the search input closes the options list if the user isn't navigating the options`, (done) => {
+    test(`off the search input closes the options list if the user isn't navigating the options`, () => {
       const component = mount(
         <EuiComboBox
           options={options}
@@ -155,14 +155,11 @@ describe('behavior', () => {
       // Tab backwards to take focus off the combo box.
       searchInput.simulate('keyDown', { keyCode: comboBoxKeyCodes.TAB, shiftKey: true });
 
-      // Losing focus will close the options list. Wait a bit for the list to be removed.
-      setTimeout(() => {
-        expect(hasComboBoxLostFocus).toBe(true);
-        done();
-      }, 10);
+      // Losing focus will close the options list.
+      expect(hasComboBoxLostFocus).toBe(true);
     });
 
-    test('off the search input does nothing if the user is navigating the options', (done) => {
+    test('off the search input does nothing if the user is navigating the options', () => {
       const component = mount(
         <EuiComboBox
           options={options}
@@ -183,10 +180,7 @@ describe('behavior', () => {
       searchInput.simulate('keyDown', { keyCode: comboBoxKeyCodes.TAB, shiftKey: true });
 
       // List remains open.
-      setTimeout(() => {
-        expect(hasComboBoxLostFocus).toBe(false);
-        done();
-      }, 10);
+      expect(hasComboBoxLostFocus).toBe(false);
     });
   });
 

--- a/src/components/combo_box/combo_box.test.js
+++ b/src/components/combo_box/combo_box.test.js
@@ -2,8 +2,18 @@ import React from 'react';
 import { shallow, render, mount } from 'enzyme';
 import sinon from 'sinon';
 import { requiredProps, findTestSubject } from '../../test';
+import { comboBoxKeyCodes } from '../../services';
 
 import { EuiComboBox } from './combo_box';
+
+// This module requires a browser environment, so we'll fake what it returns.
+jest.mock('tabbable', () => () => [{
+  focus: () => {},
+}, {
+  focus: () => {},
+}, {
+  focus: () => {},
+}]);
 
 const options = [{
   label: 'Titan',
@@ -111,6 +121,53 @@ describe('props', () => {
 });
 
 describe('behavior', () => {
+  describe('tabbing', () => {
+    test.skip(`off the search input closes the options list if the user isn't navigating the options`, () => {
+      const component = mount(
+        <EuiComboBox
+          options={options}
+          selectedOptions={[options[2]]}
+        />
+      );
+
+      const searchInput = findTestSubject(component, 'comboBoxSearchInput');
+      searchInput.simulate('focus');
+
+      // Focusing the input should open the options list.
+      expect(findTestSubject(component, 'comboBoxOptionsList')).toBeDefined();
+
+      // Tab backwards to take focus off the combo box.
+      searchInput.simulate('keyDown', { keyCode: comboBoxKeyCodes.TAB, shiftKey: true });
+
+      // Losing focus will close the options list.
+      expect(findTestSubject(component, 'comboBoxOptionsList')).toBeUndefined();
+    });
+
+    test('off the search input does nothing if the user is navigating the options', () => {
+      const component = mount(
+        <EuiComboBox
+          options={options}
+          selectedOptions={[options[2]]}
+        />
+      );
+
+      const searchInput = findTestSubject(component, 'comboBoxSearchInput');
+      searchInput.simulate('focus');
+
+      // Focusing the input should open the options list.
+      expect(findTestSubject(component, 'comboBoxOptionsList')).toBeDefined();
+
+      // Navigate to an option.
+      searchInput.simulate('keyDown', { keyCode: comboBoxKeyCodes.DOWN });
+
+      // Tab backwards to take focus off the combo box.
+      searchInput.simulate('keyDown', { keyCode: comboBoxKeyCodes.TAB, shiftKey: true });
+
+      // List remains open.
+      expect(findTestSubject(component, 'comboBoxOptionsList')).toBeDefined();
+    });
+  });
+
   describe('clear button', () => {
     test('calls onChange callback with empty array', () => {
       const onChangeHandler = sinon.spy();


### PR DESCRIPTION
This fixes a bug I introduced in https://github.com/elastic/eui/pull/866. In previous discussions, we decided to block the user from tabbing off the combo box if they're navigating through the options list. This mimics how Chrome blocks the user from tabbing off an open select.