### PR TITLE
Fix combobox zindex

### DIFF
--- a/src/global_styling/variables/_z_index.scss
+++ b/src/global_styling/variables/_z_index.scss
@@ -1,5 +1,19 @@
 // Z-Index
 
+/*
+Remember that z-index is relative to parent and based on the stacking context. 
+z-indexs only compete against other z-indexs when they exist as children of
+that shared parent.
+
+That means a popover with a settings of 2, will still show above a modal
+with a setting of 100, if it is within that modal and not besides it.
+
+Generaly that means it's a good idea to consider things added to this file
+as competitive only as siblings.
+
+https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
+*/
+
 $euiZLevel0:          0;
 $euiZLevel1:          1000;
 $euiZLevel2:          2000;
@@ -14,8 +28,8 @@ $euiZLevel9:          9000;
 $euiZContent:         $euiZLevel0;
 $euiZHeader:          $euiZLevel1;
 $euiZContentMenu:     $euiZLevel2;
+$euiZComboBox:        $euiZContentMenu - 1;
 $euiZNavigation:      $euiZLevel4;
 $euiZMask:            $euiZLevel6;
 $euiZModal:           $euiZLevel8;
-$euiZComboBox:        $euiZModal + 10;
 $euiZToastList:       $euiZLevel9;


### PR DESCRIPTION
### Combo still works in modal/popovers

![image](https://user-images.githubusercontent.com/324519/44598690-ae82d200-a788-11e8-9c6b-f83aee6ceb82.png)

![image](https://user-images.githubusercontent.com/324519/44598767-f6095e00-a788-11e8-90c1-7bf3f2cef665.png)

### Combo now sits below flyouts/modals

![image](https://user-images.githubusercontent.com/324519/44598709-bf334800-a788-11e8-9d61-91b9026bf538.png)


### Before

![image](https://user-images.githubusercontent.com/324519/44598743-deca7080-a788-11e8-8ea9-74ec1430da56.png)



