### PR TITLE
Accessibility/tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `infraApp` icon ([#1161](https://github.com/elastic/eui/pull/1161))
 - Added sizes to `EuiButtonIcon` ([#1145](https://github.com/elastic/eui/pull/1145))
 - Added `singleSelection.asPlainText` prop to `EuiComboBox` ([#1139](https://github.com/elastic/eui/pull/1139))
+- Added proper aria labeling to `EuiSearchBar` and `EuiBasicTable` so searching is properly announced ([#1181](https://github.com/elastic/eui/pull/1181))
 
 **Bug fixes**
 

--- a/src/components/basic_table/__snapshots__/basic_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.js.snap
@@ -11,7 +11,8 @@ exports[`EuiBasicTable cellProps renders cells with custom props from a callback
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="assertive"
+          aria-live="polite"
+          aria-relevant="text"
           role="status"
         >
           Below is a table of 
@@ -104,7 +105,8 @@ exports[`EuiBasicTable cellProps renders rows with custom props from an object 1
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="assertive"
+          aria-live="polite"
+          aria-relevant="text"
           role="status"
         >
           Below is a table of 
@@ -199,7 +201,8 @@ exports[`EuiBasicTable empty is rendered 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="assertive"
+          aria-live="polite"
+          aria-relevant="text"
           role="status"
         >
           Below is a table of 
@@ -245,7 +248,8 @@ exports[`EuiBasicTable empty renders a node as a custom message 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="assertive"
+          aria-live="polite"
+          aria-relevant="text"
           role="status"
         >
           Below is a table of 
@@ -299,7 +303,8 @@ exports[`EuiBasicTable empty renders a string as a custom message 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="assertive"
+          aria-live="polite"
+          aria-relevant="text"
           role="status"
         >
           Below is a table of 
@@ -345,7 +350,8 @@ exports[`EuiBasicTable itemIdToExpandedRowMap renders an expanded row 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="assertive"
+          aria-live="polite"
+          aria-relevant="text"
           role="status"
         >
           Below is a table of 
@@ -444,7 +450,8 @@ exports[`EuiBasicTable rowProps renders rows with custom props from a callback 1
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="assertive"
+          aria-live="polite"
+          aria-relevant="text"
           role="status"
         >
           Below is a table of 
@@ -537,7 +544,8 @@ exports[`EuiBasicTable rowProps renders rows with custom props from an object 1`
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="assertive"
+          aria-live="polite"
+          aria-relevant="text"
           role="status"
         >
           Below is a table of 
@@ -630,7 +638,8 @@ exports[`EuiBasicTable with pagination - 2nd page 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="assertive"
+          aria-live="polite"
+          aria-relevant="text"
           role="status"
         >
           Below is a table of 
@@ -709,7 +718,8 @@ exports[`EuiBasicTable with pagination 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="assertive"
+          aria-live="polite"
+          aria-relevant="text"
           role="status"
         >
           Below is a table of 
@@ -804,7 +814,8 @@ exports[`EuiBasicTable with pagination and error 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="assertive"
+          aria-live="polite"
+          aria-relevant="text"
           role="status"
         >
           Below is a table of 
@@ -856,7 +867,8 @@ exports[`EuiBasicTable with pagination and selection 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="assertive"
+          aria-live="polite"
+          aria-relevant="text"
           role="status"
         >
           Below is a table of 
@@ -1013,7 +1025,8 @@ exports[`EuiBasicTable with pagination, hiding the per page options 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="assertive"
+          aria-live="polite"
+          aria-relevant="text"
           role="status"
         >
           Below is a table of 
@@ -1123,7 +1136,8 @@ exports[`EuiBasicTable with pagination, selection and sorting 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="assertive"
+          aria-live="polite"
+          aria-relevant="text"
           role="status"
         >
           Below is a table of 
@@ -1297,7 +1311,8 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="assertive"
+          aria-live="polite"
+          aria-relevant="text"
           role="status"
         >
           Below is a table of 
@@ -1562,7 +1577,8 @@ exports[`EuiBasicTable with pagination, selection, sorting and column dataType 1
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="assertive"
+          aria-live="polite"
+          aria-relevant="text"
           role="status"
         >
           Below is a table of 
@@ -1736,7 +1752,8 @@ exports[`EuiBasicTable with pagination, selection, sorting and column renderer 1
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="assertive"
+          aria-live="polite"
+          aria-relevant="text"
           role="status"
         >
           Below is a table of 
@@ -1910,7 +1927,8 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="assertive"
+          aria-live="polite"
+          aria-relevant="text"
           role="status"
         >
           Below is a table of 
@@ -2169,7 +2187,8 @@ exports[`EuiBasicTable with pagination, selection, sorting, column renderer and 
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="assertive"
+          aria-live="polite"
+          aria-relevant="text"
           role="status"
         >
           Below is a table of 
@@ -2329,7 +2348,8 @@ exports[`EuiBasicTable with sortable columns and sorting disabled 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="assertive"
+          aria-live="polite"
+          aria-relevant="text"
           role="status"
         >
           Below is a table of 
@@ -2427,7 +2447,8 @@ exports[`EuiBasicTable with sorting 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="assertive"
+          aria-live="polite"
+          aria-relevant="text"
           role="status"
         >
           Below is a table of 

--- a/src/components/basic_table/__snapshots__/basic_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.js.snap
@@ -9,6 +9,16 @@ exports[`EuiBasicTable cellProps renders cells with custom props from a callback
     <EuiTable
       responsive={true}
     >
+      <EuiScreenReaderOnly>
+        <caption
+          aria-live="assertive"
+          role="status"
+        >
+          Below is a table of 
+          3
+           items.
+        </caption>
+      </EuiScreenReaderOnly>
       <EuiTableHeader>
         <EuiTableHeaderCell
           align="left"
@@ -92,6 +102,16 @@ exports[`EuiBasicTable cellProps renders rows with custom props from an object 1
     <EuiTable
       responsive={true}
     >
+      <EuiScreenReaderOnly>
+        <caption
+          aria-live="assertive"
+          role="status"
+        >
+          Below is a table of 
+          3
+           items.
+        </caption>
+      </EuiScreenReaderOnly>
       <EuiTableHeader>
         <EuiTableHeaderCell
           align="left"
@@ -177,6 +197,16 @@ exports[`EuiBasicTable empty is rendered 1`] = `
     <EuiTable
       responsive={true}
     >
+      <EuiScreenReaderOnly>
+        <caption
+          aria-live="assertive"
+          role="status"
+        >
+          Below is a table of 
+          0
+           items.
+        </caption>
+      </EuiScreenReaderOnly>
       <EuiTableHeader>
         <EuiTableHeaderCell
           align="left"
@@ -213,6 +243,16 @@ exports[`EuiBasicTable empty renders a node as a custom message 1`] = `
     <EuiTable
       responsive={true}
     >
+      <EuiScreenReaderOnly>
+        <caption
+          aria-live="assertive"
+          role="status"
+        >
+          Below is a table of 
+          0
+           items.
+        </caption>
+      </EuiScreenReaderOnly>
       <EuiTableHeader>
         <EuiTableHeaderCell
           align="left"
@@ -257,6 +297,16 @@ exports[`EuiBasicTable empty renders a string as a custom message 1`] = `
     <EuiTable
       responsive={true}
     >
+      <EuiScreenReaderOnly>
+        <caption
+          aria-live="assertive"
+          role="status"
+        >
+          Below is a table of 
+          0
+           items.
+        </caption>
+      </EuiScreenReaderOnly>
       <EuiTableHeader>
         <EuiTableHeaderCell
           align="left"
@@ -293,6 +343,16 @@ exports[`EuiBasicTable itemIdToExpandedRowMap renders an expanded row 1`] = `
     <EuiTable
       responsive={true}
     >
+      <EuiScreenReaderOnly>
+        <caption
+          aria-live="assertive"
+          role="status"
+        >
+          Below is a table of 
+          3
+           items.
+        </caption>
+      </EuiScreenReaderOnly>
       <EuiTableHeader>
         <EuiTableHeaderCell
           align="left"
@@ -382,6 +442,16 @@ exports[`EuiBasicTable rowProps renders rows with custom props from a callback 1
     <EuiTable
       responsive={true}
     >
+      <EuiScreenReaderOnly>
+        <caption
+          aria-live="assertive"
+          role="status"
+        >
+          Below is a table of 
+          3
+           items.
+        </caption>
+      </EuiScreenReaderOnly>
       <EuiTableHeader>
         <EuiTableHeaderCell
           align="left"
@@ -465,6 +535,16 @@ exports[`EuiBasicTable rowProps renders rows with custom props from an object 1`
     <EuiTable
       responsive={true}
     >
+      <EuiScreenReaderOnly>
+        <caption
+          aria-live="assertive"
+          role="status"
+        >
+          Below is a table of 
+          3
+           items.
+        </caption>
+      </EuiScreenReaderOnly>
       <EuiTableHeader>
         <EuiTableHeaderCell
           align="left"
@@ -548,6 +628,16 @@ exports[`EuiBasicTable with pagination - 2nd page 1`] = `
     <EuiTable
       responsive={true}
     >
+      <EuiScreenReaderOnly>
+        <caption
+          aria-live="assertive"
+          role="status"
+        >
+          Below is a table of 
+          2
+           items.
+        </caption>
+      </EuiScreenReaderOnly>
       <EuiTableHeader>
         <EuiTableHeaderCell
           align="left"
@@ -617,6 +707,16 @@ exports[`EuiBasicTable with pagination 1`] = `
     <EuiTable
       responsive={true}
     >
+      <EuiScreenReaderOnly>
+        <caption
+          aria-live="assertive"
+          role="status"
+        >
+          Below is a table of 
+          3
+           items.
+        </caption>
+      </EuiScreenReaderOnly>
       <EuiTableHeader>
         <EuiTableHeaderCell
           align="left"
@@ -702,6 +802,16 @@ exports[`EuiBasicTable with pagination and error 1`] = `
     <EuiTable
       responsive={true}
     >
+      <EuiScreenReaderOnly>
+        <caption
+          aria-live="assertive"
+          role="status"
+        >
+          Below is a table of 
+          3
+           items.
+        </caption>
+      </EuiScreenReaderOnly>
       <EuiTableHeader>
         <EuiTableHeaderCell
           align="left"
@@ -744,6 +854,16 @@ exports[`EuiBasicTable with pagination and selection 1`] = `
     <EuiTable
       responsive={true}
     >
+      <EuiScreenReaderOnly>
+        <caption
+          aria-live="assertive"
+          role="status"
+        >
+          Below is a table of 
+          3
+           items.
+        </caption>
+      </EuiScreenReaderOnly>
       <EuiTableHeader>
         <EuiTableHeaderCellCheckbox
           key="_selection_column_h"
@@ -891,6 +1011,16 @@ exports[`EuiBasicTable with pagination, hiding the per page options 1`] = `
     <EuiTable
       responsive={true}
     >
+      <EuiScreenReaderOnly>
+        <caption
+          aria-live="assertive"
+          role="status"
+        >
+          Below is a table of 
+          3
+           items.
+        </caption>
+      </EuiScreenReaderOnly>
       <EuiTableHeader>
         <EuiTableHeaderCell
           align="left"
@@ -991,6 +1121,16 @@ exports[`EuiBasicTable with pagination, selection and sorting 1`] = `
     <EuiTable
       responsive={true}
     >
+      <EuiScreenReaderOnly>
+        <caption
+          aria-live="assertive"
+          role="status"
+        >
+          Below is a table of 
+          3
+           items.
+        </caption>
+      </EuiScreenReaderOnly>
       <EuiTableHeader>
         <EuiTableHeaderCellCheckbox
           key="_selection_column_h"
@@ -1155,6 +1295,16 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
     <EuiTable
       responsive={true}
     >
+      <EuiScreenReaderOnly>
+        <caption
+          aria-live="assertive"
+          role="status"
+        >
+          Below is a table of 
+          3
+           items.
+        </caption>
+      </EuiScreenReaderOnly>
       <EuiTableHeader>
         <EuiTableHeaderCellCheckbox
           key="_selection_column_h"
@@ -1410,6 +1560,16 @@ exports[`EuiBasicTable with pagination, selection, sorting and column dataType 1
     <EuiTable
       responsive={true}
     >
+      <EuiScreenReaderOnly>
+        <caption
+          aria-live="assertive"
+          role="status"
+        >
+          Below is a table of 
+          3
+           items.
+        </caption>
+      </EuiScreenReaderOnly>
       <EuiTableHeader>
         <EuiTableHeaderCellCheckbox
           key="_selection_column_h"
@@ -1574,6 +1734,16 @@ exports[`EuiBasicTable with pagination, selection, sorting and column renderer 1
     <EuiTable
       responsive={true}
     >
+      <EuiScreenReaderOnly>
+        <caption
+          aria-live="assertive"
+          role="status"
+        >
+          Below is a table of 
+          3
+           items.
+        </caption>
+      </EuiScreenReaderOnly>
       <EuiTableHeader>
         <EuiTableHeaderCellCheckbox
           key="_selection_column_h"
@@ -1738,6 +1908,16 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
     <EuiTable
       responsive={true}
     >
+      <EuiScreenReaderOnly>
+        <caption
+          aria-live="assertive"
+          role="status"
+        >
+          Below is a table of 
+          3
+           items.
+        </caption>
+      </EuiScreenReaderOnly>
       <EuiTableHeader>
         <EuiTableHeaderCellCheckbox
           key="_selection_column_h"
@@ -1987,6 +2167,16 @@ exports[`EuiBasicTable with pagination, selection, sorting, column renderer and 
     <EuiTable
       responsive={true}
     >
+      <EuiScreenReaderOnly>
+        <caption
+          aria-live="assertive"
+          role="status"
+        >
+          Below is a table of 
+          3
+           items.
+        </caption>
+      </EuiScreenReaderOnly>
       <EuiTableHeader>
         <EuiTableHeaderCellCheckbox
           key="_selection_column_h"
@@ -2137,6 +2327,16 @@ exports[`EuiBasicTable with sortable columns and sorting disabled 1`] = `
     <EuiTable
       responsive={true}
     >
+      <EuiScreenReaderOnly>
+        <caption
+          aria-live="assertive"
+          role="status"
+        >
+          Below is a table of 
+          3
+           items.
+        </caption>
+      </EuiScreenReaderOnly>
       <EuiTableHeader>
         <EuiTableHeaderCell
           align="left"
@@ -2225,6 +2425,16 @@ exports[`EuiBasicTable with sorting 1`] = `
     <EuiTable
       responsive={true}
     >
+      <EuiScreenReaderOnly>
+        <caption
+          aria-live="assertive"
+          role="status"
+        >
+          Below is a table of 
+          3
+           items.
+        </caption>
+      </EuiScreenReaderOnly>
       <EuiTableHeader>
         <EuiTableHeaderCell
           align="left"

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
@@ -106,6 +106,17 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
           <table
             className="euiTable euiTable--responsive"
           >
+            <EuiScreenReaderOnly>
+              <caption
+                aria-live="assertive"
+                className="euiScreenReaderOnly"
+                role="status"
+              >
+                Below is a table of 
+                2
+                 items.
+              </caption>
+            </EuiScreenReaderOnly>
             <EuiTableHeader>
               <thead>
                 <tr>

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
@@ -108,7 +108,8 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
           >
             <EuiScreenReaderOnly>
               <caption
-                aria-live="assertive"
+                aria-live="polite"
+                aria-relevant="text"
                 className="euiScreenReaderOnly"
                 role="status"
               >

--- a/src/components/basic_table/basic_table.js
+++ b/src/components/basic_table/basic_table.js
@@ -29,6 +29,7 @@ import { LoadingTableBody } from './loading_table_body';
 import { EuiTableHeaderMobile } from '../table/mobile/table_header_mobile';
 import { EuiTableSortMobile } from '../table/mobile/table_sort_mobile';
 import { withRequiredProp } from '../../utils/prop_types/with_required_prop';
+import { EuiScreenReaderOnly } from '../accessibility';
 
 const dataTypesProfiles = {
   auto: {
@@ -341,6 +342,7 @@ export class EuiBasicTable extends Component {
     const { compressed, responsive } = this.props;
 
     const mobileHeader = responsive ? (<EuiTableHeaderMobile>{this.renderTableMobileSort()}</EuiTableHeaderMobile>) : undefined;
+    const caption = this.renderTableCaption();
     const head = this.renderTableHead();
     const body = this.renderTableBody();
     return (
@@ -348,7 +350,11 @@ export class EuiBasicTable extends Component {
         ref={element => { this.tableElement = element; }}
       >
         {mobileHeader}
-        <EuiTable responsive={responsive} compressed={compressed}>{head}{body}</EuiTable>
+        <EuiTable responsive={responsive} compressed={compressed}>
+          {caption}
+          {head}
+          {body}
+        </EuiTable>
       </div>
     );
   }
@@ -378,6 +384,17 @@ export class EuiBasicTable extends Component {
     });
 
     return items.length ? <EuiTableSortMobile items={items} /> : null;
+  }
+
+  renderTableCaption() {
+
+    const { items } = this.props;
+
+    return (
+      <EuiScreenReaderOnly>
+        <caption role="status" aria-live="assertive">Below is a table of {items.length} items.</caption>
+      </EuiScreenReaderOnly>
+    );
   }
 
   renderTableHead() {

--- a/src/components/basic_table/basic_table.js
+++ b/src/components/basic_table/basic_table.js
@@ -392,7 +392,7 @@ export class EuiBasicTable extends Component {
 
     return (
       <EuiScreenReaderOnly>
-        <caption role="status" aria-live="assertive">Below is a table of {items.length} items.</caption>
+        <caption role="status" aria-relevant="text" aria-live="polite">Below is a table of {items.length} items.</caption>
       </EuiScreenReaderOnly>
     );
   }

--- a/src/components/search_bar/search_box.js
+++ b/src/components/search_bar/search_box.js
@@ -48,6 +48,13 @@ export class EuiSearchBox extends Component {
       ...rest
     } = this.props;
 
+    let ariaLabel;
+    if (incremental) {
+      ariaLabel = 'This is a search bar. As you type, the results lower in the page will automatically filter.';
+    } else {
+      ariaLabel = 'This is a search bar. After typing your query, hit enter to filter the results lower in the page.';
+    }
+
     return (
       <EuiFieldSearch
         inputRef={input => this.inputElement = input}
@@ -57,6 +64,7 @@ export class EuiSearchBox extends Component {
         incremental={incremental}
         onSearch={(query) => onSearch(query)}
         isInvalid={isInvalid}
+        aria-label={ariaLabel}
         title={title}
         {...rest}
       />


### PR DESCRIPTION
### Summary

Fixes https://github.com/elastic/eui/issues/1028
Possibly fixes https://github.com/elastic/eui/issues/749


This adds some aria labeling to the search bar and table. Due to some funkiness with aria-live in [various](https://bugs.chromium.org/p/chromium/issues/detail?id=882443) [browsers](https://support.mozilla.org/en-US/kb/can-i-use-my-screen-reader-new-firefox) at the moment some of it doesn't work (specifically re-reading the content after its been updated). However, this is how the aria-live spec says to do stuff.

### Methods used

Searchbar now has an aria label that announces what it does and lets the user know if the content will auto update or not.

BasicTable now includes a caption which announces the amount of items present through `aria-live`. In combo with search bar this _should_ read as the content changes. However, right now that isn't the case due to the bugs mentioned above. Worst case scenario is that there is a hidden table caption that does nothing at the moment.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions

### Checklist

- [ ] ~~This was checked in mobile~~
- [ ] ~~This was checked in IE11~~
- [ ] ~~This was checked in dark mode~~
- [ ] ~~Any props added have proper autodocs~~
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios
- [x] This was checked against keyboard-only and screenreader scenarios
