### PR TITLE
Adds maxWidth prop to EuiModal

### DIFF
--- a/src-docs/src/views/modal/modal_example.js
+++ b/src-docs/src/views/modal/modal_example.js
@@ -62,7 +62,7 @@ export const ModalExample = {
     props: { EuiConfirmModal },
     demo: <ConfirmModal />,
   }, {
-    title: 'Overflow overflow test',
+    title: 'Overflow test',
     source: [{
       type: GuideSectionTypes.JS,
       code: overflowTestSource,
@@ -72,7 +72,7 @@ export const ModalExample = {
     }],
     text: (
       <p>
-          This demo is to test long overflowing body content.
+          This demo is to test long overflowing body content. It also demonstrates the <EuiCode>maxWidth</EuiCode> property.
       </p>
     ),
     props: { EuiConfirmModal },

--- a/src-docs/src/views/modal/overflow_test.js
+++ b/src-docs/src/views/modal/overflow_test.js
@@ -50,7 +50,7 @@ export class OverflowTest extends Component {
         <EuiOverlayMask>
           <EuiModal
             onClose={this.closeModal}
-            style={{ width: '800px' }}
+            maxWidth
           >
             <EuiModalHeader>
               <EuiModalHeaderTitle >

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -23,6 +23,10 @@
   }
 }
 
+.euiModal--maxWidth-default {
+  max-width: map-get($euiBreakpoints, "m");
+}
+
 .euiModal--confirmation {
   width: 450px;
   min-width: auto;

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -23,10 +23,21 @@ export class EuiModal extends Component {
       className,
       children,
       onClose, // eslint-disable-line no-unused-vars
+      maxWidth,
+      style,
       ...rest
     } = this.props;
 
-    const classes = classnames('euiModal', className);
+    let newStyle;
+    let widthClassName;
+    if (maxWidth === true) {
+      widthClassName = 'euiModal--maxWidth-default';
+    } else if (maxWidth !== false) {
+      const value = typeof maxWidth === 'number' ? `${maxWidth}px` : maxWidth;
+      newStyle = { ...style, maxWidth: value };
+    }
+
+    const classes = classnames('euiModal', widthClassName, className);
 
     return (
       <FocusTrap
@@ -43,6 +54,7 @@ export class EuiModal extends Component {
           className={classes}
           onKeyDown={this.onKeyDown}
           tabIndex={0}
+          style={newStyle || style}
           {...rest}
         >
           <EuiButtonIcon
@@ -65,4 +77,20 @@ EuiModal.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
   onClose: PropTypes.func.isRequired,
+  /**
+   * Sets the max-width of the modal.
+   * Set to `false` to not restrict the width,
+   * set to `true` to use the default (`euiBreakpoints 'm'`),
+   * set to a number for a custom width in px,
+   * set to a string for a custom width in custom measurement.
+   */
+  maxWidth: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+};
+
+EuiModal.defaultProps = {
+  maxWidth: false,
 };


### PR DESCRIPTION
Adds a `maxWidth` prop to `EuiModal` that is disabled by default. 

When enabled, a default class is applied that sets the `max-width` to the EUI medium breakpoint value. Users can optionally provide a number value that converts to a max px width value, or they can provide a string that includes an alternative form of measurement (e.g. `90vw`).