### PR TITLE
FlexGrid now accepts columns={1}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `4.2.0`.
+- Added `1` as a valid value for the `columns` prop in `EuiFlexGrid` ([#1210](https://github.com/elastic/eui/pull/1210))
 
 ## [`4.2.0`](https://github.com/elastic/eui/tree/v4.2.0)
 

--- a/src-docs/src/views/flex/flex_example.js
+++ b/src-docs/src/views/flex/flex_example.js
@@ -294,7 +294,7 @@ export const FlexExample = {
     text: (
       <p>
         You can set a <EuiCode>columns</EuiCode> prop to specify
-        anywhere between 2-4 columns. Any more would likely break on laptop screens.
+        anywhere between 1-4 columns. Any more would likely break on laptop screens.
       </p>
     ),
     demo: <div className="guideDemo__highlightGridWrap"><FlexGridColumns /></div>,

--- a/src/components/flex/__snapshots__/flex_grid.test.js.snap
+++ b/src/components/flex/__snapshots__/flex_grid.test.js.snap
@@ -18,6 +18,12 @@ exports[`EuiFlexGrid props columns 0 is rendered 1`] = `
 />
 `;
 
+exports[`EuiFlexGrid props columns 1 is rendered 1`] = `
+<div
+  class="euiFlexGrid euiFlexGrid--gutterLarge euiFlexGrid--single euiFlexGrid--responsive"
+/>
+`;
+
 exports[`EuiFlexGrid props columns 2 is rendered 1`] = `
 <div
   class="euiFlexGrid euiFlexGrid--gutterLarge euiFlexGrid--halves euiFlexGrid--responsive"

--- a/src/components/flex/_flex_grid.scss
+++ b/src/components/flex/_flex_grid.scss
@@ -24,6 +24,7 @@ $fractions: (
   fourths: 25%,
   thirds: 33.3%,
   halves: 50%,
+  single: 100%,
 );
 
 @each $gutterName, $gutterSize in $gutterTypes {

--- a/src/components/flex/flex_grid.js
+++ b/src/components/flex/flex_grid.js
@@ -14,6 +14,7 @@ export const GUTTER_SIZES = Object.keys(gutterSizeToClassNameMap);
 
 const columnsToClassNameMap = {
   0: 'euiFlexGrid--wrap',
+  1: 'euiFlexGrid--single',
   2: 'euiFlexGrid--halves',
   3: 'euiFlexGrid--thirds',
   4: 'euiFlexGrid--fourths',

--- a/src/components/flex/flex_grid.js
+++ b/src/components/flex/flex_grid.js
@@ -47,6 +47,9 @@ EuiFlexGrid.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   gutterSize: PropTypes.oneOf(GUTTER_SIZES),
+  /**
+   * Number of columns to show in the grid. Up to 4.
+   */
   columns: PropTypes.oneOf(COLUMNS).isRequired,
   /**
    * Allow grid items display at block level on small screens


### PR DESCRIPTION
### Summary

`EuiFlexGrid` now accepts `columns={1}`. This was at the request of @walterra.

Screen just shows that it's working, I didn't add this example to the docs.

![image](https://user-images.githubusercontent.com/324519/45978975-82b27080-c002-11e8-8fd7-d9a372f913e5.png)


### Checklist

- [x] This was checked in mobile
~~- [ ] This was checked in IE11~~
~~- [ ] This was checked in dark mode~~
- [x] Any props added have proper autodocs
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
~~- [ ] This was checked for breaking changes and labeled appropriately~~
- [x] Jest tests were updated or added to match the most common scenarios
~~- [ ] This was checked against keyboard-only and screenreader scenarios~~
