### PR TITLE
Reduce class specificity in EUI SASS/BEM guide.

### DIFF
--- a/src-docs/src/views/guidelines/sass.js
+++ b/src-docs/src/views/guidelines/sass.js
@@ -267,22 +267,21 @@ const bemExample = (`// Use camelCase naming
   @include euiSlightShadow;
 
   border-radius: $euiBorderRadius;
+}
 
+// Elements within the component
+.euiButton__content {
+  padding: 0 ($euiSize - $euiSizeXS);
+}
 
-  // Elements exist within the component
-  .euiButton__content {
-    padding: 0 ($euiSize - $euiSizeXS);
-  }
+// Modifiers augment existing components or elements
+.euiButton--primary {
+  background-color: $euiColorPrimary;
+}
 
-  // Modifiers augment existing components or elements
-  &.euiButton--primary {
-    background-color: $euiColorPrimary;
-  }
-
-  // States are written with a verb prefix
-  &.euiButton-isLoading {
-    opacity: .5;
-  }
+// States are written with a verb prefix
+.euiButton--isLoading {
+  opacity: .5;
 }
 
 // Put breakpoints at the bottom of the document


### PR DESCRIPTION
### Summary

I'd like to suggest a change in EUI's SASS/BEM guide.

The current guide uses:

```
.euiButton {
  ...
  .euiButton_content {
    ...
  }
}
```

This compiles down to:

```
.euiButton { ... }
.euiButton .euiButton__content { ... }
```

The second row results in a nested rule and tighter specificity.
To avoid this, the PR changes the guide to use:

```
.euiButton {
  ...
}

.euiButton__content {
 ...
}
```

An alternative might be to reflect the structure with indentation (but without actually nesting the classes):

```
.euiButton {
  ...
}

  .euiButton__content {
   ...
  }
```

Let me know what you'd prefer.

The PR also changes `euiButton-isLoading` to use two hyphens like `euiButton--isLoading`. I'd like to suggest that we use single or double hyphens/underscore everywhere but don't mix it.

### Checklist

- [x] Documentation examples were updated
