### PR TITLE
Update Installation readme section to reference yarn instead of npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ You should check out our [living style guide][docs], which contains many example
 
 ## Installation
 
-To install the Elastic UI Framework, use the `npm` CLI.
+To install the Elastic UI Framework into an existing project, use the `yarn` CLI (`npm` is not supported).
 
 ```
-npm install @elastic/eui
+yarn add @elastic/eui
 ```
 
 ## Running Locally


### PR DESCRIPTION
### Summary

Addresses an out-of-date doc section brought up in #1239. Support for `npm` was removed in #1217.

### Checklist

- ~[ ] This was checked in mobile~
- ~[ ] This was checked in IE11~
- ~[ ] This was checked in dark mode~
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- ~[ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
