### PR TITLE
Update the typedef for EuiSwitch's onChange prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `3.7.0`.
-
 - Added color and monotone icons for AWS and GCP. ([#1135](https://github.com/elastic/eui/pull/1135))
+
+**Bug fixes**
+
+- Fixed `onChange` typedef on `EuiSwitch` ([#1144](https://github.com/elastic/eui/pull/1144)
 
 ## [`3.7.0`](https://github.com/elastic/eui/tree/v3.7.0)
 

--- a/src/components/form/switch/index.d.ts
+++ b/src/components/form/switch/index.d.ts
@@ -6,12 +6,9 @@ declare module '@elastic/eui' {
   /**
    * @see './switch.js'
    */
-  export type EuiSwitchChangeCallback = (state: boolean) => void;
-
   export type EuiSwitchProps = CommonProps &
-    Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange'> & {
+    InputHTMLAttributes<HTMLInputElement> & {
       label?: ReactNode;
-      onChange?: EuiSwitchChangeCallback;
     };
 
   export const EuiSwitch: SFC<EuiSwitchProps>;


### PR DESCRIPTION
Fixes #1134 

There's no reason to omit `onChange` from the `InputHTMLAttributes<HTMLInputElement>`, as the callback function is passed straight into the input. This change removes that song and dance, cleanly indicating what props are available.