### PR TITLE
Make EuiBasicTable rows keyboard-accessible when they are clickable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Fixed issue with unselected tabs and aria-controls attribute in EuiTabbedContent
 - Added `tag` icon ([#1188](https://github.com/elastic/eui/pull/1188))
 - Replaced `logging` app icon ([#1194](https://github.com/elastic/eui/pull/1194))
-- Made `EuiBasicTable` rows keyboard-accessibile when they are clickable
+- Made `EuiBasicTable` rows keyboard-accessibile when they are clickable ([#1206](https://github.com/elastic/eui/pull/1206))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed issue with unselected tabs and aria-controls attribute in EuiTabbedContent
 - Added `tag` icon ([#1188](https://github.com/elastic/eui/pull/1188))
 - Replaced `logging` app icon ([#1194](https://github.com/elastic/eui/pull/1194))
+- Made `EuiBasicTable` rows keyboard-accessibile when they are clickable
 
 **Bug fixes**
 

--- a/src/components/basic_table/__snapshots__/basic_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.js.snap
@@ -473,59 +473,65 @@ exports[`EuiBasicTable rowProps renders rows with custom props from a callback 1
         <React.Fragment
           key="row_0"
         >
-          <EuiTableRow
-            className="customRowClass"
-            data-test-subj="row-1"
-            isSelected={false}
-            onClick={[Function]}
-          >
-            <EuiTableRowCell
-              align="left"
-              header="Name"
-              key="_data_column_name_0_0"
-              textOnly={true}
+          <EuiKeyboardAccessible>
+            <EuiTableRow
+              className="customRowClass"
+              data-test-subj="row-1"
+              isSelected={false}
+              onClick={[Function]}
             >
-              name1
-            </EuiTableRowCell>
-          </EuiTableRow>
+              <EuiTableRowCell
+                align="left"
+                header="Name"
+                key="_data_column_name_0_0"
+                textOnly={true}
+              >
+                name1
+              </EuiTableRowCell>
+            </EuiTableRow>
+          </EuiKeyboardAccessible>
         </React.Fragment>
         <React.Fragment
           key="row_1"
         >
-          <EuiTableRow
-            className="customRowClass"
-            data-test-subj="row-2"
-            isSelected={false}
-            onClick={[Function]}
-          >
-            <EuiTableRowCell
-              align="left"
-              header="Name"
-              key="_data_column_name_1_0"
-              textOnly={true}
+          <EuiKeyboardAccessible>
+            <EuiTableRow
+              className="customRowClass"
+              data-test-subj="row-2"
+              isSelected={false}
+              onClick={[Function]}
             >
-              name2
-            </EuiTableRowCell>
-          </EuiTableRow>
+              <EuiTableRowCell
+                align="left"
+                header="Name"
+                key="_data_column_name_1_0"
+                textOnly={true}
+              >
+                name2
+              </EuiTableRowCell>
+            </EuiTableRow>
+          </EuiKeyboardAccessible>
         </React.Fragment>
         <React.Fragment
           key="row_2"
         >
-          <EuiTableRow
-            className="customRowClass"
-            data-test-subj="row-3"
-            isSelected={false}
-            onClick={[Function]}
-          >
-            <EuiTableRowCell
-              align="left"
-              header="Name"
-              key="_data_column_name_2_0"
-              textOnly={true}
+          <EuiKeyboardAccessible>
+            <EuiTableRow
+              className="customRowClass"
+              data-test-subj="row-3"
+              isSelected={false}
+              onClick={[Function]}
             >
-              name3
-            </EuiTableRowCell>
-          </EuiTableRow>
+              <EuiTableRowCell
+                align="left"
+                header="Name"
+                key="_data_column_name_2_0"
+                textOnly={true}
+              >
+                name3
+              </EuiTableRowCell>
+            </EuiTableRow>
+          </EuiKeyboardAccessible>
         </React.Fragment>
       </EuiTableBody>
     </EuiTable>
@@ -567,59 +573,65 @@ exports[`EuiBasicTable rowProps renders rows with custom props from an object 1`
         <React.Fragment
           key="row_0"
         >
-          <EuiTableRow
-            className="customClass"
-            data-test-subj="row"
-            isSelected={false}
-            onClick={[Function]}
-          >
-            <EuiTableRowCell
-              align="left"
-              header="Name"
-              key="_data_column_name_0_0"
-              textOnly={true}
+          <EuiKeyboardAccessible>
+            <EuiTableRow
+              className="customClass"
+              data-test-subj="row"
+              isSelected={false}
+              onClick={[Function]}
             >
-              name1
-            </EuiTableRowCell>
-          </EuiTableRow>
+              <EuiTableRowCell
+                align="left"
+                header="Name"
+                key="_data_column_name_0_0"
+                textOnly={true}
+              >
+                name1
+              </EuiTableRowCell>
+            </EuiTableRow>
+          </EuiKeyboardAccessible>
         </React.Fragment>
         <React.Fragment
           key="row_1"
         >
-          <EuiTableRow
-            className="customClass"
-            data-test-subj="row"
-            isSelected={false}
-            onClick={[Function]}
-          >
-            <EuiTableRowCell
-              align="left"
-              header="Name"
-              key="_data_column_name_1_0"
-              textOnly={true}
+          <EuiKeyboardAccessible>
+            <EuiTableRow
+              className="customClass"
+              data-test-subj="row"
+              isSelected={false}
+              onClick={[Function]}
             >
-              name2
-            </EuiTableRowCell>
-          </EuiTableRow>
+              <EuiTableRowCell
+                align="left"
+                header="Name"
+                key="_data_column_name_1_0"
+                textOnly={true}
+              >
+                name2
+              </EuiTableRowCell>
+            </EuiTableRow>
+          </EuiKeyboardAccessible>
         </React.Fragment>
         <React.Fragment
           key="row_2"
         >
-          <EuiTableRow
-            className="customClass"
-            data-test-subj="row"
-            isSelected={false}
-            onClick={[Function]}
-          >
-            <EuiTableRowCell
-              align="left"
-              header="Name"
-              key="_data_column_name_2_0"
-              textOnly={true}
+          <EuiKeyboardAccessible>
+            <EuiTableRow
+              className="customClass"
+              data-test-subj="row"
+              isSelected={false}
+              onClick={[Function]}
             >
-              name3
-            </EuiTableRowCell>
-          </EuiTableRow>
+              <EuiTableRowCell
+                align="left"
+                header="Name"
+                key="_data_column_name_2_0"
+                textOnly={true}
+              >
+                name3
+              </EuiTableRowCell>
+            </EuiTableRow>
+          </EuiKeyboardAccessible>
         </React.Fragment>
       </EuiTableBody>
     </EuiTable>

--- a/src/components/basic_table/basic_table.js
+++ b/src/components/basic_table/basic_table.js
@@ -30,7 +30,7 @@ import { LoadingTableBody } from './loading_table_body';
 import { EuiTableHeaderMobile } from '../table/mobile/table_header_mobile';
 import { EuiTableSortMobile } from '../table/mobile/table_sort_mobile';
 import { withRequiredProp } from '../../utils/prop_types/with_required_prop';
-import { EuiScreenReaderOnly } from '../accessibility';
+import { EuiScreenReaderOnly, EuiKeyboardAccessible } from '../accessibility';
 
 const dataTypesProfiles = {
   auto: {
@@ -609,19 +609,25 @@ export class EuiBasicTable extends Component {
 
     const { rowProps: rowPropsCallback } = this.props;
     const rowProps = getRowProps(item, rowPropsCallback);
+    const row = (
+      <EuiTableRow
+        aria-owns={expandedRowId}
+        isSelectable={isSelectable == null ? calculatedHasSelection : isSelectable}
+        isSelected={selected}
+        hasActions={hasActions == null ? calculatedHasActions : hasActions}
+        isExpandable={isExpandable}
+        {...rowProps}
+      >
+        {cells}
+      </EuiTableRow>
+    );
 
     return (
       <Fragment key={`row_${itemId}`}>
-        <EuiTableRow
-          aria-owns={expandedRowId}
-          isSelectable={isSelectable == null ? calculatedHasSelection : isSelectable}
-          isSelected={selected}
-          hasActions={hasActions == null ? calculatedHasActions : hasActions}
-          isExpandable={isExpandable}
-          {...rowProps}
-        >
-          {cells}
-        </EuiTableRow>
+        {rowProps.onClick
+          ? <EuiKeyboardAccessible>{row}</EuiKeyboardAccessible>
+          : row
+        }
         {expandedRow}
       </Fragment>
     );

--- a/src/components/flex/_flex_item.scss
+++ b/src/components/flex/_flex_item.scss
@@ -6,7 +6,7 @@
 .euiFlexItem {
   display: flex; /* 1 */
   flex-direction: column; /* 1 */
-  
+
   @include internetExplorerOnly {
     min-width: 1px; /* 2 */
   }

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -219,3 +219,10 @@
     max-height: 1000px;
   }
 }
+
+.euiTableRow-isClickable {
+  &:focus {
+    outline: solid 3px transparentize($euiColorPrimary, .9);
+    background-color: transparentize($euiColorPrimary, .9);
+  }
+}

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -221,8 +221,11 @@
 }
 
 .euiTableRow-isClickable {
+  &:hover {
+    background-color: $euiTableHoverClickableColor;
+  }
+
   &:focus {
-    outline: solid 3px transparentize($euiColorPrimary, .9);
-    background-color: transparentize($euiColorPrimary, .9);
+    background-color: $euiTableFocusClickableColor;
   }
 }

--- a/src/components/table/_variables.scss
+++ b/src/components/table/_variables.scss
@@ -9,6 +9,8 @@ $euiTableActionsAreaWidth: $euiSizeXXL;
 
 // Colors
 
+$euiTableHoverClickableColor: transparentize($euiColorPrimary, .95);
+$euiTableFocusClickableColor: transparentize($euiColorPrimary, .9)
 $euiTableHoverColor: tintOrShade($euiColorLightestShade, 50%, 20%);
 $euiTableSelectedColor: tintOrShade($euiFocusBackgroundColor, 30%, 0%);
 $euiTableHoverSelectedColor: tintOrShade($euiFocusBackgroundColor, 0, 10%);

--- a/src/components/table/_variables.scss
+++ b/src/components/table/_variables.scss
@@ -9,9 +9,9 @@ $euiTableActionsAreaWidth: $euiSizeXXL;
 
 // Colors
 
-$euiTableHoverClickableColor: transparentize($euiColorPrimary, .95);
-$euiTableFocusClickableColor: transparentize($euiColorPrimary, .9)
 $euiTableHoverColor: tintOrShade($euiColorLightestShade, 50%, 20%);
 $euiTableSelectedColor: tintOrShade($euiFocusBackgroundColor, 30%, 0%);
 $euiTableHoverSelectedColor: tintOrShade($euiFocusBackgroundColor, 0, 10%);
 $euiTableActionsBorderColor: transparentize($euiColorMediumShade, .9);
+$euiTableHoverClickableColor: transparentize($euiColorPrimary, .95);
+$euiTableFocusClickableColor: transparentize($euiColorPrimary, .9);

--- a/src/components/table/table_row.js
+++ b/src/components/table/table_row.js
@@ -10,6 +10,7 @@ export const EuiTableRow = ({
   hasActions,
   isExpandedRow,
   isExpandable,
+  onClick,
   ...rest
 }) => {
   const classes = classNames('euiTableRow', className, {
@@ -18,11 +19,13 @@ export const EuiTableRow = ({
     'euiTableRow-hasActions': hasActions,
     'euiTableRow-isExpandedRow': isExpandedRow,
     'euiTableRow-isExpandable': isExpandable,
+    'euiTableRow-isClickable': onClick,
   });
 
   return (
     <tr
       className={classes}
+      onClick={onClick}
       {...rest}
     >
       {children}


### PR DESCRIPTION
### Summary

When a row has an `onClick` applied to it, the row becomes keyboard-accessible (you can tab to it) and has a visual focus state.

![table_keyboard_accessibility](https://user-images.githubusercontent.com/1238659/45907784-2f47e480-bdae-11e8-9cc6-a6fa0443ac14.gif)

### Checklist

- [x] This was checked in mobile
- [ ] This was checked in IE11
- [x] This was checked in dark mode
- [x] Any props added have proper autodocs
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios
- [x] This was checked against keyboard-only and screenreader scenarios
