### PR TITLE
fix EuiToolTip from setting state on unmounted component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed `EuiTooltip` to interact correctly when the anchor is a disabled form element ([#1158](https://github.com/elastic/eui/pull/1158))
 - Fixed `EuiButton` (with icon) and `EuiButtonEmpty` truncation ([#1145](https://github.com/elastic/eui/pull/1145))
 - Fixed alignment and coloring of form control clear button ([#1145](https://github.com/elastic/eui/pull/1145))
+- Fixed `EuiToolTip` from setting state after component unmounts ([#1163](https://github.com/elastic/eui/pull/1163))
 
 ## [`3.8.0`](https://github.com/elastic/eui/tree/v3.8.0)
 

--- a/src/components/tool_tip/tool_tip.js
+++ b/src/components/tool_tip/tool_tip.js
@@ -62,10 +62,6 @@ export class EuiToolTip extends Component {
   }
 
   testAnchor = () => {
-    if (!this._isMounted) {
-      return;
-    }
-
     // when the tooltip is visible, this checks if the anchor is still part of document
     // this fixes when the react root is removed from the dom without unmounting
     // https://github.com/elastic/eui/issues/1105
@@ -125,7 +121,9 @@ export class EuiToolTip extends Component {
   };
 
   hideToolTip = () => {
-    this.setState({ visible: false });
+    if (this._isMounted) {
+      this.setState({ visible: false });
+    }
   };
 
   onFocus = () => {

--- a/src/components/tool_tip/tool_tip.js
+++ b/src/components/tool_tip/tool_tip.js
@@ -47,6 +47,14 @@ export class EuiToolTip extends Component {
     };
   }
 
+  componentDidMount() {
+    this._isMounted = true;
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
   componentDidUpdate(prevProps, prevState) {
     if (prevState.visible === false && this.state.visible === true) {
       requestAnimationFrame(this.testAnchor);
@@ -54,6 +62,10 @@ export class EuiToolTip extends Component {
   }
 
   testAnchor = () => {
+    if (!this._isMounted) {
+      return;
+    }
+
     // when the tooltip is visible, this checks if the anchor is still part of document
     // this fixes when the react root is removed from the dom without unmounting
     // https://github.com/elastic/eui/issues/1105


### PR DESCRIPTION
Fixes Kibana issue https://github.com/elastic/kibana/issues/22543

Putting an EuiToolTip in a popover, opening the popover, and then using `esc` to close the popover causes `hideToolTip` to set state on an unmounted component.