### PR TITLE
Updated popover position to correctly address arrow buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `6.7.3`.
+**Bug fixes**
+
+- Fixed popover & tooltip positioning to properly account for arrow buffer ([#1490](https://github.com/elastic/eui/pull/1490))
 
 ## [`6.7.3`](https://github.com/elastic/eui/tree/v6.7.3)
 

--- a/src/services/popover/popover_positioning.test.ts
+++ b/src/services/popover/popover_positioning.test.ts
@@ -297,12 +297,33 @@ describe('popover_positioning', () => {
           offset: 10,
           arrowConfig: { arrowWidth: 5, arrowBuffer: 10 },
         })).toEqual({
-          fit: 0.63,
+          fit: 0.665,
           top: -15,
-          left: 35,
+          left: 37.5,
           arrow: {
             top: 50,
-            left: 12.5,
+            left: 10,
+          },
+        });
+      });
+
+      it('respects both popover & arrow buffers', () => {
+        expect(getPopoverScreenCoordinates({
+          position: 'top',
+          anchorBoundingBox: makeBB(45, 55, 55, 45),
+          popoverBoundingBox: makeBB(0, 50, 50, 0),
+          windowBoundingBox: makeBB(0, 1024, 768, 0),
+          containerBoundingBox: makeBB(0, 1024, 768, 40),
+          offset: 10,
+          buffer: 15,
+          arrowConfig: { arrowWidth: 5, arrowBuffer: 10 },
+        })).toEqual({
+          fit: 0.26,
+          top: -15,
+          left: 37.5,
+          arrow: {
+            top: 50,
+            left: 10,
           },
         });
       });

--- a/src/services/popover/popover_positioning.ts
+++ b/src/services/popover/popover_positioning.ts
@@ -405,8 +405,6 @@ function getCrossAxisPosition({
   const combinedBoundingBox = intersectBoundingBoxes(windowBoundingBox, containerBoundingBox);
   const availableSpace = getAvailableSpace(anchorBoundingBox, combinedBoundingBox, buffer, offset, position);
   const minimumSpace = arrowConfig ? arrowConfig.arrowBuffer : 0;
-  availableSpace[crossAxisFirstSide] = Math.max(availableSpace[crossAxisFirstSide], minimumSpace);
-  availableSpace[crossAxisSecondSide] = Math.max(availableSpace[crossAxisSecondSide], minimumSpace);
 
   const contentOverflowSize = (popoverSizeOnCrossAxis - anchorSizeOnCrossAxis) / 2;
 


### PR DESCRIPTION
### Summary

Addresses a bug @nreese found in https://github.com/elastic/kibana/pull/29235

The tooltip has a whitespace buffer of 16px, and its arrow must be 4px from its edge. Nathan's super update button is less than 16px from the right side of the screen; the calculations were shifting the popover to meet the buffer but didn't properly account for the 4px needed for the arrow, which forced the popover to an undesired position.

@nreese mind building the fix and confirming it works in your Kibana branch?

### Checklist

- [x] This was checked in mobile
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
