### PR TITLE
Position EuiProgress over EuiHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Added `z-index` to `EuiProgress` and example usage with `EuiHeader` ([#1471](https://github.com/elastic/eui/pull/1471))
 - Added a new app icon for Code ([#1467](https://github.com/elastic/eui/pull/1467))
 No public interface changes since `6.6.0`.
 - Re-added EuiI18n, EuiI18nNumber, and EuiContext for localization ([#1466](https://github.com/elastic/eui/pull/1466))

--- a/src-docs/src/views/progress/progress_example.js
+++ b/src-docs/src/views/progress/progress_example.js
@@ -75,14 +75,25 @@ export const ProgressExample = {
       code: progressFixedHtml,
     }],
     text: (
-      <p>
-        Using the <EuiCode>position</EuiCode> prop we can align our bar
-        to be <EuiCode>fixed</EuiCode> or <EuiCode>absolute</EuiCode>. In both
-        options, the background color of the base bar is dropped (since the
-        context of width is already known from your wrapping element). For the
-        absolute option, make sure that your wrapping element
-        has <EuiCode>position: relative</EuiCode> applied.
-      </p>
+      <div>
+        <p>
+          Using the <EuiCode>position</EuiCode> prop we can align our bar
+          to be <EuiCode>fixed</EuiCode> or <EuiCode>absolute</EuiCode>. In both
+          options, the background color of the base bar is dropped (since the
+          context of width is already known from your wrapping element). For the
+          absolute option, make sure that your wrapping element
+          has <EuiCode>position: relative</EuiCode> applied.
+        </p>
+
+        <p>
+          Using <EuiCode>EuiProgress</EuiCode> with
+          a <EuiCode>fixed</EuiCode> position may result in it being overlayed
+          when its parent wrapper has a <EuiCode>z-index</EuiCode> value lower
+          than another fixed element, such as <EuiCode>EuiHeader</EuiCode>. In
+          that case, wrap <EuiCode>EuiProgress</EuiCode> in
+          an <EuiCode>EuiPortal</EuiCode>.
+        </p>
+      </div>
     ),
     demo: <ProgressFixed />,
   }, {

--- a/src-docs/src/views/progress/progress_fixed.js
+++ b/src-docs/src/views/progress/progress_fixed.js
@@ -9,6 +9,14 @@ import {
   EuiText,
   EuiPanel,
   EuiCallOut,
+  EuiCode,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHeader,
+  EuiHeaderLogo,
+  EuiHeaderSection,
+  EuiHeaderSectionItem,
+  EuiPortal,
 } from '../../../../src/components';
 
 export default class extends Component {
@@ -18,9 +26,11 @@ export default class extends Component {
     this.state = {
       value: 0,
       showProgress: false,
+      showHeader: false,
     };
 
     this.toggleProgress = this.toggleProgress.bind(this);
+    this.toggleHeader = this.toggleHeader.bind(this);
   }
 
   toggleProgress() {
@@ -36,6 +46,14 @@ export default class extends Component {
 
     this.setState({
       showProgress: !this.state.showProgress,
+      showHeader: false
+    });
+  }
+
+  toggleHeader() {
+    this.setState({
+      showHeader: !this.state.showHeader,
+      showProgress: false,
     });
   }
 
@@ -73,6 +91,35 @@ export default class extends Component {
       );
     }
 
+    if (this.state.showHeader) {
+      progress = (
+        <div>
+          <EuiCallOut
+            title="Look up!"
+            color="warning"
+            iconType="sortUp"
+          >
+            <p>
+              The progress bar is fixed to the top of your browser and
+              positioned above an <EuiCode>EuiHeader</EuiCode>.
+            </p>
+          </EuiCallOut>
+          <EuiHeader style={{ position: 'fixed', top: 0, left: 0, width: '100%' }}>
+            <EuiHeaderSection grow={false}>
+              <EuiHeaderSectionItem border="right">
+                <EuiHeaderLogo iconType="logoKibana" href="#" aria-label="Go to home page" />
+              </EuiHeaderSectionItem>
+            </EuiHeaderSection>
+          </EuiHeader>
+          <div style={{ position: 'absolute', zIndex: '5' }}>
+            <EuiPortal>
+              <EuiProgress size="xs" color="accent" position="fixed" />
+            </EuiPortal>
+          </div>
+        </div>
+      );
+    }
+
     return (
       <div>
 
@@ -89,9 +136,18 @@ export default class extends Component {
 
         <EuiSpacer size="l" />
 
-        <EuiButton size="s" onClick={this.toggleProgress}>
-          Toggle a fixed bar
-        </EuiButton>
+        <EuiFlexGroup gutterSize="s" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiButton size="s" onClick={this.toggleProgress}>
+              Toggle a fixed bar
+            </EuiButton>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton size="s" onClick={this.toggleHeader}>
+              Toggle a fixed bar with header
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
 
         <EuiSpacer size="l" />
 

--- a/src/components/progress/_progress.scss
+++ b/src/components/progress/_progress.scss
@@ -64,6 +64,7 @@ $euiProgressSizes: (
 // Progress bars can be set to fixed or absolute.
 .euiProgress--fixed {
   position: fixed;
+  z-index: $euiZHeader + 1;
 }
 
 .euiProgress--absolute {


### PR DESCRIPTION
### Summary

In cases where `EuiProgress` is nested within a parent whose `z-index` value is lower than `EuiHeader` (e.g. from a Kibana plugin), the header will overlay the progress bar preventing it from being seen.

To overcome this situation, a user will need to use an `EuiPortal` while the `EuiProgress` needs a `z-index` greater than the default for `EuiHeader`. This PR adds a `z-index` to `EuiProgress` and provides an example use case in the docs.

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
- [ ] ~Any props added have proper autodocs~
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [ ] ~Jest tests were updated or added to match the most common scenarios~
- [ ] ~This was checked against keyboard-only and screenreader scenarios~
- [ ] ~This required updates to Framer X components~
