### PR TITLE
Altering the avatars a bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Reduced font sizes of `EuiAvatar` ([#945](https://github.com/elastic/eui/pull/945))
+
 **Bug fixes**
 
 - `EuiTooltip` re-positions content correctly after the window is resized ([#936](https://github.com/elastic/eui/pull/936))

--- a/src/components/avatar/_avatar.scss
+++ b/src/components/avatar/_avatar.scss
@@ -5,6 +5,7 @@
   vertical-align: middle;
   overflow-x: hidden;
   cursor: default; // Make sure we don't get the text cursor
+  font-weight: $euiFontWeightRegular; // Explicitly state so it doesn't get overridden by inheritence
 }
 
 .euiAvatar--user {
@@ -21,19 +22,19 @@
 $avatarSizing: (
   s: (
     size: $euiSizeL,
-    font-size: $euiSizeM
+    font-size: $euiSizeM*.9
   ),
   m: (
     size: $euiSizeXL,
-    font-size: $euiSize
+    font-size: $euiSize*.9
   ),
   l: (
     size: $euiSizeXXL,
-    font-size: $euiSizeL
+    font-size: $euiSizeL*.8
   ),
   xl: (
     size: ($euiSize * 4),
-    font-size: $euiSizeXL
+    font-size: $euiSizeXL*.8
   ),
 );
 


### PR DESCRIPTION
- Reducing font sizing so 2 initials fits better
- Explicitly stating font weight so it doesn't get overridden by inheritence

### Before:
<img width="393" alt="screen shot 2018-06-22 at 14 58 54 pm" src="https://user-images.githubusercontent.com/549577/41794767-7621e530-762e-11e8-81da-e4957b52f55c.png">

### After:
<img width="250" alt="screen shot 2018-06-22 at 15 08 21 pm" src="https://user-images.githubusercontent.com/549577/41794773-7d52df9e-762e-11e8-95fb-5591e1da397a.png">
