### PR TITLE
Don’t add the variant font family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug fixes**
 
 - `EuiSuperDatePicker` always trigger `onTimeChange` when time changes and prop `showUpdateButton` is false ([#1477](https://github.com/elastic/eui/pull/1477))
+- Fixed font rendering in italics only in Safari ([#1481](https://github.com/elastic/eui/pull/1481))
 
 ## [`6.7.1`](https://github.com/elastic/eui/tree/v6.7.1)
 

--- a/src/global_styling/mixins/_typography.scss
+++ b/src/global_styling/mixins/_typography.scss
@@ -10,10 +10,6 @@
   -ms-text-size-adjust: 100%;
   font-kerning: normal;
   font-feature-settings: $euiFontFeatureSettings;
-
-  @supports (font-variation-settings: normal) {
-    font-family: $euiFontFamilyVariable;
-  }
 }
 
 @mixin euiCodeFont {

--- a/src/global_styling/variables/_typography.scss
+++ b/src/global_styling/variables/_typography.scss
@@ -27,7 +27,6 @@
 // Families
 
 $euiFontFamily: 'Inter UI', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol' !default;
-$euiFontFamilyVariable: 'Inter UI var', $euiFontFamily !default;
 $euiFontFeatureSettings: 'calt' 1, 'kern' 1, 'liga' 1 !default;
 
 $euiCodeFontFamily: 'Roboto Mono', Consolas, Menlo, Courier, monospace !default;

--- a/src/themes/k6/k6_globals.scss
+++ b/src/themes/k6/k6_globals.scss
@@ -1,6 +1,5 @@
 // Font families
 $euiFontFamily: 'Open Sans', 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol' !default;
-$euiFontFamilyVariable: $euiFontFamily;
 
 $euiTextScale: 2.28571429, 1.71428571, 1.28571429, 1.14285714, 1, 1, .85714286;
 


### PR DESCRIPTION
### Summary

Fixes Safari only showing italics.

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- ~[ ] This was checked in dark mode~
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
