### PR TITLE
Adds secondary trigger functionality and updates tests

### DIFF
--- a/src-docs/src/views/popover/popover.js
+++ b/src-docs/src/views/popover/popover.js
@@ -1,11 +1,6 @@
-import React, {
-  Component,
-} from 'react';
+import React, { Component } from 'react';
 
-import {
-  EuiPopover,
-  EuiButton,
-} from '../../../../src/components';
+import { EuiPopover, EuiButton } from '../../../../src/components';
 
 export default class extends Component {
   constructor(props) {
@@ -30,24 +25,24 @@ export default class extends Component {
 
   render() {
     const button = (
-      <EuiButton
-        iconType="arrowDown"
-        iconSide="right"
-        onClick={this.onButtonClick.bind(this)}
-      >
+      <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick.bind(this)}>
         Show popover
       </EuiButton>
     );
 
     return (
-      <EuiPopover
-        id="popover"
-        button={button}
-        isOpen={this.state.isPopoverOpen}
-        closePopover={this.closePopover.bind(this)}
-      >
-        <div style={{ width: '300px' }}>Popover content that&rsquo;s wider than the default width</div>
-      </EuiPopover>
+      <div>
+        <EuiPopover
+          id="popover"
+          button={button}
+          isOpen={this.state.isPopoverOpen}
+          closePopover={this.closePopover.bind(this)}
+        >
+          <div style={{ width: '300px' }}>
+            Popover content that&rsquo;s wider than the default width
+          </div>
+        </EuiPopover>
+      </div>
     );
   }
 }

--- a/src-docs/src/views/popover/popover_example.js
+++ b/src-docs/src/views/popover/popover_example.js
@@ -2,19 +2,17 @@ import React from 'react';
 
 import { renderToHtml } from '../../services';
 
-import {
-  GuideSectionTypes,
-} from '../../components';
+import { GuideSectionTypes } from '../../components';
 
-import {
-  EuiCode,
-  EuiPopover,
-  EuiPopoverTitle,
-} from '../../../../src/components';
+import { EuiCode, EuiPopover, EuiPopoverTitle } from '../../../../src/components';
 
 import Popover from './popover';
 const popoverSource = require('!!raw-loader!./popover');
 const popoverHtml = renderToHtml(Popover);
+
+import SecondaryTrigger from './secondary_trigger';
+const secondaryTriggerSource = require('!!raw-loader!./secondary_trigger');
+const secondaryTriggerHtml = renderToHtml(SecondaryTrigger);
 
 import TrapFocus from './trap_focus';
 const trapFocusSource = require('!!raw-loader!./trap_focus');
@@ -50,179 +48,235 @@ const popoverFixedHtml = renderToHtml(PopoverFixed);
 
 export const PopoverExample = {
   title: 'Popover',
-  sections: [{
-    source: [{
-      type: GuideSectionTypes.JS,
-      code: popoverSource,
-    }, {
-      type: GuideSectionTypes.HTML,
-      code: popoverHtml,
-    }],
-    text: (
-      <p>
-        Use the Popover component to hide controls or options behind a clickable element.
-      </p>
-    ),
-    props: { EuiPopover },
-    demo: <Popover />,
-  }, {
-    title: 'Trap focus',
-    source: [{
-      type: GuideSectionTypes.JS,
-      code: trapFocusSource,
-    }, {
-      type: GuideSectionTypes.HTML,
-      code: trapFocusHtml,
-    }],
-    text: (
-      <p>
-        If the Popover should be responsible for trapping the focus within itself (as opposed
-        to a child component), then you should set <EuiCode>ownFocus</EuiCode>.
-      </p>
-    ),
-    demo: <TrapFocus />,
-  }, {
-    title: 'Anchor position',
-    source: [{
-      type: GuideSectionTypes.JS,
-      code: popoverAnchorPositionSource,
-    }, {
-      type: GuideSectionTypes.HTML,
-      code: popoverAnchorPositionHtml,
-    }],
-    text: (
-      <div>
+  sections: [
+    {
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: popoverSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: popoverHtml,
+        },
+      ],
+      text: (
+        <p>Use the Popover component to hide controls or options behind a clickable element.</p>
+      ),
+      props: { EuiPopover },
+      demo: <Popover />,
+    },
+    {
+      title: 'Secondary trigger',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: secondaryTriggerSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: secondaryTriggerHtml,
+        },
+      ],
+      text: (
         <p>
-          The alignment and arrow on your popover can be set with
-          the <EuiCode>anchorPostion</EuiCode> prop. These positions will not
-          update based upon screen real estate and will stick to the positions
-          you declare. Because of this,
-          <strong>be careful when using left or right positioning</strong>.
-        </p>
-        <p><strong>Some tips:</strong></p>
-        <ul>
-          <li>
-            The first word in the <EuiCode>anchorPosition</EuiCode> denotes
-            where the popover will appear relative to the button.
-          </li>
-          <li>
-            The second word in the <EuiCode>anchorPosition</EuiCode> denotes
-            where the gravity / pin position will appear relative to the popover.
-          </li>
-        </ul>
-      </div>
-    ),
-    demo: <PopoverAnchorPosition />,
-  }, {
-    title: 'Popover with title',
-    source: [{
-      type: GuideSectionTypes.JS,
-      code: popoverWithTitleSource,
-    }, {
-      type: GuideSectionTypes.HTML,
-      code: popoverWithTitleHtml,
-    }],
-    text: (
-      <div>
-        <p>
-          Popovers often have need for titling. This can be applied through
-          a prop or used separately as its own component
-          <EuiCode>EuiPopoverTitle</EuiCode> nested somwhere in the child
+          Other elements can trigger the popover open and closed, besides the passed in button node
           prop.
         </p>
-      </div>
-    ),
-    props: { EuiPopoverTitle },
-    demo: <PopoverWithTitle />,
-  }, {
-    title: 'Panel class name and padding size',
-    source: [{
-      type: GuideSectionTypes.JS,
-      code: popoverPanelClassNameSource,
-    }, {
-      type: GuideSectionTypes.HTML,
-      code: popoverPanelClassNameHtml,
-    }],
-    text: (
-      <p>
-        Use the <EuiCode>panelPaddingSize</EuiCode> prop to adjust the padding
-        on the panel within the panel. Use the <EuiCode>panelClassName</EuiCode> prop
-        to pass a custom class to the panel. inside a popover.
-      </p>
-    ),
-    demo: <PopoverPanelClassName />,
-  }, {
-    title: 'Popover with title and padding size',
-    source: [{
-      type: GuideSectionTypes.JS,
-      code: popoverWithTitlePaddingSource,
-    }, {
-      type: GuideSectionTypes.HTML,
-      code: popoverWithTitlePaddingHtml,
-    }],
-    text: (
-      <div>
+      ),
+      props: { EuiPopover },
+      demo: <SecondaryTrigger />,
+    },
+    {
+      title: 'Trap focus',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: trapFocusSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: trapFocusHtml,
+        },
+      ],
+      text: (
         <p>
-          When using popover titles, you can still propogate the padding size
-          by using <EuiCode>panelPaddingSize</EuiCode>. This will only affect
-          the horizontal padding of the title and the overall padding of the content.
+          If the Popover should be responsible for trapping the focus within itself (as opposed to a
+          child component), then you should set <EuiCode>ownFocus</EuiCode>.
         </p>
-      </div>
-    ),
-    demo: <PopoverWithTitlePadding />,
-  }, {
-    title: 'Constraining a popover inside a container',
-    source: [{
-      type: GuideSectionTypes.JS,
-      code: popoverContainerSource,
-    }, {
-      type: GuideSectionTypes.HTML,
-      code: popoverContainerHtml,
-    }],
-    text: (
-      <div>
+      ),
+      demo: <TrapFocus />,
+    },
+    {
+      title: 'Anchor position',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: popoverAnchorPositionSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: popoverAnchorPositionHtml,
+        },
+      ],
+      text: (
+        <div>
+          <p>
+            The alignment and arrow on your popover can be set with the{' '}
+            <EuiCode>anchorPostion</EuiCode> prop. These positions will not update based upon screen
+            real estate and will stick to the positions you declare. Because of this,
+            <strong>be careful when using left or right positioning</strong>.
+          </p>
+          <p>
+            <strong>Some tips:</strong>
+          </p>
+          <ul>
+            <li>
+              The first word in the <EuiCode>anchorPosition</EuiCode> denotes where the popover will
+              appear relative to the button.
+            </li>
+            <li>
+              The second word in the <EuiCode>anchorPosition</EuiCode> denotes where the gravity /
+              pin position will appear relative to the popover.
+            </li>
+          </ul>
+        </div>
+      ),
+      demo: <PopoverAnchorPosition />,
+    },
+    {
+      title: 'Popover with title',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: popoverWithTitleSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: popoverWithTitleHtml,
+        },
+      ],
+      text: (
+        <div>
+          <p>
+            Popovers often have need for titling. This can be applied through a prop or used
+            separately as its own component
+            <EuiCode>EuiPopoverTitle</EuiCode> nested somwhere in the child prop.
+          </p>
+        </div>
+      ),
+      props: { EuiPopoverTitle },
+      demo: <PopoverWithTitle />,
+    },
+    {
+      title: 'Panel class name and padding size',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: popoverPanelClassNameSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: popoverPanelClassNameHtml,
+        },
+      ],
+      text: (
         <p>
-          <EuiCode>EuiPopover</EuiCode> can accept a React or DOM element as
-          a <EuiCode>container</EuiCode> prop and restrict the popover from
-          overflowing that container.
+          Use the <EuiCode>panelPaddingSize</EuiCode> prop to adjust the padding on the panel within
+          the panel. Use the <EuiCode>panelClassName</EuiCode> prop to pass a custom class to the
+          panel. inside a popover.
         </p>
-      </div>
-    ),
-    demo: <PopoverContainer />,
-  }, {
-    title: 'Popover using an HTMLElement as the anchor',
-    source: [{
-      type: GuideSectionTypes.JS,
-      code: popoverHTMLElementAnchorSource,
-    }, {
-      type: GuideSectionTypes.HTML,
-      code: popoverHTMLElementAnchorHtml,
-    }],
-    text: (
-      <div>
-        <p>
-          <EuiCode>EuiWrappingPopover</EuiCode> is an extra popover component that allows
-          any existing DOM element to be passed as the <EuiCode>button</EuiCode> prop.
-        </p>
-      </div>
-    ),
-    demo: <PopoverHTMLElementAnchor />,
-  }, {
-    title: 'Popover on a fixed element',
-    source: [{
-      type: GuideSectionTypes.JS,
-      code: popoverFixedSource,
-    }, {
-      type: GuideSectionTypes.HTML,
-      code: popoverFixedHtml,
-    }],
-    text: (
-      <div>
-        <p>
-          Popover content even works on <EuiCode>position: fixed;</EuiCode> elements.
-        </p>
-      </div>
-    ),
-    demo: <PopoverFixed />,
-  }],
+      ),
+      demo: <PopoverPanelClassName />,
+    },
+    {
+      title: 'Popover with title and padding size',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: popoverWithTitlePaddingSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: popoverWithTitlePaddingHtml,
+        },
+      ],
+      text: (
+        <div>
+          <p>
+            When using popover titles, you can still propogate the padding size by using{' '}
+            <EuiCode>panelPaddingSize</EuiCode>. This will only affect the horizontal padding of the
+            title and the overall padding of the content.
+          </p>
+        </div>
+      ),
+      demo: <PopoverWithTitlePadding />,
+    },
+    {
+      title: 'Constraining a popover inside a container',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: popoverContainerSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: popoverContainerHtml,
+        },
+      ],
+      text: (
+        <div>
+          <p>
+            <EuiCode>EuiPopover</EuiCode> can accept a React or DOM element as a{' '}
+            <EuiCode>container</EuiCode> prop and restrict the popover from overflowing that
+            container.
+          </p>
+        </div>
+      ),
+      demo: <PopoverContainer />,
+    },
+    {
+      title: 'Popover using an HTMLElement as the anchor',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: popoverHTMLElementAnchorSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: popoverHTMLElementAnchorHtml,
+        },
+      ],
+      text: (
+        <div>
+          <p>
+            <EuiCode>EuiWrappingPopover</EuiCode> is an extra popover component that allows any
+            existing DOM element to be passed as the <EuiCode>button</EuiCode> prop.
+          </p>
+        </div>
+      ),
+      demo: <PopoverHTMLElementAnchor />,
+    },
+    {
+      title: 'Popover on a fixed element',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: popoverFixedSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: popoverFixedHtml,
+        },
+      ],
+      text: (
+        <div>
+          <p>
+            Popover content even works on <EuiCode>position: fixed;</EuiCode> elements.
+          </p>
+        </div>
+      ),
+      demo: <PopoverFixed />,
+    },
+  ],
 };

--- a/src-docs/src/views/popover/secondary_trigger.js
+++ b/src-docs/src/views/popover/secondary_trigger.js
@@ -1,0 +1,56 @@
+import React, { Component } from 'react';
+import { EuiPopover, EuiButton, EuiSpacer } from '../../../../src/components';
+
+export default class extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isPopoverOpen: false,
+    };
+  }
+
+  onButtonClick() {
+    this.setState({
+      isPopoverOpen: !this.state.isPopoverOpen,
+    });
+  }
+
+  open = () => {
+    this.setState({ isPopoverOpen: true });
+  };
+
+  closePopover() {
+    this.setState({
+      isPopoverOpen: false,
+    });
+  }
+
+  render() {
+    const button = (
+      <EuiButton iconType="arrowDown" iconSide="right" onClick={this.onButtonClick.bind(this)}>
+        Show popover
+      </EuiButton>
+    );
+
+    return (
+      <div>
+        <div>
+          <EuiPopover
+            id="popover"
+            button={button}
+            isOpen={this.state.isPopoverOpen}
+            closePopover={this.closePopover.bind(this)}
+          >
+            <h1>This one!</h1>
+            <div style={{ width: '300px' }}>
+              Popover content that&rsquo;s wider than the default width
+            </div>
+          </EuiPopover>
+        </div>
+        <EuiSpacer size="l" />
+        <a onClick={this.open}>Secondary popover trigger</a>
+      </div>
+    );
+  }
+}

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
@@ -292,17 +292,16 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                       panelPaddingSize="none"
                       withTitle={true}
                     >
-                      <EuiOutsideClickDetector
-                        onOutsideClick={[Function]}
+                      <div
+                        className="euiPopover euiPopover--anchorUpRight euiPopover--withTitle"
+                        id="customizablePagination"
+                        onKeyDown={[Function]}
                       >
                         <div
-                          className="euiPopover euiPopover--anchorUpRight euiPopover--withTitle"
-                          id="customizablePagination"
-                          onClick={[Function]}
-                          onKeyDown={[Function]}
+                          className="euiPopover__anchor"
                         >
                           <div
-                            className="euiPopover__anchor"
+                            onClick={[Function]}
                           >
                             <EuiButtonEmpty
                               color="text"
@@ -379,7 +378,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                             </EuiButtonEmpty>
                           </div>
                         </div>
-                      </EuiOutsideClickDetector>
+                      </div>
                     </EuiPopover>
                   </div>
                 </EuiFlexItem>

--- a/src/components/form/super_select/__snapshots__/super_select.test.js.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.js.snap
@@ -7,59 +7,61 @@ exports[`EuiSuperSelect is rendered 1`] = `
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value=""
-    />
-    <div
-      class="euiFormControlLayout"
-    >
+    <div>
+      <input
+        type="hidden"
+        value=""
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
-        >
-          Select an option: , is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-label="aria-label"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl testClass1 testClass2"
-          data-test-subj="test subject string"
-          role="option"
-          type="button"
-        />
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
           >
-            <svg
-              aria-hidden="true"
-              class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-              focusable="false"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xlink="http://www.w3.org/1999/xlink"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <defs>
-                <path
-                  d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
-                  id="arrow_down-a"
-                />
-              </defs>
-              <use
-                fill-rule="nonzero"
-                href="#arrow_down-a"
-              />
-            </svg>
+            Select an option: , is selected
           </span>
+          <button
+            aria-haspopup="true"
+            aria-label="aria-label"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl testClass1 testClass2"
+            data-test-subj="test subject string"
+            role="option"
+            type="button"
+          />
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          >
+            <span
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <svg
+                aria-hidden="true"
+                class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xlink="http://www.w3.org/1999/xlink"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <defs>
+                  <path
+                    d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+                    id="arrow_down-a"
+                  />
+                </defs>
+                <use
+                  fill-rule="nonzero"
+                  href="#arrow_down-a"
+                />
+              </svg>
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -74,128 +76,132 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value=""
-    />
-    <div
-      class="euiFormControlLayout"
-    >
+    <div>
+      <input
+        type="hidden"
+        value=""
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
-        >
-          Select an option: , is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl euiSuperSelect--isOpen__button"
-          data-test-subj="superSelect"
-          role="option"
-          type="button"
-        />
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
           >
-            <svg
-              aria-hidden="true"
-              class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-              focusable="false"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlns:xlink="http://www.w3.org/1999/xlink"
-            >
-              <defs>
-                <path
-                  d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
-                  id="arrow_down-a"
-                />
-              </defs>
-              <use
-                fill-rule="nonzero"
-                xlink:href="#arrow_down-a"
-              />
-            </svg>
+            Select an option: , is selected
           </span>
+          <button
+            aria-haspopup="true"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl euiSuperSelect--isOpen__button"
+            data-test-subj="superSelect"
+            role="option"
+            type="button"
+          />
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          >
+            <span
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <svg
+                aria-hidden="true"
+                class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+              >
+                <defs>
+                  <path
+                    d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+                    id="arrow_down-a"
+                  />
+                </defs>
+                <use
+                  fill-rule="nonzero"
+                  xlink:href="#arrow_down-a"
+                />
+              </svg>
+            </span>
+          </div>
         </div>
       </div>
     </div>
   </div>
   <div>
-    <div
-      aria-live="assertive"
-      class="euiPanel euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
-      style="top: 8px; left: -22px; z-index: 0;"
-    >
+    <div>
       <div
-        class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
-      />
-      <p
-        class="euiScreenReaderOnly"
-        role="alert"
+        aria-live="assertive"
+        class="euiPanel euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
+        style="top: 8px; left: -22px; z-index: 0;"
       >
-        You are in a form selector of 2 items and must select a single option. Use the up and down keys to navigate or escape to close.
-      </p>
-      <div
-        role="listbox"
-      >
-        <button
-          class="euiContextMenuItem euiSuperSelect__item"
-          id="1"
-          role="option"
-          type="button"
+        <div
+          class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
+        />
+        <p
+          class="euiScreenReaderOnly"
+          role="alert"
         >
-          <span
-            class="euiContextMenu__itemLayout"
-          >
-            <svg
-              class="euiIcon euiIcon--medium euiContextMenu__icon"
-              focusable="false"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            />
-            <span
-              class="euiContextMenuItem__text"
-            >
-              Custom Display #1
-            </span>
-          </span>
-        </button>
-        <button
-          class="euiContextMenuItem euiSuperSelect__item"
-          id="2"
-          role="option"
-          type="button"
+          You are in a form selector of 2 items and must select a single option. Use the up and down keys to navigate or escape to close.
+        </p>
+        <div
+          role="listbox"
         >
-          <span
-            class="euiContextMenu__itemLayout"
+          <button
+            class="euiContextMenuItem euiSuperSelect__item"
+            id="1"
+            role="option"
+            type="button"
           >
-            <svg
-              class="euiIcon euiIcon--medium euiContextMenu__icon"
-              focusable="false"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            />
             <span
-              class="euiContextMenuItem__text"
+              class="euiContextMenu__itemLayout"
             >
-              Custom Display #2
+              <svg
+                class="euiIcon euiIcon--medium euiContextMenu__icon"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <span
+                class="euiContextMenuItem__text"
+              >
+                Custom Display #1
+              </span>
             </span>
-          </span>
-        </button>
+          </button>
+          <button
+            class="euiContextMenuItem euiSuperSelect__item"
+            id="2"
+            role="option"
+            type="button"
+          >
+            <span
+              class="euiContextMenu__itemLayout"
+            >
+              <svg
+                class="euiIcon euiIcon--medium euiContextMenu__icon"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <span
+                class="euiContextMenuItem__text"
+              >
+                Custom Display #2
+              </span>
+            </span>
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -209,137 +215,141 @@ exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value="1"
-    />
-    <div
-      class="euiFormControlLayout"
-    >
+    <div>
+      <input
+        type="hidden"
+        value="1"
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
-        >
-          Select an option: Option #1, is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl euiSuperSelect--isOpen__button"
-          data-test-subj="superSelect"
-          role="option"
-          type="button"
-        >
-          Option #1
-        </button>
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
           >
-            <svg
-              aria-hidden="true"
-              class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-              focusable="false"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlns:xlink="http://www.w3.org/1999/xlink"
-            >
-              <defs>
-                <path
-                  d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
-                  id="arrow_down-a"
-                />
-              </defs>
-              <use
-                fill-rule="nonzero"
-                xlink:href="#arrow_down-a"
-              />
-            </svg>
+            Select an option: Option #1, is selected
           </span>
+          <button
+            aria-haspopup="true"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl euiSuperSelect--isOpen__button"
+            data-test-subj="superSelect"
+            role="option"
+            type="button"
+          >
+            Option #1
+          </button>
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          >
+            <span
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <svg
+                aria-hidden="true"
+                class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+              >
+                <defs>
+                  <path
+                    d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+                    id="arrow_down-a"
+                  />
+                </defs>
+                <use
+                  fill-rule="nonzero"
+                  xlink:href="#arrow_down-a"
+                />
+              </svg>
+            </span>
+          </div>
         </div>
       </div>
     </div>
   </div>
   <div>
-    <div
-      aria-live="assertive"
-      class="euiPanel euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
-      style="top: 8px; left: -22px; z-index: 0;"
-    >
+    <div>
       <div
-        class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
-      />
-      <p
-        class="euiScreenReaderOnly"
-        role="alert"
+        aria-live="assertive"
+        class="euiPanel euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
+        style="top: 8px; left: -22px; z-index: 0;"
       >
-        You are in a form selector of 2 items and must select a single option. Use the up and down keys to navigate or escape to close.
-      </p>
-      <div
-        aria-activedescendant="1"
-        role="listbox"
-      >
-        <button
-          class="euiContextMenuItem euiSuperSelect__item euiContextMenuItem-isDisabled"
-          disabled=""
-          id="1"
-          role="option"
-          type="button"
+        <div
+          class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
+        />
+        <p
+          class="euiScreenReaderOnly"
+          role="alert"
         >
-          <span
-            class="euiContextMenu__itemLayout"
+          You are in a form selector of 2 items and must select a single option. Use the up and down keys to navigate or escape to close.
+        </p>
+        <div
+          aria-activedescendant="1"
+          role="listbox"
+        >
+          <button
+            class="euiContextMenuItem euiSuperSelect__item euiContextMenuItem-isDisabled"
+            disabled=""
+            id="1"
+            role="option"
+            type="button"
           >
-            <svg
-              class="euiIcon euiIcon--medium euiContextMenu__icon"
-              focusable="false"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
+            <span
+              class="euiContextMenu__itemLayout"
             >
-              <path
-                d="M6.5 12a.502.502 0 0 1-.354-.146l-4-4a.502.502 0 0 1 .708-.708L6.5 10.793l6.646-6.647a.502.502 0 0 1 .708.708l-7 7A.502.502 0 0 1 6.5 12"
+              <svg
+                class="euiIcon euiIcon--medium euiContextMenu__icon"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M6.5 12a.502.502 0 0 1-.354-.146l-4-4a.502.502 0 0 1 .708-.708L6.5 10.793l6.646-6.647a.502.502 0 0 1 .708.708l-7 7A.502.502 0 0 1 6.5 12"
+                />
+              </svg>
+              <span
+                class="euiContextMenuItem__text"
+              >
+                Option #1
+              </span>
+            </span>
+          </button>
+          <button
+            class="euiContextMenuItem euiSuperSelect__item"
+            data-test-subj="option two"
+            id="2"
+            role="option"
+            type="button"
+          >
+            <span
+              class="euiContextMenu__itemLayout"
+            >
+              <svg
+                class="euiIcon euiIcon--medium euiContextMenu__icon"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
               />
-            </svg>
-            <span
-              class="euiContextMenuItem__text"
-            >
-              Option #1
+              <span
+                class="euiContextMenuItem__text"
+              >
+                Option #2
+              </span>
             </span>
-          </span>
-        </button>
-        <button
-          class="euiContextMenuItem euiSuperSelect__item"
-          data-test-subj="option two"
-          id="2"
-          role="option"
-          type="button"
-        >
-          <span
-            class="euiContextMenu__itemLayout"
-          >
-            <svg
-              class="euiIcon euiIcon--medium euiContextMenu__icon"
-              focusable="false"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            />
-            <span
-              class="euiContextMenuItem__text"
-            >
-              Option #2
-            </span>
-          </span>
-        </button>
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -404,16 +414,15 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
     panelPaddingSize="none"
     popoverRef={[Function]}
   >
-    <EuiOutsideClickDetector
-      onOutsideClick={[Function]}
+    <div
+      className="euiPopover euiPopover--anchorDownCenter euiSuperSelect"
+      onKeyDown={[Function]}
     >
       <div
-        className="euiPopover euiPopover--anchorDownCenter euiSuperSelect"
-        onClick={[Function]}
-        onKeyDown={[Function]}
+        className="euiPopover__anchor"
       >
         <div
-          className="euiPopover__anchor"
+          onClick={[Function]}
         >
           <EuiSuperSelectControl
             className="euiSuperSelect--isOpen__button"
@@ -560,38 +569,34 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
             </EuiFormControlLayout>
           </EuiSuperSelectControl>
         </div>
-        <EuiPortal>
-          <FocusTrap
-            _createFocusTrap={[Function]}
-            active={false}
-            focusTrapOptions={
-              Object {
-                "clickOutsideDeactivates": true,
-                "initialFocus": undefined,
-              }
-            }
-            paused={false}
-            tag="div"
-          >
-            <div>
-              <EuiPanel
-                aria-live="assertive"
-                className="euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
-                grow={true}
-                hasShadow={false}
-                paddingSize="none"
-                panelRef={[Function]}
-                style={
-                  Object {
-                    "left": -22,
-                    "top": 8,
-                    "zIndex": "0",
-                  }
+      </div>
+      <EuiOutsideClickDetector
+        onOutsideClick={[Function]}
+      >
+        <div
+          onClick={[Function]}
+        >
+          <EuiPortal>
+            <FocusTrap
+              _createFocusTrap={[Function]}
+              active={false}
+              focusTrapOptions={
+                Object {
+                  "clickOutsideDeactivates": true,
+                  "initialFocus": undefined,
                 }
-              >
-                <div
+              }
+              paused={false}
+              tag="div"
+            >
+              <div>
+                <EuiPanel
                   aria-live="assertive"
-                  className="euiPanel euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
+                  className="euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
+                  grow={true}
+                  hasShadow={false}
+                  paddingSize="none"
+                  panelRef={[Function]}
                   style={
                     Object {
                       "left": -22,
@@ -601,22 +606,21 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                   }
                 >
                   <div
-                    className="euiPopover__panelArrow euiPopover__panelArrow--bottom"
-                    style={null}
-                  />
-                  <EuiMutationObserver
-                    observerOptions={
+                    aria-live="assertive"
+                    className="euiPanel euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
+                    style={
                       Object {
-                        "attributes": true,
-                        "characterData": true,
-                        "childList": true,
-                        "subtree": true,
+                        "left": -22,
+                        "top": 8,
+                        "zIndex": "0",
                       }
                     }
-                    onMutation={[Function]}
                   >
+                    <div
+                      className="euiPopover__panelArrow euiPopover__panelArrow--bottom"
+                      style={null}
+                    />
                     <EuiMutationObserver
-                      key=".0"
                       observerOptions={
                         Object {
                           "attributes": true,
@@ -627,55 +631,53 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                       }
                       onMutation={[Function]}
                     >
-                      <EuiScreenReaderOnly>
-                        <p
-                          className="euiScreenReaderOnly"
-                          role="alert"
-                        >
-                          You are in a form selector of 
-                          2
-                           items and must select a single option. Use the up and down keys to navigate or escape to close.
-                        </p>
-                      </EuiScreenReaderOnly>
-                    </EuiMutationObserver>
-                    <EuiMutationObserver
-                      key=".1"
-                      observerOptions={
-                        Object {
-                          "attributes": true,
-                          "characterData": true,
-                          "childList": true,
-                          "subtree": true,
-                        }
-                      }
-                      onMutation={[Function]}
-                    >
-                      <div
-                        aria-activedescendant="1"
-                        role="listbox"
-                      >
-                        <EuiContextMenuItem
-                          buttonRef={[Function]}
-                          className="euiSuperSelect__item"
-                          disabled={true}
-                          icon="check"
-                          id="1"
-                          key="0"
-                          layoutAlign="center"
-                          onClick={[Function]}
-                          onKeyDown={[Function]}
-                          role="option"
-                          style={
-                            Object {
-                              "width": null,
-                            }
+                      <EuiMutationObserver
+                        key=".0"
+                        observerOptions={
+                          Object {
+                            "attributes": true,
+                            "characterData": true,
+                            "childList": true,
+                            "subtree": true,
                           }
-                          toolTipPosition="right"
+                        }
+                        onMutation={[Function]}
+                      >
+                        <EuiScreenReaderOnly>
+                          <p
+                            className="euiScreenReaderOnly"
+                            role="alert"
+                          >
+                            You are in a form selector of 
+                            2
+                             items and must select a single option. Use the up and down keys to navigate or escape to close.
+                          </p>
+                        </EuiScreenReaderOnly>
+                      </EuiMutationObserver>
+                      <EuiMutationObserver
+                        key=".1"
+                        observerOptions={
+                          Object {
+                            "attributes": true,
+                            "characterData": true,
+                            "childList": true,
+                            "subtree": true,
+                          }
+                        }
+                        onMutation={[Function]}
+                      >
+                        <div
+                          aria-activedescendant="1"
+                          role="listbox"
                         >
-                          <button
-                            className="euiContextMenuItem euiSuperSelect__item euiContextMenuItem-isDisabled"
+                          <EuiContextMenuItem
+                            buttonRef={[Function]}
+                            className="euiSuperSelect__item"
                             disabled={true}
+                            icon="check"
                             id="1"
+                            key="0"
+                            layoutAlign="center"
                             onClick={[Function]}
                             onKeyDown={[Function]}
                             role="option"
@@ -684,30 +686,31 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                                 "width": null,
                               }
                             }
-                            type="button"
+                            toolTipPosition="right"
                           >
-                            <span
-                              className="euiContextMenu__itemLayout"
+                            <button
+                              className="euiContextMenuItem euiSuperSelect__item euiContextMenuItem-isDisabled"
+                              disabled={true}
+                              id="1"
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              role="option"
+                              style={
+                                Object {
+                                  "width": null,
+                                }
+                              }
+                              type="button"
                             >
-                              <EuiIcon
-                                className="euiContextMenu__icon"
-                                size="m"
-                                type="check"
+                              <span
+                                className="euiContextMenu__itemLayout"
                               >
-                                <check
-                                  className="euiIcon euiIcon--medium euiContextMenu__icon"
-                                  focusable="false"
-                                  height="16"
-                                  style={
-                                    Object {
-                                      "fill": undefined,
-                                    }
-                                  }
-                                  viewBox="0 0 16 16"
-                                  width="16"
-                                  xmlns="http://www.w3.org/2000/svg"
+                                <EuiIcon
+                                  className="euiContextMenu__icon"
+                                  size="m"
+                                  type="check"
                                 >
-                                  <svg
+                                  <check
                                     className="euiIcon euiIcon--medium euiContextMenu__icon"
                                     focusable="false"
                                     height="16"
@@ -720,42 +723,41 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                                     width="16"
                                     xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <path
-                                      d="M6.5 12a.502.502 0 0 1-.354-.146l-4-4a.502.502 0 0 1 .708-.708L6.5 10.793l6.646-6.647a.502.502 0 0 1 .708.708l-7 7A.502.502 0 0 1 6.5 12"
-                                    />
-                                  </svg>
-                                </check>
-                              </EuiIcon>
-                              <span
-                                className="euiContextMenuItem__text"
-                              >
-                                Option #1
+                                    <svg
+                                      className="euiIcon euiIcon--medium euiContextMenu__icon"
+                                      focusable="false"
+                                      height="16"
+                                      style={
+                                        Object {
+                                          "fill": undefined,
+                                        }
+                                      }
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M6.5 12a.502.502 0 0 1-.354-.146l-4-4a.502.502 0 0 1 .708-.708L6.5 10.793l6.646-6.647a.502.502 0 0 1 .708.708l-7 7A.502.502 0 0 1 6.5 12"
+                                      />
+                                    </svg>
+                                  </check>
+                                </EuiIcon>
+                                <span
+                                  className="euiContextMenuItem__text"
+                                >
+                                  Option #1
+                                </span>
                               </span>
-                            </span>
-                          </button>
-                        </EuiContextMenuItem>
-                        <EuiContextMenuItem
-                          buttonRef={[Function]}
-                          className="euiSuperSelect__item"
-                          data-test-subj="option two"
-                          icon="empty"
-                          id="2"
-                          key="1"
-                          layoutAlign="center"
-                          onClick={[Function]}
-                          onKeyDown={[Function]}
-                          role="option"
-                          style={
-                            Object {
-                              "width": null,
-                            }
-                          }
-                          toolTipPosition="right"
-                        >
-                          <button
-                            className="euiContextMenuItem euiSuperSelect__item"
+                            </button>
+                          </EuiContextMenuItem>
+                          <EuiContextMenuItem
+                            buttonRef={[Function]}
+                            className="euiSuperSelect__item"
                             data-test-subj="option two"
+                            icon="empty"
                             id="2"
+                            key="1"
+                            layoutAlign="center"
                             onClick={[Function]}
                             onKeyDown={[Function]}
                             role="option"
@@ -764,30 +766,31 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                                 "width": null,
                               }
                             }
-                            type="button"
+                            toolTipPosition="right"
                           >
-                            <span
-                              className="euiContextMenu__itemLayout"
+                            <button
+                              className="euiContextMenuItem euiSuperSelect__item"
+                              data-test-subj="option two"
+                              id="2"
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              role="option"
+                              style={
+                                Object {
+                                  "width": null,
+                                }
+                              }
+                              type="button"
                             >
-                              <EuiIcon
-                                className="euiContextMenu__icon"
-                                size="m"
-                                type="empty"
+                              <span
+                                className="euiContextMenu__itemLayout"
                               >
-                                <empty
-                                  className="euiIcon euiIcon--medium euiContextMenu__icon"
-                                  focusable="false"
-                                  height="16"
-                                  style={
-                                    Object {
-                                      "fill": undefined,
-                                    }
-                                  }
-                                  viewBox="0 0 16 16"
-                                  width="16"
-                                  xmlns="http://www.w3.org/2000/svg"
+                                <EuiIcon
+                                  className="euiContextMenu__icon"
+                                  size="m"
+                                  type="empty"
                                 >
-                                  <svg
+                                  <empty
                                     className="euiIcon euiIcon--medium euiContextMenu__icon"
                                     focusable="false"
                                     height="16"
@@ -799,27 +802,41 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                                     viewBox="0 0 16 16"
                                     width="16"
                                     xmlns="http://www.w3.org/2000/svg"
-                                  />
-                                </empty>
-                              </EuiIcon>
-                              <span
-                                className="euiContextMenuItem__text"
-                              >
-                                Option #2
+                                  >
+                                    <svg
+                                      className="euiIcon euiIcon--medium euiContextMenu__icon"
+                                      focusable="false"
+                                      height="16"
+                                      style={
+                                        Object {
+                                          "fill": undefined,
+                                        }
+                                      }
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    />
+                                  </empty>
+                                </EuiIcon>
+                                <span
+                                  className="euiContextMenuItem__text"
+                                >
+                                  Option #2
+                                </span>
                               </span>
-                            </span>
-                          </button>
-                        </EuiContextMenuItem>
-                      </div>
+                            </button>
+                          </EuiContextMenuItem>
+                        </div>
+                      </EuiMutationObserver>
                     </EuiMutationObserver>
-                  </EuiMutationObserver>
-                </div>
-              </EuiPanel>
-            </div>
-          </FocusTrap>
-        </EuiPortal>
-      </div>
-    </EuiOutsideClickDetector>
+                  </div>
+                </EuiPanel>
+              </div>
+            </FocusTrap>
+          </EuiPortal>
+        </div>
+      </EuiOutsideClickDetector>
+    </div>
   </EuiPopover>
 </EuiSuperSelect>
 `;
@@ -831,128 +848,132 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value=""
-    />
-    <div
-      class="euiFormControlLayout"
-    >
+    <div>
+      <input
+        type="hidden"
+        value=""
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
-        >
-          Select an option: , is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl euiSuperSelect--isOpen__button"
-          data-test-subj="superSelect"
-          role="option"
-          type="button"
-        />
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
           >
-            <svg
-              aria-hidden="true"
-              class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-              focusable="false"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlns:xlink="http://www.w3.org/1999/xlink"
-            >
-              <defs>
-                <path
-                  d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
-                  id="arrow_down-a"
-                />
-              </defs>
-              <use
-                fill-rule="nonzero"
-                xlink:href="#arrow_down-a"
-              />
-            </svg>
+            Select an option: , is selected
           </span>
+          <button
+            aria-haspopup="true"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl euiSuperSelect--isOpen__button"
+            data-test-subj="superSelect"
+            role="option"
+            type="button"
+          />
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          >
+            <span
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <svg
+                aria-hidden="true"
+                class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+              >
+                <defs>
+                  <path
+                    d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+                    id="arrow_down-a"
+                  />
+                </defs>
+                <use
+                  fill-rule="nonzero"
+                  xlink:href="#arrow_down-a"
+                />
+              </svg>
+            </span>
+          </div>
         </div>
       </div>
     </div>
   </div>
   <div>
-    <div
-      aria-live="assertive"
-      class="euiPanel euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
-      style="top: 8px; left: -22px; z-index: 0;"
-    >
+    <div>
       <div
-        class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
-      />
-      <p
-        class="euiScreenReaderOnly"
-        role="alert"
+        aria-live="assertive"
+        class="euiPanel euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
+        style="top: 8px; left: -22px; z-index: 0;"
       >
-        You are in a form selector of 2 items and must select a single option. Use the up and down keys to navigate or escape to close.
-      </p>
-      <div
-        role="listbox"
-      >
-        <button
-          class="euiContextMenuItem euiSuperSelect__item"
-          id="1"
-          role="option"
-          type="button"
+        <div
+          class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
+        />
+        <p
+          class="euiScreenReaderOnly"
+          role="alert"
         >
-          <span
-            class="euiContextMenu__itemLayout"
-          >
-            <svg
-              class="euiIcon euiIcon--medium euiContextMenu__icon"
-              focusable="false"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            />
-            <span
-              class="euiContextMenuItem__text"
-            >
-              Option #1
-            </span>
-          </span>
-        </button>
-        <button
-          class="euiContextMenuItem euiSuperSelect__item"
-          id="2"
-          role="option"
-          type="button"
+          You are in a form selector of 2 items and must select a single option. Use the up and down keys to navigate or escape to close.
+        </p>
+        <div
+          role="listbox"
         >
-          <span
-            class="euiContextMenu__itemLayout"
+          <button
+            class="euiContextMenuItem euiSuperSelect__item"
+            id="1"
+            role="option"
+            type="button"
           >
-            <svg
-              class="euiIcon euiIcon--medium euiContextMenu__icon"
-              focusable="false"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            />
             <span
-              class="euiContextMenuItem__text"
+              class="euiContextMenu__itemLayout"
             >
-              Option #2
+              <svg
+                class="euiIcon euiIcon--medium euiContextMenu__icon"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <span
+                class="euiContextMenuItem__text"
+              >
+                Option #1
+              </span>
             </span>
-          </span>
-        </button>
+          </button>
+          <button
+            class="euiContextMenuItem euiSuperSelect__item"
+            id="2"
+            role="option"
+            type="button"
+          >
+            <span
+              class="euiContextMenu__itemLayout"
+            >
+              <svg
+                class="euiIcon euiIcon--medium euiContextMenu__icon"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <span
+                class="euiContextMenuItem__text"
+              >
+                Option #2
+              </span>
+            </span>
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -966,57 +987,59 @@ exports[`EuiSuperSelect props select component is rendered 1`] = `
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value=""
-    />
-    <div
-      class="euiFormControlLayout"
-    >
+    <div>
+      <input
+        type="hidden"
+        value=""
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
-        >
-          Select an option: , is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl"
-          role="option"
-          type="button"
-        />
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
           >
-            <svg
-              aria-hidden="true"
-              class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-              focusable="false"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xlink="http://www.w3.org/1999/xlink"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <defs>
-                <path
-                  d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
-                  id="arrow_down-a"
-                />
-              </defs>
-              <use
-                fill-rule="nonzero"
-                href="#arrow_down-a"
-              />
-            </svg>
+            Select an option: , is selected
           </span>
+          <button
+            aria-haspopup="true"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl"
+            role="option"
+            type="button"
+          />
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          >
+            <span
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <svg
+                aria-hidden="true"
+                class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xlink="http://www.w3.org/1999/xlink"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <defs>
+                  <path
+                    d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+                    id="arrow_down-a"
+                  />
+                </defs>
+                <use
+                  fill-rule="nonzero"
+                  href="#arrow_down-a"
+                />
+              </svg>
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -1031,59 +1054,61 @@ exports[`EuiSuperSelect props valueSelected is rendered 1`] = `
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value="2"
-    />
-    <div
-      class="euiFormControlLayout"
-    >
+    <div>
+      <input
+        type="hidden"
+        value="2"
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
-        >
-          Select an option: Option #2, is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl"
-          role="option"
-          type="button"
-        >
-          Option #2
-        </button>
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
           >
-            <svg
-              aria-hidden="true"
-              class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-              focusable="false"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xlink="http://www.w3.org/1999/xlink"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <defs>
-                <path
-                  d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
-                  id="arrow_down-a"
-                />
-              </defs>
-              <use
-                fill-rule="nonzero"
-                href="#arrow_down-a"
-              />
-            </svg>
+            Select an option: Option #2, is selected
           </span>
+          <button
+            aria-haspopup="true"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl"
+            role="option"
+            type="button"
+          >
+            Option #2
+          </button>
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          >
+            <span
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <svg
+                aria-hidden="true"
+                class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xlink="http://www.w3.org/1999/xlink"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <defs>
+                  <path
+                    d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+                    id="arrow_down-a"
+                  />
+                </defs>
+                <use
+                  fill-rule="nonzero"
+                  href="#arrow_down-a"
+                />
+              </svg>
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/form/super_select/super_select.test.js
+++ b/src/components/form/super_select/super_select.test.js
@@ -6,21 +6,15 @@ import { EuiSuperSelect } from './super_select';
 
 jest.mock(`../form_row/make_id`, () => () => `generated-id`);
 
-jest.mock(
-  '../../portal',
-  () => ({
-    EuiPortal: ({ children }) => children
-  })
-);
+jest.mock('../../portal', () => ({
+  EuiPortal: ({ children }) => children,
+}));
 
 describe('EuiSuperSelect', () => {
   test('is rendered', () => {
-    const component = render(
-      <EuiSuperSelect {...requiredProps} onChange={() => {}} />
-    );
+    const component = render(<EuiSuperSelect {...requiredProps} onChange={() => {}} />);
 
-    expect(component)
-      .toMatchSnapshot();
+    expect(component).toMatchSnapshot();
   });
 
   describe('props', () => {
@@ -29,14 +23,13 @@ describe('EuiSuperSelect', () => {
         <EuiSuperSelect
           options={[
             { value: '1', inputDisplay: 'Option #1' },
-            { value: '2', inputDisplay: 'Option #2' }
+            { value: '2', inputDisplay: 'Option #2' },
           ]}
           onChange={() => {}}
         />
       );
 
-      expect(component)
-        .toMatchSnapshot();
+      expect(component).toMatchSnapshot();
     });
 
     test('options are rendered when select is open', () => {
@@ -44,17 +37,18 @@ describe('EuiSuperSelect', () => {
         <EuiSuperSelect
           options={[
             { value: '1', inputDisplay: 'Option #1' },
-            { value: '2', inputDisplay: 'Option #2' }
+            { value: '2', inputDisplay: 'Option #2' },
           ]}
           onChange={() => {}}
           data-test-subj="superSelect"
         />
       );
 
-      component.find('button[data-test-subj="superSelect"]').simulate('click');
+      const event = { nativeEvent: { stopImmediatePropagation: jest.fn() } };
+      component.find('button[data-test-subj="superSelect"]').simulate('click', event);
 
-      expect(takeMountedSnapshot(component))
-        .toMatchSnapshot();
+      expect(takeMountedSnapshot(component)).toMatchSnapshot();
+      expect(event.nativeEvent.stopImmediatePropagation).toHaveBeenCalledTimes(1);
     });
 
     test('valueSelected is rendered', () => {
@@ -62,15 +56,14 @@ describe('EuiSuperSelect', () => {
         <EuiSuperSelect
           options={[
             { value: '1', inputDisplay: 'Option #1' },
-            { value: '2', inputDisplay: 'Option #2' }
+            { value: '2', inputDisplay: 'Option #2' },
           ]}
           valueOfSelected="2"
           onChange={() => {}}
         />
       );
 
-      expect(component)
-        .toMatchSnapshot();
+      expect(component).toMatchSnapshot();
     });
 
     test('custom display is propagated to dropdown', () => {
@@ -78,17 +71,18 @@ describe('EuiSuperSelect', () => {
         <EuiSuperSelect
           options={[
             { value: '1', inputDisplay: 'Option #1', dropdownDisplay: 'Custom Display #1' },
-            { value: '2', inputDisplay: 'Option #2', dropdownDisplay: 'Custom Display #2' }
+            { value: '2', inputDisplay: 'Option #2', dropdownDisplay: 'Custom Display #2' },
           ]}
           onChange={() => {}}
           data-test-subj="superSelect"
         />
       );
 
-      component.find('button[data-test-subj="superSelect"]').simulate('click');
+      const event = { nativeEvent: { stopImmediatePropagation: jest.fn() } };
+      component.find('button[data-test-subj="superSelect"]').simulate('click', event);
 
-      expect(takeMountedSnapshot(component))
-        .toMatchSnapshot();
+      expect(takeMountedSnapshot(component)).toMatchSnapshot();
+      expect(event.nativeEvent.stopImmediatePropagation).toHaveBeenCalledTimes(1);
     });
 
     test('more props are propogated to each option', () => {
@@ -96,7 +90,7 @@ describe('EuiSuperSelect', () => {
         <EuiSuperSelect
           options={[
             { value: '1', inputDisplay: 'Option #1', disabled: true },
-            { value: '2', inputDisplay: 'Option #2', 'data-test-subj': 'option two', }
+            { value: '2', inputDisplay: 'Option #2', 'data-test-subj': 'option two' },
           ]}
           valueOfSelected="1"
           onChange={() => {}}
@@ -104,13 +98,12 @@ describe('EuiSuperSelect', () => {
         />
       );
 
-      component.find('button[data-test-subj="superSelect"]').simulate('click');
+      const event = { nativeEvent: { stopImmediatePropagation: jest.fn() } };
+      component.find('button[data-test-subj="superSelect"]').simulate('click', event);
 
-      expect(takeMountedSnapshot(component))
-        .toMatchSnapshot();
-
-      expect(component)
-        .toMatchSnapshot();
+      expect(takeMountedSnapshot(component)).toMatchSnapshot();
+      expect(component).toMatchSnapshot();
+      expect(event.nativeEvent.stopImmediatePropagation).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/components/header/header_links/__snapshots__/header_links.test.js.snap
+++ b/src/components/header/header_links/__snapshots__/header_links.test.js.snap
@@ -16,34 +16,36 @@ exports[`EuiHeaderLinks is rendered 1`] = `
     <div
       class="euiPopover__anchor"
     >
-      <div
-        class="euiHeaderSectionItem euiHeaderSectionItem--borderLeft"
-      >
-        <button
-          aria-label="Open navigation menu"
-          class="euiHeaderSectionItem__button"
-          type="button"
+      <div>
+        <div
+          class="euiHeaderSectionItem euiHeaderSectionItem--borderLeft"
         >
-          <svg
-            class="euiIcon euiIcon--medium"
-            focusable="false"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
-            xlink="http://www.w3.org/1999/xlink"
-            xmlns="http://www.w3.org/2000/svg"
+          <button
+            aria-label="Open navigation menu"
+            class="euiHeaderSectionItem__button"
+            type="button"
           >
-            <defs>
-              <path
-                d="M2 4V2h2v2H2zm5 0V2h2v2H7zm5 0V2h2v2h-2zM2 9V7h2v2H2zm5 0V7h2v2H7zm5 0V7h2v2h-2zM2 14v-2h2v2H2zm5 0v-2h2v2H7zm5 0v-2h2v2h-2z"
-                id="apps-a"
+            <svg
+              class="euiIcon euiIcon--medium"
+              focusable="false"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+              xlink="http://www.w3.org/1999/xlink"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <defs>
+                <path
+                  d="M2 4V2h2v2H2zm5 0V2h2v2H7zm5 0V2h2v2h-2zM2 9V7h2v2H2zm5 0V7h2v2H7zm5 0V7h2v2h-2zM2 14v-2h2v2H2zm5 0v-2h2v2H7zm5 0v-2h2v2h-2z"
+                  id="apps-a"
+                />
+              </defs>
+              <use
+                href="#apps-a"
               />
-            </defs>
-            <use
-              href="#apps-a"
-            />
-          </svg>
-        </button>
+            </svg>
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/src/components/outside_click_detector/outside_click_detector.js
+++ b/src/components/outside_click_detector/outside_click_detector.js
@@ -1,8 +1,4 @@
-import {
-  Children,
-  cloneElement,
-  Component,
-} from 'react';
+import { Children, cloneElement, Component } from 'react';
 import PropTypes from 'prop-types';
 import { htmlIdGenerator } from '../../services/accessibility';
 
@@ -11,7 +7,7 @@ export class EuiOutsideClickDetector extends Component {
     children: PropTypes.node.isRequired,
     onOutsideClick: PropTypes.func.isRequired,
     isDisabled: PropTypes.bool,
-  }
+  };
 
   constructor(...args) {
     super(...args);
@@ -36,10 +32,7 @@ export class EuiOutsideClickDetector extends Component {
   }
 
   onClickOutside = event => {
-    const {
-      isDisabled,
-      onOutsideClick,
-    } = this.props;
+    const { isDisabled, onOutsideClick } = this.props;
 
     if (isDisabled) {
       return;
@@ -50,7 +43,7 @@ export class EuiOutsideClickDetector extends Component {
     }
 
     onOutsideClick();
-  }
+  };
 
   componentDidMount() {
     document.addEventListener('click', this.onClickOutside);
@@ -69,12 +62,13 @@ export class EuiOutsideClickDetector extends Component {
       event.nativeEvent.euiGeneratedBy = [this.id];
     }
     if (this.props.onClick) this.props.onClick(event);
-  }
+  };
 
   render() {
-    const props = ({ ...this.props.children.props, ...{
+    const props = {
+      ...this.props.children.props,
       onClick: this.onChildClick,
-    } });
+    };
 
     const child = Children.only(this.props.children);
     return cloneElement(child, props);

--- a/src/components/popover/__snapshots__/popover.test.js.snap
+++ b/src/components/popover/__snapshots__/popover.test.js.snap
@@ -8,7 +8,9 @@ exports[`EuiPopover children is rendered 1`] = `
   <div
     class="euiPopover__anchor"
   >
-    <button />
+    <div>
+      <button />
+    </div>
   </div>
 </div>
 `;
@@ -23,7 +25,9 @@ exports[`EuiPopover is rendered 1`] = `
   <div
     class="euiPopover__anchor"
   >
-    <button />
+    <div>
+      <button />
+    </div>
   </div>
 </div>
 `;
@@ -36,7 +40,9 @@ exports[`EuiPopover props anchorPosition defaults to centerDown 1`] = `
   <div
     class="euiPopover__anchor"
   >
-    <button />
+    <div>
+      <button />
+    </div>
   </div>
 </div>
 `;
@@ -49,7 +55,9 @@ exports[`EuiPopover props anchorPosition downRight is rendered 1`] = `
   <div
     class="euiPopover__anchor"
   >
-    <button />
+    <div>
+      <button />
+    </div>
   </div>
 </div>
 `;
@@ -62,7 +70,9 @@ exports[`EuiPopover props anchorPosition leftCenter is rendered 1`] = `
   <div
     class="euiPopover__anchor"
   >
-    <button />
+    <div>
+      <button />
+    </div>
   </div>
 </div>
 `;
@@ -75,7 +85,9 @@ exports[`EuiPopover props isOpen defaults to false 1`] = `
   <div
     class="euiPopover__anchor"
   >
-    <button />
+    <div>
+      <button />
+    </div>
   </div>
 </div>
 `;
@@ -89,18 +101,22 @@ exports[`EuiPopover props isOpen renders true 1`] = `
     <div
       class="euiPopover__anchor"
     >
-      <button />
+      <div>
+        <button />
+      </div>
     </div>
     <div>
-      <div
-        aria-live="assertive"
-        class="euiPanel euiPanel--paddingMedium euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
-        style="top: 16px; left: -22px; z-index: 0;"
-      >
+      <div>
         <div
-          class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
-          style="left: 10px; top: 0px;"
-        />
+          aria-live="assertive"
+          class="euiPanel euiPanel--paddingMedium euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
+          style="top: 16px; left: -22px; z-index: 0;"
+        >
+          <div
+            class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
+            style="left: 10px; top: 0px;"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -116,18 +132,22 @@ exports[`EuiPopover props ownFocus defaults to false 1`] = `
     <div
       class="euiPopover__anchor"
     >
-      <button />
+      <div>
+        <button />
+      </div>
     </div>
     <div>
-      <div
-        aria-live="assertive"
-        class="euiPanel euiPanel--paddingMedium euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
-        style="top: 16px; left: -22px; z-index: 0;"
-      >
+      <div>
         <div
-          class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
-          style="left: 10px; top: 0px;"
-        />
+          aria-live="assertive"
+          class="euiPanel euiPanel--paddingMedium euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
+          style="top: 16px; left: -22px; z-index: 0;"
+        >
+          <div
+            class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
+            style="left: 10px; top: 0px;"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -143,25 +163,29 @@ exports[`EuiPopover props ownFocus renders true 1`] = `
     <div
       class="euiPopover__anchor"
     >
-      <button />
+      <div>
+        <button />
+      </div>
     </div>
     <div>
-      <p
-        class="euiScreenReaderOnly"
-        role="alert"
-      >
-        You are in a popup. To exit this popup, hit escape.
-      </p>
-      <div
-        aria-live="off"
-        class="euiPanel euiPanel--paddingMedium euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
-        style="top: 16px; left: -22px; z-index: 0;"
-        tabindex="0"
-      >
+      <div>
+        <p
+          class="euiScreenReaderOnly"
+          role="alert"
+        >
+          You are in a popup. To exit this popup, hit escape.
+        </p>
         <div
-          class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
-          style="left: 10px; top: 0px;"
-        />
+          aria-live="off"
+          class="euiPanel euiPanel--paddingMedium euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
+          style="top: 16px; left: -22px; z-index: 0;"
+          tabindex="0"
+        >
+          <div
+            class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
+            style="left: 10px; top: 0px;"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -177,18 +201,22 @@ exports[`EuiPopover props panelClassName is rendered 1`] = `
     <div
       class="euiPopover__anchor"
     >
-      <button />
+      <div>
+        <button />
+      </div>
     </div>
     <div>
-      <div
-        aria-live="assertive"
-        class="euiPanel euiPanel--paddingMedium euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen test"
-        style="top: 16px; left: -22px; z-index: 0;"
-      >
+      <div>
         <div
-          class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
-          style="left: 10px; top: 0px;"
-        />
+          aria-live="assertive"
+          class="euiPanel euiPanel--paddingMedium euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen test"
+          style="top: 16px; left: -22px; z-index: 0;"
+        >
+          <div
+            class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
+            style="left: 10px; top: 0px;"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -204,18 +232,22 @@ exports[`EuiPopover props panelPaddingSize is rendered 1`] = `
     <div
       class="euiPopover__anchor"
     >
-      <button />
+      <div>
+        <button />
+      </div>
     </div>
     <div>
-      <div
-        aria-live="assertive"
-        class="euiPanel euiPanel--paddingSmall euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
-        style="top: 16px; left: -22px; z-index: 0;"
-      >
+      <div>
         <div
-          class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
-          style="left: 10px; top: 0px;"
-        />
+          aria-live="assertive"
+          class="euiPanel euiPanel--paddingSmall euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
+          style="top: 16px; left: -22px; z-index: 0;"
+        >
+          <div
+            class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
+            style="left: 10px; top: 0px;"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -230,7 +262,9 @@ exports[`EuiPopover props withTitle is rendered 1`] = `
   <div
     class="euiPopover__anchor"
   >
-    <button />
+    <div>
+      <button />
+    </div>
   </div>
 </div>
 `;

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -1,30 +1,21 @@
-import React, {
-  Component,
-} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import FocusTrap from 'focus-trap-react';
 import tabbable from 'tabbable';
-
 import { cascadingMenuKeyCodes } from '../../services';
-
 import { EuiOutsideClickDetector } from '../outside_click_detector';
-
 import { EuiScreenReaderOnly } from '../accessibility';
-
 import { EuiPanel, SIZES } from '../panel';
-
 import { EuiPortal } from '../portal';
-
 import { EuiMutationObserver } from '../mutation_observer';
-
 import { findPopoverPosition, getElementZIndex } from '../../services/popover/popover_positioning';
 
 const anchorPositionToPopoverPositionMap = {
-  'up': 'top',
-  'right': 'right',
-  'down': 'bottom',
-  'left': 'left'
+  up: 'top',
+  right: 'right',
+  down: 'bottom',
+  left: 'left',
 };
 export function getPopoverPositionFromAnchorPosition(anchorPosition) {
   // maps the anchor position to the matching popover position
@@ -53,18 +44,18 @@ export function getPopoverAlignFromAnchorPosition(anchorPosition) {
 }
 
 const anchorPositionToClassNameMap = {
-  'upCenter': 'euiPopover--anchorUpCenter',
-  'upLeft': 'euiPopover--anchorUpLeft',
-  'upRight': 'euiPopover--anchorUpRight',
-  'downCenter': 'euiPopover--anchorDownCenter',
-  'downLeft': 'euiPopover--anchorDownLeft',
-  'downRight': 'euiPopover--anchorDownRight',
-  'leftCenter': 'euiPopover--anchorLeftCenter',
-  'leftUp': 'euiPopover--anchorLeftUp',
-  'leftDown': 'euiPopover--anchorLeftDown',
-  'rightCenter': 'euiPopover--anchorRightCenter',
-  'rightUp': 'euiPopover--anchorRightUp',
-  'rightDown': 'euiPopover--anchorRightDown',
+  upCenter: 'euiPopover--anchorUpCenter',
+  upLeft: 'euiPopover--anchorUpLeft',
+  upRight: 'euiPopover--anchorUpRight',
+  downCenter: 'euiPopover--anchorDownCenter',
+  downLeft: 'euiPopover--anchorDownLeft',
+  downRight: 'euiPopover--anchorDownRight',
+  leftCenter: 'euiPopover--anchorLeftCenter',
+  leftUp: 'euiPopover--anchorLeftUp',
+  leftDown: 'euiPopover--anchorLeftDown',
+  rightCenter: 'euiPopover--anchorRightCenter',
+  rightUp: 'euiPopover--anchorRightUp',
+  rightDown: 'euiPopover--anchorRightDown',
 };
 
 export const ANCHOR_POSITIONS = Object.keys(anchorPositionToClassNameMap);
@@ -88,7 +79,7 @@ export class EuiPopover extends Component {
     if (prevState.prevProps.isOpen && !nextProps.isOpen) {
       return {
         prevProps: {
-          isOpen: nextProps.isOpen
+          isOpen: nextProps.isOpen,
         },
         isClosing: true,
         isOpening: false,
@@ -98,8 +89,8 @@ export class EuiPopover extends Component {
     if (prevState.prevProps.isOpen !== nextProps.isOpen) {
       return {
         prevProps: {
-          isOpen: nextProps.isOpen
-        }
+          isOpen: nextProps.isOpen,
+        },
       };
     }
 
@@ -114,7 +105,7 @@ export class EuiPopover extends Component {
 
     this.state = {
       prevProps: {
-        isOpen: props.isOpen
+        isOpen: props.isOpen,
       },
       suppressingPopover: this.props.isOpen, // only suppress if created with isOpen=true
       isClosing: false,
@@ -223,28 +214,25 @@ export class EuiPopover extends Component {
     clearTimeout(this.closingTransitionTimeout);
   }
 
-  onMutation = (records) => {
-    const waitDuration = records.reduce(
-      (waitDuration, record) => {
-        // only check for CSS transition values for ELEMENT nodes
-        if (record.target.nodeType === document.ELEMENT_NODE) {
-          const computedStyle = window.getComputedStyle(record.target);
+  onMutation = records => {
+    const waitDuration = records.reduce((waitDuration, record) => {
+      // only check for CSS transition values for ELEMENT nodes
+      if (record.target.nodeType === document.ELEMENT_NODE) {
+        const computedStyle = window.getComputedStyle(record.target);
 
-          const computedDuration = computedStyle.getPropertyValue('transition-duration');
-          let durationMatch = computedDuration.match(GROUP_NUMERIC);
-          durationMatch = durationMatch ? parseFloat(durationMatch[1]) * 1000 : 0;
+        const computedDuration = computedStyle.getPropertyValue('transition-duration');
+        let durationMatch = computedDuration.match(GROUP_NUMERIC);
+        durationMatch = durationMatch ? parseFloat(durationMatch[1]) * 1000 : 0;
 
-          const computedDelay = computedStyle.getPropertyValue('transition-delay');
-          let delayMatch = computedDelay.match(GROUP_NUMERIC);
-          delayMatch = delayMatch ? parseFloat(delayMatch[1]) * 1000 : 0;
+        const computedDelay = computedStyle.getPropertyValue('transition-delay');
+        let delayMatch = computedDelay.match(GROUP_NUMERIC);
+        delayMatch = delayMatch ? parseFloat(delayMatch[1]) * 1000 : 0;
 
-          waitDuration = Math.max(waitDuration, durationMatch + delayMatch);
-        }
+        waitDuration = Math.max(waitDuration, durationMatch + delayMatch);
+      }
 
-        return waitDuration;
-      },
-      0
-    );
+      return waitDuration;
+    }, 0);
     this.positionPopover();
 
     if (waitDuration > 0) {
@@ -261,7 +249,7 @@ export class EuiPopover extends Component {
 
       requestAnimationFrame(onFrame);
     }
-  }
+  };
 
   positionPopover = () => {
     if (this.button == null || this.panel == null) return;
@@ -276,7 +264,7 @@ export class EuiPopover extends Component {
       arrowConfig: {
         arrowWidth: 24,
         arrowBuffer: 10,
-      }
+      },
     });
 
     // the popover's z-index must inherit from the button
@@ -295,7 +283,7 @@ export class EuiPopover extends Component {
     const arrowPosition = position;
 
     this.setState({ popoverStyles, arrowStyles, arrowPosition });
-  }
+  };
 
   panelRef = node => {
     this.panel = node;
@@ -315,7 +303,11 @@ export class EuiPopover extends Component {
     }
   };
 
-  buttonRef = node => this.button = node;
+  stopPropagation = e => {
+    e.nativeEvent.stopImmediatePropagation();
+  };
+
+  buttonRef = node => (this.button = node);
 
   render() {
     const {
@@ -344,7 +336,7 @@ export class EuiPopover extends Component {
         'euiPopover-isOpen': this.state.isOpening,
         'euiPopover--withTitle': withTitle,
       },
-      className,
+      className
     );
 
     const panelClasses = classNames(
@@ -356,7 +348,7 @@ export class EuiPopover extends Component {
       panelClassName
     );
 
-    let panel;
+    let panel = <div />;
 
     if (!this.state.suppressingPopover && (isOpen || this.state.isClosing)) {
       let tabIndex;
@@ -386,63 +378,64 @@ export class EuiPopover extends Component {
         `euiPopover__panelArrow--${this.state.arrowPosition}`
       );
 
+      // wrapping div required because outside click detector component
+      // can't use a Portal as its direct child, because it hijacks onClick
       panel = (
-        <EuiPortal>
-          <FocusTrap
-            active={ownFocus}
-            focusTrapOptions={{
-              clickOutsideDeactivates: true,
-              initialFocus,
-            }}
-          >
-            {focusTrapScreenReaderText}
-            <EuiPanel
-              panelRef={this.panelRef}
-              className={panelClasses}
-              paddingSize={panelPaddingSize}
-              tabIndex={tabIndex}
-              aria-live={ariaLive}
-              style={this.state.popoverStyles}
+        <div>
+          <EuiPortal>
+            <FocusTrap
+              active={ownFocus}
+              focusTrapOptions={{
+                clickOutsideDeactivates: true,
+                initialFocus,
+              }}
             >
-              <div className={arrowClassNames} style={this.state.arrowStyles}/>
-              {
-                children
-                  ? (
-                    <EuiMutationObserver
-                      observerOptions={{
-                        attributes: true, // element attribute changes
-                        childList: true, // added/removed elements
-                        characterData: true, // text changes
-                        subtree: true // watch all child elements
-                      }}
-                      onMutation={this.onMutation}
-                    >
-                      {children}
-                    </EuiMutationObserver>
-                  )
-                  : null
-
-              }
-            </EuiPanel>
-          </FocusTrap>
-        </EuiPortal>
+              {focusTrapScreenReaderText}
+              <EuiPanel
+                panelRef={this.panelRef}
+                className={panelClasses}
+                paddingSize={panelPaddingSize}
+                tabIndex={tabIndex}
+                aria-live={ariaLive}
+                style={this.state.popoverStyles}
+              >
+                <div className={arrowClassNames} style={this.state.arrowStyles} />
+                {children ? (
+                  <EuiMutationObserver
+                    observerOptions={{
+                      attributes: true, // element attribute changes
+                      childList: true, // added/removed elements
+                      characterData: true, // text changes
+                      subtree: true, // watch all child elements
+                    }}
+                    onMutation={this.onMutation}
+                  >
+                    {children}
+                  </EuiMutationObserver>
+                ) : null}
+              </EuiPanel>
+            </FocusTrap>
+          </EuiPortal>
+        </div>
       );
     }
 
+    // 1. The button node is wrapped in a div that stops further propagation of the click event,
+    //    so that the primary button click isn't also interpreted as an outside click.
+    //
+    // 2. Every time the popover opens, the outside click detector is re-mounted, which
+    //    recreates its listeners. When the popover closes, the listeners are removed. This
+    //    avoids the problem of outside clicks opening and then immediately closing the popover,
+    //    etc. It also prevents unnecessary listeners when popovers aren't open.
     return (
-      <EuiOutsideClickDetector onOutsideClick={closePopover}>
-        <div
-          className={classes}
-          onKeyDown={this.onKeyDown}
-          ref={popoverRef}
-          {...rest}
-        >
-          <div className="euiPopover__anchor" ref={this.buttonRef}>
-            {button instanceof HTMLElement ? null : button}
-          </div>
-          {panel}
+      <div className={classes} onKeyDown={this.onKeyDown} ref={popoverRef} {...rest}>
+        <div className="euiPopover__anchor" ref={this.buttonRef}>
+          <div onClick={this.stopPropagation}>{button instanceof HTMLElement ? null : button}</div>
         </div>
-      </EuiOutsideClickDetector>
+        {isOpen || this.state.isClosing ? (
+          <EuiOutsideClickDetector onOutsideClick={closePopover}>{panel}</EuiOutsideClickDetector>
+        ) : null}
+      </div>
     );
   }
 }
@@ -459,10 +452,7 @@ EuiPopover.propTypes = {
   panelPaddingSize: PropTypes.oneOf(SIZES),
   popoverRef: PropTypes.func,
   hasArrow: PropTypes.bool,
-  container: PropTypes.oneOfType([
-    PropTypes.node,
-    PropTypes.instanceOf(HTMLElement)
-  ]),
+  container: PropTypes.oneOfType([PropTypes.node, PropTypes.instanceOf(HTMLElement)]),
   /** When `true`, the popover's position is re-calculated when the user scrolls, this supports having fixed-position popover anchors. */
   repositionOnScroll: PropTypes.bool,
   /** By default, popover content inherits the z-index of the anchor component; pass zIndex to override */

--- a/src/components/table/mobile/__snapshots__/table_sort_mobile.test.js.snap
+++ b/src/components/table/mobile/__snapshots__/table_sort_mobile.test.js.snap
@@ -13,41 +13,43 @@ exports[`EuiTableSortMobile is rendered 1`] = `
     <div
       class="euiPopover__anchor"
     >
-      <button
-        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--iconRight euiButtonEmpty--flushRight"
-        type="button"
-      >
-        <span
-          class="euiButtonEmpty__content"
+      <div>
+        <button
+          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--iconRight euiButtonEmpty--flushRight"
+          type="button"
         >
-          <svg
-            aria-hidden="true"
-            class="euiIcon euiIcon--medium euiButtonEmpty__icon"
-            focusable="false"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
-            xlink="http://www.w3.org/1999/xlink"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <defs>
-              <path
-                d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
-                id="arrow_down-a"
-              />
-            </defs>
-            <use
-              fill-rule="nonzero"
-              href="#arrow_down-a"
-            />
-          </svg>
           <span
-            class="euiButtonEmpty__text"
+            class="euiButtonEmpty__content"
           >
-            Sorting
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiButtonEmpty__icon"
+              focusable="false"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+              xlink="http://www.w3.org/1999/xlink"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <defs>
+                <path
+                  d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+                  id="arrow_down-a"
+                />
+              </defs>
+              <use
+                fill-rule="nonzero"
+                href="#arrow_down-a"
+              />
+            </svg>
+            <span
+              class="euiButtonEmpty__text"
+            >
+              Sorting
+            </span>
           </span>
-        </span>
-      </button>
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/src/components/table/table_pagination/__snapshots__/table_pagination.test.js.snap
+++ b/src/components/table/table_pagination/__snapshots__/table_pagination.test.js.snap
@@ -14,41 +14,43 @@ exports[`EuiTablePagination is rendered 1`] = `
       <div
         class="euiPopover__anchor"
       >
-        <button
-          class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--iconRight"
-          type="button"
-        >
-          <span
-            class="euiButtonEmpty__content"
+        <div>
+          <button
+            class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--iconRight"
+            type="button"
           >
-            <svg
-              aria-hidden="true"
-              class="euiIcon euiIcon--medium euiButtonEmpty__icon"
-              focusable="false"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xlink="http://www.w3.org/1999/xlink"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <defs>
-                <path
-                  d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
-                  id="arrow_down-a"
-                />
-              </defs>
-              <use
-                fill-rule="nonzero"
-                href="#arrow_down-a"
-              />
-            </svg>
             <span
-              class="euiButtonEmpty__text"
+              class="euiButtonEmpty__content"
             >
-              Rows per page: 50
+              <svg
+                aria-hidden="true"
+                class="euiIcon euiIcon--medium euiButtonEmpty__icon"
+                focusable="false"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xlink="http://www.w3.org/1999/xlink"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <defs>
+                  <path
+                    d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+                    id="arrow_down-a"
+                  />
+                </defs>
+                <use
+                  fill-rule="nonzero"
+                  href="#arrow_down-a"
+                />
+              </svg>
+              <span
+                class="euiButtonEmpty__text"
+              >
+                Rows per page: 50
+              </span>
             </span>
-          </span>
-        </button>
+          </button>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Summary

Closes #1218 -- only renders the "outside click detector" component when the popover is open, so that the listeners are mounted and unmounted at the correct times and you don't get unexpected listeners firing.

Most snapshot tests are only different because the popover output is slightly different, with the button wrapped in a containing div so that it doesn't create an unexpected outside click.

### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] ~Any props added have proper autodocs~
- [x] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] ~This was checked for breaking changes and labeled appropriately~
- [x] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
