### PR TITLE
Fix: accordion observer issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed some IE11 flex box bugs and documented others (modal overflowing, image shrinking, and flex group wrapping) ([#973](https://github.com/elastic/eui/pull/973))
 - Fixed white square that show in double scollbar via `euiScrollBar()` ([989](https://github.com/elastic/eui/pull/989))
+- Fixed issue with Accordion would attempt to use properties and accessors on null ([#982](https://github.com/elastic/eui/pull/982))
 
 ## [`1.1.0`](https://github.com/elastic/eui/tree/v1.1.0)
 

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -37,7 +37,7 @@ export class EuiAccordion extends Component {
 
   setChildContentHeight = () => {
     requestAnimationFrame(() => {
-      const height = this.state.isOpen ? this.childContent.clientHeight : 0;
+      const height = this.childContent && this.state.isOpen ? this.childContent.clientHeight : 0;
       this.childWrapper.setAttribute('style', `height: ${height}px`);
     });
   }

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -38,7 +38,7 @@ export class EuiAccordion extends Component {
   setChildContentHeight = () => {
     requestAnimationFrame(() => {
       const height = this.childContent && this.state.isOpen ? this.childContent.clientHeight : 0;
-      this.childWrapper.setAttribute('style', `height: ${height}px`);
+      this.childWrapper && this.childWrapper.setAttribute('style', `height: ${height}px`);
     });
   }
 


### PR DESCRIPTION
Quick fix for https://github.com/elastic/eui/issues/981

Mostly a quick patch to the Accordion so that the mutation observer stops causing uncaught errors.

- in `setChildContentHeight`, check that `this.childContent` is truthy before trying to read the `clientHeight` property
- in `setChildContentHeight`, check that `this.childWrapper` is set before trying to use `setAttribute`