### PR TITLE
Fix #1520 match_all query should be "*"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed React key usage in `EuiPagination` ([#1514](https://github.com/elastic/eui/pull/1514))
 - Fixed bug which prevented `EuiSwitch` with generated ID from having its label announced by VoiceOver ([#1519](https://github.com/elastic/eui/pull/1519))
 - Fixed `EuiFilterButton` handling `numFilters` when `0` was specified ([#1510](https://github.com/elastic/eui/pull/1510))
+- Fixed `EuiSearchBar.Query` match_all query string must be `*` ([#1521](https://github.com/elastic/eui/pull/1521))
 
 ## [`6.8.0`](https://github.com/elastic/eui/tree/v6.8.0)
 

--- a/src/components/search_bar/query/__snapshots__/ast_to_es_query_string.test.js.snap
+++ b/src/components/search_bar/query/__snapshots__/ast_to_es_query_string.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`astToEsQueryString ast - '' 1`] = `""`;
+exports[`astToEsQueryString ast - '*' 1`] = `"*"`;
 
 exports[`astToEsQueryString ast - '-group:es group:kibana -group:beats group:logstash' 1`] = `"-group:es +group:kibana -group:beats +group:logstash"`;
 

--- a/src/components/search_bar/query/ast_to_es_query_string.js
+++ b/src/components/search_bar/query/ast_to_es_query_string.js
@@ -127,7 +127,7 @@ const emitIsClause = (clause) => {
 export const astToEsQueryString = (ast) => {
 
   if (ast.clauses.length === 0) {
-    return '';
+    return '*';
   }
 
   return ast.clauses.map(clause => {

--- a/src/components/search_bar/query/ast_to_es_query_string.test.js
+++ b/src/components/search_bar/query/ast_to_es_query_string.test.js
@@ -6,7 +6,7 @@ import { astToEsQueryString } from './ast_to_es_query_string';
 
 describe('astToEsQueryString', () => {
 
-  test(`ast - ''`, () => {
+  test(`ast - '*'`, () => {
     const query = astToEsQueryString(AST.create([]));
     expect(query).toMatchSnapshot();
   });


### PR DESCRIPTION
### Summary

Summarize your PR. If it includes design elements include a screenshot or gif.

### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
