### PR TITLE
add MutationObserver to accordion to trigger setChildContentHeight when children change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `1.0.0`.
+- `EuiAccordion` use MutationObserver to re-calculate height when children DOM changes ([#947](https://github.com/elastic/eui/pull/947))
 
 ## [`1.0.0`](https://github.com/elastic/eui/tree/v1.0.0)
 

--- a/src-docs/src/views/accordion/accordion_grow.js
+++ b/src-docs/src/views/accordion/accordion_grow.js
@@ -10,8 +10,7 @@ import {
   EuiText,
 } from '../../../../src/components';
 
-// because it grows like a weed and naming is hard
-class Weed extends Component {
+class Rows extends Component {
   state = {
     counter: 1
   }
@@ -56,7 +55,7 @@ class AccordionGrow extends Component {
         initialIsOpen={true}
         paddingSize="l"
       >
-        <Weed/>
+        <Rows/>
       </EuiAccordion>
     );
   }

--- a/src-docs/src/views/accordion/accordion_grow.js
+++ b/src-docs/src/views/accordion/accordion_grow.js
@@ -1,3 +1,6 @@
+/* eslint react/no-multi-comp: 0 */
+/* eslint react/prefer-stateless-function: 0 */
+
 import React, { Component } from 'react';
 
 import {
@@ -7,36 +10,10 @@ import {
   EuiText,
 } from '../../../../src/components';
 
-
-class AccordionGrow extends Component {
+// because it grows like a weed and naming is hard
+class Weed extends Component {
   state = {
     counter: 1
-  }
-
-  render() {
-    const rows = [];
-    for (let i = 1; i <= this.state.counter; i++) {
-      rows.push(<p key={i}>Row {i}</p>);
-    }
-
-    return (
-      <EuiAccordion
-        id="accordion1"
-        buttonContent="Click me to toggle close / open"
-        initialIsOpen={true}
-        paddingSize="l"
-      >
-        <EuiText>
-          <EuiSpacer size="s" />
-          <p>
-            <EuiButton onClick={() => this.onIncrease()}>Increase height</EuiButton>
-            {' '}
-            <EuiButton onClick={() => this.onDecrease()}>Decrease height</EuiButton>
-          </p>
-          { rows }
-        </EuiText>
-      </EuiAccordion>
-    );
   }
 
   onIncrease() {
@@ -49,6 +26,39 @@ class AccordionGrow extends Component {
     this.setState(prevState => ({
       counter: Math.max(0, prevState.counter - 1)
     }));
+  }
+
+  render() {
+    const rows = [];
+    for (let i = 1; i <= this.state.counter; i++) {
+      rows.push(<p key={i}>Row {i}</p>);
+    }
+    return (
+      <EuiText>
+        <EuiSpacer size="s" />
+        <p>
+          <EuiButton onClick={() => this.onIncrease()}>Increase height</EuiButton>
+          {' '}
+          <EuiButton onClick={() => this.onDecrease()}>Decrease height</EuiButton>
+        </p>
+        { rows }
+      </EuiText>
+    );
+  }
+}
+
+class AccordionGrow extends Component {
+  render() {
+    return (
+      <EuiAccordion
+        id="accordion1"
+        buttonContent="Click me to toggle close / open"
+        initialIsOpen={true}
+        paddingSize="l"
+      >
+        <Weed/>
+      </EuiAccordion>
+    );
   }
 }
 

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -45,10 +45,8 @@ export class EuiAccordion extends Component {
   componentDidMount() {
     this.setChildContentHeight();
 
-    requestAnimationFrame(() => {
-      this.observer = new MutationObserver(this.setChildContentHeight);
-      this.observer.observe(this.childContent, { childList: true, subtree: true });
-    });
+    this.observer = new MutationObserver(this.setChildContentHeight);
+    this.observer.observe(this.childContent, { childList: true, subtree: true });
   }
 
   componentWillUnmount() {

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -44,6 +44,15 @@ export class EuiAccordion extends Component {
 
   componentDidMount() {
     this.setChildContentHeight();
+
+    requestAnimationFrame(() => {
+      this.observer = new MutationObserver(this.setChildContentHeight);
+      this.observer.observe(this.childContent, { childList: true, subtree: true });
+    });
+  }
+
+  componentWillUnmount() {
+    this.observer.disconnect();
   }
 
   componentDidUpdate() {

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -44,13 +44,6 @@ export class EuiAccordion extends Component {
 
   componentDidMount() {
     this.setChildContentHeight();
-
-    this.observer = new MutationObserver(this.setChildContentHeight);
-    this.observer.observe(this.childContent, { childList: true, subtree: true });
-  }
-
-  componentWillUnmount() {
-    this.observer.disconnect();
   }
 
   componentDidUpdate() {
@@ -61,6 +54,20 @@ export class EuiAccordion extends Component {
     this.setState(prevState => ({
       isOpen: !prevState.isOpen
     }));
+  }
+
+  setChildContentRef = (node) => {
+    this.childContent = node;
+
+    if (this.observer) {
+      this.observer.disconnect();
+      this.observer = null;
+    }
+
+    if (node) {
+      this.observer = new MutationObserver(this.setChildContentHeight);
+      this.observer.observe(this.childContent, { childList: true, subtree: true });
+    }
   }
 
   render() {
@@ -147,7 +154,7 @@ export class EuiAccordion extends Component {
           ref={node => { this.childWrapper = node; }}
           id={id}
         >
-          <div ref={node => { this.childContent = node; }}>
+          <div ref={this.setChildContentRef}>
             <div className={paddingClass}>
               {children}
             </div>

--- a/src/components/accordion/accordion.test.js
+++ b/src/components/accordion/accordion.test.js
@@ -81,6 +81,18 @@ describe('EuiAccordion', () => {
   });
 
   describe('behavior', () => {
+    beforeAll(() => {
+      global.MutationObserver = class {
+        constructor() {}
+        disconnect() {}
+        observe() {}
+      };
+    });
+
+    afterAll(() => {
+      delete global.MutationObserver;
+    });
+
     it('opens when clicked once', () => {
       const component = mount(
         <EuiAccordion


### PR DESCRIPTION
EuiAccordion does not update height when children internal state changes. I updated the AccordionGrow example to demonstrate. When the counter is modified inside the sub-component than EuiAccordion's componentDidUpdate never gets called because none of the props passed to children changed.

This PR adds a MutationObserver to update height any time the children DOM tree changes.