### PR TITLE
Fix word-break in tables on most browsers

### DIFF
--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -139,10 +139,14 @@
   *    the cell.
   */
 .euiTableCellContent__text {
+  @include internetExplorerOnly {
+    word-break: break-all;
+  }
+
   min-width: 0;
   text-overflow: ellipsis;
-  word-break: break-all; /* 1 */ // Fallback for FF and IE
-  word-break: break-word; /* 1 */
+  overflow-wrap: break-word; /* 1 */
+
 }
 
 .euiTableCellContent--alignRight {
@@ -168,15 +172,6 @@
 .euiTableCellContent--overflowingContent {
   overflow: visible;
   white-space: normal;
-  word-break: break-word;
-
-  /**
-   * 1. Prevent very long single words (e.g. the name of a field in a document) from overflowing
-   *    the cell.
-   */
-  .euiTableCellContent__text {
-    overflow: visible; /* 1 */
-  }
 }
 
 .euiTableCellContent--showOnHover {


### PR DESCRIPTION
The problem came about that browser's were breaking on words unnecessarily. This PR swaps the usage of `word-break` for `overflow-wrap`. 

```css
overflow-wrap: break-word
```

Behaves similarly to `word-break: break-word` but is more universally accepted and does a better job to try to preserve words before breaking on them. The behavior **should** look the same most of the time.


<img src="https://d.pr/free/i/fmX1ds+" />

<img src="https://d.pr/free/i/WpbFPK+" />

<img src="https://d.pr/free/i/H0PGwG+" />

<img src="https://d.pr/free/i/X3ClDb+" />

### IE11
Unfortunately, IE11 has no support for anything except `word-break: break-all` so it will have to have it's own fallback.

<img src="https://d.pr/free/i/JPLZ6w+" />


### Checklist

- ~[ ] This was checked in mobile~
- [ ] This was checked in IE11
- ~[ ] This was checked in dark mode~
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
