### PR TITLE
Add direction prop for EuiFlexGroup typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Add `direction` to `EuiFlexGroup` prop types interface ([#{PRNUM}])({PRURL})
+- Add `direction` to `EuiFlexGroup` prop types interface ([#1196](https://github.com/elastic/eui/pull/1196))
 - Made `description` prop optional for `EuiDescribedFormGroup` ([#1191](https://github.com/elastic/eui/pull/1191))
 - Fixed issue with unselected tabs and aria-controls attribute in EuiTabbedContent
 - Added `tag` icon ([#1188](https://github.com/elastic/eui/pull/1188))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Add `direction` to `EuiFlexGroup` prop types interface ([#{PRNUM}])({PRURL})
 - Made `description` prop optional for `EuiDescribedFormGroup` ([#1191](https://github.com/elastic/eui/pull/1191))
 - Fixed issue with unselected tabs and aria-controls attribute in EuiTabbedContent
 - Added `tag` icon ([#1188](https://github.com/elastic/eui/pull/1188))

--- a/src/components/flex/flex_group.js
+++ b/src/components/flex/flex_group.js
@@ -79,14 +79,14 @@ export const EuiFlexGroup = ({
 };
 
 EuiFlexGroup.propTypes = {
+  alignItems: PropTypes.oneOf(ALIGN_ITEMS),
   children: PropTypes.node,
   className: PropTypes.string,
-  responsive: PropTypes.bool,
-  gutterSize: PropTypes.oneOf(GUTTER_SIZES),
-  alignItems: PropTypes.oneOf(ALIGN_ITEMS),
-  justifyContent: PropTypes.oneOf(JUSTIFY_CONTENTS),
-  direction: PropTypes.oneOf(DIRECTIONS),
   component: PropTypes.oneOf(['div', 'span']),
+  direction: PropTypes.oneOf(DIRECTIONS),
+  gutterSize: PropTypes.oneOf(GUTTER_SIZES),
+  justifyContent: PropTypes.oneOf(JUSTIFY_CONTENTS),
+  responsive: PropTypes.bool,
   wrap: PropTypes.bool,
 };
 

--- a/src/components/flex/index.d.ts
+++ b/src/components/flex/index.d.ts
@@ -49,8 +49,8 @@ declare module '@elastic/eui' {
 
   export interface EuiFlexGroupProps {
     alignItems?: FlexGroupAlignItems;
-    direction?: FlexGroupDirection;
     component?: FlexGroupCmponentType;
+    direction?: FlexGroupDirection;
     gutterSize?: FlexGroupGutterSize;
     justifyContent?: FlexGroupJustifyContent;
     responsive?: boolean;

--- a/src/components/flex/index.d.ts
+++ b/src/components/flex/index.d.ts
@@ -33,6 +33,11 @@ declare module '@elastic/eui' {
     | 'flexStart'
     | 'flexEnd'
     | 'center';
+  export type FlexGroupDirection =
+    | 'column'
+    | 'columnReverse'
+    | 'row'
+    | 'rowReverse';
   export type FlexGroupJustifyContent =
     | 'flexStart'
     | 'flexEnd'
@@ -43,11 +48,12 @@ declare module '@elastic/eui' {
   export type FlexGroupCmponentType = 'div' | 'span';
 
   export interface EuiFlexGroupProps {
-    responsive?: boolean;
-    gutterSize?: FlexGroupGutterSize;
     alignItems?: FlexGroupAlignItems;
-    justifyContent?: FlexGroupJustifyContent;
+    direction?: FlexGroupDirection;
     component?: FlexGroupCmponentType;
+    gutterSize?: FlexGroupGutterSize;
+    justifyContent?: FlexGroupJustifyContent;
+    responsive?: boolean;
     wrap?: boolean;
   }
 

--- a/src/components/flex/index.d.ts
+++ b/src/components/flex/index.d.ts
@@ -32,7 +32,6 @@ declare module '@elastic/eui' {
     | 'flexStart'
     | 'flexEnd'
     | 'center';
-  export type FlexGroupClassName = 'div' | 'span';
   export type FlexGroupComponentType = 'div' | 'span';
   export type FlexGroupDirection =
     | 'column'
@@ -51,7 +50,7 @@ declare module '@elastic/eui' {
   export interface EuiFlexGroupProps {
     alignItems?: FlexGroupAlignItems;
     children?: React.ReactNode;
-    className?: FlexGroupClassName;
+    className?: string;
     component?: FlexGroupComponentType;
     direction?: FlexGroupDirection;
     gutterSize?: FlexGroupGutterSize;

--- a/src/components/flex/index.d.ts
+++ b/src/components/flex/index.d.ts
@@ -27,17 +27,19 @@ declare module '@elastic/eui' {
    * @see './flex_group.js'
    */
 
-  export type FlexGroupGutterSize = 'none' | 'xs' | 's' | 'm' | 'l' | 'xl';
   export type FlexGroupAlignItems =
     | 'stretch'
     | 'flexStart'
     | 'flexEnd'
     | 'center';
+  export type FlexGroupClassName = 'div' | 'span';
+  export type FlexGroupComponentType = 'div' | 'span';
   export type FlexGroupDirection =
     | 'column'
     | 'columnReverse'
     | 'row'
     | 'rowReverse';
+  export type FlexGroupGutterSize = 'none' | 'xs' | 's' | 'm' | 'l' | 'xl';
   export type FlexGroupJustifyContent =
     | 'flexStart'
     | 'flexEnd'
@@ -45,11 +47,12 @@ declare module '@elastic/eui' {
     | 'spaceBetween'
     | 'spaceAround'
     | 'spaceEvenly';
-  export type FlexGroupCmponentType = 'div' | 'span';
-
+  
   export interface EuiFlexGroupProps {
     alignItems?: FlexGroupAlignItems;
-    component?: FlexGroupCmponentType;
+    children?: React.ReactNode;
+    className?: FlexGroupClassName;
+    component?: FlexGroupComponentType;
     direction?: FlexGroupDirection;
     gutterSize?: FlexGroupGutterSize;
     justifyContent?: FlexGroupJustifyContent;


### PR DESCRIPTION
### Summary

Add support for the `direction` prop of the `EuiFlexGroup` component for TypeScript.

### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [X] Any props added have proper autodocs
- [ ] Documentation examples were added
- [X] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [X] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios

*Note: any checks not completed were deemed unnecessary by me. Please let me know if any further check work needs to be done before this is ready to merge.*