### PR TITLE
Add TS types for EuiTab/EuiTabs/EuiTabbedContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 No public interface changes since `4.8.0`.
 
+**Bug fixes**
+- Added TypeScript definitions for tab components ([#1288](https://github.com/elastic/eui/pull/1288))
+
 ## [`4.8.0`](https://github.com/elastic/eui/tree/v4.8.0)
 
 - Adding a `branch` icon to `EuiIcon` ([#1249](https://github.com/elastic/eui/pull/1249/))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `4.8.0`.
-
 **Bug fixes**
 - Added TypeScript definitions for tab components ([#1288](https://github.com/elastic/eui/pull/1288))
 

--- a/src/components/tabs/index.d.ts
+++ b/src/components/tabs/index.d.ts
@@ -1,0 +1,39 @@
+/// <reference path="../common.d.ts" />
+
+declare module '@elastic/eui' {
+  import { MouseEventHandler, ReactNode, SFC } from 'react';
+
+  type TAB_SIZES = 's' | 'm';
+
+  type EuiTabProps = CommonProps & {
+    onClick: MouseEventHandler<HTMLButtonElement>;
+    isSelected?: boolean;
+    children?: ReactNode[];
+    disabled?: boolean;
+  };
+
+  type EuiTabsProps = CommonProps & {
+    children?: ReactNode[];
+    size?: TAB_SIZES;
+    expand?: boolean;
+  };
+
+  export interface EuiTabbedContentTab {
+    id: string;
+    name: string;
+    content: ReactNode;
+  }
+
+  type EuiTabbedContentProps = CommonProps & {
+    tabs: EuiTabbedContentTab[];
+    onTabClick?: (tab: EuiTabbedContentTab) => void;
+    selectedTab?: EuiTabbedContentTab;
+    initialSelectedTab?: EuiTabbedContentTab;
+    size?: TAB_SIZES;
+    expand?: boolean;
+  }
+
+  export const EuiTab: SFC<EuiTabProps>;
+  export const EuiTabs: SFC<EuiTabsProps>;
+  export const EuiTabbedContent: SFC<EuiTabbedContentProps>;
+}

--- a/src/components/tabs/index.d.ts
+++ b/src/components/tabs/index.d.ts
@@ -1,19 +1,17 @@
 /// <reference path="../common.d.ts" />
 
 declare module '@elastic/eui' {
-  import { MouseEventHandler, ReactNode, SFC } from 'react';
+  import { MouseEventHandler, ReactNode, SFC, HTMLAttributes } from 'react';
 
   type TAB_SIZES = 's' | 'm';
 
-  type EuiTabProps = CommonProps & {
+  type EuiTabProps = {
     onClick: MouseEventHandler<HTMLButtonElement>;
     isSelected?: boolean;
-    children?: ReactNode[];
     disabled?: boolean;
   };
 
-  type EuiTabsProps = CommonProps & {
-    children?: ReactNode[];
+  type EuiTabsProps = {
     size?: TAB_SIZES;
     expand?: boolean;
   };
@@ -24,7 +22,7 @@ declare module '@elastic/eui' {
     content: ReactNode;
   }
 
-  type EuiTabbedContentProps = CommonProps & {
+  type EuiTabbedContentProps = {
     tabs: EuiTabbedContentTab[];
     onTabClick?: (tab: EuiTabbedContentTab) => void;
     selectedTab?: EuiTabbedContentTab;
@@ -33,7 +31,7 @@ declare module '@elastic/eui' {
     expand?: boolean;
   }
 
-  export const EuiTab: SFC<EuiTabProps>;
-  export const EuiTabs: SFC<EuiTabsProps>;
-  export const EuiTabbedContent: SFC<EuiTabbedContentProps>;
+  export const EuiTab: SFC<EuiTabProps & CommonProps & HTMLAttributes<HTMLDivElement>>;
+  export const EuiTabs: SFC<EuiTabsProps & CommonProps & HTMLAttributes<HTMLDivElement>>;
+  export const EuiTabbedContent: SFC<EuiTabbedContentProps & CommonProps & HTMLAttributes<HTMLDivElement>>;
 }

--- a/src/components/text/index.d.ts
+++ b/src/components/text/index.d.ts
@@ -9,7 +9,7 @@ declare module '@elastic/eui' {
    * @see './text.js'
    * @see './text_color.js'
    */
-  type SIZES = 's' | 'xs';
+  type TEXT_SIZES = 's' | 'xs';
 
   type COLORS =
     | 'default'
@@ -22,7 +22,7 @@ declare module '@elastic/eui' {
 
   type EuiTextProps = CommonProps &
     HTMLAttributes<HTMLDivElement> & {
-      size?: SIZES;
+      size?: TEXT_SIZES;
       color?: COLORS;
       grow?: boolean;
     };


### PR DESCRIPTION
### Summary

Adds type definitions for the EuiTab and similar components.

### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
