### PR TITLE
Added word-break fallback for FF & IE in table cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Added more (mainly style) options to `EuiRange` ([#932](https://github.com/elastic/eui/pull/932))
 
+**Bug fixes**
+
+- Added word-break fallback for FF & IE in table cell ([#962](https://github.com/elastic/eui/pull/962))
+
 ## [`1.0.1`](https://github.com/elastic/eui/tree/v1.0.1)
 
 - `EuiAccordion` use MutationObserver to re-calculate height when children DOM changes ([#947](https://github.com/elastic/eui/pull/947))

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -132,6 +132,7 @@
   .euiTableCellContent__text {
     min-width: 0;
     text-overflow: ellipsis;
+    word-break: break-all; /* 1 */ // Fallback for FF and IE
     word-break: break-word; /* 1 */
   }
 


### PR DESCRIPTION
## Before

<img width="558" alt="screen shot 2018-07-02 at 16 56 09 pm" src="https://user-images.githubusercontent.com/549577/42186021-02aae780-7e19-11e8-9376-83e5dd21b7b5.png">


## After

<img width="541" alt="screen shot 2018-07-02 at 16 56 24 pm" src="https://user-images.githubusercontent.com/549577/42186022-03b0300e-7e19-11e8-9668-9e9e376379be.png">

---

Addresses https://github.com/elastic/eui/issues/855#event-1709607391 and fixes #855 and fixes #943

cc @jen-huang 