### PR TITLE
EuiSuperDatePicker determine state.isInvalid on props update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `6.7.2`.
+**Bug fixes**
+
+- Fixed `EuiSuperDatePicker` not updating derived `isInvalid` state on prop update ([#1483](https://github.com/elastic/eui/pull/1483))
 
 ## [`6.7.2`](https://github.com/elastic/eui/tree/v6.7.2)
 

--- a/src/components/date_picker/super_date_picker/super_date_picker.js
+++ b/src/components/date_picker/super_date_picker/super_date_picker.js
@@ -16,6 +16,20 @@ import { EuiDatePickerRange } from '../date_picker_range';
 import { EuiFormControlLayout } from '../../form';
 import { EuiFlexGroup, EuiFlexItem } from '../../flex';
 
+function isRangeInvalid(start, end) {
+  if (start === 'now' && end === 'now') {
+    return true;
+  }
+
+  const startMoment = dateMath.parse(start);
+  const endMoment = dateMath.parse(end, { roundUp: true });
+  if (startMoment.isAfter(endMoment)) {
+    return true;
+  }
+
+  return false;
+}
+
 export class EuiSuperDatePicker extends Component {
 
   static propTypes = {
@@ -97,7 +111,7 @@ export class EuiSuperDatePicker extends Component {
         },
         start: nextProps.start,
         end: nextProps.end,
-        isInvalid: false,
+        isInvalid: isRangeInvalid(nextProps.start, nextProps.end),
         hasChanged: false,
         showPrettyDuration: showPrettyDuration(nextProps.start, nextProps.end, nextProps.commonlyUsedRanges),
       };
@@ -129,15 +143,7 @@ export class EuiSuperDatePicker extends Component {
   }
 
   setTime = ({ start, end }) => {
-    const startMoment = dateMath.parse(start);
-    const endMoment = dateMath.parse(end, { roundUp: true });
-    const isInvalid = (start === 'now' && end === 'now') || startMoment.isAfter(endMoment);
-
-    if (this.tooltipTimeout) {
-      clearTimeout(this.tooltipTimeout);
-      this.hideTooltip();
-      this.tooltipTimeout = null;
-    }
+    const isInvalid = isRangeInvalid(start, end);
 
     this.setState({
       start,

--- a/src/components/date_picker/super_date_picker/super_date_picker.js
+++ b/src/components/date_picker/super_date_picker/super_date_picker.js
@@ -136,7 +136,7 @@ export class EuiSuperDatePicker extends Component {
       },
       start,
       end,
-      isInvalid: false,
+      isInvalid: isRangeInvalid(start, end),
       hasChanged: false,
       showPrettyDuration: showPrettyDuration(start, end, commonlyUsedRanges),
     };


### PR DESCRIPTION
Invalid ranges are not colored as invalid because `isInvalid` was not getting calculated by `getDerivedStateFromProps`. Other than that, things are looking really good with embedding EuiSuperDatePicker in Kibana's QueryBar

<img width="683" alt="screen shot 2019-01-25 at 4 11 03 pm" src="https://user-images.githubusercontent.com/373691/51777783-d5d52680-20bb-11e9-9894-27508836af83.png">
