### PR TITLE
Support non-ASCII characters in EuiSearchBar & Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 - Added `onBlur` prop to `EuiComboBox` ([#1400](https://github.com/elastic/eui/pull/1400))
 - Added `initialFocus` prop typedefs to `EuiModal` and `EuiPopover` ([#1410](https://github.com/elastic/eui/pull/1410))
 
+**Bug fixes**
+
+- Support extended characters (e.g. non-latin, unicode) in `EuiSearchBar` and `EuiQuery` ([#1415](https://github.com/elastic/eui/pull/1415))
+
 ## [`6.2.0`](https://github.com/elastic/eui/tree/v6.2.0)
 
 - Added `logoCodesandbox` and updated `apmApp` icons ([#1407](https://github.com/elastic/eui/pull/1407))

--- a/src/components/search_bar/query/default_syntax.js
+++ b/src/components/search_bar/query/default_syntax.js
@@ -127,7 +127,7 @@ word
 
 wordChar
   = alnum
-  / [-_:*]
+  / [-_*:]
   / escapedChar
   / extendedGlyph
   

--- a/src/components/search_bar/query/default_syntax.test.js
+++ b/src/components/search_bar/query/default_syntax.test.js
@@ -68,6 +68,28 @@ describe('defaultSyntax', () => {
     expect(clause.value).toBe('dash-3');
   });
 
+  test('unicode field and term values', () => {
+    const query = 'name:👸Queen_Elizabeth 🤴King_Henry';
+    const ast = defaultSyntax.parse(query);
+
+    expect(ast).toBeDefined();
+    expect(ast.clauses).toBeDefined();
+    expect(ast.clauses).toHaveLength(2);
+
+    let clause = ast.getSimpleFieldClause('name', '👸Queen_Elizabeth');
+    expect(clause).toBeDefined();
+    expect(AST.Field.isInstance(clause)).toBe(true);
+    expect(AST.Match.isMustClause(clause)).toBe(true);
+    expect(clause.field).toBe('name');
+    expect(clause.value).toBe('👸Queen_Elizabeth');
+
+    clause = ast.getTermClause('🤴King_Henry');
+    expect(clause).toBeDefined();
+    expect(AST.Term.isInstance(clause)).toBe(true);
+    expect(AST.Match.isMustClause(clause)).toBe(true);
+    expect(clause.value).toBe('🤴King_Henry');
+  });
+
   test('escaped chars as default clauses', () => {
     const query = '-\\: \\\\';
     const ast = defaultSyntax.parse(query);

--- a/yarn.lock
+++ b/yarn.lock
@@ -13720,11 +13720,6 @@ underscore@~1.4.4:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
   integrity sha1-YaajIBBiKvoHljvzJSA88SI51gQ=
 
-unicode-11.0.0@^0.7.8:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/unicode-11.0.0/-/unicode-11.0.0-0.7.8.tgz#5eecdd6c2802fdd6b260661c57921d0294aeea98"
-  integrity sha512-O/7kwPxe1ZOiwbLr4/OleBnUDwDRldjubW5SqcQvz1b2EMPp5mQotOdf4L1z/5CNzSDVmWM9cFmseOI6L8vb6g==
-
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13720,6 +13720,11 @@ underscore@~1.4.4:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
   integrity sha1-YaajIBBiKvoHljvzJSA88SI51gQ=
 
+unicode-11.0.0@^0.7.8:
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/unicode-11.0.0/-/unicode-11.0.0-0.7.8.tgz#5eecdd6c2802fdd6b260661c57921d0294aeea98"
+  integrity sha512-O/7kwPxe1ZOiwbLr4/OleBnUDwDRldjubW5SqcQvz1b2EMPp5mQotOdf4L1z/5CNzSDVmWM9cFmseOI6L8vb6g==
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"


### PR DESCRIPTION
### Summary

Fixes #1409 by adding support for non-western/latin/ASCII characters & punctuation within term & field values. This casts a wide net, allowing any and all UTF-16 characters in the range `U+00C0`-`U+FFFF` (begins in [Latin-1 Supplement](https://en.wikipedia.org/wiki/List_of_Unicode_characters#Latin-1_Supplement)). It's highly unlikely we would want to use any character in that range for another purpose in queries.

**Implementation**

I added the `U+00C0`-`U+FFFF` range as a supported value within the grammar's `wordChar` entry. [PEG.js doesn't understand regex character classes](https://github.com/pegjs/pegjs/issues/247) so this abuses the fact that character ranges only care about byte code values. The exact characters for `U+00C0` and `U+FFFF` are injected into the grammar's source instead of their unicode escape sequences.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
