### PR TITLE
1324: copy ExpressionButton's active state to a focused state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `EuiBasicTable` now converts the `EuiTableRowCell` `header` into `undefined` if it's been provided as a non-string node, hiding the header and preventing the node from being rendered as `[object Object]` on narrow screens ([#1312](https://github.com/elastic/eui/pull/1312))
 - Fixed `fullWidth` size of `EuiComboBox`, a regression introduced in `4.7.0` ([#1314](https://github.com/elastic/eui/pull/1314))
 - Fixed error when passing empty string as `value` prop for `EuiSuperSelect` ([#1319](https://github.com/elastic/eui/pull/1319))
+- `EuiExpressionButton` now shows focus state when user tabs to it ([#1326](https://github.com/elastic/eui/pull/1326))
 
 ## [`5.1.0`](https://github.com/elastic/eui/tree/v5.1.0)
 

--- a/src/components/expression/_expression.scss
+++ b/src/components/expression/_expression.scss
@@ -10,6 +10,10 @@
   border-bottom: $euiBorderEditable;
   font-size: $euiFontSize;
   cursor: pointer;
+
+  &:focus {
+    border-bottom: solid 2px $expressionColorHighlight;
+  }
 }
 
 .euiExpressionButton__description {


### PR DESCRIPTION
### Summary

Fixes #1324 by copying the expression button's active style to `:focus`.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
