### PR TITLE
Increase default font size of tabs in KUI theme

### DIFF
--- a/src/components/tabs/_index.scss
+++ b/src/components/tabs/_index.scss
@@ -1,4 +1,2 @@
-$tabBackgroundColor: #FFF;
-$tabHoverBackgroundColor: #F2F2F2;
-
+@import "variables";
 @import "tabs";

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -13,7 +13,7 @@
 
   &.euiTabs--small {
     .euiTab {
-      @include euiFontSizeS;
+      @include fontSize($euiTabFontSizeS);
       padding: $euiSizeS $euiSizeS;
     }
   }
@@ -27,7 +27,8 @@
 }
 
 .euiTab {
-  @include euiFontSize;
+  @include fontSize($euiTabFontSize);
+  line-height: $euiLineHeight;
 
   position: relative;
   cursor: pointer;

--- a/src/components/tabs/_variables.scss
+++ b/src/components/tabs/_variables.scss
@@ -1,0 +1,2 @@
+$euiTabFontSize: $euiFontSize !default;
+$euiTabFontSizeS: $euiFontSizeS !default;

--- a/src/themes/k6/k6_globals.scss
+++ b/src/themes/k6/k6_globals.scss
@@ -14,3 +14,7 @@ $euiFontSizeXXL:    $euiFontSize * nth($euiTextScale, 1); // 32px
 
 // Make titles bold.
 $euiFontWeightLight: 600;
+
+// Ensure non-small tabs actually have a larger font size
+$euiTabFontSize: $euiFontSizeM;
+$euiTabFontSizeS: $euiFontSizeS;


### PR DESCRIPTION
### Summary

Since Kibana's default font size is 14px, the differences between the small and regular tabs were nil. This creates 2 variables for the tab font sizes and then changes them in the K6_globals.scss file.

<img width="1275" alt="screen shot 2018-10-15 at 18 51 11 pm" src="https://user-images.githubusercontent.com/549577/46983335-00234b00-d0ae-11e8-8dc1-4d1f68bda28f.png">


### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
