### PR TITLE
fix misspell in read-only example

### DIFF
--- a/src-docs/src/views/code_editor/read_only.js
+++ b/src-docs/src/views/code_editor/read_only.js
@@ -21,7 +21,7 @@ export default class extends Component {
         value={this.state.value}
         setOptions={{ fontSize: '14px' }}
         isReadOnly
-        arial-label="Read only code editor"
+        aria-label="Read only code editor"
       />
     );
   }


### PR DESCRIPTION
### Summary

Fixes a minor misspell in the *EuiCodeEditor* read-only example that prevented the `aria-label` from rendering.