### PR TITLE
Fixing size of inputs via box-shadow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - `EuiComboBox` is now decorated with `data-test-subj` selectors for the search input (`comboxBoxSearchInput`), toggle button (`comboBoxToggleListButton`), and clear button (`comboBoxClearButton`) ([#918](https://github.com/elastic/eui/pull/918))
 - `EuiComboBox` now gives focus to the search input when the user clicks the clear button, to prevent focus from defaulting to the body ([#918](https://github.com/elastic/eui/pull/918))
+- Fixed visual size of inputs by setting the box-shadow border to `inset` ([#928](https://github.com/elastic/eui/pull/928))
 
 **Non-breaking major changes**
 

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -50,12 +50,7 @@
 
   &.euiComboBox-isOpen {
     .euiComboBox__inputWrap {
-      background: $euiColorEmptyShade;
-      box-shadow:
-        0 4px 4px -2px rgba(0, 0, 0, 0.1),
-        0 0 0 1px rgba(0,0,0,0.16),
-        inset 0 0 0 0 $euiColorEmptyShade,
-        inset 0 -2px 0 0 $euiColorPrimary;
+      @include euiFormControlFocusStyle;
     }
   }
 

--- a/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
@@ -6,9 +6,7 @@
  * 3. The height can expand, hence auto
  */
 .euiComboBoxOptionsList {
-  @include euiFormControlSize(auto);
-  box-sizing: content-box; /* 3 */
-  margin-left: -1px; /* 1 */
+  @include euiFormControlSize(auto); /* 3 */
   z-index: $euiZComboBox;
   position: absolute; /* 2 */
   top: 0; /* 2 */

--- a/src/components/form/_mixins.scss
+++ b/src/components/form/_mixins.scss
@@ -38,15 +38,15 @@
 
 @mixin euiFormControlDefaultShadow {
   box-shadow:
-    0 2px 2px -1px rgba($euiShadowColor, 0.2),
-    0 0 0 1px transparentize($euiColorFullShade, .92),
+    0 3px 2px -2px rgba($euiShadowColor, 0.2),
+    inset 0 0 0 1px transparentize($euiColorFullShade, .9),
     inset #{-$euiFormMaxWidth} 0 0 0 $euiFormBackgroundColor;
 }
 
 @mixin euiFormControlInvalidStyle {
   box-shadow:
     0 $euiSizeXS $euiSizeXS (-$euiSizeXS / 2) rgba($euiShadowColor, 0.2),
-    0 0 0 1px transparentize($euiColorFullShade, .84),
+    inset 0 0 0 1px transparentize($euiColorFullShade, .84),
     inset 0 0 0 0 $euiColorEmptyShade,
     inset 0 (-$euiSizeXS / 2) 0 0 $euiColorDanger;
 }
@@ -55,7 +55,7 @@
   background: tintOrShade($euiColorEmptyShade, 0%, 20%);
   box-shadow:
     0 4px 4px -2px rgba($euiShadowColor, 0.2),
-    0 0 0 1px transparentize($euiColorFullShade, .84),
+    inset 0 0 0 1px transparentize($euiColorFullShade, .84),
     inset 0 0 0 0 tintOrShade($euiColorEmptyShade, 0%, 20%),
     inset 0 -2px 0 0 $euiColorPrimary;
 }
@@ -63,7 +63,7 @@
 @mixin euiFormControlDisabledStyle {
   cursor: not-allowed;
   background: darken($euiColorLightestShade, 2%);
-  box-shadow: 0 0 0 1px transparentize($euiColorFullShade, .92);
+  box-shadow: inset 0 0 0 1px transparentize($euiColorFullShade, .92);
   color: $euiFormControlDisabledColor;
 
   &::placeholder {

--- a/src/components/form/_mixins.scss
+++ b/src/components/form/_mixins.scss
@@ -90,6 +90,7 @@
   font-size: $euiFontSizeS;
   font-family: $euiFontFamily;
   padding: $euiFormControlPadding;
+  line-height: 1em; // fixes text alignment in IE
   color: $euiTextColor;
   background: $euiFormBackgroundColor;
   transition: box-shadow $euiAnimSpeedNormal ease-in, background $euiAnimSpeedNormal ease-in;

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -68,10 +68,9 @@
     background: $euiFormBackgroundColor;
     text-align: center;
     transition:
-      box-shadow $euiAnimSpeedNormal ease-in, background $euiAnimSpeedNormal ease-in,
-      background-color $euiAnimSpeedSlow ease-in,
-      border-color $euiAnimSpeedSlow ease-in,
-      color $euiAnimSpeedSlow ease-in;
+      box-shadow $euiAnimSpeedNormal ease-in,
+      background $euiAnimSpeedNormal ease-in,
+      color $euiAnimSpeedNormal ease-in;
 
     @at-root {
       .euiFilePicker--compressed#{&} {


### PR DESCRIPTION
The box-shadow that mimics the input’s border is now `inset`. This means the `40px` height is **actually** `40px` and the box-shadow ensure it's borders don't spill over the `400px` width.

<img src="https://d.pr/free/i/iqredL+" />

It's very subtle, hence the zoomed in gif. I also tweaked the second box-shadow slightly to have a better edge to it.

This also touched the `EuiComboBoxList` styles since it was doing extra css to account for the extended border.

---

This originally was noticed as an issue when I saw this:
https://github.com/elastic/kibana/blame/master/src/core_plugins/input_control_vis/public/components/editor/controls_tab.less

So cc'ing @nreese : This will fix the problem you were running into with inputs inside of accordions. When this get's merged into Kibana, can you remove this extra style? It will cause visual issues with the accordion if for some reason it doesn't correctly get the height of `0`. See example:

![image](https://user-images.githubusercontent.com/549577/41439887-7fa61c50-6ffa-11e8-90fd-c36d18db636c.png)
