### PR TITLE
Validate eui.d.ts after generating during build

### DIFF
--- a/scripts/compile-eui.js
+++ b/scripts/compile-eui.js
@@ -20,7 +20,9 @@ function compileLib() {
 
   // Use `tsc` to emit typescript declaration files for .ts files
   console.log('Generating typescript definitions file');
-  execSync(`node ${path.resolve(__dirname, 'dtsgenerator.js')}`);
+  execSync(`node ${path.resolve(__dirname, 'dtsgenerator.js')}`, { stdio: 'inherit' });
+  // validate the generated eui.d.ts doesn't contain errors
+  execSync(`tsc --noEmit -p tsconfig-builttypes.json`, { stdio: 'inherit' });
   console.log(chalk.green('✔ Finished generating definitions'));
 
   // Also copy over SVGs. Babel has a --copy-files option but that brings over

--- a/scripts/dtsgenerator.js
+++ b/scripts/dtsgenerator.js
@@ -3,7 +3,6 @@ const path = require('path');
 const dtsGenerator = require('dts-generator').default;
 
 const baseDir = path.resolve(__dirname, '..');
-const srcDir = path.resolve(baseDir, 'src');
 
 const generator = dtsGenerator({
   name: '@elastic/eui',
@@ -24,10 +23,22 @@ const generator = dtsGenerator({
 
     if (isRelativeImport) {
       // path to the import target, assuming it's a `.d.ts` file
-      const importTargetDTs = `${path.resolve(srcDir, path.dirname(params.currentModuleId), params.importedModuleId)}.d.ts`;
+      const importTargetDTs = `${path.resolve(baseDir, path.dirname(params.currentModuleId), params.importedModuleId)}.d.ts`;
 
       // if importing an `index` file
-      const isModuleIndex = path.basename(params.importedModuleId) === 'index';
+      let isModuleIndex = false;
+      if (path.basename(params.importedModuleId) === 'index') {
+        isModuleIndex = true;
+      } else {
+        const basePath = path.resolve(baseDir, path.dirname(params.currentModuleId));
+        // check if the imported module resolves to ${importedModuleId}/index.ts
+        if (!fs.existsSync(path.resolve(basePath, `${params.importedModuleId}.ts`))) {
+          // not pointing at ${importedModuleId}.ts, check if it's a directory with `index.ts`
+          if (fs.existsSync(path.resolve(basePath, `${params.importedModuleId}/index.ts`))) {
+            isModuleIndex = true;
+          }
+        }
+      }
 
       if (fs.existsSync(importTargetDTs)) {
         // the import target is a `.d.ts` file which means it is hand-crafted and already added to the right places, don't modify

--- a/scripts/dtsgenerator.js
+++ b/scripts/dtsgenerator.js
@@ -22,9 +22,6 @@ const generator = dtsGenerator({
     const isRelativeImport = params.importedModuleId[0] === '.';
 
     if (isRelativeImport) {
-      // path to the import target, assuming it's a `.d.ts` file
-      const importTargetDTs = `${path.resolve(baseDir, path.dirname(params.currentModuleId), params.importedModuleId)}.d.ts`;
-
       // if importing an `index` file
       let isModuleIndex = false;
       if (path.basename(params.importedModuleId) === 'index') {
@@ -40,10 +37,7 @@ const generator = dtsGenerator({
         }
       }
 
-      if (fs.existsSync(importTargetDTs)) {
-        // the import target is a `.d.ts` file which means it is hand-crafted and already added to the right places, don't modify
-        return path.join('@elastic/eui', params.importedModuleId);
-      } else if (isModuleIndex) {
+      if (isModuleIndex) {
         // importing an `index` file, in `resolveModuleId` above we change those modules to '@elastic/eui'
         return '@elastic/eui';
       } else {

--- a/tsconfig-builttypes.json
+++ b/tsconfig-builttypes.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "eui.d.ts"
+  ]
+}


### PR DESCRIPTION
### Summary

Adds a step to `yarn build` that validates the generated _eui.d.ts_ file. This is prevent future regressions similar to #1359 

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
