### PR TITLE
Misc small fixes related to nav drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added Inter UI to the font family stack ([#1402](https://github.com/elastic/eui/pull/1402))
+- Changed padding on `EuiHeaderLogo` and updated `EuiNavDrawer` example ([#1448](https://github.com/elastic/eui/pull/1448))
 
 **Bug fixes**
 
@@ -9,6 +10,7 @@
 
 ## [`6.4.0`](https://github.com/elastic/eui/tree/v6.4.0)
 
+- Added `EuiNavDrawer` side nav component ([#1427](https://github.com/elastic/eui/pull/1427))
 - Added `inputRef` prop to `EuiComboBox` ([#1433](https://github.com/elastic/eui/pull/1433))
 - Added custom date string formatting for series charts crosshair overlay ([#1429](https://github.com/elastic/eui/pull/1429))
 - Added new icons for `symlink` and `submodule` ([#1439](https://github.com/elastic/eui/pull/1439))

--- a/src-docs/src/views/nav_drawer/nav_drawer.js
+++ b/src-docs/src/views/nav_drawer/nav_drawer.js
@@ -41,7 +41,7 @@ export default class extends Component {
       navFlyoutContent: [],
       mobileIsHidden: true,
       showScrollbar: false,
-      outsideClickDisaled: true,
+      outsideClickDisabled: true,
       isManagingFocus: false,
     };
 
@@ -477,9 +477,9 @@ export default class extends Component {
 
     setTimeout(() => {
       this.setState({
-        outsideClickDisaled: this.state.mobileIsHidden ? true : false,
+        outsideClickDisabled: this.state.mobileIsHidden ? true : false,
       });
-    }, 150);
+    }, 350);
   };
 
   expandDrawer = () => {
@@ -516,7 +516,7 @@ export default class extends Component {
         flyoutIsCollapsed: true,
         mobileIsHidden: true,
         showScrollbar: false,
-        outsideClickDisaled: true,
+        outsideClickDisabled: true,
       });
     }, 350);
 
@@ -576,7 +576,7 @@ export default class extends Component {
       navFlyoutContent,
       mobileIsHidden,
       showScrollbar,
-      outsideClickDisaled,
+      outsideClickDisabled,
     } = this.state;
 
     return (
@@ -605,7 +605,7 @@ export default class extends Component {
           </EuiHeader>
           <EuiOutsideClickDetector
             onOutsideClick={() => this.collapseDrawer()}
-            isDisabled={outsideClickDisaled}
+            isDisabled={outsideClickDisabled}
           >
             <EuiNavDrawer
               isCollapsed={isCollapsed}

--- a/src/components/header/_header_logo.scss
+++ b/src/components/header/_header_logo.scss
@@ -6,7 +6,7 @@
   position: relative;
   height: $euiHeaderChildSize;
   line-height: $euiHeaderChildSize;
-  padding: 0 $euiSize;
+  padding: 0 $euiSizeM;
   display: inline-block;
   vertical-align: middle;
   white-space: nowrap;


### PR DESCRIPTION
### Summary

A few miscellaneous fixes are combined in this PR:
1. Forgot the CHANGELOG entry on my `EuiNavDrawer` PR https://github.com/elastic/eui/pull/1427
2. Discovered a misspell to a variable name
3. Added more time to OutsideClickDetector to prevent it from immediately closing on mobile toggle
4. Reduced padding on `EuiHeaderLogo` (used in Kibana) to align logo button with new nav width

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
- [x] Any props added have proper autodocs
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [x] This was checked against keyboard-only and screenreader scenarios
- [ ] ~This required updates to Framer X components~
