### PR TITLE
Fix color contrast function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `3.8.0`.
+**Bug fixes**
+
+- Fixed `makeHighContrastColor` sass mixin to properly output an accessible color contrast. ([#1158](https://github.com/elastic/eui/pull/1158))
 
 ## [`3.8.0`](https://github.com/elastic/eui/tree/v3.8.0)
 

--- a/src/global_styling/functions/_colors.scss
+++ b/src/global_styling/functions/_colors.scss
@@ -91,7 +91,7 @@
 
   @while ($contrast < 4.5) {
     $highContrastTextColor: shadeOrTint($highContrastTextColor, 5%, 5%);
-    $contrast: contrastRatio($highContrastTextColor, $euiColorEmptyShade);
+    $contrast: contrastRatio($highContrastTextColor, $background);
   }
 
   @return $highContrastTextColor;


### PR DESCRIPTION
Fixes #1156 

The color contrast function had a bad variable in it that was causing it to do its contrast check against the wrong color.

Hat tip to @chandlerprall for spotting it over my shoulder.