### PR TITLE
Bug/popover realignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 **Bug fixes**
 
+- Fixed cross-axis alignment bug when positioning EuiPopover ([#1197](https://github.com/elastic/eui/pull/1197))
 - Added background to `readOnly` inputs ([#1188](https://github.com/elastic/eui/pull/1188))
 - Fixed some modal default and responsive sizing ([#1188](https://github.com/elastic/eui/pull/1188))
 - Fixed z-index issue of `EuiComboBoxOptionsList` especiall inside modals ([#1192](https://github.com/elastic/eui/pull/1192))

--- a/src/services/popover/popover_positioning.js
+++ b/src/services/popover/popover_positioning.js
@@ -99,16 +99,18 @@ export function findPopoverPosition({
     position,                       // Try the user-desired position first.
     positionComplements[position],  // Try the complementary position.
   ];
+  const iterationAlignments = [align, align]; // keep user-defined alignment in the original and complementary positions
   if (allowCrossAxis) {
     iterationPositions.push(
       positionSubstitutes[position],                      // Switch to the cross axis.
       positionComplements[positionSubstitutes[position]]  // Try the complementary position on the cross axis.
     );
+    iterationAlignments.push(null, null); // discard desired alignment on cross-axis
   }
 
   const {
     bestPosition,
-  } = iterationPositions.reduce(({ bestFit, bestPosition }, iterationPosition) => {
+  } = iterationPositions.reduce(({ bestFit, bestPosition }, iterationPosition, idx) => {
     // If we've already found the ideal fit, use that position.
     if (bestFit === 1) {
       return { bestFit, bestPosition };
@@ -117,7 +119,7 @@ export function findPopoverPosition({
     // Otherwise, see if we can find a position with a better fit than we've found so far.
     const screenCoordinates = getPopoverScreenCoordinates({
       position: iterationPosition,
-      align,
+      align: iterationAlignments[idx],
       anchorBoundingBox,
       popoverBoundingBox,
       windowBoundingBox,

--- a/src/services/popover/popover_positioning.test.js
+++ b/src/services/popover/popover_positioning.test.js
@@ -473,6 +473,32 @@ describe('popover_positioning', () => {
           left: 85
         });
       });
+
+      it('ignores any specified alignment', () => {
+        const anchor = document.createElement('div');
+        anchor.getBoundingClientRect = () => makeBB(100, 150, 120, 50);
+
+        const popover = document.createElement('div');
+        popover.getBoundingClientRect = () => makeBB(0, 30, 50, 0);
+
+        // give the container limited space on both left and right, forcing to top
+        const container = document.createElement('div');
+        container.getBoundingClientRect = () => makeBB(0, 160, 768, 40);
+
+        expect(findPopoverPosition({
+          position: 'right',
+          align: 'down',
+          anchor,
+          popover,
+          container,
+          offset: 5
+        })).toEqual({
+          fit: 1,
+          position: 'top',
+          top: 45,
+          left: 85
+        });
+      });
     });
 
     describe('placement falls back to second complementary position', () => {


### PR DESCRIPTION
### Summary

This fixes a bug @cjcenizal found in the popover positioning, as shown in this gif - https://d.pr/free/i/UAiOih (filesize too big to inline). The target position/alignment is `downRight`, but when there isn't enough space _down_ the popover is placed to the left and the code still tries to respect the _right_ alignment, which is silly (left and to the right). I've resolved by dropping the alignment value when checking cross-axis placement, so effectively the positions looked for become

* downRight
* topRight
* left
* right

### Checklist

- [ ] ~This was checked in mobile~
- [ ] ~This was checked in IE11~
- [ ] ~This was checked in dark mode~
- [ ] ~Any props added have proper autodocs~
- [ ] ~Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios
- [ ] ~This was checked against keyboard-only and screenreader scenarios~
