### PR TITLE
Fix modal min-width issue in IE11

### DIFF
--- a/src-docs/src/views/modal/modal.js
+++ b/src-docs/src/views/modal/modal.js
@@ -87,7 +87,6 @@ export class Modal extends Component {
         <EuiOverlayMask>
           <EuiModal
             onClose={this.closeModal}
-            style={{ width: '400px' }}
           >
             <EuiModalHeader>
               <EuiModalHeaderTitle >

--- a/src/components/modal/_index.scss
+++ b/src/components/modal/_index.scss
@@ -1,1 +1,3 @@
+@import "../form/variables";
+
 @import "modal";

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -1,6 +1,8 @@
 /**
  * 1. Fix IE overflow issue (min-height) by adding a separate wrapper for the
  *    flex display. https://github.com/philipwalton/flexbugs#flexbug-3
+ * 2. IE has trouble with min-widths on flex elements. Use the pixel value
+ *    from our forms since that's usually the smallest we want them.
  */
 
 .euiModal {
@@ -8,11 +10,11 @@
   @include euiBottomShadowLarge($adjustBorders: true);
   display: flex; /* 1 */
 
-  position: relative;
+  position: relatie;
   background-color: $euiColorEmptyShade;
   border-radius: $euiBorderRadius;
   z-index: $euiZModal;
-  min-width: 50%;
+  min-width: $euiFormMaxWidth;
   animation: euiModal $euiAnimSpeedSlow $euiAnimSlightBounce;
 
   .euiModal__flex { /* 1 */


### PR DESCRIPTION
### Summary

IE has trouble with min-widths and flex boxes if not used as as a pixel value. This PR makes the min-width use our max-form width (400px) as the min-width we'd accept on a modal. I picked that value because it's good for short notices, and our modals tend to hold input values of some kind. I updated our default modal to not use style tags for width so this would be a better default for IE11.

![image](https://user-images.githubusercontent.com/324519/45242469-ffc0b480-b2a4-11e8-80d6-458e92314d39.png)


### Checklist

- [x] This works well on mobile
- [x] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [x] Proper documentation examples were added
- [ ] A changelog entry exists and is marked appropriately
- [x] This was checked for breaking changes or labeled appropriately
- [x] Jest tests were added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
