### PR TITLE
Some fixes for EuiSuperSelect and Firefox Scrollbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `5.7.0`.
+- Added `anchorClassName` prop to `EuiPopover` ([#1367](https://github.com/elastic/eui/pull/1367))
+- Added support for `fullWidth` on `EuiSuperSelect` ([#1367](https://github.com/elastic/eui/pull/1367))
+- Applied new scrollbar customization for Firefox ([#1367](https://github.com/elastic/eui/pull/1367))
 
 ## [`5.7.0`](https://github.com/elastic/eui/tree/v5.7.0)
 

--- a/src-docs/src/views/super_select/super_select.js
+++ b/src-docs/src/views/super_select/super_select.js
@@ -85,6 +85,15 @@ export default class extends Component {
           onChange={this.onChange}
           compressed
         />
+
+        <EuiSpacer size="m" />
+
+        <EuiSuperSelect
+          options={this.options}
+          valueOfSelected={this.state.value}
+          onChange={this.onChange}
+          fullWidth
+        />
       </Fragment>
     );
   }

--- a/src/components/form/super_select/__snapshots__/super_select.test.js.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.js.snap
@@ -5,7 +5,7 @@ exports[`EuiSuperSelect is rendered 1`] = `
   class="euiPopover euiPopover--anchorDownCenter euiSuperSelect"
 >
   <div
-    class="euiPopover__anchor"
+    class="euiPopover__anchor euiSuperSelect__popoverAnchor"
   >
     <input
       type="hidden"
@@ -72,7 +72,7 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
   class="euiPopover euiPopover--anchorDownCenter euiSuperSelect"
 >
   <div
-    class="euiPopover__anchor"
+    class="euiPopover__anchor euiSuperSelect__popoverAnchor"
   >
     <input
       type="hidden"
@@ -204,12 +204,79 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
 </div>
 `;
 
+exports[`EuiSuperSelect props fullWidth is rendered 1`] = `
+<div
+  class="euiPopover euiPopover--anchorDownCenter euiSuperSelect euiSuperSelect--fullWidth"
+>
+  <div
+    class="euiPopover__anchor euiSuperSelect__popoverAnchor"
+  >
+    <input
+      type="hidden"
+      value=""
+    />
+    <div
+      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+    >
+      <div
+        class="euiFormControlLayout__childrenWrapper"
+      >
+        <span
+          class="euiScreenReaderOnly"
+          id="generated-id"
+        >
+          Select an option: , is selected
+        </span>
+        <button
+          aria-haspopup="true"
+          aria-label="aria-label"
+          aria-labelledby="undefined generated-id"
+          class="euiSuperSelectControl euiSuperSelectControl--fullWidth testClass1 testClass2"
+          data-test-subj="test subject string"
+          role="option"
+          type="button"
+        />
+        <div
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+        >
+          <span
+            class="euiFormControlLayoutCustomIcon"
+          >
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+              focusable="false"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+              xlink="http://www.w3.org/1999/xlink"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <defs>
+                <path
+                  d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+                  id="arrow_down-a"
+                />
+              </defs>
+              <use
+                fill-rule="nonzero"
+                href="#arrow_down-a"
+              />
+            </svg>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter euiSuperSelect"
 >
   <div
-    class="euiPopover__anchor"
+    class="euiPopover__anchor euiSuperSelect__popoverAnchor"
   >
     <input
       type="hidden"
@@ -371,6 +438,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
   valueOfSelected="1"
 >
   <EuiPopover
+    anchorClassName="euiSuperSelect__popoverAnchor"
     anchorPosition="downCenter"
     button={
       <EuiSuperSelectControl
@@ -417,7 +485,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
         onKeyDown={[Function]}
       >
         <div
-          className="euiPopover__anchor"
+          className="euiPopover__anchor euiSuperSelect__popoverAnchor"
         >
           <EuiSuperSelectControl
             className="euiSuperSelect--isOpen__button"
@@ -809,7 +877,7 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
   class="euiPopover euiPopover--anchorDownCenter euiSuperSelect"
 >
   <div
-    class="euiPopover__anchor"
+    class="euiPopover__anchor euiSuperSelect__popoverAnchor"
   >
     <input
       type="hidden"
@@ -946,7 +1014,7 @@ exports[`EuiSuperSelect props select component is rendered 1`] = `
   class="euiPopover euiPopover--anchorDownCenter euiSuperSelect"
 >
   <div
-    class="euiPopover__anchor"
+    class="euiPopover__anchor euiSuperSelect__popoverAnchor"
   >
     <input
       type="hidden"
@@ -1011,7 +1079,7 @@ exports[`EuiSuperSelect props valueSelected is rendered 1`] = `
   class="euiPopover euiPopover--anchorDownCenter euiSuperSelect"
 >
   <div
-    class="euiPopover__anchor"
+    class="euiPopover__anchor euiSuperSelect__popoverAnchor"
   >
     <input
       type="hidden"

--- a/src/components/form/super_select/__snapshots__/super_select.test.js.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.js.snap
@@ -419,7 +419,10 @@ exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
 
 exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
 <EuiSuperSelect
+  compressed={false}
   data-test-subj="superSelect"
+  fullWidth={false}
+  hasDividers={false}
   onChange={[Function]}
   options={
     Array [

--- a/src/components/form/super_select/_super_select.scss
+++ b/src/components/form/super_select/_super_select.scss
@@ -1,26 +1,29 @@
 /*
  * 1. Make popover the same width as the form control
  * 2. Style popover similar to combobox
- * 3. Need specificity to override default popover styles
- * 4. Use attribute selector to match popover position without needing the full popover class name
+ * 3. Use attribute selector to match popover position without needing the full popover class name
  */
 
-.euiSuperSelect.euiPopover { /* 3 */
-  @include euiFormControlSize; /* 1 */
-  height: auto;
+.euiSuperSelect {
+  width: 100%;
 
-  .euiPopover__anchor {
+  &:not(.euiSuperSelect--fullWidth) { /* 1 */
+    // sass-lint:disable-block no-important
+    max-width: $euiFormMaxWidth !important; // override default popover styles
+  }
+
+  .euiSuperSelect__popoverAnchor {
     display: block;
   }
 }
 
-.euiSuperSelect__popoverPanel[class*='bottom'] { /* 4 */
+.euiSuperSelect__popoverPanel[class*='bottom'] { /* 3 */
   border-top-color: transparentize($euiBorderColor, .2);
   border-top-right-radius: 0; /* 2 */
   border-top-left-radius: 0; /* 2 */
 }
 
-.euiSuperSelect__popoverPanel[class*='top'] { /* 4 */
+.euiSuperSelect__popoverPanel[class*='top'] { /* 3 */
   @include euiBottomShadowFlat; /* 2 */
 
   border-bottom-color: transparentize($euiBorderColor, .2);

--- a/src/components/form/super_select/super_select.js
+++ b/src/components/form/super_select/super_select.js
@@ -150,8 +150,18 @@ export class EuiSuperSelect extends Component {
       hasDividers,
       itemClassName,
       itemLayoutAlign,
+      fullWidth,
+      popoverClassName,
       ...rest
     } = this.props;
+
+    const popoverClasses = classNames(
+      'euiSuperSelect',
+      {
+        'euiSuperSelect--fullWidth': fullWidth,
+      },
+      popoverClassName,
+    );
 
     const buttonClasses = classNames(
       {
@@ -176,6 +186,7 @@ export class EuiSuperSelect extends Component {
         onClick={this.state.isPopoverOpen ? this.closePopover : this.openPopover}
         onKeyDown={this.onSelectKeyDown}
         className={buttonClasses}
+        fullWidth={fullWidth}
         {...rest}
       />
     );
@@ -209,7 +220,8 @@ export class EuiSuperSelect extends Component {
 
     return (
       <EuiPopover
-        className="euiSuperSelect"
+        className={popoverClasses}
+        anchorClassName="euiSuperSelect__popoverAnchor"
         panelClassName="euiSuperSelect__popoverPanel"
         button={button}
         isOpen={isOpen || this.state.isPopoverOpen}
@@ -270,6 +282,9 @@ EuiSuperSelect.propTypes = {
    * Change `EuiContextMenuItem` layout position of icon
    */
   itemLayoutAlign: PropTypes.string,
+  fullWidth: PropTypes.bool,
+  compressed: PropTypes.bool,
+  popoverClassName: PropTypes.string,
 };
 
 EuiSuperSelect.defaultProps = {

--- a/src/components/form/super_select/super_select.js
+++ b/src/components/form/super_select/super_select.js
@@ -282,11 +282,23 @@ EuiSuperSelect.propTypes = {
    * Change `EuiContextMenuItem` layout position of icon
    */
   itemLayoutAlign: PropTypes.string,
+  /**
+   * Make it wide
+   */
   fullWidth: PropTypes.bool,
+  /**
+   * Make it short
+   */
   compressed: PropTypes.bool,
+  /**
+   * Applied to the outermost wrapper (popover)
+   */
   popoverClassName: PropTypes.string,
 };
 
 EuiSuperSelect.defaultProps = {
+  hasDividers: false,
+  fullWidth: false,
+  compressed: false,
   options: [],
 };

--- a/src/components/form/super_select/super_select.test.js
+++ b/src/components/form/super_select/super_select.test.js
@@ -24,6 +24,15 @@ describe('EuiSuperSelect', () => {
   });
 
   describe('props', () => {
+    test('fullWidth is rendered', () => {
+      const component = render(
+        <EuiSuperSelect {...requiredProps} onChange={() => {}} fullWidth />
+      );
+
+      expect(component)
+        .toMatchSnapshot();
+    });
+
     test('select component is rendered', () => {
       const component = render(
         <EuiSuperSelect

--- a/src/components/popover/__snapshots__/popover.test.js.snap
+++ b/src/components/popover/__snapshots__/popover.test.js.snap
@@ -28,10 +28,23 @@ exports[`EuiPopover is rendered 1`] = `
 </div>
 `;
 
+exports[`EuiPopover props anchorClassName is rendered 1`] = `
+<div
+  class="euiPopover euiPopover--anchorDownCenter"
+  id="3"
+>
+  <div
+    class="euiPopover__anchor test"
+  >
+    <button />
+  </div>
+</div>
+`;
+
 exports[`EuiPopover props anchorPosition defaults to centerDown 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
-  id="4"
+  id="5"
 >
   <div
     class="euiPopover__anchor"
@@ -44,7 +57,7 @@ exports[`EuiPopover props anchorPosition defaults to centerDown 1`] = `
 exports[`EuiPopover props anchorPosition downRight is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownRight"
-  id="6"
+  id="7"
 >
   <div
     class="euiPopover__anchor"
@@ -57,7 +70,7 @@ exports[`EuiPopover props anchorPosition downRight is rendered 1`] = `
 exports[`EuiPopover props anchorPosition leftCenter is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorLeftCenter"
-  id="5"
+  id="6"
 >
   <div
     class="euiPopover__anchor"
@@ -70,7 +83,7 @@ exports[`EuiPopover props anchorPosition leftCenter is rendered 1`] = `
 exports[`EuiPopover props isOpen defaults to false 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
-  id="7"
+  id="8"
 >
   <div
     class="euiPopover__anchor"
@@ -81,34 +94,6 @@ exports[`EuiPopover props isOpen defaults to false 1`] = `
 `;
 
 exports[`EuiPopover props isOpen renders true 1`] = `
-<div>
-  <div
-    class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
-    id="8"
-  >
-    <div
-      class="euiPopover__anchor"
-    >
-      <button />
-    </div>
-    <div>
-      <div
-        aria-live="assertive"
-        class="euiPanel euiPanel--paddingMedium euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
-        style="top: 16px; left: -22px; z-index: 0;"
-      >
-        <div
-          class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
-          style="left: 10px; top: 0px;"
-        />
-        <div />
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`EuiPopover props ownFocus defaults to false 1`] = `
 <div>
   <div
     class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
@@ -136,11 +121,39 @@ exports[`EuiPopover props ownFocus defaults to false 1`] = `
 </div>
 `;
 
-exports[`EuiPopover props ownFocus renders true 1`] = `
+exports[`EuiPopover props ownFocus defaults to false 1`] = `
 <div>
   <div
     class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
     id="10"
+  >
+    <div
+      class="euiPopover__anchor"
+    >
+      <button />
+    </div>
+    <div>
+      <div
+        aria-live="assertive"
+        class="euiPanel euiPanel--paddingMedium euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
+        style="top: 16px; left: -22px; z-index: 0;"
+      >
+        <div
+          class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
+          style="left: 10px; top: 0px;"
+        />
+        <div />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiPopover props ownFocus renders true 1`] = `
+<div>
+  <div
+    class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
+    id="11"
   >
     <div
       class="euiPopover__anchor"
@@ -175,7 +188,7 @@ exports[`EuiPopover props panelClassName is rendered 1`] = `
 <div>
   <div
     class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
-    id="11"
+    id="12"
   >
     <div
       class="euiPopover__anchor"
@@ -203,7 +216,7 @@ exports[`EuiPopover props panelPaddingSize is rendered 1`] = `
 <div>
   <div
     class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
-    id="12"
+    id="13"
   >
     <div
       class="euiPopover__anchor"

--- a/src/components/popover/index.d.ts
+++ b/src/components/popover/index.d.ts
@@ -32,6 +32,7 @@ declare module '@elastic/eui' {
     isOpen?: boolean;
     ownFocus?: boolean;
     hasArrow?: boolean;
+    anchorClassName?: string;
     anchorPosition?: PopoverAnchorPosition;
     panelClassName?: string;
     panelPaddingSize?: PanelPaddingSize;

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -367,6 +367,7 @@ export class EuiPopover extends Component {
 
   render() {
     const {
+      anchorClassName,
       anchorPosition,
       button,
       isOpen,
@@ -393,6 +394,11 @@ export class EuiPopover extends Component {
         'euiPopover--withTitle': withTitle,
       },
       className,
+    );
+
+    const anchorClasses = classNames(
+      'euiPopover__anchor',
+      anchorClassName
     );
 
     const panelClasses = classNames(
@@ -478,7 +484,7 @@ export class EuiPopover extends Component {
           ref={popoverRef}
           {...rest}
         >
-          <div className="euiPopover__anchor" ref={this.buttonRef}>
+          <div className={anchorClasses} ref={this.buttonRef}>
             {button instanceof HTMLElement ? null : button}
           </div>
           {panel}
@@ -489,13 +495,14 @@ export class EuiPopover extends Component {
 }
 
 EuiPopover.propTypes = {
+  anchorClassName: PropTypes.string,
+  anchorPosition: PropTypes.oneOf(ANCHOR_POSITIONS),
   isOpen: PropTypes.bool,
   ownFocus: PropTypes.bool,
   withTitle: PropTypes.bool,
   closePopover: PropTypes.func.isRequired,
   button: PropTypes.node.isRequired,
   children: PropTypes.node,
-  anchorPosition: PropTypes.oneOf(ANCHOR_POSITIONS),
   panelClassName: PropTypes.string,
   panelPaddingSize: PropTypes.oneOf(SIZES),
   popoverRef: PropTypes.func,

--- a/src/components/popover/popover.test.js
+++ b/src/components/popover/popover.test.js
@@ -68,6 +68,22 @@ describe('EuiPopover', () => {
       });
     });
 
+    describe('anchorClassName', () => {
+      test('is rendered', () => {
+        const component = render(
+          <EuiPopover
+            id={getId()}
+            anchorClassName="test"
+            button={<button />}
+            closePopover={() => {}}
+          />
+        );
+
+        expect(component)
+          .toMatchSnapshot();
+      });
+    });
+
     describe('closePopover', () => {
       it('is called when ESC key is hit', () => {
         const closePopoverHandler = sinon.stub();

--- a/src/global_styling/mixins/_helpers.scss
+++ b/src/global_styling/mixins/_helpers.scss
@@ -29,8 +29,13 @@
   }
 }
 
-// Set scroll bar appearance on Chrome.
+// Set scroll bar appearance on Chrome (and firefox).
 @mixin euiScrollBar {
+  // Firefox's scrollbar coloring cascades, but the sizing does not,
+  // so it's being added to this mixin for allowing support wherever custom scrollbars are
+  // sass-lint:disable-block no-misspelled-properties
+  scrollbar-width: thin;
+
   // sass-lint:disable-block no-vendor-prefixes
   &::-webkit-scrollbar {
     width: 16px;

--- a/src/global_styling/reset/_index.scss
+++ b/src/global_styling/reset/_index.scss
@@ -1,1 +1,2 @@
 @import 'reset';
+@import 'scrollbar';

--- a/src/global_styling/reset/_scrollbar.scss
+++ b/src/global_styling/reset/_scrollbar.scss
@@ -1,0 +1,8 @@
+// Firefox's scrollbar coloring cascades throughout which is why it's set at the html level
+// However, the width sizing is not, but this has been added to the euiScrollBar mixin as well
+
+html {
+  // sass-lint:disable-block no-misspelled-properties
+  scrollbar-width: thin;
+  scrollbar-color: transparentize($euiColorDarkShade, .5) transparent; // Firefox support
+}


### PR DESCRIPTION
## Added `anchorClassName` prop to `EuiPopover`

This was needed for the following:

## Added support for `fullWidth` on `EuiSuperSelect`

Fixes #1352 cc @cjcenizal 

<img width="964" alt="screen shot 2018-12-11 at 16 49 22 pm" src="https://user-images.githubusercontent.com/549577/49832963-25f36600-fd66-11e8-8893-edf1d0b5e9be.png">

## Applied new scrollbar customization for Firefox


<img src="https://d.pr/free/i/jOerNm+" />


### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
- [x] Any props added have proper autodocs
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- [x] Jest tests were updated or added to match the most common scenarios
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
