### PR TITLE
[types/EuiButtonEmpty] add missing isLoading and href props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added beta version of `EuiXYChart` and associated components ([#309](https://github.com/elastic/eui/pull/309))
 - Added `size` prop to `EuiIconTip` ([987](https://github.com/elastic/eui/pull/987))
 - Added `database`, `filter`, `globe`, and `save` icons ([990](https://github.com/elastic/eui/pull/990))
+- Updated typings for `EuiButton`, `EuiButtonEmpty`, and `EuiButtonIcon` to include `<a>` tag attributes like `href` ([#992](https://github.com/elastic/eui/pull/992))
 
 **Bug fixes**
 

--- a/src/components/button/index.d.ts
+++ b/src/components/button/index.d.ts
@@ -27,7 +27,6 @@ declare module '@elastic/eui' {
     size?: ButtonSize;
     isLoading?: boolean;
     isDisabled?: boolean;
-    href?: string;
   }
   export const EuiButton: SFC<
     CommonProps & ButtonHTMLAttributes<HTMLButtonElement> & AnchorHTMLAttributes<HTMLAnchorElement> & EuiButtonProps
@@ -52,7 +51,6 @@ declare module '@elastic/eui' {
     'aria-label'?: string;
     'aria-labelledby'?: string;
     isDisabled?: boolean;
-    href?: string;
   }
   export const EuiButtonIcon: SFC<
     CommonProps & ButtonHTMLAttributes<HTMLButtonElement> & AnchorHTMLAttributes<HTMLAnchorElement> & EuiButtonIconProps
@@ -82,7 +80,6 @@ declare module '@elastic/eui' {
     flush?: EmptyButtonFlush;
     isLoading?: boolean;
     isDisabled?: boolean;
-    href?: string;
   }
 
   export const EuiButtonEmpty: SFC<

--- a/src/components/button/index.d.ts
+++ b/src/components/button/index.d.ts
@@ -1,7 +1,7 @@
 /// <reference path="../common.d.ts" />
 /// <reference path="../icon/index.d.ts" />
 
-import { SFC, ButtonHTMLAttributes, MouseEventHandler } from 'react';
+import { SFC, ButtonHTMLAttributes, AnchorHTMLAttributes } from 'react';
 
 declare module '@elastic/eui' {
   /**
@@ -20,17 +20,17 @@ declare module '@elastic/eui' {
   export type ButtonSize = 's' | 'l';
 
   export interface EuiButtonProps {
-    onClick: MouseEventHandler<HTMLButtonElement>; //overriding DOMAttributes to make this required
     iconType?: IconType;
     iconSide?: ButtonIconSide;
     fill?: boolean;
     color?: ButtonColor;
     size?: ButtonSize;
+    isLoading?: boolean;
     isDisabled?: boolean;
+    href?: string;
   }
-
   export const EuiButton: SFC<
-    CommonProps & ButtonHTMLAttributes<HTMLButtonElement> & EuiButtonProps
+    CommonProps & ButtonHTMLAttributes<HTMLButtonElement> & AnchorHTMLAttributes<HTMLAnchorElement> & EuiButtonProps
   >;
 
   /**
@@ -47,15 +47,15 @@ declare module '@elastic/eui' {
     | 'text';
 
   export interface EuiButtonIconProps {
-    onClick: MouseEventHandler<HTMLButtonElement>; //overriding DOMAttributes to make this required
     iconType?: IconType;
     color?: ButtonIconColor;
-    isDisabled?: boolean;
     'aria-label'?: string;
     'aria-labelledby'?: string;
+    isDisabled?: boolean;
+    href?: string;
   }
   export const EuiButtonIcon: SFC<
-    CommonProps & ButtonHTMLAttributes<HTMLButtonElement> & EuiButtonIconProps
+    CommonProps & ButtonHTMLAttributes<HTMLButtonElement> & AnchorHTMLAttributes<HTMLAnchorElement> & EuiButtonIconProps
   >;
 
   /**
@@ -80,12 +80,12 @@ declare module '@elastic/eui' {
     color?: EmptyButtonColor;
     size?: EmptyButtonSizes;
     flush?: EmptyButtonFlush;
-    isDisabled?: boolean;
     isLoading?: boolean;
+    isDisabled?: boolean;
     href?: string;
   }
 
   export const EuiButtonEmpty: SFC<
-    CommonProps & ButtonHTMLAttributes<HTMLButtonElement> & EuiButtonEmptyProps
+    CommonProps & ButtonHTMLAttributes<HTMLButtonElement> & AnchorHTMLAttributes<HTMLAnchorElement> & EuiButtonEmptyProps
   >;
 }

--- a/src/components/button/index.d.ts
+++ b/src/components/button/index.d.ts
@@ -81,6 +81,8 @@ declare module '@elastic/eui' {
     size?: EmptyButtonSizes;
     flush?: EmptyButtonFlush;
     isDisabled?: boolean;
+    isLoading?: boolean;
+    href?: string;
   }
 
   export const EuiButtonEmpty: SFC<

--- a/src/components/button/index.d.ts
+++ b/src/components/button/index.d.ts
@@ -1,9 +1,15 @@
 /// <reference path="../common.d.ts" />
 /// <reference path="../icon/index.d.ts" />
 
-import { SFC, ButtonHTMLAttributes, AnchorHTMLAttributes } from 'react';
+import { SFC, ButtonHTMLAttributes, AnchorHTMLAttributes, MouseEventHandler } from 'react';
 
 declare module '@elastic/eui' {
+  type EuiButtonPropsForButtonOrLink<Props> = (
+    (Props & { onClick: MouseEventHandler<HTMLButtonElement> } & ButtonHTMLAttributes<HTMLButtonElement>) |
+    (Props & { href: string; onClick: MouseEventHandler<HTMLAnchorElement> } & AnchorHTMLAttributes<HTMLAnchorElement>) |
+    (Props & AnchorHTMLAttributes<HTMLAnchorElement> & ButtonHTMLAttributes<HTMLButtonElement>)
+  )
+
   /**
    * Normal button type defs
    *
@@ -29,7 +35,7 @@ declare module '@elastic/eui' {
     isDisabled?: boolean;
   }
   export const EuiButton: SFC<
-    CommonProps & ButtonHTMLAttributes<HTMLButtonElement> & AnchorHTMLAttributes<HTMLAnchorElement> & EuiButtonProps
+    EuiButtonPropsForButtonOrLink<CommonProps & EuiButtonProps>
   >;
 
   /**
@@ -53,7 +59,7 @@ declare module '@elastic/eui' {
     isDisabled?: boolean;
   }
   export const EuiButtonIcon: SFC<
-    CommonProps & ButtonHTMLAttributes<HTMLButtonElement> & AnchorHTMLAttributes<HTMLAnchorElement> & EuiButtonIconProps
+    EuiButtonPropsForButtonOrLink<CommonProps & EuiButtonIconProps>
   >;
 
   /**
@@ -83,6 +89,6 @@ declare module '@elastic/eui' {
   }
 
   export const EuiButtonEmpty: SFC<
-    CommonProps & ButtonHTMLAttributes<HTMLButtonElement> & AnchorHTMLAttributes<HTMLAnchorElement> & EuiButtonEmptyProps
+    EuiButtonPropsForButtonOrLink<CommonProps & EuiButtonEmptyProps>
   >;
 }


### PR DESCRIPTION
Tried to use `<EuiButtonEmpty />` in typescript but the `href` prop wasn't typed, pulled over the `isLoading` prop too because it seemed to be missing but is defined in the `propTypes`