### PR TITLE
Default light theme now comes with an empty light colors file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `6.7.1`.
+- Default light theme now comes with an empty light variables file  to make theme switching easier ([#1479](https://github.com/elastic/eui/pull/1479))
 
 ## [`6.7.1`](https://github.com/elastic/eui/tree/v6.7.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Default light theme now comes with an empty light variables file  to make theme switching easier ([#1479](https://github.com/elastic/eui/pull/1479))
+- Default light theme now comes with an empty light variables file to make theme switching easier ([#1479](https://github.com/elastic/eui/pull/1479))
 
 ## [`6.7.1`](https://github.com/elastic/eui/tree/v6.7.1)
 

--- a/src/theme_light.scss
+++ b/src/theme_light.scss
@@ -1,4 +1,5 @@
-// This is the default theme, it does not contain any variable overwrites.
+// This is the default theme.
+@import 'themes/eui/eui_colors_light';
 
 // Global styling
 @import 'global_styling/index';

--- a/src/themes/eui/eui_colors_light.scss
+++ b/src/themes/eui/eui_colors_light.scss
@@ -1,0 +1,2 @@
+// This file contains no overwrites because EUI's default theme is this colorscheme.
+// The file exists in case you ever need to write logic to flip files in a build process.

--- a/src/themes/eui/eui_colors_light.scss
+++ b/src/themes/eui/eui_colors_light.scss
@@ -1,2 +1,2 @@
-// This file contains no overwrites because EUI's default theme is this colorscheme.
-// The file exists in case you ever need to write logic to flip files in a build process.
+// This file contains no overwrites because EUI by default is light.
+// The file exists in case you ever need to write logic to flip imports in a build process.


### PR DESCRIPTION
### Summary

Because Kibana switches themes by doing some string magic on the sass files themselves we need to make an `eui_colors_light.scss` file to swap against `eui_colors_dark.scss`. This file changes nothing in the build of EUI itself, and although empty, does provide some symmetry to our theming system and load order.

Checklist not needed. This is an empty change for EUI, but a CL item will be added for documentation.
