### PR TITLE
Fix bug in EuiInMemoryTable to not mutate the items prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Fixed `EuiXYChart` responsive resize in a flexbox layout ([#1041](https://github.com/elastic/eui/pull/1041))
+- `EuiInMemoryTable` no longer mutates the `items` prop array when sorting, adding deterministic sorting ([#1057](https://github.com/elastic/eui/pull/1057))
 
 ## [`3.2.1`](https://github.com/elastic/eui/tree/v3.2.1)
 

--- a/src/components/basic_table/in_memory_table.js
+++ b/src/components/basic_table/in_memory_table.js
@@ -275,7 +275,11 @@ export class EuiInMemoryTable extends Component {
     const matchingItems = query ? EuiSearchBar.Query.execute(query, items) : items;
 
     const sortedItems =
-      sortField ? matchingItems.sort(this.getItemSorter()) : matchingItems;
+      sortField
+        ? matchingItems
+          .slice(0) // avoid mutating the source array
+          .sort(this.getItemSorter()) // sort, causes mutation
+        : matchingItems;
 
     const visibleItems = pageSize ? (() => {
       const startIndex = pageIndex * pageSize;

--- a/src/components/basic_table/in_memory_table.test.js
+++ b/src/components/basic_table/in_memory_table.test.js
@@ -257,13 +257,18 @@ describe('EuiInMemoryTable', () => {
 
   test('with initial sorting', () => {
 
+    const items = [
+      { id: '1', name: 'name1' },
+      { id: '2', name: 'name2' },
+      { id: '3', name: 'name3' }
+    ];
+
+    // copy the array to ensure the `items` prop doesn't mutate
+    const itemsProp = items.slice(0);
+
     const props = {
       ...requiredProps,
-      items: [
-        { id: '1', name: 'name1' },
-        { id: '2', name: 'name2' },
-        { id: '3', name: 'name3' }
-      ],
+      items: itemsProp,
       columns: [
         {
           field: 'name',
@@ -284,6 +289,7 @@ describe('EuiInMemoryTable', () => {
     );
 
     expect(component).toMatchSnapshot();
+    expect(itemsProp).toEqual(items);
   });
 
   test('with pagination and selection', () => {


### PR DESCRIPTION
Fixes #860 

`EuiInMemoryTable`'s sorting operated on the saved reference to its `items` prop, and JS's sorting mutates the source which meant the original `items` array was itself sorted. Visually this caused non-deterministic sorting behaviour on the tables.