### PR TITLE
[EuiColorPicker] align color picker popup with color selector when page is scrolled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Only style anchor tags in `EuiText` that have no class attribute ([#1373](https://github.com/elastic/eui/pull/1373))
 - Fixed some EUI services' TS definitions ([#1380](https://github.com/elastic/eui/pull/1380))
+- `EuiColorPicker` align color picker popup with color selector when page is scrolled ([#1397](https://github.com/elastic/eui/pull/1397))
 
 **Breaking changes**
 

--- a/src/components/color_picker/_color_picker.scss
+++ b/src/components/color_picker/_color_picker.scss
@@ -1,4 +1,5 @@
 .euiColorPicker {
+  position: relative;
   cursor: pointer;
 }
 


### PR DESCRIPTION
### Summary

Fixes https://github.com/elastic/eui/issues/1394. Sets parent to `relative` so color picker popup stays with color selector element when scrolled

### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
