### PR TITLE
Adds colorPalette service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `4.2.0`.
+- Added a new `colorPalette` service for retrieving and generating color arrays for use in charts ([#1209](https://github.com/elastic/eui/pull/1209))
 
 ## [`4.2.0`](https://github.com/elastic/eui/tree/v4.2.0)
 

--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -150,6 +150,21 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   outline: solid 2px purple;
 }
 
+.guideColorPalette__swatch {
+  
+  span {
+    height: $euiSize;
+    width: $euiSizeL;
+  }
+  
+  &:first-child span {
+    border-radius: $euiBorderRadius 0 0 $euiBorderRadius;
+  }
+
+  &:last-child span {
+    border-radius: 0 $euiBorderRadius $euiBorderRadius 0;
+  }
+}
 
 @import "../views/guidelines/index";
 @import "guide_section/index";
@@ -192,5 +207,22 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
 
   .guidePageContent {
     margin-left: 0;
+  }
+
+  .euiFlexGroup--responsive > .euiFlexItem.guideColorPalette__swatch {
+    margin-bottom: 0 !important;
+
+    span {
+      height: $euiSize;
+      width: $euiSizeL;
+    }
+    
+    &:first-child span {
+      border-radius: $euiBorderRadius $euiBorderRadius 0 0;
+    }
+  
+    &:last-child span {
+      border-radius: 0 0 $euiBorderRadius $euiBorderRadius;
+    }
   }
 }

--- a/src-docs/src/routes.js
+++ b/src-docs/src/routes.js
@@ -36,6 +36,9 @@ import WritingGuidelines
 
 // Services
 
+import { ColorPaletteExample }
+  from './views/color_palette/color_palette_example';
+
 import { IsColorDarkExample }
   from './views/is_color_dark/is_color_dark_example';
 
@@ -395,17 +398,18 @@ const navigation = [{
   name: 'Utilities',
   items: [
     AccessibilityExample,
+    ColorPaletteExample,
     CopyExample,
-    ResponsiveExample,
+    UtilityClassesExample,
     DelayHideExample,
     ErrorBoundaryExample,
     HighlightExample,
     IsColorDarkExample,
+    MutationObserverExample,
     OutsideClickDetectorExample,
     PortalExample,
+    ResponsiveExample,
     ToggleExample,
-    UtilityClassesExample,
-    MutationObserverExample,
     WindowEventExample,
   ].map(example => createExample(example)),
 }, {

--- a/src-docs/src/views/color_palette/color_palette.js
+++ b/src-docs/src/views/color_palette/color_palette.js
@@ -8,22 +8,22 @@ import {
 } from '../../../../src/components';
 
 import {
-  colorPalette,
   palettes,
 } from '../../../../src/services';
 
-const availablePalettes = Object.keys(palettes);
+const paletteData = palettes;
+const paletteNames = Object.keys(paletteData);
 
 export default () => (
   <Fragment>
     {
-      availablePalettes.map((paletteName, i) => (
+      paletteNames.map((paletteName, i) => (
         <div key={paletteName}>
           <EuiTitle key={i} size="xxs"><h3>{paletteName}</h3></EuiTitle>
           <EuiSpacer size="s" />
           <EuiFlexGroup gutterSize="none" alignItems="flexStart" key={`${paletteName}-${i}`}>
             {
-              colorPalette(paletteName).map((hexCode, j) => (
+              paletteData[paletteName].colors.map((hexCode, j) => (
                 <EuiFlexItem key={`${hexCode}-${j}`} grow={false} className={'guideColorPalette__swatch'}>
                   <span title={hexCode} style={{ backgroundColor: hexCode }} />
                 </EuiFlexItem>

--- a/src-docs/src/views/color_palette/color_palette.js
+++ b/src-docs/src/views/color_palette/color_palette.js
@@ -1,0 +1,38 @@
+import React, { Fragment } from 'react';
+
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiTitle,
+  EuiSpacer,
+} from '../../../../src/components';
+
+import {
+  colorPalette,
+  palettes,
+} from '../../../../src/services';
+
+const availablePalettes = Object.keys(palettes);
+
+export default () => (
+  <Fragment>
+    {
+      availablePalettes.map((paletteName, i) => (
+        <div key={paletteName}>
+          <EuiTitle key={i} size="xxs"><h3>{paletteName}</h3></EuiTitle>
+          <EuiSpacer size="s" />
+          <EuiFlexGroup gutterSize="none" alignItems="flexStart" key={`${paletteName}-${i}`}>
+            {
+              colorPalette(paletteName).map((hexCode, j) => (
+                <EuiFlexItem key={`${hexCode}-${j}`} grow={false} className={'guideColorPalette__swatch'}>
+                  <span title={hexCode} style={{ backgroundColor: hexCode }} />
+                </EuiFlexItem>
+              ))
+            }
+          </EuiFlexGroup>
+          <EuiSpacer size="l" />
+        </div>
+      ))
+    }
+  </Fragment>
+);

--- a/src-docs/src/views/color_palette/color_palette_custom.js
+++ b/src-docs/src/views/color_palette/color_palette_custom.js
@@ -9,27 +9,37 @@ import {
 
 import {
   colorPalette,
+  palettes,
 } from '../../../../src/services';
+
+const euiColors = palettes.euiPaletteForLightBackground.colors;
 
 export default () => (
   <Fragment>
-    <EuiTitle size="xxs"><h3>Status: yellow to green</h3></EuiTitle>
+    <EuiTitle size="xxs"><h3>For mapping density, low to high</h3></EuiTitle>
     <EuiSpacer size="s" />
-    <EuiFlexGroup gutterSize="none" alignItems="flexStart">
-      {
-        colorPalette('FFFF6D', '1EA593', 20).map((hexCode, k) => (
-          <EuiFlexItem key={`${hexCode}-${k}`} grow={false} className={'guideColorPalette__swatch'}>
-            <span title={hexCode} style={{ backgroundColor: hexCode }} />
-          </EuiFlexItem>
-        ))
-      }
-    </EuiFlexGroup>
+    {
+      euiColors.map((color, j) => (
+        <div key={j}>
+          <EuiFlexGroup gutterSize="none" alignItems="flexStart" key={`${color}-${j}`}>
+            {
+              colorPalette('FFFFFF', color, 20).map((hexCode, k) => (
+                <EuiFlexItem key={`${hexCode}-${k}`} grow={false} className={'guideColorPalette__swatch'}>
+                  <span title={hexCode} style={{ backgroundColor: hexCode }} />
+                </EuiFlexItem>
+              ))
+            }
+          </EuiFlexGroup>
+          <EuiSpacer size="m" />
+        </div>
+      ))
+    }
     <EuiSpacer size="l" />
-    <EuiTitle size="xxs"><h3>Status: yellow to red</h3></EuiTitle>
+    <EuiTitle size="xxs"><h3>For communicating state, trending negaitve</h3></EuiTitle>
     <EuiSpacer size="s" />
     <EuiFlexGroup gutterSize="none" alignItems="flexStart">
       {
-        colorPalette('#FFFF6D', '#A30000', 15).map((hexCode, l) => (
+        colorPalette('#FBEFD3', '#BD4C48').map((hexCode, l) => (
           <EuiFlexItem key={`${hexCode}-${l}`} grow={false} className={'guideColorPalette__swatch'}>
             <span title={hexCode} style={{ backgroundColor: hexCode }} />
           </EuiFlexItem>
@@ -37,11 +47,11 @@ export default () => (
       }
     </EuiFlexGroup>
     <EuiSpacer size="l" />
-    <EuiTitle size="xxs"><h3>Status: green to pink</h3></EuiTitle>
+    <EuiTitle size="xxs"><h3>For communicating state, trending positive</h3></EuiTitle>
     <EuiSpacer size="s" />
     <EuiFlexGroup gutterSize="none" alignItems="flexStart">
       {
-        colorPalette('#1EA593', '#DD0A73').map((hexCode, l) => (
+        colorPalette('#FFFFE0', '#017F75').map((hexCode, l) => (
           <EuiFlexItem key={`${hexCode}-${l}`} grow={false} className={'guideColorPalette__swatch'}>
             <span title={hexCode} style={{ backgroundColor: hexCode }} />
           </EuiFlexItem>

--- a/src-docs/src/views/color_palette/color_palette_custom.js
+++ b/src-docs/src/views/color_palette/color_palette_custom.js
@@ -1,0 +1,52 @@
+import React, { Fragment } from 'react';
+
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiTitle,
+  EuiSpacer,
+} from '../../../../src/components';
+
+import {
+  colorPalette,
+} from '../../../../src/services';
+
+export default () => (
+  <Fragment>
+    <EuiTitle size="xxs"><h3>Custom red to blue</h3></EuiTitle>
+    <EuiSpacer size="s" />
+    <EuiFlexGroup gutterSize="none" alignItems="flexStart">
+      {
+        colorPalette('custom', '#FF0000', '#00FFFF', 25).map((hexCode, j) => (
+          <EuiFlexItem key={`${hexCode}-${j}`} grow={false} className={'guideColorPalette__swatch'}>
+            <span title={hexCode} style={{ backgroundColor: hexCode }} />
+          </EuiFlexItem>
+        ))
+      }
+    </EuiFlexGroup>
+    <EuiSpacer size="l" />
+    <EuiTitle size="xxs"><h3>Custom yellow to green</h3></EuiTitle>
+    <EuiSpacer size="s" />
+    <EuiFlexGroup gutterSize="none" alignItems="flexStart">
+      {
+        colorPalette('custom', 'F7EE55', '4EB265', 20).map((hexCode, k) => (
+          <EuiFlexItem key={`${hexCode}-${k}`} grow={false} className={'guideColorPalette__swatch'}>
+            <span title={hexCode} style={{ backgroundColor: hexCode }} />
+          </EuiFlexItem>
+        ))
+      }
+    </EuiFlexGroup>
+    <EuiSpacer size="l" />
+    <EuiTitle size="xxs"><h3>Custom green to red</h3></EuiTitle>
+    <EuiSpacer size="s" />
+    <EuiFlexGroup gutterSize="none" alignItems="flexStart">
+      {
+        colorPalette('custom', '#4EB265', '#920000').map((hexCode, l) => (
+          <EuiFlexItem key={`${hexCode}-${l}`} grow={false} className={'guideColorPalette__swatch'}>
+            <span title={hexCode} style={{ backgroundColor: hexCode }} />
+          </EuiFlexItem>
+        ))
+      }
+    </EuiFlexGroup>
+  </Fragment>
+);

--- a/src-docs/src/views/color_palette/color_palette_custom.js
+++ b/src-docs/src/views/color_palette/color_palette_custom.js
@@ -13,23 +13,11 @@ import {
 
 export default () => (
   <Fragment>
-    <EuiTitle size="xxs"><h3>Custom red to blue</h3></EuiTitle>
+    <EuiTitle size="xxs"><h3>Status: yellow to green</h3></EuiTitle>
     <EuiSpacer size="s" />
     <EuiFlexGroup gutterSize="none" alignItems="flexStart">
       {
-        colorPalette('custom', '#FF0000', '#00FFFF', 25).map((hexCode, j) => (
-          <EuiFlexItem key={`${hexCode}-${j}`} grow={false} className={'guideColorPalette__swatch'}>
-            <span title={hexCode} style={{ backgroundColor: hexCode }} />
-          </EuiFlexItem>
-        ))
-      }
-    </EuiFlexGroup>
-    <EuiSpacer size="l" />
-    <EuiTitle size="xxs"><h3>Custom yellow to green</h3></EuiTitle>
-    <EuiSpacer size="s" />
-    <EuiFlexGroup gutterSize="none" alignItems="flexStart">
-      {
-        colorPalette('custom', 'F7EE55', '4EB265', 20).map((hexCode, k) => (
+        colorPalette('FFFF6D', '1EA593', 20).map((hexCode, k) => (
           <EuiFlexItem key={`${hexCode}-${k}`} grow={false} className={'guideColorPalette__swatch'}>
             <span title={hexCode} style={{ backgroundColor: hexCode }} />
           </EuiFlexItem>
@@ -37,11 +25,23 @@ export default () => (
       }
     </EuiFlexGroup>
     <EuiSpacer size="l" />
-    <EuiTitle size="xxs"><h3>Custom green to red</h3></EuiTitle>
+    <EuiTitle size="xxs"><h3>Status: yellow to red</h3></EuiTitle>
     <EuiSpacer size="s" />
     <EuiFlexGroup gutterSize="none" alignItems="flexStart">
       {
-        colorPalette('custom', '#4EB265', '#920000').map((hexCode, l) => (
+        colorPalette('#FFFF6D', '#A30000', 15).map((hexCode, l) => (
+          <EuiFlexItem key={`${hexCode}-${l}`} grow={false} className={'guideColorPalette__swatch'}>
+            <span title={hexCode} style={{ backgroundColor: hexCode }} />
+          </EuiFlexItem>
+        ))
+      }
+    </EuiFlexGroup>
+    <EuiSpacer size="l" />
+    <EuiTitle size="xxs"><h3>Status: green to pink</h3></EuiTitle>
+    <EuiSpacer size="s" />
+    <EuiFlexGroup gutterSize="none" alignItems="flexStart">
+      {
+        colorPalette('#1EA593', '#DD0A73').map((hexCode, l) => (
           <EuiFlexItem key={`${hexCode}-${l}`} grow={false} className={'guideColorPalette__swatch'}>
             <span title={hexCode} style={{ backgroundColor: hexCode }} />
           </EuiFlexItem>

--- a/src-docs/src/views/color_palette/color_palette_example.js
+++ b/src-docs/src/views/color_palette/color_palette_example.js
@@ -1,0 +1,79 @@
+import React from 'react';
+
+import { renderToHtml } from '../../services';
+
+import {
+  GuideSectionTypes,
+} from '../../components';
+
+import {
+  EuiCode,
+} from '../../../../src/components';
+
+import ColorPalette from './color_palette';
+const colorPaletteSource = require('!!raw-loader!./color_palette');
+const colorPaletteHtml = renderToHtml(ColorPalette);
+
+import ColorPaletteCustom from './color_palette_custom';
+const colorPaletteCustomSource = require('!!raw-loader!./color_palette_custom');
+const colorPaletteCustomHtml = renderToHtml(ColorPaletteCustom);
+
+import ColorPaletteHistogram from './color_palette_histogram';
+const colorPaletteHistogramSource = require('!!raw-loader!./color_palette_histogram');
+const colorPaletteHistogramHtml = renderToHtml(ColorPaletteHistogram);
+
+export const ColorPaletteExample = {
+  title: 'Color Palettes',
+  sections: [{
+    title: 'Preset color palettes',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: colorPaletteSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: colorPaletteHtml,
+    }],
+    text: (
+      <p>
+        Use the <EuiCode>colorPalette</EuiCode> service to obtain an array of
+        hexidecimal color codes for a given palette such as
+        <EuiCode>colorPalette&#40;&#39;color_blind&#39;&#41;</EuiCode>, then apply them to UI
+        elements such as charts.
+      </p>
+    ),
+    demo: <ColorPalette />,
+  }, {
+    title: 'Custom color palettes',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: colorPaletteCustomSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: colorPaletteCustomHtml,
+    }],
+    text: (
+      <p>
+        Generate a custom palette of any length from two hexidecimal color
+        codes such as
+        <EuiCode>colorPalette&#40;&#39;custom&#39;, &#39;#FF0000&#39;, &#39;#00FFFF&#39;, 25&#41;</EuiCode>.
+      </p>
+    ),
+    demo: <ColorPaletteCustom />,
+  }, {
+    title: 'Chart example',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: colorPaletteHistogramSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: colorPaletteHistogramHtml,
+    }],
+    text: (
+      <p>
+        Apply the results of <EuiCode>colorPalette</EuiCode> to the
+        <EuiCode>color</EuiCode> prop of EUI chart components.
+      </p>
+    ),
+    demo: <ColorPaletteHistogram />,
+  }],
+};

--- a/src-docs/src/views/color_palette/color_palette_example.js
+++ b/src-docs/src/views/color_palette/color_palette_example.js
@@ -25,7 +25,7 @@ const colorPaletteHistogramHtml = renderToHtml(ColorPaletteHistogram);
 export const ColorPaletteExample = {
   title: 'Color Palettes',
   sections: [{
-    title: 'Preset color palettes',
+    title: 'Preset qualitative palettes',
     source: [{
       type: GuideSectionTypes.JS,
       code: colorPaletteSource,
@@ -34,16 +34,22 @@ export const ColorPaletteExample = {
       code: colorPaletteHtml,
     }],
     text: (
-      <p>
-        Use the <EuiCode>colorPalette</EuiCode> service to obtain an array of
-        hexidecimal color codes for a given palette such as
-        <EuiCode>colorPalette&#40;&#39;color_blind&#39;&#41;</EuiCode>, then apply them to UI
-        elements such as charts.
-      </p>
+      <div>
+        <p>
+          The <EuiCode>eui_palettes.js</EuiCode> file provides a base set of color palettes in
+          an array format. The hexidecimal color codes in these sets consist of both color safe
+          and EUI themed colors. Import the file, then use javascript to read and apply the color
+          array values to other EUI components, such as charts.
+        </p>
+        <p>
+          Quantitative palettes are best suited for communicating and comparing discrete
+          data series.
+        </p>
+      </div>
     ),
     demo: <ColorPalette />,
   }, {
-    title: 'Custom color palettes',
+    title: 'Recommended quantitative palettes',
     source: [{
       type: GuideSectionTypes.JS,
       code: colorPaletteCustomSource,
@@ -52,15 +58,22 @@ export const ColorPaletteExample = {
       code: colorPaletteCustomHtml,
     }],
     text: (
-      <p>
-        Generate a custom palette of any length from two hexidecimal color
-        codes such as
-        <EuiCode>colorPalette&#40;&#39;custom&#39;, &#39;#FF0000&#39;, &#39;#00FFFF&#39;, 25&#41;</EuiCode>.
-      </p>
+      <div>
+        <p>
+          Use the <EuiCode>colorPalette</EuiCode> service to generate a custom, gradiated palette
+          array of any length from two hexidecimal color codes. For example, obtain an array of
+          yellow-to-green health status colors using
+          <EuiCode>colorPalette&#40;&#39;#FFFF6D&#39;, &#39;#1EA593&#39;, 20&#41;</EuiCode>.
+        </p>
+        <p>
+          Custom palettes are best suited for displaying data on a continuum, as in the case of
+          health statuses and large geographic or demographic-based data sets.
+        </p>
+      </div>
     ),
     demo: <ColorPaletteCustom />,
   }, {
-    title: 'Chart example',
+    title: 'Usage examples',
     source: [{
       type: GuideSectionTypes.JS,
       code: colorPaletteHistogramSource,
@@ -70,8 +83,8 @@ export const ColorPaletteExample = {
     }],
     text: (
       <p>
-        Apply the results of <EuiCode>colorPalette</EuiCode> to the
-        <EuiCode>color</EuiCode> prop of EUI chart components.
+        Apply the colors from <EuiCode>eui_palettes.js</EuiCode> or the <EuiCode>colorPalette</EuiCode>
+        service to the <EuiCode>color</EuiCode> prop of EUI chart components.
       </p>
     ),
     demo: <ColorPaletteHistogram />,

--- a/src-docs/src/views/color_palette/color_palette_histogram.js
+++ b/src-docs/src/views/color_palette/color_palette_histogram.js
@@ -1,13 +1,17 @@
 import React, { Component, Fragment } from 'react';
 
 import {
+  EuiSpacer,
+} from '../../../../src/components';
+import {
   EuiSeriesChart,
   EuiHistogramSeries,
   EuiSeriesChartUtils,
 } from '../../../../src/experimental';
 import {
   colorPalette,
-} from '../../../../src/services/color/color_palette';
+  palettes,
+} from '../../../../src/services/color';
 
 const { SCALE } = EuiSeriesChartUtils;
 const timestamp = Date.now();
@@ -18,7 +22,8 @@ const margins = {
   right: 0,
   bottom: 20,
 };
-const colors = colorPalette('custom', 'FF0000', '#00FFFF', 6);
+const qualColors = palettes.color_blind.colors;
+const quantColors = colorPalette('#FFFF6D', '#1EA593', 6);
 
 function randomizeData(size = 24, max = 8) {
   return new Array(size)
@@ -48,7 +53,11 @@ export default class Example extends Component {
     return (
       <Fragment>
         <EuiSeriesChart width={600} height={200} xType={SCALE.TIME} stackBy="y" margins={margins}>
-          {data.map((d, i) => <EuiHistogramSeries key={i} name={`Chart ${i}`} data={d} color={colors[i]} />)}
+          {data.map((d, i) => <EuiHistogramSeries key={i} name={`Chart ${i}`} data={d} color={qualColors[i]} />)}
+        </EuiSeriesChart>
+        <EuiSpacer size="xl" />
+        <EuiSeriesChart width={600} height={200} xType={SCALE.TIME} stackBy="y" margins={margins}>
+          {data.map((d, i) => <EuiHistogramSeries key={i} name={`Chart ${i}`} data={d} color={quantColors[i]} />)}
         </EuiSeriesChart>
       </Fragment>
     );

--- a/src-docs/src/views/color_palette/color_palette_histogram.js
+++ b/src-docs/src/views/color_palette/color_palette_histogram.js
@@ -22,7 +22,7 @@ const margins = {
   right: 0,
   bottom: 20,
 };
-const qualColors = palettes.color_blind.colors;
+const qualColors = palettes.euiPaletteColorBlind.colors;
 const quantColors = colorPalette('#FFFF6D', '#1EA593', 6);
 
 function randomizeData(size = 24, max = 8) {

--- a/src-docs/src/views/color_palette/color_palette_histogram.js
+++ b/src-docs/src/views/color_palette/color_palette_histogram.js
@@ -1,0 +1,56 @@
+import React, { Component, Fragment } from 'react';
+
+import {
+  EuiSeriesChart,
+  EuiHistogramSeries,
+  EuiSeriesChartUtils,
+} from '../../../../src/experimental';
+import {
+  colorPalette,
+} from '../../../../src/services/color/color_palette';
+
+const { SCALE } = EuiSeriesChartUtils;
+const timestamp = Date.now();
+const ONE_HOUR = 3600000;
+const margins = {
+  top: 10,
+  left: 80,
+  right: 0,
+  bottom: 20,
+};
+const colors = colorPalette('custom', 'FF0000', '#00FFFF', 6);
+
+function randomizeData(size = 24, max = 8) {
+  return new Array(size)
+    .fill(0)
+    .map((d, i) => ({
+      x0: ONE_HOUR * i,
+      x: ONE_HOUR * (i + 1),
+      y: Math.floor(Math.random() * max),
+    }))
+    .map(el => ({
+      x0: el.x0 + timestamp,
+      x: el.x + timestamp,
+      y: el.y,
+    }));
+}
+function buildData(series) {
+  const max = Math.ceil(Math.random() * 1000000);
+  return new Array(series).fill(0).map(() => randomizeData(20, max));
+}
+export default class Example extends Component {
+  state = {
+    series: 6,
+    data: buildData(6),
+  };
+  render() {
+    const { data } = this.state;
+    return (
+      <Fragment>
+        <EuiSeriesChart width={600} height={200} xType={SCALE.TIME} stackBy="y" margins={margins}>
+          {data.map((d, i) => <EuiHistogramSeries key={i} name={`Chart ${i}`} data={d} color={colors[i]} />)}
+        </EuiSeriesChart>
+      </Fragment>
+    );
+  }
+}

--- a/src/components/series_chart/series/area_series.js
+++ b/src/components/series_chart/series/area_series.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import { AreaSeries, AbstractSeries, LineSeries } from 'react-vis';
 import { CURVE } from '../utils/chart_utils';
 
-import { VisualizationColorType } from '../utils/visualization_color_type';
-
 // TODO: needs to send a PR to react-vis for incorporate these changes into AreaSeries class for vertical
 // area chart visualizations.
 // class ExtendedAreaSeries extends AreaSeries {
@@ -90,8 +88,8 @@ EuiAreaSeries.propTypes = {
       y: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     })
   ).isRequired,
-  /** An EUI visualization color, the default value is enforced by EuiSeriesChart */
-  color: VisualizationColorType,
+  /** See eui_palettes.js or colorPalette service for recommended colors */
+  color: PropTypes.string,
   curve: PropTypes.oneOf(Object.values(CURVE)),
   onSeriesClick: PropTypes.func,
   lineSize: PropTypes.number,

--- a/src/components/series_chart/series/bar_series.js
+++ b/src/components/series_chart/series/bar_series.js
@@ -4,8 +4,6 @@ import { VerticalBarSeries, HorizontalBarSeries, AbstractSeries } from 'react-vi
 import { ORIENTATION } from '../utils/chart_utils';
 import classNames from 'classnames';
 
-import { VisualizationColorType } from '../utils/visualization_color_type';
-
 export class EuiBarSeries extends AbstractSeries {
   state = {
     isMouseOverValue: false,
@@ -68,10 +66,8 @@ EuiBarSeries.propTypes = {
       PropTypes.number
     ]),
   })).isRequired,
-  /**
-   * An EUI visualization color, the default value is passed through EuiSeriesChart
-   */
-  color: VisualizationColorType,
+  /** See eui_palettes.js or colorPalette service for recommended colors */
+  color: PropTypes.string,
   /**
    * @private passed via XYChart
    */

--- a/src/components/series_chart/series/histogram_series.js
+++ b/src/components/series_chart/series/histogram_series.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { VerticalRectSeries, HorizontalRectSeries, AbstractSeries } from 'react-vis';
 import { ORIENTATION } from '../utils/chart_utils';
-import { VISUALIZATION_COLORS } from '../../../services';
 import classNames from 'classnames';
 
 export class EuiHistogramSeries extends AbstractSeries {
@@ -63,8 +62,8 @@ EuiHistogramSeries.propTypes = {
       PropTypes.number
     ]),
   })).isRequired,
-  /** An EUI visualization color, the default value is enforced by EuiSeriesChart */
-  color: PropTypes.oneOf(VISUALIZATION_COLORS),
+  /** See eui_palettes.js or colorPalette service for recommended colors */
+  color: PropTypes.string,
 
   /**
    * @private passed via XYChart

--- a/src/components/series_chart/series/horizontal_bar_series.js
+++ b/src/components/series_chart/series/horizontal_bar_series.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import { HorizontalBarSeries } from 'react-vis';
 import classNames from 'classnames';
 
-import { VisualizationColorType } from '../utils/visualization_color_type';
-
 export class EuiHorizontalBarSeries extends HorizontalBarSeries {
   state = {
     isMouseOverValue: false,
@@ -55,8 +53,8 @@ EuiHorizontalBarSeries.propTypes = {
       PropTypes.number
     ]),
   })).isRequired,
-  /** An EUI visualization color, the default value is enforced by EuiSeriesChart */
-  color: VisualizationColorType,
+  /** See eui_palettes.js or colorPalette service for recommended colors */
+  color: PropTypes.string,
   /**
    * Callback when clicking on a bar. Returns { x, y } object.
    */

--- a/src/components/series_chart/series/horizontal_rect_series.js
+++ b/src/components/series_chart/series/horizontal_rect_series.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import { HorizontalRectSeries } from 'react-vis';
 import classNames from 'classnames';
 
-import { VisualizationColorType } from '../utils/visualization_color_type';
-
 export class EuiHorizontalRectSeries extends HorizontalRectSeries {
   state = {
     isMouseOverValue: false,
@@ -53,8 +51,8 @@ EuiHorizontalRectSeries.propTypes = {
     y: PropTypes.number,
     y0: PropTypes.number,
   })).isRequired,
-  /** An EUI visualization color, the default value is enforced by EuiSeriesChart */
-  color: VisualizationColorType,
+  /** See eui_palettes.js or colorPalette service for recommended colors */
+  color: PropTypes.string,
   /**
    * Callback when clicking on a bar. Returns { x, y } object.
    */

--- a/src/components/series_chart/series/line_series.js
+++ b/src/components/series_chart/series/line_series.js
@@ -2,7 +2,6 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { LineSeries, MarkSeries, AbstractSeries } from 'react-vis';
 import { CURVE } from '../utils/chart_utils';
-import { VisualizationColorType } from '../utils/visualization_color_type';
 
 export class EuiLineSeries extends AbstractSeries {
   render() {
@@ -83,8 +82,8 @@ EuiLineSeries.propTypes = {
       PropTypes.number
     ]),
   })).isRequired,
-  /** An EUI visualization color, the default value is enforced by EuiSeriesChart */
-  color: VisualizationColorType,
+  /** See eui_palettes.js or colorPalette service for recommended colors */
+  color: PropTypes.string,
   curve: PropTypes.oneOf(Object.values(CURVE)),
   showLineMarks: PropTypes.bool,
   lineSize: PropTypes.number,

--- a/src/components/series_chart/series/vertical_bar_series.js
+++ b/src/components/series_chart/series/vertical_bar_series.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import { VerticalBarSeries } from 'react-vis';
 import classNames from 'classnames';
 
-import { VisualizationColorType } from '../utils/visualization_color_type';
-
 export class EuiVerticalBarSeries extends VerticalBarSeries {
   state = {
     isMouseOverValue: false,
@@ -55,8 +53,8 @@ EuiVerticalBarSeries.propTypes = {
     ]),
     y: PropTypes.number,
   })).isRequired,
-  /** An EUI visualization color, the default value is enforced by EuiSeriesChart */
-  color: VisualizationColorType,
+  /** See eui_palettes.js or colorPalette service for recommended colors */
+  color: PropTypes.string,
   /**
    * Callback when clicking on a bar. Returns { x, y } object.
    */

--- a/src/components/series_chart/series/vertical_rect_series.js
+++ b/src/components/series_chart/series/vertical_rect_series.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import { VerticalRectSeries } from 'react-vis';
 import classNames from 'classnames';
 
-import { VisualizationColorType } from '../utils/visualization_color_type';
-
 export class EuiVerticalRectSeries extends VerticalRectSeries {
   state = {
     isMouseOverValue: false,
@@ -53,8 +51,8 @@ EuiVerticalRectSeries.propTypes = {
     x: PropTypes.number,
     y: PropTypes.number,
   })).isRequired,
-  /** An EUI visualization color, the default value is enforced by EuiSeriesChart */
-  color: VisualizationColorType,
+  /** See eui_palettes.js or colorPalette service for recommended colors */
+  color: PropTypes.string,
   /**
    * Callback when clicking on a bar. Returns { x, y } object.
    */

--- a/src/services/color/color_palette.js
+++ b/src/services/color/color_palette.js
@@ -1,0 +1,165 @@
+import { palettes } from './eui_palettes';
+
+/**
+ * This function takes a color palette name and returns an array of hex color
+ * codes for use in UI elements such as charts.
+ *
+ * @param {string} paletteName Required. The name of the palette being requested
+ * Set paletteName to "custom" and provide two hex color codes for a custom palette
+ * @param {string} hexStart The beginning hexidecimal color code
+ * @param {string} hexEnd The ending hexidecimal color code
+ * @param {number} len The number of colors in the resulting array (default 10)
+ * @returns {Array} Returns an array of hexidecimal color codes
+ */
+
+function colorPalette(paletteName, hexStart, hexEnd, len = 10) {
+  if (typeof paletteName !== 'undefined' && paletteName !== 'custom') {
+    try {
+      const palette = palettes[paletteName]; // get the palette
+      const hexColors = palette.colors; // get the palette colors
+      return hexColors;
+    } catch(e) {
+      const availablePalettes = Object.keys(palettes);
+      throw new Error(`${paletteName} is not a valid palette name. Please select from ${availablePalettes}`);
+    }
+  } else if (paletteName === 'custom') {
+    if (isHex(hexStart) && isHex(hexEnd)) {
+      const hex1 = formatHex(hexStart);
+      const hex2 = formatHex(hexEnd);
+      const customColors = generatePalette(hex1, hex2, len); // generate custom palette
+      return customColors;
+    } else {
+      throw new Error('Please provide two valid hex color codes.');
+    }
+  }
+}
+
+/**
+ * Check if argument is a valid 3 or 6 character hexidecimal color code
+ */
+function isHex(value) {
+  return /^#?([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/.test(value);
+}
+
+/**
+ * Check if value can be interpreted as a number for subsequent math operations
+ */
+function isValid(c) {
+  let valid = 'n';
+  if ((!isNaN(c[0])) && (!isNaN(c[1])) && (!isNaN(c[2]))) {valid = 'y';}
+  return valid;
+}
+
+/**
+ * Calculate and construct the hexideciaml color code from RGB values
+ */
+function createHex(c) {
+  let result = '';
+  let k = 0;
+  let val = 0;
+  let piece;
+  const d = 1;
+  const base = 16;
+  for (k = 0; k < 3; k++) {
+    val = Math.round(c[k] / d);
+    piece = val.toString(base); // Converts to radix 16 based value (0-9, A-F)
+    if (piece.length < 2) {piece = `0${piece}`;}
+    result = result + piece;
+  }
+  result = `#${result.toUpperCase()}`; // Return in #RRGGBB fomat
+  return result;
+}
+
+/**
+ * Create the color object for manipulation by other functions
+ */
+class Color {
+  constructor(r, g, b) {
+    this.r = r; // Red value
+    this.g = g; // Green value
+    this.b = b; // Blue value
+    this.collection = new Array(r, g, b);
+    this.valid = isValid(this.collection);
+    this.text = createHex(this.collection);
+  }
+}
+
+/**
+ * Convert hexideciaml color into an array of RGB integer values
+ */
+function colorParse(color) {
+  const m = 1;
+  const base = 16;
+  let a;
+  let b;
+  let c = color.toUpperCase();
+  let col = c.replace(/[\#\(]*/i, '');
+
+  if (col.length === 3) {
+    a = col.substr(0, 1);
+    b = col.substr(1, 1);
+    c = col.substr(2, 1);
+    col = a + a + b + b + c + c;
+  }
+  const num = new Array(col.substr(0, 2), col.substr(2, 2), col.substr(4, 2));
+  const ret = new Array(parseInt(num[0], base) * m, parseInt(num[1], base) * m, parseInt(num[2], base) * m);
+  return(ret);
+}
+
+/**
+ * Format hexideciaml inputs to #RRGGBB
+ */
+function formatHex(hex) {
+  let cleanHex = hex;
+  if (cleanHex.length === 3 || cleanHex.length === 6) {
+    cleanHex = `#${cleanHex}`;
+  }
+  if (cleanHex.length === 4) {
+    cleanHex = cleanHex.split('');
+    cleanHex = cleanHex[0] + cleanHex[1] + cleanHex[1] + cleanHex[2] + cleanHex[2] + cleanHex[3] + cleanHex[3];
+  }
+  return cleanHex;
+}
+
+/**
+ * Calculate the step increment for each piece of the hexidecimal color code
+ */
+function stepCalc(st, cStart, cEnd) {
+  const steps = st;
+  const step = new Array(3);
+  step[0] = (cEnd.r - cStart.r) / steps; // Calc step amount for red value
+  step[1] = (cEnd.g - cStart.g) / steps; // Calc step amount for green value
+  step[2] = (cEnd.b - cStart.b) / steps; // Calc step amount for blue value
+
+  return step;
+}
+
+/**
+ * Generate a custom plette array from two hexidecimal color code values
+ */
+function generatePalette(start, end, len) {
+  const colorArray = new Array();
+  const hexPalette = new Array();
+  const count = len - 1;
+  const startHex = colorParse(start);
+  const endHex = colorParse(end);
+  let i = 1;
+  let step = new Array(3);
+  colorArray[0] = new Color(startHex[0], startHex[1], startHex[2]); // first color
+  colorArray[count] = new Color(endHex[0], endHex[1], endHex[2]); // last color
+  step = stepCalc(count, colorArray[0], colorArray[count]); // get array of step increments
+  hexPalette[0] = colorArray[0].text; // set the first index value of the array
+  for (i = 1; i < count; i++) {
+    // set the intermediate index values of the array
+    const r = (colorArray[0].r + (step[0] * i));
+    const g = (colorArray[0].g + (step[1] * i));
+    const b = (colorArray[0].b + (step[2] * i));
+    colorArray[i] = new Color(r, g, b);
+    hexPalette[i] = colorArray[i].text;
+  } // all the colors in between
+  hexPalette[count] = colorArray[count].text; // set the last index value of the array
+
+  return hexPalette;
+}
+
+export { colorPalette };

--- a/src/services/color/color_palette.js
+++ b/src/services/color/color_palette.js
@@ -1,4 +1,15 @@
-import { palettes } from './eui_palettes';
+/**
+ * Create the color object for manipulation by other functions
+ */
+class Color {
+  constructor(r, g, b) {
+    this.r = r; // Red value
+    this.g = g; // Green value
+    this.b = b; // Blue value
+    this.collection = [r, g, b];
+    this.text = createHex(this.collection);
+  }
+}
 
 /**
  * This function takes a color palette name and returns an array of hex color
@@ -12,25 +23,34 @@ import { palettes } from './eui_palettes';
  * @returns {Array} Returns an array of hexidecimal color codes
  */
 
-function colorPalette(paletteName, hexStart, hexEnd, len = 10) {
-  if (typeof paletteName !== 'undefined' && paletteName !== 'custom') {
-    try {
-      const palette = palettes[paletteName]; // get the palette
-      const hexColors = palette.colors; // get the palette colors
-      return hexColors;
-    } catch(e) {
-      const availablePalettes = Object.keys(palettes);
-      throw new Error(`${paletteName} is not a valid palette name. Please select from ${availablePalettes}`);
-    }
-  } else if (paletteName === 'custom') {
-    if (isHex(hexStart) && isHex(hexEnd)) {
-      const hex1 = formatHex(hexStart);
-      const hex2 = formatHex(hexEnd);
-      const customColors = generatePalette(hex1, hex2, len); // generate custom palette
-      return customColors;
-    } else {
-      throw new Error('Please provide two valid hex color codes.');
-    }
+function colorPalette(hexStart, hexEnd, len = 10) {
+  if (isHex(hexStart) && isHex(hexEnd)) {
+    const hex1 = formatHex(hexStart); // format to #RRGGBB
+    const hex2 = formatHex(hexEnd); // format to #RRGGBB
+    const colorArray = [];
+    const hexPalette = [];
+    const count = len - 1;
+    const startHex = colorParse(hex1); // get RGB equivalent values as array
+    const endHex = colorParse(hex2); // get RGB equivalent values as array
+    let step = new Array(3); // to collect each step increment piece (r,g,b)
+    colorArray[0] = new Color(startHex[0], startHex[1], startHex[2]); // create first color obj
+    colorArray[count] = new Color(endHex[0], endHex[1], endHex[2]); // create last color obj
+    step = stepCalc(count, colorArray[0], colorArray[count]); // create array of step increments
+    // build the color palette array
+    hexPalette[0] = colorArray[0].text; // set the first color in the array
+    for (let i = 1; i < count; i++) {
+      // set the intermediate colors in the array
+      const r = (colorArray[0].r + (step[0] * i));
+      const g = (colorArray[0].g + (step[1] * i));
+      const b = (colorArray[0].b + (step[2] * i));
+      colorArray[i] = new Color(r, g, b);
+      hexPalette[i] = colorArray[i].text;
+    } // all the colors in between
+    hexPalette[count] = colorArray[count].text; // set the last color in the array
+
+    return hexPalette;
+  } else {
+    throw new Error('Please provide two valid hex color codes.');
   }
 }
 
@@ -44,33 +64,20 @@ function isHex(value) {
 /**
  * Calculate and construct the hexideciaml color code from RGB values
  */
-function createHex(c) {
+function createHex(rgbValues) {
   let result = '';
   let val = 0;
   let piece;
   const d = 1;
   const base = 16;
   for (let k = 0; k < 3; k++) {
-    val = Math.round(c[k] / d);
+    val = Math.round(rgbValues[k] / d);
     piece = val.toString(base); // Converts to radix 16 based value (0-9, A-F)
     if (piece.length < 2) {piece = `0${piece}`;}
     result = result + piece;
   }
   result = `#${result.toUpperCase()}`; // Return in #RRGGBB fomat
   return result;
-}
-
-/**
- * Create the color object for manipulation by other functions
- */
-class Color {
-  constructor(r, g, b) {
-    this.r = r; // Red value
-    this.g = g; // Green value
-    this.b = b; // Blue value
-    this.collection = [r, g, b];
-    this.text = createHex(this.collection);
-  }
 }
 
 /**
@@ -121,33 +128,6 @@ function stepCalc(st, cStart, cEnd) {
   step[2] = (cEnd.b - cStart.b) / steps; // Calc step amount for blue value
 
   return step;
-}
-
-/**
- * Generate a custom plette array from two hexidecimal color code values
- */
-function generatePalette(start, end, len) {
-  const colorArray = [];
-  const hexPalette = [];
-  const count = len - 1;
-  const startHex = colorParse(start);
-  const endHex = colorParse(end);
-  let step = new Array(3);
-  colorArray[0] = new Color(startHex[0], startHex[1], startHex[2]); // first color
-  colorArray[count] = new Color(endHex[0], endHex[1], endHex[2]); // last color
-  step = stepCalc(count, colorArray[0], colorArray[count]); // get array of step increments
-  hexPalette[0] = colorArray[0].text; // set the first index value of the array
-  for (let i = 1; i < count; i++) {
-    // set the intermediate index values of the array
-    const r = (colorArray[0].r + (step[0] * i));
-    const g = (colorArray[0].g + (step[1] * i));
-    const b = (colorArray[0].b + (step[2] * i));
-    colorArray[i] = new Color(r, g, b);
-    hexPalette[i] = colorArray[i].text;
-  } // all the colors in between
-  hexPalette[count] = colorArray[count].text; // set the last index value of the array
-
-  return hexPalette;
 }
 
 export { colorPalette };

--- a/src/services/color/color_palette.js
+++ b/src/services/color/color_palette.js
@@ -15,8 +15,6 @@ class Color {
  * This function takes a color palette name and returns an array of hex color
  * codes for use in UI elements such as charts.
  *
- * @param {string} paletteName Required. The name of the palette being requested
- * Set paletteName to "custom" and provide two hex color codes for a custom palette
  * @param {string} hexStart The beginning hexidecimal color code
  * @param {string} hexEnd The ending hexidecimal color code
  * @param {number} len The number of colors in the resulting array (default 10)
@@ -32,10 +30,9 @@ function colorPalette(hexStart, hexEnd, len = 10) {
     const count = len - 1;
     const startHex = colorParse(hex1); // get RGB equivalent values as array
     const endHex = colorParse(hex2); // get RGB equivalent values as array
-    let step = new Array(3); // to collect each step increment piece (r,g,b)
     colorArray[0] = new Color(startHex[0], startHex[1], startHex[2]); // create first color obj
     colorArray[count] = new Color(endHex[0], endHex[1], endHex[2]); // create last color obj
-    step = stepCalc(count, colorArray[0], colorArray[count]); // create array of step increments
+    const step = stepCalc(count, colorArray[0], colorArray[count]); // create array of step increments
     // build the color palette array
     hexPalette[0] = colorArray[0].text; // set the first color in the array
     for (let i = 1; i < count; i++) {
@@ -68,10 +65,9 @@ function createHex(rgbValues) {
   let result = '';
   let val = 0;
   let piece;
-  const d = 1;
   const base = 16;
   for (let k = 0; k < 3; k++) {
-    val = Math.round(rgbValues[k] / d);
+    val = Math.round(rgbValues[k]);
     piece = val.toString(base); // Converts to radix 16 based value (0-9, A-F)
     if (piece.length < 2) {piece = `0${piece}`;}
     result = result + piece;
@@ -84,21 +80,17 @@ function createHex(rgbValues) {
  * Convert hexideciaml color into an array of RGB integer values
  */
 function colorParse(color) {
-  const m = 1;
   const base = 16;
-  let a;
-  let b;
-  let c = color.toUpperCase();
-  let col = c.replace('#', '');
+  let col = color.toUpperCase().replace('#', '');
 
   if (col.length === 3) {
-    a = col.substr(0, 1);
-    b = col.substr(1, 1);
-    c = col.substr(2, 1);
+    const a = col.substr(0, 1);
+    const b = col.substr(1, 1);
+    const c = col.substr(2, 1);
     col = a + a + b + b + c + c;
   }
   const num = [col.substr(0, 2), col.substr(2, 2), col.substr(4, 2)];
-  const ret = [parseInt(num[0], base) * m, parseInt(num[1], base) * m, parseInt(num[2], base) * m];
+  const ret = [parseInt(num[0], base), parseInt(num[1], base), parseInt(num[2], base)];
   return(ret);
 }
 
@@ -122,10 +114,11 @@ function formatHex(hex) {
  */
 function stepCalc(st, cStart, cEnd) {
   const steps = st;
-  const step = new Array(3);
-  step[0] = (cEnd.r - cStart.r) / steps; // Calc step amount for red value
-  step[1] = (cEnd.g - cStart.g) / steps; // Calc step amount for green value
-  step[2] = (cEnd.b - cStart.b) / steps; // Calc step amount for blue value
+  const step = [
+    (cEnd.r - cStart.r) / steps, // Calc step amount for red value
+    (cEnd.g - cStart.g) / steps, // Calc step amount for green value
+    (cEnd.b - cStart.b) / steps, // Calc step amount for blue value
+  ];
 
   return step;
 }

--- a/src/services/color/color_palette.js
+++ b/src/services/color/color_palette.js
@@ -42,25 +42,15 @@ function isHex(value) {
 }
 
 /**
- * Check if value can be interpreted as a number for subsequent math operations
- */
-function isValid(c) {
-  let valid = 'n';
-  if ((!isNaN(c[0])) && (!isNaN(c[1])) && (!isNaN(c[2]))) {valid = 'y';}
-  return valid;
-}
-
-/**
  * Calculate and construct the hexideciaml color code from RGB values
  */
 function createHex(c) {
   let result = '';
-  let k = 0;
   let val = 0;
   let piece;
   const d = 1;
   const base = 16;
-  for (k = 0; k < 3; k++) {
+  for (let k = 0; k < 3; k++) {
     val = Math.round(c[k] / d);
     piece = val.toString(base); // Converts to radix 16 based value (0-9, A-F)
     if (piece.length < 2) {piece = `0${piece}`;}
@@ -78,8 +68,7 @@ class Color {
     this.r = r; // Red value
     this.g = g; // Green value
     this.b = b; // Blue value
-    this.collection = new Array(r, g, b);
-    this.valid = isValid(this.collection);
+    this.collection = [r, g, b];
     this.text = createHex(this.collection);
   }
 }
@@ -93,7 +82,7 @@ function colorParse(color) {
   let a;
   let b;
   let c = color.toUpperCase();
-  let col = c.replace(/[\#\(]*/i, '');
+  let col = c.replace('#', '');
 
   if (col.length === 3) {
     a = col.substr(0, 1);
@@ -101,8 +90,8 @@ function colorParse(color) {
     c = col.substr(2, 1);
     col = a + a + b + b + c + c;
   }
-  const num = new Array(col.substr(0, 2), col.substr(2, 2), col.substr(4, 2));
-  const ret = new Array(parseInt(num[0], base) * m, parseInt(num[1], base) * m, parseInt(num[2], base) * m);
+  const num = [col.substr(0, 2), col.substr(2, 2), col.substr(4, 2)];
+  const ret = [parseInt(num[0], base) * m, parseInt(num[1], base) * m, parseInt(num[2], base) * m];
   return(ret);
 }
 
@@ -138,18 +127,17 @@ function stepCalc(st, cStart, cEnd) {
  * Generate a custom plette array from two hexidecimal color code values
  */
 function generatePalette(start, end, len) {
-  const colorArray = new Array();
-  const hexPalette = new Array();
+  const colorArray = [];
+  const hexPalette = [];
   const count = len - 1;
   const startHex = colorParse(start);
   const endHex = colorParse(end);
-  let i = 1;
   let step = new Array(3);
   colorArray[0] = new Color(startHex[0], startHex[1], startHex[2]); // first color
   colorArray[count] = new Color(endHex[0], endHex[1], endHex[2]); // last color
   step = stepCalc(count, colorArray[0], colorArray[count]); // get array of step increments
   hexPalette[0] = colorArray[0].text; // set the first index value of the array
-  for (i = 1; i < count; i++) {
+  for (let i = 1; i < count; i++) {
     // set the intermediate index values of the array
     const r = (colorArray[0].r + (step[0] * i));
     const g = (colorArray[0].g + (step[1] * i));

--- a/src/services/color/eui_palettes.js
+++ b/src/services/color/eui_palettes.js
@@ -1,16 +1,16 @@
 export const palettes = {
   color_blind: {
     colors: [
-      '#1ea593',
-      '#2b70f7',
-      '#ce0060',
-      '#38007e',
-      '#fca5d3',
-      '#f37020',
-      '#e49e29',
-      '#b0916f',
-      '#7b000b',
-      '#34130c',
+      '#1EA593',
+      '#2B70F7',
+      '#CE0060',
+      '#38007E',
+      '#FCA5D3',
+      '#F37020',
+      '#E49E29',
+      '#B0916F',
+      '#7B000B',
+      '#34130C',
     ],
   },
   color_blind_15: {
@@ -18,21 +18,21 @@ export const palettes = {
       '#000000',
       '#004949',
       '#009292',
-      '#ff6db6',
-      '#ffb6db',
+      '#FF6DB6',
+      '#FFB6DB',
       '#490092',
-      '#006ddb',
-      '#b66dff',
-      '#6db6ff',
-      '#b6dbff',
+      '#006DDB',
+      '#B66DFF',
+      '#6DB6FF',
+      '#B6DBFF',
       '#920000',
       '#924900',
-      '#db6d00',
-      '#24ff24',
-      '#ffff6d',
+      '#DB6D00',
+      '#24FF24',
+      '#FFFF6D',
     ]
   },
-  eui_colors: {
+  eui_light: {
     colors: [
       '#0079A5',
       '#017F75',
@@ -41,31 +41,13 @@ export const palettes = {
       '#DD0A73',
     ]
   },
-  eui_colors_light: {
+  eui_dark: {
     colors: [
-      '#009ED8',
+      '#4DA1C0',
       '#01B2A4',
-      '#F39B33',
-      '#D60000',
+      '#C06C4C',
+      '#BF4D4D',
       '#F5258C',
     ]
   },
-  spectrum: {
-    colors: [
-      '#882E72',
-      '#B178A6',
-      '#D6C1DE',
-      '#1965B0',
-      '#5289C7',
-      '#7BAFDE',
-      '#4EB265',
-      '#90C987',
-      '#CAE0AB',
-      '#F7EE55',
-      '#F6C141',
-      '#F1932D',
-      '#E8601C',
-      '#DC050C',
-    ]
-  }
 };

--- a/src/services/color/eui_palettes.js
+++ b/src/services/color/eui_palettes.js
@@ -1,5 +1,5 @@
 export const palettes = {
-  color_blind: {
+  euiPaletteColorBlind: {
     colors: [
       '#1EA593',
       '#2B70F7',
@@ -13,26 +13,7 @@ export const palettes = {
       '#34130C',
     ],
   },
-  color_blind_15: {
-    colors: [
-      '#000000',
-      '#004949',
-      '#009292',
-      '#FF6DB6',
-      '#FFB6DB',
-      '#490092',
-      '#006DDB',
-      '#B66DFF',
-      '#6DB6FF',
-      '#B6DBFF',
-      '#920000',
-      '#924900',
-      '#DB6D00',
-      '#24FF24',
-      '#FFFF6D',
-    ]
-  },
-  eui_light: {
+  euiPaletteForLightBackground: {
     colors: [
       '#0079A5',
       '#017F75',
@@ -41,13 +22,27 @@ export const palettes = {
       '#DD0A73',
     ]
   },
-  eui_dark: {
+  euiPaletteForDarkBackground: {
     colors: [
       '#4DA1C0',
       '#01B2A4',
       '#C06C4C',
       '#BF4D4D',
       '#F5258C',
+    ]
+  },
+  euiPaletteForStatus: {
+    colors: [
+      '#58BA6D',
+      '#6ECE67',
+      '#A5E26A',
+      '#D2E26A',
+      '#EBDF61',
+      '#EBD361',
+      '#EBC461',
+      '#D99D4C',
+      '#D97E4C',
+      '#D75949',
     ]
   },
 };

--- a/src/services/color/eui_palettes.js
+++ b/src/services/color/eui_palettes.js
@@ -1,9 +1,3 @@
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License;
- * you may not use this file except in compliance with the Elastic License.
- */
-
 export const palettes = {
   color_blind: {
     colors: [

--- a/src/services/color/eui_palettes.js
+++ b/src/services/color/eui_palettes.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+export const palettes = {
+  color_blind: {
+    colors: [
+      '#1ea593',
+      '#2b70f7',
+      '#ce0060',
+      '#38007e',
+      '#fca5d3',
+      '#f37020',
+      '#e49e29',
+      '#b0916f',
+      '#7b000b',
+      '#34130c',
+    ],
+  },
+  color_blind_15: {
+    colors: [
+      '#000000',
+      '#004949',
+      '#009292',
+      '#ff6db6',
+      '#ffb6db',
+      '#490092',
+      '#006ddb',
+      '#b66dff',
+      '#6db6ff',
+      '#b6dbff',
+      '#920000',
+      '#924900',
+      '#db6d00',
+      '#24ff24',
+      '#ffff6d',
+    ]
+  },
+  eui_colors: {
+    colors: [
+      '#0079A5',
+      '#017F75',
+      '#E5830E',
+      '#A30000',
+      '#DD0A73',
+    ]
+  },
+  eui_colors_light: {
+    colors: [
+      '#009ED8',
+      '#01B2A4',
+      '#F39B33',
+      '#D60000',
+      '#F5258C',
+    ]
+  },
+  spectrum: {
+    colors: [
+      '#882E72',
+      '#B178A6',
+      '#D6C1DE',
+      '#1965B0',
+      '#5289C7',
+      '#7BAFDE',
+      '#4EB265',
+      '#90C987',
+      '#CAE0AB',
+      '#F7EE55',
+      '#F6C141',
+      '#F1932D',
+      '#E8601C',
+      '#DC050C',
+    ]
+  }
+};

--- a/src/services/color/index.js
+++ b/src/services/color/index.js
@@ -3,3 +3,5 @@ export { hexToRgb } from './hex_to_rgb';
 export { rgbToHex } from './rgb_to_hex';
 export { calculateContrast, calculateLuminance } from './luminance_and_contrast';
 export { VISUALIZATION_COLORS, DEFAULT_VISUALIZATION_COLOR } from './visualization_colors';
+export { colorPalette } from './color_palette';
+export { palettes } from './eui_palettes';

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -23,6 +23,8 @@ export {
   rgbToHex,
   VISUALIZATION_COLORS,
   DEFAULT_VISUALIZATION_COLOR,
+  colorPalette,
+  palettes,
 } from './color';
 
 export {


### PR DESCRIPTION
### Summary

Adds a service that accepts a palette name and returns an array of hexidecimal color codes for use in other EUI components such as charts.

You can either...
a) pull a palette by name from the eui_palettes file,
b) provide your own palettes file, or 
c) use the "custom" palette name along with two hex color codes and a number of stops for a gradiated array of hex color codes.

![localhost_8030_](https://user-images.githubusercontent.com/446285/45958216-7adfd580-bfdc-11e8-91d0-47e2c28a05cf.png)

### Checklist

- [x] This was checked in mobile - There is no UI other than docs which was checked on mobile.
- [x] This was checked in IE11
- [x] This was checked in dark mode - There is no UI however a lighter version of the eui_colors palette has been added.
- [ ] ~Any props added have proper autodocs~ - No props since it's a service, but documented code
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] ~This was checked against keyboard-only and screenreader scenarios~ - There is no UI as this is a service/function.
