### PR TITLE
Move pagination react keys onto wrapping elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug fixes**
 
 - Updated `EuiPage` background color to match body background color ([#1513](https://github.com/elastic/eui/pull/1513))
+- Fixed React key usage in `EuiPagination` ([#1514](https://github.com/elastic/eui/pull/1514))
 
 ## [`6.8.0`](https://github.com/elastic/eui/tree/v6.8.0)
 

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -67,13 +67,13 @@ export const EuiPagination = ({
   if (firstPageInRange > 0) {
     firstPageButtons.push(
       <EuiI18n
+        key="0"
         token="euiPagination.pageOfTotal"
         default="Page {page} of {total}"
         values={{ page: 1, total: lastPageInRange }}
       >
         {pageOfTotal => (
           <EuiPaginationButton
-            key="0"
             onClick={onPageClick.bind(null, 0)}
             hideOnMobile
             aria-label={pageOfTotal}
@@ -116,13 +116,13 @@ export const EuiPagination = ({
 
     lastPageButtons.push(
       <EuiI18n
+        key={pageCount - 1}
         token="euiPagination.jumpToLastPage"
         default="Jump to the last page, number {pageCount}"
         values={{ pageCount }}
       >
         {jumpToLastPage => (
           <EuiPaginationButton
-            key={pageCount - 1}
             onClick={onPageClick.bind(null, pageCount - 1)}
             hideOnMobile
             aria-label={jumpToLastPage}


### PR DESCRIPTION
### Summary

Refactor of `EuiPagination` for I18n didn't move the React keys to the new wrapping elements.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
