### PR TITLE
Update Custom Table docs to not re-render on every. single. click.

### DIFF
--- a/src-docs/src/views/tables/custom/custom.js
+++ b/src-docs/src/views/tables/custom/custom.js
@@ -335,16 +335,19 @@ export default class extends Component {
   };
 
   closePopover = itemId => {
-    this.setState(previousState => {
-      const newItemIdToOpenActionsPopoverMap = {
-        ...previousState.itemIdToOpenActionsPopoverMap,
-        [itemId]: false,
-      };
+    // only update the state if this item's popover is open
+    if (this.isPopoverOpen(itemId)) {
+      this.setState(previousState => {
+        const newItemIdToOpenActionsPopoverMap = {
+          ...previousState.itemIdToOpenActionsPopoverMap,
+          [itemId]: false,
+        };
 
-      return {
-        itemIdToOpenActionsPopoverMap: newItemIdToOpenActionsPopoverMap,
-      };
-    });
+        return {
+          itemIdToOpenActionsPopoverMap: newItemIdToOpenActionsPopoverMap,
+        };
+      });
+    }
   };
 
   isPopoverOpen = itemId => {


### PR DESCRIPTION
The docs' custom table OutsideClickDetector currently sets the component state _anytime_ the user clicks, not only when a custom action popover is open. The resulting setState and re-render takes ~500ms and blocks all other UI like _any_ sorting or pagination on the docs page. This lag really bothers me, so I've updated the custom table to only setState if it needs to close.