### PR TITLE
EuiCodeEditor: make it take a custom mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added `getPopoverScreenCoordinates` service function for positioining popover/tooltip content, updated `EuiToolTip` to use it ([#924](https://github.com/elastic/eui/pull/924))
+- Allow `mode` prop in `EuiCodeEditor` to take custom mode object ([#935](https://github.com/elastic/eui/pull/935))
 
 ## [`0.0.54`](https://github.com/elastic/eui/tree/v0.0.54)
 

--- a/src-docs/src/views/code_editor/code_editor_example.js
+++ b/src-docs/src/views/code_editor/code_editor_example.js
@@ -19,6 +19,10 @@ import ReadOnly from './read_only';
 const readOnlySource = require('!!raw-loader!./read_only');
 const readOnlyrHtml = renderToHtml(ReadOnly);
 
+import CustomMode from './custom_mode';
+const customModeSource = require('!!raw-loader!./custom_mode');
+const customModeHtml = renderToHtml(CustomMode);
+
 export const CodeEditorExample = {
   title: 'Code Editor',
   sections: [{
@@ -54,5 +58,15 @@ export const CodeEditorExample = {
       code: readOnlyrHtml,
     }],
     demo: <ReadOnly />,
+  }, {
+    title: 'Custom mode',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: customModeSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: customModeHtml,
+    }],
+    demo: <CustomMode />,
   }],
 };

--- a/src-docs/src/views/code_editor/custom_mode.js
+++ b/src-docs/src/views/code_editor/custom_mode.js
@@ -1,0 +1,30 @@
+import React, { Component } from 'react';
+import 'brace/mode/text';
+
+import {
+  EuiCodeEditor,
+} from '../../../../src/components';
+
+const TextMode = window.ace.acequire('ace/mode/text').Mode;
+class MyCustomAceMode extends TextMode {
+  // Your custom mode definition goes here.
+  // See https://github.com/ajaxorg/ace/wiki/Creating-or-Extending-an-Edit-Mode
+}
+
+export default class extends Component {
+  state = {
+    value: ''
+  };
+
+  render() {
+    return (
+      <EuiCodeEditor
+        mode={new MyCustomAceMode()}
+        theme="github"
+        width="100%"
+        value={this.state.value}
+        setOptions={{ fontSize: '14px' }}
+      />
+    );
+  }
+}

--- a/src/components/code_editor/code_editor.js
+++ b/src/components/code_editor/code_editor.js
@@ -150,6 +150,10 @@ export class EuiCodeEditor extends Component {
       </div>
     );
 
+    if (this.isCustomMode()) {
+      delete rest.mode; // Otherwise, the AceEditor component will complain about wanting a string value for the mode prop.
+    }
+
     return (
       <div
         className={classes}

--- a/src/components/code_editor/code_editor.js
+++ b/src/components/code_editor/code_editor.js
@@ -72,6 +72,20 @@ export class EuiCodeEditor extends Component {
     });
   }
 
+  isCustomMode() {
+    return typeof this.props.mode === 'object';
+  }
+
+  setCustomMode() {
+    this.aceEditor.editor.getSession().setMode(this.props.mode);
+  }
+
+  componentDidMount() {
+    if (this.isCustomMode()) {
+      this.setCustomMode();
+    }
+  }
+
   render() {
     const {
       width,

--- a/src/components/code_editor/code_editor.js
+++ b/src/components/code_editor/code_editor.js
@@ -179,6 +179,10 @@ EuiCodeEditor.propTypes = {
   isReadOnly: PropTypes.bool,
   setOptions: PropTypes.object,
   cursorStart: PropTypes.number,
+  mode: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object
+  ]),
 };
 
 EuiCodeEditor.defaultProps = {

--- a/src/components/code_editor/code_editor.js
+++ b/src/components/code_editor/code_editor.js
@@ -86,6 +86,12 @@ export class EuiCodeEditor extends Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    if ((this.props.mode !== prevProps.mode) && this.isCustomMode()) {
+      this.setCustomMode();
+    }
+  }
+
   render() {
     const {
       width,

--- a/src/components/code_editor/code_editor.js
+++ b/src/components/code_editor/code_editor.js
@@ -179,6 +179,10 @@ EuiCodeEditor.propTypes = {
   isReadOnly: PropTypes.bool,
   setOptions: PropTypes.object,
   cursorStart: PropTypes.number,
+
+  /**
+   * Use string for a built-in mode or object for a custom mode
+   */
   mode: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.object


### PR DESCRIPTION
Resolves #933.

Allows the `mode` prop in the `EuiCodeEditor` component to take an `object` representing a custom Ace mode.

### To test this PR
* Run this PR along with https://github.com/elastic/kibana/pull/20027.
* In Kibana, open Dev Tools > Grok Debugger
* In the Grok Pattern field (which uses a custom mode), enter:

   ```
   %{WORD:foo}
   ```
* Verify that the syntax highlighting changes once you finish typing.