### PR TITLE
Context panel docs cleanup

### DIFF
--- a/src-docs/src/views/card/card_beta.js
+++ b/src-docs/src/views/card/card_beta.js
@@ -19,6 +19,7 @@ const cardNodes = icons.map(function (item, index) {
         description="Example of a card's description. Stick to one or two sentences."
         betaBadgeLabel={badges[index]}
         betaBadgeTooltipContent={badges[index] ? 'This module is not GA. Please help us by reporting any bugs.' : undefined}
+        bottomGraphic
         onClick={() => window.alert('Card clicked')}
       />
     </EuiFlexItem>

--- a/src-docs/src/views/context_menu/context_menu_with_content.js
+++ b/src-docs/src/views/context_menu/context_menu_with_content.js
@@ -7,8 +7,7 @@ import {
   EuiContextMenu,
   EuiIcon,
   EuiPopover,
-  EuiPanel,
-  EuiCard
+  EuiText
 } from '../../../../src/components';
 
 function flattenPanelTree(tree, array = []) {
@@ -54,13 +53,15 @@ export default class extends Component {
           width: 400,
           title: 'See more',
           content: (
-            <EuiPanel>
-              <EuiCard
-                icon={<EuiIcon size="l" type="bolt" />}
-                title="More Details"
-                description="This menu demonstrates using panels that have items and panels with content."
-              />
-            </EuiPanel>
+            <EuiText style={{ padding: 24 }} textAlign="center">
+              <p><EuiIcon type="faceHappy" size="xxl" /></p>
+
+              <h3>Context panels can contain anything</h3>
+              <p>
+                You can stuff just about anything into these panels. Be mindful of size though.
+                This panel is set to 400px and the height will grow as space allows.
+              </p>
+            </EuiText>
           )
         },
       }],


### PR DESCRIPTION
### Summary

Fixes https://github.com/elastic/eui/issues/1339 and makes the context panel docs a little more pretty / helpful.

![image](https://user-images.githubusercontent.com/324519/49314541-a03b0500-f49f-11e8-87b1-b80bef3ac64d.png)


### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
- [x] Documentation examples were added
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
