### PR TITLE
Fix eslint extends order so kibana rules become more important

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,8 +10,8 @@
     }
   },
   "extends": [
-    "@elastic/eslint-config-kibana",
-    "prettier"
+    "prettier",
+    "@elastic/eslint-config-kibana"
   ],
   "plugins": [
     "prettier"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,11 @@
   "plugins": [
     "prettier"
   ],
+  "rules": {
+    // This is a temporary rule that can be removed as soon as
+    // it is added into eslint-config-kibana
+    "prefer-template": "error"
+  },
   "env": {
     "jest": true
   }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,8 +17,6 @@
     "prettier"
   ],
   "rules": {
-    // This is a temporary rule that can be removed as soon as
-    // it is added into eslint-config-kibana
     "prefer-template": "error"
   },
   "env": {

--- a/src-docs/src/routes.js
+++ b/src-docs/src/routes.js
@@ -174,8 +174,8 @@ import { PortalExample }
 import { ProgressExample }
   from './views/progress/progress_example';
 
-  import { ResponsiveExample }
-    from './views/responsive/responsive_example';
+import { ResponsiveExample }
+  from './views/responsive/responsive_example';
 
 import { SearchBarExample }
   from './views/search_bar/search_bar_example';

--- a/src-docs/src/views/accordion/accordion_grow.js
+++ b/src-docs/src/views/accordion/accordion_grow.js
@@ -27,7 +27,7 @@ class AccordionGrow extends Component {
         paddingSize="l"
       >
         <EuiText>
-          <EuiSpacer size='s' />
+          <EuiSpacer size="s" />
           <p>
             <EuiButton onClick={() => this.onIncrease()}>Increase height</EuiButton>
             {' '}

--- a/src-docs/src/views/avatar/avatar_example.js
+++ b/src-docs/src/views/avatar/avatar_example.js
@@ -42,7 +42,7 @@ export const AvatarExample = {
     ),
     props: { EuiAvatar },
     demo: <Avatar />,
-  },{
+  }, {
     title: 'Initials',
     source: [{
       type: GuideSectionTypes.JS,

--- a/src-docs/src/views/badge/badge_example.js
+++ b/src-docs/src/views/badge/badge_example.js
@@ -106,9 +106,8 @@ export const BadgeExample = {
           components like the EuiKeyPadMenuItem.
         </p>
         <p>
-          They can also be used in conjunction
-          with <EuiLink href="/#/display/card">EuiCards</EuiLink>
-          and <EuiLink href="/#/navigation/key-pad-menu">EuiKeyPadMenuItems</EuiLink>.
+          They can also be used in conjunction with <EuiLink href="/#/display/card">EuiCards</EuiLink>
+          &nbsp;and <EuiLink href="/#/navigation/key-pad-menu">EuiKeyPadMenuItems</EuiLink>.
         </p>
       </div>
     ),

--- a/src-docs/src/views/badge/badge_example.js
+++ b/src-docs/src/views/badge/badge_example.js
@@ -107,7 +107,8 @@ export const BadgeExample = {
         </p>
         <p>
           They can also be used in conjunction
-          with <EuiLink href="/#/display/card">EuiCards</EuiLink> and <EuiLink href="/#/navigation/key-pad-menu">EuiKeyPadMenuItems</EuiLink>.
+          with <EuiLink href="/#/display/card">EuiCards</EuiLink>
+          and <EuiLink href="/#/navigation/key-pad-menu">EuiKeyPadMenuItems</EuiLink>.
         </p>
       </div>
     ),

--- a/src-docs/src/views/badge/beta_badge.js
+++ b/src-docs/src/views/badge/beta_badge.js
@@ -17,7 +17,7 @@ export default () => (
     <EuiSpacer />
     <EuiTitle>
       <h3>
-        Beta badges will also line up nicely with titles
+        Beta badges will also line up nicely with titles &nbsp;
         <EuiBetaBadge label="Lab" tooltipContent="This module is not GA. Please help us by reporting any bugs." />
       </h3>
     </EuiTitle>

--- a/src-docs/src/views/badge/beta_badge.js
+++ b/src-docs/src/views/badge/beta_badge.js
@@ -16,7 +16,10 @@ export default () => (
 
     <EuiSpacer />
     <EuiTitle>
-      <h3>Beta badges will also line up nicely with titles <EuiBetaBadge label="Lab" tooltipContent="This module is not GA. Please help us by reporting any bugs." /></h3>
+      <h3>
+        Beta badges will also line up nicely with titles
+        <EuiBetaBadge label="Lab" tooltipContent="This module is not GA. Please help us by reporting any bugs." />
+      </h3>
     </EuiTitle>
   </div>
 );

--- a/src-docs/src/views/button/button_icon.js
+++ b/src-docs/src/views/button/button_icon.js
@@ -27,7 +27,7 @@ export default () => (
             onClick={() => window.alert('Button clicked')}
             iconType="arrowRight"
             aria-label="Next"
-            disabled={color === "disabled" ? true : false}
+            disabled={color === 'disabled' ? true : false}
           />
         </EuiFlexItem>
       ))

--- a/src-docs/src/views/button/button_toggle.js
+++ b/src-docs/src/views/button/button_toggle.js
@@ -43,7 +43,7 @@ export default class extends Component {
         &emsp;
 
         <EuiButtonToggle
-          label={this.state.toggle1On ? "I'm a filled toggle" : "I'm a primary toggle"}
+          label={this.state.toggle1On ? 'I\'m a filled toggle' : 'I\'m a primary toggle'}
           fill={this.state.toggle1On}
           onChange={this.onToggle1Change}
         />

--- a/src-docs/src/views/call_out/call_out_example.js
+++ b/src-docs/src/views/call_out/call_out_example.js
@@ -67,7 +67,7 @@ export const CallOutExample = {
       </EuiText>
       <EuiSpacer size="l"/>
     </Fragment>
- ),
+  ),
   sections: [{
     title: 'Info',
     source: [{

--- a/src-docs/src/views/card/card_beta.js
+++ b/src-docs/src/views/card/card_beta.js
@@ -18,7 +18,7 @@ const cardNodes = icons.map(function (item, index) {
         title={`Kibana ${item}`}
         description="Example of a card's description. Stick to one or two sentences."
         betaBadgeLabel={badges[index]}
-        betaBadgeTooltipContent={badges[index] ? "This module is not GA. Please help us by reporting any bugs." : undefined}
+        betaBadgeTooltipContent={badges[index] ? 'This module is not GA. Please help us by reporting any bugs.' : undefined}
         onClick={() => window.alert('Card clicked')}
       />
     </EuiFlexItem>

--- a/src-docs/src/views/card/card_example.js
+++ b/src-docs/src/views/card/card_example.js
@@ -72,11 +72,16 @@ export const CardExample = {
       <div>
         <p>
           Most of the time, cards should read from top to bottom (vertical). However, in some cases, you may
-          want the icon to be to the left of the content. In this case, add the prop <EuiCode>layout=&quot;horizontal&quot;</EuiCode>.
+          want the icon to be to the left of the content. In this case, add
+          the prop <EuiCode>layout=&quot;horizontal&quot;</EuiCode>.
         </p>
         <EuiCallOut
           color="danger"
-          title={<span>Horizontal layouts <strong>do not</strong> work with images, footers or <EuiCode>textAlign</EuiCode>. Therefore, these properties will be ignored.</span>}
+          title={
+            <span>Horizontal layouts <strong>do not</strong> work with images,
+            footers or <EuiCode>textAlign</EuiCode>. Therefore, these properties will be ignored.
+            </span>
+          }
         />
       </div>
     ),
@@ -99,7 +104,11 @@ export const CardExample = {
           Just pass a url into the <EuiCode>image</EuiCode> prop and it will expand to to edges of the card.
         </p>
         <EuiCallOut
-          title={<span>Make sure that all images are the <strong>same proportions</strong> when used in a singular row.</span>}
+          title={
+            <span>Make sure that all images are the <strong>same proportions</strong> when
+              used in a singular row.
+            </span>
+          }
         />
       </div>
     ),

--- a/src-docs/src/views/combo_box/virtualized.js
+++ b/src-docs/src/views/combo_box/virtualized.js
@@ -10,7 +10,7 @@ export default class extends Component {
 
     this.options = [];
     let groupOptions = [];
-    for (let i=1; i < 5000; i++) {
+    for (let i = 1; i < 5000; i++) {
       groupOptions.push({ label: `option${i}` });
       if (i % 25 === 0) {
         this.options.push({

--- a/src-docs/src/views/date_picker/custom_input.js
+++ b/src-docs/src/views/date_picker/custom_input.js
@@ -15,7 +15,7 @@ import {
 // eslint-disable-next-line react/prefer-stateless-function
 class ExampleCustomInput extends React.Component {
 
-  render () {
+  render() {
     return (
       <EuiButton
         className="example-custom-input"
@@ -23,7 +23,7 @@ class ExampleCustomInput extends React.Component {
       >
         {this.props.value}
       </EuiButton>
-    )
+    );
   }
 }
 

--- a/src-docs/src/views/date_picker/date_picker_example.js
+++ b/src-docs/src/views/date_picker/date_picker_example.js
@@ -233,27 +233,27 @@ export const DatePickerExample = {
       </p>
     ),
     demo: <Inline />,
+  }, {
+    title: 'Custom classes',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: classesSource,
     }, {
-      title: 'Custom classes',
-      source: [{
-        type: GuideSectionTypes.JS,
-        code: classesSource,
-      }, {
-        type: GuideSectionTypes.HTML,
-        code: classesHtml,
-      }],
-      text: (
-        <div>
-          <p>
+      type: GuideSectionTypes.HTML,
+      code: classesHtml,
+    }],
+    text: (
+      <div>
+        <p>
             Custom classes can be passed to various bits of the calendar and input.
-          </p>
-          <ul>
-            <li><EuiCode>className</EuiCode> will pass onto the input.</li>
-            <li><EuiCode>calendarClassName</EuiCode> will pass onto the calendar itself.</li>
-            <li><EuiCode>dayClassName</EuiCode> will pass onto specificed days.</li>
-          </ul>
-        </div>
-      ),
-      demo: <Classes />,
+        </p>
+        <ul>
+          <li><EuiCode>className</EuiCode> will pass onto the input.</li>
+          <li><EuiCode>calendarClassName</EuiCode> will pass onto the calendar itself.</li>
+          <li><EuiCode>dayClassName</EuiCode> will pass onto specificed days.</li>
+        </ul>
+      </div>
+    ),
+    demo: <Classes />,
   }],
 };

--- a/src-docs/src/views/date_picker/min_max.js
+++ b/src-docs/src/views/date_picker/min_max.js
@@ -18,8 +18,8 @@ export default class extends Component {
     this.state = {
       startDate: moment(),
       startDate2: moment(),
-      startDate3: moment().add(1, "days"),
-      startDate4: moment().add(1, "days"),
+      startDate3: moment().add(1, 'days'),
+      startDate4: moment().add(1, 'days'),
       startDate5: moment(),
     };
 
@@ -63,7 +63,7 @@ export default class extends Component {
   isWeekday(date) {
     const day = date.day();
     return day !== 0 && day !== 6;
-  };
+  }
 
   render() {
     return (
@@ -73,8 +73,8 @@ export default class extends Component {
             showTimeSelect
             selected={this.state.startDate}
             onChange={this.handleChange}
-            minDate={moment().subtract(2, "days")}
-            maxDate={moment().add(5, "days")}
+            minDate={moment().subtract(2, 'days')}
+            maxDate={moment().add(5, 'days')}
           />
         </EuiFormRow>
 
@@ -97,7 +97,7 @@ export default class extends Component {
             showTimeSelect
             selected={this.state.startDate3}
             onChange={this.handleChange3}
-            excludeDates={[moment(), moment().subtract(1, "days")]}
+            excludeDates={[moment(), moment().subtract(1, 'days')]}
           />
         </EuiFormRow>
 

--- a/src-docs/src/views/date_picker/open_to_date.js
+++ b/src-docs/src/views/date_picker/open_to_date.js
@@ -33,7 +33,7 @@ export default class extends Component {
         <EuiDatePicker
           selected={this.state.startDate}
           onChange={this.handleChange}
-          openToDate={moment("1993-09-28")}
+          openToDate={moment('1993-09-28')}
           placeholder="Back to 1993"
         />
       </EuiFormRow>

--- a/src-docs/src/views/date_picker/states.js
+++ b/src-docs/src/views/date_picker/states.js
@@ -28,9 +28,9 @@ export default class extends Component {
 
   render() {
     const errors = [
-        'Here\'s an example of an error',
-        'You might have more than one error, so pass an array.',
-      ];
+      'Here\'s an example of an error',
+      'You might have more than one error, so pass an array.',
+    ];
 
     return (
       <div>

--- a/src-docs/src/views/empty_prompt/custom.js
+++ b/src-docs/src/views/empty_prompt/custom.js
@@ -13,7 +13,10 @@ export default () => (
     titleSize="xs"
     body={
       <Fragment>
-        <p>Navigators use massive amounts of spice to gain a limited form of prescience. This allows them to safely navigate interstellar space, enabling trade and travel throughout the galaxy.</p>
+        <p>
+          Navigators use massive amounts of spice to gain a limited form of prescience.
+          This allows them to safely navigate interstellar space, enabling trade and travel throughout the galaxy.
+        </p>
         <p>You&rsquo;ll need spice to rule Arrakis, young Atreides.</p>
       </Fragment>
     }

--- a/src-docs/src/views/empty_prompt/empty_prompt.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt.js
@@ -11,7 +11,10 @@ export default () => (
     title={<h2>You have no spice</h2>}
     body={
       <Fragment>
-        <p>Navigators use massive amounts of spice to gain a limited form of prescience. This allows them to safely navigate interstellar space, enabling trade and travel throughout the galaxy.</p>
+        <p>
+          Navigators use massive amounts of spice to gain a limited form of prescience.
+          This allows them to safely navigate interstellar space, enabling trade and travel throughout the galaxy.
+        </p>
         <p>You&rsquo;ll need spice to rule Arrakis, young Atreides.</p>
       </Fragment>
     }

--- a/src-docs/src/views/flyout/flyout_complicated.js
+++ b/src-docs/src/views/flyout/flyout_complicated.js
@@ -157,7 +157,7 @@ export class FlyoutComplicated extends Component {
             <EuiText color="subdued">
               <p>Put navigation items in the header, and cross tab actions in a footer.</p>
             </EuiText>
-            <EuiTabs style={{ marginBottom: "-25px" }}>
+            <EuiTabs style={{ marginBottom: '-25px' }}>
               {this.renderTabs()}
             </EuiTabs>
           </EuiFlyoutHeader>

--- a/src-docs/src/views/form_layouts/described_form_group.js
+++ b/src-docs/src/views/form_layouts/described_form_group.js
@@ -60,8 +60,8 @@ export default class extends Component {
 
   onCheckboxChange = optionId => {
     const newCheckboxIdToSelectedMap = ({ ...this.state.checkboxIdToSelectedMap, ...{
-        [optionId]: !this.state.checkboxIdToSelectedMap[optionId],
-      } });
+      [optionId]: !this.state.checkboxIdToSelectedMap[optionId],
+    } });
 
     this.setState({
       checkboxIdToSelectedMap: newCheckboxIdToSelectedMap,

--- a/src-docs/src/views/header/header_example.js
+++ b/src-docs/src/views/header/header_example.js
@@ -50,8 +50,8 @@ export const HeaderExample = {
       EuiHeaderLogo,
     },
     demo: <Header />,
-  },{
-    title: "Links",
+  }, {
+    title: 'Links',
     source: [{
       type: GuideSectionTypes.JS,
       code: headerLinksSource,
@@ -61,7 +61,8 @@ export const HeaderExample = {
     }],
     text: (
       <p>
-        If you&rsquo;re using EUI in a one-off site or page, you can use <EuiCode>EuiHeaderLinks</EuiCode>, <EuiCode>EuiHeaderLink</EuiCode>s instead of breadcrumbs.
+        If you&rsquo;re using EUI in a one-off site or page, you can use <EuiCode>EuiHeaderLinks</EuiCode>,
+        <EuiCode>EuiHeaderLink</EuiCode>s instead of breadcrumbs.
       </p>
     ),
     props: {

--- a/src-docs/src/views/header/header_example.js
+++ b/src-docs/src/views/header/header_example.js
@@ -62,7 +62,7 @@ export const HeaderExample = {
     text: (
       <p>
         If you&rsquo;re using EUI in a one-off site or page, you can use <EuiCode>EuiHeaderLinks</EuiCode>,
-        <EuiCode>EuiHeaderLink</EuiCode>s instead of breadcrumbs.
+        &nbsp;<EuiCode>EuiHeaderLink</EuiCode>s instead of breadcrumbs.
       </p>
     ),
     props: {

--- a/src-docs/src/views/package/changelog.js
+++ b/src-docs/src/views/package/changelog.js
@@ -2,8 +2,8 @@ import React from 'react';
 
 import MarkdownIt from 'markdown-it';
 
-import { EuiText } from '../../../..'
-import { GuidePage } from '../../components/guide_page'
+import { EuiText } from '../../../..';
+import { GuidePage } from '../../components/guide_page';
 
 const changelogSource = require('!!raw-loader!../../../../CHANGELOG.md');
 const md = new MarkdownIt();

--- a/src-docs/src/views/panel/panel_badge.js
+++ b/src-docs/src/views/panel/panel_badge.js
@@ -13,7 +13,10 @@ const panelNodes = badges.map(function (item, index) {
     <EuiFlexItem key={index}>
       <EuiPanel
         betaBadgeLabel={badges[index]}
-        betaBadgeTooltipContent={badges[index] ? "This module is not GA. Please help us by reporting any bugs." : undefined}
+        betaBadgeTooltipContent={badges[index]
+          ? 'This module is not GA. Please help us by reporting any bugs.'
+          : undefined
+        }
         onClick={() => window.alert('Card clicked')}
       >
         I am some panel content

--- a/src-docs/src/views/responsive/responsive.js
+++ b/src-docs/src/views/responsive/responsive.js
@@ -12,11 +12,11 @@ export default () => (
       Hiding from <EuiCode>xs</EuiCode> screens only
     </EuiHideFor>
     <br/>
-    <EuiHideFor sizes={['xs','s']}>
+    <EuiHideFor sizes={['xs', 's']}>
       Hiding from <EuiCode>xs, s</EuiCode> screens
     </EuiHideFor>
     <br/>
-    <EuiHideFor sizes={['xs','s','m', 'l']}>
+    <EuiHideFor sizes={['xs', 's', 'm', 'l']}>
       Hiding from <EuiCode>xs, s, m, l</EuiCode> screens
     </EuiHideFor>
     <br/>
@@ -31,11 +31,11 @@ export default () => (
       Showing for <EuiCode>xs</EuiCode> screens only
     </EuiShowFor>
     <br/>
-    <EuiShowFor sizes={['xs','s']}>
+    <EuiShowFor sizes={['xs', 's']}>
       Showing for <EuiCode>xs, s</EuiCode> screens
     </EuiShowFor>
     <br/>
-    <EuiShowFor sizes={['xs','s','m', 'l']}>
+    <EuiShowFor sizes={['xs', 's', 'm', 'l']}>
       Showing for <EuiCode>xs, s, m, l</EuiCode> screens
     </EuiShowFor>
     <br/>

--- a/src-docs/src/views/responsive/responsive_example.js
+++ b/src-docs/src/views/responsive/responsive_example.js
@@ -22,16 +22,16 @@ function renderSizes(size, index) {
   let code = `'${size}': ${sizes.euiBreakpoints[size]}px`;
 
   if (index < sizes.euiBreakpointKeys.length - 1) {
-    code += ` (to ${(sizes.euiBreakpoints[sizes.euiBreakpointKeys[index+1]] - 1)}px)`;
+    code += ` (to ${(sizes.euiBreakpoints[sizes.euiBreakpointKeys[index + 1]] - 1)}px)`;
   } else {
-  code += ` +`;
+    code += ` +`;
   }
 
   return (
     <div key={index}>
       {code}
     </div>
-  )
+  );
 }
 
 export const ResponsiveExample = {

--- a/src-docs/src/views/search_bar/search_bar_example.js
+++ b/src-docs/src/views/search_bar/search_bar_example.js
@@ -108,7 +108,10 @@ export const SearchBarExample = {
       text: (
         <div>
           <p>
-            A <EuiCode>EuiSearchBar</EuiCode> can have its query controlled by a parent component by passing the <EuiCode>query</EuiCode> prop. Changes to the query will be passed back up through the <EuiCode>onChange</EuiCode> callback where the new Query must be stored in state and passed back into the search bar.
+            A <EuiCode>EuiSearchBar</EuiCode> can have its query controlled by a parent component by
+            passing the <EuiCode>query</EuiCode> prop. Changes to the query will be passed back up through
+            the <EuiCode>onChange</EuiCode> callback where the new Query must be stored in state and
+            passed back into the search bar.
           </p>
         </div>
       ),

--- a/src-docs/src/views/steps/status.js
+++ b/src-docs/src/views/steps/status.js
@@ -31,7 +31,7 @@ export default class extends Component {
   render() {
 
     let button;
-    if (this.state.status === "incomplete") {
+    if (this.state.status === 'incomplete') {
       button = (
         <EuiButton onClick={this.handleComplete}>You complete me</EuiButton>
       );

--- a/src-docs/src/views/tables/custom/custom.js
+++ b/src-docs/src/views/tables/custom/custom.js
@@ -67,7 +67,11 @@ export default class extends Component {
       health: <EuiHealth color="success">Healthy</EuiHealth>,
     }, {
       id: 2,
-      title: <span>A very long line in an ELEMENT which will wrap on narrower screens and NOT become truncated and replaced by an ellipsis</span>,
+      title:
+  <span>
+          A very long line in an ELEMENT which will wrap on narrower screens and NOT become
+          truncated and replaced by an ellipsis
+  </span>,
       type: 'user',
       dateCreated: <span>Tue Dec 01 2016 &nbsp; <EuiBadge color="secondary">New!</EuiBadge></span>,
       magnitude: 10,
@@ -75,7 +79,11 @@ export default class extends Component {
     }, {
       id: 3,
       title: {
-        value: <span>A very long line in an ELEMENT which will not wrap on narrower screens and instead will become truncated and replaced by an ellipsis</span>,
+        value:
+  <span>
+            A very long line in an ELEMENT which will not wrap on narrower screens and instead
+            will become truncated and replaced by an ellipsis
+  </span>,
         truncateText: true,
       },
       type: 'user',
@@ -221,7 +229,7 @@ export default class extends Component {
       label: 'Title',
       isMobileHeader: true,
       render: (title, item) => (
-        <span><EuiIcon type={item.type} size="m" style={{ verticalAlign: "text-top" }} /> {title}</span>
+        <span><EuiIcon type={item.type} size="m" style={{ verticalAlign: 'text-top' }} /> {title}</span>
       ),
     }, {
       id: 'health',

--- a/src-docs/src/views/tables/custom/custom_section.js
+++ b/src-docs/src/views/tables/custom/custom_section.js
@@ -38,7 +38,7 @@ export const section = {
       <p>
         As an alternative to <EuiCode>EuiBasicTable</EuiCode> you can instead construct a table from
         individual <strong>low level, basic components</strong> like <EuiCode>EuiTableHeader</EuiCode>
-        and <EuiCode>EuiTableRowCell</EuiCode>.
+        &nbsp;and <EuiCode>EuiTableRowCell</EuiCode>.
         Below is one of many ways you might set this up on your own.
         Important to note are how you need to set individual props like
         the <EuiCode>truncateText</EuiCode> prop to cells to enforce a single-line behavior
@@ -58,7 +58,7 @@ export const section = {
         like selection and filtering. In order to add mobile support for these functions,
         you will need to implement the <EuiCode>EuiTableHeaderMobile</EuiCode> component
         as a wrapper around these and use <EuiCode>EuiTableSortMobile</EuiCode>
-        and <EuiCode>EuiTableSortMobileItem</EuiCode> components
+        &nbsp;and <EuiCode>EuiTableSortMobileItem</EuiCode> components
         to supply mobile sorting. See demo below.
       </p>
     </div>

--- a/src-docs/src/views/tables/custom/custom_section.js
+++ b/src-docs/src/views/tables/custom/custom_section.js
@@ -37,7 +37,8 @@ export const section = {
     <div>
       <p>
         As an alternative to <EuiCode>EuiBasicTable</EuiCode> you can instead construct a table from
-        individual <strong>low level, basic components</strong> like <EuiCode>EuiTableHeader</EuiCode> and <EuiCode>EuiTableRowCell</EuiCode>.
+        individual <strong>low level, basic components</strong> like <EuiCode>EuiTableHeader</EuiCode>
+        and <EuiCode>EuiTableRowCell</EuiCode>.
         Below is one of many ways you might set this up on your own.
         Important to note are how you need to set individual props like
         the <EuiCode>truncateText</EuiCode> prop to cells to enforce a single-line behavior
@@ -56,7 +57,8 @@ export const section = {
         Also, custom table implementation <strong>will not</strong> auto-populate any header level functions
         like selection and filtering. In order to add mobile support for these functions,
         you will need to implement the <EuiCode>EuiTableHeaderMobile</EuiCode> component
-        as a wrapper around these and use <EuiCode>EuiTableSortMobile</EuiCode> and <EuiCode>EuiTableSortMobileItem</EuiCode> components
+        as a wrapper around these and use <EuiCode>EuiTableSortMobile</EuiCode>
+        and <EuiCode>EuiTableSortMobileItem</EuiCode> components
         to supply mobile sorting. See demo below.
       </p>
     </div>

--- a/src-docs/src/views/tables/in_memory/in_memory_selection.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_selection.js
@@ -132,14 +132,15 @@ export class Table extends Component {
       >
         Load Users
       </EuiButton>
-    ), (
-      <EuiButton
-        key="loadUsersError"
-        onClick={this.loadUsersWithError.bind(this)}
-        isDisabled={this.state.loading}
-      >
-        Load Users (Error)
-      </EuiButton>
+    ),
+      (
+        <EuiButton
+          key="loadUsersError"
+          onClick={this.loadUsersWithError.bind(this)}
+          isDisabled={this.state.loading}
+        >
+      Load Users (Error)
+        </EuiButton>
       )];
   }
 

--- a/src-docs/src/views/tables/in_memory/props_info.js
+++ b/src-docs/src/views/tables/in_memory/props_info.js
@@ -87,8 +87,8 @@ export const propsInfo = {
           type: { name: '#SearchFilters' }
         },
         onChange: {
-          description: 'Callback for when the search bar value changes. By default this will prevent in-memory ' +
-            'searching. Return `true` to allow in-memory searching.',
+          description: `Callback for when the search bar value changes. By default this will prevent in-memory 
+            searching. Return \`true\` to allow in-memory searching.`,
           required: false,
           type: { name: 'function' }
         }

--- a/src-docs/src/views/tables/in_memory/props_info.js
+++ b/src-docs/src/views/tables/in_memory/props_info.js
@@ -87,7 +87,8 @@ export const propsInfo = {
           type: { name: '#SearchFilters' }
         },
         onChange: {
-          description: 'Callback for when the search bar value changes. By default this will prevent in-memory searching. Return `true` to allow in-memory searching.',
+          description: 'Callback for when the search bar value changes. By default this will prevent in-memory ' +
+            'searching. Return `true` to allow in-memory searching.',
           required: false,
           type: { name: 'function' }
         }

--- a/src-docs/src/views/tables/in_memory/props_info.js
+++ b/src-docs/src/views/tables/in_memory/props_info.js
@@ -88,7 +88,7 @@ export const propsInfo = {
         },
         onChange: {
           description: `Callback for when the search bar value changes. By default this will prevent in-memory 
-            searching. Return \`true\` to allow in-memory searching.`,
+          searching. Return \`true\` to allow in-memory searching.`,
           required: false,
           type: { name: 'function' }
         }

--- a/src-docs/src/views/tables/in_memory/props_info.js
+++ b/src-docs/src/views/tables/in_memory/props_info.js
@@ -17,13 +17,13 @@ export const propsInfo = {
         },
         message: {
           description: `A message to be shown by the table. When set, the message will be displayed 
-            instead of the configured items`,
+          instead of the configured items`,
           required: false,
           type: { name: 'string' }
         },
         error: {
           description: `An error message to be shown by the table. Takes precedence over the 
-            configured \`message\` or \`items\``,
+          configured \`message\` or \`items\``,
           required: false,
           type: { name: 'string' }
         },

--- a/src-docs/src/views/tables/in_memory/props_info.js
+++ b/src-docs/src/views/tables/in_memory/props_info.js
@@ -16,14 +16,14 @@ export const propsInfo = {
           type: { name: `object[]` }
         },
         message: {
-          description: 'A message to be shown by the table. When set, the message will be displayed instead of ' +
-          'the configured items',
+          description: `A message to be shown by the table. When set, the message will be displayed 
+            instead of the configured items`,
           required: false,
           type: { name: 'string' }
         },
         error: {
-          description: 'An error message to be shown by the table. Takes precedence over the configured `message` ' +
-                       'or `items`',
+          description: `An error message to be shown by the table. Takes precedence over the 
+            configured \`message\` or \`items\``,
           required: false,
           type: { name: 'string' }
         },

--- a/src-docs/src/views/tables/mobile/mobile_section.js
+++ b/src-docs/src/views/tables/mobile/mobile_section.js
@@ -47,7 +47,7 @@ export const section = {
       </h4>
       <p>
         Add the following properties to your data and/or <EuiCode>&lt;EuiTableRowCell&gt;</EuiCode>
-        and <EuiCode>&lt;EuiTableHeaderCell&gt;</EuiCode> to
+        &nbsp;and <EuiCode>&lt;EuiTableHeaderCell&gt;</EuiCode> to
         customize the look of the section header.
       </p>
       <ul>

--- a/src-docs/src/views/tables/mobile/mobile_section.js
+++ b/src-docs/src/views/tables/mobile/mobile_section.js
@@ -46,7 +46,8 @@ export const section = {
         Custom mobile headers
       </h4>
       <p>
-        Add the following properties to your data and/or <EuiCode>&lt;EuiTableRowCell&gt;</EuiCode> and <EuiCode>&lt;EuiTableHeaderCell&gt;</EuiCode> to
+        Add the following properties to your data and/or <EuiCode>&lt;EuiTableRowCell&gt;</EuiCode>
+        and <EuiCode>&lt;EuiTableHeaderCell&gt;</EuiCode> to
         customize the look of the section header.
       </p>
       <ul>

--- a/src-docs/src/views/tabs/controlled.js
+++ b/src-docs/src/views/tabs/controlled.js
@@ -19,7 +19,12 @@ class EuiTabsExample extends Component {
         <Fragment>
           <EuiSpacer />
           <EuiTitle><h3>Cobalt</h3></EuiTitle>
-          <EuiText>Cobalt is a chemical element with symbol Co and atomic number 27. Like nickel, cobalt is found in the Earth&rsquo;s crust only in chemically combined form, save for small deposits found in alloys of natural meteoric iron. The free element, produced by reductive smelting, is a hard, lustrous, silver-gray metal.</EuiText>
+          <EuiText>
+            Cobalt is a chemical element with symbol Co and atomic number 27. Like nickel, cobalt is
+            found in the Earth&rsquo;s crust only in chemically combined form, save for small deposits found
+            in alloys of natural meteoric iron. The free element, produced by reductive smelting, is a hard,
+            lustrous, silver-gray metal.
+          </EuiText>
         </Fragment>
       ),
     }, {
@@ -29,7 +34,10 @@ class EuiTabsExample extends Component {
         <Fragment>
           <EuiSpacer />
           <EuiTitle><h3>Dextrose</h3></EuiTitle>
-          <EuiText>Intravenous sugar solution, also known as dextrose solution, is a mixture of dextrose (glucose) and water. It is used to treat low blood sugar or water loss without electrolyte loss.</EuiText>
+          <EuiText>
+            Intravenous sugar solution, also known as dextrose solution, is a mixture of dextrose (glucose)
+            and water. It is used to treat low blood sugar or water loss without electrolyte loss.
+          </EuiText>
         </Fragment>
       ),
     }, {
@@ -39,7 +47,10 @@ class EuiTabsExample extends Component {
         <Fragment>
           <EuiSpacer />
           <EuiTitle><h3>Hydrogen</h3></EuiTitle>
-          <EuiText>Hydrogen is a chemical element with symbol H and atomic number 1. With a standard atomic weight of 1.008, hydrogen is the lightest element on the periodic table</EuiText>
+          <EuiText>
+            Hydrogen is a chemical element with symbol H and atomic number 1. With a standard atomic weight
+            of 1.008, hydrogen is the lightest element on the periodic table
+          </EuiText>
         </Fragment>
       ),
     }, {
@@ -49,7 +60,11 @@ class EuiTabsExample extends Component {
         <Fragment>
           <EuiSpacer />
           <EuiTitle><h3>Monosodium Glutamate</h3></EuiTitle>
-          <EuiText>Monosodium glutamate (MSG, also known as sodium glutamate) is the sodium salt of glutamic acid, one of the most abundant naturally occurring non-essential amino acids. Monosodium glutamate is found naturally in tomatoes, cheese and other foods.</EuiText>
+          <EuiText>
+            Monosodium glutamate (MSG, also known as sodium glutamate) is the sodium salt of glutamic acid,
+            one of the most abundant naturally occurring non-essential amino acids. Monosodium glutamate is found
+            naturally in tomatoes, cheese and other foods.
+          </EuiText>
         </Fragment>
       ),
     }];
@@ -64,7 +79,7 @@ class EuiTabsExample extends Component {
   };
 
   cycleTab = () => {
-    const selectedTabIndex = this.tabs.indexOf(this.state.selectedTab)
+    const selectedTabIndex = this.tabs.indexOf(this.state.selectedTab);
     const nextTabIndex = selectedTabIndex < this.tabs.length - 1 ? selectedTabIndex + 1 : 0;
     this.setState({
       selectedTab: this.tabs[nextTabIndex],

--- a/src-docs/src/views/tabs/tabbed_content.js
+++ b/src-docs/src/views/tabs/tabbed_content.js
@@ -18,7 +18,12 @@ class EuiTabsExample extends Component {
         <Fragment>
           <EuiSpacer />
           <EuiTitle><h3>Cobalt</h3></EuiTitle>
-          <EuiText>Cobalt is a chemical element with symbol Co and atomic number 27. Like nickel, cobalt is found in the Earth&rsquo;s crust only in chemically combined form, save for small deposits found in alloys of natural meteoric iron. The free element, produced by reductive smelting, is a hard, lustrous, silver-gray metal.</EuiText>
+          <EuiText>
+            Cobalt is a chemical element with symbol Co and atomic number 27. Like nickel, cobalt is found
+            in the Earth&rsquo;s crust only in chemically combined form, save for small deposits found in alloys of
+            natural meteoric iron. The free element, produced by reductive smelting, is a hard, lustrous,
+            silver-gray metal.
+          </EuiText>
         </Fragment>
       ),
     }, {
@@ -28,7 +33,10 @@ class EuiTabsExample extends Component {
         <Fragment>
           <EuiSpacer />
           <EuiTitle><h3>Dextrose</h3></EuiTitle>
-          <EuiText>Intravenous sugar solution, also known as dextrose solution, is a mixture of dextrose (glucose) and water. It is used to treat low blood sugar or water loss without electrolyte loss.</EuiText>
+          <EuiText>
+            Intravenous sugar solution, also known as dextrose solution, is a mixture of dextrose (glucose)
+            and water. It is used to treat low blood sugar or water loss without electrolyte loss.
+          </EuiText>
         </Fragment>
       ),
     }, {
@@ -38,7 +46,10 @@ class EuiTabsExample extends Component {
         <Fragment>
           <EuiSpacer />
           <EuiTitle><h3>Hydrogen</h3></EuiTitle>
-          <EuiText>Hydrogen is a chemical element with symbol H and atomic number 1. With a standard atomic weight of 1.008, hydrogen is the lightest element on the periodic table</EuiText>
+          <EuiText>
+            Hydrogen is a chemical element with symbol H and atomic number 1. With a standard atomic
+            weight of 1.008, hydrogen is the lightest element on the periodic table
+          </EuiText>
         </Fragment>
       ),
     }, {
@@ -48,7 +59,11 @@ class EuiTabsExample extends Component {
         <Fragment>
           <EuiSpacer />
           <EuiTitle><h3>Monosodium Glutamate</h3></EuiTitle>
-          <EuiText>Monosodium glutamate (MSG, also known as sodium glutamate) is the sodium salt of glutamic acid, one of the most abundant naturally occurring non-essential amino acids. Monosodium glutamate is found naturally in tomatoes, cheese and other foods.</EuiText>
+          <EuiText>
+            Monosodium glutamate (MSG, also known as sodium glutamate) is the sodium salt of glutamic acid,
+            one of the most abundant naturally occurring non-essential amino acids. Monosodium glutamate is
+            found naturally in tomatoes, cheese and other foods.
+          </EuiText>
         </Fragment>
       ),
     }];

--- a/src-docs/src/views/text/text_example.js
+++ b/src-docs/src/views/text/text_example.js
@@ -87,7 +87,7 @@ export const TextExample = {
         There are two ways to color text. Either individually by
         applying <EuiCode>EuiTextColor</EuiCode> on individual text objects, or
         by passing the <EuiCode>color</EuiCode> prop directly on <EuiCode>EuiText</EuiCode> for
-        a blanket approach across the entirely of your text. 
+        a blanket approach across the entirely of your text.
       </p>
     ),
     props: { EuiTextColor },

--- a/src-docs/src/views/text/text_width.js
+++ b/src-docs/src/views/text/text_width.js
@@ -7,11 +7,14 @@ import {
 export default () => (
   <EuiText grow>
     <p>
-      Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy lies a small unregarded yellow sun.
+      Far out in the uncharted backwaters of the unfashionable end of the western spiral arm
+      of the Galaxy lies a small unregarded yellow sun.
     </p>
 
     <p>
-      Orbiting this at a distance of roughly ninety-two million miles is an utterly insignificant little blue green planet whose ape- descended life forms are so amazingly primitive that they still think digital watches are a pretty neat idea.
+      Orbiting this at a distance of roughly ninety-two million miles is an utterly insignificant
+      little blue green planet whose ape- descended life forms are so amazingly primitive that they
+      still think digital watches are a pretty neat idea.
     </p>
   </EuiText>
 );

--- a/src-docs/src/views/toggle/toggle_example.js
+++ b/src-docs/src/views/toggle/toggle_example.js
@@ -36,7 +36,8 @@ export const ToggleExample = {
         </p>
         <p>
           By default, the children will be wrapped in a block element. To change the display you can
-          simply use one of the <EuiLink href="/#/utilities/css-utility-classes">utility classes</EuiLink> like <EuiCode>.eui-displayInlineBlock</EuiCode>.
+          simply use one of the <EuiLink href="/#/utilities/css-utility-classes">utility classes</EuiLink>
+          like <EuiCode>.eui-displayInlineBlock</EuiCode>.
         </p>
         <EuiCallOut title="Accessibility">
           <p>

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -37,7 +37,7 @@ export class EuiAccordion extends Component {
 
   setChildContentHeight = () => {
     requestAnimationFrame(() => {
-      const height = this.state.isOpen ? this.childContent.clientHeight: 0;
+      const height = this.state.isOpen ? this.childContent.clientHeight : 0;
       this.childWrapper.setAttribute('style', `height: ${height}px`);
     });
   }

--- a/src/components/avatar/avatar.js
+++ b/src/components/avatar/avatar.js
@@ -74,7 +74,7 @@ export const EuiAvatar = ({
   const textColor = isColorDark(...hexToRgb(assignedColor)) ? '#FFFFFF' : '#000000';
 
   const avatarStyle = {
-    backgroundImage: imageUrl ? 'url(' + imageUrl + ')' : 'none',
+    backgroundImage: imageUrl ? `url(${  imageUrl  })` : 'none',
     backgroundColor: assignedColor,
     color: textColor,
   };

--- a/src/components/avatar/avatar.js
+++ b/src/components/avatar/avatar.js
@@ -43,7 +43,7 @@ export const EuiAvatar = ({
   let optionalInitial;
   if (name && !imageUrl) {
     // Calculate the number of initials to show, maxing out at 2
-    let calculatedInitialsLength = initials ? initials.split(" ").length : name.split(" ").length;
+    let calculatedInitialsLength = initials ? initials.split(' ').length : name.split(' ').length;
     calculatedInitialsLength = calculatedInitialsLength > 2 ? 2 : calculatedInitialsLength;
 
     // Check if initialsLength was passed and set to calculated, unless greater than 2
@@ -56,7 +56,7 @@ export const EuiAvatar = ({
     if (initials) {
       calculatedInitials = initials.substring(0, calculatedInitialsLength);
     } else {
-      if (name.split(" ").length > 1) {
+      if (name.split(' ').length > 1) {
         // B. If there are any spaces in the name, set to first letter of each word
         calculatedInitials = name.match(/\b(\w)/g).join('').substring(0, calculatedInitialsLength);
       } else {

--- a/src/components/badge/beta_badge/beta_badge.js
+++ b/src/components/badge/beta_badge/beta_badge.js
@@ -63,9 +63,9 @@ export const EuiBetaBadge = ({
       >
         {icon || label}
       </span>
-    )
+    );
   }
-}
+};
 
 EuiBetaBadge.propTypes = {
   className: PropTypes.string,
@@ -94,7 +94,7 @@ EuiBetaBadge.propTypes = {
    * Optional title will be supplied as tooltip title or title attribute otherwise the label will be used
    */
   title: PropTypes.string,
-}
+};
 
 EuiBetaBadge.defaultProps = {
   tooltipPosition: 'top',

--- a/src/components/bottom_bar/bottom_bar.js
+++ b/src/components/bottom_bar/bottom_bar.js
@@ -20,7 +20,7 @@ export class EuiBottomBar extends Component {
 
   componentDidMount() {
     const height = this.bar.clientHeight;
-    document.body.style.paddingBottom= `${height}px`;
+    document.body.style.paddingBottom = `${height}px`;
     if (this.props.bodyClassName) {
       document.body.classList.add(this.props.bodyClassName);
     }
@@ -65,7 +65,7 @@ export class EuiBottomBar extends Component {
         </div>
       </EuiPortal>
     );
-  };
+  }
 }
 
 EuiBottomBar.propTypes = {

--- a/src/components/breadcrumbs/breadcrumbs.js
+++ b/src/components/breadcrumbs/breadcrumbs.js
@@ -29,14 +29,14 @@ const limitBreadcrumbs = (breadcrumbs, max) => {
   }
 
   if (max < breadcrumbs.length) {
-    breadcrumbsAtStart.push(<EuiBreadcrumbCollapsed key='collapsed' />);
+    breadcrumbsAtStart.push(<EuiBreadcrumbCollapsed key="collapsed" />);
   }
 
   return [
     ...breadcrumbsAtStart,
     ...breadcrumbsAtEnd,
   ];
-}
+};
 
 const EuiBreadcrumbCollapsed = () => (
   <Fragment>
@@ -45,7 +45,7 @@ const EuiBreadcrumbCollapsed = () => (
   </Fragment>
 );
 
-const EuiBreadcrumbSeparator = () => <div className='euiBreadcrumbSeparator' />;
+const EuiBreadcrumbSeparator = () => <div className="euiBreadcrumbSeparator" />;
 
 export const EuiBreadcrumbs = ({
   breadcrumbs,
@@ -86,7 +86,7 @@ export const EuiBreadcrumbs = ({
     } else {
       link = (
         <EuiLink
-          color='subdued'
+          color="subdued"
           href={href}
           onClick={onClick}
           className={breadcrumbClasses}
@@ -110,7 +110,7 @@ export const EuiBreadcrumbs = ({
         {separator}
       </Fragment>
     );
-  })
+  });
 
   const limitedBreadcrumbs = max ? limitBreadcrumbs(breadcrumbElements, max) : breadcrumbElements;
 

--- a/src/components/button/button_group/button_group.js
+++ b/src/components/button/button_group/button_group.js
@@ -63,7 +63,7 @@ export const EuiButtonGroup = ({
         );
       })}
     </div>
-  )
+  );
 };
 
 EuiButtonGroup.propTypes = {

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -26,7 +26,7 @@ const cardLayout = (props, propName, componentName, ...rest) => {
   const oneOfResult = oneOfLayouts(props, propName, componentName, ...rest);
   if (oneOfResult) return oneOfResult;
 
-  if (props[propName] === 'horizontal' ) {
+  if (props[propName] === 'horizontal') {
     if (props.image || props.footer) {
       return new Error(
         `${componentName}: '${propName} = horizontal' cannot be used in conjunction with 'image', 'footer', or 'textAlign'.`
@@ -100,9 +100,14 @@ export const EuiCard = ({
   if (betaBadgeLabel) {
     optionalBetaBadge = (
       <span className="euiCard__betaBadgeWrapper">
-        <EuiBetaBadge label={betaBadgeLabel} title={betaBadgeTitle} tooltipContent={betaBadgeTooltipContent} className="euiCard__betaBadge" />
+        <EuiBetaBadge
+          label={betaBadgeLabel}
+          title={betaBadgeTitle}
+          tooltipContent={betaBadgeTooltipContent}
+          className="euiCard__betaBadge"
+        />
       </span>
-    )
+    );
   }
 
   return (

--- a/src/components/combo_box/combo_box_input/combo_box_input.js
+++ b/src/components/combo_box/combo_box_input/combo_box_input.js
@@ -118,10 +118,10 @@ export class EuiComboBoxInput extends Component {
 
     if (this.state.hasFocus) {
       const removeOptionMessageContent =
-        `Combo box. Selected. ` +
-        (searchValue ? `${searchValue}. Selected. ` : '') +
-        (selectedOptions.length ? `${value}. Press Backspace to delete ${selectedOptions[selectedOptions.length - 1].label}. ` : '') +
-        `You are currently on a combo box. Type text or, to display a list of choices, press Down Arrow. ` +
+        `Combo box. Selected. ${
+          searchValue ? `${searchValue}. Selected. ` : ''
+        }${selectedOptions.length ? `${value}. Press Backspace to delete ${selectedOptions[selectedOptions.length - 1].label}. ` : ''
+        }You are currently on a combo box. Type text or, to display a list of choices, press Down Arrow. ` +
         `To exit the list of choices, press Escape.`;
 
       removeOptionMessageId = makeId();

--- a/src/components/combo_box/combo_box_input/combo_box_input.js
+++ b/src/components/combo_box/combo_box_input/combo_box_input.js
@@ -110,7 +110,7 @@ export class EuiComboBoxInput extends Component {
         >
           {label}
         </EuiComboBoxPill>
-      )
+      );
     });
 
     let removeOptionMessage;

--- a/src/components/context_menu/context_menu.js
+++ b/src/components/context_menu/context_menu.js
@@ -82,7 +82,7 @@ export class EuiContextMenu extends Component {
   static getDerivedStateFromProps(nextProps, prevState) {
     const { panels } = nextProps;
 
-    if ( prevState.prevProps.panels !== panels ) {
+    if (prevState.prevProps.panels !== panels) {
       return {
         prevProps: { panels },
         idToPanelMap: mapIdsToPanels(panels),

--- a/src/components/context_menu/context_menu_item.js
+++ b/src/components/context_menu/context_menu_item.js
@@ -161,5 +161,5 @@ export class EuiContextMenuItem extends Component {
 }
 
 EuiContextMenuItem.defaultProps = {
-  toolTipPosition: "right",
+  toolTipPosition: 'right',
 };

--- a/src/components/context_menu/context_menu_item.test.js
+++ b/src/components/context_menu/context_menu_item.test.js
@@ -84,7 +84,7 @@ describe('EuiContextMenuItem', () => {
     describe('href', () => {
       test('renders a link', () => {
         const component = render(
-          <EuiContextMenuItem {...requiredProps} href='url' />
+          <EuiContextMenuItem {...requiredProps} href="url" />
         );
 
         expect(component).toMatchSnapshot();
@@ -94,7 +94,7 @@ describe('EuiContextMenuItem', () => {
     describe('rel', () => {
       test('is rendered', () => {
         const component = render(
-          <EuiContextMenuItem {...requiredProps} href='url' rel='help' />
+          <EuiContextMenuItem {...requiredProps} href="url" rel="help" />
         );
 
         expect(component).toMatchSnapshot();
@@ -104,7 +104,7 @@ describe('EuiContextMenuItem', () => {
     describe('target', () => {
       test('is rendered', () => {
         const component = render(
-          <EuiContextMenuItem {...requiredProps} href='url' target='_blank' />
+          <EuiContextMenuItem {...requiredProps} href="url" target="_blank" />
         );
 
         expect(component).toMatchSnapshot();

--- a/src/components/date_picker/date_picker.js
+++ b/src/components/date_picker/date_picker.js
@@ -80,9 +80,9 @@ export class EuiDatePicker extends Component {
     if (inline || customInput) {
       optionalIcon = null;
     } else if (showTimeSelectOnly) {
-      optionalIcon = "clock";
+      optionalIcon = 'clock';
     } else {
-      optionalIcon = "calendar";
+      optionalIcon = 'calendar';
     }
 
     // EuiDatePicker only supports a subset of props from react-datepicker. Using any of
@@ -283,10 +283,10 @@ EuiDatePicker.propTypes = {
 };
 
 EuiDatePicker.defaultProps = {
-  dateFormat:"MM/DD/YYYY hh:mm A",
+  dateFormat: 'MM/DD/YYYY hh:mm A',
   fullWidth: false,
   isLoading: false,
   shadow: true,
   shouldCloseOnSelect: true,
-  timeFormat:"hh:mm A",
+  timeFormat: 'hh:mm A',
 };

--- a/src/components/empty_prompt/empty_prompt.js
+++ b/src/components/empty_prompt/empty_prompt.js
@@ -29,7 +29,7 @@ export const EuiEmptyPrompt = ({
         <EuiIcon type={iconType} size="xxl" color={iconColor} />
         <EuiSpacer size="s" />
       </Fragment>
-    )
+    );
   }
 
   let content;
@@ -45,7 +45,7 @@ export const EuiEmptyPrompt = ({
           </EuiTitle>
           <EuiSpacer size="m" />
         </Fragment>
-      )
+      );
     }
 
     let bodyEl;
@@ -58,7 +58,7 @@ export const EuiEmptyPrompt = ({
           </EuiText>
           <EuiSpacer size="l" />
         </Fragment>
-      )
+      );
     }
 
     content = (
@@ -66,7 +66,7 @@ export const EuiEmptyPrompt = ({
         {titleEl}
         {bodyEl}
       </EuiTextColor>
-    )
+    );
   }
 
   let actionsEl;
@@ -88,9 +88,9 @@ export const EuiEmptyPrompt = ({
             </EuiFlexItem>
           ))}
         </EuiFlexGroup>
-      )
+      );
     } else {
-      actionsRow = actions
+      actionsRow = actions;
     }
 
     actionsEl = (
@@ -98,7 +98,7 @@ export const EuiEmptyPrompt = ({
         <EuiSpacer size="s" />
         {actionsRow}
       </Fragment>
-    )
+    );
   }
 
   return (
@@ -128,5 +128,5 @@ EuiEmptyPrompt.propTypes = {
 };
 
 EuiEmptyPrompt.defaultProps = {
-  iconColor: "subdued",
+  iconColor: 'subdued',
 };

--- a/src/components/empty_prompt/empty_prompt.test.js
+++ b/src/components/empty_prompt/empty_prompt.test.js
@@ -48,7 +48,7 @@ describe('EuiEmptyPrompt', () => {
       });
 
       test('renders an array', () => {
-        const component = render(<EuiEmptyPrompt actions={[ "action1", "action2" ]} />);
+        const component = render(<EuiEmptyPrompt actions={[ 'action1', 'action2' ]} />);
         expect(component).toMatchSnapshot();
       });
     });

--- a/src/components/form/field_number/field_number.test.js
+++ b/src/components/form/field_number/field_number.test.js
@@ -5,11 +5,11 @@ import { requiredProps } from '../../../test/required_props';
 import { EuiFieldNumber } from './field_number';
 
 jest.mock('../form_control_layout', () => {
-  const formControlLayout = require.requireActual('../form_control_layout')
+  const formControlLayout = require.requireActual('../form_control_layout');
   return {
     ...formControlLayout,
     EuiFormControlLayout: 'eui-form-control-layout',
-  }
+  };
 });
 jest.mock('../validatable_control', () => ({ EuiValidatableControl: 'eui-validatable-control' }));
 

--- a/src/components/form/field_text/field_text.test.js
+++ b/src/components/form/field_text/field_text.test.js
@@ -5,11 +5,11 @@ import { requiredProps } from '../../../test/required_props';
 import { EuiFieldText } from './field_text';
 
 jest.mock('../form_control_layout', () => {
-  const formControlLayout = require.requireActual('../form_control_layout')
+  const formControlLayout = require.requireActual('../form_control_layout');
   return {
     ...formControlLayout,
     EuiFormControlLayout: 'eui-form-control-layout',
-  }
+  };
 });
 jest.mock('../validatable_control', () => ({ EuiValidatableControl: 'eui-validatable-control' }));
 

--- a/src/components/form/file_picker/file_picker.js
+++ b/src/components/form/file_picker/file_picker.js
@@ -108,7 +108,7 @@ export class EuiFilePicker extends Component {
               type="cross"
             />
           </button>
-        )
+        );
       } else {
         clearButton = (
           <EuiButtonEmpty

--- a/src/components/form/form_control_layout/form_control_layout.js
+++ b/src/components/form/form_control_layout/form_control_layout.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { EuiFormControlLayoutIcons } from './form_control_layout_icons'
+import { EuiFormControlLayoutIcons } from './form_control_layout_icons';
 
 export const ICON_SIDES = ['left', 'right'];
 

--- a/src/components/form/text_area/text_area.js
+++ b/src/components/form/text_area/text_area.js
@@ -43,7 +43,7 @@ export const EuiTextArea = ({
 
   if (rows) {
     definedRows = rows;
-  } else if (compressed){
+  } else if (compressed) {
     definedRows = 3;
   } else {
     definedRows = 6;

--- a/src/components/header/header_breadcrumbs/header_breadcrumbs.js
+++ b/src/components/header/header_breadcrumbs/header_breadcrumbs.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { EuiBreadcrumbs } from '../../breadcrumbs'
+import { EuiBreadcrumbs } from '../../breadcrumbs';
 
 export const EuiHeaderBreadcrumbs = ({ className, breadcrumbs, ...rest }) => {
   const classes = classNames('euiHeaderBreadcrumbs', className);

--- a/src/components/highlight/highlight.js
+++ b/src/components/highlight/highlight.js
@@ -15,7 +15,7 @@ const highlight = (searchSubject, searchValue, isStrict = false) => {
   }
 
   const preMatch = searchSubject.substr(0, indexOfMatch);
-  const match = searchSubject.substr(indexOfMatch, searchValue.length)
+  const match = searchSubject.substr(indexOfMatch, searchValue.length);
   const postMatch = searchSubject.substr(indexOfMatch + searchValue.length);
 
   return (
@@ -23,7 +23,7 @@ const highlight = (searchSubject, searchValue, isStrict = false) => {
       {preMatch}<strong>{match}</strong>{postMatch}
     </Fragment>
   );
-}
+};
 
 export const EuiHighlight = ({
   children,

--- a/src/components/key_pad_menu/key_pad_menu_item.js
+++ b/src/components/key_pad_menu/key_pad_menu_item.js
@@ -51,7 +51,8 @@ const commonPropTypes = {
   betaBadgeTooltipContent: PropTypes.node,
 };
 
-export const EuiKeyPadMenuItem = ({ href, label, children, className, betaBadgeLabel, betaBadgeTooltipContent, betaBadgeIconType, ...rest }) => {
+export const EuiKeyPadMenuItem = ({ href, label, children, className, betaBadgeLabel,
+  betaBadgeTooltipContent, betaBadgeIconType, ...rest }) => {
   const classes = classNames(
     'euiKeyPadMenuItem',
     {
@@ -76,7 +77,8 @@ EuiKeyPadMenuItem.propTypes = ({ ...{
   href: PropTypes.string,
 }, ...commonPropTypes });
 
-export const EuiKeyPadMenuItemButton = ({ onClick, label, children, className, betaBadgeLabel, betaBadgeTooltipContent, betaBadgeIconType, ...rest }) => {
+export const EuiKeyPadMenuItemButton = ({ onClick, label, children, className, betaBadgeLabel,
+  betaBadgeTooltipContent, betaBadgeIconType, ...rest }) => {
   const classes = classNames(
     'euiKeyPadMenuItem',
     {

--- a/src/components/page/page.js
+++ b/src/components/page/page.js
@@ -57,4 +57,4 @@ EuiPage.propTypes = {
 
 EuiPage.defaultProps = {
   restrictWidth: false,
-}
+};

--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -56,9 +56,14 @@ export const EuiPanel = ({
   if (betaBadgeLabel) {
     optionalBetaBadge = (
       <span className="euiPanel__betaBadgeWrapper">
-        <EuiBetaBadge label={betaBadgeLabel} title={betaBadgeTitle} tooltipContent={betaBadgeTooltipContent} className="euiPanel__betaBadge" />
+        <EuiBetaBadge
+          label={betaBadgeLabel}
+          title={betaBadgeTitle}
+          tooltipContent={betaBadgeTooltipContent}
+          className="euiPanel__betaBadge"
+        />
       </span>
-    )
+    );
   }
 
   return (

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -53,7 +53,7 @@ export class EuiPopover extends Component {
 
     return null;
   }
-  
+
   constructor(props) {
     super(props);
 

--- a/src/components/responsive/hide_from.js
+++ b/src/components/responsive/hide_from.js
@@ -4,11 +4,11 @@ import classNames from 'classnames';
 
 const responsiveSizesToClassNameMap = {
   xs: 'eui-hideFor--xs',
-  s:  'eui-hideFor--s',
-  m:  'eui-hideFor--m',
-  l:  'eui-hideFor--l',
-  xl:  'eui-hideFor--xl',
-}
+  s: 'eui-hideFor--s',
+  m: 'eui-hideFor--m',
+  l: 'eui-hideFor--l',
+  xl: 'eui-hideFor--xl',
+};
 
 export const RESPONSIVE_SIZES = Object.keys(responsiveSizesToClassNameMap);
 
@@ -19,7 +19,7 @@ export const EuiHideFor = ({
   ...rest,
 }) => {
 
-  const sizingClasses = sizes.map(function(item){
+  const sizingClasses = sizes.map(function (item) {
     return responsiveSizesToClassNameMap[item];
   });
 

--- a/src/components/responsive/show_for.js
+++ b/src/components/responsive/show_for.js
@@ -4,11 +4,11 @@ import classNames from 'classnames';
 
 const responsiveSizesToClassNameMap = {
   xs: 'eui-showFor--xs',
-  s:  'eui-showFor--s',
-  m:  'eui-showFor--m',
-  l:  'eui-showFor--l',
+  s: 'eui-showFor--s',
+  m: 'eui-showFor--m',
+  l: 'eui-showFor--l',
   xl: 'eui-showFor--xl',
-}
+};
 
 export const RESPONSIVE_SIZES = Object.keys(responsiveSizesToClassNameMap);
 
@@ -19,7 +19,7 @@ export const EuiShowFor = ({
   ...rest,
 }) => {
 
-  const sizingClasses = sizes.map(function(item){
+  const sizingClasses = sizes.map(function (item) {
     return responsiveSizesToClassNameMap[item];
   });
 

--- a/src/components/search_bar/query/ast_to_es_query_string.js
+++ b/src/components/search_bar/query/ast_to_es_query_string.js
@@ -132,7 +132,7 @@ export const astToEsQueryString = (ast) => {
 
   return ast.clauses.map(clause => {
     if (AST.Field.isInstance(clause)) {
-      return emitFieldClause(clause)
+      return emitFieldClause(clause);
     }
     if (AST.Term.isInstance(clause)) {
       return emitTermClause(clause);

--- a/src/components/steps/step.js
+++ b/src/components/steps/step.js
@@ -27,15 +27,15 @@ export const EuiStep = ({
   const circleClasses = classNames(
     'euiStep__circle',
     {
-      'euiStep__circle--complete': (status === "complete"),
-      'euiStep__circle--incomplete': (status === "incomplete"),
+      'euiStep__circle--complete': (status === 'complete'),
+      'euiStep__circle--incomplete': (status === 'incomplete'),
     }
   );
 
   let numberOrIcon;
-  if (status === "complete") {
-      numberOrIcon = <EuiIcon type="check" color="ghost" className="euiStep__circleIcon" />;
-  } else if (status !== "incomplete") {
+  if (status === 'complete') {
+    numberOrIcon = <EuiIcon type="check" color="ghost" className="euiStep__circleIcon" />;
+  } else if (status !== 'incomplete') {
     numberOrIcon = step;
   }
 

--- a/src/components/steps/step_horizontal.js
+++ b/src/components/steps/step_horizontal.js
@@ -47,7 +47,7 @@ export const EuiStepHorizontal = ({
     }
 
     onClick(e);
-  }
+  };
 
   const buttonTitle = `Step ${step}: ${title}${titleAppendix}`;
 

--- a/src/components/table/mobile/table_sort_mobile.js
+++ b/src/components/table/mobile/table_sort_mobile.js
@@ -70,7 +70,7 @@ export class EuiTableSortMobile extends Component {
         button={mobileSortButton}
         isOpen={this.state.isPopoverOpen}
         closePopover={this.closePopover}
-        anchorPosition={anchorPosition || "downRight"}
+        anchorPosition={anchorPosition || 'downRight'}
         panelPaddingSize="none"
         {...rest}
       >

--- a/src/components/table/table_row.js
+++ b/src/components/table/table_row.js
@@ -10,7 +10,7 @@ export const EuiTableRow = ({
   hasActions,
   isExpandedRow,
   isExpandable,
-   ...rest
+  ...rest
 }) => {
   const classes = classNames('euiTableRow', className, {
     'euiTableRow-isSelectable': isSelectable,

--- a/src/components/tabs/tabbed_content/tabbed_content.js
+++ b/src/components/tabs/tabbed_content/tabbed_content.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import { htmlIdGenerator } from '../../../services';
@@ -55,12 +55,12 @@ export class EuiTabbedContent extends Component {
     const { onTabClick, selectedTab: externalSelectedTab } = this.props;
 
     if (onTabClick) {
-      onTabClick(selectedTab)
+      onTabClick(selectedTab);
     }
 
     // Only track selection state if it's not controlled externally.
     if (!externalSelectedTab) {
-      this.setState({ selectedTab })
+      this.setState({ selectedTab });
     }
   };
 
@@ -76,12 +76,12 @@ export class EuiTabbedContent extends Component {
     } = this.props;
 
     // Allow the consumer to control tab selection.
-    const selectedTab = externalSelectedTab || this.state.selectedTab
+    const selectedTab = externalSelectedTab || this.state.selectedTab;
 
     const {
       content: selectedTabContent,
       id: selectedTabId,
-    } = selectedTab
+    } = selectedTab;
 
     return (
       <div className={className} {...rest}>
@@ -92,7 +92,7 @@ export class EuiTabbedContent extends Component {
               name,
               content, // eslint-disable-line no-unused-vars
               ...tabProps
-            } = tab
+            } = tab;
             const props = {
               key: id,
               id,
@@ -107,13 +107,13 @@ export class EuiTabbedContent extends Component {
         </EuiTabs>
 
         <div
-          role='tabpanel'
+          role="tabpanel"
           id={`${this.rootId}-${selectedTabId}`}
           aria-labelledby={selectedTabId}
         >
           {selectedTabContent}
         </div>
       </div>
-    )
+    );
   }
 }

--- a/src/components/text/text.test.js
+++ b/src/components/text/text.test.js
@@ -26,6 +26,6 @@ describe('EuiText', () => {
 
         expect(component).toMatchSnapshot();
       });
-    })
+    });
   });
 });

--- a/src/components/toggle/toggle.js
+++ b/src/components/toggle/toggle.js
@@ -7,7 +7,7 @@ const typeToInputTypeMap = {
   'multi': 'checkbox',
 };
 
-export const TYPES = Object.keys(typeToInputTypeMap);;
+export const TYPES = Object.keys(typeToInputTypeMap);
 
 export const EuiToggle = ({
   id,

--- a/src/services/color/rgb_to_hex.js
+++ b/src/services/color/rgb_to_hex.js
@@ -1,9 +1,9 @@
 function rgbToHex(rgb) {
   rgb = rgb.match(/^rgba?[\s+]?\([\s+]?(\d+)[\s+]?,[\s+]?(\d+)[\s+]?,[\s+]?(\d+)[\s+]?/i);
-  return (rgb && rgb.length === 4) ? '#' +
-  ('0' + parseInt(rgb[1], 10).toString(16)).slice(-2) +
-  ('0' + parseInt(rgb[2], 10).toString(16)).slice(-2) +
-  ('0' + parseInt(rgb[3], 10).toString(16)).slice(-2) : '';
+  return (rgb && rgb.length === 4) ? `#${
+    (`0${  parseInt(rgb[1], 10).toString(16)}`).slice(-2)
+  }${(`0${  parseInt(rgb[2], 10).toString(16)}`).slice(-2)
+  }${(`0${  parseInt(rgb[3], 10).toString(16)}`).slice(-2)}` : '';
 }
 
 export { rgbToHex };

--- a/src/services/popover/calculate_popover_position.js
+++ b/src/services/popover/calculate_popover_position.js
@@ -52,7 +52,8 @@ const positionToPositionerMap = {
  *
  * @returns {Object} With properties position (one of ["top", "right", "bottom", "left"]), left, top, width, and height.
  */
-export function calculatePopoverPosition(anchorBounds, popoverBounds, requestedPosition, buffer = 16, positions = ['top', 'right', 'bottom', 'left']) {
+export function calculatePopoverPosition(anchorBounds, popoverBounds, requestedPosition,
+  buffer = 16, positions = ['top', 'right', 'bottom', 'left']) {
   if (typeof buffer !== 'number') {
     throw new Error(`calculatePopoverPosition received a buffer argument of ${buffer}' but expected a number`);
   }

--- a/src/services/sort/comparators.test.js
+++ b/src/services/sort/comparators.test.js
@@ -49,7 +49,7 @@ describe('comparators - property', () => {
 describe('default comparator', () => {
   test('null/undefined values are sorted to the end', () => {
     const sorted = [undefined, '7', 3, null, 5, undefined].sort(Comparators.default());
-    expect(sorted).toEqual([3, 5, '7', null, undefined, undefined])
-  })
+    expect(sorted).toEqual([3, 5, '7', null, undefined, undefined]);
+  });
 });
 

--- a/src/utils/prop_types/with_required_prop.js
+++ b/src/utils/prop_types/with_required_prop.js
@@ -22,8 +22,8 @@ export const withRequiredProp = (proptype, requiredPropName, messageDescription)
       // if this property was passed, check that the required property also exists
       if (props[propName] != null && props[requiredPropName] == null) {
         result = new Error(
-          `Property "${propName}" was passed without corresponding property "${requiredPropName}"` +
-          (messageDescription ? `; ${messageDescription}` : '')
+          `Property "${propName}" was passed without corresponding property "${requiredPropName}"${
+            messageDescription ? `; ${messageDescription}` : ''}`
         );
       }
     }


### PR DESCRIPTION
This is a small improvement detected by a problem reported by @markov00 .
This change allow to make the Kibana eslint rules more important than the ones from prettier.

Added `prefer-template` as temporary local eslint rule  to prefer template literals instead of string concatenation, following the rule on [Kibana styleguide](https://github.com/elastic/kibana/blob/master/style_guides/js_style_guide.md#use-template-strings-to-interpolate-variables-into-strings).