### PR TITLE
Better support for string values in search queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `4.0.0`.
+**Bug fixes**
+
+- Fixed some issues around parsing string values in EuiSearchBar / EuiQuery ([#1189](https://github.com/elastic/eui/pull/1189))
 
 ## [`4.0.0`](https://github.com/elastic/eui/tree/v4.0.0)
 

--- a/src/components/search_bar/query/default_syntax.test.js
+++ b/src/components/search_bar/query/default_syntax.test.js
@@ -777,6 +777,36 @@ describe('defaultSyntax', () => {
     expect(printedQuery).toBe(query);
   });
 
+  test('number type', () => {
+    const query = 'count:15';
+    const ast = defaultSyntax.parse(query);
+
+    expect(ast).toBeDefined();
+    expect(ast.clauses).toHaveLength(1);
+
+    const clause = ast.getSimpleFieldClause('count');
+    expect(clause).toBeDefined();
+    expect(AST.Field.isInstance(clause)).toBe(true);
+    expect(AST.Match.isMustClause(clause)).toBe(true);
+    expect(clause.field).toBe('count');
+    expect(clause.value).toBe(15);
+  });
+
+  test('string that starts with a number', () => {
+    const query = 'count:15n';
+    const ast = defaultSyntax.parse(query);
+
+    expect(ast).toBeDefined();
+    expect(ast.clauses).toHaveLength(1);
+
+    const clause = ast.getSimpleFieldClause('count');
+    expect(clause).toBeDefined();
+    expect(AST.Field.isInstance(clause)).toBe(true);
+    expect(AST.Match.isMustClause(clause)).toBe(true);
+    expect(clause.field).toBe('count');
+    expect(clause.value).toBe('15n');
+  });
+
   test('strict schema - flags - listed', () => {
 
     const query = `is:active`;
@@ -933,4 +963,26 @@ describe('defaultSyntax', () => {
     }).toThrow('Unknown field `name`');
   });
 
+  test('strict schema - string fields have their values coerced', () => {
+    const query = `name:15`;
+    const schema = {
+      strict: true,
+      fields: {
+        name: {
+          type: 'string'
+        }
+      }
+    };
+    const ast = defaultSyntax.parse(query, { schema });
+
+    expect(ast).toBeDefined();
+    expect(ast.clauses).toHaveLength(1);
+
+    const clause = ast.getSimpleFieldClause('name');
+    expect(clause).toBeDefined();
+    expect(AST.Field.isInstance(clause)).toBe(true);
+    expect(AST.Match.isMustClause(clause)).toBe(true);
+    expect(clause.field).toBe('name');
+    expect(clause.value).toBe('15');
+  });
 });


### PR DESCRIPTION
closes #1177 

### Summary

Addresses two string-related issues
* if a string value began with a number (e.g. `15m`) it would be parsed only as the leading number
* if a non-string value (e.g. `15`, `true`) was passed to a string-type field, it would fail to pass schema validation instead of being coerced to a string

### Checklist

- [ ] ~This was checked in mobile~
- [ ] ~This was checked in IE11~
- [ ] ~This was checked in dark mode~
- [ ] ~Any props added have proper autodocs~
- [ ] ~Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios
- [ ] ~This was checked against keyboard-only and screenreader scenarios~
