### PR TITLE
Allow any <color> value in EuiIcon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Reinstate ([#1353](https://github.com/elastic/eui/pull/1353)) `onBlur` action on `EuiComboBox` ([#1364](https://github.com/elastic/eui/pull/1364))
-- Convert roughly half of the services to TypeScript ([#1400](https://github.com/elastic/eui/pull/1400))
+- Convert roughly half of the services to TypeScript ([#1360](https://github.com/elastic/eui/pull/1360))
 
 **Bug fixes**
 
@@ -9,6 +9,7 @@
 - Added `anchorClassName` prop to `EuiPopover` ([#1367](https://github.com/elastic/eui/pull/1367))
 - Added support for `fullWidth` on `EuiSuperSelect` ([#1367](https://github.com/elastic/eui/pull/1367))
 - Applied new scrollbar customization for Firefox ([#1367](https://github.com/elastic/eui/pull/1367))
+- Allow any color value to be passed to `EuiIcon` ([#1370](https://github.com/elastic/eui/pull/1370))
 
 ## [`5.7.0`](https://github.com/elastic/eui/tree/v5.7.0)
 

--- a/src-docs/src/views/icon/icon_example.js
+++ b/src-docs/src/views/icon/icon_example.js
@@ -204,9 +204,10 @@ export const IconExample = {
     text: (
       <p>
         Use the <EuiCode>color</EuiCode> prop to assign a color for your icons. It
-        can accept named colors from our pallete or a three or six color hex code.
-        The default behavior is to inherit the text color as the SVG
-        color <EuiCode>fill</EuiCode> property via <EuiCode>currentColor</EuiCode> in CSS.
+        can accept named colors from our palette, a three or six color hex code,
+        and rgb(r, g, b) or rgba(r, g, b, a) formats. The default behavior is to
+        inherit the text color as the SVG color <EuiCode>fill</EuiCode> property
+        via <EuiCode>currentColor</EuiCode> in CSS.
       </p>
     ),
     demo: <IconColors />,

--- a/src-docs/src/views/icon/icon_example.js
+++ b/src-docs/src/views/icon/icon_example.js
@@ -10,6 +10,7 @@ import {
   EuiCode,
   EuiIcon,
   EuiToken,
+  EuiLink,
 } from '../../../../src/components';
 
 const iconHtmlWarning = () => (
@@ -203,11 +204,13 @@ export const IconExample = {
     }],
     text: (
       <p>
-        Use the <EuiCode>color</EuiCode> prop to assign a color for your icons. It
-        can accept named colors from our palette, a three or six color hex code,
-        and rgb(r, g, b) or rgba(r, g, b, a) formats. The default behavior is to
-        inherit the text color as the SVG color <EuiCode>fill</EuiCode> property
-        via <EuiCode>currentColor</EuiCode> in CSS.
+        The default behavior of icons is to inherit from the text color. You can
+        use the <EuiCode>color</EuiCode> prop to assign a custom color which
+        accepts a named color from our palette or a valid&nbsp;
+        <EuiLink target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/color_value">CSS color data type</EuiLink>
+        &nbsp;which will be passed down through the inline-style <EuiCode>fill</EuiCode>&nbsp;
+        property. <strong>We recommend relying on the EUI named color palette</strong>&nbsp;
+        unless the custom color is initiated by the user (like as a graph color).
       </p>
     ),
     demo: <IconColors />,

--- a/src/components/accordion/__snapshots__/accordion.test.js.snap
+++ b/src/components/accordion/__snapshots__/accordion.test.js.snap
@@ -62,11 +62,7 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
                           className="euiIcon euiIcon--medium"
                           focusable="false"
                           height="16"
-                          style={
-                            Object {
-                              "fill": undefined,
-                            }
-                          }
+                          style={null}
                           viewBox="0 0 16 16"
                           width="16"
                           xmlns="http://www.w3.org/2000/svg"
@@ -76,11 +72,7 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
                             className="euiIcon euiIcon--medium"
                             focusable="false"
                             height="16"
-                            style={
-                              Object {
-                                "fill": undefined,
-                              }
-                            }
+                            style={null}
                             viewBox="0 0 16 16"
                             width="16"
                             xmlns="http://www.w3.org/2000/svg"
@@ -204,11 +196,7 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
                           className="euiIcon euiIcon--medium"
                           focusable="false"
                           height="16"
-                          style={
-                            Object {
-                              "fill": undefined,
-                            }
-                          }
+                          style={null}
                           viewBox="0 0 16 16"
                           width="16"
                           xmlns="http://www.w3.org/2000/svg"
@@ -218,11 +206,7 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
                             className="euiIcon euiIcon--medium"
                             focusable="false"
                             height="16"
-                            style={
-                              Object {
-                                "fill": undefined,
-                              }
-                            }
+                            style={null}
                             viewBox="0 0 16 16"
                             width="16"
                             xmlns="http://www.w3.org/2000/svg"

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
@@ -331,11 +331,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                       className="euiIcon euiIcon--medium euiButtonEmpty__icon"
                                       focusable="false"
                                       height="16"
-                                      style={
-                                        Object {
-                                          "fill": undefined,
-                                        }
-                                      }
+                                      style={null}
                                       viewBox="0 0 16 16"
                                       width="16"
                                       xmlns="http://www.w3.org/2000/svg"
@@ -346,11 +342,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                         className="euiIcon euiIcon--medium euiButtonEmpty__icon"
                                         focusable="false"
                                         height="16"
-                                        style={
-                                          Object {
-                                            "fill": undefined,
-                                          }
-                                        }
+                                        style={null}
                                         viewBox="0 0 16 16"
                                         width="16"
                                         xmlns="http://www.w3.org/2000/svg"
@@ -428,11 +420,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                 className="euiIcon euiIcon--medium euiButtonIcon__icon"
                                 focusable="false"
                                 height="16"
-                                style={
-                                  Object {
-                                    "fill": undefined,
-                                  }
-                                }
+                                style={null}
                                 viewBox="0 0 16 16"
                                 width="16"
                                 xmlns="http://www.w3.org/2000/svg"
@@ -443,11 +431,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                   className="euiIcon euiIcon--medium euiButtonIcon__icon"
                                   focusable="false"
                                   height="16"
-                                  style={
-                                    Object {
-                                      "fill": undefined,
-                                    }
-                                  }
+                                  style={null}
                                   viewBox="0 0 16 16"
                                   width="16"
                                   xmlns="http://www.w3.org/2000/svg"
@@ -572,11 +556,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                 className="euiIcon euiIcon--medium euiButtonIcon__icon"
                                 focusable="false"
                                 height="16"
-                                style={
-                                  Object {
-                                    "fill": undefined,
-                                  }
-                                }
+                                style={null}
                                 viewBox="0 0 16 16"
                                 width="16"
                                 xmlns="http://www.w3.org/2000/svg"
@@ -587,11 +567,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                   className="euiIcon euiIcon--medium euiButtonIcon__icon"
                                   focusable="false"
                                   height="16"
-                                  style={
-                                    Object {
-                                      "fill": undefined,
-                                    }
-                                  }
+                                  style={null}
                                   viewBox="0 0 16 16"
                                   width="16"
                                   xmlns="http://www.w3.org/2000/svg"

--- a/src/components/form/super_select/__snapshots__/super_select.test.js.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.js.snap
@@ -588,11 +588,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                               className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
                               focusable="false"
                               height="16"
-                              style={
-                                Object {
-                                  "fill": undefined,
-                                }
-                              }
+                              style={null}
                               viewBox="0 0 16 16"
                               width="16"
                               xmlns="http://www.w3.org/2000/svg"
@@ -603,11 +599,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                                 className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
                                 focusable="false"
                                 height="16"
-                                style={
-                                  Object {
-                                    "fill": undefined,
-                                  }
-                                }
+                                style={null}
                                 viewBox="0 0 16 16"
                                 width="16"
                                 xmlns="http://www.w3.org/2000/svg"
@@ -749,11 +741,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                                   className="euiIcon euiIcon--medium euiContextMenu__icon"
                                   focusable="false"
                                   height="16"
-                                  style={
-                                    Object {
-                                      "fill": undefined,
-                                    }
-                                  }
+                                  style={null}
                                   viewBox="0 0 16 16"
                                   width="16"
                                   xmlns="http://www.w3.org/2000/svg"
@@ -762,11 +750,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                                     className="euiIcon euiIcon--medium euiContextMenu__icon"
                                     focusable="false"
                                     height="16"
-                                    style={
-                                      Object {
-                                        "fill": undefined,
-                                      }
-                                    }
+                                    style={null}
                                     viewBox="0 0 16 16"
                                     width="16"
                                     xmlns="http://www.w3.org/2000/svg"
@@ -829,11 +813,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                                   className="euiIcon euiIcon--medium euiContextMenu__icon"
                                   focusable="false"
                                   height="16"
-                                  style={
-                                    Object {
-                                      "fill": undefined,
-                                    }
-                                  }
+                                  style={null}
                                   viewBox="0 0 16 16"
                                   width="16"
                                   xmlns="http://www.w3.org/2000/svg"
@@ -842,11 +822,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                                     className="euiIcon euiIcon--medium euiContextMenu__icon"
                                     focusable="false"
                                     height="16"
-                                    style={
-                                      Object {
-                                        "fill": undefined,
-                                      }
-                                    }
+                                    style={null}
                                     viewBox="0 0 16 16"
                                     width="16"
                                     xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icon/__snapshots__/icon.test.tsx.snap
+++ b/src/components/icon/__snapshots__/icon.test.tsx.snap
@@ -24,6 +24,164 @@ exports[`EuiIcon is rendered 1`] = `
 </svg>
 `;
 
+exports[`EuiIcon props color #885522 is rendered 1`] = `
+<svg
+  class="euiIcon euiIcon--medium"
+  focusable="false"
+  height="16"
+  style="fill:#885522"
+  viewBox="0 0 16 16"
+  width="16"
+  xmlns="http://www.w3.org/2000/svg"
+/>
+`;
+
+exports[`EuiIcon props color #fde is rendered 1`] = `
+<svg
+  class="euiIcon euiIcon--medium"
+  focusable="false"
+  height="16"
+  style="fill:#fde"
+  viewBox="0 0 16 16"
+  width="16"
+  xmlns="http://www.w3.org/2000/svg"
+/>
+`;
+
+exports[`EuiIcon props color accent is rendered 1`] = `
+<svg
+  class="euiIcon euiIcon--medium euiIcon--accent"
+  focusable="false"
+  height="16"
+  viewBox="0 0 16 16"
+  width="16"
+  xmlns="http://www.w3.org/2000/svg"
+/>
+`;
+
+exports[`EuiIcon props color danger is rendered 1`] = `
+<svg
+  class="euiIcon euiIcon--medium euiIcon--danger"
+  focusable="false"
+  height="16"
+  viewBox="0 0 16 16"
+  width="16"
+  xmlns="http://www.w3.org/2000/svg"
+/>
+`;
+
+exports[`EuiIcon props color default is rendered 1`] = `
+<svg
+  class="euiIcon euiIcon--medium"
+  focusable="false"
+  height="16"
+  viewBox="0 0 16 16"
+  width="16"
+  xmlns="http://www.w3.org/2000/svg"
+/>
+`;
+
+exports[`EuiIcon props color ghost is rendered 1`] = `
+<svg
+  class="euiIcon euiIcon--medium euiIcon--ghost"
+  focusable="false"
+  height="16"
+  viewBox="0 0 16 16"
+  width="16"
+  xmlns="http://www.w3.org/2000/svg"
+/>
+`;
+
+exports[`EuiIcon props color hsla(270, 60%, 70%, 0.9) is rendered 1`] = `
+<svg
+  class="euiIcon euiIcon--medium"
+  focusable="false"
+  height="16"
+  style="fill:hsla(270, 60%, 70%, 0.9)"
+  viewBox="0 0 16 16"
+  width="16"
+  xmlns="http://www.w3.org/2000/svg"
+/>
+`;
+
+exports[`EuiIcon props color primary is rendered 1`] = `
+<svg
+  class="euiIcon euiIcon--medium euiIcon--primary"
+  focusable="false"
+  height="16"
+  viewBox="0 0 16 16"
+  width="16"
+  xmlns="http://www.w3.org/2000/svg"
+/>
+`;
+
+exports[`EuiIcon props color rgb(100, 150, 200) is rendered 1`] = `
+<svg
+  class="euiIcon euiIcon--medium"
+  focusable="false"
+  height="16"
+  style="fill:rgb(100, 150, 200)"
+  viewBox="0 0 16 16"
+  width="16"
+  xmlns="http://www.w3.org/2000/svg"
+/>
+`;
+
+exports[`EuiIcon props color secondary is rendered 1`] = `
+<svg
+  class="euiIcon euiIcon--medium euiIcon--secondary"
+  focusable="false"
+  height="16"
+  viewBox="0 0 16 16"
+  width="16"
+  xmlns="http://www.w3.org/2000/svg"
+/>
+`;
+
+exports[`EuiIcon props color subdued is rendered 1`] = `
+<svg
+  class="euiIcon euiIcon--medium euiIcon--subdued"
+  focusable="false"
+  height="16"
+  viewBox="0 0 16 16"
+  width="16"
+  xmlns="http://www.w3.org/2000/svg"
+/>
+`;
+
+exports[`EuiIcon props color success is rendered 1`] = `
+<svg
+  class="euiIcon euiIcon--medium euiIcon--success"
+  focusable="false"
+  height="16"
+  viewBox="0 0 16 16"
+  width="16"
+  xmlns="http://www.w3.org/2000/svg"
+/>
+`;
+
+exports[`EuiIcon props color text is rendered 1`] = `
+<svg
+  class="euiIcon euiIcon--medium euiIcon--text"
+  focusable="false"
+  height="16"
+  viewBox="0 0 16 16"
+  width="16"
+  xmlns="http://www.w3.org/2000/svg"
+/>
+`;
+
+exports[`EuiIcon props color warning is rendered 1`] = `
+<svg
+  class="euiIcon euiIcon--medium euiIcon--warning"
+  focusable="false"
+  height="16"
+  viewBox="0 0 16 16"
+  width="16"
+  xmlns="http://www.w3.org/2000/svg"
+/>
+`;
+
 exports[`EuiIcon props other props are passed through to the icon 1`] = `
 <svg
   aria-label="a custom title"

--- a/src/components/icon/icon.test.tsx
+++ b/src/components/icon/icon.test.tsx
@@ -6,6 +6,7 @@ import {
   EuiIcon,
   SIZES,
   TYPES,
+  COLORS,
 } from './icon';
 
 describe('EuiIcon', () => {
@@ -45,6 +46,18 @@ describe('EuiIcon', () => {
         test(`${type} is rendered`, () => {
           const component = render(
             <EuiIcon type={type} />
+          );
+
+          expect(component).toMatchSnapshot();
+        });
+      });
+    });
+
+    describe('color', () => {
+      COLORS.concat(['#fde', '#885522', 'rgb(100, 150, 200)', 'hsla(270, 60%, 70%, 0.9)']).forEach(color => {
+        test(`${color} is rendered`, () => {
+          const component = render(
+            <EuiIcon color={color} />
           );
 
           expect(component).toMatchSnapshot();

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -604,15 +604,11 @@ export const EuiIcon: SFC<Props> = ({
   let optionalCustomStyles = null;
 
   if (color) {
-    checkValidColor(color, type || 'empty');
-
     if (COLORS.indexOf(color) > -1) {
       optionalColorClass = colorToClassMap[color];
     } else {
       optionalCustomStyles = { fill: color };
     }
-  } else {
-    optionalCustomStyles = { fill: undefined };
   }
 
   // These icons are a little special and get some extra CSS flexibility
@@ -648,16 +644,6 @@ export const EuiIcon: SFC<Props> = ({
     />
   );
 };
-
-function checkValidColor(color: string, type: string) {
-  const validHex = /(^#[0-9A-F]{6}$)|(^#[0-9A-F]{3}$)/i.test(color);
-  if (color && !validHex && !COLORS.includes(color)) {
-    throw new Error(
-      `EuiIcon[${type}} needs to pass a valid color. This can either be a three ` +
-      `or six character hex value or one of the following: ${COLORS}`
-    );
-  }
-}
 
 EuiIcon.defaultProps = {
   size: 'm',

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -586,6 +586,9 @@ export type IconSize = keyof typeof sizeToClassNameMap;
 
 export interface EuiIconProps {
   type?: IconType;
+  /**
+   * One of EUI's color palette or a valid CSS color value https://developer.mozilla.org/en-US/docs/Web/CSS/color_value
+   */
   color?: IconColor;
   size?: IconSize;
 }


### PR DESCRIPTION
### Summary

Allows any color value to be passed to `EuiIcon`

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
