### PR TITLE
Convert table cell header into an empty string if it's been provided to EuiBasicTable as a non-string node.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `5.1.0`.
+**Bug fixes**
+
+- `EuiBasicTable` now converts the `EuiTableRowCell` `header` into an empty string if it's been provided as a non-string node, preventing the node from being rendered as `[object Object]` on narrow screens ([#1312](https://github.com/elastic/eui/pull/1312))
 
 ## [`5.1.0`](https://github.com/elastic/eui/tree/v5.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Bug fixes**
 
-- `EuiBasicTable` now converts the `EuiTableRowCell` `header` into an empty string if it's been provided as a non-string node, preventing the node from being rendered as `[object Object]` on narrow screens ([#1312](https://github.com/elastic/eui/pull/1312))
+- `EuiBasicTable` now converts the `EuiTableRowCell` `header` into `undefined` if it's been provided as a non-string node, hiding the header and preventing the node from being rendered as `[object Object]` on narrow screens ([#1312](https://github.com/elastic/eui/pull/1312))
 
 ## [`5.1.0`](https://github.com/elastic/eui/tree/v5.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Added support for nodes as "Action" column headers in `EuiBasicTable`, which was overlooked in the original change in `4.5.0` ([#1312](https://github.com/elastic/eui/pull/1312))
+
 **Bug fixes**
 
 - `EuiBasicTable` now converts the `EuiTableRowCell` `header` into an empty string if it's been provided as a non-string node, preventing the node from being rendered as `[object Object]` on narrow screens ([#1312](https://github.com/elastic/eui/pull/1312))
@@ -98,7 +100,7 @@
 
 - Added export for `TYPES` to `EuiAvatar` ([#1238](https://github.com/elastic/eui/pull/1238))
 - Updated node-sass dependency to support OSX Mojave ([#1238](https://github.com/elastic/eui/pull/1238))
-- Added TypeScript definitions for `EuiFieldNumber, `EuiFormLabel` and `EuiSelect`, and fix the `EuiTextColor` definition. ([#1240](https://github.com/elastic/eui/pull/1240))
+- Added TypeScript definitions for `EuiFieldNumber`, `EuiFormLabel` and `EuiSelect`, and fix the `EuiTextColor` definition. ([#1240](https://github.com/elastic/eui/pull/1240))
 - Added support for nodes as column headers in `EuiBasicTable` for supporting things like tooltips and localized text. ([#1234](https://github.com/elastic/eui/pull/1234))
 
 ## [`4.4.1`](https://github.com/elastic/eui/tree/v4.4.1)

--- a/src/components/basic_table/basic_table.js
+++ b/src/components/basic_table/basic_table.js
@@ -829,10 +829,10 @@ export class EuiBasicTable extends Component {
     const columnAlign = align || this.getAlignForDataType(dataType);
     const { cellProps: cellPropsCallback } = this.props;
     const cellProps = getCellProps(item, column, cellPropsCallback);
-    // Name can also be an array or an element, so we need to convert it into a string. We can't
+    // Name can also be an array or an element, so we need to convert it to undefined. We can't
     // stringify the value, because this value is rendered directly in the mobile layout. So the
-    // best thing we can do is render nothing.
-    const header = typeof name === 'string' ? name : '';
+    // best thing we can do is render no header at all.
+    const header = typeof name === 'string' ? name : undefined;
 
     return (
       <EuiTableRowCell

--- a/src/components/basic_table/basic_table.js
+++ b/src/components/basic_table/basic_table.js
@@ -91,7 +91,7 @@ const SupportedItemActionType = PropTypes.oneOfType([
 
 export const ActionsColumnType = PropTypes.shape({
   actions: PropTypes.arrayOf(SupportedItemActionType).isRequired,
-  name: PropTypes.string,
+  name: PropTypes.node,
   description: PropTypes.string,
   width: PropTypes.string
 });
@@ -829,12 +829,16 @@ export class EuiBasicTable extends Component {
     const columnAlign = align || this.getAlignForDataType(dataType);
     const { cellProps: cellPropsCallback } = this.props;
     const cellProps = getCellProps(item, column, cellPropsCallback);
+    // Name can also be an array or an element, so we need to convert it into a string. We can't
+    // stringify the value, because this value is rendered directly in the mobile layout. So the
+    // best thing we can do is render nothing.
+    const header = typeof name === 'string' ? name : '';
 
     return (
       <EuiTableRowCell
         key={key}
         align={columnAlign}
-        header={name}
+        header={header}
         isExpander={isExpander}
         textOnly={textOnly || !render}
         {...cellProps}

--- a/src/components/table/_responsive.scss
+++ b/src/components/table/_responsive.scss
@@ -113,8 +113,8 @@
       min-width: 50%;
       border: none;
 
-      // Prepend the data attribute "data-header" to each cell
-      &::before {
+      // Prepend the data attribute "data-header" to each cell, if the data-header exists.
+      &[data-header]::before {
         @include fontSize($euiFontSize * .6875);
 
         content: attr(data-header);

--- a/src/components/table/table_row_cell.js
+++ b/src/components/table/table_row_cell.js
@@ -115,5 +115,5 @@ EuiTableRowCell.propTypes = {
 
 EuiTableRowCell.defaultProps = {
   align: LEFT_ALIGNMENT,
-  textOnly: true
+  textOnly: true,
 };


### PR DESCRIPTION
This fixes a prop-type warning and poor UI when you provide a non-string node. This PR also changes the `name` prop-type of action columns to node, leftover from https://github.com/elastic/eui/pull/1234.

## Before

![image](https://user-images.githubusercontent.com/1238659/48582676-fe7dba80-e8d9-11e8-9dce-f2846339d64c.png)

## After

![image](https://user-images.githubusercontent.com/1238659/48582686-03426e80-e8da-11e8-9d73-45a89ef590de.png)
