### PR TITLE
[EuiCodeEditor] Provide selection target for functional tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added `getPopoverScreenCoordinates` service function for positioining popover/tooltip content, updated `EuiToolTip` to use it ([#924](https://github.com/elastic/eui/pull/924))
 - Allow `mode` prop in `EuiCodeEditor` to take custom mode object ([#935](https://github.com/elastic/eui/pull/935))
+- `EuiCodeEditor` is now decorated with a `data-test-subj` selector (`codeEditorContainer`) ([#939](https://github.com/elastic/eui/pull/939))
 
 ## [`0.0.54`](https://github.com/elastic/eui/tree/v0.0.54)
 

--- a/src/components/code_editor/__snapshots__/code_editor.test.js.snap
+++ b/src/components/code_editor/__snapshots__/code_editor.test.js.snap
@@ -78,6 +78,7 @@ exports[`EuiCodeEditor behavior hint element should be tabable 1`] = `
 exports[`EuiCodeEditor is rendered 1`] = `
 <div
   class="euiCodeEditorWrapper"
+  data-test-subj="codeEditorContainer"
 >
   <div
     class="euiCodeEditorKeyboardHint"
@@ -192,6 +193,7 @@ exports[`EuiCodeEditor is rendered 1`] = `
 exports[`EuiCodeEditor props isReadOnly renders alternate hint text 1`] = `
 <div
   class="euiCodeEditorWrapper"
+  data-test-subj="codeEditorContainer"
 >
   <div
     class="euiCodeEditorKeyboardHint"

--- a/src/components/code_editor/code_editor.js
+++ b/src/components/code_editor/code_editor.js
@@ -164,6 +164,7 @@ export class EuiCodeEditor extends Component {
       <div
         className={classes}
         style={{ width, height }}
+        data-test-subj="codeEditorContainer"
       >
         {prompt}
 


### PR DESCRIPTION
With this change, functional tests of code consuming this component can select the `EuiCodeEditor` element.

You can see an example of this in action if you pull down https://github.com/elastic/kibana/pull/20027 along side this PR and run the functional tests for the Grok Debugger app. More specifically, you can see how the `data-test-subj` introduced in this PR is used for selection here:

https://github.com/elastic/kibana/pull/20027/files#diff-4621acc6e44779ce105ee52070f80bafR17
