### PR TITLE
Some quick `EuiSeriesChart` additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed issue with unselected tabs and aria-controls attribute in EuiTabbedContent
 - Added `tag` icon ([#1188](https://github.com/elastic/eui/pull/1188))
 - Replaced `logging` app icon ([#1194](https://github.com/elastic/eui/pull/1194))
+- Added some opacity options to `EuiLineSeries` and `EuiAreaSeries` ([#1198](https://github.com/elastic/eui/pull/1198))
 
 **Bug fixes**
 

--- a/src/components/empty_prompt/__snapshots__/empty_prompt.test.js.snap
+++ b/src/components/empty_prompt/__snapshots__/empty_prompt.test.js.snap
@@ -48,10 +48,10 @@ exports[`EuiEmptyPrompt is rendered 1`] = `
         Body
       </p>
     </div>
-    <div
-      class="euiSpacer euiSpacer--l"
-    />
   </span>
+  <div
+    class="euiSpacer euiSpacer--l"
+  />
   <div
     class="euiSpacer euiSpacer--s"
   />
@@ -108,9 +108,6 @@ exports[`EuiEmptyPrompt props body renders alone 1`] = `
     >
       body
     </div>
-    <div
-      class="euiSpacer euiSpacer--l"
-    />
   </span>
 </div>
 `;

--- a/src/components/empty_prompt/empty_prompt.js
+++ b/src/components/empty_prompt/empty_prompt.js
@@ -56,7 +56,6 @@ export const EuiEmptyPrompt = ({
           <EuiText>
             {body}
           </EuiText>
-          <EuiSpacer size="l" />
         </Fragment>
       );
     }
@@ -108,6 +107,9 @@ export const EuiEmptyPrompt = ({
     >
       {icon}
       {content}
+      {body && actions &&
+        <EuiSpacer size="l" />
+      }
       {actionsEl}
     </div>
   );

--- a/src/components/series_chart/__snapshots__/series_chart.test.js.snap
+++ b/src/components/series_chart/__snapshots__/series_chart.test.js.snap
@@ -5,20 +5,45 @@ exports[`EuiSeriesChart renders an empty chart 1`] = `
   style="width: 100%; height: 100%;"
 >
   <div
-    class="euiEmptyPrompt"
+    class="euiEmptyPrompt euiSeriesChartContainer__emptyPrompt"
   >
     <svg
       class="euiIcon euiIcon--xxLarge euiIcon--subdued"
       focusable="false"
-      height="16"
-      viewBox="0 0 16 16"
-      width="16"
+      height="32"
+      viewBox="0 0 32 32"
+      width="32"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <path
-        d="M8 14v-4h1v4h5V5h1v9a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1v-2h1v2h6zm4.853-10.146l-2.999 3a1.5 1.5 0 0 1-2.538 1.568l-2.714.904L4 9.527a1.5 1.5 0 1 1-.316-.948L7 7.473a1.5 1.5 0 0 1 2.146-1.327l3-3a1.5 1.5 0 1 1 .707.707z"
+      <g
+        fill="none"
         fill-rule="evenodd"
-      />
+      >
+        <rect
+          fill="#00A9E5"
+          height="18"
+          rx="2"
+          width="8"
+          x="1"
+          y="13"
+        />
+        <rect
+          fill="#00A9E5"
+          height="22"
+          rx="2"
+          width="8"
+          x="23"
+          y="9"
+        />
+        <rect
+          fill="#00BFB3"
+          height="30"
+          rx="2"
+          width="8"
+          x="12"
+          y="1"
+        />
+      </g>
     </svg>
     <div
       class="euiSpacer euiSpacer--s"
@@ -26,11 +51,11 @@ exports[`EuiSeriesChart renders an empty chart 1`] = `
     <span
       class="euiTextColor euiTextColor--subdued"
     >
-      <h2
+      <span
         class="euiTitle euiTitle--medium"
       >
         Chart not available
-      </h2>
+      </span>
       <div
         class="euiSpacer euiSpacer--m"
       />
@@ -41,9 +66,6 @@ exports[`EuiSeriesChart renders an empty chart 1`] = `
           ~~Empty Chart~~
         </p>
       </div>
-      <div
-        class="euiSpacer euiSpacer--l"
-      />
     </span>
   </div>
 </div>

--- a/src/components/series_chart/_index.scss
+++ b/src/components/series_chart/_index.scss
@@ -10,3 +10,4 @@
 @import "series/index";
 @import "legend";
 @import "line_annotation";
+@import "series_chart";

--- a/src/components/series_chart/_series_chart.scss
+++ b/src/components/series_chart/_series_chart.scss
@@ -1,0 +1,8 @@
+.euiSeriesChartContainer__emptyPrompt {
+  // Center the empty prompt within the series container
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/components/series_chart/series/__snapshots__/area_series.test.js.snap
+++ b/src/components/series_chart/series/__snapshots__/area_series.test.js.snap
@@ -153,6 +153,7 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                   ]
                 }
                 fillDomain={Array []}
+                fillOpacity={1}
                 fillRange={
                   Array [
                     "#EF5D28",
@@ -181,6 +182,7 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                 innerHeight={150}
                 innerWidth={550}
                 key=".0:$.0"
+                lineSize={1}
                 marginBottom={40}
                 marginLeft={40}
                 marginRight={10}
@@ -236,6 +238,513 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                 }
                 yType="linear"
               >
+                <LineSeries
+                  _adjustBy={Array []}
+                  _adjustWhat={Array []}
+                  _allData={
+                    Array [
+                      Array [
+                        Object {
+                          "x": 0,
+                          "y": 5,
+                        },
+                        Object {
+                          "x": 1,
+                          "y": 10,
+                        },
+                      ],
+                      undefined,
+                    ]
+                  }
+                  _colorValue="#00B3A4"
+                  _opacityValue={1}
+                  _orientation="vertical"
+                  angleDomain={Array []}
+                  animation={true}
+                  className=""
+                  clusters={
+                    Set {
+                      undefined,
+                    }
+                  }
+                  color="#00B3A4"
+                  colorDomain={Array []}
+                  colorRange={
+                    Array [
+                      "#EF5D28",
+                      "#FF9833",
+                    ]
+                  }
+                  curve="linear"
+                  data={
+                    Array [
+                      Object {
+                        "x": 0,
+                        "y": 5,
+                      },
+                      Object {
+                        "x": 1,
+                        "y": 10,
+                      },
+                    ]
+                  }
+                  fillDomain={Array []}
+                  fillRange={
+                    Array [
+                      "#EF5D28",
+                      "#FF9833",
+                    ]
+                  }
+                  getAngle={[Function]}
+                  getAngle0={[Function]}
+                  getColor={[Function]}
+                  getColor0={[Function]}
+                  getFill={[Function]}
+                  getFill0={[Function]}
+                  getNull={[Function]}
+                  getOpacity={[Function]}
+                  getOpacity0={[Function]}
+                  getRadius={[Function]}
+                  getRadius0={[Function]}
+                  getSize={[Function]}
+                  getSize0={[Function]}
+                  getStroke={[Function]}
+                  getStroke0={[Function]}
+                  getX={[Function]}
+                  getX0={[Function]}
+                  getY={[Function]}
+                  getY0={[Function]}
+                  id="chart-0"
+                  innerHeight={150}
+                  innerWidth={550}
+                  key="name-line"
+                  marginBottom={40}
+                  marginLeft={40}
+                  marginRight={10}
+                  marginTop={10}
+                  onSeriesClick={[MockFunction]}
+                  opacity={1}
+                  opacityDomain={Array []}
+                  opacityType="literal"
+                  radiusDomain={Array []}
+                  sameTypeIndex={0}
+                  sameTypeTotal={1}
+                  seriesIndex={0}
+                  sizeDomain={Array []}
+                  sizeRange={
+                    Array [
+                      1,
+                      10,
+                    ]
+                  }
+                  stack={false}
+                  strokeDomain={Array []}
+                  strokeRange={
+                    Array [
+                      "#EF5D28",
+                      "#FF9833",
+                    ]
+                  }
+                  strokeStyle="solid"
+                  style={
+                    Object {
+                      "pointerEvents": "visiblestroke",
+                      "strokeWidth": 1,
+                    }
+                  }
+                  xDomain={
+                    Array [
+                      0,
+                      1,
+                    ]
+                  }
+                  xPadding={0}
+                  xRange={
+                    Array [
+                      0,
+                      550,
+                    ]
+                  }
+                  xType="linear"
+                  yDomain={
+                    Array [
+                      5,
+                      10,
+                    ]
+                  }
+                  yPadding={0}
+                  yRange={
+                    Array [
+                      150,
+                      0,
+                    ]
+                  }
+                  yType="linear"
+                >
+                  <Animation
+                    _adjustBy={Array []}
+                    _adjustWhat={Array []}
+                    _allData={
+                      Array [
+                        Array [
+                          Object {
+                            "x": 0,
+                            "y": 5,
+                          },
+                          Object {
+                            "x": 1,
+                            "y": 10,
+                          },
+                        ],
+                        undefined,
+                      ]
+                    }
+                    _colorValue="#00B3A4"
+                    _opacityValue={1}
+                    _orientation="vertical"
+                    angleDomain={Array []}
+                    animatedProps={
+                      Array [
+                        "xRange",
+                        "xDomain",
+                        "x",
+                        "yRange",
+                        "yDomain",
+                        "y",
+                        "colorRange",
+                        "colorDomain",
+                        "color",
+                        "opacityRange",
+                        "opacityDomain",
+                        "opacity",
+                        "strokeRange",
+                        "strokeDomain",
+                        "stroke",
+                        "fillRange",
+                        "fillDomain",
+                        "fill",
+                        "width",
+                        "height",
+                        "marginLeft",
+                        "marginTop",
+                        "marginRight",
+                        "marginBottom",
+                        "data",
+                        "angleDomain",
+                        "angleRange",
+                        "angle",
+                        "radiusDomain",
+                        "radiusRange",
+                        "radius",
+                        "innerRadiusDomain",
+                        "innerRadiusRange",
+                        "innerRadius",
+                      ]
+                    }
+                    animation={true}
+                    className=""
+                    clusters={
+                      Set {
+                        undefined,
+                      }
+                    }
+                    color="#00B3A4"
+                    colorDomain={Array []}
+                    colorRange={
+                      Array [
+                        "#EF5D28",
+                        "#FF9833",
+                      ]
+                    }
+                    curve="linear"
+                    data={
+                      Array [
+                        Object {
+                          "x": 0,
+                          "y": 5,
+                        },
+                        Object {
+                          "x": 1,
+                          "y": 10,
+                        },
+                      ]
+                    }
+                    fillDomain={Array []}
+                    fillRange={
+                      Array [
+                        "#EF5D28",
+                        "#FF9833",
+                      ]
+                    }
+                    getAngle={[Function]}
+                    getAngle0={[Function]}
+                    getColor={[Function]}
+                    getColor0={[Function]}
+                    getFill={[Function]}
+                    getFill0={[Function]}
+                    getNull={[Function]}
+                    getOpacity={[Function]}
+                    getOpacity0={[Function]}
+                    getRadius={[Function]}
+                    getRadius0={[Function]}
+                    getSize={[Function]}
+                    getSize0={[Function]}
+                    getStroke={[Function]}
+                    getStroke0={[Function]}
+                    getX={[Function]}
+                    getX0={[Function]}
+                    getY={[Function]}
+                    getY0={[Function]}
+                    id="chart-0"
+                    innerHeight={150}
+                    innerWidth={550}
+                    marginBottom={40}
+                    marginLeft={40}
+                    marginRight={10}
+                    marginTop={10}
+                    onSeriesClick={[MockFunction]}
+                    opacity={1}
+                    opacityDomain={Array []}
+                    opacityType="literal"
+                    radiusDomain={Array []}
+                    sameTypeIndex={0}
+                    sameTypeTotal={1}
+                    seriesIndex={0}
+                    sizeDomain={Array []}
+                    sizeRange={
+                      Array [
+                        1,
+                        10,
+                      ]
+                    }
+                    stack={false}
+                    strokeDomain={Array []}
+                    strokeRange={
+                      Array [
+                        "#EF5D28",
+                        "#FF9833",
+                      ]
+                    }
+                    strokeStyle="solid"
+                    style={
+                      Object {
+                        "pointerEvents": "visiblestroke",
+                        "strokeWidth": 1,
+                      }
+                    }
+                    xDomain={
+                      Array [
+                        0,
+                        1,
+                      ]
+                    }
+                    xPadding={0}
+                    xRange={
+                      Array [
+                        0,
+                        550,
+                      ]
+                    }
+                    xType="linear"
+                    yDomain={
+                      Array [
+                        5,
+                        10,
+                      ]
+                    }
+                    yPadding={0}
+                    yRange={
+                      Array [
+                        150,
+                        0,
+                      ]
+                    }
+                    yType="linear"
+                  >
+                    <Motion
+                      defaultStyle={
+                        Object {
+                          "i": 0,
+                        }
+                      }
+                      key="0.00001"
+                      onRest={[Function]}
+                      style={
+                        Object {
+                          "i": Object {
+                            "damping": 26,
+                            "precision": 0.01,
+                            "stiffness": 170,
+                            "val": 1,
+                          },
+                        }
+                      }
+                    >
+                      <LineSeries
+                        _adjustBy={Array []}
+                        _adjustWhat={Array []}
+                        _allData={
+                          Array [
+                            Array [
+                              Object {
+                                "x": 0,
+                                "y": 5,
+                              },
+                              Object {
+                                "x": 1,
+                                "y": 10,
+                              },
+                            ],
+                            undefined,
+                          ]
+                        }
+                        _animation={0.00002}
+                        _colorValue="#00B3A4"
+                        _opacityValue={1}
+                        _orientation="vertical"
+                        angleDomain={Array []}
+                        animation={null}
+                        className=""
+                        clusters={
+                          Set {
+                            undefined,
+                          }
+                        }
+                        color="#00B3A4"
+                        colorDomain={Array []}
+                        colorRange={
+                          Array [
+                            "#EF5D28",
+                            "#FF9833",
+                          ]
+                        }
+                        curve="linear"
+                        data={
+                          Array [
+                            Object {
+                              "x": 0,
+                              "y": 5,
+                            },
+                            Object {
+                              "x": 1,
+                              "y": 10,
+                            },
+                          ]
+                        }
+                        fillDomain={Array []}
+                        fillRange={
+                          Array [
+                            "#EF5D28",
+                            "#FF9833",
+                          ]
+                        }
+                        getAngle={[Function]}
+                        getAngle0={[Function]}
+                        getColor={[Function]}
+                        getColor0={[Function]}
+                        getFill={[Function]}
+                        getFill0={[Function]}
+                        getNull={[Function]}
+                        getOpacity={[Function]}
+                        getOpacity0={[Function]}
+                        getRadius={[Function]}
+                        getRadius0={[Function]}
+                        getSize={[Function]}
+                        getSize0={[Function]}
+                        getStroke={[Function]}
+                        getStroke0={[Function]}
+                        getX={[Function]}
+                        getX0={[Function]}
+                        getY={[Function]}
+                        getY0={[Function]}
+                        id="chart-0"
+                        innerHeight={150}
+                        innerWidth={550}
+                        marginBottom={40}
+                        marginLeft={40}
+                        marginRight={10}
+                        marginTop={10}
+                        onSeriesClick={[MockFunction]}
+                        opacity={1}
+                        opacityDomain={Array []}
+                        opacityType="literal"
+                        radiusDomain={Array []}
+                        sameTypeIndex={0}
+                        sameTypeTotal={1}
+                        seriesIndex={0}
+                        sizeDomain={Array []}
+                        sizeRange={
+                          Array [
+                            1,
+                            10,
+                          ]
+                        }
+                        stack={false}
+                        strokeDomain={Array []}
+                        strokeRange={
+                          Array [
+                            "#EF5D28",
+                            "#FF9833",
+                          ]
+                        }
+                        strokeStyle="solid"
+                        style={
+                          Object {
+                            "pointerEvents": "visiblestroke",
+                            "strokeWidth": 1,
+                          }
+                        }
+                        xDomain={
+                          Array [
+                            0,
+                            1,
+                          ]
+                        }
+                        xPadding={0}
+                        xRange={
+                          Array [
+                            0,
+                            550,
+                          ]
+                        }
+                        xType="linear"
+                        yDomain={
+                          Array [
+                            5,
+                            10,
+                          ]
+                        }
+                        yPadding={0}
+                        yRange={
+                          Array [
+                            150,
+                            0,
+                          ]
+                        }
+                        yType="linear"
+                      >
+                        <path
+                          className="rv-xy-plot__series rv-xy-plot__series--line "
+                          d="M0,150L550,0"
+                          onClick={[Function]}
+                          onContextMenu={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                          style={
+                            Object {
+                              "opacity": 1,
+                              "pointerEvents": "visiblestroke",
+                              "stroke": "#00B3A4",
+                              "strokeDasharray": undefined,
+                              "strokeWidth": 1,
+                            }
+                          }
+                          transform="translate(40,10)"
+                        />
+                      </LineSeries>
+                    </Motion>
+                  </Animation>
+                </LineSeries>
                 <AreaSeries
                   _adjustBy={Array []}
                   _adjustWhat={Array []}
@@ -323,6 +832,7 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                   onSeriesClick={[MockFunction]}
                   onSeriesMouseOut={[Function]}
                   onSeriesMouseOver={[Function]}
+                  opacity={1}
                   opacityDomain={Array []}
                   opacityType="literal"
                   radiusDomain={Array []}
@@ -502,6 +1012,7 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                     onSeriesClick={[MockFunction]}
                     onSeriesMouseOut={[Function]}
                     onSeriesMouseOver={[Function]}
+                    opacity={1}
                     opacityDomain={Array []}
                     opacityType="literal"
                     radiusDomain={Array []}
@@ -563,7 +1074,7 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                           "i": 0,
                         }
                       }
-                      key="0.00001"
+                      key="0.000030000000000000004"
                       onRest={[Function]}
                       style={
                         Object {
@@ -594,7 +1105,7 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                             undefined,
                           ]
                         }
-                        _animation={0.00002}
+                        _animation={0.00004}
                         _colorValue="#00B3A4"
                         _opacityValue={1}
                         _orientation="vertical"
@@ -663,6 +1174,7 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                         onSeriesClick={[MockFunction]}
                         onSeriesMouseOut={[Function]}
                         onSeriesMouseOver={[Function]}
+                        opacity={1}
                         opacityDomain={Array []}
                         opacityType="literal"
                         radiusDomain={Array []}
@@ -1292,7 +1804,7 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                               "i": 0,
                             }
                           }
-                          key="0.000030000000000000004"
+                          key="0.00005"
                           onRest={[Function]}
                           style={
                             Object {
@@ -1323,7 +1835,7 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                                 undefined,
                               ]
                             }
-                            _animation={0.00004}
+                            _animation={0.00006}
                             angleDomain={Array []}
                             animation={null}
                             attr="y"
@@ -1940,7 +2452,7 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                               "i": 0,
                             }
                           }
-                          key="0.00005"
+                          key="0.00007000000000000001"
                           onRest={[Function]}
                           style={
                             Object {
@@ -1971,7 +2483,7 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                                 undefined,
                               ]
                             }
-                            _animation={0.00006}
+                            _animation={0.00008}
                             angleDomain={Array []}
                             animation={null}
                             attr="x"
@@ -2106,7 +2618,7 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                                     undefined,
                                   ]
                                 }
-                                _animation={0.00006}
+                                _animation={0.00008}
                                 angleDomain={Array []}
                                 animation={null}
                                 attr="x"
@@ -2953,7 +3465,7 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                               "i": 0,
                             }
                           }
-                          key="0.00007000000000000001"
+                          key="0.00009"
                           onRest={[Function]}
                           style={
                             Object {
@@ -2984,7 +3496,7 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                                 undefined,
                               ]
                             }
-                            _animation={0.00008}
+                            _animation={0.0001}
                             angleDomain={Array []}
                             animation={null}
                             attr="y"
@@ -3119,7 +3631,7 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                                     undefined,
                                   ]
                                 }
-                                _animation={0.00008}
+                                _animation={0.0001}
                                 angleDomain={Array []}
                                 animation={null}
                                 attr="y"

--- a/src/components/series_chart/series/__snapshots__/area_series.test.js.snap
+++ b/src/components/series_chart/series/__snapshots__/area_series.test.js.snap
@@ -832,7 +832,6 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                   onSeriesClick={[MockFunction]}
                   onSeriesMouseOut={[Function]}
                   onSeriesMouseOver={[Function]}
-                  opacity={1}
                   opacityDomain={Array []}
                   opacityType="literal"
                   radiusDomain={Array []}
@@ -857,6 +856,7 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                   style={
                     Object {
                       "cursor": "default",
+                      "opacity": 1,
                     }
                   }
                   xDomain={
@@ -1012,7 +1012,6 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                     onSeriesClick={[MockFunction]}
                     onSeriesMouseOut={[Function]}
                     onSeriesMouseOver={[Function]}
-                    opacity={1}
                     opacityDomain={Array []}
                     opacityType="literal"
                     radiusDomain={Array []}
@@ -1037,6 +1036,7 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                     style={
                       Object {
                         "cursor": "default",
+                        "opacity": 1,
                       }
                     }
                     xDomain={
@@ -1174,7 +1174,6 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                         onSeriesClick={[MockFunction]}
                         onSeriesMouseOut={[Function]}
                         onSeriesMouseOver={[Function]}
-                        opacity={1}
                         opacityDomain={Array []}
                         opacityType="literal"
                         radiusDomain={Array []}
@@ -1199,6 +1198,7 @@ exports[`EuiAreaSeries all props are rendered 1`] = `
                         style={
                           Object {
                             "cursor": "default",
+                            "opacity": 1,
                           }
                         }
                         xDomain={

--- a/src/components/series_chart/series/__snapshots__/line_series.test.js.snap
+++ b/src/components/series_chart/series/__snapshots__/line_series.test.js.snap
@@ -118,6 +118,7 @@ exports[`EuiLineSeries all props are rendered 1`] = `
                 _orientation="vertical"
                 angleDomain={Array []}
                 animation={true}
+                borderOpacity={1}
                 clusters={
                   Set {
                     undefined,
@@ -4241,6 +4242,7 @@ exports[`EuiLineSeries is rendered 1`] = `
                 _orientation="vertical"
                 angleDomain={Array []}
                 animation={true}
+                borderOpacity={1}
                 clusters={
                   Set {
                     undefined,

--- a/src/components/series_chart/series/__snapshots__/line_series.test.js.snap
+++ b/src/components/series_chart/series/__snapshots__/line_series.test.js.snap
@@ -345,6 +345,7 @@ exports[`EuiLineSeries all props are rendered 1`] = `
                   strokeStyle="solid"
                   style={
                     Object {
+                      "opacity": 1,
                       "pointerEvents": "visiblestroke",
                       "strokeWidth": 3,
                     }
@@ -525,6 +526,7 @@ exports[`EuiLineSeries all props are rendered 1`] = `
                     strokeStyle="solid"
                     style={
                       Object {
+                        "opacity": 1,
                         "pointerEvents": "visiblestroke",
                         "strokeWidth": 3,
                       }
@@ -687,6 +689,7 @@ exports[`EuiLineSeries all props are rendered 1`] = `
                         strokeStyle="solid"
                         style={
                           Object {
+                            "opacity": 1,
                             "pointerEvents": "visiblestroke",
                             "strokeWidth": 3,
                           }
@@ -4463,6 +4466,7 @@ exports[`EuiLineSeries is rendered 1`] = `
                   strokeStyle="solid"
                   style={
                     Object {
+                      "opacity": 1,
                       "pointerEvents": "visiblestroke",
                       "strokeWidth": 3,
                     }
@@ -4641,6 +4645,7 @@ exports[`EuiLineSeries is rendered 1`] = `
                     strokeStyle="solid"
                     style={
                       Object {
+                        "opacity": 1,
                         "pointerEvents": "visiblestroke",
                         "strokeWidth": 3,
                       }
@@ -4801,6 +4806,7 @@ exports[`EuiLineSeries is rendered 1`] = `
                         strokeStyle="solid"
                         style={
                           Object {
+                            "opacity": 1,
                             "pointerEvents": "visiblestroke",
                             "strokeWidth": 3,
                           }

--- a/src/components/series_chart/series/_area_series.scss
+++ b/src/components/series_chart/series/_area_series.scss
@@ -1,3 +1,4 @@
 .euiAreaSeries {
   stroke-width: 0;
+  opacity: .2 !important;
 }

--- a/src/components/series_chart/series/_area_series.scss
+++ b/src/components/series_chart/series/_area_series.scss
@@ -1,4 +1,3 @@
 .euiAreaSeries {
-  stroke-width: 0;
-  opacity: .2 !important;
+  stroke-width: 0 !important;
 }

--- a/src/components/series_chart/series/area_series.js
+++ b/src/components/series_chart/series/area_series.js
@@ -65,13 +65,13 @@ export class EuiAreaSeries extends AbstractSeries {
           className="euiAreaSeries"
           curve={curve}
           color={color}
-          opacity={fillOpacity}
           data={data}
           onSeriesClick={onSeriesClick}
           onSeriesMouseOver={this._onSeriesMouseOver}
           onSeriesMouseOut={this._onSeriesMouseOut}
           style={{
             cursor: isMouseOverSeries && onSeriesClick ? 'pointer' : 'default',
+            opacity: fillOpacity,
           }}
           {...rest}
         />

--- a/src/components/series_chart/series/area_series.js
+++ b/src/components/series_chart/series/area_series.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { AreaSeries, AbstractSeries } from 'react-vis';
+import { AreaSeries, AbstractSeries, LineSeries } from 'react-vis';
 import { CURVE } from '../utils/chart_utils';
 
 import { VisualizationColorType } from '../utils/visualization_color_type';
@@ -44,22 +44,38 @@ export class EuiAreaSeries extends AbstractSeries {
 
   render() {
     const { isMouseOverSeries } = this.state;
-    const { name, data, curve, color, onSeriesClick, ...rest } = this.props;
+    const { name, data, curve, color, lineSize, onSeriesClick, fillOpacity, ...rest } = this.props;
     return (
-      <AreaSeries
-        key={`${name}-area`}
-        className="euiAreaSeries"
-        curve={curve}
-        color={color}
-        data={data}
-        onSeriesClick={onSeriesClick}
-        onSeriesMouseOver={this._onSeriesMouseOver}
-        onSeriesMouseOut={this._onSeriesMouseOut}
-        style={{
-          cursor: isMouseOverSeries && onSeriesClick ? 'pointer' : 'default',
-        }}
-        {...rest}
-      />
+      <React.Fragment>
+        <LineSeries
+          {...rest}
+          key={`${name}-line`}
+          curve={curve}
+          data={data}
+          opacity={1}
+          onSeriesClick={onSeriesClick}
+          color={color}
+          style={{
+            pointerEvents: 'visiblestroke',
+            strokeWidth: lineSize
+          }}
+        />
+        <AreaSeries
+          key={`${name}-area`}
+          className="euiAreaSeries"
+          curve={curve}
+          color={color}
+          opacity={fillOpacity}
+          data={data}
+          onSeriesClick={onSeriesClick}
+          onSeriesMouseOver={this._onSeriesMouseOver}
+          onSeriesMouseOut={this._onSeriesMouseOut}
+          style={{
+            cursor: isMouseOverSeries && onSeriesClick ? 'pointer' : 'default',
+          }}
+          {...rest}
+        />
+      </React.Fragment>
     );
   }
 }
@@ -78,8 +94,12 @@ EuiAreaSeries.propTypes = {
   color: VisualizationColorType,
   curve: PropTypes.oneOf(Object.values(CURVE)),
   onSeriesClick: PropTypes.func,
+  lineSize: PropTypes.number,
+  fillOpacity: PropTypes.number,
 };
 
 EuiAreaSeries.defaultProps = {
   curve: CURVE.LINEAR,
+  lineSize: 1,
+  fillOpacity: 1,
 };

--- a/src/components/series_chart/series/line_series.js
+++ b/src/components/series_chart/series/line_series.js
@@ -17,6 +17,7 @@ export class EuiLineSeries extends AbstractSeries {
       lineMarkColor,
       lineMarkSize,
       color,
+      borderOpacity,
       ...rest
     } = this.props;
 
@@ -27,7 +28,7 @@ export class EuiLineSeries extends AbstractSeries {
           key={`${name}-border`}
           curve={curve}
           data={data}
-          opacity={1}
+          opacity={borderOpacity}
           onSeriesClick={onSeriesClick}
           style={{
             pointerEvents: 'visiblestroke',
@@ -90,12 +91,14 @@ EuiLineSeries.propTypes = {
   lineMarkColor: PropTypes.string,
   lineMarkSize: PropTypes.number,
   onSeriesClick: PropTypes.func,
-  onValueClick: PropTypes.func
+  onValueClick: PropTypes.func,
+  borderOpacity: PropTypes.number,
 };
 
 EuiLineSeries.defaultProps = {
   curve: CURVE.LINEAR,
   showLineMarks: false,
   lineSize: 1,
-  lineMarkSize: 0
+  lineMarkSize: 0,
+  borderOpacity: 1,
 };

--- a/src/components/series_chart/series/line_series.js
+++ b/src/components/series_chart/series/line_series.js
@@ -28,11 +28,11 @@ export class EuiLineSeries extends AbstractSeries {
           key={`${name}-border`}
           curve={curve}
           data={data}
-          opacity={borderOpacity}
           onSeriesClick={onSeriesClick}
           style={{
             pointerEvents: 'visiblestroke',
             strokeWidth: lineSize + 2, // border margin
+            opacity: borderOpacity,
           }}
           _colorValue={'white'}
         />

--- a/src/components/series_chart/series_chart.js
+++ b/src/components/series_chart/series_chart.js
@@ -1,4 +1,4 @@
-import React, { PureComponent, Fragment } from 'react';
+import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 import { XYPlot, AbstractSeries  } from 'react-vis';
 import { makeFlexible } from './utils/flexible';
@@ -116,12 +116,11 @@ class XYChart extends PureComponent {
     if (this._isEmptyPlot(children)) {
       return (
         <EuiEmptyPrompt
-          iconType="stats"
-          title={<h2>Chart not available</h2>}
+          className="euiSeriesChartContainer__emptyPrompt"
+          iconType="visualizeApp"
+          title={<span>Chart not available</span>}
           body={
-            <Fragment>
-              <p>{ statusText }</p>
-            </Fragment>
+            <p>{ statusText }</p>
           }
         />
       );

--- a/src/components/series_chart/series_chart.test.js
+++ b/src/components/series_chart/series_chart.test.js
@@ -119,20 +119,4 @@ describe('EuiSeriesChart', () => {
     expect(lineComponents.at(2).props().color).toBe(VISUALIZATION_COLORS[1]);
     expect(lineComponents.at(AVAILABLE_COLORS + 1).props().color).toBe(VISUALIZATION_COLORS[0]);
   });
-
-  // Suppressing warning for now
-  // test(`Check wrong EUI color warning`, () => {
-  //   const data = [ { x: 0, y: 1 }, { x: 1, y: 2 }];
-  //   const original = console.warn;
-  //   const mock = jest.fn();
-  //   console.warn = mock;
-  //   mount(
-  //     <EuiSeriesChart {...XYCHART_PROPS} {...requiredProps}>
-  //       <EuiLineSeries name="test" color="#000000" data={data} />
-  //     </EuiSeriesChart>);
-  //   expect(console.warn.mock.calls[0][0]).toBe('Prefer safe EUI Visualization Colors.');
-  //   console.warn.mockClear();
-  //   console.warn = original;
-
-  // });
 });

--- a/src/components/series_chart/series_chart.test.js
+++ b/src/components/series_chart/series_chart.test.js
@@ -120,18 +120,19 @@ describe('EuiSeriesChart', () => {
     expect(lineComponents.at(AVAILABLE_COLORS + 1).props().color).toBe(VISUALIZATION_COLORS[0]);
   });
 
-  test(`Check wrong EUI color warning`, () => {
-    const data = [ { x: 0, y: 1 }, { x: 1, y: 2 }];
-    const original = console.warn;
-    const mock = jest.fn();
-    console.warn = mock;
-    mount(
-      <EuiSeriesChart {...XYCHART_PROPS} {...requiredProps}>
-        <EuiLineSeries name="test" color="#000000" data={data} />
-      </EuiSeriesChart>);
-    expect(console.warn.mock.calls[0][0]).toBe('Prefer safe EUI Visualization Colors.');
-    console.warn.mockClear();
-    console.warn = original;
+  // Suppressing warning for now
+  // test(`Check wrong EUI color warning`, () => {
+  //   const data = [ { x: 0, y: 1 }, { x: 1, y: 2 }];
+  //   const original = console.warn;
+  //   const mock = jest.fn();
+  //   console.warn = mock;
+  //   mount(
+  //     <EuiSeriesChart {...XYCHART_PROPS} {...requiredProps}>
+  //       <EuiLineSeries name="test" color="#000000" data={data} />
+  //     </EuiSeriesChart>);
+  //   expect(console.warn.mock.calls[0][0]).toBe('Prefer safe EUI Visualization Colors.');
+  //   console.warn.mockClear();
+  //   console.warn = original;
 
-  });
+  // });
 });

--- a/src/components/series_chart/status-text.js
+++ b/src/components/series_chart/status-text.js
@@ -16,7 +16,7 @@ function StatusText({ width, height, text }) {
         }}
       >
         <div className="euiToastHeader--withBody">
-          <EuiIcon className="euiToastHeader__icon" type="stats" size="m" aria-hidden="true" />
+          <EuiIcon className="euiToastHeader__icon" type="visualizeApp" color="subdued" size="m" aria-hidden="true" />
           <span className="euiToastHeader__title">Graph not avaliable</span>
         </div>
         {text && <EuiText size="s">{text}</EuiText>}

--- a/src/components/series_chart/utils/visualization_color_type.js
+++ b/src/components/series_chart/utils/visualization_color_type.js
@@ -1,5 +1,3 @@
-import { VISUALIZATION_COLORS } from '../../../services';
-
 export function VisualizationColorType(props, propName) {
   const color = props[propName];
   if (color === undefined) {
@@ -9,9 +7,5 @@ export function VisualizationColorType(props, propName) {
   // using libs like colorjs
   if (!(typeof color === 'string' || color instanceof String) || !color.startsWith('#')) {
     return new Error('Color must be a valid hex color string in the form #RRGGBB');
-  }
-  if (!VISUALIZATION_COLORS.includes(color.toUpperCase())) {
-    // Suppress warning for now as it can overwhelm the console for custom charts
-    // console.warn('Prefer safe EUI Visualization Colors.');
   }
 }

--- a/src/components/series_chart/utils/visualization_color_type.js
+++ b/src/components/series_chart/utils/visualization_color_type.js
@@ -11,6 +11,7 @@ export function VisualizationColorType(props, propName) {
     return new Error('Color must be a valid hex color string in the form #RRGGBB');
   }
   if (!VISUALIZATION_COLORS.includes(color.toUpperCase())) {
-    console.warn('Prefer safe EUI Visualization Colors.');
+    // Suppress warning for now as it can overwhelm the console for custom charts
+    // console.warn('Prefer safe EUI Visualization Colors.');
   }
 }


### PR DESCRIPTION
### Summary

### 1. Suppressing non-EUI vis color warning
I commented out the console warning (and tests) that displayed if you passed a color that is not one of the EUI vis palette colors. Every chart render would spit out this warning and would really overload the console output. I only commented it for now to allow us to revisit if necessary.

### 2. Added some opacity options to line and area series’
I kept the defaults of `1` but this helps to be able to lessen the line series border and area series fill.

Ex:

<img width="550" alt="screen shot 2018-09-18 at 12 38 08 pm" src="https://user-images.githubusercontent.com/549577/45702447-d8d56e80-bb3f-11e8-8ab0-8870739837df.png">

### 3. Using the visualize app logo for empty prompt and vertically centering
Also, changed some spacing to be conditional EuiEmptyPrompt (only add space between content and actions if both `body` and `actions` exist).

**Before**

<img width="414" alt="screen shot 2018-09-18 at 12 22 00 pm" src="https://user-images.githubusercontent.com/549577/45702559-27830880-bb40-11e8-8bd0-7265c7b88f05.png">


**After**

<img width="433" alt="screen shot 2018-09-18 at 12 21 37 pm" src="https://user-images.githubusercontent.com/549577/45702565-2f42ad00-bb40-11e8-9034-2716ca1ba8cd.png">


### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode (Yes, but charts still have dark mode issues)
- [x] Any props added have proper autodocs
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
~- [ ] This was checked for breaking changes and labeled appropriately~
- [x] Jest tests were updated or added to match the most common scenarios
~- [ ] This was checked against keyboard-only and screenreader scenarios~
