### PR TITLE
Re-export some service TS defs

### DIFF
--- a/src/services/color/index.ts
+++ b/src/services/color/index.ts
@@ -5,3 +5,4 @@ export { calculateContrast, calculateLuminance } from './luminance_and_contrast'
 export { VISUALIZATION_COLORS, DEFAULT_VISUALIZATION_COLOR } from './visualization_colors';
 export { colorPalette } from './color_palette';
 export { palettes } from './eui_palettes';
+export { rgbDef } from './color_types';

--- a/src/services/index.d.ts
+++ b/src/services/index.d.ts
@@ -1,1 +1,16 @@
 /// <reference path="./popover/index.d.ts" />
+
+declare module '@elastic/eui' {
+  // @ts-ignore
+  export * from '@elastic/eui/src/services/alignment';
+  // @ts-ignore
+  export * from '@elastic/eui/src/services/copy_to_clipboard';
+  // @ts-ignore
+  export * from '@elastic/eui/src/services/key_codes';
+  // @ts-ignore
+  export * from '@elastic/eui/src/services/objects';
+  // @ts-ignore
+  export * from '@elastic/eui/src/services/random';
+  // @ts-ignore
+  export * from '@elastic/eui/src/services/utils';
+}


### PR DESCRIPTION
### Summary

Fixes a bug introduced in `v5.8.0` which removed some of our services' TS defs

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
