### PR TITLE
EuiTableRowCellProps TS defs fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - `EuiToken` now exports enumerated constants for `SHAPES` and `COLORS` ([#1301](https://github.com/elastic/eui/pull/1301))
 - Added mixins for `EuiCallOut` coloring and `EuiTooltip` styles ([#1305](https://github.com/elastic/eui/pull/1305))
+- Improve TypeScript definitions for `EuiTableRowCellProps` ([#1310](https://github.com/elastic/eui/pull/1310))
 
 ## [`5.0.1`](https://github.com/elastic/eui/tree/v5.0.1)
 

--- a/src/components/table/index.d.ts
+++ b/src/components/table/index.d.ts
@@ -132,9 +132,16 @@ declare module '@elastic/eui' {
    */
 
   export interface EuiTableRowCellProps {
-    truncateText?: boolean;
     align?: HorizontalAlignment;
+    hasActions?: boolean;
+    header?: string;
+    hideForMobile?: boolean;
+    isExpander?: boolean;
+    isMobileFullWidth?: boolean;
+    isMobileHeader?: boolean;
+    showOnHover?: boolean;
     textOnly?: boolean;
+    truncateText?: boolean;
   }
 
   export const EuiTableRowCell: SFC<


### PR DESCRIPTION
This PR just adds a bunch of missing props to the TS definition for `EuiTableRowCellProps`.