### PR TITLE
Exclude `custom_typings` from `eui.d.ts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added `EuiSuperDatePicker` component ([#1351](https://github.com/elastic/eui/pull/1351))
 - Fixed up styles for `EuiSuperDatePicker` ([#1389](https://github.com/elastic/eui/pull/1389))
 - Altered a few icons and added more: `crossInACircleFilled`, `editorRedo`, `editorUndo`, `grabHorizontal`, `minusInCircleFilled`, `plusInCircleFilled`, `sortable`, `starEmptySpace`, `starFilledSpace`, `starFilled`, `starMinusEmpty`, `starMinusFilled`, `starPlusEmpty`, `pinFilled` ([#1374](https://github.com/elastic/eui/pull/1374))
+- Exclude `custom_typings` from `eui.d.ts` ([#1395](https://github.com/elastic/eui/pull/1395))
 
 **Bug fixes**
 

--- a/scripts/dtsgenerator.js
+++ b/scripts/dtsgenerator.js
@@ -8,6 +8,7 @@ const generator = dtsGenerator({
   name: '@elastic/eui',
   project: baseDir,
   out: 'eui.d.ts',
+  exclude: ['node_modules/**/*.d.ts', 'src/custom_typings/**/*.d.ts'],
   resolveModuleId(params) {
     if (path.basename(params.currentModuleId) === 'index') {
       // this module is exporting from an `index(.d)?.ts` file, declare its exports straight to @elastic/eui module


### PR DESCRIPTION
### Summary

Closes #1388. The `src/custom_typings` directory contains some TS definitions that allows TS files to import images without complaint. However, these definitions were being included in `eui.d.ts`, which meant downstream projects couldn't include their own mechanisms for importing images. The fix is to exclude `custom_typings` from `eui.d.ts`

### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
