### PR TITLE
Description list framer component

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,3 +13,4 @@ Summarize your PR. If it includes design elements include a screenshot or gif.
 - [ ] This was checked for breaking changes and labeled appropriately
 - [ ] Jest tests were updated or added to match the most common scenarios
 - [ ] This was checked against keyboard-only and screenreader scenarios
+- [ ] This required updates to Framer X components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+**Framer X**
+
 - Added Framer component for `EuiDescirptionList` ([#1276](https://github.com/elastic/eui/pull/1276))
 
 ## [`4.7.0`](https://github.com/elastic/eui/tree/v4.7.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `4.7.0`.
+- Added Framer component for `EuiDescirptionList` ([#1276](https://github.com/elastic/eui/pull/1276))
 
 ## [`4.7.0`](https://github.com/elastic/eui/tree/v4.7.0)
 

--- a/src-framer/code/_framer_helpers/frame_size.tsx
+++ b/src-framer/code/_framer_helpers/frame_size.tsx
@@ -1,5 +1,5 @@
 import { ControlType, PropertyControls } from 'framer';
-import React, { Fragment } from 'react';
+import * as React from 'react';
 
 // Define type of property
 interface Props {
@@ -32,6 +32,6 @@ export class FrameSize extends React.Component<Props> {
     } else {
       optionallyFramedComponent = (this.props.children);
     }
-    return (<Fragment>{optionallyFramedComponent}</Fragment>);
+    return (<React.Fragment>{optionallyFramedComponent}</React.Fragment>);
   }
 }

--- a/src-framer/code/description_list/description_list.tsx
+++ b/src-framer/code/description_list/description_list.tsx
@@ -32,9 +32,9 @@ export class DescriptionList extends React.Component<Props> {
     compressed: false,
     textStyle: 'normal',
     type: 'row',
+    // Framer only props for ease of use below
     titleText: 'Title',
     descText: 'Description',
-    // Decent default for Framer to start with
     height: 40,
   };
 

--- a/src-framer/code/description_list/description_list.tsx
+++ b/src-framer/code/description_list/description_list.tsx
@@ -1,0 +1,87 @@
+import {
+  EuiDescriptionList,
+  TYPES,
+  ALIGNMENTS,
+  TEXT_STYLES
+} from '@elastic/eui/lib/components/description_list/description_list.js';
+import {
+  EuiDescriptionListTitle
+} from '@elastic/eui/lib/components/description_list/description_list_title.js';
+import {
+  EuiDescriptionListDescription
+} from '@elastic/eui/lib/components/description_list/description_list_description.js';
+import { ControlType, PropertyControls } from 'framer';
+import * as React from 'react';
+
+// Define type of property
+interface Props {
+  align: ALIGNMENTS;
+  compressed: boolean;
+  textStyle: TEXT_STYLES;
+  type: TYPES;
+  titleText: string;
+  descText: string;
+  height: number;
+}
+
+export class DescriptionList extends React.Component<Props> {
+
+  // Set default properties
+  public static defaultProps = {
+    align: 'left',
+    compressed: false,
+    textStyle: 'normal',
+    type: 'row',
+    titleText: 'Title',
+    descText: 'Description',
+    // Decent default for Framer to start with
+    height: 40,
+  };
+
+  // Items shown in property panel
+  public static propertyControls: PropertyControls = {
+    titleText: {
+      type: ControlType.String,
+      title: '🧙 titleText',
+    },
+    descText: {
+      type: ControlType.String,
+      title: '🧙 descText',
+    },
+    compressed: {
+      type: ControlType.Boolean,
+      title: 'compressed',
+    },
+    align: {
+      type: ControlType.SegmentedEnum,
+      options: ALIGNMENTS,
+      align: 'size',
+    },
+    textStyle: {
+      type: ControlType.SegmentedEnum,
+      options: TEXT_STYLES,
+      align: 'textStyle',
+    },
+    type: {
+      type: ControlType.SegmentedEnum,
+      options: TYPES,
+      title: 'type',
+    },
+  };
+
+  public render() {
+    return (
+      <EuiDescriptionList
+        titleText={this.props.titleText}
+        descText={this.props.descText}
+        compressed={this.props.compressed}
+        align={this.props.align}
+        textStyle={this.props.textStyle}
+        type={this.props.type}
+      >
+        <EuiDescriptionListTitle>{this.props.titleText}</EuiDescriptionListTitle>
+        <EuiDescriptionListDescription>{this.props.descText}</EuiDescriptionListDescription>
+      </EuiDescriptionList>
+    );
+  }
+}

--- a/src-framer/code/text/text.tsx
+++ b/src-framer/code/text/text.tsx
@@ -23,7 +23,7 @@ export class Text extends React.Component<Props> {
 
   // Items shown in property panel
   public static propertyControls: PropertyControls = {
-    textChild: {
+    childText: {
       type: ControlType.String,
       title: '🧙 childText',
     },

--- a/src-framer/code/text/text.tsx
+++ b/src-framer/code/text/text.tsx
@@ -14,7 +14,7 @@ interface Props {
   grow: boolean;
 }
 
-export class Button extends React.Component<Props> {
+export class Text extends React.Component<Props> {
 
   // Set default properties
   public static defaultProps = {


### PR DESCRIPTION
### Summary

Adds a version of the `EuiDescriptionList` component to Framer. To make things easier to use in Framer, it creates a single row containing `EuiDescriptionListTitle` and `EuiDescriptionListDescription` so you don't need to pass a full list. I added Framer props for the text content of these two.

![image](http://snid.es/86dd050476dc/Screen%252520Recording%2525202018-10-31%252520at%25252009.48%252520PM.gif)

### Testing

I've published this in the Framer Store. Simply install it and have fun.

### Checklist

Not required.
