### PR TITLE
Disable pointer-events on all disabled descendents of tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `4.3.0`.
+**Bug fixes**
+
+- Fix EuiToolTip to show tooltips on disabled elements ([#1222](https://github.com/elastic/eui/pull/1222))
 
 ## [`4.3.0`](https://github.com/elastic/eui/tree/v4.3.0)
 

--- a/src/components/tool_tip/_tool_tip.scss
+++ b/src/components/tool_tip/_tool_tip.scss
@@ -78,7 +78,7 @@
   // wouldn't trigger the onMouseOut and hide the tooltip; disabling pointer events
   // on disabled elements means any mouse events remain handled by parent elements
   // https://jakearchibald.com/2017/events-and-disabled-form-fields/
-  > *[disabled] {
+  *[disabled] {
     pointer-events: none;
   }
 }


### PR DESCRIPTION
### Summary

Fixes #1211 

Disabled pointer events on _any_ disabled element that is a child of EuiToolTip, not only direct child descendants.

Tested on all browsers, this has a side effect that the disabled mouse cursor state does not trigger when hovering over the disabled element - except ironically in IE11 where you still see the disabled cursor.

### Checklist

~- [ ] This was checked in mobile~
- [x] This was checked in IE11
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
