### PR TITLE
Fixes issue with outside clicks on a secondary popover trigger (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `4.4.1`.
+**Bug fixes**
+
+- Fixes issue with outside element triggers for a popover where the popover would open
+and then immediately auto-close ([#1233](https://github.com/elastic/eui/pull/1233))
 
 ## [`4.4.1`](https://github.com/elastic/eui/tree/v4.4.1)
 

--- a/src-docs/src/views/popover/popover.js
+++ b/src-docs/src/views/popover/popover.js
@@ -35,7 +35,7 @@ export default class extends Component {
         iconSide="right"
         onClick={this.onButtonClick.bind(this)}
       >
-        Show popover
+        Toggle popover
       </EuiButton>
     );
 

--- a/src-docs/src/views/popover/popover_example.js
+++ b/src-docs/src/views/popover/popover_example.js
@@ -16,6 +16,10 @@ import Popover from './popover';
 const popoverSource = require('!!raw-loader!./popover');
 const popoverHtml = renderToHtml(Popover);
 
+import SecondaryTrigger from './secondary_trigger';
+const secondaryTriggerSource = require('!!raw-loader!./secondary_trigger');
+const secondaryTriggerHtml = renderToHtml(SecondaryTrigger);
+
 import TrapFocus from './trap_focus';
 const trapFocusSource = require('!!raw-loader!./trap_focus');
 const trapFocusHtml = renderToHtml(TrapFocus);
@@ -65,6 +69,29 @@ export const PopoverExample = {
     ),
     props: { EuiPopover },
     demo: <Popover />,
+  }, {
+    title: 'Secondary trigger',
+    source: [
+      {
+        type: GuideSectionTypes.JS,
+        code: secondaryTriggerSource,
+      },
+      {
+        type: GuideSectionTypes.HTML,
+        code: secondaryTriggerHtml,
+      },
+    ],
+    text: (
+      <p>
+        Usually you pass a button node to the popover whose onClick handler
+        will open the popover or toggle the popover open and closed. You can
+        also trigger this behavior from other elements that live outside of
+        the popover element. Note: clicks on these outside elements while
+        a popover is open will <em>always</em> close the popover.
+      </p>
+    ),
+    props: { EuiPopover },
+    demo: <SecondaryTrigger />,
   }, {
     title: 'Trap focus',
     source: [{

--- a/src-docs/src/views/popover/secondary_trigger.js
+++ b/src-docs/src/views/popover/secondary_trigger.js
@@ -1,0 +1,51 @@
+import React, { Component } from 'react';
+import { EuiPopover, EuiButton, EuiSpacer, EuiButtonEmpty } from '../../../../src/components';
+
+export default class SecondaryTrigger extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isPopoverOpen: false,
+    };
+  }
+
+  openPopover = () => {
+    this.setState({ isPopoverOpen: true });
+  };
+
+  closePopover = () => {
+    this.setState({
+      isPopoverOpen: false,
+    });
+  }
+
+  render() {
+    const button = (
+      <EuiButton iconType="arrowDown" iconSide="right" onClick={this.openPopover}>
+        Open this popover
+      </EuiButton>
+    );
+
+    return (
+      <div>
+        <div>
+          <EuiPopover
+            id="popover"
+            button={button}
+            isOpen={this.state.isPopoverOpen}
+            closePopover={this.closePopover}
+          >
+            <div>
+              Some regular popover content
+            </div>
+          </EuiPopover>
+        </div>
+        <EuiSpacer size="l" />
+        <EuiSpacer size="l" />
+        <EuiSpacer size="l" />
+        <EuiButtonEmpty onClick={this.openPopover}>Secondary popover trigger</EuiButtonEmpty>
+      </div>
+    );
+  }
+}

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
@@ -292,41 +292,52 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                       panelPaddingSize="none"
                       withTitle={true}
                     >
-                      <EuiOutsideClickDetector
-                        onOutsideClick={[Function]}
+                      <div
+                        className="euiPopover euiPopover--anchorUpRight euiPopover--withTitle"
+                        id="customizablePagination"
+                        onKeyDown={[Function]}
                       >
                         <div
-                          className="euiPopover euiPopover--anchorUpRight euiPopover--withTitle"
-                          id="customizablePagination"
-                          onClick={[Function]}
-                          onKeyDown={[Function]}
+                          className="euiPopover__anchor"
                         >
-                          <div
-                            className="euiPopover__anchor"
+                          <EuiButtonEmpty
+                            color="text"
+                            iconSide="right"
+                            iconType="arrowDown"
+                            onClick={[Function]}
+                            size="xs"
+                            type="button"
                           >
-                            <EuiButtonEmpty
-                              color="text"
-                              iconSide="right"
-                              iconType="arrowDown"
+                            <button
+                              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--iconRight"
                               onClick={[Function]}
-                              size="xs"
                               type="button"
                             >
-                              <button
-                                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--iconRight"
-                                onClick={[Function]}
-                                type="button"
+                              <span
+                                className="euiButtonEmpty__content"
                               >
-                                <span
-                                  className="euiButtonEmpty__content"
+                                <EuiIcon
+                                  aria-hidden="true"
+                                  className="euiButtonEmpty__icon"
+                                  size="m"
+                                  type="arrowDown"
                                 >
-                                  <EuiIcon
+                                  <arrowDown
                                     aria-hidden="true"
-                                    className="euiButtonEmpty__icon"
-                                    size="m"
-                                    type="arrowDown"
+                                    className="euiIcon euiIcon--medium euiButtonEmpty__icon"
+                                    focusable="false"
+                                    height="16"
+                                    style={
+                                      Object {
+                                        "fill": undefined,
+                                      }
+                                    }
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    xmlnsXlink="http://www.w3.org/1999/xlink"
                                   >
-                                    <arrowDown
+                                    <svg
                                       aria-hidden="true"
                                       className="euiIcon euiIcon--medium euiButtonEmpty__icon"
                                       focusable="false"
@@ -341,45 +352,29 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                       xmlns="http://www.w3.org/2000/svg"
                                       xmlnsXlink="http://www.w3.org/1999/xlink"
                                     >
-                                      <svg
-                                        aria-hidden="true"
-                                        className="euiIcon euiIcon--medium euiButtonEmpty__icon"
-                                        focusable="false"
-                                        height="16"
-                                        style={
-                                          Object {
-                                            "fill": undefined,
-                                          }
-                                        }
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                        xmlnsXlink="http://www.w3.org/1999/xlink"
-                                      >
-                                        <defs>
-                                          <path
-                                            d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
-                                            id="arrow_down-a"
-                                          />
-                                        </defs>
-                                        <use
-                                          fillRule="nonzero"
-                                          xlinkHref="#arrow_down-a"
+                                      <defs>
+                                        <path
+                                          d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+                                          id="arrow_down-a"
                                         />
-                                      </svg>
-                                    </arrowDown>
-                                  </EuiIcon>
-                                  <span
-                                    className="euiButtonEmpty__text"
-                                  >
-                                    Rows per page: 2
-                                  </span>
+                                      </defs>
+                                      <use
+                                        fillRule="nonzero"
+                                        xlinkHref="#arrow_down-a"
+                                      />
+                                    </svg>
+                                  </arrowDown>
+                                </EuiIcon>
+                                <span
+                                  className="euiButtonEmpty__text"
+                                >
+                                  Rows per page: 2
                                 </span>
-                              </button>
-                            </EuiButtonEmpty>
-                          </div>
+                              </span>
+                            </button>
+                          </EuiButtonEmpty>
                         </div>
-                      </EuiOutsideClickDetector>
+                      </div>
                     </EuiPopover>
                   </div>
                 </EuiFlexItem>

--- a/src/components/popover/__snapshots__/popover.test.js.snap
+++ b/src/components/popover/__snapshots__/popover.test.js.snap
@@ -3,7 +3,7 @@
 exports[`EuiPopover children is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
-  id="1"
+  id="test-id"
 >
   <div
     class="euiPopover__anchor"
@@ -18,7 +18,7 @@ exports[`EuiPopover is rendered 1`] = `
   aria-label="aria-label"
   class="euiPopover euiPopover--anchorDownCenter testClass1 testClass2"
   data-test-subj="test subject string"
-  id="0"
+  id="test-id"
 >
   <div
     class="euiPopover__anchor"
@@ -28,10 +28,26 @@ exports[`EuiPopover is rendered 1`] = `
 </div>
 `;
 
+exports[`EuiPopover outside click detector is not rendered when closed 1`] = `
+<div
+  aria-label="aria-label"
+  className="euiPopover euiPopover--anchorDownCenter testClass1 testClass2"
+  data-test-subj="test subject string"
+  id="test-id"
+  onKeyDown={[Function]}
+>
+  <div
+    className="euiPopover__anchor"
+  >
+    <button />
+  </div>
+</div>
+`;
+
 exports[`EuiPopover props anchorPosition defaults to centerDown 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
-  id="4"
+  id="test-id"
 >
   <div
     class="euiPopover__anchor"
@@ -44,7 +60,7 @@ exports[`EuiPopover props anchorPosition defaults to centerDown 1`] = `
 exports[`EuiPopover props anchorPosition downRight is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownRight"
-  id="6"
+  id="test-id"
 >
   <div
     class="euiPopover__anchor"
@@ -57,7 +73,7 @@ exports[`EuiPopover props anchorPosition downRight is rendered 1`] = `
 exports[`EuiPopover props anchorPosition leftCenter is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorLeftCenter"
-  id="5"
+  id="test-id"
 >
   <div
     class="euiPopover__anchor"
@@ -70,7 +86,7 @@ exports[`EuiPopover props anchorPosition leftCenter is rendered 1`] = `
 exports[`EuiPopover props isOpen defaults to false 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
-  id="7"
+  id="test-id"
 >
   <div
     class="euiPopover__anchor"
@@ -80,11 +96,78 @@ exports[`EuiPopover props isOpen defaults to false 1`] = `
 </div>
 `;
 
+exports[`EuiPopover props isOpen renders outside click detector when open 1`] = `
+<EuiOutsideClickDetector
+  onOutsideClick={[Function]}
+>
+  <div
+    aria-label="aria-label"
+    className="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen testClass1 testClass2"
+    data-test-subj="test subject string"
+    id="test-id"
+    onKeyDown={[Function]}
+  >
+    <div
+      className="euiPopover__anchor"
+    >
+      <button />
+    </div>
+    <EuiPortal>
+      <FocusTrap
+        _createFocusTrap={[Function]}
+        active={false}
+        focusTrapOptions={
+          Object {
+            "clickOutsideDeactivates": true,
+            "initialFocus": undefined,
+          }
+        }
+        paused={false}
+        tag="div"
+      >
+        <EuiPanel
+          aria-live="assertive"
+          className="euiPopover__panel euiPopover__panel--null euiPopover__panel-isOpen"
+          grow={true}
+          hasShadow={false}
+          paddingSize="m"
+          panelRef={[Function]}
+          style={
+            Object {
+              "left": 50,
+              "top": 50,
+            }
+          }
+        >
+          <div
+            className="euiPopover__panelArrow euiPopover__panelArrow--null"
+            style={Object {}}
+          />
+          <EuiMutationObserver
+            observerOptions={
+              Object {
+                "attributes": true,
+                "characterData": true,
+                "childList": true,
+                "subtree": true,
+              }
+            }
+            onMutation={[Function]}
+          >
+            Children
+          </EuiMutationObserver>
+        </EuiPanel>
+      </FocusTrap>
+    </EuiPortal>
+  </div>
+</EuiOutsideClickDetector>
+`;
+
 exports[`EuiPopover props isOpen renders true 1`] = `
 <div>
   <div
     class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
-    id="8"
+    id="test-id"
   >
     <div
       class="euiPopover__anchor"
@@ -111,7 +194,7 @@ exports[`EuiPopover props ownFocus defaults to false 1`] = `
 <div>
   <div
     class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
-    id="9"
+    id="test-id"
   >
     <div
       class="euiPopover__anchor"
@@ -138,7 +221,7 @@ exports[`EuiPopover props ownFocus renders true 1`] = `
 <div>
   <div
     class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
-    id="10"
+    id="test-id"
   >
     <div
       class="euiPopover__anchor"
@@ -172,7 +255,7 @@ exports[`EuiPopover props panelClassName is rendered 1`] = `
 <div>
   <div
     class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
-    id="11"
+    id="test-id"
   >
     <div
       class="euiPopover__anchor"
@@ -199,7 +282,7 @@ exports[`EuiPopover props panelPaddingSize is rendered 1`] = `
 <div>
   <div
     class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
-    id="12"
+    id="test-id"
   >
     <div
       class="euiPopover__anchor"
@@ -225,7 +308,7 @@ exports[`EuiPopover props panelPaddingSize is rendered 1`] = `
 exports[`EuiPopover props withTitle is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter euiPopover--withTitle"
-  id="2"
+  id="test-id"
 >
   <div
     class="euiPopover__anchor"

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -452,7 +452,7 @@ export class EuiPopover extends Component {
               aria-live={ariaLive}
               style={this.state.popoverStyles}
             >
-              <div className={arrowClassNames} style={this.state.arrowStyles}/>
+              <div className={arrowClassNames} style={this.state.arrowStyles} />
               {
                 children
                   ? (
@@ -477,21 +477,27 @@ export class EuiPopover extends Component {
       );
     }
 
-    return (
-      <EuiOutsideClickDetector onOutsideClick={closePopover}>
-        <div
-          className={classes}
-          onKeyDown={this.onKeyDown}
-          ref={popoverRef}
-          {...rest}
-        >
-          <div className="euiPopover__anchor" ref={this.buttonRef}>
-            {button instanceof HTMLElement ? null : button}
-          </div>
-          {panel}
+    const popover = (
+      <div
+        className={classes}
+        onKeyDown={this.onKeyDown}
+        ref={popoverRef}
+        {...rest}
+      >
+        <div className="euiPopover__anchor" ref={this.buttonRef}>
+          {button instanceof HTMLElement ? null : button}
         </div>
-      </EuiOutsideClickDetector>
+        {panel}
+      </div>
     );
+
+    return (isOpen || this.state.isClosing)
+      ? (
+        <EuiOutsideClickDetector onOutsideClick={closePopover}>
+          {popover}
+        </EuiOutsideClickDetector>
+      )
+      : popover;
   }
 }
 

--- a/src/components/popover/popover.test.js
+++ b/src/components/popover/popover.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, mount } from 'enzyme';
+import { render, mount, shallow } from 'enzyme';
 import sinon from 'sinon';
 import { requiredProps } from '../../test/required_props';
 
@@ -18,16 +18,15 @@ jest.mock(
   })
 );
 
-let id = 0;
-const getId = () => (`${id++}`);
+const testId = 'test-id';
 
 describe('EuiPopover', () => {
   test('is rendered', () => {
     const component = render(
       <EuiPopover
-        id={getId()}
+        id={testId}
         button={<button />}
-        closePopover={() => {}}
+        closePopover={() => { }}
         {...requiredProps}
       />
     );
@@ -39,9 +38,25 @@ describe('EuiPopover', () => {
   test('children is rendered', () => {
     const component = render(
       <EuiPopover
-        id={getId()}
+        id={testId}
         button={<button />}
-        closePopover={() => {}}
+        closePopover={() => { }}
+      >
+        Children
+      </EuiPopover>
+    );
+
+    expect(component)
+      .toMatchSnapshot();
+  });
+
+  test('outside click detector is not rendered when closed', () => {
+    const component = shallow(
+      <EuiPopover
+        id={testId}
+        button={<button />}
+        closePopover={() => { }}
+        {...requiredProps}
       >
         Children
       </EuiPopover>
@@ -56,10 +71,10 @@ describe('EuiPopover', () => {
       test('is rendered', () => {
         const component = render(
           <EuiPopover
-            id={getId()}
+            id={testId}
             withTitle
             button={<button />}
-            closePopover={() => {}}
+            closePopover={() => { }}
           />
         );
 
@@ -74,7 +89,7 @@ describe('EuiPopover', () => {
 
         const component = mount(
           <EuiPopover
-            id={getId()}
+            id={testId}
             withTitle
             button={<button />}
             closePopover={closePopoverHandler}
@@ -90,9 +105,9 @@ describe('EuiPopover', () => {
       test('defaults to centerDown', () => {
         const component = render(
           <EuiPopover
-            id={getId()}
+            id={testId}
             button={<button />}
-            closePopover={() => {}}
+            closePopover={() => { }}
           />
         );
 
@@ -103,9 +118,9 @@ describe('EuiPopover', () => {
       test('leftCenter is rendered', () => {
         const component = render(
           <EuiPopover
-            id={getId()}
+            id={testId}
             button={<button />}
-            closePopover={() => {}}
+            closePopover={() => { }}
             anchorPosition="leftCenter"
           />
         );
@@ -117,9 +132,9 @@ describe('EuiPopover', () => {
       test('downRight is rendered', () => {
         const component = render(
           <EuiPopover
-            id={getId()}
+            id={testId}
             button={<button />}
-            closePopover={() => {}}
+            closePopover={() => { }}
             anchorPosition="downRight"
           />
         );
@@ -133,9 +148,9 @@ describe('EuiPopover', () => {
       test('defaults to false', () => {
         const component = render(
           <EuiPopover
-            id={getId()}
+            id={testId}
             button={<button />}
-            closePopover={() => {}}
+            closePopover={() => { }}
           />
         );
 
@@ -147,9 +162,9 @@ describe('EuiPopover', () => {
         const component = mount(
           <div>
             <EuiPopover
-              id={getId()}
+              id={testId}
               button={<button />}
-              closePopover={() => {}}
+              closePopover={() => { }}
               isOpen
             />
           </div>
@@ -160,6 +175,23 @@ describe('EuiPopover', () => {
         expect(component.render())
           .toMatchSnapshot();
       });
+
+      test('renders outside click detector when open', () => {
+        const component = shallow(
+          <EuiPopover
+            id={testId}
+            button={<button />}
+            closePopover={() => { }}
+            isOpen={true}
+            {...requiredProps}
+          >
+            Children
+          </EuiPopover>
+        );
+
+        expect(component)
+          .toMatchSnapshot();
+      });
     });
 
     describe('ownFocus', () => {
@@ -167,10 +199,10 @@ describe('EuiPopover', () => {
         const component = mount(
           <div>
             <EuiPopover
-              id={getId()}
+              id={testId}
               isOpen
               button={<button />}
-              closePopover={() => {}}
+              closePopover={() => { }}
             />
           </div>
         );
@@ -183,11 +215,11 @@ describe('EuiPopover', () => {
         const component = mount(
           <div>
             <EuiPopover
-              id={getId()}
+              id={testId}
               isOpen
               ownFocus
               button={<button />}
-              closePopover={() => {}}
+              closePopover={() => { }}
             />
           </div>
         );
@@ -202,9 +234,9 @@ describe('EuiPopover', () => {
         const component = mount(
           <div>
             <EuiPopover
-              id={getId()}
+              id={testId}
               button={<button />}
-              closePopover={() => {}}
+              closePopover={() => { }}
               panelClassName="test"
               isOpen
             />
@@ -221,9 +253,9 @@ describe('EuiPopover', () => {
         const component = mount(
           <div>
             <EuiPopover
-              id={getId()}
+              id={testId}
               button={<button />}
-              closePopover={() => {}}
+              closePopover={() => { }}
               panelPaddingSize="s"
               isOpen
             />


### PR DESCRIPTION
### Summary

Closes #1218 -- only renders the "outside click detector" component when the popover is open, so that the listeners are mounted and unmounted at the correct times and you don't get unexpected listeners firing.

Note: this is "v2" of this PR because the first one solved this same problem in a more complicated way which led to many more snapshot updates, and the PR also included a ton of editor-driven prettier formatting changes that weren't relevant for this repo.

### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] ~Any props added have proper autodocs~
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] ~This was checked for breaking changes and labeled appropriately~
- [x] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
