### PR TITLE
Make EUIXYChart responsive using ResizeObserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `3.2.1`.
+**Bug fixes**
+
+- Fixed `EuiXYChart` responsive resize in a flexbox layout ([#1041](https://github.com/elastic/eui/pull/1041))
 
 ## [`3.2.1`](https://github.com/elastic/eui/tree/v3.2.1)
 

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "react-test-renderer": "^16.2.0",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
+    "resize-observer-polyfill": "^1.5.0",
     "rimraf": "^2.6.2",
     "sass-extract": "^2.1.0",
     "sass-extract-js": "^0.3.0",

--- a/src-docs/src/views/xy_chart/responsive_chart.js
+++ b/src-docs/src/views/xy_chart/responsive_chart.js
@@ -1,0 +1,84 @@
+import React from 'react';
+
+import {
+  EuiXYChart,
+  EuiLineSeries,
+} from '../../../../src/experimental';
+import {
+  EuiButton,
+  EuiPage,
+  EuiPageBody,
+  EuiPageContent,
+  EuiPageContentBody,
+  EuiPageContentHeader,
+  EuiPageContentHeaderSection,
+  EuiPageHeader,
+  EuiPageHeaderSection,
+  EuiPageSideBar,
+  EuiTitle,
+} from '../../../../src/components';
+
+const DATA_A = [
+  { x: 0, y: 1 },
+  { x: 1, y: 1 },
+  { x: 2, y: 2 },
+  { x: 3, y: -1 },
+  { x: 4, y: 3 },
+  { x: 5, y: 2 },
+];
+
+export default class Example extends React.Component {
+  state = {
+    sideBarVisible: true,
+  }
+  onClick = () => {
+    this.setState((prevState) => ({ sideBarVisible: !prevState.sideBarVisible }));
+  }
+  render() {
+    const { sideBarVisible } = this.state;
+    return (
+      <EuiPage>
+        {
+          sideBarVisible && (
+            <EuiPageSideBar>
+              Side bar
+            </EuiPageSideBar>
+          )
+        }
+        <EuiPageBody>
+          <EuiPageHeader>
+            <EuiPageHeaderSection>
+              <EuiTitle size="l">
+                <h1>Page title</h1>
+              </EuiTitle>
+            </EuiPageHeaderSection>
+            <EuiPageHeaderSection>
+              <EuiButton
+                onClick={this.onClick}
+              >
+                Toggle Sidebar
+              </EuiButton>
+            </EuiPageHeaderSection>
+          </EuiPageHeader>
+          <EuiPageContent>
+            <EuiPageContentHeader>
+              <EuiPageContentHeaderSection>
+                <EuiTitle>
+                  <h2>Chart title</h2>
+                </EuiTitle>
+              </EuiPageContentHeaderSection>
+              <EuiPageContentHeaderSection>
+                Chart abilities
+              </EuiPageContentHeaderSection>
+            </EuiPageContentHeader>
+            <EuiPageContentBody style={{ height: '300px' }}>
+              <EuiXYChart showDefaultAxis={false} margins={0}>
+                <EuiLineSeries name="Total Bytes" data={DATA_A} />
+              </EuiXYChart>
+            </EuiPageContentBody>
+          </EuiPageContent>
+        </EuiPageBody>
+      </EuiPage>
+    );
+  }
+}

--- a/src-docs/src/views/xy_chart/xy_chart_example.js
+++ b/src-docs/src/views/xy_chart/xy_chart_example.js
@@ -49,11 +49,7 @@ export const XYChartExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (
-        <div style={{ margin: 60 }}>
-          <ComplexChartExampleCode />
-        </div>
-      ),
+      demo: <ComplexChartExampleCode />,
     },
     {
       title: 'Empty Chart',
@@ -72,11 +68,7 @@ export const XYChartExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (
-        <div style={{ margin: 60 }}>
-          <EmptyExampleCode />
-        </div>
-      ),
+      demo: <EmptyExampleCode />,
     },
     {
       title: 'Keep cross-hair in sync',
@@ -97,11 +89,7 @@ export const XYChartExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (
-        <div style={{ margin: 60 }}>
-          <ExampleCrosshair />
-        </div>
-      ),
+      demo: <ExampleCrosshair />,
     },
     {
       title: 'Multi Axis',
@@ -120,11 +108,7 @@ export const XYChartExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (
-        <div style={{ margin: 60 }}>
-          <MultiAxisChartExampleCode />
-        </div>
-      ),
+      demo: <MultiAxisChartExampleCode />,
     },
     {
       title: 'Responsive chart',
@@ -147,11 +131,7 @@ export const XYChartExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (
-        <div style={{ margin: 60 }}>
-          <ResponsiveChartExample />
-        </div>
-      ),
+      demo: <ResponsiveChartExample />,
     },
     // TODO include the following example when AreasSeries PR (create vertical areachart)
     // will be merged into react-vis and orientation prop semantic will be solved.

--- a/src-docs/src/views/xy_chart/xy_chart_example.js
+++ b/src-docs/src/views/xy_chart/xy_chart_example.js
@@ -5,6 +5,7 @@ import { EuiXYChart } from '../../../../src/experimental';
 import ComplexChartExampleCode from './complex';
 import EmptyExampleCode from './empty';
 import MultiAxisChartExampleCode from './multi_axis';
+import ResponsiveChartExample from './responsive_chart';
 import { ExampleCrosshair } from './crosshair_sync';
 
 export const XYChartExample = {
@@ -122,6 +123,33 @@ export const XYChartExample = {
       demo: (
         <div style={{ margin: 60 }}>
           <MultiAxisChartExampleCode />
+        </div>
+      ),
+    },
+    {
+      title: 'Responsive chart',
+      text: (
+        <div>
+          <p>
+            You can omit <EuiCode>width</EuiCode> ando/or <EuiCode>height</EuiCode>
+            prop and the chart takes the full width and/or height of it&apos;s parent.
+          </p>
+          <p>The parent container needs to have computed a height and or width.</p>
+        </div>
+      ),
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: require('!!raw-loader!./responsive_chart'),
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: 'This component can only be used from React',
+        },
+      ],
+      demo: (
+        <div style={{ margin: 60 }}>
+          <ResponsiveChartExample />
         </div>
       ),
     },

--- a/src-docs/src/views/xy_chart/xy_chart_example.js
+++ b/src-docs/src/views/xy_chart/xy_chart_example.js
@@ -115,10 +115,10 @@ export const XYChartExample = {
       text: (
         <div>
           <p>
-            You can omit <EuiCode>width</EuiCode> ando/or <EuiCode>height</EuiCode>
+            You can omit <EuiCode>width</EuiCode> and/or <EuiCode>height</EuiCode>
             prop and the chart takes the full width and/or height of it&apos;s parent.
           </p>
-          <p>The parent container needs to have computed a height and or width.</p>
+          <p>The parent container needs to have computed a height and/or width.</p>
         </div>
       ),
       source: [

--- a/src-docs/src/views/xy_chart_area/area_example.js
+++ b/src-docs/src/views/xy_chart_area/area_example.js
@@ -46,11 +46,7 @@ export const XYChartAreaExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (
-        <div style={{ margin: 60 }}>
-          <AreaSeriesExample />
-        </div>
-      ),
+      demo: <AreaSeriesExample />,
     },
     {
       title: 'Stacked Area Series',
@@ -74,11 +70,7 @@ export const XYChartAreaExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (
-        <div style={{ margin: 60 }}>
-          <StackedAreaSeriesExample />
-        </div>
-      ),
+      demo: <StackedAreaSeriesExample />,
     },
     {
       title: 'Curved Area Series',
@@ -104,11 +96,7 @@ export const XYChartAreaExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (
-        <div style={{ margin: 60 }}>
-          <CurvedAreaExample />
-        </div>
-      ),
+      demo: <CurvedAreaExample />,
     },
     {
       title: 'Range area chart',
@@ -129,11 +117,7 @@ export const XYChartAreaExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (
-        <div style={{ margin: 60 }}>
-          <RangeAreaExample/>
-        </div>
-      ),
+      demo: <RangeAreaExample/>,
     },
   ],
 };

--- a/src-docs/src/views/xy_chart_axis/xy_axis_example.js
+++ b/src-docs/src/views/xy_chart_axis/xy_axis_example.js
@@ -46,11 +46,7 @@ export const XYChartAxisExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (
-        <div style={{ margin: 60 }}>
-          <SimpleAxisExampleCode />
-        </div>
-      ),
+      demo: <SimpleAxisExampleCode />,
     },
     {
       title: 'Annotations',
@@ -73,11 +69,7 @@ export const XYChartAxisExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (
-        <div style={{ margin: 60 }}>
-          <AnnotationExampleCode />
-        </div>
-      ),
+      demo: <AnnotationExampleCode />,
     },
   ],
 };

--- a/src-docs/src/views/xy_chart_bar/bar_example.js
+++ b/src-docs/src/views/xy_chart_bar/bar_example.js
@@ -91,7 +91,7 @@ export const XYChartBarExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (<VerticalBarSeriesExample />),
+      demo: <VerticalBarSeriesExample />,
     },
     {
       title: 'Stacked Vertical Bar Chart',
@@ -113,7 +113,7 @@ export const XYChartBarExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (<StackedVerticalBarSeriesExample />),
+      demo: <StackedVerticalBarSeriesExample />,
     },
     {
       title: 'Horizontal Bar Chart',
@@ -138,7 +138,7 @@ export const XYChartBarExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (<HorizontalBarSeriesExample />),
+      demo: <HorizontalBarSeriesExample />,
     },
     {
       title: 'Stacked Horizontal Bar Chart',
@@ -163,7 +163,7 @@ export const XYChartBarExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (<StackedHorizontalBarSeriesExample />),
+      demo: <StackedHorizontalBarSeriesExample />,
     },
 
     {
@@ -185,7 +185,7 @@ export const XYChartBarExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (<TimeSeriesExample />),
+      demo: <TimeSeriesExample />,
     },
   ],
 };

--- a/src-docs/src/views/xy_chart_histogram/histogram_example.js
+++ b/src-docs/src/views/xy_chart_histogram/histogram_example.js
@@ -89,7 +89,7 @@ export const XYChartHistogramExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (<VerticalRectSeriesExample />),
+      demo: <VerticalRectSeriesExample />,
     },
     {
       title: 'Stacked Vertical Histogram',
@@ -121,7 +121,7 @@ export const XYChartHistogramExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (<StackedVerticalRectSeriesExample />),
+      demo: <StackedVerticalRectSeriesExample />,
     },
     {
       title: 'Horizontal Histogram',
@@ -144,7 +144,7 @@ export const XYChartHistogramExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (<HorizontalRectSeriesExample />),
+      demo: <HorizontalRectSeriesExample />,
     },
     {
       title: 'Stacked Horizontal Histogram',
@@ -175,7 +175,7 @@ export const XYChartHistogramExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (<StackedHorizontalRectSeriesExample />),
+      demo: <StackedHorizontalRectSeriesExample />,
     },
     {
       title: 'Time Series Histogram version',
@@ -196,7 +196,7 @@ export const XYChartHistogramExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (<TimeHistogramSeriesExample />),
+      demo: <TimeHistogramSeriesExample />,
     },
   ],
 };

--- a/src-docs/src/views/xy_chart_histogram/time_histogram_series.js
+++ b/src-docs/src/views/xy_chart_histogram/time_histogram_series.js
@@ -13,7 +13,12 @@ import {
 const { SCALE } = EuiXYChartUtils;
 const timestamp = Date.now();
 const ONE_HOUR = 3600000;
-
+const margins = {
+  top: 10,
+  left: 80,
+  right: 0,
+  bottom: 20,
+};
 
 function randomizeData(size = 24, max = 15) {
   return new Array(size)
@@ -50,7 +55,7 @@ export default class Example extends Component {
         <EuiButton onClick={this.handleRandomize}>Randomize data</EuiButton>
 
         <EuiSpacer size="xl" />
-        <EuiXYChart width={600} height={200} xType={SCALE.TIME} stackBy="y">
+        <EuiXYChart width={600} height={200} xType={SCALE.TIME} stackBy="y" margins={margins}>
           {data.map((d, i) => <EuiHistogramSeries key={i} name={`Chart ${i}`} data={d} />)}
         </EuiXYChart>
       </Fragment>

--- a/src-docs/src/views/xy_chart_line/line_example.js
+++ b/src-docs/src/views/xy_chart_line/line_example.js
@@ -48,11 +48,7 @@ export const XYChartLineExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (
-        <div style={{ margin: 60 }}>
-          <LineChartExample />
-        </div>
-      ),
+      demo: <LineChartExample />,
     },
     {
       title: 'Custom domain line chart',
@@ -76,11 +72,7 @@ export const XYChartLineExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (
-        <div style={{ margin: 60 }}>
-          <CustomDomainLineChartExample />
-        </div>
-      ),
+      demo: <CustomDomainLineChartExample />,
     },
     {
       title: 'Multi Line chart',
@@ -102,11 +94,7 @@ export const XYChartLineExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (
-        <div style={{ margin: 60 }}>
-          <MultiLineChartExample />
-        </div>
-      ),
+      demo: <MultiLineChartExample />,
     },
     {
       title: 'Curved Line chart',
@@ -132,11 +120,7 @@ export const XYChartLineExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (
-        <div style={{ margin: 60 }}>
-          <CurvedLineChartExample />
-        </div>
-      ),
+      demo: <CurvedLineChartExample />,
     },
     {
       title: 'Custom style Line chart',
@@ -170,11 +154,7 @@ export const XYChartLineExample = {
           code: 'This component can only be used from React',
         },
       ],
-      demo: (
-        <div style={{ margin: 60 }}>
-          <CustomStyleLineChartExample />
-        </div>
-      ),
+      demo: <CustomStyleLineChartExample />,
     },
   ],
 };

--- a/src/components/xy_chart/_xy_chart.scss
+++ b/src/components/xy_chart/_xy_chart.scss
@@ -1,6 +1,3 @@
-.rv-xy-plot__inner {
-  overflow: visible; // TODO fix when adding automatic margin into svg
-}
 .rv-xy-plot {
   width: 100% !important;  // this because react-vis fix the width of the container in px
   height: 100% !important; // avoid a correct computation of the component size

--- a/src/components/xy_chart/_xy_chart.scss
+++ b/src/components/xy_chart/_xy_chart.scss
@@ -1,3 +1,7 @@
 .rv-xy-plot__inner {
   overflow: visible; // TODO fix when adding automatic margin into svg
 }
+.rv-xy-plot {
+  width: 100% !important;  // this because react-vis fix the width of the container in px
+  height: 100% !important; // avoid a correct computation of the component size
+}

--- a/src/components/xy_chart/axis/__snapshots__/default_axis.test.js.snap
+++ b/src/components/xy_chart/axis/__snapshots__/default_axis.test.js.snap
@@ -16,6 +16,7 @@ exports[`EuiDefaultAxis render default axis 1`] = `
       <svg
         class="rv-xy-plot__inner"
         height="200"
+        style="width: 100%; height: 100%;"
         width="600"
       >
         <path
@@ -473,6 +474,7 @@ exports[`EuiDefaultAxis render rotated 90deg default axis 1`] = `
       <svg
         class="rv-xy-plot__inner"
         height="200"
+        style="width: 100%; height: 100%;"
         width="600"
       >
         <path

--- a/src/components/xy_chart/axis/__snapshots__/horizontal_grid.test.js.snap
+++ b/src/components/xy_chart/axis/__snapshots__/horizontal_grid.test.js.snap
@@ -16,6 +16,7 @@ exports[`EuiHorizontalGrid render the horizontal grid 1`] = `
       <svg
         class="rv-xy-plot__inner"
         height="200"
+        style="width: 100%; height: 100%;"
         width="600"
       >
         <g

--- a/src/components/xy_chart/axis/__snapshots__/vertical_grid.test.js.snap
+++ b/src/components/xy_chart/axis/__snapshots__/vertical_grid.test.js.snap
@@ -16,6 +16,7 @@ exports[`EuiVerticalGrid render the vertical grid 1`] = `
       <svg
         class="rv-xy-plot__inner"
         height="200"
+        style="width: 100%; height: 100%;"
         width="600"
       >
         <g

--- a/src/components/xy_chart/axis/__snapshots__/x_axis.test.js.snap
+++ b/src/components/xy_chart/axis/__snapshots__/x_axis.test.js.snap
@@ -16,6 +16,7 @@ exports[`EuiXAxis render the x axis 1`] = `
       <svg
         class="rv-xy-plot__inner"
         height="200"
+        style="width: 100%; height: 100%;"
         width="600"
       >
         <g

--- a/src/components/xy_chart/axis/__snapshots__/y_axis.test.js.snap
+++ b/src/components/xy_chart/axis/__snapshots__/y_axis.test.js.snap
@@ -16,6 +16,7 @@ exports[`EuiYAxis render the y axis 1`] = `
       <svg
         class="rv-xy-plot__inner"
         height="200"
+        style="width: 100%; height: 100%;"
         width="600"
       >
         <g

--- a/src/components/xy_chart/crosshairs/__snapshots__/crosshair_x.test.js.snap
+++ b/src/components/xy_chart/crosshairs/__snapshots__/crosshair_x.test.js.snap
@@ -16,6 +16,7 @@ exports[`EuiCrosshairX render the X crosshair 1`] = `
       <svg
         class="rv-xy-plot__inner"
         height="200"
+        style="width: 100%; height: 100%;"
         width="600"
       >
         <g

--- a/src/components/xy_chart/crosshairs/__snapshots__/crosshair_y.test.js.snap
+++ b/src/components/xy_chart/crosshairs/__snapshots__/crosshair_y.test.js.snap
@@ -16,6 +16,7 @@ exports[`EuiCrosshairY render the Y crosshair 1`] = `
       <svg
         class="rv-xy-plot__inner"
         height="200"
+        style="width: 100%; height: 100%;"
         width="600"
       >
         <g

--- a/src/components/xy_chart/series/__snapshots__/area_series.test.js.snap
+++ b/src/components/xy_chart/series/__snapshots__/area_series.test.js.snap
@@ -18,7 +18,6 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
   >
     <EuiXYChart
       animateData={true}
-      animation={null}
       aria-label="aria-label"
       className="testClass1 testClass2"
       data-test-subj="test subject string"
@@ -43,7 +42,6 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
       yType="linear"
     >
       <div
-        animation={null}
         aria-label="aria-label"
         className="testClass1 testClass2"
         data-test-subj="test subject string"
@@ -59,6 +57,12 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
               "left": 40,
               "right": 10,
               "top": 10,
+            }
+          }
+          style={
+            Object {
+              "height": "100%",
+              "width": "100%",
             }
           }
           width={600}
@@ -91,6 +95,12 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
               onTouchMove={[Function]}
               onTouchStart={[Function]}
               onWheel={[Function]}
+              style={
+                Object {
+                  "height": "100%",
+                  "width": "100%",
+                }
+              }
               width={600}
             >
               <EuiAreaSeries

--- a/src/components/xy_chart/series/__snapshots__/horizontal_bar_series.test.js.snap
+++ b/src/components/xy_chart/series/__snapshots__/horizontal_bar_series.test.js.snap
@@ -12,6 +12,7 @@ exports[`EuiHorizontalBarSeries all props are rendered 1`] = `
       <svg
         class="rv-xy-plot__inner"
         height="200"
+        style="width:100%;height:100%"
         width="600"
       >
         <g
@@ -449,6 +450,7 @@ exports[`EuiHorizontalBarSeries is rendered 1`] = `
       <svg
         class="rv-xy-plot__inner"
         height="200"
+        style="width: 100%; height: 100%;"
         width="600"
       >
         <g
@@ -882,6 +884,7 @@ exports[`EuiHorizontalBarSeries renders stacked bar chart 1`] = `
       <svg
         class="rv-xy-plot__inner"
         height="200"
+        style="width:100%;height:100%"
         width="600"
       >
         <g

--- a/src/components/xy_chart/series/__snapshots__/horizontal_rect_series.test.js.snap
+++ b/src/components/xy_chart/series/__snapshots__/horizontal_rect_series.test.js.snap
@@ -12,6 +12,7 @@ exports[`EuiHorizontalRectSeries all props are rendered 1`] = `
       <svg
         class="rv-xy-plot__inner"
         height="200"
+        style="width:100%;height:100%"
         width="600"
       >
         <g
@@ -449,6 +450,7 @@ exports[`EuiHorizontalRectSeries is rendered 1`] = `
       <svg
         class="rv-xy-plot__inner"
         height="200"
+        style="width: 100%; height: 100%;"
         width="600"
       >
         <g
@@ -882,6 +884,7 @@ exports[`EuiHorizontalRectSeries renders stacked bar chart 1`] = `
       <svg
         class="rv-xy-plot__inner"
         height="200"
+        style="width:100%;height:100%"
         width="600"
       >
         <g

--- a/src/components/xy_chart/series/__snapshots__/line_series.test.js.snap
+++ b/src/components/xy_chart/series/__snapshots__/line_series.test.js.snap
@@ -15,7 +15,6 @@ exports[`EuiLineSeries all props are rendered 1`] = `
   >
     <EuiXYChart
       animateData={true}
-      animation={null}
       enableSelectionBrush={false}
       height={200}
       margins={
@@ -36,9 +35,7 @@ exports[`EuiLineSeries all props are rendered 1`] = `
       yPadding={0}
       yType="linear"
     >
-      <div
-        animation={null}
-      >
+      <div>
         <XYPlot
           animation={true}
           className=""
@@ -50,6 +47,12 @@ exports[`EuiLineSeries all props are rendered 1`] = `
               "left": 40,
               "right": 10,
               "top": 10,
+            }
+          }
+          style={
+            Object {
+              "height": "100%",
+              "width": "100%",
             }
           }
           width={600}
@@ -82,6 +85,12 @@ exports[`EuiLineSeries all props are rendered 1`] = `
               onTouchMove={[Function]}
               onTouchStart={[Function]}
               onWheel={[Function]}
+              style={
+                Object {
+                  "height": "100%",
+                  "width": "100%",
+                }
+              }
               width={600}
             >
               <EuiLineSeries
@@ -4122,7 +4131,6 @@ exports[`EuiLineSeries is rendered 1`] = `
   >
     <EuiXYChart
       animateData={true}
-      animation={null}
       aria-label="aria-label"
       className="testClass1 testClass2"
       data-test-subj="test subject string"
@@ -4147,7 +4155,6 @@ exports[`EuiLineSeries is rendered 1`] = `
       yType="linear"
     >
       <div
-        animation={null}
         aria-label="aria-label"
         className="testClass1 testClass2"
         data-test-subj="test subject string"
@@ -4163,6 +4170,12 @@ exports[`EuiLineSeries is rendered 1`] = `
               "left": 40,
               "right": 10,
               "top": 10,
+            }
+          }
+          style={
+            Object {
+              "height": "100%",
+              "width": "100%",
             }
           }
           width={600}
@@ -4195,6 +4208,12 @@ exports[`EuiLineSeries is rendered 1`] = `
               onTouchMove={[Function]}
               onTouchStart={[Function]}
               onWheel={[Function]}
+              style={
+                Object {
+                  "height": "100%",
+                  "width": "100%",
+                }
+              }
               width={600}
             >
               <EuiLineSeries

--- a/src/components/xy_chart/series/__snapshots__/vertical_bar_series.test.js.snap
+++ b/src/components/xy_chart/series/__snapshots__/vertical_bar_series.test.js.snap
@@ -12,6 +12,7 @@ exports[`EuiVerticalBarSeries all props are rendered 1`] = `
       <svg
         class="rv-xy-plot__inner"
         height="200"
+        style="width:100%;height:100%"
         width="600"
       >
         <g
@@ -510,6 +511,7 @@ exports[`EuiVerticalBarSeries is rendered 1`] = `
       <svg
         class="rv-xy-plot__inner"
         height="200"
+        style="width: 100%; height: 100%;"
         width="600"
       >
         <g
@@ -1004,6 +1006,7 @@ exports[`EuiVerticalBarSeries renders stacked bar chart 1`] = `
       <svg
         class="rv-xy-plot__inner"
         height="200"
+        style="width:100%;height:100%"
         width="600"
       >
         <g

--- a/src/components/xy_chart/series/__snapshots__/vertical_rect_series.test.js.snap
+++ b/src/components/xy_chart/series/__snapshots__/vertical_rect_series.test.js.snap
@@ -12,6 +12,7 @@ exports[`EuiVerticalRectSeries all props are rendered 1`] = `
       <svg
         class="rv-xy-plot__inner"
         height="200"
+        style="width:100%;height:100%"
         width="600"
       >
         <g
@@ -530,6 +531,7 @@ exports[`EuiVerticalRectSeries is rendered 1`] = `
       <svg
         class="rv-xy-plot__inner"
         height="200"
+        style="width: 100%; height: 100%;"
         width="600"
       >
         <g
@@ -1044,6 +1046,7 @@ exports[`EuiVerticalRectSeries renders stacked vertical histogram 1`] = `
       <svg
         class="rv-xy-plot__inner"
         height="200"
+        style="width:100%;height:100%"
         width="600"
       >
         <g

--- a/src/components/xy_chart/utils/flexible.js
+++ b/src/components/xy_chart/utils/flexible.js
@@ -11,7 +11,7 @@ export function makeFlexible(WrappedComponent) {
         width: 0,
       };
       this.containerRef = React.createRef();
-      this.ro = new ResizeObserver(this.createResizeObserver);
+      this.ro = new ResizeObserver(this.onResize);
     }
 
     componentDidMount() {
@@ -22,7 +22,7 @@ export function makeFlexible(WrappedComponent) {
       this.ro.unobserve(this.containerRef.current);
     }
 
-    createResizeObserver = (entries) => {
+    onResize = (entries) => {
       entries.forEach((entry) => {
         const { width, height } = entry.contentRect;
         const notifyWidth = this.state.width !== width;

--- a/src/components/xy_chart/utils/flexible.js
+++ b/src/components/xy_chart/utils/flexible.js
@@ -1,0 +1,47 @@
+import React, { PureComponent } from 'react';
+import ResizeObserver from 'resize-observer-polyfill';
+
+export function makeFlexible(WrappedComponent) {
+
+  return class FlexibleEuiXYChart extends PureComponent {
+    constructor(props) {
+      super(props);
+      this.state = {
+        height: 0,
+        width: 0,
+      };
+      this.containerRef = React.createRef();
+      this.ro = new ResizeObserver(this.createResizeObserver);
+    }
+
+    componentDidMount() {
+      this.ro.observe(this.containerRef.current);
+    }
+
+    componentWillUnmount() {
+      this.ro.unobserve(this.containerRef.current);
+    }
+
+    createResizeObserver = (entries) => {
+      entries.forEach((entry) => {
+        const { width, height } = entry.contentRect;
+        const notifyWidth = this.state.width !== width;
+        const notifyHeight = this.state.height !== height;
+        if (notifyWidth || notifyHeight) {
+          this.setState({ width, height });
+        }
+      });
+    };
+
+    render() {
+      return (
+        <div
+          ref={this.containerRef}
+          style={{ width: '100%', height: '100%' }}
+        >
+          <WrappedComponent {...this.state} {...this.props} />
+        </div>
+      );
+    }
+  };
+}

--- a/src/components/xy_chart/xy_chart.js
+++ b/src/components/xy_chart/xy_chart.js
@@ -1,6 +1,6 @@
 import React, { PureComponent, Fragment } from 'react';
-import { XYPlot, AbstractSeries, makeVisFlexible  } from 'react-vis';
-
+import { XYPlot, AbstractSeries  } from 'react-vis';
+import { makeFlexible } from './utils/flexible';
 import PropTypes from 'prop-types';
 import { EuiEmptyPrompt } from '../empty_prompt';
 import { EuiSelectionBrush } from './selection_brush';
@@ -143,6 +143,7 @@ class XYChart extends PureComponent {
           stackBy={stackBy}
           yPadding={yPadding}
           xPadding={xPadding}
+          style={{ width: '100%', height: '100%' }}
         >
           {this._renderChildren(children)}
           {showDefaultAxis && <EuiDefaultAxis orientation={orientation} />}
@@ -218,4 +219,4 @@ XYChart.defaultProps = {
   margins: DEFAULT_MARGINS,
 };
 
-export const EuiXYChart = makeVisFlexible(XYChart);
+export const EuiXYChart = makeFlexible(XYChart);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8604,6 +8604,10 @@ requires-port@1.0.x, requires-port@1.x.x, requires-port@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
+resize-observer-polyfill@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz#660ff1d9712a2382baa2cad450a4716209f9ca69"
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"


### PR DESCRIPTION
This drops the use of native `react-vis` `makeVisFlexible` HOC in favour of the ResizeObserver to support resizing of the chart container as in kibana dashboard.

It also fix some resizing problem in flexbox discrovered on the new editor POC by @cchaos.

