### PR TITLE
Added more css text utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `repositionOnScroll` prop to `EuiPopover` which enables repositioning the popover when the window is scrolled. ([#1064](https://github.com/elastic/eui/pull/1064))
 - Allow `_` and `*` characters to be used in `EuiSearchBar` query terms ([#1058](https://github.com/elastic/eui/pull/1058))
 - Added more `status` options for `EuiSteps` ([#1088](https://github.com/elastic/eui/pull/1088))
+- Added more `.eui-textBreakNormal` and `@mixin euiTextTruncate` as CSS/SASS utilities ([#1092](https://github.com/elastic/eui/pull/1092))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Added `repositionOnScroll` prop to `EuiPopover` which enables repositioning the popover when the window is scrolled. ([#1064](https://github.com/elastic/eui/pull/1064))
 - Allow `_` and `*` characters to be used in `EuiSearchBar` query terms ([#1058](https://github.com/elastic/eui/pull/1058))
 - Added more `status` options for `EuiSteps` ([#1088](https://github.com/elastic/eui/pull/1088))
-- Added more `.eui-textBreakNormal` and `@mixin euiTextTruncate` as CSS/SASS utilities ([#1092](https://github.com/elastic/eui/pull/1092))
+- Added `.eui-textBreakNormal` and `@mixin euiTextTruncate` as CSS/SASS utilities ([#1092](https://github.com/elastic/eui/pull/1092))
 
 **Bug fixes**
 

--- a/src-docs/src/components/guide_section/guide_section.js
+++ b/src-docs/src/components/guide_section/guide_section.js
@@ -162,7 +162,7 @@ export class GuideSection extends Component {
       } = props[propName];
 
       let humanizedName = (
-        <strong className="eui-textNoWrap">{propName}</strong>
+        <strong className="eui-textBreakNormal">{propName}</strong>
       );
 
       if (required) {
@@ -175,13 +175,13 @@ export class GuideSection extends Component {
 
       const humanizedType = humanizeType(type);
 
-      const typeMarkup = (<span className="eui-textNoWrap">{markup(humanizedType)}</span>);
+      const typeMarkup = (<span className="eui-textBreakNormal">{markup(humanizedType)}</span>);
       const descriptionMarkup = markup(propDescription);
       let defaultValueMarkup = '';
       if (defaultValue) {
         defaultValueMarkup = [(
           <EuiCode key={`defaultValue-${propName}`}>
-            <span className="eui-textNoWrap">{defaultValue.value}</span>
+            <span className="eui-textBreakNormal">{defaultValue.value}</span>
           </EuiCode>
         )];
         if (defaultValue.comment) {

--- a/src/global_styling/mixins/_typography.scss
+++ b/src/global_styling/mixins/_typography.scss
@@ -84,3 +84,22 @@
   line-height: 1.25;
   font-weight: $euiFontWeightLight; // always apply light weight to x-large type
 }
+
+/**
+ * Text truncation
+ *
+ * Prevent text from wrapping onto multiple lines, and truncate with an
+ * ellipsis.
+ *
+ * 1. Ensure that the node has a maximum width after which truncation can
+ *    occur.
+ * 2. Fix for IE 8/9 if `word-wrap: break-word` is in effect on ancestor
+ *    nodes.
+ */
+ @mixin euiTextTruncate {
+  max-width: 100%; /* 1 */
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  white-space: nowrap !important;
+  word-wrap: normal !important; /* 2 */
+}

--- a/src/global_styling/utility/_utility.scss
+++ b/src/global_styling/utility/_utility.scss
@@ -16,29 +16,15 @@
 .eui-textNoWrap {white-space: nowrap !important;}
 .eui-textInheritColor {color: inherit !important;}
 
-.eui-textBreakAll {word-break: break-all !important;}
 .eui-textBreakWord {
   word-break: break-all !important; // Fallback for FF and IE
   word-break: break-word !important;
 }
+.eui-textBreakAll {word-break: break-all !important;}
+.eui-textBreakNormal {word-break: normal !important;}
 
-/**
- * Text truncation
- *
- * Prevent text from wrapping onto multiple lines, and truncate with an
- * ellipsis.
- *
- * 1. Ensure that the node has a maximum width after which truncation can
- *    occur.
- * 2. Fix for IE 8/9 if `word-wrap: break-word` is in effect on ancestor
- *    nodes.
- */
 .eui-textTruncate {
-  max-width: 100%; /* 1 */
-  overflow: hidden !important;
-  text-overflow: ellipsis !important;
-  white-space: nowrap !important;
-  word-wrap: normal !important; /* 2 */
+  @include euiTextTruncate;
 }
 
 /**


### PR DESCRIPTION
- Moved properties from `.eui-textTruncate` into a mixin and including that mixin in the utility class
- Added `.eui-textBreakNormal` in case consumers need to override a applied `word-break: break-all`
- Using the above class on props doc table contents to fix #678 

<img width="560" alt="screen shot 2018-08-07 at 12 12 33 pm" src="https://user-images.githubusercontent.com/549577/43788380-3eac8a98-9a3b-11e8-818d-52005247b95f.png">
