### PR TITLE
Allow setting autoFocus on radio group option

### DIFF
--- a/src/components/form/radio/radio.js
+++ b/src/components/form/radio/radio.js
@@ -12,6 +12,7 @@ export const EuiRadio = ({
   onChange,
   disabled,
   compressed,
+  autoFocus,
   ...rest
 }) => {
   const classes = classNames(
@@ -50,6 +51,7 @@ export const EuiRadio = ({
         checked={checked}
         onChange={onChange}
         disabled={disabled}
+        autoFocus={autoFocus}
       />
 
       <div className="euiRadio__circle" />
@@ -71,6 +73,7 @@ EuiRadio.propTypes = {
    * when `true` creates a shorter height radio row
    */
   compressed: PropTypes.bool,
+  autoFocus: PropTypes.bool,
 };
 
 EuiRadio.defaultProps = {

--- a/src/components/form/radio/radio_group.js
+++ b/src/components/form/radio/radio_group.js
@@ -15,19 +15,28 @@ export const EuiRadioGroup = ({
 }) => (
   <div className={className} {...rest}>
     {options.map((option, index) => {
+      const {
+        id,
+        label,
+        value,
+        disabled: isOptionDisabled,
+        autoFocus,
+        ...optionRest
+      } = option;
       return (
         <EuiRadio
           className="euiRadioGroup__item"
           key={index}
-          id={option.id}
+          id={id}
           name={name}
-          checked={option.id === idSelected}
-          label={option.label}
-          value={option.value}
-          disabled={disabled || option.disabled}
-          onChange={onChange.bind(null, option.id, option.value)}
+          checked={id === idSelected}
+          label={label}
+          value={value}
+          disabled={disabled || isOptionDisabled}
+          onChange={onChange.bind(null, id, value)}
           compressed={compressed}
-          autoFocus={option.autofocus}
+          autoFocus={autoFocus}
+          {...optionRest}
         />
       );
     })}

--- a/src/components/form/radio/radio_group.js
+++ b/src/components/form/radio/radio_group.js
@@ -27,6 +27,7 @@ export const EuiRadioGroup = ({
           disabled={disabled || option.disabled}
           onChange={onChange.bind(null, option.id, option.value)}
           compressed={compressed}
+          autoFocus={option.autofocus}
         />
       );
     })}
@@ -40,6 +41,7 @@ EuiRadioGroup.propTypes = {
       label: PropTypes.node,
       value: PropTypes.string,
       disabled: PropTypes.bool,
+      autoFocus: PropTypes.bool,
     }),
   ).isRequired,
   idSelected: PropTypes.string,

--- a/src/components/form/radio/radio_group.js
+++ b/src/components/form/radio/radio_group.js
@@ -20,7 +20,6 @@ export const EuiRadioGroup = ({
         label,
         value,
         disabled: isOptionDisabled,
-        autoFocus,
         ...optionRest
       } = option;
       return (
@@ -35,7 +34,6 @@ export const EuiRadioGroup = ({
           disabled={disabled || isOptionDisabled}
           onChange={onChange.bind(null, id, value)}
           compressed={compressed}
-          autoFocus={autoFocus}
           {...optionRest}
         />
       );
@@ -50,7 +48,6 @@ EuiRadioGroup.propTypes = {
       label: PropTypes.node,
       value: PropTypes.string,
       disabled: PropTypes.bool,
-      autoFocus: PropTypes.bool,
     }),
   ).isRequired,
   idSelected: PropTypes.string,

--- a/src/components/form/radio/radio_group.js
+++ b/src/components/form/radio/radio_group.js
@@ -16,9 +16,6 @@ export const EuiRadioGroup = ({
   <div className={className} {...rest}>
     {options.map((option, index) => {
       const {
-        id,
-        label,
-        value,
         disabled: isOptionDisabled,
         ...optionRest
       } = option;
@@ -26,13 +23,10 @@ export const EuiRadioGroup = ({
         <EuiRadio
           className="euiRadioGroup__item"
           key={index}
-          id={id}
           name={name}
-          checked={id === idSelected}
-          label={label}
-          value={value}
+          checked={option.id === idSelected}
           disabled={disabled || isOptionDisabled}
-          onChange={onChange.bind(null, id, value)}
+          onChange={onChange.bind(null, option.id, option.value)}
           compressed={compressed}
           {...optionRest}
         />


### PR DESCRIPTION
`EuiRadioGroup` in the following situation exposes the need to pass autoFocus to `EuiRadio`
* Inside of EuiContextMenu (or another component that sets focus on open)
* EuiRadioGroup is first component in a panel
* The first option is disabled
* The first option has a `EuiIconTip` in the label

The problem is that the tooltip opens when the panel is opened.

Setting autoFocus on the first enabled option solves this problem

<img width="511" alt="screen shot 2018-08-15 at 8 15 31 am" src="https://user-images.githubusercontent.com/373691/44158572-3b83a800-a072-11e8-8d86-0ee4dcaa45ae.png">


