### PR TITLE
Update page background to match body background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Converted a number of components to support text localization ([#1504](https://github.com/elastic/eui/pull/1504))
 
+**Bug fixes**
+
+- Updated `EuiPage` background color to match body background color ([#1513](https://github.com/elastic/eui/pull/1513))
+
 ## [`6.8.0`](https://github.com/elastic/eui/tree/v6.8.0)
 
 - Changed `flex-basis` value on `EuiPageBody` for better cross-browser support ([#1497](https://github.com/elastic/eui/pull/1497))

--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -4,7 +4,7 @@ $guideSideNavWidth: 240px;
 $guideZLevelHighest: $euiZLevel9 + 1000;
 
 .guideBody {
-  background: linear-gradient(90deg, $euiColorLightestShade 50%, $euiColorEmptyShade 50%);
+  background: linear-gradient(90deg, $euiPageBackgroundColor 50%, $euiColorEmptyShade 50%);
 }
 
 .guidePage {

--- a/src/components/page/_page.scss
+++ b/src/components/page/_page.scss
@@ -1,7 +1,7 @@
 .euiPage {
   display: flex;
   padding: $euiSize;
-  background-color: $euiColorLightestShade;
+  background-color: $euiPageBackgroundColor;
 
   &--restrictWidth-default,
   &--restrictWidth-custom {


### PR DESCRIPTION
When the background color was updated to be a bit lighter, the page background did not get updated as well, so it ended up like this:

<img width="715" alt="screen shot 2019-02-04 at 11 52 02 am" src="https://user-images.githubusercontent.com/549577/52223427-99e85100-2873-11e9-836d-3826fbcad49a.png">

Now it it's the same lighter color:

<img width="715" alt="screen shot 2019-02-04 at 11 51 14 am" src="https://user-images.githubusercontent.com/549577/52223441-a10f5f00-2873-11e9-9a0b-503b4e70d9e5.png">


### Checklist

- ~[ ] This was checked in mobile~
- ~[ ] This was checked in IE11~
- [x] This was checked in dark mode
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
