### PR TITLE
Make EuiPopover copy the anchor's z-index to the popover content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed disabled states of icon buttons ([#963](https://github.com/elastic/eui/pull/963))
 - Added word-break fallback for FF & IE in table cell ([#962](https://github.com/elastic/eui/pull/962))
+- Fixed `EuiPopover` to show content over modals, flyouts, etc ([#967](https://github.com/elastic/eui/pull/967))
 
 ## [`1.0.1`](https://github.com/elastic/eui/tree/v1.0.1)
 

--- a/src-docs/src/views/flyout/flyout_complicated.js
+++ b/src-docs/src/views/flyout/flyout_complicated.js
@@ -12,6 +12,7 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
+  EuiPopover,
   EuiSpacer,
   EuiTab,
   EuiTabs,
@@ -27,6 +28,7 @@ export class FlyoutComplicated extends Component {
       isFlyoutVisible: false,
       isSwitchChecked: true,
       selectedTabId: '1',
+      isPopoverOpen: false,
     };
 
     this.tabs = [{
@@ -53,6 +55,10 @@ export class FlyoutComplicated extends Component {
 
   showFlyout() {
     this.setState({ isFlyoutVisible: true });
+  }
+
+  togglePopover = () => {
+    this.setState(({ isPopoverOpen }) => ({ isPopoverOpen: !isPopoverOpen }));
   }
 
   onSelectedTabChanged = id => {
@@ -156,6 +162,13 @@ export class FlyoutComplicated extends Component {
             <EuiSpacer size="s" />
             <EuiText color="subdued">
               <p>Put navigation items in the header, and cross tab actions in a footer.</p>
+              <EuiPopover
+                closePopover={this.togglePopover}
+                button={<EuiButton onClick={this.togglePopover}>Even popovers can be included</EuiButton>}
+                isOpen={this.state.isPopoverOpen}
+              >
+                <p>This is the popover content, notice how it can overflow the flyout!</p>
+              </EuiPopover>
             </EuiText>
             <EuiTabs style={{ marginBottom: '-25px' }}>
               {this.renderTabs()}

--- a/src-docs/src/views/flyout/flyout_complicated.js
+++ b/src-docs/src/views/flyout/flyout_complicated.js
@@ -162,14 +162,14 @@ export class FlyoutComplicated extends Component {
             <EuiSpacer size="s" />
             <EuiText color="subdued">
               <p>Put navigation items in the header, and cross tab actions in a footer.</p>
-              <EuiPopover
-                closePopover={this.togglePopover}
-                button={<EuiButton onClick={this.togglePopover}>Even popovers can be included</EuiButton>}
-                isOpen={this.state.isPopoverOpen}
-              >
-                <p>This is the popover content, notice how it can overflow the flyout!</p>
-              </EuiPopover>
             </EuiText>
+            <EuiPopover
+              closePopover={this.togglePopover}
+              button={<EuiButton onClick={this.togglePopover}>Even popovers can be included</EuiButton>}
+              isOpen={this.state.isPopoverOpen}
+            >
+              <p>This is the popover content, notice how it can overflow the flyout!</p>
+            </EuiPopover>
             <EuiTabs style={{ marginBottom: '-25px' }}>
               {this.renderTabs()}
             </EuiTabs>

--- a/src-docs/src/views/flyout/flyout_complicated.js
+++ b/src-docs/src/views/flyout/flyout_complicated.js
@@ -57,6 +57,10 @@ export class FlyoutComplicated extends Component {
     this.setState({ isFlyoutVisible: true });
   }
 
+  closePopover = () => {
+    this.setState({ isPopoverOpen: false });
+  }
+
   togglePopover = () => {
     this.setState(({ isPopoverOpen }) => ({ isPopoverOpen: !isPopoverOpen }));
   }
@@ -163,18 +167,18 @@ export class FlyoutComplicated extends Component {
             <EuiText color="subdued">
               <p>Put navigation items in the header, and cross tab actions in a footer.</p>
             </EuiText>
-            <EuiPopover
-              closePopover={this.togglePopover}
-              button={<EuiButton onClick={this.togglePopover}>Even popovers can be included</EuiButton>}
-              isOpen={this.state.isPopoverOpen}
-            >
-              <p>This is the popover content, notice how it can overflow the flyout!</p>
-            </EuiPopover>
             <EuiTabs style={{ marginBottom: '-25px' }}>
               {this.renderTabs()}
             </EuiTabs>
           </EuiFlyoutHeader>
           <EuiFlyoutBody>
+            <EuiPopover
+              closePopover={this.closePopover}
+              button={<EuiButton onClick={this.togglePopover}>Even popovers can be included</EuiButton>}
+              isOpen={this.state.isPopoverOpen}
+            >
+              <p>This is the popover content, notice how it can overflow the flyout!</p>
+            </EuiPopover>
             {flyoutContent}
             <EuiCodeBlock language="html">
               {htmlCode}

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -16,7 +16,7 @@ import { EuiPanel, SIZES } from '../panel';
 
 import { EuiPortal } from '../portal';
 
-import { findPopoverPosition } from '../../services/popover/popover_positioning';
+import { findPopoverPosition, getElementZIndex } from '../../services/popover/popover_positioning';
 
 const anchorPositionToPopoverPositionMap = {
   'up': 'top',
@@ -189,9 +189,15 @@ export class EuiPopover extends Component {
       }
     });
 
+    // the popver's z-index must inherit from the button
+    // this keeps a button's popver under a flyover that would covert the button
+    // but a popover triggered inside a flyover will appear over that flyover
+    const zIndex = getElementZIndex(this.button);
+
     const popoverStyles = {
       top,
       left,
+      zIndex,
     };
 
     const arrowStyles = arrow;

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -192,7 +192,7 @@ export class EuiPopover extends Component {
     // the popver's z-index must inherit from the button
     // this keeps a button's popver under a flyover that would covert the button
     // but a popover triggered inside a flyover will appear over that flyover
-    const zIndex = getElementZIndex(this.button);
+    const zIndex = getElementZIndex(this.button, this.panel);
 
     const popoverStyles = {
       top,

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -190,7 +190,7 @@ export class EuiPopover extends Component {
     });
 
     // the popver's z-index must inherit from the button
-    // this keeps a button's popver under a flyover that would covert the button
+    // this keeps a button's popver under a flyover that would cover the button
     // but a popover triggered inside a flyover will appear over that flyover
     const zIndex = getElementZIndex(this.button, this.panel);
 

--- a/src/services/popover/popover_positioning.js
+++ b/src/services/popover/popover_positioning.js
@@ -511,16 +511,64 @@ export function intersectBoundingBoxes(firstBox, secondBox) {
 
 
 /**
- * Returns the nearest defined z-index for an element, or 0 if there isn't any
- * starts at the element and recursively walks up its offsetParent tree
+ * Returns the top-most defined z-index in the element's ancestor hierarchy
+ * relative to the `target` element; if no z-index is defined, returns "0"
  * @param element {HTMLElement|React.Component}
+ * @param cousin {HTMLElement|React.Component}
  * @returns {string}
  */
-export function getElementZIndex(element) {
+export function getElementZIndex(element, cousin) {
   element = findDOMNode(element);
-  const zIndex = window.document.defaultView.getComputedStyle(element).getPropertyValue('z-index');
-  if (isNaN(zIndex)) {
-    return element.offsetParent ? getElementZIndex(element.offsetParent) : '0';
+  cousin = findDOMNode(cousin);
+
+  /**
+   * finding the z-index of `element` is not the full story
+   * its the CSS stacking context that is important
+   * take this DOM for example:
+   * body
+   *   section[z-index: 1000]
+   *     p[z-index: 500]
+   *       button
+   *   div
+   *
+   * what z-index does the `div` need to display next to `button`?
+   * the `div` and `section` are where the stacking context splits
+   * so `div` needs to copy `section`'s z-index in order to
+   * appear next to / over `button`
+   *
+   * calculate this by starting at `button` and finding its offsetParents
+   * then walk the parents from top -> down until the stacking context
+   * split is found, or if there is no split then a specific z-index is unimportant
+   */
+
+  // build the array of the element + its offset parents
+  const nodesToInspect = [];
+  while (true) {
+    nodesToInspect.push(element);
+
+    element = element.offsetParent;
+
+    // stop if there is no parent
+    if (element == null) break;
+
+    // stop if the parent contains the related element
+    // as this is the z-index ancestor
+    if (element.contains(cousin)) break;
   }
-  return zIndex;
+
+  // reverse the nodes to walk from top -> element
+  nodesToInspect.reverse();
+
+  return nodesToInspect.reduce(
+    (foundZIndex, node) => {
+      if (foundZIndex != null) return foundZIndex;
+
+      // get this node's z-index css value
+      const zIndex = window.document.defaultView.getComputedStyle(node).getPropertyValue('z-index');
+
+      // if the z-index is not a number (e.g. "auto") return null, else the value
+      return isNaN(zIndex) ? null : zIndex;
+    },
+    null
+  ) || '0';
 }

--- a/src/services/popover/popover_positioning.js
+++ b/src/services/popover/popover_positioning.js
@@ -508,3 +508,19 @@ export function intersectBoundingBoxes(firstBox, secondBox) {
 
   return intersection;
 }
+
+
+/**
+ * Returns the nearest defined z-index for an element, or 0 if there isn't any
+ * starts at the element and recursively walks up its offsetParent tree
+ * @param element {HTMLElement|React.Component}
+ * @returns {string}
+ */
+export function getElementZIndex(element) {
+  element = findDOMNode(element);
+  const zIndex = window.document.defaultView.getComputedStyle(element).getPropertyValue('z-index');
+  if (isNaN(zIndex)) {
+    return element.offsetParent ? getElementZIndex(element.offsetParent) : '0';
+  }
+  return zIndex;
+}


### PR DESCRIPTION
Fixes #965 

This sets the content's z-index from the anchor element's z-index. The value must be calculated/copied instead of hard-coding in css as e.g. the popover may need to show behind a flyout from one button but be in front if it relates to content in the flyout.

_without setting z-index_
![without z-index](https://d.pr/i/uz5U8p.gif)

_with z-index_
![with z-index](https://d.pr/i/5uQoiD.gif)

adding
@cchaos sanity check, testing
@nreese / @cjcenizal to make sure the code change & comments are understandable

