### PR TITLE
Fix EuiFilterGroupButton bolding with notification and...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `6.5.1`.
+**Bug fixes**
+
+- Fixed `textProps` and `contentProps` of `EuiButton` and `EuiButtonEmpty` so they don’t override classes ([#1455](https://github.com/elastic/eui/pull/1455))
+- Fixed `closeButtonProps` of `EuiBadge` so it doesn't override classes ([#1455](https://github.com/elastic/eui/pull/1455))
+- Fixed font weight shift of `EuiFilterButton` when notification is present ([#1455](https://github.com/elastic/eui/pull/1455))
 
 ## [`6.5.1`](https://github.com/elastic/eui/tree/v6.5.1)
 

--- a/src/components/badge/badge.js
+++ b/src/components/badge/badge.js
@@ -61,12 +61,16 @@ export const EuiBadge = ({
     optionalCustomStyles = { backgroundColor: color, color: textColor };
   }
 
-
   const classes = classNames(
     'euiBadge',
     iconSideToClassNameMap[iconSide],
     optionalColorClass,
     className
+  );
+
+  const closeClassNames = classNames(
+    'euiBadge__icon',
+    closeButtonProps && closeButtonProps.className,
   );
 
   let optionalIcon = null;
@@ -78,9 +82,9 @@ export const EuiBadge = ({
             onClick={iconOnClick}
             type={iconType}
             size="s"
-            className="euiBadge__icon"
             aria-label={iconOnClickAriaLabel}
             {...closeButtonProps}
+            className={closeClassNames}
           />
         </EuiKeyboardAccessible>
       );

--- a/src/components/badge/notification_badge/_notification_badge.scss
+++ b/src/components/badge/notification_badge/_notification_badge.scss
@@ -4,6 +4,7 @@
   background: $euiColorAccent;
   color: lightOrDarkTheme($euiColorEmptyShade, $euiColorFullShade);
   font-size: $euiFontSizeXS;
+  font-weight: $euiFontWeightMedium;
   line-height: $euiSize;
   height: $euiSize;
   min-width: $euiSize;

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -72,6 +72,16 @@ export const EuiButton = ({
     },
   );
 
+  const contentClassNames = classNames(
+    'euiButton__content',
+    contentProps && contentProps.className,
+  );
+
+  const textClassNames = classNames(
+    'euiButton__text',
+    textProps && textProps.className,
+  );
+
   // Add an icon to the button if one exists.
   let buttonIcon;
 
@@ -93,6 +103,13 @@ export const EuiButton = ({
     );
   }
 
+  const innerNode = (
+    <span {...contentProps} className={contentClassNames}>
+      {buttonIcon}
+      <span {...textProps} className={textClassNames}>{children}</span>
+    </span>
+  );
+
   // <a> elements don't respect the `disabled` attribute. So if we're disabled, we'll just pretend
   // this is a button and piggyback off its disabled styles.
   if (href && !isDisabled) {
@@ -107,10 +124,7 @@ export const EuiButton = ({
         ref={buttonRef}
         {...rest}
       >
-        <span className="euiButton__content" {...contentProps}>
-          {buttonIcon}
-          <span className="euiButton__text" {...textProps}>{children}</span>
-        </span>
+        {innerNode}
       </a>
     );
   } else {
@@ -122,10 +136,7 @@ export const EuiButton = ({
         ref={buttonRef}
         {...rest}
       >
-        <span className="euiButton__content" {...contentProps}>
-          {buttonIcon}
-          <span className="euiButton__text" {...textProps}>{children}</span>
-        </span>
+        {innerNode}
       </button>
     );
   }

--- a/src/components/button/button_empty/button_empty.js
+++ b/src/components/button/button_empty/button_empty.js
@@ -87,7 +87,6 @@ export const EuiButtonEmpty = ({
     textProps && textProps.className,
   );
 
-
   // Add an icon to the button if one exists.
   let buttonIcon;
 

--- a/src/components/button/button_empty/button_empty.js
+++ b/src/components/button/button_empty/button_empty.js
@@ -77,6 +77,17 @@ export const EuiButtonEmpty = ({
     className,
   );
 
+  const contentClassNames = classNames(
+    'euiButtonEmpty__content',
+    contentProps && contentProps.className,
+  );
+
+  const textClassNames = classNames(
+    'euiButtonEmpty__text',
+    textProps && textProps.className,
+  );
+
+
   // Add an icon to the button if one exists.
   let buttonIcon;
 
@@ -98,6 +109,13 @@ export const EuiButtonEmpty = ({
     );
   }
 
+  const innerNode = (
+    <span {...contentProps} className={contentClassNames}>
+      {buttonIcon}
+      <span {...textProps} className={textClassNames}>{children}</span>
+    </span>
+  );
+
   // <a> elements don't respect the `disabled` attribute. So if we're disabled, we'll just pretend
   // this is a button and piggyback off its disabled styles.
   if (href && !isDisabled) {
@@ -112,10 +130,7 @@ export const EuiButtonEmpty = ({
         ref={buttonRef}
         {...rest}
       >
-        <span className="euiButtonEmpty__content" {...contentProps}>
-          {buttonIcon}
-          <span className="euiButtonEmpty__text" {...textProps}>{children}</span>
-        </span>
+        {innerNode}
       </a>
     );
   } else {
@@ -127,10 +142,7 @@ export const EuiButtonEmpty = ({
         ref={buttonRef}
         {...rest}
       >
-        <span className="euiButtonEmpty__content" {...contentProps}>
-          {buttonIcon}
-          <span className="euiButtonEmpty__text"{...textProps}>{children}</span>
-        </span>
+        {innerNode}
       </button>
     );
   }
@@ -159,12 +171,12 @@ EuiButtonEmpty.propTypes = {
   buttonRef: PropTypes.func,
 
   /**
-   * Passes props to `euiButton__content` span
+   * Passes props to `euiButtonEmpty__content` span
    */
   contentProps: PropTypes.object,
 
   /**
-   * Passes props to `euiButton__text` span
+   * Passes props to `euiButtonEmpty__text` span
    */
   textProps: PropTypes.object,
 };

--- a/src/components/filter_group/_filter_button.scss
+++ b/src/components/filter_group/_filter_button.scss
@@ -19,6 +19,17 @@
     font-style: italic;
   }
 
+  &:hover:not(:disabled),
+  &:focus {
+    // Remove underline from whole button so notifications don't get the underline
+    text-decoration: none;
+
+    .euiFilterButton__textShift {
+      // Add put it only on the actual text part
+      text-decoration: underline;
+    }
+  }
+
   &.euiFilterButton--grow {
     flex-grow: 1;
     width: 100%;
@@ -38,6 +49,11 @@
     margin-left: $euiSizeS;
     vertical-align: text-bottom;
   }
+}
+
+.euiFilterButton__text-hasNotification {
+  display: flex;
+  align-items: center;
 }
 
 .euiFilterButton__textShift {

--- a/src/components/filter_group/filter_button.js
+++ b/src/components/filter_group/filter_button.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -27,6 +27,7 @@ export const EuiFilterButton = ({
   type,
   grow,
   noDivider,
+  textProps,
   ...rest
 }) => {
 
@@ -41,13 +42,20 @@ export const EuiFilterButton = ({
     className,
   );
 
+  const buttonTextClassNames = classNames(
+    { 'euiFilterButton__text-hasNotification': numFilters, },
+    textProps && textProps.className,
+  );
+
   const buttonContents = (
-    <span className="euiFilterButton__textShift" data-text={children}>
-      {children}
+    <Fragment>
+      <span className="euiFilterButton__textShift" data-text={children}>
+        {children}
+      </span>
       {numFilters &&
         <EuiNotificationBadge className="euiFilterButton__notification">{numFilters}</EuiNotificationBadge>
       }
-    </span>
+    </Fragment>
   );
 
   return (
@@ -58,6 +66,7 @@ export const EuiFilterButton = ({
       iconSide={iconSide}
       iconType={iconType}
       type={type}
+      textProps={{ ...textProps, className: buttonTextClassNames }}
       {...rest}
     >
       {buttonContents}


### PR DESCRIPTION
## Two things ended up getting fixed with this one

### 1. I realized that when sending `textProps` and `contentProps` to EuiButton and EuiButtonEmpty, I wasn't accounting for the fact that it would replace `className` is passed down.

So these components now append the button classNames to any classNames passed in those objects before applying those props objects to the element.

### 2. The bolding trick now works on EuiFilterGroupButtons that have the numFilters notification

**Before**
<img src="https://d.pr/free/i/evTK1K+" />

**After**
<img src="https://d.pr/free/i/H4cpjm+" />

### Checklist

- ~[ ] This was checked in mobile~
- [x] This was checked in IE11
- [x] This was checked in dark mode
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
