### PR TITLE
Slight tweak with dark bg color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Adjust dark mode background color ([#1530](https://github.com/elastic/eui/pull/1530))
 - TypeScript are now formatted with Prettier ([#1529](https://github.com/elastic/eui/pull/1529))
 - Updated `EuiPopover` and `EuiColorPicker` to pause `EuiOutsideClickDetector` in when not open ([#1527](https://github.com/elastic/eui/pull/1527))
 

--- a/src/global_styling/variables/_colors.scss
+++ b/src/global_styling/variables/_colors.scss
@@ -26,7 +26,7 @@ $euiTextColor: $euiColorDarkestShade !default;
 $euiTitleColor: shadeOrTint($euiTextColor, 50%, 0%) !default;
 $euiLinkColor: $euiColorPrimary !default;
 $euiFocusBackgroundColor: tintOrShade($euiColorPrimary, 90%, 50%) !default;
-$euiPageBackgroundColor: tintOrShade($euiColorLightestShade, 50%, 50%) !default;
+$euiPageBackgroundColor: tintOrShade($euiColorLightestShade, 50%, 25%) !default;
 
 // Visualization colors
 


### PR DESCRIPTION
### Summary

Related to https://github.com/elastic/kibana/pull/30136#issuecomment-460841965

Makes the dark BG less dark so that it fits closer to the contrast patterns we have going in the light mode.

![image](https://user-images.githubusercontent.com/324519/52311944-a052f780-295d-11e9-8555-3209b4a19a60.png)

![image](https://user-images.githubusercontent.com/324519/52311951-a3e67e80-295d-11e9-9161-0e7344aff9ba.png)


### Checklist

- [ ] ~This was checked in mobile~
- [ ] ~This was checked in IE11~
- [x] This was checked in dark mode
- [ ] ~Any props added have proper autodocs~
- [ ] ~Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] ~This was checked for breaking changes and labeled appropriately~
- [ ] ~Jest tests were updated or added to match the most common scenarios~
- [ ] ~This was checked against keyboard-only and screenreader scenarios~
- [ ] ~This required updates to Framer X components~
