### PR TITLE
Adds side nav component (EuiNavDrawer)

### DIFF
--- a/src-docs/src/routes.js
+++ b/src-docs/src/routes.js
@@ -171,6 +171,9 @@ import { ModalExample }
 import { MutationObserverExample }
   from './views/mutation_observer/mutation_observer_example';
 
+import { NavDrawerExample }
+  from './views/nav_drawer/nav_drawer_example';
+
 import { OutsideClickDetectorExample }
   from './views/outside_click_detector/outside_click_detector_example';
 
@@ -335,6 +338,7 @@ const navigation = [{
     HeaderExample,
     HorizontalRuleExample,
     ModalExample,
+    NavDrawerExample,
     PageExample,
     PanelExample,
     PopoverExample,

--- a/src-docs/src/views/nav_drawer/nav_drawer.js
+++ b/src-docs/src/views/nav_drawer/nav_drawer.js
@@ -519,6 +519,10 @@ export default class extends Component {
         outsideClickDisaled: true,
       });
     }, 350);
+
+    // Scrolls the menu and flyout back to top when the nav drawer collapses
+    document.getElementById('navDrawerMenu').scroll(0, 0);
+    document.getElementById('navDrawerFlyout').scroll(0, 0);
   };
 
   focusOut = () => {
@@ -555,7 +559,11 @@ export default class extends Component {
     this.setState({ flyoutIsAnimating: true });
 
     setTimeout(() => {
-      this.setState({ flyoutIsCollapsed: true });
+      this.setState({
+        flyoutIsCollapsed: true,
+        navFlyoutTitle: null,
+        navFlyoutContent: null
+      });
     }, 250);
   };
 
@@ -611,7 +619,7 @@ export default class extends Component {
               showScrollbar={showScrollbar}
               style={{ position: 'absolute' }} // This is for the embedded docs example only
             >
-              <EuiNavDrawerMenu>
+              <EuiNavDrawerMenu id="navDrawerMenu">
                 <EuiListGroup listItems={this.topLinks} />
                 <EuiHorizontalRule margin="none" />
                 <EuiListGroup listItems={this.exploreLinks} />
@@ -621,6 +629,7 @@ export default class extends Component {
                 <EuiListGroup listItems={this.adminLinks} />
               </EuiNavDrawerMenu>
               <EuiNavDrawerFlyout
+                id="navDrawerFlyout"
                 title={navFlyoutTitle}
                 isCollapsed={flyoutIsCollapsed}
                 listItems={navFlyoutContent}

--- a/src-docs/src/views/nav_drawer/nav_drawer.js
+++ b/src-docs/src/views/nav_drawer/nav_drawer.js
@@ -52,6 +52,7 @@ export default class extends Component {
           iconSize: 's',
           'aria-label': 'Expand to view recent apps and objects',
           onClick: () => this.expandFlyout('recents', 'Recent items'),
+          alwaysShow: true,
         },
       },
       {
@@ -67,11 +68,42 @@ export default class extends Component {
           iconSize: 's',
           'aria-label': 'Expand to view favorited apps and objects',
           onClick: () => this.expandFlyout('favorites', 'Favorited items'),
+          alwaysShow: true,
         },
       },
     ];
 
     this.bottomLinks = [
+      {
+        label: 'Canvas',
+        href: '/#/layout/nav-drawer',
+        iconType: 'canvasApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Canvas',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pinFilled',
+          iconSize: 's',
+          'aria-label': 'Pin to top',
+          alwaysShow: true,
+        },
+      },
+      {
+        label: 'Maps',
+        href: '/#/layout/nav-drawer',
+        iconType: 'gisApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Maps',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pinFilled',
+          iconSize: 's',
+          'aria-label': 'Pin to top',
+          alwaysShow: true,
+        },
+      },
       {
         label: 'Discover',
         href: '/#/layout/nav-drawer',
@@ -83,7 +115,7 @@ export default class extends Component {
           color: 'subdued',
           iconType: 'pin',
           iconSize: 's',
-          'aria-label': 'Add to favorites',
+          'aria-label': 'Pin to top',
         },
       },
       {
@@ -97,7 +129,7 @@ export default class extends Component {
           color: 'subdued',
           iconType: 'pin',
           iconSize: 's',
-          'aria-label': 'Add to favorites',
+          'aria-label': 'Pin to top',
         },
       },
       {
@@ -111,35 +143,7 @@ export default class extends Component {
           color: 'subdued',
           iconType: 'pin',
           iconSize: 's',
-          'aria-label': 'Add to favorites',
-        },
-      },
-      {
-        label: 'Timelion',
-        href: '/#/layout/nav-drawer',
-        iconType: 'timelionApp',
-        size: 's',
-        style: { color: 'inherit' },
-        'aria-label': 'Timelion',
-        extraAction: {
-          color: 'subdued',
-          iconType: 'pin',
-          iconSize: 's',
-          'aria-label': 'Add to favorites',
-        },
-      },
-      {
-        label: 'Canvas',
-        href: '/#/layout/nav-drawer',
-        iconType: 'canvasApp',
-        size: 's',
-        style: { color: 'inherit' },
-        'aria-label': 'Canvas',
-        extraAction: {
-          color: 'subdued',
-          iconType: 'pin',
-          iconSize: 's',
-          'aria-label': 'Add to favorites',
+          'aria-label': 'Pin to top',
         },
       },
       {
@@ -153,7 +157,7 @@ export default class extends Component {
           color: 'subdued',
           iconType: 'pin',
           iconSize: 's',
-          'aria-label': 'Add to favorites',
+          'aria-label': 'Pin to top',
         },
       },
       {
@@ -167,7 +171,7 @@ export default class extends Component {
           color: 'subdued',
           iconType: 'pin',
           iconSize: 's',
-          'aria-label': 'Add to favorites',
+          'aria-label': 'Pin to top',
         },
       },
       {
@@ -181,7 +185,7 @@ export default class extends Component {
           color: 'subdued',
           iconType: 'pin',
           iconSize: 's',
-          'aria-label': 'Add to favorites',
+          'aria-label': 'Pin to top',
         },
       },
       {
@@ -195,7 +199,7 @@ export default class extends Component {
           color: 'subdued',
           iconType: 'pin',
           iconSize: 's',
-          'aria-label': 'Add to favorites',
+          'aria-label': 'Pin to top',
         },
       },
       {
@@ -209,7 +213,7 @@ export default class extends Component {
           color: 'subdued',
           iconType: 'pin',
           iconSize: 's',
-          'aria-label': 'Add to favorites',
+          'aria-label': 'Pin to top',
         },
       },
       {
@@ -223,7 +227,7 @@ export default class extends Component {
           color: 'subdued',
           iconType: 'pin',
           iconSize: 's',
-          'aria-label': 'Add to favorites',
+          'aria-label': 'Pin to top',
         },
       },
       {
@@ -237,21 +241,7 @@ export default class extends Component {
           color: 'subdued',
           iconType: 'pin',
           iconSize: 's',
-          'aria-label': 'Add to favorites',
-        },
-      },
-      {
-        label: 'Maps',
-        href: '/#/layout/nav-drawer',
-        iconType: 'gisApp',
-        size: 's',
-        style: { color: 'inherit' },
-        'aria-label': 'Maps',
-        extraAction: {
-          color: 'subdued',
-          iconType: 'pin',
-          iconSize: 's',
-          'aria-label': 'Add to favorites',
+          'aria-label': 'Pin to top',
         },
       },
       {
@@ -265,7 +255,7 @@ export default class extends Component {
           color: 'subdued',
           iconType: 'pin',
           iconSize: 's',
-          'aria-label': 'Add to favorites',
+          'aria-label': 'Pin to top',
         },
       },
     ];
@@ -325,9 +315,10 @@ export default class extends Component {
         'aria-label': 'My workpad',
         extraAction: {
           color: 'subdued',
-          iconType: 'starEmpty',
+          iconType: 'starFilled',
           iconSize: 's',
           'aria-label': 'Add to favorites',
+          alwaysShow: true,
         },
       },
       {
@@ -339,9 +330,10 @@ export default class extends Component {
         'aria-label': 'My logs',
         extraAction: {
           color: 'subdued',
-          iconType: 'starEmpty',
+          iconType: 'starFilled',
           iconSize: 's',
           'aria-label': 'Add to favorites',
+          alwaysShow: true,
         },
       },
     ];

--- a/src-docs/src/views/nav_drawer/nav_drawer.js
+++ b/src-docs/src/views/nav_drawer/nav_drawer.js
@@ -15,239 +15,11 @@ import {
   EuiHeaderLogo,
   EuiTitle,
   EuiNavDrawer,
+  EuiNavDrawerMenu,
+  EuiNavDrawerFlyout,
   EuiListGroup,
   EuiHorizontalRule,
 } from '../../../../src/components';
-
-const topLinks = [
-  {
-    label: 'Recently viewed',
-    href: '/#/layout/nav-drawer',
-    iconType: 'clock',
-    size: 's',
-    style: { color: 'inherit' },
-    'aria-label': 'Recently viewed items',
-    extraAction: {
-      color: 'subdued',
-      iconType: 'arrowRight',
-      iconSize: 's',
-      'aria-label': 'Expand to view recent apps and objects',
-    },
-  },
-  {
-    label: 'Favorites',
-    href: '/#/layout/nav-drawer',
-    iconType: 'pin',
-    size: 's',
-    style: { color: 'inherit' },
-    'aria-label': 'Favorited items',
-    extraAction: {
-      color: 'subdued',
-      iconType: 'arrowRight',
-      iconSize: 's',
-      'aria-label': 'Expand to view favorited apps and objects',
-    },
-  },
-];
-
-const bottomLinks = [
-  {
-    label: 'Discover',
-    href: '/#/layout/nav-drawer',
-    iconType: 'discoverApp',
-    size: 's',
-    style: { color: 'inherit' },
-    'aria-label': 'Discover',
-    extraAction: {
-      color: 'subdued',
-      iconType: 'pin',
-      iconSize: 's',
-      'aria-label': 'Add to favorites',
-    },
-  },
-  {
-    label: 'Visualize',
-    href: '/#/layout/nav-drawer',
-    iconType: 'visualizeApp',
-    size: 's',
-    style: { color: 'inherit' },
-    'aria-label': 'Visualize',
-    extraAction: {
-      color: 'subdued',
-      iconType: 'pin',
-      iconSize: 's',
-      'aria-label': 'Add to favorites',
-    },
-  },
-  {
-    label: 'Dashboard',
-    href: '/#/layout/nav-drawer',
-    iconType: 'dashboardApp',
-    size: 's',
-    style: { color: 'inherit' },
-    'aria-label': 'Dashboard',
-    extraAction: {
-      color: 'subdued',
-      iconType: 'pin',
-      iconSize: 's',
-      'aria-label': 'Add to favorites',
-    },
-  },
-  {
-    label: 'Timelion',
-    href: '/#/layout/nav-drawer',
-    iconType: 'timelionApp',
-    size: 's',
-    style: { color: 'inherit' },
-    'aria-label': 'Timelion',
-    extraAction: {
-      color: 'subdued',
-      iconType: 'pin',
-      iconSize: 's',
-      'aria-label': 'Add to favorites',
-    },
-  },
-  {
-    label: 'Canvas',
-    href: '/#/layout/nav-drawer',
-    iconType: 'canvasApp',
-    size: 's',
-    style: { color: 'inherit' },
-    'aria-label': 'Canvas',
-    extraAction: {
-      color: 'subdued',
-      iconType: 'pin',
-      iconSize: 's',
-      'aria-label': 'Add to favorites',
-    },
-  },
-  {
-    label: 'APM',
-    href: '/#/layout/nav-drawer',
-    iconType: 'apmApp',
-    size: 's',
-    style: { color: 'inherit' },
-    'aria-label': 'APM',
-    extraAction: {
-      color: 'subdued',
-      iconType: 'pin',
-      iconSize: 's',
-      'aria-label': 'Add to favorites',
-    },
-  },
-  {
-    label: 'Machine learning',
-    href: '/#/layout/nav-drawer',
-    iconType: 'machineLearningApp',
-    size: 's',
-    style: { color: 'inherit' },
-    'aria-label': 'Machine learning',
-    extraAction: {
-      color: 'subdued',
-      iconType: 'pin',
-      iconSize: 's',
-      'aria-label': 'Add to favorites',
-    },
-  },
-  {
-    label: 'Infra ops',
-    href: '/#/layout/nav-drawer',
-    iconType: 'infraApp',
-    size: 's',
-    style: { color: 'inherit' },
-    'aria-label': 'Infra',
-    extraAction: {
-      color: 'subdued',
-      iconType: 'pin',
-      iconSize: 's',
-      'aria-label': 'Add to favorites',
-    },
-  },
-  {
-    label: 'Logs',
-    href: '/#/layout/nav-drawer',
-    iconType: 'loggingApp',
-    size: 's',
-    style: { color: 'inherit' },
-    'aria-label': 'Logs',
-    extraAction: {
-      color: 'subdued',
-      iconType: 'pin',
-      iconSize: 's',
-      'aria-label': 'Add to favorites',
-    },
-  },
-  {
-    label: 'Graph',
-    href: '/#/layout/nav-drawer',
-    iconType: 'graphApp',
-    size: 's',
-    style: { color: 'inherit' },
-    'aria-label': 'Graph',
-    extraAction: {
-      color: 'subdued',
-      iconType: 'pin',
-      iconSize: 's',
-      'aria-label': 'Add to favorites',
-    },
-  },
-  {
-    label: 'Dev tools',
-    href: '/#/layout/nav-drawer',
-    iconType: 'devToolsApp',
-    size: 's',
-    style: { color: 'inherit' },
-    'aria-label': 'Dev tools',
-    extraAction: {
-      color: 'subdued',
-      iconType: 'pin',
-      iconSize: 's',
-      'aria-label': 'Add to favorites',
-    },
-  },
-  {
-    label: 'Monitoring',
-    href: '/#/layout/nav-drawer',
-    iconType: 'monitoringApp',
-    size: 's',
-    style: { color: 'inherit' },
-    'aria-label': 'Monitoring',
-    extraAction: {
-      color: 'subdued',
-      iconType: 'pin',
-      iconSize: 's',
-      'aria-label': 'Add to favorites',
-    },
-  },
-  {
-    label: 'Maps',
-    href: '/#/layout/nav-drawer',
-    iconType: 'gisApp',
-    size: 's',
-    style: { color: 'inherit' },
-    'aria-label': 'Maps',
-    extraAction: {
-      color: 'subdued',
-      iconType: 'pin',
-      iconSize: 's',
-      'aria-label': 'Add to favorites',
-    },
-  },
-  {
-    label: 'Management',
-    href: '/#/layout/nav-drawer',
-    iconType: 'managementApp',
-    size: 's',
-    style: { color: 'inherit' },
-    'aria-label': 'Management',
-    extraAction: {
-      color: 'subdued',
-      iconType: 'pin',
-      iconSize: 's',
-      'aria-label': 'Add to favorites',
-    },
-  },
-];
 
 export default class extends Component {
   constructor(props) {
@@ -255,7 +27,284 @@ export default class extends Component {
 
     this.state = {
       isCollapsed: true,
+      flyoutIsCollapsed: true,
     };
+
+    this.topLinks = [
+      {
+        label: 'Recently viewed',
+        iconType: 'clock',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Recently viewed items',
+        onClick: this.expandFlyout,
+        extraAction: {
+          color: 'subdued',
+          iconType: 'arrowRight',
+          iconSize: 's',
+          'aria-label': 'Expand to view recent apps and objects',
+          onClick: this.expandFlyout,
+        },
+      },
+      {
+        label: 'Favorites',
+        href: '/#/layout/nav-drawer',
+        iconType: 'starEmpty',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Favorited items',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'arrowRight',
+          iconSize: 's',
+          'aria-label': 'Expand to view favorited apps and objects',
+        },
+      },
+    ];
+
+    this.bottomLinks = [
+      {
+        label: 'Discover',
+        href: '/#/layout/nav-drawer',
+        iconType: 'discoverApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Discover',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pin',
+          iconSize: 's',
+          'aria-label': 'Add to favorites',
+        },
+      },
+      {
+        label: 'Visualize',
+        href: '/#/layout/nav-drawer',
+        iconType: 'visualizeApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Visualize',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pin',
+          iconSize: 's',
+          'aria-label': 'Add to favorites',
+        },
+      },
+      {
+        label: 'Dashboard',
+        href: '/#/layout/nav-drawer',
+        iconType: 'dashboardApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Dashboard',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pin',
+          iconSize: 's',
+          'aria-label': 'Add to favorites',
+        },
+      },
+      {
+        label: 'Timelion',
+        href: '/#/layout/nav-drawer',
+        iconType: 'timelionApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Timelion',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pin',
+          iconSize: 's',
+          'aria-label': 'Add to favorites',
+        },
+      },
+      {
+        label: 'Canvas',
+        href: '/#/layout/nav-drawer',
+        iconType: 'canvasApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Canvas',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pin',
+          iconSize: 's',
+          'aria-label': 'Add to favorites',
+        },
+      },
+      {
+        label: 'APM',
+        href: '/#/layout/nav-drawer',
+        iconType: 'apmApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'APM',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pin',
+          iconSize: 's',
+          'aria-label': 'Add to favorites',
+        },
+      },
+      {
+        label: 'Machine learning',
+        href: '/#/layout/nav-drawer',
+        iconType: 'machineLearningApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Machine learning',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pin',
+          iconSize: 's',
+          'aria-label': 'Add to favorites',
+        },
+      },
+      {
+        label: 'Infra ops',
+        href: '/#/layout/nav-drawer',
+        iconType: 'infraApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Infra',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pin',
+          iconSize: 's',
+          'aria-label': 'Add to favorites',
+        },
+      },
+      {
+        label: 'Logs',
+        href: '/#/layout/nav-drawer',
+        iconType: 'loggingApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Logs',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pin',
+          iconSize: 's',
+          'aria-label': 'Add to favorites',
+        },
+      },
+      {
+        label: 'Graph',
+        href: '/#/layout/nav-drawer',
+        iconType: 'graphApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Graph',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pin',
+          iconSize: 's',
+          'aria-label': 'Add to favorites',
+        },
+      },
+      {
+        label: 'Dev tools',
+        href: '/#/layout/nav-drawer',
+        iconType: 'devToolsApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Dev tools',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pin',
+          iconSize: 's',
+          'aria-label': 'Add to favorites',
+        },
+      },
+      {
+        label: 'Monitoring',
+        href: '/#/layout/nav-drawer',
+        iconType: 'monitoringApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Monitoring',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pin',
+          iconSize: 's',
+          'aria-label': 'Add to favorites',
+        },
+      },
+      {
+        label: 'Maps',
+        href: '/#/layout/nav-drawer',
+        iconType: 'gisApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Maps',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pin',
+          iconSize: 's',
+          'aria-label': 'Add to favorites',
+        },
+      },
+      {
+        label: 'Management',
+        href: '/#/layout/nav-drawer',
+        iconType: 'managementApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Management',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pin',
+          iconSize: 's',
+          'aria-label': 'Add to favorites',
+        },
+      },
+    ];
+
+    this.recentLinks = [
+      {
+        label: 'My dashboard',
+        href: '/#/layout/nav-drawer',
+        iconType: 'dashboardApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'My dashboard',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'starEmpty',
+          iconSize: 's',
+          'aria-label': 'Add to favorites',
+        },
+      },
+      {
+        label: 'My workpad',
+        href: '/#/layout/nav-drawer',
+        iconType: 'canvasApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'My workpad',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'starEmpty',
+          iconSize: 's',
+          'aria-label': 'Add to favorites',
+        },
+      },
+      {
+        label: 'My logs',
+        href: '/#/layout/nav-drawer',
+        iconType: 'loggingApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'My logs',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'starEmpty',
+          iconSize: 's',
+          'aria-label': 'Add to favorites',
+        },
+      },
+    ];
   }
 
   renderLogo() {
@@ -270,9 +319,18 @@ export default class extends Component {
     this.setState({ isCollapsed: true });
   };
 
+  expandFlyout = () => {
+    this.setState({ flyoutIsCollapsed: false });
+  };
+
+  collapseFlyout = () => {
+    this.setState({ flyoutIsCollapsed: true });
+  };
+
   render() {
     const {
       isCollapsed,
+      flyoutIsCollapsed,
     } = this.state;
 
     return (
@@ -283,10 +341,23 @@ export default class extends Component {
           </EuiHeaderSection>
         </EuiHeader>
         <EuiPage style={{ position: 'relative', minHeight: '800px' }}>
-          <EuiNavDrawer isCollapsed={isCollapsed} onMouseOver={this.expandDrawer} onMouseOut={this.collapseDrawer}>
-            <EuiListGroup listItems={topLinks} />
-            <EuiHorizontalRule margin="s" />
-            <EuiListGroup listItems={bottomLinks} />
+          <EuiNavDrawer
+            isCollapsed={isCollapsed}
+            flyoutIsCollapsed={flyoutIsCollapsed}
+            onMouseOver={this.expandDrawer}
+            onMouseLeave={this.collapseDrawer}
+          >
+            <EuiNavDrawerMenu>
+              <EuiListGroup listItems={this.topLinks} />
+              <EuiHorizontalRule margin="s" />
+              <EuiListGroup listItems={this.bottomLinks} />
+            </EuiNavDrawerMenu>
+            <EuiNavDrawerFlyout
+              title="Recently viewed"
+              isCollapsed={flyoutIsCollapsed}
+              listItems={this.recentLinks}
+              onMouseLeave={this.collapseFlyout}
+            />
           </EuiNavDrawer>
 
           <EuiPageBody style={{ marginLeft: '64px' }}>

--- a/src-docs/src/views/nav_drawer/nav_drawer.js
+++ b/src-docs/src/views/nav_drawer/nav_drawer.js
@@ -21,6 +21,7 @@ import {
   EuiListGroup,
   EuiHorizontalRule,
   EuiShowFor,
+  EuiHideFor
 } from '../../../../src/components';
 
 export default class extends Component {
@@ -509,25 +510,27 @@ export default class extends Component {
           </EuiNavDrawer>
           <EuiPage style={{ minHeight: '800px' }}>
             <EuiPageBody style={{ marginLeft: '64px' }}>
-              <EuiPageHeader>
-                <EuiPageHeaderSection>
-                  <EuiTitle size="l">
-                    <h1>Page title</h1>
-                  </EuiTitle>
-                </EuiPageHeaderSection>
-              </EuiPageHeader>
-              <EuiPageContent>
-                <EuiPageContentHeader>
-                  <EuiPageContentHeaderSection>
-                    <EuiTitle>
-                      <h2>Content title</h2>
+              <EuiHideFor sizes={['xs', 's']}>
+                <EuiPageHeader>
+                  <EuiPageHeaderSection>
+                    <EuiTitle size="l">
+                      <h1>Page title</h1>
                     </EuiTitle>
-                  </EuiPageContentHeaderSection>
-                </EuiPageContentHeader>
-                <EuiPageContentBody>
-                  Content body
-                </EuiPageContentBody>
-              </EuiPageContent>
+                  </EuiPageHeaderSection>
+                </EuiPageHeader>
+                <EuiPageContent>
+                  <EuiPageContentHeader>
+                    <EuiPageContentHeaderSection>
+                      <EuiTitle>
+                        <h2>Content title</h2>
+                      </EuiTitle>
+                    </EuiPageContentHeaderSection>
+                  </EuiPageContentHeader>
+                  <EuiPageContentBody>
+                    Content body
+                  </EuiPageContentBody>
+                </EuiPageContent>
+              </EuiHideFor>
             </EuiPageBody>
           </EuiPage>
         </div>

--- a/src-docs/src/views/nav_drawer/nav_drawer.js
+++ b/src-docs/src/views/nav_drawer/nav_drawer.js
@@ -1,0 +1,317 @@
+import React, { Component } from 'react';
+
+import {
+  EuiPage,
+  EuiPageBody,
+  EuiPageHeader,
+  EuiPageHeaderSection,
+  EuiPageContent,
+  EuiPageContentHeader,
+  EuiPageContentHeaderSection,
+  EuiPageContentBody,
+  EuiHeader,
+  EuiHeaderSection,
+  EuiHeaderSectionItem,
+  EuiHeaderLogo,
+  EuiTitle,
+  EuiNavDrawer,
+  EuiListGroup,
+  EuiHorizontalRule,
+} from '../../../../src/components';
+
+const topLinks = [
+  {
+    label: 'Recently viewed',
+    href: '/#/layout/nav-drawer',
+    iconType: 'clock',
+    size: 's',
+    style: { color: 'inherit' },
+    'aria-label': 'Recently viewed items',
+    extraAction: {
+      color: 'subdued',
+      iconType: 'arrowRight',
+      iconSize: 's',
+      'aria-label': 'Expand to view recent apps and objects',
+    },
+  },
+  {
+    label: 'Favorites',
+    href: '/#/layout/nav-drawer',
+    iconType: 'pin',
+    size: 's',
+    style: { color: 'inherit' },
+    'aria-label': 'Favorited items',
+    extraAction: {
+      color: 'subdued',
+      iconType: 'arrowRight',
+      iconSize: 's',
+      'aria-label': 'Expand to view favorited apps and objects',
+    },
+  },
+];
+
+const bottomLinks = [
+  {
+    label: 'Discover',
+    href: '/#/layout/nav-drawer',
+    iconType: 'discoverApp',
+    size: 's',
+    style: { color: 'inherit' },
+    'aria-label': 'Discover',
+    extraAction: {
+      color: 'subdued',
+      iconType: 'pin',
+      iconSize: 's',
+      'aria-label': 'Add to favorites',
+    },
+  },
+  {
+    label: 'Visualize',
+    href: '/#/layout/nav-drawer',
+    iconType: 'visualizeApp',
+    size: 's',
+    style: { color: 'inherit' },
+    'aria-label': 'Visualize',
+    extraAction: {
+      color: 'subdued',
+      iconType: 'pin',
+      iconSize: 's',
+      'aria-label': 'Add to favorites',
+    },
+  },
+  {
+    label: 'Dashboard',
+    href: '/#/layout/nav-drawer',
+    iconType: 'dashboardApp',
+    size: 's',
+    style: { color: 'inherit' },
+    'aria-label': 'Dashboard',
+    extraAction: {
+      color: 'subdued',
+      iconType: 'pin',
+      iconSize: 's',
+      'aria-label': 'Add to favorites',
+    },
+  },
+  {
+    label: 'Timelion',
+    href: '/#/layout/nav-drawer',
+    iconType: 'timelionApp',
+    size: 's',
+    style: { color: 'inherit' },
+    'aria-label': 'Timelion',
+    extraAction: {
+      color: 'subdued',
+      iconType: 'pin',
+      iconSize: 's',
+      'aria-label': 'Add to favorites',
+    },
+  },
+  {
+    label: 'Canvas',
+    href: '/#/layout/nav-drawer',
+    iconType: 'canvasApp',
+    size: 's',
+    style: { color: 'inherit' },
+    'aria-label': 'Canvas',
+    extraAction: {
+      color: 'subdued',
+      iconType: 'pin',
+      iconSize: 's',
+      'aria-label': 'Add to favorites',
+    },
+  },
+  {
+    label: 'APM',
+    href: '/#/layout/nav-drawer',
+    iconType: 'apmApp',
+    size: 's',
+    style: { color: 'inherit' },
+    'aria-label': 'APM',
+    extraAction: {
+      color: 'subdued',
+      iconType: 'pin',
+      iconSize: 's',
+      'aria-label': 'Add to favorites',
+    },
+  },
+  {
+    label: 'Machine learning',
+    href: '/#/layout/nav-drawer',
+    iconType: 'machineLearningApp',
+    size: 's',
+    style: { color: 'inherit' },
+    'aria-label': 'Machine learning',
+    extraAction: {
+      color: 'subdued',
+      iconType: 'pin',
+      iconSize: 's',
+      'aria-label': 'Add to favorites',
+    },
+  },
+  {
+    label: 'Infra ops',
+    href: '/#/layout/nav-drawer',
+    iconType: 'infraApp',
+    size: 's',
+    style: { color: 'inherit' },
+    'aria-label': 'Infra',
+    extraAction: {
+      color: 'subdued',
+      iconType: 'pin',
+      iconSize: 's',
+      'aria-label': 'Add to favorites',
+    },
+  },
+  {
+    label: 'Logs',
+    href: '/#/layout/nav-drawer',
+    iconType: 'loggingApp',
+    size: 's',
+    style: { color: 'inherit' },
+    'aria-label': 'Logs',
+    extraAction: {
+      color: 'subdued',
+      iconType: 'pin',
+      iconSize: 's',
+      'aria-label': 'Add to favorites',
+    },
+  },
+  {
+    label: 'Graph',
+    href: '/#/layout/nav-drawer',
+    iconType: 'graphApp',
+    size: 's',
+    style: { color: 'inherit' },
+    'aria-label': 'Graph',
+    extraAction: {
+      color: 'subdued',
+      iconType: 'pin',
+      iconSize: 's',
+      'aria-label': 'Add to favorites',
+    },
+  },
+  {
+    label: 'Dev tools',
+    href: '/#/layout/nav-drawer',
+    iconType: 'devToolsApp',
+    size: 's',
+    style: { color: 'inherit' },
+    'aria-label': 'Dev tools',
+    extraAction: {
+      color: 'subdued',
+      iconType: 'pin',
+      iconSize: 's',
+      'aria-label': 'Add to favorites',
+    },
+  },
+  {
+    label: 'Monitoring',
+    href: '/#/layout/nav-drawer',
+    iconType: 'monitoringApp',
+    size: 's',
+    style: { color: 'inherit' },
+    'aria-label': 'Monitoring',
+    extraAction: {
+      color: 'subdued',
+      iconType: 'pin',
+      iconSize: 's',
+      'aria-label': 'Add to favorites',
+    },
+  },
+  {
+    label: 'Maps',
+    href: '/#/layout/nav-drawer',
+    iconType: 'gisApp',
+    size: 's',
+    style: { color: 'inherit' },
+    'aria-label': 'Maps',
+    extraAction: {
+      color: 'subdued',
+      iconType: 'pin',
+      iconSize: 's',
+      'aria-label': 'Add to favorites',
+    },
+  },
+  {
+    label: 'Management',
+    href: '/#/layout/nav-drawer',
+    iconType: 'managementApp',
+    size: 's',
+    style: { color: 'inherit' },
+    'aria-label': 'Management',
+    extraAction: {
+      color: 'subdued',
+      iconType: 'pin',
+      iconSize: 's',
+      'aria-label': 'Add to favorites',
+    },
+  },
+];
+
+export default class extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isCollapsed: true,
+    };
+  }
+
+  renderLogo() {
+    return <EuiHeaderLogo iconType="logoKibana" href="#" aria-label="Go to home page" />;
+  }
+
+  expandDrawer = () => {
+    this.setState({ isCollapsed: false });
+  };
+
+  collapseDrawer = () => {
+    this.setState({ isCollapsed: true });
+  };
+
+  render() {
+    const {
+      isCollapsed,
+    } = this.state;
+
+    return (
+      <div>
+        <EuiHeader>
+          <EuiHeaderSection grow={false}>
+            <EuiHeaderSectionItem border="right">{this.renderLogo()}</EuiHeaderSectionItem>
+          </EuiHeaderSection>
+        </EuiHeader>
+        <EuiPage style={{ position: 'relative', minHeight: '800px' }}>
+          <EuiNavDrawer isCollapsed={isCollapsed} onMouseOver={this.expandDrawer} onMouseOut={this.collapseDrawer}>
+            <EuiListGroup listItems={topLinks} />
+            <EuiHorizontalRule margin="s" />
+            <EuiListGroup listItems={bottomLinks} />
+          </EuiNavDrawer>
+
+          <EuiPageBody style={{ marginLeft: '64px' }}>
+            <EuiPageHeader>
+              <EuiPageHeaderSection>
+                <EuiTitle size="l">
+                  <h1>Page title</h1>
+                </EuiTitle>
+              </EuiPageHeaderSection>
+            </EuiPageHeader>
+            <EuiPageContent>
+              <EuiPageContentHeader>
+                <EuiPageContentHeaderSection>
+                  <EuiTitle>
+                    <h2>Content title</h2>
+                  </EuiTitle>
+                </EuiPageContentHeaderSection>
+              </EuiPageContentHeader>
+              <EuiPageContentBody>
+                Content body
+              </EuiPageContentBody>
+            </EuiPageContent>
+          </EuiPageBody>
+        </EuiPage>
+      </div>
+    );
+  }
+}

--- a/src-docs/src/views/nav_drawer/nav_drawer.js
+++ b/src-docs/src/views/nav_drawer/nav_drawer.js
@@ -405,35 +405,35 @@ export default class extends Component {
 
         <EuiSpacer size="l" />
 
-        <div>
+        <div style={{ position: 'relative' }}>
           <EuiHeader>
             <EuiHeaderSection grow={false}>
               <EuiHeaderSectionItem border="right">{this.renderLogo()}</EuiHeaderSectionItem>
             </EuiHeaderSection>
           </EuiHeader>
-          <EuiPage style={{ position: 'relative', minHeight: '800px' }}>
-            <EuiNavDrawer
-              isCollapsed={isCollapsed}
-              hasDelay={hasDelay}
-              flyoutIsCollapsed={flyoutIsCollapsed}
-              flyoutIsAnimating={flyoutIsAnimating}
-              onMouseOver={this.expandDrawer}
-              onFocus={this.expandDrawer}
-              onMouseLeave={this.collapseDrawer}
-            >
-              <EuiNavDrawerMenu>
-                <EuiListGroup listItems={this.topLinks} />
-                <EuiHorizontalRule margin="s" />
-                <EuiListGroup listItems={this.bottomLinks} />
-              </EuiNavDrawerMenu>
-              <EuiNavDrawerFlyout
-                title={navFlyoutTitle}
-                isCollapsed={flyoutIsCollapsed}
-                listItems={navFlyoutContent}
-                onMouseLeave={this.collapseFlyout}
-              />
-            </EuiNavDrawer>
-
+          <EuiNavDrawer
+            isCollapsed={isCollapsed}
+            hasDelay={hasDelay}
+            flyoutIsCollapsed={flyoutIsCollapsed}
+            flyoutIsAnimating={flyoutIsAnimating}
+            onMouseOver={this.expandDrawer}
+            onFocus={this.expandDrawer}
+            onMouseLeave={this.collapseDrawer}
+            style={{ position: 'absolute' }} // This is for the embedded docs example only
+          >
+            <EuiNavDrawerMenu>
+              <EuiListGroup listItems={this.topLinks} />
+              <EuiHorizontalRule margin="s" />
+              <EuiListGroup listItems={this.bottomLinks} />
+            </EuiNavDrawerMenu>
+            <EuiNavDrawerFlyout
+              title={navFlyoutTitle}
+              isCollapsed={flyoutIsCollapsed}
+              listItems={navFlyoutContent}
+              onMouseLeave={this.collapseFlyout}
+            />
+          </EuiNavDrawer>
+          <EuiPage style={{ minHeight: '800px' }}>
             <EuiPageBody style={{ marginLeft: '64px' }}>
               <EuiPageHeader>
                 <EuiPageHeaderSection>

--- a/src-docs/src/views/nav_drawer/nav_drawer.js
+++ b/src-docs/src/views/nav_drawer/nav_drawer.js
@@ -39,6 +39,7 @@ export default class extends Component {
       navFlyoutTitle: undefined,
       navFlyoutContent: [],
       mobileIsHidden: true,
+      showScrollbar: false,
     };
 
     this.topLinks = [
@@ -472,16 +473,25 @@ export default class extends Component {
 
   expandDrawer = () => {
     this.setState({ isCollapsed: false });
+
+    setTimeout(() => {
+      this.setState({
+        showScrollbar: true,
+      });
+    }, 350);
   };
 
   collapseDrawer = () => {
-    this.setState({ flyoutIsAnimating: false });
+    this.setState({
+      flyoutIsAnimating: false,
+    });
 
     setTimeout(() => {
       this.setState({
         isCollapsed: true,
         flyoutIsCollapsed: true,
         mobileIsHidden: true,
+        showScrollbar: false,
       });
     }, 350);
   };
@@ -516,6 +526,7 @@ export default class extends Component {
       navFlyoutTitle,
       navFlyoutContent,
       mobileIsHidden,
+      showScrollbar,
     } = this.state;
 
     return (
@@ -553,6 +564,7 @@ export default class extends Component {
             onFocus={this.expandDrawer}
             onMouseLeave={this.collapseDrawer}
             mobileIsHidden={mobileIsHidden}
+            showScrollbar={showScrollbar}
             style={{ position: 'absolute' }} // This is for the embedded docs example only
           >
             <EuiNavDrawerMenu>
@@ -571,7 +583,7 @@ export default class extends Component {
               onMouseLeave={this.collapseFlyout}
             />
           </EuiNavDrawer>
-          <EuiPage style={{ minHeight: '800px' }}>
+          <EuiPage style={{ minHeight: '400px' }}>
             <EuiPageBody style={{ marginLeft: '64px' }}>
               <EuiHideFor sizes={['xs', 's']}>
                 <EuiPageHeader>

--- a/src-docs/src/views/nav_drawer/nav_drawer.js
+++ b/src-docs/src/views/nav_drawer/nav_drawer.js
@@ -12,17 +12,14 @@ import {
   EuiHeader,
   EuiHeaderSection,
   EuiHeaderSectionItem,
-  EuiHeaderLogo,
+  EuiHeaderSectionItemButton,
+  EuiIcon,
   EuiTitle,
   EuiNavDrawer,
   EuiNavDrawerMenu,
   EuiNavDrawerFlyout,
   EuiListGroup,
   EuiHorizontalRule,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiSpacer,
-  EuiSwitch,
 } from '../../../../src/components';
 
 export default class extends Component {
@@ -33,7 +30,6 @@ export default class extends Component {
       isCollapsed: true,
       flyoutIsCollapsed: true,
       flyoutIsAnimating: false,
-      hasDelay: true,
       navFlyoutTitle: undefined,
       navFlyoutContent: [],
     };
@@ -45,13 +41,13 @@ export default class extends Component {
         size: 's',
         style: { color: 'inherit' },
         'aria-label': 'Recently viewed items',
-        onClick: () => this.expandFlyout('recents', 'Recent items'),
+        onClick: () => this.expandFlyout(this.recentLinks, 'Recent items'),
         extraAction: {
           color: 'subdued',
           iconType: 'arrowRight',
           iconSize: 's',
           'aria-label': 'Expand to view recent apps and objects',
-          onClick: () => this.expandFlyout('recents', 'Recent items'),
+          onClick: () => this.expandFlyout(this.recentLinks, 'Recent items'),
           alwaysShow: true,
         },
       },
@@ -61,19 +57,19 @@ export default class extends Component {
         size: 's',
         style: { color: 'inherit' },
         'aria-label': 'Favorited items',
-        onClick: () => this.expandFlyout('favorites', 'Favorited items'),
+        onClick: () => this.expandFlyout(this.favoriteLinks, 'Favorite items'),
         extraAction: {
           color: 'subdued',
           iconType: 'arrowRight',
           iconSize: 's',
           'aria-label': 'Expand to view favorited apps and objects',
-          onClick: () => this.expandFlyout('favorites', 'Favorited items'),
+          onClick: () => this.expandFlyout(this.favoriteLinks, 'Favorite items'),
           alwaysShow: true,
         },
       },
     ];
 
-    this.bottomLinks = [
+    this.exploreLinks = [
       {
         label: 'Canvas',
         href: '/#/layout/nav-drawer',
@@ -81,21 +77,7 @@ export default class extends Component {
         size: 's',
         style: { color: 'inherit' },
         'aria-label': 'Canvas',
-        extraAction: {
-          color: 'subdued',
-          iconType: 'pinFilled',
-          iconSize: 's',
-          'aria-label': 'Pin to top',
-          alwaysShow: true,
-        },
-      },
-      {
-        label: 'Maps',
-        href: '/#/layout/nav-drawer',
-        iconType: 'gisApp',
-        size: 's',
-        style: { color: 'inherit' },
-        'aria-label': 'Maps',
+        isActive: true,
         extraAction: {
           color: 'subdued',
           iconType: 'pinFilled',
@@ -147,54 +129,12 @@ export default class extends Component {
         },
       },
       {
-        label: 'APM',
-        href: '/#/layout/nav-drawer',
-        iconType: 'apmApp',
-        size: 's',
-        style: { color: 'inherit' },
-        'aria-label': 'APM',
-        extraAction: {
-          color: 'subdued',
-          iconType: 'pin',
-          iconSize: 's',
-          'aria-label': 'Pin to top',
-        },
-      },
-      {
         label: 'Machine learning',
         href: '/#/layout/nav-drawer',
         iconType: 'machineLearningApp',
         size: 's',
         style: { color: 'inherit' },
         'aria-label': 'Machine learning',
-        extraAction: {
-          color: 'subdued',
-          iconType: 'pin',
-          iconSize: 's',
-          'aria-label': 'Pin to top',
-        },
-      },
-      {
-        label: 'Infra ops',
-        href: '/#/layout/nav-drawer',
-        iconType: 'infraApp',
-        size: 's',
-        style: { color: 'inherit' },
-        'aria-label': 'Infra',
-        extraAction: {
-          color: 'subdued',
-          iconType: 'pin',
-          iconSize: 's',
-          'aria-label': 'Pin to top',
-        },
-      },
-      {
-        label: 'Logs',
-        href: '/#/layout/nav-drawer',
-        iconType: 'loggingApp',
-        size: 's',
-        style: { color: 'inherit' },
-        'aria-label': 'Logs',
         extraAction: {
           color: 'subdued',
           iconType: 'pin',
@@ -215,7 +155,116 @@ export default class extends Component {
           iconSize: 's',
           'aria-label': 'Pin to top',
         },
+      }
+    ];
+
+    this.solutionsLinks = [
+      {
+        label: 'APM',
+        href: '/#/layout/nav-drawer',
+        iconType: 'apmApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'APM',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pin',
+          iconSize: 's',
+          'aria-label': 'Pin to top',
+        },
       },
+      {
+        label: 'Infrastructure',
+        href: '/#/layout/nav-drawer',
+        iconType: 'infraApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Infra',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pin',
+          iconSize: 's',
+          'aria-label': 'Pin to top',
+        },
+      },
+      {
+        label: 'Log viewer',
+        href: '/#/layout/nav-drawer',
+        iconType: 'loggingApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Logs',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pin',
+          iconSize: 's',
+          'aria-label': 'Pin to top',
+        },
+      },
+      {
+        label: 'Uptime',
+        href: '/#/layout/nav-drawer',
+        iconType: 'upgradeAssistantApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Graph',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pin',
+          iconSize: 's',
+          'aria-label': 'Pin to top',
+        },
+      },
+      {
+        label: 'Maps',
+        href: '/#/layout/nav-drawer',
+        iconType: 'gisApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Maps',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pin',
+          iconSize: 's',
+          'aria-label': 'Pin to top',
+        },
+      },
+      {
+        label: 'SIEM',
+        href: '/#/layout/nav-drawer',
+        iconType: 'securityAnalyticsApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'SIEM',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'pin',
+          iconSize: 's',
+          'aria-label': 'Pin to top',
+        },
+      }
+    ];
+
+    this.adminLinks = [
+      {
+        label: 'Admin',
+        iconType: 'managementApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'Admin',
+        onClick: () => this.expandFlyout(this.adminSubLinks, 'Tools and settings'),
+        extraAction: {
+          color: 'subdued',
+          iconType: 'arrowRight',
+          iconSize: 's',
+          'aria-label': 'Pin to top',
+          alwaysShow: true,
+          onClick: () => this.expandFlyout(this.adminSubLinks, 'Tools and settings'),
+        },
+      },
+    ];
+
+    this.adminSubLinks = [
       {
         label: 'Dev tools',
         href: '/#/layout/nav-drawer',
@@ -225,13 +274,13 @@ export default class extends Component {
         'aria-label': 'Dev tools',
         extraAction: {
           color: 'subdued',
-          iconType: 'pin',
+          iconType: 'starEmpty',
           iconSize: 's',
-          'aria-label': 'Pin to top',
+          'aria-label': 'Add to favorites',
         },
       },
       {
-        label: 'Monitoring',
+        label: 'Stack Monitoring',
         href: '/#/layout/nav-drawer',
         iconType: 'monitoringApp',
         size: 's',
@@ -239,13 +288,13 @@ export default class extends Component {
         'aria-label': 'Monitoring',
         extraAction: {
           color: 'subdued',
-          iconType: 'pin',
+          iconType: 'starEmpty',
           iconSize: 's',
-          'aria-label': 'Pin to top',
+          'aria-label': 'Add to favorites',
         },
       },
       {
-        label: 'Management',
+        label: 'Stack Management',
         href: '/#/layout/nav-drawer',
         iconType: 'managementApp',
         size: 's',
@@ -253,9 +302,9 @@ export default class extends Component {
         'aria-label': 'Management',
         extraAction: {
           color: 'subdued',
-          iconType: 'pin',
+          iconType: 'starEmpty',
           iconSize: 's',
-          'aria-label': 'Pin to top',
+          'aria-label': 'Add to favorites',
         },
       },
     ];
@@ -340,12 +389,14 @@ export default class extends Component {
   }
 
   renderLogo() {
-    return <EuiHeaderLogo iconType="logoKibana" href="#" aria-label="Go to home page" />;
+    return (
+      <EuiHeaderSectionItemButton
+        aria-label="Go to home page"
+      >
+        <EuiIcon type="logoKibana" href="#" size="l" />
+      </EuiHeaderSectionItemButton>
+    );
   }
-
-  toggleHasDelay = () => {
-    this.setState(prevState => ({ hasDelay: !prevState.hasDelay }));
-  };
 
   expandDrawer = () => {
     this.setState({ isCollapsed: false });
@@ -362,14 +413,14 @@ export default class extends Component {
     }, 350);
   };
 
-  expandFlyout = (id, title) => {
-    const content = (id === 'recents') ? this.recentLinks : this.favoriteLinks;
+  expandFlyout = (links, title) => {
+    const content = links;
 
     this.setState({
       flyoutIsCollapsed: false,
       flyoutIsAnimating: true,
       navFlyoutTitle: title,
-      navFlyoutContent: content,
+      navFlyoutContent: content
     });
   };
 
@@ -386,25 +437,12 @@ export default class extends Component {
       isCollapsed,
       flyoutIsCollapsed,
       flyoutIsAnimating,
-      hasDelay,
       navFlyoutTitle,
       navFlyoutContent,
     } = this.state;
 
     return (
       <Fragment>
-        <EuiFlexGroup alignItems="center">
-          <EuiFlexItem grow={false}>
-            <EuiSwitch
-              label={<span>Show with hover delay</span>}
-              checked={this.state.hasDelay}
-              onChange={this.toggleHasDelay}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-
-        <EuiSpacer size="l" />
-
         <div style={{ position: 'relative' }}>
           <EuiHeader>
             <EuiHeaderSection grow={false}>
@@ -413,7 +451,6 @@ export default class extends Component {
           </EuiHeader>
           <EuiNavDrawer
             isCollapsed={isCollapsed}
-            hasDelay={hasDelay}
             flyoutIsCollapsed={flyoutIsCollapsed}
             flyoutIsAnimating={flyoutIsAnimating}
             onMouseOver={this.expandDrawer}
@@ -423,8 +460,12 @@ export default class extends Component {
           >
             <EuiNavDrawerMenu>
               <EuiListGroup listItems={this.topLinks} />
-              <EuiHorizontalRule margin="s" />
-              <EuiListGroup listItems={this.bottomLinks} />
+              <EuiHorizontalRule margin="none" />
+              <EuiListGroup listItems={this.exploreLinks} />
+              <EuiHorizontalRule margin="none" />
+              <EuiListGroup listItems={this.solutionsLinks} />
+              <EuiHorizontalRule margin="none" />
+              <EuiListGroup listItems={this.adminLinks} />
             </EuiNavDrawerMenu>
             <EuiNavDrawerFlyout
               title={navFlyoutTitle}

--- a/src-docs/src/views/nav_drawer/nav_drawer.js
+++ b/src-docs/src/views/nav_drawer/nav_drawer.js
@@ -479,7 +479,7 @@ export default class extends Component {
       this.setState({
         outsideClickDisaled: this.state.mobileIsHidden ? true : false,
       });
-    }, 0);
+    }, 150);
   };
 
   expandDrawer = () => {

--- a/src-docs/src/views/nav_drawer/nav_drawer.js
+++ b/src-docs/src/views/nav_drawer/nav_drawer.js
@@ -23,6 +23,7 @@ import {
   EuiHorizontalRule,
   EuiShowFor,
   EuiHideFor,
+  EuiOutsideClickDetector,
 } from '../../../../src/components';
 
 import HeaderUserMenu from '../header/header_user_menu';
@@ -40,6 +41,7 @@ export default class extends Component {
       navFlyoutContent: [],
       mobileIsHidden: true,
       showScrollbar: false,
+      outsideClickDisaled: true,
     };
 
     this.topLinks = [
@@ -469,6 +471,12 @@ export default class extends Component {
     this.setState({
       mobileIsHidden: !this.state.mobileIsHidden
     });
+
+    setTimeout(() => {
+      this.setState({
+        outsideClickDisaled: this.state.mobileIsHidden ? true : false,
+      });
+    }, 150);
   };
 
   expandDrawer = () => {
@@ -492,6 +500,7 @@ export default class extends Component {
         flyoutIsCollapsed: true,
         mobileIsHidden: true,
         showScrollbar: false,
+        outsideClickDisaled: true,
       });
     }, 350);
   };
@@ -527,6 +536,7 @@ export default class extends Component {
       navFlyoutContent,
       mobileIsHidden,
       showScrollbar,
+      outsideClickDisaled,
     } = this.state;
 
     return (
@@ -553,33 +563,38 @@ export default class extends Component {
               </EuiHeaderSectionItem>
             </EuiHeaderSection>
           </EuiHeader>
-          <EuiNavDrawer
-            isCollapsed={isCollapsed}
-            flyoutIsCollapsed={flyoutIsCollapsed}
-            flyoutIsAnimating={flyoutIsAnimating}
-            onMouseOver={this.expandDrawer}
-            onFocus={this.expandDrawer}
-            onMouseLeave={this.collapseDrawer}
-            mobileIsHidden={mobileIsHidden}
-            showScrollbar={showScrollbar}
-            style={{ position: 'absolute' }} // This is for the embedded docs example only
+          <EuiOutsideClickDetector
+            onOutsideClick={() => this.collapseDrawer()}
+            isDisabled={outsideClickDisaled}
           >
-            <EuiNavDrawerMenu>
-              <EuiListGroup listItems={this.topLinks} />
-              <EuiHorizontalRule margin="none" />
-              <EuiListGroup listItems={this.exploreLinks} />
-              <EuiHorizontalRule margin="none" />
-              <EuiListGroup listItems={this.solutionsLinks} />
-              <EuiHorizontalRule margin="none" />
-              <EuiListGroup listItems={this.adminLinks} />
-            </EuiNavDrawerMenu>
-            <EuiNavDrawerFlyout
-              title={navFlyoutTitle}
-              isCollapsed={flyoutIsCollapsed}
-              listItems={navFlyoutContent}
-              onMouseLeave={this.collapseFlyout}
-            />
-          </EuiNavDrawer>
+            <EuiNavDrawer
+              isCollapsed={isCollapsed}
+              flyoutIsCollapsed={flyoutIsCollapsed}
+              flyoutIsAnimating={flyoutIsAnimating}
+              onMouseOver={this.expandDrawer}
+              onFocus={this.expandDrawer}
+              onMouseLeave={this.collapseDrawer}
+              mobileIsHidden={mobileIsHidden}
+              showScrollbar={showScrollbar}
+              style={{ position: 'absolute' }} // This is for the embedded docs example only
+            >
+              <EuiNavDrawerMenu>
+                <EuiListGroup listItems={this.topLinks} />
+                <EuiHorizontalRule margin="none" />
+                <EuiListGroup listItems={this.exploreLinks} />
+                <EuiHorizontalRule margin="none" />
+                <EuiListGroup listItems={this.solutionsLinks} />
+                <EuiHorizontalRule margin="none" />
+                <EuiListGroup listItems={this.adminLinks} />
+              </EuiNavDrawerMenu>
+              <EuiNavDrawerFlyout
+                title={navFlyoutTitle}
+                isCollapsed={flyoutIsCollapsed}
+                listItems={navFlyoutContent}
+                onMouseLeave={this.collapseFlyout}
+              />
+            </EuiNavDrawer>
+          </EuiOutsideClickDetector>
           <EuiPage style={{ minHeight: '600px' }}>
             <EuiPageBody style={{ marginLeft: '64px' }}>
               <EuiHideFor sizes={['xs', 's']}>

--- a/src-docs/src/views/nav_drawer/nav_drawer.js
+++ b/src-docs/src/views/nav_drawer/nav_drawer.js
@@ -22,7 +22,7 @@ import {
   EuiListGroup,
   EuiHorizontalRule,
   EuiShowFor,
-  EuiHideFor
+  EuiHideFor,
 } from '../../../../src/components';
 
 import HeaderUserMenu from '../header/header_user_menu';
@@ -535,10 +535,7 @@ export default class extends Component {
           <EuiHeader>
             <EuiHeaderSection grow={false}>
               <EuiShowFor sizes={['xs', 's']}>
-                <EuiHeaderSectionItem
-                  className="euiNavDrawer-mobileIsHidden"
-                  border="right"
-                >
+                <EuiHeaderSectionItem border="right">
                   {this.renderMenuTrigger()}
                 </EuiHeaderSectionItem>
               </EuiShowFor>
@@ -583,7 +580,7 @@ export default class extends Component {
               onMouseLeave={this.collapseFlyout}
             />
           </EuiNavDrawer>
-          <EuiPage style={{ minHeight: '400px' }}>
+          <EuiPage style={{ minHeight: '600px' }}>
             <EuiPageBody style={{ marginLeft: '64px' }}>
               <EuiHideFor sizes={['xs', 's']}>
                 <EuiPageHeader>

--- a/src-docs/src/views/nav_drawer/nav_drawer.js
+++ b/src-docs/src/views/nav_drawer/nav_drawer.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 
 import {
   EuiPage,
@@ -19,6 +19,10 @@ import {
   EuiNavDrawerFlyout,
   EuiListGroup,
   EuiHorizontalRule,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiSwitch,
 } from '../../../../src/components';
 
 export default class extends Component {
@@ -28,6 +32,10 @@ export default class extends Component {
     this.state = {
       isCollapsed: true,
       flyoutIsCollapsed: true,
+      flyoutIsAnimating: false,
+      hasDelay: true,
+      navFlyoutTitle: undefined,
+      navFlyoutContent: [],
     };
 
     this.topLinks = [
@@ -37,27 +45,28 @@ export default class extends Component {
         size: 's',
         style: { color: 'inherit' },
         'aria-label': 'Recently viewed items',
-        onClick: this.expandFlyout,
+        onClick: () => this.expandFlyout('recents', 'Recent items'),
         extraAction: {
           color: 'subdued',
           iconType: 'arrowRight',
           iconSize: 's',
           'aria-label': 'Expand to view recent apps and objects',
-          onClick: this.expandFlyout,
+          onClick: () => this.expandFlyout('recents', 'Recent items'),
         },
       },
       {
         label: 'Favorites',
-        href: '/#/layout/nav-drawer',
         iconType: 'starEmpty',
         size: 's',
         style: { color: 'inherit' },
         'aria-label': 'Favorited items',
+        onClick: () => this.expandFlyout('favorites', 'Favorited items'),
         extraAction: {
           color: 'subdued',
           iconType: 'arrowRight',
           iconSize: 's',
           'aria-label': 'Expand to view favorited apps and objects',
+          onClick: () => this.expandFlyout('favorites', 'Favorited items'),
         },
       },
     ];
@@ -305,84 +314,158 @@ export default class extends Component {
         },
       },
     ];
+
+    this.favoriteLinks = [
+      {
+        label: 'My workpad',
+        href: '/#/layout/nav-drawer',
+        iconType: 'canvasApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'My workpad',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'starEmpty',
+          iconSize: 's',
+          'aria-label': 'Add to favorites',
+        },
+      },
+      {
+        label: 'My logs',
+        href: '/#/layout/nav-drawer',
+        iconType: 'loggingApp',
+        size: 's',
+        style: { color: 'inherit' },
+        'aria-label': 'My logs',
+        extraAction: {
+          color: 'subdued',
+          iconType: 'starEmpty',
+          iconSize: 's',
+          'aria-label': 'Add to favorites',
+        },
+      },
+    ];
   }
 
   renderLogo() {
     return <EuiHeaderLogo iconType="logoKibana" href="#" aria-label="Go to home page" />;
   }
 
+  toggleHasDelay = () => {
+    this.setState(prevState => ({ hasDelay: !prevState.hasDelay }));
+  };
+
   expandDrawer = () => {
     this.setState({ isCollapsed: false });
   };
 
   collapseDrawer = () => {
-    this.setState({ isCollapsed: true });
+    this.setState({ flyoutIsAnimating: false });
+
+    setTimeout(() => {
+      this.setState({
+        isCollapsed: true,
+        flyoutIsCollapsed: true,
+      });
+    }, 350);
   };
 
-  expandFlyout = () => {
-    this.setState({ flyoutIsCollapsed: false });
+  expandFlyout = (id, title) => {
+    const content = (id === 'recents') ? this.recentLinks : this.favoriteLinks;
+
+    this.setState({
+      flyoutIsCollapsed: false,
+      flyoutIsAnimating: true,
+      navFlyoutTitle: title,
+      navFlyoutContent: content,
+    });
   };
 
   collapseFlyout = () => {
-    this.setState({ flyoutIsCollapsed: true });
+    this.setState({ flyoutIsAnimating: true });
+
+    setTimeout(() => {
+      this.setState({ flyoutIsCollapsed: true });
+    }, 250);
   };
 
   render() {
     const {
       isCollapsed,
       flyoutIsCollapsed,
+      flyoutIsAnimating,
+      hasDelay,
+      navFlyoutTitle,
+      navFlyoutContent,
     } = this.state;
 
     return (
-      <div>
-        <EuiHeader>
-          <EuiHeaderSection grow={false}>
-            <EuiHeaderSectionItem border="right">{this.renderLogo()}</EuiHeaderSectionItem>
-          </EuiHeaderSection>
-        </EuiHeader>
-        <EuiPage style={{ position: 'relative', minHeight: '800px' }}>
-          <EuiNavDrawer
-            isCollapsed={isCollapsed}
-            flyoutIsCollapsed={flyoutIsCollapsed}
-            onMouseOver={this.expandDrawer}
-            onMouseLeave={this.collapseDrawer}
-          >
-            <EuiNavDrawerMenu>
-              <EuiListGroup listItems={this.topLinks} />
-              <EuiHorizontalRule margin="s" />
-              <EuiListGroup listItems={this.bottomLinks} />
-            </EuiNavDrawerMenu>
-            <EuiNavDrawerFlyout
-              title="Recently viewed"
-              isCollapsed={flyoutIsCollapsed}
-              listItems={this.recentLinks}
-              onMouseLeave={this.collapseFlyout}
+      <Fragment>
+        <EuiFlexGroup alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiSwitch
+              label={<span>Show with hover delay</span>}
+              checked={this.state.hasDelay}
+              onChange={this.toggleHasDelay}
             />
-          </EuiNavDrawer>
+          </EuiFlexItem>
+        </EuiFlexGroup>
 
-          <EuiPageBody style={{ marginLeft: '64px' }}>
-            <EuiPageHeader>
-              <EuiPageHeaderSection>
-                <EuiTitle size="l">
-                  <h1>Page title</h1>
-                </EuiTitle>
-              </EuiPageHeaderSection>
-            </EuiPageHeader>
-            <EuiPageContent>
-              <EuiPageContentHeader>
-                <EuiPageContentHeaderSection>
-                  <EuiTitle>
-                    <h2>Content title</h2>
+        <EuiSpacer size="l" />
+
+        <div>
+          <EuiHeader>
+            <EuiHeaderSection grow={false}>
+              <EuiHeaderSectionItem border="right">{this.renderLogo()}</EuiHeaderSectionItem>
+            </EuiHeaderSection>
+          </EuiHeader>
+          <EuiPage style={{ position: 'relative', minHeight: '800px' }}>
+            <EuiNavDrawer
+              isCollapsed={isCollapsed}
+              hasDelay={hasDelay}
+              flyoutIsCollapsed={flyoutIsCollapsed}
+              flyoutIsAnimating={flyoutIsAnimating}
+              onMouseOver={this.expandDrawer}
+              onFocus={this.expandDrawer}
+              onMouseLeave={this.collapseDrawer}
+            >
+              <EuiNavDrawerMenu>
+                <EuiListGroup listItems={this.topLinks} />
+                <EuiHorizontalRule margin="s" />
+                <EuiListGroup listItems={this.bottomLinks} />
+              </EuiNavDrawerMenu>
+              <EuiNavDrawerFlyout
+                title={navFlyoutTitle}
+                isCollapsed={flyoutIsCollapsed}
+                listItems={navFlyoutContent}
+                onMouseLeave={this.collapseFlyout}
+              />
+            </EuiNavDrawer>
+
+            <EuiPageBody style={{ marginLeft: '64px' }}>
+              <EuiPageHeader>
+                <EuiPageHeaderSection>
+                  <EuiTitle size="l">
+                    <h1>Page title</h1>
                   </EuiTitle>
-                </EuiPageContentHeaderSection>
-              </EuiPageContentHeader>
-              <EuiPageContentBody>
-                Content body
-              </EuiPageContentBody>
-            </EuiPageContent>
-          </EuiPageBody>
-        </EuiPage>
-      </div>
+                </EuiPageHeaderSection>
+              </EuiPageHeader>
+              <EuiPageContent>
+                <EuiPageContentHeader>
+                  <EuiPageContentHeaderSection>
+                    <EuiTitle>
+                      <h2>Content title</h2>
+                    </EuiTitle>
+                  </EuiPageContentHeaderSection>
+                </EuiPageContentHeader>
+                <EuiPageContentBody>
+                  Content body
+                </EuiPageContentBody>
+              </EuiPageContent>
+            </EuiPageBody>
+          </EuiPage>
+        </div>
+      </Fragment>
     );
   }
 }

--- a/src-docs/src/views/nav_drawer/nav_drawer.js
+++ b/src-docs/src/views/nav_drawer/nav_drawer.js
@@ -13,6 +13,7 @@ import {
   EuiHeaderSection,
   EuiHeaderSectionItem,
   EuiHeaderSectionItemButton,
+  EuiHeaderBreadcrumbs,
   EuiIcon,
   EuiTitle,
   EuiNavDrawer,
@@ -23,6 +24,9 @@ import {
   EuiShowFor,
   EuiHideFor
 } from '../../../../src/components';
+
+import HeaderUserMenu from '../header/header_user_menu';
+import HeaderSpacesMenu from '../header/header_spaces_menu';
 
 export default class extends Component {
   constructor(props) {
@@ -412,6 +416,54 @@ export default class extends Component {
     );
   }
 
+  renderBreadcrumbs() {
+    const breadcrumbs = [
+      {
+        text: 'Management',
+        href: '#',
+        onClick: e => {
+          e.preventDefault();
+          console.log('You clicked management');
+        },
+        'data-test-subj': 'breadcrumbsAnimals',
+        className: 'customClass'
+      },
+      {
+        text: 'Truncation test is here for a really long item',
+        href: '#',
+        onClick: e => {
+          e.preventDefault();
+          console.log('You clicked truncation test');
+        }
+      },
+      {
+        text: 'hidden',
+        href: '#',
+        onClick: e => {
+          e.preventDefault();
+          console.log('You clicked hidden');
+        }
+      },
+      {
+        text: 'Users',
+        href: '#',
+        onClick: e => {
+          e.preventDefault();
+          console.log('You clicked users');
+        }
+      },
+      {
+        text: 'Create'
+      }
+    ];
+
+    return (
+      <EuiHeaderBreadcrumbs
+        breadcrumbs={breadcrumbs}
+      />
+    );
+  }
+
   toggleOpen = () => {
     this.setState({
       mobileIsHidden: !this.state.mobileIsHidden
@@ -480,6 +532,17 @@ export default class extends Component {
                 </EuiHeaderSectionItem>
               </EuiShowFor>
               <EuiHeaderSectionItem border="right">{this.renderLogo()}</EuiHeaderSectionItem>
+              <EuiHeaderSectionItem border="right">
+                <HeaderSpacesMenu />
+              </EuiHeaderSectionItem>
+            </EuiHeaderSection>
+
+            {this.renderBreadcrumbs()}
+
+            <EuiHeaderSection side="right">
+              <EuiHeaderSectionItem>
+                <HeaderUserMenu />
+              </EuiHeaderSectionItem>
             </EuiHeaderSection>
           </EuiHeader>
           <EuiNavDrawer

--- a/src-docs/src/views/nav_drawer/nav_drawer.js
+++ b/src-docs/src/views/nav_drawer/nav_drawer.js
@@ -20,6 +20,7 @@ import {
   EuiNavDrawerFlyout,
   EuiListGroup,
   EuiHorizontalRule,
+  EuiShowFor,
 } from '../../../../src/components';
 
 export default class extends Component {
@@ -32,6 +33,7 @@ export default class extends Component {
       flyoutIsAnimating: false,
       navFlyoutTitle: undefined,
       navFlyoutContent: [],
+      mobileIsHidden: true,
     };
 
     this.topLinks = [
@@ -398,6 +400,23 @@ export default class extends Component {
     );
   }
 
+  renderMenuTrigger() {
+    return (
+      <EuiHeaderSectionItemButton
+        aria-label="Open nav"
+        onClick={this.toggleOpen}
+      >
+        <EuiIcon type="apps" href="#" size="m" />
+      </EuiHeaderSectionItemButton>
+    );
+  }
+
+  toggleOpen = () => {
+    this.setState({
+      mobileIsHidden: !this.state.mobileIsHidden
+    });
+  };
+
   expandDrawer = () => {
     this.setState({ isCollapsed: false });
   };
@@ -409,6 +428,7 @@ export default class extends Component {
       this.setState({
         isCollapsed: true,
         flyoutIsCollapsed: true,
+        mobileIsHidden: true,
       });
     }, 350);
   };
@@ -416,8 +436,11 @@ export default class extends Component {
   expandFlyout = (links, title) => {
     const content = links;
 
+    this.setState(prevState => ({
+      flyoutIsCollapsed: prevState.navFlyoutTitle === title ? !this.state.flyoutIsCollapsed : false,
+    }));
+
     this.setState({
-      flyoutIsCollapsed: false,
       flyoutIsAnimating: true,
       navFlyoutTitle: title,
       navFlyoutContent: content
@@ -439,6 +462,7 @@ export default class extends Component {
       flyoutIsAnimating,
       navFlyoutTitle,
       navFlyoutContent,
+      mobileIsHidden,
     } = this.state;
 
     return (
@@ -446,6 +470,14 @@ export default class extends Component {
         <div style={{ position: 'relative' }}>
           <EuiHeader>
             <EuiHeaderSection grow={false}>
+              <EuiShowFor sizes={['xs', 's']}>
+                <EuiHeaderSectionItem
+                  className="euiNavDrawer-mobileIsHidden"
+                  border="right"
+                >
+                  {this.renderMenuTrigger()}
+                </EuiHeaderSectionItem>
+              </EuiShowFor>
               <EuiHeaderSectionItem border="right">{this.renderLogo()}</EuiHeaderSectionItem>
             </EuiHeaderSection>
           </EuiHeader>
@@ -456,6 +488,7 @@ export default class extends Component {
             onMouseOver={this.expandDrawer}
             onFocus={this.expandDrawer}
             onMouseLeave={this.collapseDrawer}
+            mobileIsHidden={mobileIsHidden}
             style={{ position: 'absolute' }} // This is for the embedded docs example only
           >
             <EuiNavDrawerMenu>

--- a/src-docs/src/views/nav_drawer/nav_drawer_example.js
+++ b/src-docs/src/views/nav_drawer/nav_drawer_example.js
@@ -8,6 +8,7 @@ import {
 
 import {
   EuiNavDrawer,
+  EuiCode,
 } from '../../../../src/components';
 
 import NavDrawer from './nav_drawer';
@@ -26,7 +27,10 @@ export const NavDrawerExample = {
     }],
     text: (
       <p>
-        The nav drawer is made up of several individual components.
+        <EuiCode>EuiNavDrawer</EuiCode> provides a side navigation feature that
+        is complete with interactions and a mobile-frienly design. It can
+        contain one or more <EuiCode>EuiListGroup</EuiCode> components and is
+        designed to be used in conjunction with <EuiCode>EuiHeader</EuiCode>.
       </p>
     ),
     props: {

--- a/src-docs/src/views/nav_drawer/nav_drawer_example.js
+++ b/src-docs/src/views/nav_drawer/nav_drawer_example.js
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import { renderToHtml } from '../../services';
+
+import {
+  GuideSectionTypes,
+} from '../../components';
+
+import {
+  EuiNavDrawer,
+} from '../../../../src/components';
+
+import NavDrawer from './nav_drawer';
+const navDrawerSource = require('!!raw-loader!./nav_drawer');
+const navDrawerHtml = renderToHtml(NavDrawer);
+
+export const NavDrawerExample = {
+  title: 'Nav Drawer',
+  sections: [{
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: navDrawerSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: navDrawerHtml,
+    }],
+    text: (
+      <p>
+        The nav drawer is made up of several individual components.
+      </p>
+    ),
+    props: {
+      EuiNavDrawer,
+    },
+    demo: <NavDrawer />,
+  }]
+};

--- a/src/components/header/__snapshots__/header_logo.test.js.snap
+++ b/src/components/header/__snapshots__/header_logo.test.js.snap
@@ -7,7 +7,7 @@ exports[`EuiHeaderLogo is rendered 1`] = `
   data-test-subj="test subject string"
 >
   <svg
-    class="euiIcon euiIcon--xLarge euiHeaderLogo__icon"
+    class="euiIcon euiIcon--large euiHeaderLogo__icon"
     focusable="false"
     height="32"
     title="Elastic"
@@ -53,7 +53,7 @@ exports[`EuiHeaderLogo renders href 1`] = `
   href="#"
 >
   <svg
-    class="euiIcon euiIcon--xLarge euiHeaderLogo__icon"
+    class="euiIcon euiIcon--large euiHeaderLogo__icon"
     focusable="false"
     height="32"
     title="Elastic"
@@ -99,7 +99,7 @@ exports[`EuiHeaderLogo renders optional props 1`] = `
   style="color:red"
 >
   <svg
-    class="euiIcon euiIcon--xLarge euiHeaderLogo__icon"
+    class="euiIcon euiIcon--large euiHeaderLogo__icon"
     focusable="false"
     height="16"
     title="Moby Dick"

--- a/src/components/header/_index.scss
+++ b/src/components/header/_index.scss
@@ -1,11 +1,6 @@
-// Themable colors
-$euiHeaderBackgroundColor: $euiColorEmptyShade;
-$euiHeaderBreadcrumbColor: $euiColorDarkestShade;
-
-// Layout vars
-$euiHeaderChildSize: $euiSizeXXL + $euiSizeS;
-
 // Components
+@import '../header/variables';
+@import 'variables';
 @import 'header';
 @import 'header_profile';
 @import 'header_links/index';

--- a/src/components/header/_index.scss
+++ b/src/components/header/_index.scss
@@ -3,7 +3,7 @@ $euiHeaderBackgroundColor: $euiColorEmptyShade;
 $euiHeaderBreadcrumbColor: $euiColorDarkestShade;
 
 // Layout vars
-$euiHeaderChildSize: $euiSizeXXL + $euiSizeL;
+$euiHeaderChildSize: $euiSizeXXL + $euiSizeS;
 
 // Components
 @import 'header';

--- a/src/components/header/_variables.scss
+++ b/src/components/header/_variables.scss
@@ -5,3 +5,4 @@ $euiHeaderBreadcrumbColor: $euiColorDarkestShade;
 
 // Layout vars
 $euiHeaderChildSize: $euiSizeXXL + $euiSizeS;
+$euiHeaderChildSizeMobile: $euiHeaderChildSize * .75;

--- a/src/components/header/_variables.scss
+++ b/src/components/header/_variables.scss
@@ -1,0 +1,7 @@
+// Note - these are also used by the EuiNavDrawer (/nav_drawer) component
+// Themable colors
+$euiHeaderBackgroundColor: $euiColorEmptyShade;
+$euiHeaderBreadcrumbColor: $euiColorDarkestShade;
+
+// Layout vars
+$euiHeaderChildSize: $euiSizeXXL + $euiSizeS;

--- a/src/components/header/header_logo.js
+++ b/src/components/header/header_logo.js
@@ -13,7 +13,7 @@ export const EuiHeaderLogo = ({ iconType, iconTitle, href, children, className, 
     <a href={href} className={classes} {...rest}>
       <EuiIcon
         className="euiHeaderLogo__icon"
-        size="xl"
+        size="l"
         type={iconType}
         title={iconTitle}
       />

--- a/src/components/header/header_section/_header_section_item.scss
+++ b/src/components/header/header_section/_header_section_item.scss
@@ -19,7 +19,7 @@
 
 .euiHeaderSectionItem__button {
   height: $euiHeaderChildSize;
-  min-width: $euiHeaderChildSize;
+  min-width: $euiHeaderChildSize + 1px;
   text-align: center;
   font-size: 0; // aligns icons better vertically
 

--- a/src/components/header/header_section/_header_section_item.scss
+++ b/src/components/header/header_section/_header_section_item.scss
@@ -45,8 +45,8 @@
 
 .euiHeaderNotification {
   position: absolute;
-  top: 18%;
-  right: 18%;
+  top: 9%;
+  right: 9%;
   box-shadow: 0 0 0 1px $euiHeaderBackgroundColor;
 }
 

--- a/src/components/header/header_section/_header_section_item.scss
+++ b/src/components/header/header_section/_header_section_item.scss
@@ -53,8 +53,8 @@
 @include euiBreakpoint('xs') {
   .euiHeaderSectionItem,
   .euiHeaderSectionItem__button {
-    height: $euiHeaderChildSize * .75;
-    min-width: $euiHeaderChildSize * .75;
+    height: $euiHeaderChildSizeMobile;
+    min-width: $euiHeaderChildSizeMobile;
   }
 
   .euiHeaderSectionItem--borderLeft,

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -218,6 +218,10 @@ export {
 } from './mutation_observer';
 
 export {
+  EuiNavDrawer,
+} from './nav_drawer';
+
+export {
   EuiOutsideClickDetector,
 } from './outside_click_detector';
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -219,6 +219,8 @@ export {
 
 export {
   EuiNavDrawer,
+  EuiNavDrawerMenu,
+  EuiNavDrawerFlyout,
 } from './nav_drawer';
 
 export {

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -36,6 +36,7 @@
 @import 'list_group/index';
 @import 'loading/index';
 @import 'modal/index';
+@import 'nav_drawer/index';
 @import 'overlay_mask/index';
 @import 'page/index';
 @import 'pagination/index';

--- a/src/components/list_group/_list_group_item.scss
+++ b/src/components/list_group/_list_group_item.scss
@@ -41,7 +41,7 @@
   padding: $euiSizeM $euiSizeS;
   display: flex;
   align-items: center;
-  flex-grow: 1;
+  flex: 1 0 auto; // The flex-shrink and flex-basis values are needed for IE11
   text-align: left;
 }
 

--- a/src/components/list_group/_list_group_item.scss
+++ b/src/components/list_group/_list_group_item.scss
@@ -6,6 +6,7 @@
   display: flex;
   align-items: center;
   transition: background-color $euiAnimSpeedFast;
+  position: relative;
 
   &:first-child {
     margin-top: 0;

--- a/src/components/nav_drawer/_index.scss
+++ b/src/components/nav_drawer/_index.scss
@@ -1,5 +1,6 @@
-// Themable colors
-$euiNavDrawerBackgroundColor: $euiColorEmptyShade;
+@import 'variables';
 
 // Components
 @import 'nav_drawer';
+@import 'nav_drawer_menu';
+@import 'nav_drawer_flyout';

--- a/src/components/nav_drawer/_index.scss
+++ b/src/components/nav_drawer/_index.scss
@@ -1,0 +1,5 @@
+// Themable colors
+$euiNavDrawerBackgroundColor: $euiColorEmptyShade;
+
+// Components
+@import 'nav_drawer';

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -1,13 +1,13 @@
 // Nav drawer. Global application navigation.
 
 .euiNavDrawer {
+  @include euiScrollBar;
   width: $euiNavDrawerWidthCollapsed;
   height: calc(100% - #{$euiHeaderSize});
   position: fixed;
   left: 0;
   top: $euiHeaderSize;
-  overflow-x: hidden;
-  overflow-y: scroll;
+  overflow: hidden;
   z-index: $euiZHeader;
   background: $euiHeaderBackgroundColor;
   box-shadow: $euiNavDrawerSideShadow;
@@ -20,6 +20,7 @@
   &.euiNavDrawer-isExpanded {
     width: $euiNavDrawerWidthExpanded;
     transition-delay: $euiNavDrawerExpandingDelay;
+    overflow-y: auto;
 
     .euiNavDrawerMenu .euiListGroupItem__label {
       opacity: 1;

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -1,11 +1,7 @@
 // Nav drawer. Global application navigation.
 
-$euiNavDrawerWidthExpanded: 240px;
-$euiNavDrawerWidthCollapsed: 48px;
-$euiNavDrawerSideShadow: 2px 0 2px -1px rgba($euiShadowColor, .3);
-
 .euiNavDrawer {
-  width: $euiNavDrawerWidthExpanded;
+  width: $euiNavDrawerWidthCollapsed;
   height: 100%;
   position: absolute;
   left: 0;
@@ -15,21 +11,35 @@ $euiNavDrawerSideShadow: 2px 0 2px -1px rgba($euiShadowColor, .3);
   box-shadow: $euiNavDrawerSideShadow;
 
   &.euiNavDrawer-isCollapsed {
-    width: $euiNavDrawerWidthCollapsed;
     transition: width $euiAnimSpeedFast ease-in;
-  }
 
-  &.euiNavDrawer-isExpanded {
-    transition: width $euiAnimSpeedNormal ease-out 1.8s; // Delays the expanded view
-
-    .euiListGroupItem__label,
-    .euiListGroupItem__extraAction {
-      visibility: visible;
+    &.euiNavDrawer-flyoutIsExpanded {
+      width: $euiNavDrawerWidthCollapsed + $euiNavDrawerWidthExpanded;
     }
   }
 
-  .euiListGroupItem__label,
-  .euiListGroupItem__extraAction {
+  &.euiNavDrawer-isExpanded {
+    width: $euiNavDrawerWidthExpanded;
+    transition: width $euiAnimSpeedNormal ease-out;
+    // transition: width $euiAnimSpeedNormal ease-out 1.8s; // TODO Delays the expanded view
+
+    .euiNavDrawerMenu .euiListGroupItem__label,
+    .euiNavDrawerMenu .euiListGroupItem__extraAction {
+      visibility: visible;
+    }
+
+    &.euiNavDrawer-flyoutIsExpanded {
+      width: $euiNavDrawerWidthExpanded * 2;
+      // transition-delay: 0s; // TODO works with delay
+    }
+
+    // &.euiNavDrawer-flyoutIsCollapsed {
+    //   transition-delay: 0s; // TODO this fixes the delay when flyout collapses, but breaks the delay when menu expands
+    // }
+  }
+
+  .euiNavDrawerMenu .euiListGroupItem__label,
+  .euiNavDrawerMenu .euiListGroupItem__extraAction {
     visibility: hidden;
     white-space: nowrap;
   }

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -2,10 +2,10 @@
 
 .euiNavDrawer {
   width: $euiNavDrawerWidthCollapsed;
-  height: calc(100% - #{$euiHeaderSize});
+  height: calc(100% - #{$euiNavDrawerTopPosition});
   position: fixed;
   left: 0;
-  top: $euiHeaderSize;
+  top: $euiNavDrawerTopPosition;
   overflow: hidden;
   z-index: $euiZHeader;
   background: $euiHeaderBackgroundColor;
@@ -71,6 +71,7 @@
     &.euiNavDrawer-flyoutIsExpanded {
       .euiNavDrawerMenu {
         width: $euiNavDrawerWidthCollapsed;
+        overflow-y: hidden;
       }
 
       .euiNavDrawerMenu .euiListGroupItem__label {
@@ -92,7 +93,7 @@
 
 @include euiBreakpoint('xs') {
   .euiNavDrawer {
-    height: calc(100% - #{$euiHeaderSizeMobile});
-    top: $euiHeaderSizeMobile;
+    height: calc(100% - #{$euiNavDrawerTopPositionMobile});
+    top: $euiNavDrawerTopPositionMobile;
   }
 }

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -8,7 +8,7 @@
   top: $euiHeaderSize;
   overflow-x: hidden;
   overflow-y: scroll;
-  z-index: $euiZHeader - 1;
+  z-index: $euiZHeader;
   background: $euiHeaderBackgroundColor;
   box-shadow: $euiNavDrawerSideShadow;
   transition: width $euiAnimSpeedFast $euiAnimSlightResistance;

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -20,7 +20,6 @@
   &.euiNavDrawer-isExpanded {
     width: $euiNavDrawerWidthExpanded;
     transition-delay: $euiNavDrawerExpandingDelay;
-    overflow-y: auto;
 
     .euiNavDrawerMenu .euiListGroupItem__label {
       opacity: 1;
@@ -45,6 +44,10 @@
     transition-delay: (
       $euiNavDrawerContractingDelay + $euiNavDrawerMenuAddedDelay
     );
+  }
+
+  &.euiNavDrawer-showScrollbar {
+    overflow-y: auto;
   }
 }
 

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -8,16 +8,11 @@
   top: $euiHeaderSize;
   overflow-x: hidden;
   overflow-y: scroll;
+  z-index: $euiZHeader - 1;
   background: $euiHeaderBackgroundColor;
   box-shadow: $euiNavDrawerSideShadow;
   transition: width $euiAnimSpeedFast $euiAnimSlightResistance;
   transition-delay: $euiNavDrawerContractingDelay;
-
-  &.euiNavDrawer-isCollapsed {
-    &.euiNavDrawer-flyoutIsExpanded {
-      width: $euiNavDrawerWidthCollapsed + $euiNavDrawerWidthExpanded;
-    }
-  }
 
   &.euiNavDrawer-isExpanded {
     width: $euiNavDrawerWidthExpanded;
@@ -46,5 +41,39 @@
     transition-delay: (
       $euiNavDrawerContractingDelay + $euiNavDrawerMenuAddedDelay
     );
+  }
+}
+
+@include euiBreakpoint('xs', 's') {
+  .euiNavDrawer {
+    width: $euiNavDrawerWidthExpanded;
+    height: calc(100% - #{$euiHeaderSizeMobile});
+    top: $euiHeaderSizeMobile;
+
+    &.euiNavDrawer-mobileIsHidden {
+      width: 0;
+    }
+
+    &.euiNavDrawer-isExpanded.euiNavDrawer-flyoutIsExpanded {
+      width: $euiNavDrawerWidthCollapsed + $euiNavDrawerWidthExpanded;
+
+      .euiNavDrawerFlyout {
+        left: $euiNavDrawerWidthCollapsed;
+      }
+    }
+
+    &.euiNavDrawer-flyoutIsExpanded .euiNavDrawerMenu {
+      width: $euiNavDrawerWidthCollapsed;
+    }
+
+    &.euiNavDrawer-flyoutIsCollapsed .euiNavDrawerFlyout {
+      width: 0;
+      transition-delay: 0s;
+      transition-duration: 0s;
+    }
+
+    .euiNavDrawerMenu .euiListGroupItem__label {
+      opacity: 1;
+    }
   }
 }

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -13,9 +13,6 @@
   box-shadow: $euiNavDrawerSideShadow;
   transition: width $euiAnimSpeedFast $euiAnimSlightResistance;
   transition-delay: $euiNavDrawerContractingDelay;
-  // This prevents the scrollbar from overlapping the nav links. Scrollbars still show on hover
-  // sass-lint:disable no-vendor-prefixes
-  -ms-overflow-style: -ms-autohiding-scrollbar;
 
   &.euiNavDrawer-isExpanded {
     width: $euiNavDrawerWidthExpanded;
@@ -46,8 +43,13 @@
     );
   }
 
-  &.euiNavDrawer-showScrollbar {
+  &.euiNavDrawer-showScrollbar .euiNavDrawerMenu,
+  &.euiNavDrawer-showScrollbar .euiNavDrawerFlyout {
+    height: 100%;
     overflow-y: auto;
+    // This prevents the scrollbar from overlapping the nav links. Scrollbars still show on hover
+    // sass-lint:disable no-vendor-prefixes
+    -ms-overflow-style: -ms-autohiding-scrollbar;
   }
 }
 

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -1,7 +1,6 @@
 // Nav drawer. Global application navigation.
 
 .euiNavDrawer {
-  @include euiScrollBar;
   width: $euiNavDrawerWidthCollapsed;
   height: calc(100% - #{$euiHeaderSize});
   position: fixed;

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -6,12 +6,14 @@
   position: fixed;
   left: 0;
   top: $euiHeaderSize;
+  overflow-x: hidden;
+  overflow-y: scroll;
   background: $euiHeaderBackgroundColor;
   box-shadow: $euiNavDrawerSideShadow;
+  transition: width $euiAnimSpeedFast $euiAnimSlightResistance;
+  transition-delay: $euiNavDrawerContractingDelay;
 
   &.euiNavDrawer-isCollapsed {
-    transition: width $euiAnimSpeedExtraFast ease-in;
-
     &.euiNavDrawer-flyoutIsExpanded {
       width: $euiNavDrawerWidthCollapsed + $euiNavDrawerWidthExpanded;
     }
@@ -19,16 +21,13 @@
 
   &.euiNavDrawer-isExpanded {
     width: $euiNavDrawerWidthExpanded;
-    transition: width $euiAnimSpeedFast ease-out;
-
-    &.euiNavDrawer-isDelayed {
-      transition: width $euiAnimSpeedFast ease-out 1.8s; // TODO For prototype alternative
-    }
+    transition-delay: $euiNavDrawerExpandingDelay;
 
     .euiNavDrawerMenu .euiListGroupItem__label {
-      visibility: visible;
       opacity: 1;
-      transition: opacity $euiAnimSpeedExtraFast .2s;
+      transition-delay: (
+        $euiNavDrawerExpandingDelay + $euiNavDrawerMenuAddedDelay
+      );
     }
 
     &.euiNavDrawer-flyoutIsExpanded {
@@ -37,14 +36,15 @@
 
     &.euiNavDrawer-flyoutIsAnimating {
       transition-delay: 0s;
-      transition-property: width;
     }
   }
 
   .euiNavDrawerMenu .euiListGroupItem__label {
-    visibility: hidden;
     white-space: nowrap;
     opacity: 0;
-    transition: opacity $euiAnimSpeedExtraFast;
+    transition: opacity $euiAnimSpeedNormal;
+    transition-delay: (
+      $euiNavDrawerContractingDelay + $euiNavDrawerMenuAddedDelay
+    );
   }
 }

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -25,8 +25,7 @@
       transition: width $euiAnimSpeedFast ease-out 1.8s; // TODO For prototype alternative
     }
 
-    .euiNavDrawerMenu .euiListGroupItem__label,
-    .euiNavDrawerMenu .euiListGroupItem__extraAction {
+    .euiNavDrawerMenu .euiListGroupItem__label {
       visibility: visible;
       opacity: 1;
       transition: opacity $euiAnimSpeedExtraFast .2s;
@@ -42,8 +41,7 @@
     }
   }
 
-  .euiNavDrawerMenu .euiListGroupItem__label,
-  .euiNavDrawerMenu .euiListGroupItem__extraAction {
+  .euiNavDrawerMenu .euiListGroupItem__label {
     visibility: hidden;
     white-space: nowrap;
     opacity: 0;

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -13,6 +13,9 @@
   box-shadow: $euiNavDrawerSideShadow;
   transition: width $euiAnimSpeedFast $euiAnimSlightResistance;
   transition-delay: $euiNavDrawerContractingDelay;
+  // This prevents the scrollbar from overlapping the nav links. Scrollbars still show on hover
+  // sass-lint:disable no-vendor-prefixes
+  -ms-overflow-style: -ms-autohiding-scrollbar;
 
   &.euiNavDrawer-isExpanded {
     width: $euiNavDrawerWidthExpanded;

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -54,8 +54,6 @@
 @include euiBreakpoint('xs', 's') {
   .euiNavDrawer {
     width: $euiNavDrawerWidthExpanded;
-    height: calc(100% - #{$euiHeaderSizeMobile});
-    top: $euiHeaderSizeMobile;
 
     &.euiNavDrawer-mobileIsHidden {
       width: 0;
@@ -69,8 +67,14 @@
       }
     }
 
-    &.euiNavDrawer-flyoutIsExpanded .euiNavDrawerMenu {
-      width: $euiNavDrawerWidthCollapsed;
+    &.euiNavDrawer-flyoutIsExpanded {
+      .euiNavDrawerMenu {
+        width: $euiNavDrawerWidthCollapsed;
+      }
+
+      .euiNavDrawerMenu .euiListGroupItem__label {
+        display: none;
+      }
     }
 
     &.euiNavDrawer-flyoutIsCollapsed .euiNavDrawerFlyout {
@@ -82,5 +86,12 @@
     .euiNavDrawerMenu .euiListGroupItem__label {
       opacity: 1;
     }
+  }
+}
+
+@include euiBreakpoint('xs') {
+  .euiNavDrawer {
+    height: calc(100% - #{$euiHeaderSizeMobile});
+    top: $euiHeaderSizeMobile;
   }
 }

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -2,10 +2,10 @@
 
 .euiNavDrawer {
   width: $euiNavDrawerWidthCollapsed;
-  height: 100%;
-  position: absolute;
+  height: calc(100% - #{$euiHeaderSize});
+  position: fixed;
   left: 0;
-  top: 0;
+  top: $euiHeaderSize;
   background: $euiHeaderBackgroundColor;
   box-shadow: $euiNavDrawerSideShadow;
 

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -6,12 +6,11 @@
   position: absolute;
   left: 0;
   top: 0;
-  // z-index: $euiZHeader; // ensure the shadow shows above content
   background: $euiHeaderBackgroundColor;
   box-shadow: $euiNavDrawerSideShadow;
 
   &.euiNavDrawer-isCollapsed {
-    transition: width $euiAnimSpeedFast ease-in;
+    transition: width $euiAnimSpeedExtraFast ease-in;
 
     &.euiNavDrawer-flyoutIsExpanded {
       width: $euiNavDrawerWidthCollapsed + $euiNavDrawerWidthExpanded;
@@ -20,27 +19,34 @@
 
   &.euiNavDrawer-isExpanded {
     width: $euiNavDrawerWidthExpanded;
-    transition: width $euiAnimSpeedNormal ease-out;
-    // transition: width $euiAnimSpeedNormal ease-out 1.8s; // TODO Delays the expanded view
+    transition: width $euiAnimSpeedFast ease-out;
+
+    &.euiNavDrawer-isDelayed {
+      transition: width $euiAnimSpeedFast ease-out 1.8s; // TODO For prototype alternative
+    }
 
     .euiNavDrawerMenu .euiListGroupItem__label,
     .euiNavDrawerMenu .euiListGroupItem__extraAction {
       visibility: visible;
+      opacity: 1;
+      transition: opacity $euiAnimSpeedExtraFast .2s;
     }
 
     &.euiNavDrawer-flyoutIsExpanded {
       width: $euiNavDrawerWidthExpanded * 2;
-      // transition-delay: 0s; // TODO works with delay
     }
 
-    // &.euiNavDrawer-flyoutIsCollapsed {
-    //   transition-delay: 0s; // TODO this fixes the delay when flyout collapses, but breaks the delay when menu expands
-    // }
+    &.euiNavDrawer-flyoutIsAnimating {
+      transition-delay: 0s;
+      transition-property: width;
+    }
   }
 
   .euiNavDrawerMenu .euiListGroupItem__label,
   .euiNavDrawerMenu .euiListGroupItem__extraAction {
     visibility: hidden;
     white-space: nowrap;
+    opacity: 0;
+    transition: opacity $euiAnimSpeedExtraFast;
   }
 }

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -1,0 +1,36 @@
+// Nav drawer. Global application navigation.
+
+$euiNavDrawerWidthExpanded: 240px;
+$euiNavDrawerWidthCollapsed: 48px;
+$euiNavDrawerSideShadow: 2px 0 2px -1px rgba($euiShadowColor, .3);
+
+.euiNavDrawer {
+  width: $euiNavDrawerWidthExpanded;
+  height: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
+  // z-index: $euiZHeader; // ensure the shadow shows above content
+  background: $euiHeaderBackgroundColor;
+  box-shadow: $euiNavDrawerSideShadow;
+
+  &.euiNavDrawer-isCollapsed {
+    width: $euiNavDrawerWidthCollapsed;
+    transition: width $euiAnimSpeedFast ease-in;
+  }
+
+  &.euiNavDrawer-isExpanded {
+    transition: width $euiAnimSpeedNormal ease-out 1.8s; // Delays the expanded view
+
+    .euiListGroupItem__label,
+    .euiListGroupItem__extraAction {
+      visibility: visible;
+    }
+  }
+
+  .euiListGroupItem__label,
+  .euiListGroupItem__extraAction {
+    visibility: hidden;
+    white-space: nowrap;
+  }
+}

--- a/src/components/nav_drawer/_nav_drawer_flyout.scss
+++ b/src/components/nav_drawer/_nav_drawer_flyout.scss
@@ -1,4 +1,5 @@
 .euiNavDrawerFlyout {
+  @include euiScrollBar;
   position: absolute;
   left: $euiNavDrawerWidthExpanded;
   top: 0;

--- a/src/components/nav_drawer/_nav_drawer_flyout.scss
+++ b/src/components/nav_drawer/_nav_drawer_flyout.scss
@@ -1,0 +1,37 @@
+.euiNavDrawerFlyout {
+  position: absolute;
+  left: $euiNavDrawerWidthCollapsed;
+  top: 0;
+  width: 0;
+  height: 100%;
+  padding: $euiSize;
+  background-color: $euiNavDrawerBackgroundColor;
+  border-left: $euiBorderThin;
+  box-shadow: $euiNavDrawerSideShadow;
+  visibility: hidden;
+  opacity: 0;
+
+  &.euiNavDrawerFlyout-isExpanded {
+    visibility: visible;
+    opacity: 1;
+    width: $euiNavDrawerWidthExpanded;
+    transition: opacity $euiAnimSpeedFast .2s, width $euiAnimSpeedNormal;
+  }
+
+  &.euiNavDrawerFlyout-isCollapsed {
+    transition: opacity $euiAnimSpeedFast, width $euiAnimSpeedFast;
+  }
+
+  .euiNavDrawer-isCollapsed & {
+    left: $euiNavDrawerWidthCollapsed;
+  }
+
+  .euiNavDrawer-isExpanded & {
+    left: $euiNavDrawerWidthExpanded;
+  }
+
+  .euiNavDrawerFlyout__listGroup {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}

--- a/src/components/nav_drawer/_nav_drawer_flyout.scss
+++ b/src/components/nav_drawer/_nav_drawer_flyout.scss
@@ -1,33 +1,22 @@
 .euiNavDrawerFlyout {
   position: absolute;
-  left: $euiNavDrawerWidthCollapsed;
+  left: $euiNavDrawerWidthExpanded;
   top: 0;
-  width: 0;
+  width: $euiNavDrawerWidthExpanded;
   height: 100%;
   padding: $euiSize;
   background-color: $euiNavDrawerBackgroundColor;
   border-left: $euiBorderThin;
   box-shadow: $euiNavDrawerSideShadow;
-  visibility: hidden;
   opacity: 0;
 
   &.euiNavDrawerFlyout-isExpanded {
-    visibility: visible;
     opacity: 1;
-    width: $euiNavDrawerWidthExpanded;
-    transition: opacity $euiAnimSpeedFast .2s, width $euiAnimSpeedNormal;
+    transition: opacity $euiAnimSpeedNormal;
   }
 
   &.euiNavDrawerFlyout-isCollapsed {
-    transition: opacity $euiAnimSpeedFast, width $euiAnimSpeedFast;
-  }
-
-  .euiNavDrawer-isCollapsed & {
-    left: $euiNavDrawerWidthCollapsed;
-  }
-
-  .euiNavDrawer-isExpanded & {
-    left: $euiNavDrawerWidthExpanded;
+    transition: opacity $euiAnimSpeedFast $euiNavDrawerContractingDelay;
   }
 
   .euiNavDrawerFlyout__listGroup {

--- a/src/components/nav_drawer/_nav_drawer_menu.scss
+++ b/src/components/nav_drawer/_nav_drawer_menu.scss
@@ -1,0 +1,3 @@
+.euiNavDrawerMenu {
+  max-width: $euiNavDrawerWidthExpanded;
+}

--- a/src/components/nav_drawer/_nav_drawer_menu.scss
+++ b/src/components/nav_drawer/_nav_drawer_menu.scss
@@ -1,3 +1,4 @@
 .euiNavDrawerMenu {
+  @include euiScrollBar;
   max-width: $euiNavDrawerWidthExpanded;
 }

--- a/src/components/nav_drawer/_variables.scss
+++ b/src/components/nav_drawer/_variables.scss
@@ -8,3 +8,9 @@ $euiNavDrawerSideShadow: 2px 0 2px -1px rgba($euiShadowColor, .3);
 
 // Layout variables
 $euiHeaderSize: $euiSizeXXL + $euiSizeL;
+
+// Animation variables
+$euiNavDrawerExpandingDelay: $euiAnimSpeedNormal;
+$euiNavDrawerContractingDelay: $euiAnimSpeedSlow;
+$euiNavDrawerExtendedDelay: $euiAnimSpeedExtraSlow * 2;
+$euiNavDrawerMenuAddedDelay: $euiAnimSpeedExtraFast;

--- a/src/components/nav_drawer/_variables.scss
+++ b/src/components/nav_drawer/_variables.scss
@@ -7,8 +7,8 @@ $euiNavDrawerWidthCollapsed: $euiHeaderChildSize;
 $euiNavDrawerSideShadow: 2px 0 2px -1px rgba($euiShadowColor, .3);
 
 // Layout variables
-$euiHeaderSize: $euiHeaderChildSize + 1px;
-$euiHeaderSizeMobile: ($euiHeaderChildSize * .75) + 1px;
+$euiNavDrawerTopPosition: $euiHeaderChildSize + 1px;
+$euiNavDrawerTopPositionMobile: $euiHeaderChildSizeMobile + 1px;
 
 // Animation variables
 $euiNavDrawerExpandingDelay: $euiAnimSpeedNormal;

--- a/src/components/nav_drawer/_variables.scss
+++ b/src/components/nav_drawer/_variables.scss
@@ -7,8 +7,8 @@ $euiNavDrawerWidthCollapsed: 48px;
 $euiNavDrawerSideShadow: 2px 0 2px -1px rgba($euiShadowColor, .3);
 
 // Layout variables
-$euiHeaderSize: $euiSizeXXL + $euiSizeL;
-$euiHeaderSizeMobile: $euiHeaderSize - $euiSize;
+$euiHeaderSize: $euiSizeXXL + $euiSizeS + 1px;
+$euiHeaderSizeMobile: $euiSizeXL + $euiSizeXS + 1px;
 
 // Animation variables
 $euiNavDrawerExpandingDelay: $euiAnimSpeedNormal;

--- a/src/components/nav_drawer/_variables.scss
+++ b/src/components/nav_drawer/_variables.scss
@@ -5,3 +5,6 @@ $euiNavDrawerBackgroundColor: $euiColorEmptyShade;
 $euiNavDrawerWidthExpanded: 240px;
 $euiNavDrawerWidthCollapsed: 48px;
 $euiNavDrawerSideShadow: 2px 0 2px -1px rgba($euiShadowColor, .3);
+
+// Layout variables
+$euiHeaderSize: $euiSizeXXL + $euiSizeL;

--- a/src/components/nav_drawer/_variables.scss
+++ b/src/components/nav_drawer/_variables.scss
@@ -1,14 +1,14 @@
 // Themable colors
-$euiNavDrawerBackgroundColor: $euiColorEmptyShade;
+$euiNavDrawerBackgroundColor: $euiHeaderBackgroundColor;
 
 // Drawer variables
 $euiNavDrawerWidthExpanded: 240px;
-$euiNavDrawerWidthCollapsed: 48px;
+$euiNavDrawerWidthCollapsed: $euiHeaderChildSize;
 $euiNavDrawerSideShadow: 2px 0 2px -1px rgba($euiShadowColor, .3);
 
 // Layout variables
-$euiHeaderSize: $euiSizeXXL + $euiSizeS + 1px;
-$euiHeaderSizeMobile: $euiSizeXL + $euiSizeXS + 1px;
+$euiHeaderSize: $euiHeaderChildSize + 1px;
+$euiHeaderSizeMobile: ($euiHeaderChildSize * .75) + 1px;
 
 // Animation variables
 $euiNavDrawerExpandingDelay: $euiAnimSpeedNormal;

--- a/src/components/nav_drawer/_variables.scss
+++ b/src/components/nav_drawer/_variables.scss
@@ -1,0 +1,7 @@
+// Themable colors
+$euiNavDrawerBackgroundColor: $euiColorEmptyShade;
+
+// Drawer variables
+$euiNavDrawerWidthExpanded: 240px;
+$euiNavDrawerWidthCollapsed: 48px;
+$euiNavDrawerSideShadow: 2px 0 2px -1px rgba($euiShadowColor, .3);

--- a/src/components/nav_drawer/_variables.scss
+++ b/src/components/nav_drawer/_variables.scss
@@ -8,6 +8,7 @@ $euiNavDrawerSideShadow: 2px 0 2px -1px rgba($euiShadowColor, .3);
 
 // Layout variables
 $euiHeaderSize: $euiSizeXXL + $euiSizeL;
+$euiHeaderSizeMobile: $euiHeaderSize - $euiSize;
 
 // Animation variables
 $euiNavDrawerExpandingDelay: $euiAnimSpeedNormal;

--- a/src/components/nav_drawer/index.js
+++ b/src/components/nav_drawer/index.js
@@ -1,3 +1,11 @@
 export {
   EuiNavDrawer,
 } from './nav_drawer';
+
+export {
+  EuiNavDrawerMenu,
+} from './nav_drawer_menu';
+
+export {
+  EuiNavDrawerFlyout,
+} from './nav_drawer_flyout';

--- a/src/components/nav_drawer/index.js
+++ b/src/components/nav_drawer/index.js
@@ -1,0 +1,3 @@
+export {
+  EuiNavDrawer,
+} from './nav_drawer';

--- a/src/components/nav_drawer/nav_drawer.js
+++ b/src/components/nav_drawer/nav_drawer.js
@@ -40,7 +40,7 @@ EuiNavDrawer.propTypes = {
   className: PropTypes.string,
 
   /**
-   * Toggle the nav drawer between collapsed and expanded
+   * Toggle the nav drawer between collapsed (docked) and expanded
    */
   isCollapsed: PropTypes.bool,
 

--- a/src/components/nav_drawer/nav_drawer.js
+++ b/src/components/nav_drawer/nav_drawer.js
@@ -8,7 +8,6 @@ export const EuiNavDrawer = ({
   isCollapsed,
   flyoutIsCollapsed,
   flyoutIsAnimating,
-  hasDelay,
   mobileIsHidden,
   showScrollbar,
   ...rest
@@ -21,7 +20,6 @@ export const EuiNavDrawer = ({
       'euiNavDrawer-flyoutIsCollapsed': flyoutIsCollapsed,
       'euiNavDrawer-flyoutIsExpanded': !flyoutIsCollapsed,
       'euiNavDrawer-flyoutIsAnimating': flyoutIsAnimating,
-      'euiNavDrawer-isDelayed': hasDelay,
       'euiNavDrawer-mobileIsHidden': mobileIsHidden,
       'euiNavDrawer-showScrollbar': showScrollbar,
     },
@@ -45,19 +43,21 @@ EuiNavDrawer.propTypes = {
    * Toggle the nav drawer between collapsed (docked) and expanded
    */
   isCollapsed: PropTypes.bool,
+  mobileIsHidden: PropTypes.bool,
 
   /**
    * Toggle the flyout menu between collapsed and expanded
    */
   flyoutIsCollapsed: PropTypes.bool,
-  flyoutIsAnimatigng: PropTypes.bool,
-  hasDelay: PropTypes.bool,
-  mobileIsHidden: PropTypes.bool,
+  flyoutIsAnimating: PropTypes.bool,
+
   showScrollbar: PropTypes.bool,
 };
 
 EuiNavDrawer.defaultProps = {
   isCollapsed: true,
   mobileIsHidden: true,
+  flyoutIsCollapsed: true,
+  flyoutIsAnimating: false,
   showScrollbar: false,
 };

--- a/src/components/nav_drawer/nav_drawer.js
+++ b/src/components/nav_drawer/nav_drawer.js
@@ -10,6 +10,7 @@ export const EuiNavDrawer = ({
   flyoutIsAnimating,
   hasDelay,
   mobileIsHidden,
+  showScrollbar,
   ...rest
 }) => {
   const classes = classNames(
@@ -22,6 +23,7 @@ export const EuiNavDrawer = ({
       'euiNavDrawer-flyoutIsAnimating': flyoutIsAnimating,
       'euiNavDrawer-isDelayed': hasDelay,
       'euiNavDrawer-mobileIsHidden': mobileIsHidden,
+      'euiNavDrawer-showScrollbar': showScrollbar,
     },
     className
   );
@@ -51,9 +53,11 @@ EuiNavDrawer.propTypes = {
   flyoutIsAnimatigng: PropTypes.bool,
   hasDelay: PropTypes.bool,
   mobileIsHidden: PropTypes.bool,
+  showScrollbar: PropTypes.bool,
 };
 
 EuiNavDrawer.defaultProps = {
   isCollapsed: true,
   mobileIsHidden: true,
+  showScrollbar: false,
 };

--- a/src/components/nav_drawer/nav_drawer.js
+++ b/src/components/nav_drawer/nav_drawer.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+export const EuiNavDrawer = ({ children, className, isCollapsed, ...rest }) => {
+  const classes = classNames(
+    'euiNavDrawer',
+    {
+      'euiNavDrawer-isCollapsed': isCollapsed,
+      'euiNavDrawer-isExpanded': !isCollapsed,
+    },
+    className
+  );
+
+  return (
+    <div
+      className={classes}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+};
+
+EuiNavDrawer.propTypes = {
+  className: PropTypes.string,
+
+  /**
+   * Toggle the nav drawer between collapsed and expanded
+   */
+  isCollapsed: PropTypes.bool,
+};
+
+EuiNavDrawer.defaultProps = {
+  isCollapsed: true,
+};

--- a/src/components/nav_drawer/nav_drawer.js
+++ b/src/components/nav_drawer/nav_drawer.js
@@ -2,7 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-export const EuiNavDrawer = ({ children, className, isCollapsed, flyoutIsCollapsed, flyoutIsAnimating, hasDelay, ...rest }) => {
+export const EuiNavDrawer = ({
+  children,
+  className,
+  isCollapsed,
+  flyoutIsCollapsed,
+  flyoutIsAnimating,
+  hasDelay,
+  mobileIsHidden,
+  ...rest
+}) => {
   const classes = classNames(
     'euiNavDrawer',
     {
@@ -12,6 +21,7 @@ export const EuiNavDrawer = ({ children, className, isCollapsed, flyoutIsCollaps
       'euiNavDrawer-flyoutIsExpanded': !flyoutIsCollapsed,
       'euiNavDrawer-flyoutIsAnimating': flyoutIsAnimating,
       'euiNavDrawer-isDelayed': hasDelay,
+      'euiNavDrawer-mobileIsHidden': mobileIsHidden,
     },
     className
   );
@@ -40,8 +50,10 @@ EuiNavDrawer.propTypes = {
   flyoutIsCollapsed: PropTypes.bool,
   flyoutIsAnimatigng: PropTypes.bool,
   hasDelay: PropTypes.bool,
+  mobileIsHidden: PropTypes.bool,
 };
 
 EuiNavDrawer.defaultProps = {
   isCollapsed: true,
+  mobileIsHidden: true,
 };

--- a/src/components/nav_drawer/nav_drawer.js
+++ b/src/components/nav_drawer/nav_drawer.js
@@ -2,12 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-export const EuiNavDrawer = ({ children, className, isCollapsed, ...rest }) => {
+export const EuiNavDrawer = ({ children, className, isCollapsed, flyoutIsCollapsed, ...rest }) => {
   const classes = classNames(
     'euiNavDrawer',
     {
       'euiNavDrawer-isCollapsed': isCollapsed,
       'euiNavDrawer-isExpanded': !isCollapsed,
+      'euiNavDrawer-flyoutIsCollapsed': flyoutIsCollapsed,
+      'euiNavDrawer-flyoutIsExpanded': !flyoutIsCollapsed,
     },
     className
   );
@@ -29,6 +31,11 @@ EuiNavDrawer.propTypes = {
    * Toggle the nav drawer between collapsed and expanded
    */
   isCollapsed: PropTypes.bool,
+
+  /**
+   * Toggle the flyout menu between collapsed and expanded
+   */
+  flyoutIsCollapsed: PropTypes.bool,
 };
 
 EuiNavDrawer.defaultProps = {

--- a/src/components/nav_drawer/nav_drawer.js
+++ b/src/components/nav_drawer/nav_drawer.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-export const EuiNavDrawer = ({ children, className, isCollapsed, flyoutIsCollapsed, ...rest }) => {
+export const EuiNavDrawer = ({ children, className, isCollapsed, flyoutIsCollapsed, flyoutIsAnimating, hasDelay, ...rest }) => {
   const classes = classNames(
     'euiNavDrawer',
     {
@@ -10,6 +10,8 @@ export const EuiNavDrawer = ({ children, className, isCollapsed, flyoutIsCollaps
       'euiNavDrawer-isExpanded': !isCollapsed,
       'euiNavDrawer-flyoutIsCollapsed': flyoutIsCollapsed,
       'euiNavDrawer-flyoutIsExpanded': !flyoutIsCollapsed,
+      'euiNavDrawer-flyoutIsAnimating': flyoutIsAnimating,
+      'euiNavDrawer-isDelayed': hasDelay,
     },
     className
   );
@@ -36,6 +38,8 @@ EuiNavDrawer.propTypes = {
    * Toggle the flyout menu between collapsed and expanded
    */
   flyoutIsCollapsed: PropTypes.bool,
+  flyoutIsAnimatigng: PropTypes.bool,
+  hasDelay: PropTypes.bool,
 };
 
 EuiNavDrawer.defaultProps = {

--- a/src/components/nav_drawer/nav_drawer_flyout.js
+++ b/src/components/nav_drawer/nav_drawer_flyout.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import { EuiTitle } from '../title';
 import { EuiListGroup } from '../list_group';
 
-export const EuiNavDrawerFlyout = ({ children, className, title, isCollapsed, listItems, ...rest }) => {
+export const EuiNavDrawerFlyout = ({ className, title, isCollapsed, listItems, ...rest }) => {
   const classes = classNames(
     'euiNavDrawerFlyout',
     {
@@ -21,7 +21,6 @@ export const EuiNavDrawerFlyout = ({ children, className, title, isCollapsed, li
       aria-labelledby="navDrawerFlyoutTitle"
       {...rest}
     >
-      {children}
       <EuiTitle tabIndex="-1" size="xxs"><h5 id="navDrawerFlyoutTitle">{title}</h5></EuiTitle>
       <EuiListGroup className="euiNavDrawerFlyout__listGroup" listItems={listItems} />
     </div>
@@ -30,7 +29,7 @@ export const EuiNavDrawerFlyout = ({ children, className, title, isCollapsed, li
 
 EuiNavDrawerFlyout.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node,
+  listItems: EuiListGroup.propTypes.listItems,
 
   /**
    * Display a title atop the flyout

--- a/src/components/nav_drawer/nav_drawer_flyout.js
+++ b/src/components/nav_drawer/nav_drawer_flyout.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import { EuiTitle } from '../title';
+import { EuiListGroup } from '../list_group';
+
+export const EuiNavDrawerFlyout = ({ children, className, title, isCollapsed, listItems, ...rest }) => {
+  const classes = classNames(
+    'euiNavDrawerFlyout',
+    {
+      'euiNavDrawerFlyout-isCollapsed': isCollapsed,
+      'euiNavDrawerFlyout-isExpanded': !isCollapsed,
+    },
+    className
+  );
+
+  return (
+    <div
+      className={classes}
+      {...rest}
+    >
+      {children}
+      <EuiTitle size="xxs"><h5>{title}</h5></EuiTitle>
+      <EuiListGroup className="euiNavDrawerFlyout__listGroup" listItems={listItems} />
+    </div>
+  );
+};
+
+EuiNavDrawerFlyout.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+
+  /**
+   * Display a title atop the flyout
+   */
+  title: PropTypes.string,
+
+  /**
+   * Toggle the nav drawer between collapsed and expanded
+   */
+  isCollapsed: PropTypes.bool,
+};
+
+EuiNavDrawerFlyout.defaultProps = {
+  isCollapsed: true,
+};

--- a/src/components/nav_drawer/nav_drawer_flyout.js
+++ b/src/components/nav_drawer/nav_drawer_flyout.js
@@ -1,100 +1,47 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import FocusTrap from 'focus-trap-react';
 
 import { EuiTitle } from '../title';
 import { EuiListGroup } from '../list_group';
 
-export class EuiNavDrawerFlyout extends Component {
-  static propTypes = {
-    className: PropTypes.string,
-    listItems: EuiListGroup.propTypes.listItems,
+export const EuiNavDrawerFlyout = ({ className, title, isCollapsed, listItems, ...rest }) => {
+  const classes = classNames(
+    'euiNavDrawerFlyout',
+    {
+      'euiNavDrawerFlyout-isCollapsed': isCollapsed,
+      'euiNavDrawerFlyout-isExpanded': !isCollapsed,
+    },
+    className
+  );
 
-    /**
-     * Display a title atop the flyout
-     */
-    title: PropTypes.string,
+  return (
+    <div
+      className={classes}
+      aria-labelledby="navDrawerFlyoutTitle"
+      {...rest}
+    >
+      <EuiTitle tabIndex="-1" size="xxs"><h5 id="navDrawerFlyoutTitle">{title}</h5></EuiTitle>
+      <EuiListGroup className="euiNavDrawerFlyout__listGroup" listItems={listItems} />
+    </div>
+  );
+};
 
-    /**
-     * Toggle the nav drawer between collapsed and expanded
-     */
-    isCollapsed: PropTypes.bool,
-  };
+EuiNavDrawerFlyout.propTypes = {
+  className: PropTypes.string,
+  listItems: EuiListGroup.propTypes.listItems,
 
-  static defaultProps = {
-    isCollapsed: true,
-  };
+  /**
+   * Display a title atop the flyout
+   */
+  title: PropTypes.string,
 
-  constructor(...args) {
-    super(...args);
+  /**
+   * Toggle the nav drawer between collapsed and expanded
+   */
+  isCollapsed: PropTypes.bool,
+};
 
-    // The version of focus-trap-react that we're on only
-    // returns focus when the trap is unmounted, not on deactivation
-    // To track if we need the trap mounted or not means tracking focus
-    this.state = {
-      trappingFocus: false,
-    };
-  }
-
-  componentDidUpdate(prevProps) {
-    const { isCollapsed: wasCollapsed, listItems: prevItems } = prevProps;
-    const { isCollapsed, listItems } = this.props;
-
-    const nowExpanded = wasCollapsed && !isCollapsed;
-    const newItems = prevItems !== listItems;
-    if (nowExpanded || newItems) {
-      this.setState({ // eslint-disable-line react/no-did-update-set-state
-        trappingFocus: true
-      });
-    }
-  }
-
-  untrap = () => {
-    this.setState({
-      trappingFocus: false
-    });
-  }
-
-  render() {
-    const { className, title, isCollapsed, listItems, ...rest } = this.props;
-    const classes = classNames(
-      'euiNavDrawerFlyout',
-      {
-        'euiNavDrawerFlyout-isCollapsed': isCollapsed,
-        'euiNavDrawerFlyout-isExpanded': !isCollapsed,
-      },
-      className
-    );
-
-    const items = <EuiListGroup className="euiNavDrawerFlyout__listGroup" listItems={listItems} />;
-
-    return (
-      <div
-        className={classes}
-        aria-labelledby="navDrawerFlyoutTitle"
-        onBlur={this.onBlur}
-        {...rest}
-      >
-        <EuiTitle tabIndex="-1" size="xxs"><h5 id="navDrawerFlyoutTitle">{title}</h5></EuiTitle>
-        {
-          this.state.trappingFocus
-            ? (
-              <FocusTrap
-                active={true}
-                focusTrapOptions={{
-                  clickOutsideDeactivates: true,
-                  returnFocusOnDeactivate: true,
-                  onDeactivate: this.untrap,
-                }}
-              >
-                {items}
-              </FocusTrap>
-            )
-            : items
-        }
-      </div>
-    );
-
-  }
-}
+EuiNavDrawerFlyout.defaultProps = {
+  isCollapsed: true,
+};

--- a/src/components/nav_drawer/nav_drawer_flyout.js
+++ b/src/components/nav_drawer/nav_drawer_flyout.js
@@ -18,10 +18,11 @@ export const EuiNavDrawerFlyout = ({ children, className, title, isCollapsed, li
   return (
     <div
       className={classes}
+      aria-labelledby="navDrawerFlyoutTitle"
       {...rest}
     >
       {children}
-      <EuiTitle size="xxs"><h5>{title}</h5></EuiTitle>
+      <EuiTitle tabIndex="-1" size="xxs"><h5 id="navDrawerFlyoutTitle">{title}</h5></EuiTitle>
       <EuiListGroup className="euiNavDrawerFlyout__listGroup" listItems={listItems} />
     </div>
   );

--- a/src/components/nav_drawer/nav_drawer_menu.js
+++ b/src/components/nav_drawer/nav_drawer_menu.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+export const EuiNavDrawerMenu = ({ children, className, isCollapsed, ...rest }) => {
+  const classes = classNames(
+    'euiNavDrawerMenu',
+    {
+      'euiNavDrawerMenu-isCollapsed': isCollapsed,
+      'euiNavDrawerMenu-isExpanded': !isCollapsed,
+    },
+    className
+  );
+
+  return (
+    <div
+      className={classes}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+};
+
+EuiNavDrawerMenu.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+
+  /**
+   * Toggle the nav drawer between collapsed and expanded
+   */
+  isCollapsed: PropTypes.bool,
+};
+
+EuiNavDrawerMenu.defaultProps = {
+  isCollapsed: true,
+};

--- a/src/components/nav_drawer/nav_drawer_menu.js
+++ b/src/components/nav_drawer/nav_drawer_menu.js
@@ -2,13 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-export const EuiNavDrawerMenu = ({ children, className, isCollapsed, ...rest }) => {
+export const EuiNavDrawerMenu = ({ children, className, ...rest }) => {
   const classes = classNames(
     'euiNavDrawerMenu',
-    {
-      'euiNavDrawerMenu-isCollapsed': isCollapsed,
-      'euiNavDrawerMenu-isExpanded': !isCollapsed,
-    },
     className
   );
 
@@ -25,13 +21,4 @@ export const EuiNavDrawerMenu = ({ children, className, isCollapsed, ...rest }) 
 EuiNavDrawerMenu.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
-
-  /**
-   * Toggle the nav drawer between collapsed and expanded
-   */
-  isCollapsed: PropTypes.bool,
-};
-
-EuiNavDrawerMenu.defaultProps = {
-  isCollapsed: true,
 };


### PR DESCRIPTION
### Summary

Adds a component named `EuiNavDrawer` that wraps one or more `EuiListGroup` components into an interactive side nav. It is designed to be used in conjunction with `EuiHeader` and, relatedly, resulted in a couple of minor changes to the `EuiHeader` design, most notably shortening its height from 64 to 48 pixels.

#### Note about keyboard accessibility
While keyboard accessibility is possible, it would be improved by using focus-trap for the sub menu that slides out. I attempted to get this working and while I could trap the focus in the flyout/sub menu, I could not get it to return focus to the triggering element upon pressing the `esc` key. 

Long story short, I could use some help sorting this out.

### To-do items
- [x] Make nav collapse when you tab out of the last link
- [ ] Get focus-trap to work properly on the flyout menu, including ability to ESC back to the triggering element (see previous note)

### Recordings
#### Interaction on desktop
![nav-drawer](https://user-images.githubusercontent.com/446285/51052870-9a0b6e80-159d-11e9-87a3-40f5c32e2946.gif)

#### Interaction on mobile
![nav-drawer-mobile](https://user-images.githubusercontent.com/446285/51053013-01292300-159e-11e9-819a-6c1934e41ced.gif)

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
- [x] Any props added have proper autodocs
- [x] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] ~This required updates to Framer X components~
