### PR TITLE
Font reset is more precise, fix form label weights

### DIFF
--- a/src/components/form/form_label/_form_label.scss
+++ b/src/components/form/form_label/_form_label.scss
@@ -5,7 +5,7 @@
   font-size: $euiFontSizeXS;
   margin-bottom: $euiSizeS;
   transition: all $euiAnimSpeedFast $euiAnimSlightResistance;
-  font-weight: $euiFontWeightMedium;
+  font-weight: $euiFontWeightSemiBold;
 
   &.euiFormLabel-isInvalid {
     color: $euiColorDanger; /* 1 */

--- a/src/global_styling/reset/_reset.scss
+++ b/src/global_styling/reset/_reset.scss
@@ -29,7 +29,7 @@ time, mark, audio, video {
   vertical-align: baseline;
 }
 
-code {
+code, pre {
   font-family: $euiCodeFontFamily;
 }
 

--- a/src/global_styling/reset/_reset.scss
+++ b/src/global_styling/reset/_reset.scss
@@ -10,12 +10,6 @@
   box-sizing: border-box;
 }
 
-/**
- * 1. Inheriting the font will allow some browser defaults to take effect, e.g. Chrome applies
- *    `font: 11px system-ui` to the button element. We can't hardcode the font-family here because
- *    that will disrupt components which rely upon a different inherited font-family, e.g. code
- *    blocks.
- */
 html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
 a, abbr, acronym, address, big, cite, code,
@@ -32,13 +26,15 @@ time, mark, audio, video {
   margin: 0;
   padding: 0;
   border: none;
-  font: inherit; /* 1 */
-  font-family: inherit; /* 1 */
   vertical-align: baseline;
 }
 
+code {
+  font-family: $euiCodeFontFamily;
+}
+
 input, textarea, select, button {
-  font-family: inherit; /* 1 */
+  font-family: $euiFontFamily;
 }
 
 em {


### PR DESCRIPTION
### Summary

@w33ble noticed some inheritance problems with fonts in https://github.com/elastic/kibana/pull/29152. I also heard word from @gjones that there was some other weirdness going on in Cloud. @cchaos and I tracked it down to some over reliance on `inherit` with our reset file. We only use two fonts in EUI, the codey one and the not codey one. More explicitly declaring these in our reset fixes the issues we saw with Joe.

@cchaos I added pre on here because it fits the definition of the default. https://www.w3schools.com/tags/tag_pre.asp

Note to @zumwalt, since I like to alert everyone anytime I edit a reset file in EUI.

I also upped the weight of the form labels, which were a little weak with the new font.

### Checklist

- [ ] ~This was checked in mobile~
- [ ] This was checked in IE11
- [ ] ~This was checked in dark mode~
- [ ] ~Any props added have proper autodocs~
- [ ] ~Documentation examples were added~
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] ~This was checked for breaking changes and labeled appropriately~
- [ ] ~Jest tests were updated or added to match the most common scenarios~
- [ ] ~This was checked against keyboard-only and screenreader scenarios~
- [ ] ~This required updates to Framer X components~
