### PR TITLE
Fix combobox full width size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `5.1.0`.
+**Bug fixes**
+
+- Fixed `fullWidth` size of `EuiComboBox` ([#1314](https://github.com/elastic/eui/pull/1314))
 
 ## [`5.1.0`](https://github.com/elastic/eui/tree/v5.1.0)
 

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -16,7 +16,7 @@
   .euiComboBox__inputWrap {
     @include euiFormControlStyle($includeStates: false, $includeSizes: false);
     @include euiFormControlWithIcon($isIconOptional: true);
-    @include euiFormControlSize(auto);
+    @include euiFormControlSize(auto, $includeAlternates: true);
     padding: $euiSizeXS;
     // sass-lint:disable-block mixins-before-declarations
     @include euiFormControlLayoutPadding(1); /* 2 */ //


### PR DESCRIPTION
### Summary

Ugh... good catch @cjcenizal 

Fixes #1313

## Before

*Full width & compressed*
<img width="958" alt="screen shot 2018-11-16 at 11 15 04 am" src="https://user-images.githubusercontent.com/549577/48633544-8ecb0680-e991-11e8-86a7-3dbede60977d.png">


## After

*Full width & compressed*
<img width="973" alt="screen shot 2018-11-16 at 11 15 22 am" src="https://user-images.githubusercontent.com/549577/48633547-925e8d80-e991-11e8-8159-55fa01b98289.png">


### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
~- [ ] This was checked for breaking changes and labeled appropriately`
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
