### PR TITLE
[EuiCodeEditor] Set $blockScrolling = Infinity to prevent console warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Added `getPopoverScreenCoordinates` service function for positioining popover/tooltip content, updated `EuiToolTip` to use it ([#924](https://github.com/elastic/eui/pull/924))
 - Allow `mode` prop in `EuiCodeEditor` to take custom mode object ([#935](https://github.com/elastic/eui/pull/935))
 - `EuiCodeEditor` is now decorated with a `data-test-subj` selector (`codeEditorContainer`) ([#939](https://github.com/elastic/eui/pull/939))
-- Using `EuiCodeEditor` will no longer show a console warning ([#940](https://github.com/elastic/eui/pull/940))
+- `EuiCodeEditor` no longer automatically scrolls cursor into view on selection change ([#940](https://github.com/elastic/eui/pull/940))
 
 ## [`0.0.54`](https://github.com/elastic/eui/tree/v0.0.54)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added `getPopoverScreenCoordinates` service function for positioining popover/tooltip content, updated `EuiToolTip` to use it ([#924](https://github.com/elastic/eui/pull/924))
 - Allow `mode` prop in `EuiCodeEditor` to take custom mode object ([#935](https://github.com/elastic/eui/pull/935))
 - `EuiCodeEditor` is now decorated with a `data-test-subj` selector (`codeEditorContainer`) ([#939](https://github.com/elastic/eui/pull/939))
+- Using `EuiCodeEditor` will no longer show a console warning ([#940](https://github.com/elastic/eui/pull/940))
 
 ## [`0.0.54`](https://github.com/elastic/eui/tree/v0.0.54)
 

--- a/src/components/code_editor/code_editor.js
+++ b/src/components/code_editor/code_editor.js
@@ -175,6 +175,9 @@ export class EuiCodeEditor extends Component {
           onFocus={this.onFocusAce}
           onBlur={this.onBlurAce}
           setOptions={options}
+          editorProps={{
+            $blockScrolling: Infinity
+          }}
           cursorStart={filteredCursorStart}
           {...rest}
         />


### PR DESCRIPTION
Before this change, this warning would be shown in the console:

`Automatically scrolling cursor into view after selection change this will be disabled in the next version set editor.$blockScrolling = Infinity to disable this message`

