### PR TITLE
Adds ability to hide per page options when enabling table pagination

### DIFF
--- a/src-docs/src/views/tables/basic/props_info.js
+++ b/src-docs/src/views/tables/basic/props_info.js
@@ -39,7 +39,7 @@ export const propsInfo = {
         },
         onChange: {
           description: 'Called whenever pagination or sorting changes (this property is required when either' +
-                       'pagination or sorting is configured',
+            'pagination or sorting is configured',
           required: false,
           type: { name: '(criteria: #Criteria) => void' }
         }
@@ -71,6 +71,12 @@ export const propsInfo = {
           required: false,
           defaultValue: { value: '[5, 10, 20]' },
           type: { name: 'number[]' }
+        },
+        disablePerPageOptions: {
+          description: 'Hides the page size dropdown',
+          required: false,
+          defaultValue: { value: 'false' },
+          type: { name: 'bool' }
         }
       }
     }
@@ -105,7 +111,7 @@ export const propsInfo = {
         },
         selectableMessage: {
           description: 'A callback that is called per item to retrieve a message for its selectable state.' +
-                       'We display these messages as a tooltip on an unselectable checkbox',
+            'We display these messages as a tooltip on an unselectable checkbox',
           required: false,
           type: { name: '(selectable, item) => string' }
         }
@@ -312,7 +318,7 @@ export const propsInfo = {
       props: {
         render: {
           description: 'The function that renders the action. Note that the returned node is ' +
-                       'expected to have`onFocus` and `onBlur` functions',
+            'expected to have`onFocus` and `onBlur` functions',
           required: true,
           type: { name: '(item, enabled) => PropTypes.node' }
         },

--- a/src-docs/src/views/tables/basic/props_info.js
+++ b/src-docs/src/views/tables/basic/props_info.js
@@ -72,7 +72,7 @@ export const propsInfo = {
           defaultValue: { value: '[5, 10, 20]' },
           type: { name: 'number[]' }
         },
-        disablePerPageOptions: {
+        hidePerPageOptions: {
           description: 'Hides the page size dropdown',
           required: false,
           defaultValue: { value: 'false' },

--- a/src-docs/src/views/tables/custom/custom.js
+++ b/src-docs/src/views/tables/custom/custom.js
@@ -8,6 +8,7 @@ import {
   EuiButton,
   EuiButtonIcon,
   EuiCheckbox,
+  EuiCode,
   EuiContextMenuItem,
   EuiContextMenuPanel,
   EuiFieldSearch,
@@ -17,6 +18,7 @@ import {
   EuiLink,
   EuiPopover,
   EuiSpacer,
+  EuiSwitch,
   EuiTable,
   EuiTableBody,
   EuiTableHeader,
@@ -45,7 +47,8 @@ export default class extends Component {
       itemIdToSelectedMap: {},
       itemIdToOpenActionsPopoverMap: {},
       sortedColumn: 'title',
-      itemsPerPage: 20,
+      itemsPerPage: 10,
+      showPerPageOptions: true
     };
 
     this.items = [{
@@ -546,6 +549,8 @@ export default class extends Component {
     return rows;
   }
 
+  togglePerPageOptions = () => this.setState((state) => ({ showPerPageOptions: !state.showPerPageOptions }));
+
   render() {
     let optionalActionButtons;
 
@@ -595,8 +600,16 @@ export default class extends Component {
           itemsPerPage={this.state.itemsPerPage}
           itemsPerPageOptions={[5, 10, 20]}
           pageCount={this.pager.getTotalPages()}
+          disablePerPageOptions={!this.state.showPerPageOptions}
           onChangeItemsPerPage={this.onChangeItemsPerPage}
           onChangePage={this.onChangePage}
+        />
+
+        <EuiSpacer size="xl" />
+
+        <EuiSwitch
+          label={<span>Hide per page options with <EuiCode>pagination.disablePerPageOptions = true</EuiCode></span>}
+          onChange={this.togglePerPageOptions}
         />
       </div>
     );

--- a/src-docs/src/views/tables/custom/custom.js
+++ b/src-docs/src/views/tables/custom/custom.js
@@ -600,7 +600,7 @@ export default class extends Component {
           itemsPerPage={this.state.itemsPerPage}
           itemsPerPageOptions={[5, 10, 20]}
           pageCount={this.pager.getTotalPages()}
-          disablePerPageOptions={!this.state.showPerPageOptions}
+          hidePerPageOptions={!this.state.showPerPageOptions}
           onChangeItemsPerPage={this.onChangeItemsPerPage}
           onChangePage={this.onChangePage}
         />
@@ -608,7 +608,7 @@ export default class extends Component {
         <EuiSpacer size="xl" />
 
         <EuiSwitch
-          label={<span>Hide per page options with <EuiCode>pagination.disablePerPageOptions = true</EuiCode></span>}
+          label={<span>Hide per page options with <EuiCode>pagination.hidePerPageOptions = true</EuiCode></span>}
           onChange={this.togglePerPageOptions}
         />
       </div>

--- a/src-docs/src/views/tables/custom/custom.js
+++ b/src-docs/src/views/tables/custom/custom.js
@@ -8,7 +8,6 @@ import {
   EuiButton,
   EuiButtonIcon,
   EuiCheckbox,
-  EuiCode,
   EuiContextMenuItem,
   EuiContextMenuPanel,
   EuiFieldSearch,
@@ -18,7 +17,6 @@ import {
   EuiLink,
   EuiPopover,
   EuiSpacer,
-  EuiSwitch,
   EuiTable,
   EuiTableBody,
   EuiTableHeader,
@@ -47,8 +45,7 @@ export default class extends Component {
       itemIdToSelectedMap: {},
       itemIdToOpenActionsPopoverMap: {},
       sortedColumn: 'title',
-      itemsPerPage: 10,
-      showPerPageOptions: true
+      itemsPerPage: 10
     };
 
     this.items = [{
@@ -549,8 +546,6 @@ export default class extends Component {
     return rows;
   }
 
-  togglePerPageOptions = () => this.setState((state) => ({ showPerPageOptions: !state.showPerPageOptions }));
-
   render() {
     let optionalActionButtons;
 
@@ -600,16 +595,8 @@ export default class extends Component {
           itemsPerPage={this.state.itemsPerPage}
           itemsPerPageOptions={[5, 10, 20]}
           pageCount={this.pager.getTotalPages()}
-          hidePerPageOptions={!this.state.showPerPageOptions}
           onChangeItemsPerPage={this.onChangeItemsPerPage}
           onChangePage={this.onChangePage}
-        />
-
-        <EuiSpacer size="xl" />
-
-        <EuiSwitch
-          label={<span>Hide per page options with <EuiCode>pagination.hidePerPageOptions = true</EuiCode></span>}
-          onChange={this.togglePerPageOptions}
         />
       </div>
     );

--- a/src-docs/src/views/tables/custom/custom_section.js
+++ b/src-docs/src/views/tables/custom/custom_section.js
@@ -7,6 +7,7 @@ import {
   EuiTableHeader,
   EuiTableHeaderCell,
   EuiTableHeaderCellCheckbox,
+  EuiTablePagination,
   EuiTableRow,
   EuiTableRowCell,
   EuiTableRowCellCheckbox,
@@ -70,6 +71,7 @@ export const section = {
     EuiTableHeader,
     EuiTableHeaderCell,
     EuiTableHeaderCellCheckbox,
+    EuiTablePagination,
     EuiTableRow,
     EuiTableRowCell,
     EuiTableRowCellCheckbox,
@@ -77,5 +79,5 @@ export const section = {
     EuiTableSortMobile,
     EuiTableSortMobileItem,
   },
-  demo: <Custom/>,
+  demo: <Custom />,
 };

--- a/src-docs/src/views/tables/in_memory/in_memory.js
+++ b/src-docs/src/views/tables/in_memory/in_memory.js
@@ -83,7 +83,7 @@ export const Table = () => {
     <EuiInMemoryTable
       items={store.users}
       columns={columns}
-      pagination={{ disablePerPageOptions: true }}
+      pagination={{ hidePerPageOptions: true }}
       sorting={sorting}
     />
   );

--- a/src-docs/src/views/tables/in_memory/in_memory.js
+++ b/src-docs/src/views/tables/in_memory/in_memory.js
@@ -83,7 +83,7 @@ export const Table = () => {
     <EuiInMemoryTable
       items={store.users}
       columns={columns}
-      pagination={true}
+      pagination={{ disablePerPageOptions: true }}
       sorting={sorting}
     />
   );

--- a/src-docs/src/views/tables/in_memory/in_memory.js
+++ b/src-docs/src/views/tables/in_memory/in_memory.js
@@ -83,7 +83,7 @@ export const Table = () => {
     <EuiInMemoryTable
       items={store.users}
       columns={columns}
-      pagination={{ hidePerPageOptions: true }}
+      pagination={true}
       sorting={sorting}
     />
   );

--- a/src-docs/src/views/tables/paginated/paginated.js
+++ b/src-docs/src/views/tables/paginated/paginated.js
@@ -136,7 +136,7 @@ export class Table extends Component {
       pageSize,
       totalItemCount,
       pageSizeOptions: [3, 5, 8],
-      disablePerPageOptions: !showPerPageOptions
+      hidePerPageOptions: !showPerPageOptions
     };
 
     return (
@@ -149,7 +149,7 @@ export class Table extends Component {
         />
         <EuiSpacer size="xl" />
         <EuiSwitch
-          label={<span>Hide per page options with <EuiCode>pagination.disablePerPageOptions = true</EuiCode></span>}
+          label={<span>Hide per page options with <EuiCode>pagination.hidePerPageOptions = true</EuiCode></span>}
           onChange={this.togglePerPageOptions}
         />
       </div>

--- a/src-docs/src/views/tables/paginated/paginated.js
+++ b/src-docs/src/views/tables/paginated/paginated.js
@@ -141,16 +141,16 @@ export class Table extends Component {
 
     return (
       <div>
+        <EuiSwitch
+          label={<span>Hide per page options with <EuiCode>pagination.hidePerPageOptions = true</EuiCode></span>}
+          onChange={this.togglePerPageOptions}
+        />
+        <EuiSpacer size="xl" />
         <EuiBasicTable
           items={pageOfItems}
           columns={columns}
           pagination={pagination}
           onChange={this.onTableChange}
-        />
-        <EuiSpacer size="xl" />
-        <EuiSwitch
-          label={<span>Hide per page options with <EuiCode>pagination.hidePerPageOptions = true</EuiCode></span>}
-          onChange={this.togglePerPageOptions}
         />
       </div>
     );

--- a/src-docs/src/views/tables/paginated/paginated.js
+++ b/src-docs/src/views/tables/paginated/paginated.js
@@ -6,10 +6,13 @@ import { createDataStore } from '../data_store';
 
 import {
   EuiBasicTable,
+  EuiCode,
   EuiLink,
   EuiHealth,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiSpacer,
+  EuiSwitch
 } from '../../../../../src/components';
 
 /*
@@ -43,6 +46,7 @@ export class Table extends Component {
     this.state = {
       pageIndex: 0,
       pageSize: 5,
+      showPerPageOptions: true
     };
   }
 
@@ -64,10 +68,13 @@ export class Table extends Component {
     return <EuiHealth color={color}>{label}</EuiHealth>;
   }
 
+  togglePerPageOptions = () => this.setState((state) => ({ showPerPageOptions: !state.showPerPageOptions }));
+
   render() {
     const {
       pageIndex,
       pageSize,
+      showPerPageOptions
     } = this.state;
 
     const {
@@ -125,19 +132,27 @@ export class Table extends Component {
     }];
 
     const pagination = {
-      pageIndex: pageIndex,
-      pageSize: pageSize,
-      totalItemCount: totalItemCount,
-      pageSizeOptions: [3, 5, 8]
+      pageIndex,
+      pageSize,
+      totalItemCount,
+      pageSizeOptions: [3, 5, 8],
+      disablePerPageOptions: !showPerPageOptions
     };
 
     return (
-      <EuiBasicTable
-        items={pageOfItems}
-        columns={columns}
-        pagination={pagination}
-        onChange={this.onTableChange}
-      />
+      <div>
+        <EuiBasicTable
+          items={pageOfItems}
+          columns={columns}
+          pagination={pagination}
+          onChange={this.onTableChange}
+        />
+        <EuiSpacer size="xl" />
+        <EuiSwitch
+          label={<span>Hide per page options with <EuiCode>pagination.disablePerPageOptions = true</EuiCode></span>}
+          onChange={this.togglePerPageOptions}
+        />
+      </div>
     );
   }
 }

--- a/src/components/basic_table/__snapshots__/basic_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.js.snap
@@ -882,6 +882,92 @@ exports[`EuiBasicTable with pagination and selection 1`] = `
 </div>
 `;
 
+exports[`EuiBasicTable with pagination, hiding the per page options 1`] = `
+<div
+  className="euiBasicTable"
+>
+  <div>
+    <EuiTableHeaderMobile />
+    <EuiTable
+      responsive={true}
+    >
+      <EuiTableHeader>
+        <EuiTableHeaderCell
+          align="left"
+          data-test-subj="tableHeaderCell_name_0"
+          key="_data_h_name_0"
+          scope="col"
+        >
+          Name
+        </EuiTableHeaderCell>
+      </EuiTableHeader>
+      <EuiTableBody>
+        <React.Fragment
+          key="row_0"
+        >
+          <EuiTableRow
+            isSelected={false}
+          >
+            <EuiTableRowCell
+              align="left"
+              header="Name"
+              key="_data_column_name_0_0"
+              textOnly={true}
+            >
+              name1
+            </EuiTableRowCell>
+          </EuiTableRow>
+        </React.Fragment>
+        <React.Fragment
+          key="row_1"
+        >
+          <EuiTableRow
+            isSelected={false}
+          >
+            <EuiTableRowCell
+              align="left"
+              header="Name"
+              key="_data_column_name_1_0"
+              textOnly={true}
+            >
+              name2
+            </EuiTableRowCell>
+          </EuiTableRow>
+        </React.Fragment>
+        <React.Fragment
+          key="row_2"
+        >
+          <EuiTableRow
+            isSelected={false}
+          >
+            <EuiTableRowCell
+              align="left"
+              header="Name"
+              key="_data_column_name_2_0"
+              textOnly={true}
+            >
+              name3
+            </EuiTableRowCell>
+          </EuiTableRow>
+        </React.Fragment>
+      </EuiTableBody>
+    </EuiTable>
+  </div>
+  <PaginationBar
+    onPageChange={[Function]}
+    onPageSizeChange={[Function]}
+    pagination={
+      Object {
+        "disablePerPageOptions": true,
+        "pageIndex": 0,
+        "pageSize": 3,
+        "totalItemCount": 5,
+      }
+    }
+  />
+</div>
+`;
+
 exports[`EuiBasicTable with pagination, selection and sorting 1`] = `
 <div
   className="euiBasicTable"

--- a/src/components/basic_table/__snapshots__/basic_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.js.snap
@@ -958,7 +958,7 @@ exports[`EuiBasicTable with pagination, hiding the per page options 1`] = `
     onPageSizeChange={[Function]}
     pagination={
       Object {
-        "disablePerPageOptions": true,
+        "hidePerPageOptions": true,
         "pageIndex": 0,
         "pageSize": 3,
         "totalItemCount": 5,

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
@@ -76,7 +76,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
     onChange={[Function]}
     pagination={
       Object {
-        "disablePerPageOptions": undefined,
+        "hidePerPageOptions": undefined,
         "pageIndex": 1,
         "pageSize": 2,
         "pageSizeOptions": Array [
@@ -204,7 +204,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
         onPageSizeChange={[Function]}
         pagination={
           Object {
-            "disablePerPageOptions": undefined,
+            "hidePerPageOptions": undefined,
             "pageIndex": 1,
             "pageSize": 2,
             "pageSizeOptions": Array [
@@ -226,7 +226,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
           </EuiSpacer>
           <EuiTablePagination
             activePage={1}
-            disablePerPageOptions={false}
+            hidePerPageOptions={false}
             itemsPerPage={2}
             itemsPerPageOptions={
               Array [
@@ -865,7 +865,7 @@ exports[`EuiInMemoryTable with pagination 1`] = `
   onChange={[Function]}
   pagination={
     Object {
-      "disablePerPageOptions": undefined,
+      "hidePerPageOptions": undefined,
       "pageIndex": 0,
       "pageSize": 2,
       "pageSizeOptions": Array [
@@ -915,7 +915,7 @@ exports[`EuiInMemoryTable with pagination and default page size 1`] = `
   onChange={[Function]}
   pagination={
     Object {
-      "disablePerPageOptions": undefined,
+      "hidePerPageOptions": undefined,
       "pageIndex": 0,
       "pageSize": 4,
       "pageSizeOptions": Array [
@@ -966,7 +966,7 @@ exports[`EuiInMemoryTable with pagination and selection 1`] = `
   onChange={[Function]}
   pagination={
     Object {
-      "disablePerPageOptions": undefined,
+      "hidePerPageOptions": undefined,
       "pageIndex": 0,
       "pageSize": 10,
       "pageSizeOptions": Array [
@@ -1014,7 +1014,7 @@ exports[`EuiInMemoryTable with pagination, default page size and error 1`] = `
   onChange={[Function]}
   pagination={
     Object {
-      "disablePerPageOptions": undefined,
+      "hidePerPageOptions": undefined,
       "pageIndex": 0,
       "pageSize": 4,
       "pageSizeOptions": Array [
@@ -1064,7 +1064,7 @@ exports[`EuiInMemoryTable with pagination, hiding the per page options 1`] = `
   onChange={[Function]}
   pagination={
     Object {
-      "disablePerPageOptions": true,
+      "hidePerPageOptions": true,
       "pageIndex": 0,
       "pageSize": 10,
       "pageSizeOptions": Array [
@@ -1115,7 +1115,7 @@ exports[`EuiInMemoryTable with pagination, selection and sorting 1`] = `
   onChange={[Function]}
   pagination={
     Object {
-      "disablePerPageOptions": undefined,
+      "hidePerPageOptions": undefined,
       "pageIndex": 0,
       "pageSize": 10,
       "pageSizeOptions": Array [
@@ -1195,7 +1195,7 @@ exports[`EuiInMemoryTable with pagination, selection, sorting  and simple search
     onChange={[Function]}
     pagination={
       Object {
-        "disablePerPageOptions": undefined,
+        "hidePerPageOptions": undefined,
         "pageIndex": 0,
         "pageSize": 10,
         "pageSizeOptions": Array [
@@ -1269,7 +1269,7 @@ exports[`EuiInMemoryTable with pagination, selection, sorting and a single recor
   onChange={[Function]}
   pagination={
     Object {
-      "disablePerPageOptions": undefined,
+      "hidePerPageOptions": undefined,
       "pageIndex": 0,
       "pageSize": 10,
       "pageSizeOptions": Array [
@@ -1327,7 +1327,7 @@ exports[`EuiInMemoryTable with pagination, selection, sorting and column rendere
   onChange={[Function]}
   pagination={
     Object {
-      "disablePerPageOptions": undefined,
+      "hidePerPageOptions": undefined,
       "pageIndex": 0,
       "pageSize": 2,
       "pageSizeOptions": Array [
@@ -1419,7 +1419,7 @@ exports[`EuiInMemoryTable with pagination, selection, sorting and configured sea
     onChange={[Function]}
     pagination={
       Object {
-        "disablePerPageOptions": undefined,
+        "hidePerPageOptions": undefined,
         "pageIndex": 0,
         "pageSize": 10,
         "pageSizeOptions": Array [

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
@@ -76,6 +76,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
     onChange={[Function]}
     pagination={
       Object {
+        "disablePerPageOptions": undefined,
         "pageIndex": 1,
         "pageSize": 2,
         "pageSizeOptions": Array [
@@ -203,6 +204,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
         onPageSizeChange={[Function]}
         pagination={
           Object {
+            "disablePerPageOptions": undefined,
             "pageIndex": 1,
             "pageSize": 2,
             "pageSizeOptions": Array [
@@ -224,6 +226,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
           </EuiSpacer>
           <EuiTablePagination
             activePage={1}
+            disablePerPageOptions={false}
             itemsPerPage={2}
             itemsPerPageOptions={
               Array [
@@ -862,6 +865,7 @@ exports[`EuiInMemoryTable with pagination 1`] = `
   onChange={[Function]}
   pagination={
     Object {
+      "disablePerPageOptions": undefined,
       "pageIndex": 0,
       "pageSize": 2,
       "pageSizeOptions": Array [
@@ -911,6 +915,7 @@ exports[`EuiInMemoryTable with pagination and default page size 1`] = `
   onChange={[Function]}
   pagination={
     Object {
+      "disablePerPageOptions": undefined,
       "pageIndex": 0,
       "pageSize": 4,
       "pageSizeOptions": Array [
@@ -961,6 +966,7 @@ exports[`EuiInMemoryTable with pagination and selection 1`] = `
   onChange={[Function]}
   pagination={
     Object {
+      "disablePerPageOptions": undefined,
       "pageIndex": 0,
       "pageSize": 10,
       "pageSizeOptions": Array [
@@ -1008,6 +1014,7 @@ exports[`EuiInMemoryTable with pagination, default page size and error 1`] = `
   onChange={[Function]}
   pagination={
     Object {
+      "disablePerPageOptions": undefined,
       "pageIndex": 0,
       "pageSize": 4,
       "pageSizeOptions": Array [
@@ -1058,6 +1065,7 @@ exports[`EuiInMemoryTable with pagination, selection and sorting 1`] = `
   onChange={[Function]}
   pagination={
     Object {
+      "disablePerPageOptions": undefined,
       "pageIndex": 0,
       "pageSize": 10,
       "pageSizeOptions": Array [
@@ -1137,6 +1145,7 @@ exports[`EuiInMemoryTable with pagination, selection, sorting  and simple search
     onChange={[Function]}
     pagination={
       Object {
+        "disablePerPageOptions": undefined,
         "pageIndex": 0,
         "pageSize": 10,
         "pageSizeOptions": Array [
@@ -1210,6 +1219,7 @@ exports[`EuiInMemoryTable with pagination, selection, sorting and a single recor
   onChange={[Function]}
   pagination={
     Object {
+      "disablePerPageOptions": undefined,
       "pageIndex": 0,
       "pageSize": 10,
       "pageSizeOptions": Array [
@@ -1267,6 +1277,7 @@ exports[`EuiInMemoryTable with pagination, selection, sorting and column rendere
   onChange={[Function]}
   pagination={
     Object {
+      "disablePerPageOptions": undefined,
       "pageIndex": 0,
       "pageSize": 2,
       "pageSizeOptions": Array [
@@ -1358,6 +1369,7 @@ exports[`EuiInMemoryTable with pagination, selection, sorting and configured sea
     onChange={[Function]}
     pagination={
       Object {
+        "disablePerPageOptions": undefined,
         "pageIndex": 0,
         "pageSize": 10,
         "pageSizeOptions": Array [

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
@@ -1029,6 +1029,56 @@ exports[`EuiInMemoryTable with pagination, default page size and error 1`] = `
 />
 `;
 
+exports[`EuiInMemoryTable with pagination, hiding the per page options 1`] = `
+<EuiBasicTable
+  aria-label="aria-label"
+  className="testClass1 testClass2"
+  columns={
+    Array [
+      Object {
+        "description": "description",
+        "field": "name",
+        "name": "Name",
+        "sortable": false,
+      },
+    ]
+  }
+  data-test-subj="test subject string"
+  items={
+    Array [
+      Object {
+        "id": "1",
+        "name": "name1",
+      },
+      Object {
+        "id": "2",
+        "name": "name2",
+      },
+      Object {
+        "id": "3",
+        "name": "name3",
+      },
+    ]
+  }
+  noItemsMessage="No items found"
+  onChange={[Function]}
+  pagination={
+    Object {
+      "disablePerPageOptions": true,
+      "pageIndex": 0,
+      "pageSize": 10,
+      "pageSizeOptions": Array [
+        10,
+        25,
+        50,
+      ],
+      "totalItemCount": 3,
+    }
+  }
+  responsive={true}
+/>
+`;
+
 exports[`EuiInMemoryTable with pagination, selection and sorting 1`] = `
 <EuiBasicTable
   aria-label="aria-label"

--- a/src/components/basic_table/__snapshots__/pagination_bar.test.js.snap
+++ b/src/components/basic_table/__snapshots__/pagination_bar.test.js.snap
@@ -23,6 +23,29 @@ exports[`PaginationBar render - custom page size options 1`] = `
 </div>
 `;
 
+exports[`PaginationBar render - hiding per page options 1`] = `
+<div>
+  <EuiSpacer
+    size="m"
+  />
+  <EuiTablePagination
+    activePage={0}
+    disablePerPageOptions={true}
+    itemsPerPage={5}
+    itemsPerPageOptions={
+      Array [
+        10,
+        25,
+        50,
+      ]
+    }
+    onChangeItemsPerPage={[Function]}
+    onChangePage={[Function]}
+    pageCount={0}
+  />
+</div>
+`;
+
 exports[`PaginationBar render 1`] = `
 <div>
   <EuiSpacer

--- a/src/components/basic_table/__snapshots__/pagination_bar.test.js.snap
+++ b/src/components/basic_table/__snapshots__/pagination_bar.test.js.snap
@@ -7,7 +7,7 @@ exports[`PaginationBar render - custom page size options 1`] = `
   />
   <EuiTablePagination
     activePage={0}
-    disablePerPageOptions={false}
+    hidePerPageOptions={false}
     itemsPerPage={5}
     itemsPerPageOptions={
       Array [
@@ -30,7 +30,7 @@ exports[`PaginationBar render - hiding per page options 1`] = `
   />
   <EuiTablePagination
     activePage={0}
-    disablePerPageOptions={true}
+    hidePerPageOptions={true}
     itemsPerPage={5}
     itemsPerPageOptions={
       Array [
@@ -53,7 +53,7 @@ exports[`PaginationBar render 1`] = `
   />
   <EuiTablePagination
     activePage={0}
-    disablePerPageOptions={false}
+    hidePerPageOptions={false}
     itemsPerPage={5}
     itemsPerPageOptions={
       Array [

--- a/src/components/basic_table/__snapshots__/pagination_bar.test.js.snap
+++ b/src/components/basic_table/__snapshots__/pagination_bar.test.js.snap
@@ -7,6 +7,7 @@ exports[`PaginationBar render - custom page size options 1`] = `
   />
   <EuiTablePagination
     activePage={0}
+    disablePerPageOptions={false}
     itemsPerPage={5}
     itemsPerPageOptions={
       Array [
@@ -29,6 +30,7 @@ exports[`PaginationBar render 1`] = `
   />
   <EuiTablePagination
     activePage={0}
+    disablePerPageOptions={false}
     itemsPerPage={5}
     itemsPerPageOptions={
       Array [

--- a/src/components/basic_table/basic_table.js
+++ b/src/components/basic_table/basic_table.js
@@ -56,7 +56,7 @@ const dataTypesProfiles = {
 const DATA_TYPES = Object.keys(dataTypesProfiles);
 
 const DefaultItemActionType = PropTypes.shape({
-  type: PropTypes.oneOf([ 'icon', 'button' ]), // default is 'button'
+  type: PropTypes.oneOf(['icon', 'button']), // default is 'button'
   name: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired, // (item) => void,
@@ -362,7 +362,7 @@ export class EuiBasicTable extends Component {
     }
 
     columns.forEach((column, index) => {
-      if(!column.sortable || column.hideForMobile) {
+      if (!column.sortable || column.hideForMobile) {
         return;
       }
 
@@ -497,6 +497,7 @@ export class EuiBasicTable extends Component {
     if (items.length === 0) {
       return this.renderEmptyBody();
     }
+
     const rows = items.map((item, index) => {
       // if there's pagination the item's index must be adjusted to the where it is in the whole dataset
       const tableItemIndex = this.props.pagination ?
@@ -516,7 +517,7 @@ export class EuiBasicTable extends Component {
       <EuiTableBody>
         <EuiTableRow>
           <EuiTableRowCell align="center" colSpan={colSpan} isMobileFullWidth={true}>
-            <EuiIcon type="minusInCircle" color="danger"/> {error}
+            <EuiIcon type="minusInCircle" color="danger" /> {error}
           </EuiTableRowCell>
         </EuiTableRow>
       </EuiTableBody>

--- a/src/components/basic_table/basic_table.test.js
+++ b/src/components/basic_table/basic_table.test.js
@@ -102,7 +102,7 @@ describe('EuiBasicTable', () => {
           return {
             'data-test-subj': `row-${id}`,
             className: 'customRowClass',
-            onClick: () => {},
+            onClick: () => { },
           };
         },
       };
@@ -130,7 +130,7 @@ describe('EuiBasicTable', () => {
         rowProps: {
           'data-test-subj': `row`,
           className: 'customClass',
-          onClick: () => {},
+          onClick: () => { },
         },
       };
       const component = shallow(
@@ -162,7 +162,7 @@ describe('EuiBasicTable', () => {
           return {
             'data-test-subj': `cell-${id}-${field}`,
             className: 'customRowClass',
-            onClick: () => {},
+            onClick: () => { },
           };
         },
       };
@@ -190,7 +190,7 @@ describe('EuiBasicTable', () => {
         cellProps: {
           'data-test-subj': `cell`,
           className: 'customClass',
-          onClick: () => {},
+          onClick: () => { },
         },
       };
       const component = shallow(
@@ -219,7 +219,7 @@ describe('EuiBasicTable', () => {
       itemIdToExpandedRowMap: {
         '1': <div>Expanded row</div>,
       },
-      onChange: () => {}
+      onChange: () => { }
     };
     const component = shallow(
       <EuiBasicTable {...props} />
@@ -247,7 +247,7 @@ describe('EuiBasicTable', () => {
         pageSize: 3,
         totalItemCount: 5
       },
-      onChange: () => {}
+      onChange: () => { }
     };
     const component = shallow(
       <EuiBasicTable {...props} />
@@ -274,7 +274,7 @@ describe('EuiBasicTable', () => {
         pageSize: 3,
         totalItemCount: 5
       },
-      onChange: () => {}
+      onChange: () => { }
     };
     const component = shallow(
       <EuiBasicTable {...props} />
@@ -302,8 +302,37 @@ describe('EuiBasicTable', () => {
         pageSize: 3,
         totalItemCount: 5
       },
-      onChange: () => {},
+      onChange: () => { },
       error: 'no can do'
+    };
+    const component = shallow(
+      <EuiBasicTable {...props} />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
+  test('with pagination, hiding the per page options', () => {
+    const props = {
+      items: [
+        { id: '1', name: 'name1' },
+        { id: '2', name: 'name2' },
+        { id: '3', name: 'name3' }
+      ],
+      columns: [
+        {
+          field: 'name',
+          name: 'Name',
+          description: 'description'
+        }
+      ],
+      pagination: {
+        pageIndex: 0,
+        pageSize: 3,
+        totalItemCount: 5,
+        disablePerPageOptions: true
+      },
+      onChange: () => { }
     };
     const component = shallow(
       <EuiBasicTable {...props} />
@@ -330,7 +359,7 @@ describe('EuiBasicTable', () => {
       sorting: {
         sort: { field: 'name', direction: 'asc' }
       },
-      onChange: () => {}
+      onChange: () => { }
     };
     const component = shallow(
       <EuiBasicTable {...props} />
@@ -354,7 +383,7 @@ describe('EuiBasicTable', () => {
           sortable: true
         }
       ],
-      onChange: () => {}
+      onChange: () => { }
     };
     const component = shallow(
       <EuiBasicTable {...props} />
@@ -386,7 +415,7 @@ describe('EuiBasicTable', () => {
       selection: {
         onSelectionChanged: () => undefined
       },
-      onChange: () => {}
+      onChange: () => { }
     };
     const component = shallow(
       <EuiBasicTable {...props} />
@@ -422,7 +451,7 @@ describe('EuiBasicTable', () => {
       sorting: {
         sort: { field: 'name', direction: 'asc' }
       },
-      onChange: () => {}
+      onChange: () => { }
     };
     const component = shallow(
       <EuiBasicTable {...props} />
@@ -459,7 +488,7 @@ describe('EuiBasicTable', () => {
       sorting: {
         sort: { field: 'name', direction: 'asc' }
       },
-      onChange: () => {}
+      onChange: () => { }
     };
     const component = shallow(
       <EuiBasicTable {...props} />
@@ -496,7 +525,7 @@ describe('EuiBasicTable', () => {
       sorting: {
         sort: { field: 'count', direction: 'asc' }
       },
-      onChange: () => {}
+      onChange: () => { }
     };
     const component = shallow(
       <EuiBasicTable {...props} />
@@ -535,7 +564,7 @@ describe('EuiBasicTable', () => {
       sorting: {
         sort: { field: 'count', direction: 'asc' }
       },
-      onChange: () => {}
+      onChange: () => { }
     };
     const component = shallow(
       <EuiBasicTable {...props} />
@@ -582,7 +611,7 @@ describe('EuiBasicTable', () => {
       sorting: {
         sort: { field: 'name', direction: 'asc' }
       },
-      onChange: () => {}
+      onChange: () => { }
     };
     const component = shallow(
       <EuiBasicTable {...props} />
@@ -635,7 +664,7 @@ describe('EuiBasicTable', () => {
       sorting: {
         sort: { field: 'name', direction: 'asc' }
       },
-      onChange: () => {}
+      onChange: () => { }
     };
     const component = shallow(
       <EuiBasicTable {...props} />

--- a/src/components/basic_table/basic_table.test.js
+++ b/src/components/basic_table/basic_table.test.js
@@ -330,7 +330,7 @@ describe('EuiBasicTable', () => {
         pageIndex: 0,
         pageSize: 3,
         totalItemCount: 5,
-        disablePerPageOptions: true
+        hidePerPageOptions: true
       },
       onChange: () => { }
     };

--- a/src/components/basic_table/in_memory_table.js
+++ b/src/components/basic_table/in_memory_table.js
@@ -94,11 +94,11 @@ const getInitialPagination = (pagination) => {
   const {
     initialPageSize,
     pageSizeOptions = paginationBarDefaults.pageSizeOptions,
-    disablePerPageOptions
+    hidePerPageOptions
   } = pagination;
 
 
-  if (!disablePerPageOptions && initialPageSize && (!pageSizeOptions || !pageSizeOptions.includes(initialPageSize))) {
+  if (!hidePerPageOptions && initialPageSize && (!pageSizeOptions || !pageSizeOptions.includes(initialPageSize))) {
     throw new Error(`EuiInMemoryTable received initialPageSize ${initialPageSize}, which wasn't provided within pageSizeOptions.`);
   }
 
@@ -108,7 +108,7 @@ const getInitialPagination = (pagination) => {
     pageIndex: 0,
     pageSize: initialPageSize || defaultPageSize,
     pageSizeOptions,
-    disablePerPageOptions
+    hidePerPageOptions
   };
 };
 
@@ -158,7 +158,7 @@ export class EuiInMemoryTable extends Component {
     super(props);
 
     const { search, pagination, sorting } = props;
-    const { pageIndex, pageSize, pageSizeOptions, disablePerPageOptions } = getInitialPagination(pagination);
+    const { pageIndex, pageSize, pageSizeOptions, hidePerPageOptions } = getInitialPagination(pagination);
     const { sortField, sortDirection } = getInitialSorting(sorting);
 
     this.state = {
@@ -171,7 +171,7 @@ export class EuiInMemoryTable extends Component {
       pageSizeOptions,
       sortField,
       sortDirection,
-      disablePerPageOptions
+      hidePerPageOptions
     };
   }
 
@@ -328,7 +328,7 @@ export class EuiInMemoryTable extends Component {
       pageSizeOptions,
       sortField,
       sortDirection,
-      disablePerPageOptions
+      hidePerPageOptions
     } = this.state;
 
     const { items, totalItemCount } = this.getItems();
@@ -338,7 +338,7 @@ export class EuiInMemoryTable extends Component {
       pageSize,
       pageSizeOptions,
       totalItemCount,
-      disablePerPageOptions
+      hidePerPageOptions
     };
 
     // Data loaded from a server can have a default sort order which is meaningful to the

--- a/src/components/basic_table/in_memory_table.js
+++ b/src/components/basic_table/in_memory_table.js
@@ -94,10 +94,11 @@ const getInitialPagination = (pagination) => {
   const {
     initialPageSize,
     pageSizeOptions = paginationBarDefaults.pageSizeOptions,
+    disablePerPageOptions
   } = pagination;
 
 
-  if (initialPageSize && (!pageSizeOptions || !pageSizeOptions.includes(initialPageSize))) {
+  if (!disablePerPageOptions && initialPageSize && (!pageSizeOptions || !pageSizeOptions.includes(initialPageSize))) {
     throw new Error(`EuiInMemoryTable received initialPageSize ${initialPageSize}, which wasn't provided within pageSizeOptions.`);
   }
 
@@ -107,6 +108,7 @@ const getInitialPagination = (pagination) => {
     pageIndex: 0,
     pageSize: initialPageSize || defaultPageSize,
     pageSizeOptions,
+    disablePerPageOptions
   };
 };
 
@@ -156,7 +158,7 @@ export class EuiInMemoryTable extends Component {
     super(props);
 
     const { search, pagination, sorting } = props;
-    const { pageIndex, pageSize, pageSizeOptions } = getInitialPagination(pagination);
+    const { pageIndex, pageSize, pageSizeOptions, disablePerPageOptions } = getInitialPagination(pagination);
     const { sortField, sortDirection } = getInitialSorting(sorting);
 
     this.state = {
@@ -169,6 +171,7 @@ export class EuiInMemoryTable extends Component {
       pageSizeOptions,
       sortField,
       sortDirection,
+      disablePerPageOptions
     };
   }
 
@@ -325,6 +328,7 @@ export class EuiInMemoryTable extends Component {
       pageSizeOptions,
       sortField,
       sortDirection,
+      disablePerPageOptions
     } = this.state;
 
     const { items, totalItemCount } = this.getItems();
@@ -334,6 +338,7 @@ export class EuiInMemoryTable extends Component {
       pageSize,
       pageSizeOptions,
       totalItemCount,
+      disablePerPageOptions
     };
 
     // Data loaded from a server can have a default sort order which is meaningful to the
@@ -385,7 +390,7 @@ export class EuiInMemoryTable extends Component {
     return (
       <div>
         {searchBar}
-        <EuiSpacer size="l"/>
+        <EuiSpacer size="l" />
         {table}
       </div>
     );

--- a/src/components/basic_table/in_memory_table.test.js
+++ b/src/components/basic_table/in_memory_table.test.js
@@ -246,7 +246,7 @@ describe('EuiInMemoryTable', () => {
         }
       ],
       pagination: {
-        disablePerPageOptions: true
+        hidePerPageOptions: true
       }
     };
     const component = shallow(

--- a/src/components/basic_table/in_memory_table.test.js
+++ b/src/components/basic_table/in_memory_table.test.js
@@ -229,6 +229,33 @@ describe('EuiInMemoryTable', () => {
     expect(component).toMatchSnapshot();
   });
 
+  test('with pagination, hiding the per page options', () => {
+
+    const props = {
+      ...requiredProps,
+      items: [
+        { id: '1', name: 'name1' },
+        { id: '2', name: 'name2' },
+        { id: '3', name: 'name3' }
+      ],
+      columns: [
+        {
+          field: 'name',
+          name: 'Name',
+          description: 'description'
+        }
+      ],
+      pagination: {
+        disablePerPageOptions: true
+      }
+    };
+    const component = shallow(
+      <EuiInMemoryTable {...props} />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
   test('with sorting', () => {
 
     const props = {
@@ -562,7 +589,7 @@ describe('EuiInMemoryTable', () => {
       const props = { items, columns, search, className: 'testTable' };
 
       const component = mount(
-        <EuiInMemoryTable {...props}/>
+        <EuiInMemoryTable {...props} />
       );
 
       // should render with all three results visible
@@ -696,7 +723,7 @@ describe('EuiInMemoryTable', () => {
       };
 
       const component = mount(
-        <EuiInMemoryTable {...props}/>
+        <EuiInMemoryTable {...props} />
       );
 
       expect(props.onTableChange).toHaveBeenCalledTimes(0);

--- a/src/components/basic_table/pagination_bar.js
+++ b/src/components/basic_table/pagination_bar.js
@@ -24,7 +24,7 @@ export const PaginationBar = ({ pagination, onPageSizeChange, onPageChange }) =>
       <EuiSpacer size="m" />
       <EuiTablePagination
         activePage={pagination.pageIndex}
-        disablePerPageOptions={pagination.disablePerPageOptions}
+        hidePerPageOptions={pagination.hidePerPageOptions}
         itemsPerPage={pagination.pageSize}
         itemsPerPageOptions={pageSizeOptions}
         pageCount={pageCount}

--- a/src/components/basic_table/pagination_bar.js
+++ b/src/components/basic_table/pagination_bar.js
@@ -21,9 +21,10 @@ export const PaginationBar = ({ pagination, onPageSizeChange, onPageChange }) =>
   const pageCount = Math.ceil(pagination.totalItemCount / pagination.pageSize);
   return (
     <div>
-      <EuiSpacer size="m"/>
+      <EuiSpacer size="m" />
       <EuiTablePagination
         activePage={pagination.pageIndex}
+        disablePerPageOptions={pagination.disablePerPageOptions}
         itemsPerPage={pagination.pageSize}
         itemsPerPageOptions={pageSizeOptions}
         pageCount={pageCount}

--- a/src/components/basic_table/pagination_bar.test.js
+++ b/src/components/basic_table/pagination_bar.test.js
@@ -14,8 +14,8 @@ describe('PaginationBar', () => {
         pageSize: 5,
         totalItemCount: 0
       },
-      onPageSizeChange: () => {},
-      onPageChange: () => {}
+      onPageSizeChange: () => { },
+      onPageChange: () => { }
     };
 
     const component = shallow(
@@ -36,8 +36,30 @@ describe('PaginationBar', () => {
         totalItemCount: 0,
         pageSizeOptions: [1, 2, 3]
       },
-      onPageSizeChange: () => {},
-      onPageChange: () => {}
+      onPageSizeChange: () => { },
+      onPageChange: () => { }
+    };
+
+    const component = shallow(
+      <PaginationBar {...props} />
+    );
+
+    expect(component).toMatchSnapshot();
+
+  });
+
+  test('render - hiding per page options', () => {
+
+    const props = {
+      ...requiredProps,
+      pagination: {
+        pageIndex: 0,
+        pageSize: 5,
+        totalItemCount: 0,
+        disablePerPageOptions: true
+      },
+      onPageSizeChange: () => { },
+      onPageChange: () => { }
     };
 
     const component = shallow(

--- a/src/components/basic_table/pagination_bar.test.js
+++ b/src/components/basic_table/pagination_bar.test.js
@@ -56,7 +56,7 @@ describe('PaginationBar', () => {
         pageIndex: 0,
         pageSize: 5,
         totalItemCount: 0,
-        disablePerPageOptions: true
+        hidePerPageOptions: true
       },
       onPageSizeChange: () => { },
       onPageChange: () => { }

--- a/src/components/table/table_pagination/__snapshots__/table_pagination.test.js.snap
+++ b/src/components/table/table_pagination/__snapshots__/table_pagination.test.js.snap
@@ -53,7 +53,282 @@ exports[`EuiTablePagination is rendered 1`] = `
   <div
     class="euiFlexItem euiFlexItem--flexGrowZero"
   >
-    <span />
+    <div
+      class="euiPagination"
+      role="group"
+    >
+      <button
+        aria-label="Previous page"
+        class="euiButtonIcon euiButtonIcon--text"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiButtonIcon__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <defs>
+            <path
+              d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+              id="arrow_left-a"
+            />
+          </defs>
+          <use
+            fill-rule="nonzero"
+            href="#arrow_left-a"
+            transform="rotate(90 8 8)"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Page 1 of 5"
+        class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiPaginationButton euiPaginationButton--hideOnMobile"
+        data-test-subj="pagination-button-0"
+        type="button"
+      >
+        <span
+          class="euiButtonEmpty__content"
+        >
+          <span>
+            1
+          </span>
+        </span>
+      </button>
+      <button
+        aria-label="Page 2 of 5"
+        class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+        data-test-subj="pagination-button-1"
+        type="button"
+      >
+        <span
+          class="euiButtonEmpty__content"
+        >
+          <span>
+            2
+          </span>
+        </span>
+      </button>
+      <button
+        aria-label="Page 3 of 5"
+        class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiPaginationButton euiPaginationButton--hideOnMobile"
+        data-test-subj="pagination-button-2"
+        type="button"
+      >
+        <span
+          class="euiButtonEmpty__content"
+        >
+          <span>
+            3
+          </span>
+        </span>
+      </button>
+      <button
+        aria-label="Page 4 of 5"
+        class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiPaginationButton euiPaginationButton--hideOnMobile"
+        data-test-subj="pagination-button-3"
+        type="button"
+      >
+        <span
+          class="euiButtonEmpty__content"
+        >
+          <span>
+            4
+          </span>
+        </span>
+      </button>
+      <button
+        aria-label="Page 5 of 5"
+        class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiPaginationButton euiPaginationButton--hideOnMobile"
+        data-test-subj="pagination-button-4"
+        type="button"
+      >
+        <span
+          class="euiButtonEmpty__content"
+        >
+          <span>
+            5
+          </span>
+        </span>
+      </button>
+      <button
+        aria-label="Next page"
+        class="euiButtonIcon euiButtonIcon--text"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiButtonIcon__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <defs>
+            <path
+              d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+              id="arrow_right-a"
+            />
+          </defs>
+          <use
+            fill-rule="nonzero"
+            href="#arrow_right-a"
+            transform="matrix(0 1 1 0 0 0)"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiTablePagination is rendered when hiding the per page options 1`] = `
+<div
+  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+>
+  <div
+    class="euiFlexItem euiFlexItem--flexGrowZero"
+  />
+  <div
+    class="euiFlexItem euiFlexItem--flexGrowZero"
+  >
+    <div
+      class="euiPagination"
+      role="group"
+    >
+      <button
+        aria-label="Previous page"
+        class="euiButtonIcon euiButtonIcon--text"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiButtonIcon__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <defs>
+            <path
+              d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+              id="arrow_left-a"
+            />
+          </defs>
+          <use
+            fill-rule="nonzero"
+            href="#arrow_left-a"
+            transform="rotate(90 8 8)"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Page 1 of 5"
+        class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiPaginationButton euiPaginationButton--hideOnMobile"
+        data-test-subj="pagination-button-0"
+        type="button"
+      >
+        <span
+          class="euiButtonEmpty__content"
+        >
+          <span>
+            1
+          </span>
+        </span>
+      </button>
+      <button
+        aria-label="Page 2 of 5"
+        class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+        data-test-subj="pagination-button-1"
+        type="button"
+      >
+        <span
+          class="euiButtonEmpty__content"
+        >
+          <span>
+            2
+          </span>
+        </span>
+      </button>
+      <button
+        aria-label="Page 3 of 5"
+        class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiPaginationButton euiPaginationButton--hideOnMobile"
+        data-test-subj="pagination-button-2"
+        type="button"
+      >
+        <span
+          class="euiButtonEmpty__content"
+        >
+          <span>
+            3
+          </span>
+        </span>
+      </button>
+      <button
+        aria-label="Page 4 of 5"
+        class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiPaginationButton euiPaginationButton--hideOnMobile"
+        data-test-subj="pagination-button-3"
+        type="button"
+      >
+        <span
+          class="euiButtonEmpty__content"
+        >
+          <span>
+            4
+          </span>
+        </span>
+      </button>
+      <button
+        aria-label="Page 5 of 5"
+        class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiPaginationButton euiPaginationButton--hideOnMobile"
+        data-test-subj="pagination-button-4"
+        type="button"
+      >
+        <span
+          class="euiButtonEmpty__content"
+        >
+          <span>
+            5
+          </span>
+        </span>
+      </button>
+      <button
+        aria-label="Next page"
+        class="euiButtonIcon euiButtonIcon--text"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiButtonIcon__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <defs>
+            <path
+              d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+              id="arrow_right-a"
+            />
+          </defs>
+          <use
+            fill-rule="nonzero"
+            href="#arrow_right-a"
+            transform="matrix(0 1 1 0 0 0)"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </div>
 `;

--- a/src/components/table/table_pagination/table_pagination.js
+++ b/src/components/table/table_pagination/table_pagination.js
@@ -35,7 +35,7 @@ export class EuiTablePagination extends Component {
       activePage,
       itemsPerPage,
       itemsPerPageOptions,
-      disablePerPageOptions,
+      hidePerPageOptions,
       onChangeItemsPerPage,
       onChangePage,
       pageCount,
@@ -82,7 +82,7 @@ export class EuiTablePagination extends Component {
     return (
       <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
         <EuiFlexItem grow={false}>
-          {disablePerPageOptions ? null : itemsPerPagePopover}
+          {hidePerPageOptions ? null : itemsPerPagePopover}
         </EuiFlexItem>
 
         <EuiFlexItem grow={false}>
@@ -101,6 +101,7 @@ EuiTablePagination.propTypes = {
   activePage: PropTypes.number,
   itemsPerPage: PropTypes.number,
   itemsPerPageOptions: PropTypes.arrayOf(PropTypes.number),
+  hidePerPageOptions: PropTypes.bool,
   onChangeItemsPerPage: PropTypes.func,
   onChangePage: PropTypes.func,
   pageCount: PropTypes.number,
@@ -109,5 +110,5 @@ EuiTablePagination.propTypes = {
 EuiTablePagination.defaultProps = {
   itemsPerPage: 50,
   itemsPerPageOptions: [10, 20, 50, 100],
-  disablePerPageOptions: false
+  hidePerPageOptions: false
 };

--- a/src/components/table/table_pagination/table_pagination.js
+++ b/src/components/table/table_pagination/table_pagination.js
@@ -35,6 +35,7 @@ export class EuiTablePagination extends Component {
       activePage,
       itemsPerPage,
       itemsPerPageOptions,
+      disablePerPageOptions,
       onChangeItemsPerPage,
       onChangePage,
       pageCount,
@@ -62,22 +63,26 @@ export class EuiTablePagination extends Component {
       </EuiContextMenuItem>
     ));
 
+    const itemsPerPagePopover = (
+      <EuiPopover
+        id="customizablePagination"
+        button={button}
+        isOpen={this.state.isPopoverOpen}
+        closePopover={this.closePopover}
+        panelPaddingSize="none"
+        withTitle
+        anchorPosition="upRight"
+      >
+        <EuiContextMenuPanel
+          items={items}
+        />
+      </EuiPopover>
+    );
+
     return (
       <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" responsive={false}>
         <EuiFlexItem grow={false}>
-          <EuiPopover
-            id="customizablePagination"
-            button={button}
-            isOpen={this.state.isPopoverOpen}
-            closePopover={this.closePopover}
-            panelPaddingSize="none"
-            withTitle
-            anchorPosition="upRight"
-          >
-            <EuiContextMenuPanel
-              items={items}
-            />
-          </EuiPopover>
+          {disablePerPageOptions ? null : itemsPerPagePopover}
         </EuiFlexItem>
 
         <EuiFlexItem grow={false}>
@@ -104,4 +109,5 @@ EuiTablePagination.propTypes = {
 EuiTablePagination.defaultProps = {
   itemsPerPage: 50,
   itemsPerPageOptions: [10, 20, 50, 100],
+  disablePerPageOptions: false
 };

--- a/src/components/table/table_pagination/table_pagination.test.js
+++ b/src/components/table/table_pagination/table_pagination.test.js
@@ -5,11 +5,30 @@ import { requiredProps } from '../../../test/required_props';
 import { EuiTablePagination } from './table_pagination';
 
 describe('EuiTablePagination', () => {
+
+  const paginationProps = {
+    activePage: 1,
+    pageCount: 5,
+    onChangePage: jest.fn()
+  };
   test('is rendered', () => {
     const component = render(
       <EuiTablePagination
         {...requiredProps}
-        onChangePage={() => {}}
+        {...paginationProps}
+      />
+    );
+
+    expect(component)
+      .toMatchSnapshot();
+  });
+
+  test('is rendered when hiding the per page options', () => {
+    const component = render(
+      <EuiTablePagination
+        {...requiredProps}
+        {...paginationProps}
+        disablePerPageOptions={true}
       />
     );
 

--- a/src/components/table/table_pagination/table_pagination.test.js
+++ b/src/components/table/table_pagination/table_pagination.test.js
@@ -28,7 +28,7 @@ describe('EuiTablePagination', () => {
       <EuiTablePagination
         {...requiredProps}
         {...paginationProps}
-        disablePerPageOptions={true}
+        hidePerPageOptions={true}
       />
     );
 


### PR DESCRIPTION
On the APM team we are hoping to be able to hide the "per page" select box in table pagination, while still leaving the right-aligned page navigation buttons. (The default would be to show those options, which leaves everything working as-is.)

In master:
<img width="961" alt="screen shot 2018-08-21 at 3 41 49 pm" src="https://user-images.githubusercontent.com/159370/44425056-d5f35800-a558-11e8-883c-81ad17ccba4c.png">

vs in this PR:
<img width="961" alt="screen shot 2018-08-21 at 3 42 07 pm" src="https://user-images.githubusercontent.com/159370/44425072-dd1a6600-a558-11e8-8b4c-f1e9bc6058e4.png">

This PR addresses a few things:
- Adds a new property on the `pagination` object, called `disablePerPageOptions`
- The underlying `EuiTablePagination` component accepts this property and, when true, renders `null` in the left-aligned `EuiFlexItem` where that select box usually shows up, which keeps the rest of the layout in place
- `EuiBasicTable` also accepts this same property on its `pagination` object, and passes it along
- `EuiInMemoryTable` accepts the same property on its `pagination` object, and also passes it along (with some extra work since that object gets transformed a bit on the way in)
- Example docs for these tables are updated to include the property, where props are defined, and to show a toggle button that changes that prop to show what the table looks like with and without the per page options select box, without having to create a whole new table demo

Would be happy to jump on a zoom to discuss, talk through some other options, change property names or improve on the docs, etc. Thanks!