### PR TITLE
Fix font stack for monospace font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed `textProps` and `contentProps` of `EuiButton` and `EuiButtonEmpty` so they don’t override classes ([#1455](https://github.com/elastic/eui/pull/1455))
 - Fixed `closeButtonProps` of `EuiBadge` so it doesn't override classes ([#1455](https://github.com/elastic/eui/pull/1455))
 - Fixed font weight shift of `EuiFilterButton` when notification is present ([#1455](https://github.com/elastic/eui/pull/1455))
+- Fixed `$euiCodeFontFamily` monospace font stack and subsequent JSON asset build ([#1465](https://github.com/elastic/eui/pull/1465))
 
 ## [`6.5.1`](https://github.com/elastic/eui/tree/v6.5.1)
 

--- a/src/global_styling/variables/_typography.scss
+++ b/src/global_styling/variables/_typography.scss
@@ -30,7 +30,7 @@ $euiFontFamily: 'Inter UI', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helve
 $euiFontFamilyVariable: 'Inter UI var', $euiFontFamily !default;
 $euiFontFeatureSettings: 'calt' 1, 'kern' 1, 'liga' 1 !default;
 
-$euiCodeFontFamily: 'Roboto Mono', Consolas, Menlo, courier new , monospace !default;
+$euiCodeFontFamily: 'Roboto Mono', Consolas, Menlo, Courier, monospace !default;
 
 
 // Font sizes -- scale is loosely based on Major Third (1.250)


### PR DESCRIPTION
@weltenwort Caught a bug during the assets build process that spit out the monospace font as:

```
"euiCodeFontFamily": "Roboto Mono Consolas Menlo 'courier', 'new' monospace",
```

This just removes `new` and fixes spacing issues to it now spits out as:

```
"euiCodeFontFamily": "'Roboto Mono', 'Consolas', 'Menlo', 'Courier', monospace",
```


### Checklist

- ~[ ] This was checked in mobile~
- ~[ ] This was checked in IE11~
- ~[ ] This was checked in dark mode~
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
