### PR TITLE
Combobox fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 - Added `euiFacetButton` and `euiFacetGroup` ([#1167](https://github.com/elastic/eui/pull/1167))
 - Added `width` prop to `EuiContextMenu` panels ([#1173](https://github.com/elastic/eui/pull/1173))
 
+**Bug fixes**
+
+- Fixed `onClickAriaLabel` console error stemming from `EuiComboBoxPill`  ([#1183](https://github.com/elastic/eui/pull/1183))
+
 ## [`3.10.0`](https://github.com/elastic/eui/tree/v3.10.0)
 
 - Added `maxWidth` prop to `EuiModal` ([#1165](https://github.com/elastic/eui/pull/1165))

--- a/src/components/combo_box/combo_box_input/_combo_box_pill.scss
+++ b/src/components/combo_box/combo_box_input/_combo_box_pill.scss
@@ -5,6 +5,7 @@
   line-height: $euiSizeL - 2px;
 
   &--plainText {
+    line-height: $euiSizeL;
     font-size: $euiFontSizeS;
     font-family: $euiFontFamily;
     padding: 0 $euiSizeXS;

--- a/src/components/combo_box/combo_box_input/combo_box_pill.js
+++ b/src/components/combo_box/combo_box_input/combo_box_pill.js
@@ -12,6 +12,8 @@ export class EuiComboBoxPill extends Component {
     color: PropTypes.string,
     onClose: PropTypes.func,
     asPlainText: PropTypes.bool,
+    onClick: PropTypes.func,
+    onClickAriaLabel: PropTypes.string,
   };
 
   static defaultProps = {
@@ -30,6 +32,8 @@ export class EuiComboBoxPill extends Component {
       option, // eslint-disable-line no-unused-vars
       onClose, // eslint-disable-line no-unused-vars
       color,
+      onClick,
+      onClickAriaLabel,
       asPlainText,
       ...rest
     } = this.props;
@@ -54,6 +58,8 @@ export class EuiComboBoxPill extends Component {
           closeButtonProps={{
             tabIndex: '-1',
           }}
+          onClick={onClick}
+          onClickAriaLabel={onClickAriaLabel}
           {...rest}
         >
           {children}
@@ -62,11 +68,22 @@ export class EuiComboBoxPill extends Component {
     }
 
     if (asPlainText) {
-      return <span className={classes} {...rest}>{children}</span>;
+      return (
+        <span className={classes} {...rest}>
+          {children}
+        </span>
+      );
     }
 
     return (
-      <EuiBadge className={classes} title={children} color={color} {...rest}>
+      <EuiBadge
+        className={classes}
+        title={children}
+        color={color}
+        {...rest}
+        onClick={onClick}
+        onClickAriaLabel={onClickAriaLabel}
+      >
         {children}
       </EuiBadge>
     );


### PR DESCRIPTION
Fixes #1168
- pass `onClick` and `onClickAriaLabel` properly
- Fix plain text vertical alignment in IE

**Before**
<img width="446" alt="screen shot 2018-09-11 at 12 53 16 pm" src="https://user-images.githubusercontent.com/549577/45375444-f5fbc180-b5c2-11e8-9419-27dbc08438fa.png">


**After**
<img width="498" alt="screen shot 2018-09-11 at 12 59 57 pm" src="https://user-images.githubusercontent.com/549577/45375452-f98f4880-b5c2-11e8-9f5a-7f1e5b9e870c.png">
