### PR TITLE
Fix ligature issue in ACE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 - Changed `flex-basis` value on `EuiPageBody` for better cross-browser support ([#1497](https://github.com/elastic/eui/pull/1497))
 - Converted a number of components to support text localization ([#1485](https://github.com/elastic/eui/pull/1485))
 - Added a seconds option to the refresh interval selection in `EuiSuperDatePicker`  ([#1503](https://github.com/elastic/eui/pull/1503))
-- Changed to conditionally render `EuiModalBody` if `EuiConfirmModal` has no `children` ([#1500](https://github.com/elastic/eui/pull/1500))
+- Changed to conditionally render `EuiModalBody` if `EuiConfirmModal` has no `children` ([#1505](https://github.com/elastic/eui/pull/1505))
+
+**Bug fixes**
+
+- Remove `font-features` setting on `@euiFont` mixin to prevent breaks in ACE editor ([#1497](https://github.com/elastic/eui/pull/1497))
 
 ## [`6.7.4`](https://github.com/elastic/eui/tree/v6.7.4)
 

--- a/src/global_styling/mixins/_typography.scss
+++ b/src/global_styling/mixins/_typography.scss
@@ -9,7 +9,6 @@
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
   font-kerning: normal;
-  font-feature-settings: $euiFontFeatureSettings;
 }
 
 @mixin euiCodeFont {

--- a/src/global_styling/variables/_typography.scss
+++ b/src/global_styling/variables/_typography.scss
@@ -27,8 +27,6 @@
 // Families
 
 $euiFontFamily: 'Inter UI', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol' !default;
-$euiFontFeatureSettings: 'calt' 1, 'kern' 1, 'liga' 1 !default;
-
 $euiCodeFontFamily: 'Roboto Mono', Consolas, Menlo, Courier, monospace !default;
 
 

--- a/src/global_styling/variables/_typography.scss
+++ b/src/global_styling/variables/_typography.scss
@@ -29,6 +29,8 @@
 $euiFontFamily: 'Inter UI', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol' !default;
 $euiCodeFontFamily: 'Roboto Mono', Consolas, Menlo, Courier, monospace !default;
 
+// Careful using ligatures. Code editors like ACE will often error because of width calculations
+$euiFontFeatureSettings: 'calt' 1, 'kern' 1, 'liga' 1 !default;
 
 // Font sizes -- scale is loosely based on Major Third (1.250)
 $euiTextScale:      2.25, 1.75, 1.25, 1.125, 1, .875, .75 !default;


### PR DESCRIPTION
### Summary

@bmcconaghy noticed some issues with console and tracked to down to a Kibana upgrade of EUI from 6.3.1 to 6.5.1. I picked up the trail and tracked it down to these lines

https://github.com/elastic/eui/blob/master/src/global_styling/mixins/_typography.scss#L12
https://github.com/elastic/eui/blob/master/src/global_styling/variables/_typography.scss#L30

I don't think this is a problem with the code in EUI but a weird bug in ACE and the way they [calculate cursor position based off character widths](https://github.com/ajaxorg/ace/issues/3037). Unfortunately we use ACE everywhere in Kibana and I'd rather cut this off here than add a lot of overwrites into our ACE implementation there. I'll be honest and say I don't know enough about this property to understand much of what it does other than effect kerning. I couldn't notice any difference in the render, but I have old eyes 😄 

![](http://snid.es/2c247855848d/Screen%252520Recording%2525202019-01-31%252520at%25252006.42%252520PM.gif)



### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
