### PR TITLE
[WIP] Adjust interaction settings, add pin collapse

### DIFF
--- a/src/components/list_group/_list_group.scss
+++ b/src/components/list_group/_list_group.scss
@@ -18,6 +18,13 @@
     border-radius: $euiBorderRadius;
     border: $euiBorderThin;
   }
+
+  &.euiListGroup-isFooter {
+    @include euiBottomShadowFlat;
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+  }
 }
 
 .euiListGroup-maxWidthDefault {

--- a/src/components/list_group/_list_group_item.scss
+++ b/src/components/list_group/_list_group_item.scss
@@ -34,6 +34,10 @@
     cursor: not-allowed;
     background-color: transparent;
   }
+
+  .euiListGroup-isFooter & {
+    background-color: $euiColorEmptyShade;
+  }
 }
 
 .euiListGroupItem__text,
@@ -47,6 +51,10 @@
 
   .euiListGroupItem-hasExtraAction & {
     max-width: calc(100% - #{$euiSizeXL});
+  }
+
+  .euiListGroup-isFooter & {
+    padding-left: $euiSize;
   }
 }
 

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -10,7 +10,7 @@
   z-index: $euiZHeader;
   background: $euiHeaderBackgroundColor;
   box-shadow: $euiNavDrawerSideShadow;
-  transition: width $euiAnimSpeedFast $euiAnimSlightResistance;
+  transition: width $euiAnimSpeedExtraFast $euiAnimSlightResistance;
   transition-delay: $euiNavDrawerContractingDelay;
 
   &.euiNavDrawer-isCollapsed  {
@@ -36,6 +36,15 @@
 
     &.euiNavDrawer-flyoutIsAnimating {
       transition-delay: 0s;
+    }
+  }
+
+  &:hover.euiNavDrawer-notExpandable {
+    width: $euiNavDrawerWidthCollapsed;
+    overflow-y: auto;
+
+    &.euiNavDrawer-flyoutIsExpanded {
+      width: $euiNavDrawerWidthExpanded + $euiNavDrawerWidthCollapsed;
     }
   }
 
@@ -73,6 +82,10 @@
 @include euiBreakpoint('xs', 's') {
   .euiNavDrawer {
     width: $euiNavDrawerWidthExpanded;
+
+    &.euiNavDrawer-notExpandable {
+      width: $euiNavDrawerWidthCollapsed;
+    }
 
     &.euiNavDrawer-mobileIsHidden {
       width: 0;

--- a/src/components/nav_drawer/_nav_drawer_flyout.scss
+++ b/src/components/nav_drawer/_nav_drawer_flyout.scss
@@ -11,6 +11,10 @@
   box-shadow: $euiNavDrawerSideShadow;
   opacity: 0;
 
+  .euiNavDrawer-notExpandable & {
+    left: $euiNavDrawerWidthCollapsed;
+  }
+
   &.euiNavDrawerFlyout-isExpanded {
     opacity: 1;
     transition: opacity $euiAnimSpeedNormal;

--- a/src/components/nav_drawer/_nav_drawer_menu.scss
+++ b/src/components/nav_drawer/_nav_drawer_menu.scss
@@ -1,4 +1,12 @@
 .euiNavDrawerMenu {
   @include euiScrollBar;
   max-width: $euiNavDrawerWidthExpanded;
+
+  .euiNavDrawer-notExpandable & {
+    max-width: $euiNavDrawerWidthCollapsed;
+  }
+
+  &.euiNavDrawerMenu-hasFooter {
+    padding-bottom: $euiSizeXXL;
+  }
 }

--- a/src/components/nav_drawer/_variables.scss
+++ b/src/components/nav_drawer/_variables.scss
@@ -11,6 +11,6 @@ $euiNavDrawerTopPosition: $euiHeaderChildSize + 1px;
 
 // Animation variables
 $euiNavDrawerExpandingDelay: $euiAnimSpeedNormal;
-$euiNavDrawerContractingDelay: $euiAnimSpeedSlow;
+$euiNavDrawerContractingDelay: $euiAnimSpeedFast;
 $euiNavDrawerExtendedDelay: $euiAnimSpeedExtraSlow * 2;
 $euiNavDrawerMenuAddedDelay: $euiAnimSpeedExtraFast;

--- a/src/components/nav_drawer/nav_drawer.js
+++ b/src/components/nav_drawer/nav_drawer.js
@@ -10,6 +10,7 @@ export const EuiNavDrawer = ({
   flyoutIsAnimating,
   mobileIsHidden,
   showScrollbar,
+  isExpandable,
   ...rest
 }) => {
   const classes = classNames(
@@ -21,7 +22,8 @@ export const EuiNavDrawer = ({
       'euiNavDrawer-flyoutIsExpanded': !flyoutIsCollapsed,
       'euiNavDrawer-flyoutIsAnimating': flyoutIsAnimating,
       'euiNavDrawer-mobileIsHidden': mobileIsHidden,
-      'euiNavDrawer-showScrollbar': showScrollbar,
+      'euiNavDrawer-showScrollbar': showScrollbar && isExpandable,
+      'euiNavDrawer-notExpandable': !isExpandable,
     },
     className
   );
@@ -51,6 +53,12 @@ EuiNavDrawer.propTypes = {
   flyoutIsCollapsed: PropTypes.bool,
   flyoutIsAnimating: PropTypes.bool,
 
+
+  /**
+   * Determine whether the menu expands upon hover
+   */
+  isExpandable: PropTypes.bool,
+
   showScrollbar: PropTypes.bool,
 };
 
@@ -60,4 +68,5 @@ EuiNavDrawer.defaultProps = {
   flyoutIsCollapsed: true,
   flyoutIsAnimating: false,
   showScrollbar: false,
+  isExpandable: true,
 };

--- a/src/components/nav_drawer/nav_drawer_menu.js
+++ b/src/components/nav_drawer/nav_drawer_menu.js
@@ -2,11 +2,38 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-export const EuiNavDrawerMenu = ({ children, className, ...rest }) => {
+import { EuiListGroup, EuiListGroupItem } from '../list_group';
+
+export const EuiNavDrawerMenu = ({ children, className, footerLink, ...rest }) => {
   const classes = classNames(
     'euiNavDrawerMenu',
+    {
+      'euiNavDrawerMenu-hasFooter': footerLink,
+    },
     className
   );
+
+  let footerLinkNode;
+
+  if (footerLink) {
+    const {
+      iconType,
+      label,
+      onClick,
+      ...rest
+    } = footerLink;
+
+    footerLinkNode = (
+      <EuiListGroup className="euiListGroup-isFooter" flush>
+        <EuiListGroupItem
+          iconType={iconType}
+          onClick={onClick}
+          label={label}
+          {...rest}
+        />
+      </EuiListGroup>
+    );
+  }
 
   return (
     <div
@@ -14,6 +41,7 @@ export const EuiNavDrawerMenu = ({ children, className, ...rest }) => {
       {...rest}
     >
       {children}
+      {footerLinkNode}
     </div>
   );
 };
@@ -21,4 +49,5 @@ export const EuiNavDrawerMenu = ({ children, className, ...rest }) => {
 EuiNavDrawerMenu.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
+  footerLink: PropTypes.shape(EuiListGroupItem.propTypes),
 };


### PR DESCRIPTION
⚠️ The button position gets out of whack in this embedded docs example due to the funky positioning.
⚠️ I checked it on mobile and various browsers but then tweaked a couple things, so I'll need to check again

📢 This PR is ready for review, just note the two known items above ^ (in particular the first). I have a Kibana PR here https://github.com/elastic/kibana/pull/29978 

### Summary

This PR adjust the side nav interaction in the following ways based upon internal feedback and personal observations:
- increase delay before expanding (prevent nav expanding if I accidentally/momentarily move over it)
- decrease delay before collapsing (when I mouse out, collapse the nav more immediately)
- increase speed of the collapse animation (...and do it quickly)

This PR also adds a new fixed footer prop that display a link at the bottom of the side nav. The docs examples uses this link to demonstrate the ability for users to keep the side nav in a collapsed state.

<img width="305" alt="screenshot 2019-02-04 12 43 20" src="https://user-images.githubusercontent.com/446285/52229432-855b8700-287a-11e9-8648-43ff0b36194f.png">

### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
