### PR TITLE
Allow devserver to be served from any host

### DIFF
--- a/src-docs/webpack.config.js
+++ b/src-docs/webpack.config.js
@@ -59,6 +59,7 @@ module.exports = {
   devServer: {
     contentBase: 'src-docs/build',
     host: '0.0.0.0',
+    allowedHosts: ['*'],
     port: 8030,
     disableHostCheck: true
   }


### PR DESCRIPTION
### Summary

Tells the webpack dev server to accept connections to any host name. This allows remote machines (and VMs) to connect by IP address without ngrok or similar.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
