### PR TITLE
Fix context menu focus jumping

### DIFF
--- a/src/components/context_menu/__snapshots__/context_menu_panel.test.js.snap
+++ b/src/components/context_menu/__snapshots__/context_menu_panel.test.js.snap
@@ -1,5 +1,322 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiContextMenu is rendered 1`] = `
+<div
+  aria-label="aria-label"
+  class="euiContextMenu testClass1 testClass2"
+  data-test-subj="test subject string"
+/>
+`;
+
+exports[`EuiContextMenu props panels and initialPanelId allows you to click the title button to go back to the previous panel 1`] = `
+<div
+  class="euiContextMenu"
+  style="height: 0px;"
+>
+  <div
+    class="euiContextMenuPanel euiContextMenu__panel"
+    tabindex="0"
+  >
+    <button
+      class="euiContextMenuPanelTitle"
+      data-test-subj="contextMenuPanelTitleButton"
+      type="button"
+    >
+      <span
+        class="euiContextMenu__itemLayout"
+      >
+        <svg
+          class="euiIcon euiIcon--medium euiContextMenu__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+        >
+          <defs>
+            <path
+              d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+              id="arrow_left-a"
+            />
+          </defs>
+          <use
+            fill-rule="nonzero"
+            transform="rotate(90 8 8)"
+            xlink:href="#arrow_left-a"
+          />
+        </svg>
+        <span
+          class="euiContextMenu__text"
+        >
+          2
+        </span>
+      </span>
+    </button>
+    <div>
+      <div>
+        2
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiContextMenu props panels and initialPanelId allows you to click the title button to go back to the previous panel 2`] = `
+<div
+  class="euiContextMenu"
+  style="height: 0px;"
+>
+  <div
+    class="euiContextMenuPanel euiContextMenu__panel euiContextMenuPanel-txOutRight"
+    tabindex="0"
+  >
+    <button
+      class="euiContextMenuPanelTitle"
+      data-test-subj="contextMenuPanelTitleButton"
+      type="button"
+    >
+      <span
+        class="euiContextMenu__itemLayout"
+      >
+        <svg
+          class="euiIcon euiIcon--medium euiContextMenu__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+        >
+          <defs>
+            <path
+              d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+              id="arrow_left-a"
+            />
+          </defs>
+          <use
+            fill-rule="nonzero"
+            transform="rotate(90 8 8)"
+            xlink:href="#arrow_left-a"
+          />
+        </svg>
+        <span
+          class="euiContextMenu__text"
+        >
+          2
+        </span>
+      </span>
+    </button>
+    <div>
+      <div>
+        2
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiContextMenuPanel euiContextMenu__panel euiContextMenuPanel-txInRight"
+    tabindex="0"
+  >
+    <button
+      class="euiContextMenuPanelTitle"
+      data-test-subj="contextMenuPanelTitleButton"
+      type="button"
+    >
+      <span
+        class="euiContextMenu__itemLayout"
+      >
+        <svg
+          class="euiIcon euiIcon--medium euiContextMenu__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+        >
+          <defs>
+            <path
+              d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+              id="arrow_left-a"
+            />
+          </defs>
+          <use
+            fill-rule="nonzero"
+            transform="rotate(90 8 8)"
+            xlink:href="#arrow_left-a"
+          />
+        </svg>
+        <span
+          class="euiContextMenu__text"
+        >
+          1
+        </span>
+      </span>
+    </button>
+    <div>
+      <button
+        class="euiContextMenuItem"
+        type="button"
+      >
+        <span
+          class="euiContextMenu__itemLayout"
+        >
+          <span
+            class="euiContextMenuItem__text"
+          >
+            2a
+          </span>
+          <svg
+            class="euiIcon euiIcon--medium euiContextMenu__arrow"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <defs>
+              <path
+                d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+                id="arrow_right-a"
+              />
+            </defs>
+            <use
+              fill-rule="nonzero"
+              transform="matrix(0 1 1 0 0 0)"
+              xlink:href="#arrow_right-a"
+            />
+          </svg>
+        </span>
+      </button>
+      <button
+        class="euiContextMenuItem"
+        type="button"
+      >
+        <span
+          class="euiContextMenu__itemLayout"
+        >
+          <span
+            class="euiContextMenuItem__text"
+          >
+            2b
+          </span>
+          <svg
+            class="euiIcon euiIcon--medium euiContextMenu__arrow"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <defs>
+              <path
+                d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+                id="arrow_right-a"
+              />
+            </defs>
+            <use
+              fill-rule="nonzero"
+              transform="matrix(0 1 1 0 0 0)"
+              xlink:href="#arrow_right-a"
+            />
+          </svg>
+        </span>
+      </button>
+      <button
+        class="euiContextMenuItem"
+        type="button"
+      >
+        <span
+          class="euiContextMenu__itemLayout"
+        >
+          <span
+            class="euiContextMenuItem__text"
+          >
+            2c
+          </span>
+          <svg
+            class="euiIcon euiIcon--medium euiContextMenu__arrow"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <defs>
+              <path
+                d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+                id="arrow_right-a"
+              />
+            </defs>
+            <use
+              fill-rule="nonzero"
+              transform="matrix(0 1 1 0 0 0)"
+              xlink:href="#arrow_right-a"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiContextMenu props panels and initialPanelId renders the referenced panel 1`] = `
+<div
+  class="euiContextMenu"
+>
+  <div
+    class="euiContextMenuPanel euiContextMenu__panel"
+    tabindex="0"
+  >
+    <button
+      class="euiContextMenuPanelTitle"
+      data-test-subj="contextMenuPanelTitleButton"
+      type="button"
+    >
+      <span
+        class="euiContextMenu__itemLayout"
+      >
+        <svg
+          class="euiIcon euiIcon--medium euiContextMenu__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <defs>
+            <path
+              d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+              id="arrow_left-a"
+            />
+          </defs>
+          <use
+            fill-rule="nonzero"
+            href="#arrow_left-a"
+            transform="rotate(90 8 8)"
+          />
+        </svg>
+        <span
+          class="euiContextMenu__text"
+        >
+          2
+        </span>
+      </span>
+    </button>
+    <div>
+      <div>
+        2
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EuiContextMenuPanel is rendered 1`] = `
 <div
   aria-label="aria-label"

--- a/src/components/context_menu/context_menu.test.js
+++ b/src/components/context_menu/context_menu.test.js
@@ -44,7 +44,7 @@ const panels = [
   panel2,
 ];
 
-const tick = (ms = 0) => new Promise(resolve => {
+export const tick = (ms = 0) => new Promise(resolve => {
   setTimeout(resolve, ms);
 });
 

--- a/src/components/context_menu/context_menu_panel.js
+++ b/src/components/context_menu/context_menu_panel.js
@@ -154,47 +154,50 @@ export class EuiContextMenuPanel extends Component {
   };
 
   updateFocus() {
-    // If this panel has lost focus, then none of its content should be focused.
-    if (!this.props.hasFocus) {
-      if (this.panel.contains(document.activeElement)) {
-        document.activeElement.blur();
-      }
-      return;
-    }
-
-    // Setting focus while transitioning causes the animation to glitch, so we have to wait
-    // until it's finished before we focus anything.
-    if (this.state.isTransitioning) {
-      return;
-    }
-
-    // If there aren't any items then this is probably a form or something.
-    if (!this.state.menuItems.length) {
-      // If we've already focused on something inside the panel, everything's fine.
-      if (this.panel.contains(document.activeElement)) {
+    // Give positioning time to render before focus is applied. Otherwise page jumps.
+    requestAnimationFrame(() => {
+      // If this panel has lost focus, then none of its content should be focused.
+      if (!this.props.hasFocus) {
+        if (this.panel.contains(document.activeElement)) {
+          document.activeElement.blur();
+        }
         return;
       }
 
-      // Otherwise let's focus the first tabbable item and expedite input from the user.
-      if (this.content) {
-        const tabbableItems = tabbable(this.content);
-        if (tabbableItems.length) {
-          tabbableItems[0].focus();
-        }
+      // Setting focus while transitioning causes the animation to glitch, so we have to wait
+      // until it's finished before we focus anything.
+      if (this.state.isTransitioning) {
+        return;
       }
-      return;
-    }
 
-    // If an item is focused, focus it.
-    if (this.state.focusedItemIndex !== undefined) {
-      this.state.menuItems[this.state.focusedItemIndex].focus();
-      return;
-    }
+      // If there aren't any items then this is probably a form or something.
+      if (!this.state.menuItems.length) {
+        // If we've already focused on something inside the panel, everything's fine.
+        if (this.panel.contains(document.activeElement)) {
+          return;
+        }
 
-    // Focus on the panel as a last resort.
-    if (!this.panel.contains(document.activeElement)) {
-      this.panel.focus();
-    }
+        // Otherwise let's focus the first tabbable item and expedite input from the user.
+        if (this.content) {
+          const tabbableItems = tabbable(this.content);
+          if (tabbableItems.length) {
+            tabbableItems[0].focus();
+          }
+        }
+        return;
+      }
+
+      // If an item is focused, focus it.
+      if (this.state.focusedItemIndex !== undefined) {
+        this.state.menuItems[this.state.focusedItemIndex].focus();
+        return;
+      }
+
+      // Focus on the panel as a last resort.
+      if (!this.panel.contains(document.activeElement)) {
+        this.panel.focus();
+      }
+    });
   }
 
   onTransitionComplete = () => {

--- a/src/components/context_menu/context_menu_panel.test.js
+++ b/src/components/context_menu/context_menu_panel.test.js
@@ -11,6 +11,8 @@ import {
   EuiContextMenuItem,
 } from './context_menu_item';
 
+import { tick } from './context_menu.test';
+
 import { keyCodes } from '../../services';
 
 const items = [
@@ -162,13 +164,15 @@ describe('EuiContextMenuPanel', () => {
     });
 
     describe('initialFocusedItemIndex', () => {
-      it('sets focus on the item occupying that index', () => {
+      it('sets focus on the item occupying that index', async () => {
         const component = mount(
           <EuiContextMenuPanel
             items={items}
             initialFocusedItemIndex={1}
           />
         );
+
+        await tick(20);
 
         expect(findTestSubject(component, 'itemB').getDOMNode()).toBe(document.activeElement);
       });

--- a/src/components/context_menu/context_menu_panel.test.js
+++ b/src/components/context_menu/context_menu_panel.test.js
@@ -273,12 +273,14 @@ describe('EuiContextMenuPanel', () => {
 
   describe('behavior', () => {
     describe('focus', () => {
-      it('is set on the first focusable element by default if there are no items and hasFocus is true', () => {
+      it('is set on the first focusable element by default if there are no items and hasFocus is true', async () => {
         const component = mount(
           <EuiContextMenuPanel>
             <button data-test-subj="button" />
           </EuiContextMenuPanel>
         );
+
+        await tick(20);
 
         expect(findTestSubject(component, 'button').getDOMNode()).toBe(document.activeElement);
       });
@@ -312,47 +314,55 @@ describe('EuiContextMenuPanel', () => {
         );
       });
 
-      it(`focuses the panel by default`, () => {
+      it(`focuses the panel by default`, async () => {
+        await tick(20);
+
         expect(component.getDOMNode()).toBe(document.activeElement);
       });
 
-      it('down arrow key focuses the first menu item', () => {
+      it('down arrow key focuses the first menu item',  async () => {
         component.simulate('keydown', { keyCode: keyCodes.DOWN });
 
+        await tick(20);
         expect(findTestSubject(component, 'itemA').getDOMNode()).toBe(document.activeElement);
       });
 
-      it('subsequently, down arrow key focuses the next menu item', () => {
+      it('subsequently, down arrow key focuses the next menu item', async () => {
         component.simulate('keydown', { keyCode: keyCodes.DOWN });
         component.simulate('keydown', { keyCode: keyCodes.DOWN });
 
+        await tick(20);
         expect(findTestSubject(component, 'itemB').getDOMNode()).toBe(document.activeElement);
       });
 
-      it('down arrow key wraps to first menu item', () => {
+      it('down arrow key wraps to first menu item', async () => {
         component.simulate('keydown', { keyCode: keyCodes.UP });
         component.simulate('keydown', { keyCode: keyCodes.DOWN });
 
+        await tick(20);
         expect(findTestSubject(component, 'itemA').getDOMNode()).toBe(document.activeElement);
       });
 
-      it('up arrow key focuses the last menu item', () => {
+      it('up arrow key focuses the last menu item', async () => {
         component.simulate('keydown', { keyCode: keyCodes.UP });
 
+        await tick(20);
         expect(findTestSubject(component, 'itemC').getDOMNode()).toBe(document.activeElement);
       });
 
-      it('subsequently, up arrow key focuses the previous menu item', () => {
+      it('subsequently, up arrow key focuses the previous menu item', async () => {
         component.simulate('keydown', { keyCode: keyCodes.UP });
         component.simulate('keydown', { keyCode: keyCodes.UP });
 
+        await tick(20);
         expect(findTestSubject(component, 'itemB').getDOMNode()).toBe(document.activeElement);
       });
 
-      it('up arrow key wraps to last menu item', () => {
+      it('up arrow key wraps to last menu item', async () => {
         component.simulate('keydown', { keyCode: keyCodes.DOWN });
         component.simulate('keydown', { keyCode: keyCodes.UP });
 
+        await tick(20);
         expect(findTestSubject(component, 'itemC').getDOMNode()).toBe(document.activeElement);
       });
 


### PR DESCRIPTION
Fixes #959 

Adds an animationFrame delay on the updateFocus function for context menus. This gives it enough time for the positioning to calculate first.

![](https://d3vv6lp55qjaqc.cloudfront.net/items/2b2s3s1s2b0U091h1513/Screen%20Recording%202018-07-16%20at%2012.56%20PM.gif?X-CloudApp-Visitor-Id=59773&v=22a8972d)