### PR TITLE
Add typings for EuiToolTip and EuiIconTip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Added typings for `EuiToolTip` and `EuiIconTip` ([PR NUM](PR URL))
+- Added typings for `EuiToolTip` and `EuiIconTip` ([#1087](https://github.com/elastic/eui/pull/1087))
 - Added `spacesApp` logo to `EuiIcon` set ([#1065](https://github.com/elastic/eui/pull/1065))
 - Added `!default` to border SASS props ([#1079](https://github.com/elastic/eui/pull/1079))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Added typings for `EuiToolTip` and `EuiIconTip` ([PR NUM](PR URL))
 - Added `spacesApp` logo to `EuiIcon` set ([#1065](https://github.com/elastic/eui/pull/1065))
 - Added `!default` to border SASS props ([#1079](https://github.com/elastic/eui/pull/1079))
 

--- a/src-docs/src/views/tool_tip/tool_tip_example.js
+++ b/src-docs/src/views/tool_tip/tool_tip_example.js
@@ -44,7 +44,7 @@ export const ToolTipExample = {
         The <EuiCode>position</EuiCode> prop will take a suggested position, but will
         change it if the tool tip gets too close to the edge of the screen. You can use
         the <EuiCode>clickOnly</EuiCode> prop to tell the too tip to only appear on click
-        wrather than on hover.
+        rather than on hover.
       </EuiText>
 
       <EuiSpacer size="l" />

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -26,3 +26,4 @@
 /// <reference path="./call_out/index.d.ts" />
 /// <reference path="./badge/index.d.ts" />
 /// <reference path="./toast/index.d.ts" />
+/// <reference path="./tool_tip/index.d.ts" />

--- a/src/components/tool_tip/index.d.ts
+++ b/src/components/tool_tip/index.d.ts
@@ -1,0 +1,27 @@
+import { ReactElement, ReactNode, SFC } from 'react';
+
+declare module '@elastic/eui' {
+  export type PositionsToClassNameMap = 
+    | 'top'
+    | 'right'
+    | 'bottom'
+    | 'left';
+
+  export interface EuiToolTipProps {
+    children: ReactElement<any>;
+    className?: string;
+    content: ReactNode;
+    title?: ReactNode;
+    id?: string;
+    position?: PositionsToClassNameMap;
+  }
+  export const EuiToolTip: SFC<EuiToolTipProps>;
+
+  export interface EuiIconTipProps {
+    color?: string;
+    type?: string;
+    size?: string;
+    'aria-label'?: string;
+  }
+  export const EuiIconTip: SFC<EuiIconTipProps>;
+}

--- a/src/components/tool_tip/index.d.ts
+++ b/src/components/tool_tip/index.d.ts
@@ -1,7 +1,7 @@
 import { ReactElement, ReactNode, SFC } from 'react';
 
 declare module '@elastic/eui' {
-  export type PositionsToClassNameMap = 
+  export type TooltipPositions = 
     | 'top'
     | 'right'
     | 'bottom'
@@ -13,7 +13,7 @@ declare module '@elastic/eui' {
     content: ReactNode;
     title?: ReactNode;
     id?: string;
-    position?: PositionsToClassNameMap;
+    position?: TooltipPositions;
   }
   export const EuiToolTip: SFC<EuiToolTipProps>;
 

--- a/src/components/tool_tip/index.d.ts
+++ b/src/components/tool_tip/index.d.ts
@@ -1,7 +1,7 @@
 import { ReactElement, ReactNode, SFC } from 'react';
 
 declare module '@elastic/eui' {
-  export type TooltipPositions = 
+  export type ToolTipPositions = 
     | 'top'
     | 'right'
     | 'bottom'
@@ -13,7 +13,7 @@ declare module '@elastic/eui' {
     content: ReactNode;
     title?: ReactNode;
     id?: string;
-    position?: TooltipPositions;
+    position?: ToolTipPositions;
   }
   export const EuiToolTip: SFC<EuiToolTipProps>;
 


### PR DESCRIPTION
## Changes
Add typings for the `EuiToolTip` and `EuiIconTip` components.

## Testing
Before changes:
<img width="724" alt="screen shot 2018-08-05 at 12 52 11 pm" src="https://user-images.githubusercontent.com/18429259/43688128-429038e8-98b1-11e8-92eb-265180d73f3c.png">

After adding types to my `node_modules`:
<img width="525" alt="screen shot 2018-08-05 at 1 03 57 pm" src="https://user-images.githubusercontent.com/18429259/43688130-5474b336-98b1-11e8-851c-8be74c8e5705.png">
<img width="818" alt="screen shot 2018-08-05 at 1 03 22 pm" src="https://user-images.githubusercontent.com/18429259/43688132-58b2f318-98b1-11e8-828a-8f11dc646345.png">

## Reviewing this PR
- Ensure the types I've defined are appropriate for the two components in question
  - [EuiToolTip PropTypes](https://github.com/elastic/eui/blob/master/src/components/tool_tip/tool_tip.js#L196)
  - [EuiIconTip PropTypes](https://github.com/elastic/eui/blob/master/src/components/tool_tip/icon_tip.js#L13)