### PR TITLE
Fix bug when tooltip anchor is removed from document without being unmounted

### DIFF
--- a/src/components/tool_tip/tool_tip.js
+++ b/src/components/tool_tip/tool_tip.js
@@ -46,6 +46,24 @@ export class EuiToolTip extends Component {
     };
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    if (prevState.visible === false && this.state.visible === true) {
+      requestAnimationFrame(this.testAnchor);
+    }
+  }
+
+  testAnchor = () => {
+    if (document.contains(this.anchor) === false) {
+      // the anchor is no longer part of `document`
+      this.hideToolTip();
+    } else {
+      if (this.state.visible) {
+        // if still visible, keep checking
+        requestAnimationFrame(this.testAnchor);
+      }
+    }
+  }
+
   setPopoverRef = ref => {
     this.popover = ref;
 


### PR DESCRIPTION
Fixes #1105 by adding a requestAnimationFrame loop when a tooltip is open, each iteration tests if the anchor element is contained by `document`.

Tested in Chrome, FF, and Safari by linking EUI module into Kibana and testing the ML panel @jgowdyelastic reported issue with.