### PR TITLE
Speed up collapsing animation for EuiNavDrawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Changed animation settings for `EuiNavDrawer` ([#1524](https://github.com/elastic/eui/pull/1524))
 - Converted a number of components to support text localization ([#1504](https://github.com/elastic/eui/pull/1504))
 - Updated `app_ems.svg` ([#1517](https://github.com/elastic/eui/pull/1517))
 

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -10,7 +10,7 @@
   z-index: $euiZHeader;
   background: $euiHeaderBackgroundColor;
   box-shadow: $euiNavDrawerSideShadow;
-  transition: width $euiAnimSpeedFast $euiAnimSlightResistance;
+  transition: width $euiAnimSpeedExtraFast $euiAnimSlightResistance;
   transition-delay: $euiNavDrawerContractingDelay;
 
   &.euiNavDrawer-isCollapsed  {

--- a/src/components/nav_drawer/_variables.scss
+++ b/src/components/nav_drawer/_variables.scss
@@ -11,6 +11,6 @@ $euiNavDrawerTopPosition: $euiHeaderChildSize + 1px;
 
 // Animation variables
 $euiNavDrawerExpandingDelay: $euiAnimSpeedNormal;
-$euiNavDrawerContractingDelay: $euiAnimSpeedSlow;
+$euiNavDrawerContractingDelay: $euiAnimSpeedFast;
 $euiNavDrawerExtendedDelay: $euiAnimSpeedExtraSlow * 2;
 $euiNavDrawerMenuAddedDelay: $euiAnimSpeedExtraFast;


### PR DESCRIPTION
### Summary

Two minor animation speed adjustments to address feedback from internal K7 users.
These values are currently inlined on this Kibana PR to get in for FF - https://github.com/elastic/kibana/pull/29978

### Checklist

- [ ] ~This was checked in mobile~
- [x] This was checked in IE11
- [ ] ~This was checked in dark mode~
- [ ] ~Any props added have proper autodocs~
- [ ] ~Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] ~This was checked for breaking changes and labeled appropriately~
- [ ] ~Jest tests were updated or added to match the most common scenarios~
- [x] This was checked against keyboard-only and screenreader scenarios
- [ ] ~This required updates to Framer X components~
