### PR TITLE
EuiSuperDatePicker - always call onTimeChange when showUpdateButton is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `6.7.1`.
+**Bug fixes**
+
+- `EuiSuperDatePicker` always trigger `onTimeChange` when time changes and prop `showUpdateButton` is false ([#1477](https://github.com/elastic/eui/pull/1477))
 
 ## [`6.7.1`](https://github.com/elastic/eui/tree/v6.7.1)
 

--- a/src/components/date_picker/super_date_picker/super_date_picker.js
+++ b/src/components/date_picker/super_date_picker/super_date_picker.js
@@ -31,7 +31,7 @@ export class EuiSuperDatePicker extends Component {
      */
     end: PropTypes.string,
     /**
-     * Callback for when the time changes. Called with { start, end, isQuickSelection }
+     * Callback for when the time changes. Called with { start, end, isQuickSelection, isInvalid }
      */
     onTimeChange: PropTypes.func.isRequired,
     isPaused: PropTypes.bool,
@@ -147,8 +147,12 @@ export class EuiSuperDatePicker extends Component {
     });
 
     if (!this.props.showUpdateButton) {
-      this.props.onTimeChange({ start, end, isQuickSelection: false });
-      return;
+      this.props.onTimeChange({
+        start,
+        end,
+        isQuickSelection: false,
+        isInvalid,
+      });
     }
   }
 
@@ -163,7 +167,9 @@ export class EuiSuperDatePicker extends Component {
   applyTime = () => {
     this.props.onTimeChange({
       start: this.state.start,
-      end: this.state.end, isQuickSelection: false
+      end: this.state.end,
+      isQuickSelection: false,
+      isInvalid: false,
     });
   }
 
@@ -171,7 +177,12 @@ export class EuiSuperDatePicker extends Component {
     this.setState({
       showPrettyDuration: showPrettyDuration(start, end, this.props.commonlyUsedRanges),
     });
-    this.props.onTimeChange({ start, end, isQuickSelection: true });
+    this.props.onTimeChange({
+      start,
+      end,
+      isQuickSelection: true,
+      isInvalid: false
+    });
   }
 
   hidePrettyDuration = () => {

--- a/src/components/date_picker/super_date_picker/super_date_picker.js
+++ b/src/components/date_picker/super_date_picker/super_date_picker.js
@@ -31,7 +31,7 @@ export class EuiSuperDatePicker extends Component {
      */
     end: PropTypes.string,
     /**
-     * Callback for when the time changes. Called with { start, end }
+     * Callback for when the time changes. Called with { start, end, isQuickSelection }
      */
     onTimeChange: PropTypes.func.isRequired,
     isPaused: PropTypes.bool,
@@ -146,11 +146,9 @@ export class EuiSuperDatePicker extends Component {
       hasChanged: true,
     });
 
-    if (!isInvalid) {
-      if (!this.props.showUpdateButton) {
-        this.props.onTimeChange({ start, end });
-        return;
-      }
+    if (!this.props.showUpdateButton) {
+      this.props.onTimeChange({ start, end, isQuickSelection: false });
+      return;
     }
   }
 
@@ -163,14 +161,17 @@ export class EuiSuperDatePicker extends Component {
   }
 
   applyTime = () => {
-    this.props.onTimeChange({ start: this.state.start, end: this.state.end });
+    this.props.onTimeChange({
+      start: this.state.start,
+      end: this.state.end, isQuickSelection: false
+    });
   }
 
   applyQuickTime = ({ start, end }) => {
     this.setState({
       showPrettyDuration: showPrettyDuration(start, end, this.props.commonlyUsedRanges),
     });
-    this.props.onTimeChange({ start, end });
+    this.props.onTimeChange({ start, end, isQuickSelection: true });
   }
 
   hidePrettyDuration = () => {


### PR DESCRIPTION
Some more clean-up discovered from integrating EuiSuperDatePicker into Kibana QueryBar

1) `onTimeChange` is not getting called on each update when `showUpdateButton` is false
2) Need a way to know when `onTimeChange` is triggered from quick selection so the results can be applied immediately.