### PR TITLE
[EuiWrappingPopover] Do not re-mount button on componentWillUnmount if button has been unmounted from DOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 - Added `disabled` to `EuiRadioGroup.options` ([#1111](https://github.com/elastic/eui/pull/1111))
 
+**Bug fixes**
+
+- `EuiWrappingPopover` only re-attach anchor element on unmount if anchor element is still attached to DOM
+([#1114](https://github.com/elastic/eui/pull/1114))
+
 ## [`3.5.1`](https://github.com/elastic/eui/tree/v3.5.1)
 
 - Fixed a bug around `indeterminate` checkboxes ([#1110](https://github.com/elastic/eui/pull/1110))

--- a/src/components/popover/wrapping_popover.js
+++ b/src/components/popover/wrapping_popover.js
@@ -28,10 +28,12 @@ export class EuiWrappingPopover extends Component {
   }
 
   componentWillUnmount() {
-    this.portal.insertAdjacentElement(
-      'beforebegin',
-      this.props.button
-    );
+    if (this.props.button.parentNode) {
+      this.portal.insertAdjacentElement(
+        'beforebegin',
+        this.props.button
+      );
+    }
   }
 
   setPortalRef = node => {


### PR DESCRIPTION
There is a bug in Kibana where the anchor element gets re-attached on `componentWillUnmount` even if the anchor element has been removed from the DOM.

To see the bug in action, first open a dashboard in edit mode and click the `Options` top nav button to open the Options popover.

<img width="552" alt="screen shot 2018-08-13 at 1 23 54 pm" src="https://user-images.githubusercontent.com/373691/44053224-3cf0f994-9efc-11e8-83e7-ae6057db091a.png">

Then click the `Cancel` top nav button (while the Options popover is still open). Dashboard will remove the `Options` top nav from the menu bar. but then `componentWillUnmount` will add it back.

<img width="432" alt="screen shot 2018-08-13 at 1 24 32 pm" src="https://user-images.githubusercontent.com/373691/44053236-446725e0-9efc-11e8-9197-d454e1e81727.png">

It should look like this.

<img width="355" alt="screen shot 2018-08-13 at 1 24 24 pm" src="https://user-images.githubusercontent.com/373691/44053232-4140e11c-9efc-11e8-9edf-0443a973e63a.png">

This PR only re-mounts the button component when it still has a parent (is attached to the DOM). I have tested this in Kibana and this fixes the problem shown above


