### PR TITLE
Use yarn to run 'test' sub-commands to allow propagating ctrl+c signal

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint-es-fix": "eslint --fix --cache --ignore-pattern \"**/*.snap.js\" \"src/**/*.js\" \"src-docs/**/*.js\"",
     "lint-ts": "tslint -c ./tslint.yaml -p ./tsconfig.json && tsc -p ./tsconfig.json",
     "lint-ts-fix": "tslint -c ./tslint.yaml -p ./tsconfig.json --fix",
-    "test": "npm run lint && npm run test-unit",
+    "test": "yarn lint && yarn test-unit",
     "test-unit": "jest --config ./scripts/jest/config.json",
     "start-test-server": "webpack-dev-server --config src-docs/webpack.config.js --port 9999",
     "test-visual": "wdio test/wdio.conf.js",


### PR DESCRIPTION
### Summary

Closes #1242 - not 100% why this fixes the issue, but the `test` script was calling out to `npm` to run linting & unit tests. I changed to use `yarn` instead and now Ctrl+C stops all execution.

### Checklist

- ~[ ] This was checked in mobile~
- ~[ ] This was checked in IE11~
- ~[ ] This was checked in dark mode~
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- ~[ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
