### PR TITLE
Remove EuiNotificationBadge from badge/index.d.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `5.5.0`.
+**Bug fixes**
+
+- Fixed TypeScript definitions in `eui.d.ts` ([#1359](https://github.com/elastic/eui/pull/1359))
 
 ## [`5.5.0`](https://github.com/elastic/eui/tree/v5.5.0)
+
+**Note: this release broke the exported TypeScript definitions. This is fixed in `5.5.1`.**
 
 - Altered functionality of `truncate` on `EuiBreadcrumbs` and added `truncate` ability on breadcrumb item ([#1346](https://github.com/elastic/eui/pull/1346))
 - Altered `EuiHeader`'s location of `EuiHeaderBreadcrumbs` based on the new `truncate` ability ([#1346](https://github.com/elastic/eui/pull/1346))

--- a/src/components/badge/index.d.ts
+++ b/src/components/badge/index.d.ts
@@ -34,16 +34,4 @@ declare module '@elastic/eui' {
   export const EuiBetaBadge: SFC<
     CommonProps & HTMLAttributes<HTMLSpanElement> & EuiBetaBadgeProps
   >;
-
-  export interface EuiNotificationBadgeProps {
-    iconType?: IconType;
-    label: ReactNode;
-    tooltipContent?: ReactNode;
-    tooltipPosition?: ToolTipPositions;
-    title?: string;
-  }
-
-  export const EuiNotificationBadge: SFC<
-    CommonProps & HTMLAttributes<HTMLSpanElement>
-  >;
 }


### PR DESCRIPTION
### Summary

Fixes `eui.d.ts` by removing the EuiNotificationBadge definition from `badge/index.d.ts`, as EuiNotificationBadge is now a TS component. I'll dig into validating `eui.d.ts` at build time to prevent these issues in the future.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
