### PR TITLE
check for unmounted in requestAnimationFrame callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `3.1.0`.
+**Bug fixes**
+
+- Fixed `EuiContextMenuPanel` calling `ref` after being unmounted ([#1038](https://github.com/elastic/eui/pull/1038))
 
 ## [`3.1.0`](https://github.com/elastic/eui/tree/v3.1.0)
 

--- a/src/components/context_menu/context_menu_panel.js
+++ b/src/components/context_menu/context_menu_panel.js
@@ -156,6 +156,10 @@ export class EuiContextMenuPanel extends Component {
   updateFocus() {
     // Give positioning time to render before focus is applied. Otherwise page jumps.
     requestAnimationFrame(() => {
+      if (!this._isMounted) {
+        return;
+      }
+
       // If this panel has lost focus, then none of its content should be focused.
       if (!this.props.hasFocus) {
         if (this.panel.contains(document.activeElement)) {
@@ -212,6 +216,11 @@ export class EuiContextMenuPanel extends Component {
 
   componentDidMount() {
     this.updateFocus();
+    this._isMounted = true;
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {


### PR DESCRIPTION
Here is the kibana issue that highlights the problem https://github.com/elastic/kibana/issues/21004.

The problem is that the callback of `requestAnimationFrame` in `EuiContextMenuPanel` does not check that the component is still mounted.