### PR TITLE
Fixes header logo width and updates drawer example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added Inter UI to the font family stack ([#1402](https://github.com/elastic/eui/pull/1402))
 - Changed padding on `EuiHeaderLogo` and updated `EuiNavDrawer` example ([#1448](https://github.com/elastic/eui/pull/1448))
+- Updated `EuiNavDrawer` docs example and adjusted `EuiHeaderLogo` padding ([#1449](https://github.com/elastic/eui/pull/1449))
 
 **Bug fixes**
 

--- a/src-docs/src/views/nav_drawer/nav_drawer.js
+++ b/src-docs/src/views/nav_drawer/nav_drawer.js
@@ -14,6 +14,7 @@ import {
   EuiHeaderSectionItem,
   EuiHeaderSectionItemButton,
   EuiHeaderBreadcrumbs,
+  EuiHeaderLogo,
   EuiIcon,
   EuiTitle,
   EuiNavDrawer,
@@ -401,11 +402,11 @@ export default class extends Component {
 
   renderLogo() {
     return (
-      <EuiHeaderSectionItemButton
-        aria-label="Go to home page"
-      >
-        <EuiIcon type="logoKibana" href="#" size="l" />
-      </EuiHeaderSectionItemButton>
+      <EuiHeaderLogo
+        iconType="logoKibana"
+        href="/#/layout/nav-drawer"
+        aria-label="Goes to home"
+      />
     );
   }
 

--- a/src/components/header/_header_logo.scss
+++ b/src/components/header/_header_logo.scss
@@ -6,7 +6,7 @@
   position: relative;
   height: $euiHeaderChildSize;
   line-height: $euiHeaderChildSize;
-  padding: 0 $euiSizeM;
+  padding: 0 ($euiSizeM + 1px) 0 $euiSizeM;
   display: inline-block;
   vertical-align: middle;
   white-space: nowrap;


### PR DESCRIPTION
### Summary

I got crossed up checking between EUI and Kibana for the precise `EuiHeaderLogo` width and was off by 1px. This PR adds that extra 1px width to account for the right border while also updating the `EuiNavDrawer` docs example to use `EuiHeaderLogo` (to match the Kibana setup and the Header docs example).

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
- [ ] ~Any props added have proper autodocs~
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [ ] ~Jest tests were updated or added to match the most common scenarios~
- [x] This was checked against keyboard-only and screenreader scenarios
- [ ] ~This required updates to Framer X components~
