### PR TITLE
EuiBasicTable actions close their context menu when clicked.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 **Bug fixes**
 
-- Fixed `EuiXYChart` responsive resize in a flexbox layout ([#1041](https://github.com/elastic/eui/pull/1041))
+- Fixed `EuiSeriesChart` (previously `EuiXYChart`) responsive resize in a flexbox layout ([#1041](https://github.com/elastic/eui/pull/1041))
 - `EuiInMemoryTable` no longer mutates the `items` prop array when sorting, adding deterministic sorting ([#1057](https://github.com/elastic/eui/pull/1057))
+- `EuiBasicTable` actions now close their context menu when clicked ([#1069](https://github.com/elastic/eui/pull/1069))
 
 **Experimental breaking change**
 

--- a/src/components/basic_table/collapsed_item_actions.js
+++ b/src/components/basic_table/collapsed_item_actions.js
@@ -43,6 +43,11 @@ export class CollapsedItemActions extends Component {
     }
   }
 
+  onClickItem = (onClickAction) => {
+    this.closePopover();
+    onClickAction();
+  }
+
   render() {
 
     const { actions, itemId, item, actionEnabled, onFocus, className } = this.props;
@@ -72,7 +77,7 @@ export class CollapsedItemActions extends Component {
             key={key}
             disabled={!enabled}
             icon={action.icon}
-            onClick={action.onClick.bind(null, item)}
+            onClick={this.onClickItem.bind(null, action.onClick.bind(null, item))}
           >
             {action.name}
           </EuiContextMenuItem>


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/1068