### PR TITLE
Account for min attribute when determining EuiRange input width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Account for `min` attribute when determining `EuiRange` input width ([#1406](https://github.com/elastic/eui/pull/1406))
 - Change `EuiListGroup` PropType for `extraAction` to clearn warning ([#1405](hhttps://github.com/elastic/eui/pull/1405))
 
 ## [`6.1.0`](https://github.com/elastic/eui/tree/v6.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Account for `min` attribute when determining `EuiRange` input width ([#1406](https://github.com/elastic/eui/pull/1406))
 - Change `EuiListGroup` PropType for `extraAction` to clearn warning ([#1405](hhttps://github.com/elastic/eui/pull/1405))
+
+
+**Bug fixes**
+
+- Account for `min` attribute when determining `EuiRange` input width ([#1406](https://github.com/elastic/eui/pull/1406))
 
 ## [`6.1.0`](https://github.com/elastic/eui/tree/v6.1.0)
 

--- a/src/components/form/range/range.js
+++ b/src/components/form/range/range.js
@@ -66,9 +66,9 @@ export class EuiRange extends Component {
     let extraInputNode;
     if (showInput) {
       // Chrome will properly size the input based on the max value, but FF & IE does not.
-      // Calculate the max-width of the input based on number of characters in max unit
+      // Calculate the max-width of the input based on number of characters in min or max unit, whichever is greater.
       // Add 2 to accomodate for input stepper
-      const maxWidthStyle = { maxWidth: `${String(max).length + 2}em` };
+      const maxWidthStyle = { maxWidth: `${Math.max(String(min).length, String(max).length) + 2}em` };
 
       // Make this input the main control by disabling screen reader access to slider control
       sliderTabIndex = '-1';


### PR DESCRIPTION
### Summary

Currently, `EuiRange` inputs are assigned a dynamic width based upon the number of characters in the `max` attribute. This PR accounts for the `min` attribute as well, and chooses the longer of the two when determining input width.

Addresses https://github.com/elastic/eui/issues/1403

### Checklist

- ~[ ] This was checked in mobile~
- ~[ ] This was checked in IE11~
-~ [ ] This was checked in dark mode~
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
