### PR TITLE
fix EuiSuperSelect from accessing ref when unmounted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `anchorClassName` prop to `EuiPopover` ([#1367](https://github.com/elastic/eui/pull/1367))
 - Added support for `fullWidth` on `EuiSuperSelect` ([#1367](https://github.com/elastic/eui/pull/1367))
 - Applied new scrollbar customization for Firefox ([#1367](https://github.com/elastic/eui/pull/1367))
+- Fixed `EuiSuperSelect` from accessing ref when unmounted ([1369](https://github.com/elastic/eui/pull/1369))
 
 ## [`5.7.0`](https://github.com/elastic/eui/tree/v5.7.0)
 

--- a/src/components/form/super_select/super_select.js
+++ b/src/components/form/super_select/super_select.js
@@ -24,6 +24,14 @@ export class EuiSuperSelect extends Component {
     };
   }
 
+  componentDidMount() {
+    this._isMounted = true;
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
   setItemNode = (node, index) => {
     this.itemNodes[index] = node;
   };
@@ -48,6 +56,9 @@ export class EuiSuperSelect extends Component {
       );
 
       requestAnimationFrame(() => {
+        if (!this._isMounted) {
+          return;
+        }
         this.setState({
           menuWidth: this.popoverRef.getBoundingClientRect().width - 2, // account for border not inner shadow
         });


### PR DESCRIPTION
### Summary

The kibana GIS app places an EuiSuperSelect in a FlexItem that is unmounted when the user clicks cancel (first screen shot). If the menu is open when the cancel button is clicked, the EuiSuperSelect will be unmounted but `focusSelected` gets called afterward, via `requestAnimationFrame`, and this causes a hard crash (second screen shot, third error message). This PR just adds a check to ensure the component is still mounted before proceeding with the contents of the `requestAnimationFrame` callback.

<img width="1301" alt="screen shot 2018-12-12 at 9 46 37 pm" src="https://user-images.githubusercontent.com/373691/49916383-d42b0880-fe57-11e8-802d-4de5d594633d.png">

<img width="1793" alt="screen shot 2018-12-12 at 9 39 29 pm" src="https://user-images.githubusercontent.com/373691/49916388-dab98000-fe57-11e8-95dd-e5bebdce4208.png">

### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
