### PR TITLE
Notify parent component when a new item set changes the row selection

### DIFF
--- a/src/components/basic_table/basic_table.js
+++ b/src/components/basic_table/basic_table.js
@@ -199,7 +199,15 @@ export class EuiBasicTable extends Component {
       nextProps.items.findIndex(item => getItemId(item, itemId) === getItemId(selectedItem, itemId)) !== -1
     ));
 
-    return { selection };
+    if (selection.length !== prevState.selection.length) {
+      if (nextProps.selection.onSelectionChange) {
+        nextProps.selection.onSelectionChange(selection);
+      }
+
+      return { selection };
+    }
+
+    return null;
   }
 
   constructor(props) {


### PR DESCRIPTION
Fixes #1083 by alerting `EuiBasicTable`'s parent component when it changes the selection list in response to changing items.