### PR TITLE
Add inputRef prop to EuiFieldPassword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added more (mainly style) options to `EuiRange` ([#932](https://github.com/elastic/eui/pull/932))
 - Cleaned up some `EuiPopover` styles ([#969](https://github.com/elastic/eui/pull/969))
+- Added `inputRef` prop to `EuiFieldPassword` ([#970](https://github.com/elastic/eui/pull/970))
 
 **Bug fixes**
 

--- a/src/components/form/field_password/field_password.js
+++ b/src/components/form/field_password/field_password.js
@@ -20,6 +20,7 @@ export const EuiFieldPassword = ({
   fullWidth,
   isLoading,
   compressed,
+  inputRef,
   ...rest
 }) => {
   const classes = classNames(
@@ -47,6 +48,7 @@ export const EuiFieldPassword = ({
           placeholder={placeholder}
           className={classes}
           value={value}
+          ref={inputRef}
           {...rest}
         />
       </EuiValidatableControl>
@@ -61,6 +63,7 @@ EuiFieldPassword.propTypes = {
   value: PropTypes.string,
   isInvalid: PropTypes.bool,
   fullWidth: PropTypes.bool,
+  inputRef: PropTypes.func,
   isLoading: PropTypes.bool,
   /**
    * when `true` creates a shorter height input


### PR DESCRIPTION
Fixes #964 by adding the `inputRef` prop to `EuiFieldPassword`, making it match the other input components.