### PR TITLE
Add prepend prop to EuiFieldText's typescript definition

### DIFF
--- a/src/components/form/field_text/index.d.ts
+++ b/src/components/form/field_text/index.d.ts
@@ -15,7 +15,7 @@ declare module '@elastic/eui' {
     inputRef?: (ref: HTMLInputElement) => void;
     fullWidth?: boolean;
     isLoading?: boolean;
-    prepend: any;
+    prepend: React.ReactNode;
   }
 
   export const EuiFieldText: SFC<

--- a/src/components/form/field_text/index.d.ts
+++ b/src/components/form/field_text/index.d.ts
@@ -15,6 +15,7 @@ declare module '@elastic/eui' {
     inputRef?: (ref: HTMLInputElement) => void;
     fullWidth?: boolean;
     isLoading?: boolean;
+    prepend: any;
   }
 
   export const EuiFieldText: SFC<

--- a/src/components/form/field_text/index.d.ts
+++ b/src/components/form/field_text/index.d.ts
@@ -15,7 +15,7 @@ declare module '@elastic/eui' {
     inputRef?: (ref: HTMLInputElement) => void;
     fullWidth?: boolean;
     isLoading?: boolean;
-    prepend: React.ReactNode;
+    prepend?: React.ReactNode;
   }
 
   export const EuiFieldText: SFC<


### PR DESCRIPTION
### Summary

AFAICT we have to use `any` here. From https://www.typescriptlang.org/docs/handbook/jsx.html#the-jsx-result-type: 

> By default the result of a JSX expression is typed as any.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~