### PR TITLE
Expose EuiXYChart margins prop

### DIFF
--- a/src/components/xy_chart/series/__snapshots__/area_series.test.js.snap
+++ b/src/components/xy_chart/series/__snapshots__/area_series.test.js.snap
@@ -24,6 +24,14 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
       data-test-subj="test subject string"
       enableSelectionBrush={false}
       height={200}
+      margins={
+        Object {
+          "bottom": 40,
+          "left": 40,
+          "right": 10,
+          "top": 10,
+        }
+      }
       orientation="vertical"
       selectionBrushOrientation="horizontal"
       showCrosshair={true}

--- a/src/components/xy_chart/series/__snapshots__/line_series.test.js.snap
+++ b/src/components/xy_chart/series/__snapshots__/line_series.test.js.snap
@@ -18,6 +18,14 @@ exports[`EuiLineSeries all props are rendered 1`] = `
       animation={null}
       enableSelectionBrush={false}
       height={200}
+      margins={
+        Object {
+          "bottom": 40,
+          "left": 40,
+          "right": 10,
+          "top": 10,
+        }
+      }
       orientation="vertical"
       selectionBrushOrientation="horizontal"
       showCrosshair={true}
@@ -4120,6 +4128,14 @@ exports[`EuiLineSeries is rendered 1`] = `
       data-test-subj="test subject string"
       enableSelectionBrush={false}
       height={200}
+      margins={
+        Object {
+          "bottom": 40,
+          "left": 40,
+          "right": 10,
+          "top": 10,
+        }
+      }
       orientation="vertical"
       selectionBrushOrientation="horizontal"
       showCrosshair={true}

--- a/src/components/xy_chart/xy_chart.js
+++ b/src/components/xy_chart/xy_chart.js
@@ -90,6 +90,7 @@ class XYChart extends PureComponent {
       children,
       width,
       height,
+      margins,
       xType,
       yType,
       stackBy,
@@ -134,7 +135,7 @@ class XYChart extends PureComponent {
           width={width}
           animation={animateData}
           height={height}
-          margin={DEFAULT_MARGINS}
+          margin={margins}
           xType={xType}
           yType={yType}
           xDomain={xDomain}
@@ -214,6 +215,7 @@ XYChart.defaultProps = {
   showDefaultAxis: true,
   enableSelectionBrush: false,
   selectionBrushOrientation: HORIZONTAL,
+  margins: DEFAULT_MARGINS,
 };
 
 export const EuiXYChart = makeVisFlexible(XYChart);


### PR DESCRIPTION
The margins property is exposed but not documented in the propTypes.  It can be  used only for internal purposes until we have a the autosizing of margins.

The `margins` props takes either a "standard" margin object like:

```js
{
  top: 10,
  bottom: 20,
  left: 50,
  right: 10,
}
```

or a single number used for each margin.

@cchaos you can use this together with `showDefaultAxis={false}` prop to display a sparkline o any chart without margins and axis.

@chandlerprall since this is an internal use prop, do you think we need to add it to the changelog?