### PR TITLE
Let breadcumb be able to hold multiple EUIPopover components.

### DIFF
--- a/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.js.snap
+++ b/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.js.snap
@@ -193,6 +193,59 @@ exports[`EuiBreadcrumbs props max renders 3 items 1`] = `
 </nav>
 `;
 
+exports[`EuiBreadcrumbs props mutiple popover is rendered 1`] = `
+<nav
+  aria-label="breadcrumb"
+  class="euiBreadcrumbs euiBreadcrumbs--truncate euiBreadcrumbs--responsive"
+>
+  <button
+    class="euiLink euiLink--subdued euiBreadcrumb"
+    title="Animals"
+    type="button"
+  >
+    Animals
+  </button>
+  <div
+    class="euiBreadcrumbSeparator"
+  />
+  <div
+    aria-label="aria-label"
+    class="euiPopover euiPopover--anchorDownCenter testClass1 testClass2"
+    data-test-subj="test subject string"
+  >
+    <div
+      class="euiPopover__anchor"
+    >
+      <button />
+    </div>
+  </div>
+  <div
+    class="euiBreadcrumbSeparator"
+  />
+  <button
+    class="euiLink euiLink--subdued euiBreadcrumb"
+    title="Boa constrictor"
+    type="button"
+  >
+    Boa constrictor
+  </button>
+  <div
+    class="euiBreadcrumbSeparator"
+  />
+  <div
+    aria-label="aria-label"
+    class="euiPopover euiPopover--anchorDownCenter testClass1 testClass2"
+    data-test-subj="test subject string"
+  >
+    <div
+      class="euiPopover__anchor"
+    >
+      <button />
+    </div>
+  </div>
+</nav>
+`;
+
 exports[`EuiBreadcrumbs props responsive is rendered 1`] = `
 <nav
   aria-label="breadcrumb"

--- a/src/components/breadcrumbs/breadcrumbs.js
+++ b/src/components/breadcrumbs/breadcrumbs.js
@@ -71,8 +71,9 @@ export const EuiBreadcrumbs = ({
     });
 
     let link;
-
-    if (isLastBreadcrumb) {
+    if (breadcrumb.component) {
+      link = breadcrumb.component;
+    } else if (isLastBreadcrumb) {
       link = (
         <span
           className={breadcrumbClasses}

--- a/src/components/breadcrumbs/breadcrumbs.test.js
+++ b/src/components/breadcrumbs/breadcrumbs.test.js
@@ -3,6 +3,7 @@ import { render } from 'enzyme';
 import { requiredProps } from '../../test';
 
 import { EuiBreadcrumbs } from './breadcrumbs';
+import { EuiPopover } from '../popover';
 
 describe('EuiBreadcrumbs', () => {
   test('is rendered', () => {
@@ -72,6 +73,41 @@ describe('EuiBreadcrumbs', () => {
 
       test(`doesn't break when max exceeds the number of breadcrumbs`, () => {
         const component = render(<EuiBreadcrumbs breadcrumbs={breadcrumbs} max={20} />);
+        expect(component).toMatchSnapshot();
+      });
+    });
+
+    describe('mutiple popover', () => {
+      const breadcrumbsWithDropdowns = [{
+        text: 'Animals',
+      }, {
+        text: '',
+        component: (
+          <EuiPopover
+            closePopover={() => {}}
+            button={<button />}
+            {...requiredProps}
+          >
+            Reptiles
+          </EuiPopover>
+        ),
+      }, {
+        text: 'Boa constrictor',
+      }, {
+        text: '',
+        component: (
+          <EuiPopover
+            closePopover={() => {}}
+            button={<button />}
+            {...requiredProps}
+          >
+            Edit
+          </EuiPopover>
+        ),
+      }];
+
+      test('is rendered', () => {
+        const component = render(<EuiBreadcrumbs breadcrumbs={breadcrumbsWithDropdowns} />);
         expect(component).toMatchSnapshot();
       });
     });


### PR DESCRIPTION
When we use breadcumb, we want to put EUIPopover for each component segments, but it will throw exception if we do that. Here is the fix we found but we are open to any alternative suggestion 