### PR TITLE
Fix tooltip re-position after content resize & respect scroll bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 - Added `getPopoverScreenCoordinates` service function for positioining popover/tooltip content, updated `EuiToolTip` to use it ([#924](https://github.com/elastic/eui/pull/924))
 - Allow `mode` prop in `EuiCodeEditor` to take custom mode object ([#935](https://github.com/elastic/eui/pull/935))
 
+**Bug fixes**
+
+- `EuiTooltip` re-positions content correctly after the window is resized ([#936](https://github.com/elastic/eui/pull/936))
+
 ## [`0.0.54`](https://github.com/elastic/eui/tree/v0.0.54)
 
 **Bug fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `0.0.55`.
+**Bug fixes**
+
+- `EuiTooltip` re-positions content correctly after the window is resized ([#936](https://github.com/elastic/eui/pull/936))
 
 ## [`0.0.55`](https://github.com/elastic/eui/tree/v0.0.55)
 
@@ -8,10 +10,6 @@ No public interface changes since `0.0.55`.
 - Allow `mode` prop in `EuiCodeEditor` to take custom mode object ([#935](https://github.com/elastic/eui/pull/935))
 - `EuiCodeEditor` is now decorated with a `data-test-subj` selector (`codeEditorContainer`) ([#939](https://github.com/elastic/eui/pull/939))
 - `EuiCodeEditor` no longer automatically scrolls cursor into view on selection change ([#940](https://github.com/elastic/eui/pull/940))
-
-**Bug fixes**
-
-- `EuiTooltip` re-positions content correctly after the window is resized ([#936](https://github.com/elastic/eui/pull/936))
 
 ## [`0.0.54`](https://github.com/elastic/eui/tree/v0.0.54)
 

--- a/src/components/tool_tip/tool_tip.js
+++ b/src/components/tool_tip/tool_tip.js
@@ -24,6 +24,7 @@ export const POSITIONS = Object.keys(positionsToClassNameMap);
 const DEFAULT_TOOLTIP_STYLES = {
   // position the tooltip content near the top-left
   // corner of the window so it can't create scrollbars
+  // 50,50 because who knows what negative margins, padding, etc
   top: 50,
   left: 50,
   // just in case, avoid any potential flicker by hiding

--- a/src/components/tool_tip/tool_tip.js
+++ b/src/components/tool_tip/tool_tip.js
@@ -21,6 +21,16 @@ const positionsToClassNameMap = {
 
 export const POSITIONS = Object.keys(positionsToClassNameMap);
 
+const DEFAULT_TOOLTIP_STYLES = {
+  // position the tooltip content near the top-left
+  // corner of the window so it can't create scrollbars
+  top: 50,
+  left: 50,
+  // just in case, avoid any potential flicker by hiding
+  // the tooltip before it is positioned
+  opacity: 0
+};
+
 export class EuiToolTip extends Component {
   constructor(props) {
     super(props);
@@ -29,7 +39,7 @@ export class EuiToolTip extends Component {
       visible: false,
       hasFocus: false,
       calculatedPosition: this.props.position,
-      toolTipStyles: {},
+      toolTipStyles: DEFAULT_TOOLTIP_STYLES,
       arrowStyles: {},
       id: this.props.id || makeId(),
     };
@@ -42,7 +52,7 @@ export class EuiToolTip extends Component {
     // any previous knowledge about its size
     if (ref == null) {
       this.setState({
-        toolTipStyles: {},
+        toolTipStyles: DEFAULT_TOOLTIP_STYLES,
         arrowStyles: {}
       });
     }

--- a/src/components/tool_tip/tool_tip.js
+++ b/src/components/tool_tip/tool_tip.js
@@ -37,6 +37,15 @@ export class EuiToolTip extends Component {
 
   setPopoverRef = ref => {
     this.popover = ref;
+
+    // if the popover has been unmounted, clear
+    // any previous knowledge about its size
+    if (ref == null) {
+      this.setState({
+        toolTipStyles: {},
+        arrowStyles: {}
+      });
+    }
   }
 
   showToolTip = () => {
@@ -52,7 +61,7 @@ export class EuiToolTip extends Component {
       position: requestedPosition,
       offset: 16, // offset popover 16px from the anchor
       arrowConfig: {
-        arrowWidth: 14,
+        arrowWidth: 12,
         arrowBuffer: 4
       }
     });

--- a/src/services/popover/popover_positioning.js
+++ b/src/services/popover/popover_positioning.js
@@ -36,19 +36,18 @@ const positionSubstitutes = {
  * @param position {string} Position the user wants. One of ["top", "right", "bottom", "left"]
  * @param [buffer=16] {number} Minimum distance between the popover and the bounding container
  * @param [offset=0] {number} Distance between the popover and the anchor
- * @param [container=document.body] {HTMLElement|React.Component} Element the popover must be constrained to fit within
- * * @param [arrowConfig] {{arrowWidth: number, arrowBuffer: number}} If present, describes the size & constraints for an arrow element, and the function return value will include an `arrow` param with position details
+ * @param [container] {HTMLElement|React.Component} Element the popover must be constrained to fit within
+ * @param [arrowConfig] {{arrowWidth: number, arrowBuffer: number}} If present, describes the size & constraints for an arrow element, and the function return value will include an `arrow` param with position details
  *
  * @returns {{top: number, left: number, position: string, fit: number, arrow?: {left: number, top: number}}|null} absolute page coordinates for the popover,
  * and the placements's relation to the anchor; if there's no room this returns null
  */
-export function findPopoverPosition({ anchor, popover, position, buffer = 16, offset = 0, container = document.body, arrowConfig }) {
+export function findPopoverPosition({ anchor, popover, position, buffer = 16, offset = 0, container, arrowConfig }) {
   container = findDOMNode(container); // resolve any React abstractions
 
   // find the screen-relative bounding boxes of the anchor, popover, and container
   const anchorBoundingBox = getElementBoundingBox(anchor);
   const popoverBoundingBox = getElementBoundingBox(popover);
-  const containerBoundingBox = getElementBoundingBox(container);
 
   // calculate the window's bounds
   // window.(innerWidth|innerHeight) do not account for scrollbars
@@ -63,6 +62,9 @@ export function findPopoverPosition({ anchor, popover, position, buffer = 16, of
     height: documentHeight,
     width: documentWidth
   };
+
+  // if no container element is given fall back to using the window viewport
+  const containerBoundingBox = container ? getElementBoundingBox(container) : windowBoundingBox;
 
   /**
    * `position` was specified by the function caller and is a strong hint

--- a/src/services/popover/popover_positioning.js
+++ b/src/services/popover/popover_positioning.js
@@ -51,13 +51,17 @@ export function findPopoverPosition({ anchor, popover, position, buffer = 16, of
   const containerBoundingBox = getElementBoundingBox(container);
 
   // calculate the window's bounds
+  // window.(innerWidth|innerHeight) do not account for scrollbars
+  // so prefer the clientWidth/clientHeight of the DOM if available
+  const documentWidth = document.documentElement.clientWidth || window.innerWidth;
+  const documentHeight = document.documentElement.clientHeight || window.innerHeight;
   const windowBoundingBox = {
     top: 0,
-    right: window.innerWidth,
-    bottom: window.innerHeight,
+    right: documentWidth,
+    bottom: documentHeight,
     left: 0,
-    height: window.innerHeight,
-    width: window.innerWidth
+    height: documentHeight,
+    width: documentWidth
   };
 
   /**
@@ -236,6 +240,14 @@ export function getPopoverScreenCoordinates({
   // calculate the fit of the popover in this location
   // fit is in range 0.0 -> 1.0 and is the percentage of the popover which is visible in this location
   const combinedBoundingBox = intersectBoundingBoxes(windowBoundingBox, containerBoundingBox);
+
+  // shrink the visible bounding box by `buffer`
+  // to compute a fit value
+  combinedBoundingBox.top += buffer;
+  combinedBoundingBox.right -= buffer;
+  combinedBoundingBox.bottom -= buffer;
+  combinedBoundingBox.left += buffer;
+
   const fit = getVisibleFit(
     {
       top: popoverPlacement.top,

--- a/src/services/popover/popover_positioning.test.js
+++ b/src/services/popover/popover_positioning.test.js
@@ -371,7 +371,7 @@ describe('popover_positioning', () => {
 
         // give the container limited space on both left and top, forcing to bottom-right
         const container = document.createElement('div');
-        container.getBoundingClientRect = () => makeBB(100, 300, 768, 30);
+        container.getBoundingClientRect = () => makeBB(50, 300, 768, 30);
 
         expect(findPopoverPosition({
           position: 'left',
@@ -382,7 +382,7 @@ describe('popover_positioning', () => {
         })).toEqual({
           fit: 1,
           position: 'right',
-          top: 100,
+          top: 85,
           left: 155
         });
       });


### PR DESCRIPTION
fast follow for #924 

* `EuiTooltip` did not clear its previous knowledge of the tooltip content's size so a window resize & re-hover of the anchor would cause the new tooltip to be influenced by the previous instance's positioning
* small adjustment (1px) to tooltip's arrow position
* Popover service did not take scroll bars into account when finding available window size
* Popover service did not take `buffer` into account when calculating the content's fit value

@cchaos would you mind testing the visuals again to see if you can find any circumstances where tooltip breaks / is malformed?