### PR TITLE
Fix popover title width regression

### DIFF
--- a/src/components/popover/_mixins.scss
+++ b/src/components/popover/_mixins.scss
@@ -2,6 +2,7 @@
   @include euiTitle("xs");
   background-color: $euiColorLightestShade;
   padding: $euiSizeM;
+  max-width: none !important; // Popovers often have negative margins and can't max-width: 100%.
 
   // Subtract 1px from the border radius since it's inside another container that also has the border radius
   // -- makes for better rounded corners


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/1052

Popover titles have negative margins and would break because of the check `.euiPopover > *`. I overwrite that setting for the title now, which should always be pretty short.

## Before
![image](https://user-images.githubusercontent.com/324519/43327305-e6ef3662-916f-11e8-9b33-c9af1554c853.png)

## After
![image](https://user-images.githubusercontent.com/324519/43327185-974ecbae-916f-11e8-9f95-54d8ac21596a.png)
