### PR TITLE
Add EuiToolTip's delay prop to TS def

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Added and updated new product logos to `EuiIcon` ([#1279](https://github.com/elastic/eui/pull/1279))
 
+**Bug fixes**
+
+- Added TypeScript definitions for `EuiToolTip`'s `delay` prop. ([#1284](https://github.com/elastic/eui/pull/1284))
+
 **Framer X**
 
 - Added Framer component for `EuiDescirptionList` ([#1276](https://github.com/elastic/eui/pull/1276))

--- a/src/components/tool_tip/index.d.ts
+++ b/src/components/tool_tip/index.d.ts
@@ -7,10 +7,15 @@ declare module '@elastic/eui' {
     | 'bottom'
     | 'left';
 
+  export type ToolTipDelay =
+    | 'regular'
+    | 'long';
+
   export interface EuiToolTipProps {
     children: ReactElement<any>;
     className?: string;
     content: ReactNode;
+    delay?: ToolTipDelay;
     title?: ReactNode;
     id?: string;
     position?: ToolTipPositions;


### PR DESCRIPTION
### Summary

Adds TypeScript definition for EuiToolTip's `delay` prop.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
