### PR TITLE
Allow avatar name to be composed entirely of whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Fix EuiToolTip to show tooltips on disabled elements ([#1222](https://github.com/elastic/eui/pull/1222))
+- Fix EuiAvatar when name is composed entirely of whitespace ([#1231](https://github.com/elastic/eui/pull/1231))
 
 ## [`4.3.0`](https://github.com/elastic/eui/tree/v4.3.0)
 

--- a/src/components/avatar/__snapshots__/avatar.test.js.snap
+++ b/src/components/avatar/__snapshots__/avatar.test.js.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiAvatar allows a name composed entirely of whitespace 1`] = `
+<div
+  aria-label="aria-label"
+  class="euiAvatar euiAvatar--m euiAvatar--user testClass1 testClass2"
+  data-test-subj="test subject string"
+  style="background-image:none;background-color:#DB1374;color:#FFFFFF"
+  title="  "
+>
+  <span
+    aria-hidden="true"
+  >
+      
+  </span>
+</div>
+`;
+
 exports[`EuiAvatar is rendered 1`] = `
 <div
   aria-label="aria-label"

--- a/src/components/avatar/avatar.js
+++ b/src/components/avatar/avatar.js
@@ -56,7 +56,7 @@ export const EuiAvatar = ({
     if (initials) {
       calculatedInitials = initials.substring(0, calculatedInitialsLength);
     } else {
-      if (name.split(' ').length > 1) {
+      if (name.trim() && name.split(' ').length > 1) {
         // B. If there are any spaces in the name, set to first letter of each word
         calculatedInitials = name.match(/\b(\w)/g).join('').substring(0, calculatedInitialsLength);
       } else {

--- a/src/components/avatar/avatar.test.js
+++ b/src/components/avatar/avatar.test.js
@@ -17,6 +17,18 @@ describe('EuiAvatar', () => {
       .toMatchSnapshot();
   });
 
+  test('allows a name composed entirely of whitespace', () => {
+    const component = render(
+      <EuiAvatar
+        name="  "
+        {...requiredProps}
+      />
+    );
+
+    expect(component)
+      .toMatchSnapshot();
+  });
+
   describe('props', () => {
     describe('imageUrl', () => {
       it('is rendered', () => {


### PR DESCRIPTION
### Summary
Fixes case where EuiAvatar's name is composed entirely of whitespace. Fixes #1230

### Checklist

~~- [ ] This was checked in mobile~~
- [x] This was checked in IE11
- [x] This was checked in dark mode
~~- [ ] Any props added have proper autodocs~~
~~- [ ] Documentation examples were added~~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios
~~- [ ] This was checked against keyboard-only and screenreader scenarios~~
