### PR TITLE
Add TypeScript definitions for `EuiConfirmModal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 **Bug fixes**
 
 - Added TypeScript definitions for `EuiFieldPassword`. ([#1255](https://github.com/elastic/eui/pull/1255))
-- Added TypeScript definitions for `EuiConfirmModal`, plus several definition fixes ([#1260](https://github.com/elastic/eui/pull/1260))
+- Added TypeScript definitions for `EuiConfirmModal`, remove `AnyProps`, and several definition fixes ([#1260](https://github.com/elastic/eui/pull/1260))
 
 ## [`4.6.0`](https://github.com/elastic/eui/tree/v4.6.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `4.6.0`.
+**Bug fixes**
 
 - Added TypeScript definitions for `EuiFieldPassword`. ([#1255](https://github.com/elastic/eui/pull/1255))
+- Added TypeScript definitions for `EuiConfirmModal`, plus several definition fixes ([#1260](https://github.com/elastic/eui/pull/1260))
 
 ## [`4.6.0`](https://github.com/elastic/eui/tree/v4.6.0)
 
 - Increased default font size of tabs in K6 theme ([#1244](https://github.com/elastic/eui/pull/1244))
-  
+
 **Bug fixes**
 
 - Fixed select warning on falsy value in EuiSelect ([#1254](https://github.com/elastic/eui/pull/1254))

--- a/src/components/common.d.ts
+++ b/src/components/common.d.ts
@@ -1,5 +1,5 @@
 declare module '@elastic/eui' {
-  export type AnyProps = { [key: string]: string };
+  export type AnyProps = { [key: string]: any };
 
   export interface CommonProps {
     className?: string;

--- a/src/components/common.d.ts
+++ b/src/components/common.d.ts
@@ -1,6 +1,4 @@
 declare module '@elastic/eui' {
-  export type AnyProps = { [key: string]: any };
-
   export interface CommonProps {
     className?: string;
     'aria-label'?: string;

--- a/src/components/flex/index.d.ts
+++ b/src/components/flex/index.d.ts
@@ -10,10 +10,10 @@ declare module '@elastic/eui' {
    */
 
   export type FlexGridGutterSize = 'none' | 's' | 'm' | 'l' | 'xl';
-  export type FlexGridColumns = 0 | 2 | 3 | 4;
+  export type FlexGridColumns = 0 | 1 | 2 | 3 | 4;
 
   export interface EuiFlexGridProps {
-    columns: FlexGridColumns;
+    columns?: FlexGridColumns;
     gutterSize?: FlexGridGutterSize;
   }
 
@@ -46,7 +46,7 @@ declare module '@elastic/eui' {
     | 'spaceBetween'
     | 'spaceAround'
     | 'spaceEvenly';
-  
+
   export interface EuiFlexGroupProps {
     alignItems?: FlexGroupAlignItems;
     children?: React.ReactNode;

--- a/src/components/form/field_password/index.d.ts
+++ b/src/components/form/field_password/index.d.ts
@@ -14,6 +14,7 @@ declare module '@elastic/eui' {
     inputRef?: Ref<HTMLInputElement>;
     fullWidth?: boolean;
     isLoading?: boolean;
+    compressed?: boolean;
   }
 
   export const EuiFieldPassword: SFC<

--- a/src/components/icon/index.d.ts
+++ b/src/components/icon/index.d.ts
@@ -246,7 +246,8 @@ declare module '@elastic/eui' {
     | 'subdued'
     | 'success'
     | 'text'
-    | 'warning';
+    | 'warning'
+    | string;
 
   export interface EuiIconProps {
     type?: IconType;

--- a/src/components/modal/index.d.ts
+++ b/src/components/modal/index.d.ts
@@ -1,6 +1,7 @@
 /// <reference path="../common.d.ts" />
+/// <reference path="../button/index.d.ts" />
 
-import { SFC, HTMLAttributes } from 'react';
+import { ReactNode, SFC, HTMLAttributes } from 'react';
 
 declare module '@elastic/eui' {
 
@@ -57,5 +58,37 @@ declare module '@elastic/eui' {
     CommonProps & HTMLAttributes<HTMLDivElement>
     >;
 
+  /**
+   * Confirm modal type defs
+   *
+   * @see './confirm_modal.js'
+   */
+
+  // index.js re-exports values from confirm_modal.js with these names.
+  export const EUI_MODAL_CONFIRM_BUTTON: 'confirm';
+  export const EUI_MODAL_CANCEL_BUTTON: 'cancel';
+
+  export interface EuiConfirmModalProps {
+    buttonColor?: ButtonColor;
+    cancelButtonText?: ReactNode;
+    confirmButtonText?: ReactNode;
+    defaultFocusedButton?: 'confirm' | 'cancel';
+    title?: ReactNode;
+    onCancel?: () => void;
+    onConfirm?: () => void;
+    /**
+     * Sets the max-width of the modal,
+     * set to `true` to use the default size,
+     * set to `false` to not restrict the width,
+     * set to a number for a custom width in px,
+     * set to a string for a custom width in custom measurement.
+     */
+    maxWidth?: boolean | number | string;
+  }
+
+  // `title` from the React defs conflicts with our definition above
+  export const EuiConfirmModal: SFC<
+    CommonProps & Omit<HTMLAttributes<HTMLDivElement>, 'title'> & EuiConfirmModalProps
+    >;
 
 }

--- a/src/components/table/index.d.ts
+++ b/src/components/table/index.d.ts
@@ -122,7 +122,7 @@ declare module '@elastic/eui' {
   }
 
   export const EuiTableRow: SFC<
-    CommonProps & EuiTableRowProps
+    CommonProps & EuiTableRowProps & HTMLAttributes<HTMLTableRowElement>
   >;
 
   /**

--- a/src/components/table/index.d.ts
+++ b/src/components/table/index.d.ts
@@ -22,6 +22,7 @@ declare module '@elastic/eui' {
 
   export interface EuiTableProps {
     compressed?: boolean;
+    responsive?: boolean;
   }
 
   export const EuiTable: SFC<
@@ -121,9 +122,7 @@ declare module '@elastic/eui' {
   }
 
   export const EuiTableRow: SFC<
-    CommonProps &
-      AnyProps & // at least according to the contract of table_row.js
-      EuiTableRowProps
+    CommonProps & EuiTableRowProps
   >;
 
   /**


### PR DESCRIPTION
Add TypeScript definitions for `EuiConfirmModal`, plus other definition fixes.

Notes:

   * I changed the `AnyProps` definition to map to `any` values, because I observed that the existing definition was too restrictive.
   * However it then removed it entirely from `EuiTableRow` because `AnyProps` wasn't necessary to allow e.g. `key` or `data-foo` props, and other table rows attributes are deprecated in HTML5.
   * The `color` prop for `EuiIcon` actually allows 6 or 3 digit hex color codes, so I allowed `string` as a possible type. I left the existing values as documentation.