### PR TITLE
Feature/more i18n tokens

### DIFF
--- a/.eslintplugin.js
+++ b/.eslintplugin.js
@@ -1,0 +1,3 @@
+exports.rules = {
+  i18n: require('./scripts/eslint-plugin-i18n/i18n'),
+};

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,10 +14,12 @@
     "@elastic/eslint-config-kibana"
   ],
   "plugins": [
-    "prettier"
+    "prettier",
+    "local"
   ],
   "rules": {
-    "prefer-template": "error"
+    "prefer-template": "error",
+    "local/i18n": "error"
   },
   "env": {
     "jest": true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `6.8.0`.
+- Converted a number of components to support text localization ([#1504](https://github.com/elastic/eui/pull/1504))
 
 ## [`6.8.0`](https://github.com/elastic/eui/tree/v6.8.0)
 
 - Changed `flex-basis` value on `EuiPageBody` for better cross-browser support ([#1497](https://github.com/elastic/eui/pull/1497))
-- Converted a number of components to support text localization ([#1485](https://github.com/elastic/eui/pull/1485)) ([#1504](https://github.com/elastic/eui/pull/1504))
+- Converted a number of components to support text localization ([#1485](https://github.com/elastic/eui/pull/1485))
 - Added a seconds option to the refresh interval selection in `EuiSuperDatePicker`  ([#1503](https://github.com/elastic/eui/pull/1503))
 - Changed to conditionally render `EuiModalBody` if `EuiConfirmModal` has no `children` ([#1505](https://github.com/elastic/eui/pull/1505))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Changed `flex-basis` value on `EuiPageBody` for better cross-broswer support ([#1497](https://github.com/elastic/eui/pull/1497))
-- Converted a number of components to support text localization ([#1485](https://github.com/elastic/eui/pull/1485))
+- Converted a number of components to support text localization ([#1485](https://github.com/elastic/eui/pull/1485)) ([#1504](https://github.com/elastic/eui/pull/1504))
 
 ## [`6.7.4`](https://github.com/elastic/eui/tree/v6.7.4)
 

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-jest": "^21.6.2",
     "eslint-plugin-jsx-a11y": "^6.0.2",
+    "eslint-plugin-local": "^1.0.0",
     "eslint-plugin-mocha": "^4.11.0",
     "eslint-plugin-prefer-object-spread": "^1.2.1",
     "eslint-plugin-prettier": "^2.6.0",

--- a/scripts/eslint-plugin-i18n/i18n.js
+++ b/scripts/eslint-plugin-i18n/i18n.js
@@ -1,0 +1,217 @@
+// Enforce EuiI18n token names & variable names in render prop
+
+const path = require('path');
+
+function attributesArrayToLookup(attributesArray) {
+  return attributesArray.reduce(
+    (lookup, attribute) => {
+      lookup[attribute.name.name] = attribute.value;
+      return lookup;
+    },
+    {}
+  );
+}
+
+function getDefinedValues(valuesNode) {
+  if (valuesNode == null) return new Set();
+  return valuesNode.expression.properties.reduce(
+    (valueNames, property) => {
+      valueNames.add(property.key.name);
+      return valueNames;
+    },
+    new Set()
+  );
+}
+
+function formatSet(set) {
+  return Array.from(set).sort().join(', ');
+}
+
+function getExpectedValueNames(defaultString) {
+  const matches = defaultString.match(/{([a-zA-Z0-9_-]+)}/g);
+  const expectedNames = new Set();
+
+  if (matches) {
+    matches.forEach(match => {
+      expectedNames.add(match.substring(1, match.length - 1));
+    });
+  }
+
+  return expectedNames;
+}
+
+function areSetsEqual(set1, set2) {
+  if (set1.size !== set2.size) return false;
+  const entries = Array.from(set1);
+  for (let i = 0; i < entries.length; i++) {
+    if (set2.has(entries[i]) === false) return false;
+  }
+  return true;
+}
+
+function getRenderPropFromChildren(children) {
+  if (Array.isArray(children)) {
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
+      if (child.type === 'JSXExpressionContainer' && child.expression.type === 'ArrowFunctionExpression') {
+        return child.expression;
+      }
+    }
+  } else {
+    if (children.type === 'JSXExpressionContainer' && children.expression.type === 'ArrowFunctionExpression') {
+      return children.expression;
+    }
+  }
+}
+
+function getExpectedParamNameFromToken(tokenValue) {
+  const tokenParts = tokenValue.split(/\./g);
+  return tokenParts[tokenParts.length - 1];
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+
+    docs: {
+      description: 'Enforce EuiI18n token names & variable names in render prop',
+    },
+
+    messages: {
+      invalidToken: 'token value "{{ tokenValue }}" must be of format {{ tokenNamespace }}.tokenName',
+      mismatchedValues: 'expected values "{{ expected }}" but provided {{ provided }}',
+      mismatchedTokensAndDefaults: 'given {{ tokenLength }} tokens but {{ defaultsLength }} defaults',
+      tokenNamesNotUsedInRenderProp: 'tokens {{ tokenNames }} is not used by render prop params {{ paramNames }}',
+    },
+  },
+  create: function (context) {
+    const filename = context.getFilename();
+    const basename = path.basename(filename, path.extname(filename));
+    const expectedTokenNamespace = `eui${basename.replace(/(^|_)([a-z])/g, (match, leading, char) => char.toUpperCase())}`;
+
+    return {
+      JSXOpeningElement(node) {
+        // only process <EuiI8n/> elements
+        if (node.name.type !== 'JSXIdentifier' || node.name.name !== 'EuiI18n') return;
+
+        const jsxElement = node.parent;
+        const hasRenderProp = jsxElement.children.length > 0;
+
+        const attributes = attributesArrayToLookup(node.attributes);
+
+        const hasMultipleTokens = attributes.hasOwnProperty('tokens');
+
+        if (!hasMultipleTokens) {
+          // validate token format
+          const tokenParts = attributes.token.value.split('.');
+          if (tokenParts.length <= 1 || tokenParts[0] !== expectedTokenNamespace) {
+            context.report({
+              node,
+              loc: attributes.token.loc,
+              messageId: 'invalidToken',
+              data: { tokenValue: attributes.token.value, tokenNamespace: expectedTokenNamespace }
+            });
+          }
+
+          // validate default string interpolation matches values
+          const valueNames = getDefinedValues(attributes.values);
+
+          if (attributes.default.type === 'Literal') {
+            // default is a string literal
+            const expectedNames = getExpectedValueNames(attributes.default.value);
+            if (areSetsEqual(expectedNames, valueNames) === false) {
+              context.report({
+                node,
+                loc: attributes.values.loc,
+                messageId: 'mismatchedValues',
+                data: { expected: formatSet(expectedNames), provided: formatSet(valueNames) }
+              });
+            }
+          } else {
+            // default is a function
+            // validate the destructured param defined by default function match the values
+            const defaultFn = attributes.default.expression;
+            const objProperties = defaultFn.params ? defaultFn.params[0].properties : [];
+            const expectedNames = new Set(objProperties.map(property => property.key.name));
+            if (areSetsEqual(valueNames, expectedNames) === false) {
+              context.report({
+                node,
+                loc: attributes.values.loc,
+                messageId: 'mismatchedValues',
+                data: { expected: formatSet(expectedNames), provided: formatSet(valueNames) }
+              });
+            }
+          }
+        } else {
+          // has multiple tokens
+          // validate their names
+          const tokens = attributes.tokens.expression.elements;
+          for (let i = 0; i < tokens.length; i++) {
+            const token = tokens[i];
+            const tokenParts = token.value.split('.');
+            if (tokenParts.length <= 1 || tokenParts[0] !== expectedTokenNamespace) {
+              context.report({
+                node,
+                loc: token.loc,
+                messageId: 'invalidToken',
+                data: { tokenValue: token.value, tokenNamespace: expectedTokenNamespace }
+              });
+            }
+          }
+
+          // validate the number of tokens equals the number of defaults
+          const defaults = attributes.defaults.expression.elements;
+          if (tokens.length !== defaults.length) {
+            context.report({
+              node,
+              loc: node.loc,
+              messageId: 'mismatchedTokensAndDefaults',
+              data: { tokenLength: tokens.length, defaultsLength: defaults.length }
+            });
+          }
+        }
+
+        if (hasRenderProp) {
+          // validate the render prop
+          const renderProp = getRenderPropFromChildren(jsxElement.children);
+
+          if (hasMultipleTokens) {
+            // multiple tokens, verify each token matches an array-destructured param
+            const params = renderProp.params[0].elements;
+            const tokens = attributes.tokens.expression.elements;
+
+            const paramsSet = new Set(params.map(element => element.name));
+            const tokensSet = new Set(tokens.map(element => getExpectedParamNameFromToken(element.value)));
+
+            if (areSetsEqual(paramsSet, tokensSet) === false) {
+              context.report({
+                node,
+                loc: node.loc,
+                messageId: 'tokenNamesNotUsedInRenderProp',
+                data: { tokenNames: formatSet(tokensSet), paramNames: formatSet(paramsSet) }
+              });
+            }
+
+          } else {
+            // single token, single param should be a matching identifier
+            const param = renderProp.params[0];
+            const tokenName = getExpectedParamNameFromToken(attributes.token.value);
+            const paramName = param.name;
+
+            if (tokenName !== paramName) {
+              context.report({
+                node,
+                loc: node.loc,
+                messageId: 'tokenNamesNotUsedInRenderProp',
+                data: { tokenNames: tokenName, paramNames: paramName }
+              });
+            }
+          }
+        }
+
+        // debugger;
+      }
+      // callback functions
+    };
+  }
+};

--- a/scripts/eslint-plugin-i18n/i18n.test.js
+++ b/scripts/eslint-plugin-i18n/i18n.test.js
@@ -1,0 +1,139 @@
+const rule = require('./i18n');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parser: 'babel-eslint'
+});
+
+const valid = [
+  // nothing to validate against
+  '<EuiI18n token="euiFooBar.tokenName" default="Some default value"/>',
+
+  // values agree with default string
+  `<EuiI18n token="euiFooBar.tokenName" default="{value}, {value2}" values={{ value: 'Hello', value2: 'World' }}/>`,
+
+  // valid tokens
+  `<EuiI18n tokens={['euiFooBar.token1', 'euiFooBar.token2']} defaults={['value1', 'value 2']}/>`,
+
+  // token name is used by render prop
+  `<EuiI18n token="euiFooBar.tokenName" default="Some default value">
+      {tokenName => 'asdf'}
+    </EuiI18n>`,
+  `<EuiI18n token="euiFooBar.tokenName" default="Some default value">
+      {(tokenName) => 'asdf'}
+    </EuiI18n>`,
+
+  // token names are used by render prop
+  `<EuiI18n tokens={['euiFooBar.token1', 'euiFooBar.token2']} defaults={['value 1', 'value 2']}>
+      {([token1, token2]) => 'asdf'}
+    </EuiI18n>`,
+
+  // default callback params match values
+  `<EuiI18n token="euiFooBar.token" values={{ name: 'John' }} default={({ name }) => name}/>`,
+];
+const invalid = [
+  // token doesn't match file name
+  {
+    code: '<EuiI18n token="euiFooeyBar.tokenName" default="Some default value"/>',
+    errors: [{ messageId: 'invalidToken', data: { tokenValue: 'euiFooeyBar.tokenName', tokenNamespace: 'euiFooBar' } }]
+  },
+
+  // token doesn't have at least two parts
+  {
+    code: '<EuiI18n token="euiFooBar" default="Some default value"/>',
+    errors: [{ messageId: 'invalidToken', data: { tokenValue: 'euiFooBar', tokenNamespace: 'euiFooBar' } }]
+  },
+  {
+    code: '<EuiI18n token="tokenName" default="Some default value"/>',
+    errors: [{ messageId: 'invalidToken', data: { tokenValue: 'tokenName', tokenNamespace: 'euiFooBar' } }]
+  },
+
+  // invalid tokens
+  {
+    code: `<EuiI18n tokens={['euiFooBar.token1', 'token2']} defaults={['value1', 'value 2']}/>`,
+    errors: [{ messageId: 'invalidToken', data: { tokenValue: 'token2', tokenNamespace: 'euiFooBar' } }]
+  },
+  {
+    code: `<EuiI18n tokens={['euiFooeyBar.token1', 'euiFooBar.token2']} defaults={['value1', 'value 2']}/>`,
+    errors: [{ messageId: 'invalidToken', data: { tokenValue: 'euiFooeyBar.token1', tokenNamespace: 'euiFooBar' } }]
+  },
+  {
+    code: `<EuiI18n tokens={['euiFooBar.token1']} defaults={['value1', 'value 2']}/>`,
+    errors: [{ messageId: 'mismatchedTokensAndDefaults', data: { tokenLength: 1, defaultsLength: 2 } }]
+  },
+
+  // values not in agreement with default string
+  {
+    code: `<EuiI18n token="euiFooBar.tokenName" default="{value}, {value2}" values={{ valuee: 'Hello', value2: 'World' }}/>`,
+    errors: [{
+      messageId: 'mismatchedValues',
+      data: {
+        expected: 'value, value2',
+        provided: 'value2, valuee'
+      }
+    }]
+  },
+  {
+    code: `<EuiI18n token="euiFooBar.tokenName" default="{valuee}, {value2}" values={{ value: 'Hello', value2: 'World' }}/>`,
+    errors: [{
+      messageId: 'mismatchedValues',
+      data: {
+        expected: 'value2, valuee',
+        provided: 'value, value2'
+      }
+    }]
+  },
+
+  // token name isn't used by render prop
+  {
+    code: `<EuiI18n token="euiFooBar.tokenName" default="Some default value">
+      {tokenGame => 'asdf'}
+    </EuiI18n>`,
+    errors: [{
+      messageId: 'tokenNamesNotUsedInRenderProp',
+      data: {
+        tokenNames: 'tokenName',
+        paramNames: 'tokenGame',
+      }
+    }],
+  },
+
+  // token names aren't used by render prop
+  {
+    code: `<EuiI18n tokens={['euiFooBar.token1', 'euiFooBar.token2']} defaults={['value 1', 'value 2']}>
+      {([tokener1, token2]) => 'asdf'}
+    </EuiI18n>`,
+    errors: [{
+      messageId: 'tokenNamesNotUsedInRenderProp',
+      data: {
+        tokenNames: 'token1, token2',
+        paramNames: 'token2, tokener1'
+      }
+    }],
+  },
+
+  // default callback params don't match values
+  {
+    code: `<EuiI18n token="euiFooBar.token" values={{ nare: 'John' }} default={({ name }) => name}/>`,
+    errors: [{
+      messageId: 'mismatchedValues',
+      data: {
+        expected: 'name',
+        provided: 'nare'
+      }
+    }]
+  },
+];
+
+function withFilename(ruleset) {
+  return ruleset.map(code => {
+    const definition = typeof code === 'string' ? { code } : code;
+    definition.filename = 'foo_bar.js';
+    return definition;
+  });
+}
+
+ruleTester.run('i18n', rule, {
+  valid: withFilename(valid),
+  invalid: withFilename(invalid),
+});

--- a/scripts/eslint-plugin-i18n/i18n.test.js
+++ b/scripts/eslint-plugin-i18n/i18n.test.js
@@ -123,6 +123,40 @@ const invalid = [
       }
     }]
   },
+
+  // invalid attribute types
+  {
+    code: '<EuiI18n token={5} default="value"/>',
+    errors: [{ messageId: 'invalidTokenType', data: { type: 'JSXExpressionContainer' } }]
+  },
+  {
+    code: `<EuiI18n tokens="euiFooBar.token" defaults={['value']}/>`,
+    errors: [{ messageId: 'invalidTokensType', data: { type: 'Literal' } }]
+  },
+  {
+    code: `<EuiI18n tokens={5} defaults={['value']}/>`,
+    errors: [{ messageId: 'invalidTokensType', data: { type: 'Literal' } }]
+  },
+  {
+    code: `<EuiI18n tokens={[5]} defaults={['value']}/>`,
+    errors: [{ messageId: 'invalidTokensType', data: { type: 'Literal' } }]
+  },
+  {
+    code: '<EuiI18n token="euiFooBar.token" default={5}/>',
+    errors: [{ messageId: 'invalidDefaultType', data: { type: 'Literal' } }]
+  },
+  {
+    code: `<EuiI18n tokens={['euiFooBar.token']} defaults="value"/>`,
+    errors: [{ messageId: 'invalidDefaultsType', data: { type: 'Literal' } }]
+  },
+  {
+    code: `<EuiI18n tokens={['euiFooBar.token']} defaults={5}/>`,
+    errors: [{ messageId: 'invalidDefaultsType', data: { type: 'Literal' } }]
+  },
+  {
+    code: `<EuiI18n tokens={['euiFooBar.token']} defaults={[5]}/>`,
+    errors: [{ messageId: 'invalidDefaultsType', data: { type: 'Literal' } }]
+  },
 ];
 
 function withFilename(ruleset) {

--- a/src-docs/src/views/context/context.js
+++ b/src-docs/src/views/context/context.js
@@ -14,13 +14,13 @@ import {
 
 const mappings = {
   fr: {
-    english: 'Anglais',
-    french: 'Française',
-    greeting: 'Salutations!',
-    guestNo: 'Vous êtes invité #',
-    question: 'Quel est votre nom?',
-    placeholder: 'Jean Dupont',
-    action: 'Soumettre',
+    'euiContext.english': 'Anglais',
+    'euiContext.french': 'Française',
+    'euiContext.greeting': 'Salutations!',
+    'euiContext.guestNo': 'Vous êtes invité #',
+    'euiContext.question': 'Quel est votre nom?',
+    'euiContext.placeholder': 'Jean Dupont',
+    'euiContext.action': 'Soumettre',
   },
 };
 
@@ -44,35 +44,35 @@ export default class extends Component {
           <EuiFlexGroup gutterSize="s" alignItems="center">
             <EuiFlexItem grow={false}>
               <EuiButton fill={this.state.language === 'en'} onClick={() => this.setLanguage('en')}>
-                <EuiI18n token="english" default="English"/>
+                <EuiI18n token="euiContext.english" default="English"/>
               </EuiButton>
             </EuiFlexItem>
 
             <EuiFlexItem grow={false}>
               <EuiButton fill={this.state.language === 'fr'} onClick={() => this.setLanguage('fr')}>
-                <EuiI18n token="french" default="French"/>
+                <EuiI18n token="euiContext.french" default="French"/>
               </EuiButton>
             </EuiFlexItem>
           </EuiFlexGroup>
 
           <EuiSpacer size="m"/>
 
-          <strong><EuiI18n token="greeting" default="Welcome!"/></strong>
+          <strong><EuiI18n token="euiContext.greeting" default="Welcome!"/></strong>
 
           <EuiSpacer size="s"/>
 
-          <p><EuiI18n token="guestNo" default="You are guest #"/><EuiI18nNumber value={1582394}/></p>
+          <p><EuiI18n token="euiContext.guestNo" default="You are guest #"/><EuiI18nNumber value={1582394}/></p>
 
           <EuiSpacer size="m"/>
 
-          <EuiI18n tokens={['question', 'action']} defaults={['What is your name?', 'Submit']} >
+          <EuiI18n tokens={['euiContext.question', 'euiContext.action']} defaults={['What is your name?', 'Submit']} >
             {([question, action]) => (
               <Fragment>
                 <EuiFormRow
                   label={question}
                 >
 
-                  <EuiI18n token="placeholder" default="John Doe">
+                  <EuiI18n token="euiContext.placeholder" default="John Doe">
                     {placeholder => (
                       <EuiFieldText
                         placeholder={placeholder}

--- a/src-docs/src/views/i18n/i18n_basic.js
+++ b/src-docs/src/views/i18n/i18n_basic.js
@@ -8,7 +8,7 @@ export default () => {
   return (
     <p>
       <EuiI18n
-        token="i18n.basicexample"
+        token="euiI18nBasic.basicexample"
         default="This is the English copy that would be replaced by a translation defined by the i18n.basicexample token."
       />
     </p>

--- a/src-docs/src/views/i18n/i18n_multi.js
+++ b/src-docs/src/views/i18n/i18n_multi.js
@@ -13,7 +13,7 @@ export default () => {
         Both title and description for the card are looked up in one call to <EuiCode>EuiI18n</EuiCode>
       </p>
       <EuiI18n
-        tokens={['i18n.multiexampletitle', 'i18n.multiexampledescription']}
+        tokens={['euiI18nMulti.title', 'euiI18nMulti.description']}
         defaults={['Card Title', 'Card Description']}
       >
         {([title, description]) => (

--- a/src-docs/src/views/i18n/i18n_renderprop.js
+++ b/src-docs/src/views/i18n/i18n_renderprop.js
@@ -13,7 +13,7 @@ export default () => {
         This text field&apos;s placeholder reads from <EuiCode>i18n.renderpropexample</EuiCode>
       </p>
       <div>
-        <EuiI18n token="i18n.renderpropexample" default="John Doe">
+        <EuiI18n token="euiI18nRenderprop.placeholderName" default="John Doe">
           {placeholderName => <EuiFieldText placeholder={placeholderName}/>}
         </EuiI18n>
       </div>

--- a/src/components/basic_table/__snapshots__/basic_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.js.snap
@@ -15,9 +15,15 @@ exports[`EuiBasicTable cellProps renders cells with custom props from a callback
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          3
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 3,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -109,9 +115,15 @@ exports[`EuiBasicTable cellProps renders rows with custom props from an object 1
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          3
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 3,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -205,9 +217,15 @@ exports[`EuiBasicTable empty is rendered 1`] = `
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          0
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 0,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -252,9 +270,15 @@ exports[`EuiBasicTable empty renders a node as a custom message 1`] = `
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          0
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 0,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -307,9 +331,15 @@ exports[`EuiBasicTable empty renders a string as a custom message 1`] = `
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          0
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 0,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -354,9 +384,15 @@ exports[`EuiBasicTable footers do not render without a column footer definition 
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          3
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 3,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -517,9 +553,15 @@ exports[`EuiBasicTable footers render with pagination, selection, sorting, and f
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          3
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 3,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -528,16 +570,9 @@ exports[`EuiBasicTable footers render with pagination, selection, sorting, and f
           scope="col"
           width="24px"
         >
-          <EuiCheckbox
-            aria-label="Select all rows"
-            checked={false}
-            compressed={false}
-            data-test-subj="checkboxSelectAll"
-            disabled={false}
-            id="_selection_column-checkbox"
-            indeterminate={false}
-            onChange={[Function]}
-            type="inList"
+          <EuiI18n
+            default="Select all rows"
+            token="euiBasicTable.selectAllRows"
           />
         </EuiTableHeaderCellCheckbox>
         <EuiTableHeaderCell
@@ -579,16 +614,9 @@ exports[`EuiBasicTable footers render with pagination, selection, sorting, and f
             <EuiTableRowCellCheckbox
               key="_selection_column_1"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-1"
-                disabled={false}
-                id="_selection_column_1-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -627,16 +655,9 @@ exports[`EuiBasicTable footers render with pagination, selection, sorting, and f
             <EuiTableRowCellCheckbox
               key="_selection_column_2"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-2"
-                disabled={false}
-                id="_selection_column_2-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -675,16 +696,9 @@ exports[`EuiBasicTable footers render with pagination, selection, sorting, and f
             <EuiTableRowCellCheckbox
               key="_selection_column_3"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-3"
-                disabled={false}
-                id="_selection_column_3-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -777,9 +791,15 @@ exports[`EuiBasicTable itemIdToExpandedRowMap renders an expanded row 1`] = `
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          3
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 3,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -877,9 +897,15 @@ exports[`EuiBasicTable rowProps renders rows with custom props from a callback 1
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          3
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 3,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -977,9 +1003,15 @@ exports[`EuiBasicTable rowProps renders rows with custom props from an object 1`
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          3
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 3,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -1077,9 +1109,15 @@ exports[`EuiBasicTable with pagination - 2nd page 1`] = `
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          2
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 2,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -1157,9 +1195,15 @@ exports[`EuiBasicTable with pagination 1`] = `
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          3
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 3,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -1253,9 +1297,15 @@ exports[`EuiBasicTable with pagination and error 1`] = `
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          3
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 3,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -1306,9 +1356,15 @@ exports[`EuiBasicTable with pagination and selection 1`] = `
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          3
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 3,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -1317,16 +1373,9 @@ exports[`EuiBasicTable with pagination and selection 1`] = `
           scope="col"
           width="24px"
         >
-          <EuiCheckbox
-            aria-label="Select all rows"
-            checked={false}
-            compressed={false}
-            data-test-subj="checkboxSelectAll"
-            disabled={false}
-            id="_selection_column-checkbox"
-            indeterminate={false}
-            onChange={[Function]}
-            type="inList"
+          <EuiI18n
+            default="Select all rows"
+            token="euiBasicTable.selectAllRows"
           />
         </EuiTableHeaderCellCheckbox>
         <EuiTableHeaderCell
@@ -1349,16 +1398,9 @@ exports[`EuiBasicTable with pagination and selection 1`] = `
             <EuiTableRowCellCheckbox
               key="_selection_column_1"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-1"
-                disabled={false}
-                id="_selection_column_1-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -1381,16 +1423,9 @@ exports[`EuiBasicTable with pagination and selection 1`] = `
             <EuiTableRowCellCheckbox
               key="_selection_column_2"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-2"
-                disabled={false}
-                id="_selection_column_2-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -1413,16 +1448,9 @@ exports[`EuiBasicTable with pagination and selection 1`] = `
             <EuiTableRowCellCheckbox
               key="_selection_column_3"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-3"
-                disabled={false}
-                id="_selection_column_3-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -1467,9 +1495,15 @@ exports[`EuiBasicTable with pagination, hiding the per page options 1`] = `
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          3
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 3,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -1578,9 +1612,15 @@ exports[`EuiBasicTable with pagination, selection and sorting 1`] = `
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          3
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 3,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -1589,16 +1629,9 @@ exports[`EuiBasicTable with pagination, selection and sorting 1`] = `
           scope="col"
           width="24px"
         >
-          <EuiCheckbox
-            aria-label="Select all rows"
-            checked={false}
-            compressed={false}
-            data-test-subj="checkboxSelectAll"
-            disabled={false}
-            id="_selection_column-checkbox"
-            indeterminate={false}
-            onChange={[Function]}
-            type="inList"
+          <EuiI18n
+            default="Select all rows"
+            token="euiBasicTable.selectAllRows"
           />
         </EuiTableHeaderCellCheckbox>
         <EuiTableHeaderCell
@@ -1624,16 +1657,9 @@ exports[`EuiBasicTable with pagination, selection and sorting 1`] = `
             <EuiTableRowCellCheckbox
               key="_selection_column_1"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-1"
-                disabled={false}
-                id="_selection_column_1-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -1656,16 +1682,9 @@ exports[`EuiBasicTable with pagination, selection and sorting 1`] = `
             <EuiTableRowCellCheckbox
               key="_selection_column_2"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-2"
-                disabled={false}
-                id="_selection_column_2-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -1688,16 +1707,9 @@ exports[`EuiBasicTable with pagination, selection and sorting 1`] = `
             <EuiTableRowCellCheckbox
               key="_selection_column_3"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-3"
-                disabled={false}
-                id="_selection_column_3-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -1756,9 +1768,15 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          3
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 3,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -1767,16 +1785,9 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
           scope="col"
           width="24px"
         >
-          <EuiCheckbox
-            aria-label="Select all rows"
-            checked={false}
-            compressed={false}
-            data-test-subj="checkboxSelectAll"
-            disabled={false}
-            id="_selection_column-checkbox"
-            indeterminate={false}
-            onChange={[Function]}
-            type="inList"
+          <EuiI18n
+            default="Select all rows"
+            token="euiBasicTable.selectAllRows"
           />
         </EuiTableHeaderCellCheckbox>
         <EuiTableHeaderCell
@@ -1810,16 +1821,9 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
             <EuiTableRowCellCheckbox
               key="_selection_column_1"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-1"
-                disabled={false}
-                id="_selection_column_1-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -1871,16 +1875,9 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
             <EuiTableRowCellCheckbox
               key="_selection_column_2"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-2"
-                disabled={false}
-                id="_selection_column_2-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -1932,16 +1929,9 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
             <EuiTableRowCellCheckbox
               key="_selection_column_3"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-3"
-                disabled={false}
-                id="_selection_column_3-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -2028,9 +2018,15 @@ exports[`EuiBasicTable with pagination, selection, sorting and column dataType 1
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          3
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 3,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -2039,16 +2035,9 @@ exports[`EuiBasicTable with pagination, selection, sorting and column dataType 1
           scope="col"
           width="24px"
         >
-          <EuiCheckbox
-            aria-label="Select all rows"
-            checked={false}
-            compressed={false}
-            data-test-subj="checkboxSelectAll"
-            disabled={false}
-            id="_selection_column-checkbox"
-            indeterminate={false}
-            onChange={[Function]}
-            type="inList"
+          <EuiI18n
+            default="Select all rows"
+            token="euiBasicTable.selectAllRows"
           />
         </EuiTableHeaderCellCheckbox>
         <EuiTableHeaderCell
@@ -2074,16 +2063,9 @@ exports[`EuiBasicTable with pagination, selection, sorting and column dataType 1
             <EuiTableRowCellCheckbox
               key="_selection_column_1"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-1"
-                disabled={false}
-                id="_selection_column_1-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -2106,16 +2088,9 @@ exports[`EuiBasicTable with pagination, selection, sorting and column dataType 1
             <EuiTableRowCellCheckbox
               key="_selection_column_2"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-2"
-                disabled={false}
-                id="_selection_column_2-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -2138,16 +2113,9 @@ exports[`EuiBasicTable with pagination, selection, sorting and column dataType 1
             <EuiTableRowCellCheckbox
               key="_selection_column_3"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-3"
-                disabled={false}
-                id="_selection_column_3-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -2206,9 +2174,15 @@ exports[`EuiBasicTable with pagination, selection, sorting and column renderer 1
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          3
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 3,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -2217,16 +2191,9 @@ exports[`EuiBasicTable with pagination, selection, sorting and column renderer 1
           scope="col"
           width="24px"
         >
-          <EuiCheckbox
-            aria-label="Select all rows"
-            checked={false}
-            compressed={false}
-            data-test-subj="checkboxSelectAll"
-            disabled={false}
-            id="_selection_column-checkbox"
-            indeterminate={false}
-            onChange={[Function]}
-            type="inList"
+          <EuiI18n
+            default="Select all rows"
+            token="euiBasicTable.selectAllRows"
           />
         </EuiTableHeaderCellCheckbox>
         <EuiTableHeaderCell
@@ -2252,16 +2219,9 @@ exports[`EuiBasicTable with pagination, selection, sorting and column renderer 1
             <EuiTableRowCellCheckbox
               key="_selection_column_1"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-1"
-                disabled={false}
-                id="_selection_column_1-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -2284,16 +2244,9 @@ exports[`EuiBasicTable with pagination, selection, sorting and column renderer 1
             <EuiTableRowCellCheckbox
               key="_selection_column_2"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-2"
-                disabled={false}
-                id="_selection_column_2-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -2316,16 +2269,9 @@ exports[`EuiBasicTable with pagination, selection, sorting and column renderer 1
             <EuiTableRowCellCheckbox
               key="_selection_column_3"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-3"
-                disabled={false}
-                id="_selection_column_3-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -2384,9 +2330,15 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          3
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 3,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -2395,16 +2347,9 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
           scope="col"
           width="24px"
         >
-          <EuiCheckbox
-            aria-label="Select all rows"
-            checked={false}
-            compressed={false}
-            data-test-subj="checkboxSelectAll"
-            disabled={false}
-            id="_selection_column-checkbox"
-            indeterminate={false}
-            onChange={[Function]}
-            type="inList"
+          <EuiI18n
+            default="Select all rows"
+            token="euiBasicTable.selectAllRows"
           />
         </EuiTableHeaderCellCheckbox>
         <EuiTableHeaderCell
@@ -2438,16 +2383,9 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
             <EuiTableRowCellCheckbox
               key="_selection_column_1"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-1"
-                disabled={false}
-                id="_selection_column_1-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -2505,16 +2443,9 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
             <EuiTableRowCellCheckbox
               key="_selection_column_2"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-2"
-                disabled={false}
-                id="_selection_column_2-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -2572,16 +2503,9 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
             <EuiTableRowCellCheckbox
               key="_selection_column_3"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-3"
-                disabled={false}
-                id="_selection_column_3-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -2674,9 +2598,15 @@ exports[`EuiBasicTable with pagination, selection, sorting, column renderer and 
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          3
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 3,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -2685,16 +2615,9 @@ exports[`EuiBasicTable with pagination, selection, sorting, column renderer and 
           scope="col"
           width="24px"
         >
-          <EuiCheckbox
-            aria-label="Select all rows"
-            checked={false}
-            compressed={false}
-            data-test-subj="checkboxSelectAll"
-            disabled={false}
-            id="_selection_column-checkbox"
-            indeterminate={false}
-            onChange={[Function]}
-            type="inList"
+          <EuiI18n
+            default="Select all rows"
+            token="euiBasicTable.selectAllRows"
           />
         </EuiTableHeaderCellCheckbox>
         <EuiTableHeaderCell
@@ -2720,16 +2643,9 @@ exports[`EuiBasicTable with pagination, selection, sorting, column renderer and 
             <EuiTableRowCellCheckbox
               key="_selection_column_1"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-1"
-                disabled={false}
-                id="_selection_column_1-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -2752,16 +2668,9 @@ exports[`EuiBasicTable with pagination, selection, sorting, column renderer and 
             <EuiTableRowCellCheckbox
               key="_selection_column_2"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-2"
-                disabled={false}
-                id="_selection_column_2-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -2784,16 +2693,9 @@ exports[`EuiBasicTable with pagination, selection, sorting, column renderer and 
             <EuiTableRowCellCheckbox
               key="_selection_column_3"
             >
-              <EuiCheckbox
-                aria-label="Select this row"
-                checked={false}
-                compressed={false}
-                data-test-subj="checkboxSelectRow-3"
-                disabled={false}
-                id="_selection_column_3-checkbox"
-                indeterminate={false}
-                onChange={[Function]}
-                type="inList"
+              <EuiI18n
+                default="Select this row"
+                token="euiBasicTable.selectThisRow"
               />
             </EuiTableRowCellCheckbox>
             <EuiTableRowCell
@@ -2838,9 +2740,15 @@ exports[`EuiBasicTable with sortable columns and sorting disabled 1`] = `
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          3
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 3,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>
@@ -2937,9 +2845,15 @@ exports[`EuiBasicTable with sorting 1`] = `
           aria-relevant="text"
           role="status"
         >
-          Below is a table of 
-          3
-           items.
+          <EuiI18n
+            default="Below is a table of {itemCount} items."
+            token="euiBasicTable.tableDescription"
+            values={
+              Object {
+                "itemCount": 3,
+              }
+            }
+          />
         </caption>
       </EuiScreenReaderOnly>
       <EuiTableHeader>

--- a/src/components/basic_table/__snapshots__/collapsed_item_actions.test.js.snap
+++ b/src/components/basic_table/__snapshots__/collapsed_item_actions.test.js.snap
@@ -4,22 +4,12 @@ exports[`CollapsedItemActions render 1`] = `
 <EuiPopover
   anchorPosition="leftCenter"
   button={
-    <EuiToolTip
-      content="All actions"
-      delay="long"
-      position="top"
+    <EuiI18n
+      default="All actions"
+      token="euiCollapsedItemActions.allActions"
     >
-      <EuiButtonIcon
-        aria-label="All actions"
-        color="text"
-        iconSize="m"
-        iconType="boxesHorizontal"
-        isDisabled={false}
-        onClick={[Function]}
-        onFocus={[Function]}
-        type="button"
-      />
-    </EuiToolTip>
+      [Function]
+    </EuiI18n>
   }
   closePopover={[Function]}
   hasArrow={true}

--- a/src/components/basic_table/__snapshots__/collapsed_item_actions.test.js.snap
+++ b/src/components/basic_table/__snapshots__/collapsed_item_actions.test.js.snap
@@ -1,43 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CollapsedItemActions render 1`] = `
-<EuiPopover
-  anchorPosition="leftCenter"
-  button={
-    <EuiI18n
-      default="All actions"
-      token="euiCollapsedItemActions.allActions"
-    >
-      [Function]
-    </EuiI18n>
-  }
-  closePopover={[Function]}
-  hasArrow={true}
+<div
+  class="euiPopover euiPopover--anchorLeftCenter"
   id="id-actions"
-  isOpen={false}
-  ownFocus={false}
-  panelPaddingSize="none"
-  popoverRef={[Function]}
 >
-  <EuiContextMenuPanel
-    hasFocus={true}
-    items={
-      Array [
-        <EuiContextMenuItem
-          disabled={false}
-          layoutAlign="center"
-          onClick={[Function]}
-          toolTipPosition="right"
+  <div
+    class="euiPopover__anchor"
+  >
+    <span
+      class="euiToolTipAnchor"
+    >
+      <button
+        aria-label="All actions"
+        class="euiButtonIcon euiButtonIcon--text"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiButtonIcon__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xlink="http://www.w3.org/1999/xlink"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          default1
-        </EuiContextMenuItem>,
-        <EuiContextMenuItem
-          layoutAlign="center"
-          onClick={[Function]}
-          toolTipPosition="right"
-        />,
-      ]
-    }
-  />
-</EuiPopover>
+          <defs>
+            <path
+              d="M0 6h4v4H0V6zm1 1v2h2V7H1zm5-1h4v4H6V6zm1 1v2h2V7H7zm5-1h4v4h-4V6zm1 3h2V7h-2v2z"
+              id="boxes_horizontal-a"
+            />
+          </defs>
+          <use
+            href="#boxes_horizontal-a"
+          />
+        </svg>
+      </button>
+    </span>
+  </div>
+</div>
 `;

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
@@ -114,9 +114,17 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                 className="euiScreenReaderOnly"
                 role="status"
               >
-                Below is a table of 
-                2
-                 items.
+                <EuiI18n
+                  default="Below is a table of {itemCount} items."
+                  token="euiBasicTable.tableDescription"
+                  values={
+                    Object {
+                      "itemCount": 2,
+                    }
+                  }
+                >
+                  Below is a table of 2 items.
+                </EuiI18n>
               </caption>
             </EuiScreenReaderOnly>
             <EuiTableHeader>
@@ -405,42 +413,35 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                         className="euiPagination"
                         role="group"
                       >
-                        <EuiButtonIcon
-                          aria-label="Previous page"
-                          color="text"
-                          data-test-subj="pagination-button-previous"
-                          disabled={false}
-                          iconSize="m"
-                          iconType="arrowLeft"
-                          onClick={[Function]}
-                          type="button"
+                        <EuiI18n
+                          default="Previous page"
+                          token="euiPagination.previousPage"
                         >
-                          <button
+                          <EuiButtonIcon
                             aria-label="Previous page"
-                            className="euiButtonIcon euiButtonIcon--text"
+                            color="text"
                             data-test-subj="pagination-button-previous"
                             disabled={false}
+                            iconSize="m"
+                            iconType="arrowLeft"
                             onClick={[Function]}
                             type="button"
                           >
-                            <EuiIcon
-                              aria-hidden="true"
-                              className="euiButtonIcon__icon"
-                              size="m"
-                              type="arrowLeft"
+                            <button
+                              aria-label="Previous page"
+                              className="euiButtonIcon euiButtonIcon--text"
+                              data-test-subj="pagination-button-previous"
+                              disabled={false}
+                              onClick={[Function]}
+                              type="button"
                             >
-                              <arrowLeft
+                              <EuiIcon
                                 aria-hidden="true"
-                                className="euiIcon euiIcon--medium euiButtonIcon__icon"
-                                focusable="false"
-                                height="16"
-                                style={null}
-                                viewBox="0 0 16 16"
-                                width="16"
-                                xmlns="http://www.w3.org/2000/svg"
-                                xmlnsXlink="http://www.w3.org/1999/xlink"
+                                className="euiButtonIcon__icon"
+                                size="m"
+                                type="arrowLeft"
                               >
-                                <svg
+                                <arrowLeft
                                   aria-hidden="true"
                                   className="euiIcon euiIcon--medium euiButtonIcon__icon"
                                   focusable="false"
@@ -451,132 +452,159 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                   xmlns="http://www.w3.org/2000/svg"
                                   xmlnsXlink="http://www.w3.org/1999/xlink"
                                 >
-                                  <defs>
-                                    <path
-                                      d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
-                                      id="arrow_left-a"
+                                  <svg
+                                    aria-hidden="true"
+                                    className="euiIcon euiIcon--medium euiButtonIcon__icon"
+                                    focusable="false"
+                                    height="16"
+                                    style={null}
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                                  >
+                                    <defs>
+                                      <path
+                                        d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+                                        id="arrow_left-a"
+                                      />
+                                    </defs>
+                                    <use
+                                      fillRule="nonzero"
+                                      transform="rotate(90 8 8)"
+                                      xlinkHref="#arrow_left-a"
                                     />
-                                  </defs>
-                                  <use
-                                    fillRule="nonzero"
-                                    transform="rotate(90 8 8)"
-                                    xlinkHref="#arrow_left-a"
-                                  />
-                                </svg>
-                              </arrowLeft>
-                            </EuiIcon>
-                          </button>
-                        </EuiButtonIcon>
-                        <EuiPaginationButton
-                          aria-label="Page 1 of 2"
-                          data-test-subj="pagination-button-0"
-                          hideOnMobile={true}
-                          isActive={false}
+                                  </svg>
+                                </arrowLeft>
+                              </EuiIcon>
+                            </button>
+                          </EuiButtonIcon>
+                        </EuiI18n>
+                        <EuiI18n
+                          default="Page {page} of {total}"
                           key="0"
-                          onClick={[Function]}
+                          token="euiPagination.pageOfTotal"
+                          values={
+                            Object {
+                              "page": 1,
+                              "total": 2,
+                            }
+                          }
                         >
-                          <EuiButtonEmpty
+                          <EuiPaginationButton
                             aria-label="Page 1 of 2"
-                            className="euiPaginationButton euiPaginationButton--hideOnMobile"
-                            color="text"
                             data-test-subj="pagination-button-0"
-                            iconSide="left"
+                            hideOnMobile={true}
+                            isActive={false}
                             onClick={[Function]}
-                            size="xs"
-                            type="button"
                           >
-                            <button
+                            <EuiButtonEmpty
                               aria-label="Page 1 of 2"
-                              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiPaginationButton euiPaginationButton--hideOnMobile"
+                              className="euiPaginationButton euiPaginationButton--hideOnMobile"
+                              color="text"
                               data-test-subj="pagination-button-0"
+                              iconSide="left"
                               onClick={[Function]}
+                              size="xs"
                               type="button"
                             >
-                              <span
-                                className="euiButtonEmpty__content"
+                              <button
+                                aria-label="Page 1 of 2"
+                                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiPaginationButton euiPaginationButton--hideOnMobile"
+                                data-test-subj="pagination-button-0"
+                                onClick={[Function]}
+                                type="button"
                               >
                                 <span
-                                  className="euiButtonEmpty__text"
+                                  className="euiButtonEmpty__content"
                                 >
-                                  1
+                                  <span
+                                    className="euiButtonEmpty__text"
+                                  >
+                                    1
+                                  </span>
                                 </span>
-                              </span>
-                            </button>
-                          </EuiButtonEmpty>
-                        </EuiPaginationButton>
-                        <EuiPaginationButton
-                          aria-label="Page 2 of 2"
-                          data-test-subj="pagination-button-1"
-                          hideOnMobile={true}
-                          isActive={true}
+                              </button>
+                            </EuiButtonEmpty>
+                          </EuiPaginationButton>
+                        </EuiI18n>
+                        <EuiI18n
+                          default="Page {page} of {total}"
                           key="1"
-                          onClick={[Function]}
+                          token="euiPagination.pageOfTotal"
+                          values={
+                            Object {
+                              "page": 2,
+                              "total": 2,
+                            }
+                          }
                         >
-                          <EuiButtonEmpty
+                          <EuiPaginationButton
                             aria-label="Page 2 of 2"
-                            className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                            color="text"
                             data-test-subj="pagination-button-1"
-                            iconSide="left"
+                            hideOnMobile={true}
+                            isActive={true}
                             onClick={[Function]}
-                            size="xs"
-                            type="button"
                           >
-                            <button
+                            <EuiButtonEmpty
                               aria-label="Page 2 of 2"
-                              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                              className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                              color="text"
                               data-test-subj="pagination-button-1"
+                              iconSide="left"
                               onClick={[Function]}
+                              size="xs"
                               type="button"
                             >
-                              <span
-                                className="euiButtonEmpty__content"
+                              <button
+                                aria-label="Page 2 of 2"
+                                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                data-test-subj="pagination-button-1"
+                                onClick={[Function]}
+                                type="button"
                               >
                                 <span
-                                  className="euiButtonEmpty__text"
+                                  className="euiButtonEmpty__content"
                                 >
-                                  2
+                                  <span
+                                    className="euiButtonEmpty__text"
+                                  >
+                                    2
+                                  </span>
                                 </span>
-                              </span>
-                            </button>
-                          </EuiButtonEmpty>
-                        </EuiPaginationButton>
-                        <EuiButtonIcon
-                          aria-label="Next page"
-                          color="text"
-                          data-test-subj="pagination-button-next"
-                          disabled={true}
-                          iconSize="m"
-                          iconType="arrowRight"
-                          onClick={[Function]}
-                          type="button"
+                              </button>
+                            </EuiButtonEmpty>
+                          </EuiPaginationButton>
+                        </EuiI18n>
+                        <EuiI18n
+                          default="Next page"
+                          token="euiPagination.nextPage"
                         >
-                          <button
+                          <EuiButtonIcon
                             aria-label="Next page"
-                            className="euiButtonIcon euiButtonIcon--text"
+                            color="text"
                             data-test-subj="pagination-button-next"
                             disabled={true}
+                            iconSize="m"
+                            iconType="arrowRight"
                             onClick={[Function]}
                             type="button"
                           >
-                            <EuiIcon
-                              aria-hidden="true"
-                              className="euiButtonIcon__icon"
-                              size="m"
-                              type="arrowRight"
+                            <button
+                              aria-label="Next page"
+                              className="euiButtonIcon euiButtonIcon--text"
+                              data-test-subj="pagination-button-next"
+                              disabled={true}
+                              onClick={[Function]}
+                              type="button"
                             >
-                              <arrowRight
+                              <EuiIcon
                                 aria-hidden="true"
-                                className="euiIcon euiIcon--medium euiButtonIcon__icon"
-                                focusable="false"
-                                height="16"
-                                style={null}
-                                viewBox="0 0 16 16"
-                                width="16"
-                                xmlns="http://www.w3.org/2000/svg"
-                                xmlnsXlink="http://www.w3.org/1999/xlink"
+                                className="euiButtonIcon__icon"
+                                size="m"
+                                type="arrowRight"
                               >
-                                <svg
+                                <arrowRight
                                   aria-hidden="true"
                                   className="euiIcon euiIcon--medium euiButtonIcon__icon"
                                   focusable="false"
@@ -587,22 +615,34 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                   xmlns="http://www.w3.org/2000/svg"
                                   xmlnsXlink="http://www.w3.org/1999/xlink"
                                 >
-                                  <defs>
-                                    <path
-                                      d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
-                                      id="arrow_right-a"
+                                  <svg
+                                    aria-hidden="true"
+                                    className="euiIcon euiIcon--medium euiButtonIcon__icon"
+                                    focusable="false"
+                                    height="16"
+                                    style={null}
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    xmlnsXlink="http://www.w3.org/1999/xlink"
+                                  >
+                                    <defs>
+                                      <path
+                                        d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+                                        id="arrow_right-a"
+                                      />
+                                    </defs>
+                                    <use
+                                      fillRule="nonzero"
+                                      transform="matrix(0 1 1 0 0 0)"
+                                      xlinkHref="#arrow_right-a"
                                     />
-                                  </defs>
-                                  <use
-                                    fillRule="nonzero"
-                                    transform="matrix(0 1 1 0 0 0)"
-                                    xlinkHref="#arrow_right-a"
-                                  />
-                                </svg>
-                              </arrowRight>
-                            </EuiIcon>
-                          </button>
-                        </EuiButtonIcon>
+                                  </svg>
+                                </arrowRight>
+                              </EuiIcon>
+                            </button>
+                          </EuiButtonIcon>
+                        </EuiI18n>
                       </div>
                     </EuiPagination>
                   </div>

--- a/src/components/basic_table/basic_table.js
+++ b/src/components/basic_table/basic_table.js
@@ -33,6 +33,7 @@ import { EuiTableHeaderMobile } from '../table/mobile/table_header_mobile';
 import { EuiTableSortMobile } from '../table/mobile/table_sort_mobile';
 import { withRequiredProp } from '../../utils/prop_types/with_required_prop';
 import { EuiScreenReaderOnly, EuiKeyboardAccessible } from '../accessibility';
+import { EuiI18n } from '../i18n';
 
 const dataTypesProfiles = {
   auto: {
@@ -417,7 +418,13 @@ export class EuiBasicTable extends Component {
 
     return (
       <EuiScreenReaderOnly>
-        <caption role="status" aria-relevant="text" aria-live="polite">Below is a table of {items.length} items.</caption>
+        <caption role="status" aria-relevant="text" aria-live="polite">
+          <EuiI18n
+            token="euiBasicTable.tableDescription"
+            default="Below is a table of {itemCount} items."
+            values={{ itemCount: items.length }}
+          />
+        </caption>
       </EuiScreenReaderOnly>
     );
   }
@@ -449,15 +456,19 @@ export class EuiBasicTable extends Component {
 
       headers.push(
         <EuiTableHeaderCellCheckbox key="_selection_column_h" width="24px">
-          <EuiCheckbox
-            id="_selection_column-checkbox"
-            type="inList"
-            checked={checked}
-            disabled={disabled}
-            onChange={onChange}
-            data-test-subj="checkboxSelectAll"
-            aria-label="Select all rows"
-          />
+          <EuiI18n token="euiBasicTable.selectAllRows" default="Select all rows">
+            {selectAllRows => (
+              <EuiCheckbox
+                id="_selection_column-checkbox"
+                type="inList"
+                checked={checked}
+                disabled={disabled}
+                onChange={onChange}
+                data-test-subj="checkboxSelectAll"
+                aria-label={selectAllRows}
+              />
+            )}
+          </EuiI18n>
         </EuiTableHeaderCellCheckbox>
       );
     }
@@ -723,16 +734,20 @@ export class EuiBasicTable extends Component {
     };
     return (
       <EuiTableRowCellCheckbox key={key}>
-        <EuiCheckbox
-          id={`${key}-checkbox`}
-          type="inList"
-          disabled={disabled}
-          checked={checked}
-          onChange={onChange}
-          title={title}
-          aria-label="Select this row"
-          data-test-subj={`checkboxSelectRow-${itemId}`}
-        />
+        <EuiI18n token="euiBasicTable.selectThisRow" default="Select this row">
+          {selectThisRow => (
+            <EuiCheckbox
+              id={`${key}-checkbox`}
+              type="inList"
+              disabled={disabled}
+              checked={checked}
+              onChange={onChange}
+              title={title}
+              aria-label={selectThisRow}
+              data-test-subj={`checkboxSelectRow-${itemId}`}
+            />
+          )}
+        </EuiI18n>
       </EuiTableRowCellCheckbox>
     );
   }

--- a/src/components/basic_table/collapsed_item_actions.js
+++ b/src/components/basic_table/collapsed_item_actions.js
@@ -3,6 +3,7 @@ import { EuiContextMenuItem, EuiContextMenuPanel } from '../context_menu';
 import { EuiPopover } from '../popover';
 import { EuiButtonIcon } from '../button';
 import { EuiToolTip } from '../tool_tip';
+import { EuiI18n } from '../i18n';
 
 export class CollapsedItemActions extends Component {
 
@@ -88,21 +89,29 @@ export class CollapsedItemActions extends Component {
     }, []);
 
     const popoverButton = (
-      <EuiButtonIcon
-        className={className}
-        aria-label="All actions"
-        iconType="boxesHorizontal"
-        color="text"
-        isDisabled={allDisabled}
-        onClick={this.togglePopover.bind(this)}
-        onFocus={onFocus}
-      />
+      <EuiI18n token="euiCollapsedItemActions.allActions" default="All actions">
+        {allActions => (
+          <EuiButtonIcon
+            className={className}
+            aria-label={allActions}
+            iconType="boxesHorizontal"
+            color="text"
+            isDisabled={allDisabled}
+            onClick={this.togglePopover.bind(this)}
+            onFocus={onFocus}
+          />
+        )}
+      </EuiI18n>
     );
 
     const withTooltip = !allDisabled && (
-      <EuiToolTip content="All actions" delay="long">
-        {popoverButton}
-      </EuiToolTip>
+      <EuiI18n token="euiCollapsedItemActions.allActions" default="All actions">
+        {allActions => (
+          <EuiToolTip content={allActions} delay="long">
+            {popoverButton}
+          </EuiToolTip>
+        )}
+      </EuiI18n>
     );
 
     return (

--- a/src/components/basic_table/collapsed_item_actions.test.js
+++ b/src/components/basic_table/collapsed_item_actions.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from 'enzyme';
 import { CollapsedItemActions } from './collapsed_item_actions';
 
 describe('CollapsedItemActions', () => {
@@ -27,7 +27,7 @@ describe('CollapsedItemActions', () => {
       onFocus: () => {}
     };
 
-    const component = shallow(
+    const component = render(
       <CollapsedItemActions {...props} />
     );
 

--- a/src/components/form/super_select/__snapshots__/super_select.test.js.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.js.snap
@@ -144,8 +144,7 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
           class="euiScreenReaderOnly"
           role="alert"
         >
-          You are in a form selector of 2 items and must select a single option.
-              Use the up and down keys to navigate or escape to close.
+          You are in a form selector of 2 items and must select a single option. Use the up and down keys to navigate or escape to close.
         </p>
         <div
           role="listbox"
@@ -351,8 +350,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
           class="euiScreenReaderOnly"
           role="alert"
         >
-          You are in a form selector of 2 items and must select a single option.
-              Use the up and down keys to navigate or escape to close.
+          You are in a form selector of 2 items and must select a single option. Use the up and down keys to navigate or escape to close.
         </p>
         <div
           aria-activedescendant="1"
@@ -700,8 +698,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                           role="alert"
                         >
                           <EuiI18n
-                            default="You are in a form selector of {optionsCount} items and must select a single option.
-              Use the up and down keys to navigate or escape to close."
+                            default="You are in a form selector of {optionsCount} items and must select a single option. Use the up and down keys to navigate or escape to close."
                             token="euiSuperSelect.screenReaderAnnouncement"
                             values={
                               Object {
@@ -709,8 +706,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                               }
                             }
                           >
-                            You are in a form selector of 2 items and must select a single option.
-              Use the up and down keys to navigate or escape to close.
+                            You are in a form selector of 2 items and must select a single option. Use the up and down keys to navigate or escape to close.
                           </EuiI18n>
                         </p>
                       </EuiScreenReaderOnly>
@@ -950,8 +946,7 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
           class="euiScreenReaderOnly"
           role="alert"
         >
-          You are in a form selector of 2 items and must select a single option.
-              Use the up and down keys to navigate or escape to close.
+          You are in a form selector of 2 items and must select a single option. Use the up and down keys to navigate or escape to close.
         </p>
         <div
           role="listbox"

--- a/src/components/form/super_select/super_select.js
+++ b/src/components/form/super_select/super_select.js
@@ -248,8 +248,8 @@ export class EuiSuperSelect extends Component {
           <p role="alert">
             <EuiI18n
               token="euiSuperSelect.screenReaderAnnouncement"
-              default={`You are in a form selector of {optionsCount} items and must select a single option.
-              Use the up and down keys to navigate or escape to close.`}
+              default="You are in a form selector of {optionsCount} items and must select a single option.
+              Use the up and down keys to navigate or escape to close."
               values={{ optionsCount: options.length }}
             />
           </p>

--- a/src/components/header/header_alert/header_alert.js
+++ b/src/components/header/header_alert/header_alert.js
@@ -11,6 +11,10 @@ import {
   EuiFlexItem,
 } from '../../flex';
 
+import {
+  EuiI18n,
+} from '../../i18n';
+
 export const EuiHeaderAlert = ({
   action,
   className,
@@ -22,33 +26,37 @@ export const EuiHeaderAlert = ({
   const classes = classNames('euiHeaderAlert', className);
 
   return (
-    <div
-      className={classes}
-      {...rest}
-    >
-      <EuiButtonIcon
-        aria-label="Dismiss"
-        iconType="cross"
-        size="s"
-        className="euiHeaderAlert__dismiss"
-      />
+    <EuiI18n token="euiHeaderAlert.dismiss" default="Dismiss">
+      {dismiss => (
+        <div
+          className={classes}
+          {...rest}
+        >
+          <EuiButtonIcon
+            aria-label={dismiss}
+            iconType="cross"
+            size="s"
+            className="euiHeaderAlert__dismiss"
+          />
 
-      <div className="euiHeaderAlert__title">{title}</div>
+          <div className="euiHeaderAlert__title">{title}</div>
 
-      <div className="euiHeaderAlert__text">{text}</div>
+          <div className="euiHeaderAlert__text">{text}</div>
 
-      <EuiFlexGroup justifyContent="spaceBetween">
-        <EuiFlexItem grow={false}>
-          <div className="euiHeaderAlert__action euiLink">{action}</div>
-        </EuiFlexItem>
+          <EuiFlexGroup justifyContent="spaceBetween">
+            <EuiFlexItem grow={false}>
+              <div className="euiHeaderAlert__action euiLink">{action}</div>
+            </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <div className="euiHeaderAlert__date">
-            {date}
-          </div>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </div>
+            <EuiFlexItem grow={false}>
+              <div className="euiHeaderAlert__date">
+                {date}
+              </div>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </div>
+      )}
+    </EuiI18n>
   );
 };
 

--- a/src/components/header/header_links/header_links.js
+++ b/src/components/header/header_links/header_links.js
@@ -8,6 +8,7 @@ import classNames from 'classnames';
 
 import { EuiIcon } from '../../icon';
 import { EuiPopover } from '../../popover';
+import { EuiI18n } from '../../i18n';
 import { EuiHeaderSectionItemButton, EuiHeaderSectionItem } from '../header_section';
 
 export class EuiHeaderLinks extends Component {
@@ -42,40 +43,48 @@ export class EuiHeaderLinks extends Component {
 
     const button = (
       <EuiHeaderSectionItem border="left">
-        <EuiHeaderSectionItemButton
-          aria-label="Open navigation menu"
-          onClick={this.onMenuButtonClick}
-        >
-          <EuiIcon type="apps" size="m" />
-        </EuiHeaderSectionItemButton>
+        <EuiI18n token="euiHeaderLinks.openNavigationMenu" default="Open navigation menu">
+          {openNavigationMenu => (
+            <EuiHeaderSectionItemButton
+              aria-label={openNavigationMenu}
+              onClick={this.onMenuButtonClick}
+            >
+              <EuiIcon type="apps" size="m" />
+            </EuiHeaderSectionItemButton>
+          )}
+        </EuiI18n>
       </EuiHeaderSectionItem>
     );
 
     return (
-      <nav
-        className={classes}
-        aria-label="App navigation"
-        {...rest}
-      >
+      <EuiI18n token="euiHeaderLinks.appNavigation" default="App navigation">
+        {appNavigation => (
+          <nav
+            className={classes}
+            aria-label={appNavigation}
+            {...rest}
+          >
 
-        <div className="euiHeaderLinks__list" role="navigation">
-          {children}
-        </div>
+            <div className="euiHeaderLinks__list" role="navigation">
+              {children}
+            </div>
 
-        <EuiPopover
-          className="euiHeaderLinks__mobile"
-          ownFocus
-          button={button}
-          isOpen={this.state.isOpen}
-          anchorPosition="downRight"
-          closePopover={this.closeMenu}
-          panelClassName="euiHeaderLinks__mobileList"
-          panelPaddingSize="none"
-        >
-          {children}
-        </EuiPopover>
+            <EuiPopover
+              className="euiHeaderLinks__mobile"
+              ownFocus
+              button={button}
+              isOpen={this.state.isOpen}
+              anchorPosition="downRight"
+              closePopover={this.closeMenu}
+              panelClassName="euiHeaderLinks__mobileList"
+              panelPaddingSize="none"
+            >
+              {children}
+            </EuiPopover>
 
-      </nav>
+          </nav>
+        )}
+      </EuiI18n>
     );
   }
 }

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -9,6 +9,8 @@ import { keyCodes } from '../../services';
 
 import { EuiButtonIcon } from '../button';
 
+import { EuiI18n } from '../i18n';
+
 export class EuiModal extends Component {
   onKeyDown = event => {
     if (event.keyCode === keyCodes.ESCAPE) {
@@ -59,13 +61,17 @@ export class EuiModal extends Component {
           style={newStyle || style}
           {...rest}
         >
-          <EuiButtonIcon
-            iconType="cross"
-            onClick={onClose}
-            className="euiModal__closeIcon"
-            color="text"
-            aria-label="Closes this modal window"
-          />
+          <EuiI18n token="euiModal.closeModal" default="Closes this modal window">
+            {closeModal => (
+              <EuiButtonIcon
+                iconType="cross"
+                onClick={onClose}
+                className="euiModal__closeIcon"
+                color="text"
+                aria-label={closeModal}
+              />
+            )}
+          </EuiI18n>
           <div className="euiModal__flex">
             {children}
           </div>

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 
 import { EuiPaginationButton } from './pagination_button';
 import { EuiButtonIcon } from '../button';
+import { EuiI18n } from '../i18n';
 
 const MAX_VISIBLE_PAGES = 5;
 const NUMBER_SURROUNDING_PAGES = Math.floor(MAX_VISIBLE_PAGES * 0.5);
@@ -24,43 +25,63 @@ export const EuiPagination = ({
 
   for (let i = firstPageInRange, index = 0; i < lastPageInRange; i++, index++) {
     pages.push(
-      <EuiPaginationButton
-        isActive={i === activePage}
+      <EuiI18n
         key={index}
-        onClick={onPageClick.bind(null, i)}
-        hideOnMobile
-        aria-label={`Page ${i + 1} of ${lastPageInRange}`}
-        data-test-subj={`pagination-button-${i}`}
+        token="euiPagination.pageOfTotal"
+        default="Page {page} of {total}"
+        values={{ page: i + 1, total: lastPageInRange }}
       >
-        {i + 1}
-      </EuiPaginationButton>
+        {pageOfTotal => (
+          <EuiPaginationButton
+            isActive={i === activePage}
+            onClick={onPageClick.bind(null, i)}
+            hideOnMobile
+            aria-label={pageOfTotal}
+            data-test-subj={`pagination-button-${i}`}
+          >
+            {i + 1}
+          </EuiPaginationButton>
+        )}
+      </EuiI18n>
     );
   }
 
 
   const previousButton = (
-    <EuiButtonIcon
-      onClick={onPageClick.bind(null, activePage - 1)}
-      iconType="arrowLeft"
-      disabled={activePage === 0}
-      color="text"
-      aria-label="Previous page"
-      data-test-subj="pagination-button-previous"
-    />
+    <EuiI18n token="euiPagination.previousPage" default="Previous page">
+      {previousPage => (
+        <EuiButtonIcon
+          onClick={onPageClick.bind(null, activePage - 1)}
+          iconType="arrowLeft"
+          disabled={activePage === 0}
+          color="text"
+          aria-label={previousPage}
+          data-test-subj="pagination-button-previous"
+        />
+      )}
+    </EuiI18n>
   );
 
   const firstPageButtons = [];
 
   if (firstPageInRange > 0) {
     firstPageButtons.push(
-      <EuiPaginationButton
-        key="0"
-        onClick={onPageClick.bind(null, 0)}
-        hideOnMobile
-        aria-label={`Page 1 of ${lastPageInRange}`}
+      <EuiI18n
+        token="euiPagination.pageOfTotal"
+        default="Page {page} of {total}"
+        values={{ page: 1, total: lastPageInRange }}
       >
-        1
-      </EuiPaginationButton>
+        {pageOfTotal => (
+          <EuiPaginationButton
+            key="0"
+            onClick={onPageClick.bind(null, 0)}
+            hideOnMobile
+            aria-label={pageOfTotal}
+          >
+            1
+          </EuiPaginationButton>
+        )}
+      </EuiI18n>
     );
 
     if (firstPageInRange > 1) {
@@ -94,26 +115,38 @@ export const EuiPagination = ({
     }
 
     lastPageButtons.push(
-      <EuiPaginationButton
-        key={pageCount - 1}
-        onClick={onPageClick.bind(null, pageCount - 1)}
-        hideOnMobile
-        aria-label={`Jump to the last page, number ${pageCount}`}
+      <EuiI18n
+        token="euiPagination.jumpToLastPage"
+        default="Jump to the last page, number {pageCount}"
+        values={{ pageCount }}
       >
-        {pageCount}
-      </EuiPaginationButton>
+        {jumpToLastPage => (
+          <EuiPaginationButton
+            key={pageCount - 1}
+            onClick={onPageClick.bind(null, pageCount - 1)}
+            hideOnMobile
+            aria-label={jumpToLastPage}
+          >
+            {pageCount}
+          </EuiPaginationButton>
+        )}
+      </EuiI18n>
     );
   }
 
   const nextButton = (
-    <EuiButtonIcon
-      onClick={onPageClick.bind(null, activePage + 1)}
-      iconType="arrowRight"
-      aria-label="Next page"
-      disabled={activePage === pageCount - 1}
-      color="text"
-      data-test-subj="pagination-button-next"
-    />
+    <EuiI18n token="euiPagination.nextPage" default="Next page">
+      {nextPage => (
+        <EuiButtonIcon
+          onClick={onPageClick.bind(null, activePage + 1)}
+          iconType="arrowRight"
+          aria-label={nextPage}
+          disabled={activePage === pageCount - 1}
+          color="text"
+          data-test-subj="pagination-button-next"
+        />
+      )}
+    </EuiI18n>
   );
 
   if (pages.length > 1) {

--- a/src/components/steps/__snapshots__/step.test.js.snap
+++ b/src/components/steps/__snapshots__/step.test.js.snap
@@ -9,7 +9,7 @@ exports[`EuiStep is rendered 1`] = `
   <span
     class="euiScreenReaderOnly"
   >
-     Step 
+    Step 
   </span>
   <div
     class="euiStepNumber euiStep__circle"

--- a/src/components/steps/__snapshots__/steps.test.js.snap
+++ b/src/components/steps/__snapshots__/steps.test.js.snap
@@ -12,7 +12,7 @@ exports[`EuiSteps renders step title inside "headingElement" element 1`] = `
     <span
       class="euiScreenReaderOnly"
     >
-       Step 
+      Step 
     </span>
     <div
       class="euiStepNumber euiStep__circle"
@@ -38,7 +38,7 @@ exports[`EuiSteps renders step title inside "headingElement" element 1`] = `
     <span
       class="euiScreenReaderOnly"
     >
-       Step 
+      Step 
     </span>
     <div
       class="euiStepNumber euiStep__circle"
@@ -64,7 +64,7 @@ exports[`EuiSteps renders step title inside "headingElement" element 1`] = `
     <span
       class="euiScreenReaderOnly"
     >
-      Incomplete Step 
+      Incomplete Step 
     </span>
     <div
       class="euiStepNumber euiStepNumber--incomplete euiStepNumber-isHollow euiStep__circle"
@@ -97,7 +97,7 @@ exports[`EuiSteps renders steps 1`] = `
     <span
       class="euiScreenReaderOnly"
     >
-       Step 
+      Step 
     </span>
     <div
       class="euiStepNumber euiStep__circle"
@@ -123,7 +123,7 @@ exports[`EuiSteps renders steps 1`] = `
     <span
       class="euiScreenReaderOnly"
     >
-       Step 
+      Step 
     </span>
     <div
       class="euiStepNumber euiStep__circle"
@@ -149,7 +149,7 @@ exports[`EuiSteps renders steps 1`] = `
     <span
       class="euiScreenReaderOnly"
     >
-      Incomplete Step 
+      Incomplete Step 
     </span>
     <div
       class="euiStepNumber euiStepNumber--incomplete euiStepNumber-isHollow euiStep__circle"
@@ -182,7 +182,7 @@ exports[`EuiSteps renders steps with firstStepNumber 1`] = `
     <span
       class="euiScreenReaderOnly"
     >
-       Step 
+      Step 
     </span>
     <div
       class="euiStepNumber euiStep__circle"
@@ -208,7 +208,7 @@ exports[`EuiSteps renders steps with firstStepNumber 1`] = `
     <span
       class="euiScreenReaderOnly"
     >
-       Step 
+      Step 
     </span>
     <div
       class="euiStepNumber euiStep__circle"
@@ -234,7 +234,7 @@ exports[`EuiSteps renders steps with firstStepNumber 1`] = `
     <span
       class="euiScreenReaderOnly"
     >
-      Incomplete Step 
+      Incomplete Step 
     </span>
     <div
       class="euiStepNumber euiStepNumber--incomplete euiStepNumber-isHollow euiStep__circle"

--- a/src/components/steps/step.js
+++ b/src/components/steps/step.js
@@ -15,6 +15,10 @@ import {
   EuiStepNumber,
 } from './step_number';
 
+import {
+  EuiI18n,
+} from '../i18n';
+
 export const EuiStep = ({
   className,
   children,
@@ -26,9 +30,11 @@ export const EuiStep = ({
 }) => {
   const classes = classNames('euiStep', className);
 
-  let screenReaderPrefix;
+  let screenReaderStep;
   if (status === 'incomplete') {
-    screenReaderPrefix = 'Incomplete';
+    screenReaderStep = <EuiI18n token="euiStep.incompleteStep" default="Incomplete Step"/>;
+  } else {
+    screenReaderStep = <EuiI18n token="euiStep.completeStep" default="Step"/>;
   }
 
   return (
@@ -37,7 +43,7 @@ export const EuiStep = ({
       {...rest}
     >
 
-      <EuiScreenReaderOnly><span>{screenReaderPrefix} Step </span></EuiScreenReaderOnly>
+      <EuiScreenReaderOnly><span>{screenReaderStep}&nbsp;</span></EuiScreenReaderOnly>
 
       <EuiStepNumber className="euiStep__circle" number={step} status={status} isHollow={status === 'incomplete'}/>
 

--- a/src/components/steps/step_horizontal.js
+++ b/src/components/steps/step_horizontal.js
@@ -8,6 +8,10 @@ import {
 } from '../accessibility';
 
 import {
+  EuiI18n,
+} from '../i18n';
+
+import {
   STATUS,
   EuiStepNumber,
 } from './step_number';
@@ -30,14 +34,10 @@ export const EuiStepHorizontal = ({
     'euiStepHorizontal-isDisabled': disabled,
   });
 
-  let titleAppendix = '';
-
   if (disabled) {
     status = 'disabled';
-    titleAppendix = ' is disabled';
   } else if (isComplete) {
     status = 'complete';
-    titleAppendix = ' is complete';
   } else if (isSelected) {
     status = status;
   } else if (!isComplete && !status) {
@@ -52,29 +52,44 @@ export const EuiStepHorizontal = ({
     onClick(e);
   };
 
-  const buttonTitle = `Step ${step}: ${title}${titleAppendix}`;
-
   return (
-    <EuiKeyboardAccessible>
-      <div
-        role="tab"
-        aria-selected={!!isSelected}
-        aria-disabled={!!disabled}
-        className={classes}
-        onClick={onStepClick}
-        tabIndex={disabled ? '-1' : '0'}
-        title={buttonTitle}
-        {...rest}
-      >
-        <EuiScreenReaderOnly><div>Step</div></EuiScreenReaderOnly>
+    <EuiI18n
+      token="euiStepHorizontal.buttonTitle"
+      default={({ step, title, disabled, isComplete }) => {
+        let titleAppendix = '';
+        if (disabled) {
+          titleAppendix = ' is disabled';
+        } else if (isComplete) {
+          titleAppendix = ' is complete';
+        }
 
-        <EuiStepNumber className="euiStepHorizontal__number" status={status} number={step} />
+        return `Step ${step}: ${title}${titleAppendix}`;
+      }}
+      values={{ step, title, disabled, isComplete }}
+    >
+      {buttonTitle => (
+        <EuiKeyboardAccessible>
+          <div
+            role="tab"
+            aria-selected={!!isSelected}
+            aria-disabled={!!disabled}
+            className={classes}
+            onClick={onStepClick}
+            tabIndex={disabled ? '-1' : '0'}
+            title={buttonTitle}
+            {...rest}
+          >
+            <EuiScreenReaderOnly><div><EuiI18n token="euiStepHorizontal.step" default="Step"/></div></EuiScreenReaderOnly>
 
-        <div className="euiStepHorizontal__title">
-          {title}
-        </div>
-      </div>
-    </EuiKeyboardAccessible>
+            <EuiStepNumber className="euiStepHorizontal__number" status={status} number={step} />
+
+            <div className="euiStepHorizontal__title">
+              {title}
+            </div>
+          </div>
+        </EuiKeyboardAccessible>
+      )}
+    </EuiI18n>
   );
 };
 

--- a/src/components/steps/step_number.js
+++ b/src/components/steps/step_number.js
@@ -40,7 +40,7 @@ export const EuiStepNumber = ({
   if (status === 'complete') {
     numberOrIcon = (
       <EuiI18n token="euiStepNumber.isComplete" default="complete">
-        {complete => <EuiIcon type="check" className="euiStepNumber__icon" title={complete} />}
+        {isComplete => <EuiIcon type="check" className="euiStepNumber__icon" title={isComplete} />}
       </EuiI18n>
     );
   } else if (status === 'warning') {

--- a/src/components/steps/step_number.js
+++ b/src/components/steps/step_number.js
@@ -6,6 +6,10 @@ import {
   EuiIcon,
 } from '../icon';
 
+import {
+  EuiI18n,
+} from '../i18n';
+
 const statusToClassNameMap = {
   complete: 'euiStepNumber--complete',
   incomplete: 'euiStepNumber--incomplete',
@@ -34,11 +38,23 @@ export const EuiStepNumber = ({
 
   let numberOrIcon;
   if (status === 'complete') {
-    numberOrIcon = <EuiIcon type="check" className="euiStepNumber__icon" title="complete" />;
+    numberOrIcon = (
+      <EuiI18n token="euiStepNumber.isComplete" default="complete">
+        {complete => <EuiIcon type="check" className="euiStepNumber__icon" title={complete} />}
+      </EuiI18n>
+    );
   } else if (status === 'warning') {
-    numberOrIcon = <EuiIcon type="alert" className="euiStepNumber__icon" title="has warnings" />;
+    numberOrIcon = (
+      <EuiI18n token="euiStepNumber.hasWarnings" default="has warnings">
+        {hasWarnings => <EuiIcon type="alert" className="euiStepNumber__icon" title={hasWarnings} />}
+      </EuiI18n>
+    );
   } else if (status === 'danger') {
-    numberOrIcon = <EuiIcon type="cross" className="euiStepNumber__icon" title="has errors" />;
+    numberOrIcon = (
+      <EuiI18n token="euiStepNumber.hasErrors" default="has errors">
+        {hasErrors => <EuiIcon type="cross" className="euiStepNumber__icon" title={hasErrors} />}
+      </EuiI18n>
+    );
   } else if (!isHollow) {
     numberOrIcon = number;
   }

--- a/src/components/table/mobile/table_sort_mobile.js
+++ b/src/components/table/mobile/table_sort_mobile.js
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import { EuiButtonEmpty } from '../../button/button_empty';
 import { EuiPopover } from '../../popover';
 import { EuiContextMenuPanel } from '../../context_menu';
+import { EuiI18n } from '../../i18n';
 import { EuiTableSortMobileItem } from './table_sort_mobile_item';
 
 export class EuiTableSortMobile extends Component {
@@ -55,7 +56,7 @@ export class EuiTableSortMobile extends Component {
         flush="right"
         size="xs"
       >
-        Sorting
+        <EuiI18n token="euiTableSortMobile.sorting" default="Sorting"/>
       </EuiButtonEmpty>
     );
 

--- a/src/components/toast/__snapshots__/toast.test.js.snap
+++ b/src/components/toast/__snapshots__/toast.test.js.snap
@@ -1,143 +1,272 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiToast Props color danger is rendered 1`] = `
-<div
-  aria-live="polite"
-  className="euiToast euiToast--danger"
+<EuiToast
+  color="danger"
 >
-  <EuiScreenReaderOnly>
-    <p>
-      A new notification appears
-    </p>
-  </EuiScreenReaderOnly>
   <div
-    aria-label="Notification"
-    className="euiToastHeader"
-    data-test-subj="euiToastHeader"
+    aria-live="polite"
+    className="euiToast euiToast--danger"
   >
-    <span
-      className="euiToastHeader__title"
-    />
+    <EuiScreenReaderOnly>
+      <p
+        className="euiScreenReaderOnly"
+      >
+        <EuiI18n
+          default="A new notification appears"
+          token="euiToast.newNotification"
+        >
+          A new notification appears
+        </EuiI18n>
+      </p>
+    </EuiScreenReaderOnly>
+    <EuiI18n
+      default="Notification"
+      token="euiToast.notification"
+    >
+      <div
+        aria-label="Notification"
+        className="euiToastHeader"
+        data-test-subj="euiToastHeader"
+      >
+        <span
+          className="euiToastHeader__title"
+        />
+      </div>
+    </EuiI18n>
   </div>
-</div>
+</EuiToast>
 `;
 
 exports[`EuiToast Props color primary is rendered 1`] = `
-<div
-  aria-live="polite"
-  className="euiToast euiToast--primary"
+<EuiToast
+  color="primary"
 >
-  <EuiScreenReaderOnly>
-    <p>
-      A new notification appears
-    </p>
-  </EuiScreenReaderOnly>
   <div
-    aria-label="Notification"
-    className="euiToastHeader"
-    data-test-subj="euiToastHeader"
+    aria-live="polite"
+    className="euiToast euiToast--primary"
   >
-    <span
-      className="euiToastHeader__title"
-    />
+    <EuiScreenReaderOnly>
+      <p
+        className="euiScreenReaderOnly"
+      >
+        <EuiI18n
+          default="A new notification appears"
+          token="euiToast.newNotification"
+        >
+          A new notification appears
+        </EuiI18n>
+      </p>
+    </EuiScreenReaderOnly>
+    <EuiI18n
+      default="Notification"
+      token="euiToast.notification"
+    >
+      <div
+        aria-label="Notification"
+        className="euiToastHeader"
+        data-test-subj="euiToastHeader"
+      >
+        <span
+          className="euiToastHeader__title"
+        />
+      </div>
+    </EuiI18n>
   </div>
-</div>
+</EuiToast>
 `;
 
 exports[`EuiToast Props color success is rendered 1`] = `
-<div
-  aria-live="polite"
-  className="euiToast euiToast--success"
+<EuiToast
+  color="success"
 >
-  <EuiScreenReaderOnly>
-    <p>
-      A new notification appears
-    </p>
-  </EuiScreenReaderOnly>
   <div
-    aria-label="Notification"
-    className="euiToastHeader"
-    data-test-subj="euiToastHeader"
+    aria-live="polite"
+    className="euiToast euiToast--success"
   >
-    <span
-      className="euiToastHeader__title"
-    />
+    <EuiScreenReaderOnly>
+      <p
+        className="euiScreenReaderOnly"
+      >
+        <EuiI18n
+          default="A new notification appears"
+          token="euiToast.newNotification"
+        >
+          A new notification appears
+        </EuiI18n>
+      </p>
+    </EuiScreenReaderOnly>
+    <EuiI18n
+      default="Notification"
+      token="euiToast.notification"
+    >
+      <div
+        aria-label="Notification"
+        className="euiToastHeader"
+        data-test-subj="euiToastHeader"
+      >
+        <span
+          className="euiToastHeader__title"
+        />
+      </div>
+    </EuiI18n>
   </div>
-</div>
+</EuiToast>
 `;
 
 exports[`EuiToast Props color warning is rendered 1`] = `
-<div
-  aria-live="polite"
-  className="euiToast euiToast--warning"
+<EuiToast
+  color="warning"
 >
-  <EuiScreenReaderOnly>
-    <p>
-      A new notification appears
-    </p>
-  </EuiScreenReaderOnly>
   <div
-    aria-label="Notification"
-    className="euiToastHeader"
-    data-test-subj="euiToastHeader"
+    aria-live="polite"
+    className="euiToast euiToast--warning"
   >
-    <span
-      className="euiToastHeader__title"
-    />
+    <EuiScreenReaderOnly>
+      <p
+        className="euiScreenReaderOnly"
+      >
+        <EuiI18n
+          default="A new notification appears"
+          token="euiToast.newNotification"
+        >
+          A new notification appears
+        </EuiI18n>
+      </p>
+    </EuiScreenReaderOnly>
+    <EuiI18n
+      default="Notification"
+      token="euiToast.notification"
+    >
+      <div
+        aria-label="Notification"
+        className="euiToastHeader"
+        data-test-subj="euiToastHeader"
+      >
+        <span
+          className="euiToastHeader__title"
+        />
+      </div>
+    </EuiI18n>
   </div>
-</div>
+</EuiToast>
 `;
 
 exports[`EuiToast Props iconType is rendered 1`] = `
-<div
-  aria-live="polite"
-  className="euiToast"
+<EuiToast
+  iconType="user"
 >
-  <EuiScreenReaderOnly>
-    <p>
-      A new notification appears
-    </p>
-  </EuiScreenReaderOnly>
   <div
-    aria-label="Notification"
-    className="euiToastHeader"
-    data-test-subj="euiToastHeader"
+    aria-live="polite"
+    className="euiToast"
   >
-    <EuiIcon
-      aria-hidden="true"
-      className="euiToastHeader__icon"
-      size="m"
-      type="user"
-    />
-    <span
-      className="euiToastHeader__title"
-    />
+    <EuiScreenReaderOnly>
+      <p
+        className="euiScreenReaderOnly"
+      >
+        <EuiI18n
+          default="A new notification appears"
+          token="euiToast.newNotification"
+        >
+          A new notification appears
+        </EuiI18n>
+      </p>
+    </EuiScreenReaderOnly>
+    <EuiI18n
+      default="Notification"
+      token="euiToast.notification"
+    >
+      <div
+        aria-label="Notification"
+        className="euiToastHeader"
+        data-test-subj="euiToastHeader"
+      >
+        <EuiIcon
+          aria-hidden="true"
+          className="euiToastHeader__icon"
+          size="m"
+          type="user"
+        >
+          <user
+            aria-hidden="true"
+            className="euiIcon euiIcon--medium euiToastHeader__icon"
+            focusable="false"
+            height="18"
+            style={null}
+            viewBox="0 0 18 18"
+            width="18"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <svg
+              aria-hidden="true"
+              className="euiIcon euiIcon--medium euiToastHeader__icon"
+              focusable="false"
+              height="18"
+              style={null}
+              viewBox="0 0 18 18"
+              width="18"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g
+                fillRule="evenodd"
+              >
+                <path
+                  d="M13.689 11.132c1.155 1.222 1.953 2.879 2.183 4.748a1.007 1.007 0 0 1-1 1.12H3.007a1.005 1.005 0 0 1-1-1.12c.23-1.87 1.028-3.526 2.183-4.748.247.228.505.442.782.633-1.038 1.069-1.765 2.55-1.972 4.237L14.872 16c-.204-1.686-.93-3.166-1.966-4.235a7.01 7.01 0 0 0 .783-.633zM8.939 1c1.9 0 3 2 4.38 2.633a2.483 2.483 0 0 1-1.88.867c-.298 0-.579-.06-.844-.157A3.726 3.726 0 0 1 7.69 5.75c-1.395 0-3.75.25-3.245-1.903C5.94 3 6.952 1 8.94 1z"
+                />
+                <path
+                  d="M8.94 2c2.205 0 4 1.794 4 4s-1.795 4-4 4c-2.207 0-4-1.794-4-4s1.793-4 4-4m0 9A5 5 0 1 0 8.937.999 5 5 0 0 0 8.94 11"
+                />
+              </g>
+            </svg>
+          </user>
+        </EuiIcon>
+        <span
+          className="euiToastHeader__title"
+        />
+      </div>
+    </EuiI18n>
   </div>
-</div>
+</EuiToast>
 `;
 
 exports[`EuiToast Props title is rendered 1`] = `
-<div
-  aria-live="polite"
-  className="euiToast"
+<EuiToast
+  title="toast title"
 >
-  <EuiScreenReaderOnly>
-    <p>
-      A new notification appears
-    </p>
-  </EuiScreenReaderOnly>
   <div
-    aria-label="Notification"
-    className="euiToastHeader"
-    data-test-subj="euiToastHeader"
+    aria-live="polite"
+    className="euiToast"
   >
-    <span
-      className="euiToastHeader__title"
+    <EuiScreenReaderOnly>
+      <p
+        className="euiScreenReaderOnly"
+      >
+        <EuiI18n
+          default="A new notification appears"
+          token="euiToast.newNotification"
+        >
+          A new notification appears
+        </EuiI18n>
+      </p>
+    </EuiScreenReaderOnly>
+    <EuiI18n
+      default="Notification"
+      token="euiToast.notification"
     >
-      toast title
-    </span>
+      <div
+        aria-label="Notification"
+        className="euiToastHeader"
+        data-test-subj="euiToastHeader"
+      >
+        <span
+          className="euiToastHeader__title"
+        >
+          toast title
+        </span>
+      </div>
+    </EuiI18n>
   </div>
-</div>
+</EuiToast>
 `;
 
 exports[`EuiToast is rendered 1`] = `

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { EuiScreenReaderOnly } from '../accessibility';
+import { EuiI18n } from '../i18n';
 
 import {
   ICON_TYPES,
@@ -45,19 +46,23 @@ export const EuiToast = ({ title, color, iconType, onClose, children, className,
 
   if (onClose) {
     closeButton = (
-      <button
-        type="button"
-        className="euiToast__closeButton"
-        aria-label="Dismiss toast"
-        onClick={onClose}
-        data-test-subj="toastCloseButton"
-      >
-        <EuiIcon
-          type="cross"
-          size="m"
-          aria-hidden="true"
-        />
-      </button>
+      <EuiI18n token="euiToast.dismissToast" default="Dismiss toast">
+        {dismissToast => (
+          <button
+            type="button"
+            className="euiToast__closeButton"
+            aria-label={dismissToast}
+            onClick={onClose}
+            data-test-subj="toastCloseButton"
+          >
+            <EuiIcon
+              type="cross"
+              size="m"
+              aria-hidden="true"
+            />
+          </button>
+        )}
+      </EuiI18n>
     );
   }
 
@@ -78,20 +83,24 @@ export const EuiToast = ({ title, color, iconType, onClose, children, className,
       {...rest}
     >
       <EuiScreenReaderOnly>
-        <p>A new notification appears</p>
+        <p><EuiI18n token="euiToast.newNotification" default="A new notification appears"/></p>
       </EuiScreenReaderOnly>
 
-      <div
-        className={headerClasses}
-        aria-label="Notification"
-        data-test-subj="euiToastHeader"
-      >
-        {headerIcon}
+      <EuiI18n token="euiToast.notification" default="Notification">
+        {notification => (
+          <div
+            className={headerClasses}
+            aria-label={notification}
+            data-test-subj="euiToastHeader"
+          >
+            {headerIcon}
 
-        <span className="euiToastHeader__title">
-          {title}
-        </span>
-      </div>
+            <span className="euiToastHeader__title">
+              {title}
+            </span>
+          </div>
+        )}
+      </EuiI18n>
 
       {closeButton}
       {optionalBody}

--- a/src/components/toast/toast.test.js
+++ b/src/components/toast/toast.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, shallow } from 'enzyme';
+import { render, mount } from 'enzyme';
 import sinon from 'sinon';
 import {
   findTestSubject,
@@ -27,7 +27,7 @@ describe('EuiToast', () => {
     describe('title', () => {
       test('is rendered', () => {
         const component = <EuiToast title="toast title" />;
-        expect(shallow(component)).toMatchSnapshot();
+        expect(mount(component)).toMatchSnapshot();
       });
     });
 
@@ -35,7 +35,7 @@ describe('EuiToast', () => {
       COLORS.forEach(color => {
         test(`${color} is rendered`, () => {
           const component = <EuiToast color={color} />;
-          expect(shallow(component)).toMatchSnapshot();
+          expect(mount(component)).toMatchSnapshot();
         });
       });
     });
@@ -43,7 +43,7 @@ describe('EuiToast', () => {
     describe('iconType', () => {
       test('is rendered', () => {
         const component = <EuiToast iconType="user" />;
-        expect(shallow(component)).toMatchSnapshot();
+        expect(mount(component)).toMatchSnapshot();
       });
     });
 
@@ -51,7 +51,7 @@ describe('EuiToast', () => {
       test('is called when the close button is clicked', () => {
         const onCloseHandler = sinon.stub();
 
-        const component = shallow(
+        const component = mount(
           <EuiToast onClose={onCloseHandler} />
         );
         const closeButton = findTestSubject(component, 'toastCloseButton');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4571,6 +4571,11 @@ eslint-plugin-jsx-a11y@^6.0.2:
     emoji-regex "^6.1.0"
     jsx-ast-utils "^2.0.0"
 
+eslint-plugin-local@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-local/-/eslint-plugin-local-1.0.0.tgz#f0c07011c95fec42bfb4d909debb6ea035f3b2a4"
+  integrity sha1-8MBwEclf7EK/tNkJ3rtuoDXzsqQ=
+
 eslint-plugin-mocha@^4.11.0:
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-4.11.0.tgz#91193a2f55e20a5e35974054a0089d30198ee578"


### PR DESCRIPTION
### Summary

* Converts a number of hard-coded copy to use `EuiI18n`
* Adds a custom eslint plugin to provide validation on `EuiI18n` usage

![token name](https://d.pr/i/IrZqqi.png)

![token usage](https://d.pr/i/zSZQ2v.png)

![token+default matching](https://d.pr/i/r06jHy.png)

![token value type](https://d.pr/i/BBnsvc.png)

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
