### PR TITLE
EuiSuperDatePicker: add seconds unit option to refresh interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Changed `flex-basis` value on `EuiPageBody` for better cross-broswer support ([#1497](https://github.com/elastic/eui/pull/1497))
 - Converted a number of components to support text localization ([#1485](https://github.com/elastic/eui/pull/1485))
+- Added a seconds option to the refresh interval selection in `EuiSuperDatePicker`  ([#1503](https://github.com/elastic/eui/pull/1503))
 
 ## [`6.7.4`](https://github.com/elastic/eui/tree/v6.7.4)
 

--- a/src/components/date_picker/super_date_picker/quick_select_popover/refresh_interval.js
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/refresh_interval.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
-import { timeUnits } from '../time_units';
+import { timeUnits, timeUnitsPlural } from '../time_units';
 
 import { EuiFlexGroup, EuiFlexItem } from '../../../flex';
 import { EuiTitle } from '../../../title';
@@ -10,13 +10,14 @@ import { EuiButton } from '../../../button';
 
 const refreshUnitsOptions = Object.keys(timeUnits)
   .filter(timeUnit => {
-    return timeUnit === 'h' || timeUnit === 'm';
+    return timeUnit === 'h' || timeUnit === 'm' || timeUnit === 's';
   })
   .map(timeUnit => {
-    return { value: timeUnit, text: `${timeUnits[timeUnit]}s` };
+    return { value: timeUnit, text: timeUnitsPlural[timeUnit] };
   });
 
-const MILLISECONDS_IN_MINUTE = 1000 * 60;
+const MILLISECONDS_IN_SECOND = 1000;
+const MILLISECONDS_IN_MINUTE = MILLISECONDS_IN_SECOND * 60;
 const MILLISECONDS_IN_HOUR = MILLISECONDS_IN_MINUTE * 60;
 
 function fromMilliseconds(milliseconds) {
@@ -30,16 +31,29 @@ function fromMilliseconds(milliseconds) {
     };
   }
 
+  if (milliseconds > MILLISECONDS_IN_MINUTE) {
+    return {
+      units: 'm',
+      value: round(milliseconds / MILLISECONDS_IN_MINUTE)
+    };
+  }
+
   return {
-    units: 'm',
-    value: round(milliseconds / MILLISECONDS_IN_MINUTE)
+    units: 's',
+    value: round(milliseconds / MILLISECONDS_IN_SECOND)
   };
 }
 
 function toMilliseconds(units, value) {
-  return units === 'h'
-    ? Math.round(value * MILLISECONDS_IN_HOUR)
-    : Math.round(value * MILLISECONDS_IN_MINUTE);
+  switch (units) {
+    case 'h':
+      return Math.round(value * MILLISECONDS_IN_HOUR);
+    case 'm':
+      return Math.round(value * MILLISECONDS_IN_MINUTE);
+    case 's':
+    default:
+      return Math.round(value * MILLISECONDS_IN_SECOND);
+  }
 }
 
 export class EuiRefreshInterval extends Component {


### PR DESCRIPTION
### Summary

Resolves #1502.

Adds 'seconds' option to the Refresh Interval selection

### Checklist

~~- [ ] This was checked in mobile~~
~~- [ ] This was checked in IE11~~
~~- [ ] This was checked in dark mode~~
~~- [ ] Any props added have proper autodocs~~
~~- [ ] Documentation examples were added~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately

~~- [ ] This was checked for breaking changes and labeled appropriately~~
~~- [ ] Jest tests were updated or added to match the most common scenarios~~
~~- [ ] This was checked against keyboard-only and screenreader scenarios~~
~~- [ ] This required updates to Framer X components~~
