### PR TITLE
if no selector on anchor, don't style in EuiText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `5.8.0`.
+**Bug fixes**
+
+- Only style anchor tags in `EuiText` that have no class attribute ([#1373](https://github.com/elastic/eui/pull/1373))
 
 ## [`5.8.0`](https://github.com/elastic/eui/tree/v5.8.0)
 

--- a/src-docs/src/views/call_out/warning.js
+++ b/src-docs/src/views/call_out/warning.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {
   EuiCallOut,
   EuiLink,
+  EuiButton,
 } from '../../../../src/components';
 
 export default () => (
@@ -14,5 +15,6 @@ export default () => (
     <p>
       Here be dragons. Don&rsquo;t wanna mess with no dragons. And <EuiLink href="#">here&rsquo;s a link</EuiLink>.
     </p>
+    <EuiButton href="#" color="warning">Link button</EuiButton>
   </EuiCallOut>
 );

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -105,7 +105,7 @@
   // coloring will likely coming from the reset.scss anyway.
   color: inherit;
 
-  a {
+  a:not([class]) {
     color: $euiLinkColor;
 
     &:hover {

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -105,6 +105,8 @@
   // coloring will likely coming from the reset.scss anyway.
   color: inherit;
 
+  // Style anchors that don't have a class. This prevents overwriting "buttons"
+  // and other stylized elements passed in.
   a:not([class]) {
     color: $euiLinkColor;
 


### PR DESCRIPTION
### Summary

Fixes https://github.com/elastic/eui/issues/1372

I think this will work the way we expect `EuiText` to operate. If it's a regular anchor, pass on styling, but if it has a class, then ignore and use whatever it has. The assumption is that if you have a class on an anchor, you know how you want it styled.

![image](https://user-images.githubusercontent.com/324519/49974979-8e6e4e80-fef0-11e8-8ff0-b82dffa03f3b.png)

![image](https://user-images.githubusercontent.com/324519/49974984-929a6c00-fef0-11e8-8295-995f96b098ef.png)


### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
- [x] This was checked against keyboard-only and screenreader scenarios
~- [ ] This required updates to Framer X components~
