### PR TITLE
Add TS defs for badges, popover titles, and other fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Fixed size of `EuiSuperSelect`'s dropdown menu when there is no initial selection ([#1295](https://github.com/elastic/eui/pull/1295))
+- Added TypeScript definitions for `EuiPopoverTitle` and the beta and notification badges. Ensure tab TS definitions are included in the main definition index. ([#1299](https://github.com/elastic/eui/pull/1299))
 
 ## [`5.0.0`](https://github.com/elastic/eui/tree/v5.0.0)
 
@@ -24,10 +25,6 @@
 
 - Adding a `branch` icon to `EuiIcon` ([#1249](https://github.com/elastic/eui/pull/1249/))
 - Added and updated new product logos to `EuiIcon` ([#1279](https://github.com/elastic/eui/pull/1279))
-
-**Bug fixes**
-
-- Added TypeScript definitions for `EuiToolTip`'s `delay` prop. ([#1284](https://github.com/elastic/eui/pull/1284))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 **Bug fixes**
 
 - Fixed size of `EuiSuperSelect`'s dropdown menu when there is no initial selection ([#1295](https://github.com/elastic/eui/pull/1295))
-- Added TypeScript definitions for `EuiPopoverTitle` and the beta and notification badges. Ensure tab TS definitions are included in the main definition index. ([#1299](https://github.com/elastic/eui/pull/1299))
+- Added TypeScript definitions for `EuiPopoverTitle` and the beta and notification badges. Ensure tab TS definitions are included in the main definition index. Fix typo in icon types ([#1299](https://github.com/elastic/eui/pull/1299))
 
 ## [`5.0.0`](https://github.com/elastic/eui/tree/v5.0.0)
 

--- a/scripts/compile-eui.js
+++ b/scripts/compile-eui.js
@@ -4,7 +4,7 @@ const shell = require('shelljs');
 const glob = require('glob');
 
 function compileLib() {
-  shell.mkdir('-p', 'lib/components', 'lib/services', 'lib/test');
+  shell.mkdir('-p', 'lib/components/icon/assets/tokens', 'lib/services', 'lib/test');
 
   console.log('Compiling src/ to es/ and lib/');
 
@@ -16,15 +16,14 @@ function compileLib() {
 
   console.log(chalk.green('✔ Finished compiling src/'));
 
-  // Also copy over SVGs. Babel has a --copy-files option but that brings over
-  // all kinds of things we don't want into the lib folder.
+  // Also copy over SVGs. Babel has a --copy-files option but that brings over
+  // all kinds of things we don't want into the lib folder.
   shell.mkdir('-p', 'lib/components/icon/assets');
 
   glob('./src/components/**/*.svg', undefined, (error, files) => {
     files.forEach(file => {
       const splitPath = file.split('/');
       const basePath = splitPath.slice(2, splitPath.length).join('/');
-      console.log(basePath)
       shell.cp('-f', `${file}`, `lib/${basePath}`);
     });
 

--- a/src/components/badge/index.d.ts
+++ b/src/components/badge/index.d.ts
@@ -31,7 +31,7 @@ declare module '@elastic/eui' {
   }
 
   export const EuiBetaBadge: SFC<
-    CommonProps & HTMLAttributes<HTMLSpanElement> & HTMLAttributes<HTMLSpanElement> & EuiBetaBadgeProps
+    CommonProps & HTMLAttributes<HTMLSpanElement> & EuiBetaBadgeProps
   >;
 
   export interface EuiNotificationBadgeProps {
@@ -43,6 +43,6 @@ declare module '@elastic/eui' {
   }
 
   export const EuiNotificationBadge: SFC<
-    CommonProps & HTMLAttributes<HTMLSpanElement> & HTMLAttributes<HTMLSpanElement>
+    CommonProps & HTMLAttributes<HTMLSpanElement>
   >;
 }

--- a/src/components/badge/index.d.ts
+++ b/src/components/badge/index.d.ts
@@ -31,7 +31,7 @@ declare module '@elastic/eui' {
   }
 
   export const EuiBetaBadge: SFC<
-    CommonProps & HTMLAttributes<HTMLSpanElement> & HTMLAttributes<HTMLButtonElement> & EuiBetaBadgeProps
+    CommonProps & HTMLAttributes<HTMLSpanElement> & HTMLAttributes<HTMLSpanElement> & EuiBetaBadgeProps
   >;
 
   export interface EuiNotificationBadgeProps {
@@ -43,6 +43,6 @@ declare module '@elastic/eui' {
   }
 
   export const EuiNotificationBadge: SFC<
-    CommonProps & HTMLAttributes<HTMLSpanElement> & HTMLAttributes<HTMLButtonElement>
+    CommonProps & HTMLAttributes<HTMLSpanElement> & HTMLAttributes<HTMLSpanElement>
   >;
 }

--- a/src/components/badge/index.d.ts
+++ b/src/components/badge/index.d.ts
@@ -1,6 +1,7 @@
 /// <reference path="../icon/index.d.ts" />
+/// <reference path="../tool_tip/index.d.ts" />
 
-import { HTMLAttributes, MouseEventHandler, SFC } from 'react';
+import { HTMLAttributes, MouseEventHandler, SFC, ReactNode } from 'react';
 
 declare module '@elastic/eui' {
 
@@ -19,5 +20,29 @@ declare module '@elastic/eui' {
 
   export const EuiBadge: SFC<
     CommonProps & HTMLAttributes<HTMLSpanElement> & HTMLAttributes<HTMLButtonElement> & EuiBadgeProps
+  >;
+
+  export interface EuiBetaBadgeProps {
+    iconType?: IconType;
+    label: ReactNode;
+    tooltipContent?: ReactNode;
+    tooltipPosition?: ToolTipPositions;
+    title?: string;
+  }
+
+  export const EuiBetaBadge: SFC<
+    CommonProps & HTMLAttributes<HTMLSpanElement> & HTMLAttributes<HTMLButtonElement> & EuiBetaBadgeProps
+  >;
+
+  export interface EuiNotificationBadgeProps {
+    iconType?: IconType;
+    label: ReactNode;
+    tooltipContent?: ReactNode;
+    tooltipPosition?: ToolTipPositions;
+    title?: string;
+  }
+
+  export const EuiNotificationBadge: SFC<
+    CommonProps & HTMLAttributes<HTMLSpanElement> & HTMLAttributes<HTMLButtonElement>
   >;
 }

--- a/src/components/error_boundary/index.d.ts
+++ b/src/components/error_boundary/index.d.ts
@@ -1,0 +1,9 @@
+/// <reference path="../common.d.ts" />
+
+import { HTMLAttributes, Component } from 'react';
+
+declare module '@elastic/eui' {
+  export class EuiErrorBoundary extends Component<
+    CommonProps & HTMLAttributes<HTMLDivElement>
+    > {}
+}

--- a/src/components/icon/index.d.ts
+++ b/src/components/icon/index.d.ts
@@ -77,7 +77,7 @@ declare module '@elastic/eui' {
     | 'filter'
     | 'fullScreen'
     | 'gear'
-    | 'glob'
+    | 'globe'
     | 'grab'
     | 'graphApp'
     | 'grid'

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -31,6 +31,7 @@
 /// <reference path="./spacer/index.d.ts" />
 /// <reference path="./steps/index.d.ts" />
 /// <reference path="./table/index.d.ts" />
+/// <reference path="./tabs/index.d.ts" />
 /// <reference path="./text/index.d.ts" />
 /// <reference path="./title/index.d.ts" />
 /// <reference path="./toast/index.d.ts" />

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -10,6 +10,7 @@
 /// <reference path="./context_menu/index.d.ts" />
 /// <reference path="./description_list/index.d.ts" />
 /// <reference path="./empty_prompt/index.d.ts" />
+/// <reference path="./error_boundary/index.d.ts" />
 /// <reference path="./flex/index.d.ts" />
 /// <reference path="./flyout/index.d.ts" />
 /// <reference path="./form/index.d.ts" />

--- a/src/components/popover/index.d.ts
+++ b/src/components/popover/index.d.ts
@@ -40,4 +40,8 @@ declare module '@elastic/eui' {
   export const EuiPopover: SFC<
     CommonProps & HTMLAttributes<HTMLDivElement> & EuiPopoverProps
   >;
+
+  export const EuiPopoverTitle: SFC<
+    CommonProps & HTMLAttributes<HTMLDivElement>
+  >;
 }


### PR DESCRIPTION
Add TS defs for beta and notifications badges, and popover titles.

Fix the main TS index file so that tab definitions are included.

Fix the build to ensure all required directories are created.