### PR TITLE
Revert combobox onblur pill creation in #1353 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 **Bug fixes**
 
 - `react-datepicker` set milliseconds to zero when selecting time ([#1361](https://github.com/elastic/eui/pull/1361))
-- Revert ([#1353](https://github.com/elastic/eui/pull/1353)) `onBlur` action on `euiComboBox`. It caused regressions on Kibana. ([#1361](https://github.com/elastic/eui/pull/1361))
+- Revert ([#1353](https://github.com/elastic/eui/pull/1353)) `onBlur` action on `euiComboBox`. It caused regressions on Kibana. ([#1363](https://github.com/elastic/eui/pull/1363))
 
 ## [`5.5.1`](https://github.com/elastic/eui/tree/v5.5.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ## [`5.5.0`](https://github.com/elastic/eui/tree/v5.5.0)
 
-**Note: this release broke the exported TypeScript definitions and `EuiComboBox` in certain situations. These are both fixed in `5.5.3`.**
+**Note: this release broke the exported TypeScript definitions and `EuiComboBox` in certain situations. These are both fixed in `5.5.2`.**
 
 - Altered functionality of `truncate` on `EuiBreadcrumbs` and added `truncate` ability on breadcrumb item ([#1346](https://github.com/elastic/eui/pull/1346))
 - Altered `EuiHeader`'s location of `EuiHeaderBreadcrumbs` based on the new `truncate` ability ([#1346](https://github.com/elastic/eui/pull/1346))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 **Bug fixes**
 
 - `react-datepicker` set milliseconds to zero when selecting time ([#1361](https://github.com/elastic/eui/pull/1361))
+- Revert ([#1353](https://github.com/elastic/eui/pull/1353)) `onBlur` action on `euiComboBox`. It caused regressions on Kibana. ([#1361](https://github.com/elastic/eui/pull/1361))
 
 ## [`5.5.1`](https://github.com/elastic/eui/tree/v5.5.1)
 
@@ -15,7 +16,7 @@
 
 ## [`5.5.0`](https://github.com/elastic/eui/tree/v5.5.0)
 
-**Note: this release broke the exported TypeScript definitions. This is fixed in `5.5.1`.**
+**Note: this release broke the exported TypeScript definitions and `EuiComboBox` in certain situations. These are both fixed in `5.5.3`.**
 
 - Altered functionality of `truncate` on `EuiBreadcrumbs` and added `truncate` ability on breadcrumb item ([#1346](https://github.com/elastic/eui/pull/1346))
 - Altered `EuiHeader`'s location of `EuiHeaderBreadcrumbs` based on the new `truncate` ability ([#1346](https://github.com/elastic/eui/pull/1346))

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -258,12 +258,6 @@ export class EuiComboBox extends Component {
       this.closeList();
     }
 
-    // If the user tabs away or changes focus to another element, take whatever input they've
-    // typed and convert it into a pill, to prevent the combo box from looking like a text input.
-    if (!this.hasActiveOption()) {
-      this.addCustomOption();
-    }
-
     if (this.props.onBlur) {
       this.props.onBlur(e);
     }


### PR DESCRIPTION
### Summary

([#1353](https://github.com/elastic/eui/pull/1353)) introduced a bug where empty pills were being added to combo boxes on click. This reverts that change. We can do a follow up PR later to fix.

![](http://snid.es/84f07e069b22/Screen%252520Recording%2525202018-12-10%252520at%25252004.31%252520PM.gif)

### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
