### PR TITLE
Add typings for EuiKeyPad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Added TypeScript typings for `EuiKeyPadMenu` ([#1229](https://github.com/elastic/eui/pull/1229))
+
 **Bug fixes**
 
 - Fix EuiToolTip to show tooltips on disabled elements ([#1222](https://github.com/elastic/eui/pull/1222))

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -30,3 +30,4 @@
 /// <reference path="./toast/index.d.ts" />
 /// <reference path="./tool_tip/index.d.ts" />
 /// <reference path="./combo_box/index.d.ts" />
+/// <reference path="./key_pad_menu/index.d.ts" />

--- a/src/components/key_pad_menu/index.d.ts
+++ b/src/components/key_pad_menu/index.d.ts
@@ -1,0 +1,33 @@
+/// <reference path="../common.d.ts" />
+
+import { HTMLAttributes, MouseEventHandler, ReactNode, SFC } from 'react';
+
+declare module '@elastic/eui' {
+
+  export const EuiKeyPadMenu: SFC<
+    CommonProps & HTMLAttributes<HTMLDivElement>
+  >;
+
+  interface EuiKeyPadMenuItemCommonProps {
+    label: ReactNode;
+    betaBadgeLabel?: string;
+    betaBadgeIconType?: IconType;
+    betaBadgeTooltipContent?: ReactNode;
+  }
+
+  export interface EuiKeyPadMenuItemButtonProps extends EuiKeyPadMenuItemCommonProps {
+    onClick: (ev: MouseEventHandler<HTMLButtonElement>) => void;
+  }
+
+  export interface EuiKeyPadMenuItemProps extends EuiKeyPadMenuItemCommonProps {
+    href: string;
+  }
+
+  export const EuiKeyPadMenuItemButton: SFC<
+    CommonProps & HTMLAttributes<HTMLButtonElement> & EuiKeyPadMenuItemButtonProps
+  >;
+
+  export const EuiKeyPadMenuItem: SFC<
+    CommonProps & HTMLAttributes<HTMLAnchorElement> & EuiKeyPadMenuItemProps
+  >;
+}

--- a/src/components/key_pad_menu/index.d.ts
+++ b/src/components/key_pad_menu/index.d.ts
@@ -15,19 +15,11 @@ declare module '@elastic/eui' {
     betaBadgeTooltipContent?: ReactNode;
   }
 
-  export interface EuiKeyPadMenuItemButtonProps extends EuiKeyPadMenuItemCommonProps {
-    onClick: (ev: MouseEventHandler<HTMLButtonElement>) => void;
-  }
-
-  export interface EuiKeyPadMenuItemProps extends EuiKeyPadMenuItemCommonProps {
-    href: string;
-  }
-
   export const EuiKeyPadMenuItemButton: SFC<
-    CommonProps & HTMLAttributes<HTMLButtonElement> & EuiKeyPadMenuItemButtonProps
+    CommonProps & HTMLAttributes<HTMLButtonElement> & EuiKeyPadMenuItemCommonProps
   >;
 
   export const EuiKeyPadMenuItem: SFC<
-    CommonProps & HTMLAttributes<HTMLAnchorElement> & EuiKeyPadMenuItemProps
+    CommonProps & HTMLAttributes<HTMLAnchorElement> & EuiKeyPadMenuItemCommonProps
   >;
 }


### PR DESCRIPTION
### Summary

Adding typings for `EuiKeyPad` and its item components.

### Checklist

- ~[ ] This was checked in mobile~
- ~[ ] This was checked in IE11~
- ~[ ] This was checked in dark mode~
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- ~[ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
