### PR TITLE
Add resize-observer-polyfill as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 - `EuiMutationObserver`'s `children` prop is no longer marked as required ([#1076](https://github.com/elastic/eui/pull/1076))
 - Fixed large drop shadows so they work on darker backgrounds ([#1079](https://github.com/elastic/eui/pull/1079))
+- Added `resize-observer-polyfill` as a dependency (was previously a devDependency) ([#1085](https://github.com/elastic/eui/pull/1085))
+
 
 ## [`3.3.0`](https://github.com/elastic/eui/tree/v3.3.0)
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-input-autosize": "^2.2.1",
     "react-virtualized": "^9.18.5",
     "react-vis": "1.10.2",
+    "resize-observer-polyfill": "^1.5.0",
     "tabbable": "^1.1.0",
     "uuid": "^3.1.0"
   },
@@ -125,7 +126,6 @@
     "react-test-renderer": "^16.2.0",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
-    "resize-observer-polyfill": "^1.5.0",
     "rimraf": "^2.6.2",
     "sass-extract": "^2.1.0",
     "sass-extract-js": "^0.3.0",


### PR DESCRIPTION
Fix #1084 Add the `resize-observer-polyfill` as a `dependency`, previously was a `devDependency` and causes missing dependency error.