### PR TITLE
add data-test-subj to toast item container

### DIFF
--- a/src/components/toast/__snapshots__/global_toast_list.test.js.snap
+++ b/src/components/toast/__snapshots__/global_toast_list.test.js.snap
@@ -26,6 +26,7 @@ exports[`EuiGlobalToastList props toasts is rendered 1`] = `
     <div
       aria-label="Notification"
       class="euiToastHeader euiToastHeader--withBody"
+      data-test-subj="euiToastHeader"
     >
       <svg
         aria-hidden="true"
@@ -94,6 +95,7 @@ exports[`EuiGlobalToastList props toasts is rendered 1`] = `
     <div
       aria-label="Notification"
       class="euiToastHeader euiToastHeader--withBody"
+      data-test-subj="euiToastHeader"
     >
       <svg
         aria-hidden="true"

--- a/src/components/toast/__snapshots__/toast.test.js.snap
+++ b/src/components/toast/__snapshots__/toast.test.js.snap
@@ -4,7 +4,6 @@ exports[`EuiToast Props color danger is rendered 1`] = `
 <div
   aria-live="polite"
   className="euiToast euiToast--danger"
-  data-test-subj="euiToast-danger"
 >
   <EuiScreenReaderOnly>
     <p>
@@ -14,6 +13,7 @@ exports[`EuiToast Props color danger is rendered 1`] = `
   <div
     aria-label="Notification"
     className="euiToastHeader"
+    data-test-subj="euiToastHeader"
   >
     <span
       className="euiToastHeader__title"
@@ -26,7 +26,6 @@ exports[`EuiToast Props color primary is rendered 1`] = `
 <div
   aria-live="polite"
   className="euiToast euiToast--primary"
-  data-test-subj="euiToast-primary"
 >
   <EuiScreenReaderOnly>
     <p>
@@ -36,6 +35,7 @@ exports[`EuiToast Props color primary is rendered 1`] = `
   <div
     aria-label="Notification"
     className="euiToastHeader"
+    data-test-subj="euiToastHeader"
   >
     <span
       className="euiToastHeader__title"
@@ -48,7 +48,6 @@ exports[`EuiToast Props color success is rendered 1`] = `
 <div
   aria-live="polite"
   className="euiToast euiToast--success"
-  data-test-subj="euiToast-success"
 >
   <EuiScreenReaderOnly>
     <p>
@@ -58,6 +57,7 @@ exports[`EuiToast Props color success is rendered 1`] = `
   <div
     aria-label="Notification"
     className="euiToastHeader"
+    data-test-subj="euiToastHeader"
   >
     <span
       className="euiToastHeader__title"
@@ -70,7 +70,6 @@ exports[`EuiToast Props color warning is rendered 1`] = `
 <div
   aria-live="polite"
   className="euiToast euiToast--warning"
-  data-test-subj="euiToast-warning"
 >
   <EuiScreenReaderOnly>
     <p>
@@ -80,6 +79,7 @@ exports[`EuiToast Props color warning is rendered 1`] = `
   <div
     aria-label="Notification"
     className="euiToastHeader"
+    data-test-subj="euiToastHeader"
   >
     <span
       className="euiToastHeader__title"
@@ -92,7 +92,6 @@ exports[`EuiToast Props iconType is rendered 1`] = `
 <div
   aria-live="polite"
   className="euiToast"
-  data-test-subj="euiToast-undefined"
 >
   <EuiScreenReaderOnly>
     <p>
@@ -102,6 +101,7 @@ exports[`EuiToast Props iconType is rendered 1`] = `
   <div
     aria-label="Notification"
     className="euiToastHeader"
+    data-test-subj="euiToastHeader"
   >
     <EuiIcon
       aria-hidden="true"
@@ -120,7 +120,6 @@ exports[`EuiToast Props title is rendered 1`] = `
 <div
   aria-live="polite"
   className="euiToast"
-  data-test-subj="euiToast-undefined"
 >
   <EuiScreenReaderOnly>
     <p>
@@ -130,6 +129,7 @@ exports[`EuiToast Props title is rendered 1`] = `
   <div
     aria-label="Notification"
     className="euiToastHeader"
+    data-test-subj="euiToastHeader"
   >
     <span
       className="euiToastHeader__title"
@@ -155,6 +155,7 @@ exports[`EuiToast is rendered 1`] = `
   <div
     aria-label="Notification"
     class="euiToastHeader euiToastHeader--withBody"
+    data-test-subj="euiToastHeader"
   >
     <span
       class="euiToastHeader__title"

--- a/src/components/toast/__snapshots__/toast.test.js.snap
+++ b/src/components/toast/__snapshots__/toast.test.js.snap
@@ -4,6 +4,7 @@ exports[`EuiToast Props color danger is rendered 1`] = `
 <div
   aria-live="polite"
   className="euiToast euiToast--danger"
+  data-test-subj="euiToast-danger"
 >
   <EuiScreenReaderOnly>
     <p>
@@ -25,6 +26,7 @@ exports[`EuiToast Props color primary is rendered 1`] = `
 <div
   aria-live="polite"
   className="euiToast euiToast--primary"
+  data-test-subj="euiToast-primary"
 >
   <EuiScreenReaderOnly>
     <p>
@@ -46,6 +48,7 @@ exports[`EuiToast Props color success is rendered 1`] = `
 <div
   aria-live="polite"
   className="euiToast euiToast--success"
+  data-test-subj="euiToast-success"
 >
   <EuiScreenReaderOnly>
     <p>
@@ -67,6 +70,7 @@ exports[`EuiToast Props color warning is rendered 1`] = `
 <div
   aria-live="polite"
   className="euiToast euiToast--warning"
+  data-test-subj="euiToast-warning"
 >
   <EuiScreenReaderOnly>
     <p>
@@ -88,6 +92,7 @@ exports[`EuiToast Props iconType is rendered 1`] = `
 <div
   aria-live="polite"
   className="euiToast"
+  data-test-subj="euiToast-undefined"
 >
   <EuiScreenReaderOnly>
     <p>
@@ -115,6 +120,7 @@ exports[`EuiToast Props title is rendered 1`] = `
 <div
   aria-live="polite"
   className="euiToast"
+  data-test-subj="euiToast-undefined"
 >
   <EuiScreenReaderOnly>
     <p>

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -75,14 +75,17 @@ export const EuiToast = ({ title, color, iconType, onClose, children, className,
     <div
       className={classes}
       aria-live="polite"
-      data-test-subj={`euiToast-${color}`}
       {...rest}
     >
       <EuiScreenReaderOnly>
         <p>A new notification appears</p>
       </EuiScreenReaderOnly>
 
-      <div className={headerClasses} aria-label="Notification">
+      <div
+        className={headerClasses}
+        aria-label="Notification"
+        data-test-subj="euiToastHeader"
+      >
         {headerIcon}
 
         <span className="euiToastHeader__title">

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -75,6 +75,7 @@ export const EuiToast = ({ title, color, iconType, onClose, children, className,
     <div
       className={classes}
       aria-live="polite"
+      data-test-subj={`euiToast-${color}`}
       {...rest}
     >
       <EuiScreenReaderOnly>


### PR DESCRIPTION
### Summary

This adds a `data-test-subj` to toast messages. This gives the ability to processes that check the DOM of the page (Reporting, Selenium) to check if there is a toast message on the page.

![datatestsubj](https://user-images.githubusercontent.com/908371/48283423-b6fab880-e419-11e8-88ad-05d1e01cff9a.png)


### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [X] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
