### PR TITLE
Update global date picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added support for nodes as "Action" column headers in `EuiBasicTable`, which was overlooked in the original change in `4.5.0` ([#1312](https://github.com/elastic/eui/pull/1312))
+- Updated `GlobalDatePicker` example to include all Kibana features ([#1219](https://github.com/elastic/eui/pull/1219))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Added support for nodes as "Action" column headers in `EuiBasicTable`, which was overlooked in the original change in `4.5.0` ([#1312](https://github.com/elastic/eui/pull/1312))
 - Updated `GlobalDatePicker` example to include all Kibana features ([#1219](https://github.com/elastic/eui/pull/1219))
+- Adjusted `EuiDatePickerRange` to allow for deeper customization ([#1219](https://github.com/elastic/eui/pull/1219))
+- Added `contentProps` and `textProps` to `EuiButton` and `EuiButtonEmpty` ([#1219](https://github.com/elastic/eui/pull/1219))
 
 **Bug fixes**
 

--- a/src-docs/src/theme_dark.scss
+++ b/src-docs/src/theme_dark.scss
@@ -1,3 +1,4 @@
 @import '../../src/theme_dark';
 @import './components/guide_components';
 @import './views/header/global_filter_group';
+@import './views/date_picker/global_date_picker';

--- a/src-docs/src/theme_k6_dark.scss
+++ b/src-docs/src/theme_k6_dark.scss
@@ -1,3 +1,4 @@
 @import '../../src/theme_k6_dark';
 @import './components/guide_components';
 @import './views/header/global_filter_group';
+@import './views/date_picker/global_date_picker';

--- a/src-docs/src/theme_k6_light.scss
+++ b/src-docs/src/theme_k6_light.scss
@@ -1,3 +1,4 @@
 @import '../../src/theme_k6_light';
 @import './components/guide_components';
 @import './views/header/global_filter_group';
+@import './views/date_picker/global_date_picker';

--- a/src-docs/src/theme_light.scss
+++ b/src-docs/src/theme_light.scss
@@ -1,4 +1,4 @@
 @import '../../src/theme_light';
 @import './components/guide_components';
 @import './views/header/global_filter_group';
-
+@import './views/date_picker/global_date_picker';

--- a/src-docs/src/views/date_picker/_global_date_picker.scss
+++ b/src-docs/src/views/date_picker/_global_date_picker.scss
@@ -1,7 +1,11 @@
 //// GLOBAL Date picker
 
 .euiGlobalDatePicker__quickSelectButton {
-  .euiButtonEmpty__text {
+  // Override prepend border since button already lives inside another prepend
+  border-right: none !important;
+
+  .euiGlobalDatePicker__quickSelectButtonText {
+    // Override specificity from universal and sibiling selectors
     margin-right: $euiSizeXS !important;
   }
 }
@@ -25,13 +29,14 @@
 }
 
 .euiGlobalDatePicker__dateButton {
+  @include euiFormControlText;
   display: block;
   width: 100%;
-  @include euiFormControlText;
   padding: 0 $euiSizeS;
   line-height: $euiFormControlHeight - 2px;
   height: $euiFormControlHeight - 2px;
   word-break: break-all;
+  transition: background $euiAnimSpeedFast ease-in;
 
   $backgroundColor: tintOrShade($euiColorSuccess, 90%, 70%);
   $textColor: makeHighContrastColor($euiColorSuccess, $backgroundColor);
@@ -68,10 +73,13 @@
 }
 
 .euiGlobalDatePicker__updateButton {
+  // Just wide enough for all 3 states
+  min-width: $euiButtonMinWidth + ($euiSizeXS * 1.5);
+
   @include euiBreakpoint('xs', 's') {
     min-width: 0;
 
-    .euiButton__text {
+    .euiGlobalDatePicker__updateButtonText {
       display: none;
     }
   }

--- a/src-docs/src/views/date_picker/_global_date_picker.scss
+++ b/src-docs/src/views/date_picker/_global_date_picker.scss
@@ -1,5 +1,6 @@
 //// GLOBAL Date picker
 
+// sass-lint:disable no-important
 .euiGlobalDatePicker__quickSelectButton {
   // Override prepend border since button already lives inside another prepend
   border-right: none !important;
@@ -21,6 +22,7 @@
       max-width: none;
       width: auto;
 
+      // sass-lint:disable nesting-depth
       .euiPopover__anchor {
         display: block;
       }
@@ -75,14 +77,6 @@
 .euiGlobalDatePicker__updateButton {
   // Just wide enough for all 3 states
   min-width: $euiButtonMinWidth + ($euiSizeXS * 1.5);
-
-  @include euiBreakpoint('xs', 's') {
-    min-width: 0;
-
-    .euiGlobalDatePicker__updateButtonText {
-      display: none;
-    }
-  }
 }
 
 .euiGlobalDatePicker__popoverSection {
@@ -90,4 +84,14 @@
   max-height: $euiSizeM * 11;
   overflow: hidden;
   overflow-y: auto;
+}
+
+@include euiBreakpoint('xs', 's') {
+  .euiGlobalDatePicker__updateButton {
+    min-width: 0;
+
+    .euiGlobalDatePicker__updateButtonText {
+      display: none;
+    }
+  }
 }

--- a/src-docs/src/views/date_picker/_global_date_picker.scss
+++ b/src-docs/src/views/date_picker/_global_date_picker.scss
@@ -1,0 +1,78 @@
+//// GLOBAL Date picker
+
+.euiGlobalDatePicker__quickSelectButton {
+  .euiButtonEmpty__text {
+    margin-right: $euiSizeXS !important;
+  }
+}
+
+.euiGlobalDatePicker.euiFormControlLayout {
+  max-width: 480px;
+
+  > .euiFormControlLayout__childrenWrapper {
+    flex: 1 1 100%;
+    overflow: hidden;
+
+    > .euiDatePickerRange {
+      max-width: none;
+      width: auto;
+
+      .euiPopover__anchor {
+        display: block;
+      }
+    }
+  }
+}
+
+.euiGlobalDatePicker__dateButton {
+  display: block;
+  width: 100%;
+  @include euiFormControlText;
+  padding: 0 $euiSizeS;
+  line-height: $euiFormControlHeight - 2px;
+  height: $euiFormControlHeight - 2px;
+  word-break: break-all;
+
+  $backgroundColor: tintOrShade($euiColorSuccess, 90%, 70%);
+  $textColor: makeHighContrastColor($euiColorSuccess, $backgroundColor);
+
+  &-isSelected,
+  &-needsUpdating,
+  &:hover,
+  &:focus {
+    background-color: $backgroundColor;
+  }
+
+  &-needsUpdating {
+    color: $textColor;
+  }
+
+  &-isInvalid {
+    $backgroundColor: tintOrShade($euiColorDanger, 90%, 70%);
+    $textColor: makeHighContrastColor($euiColorDanger, $backgroundColor);
+    background-color: $backgroundColor;
+    color: $textColor;
+  }
+
+  .euiFormControlLayout__prepend {
+    border: none;
+  }
+}
+
+.euiGlobalDatePicker__dateButton--start {
+  text-align: right;
+}
+
+.euiGlobalDatePicker__dateButton--end {
+  text-align: left;
+}
+
+.euiGlobalDatePicker__updateButton {
+  @include euiBreakpoint('xs', 's') {
+    min-width: 0;
+
+    .euiButton__text {
+      display: none;
+    }
+  }
+}

--- a/src-docs/src/views/date_picker/_global_date_picker.scss
+++ b/src-docs/src/views/date_picker/_global_date_picker.scss
@@ -76,3 +76,10 @@
     }
   }
 }
+
+.euiGlobalDatePicker__popoverSection {
+  @include euiScrollBar;
+  max-height: $euiSizeM * 11;
+  overflow: hidden;
+  overflow-y: auto;
+}

--- a/src-docs/src/views/date_picker/date_picker_example.js
+++ b/src-docs/src/views/date_picker/date_picker_example.js
@@ -279,9 +279,7 @@ export const DatePickerExample = {
         <EuiCallOut color="warning" title="Demo of visual pattern only">
           <p>
             This documents a <strong>visual</strong> pattern for the eventual replacement of Kibana&apos;s
-            global date/time picker. It uses all EUI components without any custom styles. However, it
-            currently depends strongly on <EuiLink href="https://reactdatepicker.com/#example-45">react-datepicker&apos;s <code>calendarContainer</code></EuiLink> option
-            which has it&apos;s own problems and limitations (like auto-focus on input stealing focus from inputs inside of popover).
+            global date/time picker. It uses all EUI components with some custom styles.
           </p>
         </EuiCallOut>
       </div>

--- a/src-docs/src/views/date_picker/global_date_picker.js
+++ b/src-docs/src/views/date_picker/global_date_picker.js
@@ -26,7 +26,6 @@ import {
   EuiTabbedContent,
   EuiForm,
   EuiSwitch,
-  EuiTextColor,
   EuiToolTip,
   EuiFieldText,
   EuiButtonIcon,
@@ -90,7 +89,7 @@ class GlobalDatePopover extends Component {
             </EuiFlexItem>
           </EuiFlexGroup>
           <EuiFormRow>
-            <EuiDatePicker selected={moment().subtract(3, 'day')} readOnly />
+            <EuiFieldText defaultValue={String(moment().subtract(3, 'day'))} readOnly />
           </EuiFormRow>
           <EuiFormRow>
             <EuiSwitch label="Round to the day" />
@@ -101,14 +100,11 @@ class GlobalDatePopover extends Component {
       id: 'now',
       name: 'Now',
       content: (
-        <EuiText textAlign="center" style={{ width: 390, padding: 16 }}>
-          <EuiTitle size="m"><span>{moment().format('MMMM Do YYYY')}</span></EuiTitle>
-          <EuiSpacer size="s" />
-          <EuiTitle size="m">
-            <EuiTextColor color="subdued">
-              <span>{moment().format('h:mm:ss a')}</span>
-            </EuiTextColor>
-          </EuiTitle>
+        <EuiText size="s" color="subdued" style={{ width: 390, padding: 16 }}>
+          <p>
+            Setting the time to &quot;Now&quot; means that on every refresh
+            this time will be set to the time of the refresh.
+          </p>
         </EuiText>
       ),
     }];
@@ -241,9 +237,6 @@ export default class extends Component {
         ['11/25/2017 00:00 AM', '11/25/2017 11:59 PM'],
         ['3 hours ago', '4 minutes ago'],
         'Last 6 months',
-        ['06/11/2017 06:11 AM', '06/11/2017 06:11 PM'],
-        ['06/11/2017 06:11 AM', '06/11/2017 06:11 PM'],
-        ['06/11/2017 06:11 AM', '06/11/2017 06:11 PM'],
         ['06/11/2017 06:11 AM', '06/11/2017 06:11 PM'],
       ],
     };

--- a/src-docs/src/views/date_picker/global_date_picker.js
+++ b/src-docs/src/views/date_picker/global_date_picker.js
@@ -29,6 +29,7 @@ import {
   EuiTextColor,
   EuiToolTip,
   EuiFieldText,
+  EuiButtonIcon,
 } from '../../../../src/components';
 
 const commonDates = [
@@ -234,10 +235,14 @@ export default class extends Component {
       isPopoverOpen: false,
       showPrettyFormat: false,
       showNeedsUpdate: false,
+      timerIsOn: false,
       recentlyUsed: [
         ['11/25/2017 00:00 AM', '11/25/2017 11:59 PM'],
         ['3 hours ago', '4 minutes ago'],
         'Last 6 months',
+        ['06/11/2017 06:11 AM', '06/11/2017 06:11 PM'],
+        ['06/11/2017 06:11 AM', '06/11/2017 06:11 PM'],
+        ['06/11/2017 06:11 AM', '06/11/2017 06:11 PM'],
         ['06/11/2017 06:11 AM', '06/11/2017 06:11 PM'],
       ],
     };
@@ -290,6 +295,12 @@ export default class extends Component {
     });
   }
 
+  toggleTimer = () => {
+    this.setState(prevState => ({
+      timerIsOn: !prevState.timerIsOn,
+    }));
+  }
+
 
   render() {
     const quickSelectButton = (
@@ -302,7 +313,7 @@ export default class extends Component {
         iconType="arrowDown"
         iconSide="right"
       >
-        <EuiIcon type="calendar" />
+        <EuiIcon type={this.state.timerIsOn ? 'clock' : 'calendar'} />
       </EuiButtonEmpty>
     );
 
@@ -318,12 +329,14 @@ export default class extends Component {
         anchorPosition="downLeft"
         ownFocus
       >
-        <div style={{ width: '400px' }}>
+        <div style={{ maxWidth: 400 }}>
           {this.renderQuickSelect()}
-          <EuiHorizontalRule />
+          <EuiHorizontalRule margin="s" />
           {commonlyUsed}
-          <EuiHorizontalRule />
+          <EuiHorizontalRule margin="s" />
           {recentlyUsed}
+          <EuiHorizontalRule margin="s" />
+          {this.renderTimer()}
         </div>
       </EuiPopover>
     );
@@ -412,27 +425,41 @@ export default class extends Component {
 
     return (
       <Fragment>
-        <EuiTitle size="xxxs"><span>Quick select</span></EuiTitle>
+        <EuiFlexGroup responsive={false} alignItems="center" gutterSize="s">
+          <EuiFlexItem>
+            <EuiTitle size="xxxs"><span>Quick select</span></EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiToolTip content="Previous time window">
+              <EuiButtonIcon aria-label="Previous time window" iconType="arrowLeft" />
+            </EuiToolTip>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiToolTip content="Next time window">
+              <EuiButtonIcon aria-label="Next time window" iconType="arrowRight" />
+            </EuiToolTip>
+          </EuiFlexItem>
+        </EuiFlexGroup>
         <EuiSpacer size="s" />
         <EuiFlexGroup gutterSize="s" responsive={false}>
           <EuiFlexItem>
-            <EuiFormRow>
+            <EuiFormRow compressed>
               <EuiSelect options={firstOptions} />
             </EuiFormRow>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiFormRow>
+            <EuiFormRow compressed>
               <EuiFieldNumber aria-label="Count of" defaultValue="256" />
             </EuiFormRow>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiFormRow>
+            <EuiFormRow compressed>
               <EuiSelect options={lastOptions} />
             </EuiFormRow>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiFormRow>
-              <EuiButton onClick={this.closePopover} style={{ minWidth: 0 }}>Apply</EuiButton>
+              <EuiButton size="s" onClick={this.closePopover} style={{ minWidth: 0 }}>Apply</EuiButton>
             </EuiFormRow>
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -451,7 +478,7 @@ export default class extends Component {
       <Fragment>
         <EuiTitle size="xxxs"><span>Commonly used</span></EuiTitle>
         <EuiSpacer size="s" />
-        <EuiText size="s">
+        <EuiText size="s" className="euiGlobalDatePicker__popoverSection">
           <EuiFlexGrid gutterSize="s" columns={2} responsive={false}>
             {links}
           </EuiFlexGrid>
@@ -476,7 +503,7 @@ export default class extends Component {
       <Fragment>
         <EuiTitle size="xxxs"><span>Recently used date ranges</span></EuiTitle>
         <EuiSpacer size="s" />
-        <EuiText size="s">
+        <EuiText size="s" className="euiGlobalDatePicker__popoverSection">
           <EuiFlexGroup gutterSize="s" direction="column">
             {links}
           </EuiFlexGroup>
@@ -484,4 +511,43 @@ export default class extends Component {
       </Fragment>
     );
   }
+
+  renderTimer = () => {
+    const lastOptions = [
+      { value: 'minutes', text: 'minutes' },
+      { value: 'hours', text: 'hours' },
+    ];
+
+    return (
+      <Fragment>
+        <EuiTitle size="xxxs"><span>Refresh every</span></EuiTitle>
+        <EuiSpacer size="s" />
+        <EuiFlexGroup gutterSize="s" responsive={false}>
+          <EuiFlexItem>
+            <EuiFormRow compressed>
+              <EuiFieldNumber aria-label="Count of" defaultValue="256" />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiFormRow compressed>
+              <EuiSelect options={lastOptions} />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFormRow>
+              <EuiButton
+                iconType={this.state.timerIsOn ? 'stop' : 'play'}
+                size="s"
+                onClick={this.toggleTimer}
+                style={{ minWidth: 0 }}
+              >
+                {this.state.timerIsOn ? 'Stop' : 'Start'}
+              </EuiButton>
+            </EuiFormRow>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </Fragment>
+    );
+  }
+
 }

--- a/src-docs/src/views/date_picker/global_date_picker.js
+++ b/src-docs/src/views/date_picker/global_date_picker.js
@@ -235,6 +235,7 @@ export default class extends Component {
       isPopoverOpen: false,
       showPrettyFormat: false,
       showNeedsUpdate: false,
+      isUpdating: false,
       timerIsOn: false,
       recentlyUsed: [
         ['11/25/2017 00:00 AM', '11/25/2017 11:59 PM'],
@@ -301,12 +302,18 @@ export default class extends Component {
     }));
   }
 
+  toggleIsUpdating = () => {
+    this.setState(prevState => ({
+      isUpdating: !prevState.isUpdating,
+    }));
+  }
+
 
   render() {
     const quickSelectButton = (
       <EuiButtonEmpty
         className="euiFormControlLayout__prepend euiGlobalDatePicker__quickSelectButton"
-        style={{ borderRight: 'none' }}
+        textProps={{ className: 'euiGlobalDatePicker__quickSelectButtonText' }}
         onClick={this.togglePopover}
         aria-label="Date quick select"
         size="xs"
@@ -327,7 +334,6 @@ export default class extends Component {
         isOpen={this.state.isPopoverOpen}
         closePopover={this.closePopover.bind(this)}
         anchorPosition="downLeft"
-        ownFocus
       >
         <div style={{ maxWidth: 400 }}>
           {this.renderQuickSelect()}
@@ -344,7 +350,8 @@ export default class extends Component {
     return (
       <Fragment>
         <EuiSwitch label="Pretty format" onChange={this.togglePrettyFormat} checked={this.state.showPrettyFormat} /> &nbsp;
-        <EuiSwitch label="Needs update" onChange={this.toggleNeedsUpdate} checked={this.state.showNeedsUpdate} />
+        <EuiSwitch label="Needs update" onChange={this.toggleNeedsUpdate} checked={this.state.showNeedsUpdate} /> &nbsp;
+        <EuiSwitch label="Is Updating" onChange={this.toggleIsUpdating} checked={this.state.isUpdating} />
         <EuiSpacer />
 
         <EuiFlexGroup gutterSize="s" responsive={false}>
@@ -398,11 +405,24 @@ export default class extends Component {
   renderUpdateButton = () => {
     const color = this.state.showNeedsUpdate ? 'secondary' : 'primary';
     const icon = this.state.showNeedsUpdate ? 'kqlFunction' : 'refresh';
-    const text = this.state.showNeedsUpdate ? 'Update' : 'Refresh';
+    let text = this.state.showNeedsUpdate ? 'Update' : 'Refresh';
+
+    if (this.state.isUpdating) {
+      text = 'Updating';
+    }
 
     return (
       <EuiToolTip ref={this.setTootipRef} content={this.state.showNeedsUpdate ? 'Click to apply' : undefined} position="bottom">
-        <EuiButton className="euiGlobalDatePicker__updateButton" color={color} fill iconType={icon}>{text}</EuiButton>
+        <EuiButton
+          isLoading={this.state.isUpdating}
+          className="euiGlobalDatePicker__updateButton"
+          color={color}
+          fill
+          iconType={icon}
+          textProps={{ className: 'euiGlobalDatePicker__updateButtonText' }}
+        >
+          {text}
+        </EuiButton>
       </EuiToolTip>
     );
   }
@@ -539,7 +559,7 @@ export default class extends Component {
                 iconType={this.state.timerIsOn ? 'stop' : 'play'}
                 size="s"
                 onClick={this.toggleTimer}
-                style={{ minWidth: 0 }}
+                style={{ minWidth: 90 }}
               >
                 {this.state.timerIsOn ? 'Stop' : 'Start'}
               </EuiButton>

--- a/src-docs/src/views/date_picker/global_date_picker.js
+++ b/src-docs/src/views/date_picker/global_date_picker.js
@@ -328,7 +328,7 @@ export default class extends Component {
         closePopover={this.closePopover.bind(this)}
         anchorPosition="downLeft"
       >
-        <div style={{ maxWidth: 400 }}>
+        <div style={{ width: 400, maxWidth: '100%' }}>
           {this.renderQuickSelect()}
           <EuiHorizontalRule margin="s" />
           {commonlyUsed}

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -169,9 +169,13 @@ EuiButton.propTypes = {
   buttonRef: PropTypes.func,
 
   /**
-   * Props passing
+   * Passes props to `euiButton__content` span
    */
   contentProps: PropTypes.object,
+
+  /**
+   * Passes props to `euiButton__text` span
+   */
   textProps: PropTypes.object,
 };
 

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -53,6 +53,8 @@ export const EuiButton = ({
   rel,
   type,
   buttonRef,
+  contentProps,
+  textProps,
   ...rest
 }) => {
 
@@ -105,9 +107,9 @@ export const EuiButton = ({
         ref={buttonRef}
         {...rest}
       >
-        <span className="euiButton__content">
+        <span className="euiButton__content" {...contentProps}>
           {buttonIcon}
-          <span className="euiButton__text">{children}</span>
+          <span className="euiButton__text" {...textProps}>{children}</span>
         </span>
       </a>
     );
@@ -120,9 +122,9 @@ export const EuiButton = ({
         ref={buttonRef}
         {...rest}
       >
-        <span className="euiButton__content">
+        <span className="euiButton__content" {...contentProps}>
           {buttonIcon}
-          <span className="euiButton__text">{children}</span>
+          <span className="euiButton__text" {...textProps}>{children}</span>
         </span>
       </button>
     );
@@ -165,6 +167,12 @@ EuiButton.propTypes = {
    */
   type: PropTypes.string,
   buttonRef: PropTypes.func,
+
+  /**
+   * Props passing
+   */
+  contentProps: PropTypes.object,
+  textProps: PropTypes.object,
 };
 
 EuiButton.defaultProps = {

--- a/src/components/button/button_empty/button_empty.js
+++ b/src/components/button/button_empty/button_empty.js
@@ -60,6 +60,8 @@ export const EuiButtonEmpty = ({
   rel,
   type,
   buttonRef,
+  contentProps,
+  textProps,
   ...rest
 }) => {
 
@@ -110,9 +112,9 @@ export const EuiButtonEmpty = ({
         ref={buttonRef}
         {...rest}
       >
-        <span className="euiButtonEmpty__content">
+        <span className="euiButtonEmpty__content" {...contentProps}>
           {buttonIcon}
-          <span className="euiButtonEmpty__text">{children}</span>
+          <span className="euiButtonEmpty__text" {...textProps}>{children}</span>
         </span>
       </a>
     );
@@ -125,9 +127,9 @@ export const EuiButtonEmpty = ({
         ref={buttonRef}
         {...rest}
       >
-        <span className="euiButtonEmpty__content">
+        <span className="euiButtonEmpty__content" {...contentProps}>
           {buttonIcon}
-          <span className="euiButtonEmpty__text">{children}</span>
+          <span className="euiButtonEmpty__text"{...textProps}>{children}</span>
         </span>
       </button>
     );
@@ -155,6 +157,12 @@ EuiButtonEmpty.propTypes = {
 
   type: PropTypes.string,
   buttonRef: PropTypes.func,
+
+  /**
+   * Props passing
+   */
+  contentProps: PropTypes.object,
+  textProps: PropTypes.object,
 };
 
 EuiButtonEmpty.defaultProps = {

--- a/src/components/button/button_empty/button_empty.js
+++ b/src/components/button/button_empty/button_empty.js
@@ -159,9 +159,13 @@ EuiButtonEmpty.propTypes = {
   buttonRef: PropTypes.func,
 
   /**
-   * Props passing
+   * Passes props to `euiButton__content` span
    */
   contentProps: PropTypes.object,
+
+  /**
+   * Passes props to `euiButton__text` span
+   */
   textProps: PropTypes.object,
 };
 

--- a/src/components/button/index.d.ts
+++ b/src/components/button/index.d.ts
@@ -1,7 +1,7 @@
 /// <reference path="../common.d.ts" />
 /// <reference path="../icon/index.d.ts" />
 
-import { SFC, ButtonHTMLAttributes, AnchorHTMLAttributes, MouseEventHandler } from 'react';
+import { SFC, ButtonHTMLAttributes, AnchorHTMLAttributes, MouseEventHandler, HTMLAttributes } from 'react';
 
 declare module '@elastic/eui' {
   type EuiButtonPropsForButtonOrLink<Props> = (

--- a/src/components/button/index.d.ts
+++ b/src/components/button/index.d.ts
@@ -33,7 +33,7 @@ declare module '@elastic/eui' {
     size?: ButtonSize;
     isLoading?: boolean;
     isDisabled?: boolean;
-    contentProps?: object;
+    contentProps?: HTMLAttributes<HTMLSpanElement>;
     textProps?: object;
   }
   export const EuiButton: SFC<

--- a/src/components/button/index.d.ts
+++ b/src/components/button/index.d.ts
@@ -33,6 +33,8 @@ declare module '@elastic/eui' {
     size?: ButtonSize;
     isLoading?: boolean;
     isDisabled?: boolean;
+    contentProps?: object;
+    textProps?: object;
   }
   export const EuiButton: SFC<
     EuiButtonPropsForButtonOrLink<CommonProps & EuiButtonProps>
@@ -87,6 +89,8 @@ declare module '@elastic/eui' {
     flush?: EmptyButtonFlush;
     isLoading?: boolean;
     isDisabled?: boolean;
+    contentProps?: object;
+    textProps?: object;
   }
 
   export const EuiButtonEmpty: SFC<

--- a/src/components/button/index.d.ts
+++ b/src/components/button/index.d.ts
@@ -89,7 +89,7 @@ declare module '@elastic/eui' {
     flush?: EmptyButtonFlush;
     isLoading?: boolean;
     isDisabled?: boolean;
-    contentProps?: object;
+    contentProps?: HTMLAttributes<HTMLSpanElement>;
     textProps?: object;
   }
 

--- a/src/components/button/index.d.ts
+++ b/src/components/button/index.d.ts
@@ -34,7 +34,7 @@ declare module '@elastic/eui' {
     isLoading?: boolean;
     isDisabled?: boolean;
     contentProps?: HTMLAttributes<HTMLSpanElement>;
-    textProps?: object;
+    textProps?: HTMLAttributes<HTMLSpanElement>;
   }
   export const EuiButton: SFC<
     EuiButtonPropsForButtonOrLink<CommonProps & EuiButtonProps>

--- a/src/components/button/index.d.ts
+++ b/src/components/button/index.d.ts
@@ -90,7 +90,7 @@ declare module '@elastic/eui' {
     isLoading?: boolean;
     isDisabled?: boolean;
     contentProps?: HTMLAttributes<HTMLSpanElement>;
-    textProps?: object;
+    textProps?: HTMLAttributes<HTMLSpanElement>;
   }
 
   export const EuiButtonEmpty: SFC<

--- a/src/components/date_picker/_date_picker_range.scss
+++ b/src/components/date_picker/_date_picker_range.scss
@@ -13,8 +13,9 @@
   align-items: center;
   padding: 1px; /* 1 */
 
+  // Allow any child to fill entire range container
   > * {
-    flex: 1 1 0%; // All values necessary for IE support
+    flex-grow: 1;
   }
 
   .euiFieldText.euiDatePicker {
@@ -48,7 +49,7 @@
   > .euiDatePickerRange__delimeter {
     line-height: 1 !important;
     flex: 0 0 auto;
-    padding-left: $euiFormControlPadding/2;
-    padding-right: $euiFormControlPadding/2;
+    padding-left: $euiFormControlPadding / 2;
+    padding-right: $euiFormControlPadding / 2;
   }
 }

--- a/src/components/date_picker/_date_picker_range.scss
+++ b/src/components/date_picker/_date_picker_range.scss
@@ -13,7 +13,7 @@
   align-items: center;
   padding: 1px; /* 1 */
 
-  > span {
+  > * {
     flex: 1 1 0%; // All values necessary for IE support
   }
 
@@ -46,9 +46,9 @@
   }
 
   > .euiDatePickerRange__delimeter {
+    line-height: 1 !important;
+    flex: 0 0 auto;
     padding-left: $euiFormControlPadding/2;
     padding-right: $euiFormControlPadding/2;
   }
 }
-
-

--- a/src/components/date_picker/_date_picker_range.scss
+++ b/src/components/date_picker/_date_picker_range.scss
@@ -5,7 +5,7 @@
  * 1. Account for inner box-shadow style border
  */
 
- .euiDatePickerRange {
+.euiDatePickerRange {
   @include euiFormControlSize(auto, $includeAlternates: true);
   // Match just the regular drop shadow of inputs
   @include euiFormControlDefaultShadow();
@@ -36,14 +36,19 @@
       height: $euiFormControlHeight - 2px;
     }
   }
+
+  // Direct descendent selectors to override `> span`
+
+  > .euiDatePickerRange__icon {
+    flex: 0 0 auto;
+    padding-left: $euiFormControlPadding;
+    padding-right: $euiFormControlPadding;
+  }
+
+  > .euiDatePickerRange__delimeter {
+    padding-left: $euiFormControlPadding/2;
+    padding-right: $euiFormControlPadding/2;
+  }
 }
 
-.euiDatePickerRange__icon {
-  padding-left: $euiFormControlPadding;
-  padding-right: $euiFormControlPadding;
-}
 
-.euiDatePickerRange__delimeter {
-  padding-left: $euiFormControlPadding/2;
-  padding-right: $euiFormControlPadding/2;
-}

--- a/src/components/date_picker/date_picker_range.js
+++ b/src/components/date_picker/date_picker_range.js
@@ -1,5 +1,5 @@
 import React, {
-  cloneElement,
+  cloneElement, Fragment,
 } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -11,11 +11,13 @@ import {
 } from '../icon';
 
 export const EuiDatePickerRange = ({
+  children,
   className,
   startDateControl,
   endDateControl,
   iconType,
   fullWidth,
+  isCustom,
   ...rest
 }) => {
 
@@ -38,25 +40,35 @@ export const EuiDatePickerRange = ({
     optionalIcon = null;
   }
 
-  const clonedStartDate = cloneElement(startDateControl, {
-    showIcon: false,
-    fullWidth: fullWidth,
-  });
+  let startControl = startDateControl;
+  let endControl = endDateControl;
 
-  const clonedEndDate = cloneElement(endDateControl, {
-    showIcon: false,
-    fullWidth: fullWidth,
-  });
+  if (!isCustom) {
+    startControl = cloneElement(startDateControl, {
+      showIcon: false,
+      fullWidth: fullWidth,
+    });
+
+    endControl = cloneElement(endDateControl, {
+      showIcon: false,
+      fullWidth: fullWidth,
+    });
+  }
+
 
   return (
     <div
       className={classes}
       {...rest}
     >
-      {optionalIcon}
-      {clonedStartDate}
-      <EuiText className="euiDatePickerRange__delimeter" size="s" color="subdued">→</EuiText>
-      {clonedEndDate}
+      {children ? (children) : (
+        <Fragment>
+          {optionalIcon}
+          {startControl}
+          <EuiText className="euiDatePickerRange__delimeter" size="s" color="subdued">→</EuiText>
+          {endControl}
+        </Fragment>
+      )}
     </div>
   );
 };
@@ -78,6 +90,14 @@ EuiDatePickerRange.propTypes = {
     PropTypes.oneOf(ICON_TYPES),
   ]),
   fullWidth: PropTypes.bool,
+  /**
+   * Won't apply any additional props to start and end date components
+   */
+  isCustom: PropTypes.bool,
+  /**
+   * Including any children will replace all innerds with the provided children
+   */
+  children: PropTypes.node,
 };
 
 EuiDatePickerRange.defaultProps = {

--- a/src/components/form/_mixins.scss
+++ b/src/components/form/_mixins.scss
@@ -13,6 +13,13 @@
  * 3. Must supply both values to background-size or some browsers apply the single value to both directions
  */
 
+@mixin euiFormControlText {
+  font-size: $euiFontSizeS;
+  font-family: $euiFontFamily;
+  line-height: 1em; // fixes text alignment in IE
+  color: $euiTextColor;
+}
+
 @mixin euiFormControlSize(
   $height: $euiFormControlHeight,
   $includeAlternates: false
@@ -134,14 +141,11 @@
 @mixin euiFormControlStyle($borderOnly: false, $includeStates: true, $includeSizes: true) {
   @include euiFormControlSize($includeAlternates: $includeSizes);
   @include euiFormControlDefaultShadow;
+  @include euiFormControlText;
 
   border: none;
-  font-size: $euiFontSizeS;
-  font-family: $euiFontFamily;
-  padding: $euiFormControlPadding;
-  line-height: 1em; // fixes text alignment in IE
-  color: $euiTextColor;
   border-radius: 0;
+  padding: $euiFormControlPadding;
 
   @if ($includeSizes) {
     &--compressed {


### PR DESCRIPTION
### Summary

Altered global date/time picker to use buttons instead of date inputs and adds the update button. The component just needed a few adjustments, mostly on the pattern side.

Still needs:

- [x] Updated doc description
- [x] This stuff (cc @snide)
<img src="https://d.pr/free/i/2QbzFO+" />
---

Includes a fix for #1207 (don’t shrink date picker icon)

---

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
- [x] Any props added have proper autodocs
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~ (different PR for that)
