### PR TITLE
EuiMutationObserver does not require children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `3.3.0`.
+**Bug fixes**
+
+- `EuiMutationObserver`'s `children` prop is no longer marked as required ([#1076](https://github.com/elastic/eui/pull/1076))
 
 ## [`3.3.0`](https://github.com/elastic/eui/tree/v3.3.0)
 

--- a/src/components/mutation_observer/mutation_observer.js
+++ b/src/components/mutation_observer/mutation_observer.js
@@ -92,7 +92,7 @@ EuiMutationObserver.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node)
-  ]).isRequired,
+  ]),
   observerOptions: PropTypes.shape({ // matches a [MutationObserverInit](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserverInit)
     attributeFilter: PropTypes.arrayOf(PropTypes.string),
     attributeOldValue: PropTypes.bool,


### PR DESCRIPTION
Closes #1073

`EuiMutationObserver` does not actually require children to be passed. In #1073 the warning was given because `EuiFieldValueSelectionFilter`'s `searchBox` or `content` could be null, which propagates to the mutation observer as a `null` child.