### PR TITLE
Adds initialFocus prop typedefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added `onBlur` prop to `EuiComboBox` ([#1400](https://github.com/elastic/eui/pull/1400))
+- Added `initialFocus` prop typedefs to `EuiModal` and `EuiPopover` ([#1410](https://github.com/elastic/eui/pull/1410))
 
 ## [`6.2.0`](https://github.com/elastic/eui/tree/v6.2.0)
 

--- a/src/components/modal/index.d.ts
+++ b/src/components/modal/index.d.ts
@@ -1,4 +1,4 @@
-import { CommonProps, Omit, NoArgCallback } from '../common';
+import { CommonProps, Omit } from '../common';
 /// <reference path="../button/index.d.ts" />
 
 import { FocusTarget } from 'focus-trap';

--- a/src/components/modal/index.d.ts
+++ b/src/components/modal/index.d.ts
@@ -1,6 +1,7 @@
 import { CommonProps, Omit, NoArgCallback } from '../common';
 /// <reference path="../button/index.d.ts" />
 
+import { FocusTarget } from 'focus-trap';
 import { ReactNode, SFC, HTMLAttributes, ReactHTMLElement } from 'react';
 
 declare module '@elastic/eui' {
@@ -25,7 +26,7 @@ declare module '@elastic/eui' {
      * Specifies what element should initially have focus; 
      * Can be a DOM node, or a selector string (which will be passed to document.querySelector() to find the DOM node), or a function that returns a DOM node. 
      */
-    initialFocus?: string | ReactHTMLElement<any> | NoArgCallback<ReactHTMLElement<any>>;
+    initialFocus?: FocusTarget;
   }
 
   export const EuiModal: SFC<

--- a/src/components/modal/index.d.ts
+++ b/src/components/modal/index.d.ts
@@ -2,7 +2,7 @@ import { CommonProps, Omit } from '../common';
 /// <reference path="../button/index.d.ts" />
 
 import { FocusTarget } from 'focus-trap';
-import { ReactNode, SFC, HTMLAttributes, ReactHTMLElement } from 'react';
+import { ReactNode, SFC, HTMLAttributes } from 'react';
 
 declare module '@elastic/eui' {
 

--- a/src/components/modal/index.d.ts
+++ b/src/components/modal/index.d.ts
@@ -1,7 +1,7 @@
-import { CommonProps, Omit } from '../common';
+import { CommonProps, Omit, NoArgCallback } from '../common';
 /// <reference path="../button/index.d.ts" />
 
-import { ReactNode, SFC, HTMLAttributes } from 'react';
+import { ReactNode, SFC, HTMLAttributes, ReactHTMLElement } from 'react';
 
 declare module '@elastic/eui' {
 
@@ -20,6 +20,12 @@ declare module '@elastic/eui' {
      * set to a string for a custom width in custom measurement.
      */
     maxWidth?: boolean | number | string;
+
+    /** 
+     * Specifies what element should initially have focus; 
+     * Can be a DOM node, or a selector string (which will be passed to document.querySelector() to find the DOM node), or a function that returns a DOM node. 
+     */
+    initialFocus?: string | ReactHTMLElement<any> | NoArgCallback<ReactHTMLElement<any>>;
   }
 
   export const EuiModal: SFC<

--- a/src/components/popover/index.d.ts
+++ b/src/components/popover/index.d.ts
@@ -1,6 +1,7 @@
 import { CommonProps, NoArgCallback } from '../common';
 /// <reference path="../panel/index.d.ts" />
 
+import { FocusTarget } from 'focus-trap';
 import { SFC, ReactNode, HTMLAttributes, ReactHTMLElement } from 'react';
 
 declare module '@elastic/eui' {
@@ -31,7 +32,7 @@ declare module '@elastic/eui' {
     withTitle?: boolean;
     isOpen?: boolean;
     ownFocus?: boolean;
-    initialFocus?: string | ReactHTMLElement<any> | NoArgCallback<ReactHTMLElement<any>>;
+    initialFocus?: FocusTarget;
     hasArrow?: boolean;
     anchorClassName?: string;
     anchorPosition?: PopoverAnchorPosition;

--- a/src/components/popover/index.d.ts
+++ b/src/components/popover/index.d.ts
@@ -37,7 +37,7 @@ declare module '@elastic/eui' {
     anchorPosition?: PopoverAnchorPosition;
     panelClassName?: string;
     panelPaddingSize?: PanelPaddingSize;
-  }  
+  }
 
   export const EuiPopover: SFC<
     CommonProps & HTMLAttributes<HTMLDivElement> & EuiPopoverProps

--- a/src/components/popover/index.d.ts
+++ b/src/components/popover/index.d.ts
@@ -1,7 +1,7 @@
 import { CommonProps, NoArgCallback } from '../common';
 /// <reference path="../panel/index.d.ts" />
 
-import { SFC, ReactNode, HTMLAttributes } from 'react';
+import { SFC, ReactNode, HTMLAttributes, ReactHTMLElement } from 'react';
 
 declare module '@elastic/eui' {
   /**
@@ -31,12 +31,13 @@ declare module '@elastic/eui' {
     withTitle?: boolean;
     isOpen?: boolean;
     ownFocus?: boolean;
+    initialFocus?: string | ReactHTMLElement<any> | NoArgCallback<ReactHTMLElement<any>>;
     hasArrow?: boolean;
     anchorClassName?: string;
     anchorPosition?: PopoverAnchorPosition;
     panelClassName?: string;
     panelPaddingSize?: PanelPaddingSize;
-  }
+  }  
 
   export const EuiPopover: SFC<
     CommonProps & HTMLAttributes<HTMLDivElement> & EuiPopoverProps

--- a/src/components/popover/index.d.ts
+++ b/src/components/popover/index.d.ts
@@ -2,7 +2,7 @@ import { CommonProps, NoArgCallback } from '../common';
 /// <reference path="../panel/index.d.ts" />
 
 import { FocusTarget } from 'focus-trap';
-import { SFC, ReactNode, HTMLAttributes, ReactHTMLElement } from 'react';
+import { SFC, ReactNode, HTMLAttributes } from 'react';
 
 declare module '@elastic/eui' {
   /**


### PR DESCRIPTION
### Summary

Adds type definitions for the `initialFocus` prop available on `EuiModal` and `EuiPopover`

(discovered via https://github.com/elastic/kibana/pull/28195)

### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
