### PR TITLE
Change extraAction PropType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `6.1.0`.
+- Change `EuiListGroup` PropType for `extraAction` to clearn warning ([#1405](hhttps://github.com/elastic/eui/pull/1405))
 
 ## [`6.1.0`](https://github.com/elastic/eui/tree/v6.1.0)
 

--- a/src/components/list_group/list_group.js
+++ b/src/components/list_group/list_group.js
@@ -67,7 +67,7 @@ EuiListGroup.propTypes = {
   listItems: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.node,
     href: PropTypes.string,
-    extraAction: PropTypes.node,
+    extraAction: PropTypes.object,
     iconType: PropTypes.string,
     isActive: PropTypes.boolean,
     isDisabled: PropTypes.boolean,


### PR DESCRIPTION
### Summary

While building out the new nav drawer, the following warning was recognized coming from the List Group component:

<img width="867" alt="screenshot 2019-01-04 13 36 15" src="https://user-images.githubusercontent.com/446285/50707290-f4e51900-1025-11e9-81ae-a9c5e388ee40.png">

This prop did accept a React node in an earlier iteration and this line was not cleaned up when we moved away from that solution.
