### PR TITLE
Add typings for EuiBadge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `3.1.0`.
+- Added typings for 'Euibadge' ([])
 
 ## [`3.1.0`](https://github.com/elastic/eui/tree/v3.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Added typings for 'Euibadge' ([#1034](https://github.com/elastic/eui/pull/1034))
+- Added typings for 'EuiBadge' ([#1034](https://github.com/elastic/eui/pull/1034))
 
 ## [`3.1.0`](https://github.com/elastic/eui/tree/v3.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Added typings for 'Euibadge' ([])
+- Added typings for 'Euibadge' ([#1034](https://github.com/elastic/eui/pull/1034))
 
 ## [`3.1.0`](https://github.com/elastic/eui/tree/v3.1.0)
 

--- a/src/components/badge/index.d.ts
+++ b/src/components/badge/index.d.ts
@@ -1,0 +1,23 @@
+/// <reference path="../icon/index.d.ts" />
+
+import { HTMLAttributes, MouseEventHandler } from 'react';
+
+declare module '@elastic/eui' {
+
+  type IconSide = 'left';
+
+  export interface EuiBadgeProps {
+    iconType?: IconType;
+    iconSide?: IconSide;
+    iconOnClick?: MouseEventHandler<HTMLButtonElement>;
+    iconOnClickAriaLabel?: string;
+    onClick?: MouseEventHandler<HTMLButtonElement>;
+    onClickAriaLabel?: string;
+    color?: string;
+    closeButtonProps?: Object;
+  }
+
+  export const EuiBadge: SFC<
+    CommonProps & HTMLAttributes<HTMLSpanElement> & EuiBadgeProps
+  >;
+}

--- a/src/components/badge/index.d.ts
+++ b/src/components/badge/index.d.ts
@@ -18,6 +18,6 @@ declare module '@elastic/eui' {
   }
 
   export const EuiBadge: SFC<
-    CommonProps & HTMLAttributes<HTMLSpanElement> & EuiBadgeProps
+    CommonProps & HTMLAttributes<HTMLSpanElement> & HTMLAttributes<HTMLButtonElement> & EuiBadgeProps
   >;
 }

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -24,3 +24,4 @@
 /// <reference path="./empty_prompt/index.d.ts" />
 /// <reference path="./code/index.d.ts" />
 /// <reference path="./call_out/index.d.ts" />
+/// <reference path="./badge/index.d.ts" />


### PR DESCRIPTION
## Changes
Add typings for the EuiBadge component.

## Testing
Before these changes:
<img width="677" alt="screen shot 2018-07-19 at 12 33 02 pm" src="https://user-images.githubusercontent.com/18429259/42958728-6933821c-8b54-11e8-8a87-ad7e9c508a58.png">

Export the changes from my local `node_modules`:
<img width="402" alt="screen shot 2018-07-19 at 12 34 29 pm" src="https://user-images.githubusercontent.com/18429259/42958747-7b250b9e-8b54-11e8-843a-0b8e49da1b0d.png">

`EuiBadge` now a recognized type:
<img width="570" alt="screen shot 2018-07-19 at 12 54 01 pm" src="https://user-images.githubusercontent.com/18429259/42958762-845e5f3a-8b54-11e8-985f-19e55e2bbfcb.png">
