### PR TITLE
Page responsive fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 - Gave `EuiFlyout` close button a data-test-subj ([#1000](https://github.com/elastic/eui/pull/1000/files))
 - Add typings for `EuiFlyout`, `EuiFlyoutBody`, `EuiFlyoutHeader`, and `EuiFlyoutFooter` ([#1001](https://github.com/elastic/eui/pull/1001))
 
+**Breaking changes**
+
+- Altered `EuiPage` and sub-component layout ([#998](https://github.com/elastic/eui/pull/998))
+  - `EuiPageHeader` must now be contained within `EuiPageBody`
+  - `EuiPageSideBar` must now be **outside** of `EuiPageBody`
+
 ## [`1.2.1`](https://github.com/elastic/eui/tree/v1.2.1)
 
 **Bug fixes**
@@ -11,7 +17,7 @@
 
 ## [`1.2.0`](https://github.com/elastic/eui/tree/v1.2.0)
 
-**Note: this release creates a minor regression to the sizing of `EuiTitle`s. This is fixed in `master`.**
+**Note: this release creates a minor regression to the sizing of `EuiTitle`s. This is fixed in `1.2.1`.**
 
 - Added typings for keyCodes ([#988](https://github.com/elastic/eui/pull/988))
 - Changed `EuiXYChart` components exports to `/experimental` subfolder ([#975](https://github.com/elastic/eui/pull/975))

--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -9,6 +9,10 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
 
 .guidePage {
   padding: 0;
+
+  @include euiBreakpoint('xs', 's') {
+    display: block; // Fixes IE
+  }
 }
 
 .guideSideNav {
@@ -39,7 +43,7 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
 }
 
 .guidePageContent {
-  flex: 1 1 0%;
+  flex: 1 1 auto;
   padding: $euiSize $euiSizeXL;
   min-height: 100vh;
   background-color: $euiColorEmptyShade;
@@ -49,7 +53,7 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
 }
 
 .guideDemo__highlightLayout {
-  .euiPage {
+  .euiPageBody {
     min-height: 460px;
   }
 

--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -49,6 +49,10 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
 }
 
 .guideDemo__highlightLayout {
+  .euiPage {
+    min-height: 460px;
+  }
+
   div {
     background: transparentize(#0096CC, .9);
   }

--- a/src-docs/src/views/page/page.js
+++ b/src-docs/src/views/page/page.js
@@ -15,20 +15,20 @@ import {
 
 export default () => (
   <EuiPage>
-    <EuiPageHeader>
-      <EuiPageHeaderSection>
-        <EuiTitle size="l">
-          <h1>Page title</h1>
-        </EuiTitle>
-      </EuiPageHeaderSection>
-      <EuiPageHeaderSection>
-        Page abilities
-      </EuiPageHeaderSection>
-    </EuiPageHeader>
+    <EuiPageSideBar>
+      SideBar nav
+    </EuiPageSideBar>
     <EuiPageBody>
-      <EuiPageSideBar>
-        SideBar nav
-      </EuiPageSideBar>
+      <EuiPageHeader>
+        <EuiPageHeaderSection>
+          <EuiTitle size="l">
+            <h1>Page title</h1>
+          </EuiTitle>
+        </EuiPageHeaderSection>
+        <EuiPageHeaderSection>
+          Page abilities
+        </EuiPageHeaderSection>
+      </EuiPageHeader>
       <EuiPageContent>
         <EuiPageContentHeader>
           <EuiPageContentHeaderSection>

--- a/src-docs/src/views/page/page_content_center_with_side_bar.js
+++ b/src-docs/src/views/page/page_content_center_with_side_bar.js
@@ -14,22 +14,21 @@ import {
 } from '../../../../src/components';
 
 export default () => (
-
   <EuiPage>
-    <EuiPageHeader>
-      <EuiPageHeaderSection>
-        <EuiTitle size="l">
-          <h1>Page title</h1>
-        </EuiTitle>
-      </EuiPageHeaderSection>
-      <EuiPageHeaderSection>
-        Page abilities
-      </EuiPageHeaderSection>
-    </EuiPageHeader>
+    <EuiPageSideBar>
+      SideBar nav
+    </EuiPageSideBar>
     <EuiPageBody>
-      <EuiPageSideBar>
-        SideBar nav
-      </EuiPageSideBar>
+      <EuiPageHeader>
+        <EuiPageHeaderSection>
+          <EuiTitle size="l">
+            <h1>Page title</h1>
+          </EuiTitle>
+        </EuiPageHeaderSection>
+        <EuiPageHeaderSection>
+          Page abilities
+        </EuiPageHeaderSection>
+      </EuiPageHeader>
       <EuiPageContent verticalPosition="center"  horizontalPosition="center">
         <EuiPageContentHeader>
           <EuiPageContentHeaderSection>

--- a/src-docs/src/views/page/page_simple.js
+++ b/src-docs/src/views/page/page_simple.js
@@ -14,14 +14,14 @@ import {
 
 export default () => (
   <EuiPage>
-    <EuiPageHeader>
-      <EuiPageHeaderSection>
-        <EuiTitle size="l">
-          <h1>Page title</h1>
-        </EuiTitle>
-      </EuiPageHeaderSection>
-    </EuiPageHeader>
     <EuiPageBody>
+      <EuiPageHeader>
+        <EuiPageHeaderSection>
+          <EuiTitle size="l">
+            <h1>Page title</h1>
+          </EuiTitle>
+        </EuiPageHeaderSection>
+      </EuiPageHeader>
       <EuiPageContent>
         <EuiPageContentHeader>
           <EuiPageContentHeaderSection>

--- a/src/components/page/_page.scss
+++ b/src/components/page/_page.scss
@@ -1,6 +1,5 @@
 .euiPage {
   display: flex;
-  flex-direction: column;
   padding: $euiSize;
   background-color: $euiColorLightestShade;
 
@@ -15,6 +14,7 @@
   }
 
   @include euiBreakpoint('xs', 's') {
+    flex-direction: column;
     padding: 0;
   }
 }

--- a/src/components/page/_page.scss
+++ b/src/components/page/_page.scss
@@ -1,4 +1,6 @@
 .euiPage {
+  display: flex;
+  flex-direction: column;
   padding: $euiSize;
   background-color: $euiColorLightestShade;
 
@@ -10,5 +12,9 @@
 
   &--restrictWidth-default {
     max-width: 1000px;
+  }
+
+  @include euiBreakpoint('xs', 's') {
+    padding: 0;
   }
 }

--- a/src/components/page/page_body/_page_body.scss
+++ b/src/components/page/page_body/_page_body.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: row;
   align-items: stretch;
-  min-height: 400px; // Temporary till we have a better doc system.
+  flex-grow: 1;
 }
 
 @include euiBreakpoint('xs','s') {

--- a/src/components/page/page_body/_page_body.scss
+++ b/src/components/page/page_body/_page_body.scss
@@ -2,6 +2,6 @@
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  flex-grow: 1;
+  flex: 1 1 0%;
 }
 

--- a/src/components/page/page_body/_page_body.scss
+++ b/src/components/page/page_body/_page_body.scss
@@ -1,13 +1,7 @@
 .euiPageBody {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   align-items: stretch;
   flex-grow: 1;
-}
-
-@include euiBreakpoint('xs','s') {
-  .euiPageBody {
-    flex-direction: column;
-  }
 }
 

--- a/src/components/page/page_content/__snapshots__/page_content_header.test.js.snap
+++ b/src/components/page/page_content/__snapshots__/page_content_header.test.js.snap
@@ -3,7 +3,7 @@
 exports[`EuiPageContentHeader is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="euiPageContentHeader testClass1 testClass2"
+  class="euiPageContentHeader euiPageContentHeader--responsive testClass1 testClass2"
   data-test-subj="test subject string"
 />
 `;

--- a/src/components/page/page_content/_page_content.scss
+++ b/src/components/page/page_content/_page_content.scss
@@ -7,6 +7,7 @@
 
   &.euiPageContent--horizontalCenter {
     width: auto;
+    max-width: 100%; // Fixes IE
     margin: auto;
     flex-grow: 0; // Offsets the properties of .euiPanel within flexboxes
   }

--- a/src/components/page/page_content/_page_content.scss
+++ b/src/components/page/page_content/_page_content.scss
@@ -10,12 +10,14 @@
     margin: auto;
     flex-grow: 0; // Offsets the properties of .euiPanel within flexboxes
   }
-}
 
-
-@include euiBreakpoint('xs','s') {
-  .euiPageContent {
-    border-radius: 0;
-    border: none;
+  // At small screens, the content extends edge to edge, so remove the side borders and shadow
+  @include euiBreakpoint('xs', 's') {
+    &.euiPanel:not(.euiPageContent--horizontalCenter) { // Override panel styles without the need for !important
+      border-radius: 0;
+      border-left: none;
+      border-right: none;
+      box-shadow: none;
+    }
   }
 }

--- a/src/components/page/page_content/_page_content_header.scss
+++ b/src/components/page/page_content/_page_content_header.scss
@@ -1,13 +1,22 @@
+@import '../../panel/variables';
+
 .euiPageContentHeader {
-  margin-bottom: $euiSizeL;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
+
+  // Adjust vertical spacing based on content padding prop
+  @each $modifier, $amount in $euiPanelPaddingModifiers {
+    .euiPageContent[class*="#{$modifier}"] & {
+      margin-bottom: $amount;
+    }
+  }
 }
 
 @include euiBreakpoint('xs','s') {
-  .euiPageContentHeader {
+  .euiPageContentHeader--responsive {
     flex-direction: column;
+    align-items: unset;
   }
 }

--- a/src/components/page/page_content/_page_content_header.scss
+++ b/src/components/page/page_content/_page_content_header.scss
@@ -17,6 +17,6 @@
 @include euiBreakpoint('xs','s') {
   .euiPageContentHeader--responsive {
     flex-direction: column;
-    align-items: unset;
+    align-items: flex-start;
   }
 }

--- a/src/components/page/page_content/_page_content_header_section.scss
+++ b/src/components/page/page_content/_page_content_header_section.scss
@@ -1,18 +1,19 @@
-.euiPageContentHeaderSection {
+@import '../../panel/variables';
 
+.euiPageContentHeaderSection {
   & + & {
     margin-left: $euiSizeXL;
   }
 }
 
+// Adjust vertical spacing based on content padding prop
 @include euiBreakpoint('xs','s') {
-
-  .euiPageContentHeaderSection {
-    width: 100%;
-
-    & + & {
-      margin-left: 0;
-      margin-top: $euiSize;
+  @each $modifier, $amount in $euiPanelPaddingModifiers {
+    .euiPageContent[class*="#{$modifier}"] .euiPageContentHeader--responsive {
+      .euiPageContentHeaderSection + .euiPageContentHeaderSection {
+        margin-left: 0;
+        margin-top: $amount/2;
+      }
     }
   }
 }

--- a/src/components/page/page_content/page_content_header.js
+++ b/src/components/page/page_content/page_content_header.js
@@ -2,8 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-export const EuiPageContentHeader = ({ children, className, ...rest }) => {
-  const classes = classNames('euiPageContentHeader', className);
+export const EuiPageContentHeader = ({ children, className, responsive, ...rest }) => {
+  const classes = classNames(
+    'euiPageContentHeader',
+    {
+      'euiPageContentHeader--responsive': responsive,
+    },
+    className,
+  );
 
   return (
     <div
@@ -18,4 +24,13 @@ export const EuiPageContentHeader = ({ children, className, ...rest }) => {
 EuiPageContentHeader.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
+  /**
+   * Set to false if you don't want the children to stack
+   * at small screen sizes.
+   */
+  responsive: PropTypes.bool,
+};
+
+EuiPageContentHeader.defaultProps = {
+  responsive: true,
 };

--- a/src/components/page/page_header/__snapshots__/page_header.test.js.snap
+++ b/src/components/page/page_header/__snapshots__/page_header.test.js.snap
@@ -3,7 +3,7 @@
 exports[`EuiPageHeader is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="euiPageHeader testClass1 testClass2"
+  class="euiPageHeader euiPageHeader--responsive testClass1 testClass2"
   data-test-subj="test subject string"
 />
 `;

--- a/src/components/page/page_header/_page_header.scss
+++ b/src/components/page/page_header/_page_header.scss
@@ -8,8 +8,11 @@
 
 @include euiBreakpoint('xs','s') {
   .euiPageHeader {
-    flex-direction: column;
-    padding: 0 $euiSize;
+    padding: $euiSize;
     margin-bottom: 0;
+  }
+
+  .euiPageHeader--responsive {
+    flex-direction: column;
   }
 }

--- a/src/components/page/page_header/_page_header_section.scss
+++ b/src/components/page/page_header/_page_header_section.scss
@@ -1,15 +1,14 @@
 .euiPageHeaderSection {
-
   & + & {
     margin-left: $euiSizeXL;
   }
 }
-@include euiBreakpoint('xs','s') {
 
-  .euiPageHeaderSection {
+@include euiBreakpoint('xs','s') {
+  .euiPageHeader--responsive .euiPageHeaderSection {
     width: 100%;
 
-    & + & {
+    + .euiPageHeaderSection {
       margin-left: 0;
       margin-top: $euiSize;
     }

--- a/src/components/page/page_header/page_header.js
+++ b/src/components/page/page_header/page_header.js
@@ -2,8 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-export const EuiPageHeader = ({ children, className, ...rest }) => {
-  const classes = classNames('euiPageHeader', className);
+export const EuiPageHeader = ({ children, className, responsive, ...rest }) => {
+  const classes = classNames(
+    'euiPageHeader',
+    {
+      'euiPageHeader--responsive': responsive,
+    },
+    className,
+  );
 
   return (
     <div
@@ -18,4 +24,13 @@ export const EuiPageHeader = ({ children, className, ...rest }) => {
 EuiPageHeader.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
+  /**
+   * Set to false if you don't want the children to stack
+   * at small screen sizes.
+   */
+  responsive: PropTypes.bool,
+};
+
+EuiPageHeader.defaultProps = {
+  responsive: true,
 };

--- a/src/components/page/page_side_bar/_page_side_bar.scss
+++ b/src/components/page/page_side_bar/_page_side_bar.scss
@@ -3,7 +3,7 @@
  */
 .euiPageSideBar {
   min-width: $euiSize * 12; /* 1 */
-  flex: 0 0 0; /* 1 */
+  flex: 0 1 0%; /* 1 */
   margin-right: $euiSizeL;
 }
 

--- a/src/components/panel/_mixins.scss
+++ b/src/components/panel/_mixins.scss
@@ -1,6 +1,7 @@
 /**
  *  Mixin for use in:
  *  - EuiCard
+ *  - EuiPageContent
 */
 @mixin euiPanel($selector){
   @if variable-exists(selector) == false {

--- a/src/components/panel/_variables.scss
+++ b/src/components/panel/_variables.scss
@@ -1,6 +1,8 @@
 /**
  * Padding map referenced in:
  *  - Popover
+ *  - PageContentHeader
+ *  - PageContentHeaderSection
 */
 $euiPanelPaddingModifiers: (
   "paddingSmall": $euiSizeS,


### PR DESCRIPTION
This PR not only fixes the layout on small screens of `EuiPage` and it's sub components, but also shifts where the sidebar lives. @snide and I talked it over and most of our designs have gone this way and it makes the most sense to keep the page header away from the sidebar.

## Before (moving sidebar)
<img width="671" alt="screen shot 2018-07-10 at 20 10 49 pm" src="https://user-images.githubusercontent.com/549577/42544295-d1c13c20-847e-11e8-9e81-251376d26f26.png">


## After (moving sidebar)
<img width="673" alt="screen shot 2018-07-10 at 20 09 41 pm" src="https://user-images.githubusercontent.com/549577/42544298-d765d906-847e-11e8-9246-760f7d1c5faa.png">

**And it still works with centered content**
<img width="667" alt="screen shot 2018-07-10 at 20 09 53 pm" src="https://user-images.githubusercontent.com/549577/42544309-e5770a42-847e-11e8-824b-8e42e82eecd1.png">


## Before (responsive)
<img width="573" alt="screen shot 2018-07-10 at 20 11 06 pm" src="https://user-images.githubusercontent.com/549577/42544313-eb984706-847e-11e8-9ae1-5d93d24b534b.png">



## After (responsive)
<img width="567" alt="screen shot 2018-07-10 at 20 11 35 pm" src="https://user-images.githubusercontent.com/549577/42544315-efcf41d0-847e-11e8-8a96-307d308d1658.png">

_The non-existent padding around the sidebar is on purpose so that the toggle button would expand the whole width._

---

I checked Kibana master to make sure it wouldn't break too many layouts and, at least in master, no one has used the `EuiPageHeader` or `EuiPageSidebar`, so no current layouts should break. The only place it is used is in the plugin generator, but that's a quick fix.
