### PR TITLE
IconSide can be 'left' or 'right'

### DIFF
--- a/src/components/badge/index.d.ts
+++ b/src/components/badge/index.d.ts
@@ -4,7 +4,7 @@ import { HTMLAttributes, MouseEventHandler, SFC } from 'react';
 
 declare module '@elastic/eui' {
 
-  type IconSide = 'left';
+  type IconSide = 'left' | 'right';
 
   export interface EuiBadgeProps {
     iconType?: IconType;


### PR DESCRIPTION
'left' and 'right' are both valid values for the iconSide prop in EuiBadge: https://github.com/elastic/eui/blob/5e06ca13c3bd8212bd901294719ace57d6c3b55c/src/components/badge/badge.js#L26-L29