### PR TITLE
Add offwhite background color to Framer Theme component

### DIFF
--- a/src-framer/code/_framer_helpers/theme.tsx
+++ b/src-framer/code/_framer_helpers/theme.tsx
@@ -1,18 +1,22 @@
-import DarkCSS from '!!raw-loader!@elastic/eui/dist/eui_theme_dark.css';
-import LightCSS from '!!raw-loader!@elastic/eui/dist/eui_theme_light.css';
+
 import { ControlType, PropertyControls } from 'framer';
 import * as React from 'react';
 import { FrameSize } from './frame_size.tsx';
 
+const DarkCSS = require('!!raw-loader!@elastic/eui/dist/eui_theme_dark.css');
+const LightCSS = require('!!raw-loader!@elastic/eui/dist/eui_theme_light.css');
+
 // Define type of property
 interface Props {
   theme: string;
+  bgColor: string;
 }
 
 export class Theme extends React.Component<Props> {
   // Set default properties
   public static defaultProps = {
     theme: 'light',
+    bgColor: 'white',
   };
 
   // Items shown in property panel
@@ -22,13 +26,22 @@ export class Theme extends React.Component<Props> {
       options: ['light', 'dark'],
       title: 'Theme',
     },
+    bgColor: {
+      type: ControlType.SegmentedEnum,
+      options: ['white', 'offWhite'],
+      title: '↳ 🧙‍♂️ bgColor',
+      hidden(props) {
+      return props.theme === 'dark';
+      },
+    },
   };
 
   public render() {
 
-    const lightBgColor = '#FFF';
+    const whiteBgColor = '#FFF';
+    const offWhiteBgColor = '#F5F5F5';
     const darkBgColor = '#222';
-    const bgColor = (this.props.theme === 'light' ? lightBgColor : darkBgColor);
+    const bgColor = (this.props.theme === 'light' && this.props.bgColor === 'white') ? whiteBgColor : (this.props.theme === 'light' && this.props.bgColor === 'offWhite') ? offWhiteBgColor : darkBgColor);
     return (
       <FrameSize>
         <div style={{ background: bgColor, flexGrow: 1, display: 'flex' }}>

--- a/src-framer/code/_framer_helpers/theme.tsx
+++ b/src-framer/code/_framer_helpers/theme.tsx
@@ -16,7 +16,7 @@ export class Theme extends React.Component<Props> {
   // Set default properties
   public static defaultProps = {
     theme: 'light',
-    bgColor: 'white',
+    bgColor: 'emptyShade',
   };
 
   // Items shown in property panel
@@ -27,21 +27,17 @@ export class Theme extends React.Component<Props> {
       title: 'Theme',
     },
     bgColor: {
-      type: ControlType.SegmentedEnum,
-      options: ['white', 'offWhite'],
-      title: '↳ 🧙‍♂️ bgColor',
-      hidden(props) {
-      return props.theme === 'dark';
-      },
+      type: ControlType.Enum,
+      options: ['emptyShade', 'lightestShade'],
+      title: '🧙‍♂️ bgColor',
     },
   };
 
   public render() {
 
-    const whiteBgColor = '#FFF';
-    const offWhiteBgColor = '#F5F5F5';
-    const darkBgColor = '#222';
-    const bgColor = (this.props.theme === 'light' && this.props.bgColor === 'white') ? whiteBgColor : (this.props.theme === 'light' && this.props.bgColor === 'offWhite') ? offWhiteBgColor : darkBgColor);
+    const lightBgColor = this.props.bgColor === 'emptyShade' ? '#FFF' : '#F5F5F5';
+    const darkBgColor = this.props.bgColor === 'emptyShade' ? '#222' : '#242424';
+    const bgColor = (this.props.theme === 'light' ? lightBgColor : darkBgColor);
     return (
       <FrameSize>
         <div style={{ background: bgColor, flexGrow: 1, display: 'flex' }}>


### PR DESCRIPTION
### Summary

Adds alternative backgrond color to Framer Theme component.
Also moves the css `import` lines to `const` variables since styles were not loading properly.

### Checklist

- [ ] ~This was checked in mobile~
- [ ] ~This was checked in IE11~
- [x] This was checked in dark mode
- [ ] ~Any props added have proper autodocs~
- [ ] ~Documentation examples were added~
- [ ] ~A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
- [ ] ~This was checked for breaking changes and labeled appropriately~
- [ ] ~Jest tests were updated or added to match the most common scenarios~
- [ ] ~This was checked against keyboard-only and screenreader scenarios~
- [x] This required updates to Framer X components
