### PR TITLE
[DISCUSS] Make EuiBasicTable actions always visible

### DIFF
--- a/src/components/basic_table/__snapshots__/basic_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.js.snap
@@ -1116,7 +1116,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
               align="right"
               hasActions={true}
               key="record_actions_1_1"
-              showOnHover={true}
               textOnly={false}
             >
               <ExpandedItemActions
@@ -1174,7 +1173,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
               align="right"
               hasActions={true}
               key="record_actions_2_1"
-              showOnHover={true}
               textOnly={false}
             >
               <ExpandedItemActions
@@ -1232,7 +1230,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
               align="right"
               hasActions={true}
               key="record_actions_3_1"
-              showOnHover={true}
               textOnly={false}
             >
               <ExpandedItemActions
@@ -1684,7 +1681,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
               align="right"
               hasActions={true}
               key="record_actions_1_1"
-              showOnHover={true}
               textOnly={false}
             >
               <ExpandedItemActions
@@ -1740,7 +1736,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
               align="right"
               hasActions={true}
               key="record_actions_2_1"
-              showOnHover={true}
               textOnly={false}
             >
               <ExpandedItemActions
@@ -1796,7 +1791,6 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
               align="right"
               hasActions={true}
               key="record_actions_3_1"
-              showOnHover={true}
               textOnly={false}
             >
               <ExpandedItemActions

--- a/src/components/basic_table/basic_table.js
+++ b/src/components/basic_table/basic_table.js
@@ -670,7 +670,6 @@ export class EuiBasicTable extends Component {
     const key = `record_actions_${itemId}_${columnIndex}`;
     return (
       <EuiTableRowCell
-        showOnHover={true}
         key={key}
         align="right"
         textOnly={false}


### PR DESCRIPTION
CC @elastic/kibana-design 

@LeeDr Brought up again today how much he hates that the gear is hidden until you mouse over it. @bhavyarm, @bmcconaghy, and I also have a poor experience with it. Since this is pretty painful for a number of us, I think this is worth bringing up and reconsidering. For anyone who's interested, you can pull this PR down to judge the UX of when the gears are always visible and judge whether your UX is better or worse because of it:

![image](https://user-images.githubusercontent.com/1238659/43611312-880e4b18-965d-11e8-8dee-ace6bbde68c0.png)

Personally, I really appreciate knowing that a table is editable just by looking at it.

It's worth noting that @jgowdyelastic, @peteharverson, and @walterra already implemented this in ML:

![image](https://user-images.githubusercontent.com/1238659/43611350-a7599f5e-965d-11e8-83fe-2070943c5eea.png)
