### PR TITLE
Add inputRef prop to combobox like other EUI form elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `6.3.0`.
+- Added `inputRef` prop to `EuiComboBox` ([#1433](https://github.com/elastic/eui/pull/1433))
 
 ## [`6.3.0`](https://github.com/elastic/eui/tree/v6.3.0)
 

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -49,6 +49,7 @@ export class EuiComboBox extends Component {
     isClearable: PropTypes.bool,
     fullWidth: PropTypes.bool,
     compressed: PropTypes.bool,
+    inputRef: PropTypes.func,
   }
 
   static defaultProps = {
@@ -448,6 +449,9 @@ export class EuiComboBox extends Component {
 
   searchInputRef = node => {
     this.searchInput = node;
+    if (this.props.inputRef) {
+      this.props.inputRef(node);
+    }
   };
 
   optionsListRef = node => {

--- a/src/components/combo_box/index.d.ts
+++ b/src/components/combo_box/index.d.ts
@@ -73,6 +73,7 @@ declare module '@elastic/eui' {
     rowHeight?: number,
     isClearable?: boolean,
     fullWidth?: boolean,
+    inputRef?: (element: HTMLInputElement) => void;
   }
   export const EuiComboBox: SFC<EuiComboBoxProps>;
 }


### PR DESCRIPTION
### Summary

Useful for focusing comboboxes from a parent component

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
- [ ] Any props added have proper autodocs  ???
~- [ ] Documentation examples were added~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
