### PR TITLE
Don’t reduce header at at mobile size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `6.7.1`.
+- `EuiHeader` no longer reduces height at mobile sizes ([#1480](https://github.com/elastic/eui/pull/1480))
 
 ## [`6.7.1`](https://github.com/elastic/eui/tree/v6.7.1)
 

--- a/src/components/header/_header_logo.scss
+++ b/src/components/header/_header_logo.scss
@@ -6,6 +6,7 @@
   position: relative;
   height: $euiHeaderChildSize;
   line-height: $euiHeaderChildSize;
+  min-width: $euiHeaderChildSize + 1px;
   padding: 0 ($euiSizeM + 1px) 0 $euiSizeM;
   display: inline-block;
   vertical-align: middle;
@@ -31,8 +32,6 @@
 
 @include euiBreakpoint('xs') {
   .euiHeaderLogo {
-    height: $euiHeaderChildSize * .75;
-    line-height: $euiHeaderChildSize * .75;
     padding: 0 $euiSizeM;
   }
 

--- a/src/components/header/_variables.scss
+++ b/src/components/header/_variables.scss
@@ -5,4 +5,3 @@ $euiHeaderBreadcrumbColor: $euiColorDarkestShade;
 
 // Layout vars
 $euiHeaderChildSize: $euiSizeXXL + $euiSizeS;
-$euiHeaderChildSizeMobile: $euiHeaderChildSize * .75;

--- a/src/components/header/header_section/_header_section_item.scss
+++ b/src/components/header/header_section/_header_section_item.scss
@@ -19,7 +19,7 @@
 
 .euiHeaderSectionItem__button {
   height: $euiHeaderChildSize;
-  min-width: $euiHeaderChildSize + 1px;
+  min-width: $euiHeaderChildSize;
   text-align: center;
   font-size: 0; // aligns icons better vertically
 
@@ -53,8 +53,7 @@
 @include euiBreakpoint('xs') {
   .euiHeaderSectionItem,
   .euiHeaderSectionItem__button {
-    height: $euiHeaderChildSizeMobile;
-    min-width: $euiHeaderChildSizeMobile;
+    min-width: $euiHeaderChildSize * .75;
   }
 
   .euiHeaderSectionItem--borderLeft,
@@ -67,7 +66,7 @@
   // On small screens just show a small dot indicating there are notifications
   .euiHeaderNotification {
     @include size($euiSizeS);
-
+    top: 20%;
     min-width: 0;
     border-radius: $euiSizeS;
     color: $euiColorAccent;

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -116,10 +116,3 @@
     }
   }
 }
-
-@include euiBreakpoint('xs') {
-  .euiNavDrawer {
-    height: calc(100% - #{$euiNavDrawerTopPositionMobile});
-    top: $euiNavDrawerTopPositionMobile;
-  }
-}

--- a/src/components/nav_drawer/_variables.scss
+++ b/src/components/nav_drawer/_variables.scss
@@ -8,7 +8,6 @@ $euiNavDrawerSideShadow: 2px 0 2px -1px rgba($euiShadowColor, .3);
 
 // Layout variables
 $euiNavDrawerTopPosition: $euiHeaderChildSize + 1px;
-$euiNavDrawerTopPositionMobile: $euiHeaderChildSizeMobile + 1px;
 
 // Animation variables
 $euiNavDrawerExpandingDelay: $euiAnimSpeedNormal;


### PR DESCRIPTION
### Summary

The header was being too squished in height on mobile screens. This PR just keeps the height from changing (but still allows the buttons to squish in width).

<img src="https://d.pr/free/i/UooQXk+" />

### Note

To @ryankeairns : I moved the `min-width: 49px` to just the header logo because it was causing the spaces avatar to look off-center. Though when I look at it without that the button seems to still render at 49px wide (probably because the 'border' is at `right: 0`. But anyhow, you can double-check that part and let me know if you'd rather me put it back the way it was.

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
