### PR TITLE
Decorate pagination 'next' and 'previous' buttons with data-test-subj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Decorated `pagination` _next_ and _previous_ buttons with `data-test-subj`. ([{PR_NUM}](https://github.com/elastic/eui/pull/{PR_NUM}))
+- Decorated `pagination` _next_ and _previous_ buttons with `data-test-subj`. ([#1182](https://github.com/elastic/eui/pull/1182))
 
 ## [`3.10.0`](https://github.com/elastic/eui/tree/v3.10.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `3.10.0`.
+- Decorated `pagination` _next_ and _previous_ buttons with `data-test-subj`. ([{PR_NUM}](https://github.com/elastic/eui/pull/{PR_NUM}))
 
 ## [`3.10.0`](https://github.com/elastic/eui/tree/v3.10.0)
 

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
@@ -390,6 +390,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                         <EuiButtonIcon
                           aria-label="Previous page"
                           color="text"
+                          data-test-subj="pagination-button-previous"
                           disabled={false}
                           iconSize="m"
                           iconType="arrowLeft"
@@ -399,6 +400,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                           <button
                             aria-label="Previous page"
                             className="euiButtonIcon euiButtonIcon--text"
+                            data-test-subj="pagination-button-previous"
                             disabled={false}
                             onClick={[Function]}
                             type="button"
@@ -532,6 +534,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                         <EuiButtonIcon
                           aria-label="Next page"
                           color="text"
+                          data-test-subj="pagination-button-next"
                           disabled={true}
                           iconSize="m"
                           iconType="arrowRight"
@@ -541,6 +544,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                           <button
                             aria-label="Next page"
                             className="euiButtonIcon euiButtonIcon--text"
+                            data-test-subj="pagination-button-next"
                             disabled={true}
                             onClick={[Function]}
                             type="button"

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -45,6 +45,7 @@ export const EuiPagination = ({
       disabled={activePage === 0}
       color="text"
       aria-label="Previous page"
+      data-test-subj="pagination-button-previous"
     />
   );
 
@@ -111,6 +112,7 @@ export const EuiPagination = ({
       aria-label="Next page"
       disabled={activePage === pageCount - 1}
       color="text"
+      data-test-subj="pagination-button-next"
     />
   );
 

--- a/src/components/table/table_pagination/__snapshots__/table_pagination.test.js.snap
+++ b/src/components/table/table_pagination/__snapshots__/table_pagination.test.js.snap
@@ -62,6 +62,7 @@ exports[`EuiTablePagination is rendered 1`] = `
       <button
         aria-label="Previous page"
         class="euiButtonIcon euiButtonIcon--text"
+        data-test-subj="pagination-button-previous"
         type="button"
       >
         <svg
@@ -170,6 +171,7 @@ exports[`EuiTablePagination is rendered 1`] = `
       <button
         aria-label="Next page"
         class="euiButtonIcon euiButtonIcon--text"
+        data-test-subj="pagination-button-next"
         type="button"
       >
         <svg
@@ -217,6 +219,7 @@ exports[`EuiTablePagination is rendered when hiding the per page options 1`] = `
       <button
         aria-label="Previous page"
         class="euiButtonIcon euiButtonIcon--text"
+        data-test-subj="pagination-button-previous"
         type="button"
       >
         <svg
@@ -325,6 +328,7 @@ exports[`EuiTablePagination is rendered when hiding the per page options 1`] = `
       <button
         aria-label="Next page"
         class="euiButtonIcon euiButtonIcon--text"
+        data-test-subj="pagination-button-next"
         type="button"
       >
         <svg


### PR DESCRIPTION
### Summary

The purpose of this PR is to add `data-test-subj` to `Pagination`'s _next_ and _previous_ buttons. I have a number of functional tests expecting a table's pagination to have these values, and when I replaced the existing table with `eui` components I got stuck. Link to those changes: https://github.com/elastic/kibana/pull/22902

#### Screens of the props rendered in the docs:
<img width="524" alt="screen shot 2018-09-11 at 10 47 05 am" src="https://user-images.githubusercontent.com/18429259/45368949-c80e8100-b5b2-11e8-8a50-79b4ad22f0be.png">

<img width="619" alt="screen shot 2018-09-11 at 10 47 53 am" src="https://user-images.githubusercontent.com/18429259/45368961-ce9cf880-b5b2-11e8-9af1-7d30a32a777e.png">

I chose these values based on the existing naming used for the numbered buttons, per https://github.com/elastic/eui/blob/master/src/components/pagination/pagination.js#L33

### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [X] Documentation examples were added
- [X] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [X] This was checked for breaking changes and labeled appropriately
- [X] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios

_Note: anything unchecked here I did not feel was applicable, please let me know if I need to revisit any items_