### PR TITLE
Fix APM logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug fixes**
 
 - Fixed `EuiSuperDatePicker` not updating derived `isInvalid` state on prop update ([#1483](https://github.com/elastic/eui/pull/1483))
+- Fixed `logoAPM` ([#1489](https://github.com/elastic/eui/pull/1489))
 
 ## [`6.7.2`](https://github.com/elastic/eui/tree/v6.7.2)
 

--- a/src/components/icon/__snapshots__/icon.test.tsx.snap
+++ b/src/components/icon/__snapshots__/icon.test.tsx.snap
@@ -2599,15 +2599,15 @@ exports[`EuiIcon props type logoAPM is rendered 1`] = `
     fill-rule="evenodd"
   >
     <path
-      d="M0 11h24V.999H0z"
+      d="M0 10.001h24V0H0z"
       fill="#F04E98"
     />
     <path
-      d="M32 21H20c-5.522 0-10-4.478-10-10h22v10z"
+      d="M32 20H20c-5.522 0-10-4.478-10-10h22v10z"
       fill="#343741"
     />
     <path
-      d="M20 33h12v-9H20z"
+      d="M20 32h12v-9H20z"
       fill="#0080D5"
     />
   </g>

--- a/src/components/icon/assets/logo_apm.svg
+++ b/src/components/icon/assets/logo_apm.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
   <g fill="none" fill-rule="evenodd">
-    <polygon fill="#F04E98" points="0 11 24 11 24 .999 0 .999"/>
-    <path fill="#343741" d="M32,21 L20,21 C14.478,21 10,16.522 10,11 L32,11 L32,21 Z"/>
-    <polygon fill="#0080D5" points="20 33 32 33 32 24 20 24"/>
+    <polygon fill="#F04E98" points="0 10.001 24 10.001 24 0 0 0"/>
+    <path fill="#343741" d="M32,20 L20,20 C14.478,20 10,15.522 10,10 L32,10 L32,20 Z"/>
+    <polygon fill="#0080D5" points="20 32 32 32 32 23 20 23"/>
   </g>
 </svg>


### PR DESCRIPTION
### Summary

The logo wasn't properly aligned with the artboard.

**before**
<img alt="screen shot 2019-01-29 at 10 05 03 am" src="https://user-images.githubusercontent.com/549577/51917610-e8967680-23ad-11e9-9af2-b4bf5cd40bda.png">


**after**
<img alt="screen shot 2019-01-29 at 10 06 38 am" src="https://user-images.githubusercontent.com/549577/51917614-ecc29400-23ad-11e9-9723-822bb1175dac.png">


### Checklist

- ~[ ] This was checked in mobile~
- ~[ ] This was checked in IE11~
- ~[ ] This was checked in dark mode~
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- [x] Jest tests were updated or added to match the most common scenarios
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
