### PR TITLE
[EuiText] Add 'align' property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,12 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `6.7.3`.
+- Added `textAlign` property to TypeScript definition for `EuiText` ([#1487](https://github.com/elastic/eui/pull/1487))
+- Added missing `'m'` option for text `size` for `EuiText`'s TypeScript definition ([#1487](https://github.com/elastic/eui/pull/1487))
+- Added missing TypeScript definition for `EuiTextAlign` ([#1487](https://github.com/elastic/eui/pull/1487))
 
 ## [`6.7.3`](https://github.com/elastic/eui/tree/v6.7.3)
 
 - `EuiHeader` no longer reduces height at mobile sizes ([#1480](https://github.com/elastic/eui/pull/1480))
-- Added `textAlign` property to TypeScript definition for `EuiText` ([#1487](https://github.com/elastic/eui/pull/1487))
-- Added missing `'m'` option for text `size` for `EuiText`'s TypeScript definition ([#1487](https://github.com/elastic/eui/pull/1487))
-- Added missing TypeScript definition for `EuiTextAlign` ([#1487](https://github.com/elastic/eui/pull/1487))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ No public interface changes since `6.7.3`.
 ## [`6.7.3`](https://github.com/elastic/eui/tree/v6.7.3)
 
 - `EuiHeader` no longer reduces height at mobile sizes ([#1480](https://github.com/elastic/eui/pull/1480))
-- Added `align` property to TypeScript definition for `EuiText` ([#1487](https://github.com/elastic/eui/pull/1487))
+- Added `textAlign` property to TypeScript definition for `EuiText` ([#1487](https://github.com/elastic/eui/pull/1487))
 - Added missing `'m'` option for text `size` for `EuiText`'s TypeScript definition ([#1487](https://github.com/elastic/eui/pull/1487))
 - Added missing TypeScript definition for `EuiTextAlign` ([#1487](https://github.com/elastic/eui/pull/1487))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - `EuiHeader` no longer reduces height at mobile sizes ([#1480](https://github.com/elastic/eui/pull/1480))
+- Added `align` property to TypeScript definition for `EuiText` ([#1487](https://github.com/elastic/eui/pull/1487))
+- Added missing `'m'` option for text `size` for `EuiText`'s TypeScript definition ([#1487](https://github.com/elastic/eui/pull/1487))
+- Added missing TypeScript definition for `EuiTextAlign` ([#1487](https://github.com/elastic/eui/pull/1487))
 
 **Bug fixes**
 

--- a/src/components/text/index.d.ts
+++ b/src/components/text/index.d.ts
@@ -8,7 +8,15 @@ declare module '@elastic/eui' {
    * @see './text.js'
    * @see './text_color.js'
    */
-  type TEXT_SIZES = 's' | 'xs';
+  type TEXT_SIZES = 'm' | 's' | 'xs';
+
+  /**
+   * text alignment options
+   *
+   * @see './text.js'
+   * @see './text_align.js'
+   */
+  type ALIGNMENTS = 'left' | 'center' | 'right';
 
   type COLORS =
     | 'default'
@@ -19,8 +27,12 @@ declare module '@elastic/eui' {
     | 'warning'
     | 'ghost';
 
-  type EuiTextProps = CommonProps &
+  type EuiTextAlignProps = CommonProps &
     HTMLAttributes<HTMLDivElement> & {
+      align?: ALIGNMENTS;
+    };
+
+  type EuiTextProps = EuiTextAlignProps & {
       size?: TEXT_SIZES;
       color?: COLORS;
       grow?: boolean;
@@ -32,6 +44,9 @@ declare module '@elastic/eui' {
     color?: COLORS;
   };
 
+
+
   export const EuiText: SFC<EuiTextProps>;
+  export const EuiTextAlign: SFC<EuiTextAlignProps>;
   export const EuiTextColor: SFC<EuiTextColorProps>;
 }

--- a/src/components/text/index.d.ts
+++ b/src/components/text/index.d.ts
@@ -29,7 +29,7 @@ declare module '@elastic/eui' {
 
   type EuiTextAlignProps = CommonProps &
     HTMLAttributes<HTMLDivElement> & {
-      align?: ALIGNMENTS;
+      textAlign?: ALIGNMENTS;
     };
 
   type EuiTextProps = EuiTextAlignProps & {


### PR DESCRIPTION
### Summary

This also adds the missing definition for `EuiTextAlign` and the missing `align` property from `EuiText` for TypeScript usage, and the missing `m` value for the text size of `EuiText`.

### Checklist

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
