### PR TITLE
Add size properties to EuiModal

### DIFF
--- a/src-docs/src/views/modal/modal_example.js
+++ b/src-docs/src/views/modal/modal_example.js
@@ -25,6 +25,10 @@ import { OverflowTest } from './overflow_test';
 const overflowTestSource = require('!!raw-loader!./overflow_test');
 const overflowTestHtml = renderToHtml(OverflowTest);
 
+import { ModalSizing } from './modal_sizing';
+const modalSizingSource = require('!!raw-loader!./modal_sizing');
+const modalSizingHtml = renderToHtml(ModalSizing);
+
 export const ModalExample = {
   title: 'Modal',
   sections: [{
@@ -62,7 +66,7 @@ export const ModalExample = {
     props: { EuiConfirmModal },
     demo: <ConfirmModal />,
   }, {
-    title: 'Overflow overflow test',
+    title: 'Overflow test',
     source: [{
       type: GuideSectionTypes.JS,
       code: overflowTestSource,
@@ -72,10 +76,28 @@ export const ModalExample = {
     }],
     text: (
       <p>
-          This demo is to test long overflowing body content.
+        This demo is to test long overflowing body content.
       </p>
     ),
     props: { EuiConfirmModal },
     demo: <OverflowTest />,
+  }, {
+    title: 'Applying size limits',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: modalSizingSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: modalSizingHtml,
+    }],
+    text: (
+      <p>
+        In circumstances where the content in <EuiCode>EuiModalBody</EuiCode> may change
+        dynamically (e.g. search filtering on a table, tabbed content, etc.), you may want to set
+        specific size constraints on the modal to prevent jumpiness.
+      </p>
+    ),
+    props: { EuiConfirmModal },
+    demo: <ModalSizing />,
   }],
 };

--- a/src-docs/src/views/modal/modal_sizing.js
+++ b/src-docs/src/views/modal/modal_sizing.js
@@ -1,0 +1,180 @@
+import React, {
+  Component,
+  Fragment,
+} from 'react';
+
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiOverlayMask,
+  EuiText,
+  EuiTabbedContent,
+  EuiTitle,
+  EuiSpacer,
+} from '../../../../src/components';
+
+export class ModalSizing extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isModalVisible: false,
+      isSwitchChecked: true,
+    };
+
+    this.closeModal = this.closeModal.bind(this);
+    this.showModal = this.showModal.bind(this);
+
+    this.tabs = [{
+      id: 'drake',
+      name: 'Drake',
+      content: (
+        <Fragment>
+          <EuiSpacer />
+          <EuiTitle size="s"><h3>Introduction</h3></EuiTitle>
+          <EuiSpacer />
+          <EuiText>
+            Drake is a common dragon type in popular culture. Owing to the complex history of Drake as
+            both a word and a popular last name, some clarification is needed in regards to the Dragon
+            Type of Drake.
+          </EuiText>
+          <EuiSpacer />
+          <EuiTitle size="xxs"><h6>Physical Description</h6></EuiTitle>
+          <EuiSpacer />
+          <EuiText>
+            The drake is a dragon with four limbs, much like a lizard, although usually far larger in
+            size than the average lizard. A particularly potent example of a drake in the natural world is
+            the Komodo Dragon, a large species of minotaur lizard in Indonesia.
+          </EuiText>
+        </Fragment>
+      ),
+    }, {
+      id: 'seaserpent',
+      name: 'Sea Serpent',
+      content: (
+        <Fragment>
+          <EuiSpacer />
+          <EuiTitle size="s"><h3>Introduction</h3></EuiTitle>
+          <EuiSpacer />
+          <EuiText>
+            Reported in all the oceans of the world, Sea Serpents have been known from ancient times. Sea
+            Serpents live in both fresh and salt waters, [6] and they were the most feared creatures of
+            the ocean with hundreds of reported sightings to inspire terror. People often reported
+            sighting during the warmer months, and it is widely believed that Sea Serpents only appear in
+            still, warm weather. However, reports of Sea Serpents in particularly cold waters and during
+            storms indicate these creatures may appear at any time.
+          </EuiText>
+          <EuiSpacer />
+          <EuiTitle size="xxs"><h6>Physical Description</h6></EuiTitle>
+          <EuiSpacer />
+          <EuiText>
+            Sea Serpents range in size drastically, from 30 feet to 300 feet (9 m - 90 m) long with bodies
+            ranging from 5 feet to 20 feet (1 m - 6 m) thick. They range in color from greyish to chocolate
+            to black. Some sea serpents have a mane down their necks, similar to a horse; others have heads
+            shaped like those of a horse and the mane presented resembles seaweed. Some reports claim that
+            sea serpents have a single horn, approximately one foot (31 cm) in length shaped like a marlinspike.
+            While many sightings of sea serpents claim they have serpentine bodies without limbs that end with
+            a long, steering tail, there are just as many reports of sea serpents with webbed limbs, fins, or
+            even wing-like appendages, likely used for steering in the water. While the description of
+            individual Sea Serpents vary, there is one particular attribute that remains the same. They all have
+            large eyes, usually blue or pewter in color.
+          </EuiText>
+        </Fragment>
+      ),
+    }, {
+      id: 'wyvern',
+      name: 'Wyvern',
+      content: (
+        <Fragment>
+          <EuiSpacer />
+          <EuiTitle size="s"><h3>Introduction</h3></EuiTitle>
+          <EuiSpacer />
+          <EuiText>
+            Wyverns are highly aggressive and predatory creatures. They are found in the medieval bestiaries
+            of Europe, noticeably those of England and France. Believed that a wyvern will destroy
+            whatever it comes upon, they are considered malevolent and dangerous and slain on sight.
+          </EuiText>
+          <EuiSpacer />
+          <EuiText>
+            The Wyvern has the body of a serpent, the head of a dragon, the wings of a bat, and a long serpent tail.
+          </EuiText>
+        </Fragment>
+      ),
+    }];
+  }
+
+  onSwitchChange = () => {
+    this.setState({
+      isSwitchChecked: !this.state.isSwitchChecked,
+    });
+  }
+
+  closeModal() {
+    this.setState({ isModalVisible: false });
+  }
+
+  showModal() {
+    this.setState({ isModalVisible: true });
+  }
+
+  render() {
+
+    let modal;
+
+    if (this.state.isModalVisible) {
+      modal = (
+        <EuiOverlayMask>
+          <EuiModal
+            onClose={this.closeModal}
+            width={50}
+            height={75}
+            maxHeight="600px"
+          >
+            <EuiModalHeader>
+              <EuiModalHeaderTitle >
+                Basic dragon information
+              </EuiModalHeaderTitle>
+            </EuiModalHeader>
+
+            <EuiModalBody>
+              <EuiTabbedContent
+                tabs={this.tabs}
+                initialSelectedTab={this.tabs[0]}
+                onTabClick={(tab) => { console.log('clicked tab', tab); }}
+              />
+            </EuiModalBody>
+
+            <EuiModalFooter>
+              <EuiButtonEmpty
+                onClick={this.closeModal}
+              >
+                Cancel
+              </EuiButtonEmpty>
+
+              <EuiButton
+                onClick={this.closeModal}
+                fill
+              >
+                Save
+              </EuiButton>
+            </EuiModalFooter>
+          </EuiModal>
+        </EuiOverlayMask>
+      );
+    }
+    return (
+      <div>
+        <EuiButton onClick={this.showModal}>
+          Show fixed size Modal
+        </EuiButton>
+
+        {modal}
+      </div>
+    );
+  }
+}

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -23,10 +23,37 @@ export class EuiModal extends Component {
       className,
       children,
       onClose, // eslint-disable-line no-unused-vars
+      style,
+      height,
+      maxHeight,
+      width,
+      maxWidth,
       ...rest
     } = this.props;
 
     const classes = classnames('euiModal', className);
+
+    let divStyle = { ...style };
+
+    if (maxWidth !== false) {
+      const value = typeof maxWidth === 'number' ? `${maxWidth}px` : maxWidth;
+      divStyle = { ...divStyle, maxWidth: value };
+    }
+
+    if (width !== false) {
+      const value = typeof width === 'number' ? `${width}vw` : width;
+      divStyle = { ...divStyle, width: value };
+    }
+
+    if (maxHeight !== false) {
+      const value = typeof maxHeight === 'number' ? `${maxHeight}px` : maxHeight;
+      divStyle = { ...divStyle, maxHeight: value };
+    }
+
+    if (height !== false) {
+      const value = typeof height === 'number' ? `${height}vh` : height;
+      divStyle = { ...divStyle, height: value };
+    }
 
     return (
       <FocusTrap
@@ -43,6 +70,7 @@ export class EuiModal extends Component {
           className={classes}
           onKeyDown={this.onKeyDown}
           tabIndex={0}
+          style={divStyle}
           {...rest}
         >
           <EuiButtonIcon
@@ -65,4 +93,63 @@ EuiModal.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
   onClose: PropTypes.func.isRequired,
+  style: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+  ]),
+
+  /**
+   * Set a modal height regardless of content size.
+   * Set to `false` to not set a height,
+   * set to a number for a custom height in vh,
+   * set to a string for a custom height in custom measurement.
+   */
+  height: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+
+  /**
+   * Set a max modal width regardless of content size.
+   * Set to `false` to not restrict the maximum height,
+   * set to a number for a custom max-height in px,
+   * set to a string for a custom max-height in custom measurement.
+   */
+  maxHeight: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+
+  /**
+   * Set a modal width regardless of content size.
+   * Set to `false` to not set a width,
+   * set to a number for a custom width in vw,
+   * set to a string for a custom width in custom measurement.
+   */
+  width: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+
+  /**
+   * Set a max modal width regardless of content size.
+   * Set to `false` to not restrict the maximum width,
+   * set to a number for a custom max-width in px,
+   * set to a string for a custom max-width in custom measurement.
+   */
+  maxWidth: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+};
+
+EuiModal.defaultProps = {
+  width: false,
+  maxWidth: false,
+  height: false,
+  maxHeight: false,
 };


### PR DESCRIPTION
Fixes #1154 

Adds `height`, `maxHeight`, `width`, and `maxWidth` to `EuiModal`.

The need for these properties occurrs in Canvas where users can search/filter table (workpad list) and grid (element types) content thus creating a situation where the height of the`EuiModalBody` content is dynamic. 

To prevent the modal from being 'jumpy' (see https://github.com/elastic/kibana-canvas/issues/869 ) , we apply a height (in `vh`) to the modal. Related, since we're using `vh`, we don't want the modal to get too tall on large displays so we limit modal height using `max-height`.

🐉 
![fixed-modal-height](https://user-images.githubusercontent.com/446285/45118208-8185d600-b11d-11e8-9a74-def539c9f3b3.gif)
