### PR TITLE
Update tooltip positioning when content updates

### DIFF
--- a/src/components/tool_tip/tool_tip.js
+++ b/src/components/tool_tip/tool_tip.js
@@ -11,6 +11,7 @@ import { EuiToolTipPopover } from './tool_tip_popover';
 import { findPopoverPosition } from '../../services';
 
 import makeId from '../form/form_row/make_id';
+import { EuiMutationObserver } from '../mutation_observer';
 
 const positionsToClassNameMap = {
   top: 'euiToolTip--top',
@@ -160,7 +161,12 @@ export class EuiToolTip extends Component {
             {...rest}
           >
             <div style={arrowStyles} className="euiToolTip__arrow"/>
-            {content}
+            <EuiMutationObserver
+              observerOptions={{ subtree: true, childList: true, characterData: true, attributes: true }}
+              onMutation={this.positionToolTip}
+            >
+              {content}
+            </EuiMutationObserver>
           </EuiToolTipPopover>
         </EuiPortal>
       );


### PR DESCRIPTION
Fixes #996 by making `EuiToolTip` listen for DOM changes within the tooltip content and then re-positioning its popover.