### PR TITLE
Make EuiNavDrawer flyout links wrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `6.5.1`.
+- Changes `EuiNavDrawerFLyout` links to wrap ([#1457](https://github.com/elastic/eui/pull/1457))
 
 ## [`6.5.1`](https://github.com/elastic/eui/tree/v6.5.1)
 

--- a/src-docs/src/views/nav_drawer/nav_drawer.js
+++ b/src-docs/src/views/nav_drawer/nav_drawer.js
@@ -337,7 +337,7 @@ export default class extends Component {
         },
       },
       {
-        label: 'My workpad',
+        label: 'Workpad with title that wraps',
         href: '/#/layout/nav-drawer',
         iconType: 'canvasApp',
         size: 's',

--- a/src/components/nav_drawer/_nav_drawer_flyout.scss
+++ b/src/components/nav_drawer/_nav_drawer_flyout.scss
@@ -24,4 +24,14 @@
     padding-left: 0;
     padding-right: 0;
   }
+
+  .euiListGroupItem__button {
+    width: 100%;
+    word-break: break-word;
+    line-height: $euiSize;
+  }
+
+  .euiListGroupItem__icon {
+    min-width: $euiSize;
+  }
 }


### PR DESCRIPTION
### Summary

Allows long links to wrap in the side nav flyout only (e.g. under 'Recently viewed').
The Nav Drawer docs example has been updated to show this in action.

#### Screenshot

<img width="587" alt="screenshot 2019-01-18 10 43 45" src="https://user-images.githubusercontent.com/446285/51400415-f75b6e80-1b0d-11e9-97f0-d8d98628a6cf.png">


### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
- [x] Any props added have proper autodocs
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [ ] ~Jest tests were updated or added to match the most common scenarios~
- [x] This was checked against keyboard-only and screenreader scenarios
- [ ] ~This required updates to Framer X components~
