### PR TITLE
fixing issue with aria controls and unselected tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `3.11.0`.
+- Fixed issue with unselected tabs and aria-controls attribute in EuiTabbedContent
 
 ## [`3.11.0`](https://github.com/elastic/eui/tree/v3.11.0)
 

--- a/src/components/tabs/tabbed_content/__snapshots__/tabbed_content.test.js.snap
+++ b/src/components/tabs/tabbed_content/__snapshots__/tabbed_content.test.js.snap
@@ -7,7 +7,7 @@ exports[`EuiTabbedContent behavior when selected tab state isn't controlled by t
     role="tablist"
   >
     <button
-      aria-controls="42-es"
+      aria-controls="42"
       aria-selected="true"
       class="euiTab euiTab-isSelected"
       id="es"
@@ -21,7 +21,7 @@ exports[`EuiTabbedContent behavior when selected tab state isn't controlled by t
       </span>
     </button>
     <button
-      aria-controls="42-kibana"
+      aria-controls="42"
       aria-selected="false"
       class="euiTab"
       data-test-subj="kibanaTab"
@@ -38,7 +38,7 @@ exports[`EuiTabbedContent behavior when selected tab state isn't controlled by t
   </div>
   <div
     aria-labelledby="es"
-    id="42-es"
+    id="42"
     role="tabpanel"
   >
     <p>
@@ -80,7 +80,7 @@ exports[`EuiTabbedContent behavior when uncontrolled, the selected tab should up
         role="tablist"
       >
         <EuiTab
-          aria-controls="42-es"
+          aria-controls="42"
           disabled={false}
           id="es"
           isSelected={false}
@@ -88,7 +88,7 @@ exports[`EuiTabbedContent behavior when uncontrolled, the selected tab should up
           onClick={[Function]}
         >
           <button
-            aria-controls="42-es"
+            aria-controls="42"
             aria-selected={false}
             className="euiTab"
             disabled={false}
@@ -105,7 +105,7 @@ exports[`EuiTabbedContent behavior when uncontrolled, the selected tab should up
           </button>
         </EuiTab>
         <EuiTab
-          aria-controls="42-kibana"
+          aria-controls="42"
           data-test-subj="kibanaTab"
           disabled={false}
           id="kibana"
@@ -114,7 +114,7 @@ exports[`EuiTabbedContent behavior when uncontrolled, the selected tab should up
           onClick={[Function]}
         >
           <button
-            aria-controls="42-kibana"
+            aria-controls="42"
             aria-selected={true}
             className="euiTab euiTab-isSelected"
             data-test-subj="kibanaTab"
@@ -135,7 +135,7 @@ exports[`EuiTabbedContent behavior when uncontrolled, the selected tab should up
     </EuiTabs>
     <div
       aria-labelledby="kibana"
-      id="42-kibana"
+      id="42"
       role="tabpanel"
     >
       <p>
@@ -157,7 +157,7 @@ exports[`EuiTabbedContent is rendered with required props and tabs 1`] = `
     role="tablist"
   >
     <button
-      aria-controls="42-es"
+      aria-controls="42"
       aria-selected="true"
       class="euiTab euiTab-isSelected"
       id="es"
@@ -171,7 +171,7 @@ exports[`EuiTabbedContent is rendered with required props and tabs 1`] = `
       </span>
     </button>
     <button
-      aria-controls="42-kibana"
+      aria-controls="42"
       aria-selected="false"
       class="euiTab"
       data-test-subj="kibanaTab"
@@ -188,7 +188,7 @@ exports[`EuiTabbedContent is rendered with required props and tabs 1`] = `
   </div>
   <div
     aria-labelledby="es"
-    id="42-es"
+    id="42"
     role="tabpanel"
   >
     <p>
@@ -205,7 +205,7 @@ exports[`EuiTabbedContent props initialSelectedTab renders a selected tab 1`] = 
     role="tablist"
   >
     <button
-      aria-controls="42-es"
+      aria-controls="42"
       aria-selected="false"
       class="euiTab"
       id="es"
@@ -219,7 +219,7 @@ exports[`EuiTabbedContent props initialSelectedTab renders a selected tab 1`] = 
       </span>
     </button>
     <button
-      aria-controls="42-kibana"
+      aria-controls="42"
       aria-selected="true"
       class="euiTab euiTab-isSelected"
       data-test-subj="kibanaTab"
@@ -236,7 +236,7 @@ exports[`EuiTabbedContent props initialSelectedTab renders a selected tab 1`] = 
   </div>
   <div
     aria-labelledby="kibana"
-    id="42-kibana"
+    id="42"
     role="tabpanel"
   >
     <p>
@@ -253,7 +253,7 @@ exports[`EuiTabbedContent props selectedTab renders a selected tab 1`] = `
     role="tablist"
   >
     <button
-      aria-controls="42-es"
+      aria-controls="42"
       aria-selected="false"
       class="euiTab"
       id="es"
@@ -267,7 +267,7 @@ exports[`EuiTabbedContent props selectedTab renders a selected tab 1`] = `
       </span>
     </button>
     <button
-      aria-controls="42-kibana"
+      aria-controls="42"
       aria-selected="true"
       class="euiTab euiTab-isSelected"
       data-test-subj="kibanaTab"
@@ -284,7 +284,7 @@ exports[`EuiTabbedContent props selectedTab renders a selected tab 1`] = `
   </div>
   <div
     aria-labelledby="kibana"
-    id="42-kibana"
+    id="42"
     role="tabpanel"
   >
     <p>
@@ -301,7 +301,7 @@ exports[`EuiTabbedContent props size is rendered 1`] = `
     role="tablist"
   >
     <button
-      aria-controls="42-es"
+      aria-controls="42"
       aria-selected="true"
       class="euiTab euiTab-isSelected"
       id="es"
@@ -315,7 +315,7 @@ exports[`EuiTabbedContent props size is rendered 1`] = `
       </span>
     </button>
     <button
-      aria-controls="42-kibana"
+      aria-controls="42"
       aria-selected="false"
       class="euiTab"
       data-test-subj="kibanaTab"
@@ -332,7 +332,7 @@ exports[`EuiTabbedContent props size is rendered 1`] = `
   </div>
   <div
     aria-labelledby="es"
-    id="42-es"
+    id="42"
     role="tabpanel"
   >
     <p>

--- a/src/components/tabs/tabbed_content/tabbed_content.js
+++ b/src/components/tabs/tabbed_content/tabbed_content.js
@@ -106,7 +106,7 @@ export class EuiTabbedContent extends Component {
               ...tabProps,
               onClick: () => this.onTabClick(tab),
               isSelected: tab === selectedTab,
-              'aria-controls': `${this.rootId}-${id}`,
+              'aria-controls': `${this.rootId}`,
             };
 
             return <EuiTab {...props}>{name}</EuiTab>;
@@ -115,7 +115,7 @@ export class EuiTabbedContent extends Component {
 
         <div
           role="tabpanel"
-          id={`${this.rootId}-${selectedTabId}`}
+          id={`${this.rootId}`}
           aria-labelledby={selectedTabId}
         >
           {selectedTabContent}


### PR DESCRIPTION
### Summary

This addresses the issue in https://github.com/elastic/kibana/issues/22293.  aria-controls was not being used properly in EuiTabbedContent component.  The original implementation switched the content's div id to contain selected tab id, which meant that the unselected tab(s) had an aria-controls that pointed at a nonexistent id.  This change just uses the rootID for all aria-controls, which matches how aria-controls should be used (it's supposed to indicate the part of the page the button will affect when clicked).

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
~- [ ] This was checked for breaking changes and labeled appropriately~
- [x] Jest tests were updated or added to match the most common scenarios
- [x] This was checked against keyboard-only and screenreader scenarios
