### PR TITLE
Fix bug with EuiFlyout maxWidth interfering with responsive mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 - Added `zIndexAdjustment` to `EuiPopover` which allows tweaking the popover content's `z-index` ([#1097](https://github.com/elastic/eui/pull/1097))
 - Added new `EuiSuperSelect` component and `hasArrow` prop to `EuiPopover` ([#921](https://github.com/elastic/eui/pull/921))
 
+**Bug fixes**
+
+- `EuiFlyout` responsive mode now gracefully overrides a custom `maxWidth` ([]()
+
 ## [`3.6.1`](https://github.com/elastic/eui/tree/v3.6.1)
 
 - Added TypeScript definition for `findTestSubject` test util ([#1106](https://github.com/elastic/eui/pull/1106))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 **Bug fixes**
 
-- `EuiFlyout` responsive mode now gracefully overrides a custom `maxWidth` ([]()
+- `EuiFlyout` responsive mode now gracefully overrides a custom `maxWidth` ([#1124](https://github.com/elastic/eui/pull/1124)
 
 ## [`3.6.1`](https://github.com/elastic/eui/tree/v3.6.1)
 

--- a/src-docs/src/views/flyout/flyout_complicated.js
+++ b/src-docs/src/views/flyout/flyout_complicated.js
@@ -159,9 +159,9 @@ export class FlyoutComplicated extends Component {
         >
           <EuiFlyoutHeader hasBorder>
             <EuiTitle size="m">
-              <h1 id="flyoutComplicatedTitle">
+              <h2 id="flyoutComplicatedTitle">
                 Flyout header
-              </h1>
+              </h2>
             </EuiTitle>
             <EuiSpacer size="s" />
             <EuiText color="subdued">
@@ -212,7 +212,7 @@ export class FlyoutComplicated extends Component {
     return (
       <div>
         <EuiButton onClick={this.showFlyout}>
-          Show Flyout
+          Show flyout
         </EuiButton>
 
         {flyout}

--- a/src-docs/src/views/flyout/flyout_example.js
+++ b/src-docs/src/views/flyout/flyout_example.js
@@ -14,9 +14,17 @@ import { FlyoutComplicated } from './flyout_complicated';
 const flyoutComplicatedSource = require('!!raw-loader!./flyout_complicated');
 const flyoutComplicatedHtml = renderToHtml(FlyoutComplicated);
 
-import { FlyoutSize } from './flyout_size';
-const flyoutSizeSource = require('!!raw-loader!./flyout_size');
-const flyoutSizeHtml = renderToHtml(FlyoutSize);
+import { FlyoutSmall } from './flyout_small';
+const flyoutSmallSource = require('!!raw-loader!./flyout_small');
+const flyoutSmallHtml = renderToHtml(FlyoutSmall);
+
+import { FlyoutLarge } from './flyout_large';
+const flyoutLargeSource = require('!!raw-loader!./flyout_large');
+const flyoutLargeHtml = renderToHtml(FlyoutLarge);
+
+import { FlyoutMaxWidth } from './flyout_max_width';
+const flyoutMaxWidthSource = require('!!raw-loader!./flyout_max_width');
+const flyoutMaxWidthHtml = renderToHtml(FlyoutMaxWidth);
 
 export const FlyoutExample = {
   title: 'Flyout',
@@ -89,15 +97,15 @@ export const FlyoutExample = {
       demo: <FlyoutComplicated />,
     },
     {
-      title: 'Flyout sizing and focus',
+      title: 'Small flyout, ownFocus',
       source: [
         {
           type: GuideSectionTypes.JS,
-          code: flyoutSizeSource,
+          code: flyoutSmallSource,
         },
         {
           type: GuideSectionTypes.HTML,
-          code: flyoutSizeHtml,
+          code: flyoutSmallHtml,
         },
       ],
       text: (
@@ -107,7 +115,46 @@ export const FlyoutExample = {
           also adds background overlay to reinforce your boundries.
         </p>
       ),
-      demo: <FlyoutSize />,
+      demo: <FlyoutSmall />,
+    },
+    {
+      title: 'Large flyout',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: flyoutLargeSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: flyoutLargeHtml,
+        },
+      ],
+      text: (
+        <p>
+          In this example, we set <EuiCode>size</EuiCode> to <EuiCode>l</EuiCode>.
+        </p>
+      ),
+      demo: <FlyoutLarge />,
+    },
+    {
+      title: 'maxWidth',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: flyoutMaxWidthSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: flyoutMaxWidthHtml,
+        },
+      ],
+      text: (
+        <p>
+          In this example, we set <EuiCode>maxWidth</EuiCode> to <EuiCode>33vw</EuiCode>, to
+          set the width of the flyout at 33% the width of the viewport.
+        </p>
+      ),
+      demo: <FlyoutMaxWidth />,
     },
   ],
 };

--- a/src-docs/src/views/flyout/flyout_example.js
+++ b/src-docs/src/views/flyout/flyout_example.js
@@ -150,8 +150,8 @@ export const FlyoutExample = {
       ],
       text: (
         <p>
-          In this example, we set <EuiCode>maxWidth</EuiCode> to <EuiCode>33vw</EuiCode>, to
-          set the width of the flyout at 33% the width of the viewport.
+          In this example, we set <EuiCode>maxWidth</EuiCode> to <EuiCode>448px</EuiCode>, to
+          set the width of the flyout at the ideal width for a form.
         </p>
       ),
       demo: <FlyoutMaxWidth />,

--- a/src-docs/src/views/flyout/flyout_large.js
+++ b/src-docs/src/views/flyout/flyout_large.js
@@ -4,15 +4,14 @@ import React, {
 
 import {
   EuiFlyout,
-  EuiFlyoutBody,
   EuiFlyoutHeader,
+  EuiFlyoutBody,
   EuiButton,
   EuiText,
   EuiTitle,
-  EuiCodeBlock,
 } from '../../../../src/components';
 
-export class Flyout extends Component {
+export class FlyoutLarge extends Component {
   constructor(props) {
     super(props);
 
@@ -40,52 +39,36 @@ export class Flyout extends Component {
   }
 
   render() {
+
     let flyout;
-
-    const htmlCode = `<EuiFlyout ...>
-  <EuiFlyoutHeader hasBorder>
-    <EuiTitle size="m">
-      <h2></h2>
-    </EuiTitle>
-  </EuiFlyoutHeader>
-  <EuiFlyoutBody>
-    ...
-  </EuiFlyoutBody>
-</EuiFlyout>
-`;
-
     if (this.state.isFlyoutVisible) {
       flyout = (
         <EuiFlyout
           onClose={this.closeFlyout}
-          aria-labelledby="flyoutTitle"
+          size="l"
+          aria-labelledby="flyoutLargeTitle"
         >
           <EuiFlyoutHeader hasBorder>
             <EuiTitle size="m">
-              <h2 id="flyoutTitle">
-                A typical flyout
+              <h2 id="flyoutLargeTitle">
+                A large flyout
               </h2>
             </EuiTitle>
           </EuiFlyoutHeader>
           <EuiFlyoutBody>
             <EuiText>
               <p>
-                For consistency across the many flyouts, please utilize the following code for
-                implementing the flyout with a header.
+                The large flyout is very wide.
               </p>
             </EuiText>
-            <EuiCodeBlock language="html">
-              {htmlCode}
-            </EuiCodeBlock>
           </EuiFlyoutBody>
         </EuiFlyout>
       );
     }
-
     return (
       <div>
         <EuiButton onClick={this.showFlyout}>
-          Show flyout
+          Show large flyout
         </EuiButton>
 
         {flyout}

--- a/src-docs/src/views/flyout/flyout_max_width.js
+++ b/src-docs/src/views/flyout/flyout_max_width.js
@@ -12,7 +12,7 @@ import {
   EuiCodeBlock,
 } from '../../../../src/components';
 
-export class Flyout extends Component {
+export class FlyoutMaxWidth extends Component {
   constructor(props) {
     super(props);
 
@@ -58,12 +58,13 @@ export class Flyout extends Component {
       flyout = (
         <EuiFlyout
           onClose={this.closeFlyout}
-          aria-labelledby="flyoutTitle"
+          aria-labelledby="flyoutMaxWidthTitle"
+          maxWidth="33vw"
         >
           <EuiFlyoutHeader hasBorder>
             <EuiTitle size="m">
-              <h2 id="flyoutTitle">
-                A typical flyout
+              <h2 id="flyoutMaxWidthTitle">
+                33% wide flyout
               </h2>
             </EuiTitle>
           </EuiFlyoutHeader>
@@ -85,7 +86,7 @@ export class Flyout extends Component {
     return (
       <div>
         <EuiButton onClick={this.showFlyout}>
-          Show flyout
+          Show max-width flyout
         </EuiButton>
 
         {flyout}

--- a/src-docs/src/views/flyout/flyout_max_width.js
+++ b/src-docs/src/views/flyout/flyout_max_width.js
@@ -9,7 +9,13 @@ import {
   EuiButton,
   EuiText,
   EuiTitle,
-  EuiCodeBlock,
+  EuiFieldText,
+  EuiForm,
+  EuiFormRow,
+  EuiFilePicker,
+  EuiRange,
+  EuiSelect,
+  EuiSpacer,
 } from '../../../../src/components';
 
 export class FlyoutMaxWidth extends Component {
@@ -42,42 +48,68 @@ export class FlyoutMaxWidth extends Component {
   render() {
     let flyout;
 
-    const htmlCode = `<EuiFlyout ...>
-  <EuiFlyoutHeader hasBorder>
-    <EuiTitle size="m">
-      <h2></h2>
-    </EuiTitle>
-  </EuiFlyoutHeader>
-  <EuiFlyoutBody>
-    ...
-  </EuiFlyoutBody>
-</EuiFlyout>
-`;
-
     if (this.state.isFlyoutVisible) {
       flyout = (
         <EuiFlyout
           onClose={this.closeFlyout}
           aria-labelledby="flyoutMaxWidthTitle"
-          maxWidth="33vw"
+          maxWidth="448px"
         >
           <EuiFlyoutHeader hasBorder>
             <EuiTitle size="m">
               <h2 id="flyoutMaxWidthTitle">
-                33% wide flyout
+                448px wide flyout
               </h2>
             </EuiTitle>
           </EuiFlyoutHeader>
           <EuiFlyoutBody>
             <EuiText>
               <p>
-                For consistency across the many flyouts, please utilize the following code for
-                implementing the flyout with a header.
+                In many cases, you&rsquo;ll want to set a custom width that&rdquo;s tailored to your content.
+                In this case, the flyout is an ideal width for form elements.
               </p>
             </EuiText>
-            <EuiCodeBlock language="html">
-              {htmlCode}
-            </EuiCodeBlock>
+
+            <EuiSpacer />
+
+            <EuiForm>
+              <EuiFormRow
+                label="Text field"
+                helpText="I am some friendly help text."
+              >
+                <EuiFieldText name="first" />
+              </EuiFormRow>
+
+              <EuiFormRow
+                label="Select (with no initial selection)"
+              >
+                <EuiSelect
+                  hasNoInitialSelection
+                  options={[
+                    { value: 'option_one', text: 'Option one' },
+                    { value: 'option_two', text: 'Option two' },
+                    { value: 'option_three', text: 'Option three' },
+                  ]}
+                />
+              </EuiFormRow>
+
+              <EuiFormRow
+                label="File picker"
+              >
+                <EuiFilePicker />
+              </EuiFormRow>
+
+              <EuiFormRow
+                label="Range"
+              >
+                <EuiRange
+                  min={0}
+                  max={100}
+                  name="range"
+                  id="range"
+                />
+              </EuiFormRow>
+            </EuiForm>
           </EuiFlyoutBody>
         </EuiFlyout>
       );

--- a/src-docs/src/views/flyout/flyout_max_width.js
+++ b/src-docs/src/views/flyout/flyout_max_width.js
@@ -53,7 +53,7 @@ export class FlyoutMaxWidth extends Component {
         <EuiFlyout
           onClose={this.closeFlyout}
           aria-labelledby="flyoutMaxWidthTitle"
-          maxWidth="448px"
+          maxWidth={448}
         >
           <EuiFlyoutHeader hasBorder>
             <EuiTitle size="m">

--- a/src-docs/src/views/flyout/flyout_small.js
+++ b/src-docs/src/views/flyout/flyout_small.js
@@ -11,7 +11,7 @@ import {
   EuiTitle,
 } from '../../../../src/components';
 
-export class FlyoutSize extends Component {
+export class FlyoutSmall extends Component {
   constructor(props) {
     super(props);
 
@@ -47,13 +47,13 @@ export class FlyoutSize extends Component {
           ownFocus
           onClose={this.closeFlyout}
           size="s"
-          aria-labelledby="flyoutSizeTitle"
+          aria-labelledby="flyoutSmallTitle"
         >
           <EuiFlyoutHeader hasBorder>
             <EuiTitle size="s">
-              <h1 id="flyoutSizeTitle">
+              <h2 id="flyoutSmallTitle">
                 A small flyout
-              </h1>
+              </h2>
             </EuiTitle>
           </EuiFlyoutHeader>
           <EuiFlyoutBody>
@@ -69,7 +69,7 @@ export class FlyoutSize extends Component {
     return (
       <div>
         <EuiButton onClick={this.showFlyout}>
-          Show Flyout
+          Show small flyout
         </EuiButton>
 
         {flyout}

--- a/src/components/flyout/_flyout.scss
+++ b/src/components/flyout/_flyout.scss
@@ -23,6 +23,9 @@
   z-index: 3;
 }
 
+/**
+ * 1. Calculating the minimum width based on the screen takover breakpoint
+ */
 $flyoutSizes: (
   "small": (
     min: map-get($euiBreakpoints, "m") * .5, /* 1 */
@@ -64,22 +67,21 @@ $flyoutSizes: (
 }
 
 /**
- * 1. Calculating the minimum width based on the screen takover breakpoint
- * 2. Only small flyouts should NOT takover the entire screen
- * 3. If a custom maxWidth is set, we need to override it.
+ * 1. Only small flyouts should NOT takover the entire screen
+ * 2. If a custom maxWidth is set, we need to override it.
  */
 @include euiBreakpoint('xs','s') {
-  .euiFlyout:not(.euiFlyout--small) {  /* 2 */
+  .euiFlyout:not(.euiFlyout--small) {  /* 1 */
     left: 0;
     min-width: 0;
     width: auto;
     border-left: none;
-    max-width: 100vw !important; /* 3 */
+    max-width: 100vw !important; /* 2 */
   }
 
   .euiFlyout--small {
     width: 80vw; // ensure that it's only partially showing the main content
-    min-width: 0; /* 2 */
-    max-width: 80vw !important; /* 3 */
+    min-width: 0; /* 1 */
+    max-width: 80vw !important; /* 2 */
   }
 }

--- a/src/components/flyout/_flyout.scss
+++ b/src/components/flyout/_flyout.scss
@@ -23,10 +23,6 @@
   z-index: 3;
 }
 
-/**
-  * 1. Calculating the minimum width based on the screen takover breakpoint
-  * 2. Only small flyouts should NOT takover the entire screen
- */
 $flyoutSizes: (
   "small": (
     min: map-get($euiBreakpoints, "m") * .5, /* 1 */
@@ -67,16 +63,23 @@ $flyoutSizes: (
   }
 }
 
+/**
+ * 1. Calculating the minimum width based on the screen takover breakpoint
+ * 2. Only small flyouts should NOT takover the entire screen
+ * 3. If a custom maxWidth is set, we need to override it.
+ */
 @include euiBreakpoint('xs','s') {
   .euiFlyout:not(.euiFlyout--small) {  /* 2 */
     left: 0;
     min-width: 0;
     width: auto;
     border-left: none;
+    max-width: 100vw !important; /* 3 */
   }
 
   .euiFlyout--small {
     width: 80vw; // ensure that it's only partially showing the main content
     min-width: 0; /* 2 */
+    max-width: 80vw !important; /* 3 */
   }
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/1122

I also added examples for the `maxWidth` prop and the large size flyout. @elastic/kibana-design In general, are we still trying to add examples to the docs site whenever we add new props?