### PR TITLE
IE11 doesn't support document.contains()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Fixed issue with unselected tabs and aria-controls attribute in EuiTabbedContent
+**Bug fixes**
+
+- Fixed an issue in `EuiTooltip` because IE1 didn't support `document.contains()` ([#1190](https://github.com/elastic/eui/pull/1190))
 
 ## [`4.0.0`](https://github.com/elastic/eui/tree/v4.0.0)
 

--- a/src/components/tool_tip/tool_tip.js
+++ b/src/components/tool_tip/tool_tip.js
@@ -72,7 +72,7 @@ export class EuiToolTip extends Component {
     // when the tooltip is visible, this checks if the anchor is still part of document
     // this fixes when the react root is removed from the dom without unmounting
     // https://github.com/elastic/eui/issues/1105
-    if (document.contains(this.anchor) === false) {
+    if (document.body.contains(this.anchor) === false) {
       // the anchor is no longer part of `document`
       this.hideToolTip();
     } else {


### PR DESCRIPTION
### Summary

Kibana's polyfill wasn't picking up the `document.contains()` bit in EUI tooltips. Used `document.body.contains()` instead, which is supported.

https://github.com/elastic/kibana/issues/22956
https://developer.mozilla.org/en-US/docs/Web/API/Node/contains

### Checklist

~~- [ ] This was checked in mobile~~
- [x] This was checked in IE11
~~- [ ] This was checked in dark mode~~
~~- [ ] Any props added have proper autodocs~~
~~- [ ] Documentation examples were added~~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
~~- [ ] This was checked for breaking changes and labeled appropriately~~
~~- [ ] Jest tests were updated or added to match the most common scenarios~~
~~- [ ] This was checked against keyboard-only and screenreader scenarios~~
