### PR TITLE
Propagate className in EuiCodeBlock in fullscreen mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `isAutoRefreshOnly` prop to `EuiSuperDatePicker` ([#1412](https://github.com/elastic/eui/pull/1412))
 - Migrate remaining files in `accessiblity/` to TS ([#1408](https://github.com/elastic/eui/pull/1408))
 - Added `titleProps` and `descriptionProps` to `EuiDescriptionList` ([#1419](https://github.com/elastic/eui/pull/1419))
+- Propagate `className` on `EuiCodeBlock` in fullscreen mode ([#1422](https://github.com/elastic/eui/pull/1422))
 
 **Bug fixes**
 

--- a/src/components/code/_code_block.js
+++ b/src/components/code/_code_block.js
@@ -165,6 +165,7 @@ export class EuiCodeBlockImpl extends Component {
         fontSizeToClassNameMap[fontSize],
         'euiCodeBlock-paddingLarge',
         'euiCodeBlock-isFullScreen',
+        className,
       );
 
       fullScreenDisplay = (


### PR DESCRIPTION
### Summary

Propagate `className` in `EuiCodeBlock` in fullscreen mode, not just regular mode.

### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
