### PR TITLE
Add 'baseline' value to EuiFlexGroup's FlexGroupAlignItems type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `EuiBasicTable` now converts the `EuiTableRowCell` `header` into `undefined` if it's been provided as a non-string node, hiding the header and preventing the node from being rendered as `[object Object]` on narrow screens ([#1312](https://github.com/elastic/eui/pull/1312))
 - Fixed `fullWidth` size of `EuiComboBox`, a regression introduced in `4.7.0` ([#1314](https://github.com/elastic/eui/pull/1314))
 - Fixed error when passing empty string as `value` prop for `EuiSuperSelect` ([#1319](https://github.com/elastic/eui/pull/1319))
+- Added `baseline` as a possible value to `EuiFlexGroup`'s `FlexGroupAlignItems` type ([#1329](https://github.com/elastic/eui/pull/1329))
 
 ## [`5.1.0`](https://github.com/elastic/eui/tree/v5.1.0)
 

--- a/src/components/flex/index.d.ts
+++ b/src/components/flex/index.d.ts
@@ -31,7 +31,8 @@ declare module '@elastic/eui' {
     | 'stretch'
     | 'flexStart'
     | 'flexEnd'
-    | 'center';
+    | 'center'
+    | 'baseline';
   export type FlexGroupComponentType = 'div' | 'span';
   export type FlexGroupDirection =
     | 'column'


### PR DESCRIPTION
### Summary

Fixes #1325  by adding `baseline` as a possible value to `EuiFlexGroup`'s `FlexGroupAlignItems` type for `alignItems` prop

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components`
