### PR TITLE
Remove TS types & interfaces from ES exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - `EuiHeader` no longer reduces height at mobile sizes ([#1480](https://github.com/elastic/eui/pull/1480))
 
+**Bug fixes**
+
+- Remove Typescript type and interface definitions from ES and CJS exports ([#1486](https://github.com/elastic/eui/pull/1486))
+
 ## [`6.7.2`](https://github.com/elastic/eui/tree/v6.7.2)
 
 - Default light theme now comes with an empty light variables file to make theme switching easier ([#1479](https://github.com/elastic/eui/pull/1479))

--- a/scripts/babel/proptypes-from-ts-props/index.test.js
+++ b/scripts/babel/proptypes-from-ts-props/index.test.js
@@ -1877,6 +1877,57 @@ FooComponent.propTypes = {
 };`);
           });
 
+          it('resolves types exported without an import', () => {
+            const result = transform(
+              `
+import React from 'react';
+import { Foo } from '../foo';
+const FooComponent: React.SFC<{foo: Foo}> = () => {
+  return (<div>Hello World</div>);
+}`,
+              {
+                ...babelOptions,
+                plugins: [
+                  [
+                    './scripts/babel/proptypes-from-ts-props',
+                    {
+                      fs: {
+                        existsSync: () => true,
+                        statSync: () => ({ isDirectory: () => false }),
+                        readFileSync: filepath => {
+                          if (filepath.endsWith('/foo')) {
+                            return Buffer.from(`
+                              export { Foo } from './Foo';
+                            `);
+                          }
+
+                          if (filepath.endsWith('/Foo')) {
+                            return Buffer.from(`
+                              export type Foo = string;
+                            `);
+                          }
+
+                          throw new Error(`Test tried to import from ${filepath}`);
+                        }
+                      }
+                    }
+                  ],
+                ]
+              }
+            );
+
+            expect(result.code).toBe(`import React from 'react';
+import PropTypes from "prop-types";
+
+const FooComponent = () => {
+  return <div>Hello World</div>;
+};
+
+FooComponent.propTypes = {
+  foo: PropTypes.string.isRequired
+};`);
+          });
+
         });
 
       });
@@ -2126,6 +2177,63 @@ FooComponent.propTypes = {
 
     });
 
+  });
+
+  describe('remove types from exports', () => {
+    it('removes sole type export from ExportNamedDeclaration', () => {
+      const result = transform(
+        `
+type Foo = string;
+export { Foo };
+`,
+        babelOptions
+      );
+
+      expect(result.code).toBe(`export {};`);
+    });
+
+    it('removes multiple type export from ExportNamedDeclaration', () => {
+      const result = transform(
+        `
+type Foo = string;
+type Bar = number | Foo;
+export { Foo, Bar };
+`,
+        babelOptions
+      );
+
+      expect(result.code).toBe(`export {};`);
+    });
+
+    it('removes type exports from ExportNamedDeclaration, leaving legitimate exports', () => {
+      const result = transform(
+        `
+type Foo = string;
+type Bar = Foo | boolean;
+const A = 500;
+const B = { bar: A };
+export { Foo, A, Bar, B };
+`,
+        babelOptions
+      );
+
+      expect(result.code).toBe(`const A = 500;
+const B = {
+  bar: A
+};
+export { A, B };`);
+    });
+
+    it('extracts the type from an export statement', () => {
+      const result = transform(
+        `
+export type Foo = string;
+`,
+        babelOptions
+      );
+
+      expect(result.code).toBe('');
+    });
   });
 
 });


### PR DESCRIPTION
### Summary

Fixes #1376. This extends our typescript->proptypes babel plugin to also remove any types or interfaces from ExportNamedDeclarations e.g. `export { Foo, Bar }` & `export { Foo, Bar } from './source';`. Added this functionality to the existing plugin for two reasons: 1. no build tooling in TS or Babel performs this transformation 2. our plugin already tracks variable type information across imports.

I tested this change in create-react-app by generating an npm module tarball with `npm pack` and adding the contents of that tarball as a dependency in a new CRA project.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
