### PR TITLE
Fixes select warning on falsy value in EuiSelect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Increased default font size of tabs in K6 theme ([#1244](https://github.com/elastic/eui/pull/1244))
+  
+**Bug fixes**
+
+- Fixed select warning on falsy value in EuiSelect ([#1254](https://github.com/elastic/eui/pull/1254))
 
 ## [`4.5.2`](https://github.com/elastic/eui/tree/v4.5.2)
 

--- a/src/components/form/select/select.js
+++ b/src/components/form/select/select.js
@@ -48,7 +48,7 @@ export const EuiSelect = ({
   // React HTML input can not have both value and defaultValue properties.
   // https://reactjs.org/docs/uncontrolled-components.html#default-values
   let selectDefaultValue;
-  if (!value) {
+  if (value == null) {
     selectDefaultValue = defaultValue || '';
   }
 


### PR DESCRIPTION
When I passed an empty string, 0 or false to the `value` prop in the `EuiSelect` component, I would get this React warning: 
```Warning: Select elements must be either controlled or uncontrolled (specify either the value prop, or the defaultValue prop, but not both). Decide between using a controlled or uncontrolled select element and remove one of these props. More info: https://fb.me/react-controlled-components```

By switching from a falsy check to a check for null equality, these warnings no longer pop up for the falsy values.