### PR TITLE
Make TSLint issues be warnings, not errors, when running `src-docs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - Fixed `EuiSearchBar.Query` match_all query string must be `*` ([#1521](https://github.com/elastic/eui/pull/1521))
 - Fixed `EuiSuperDatePicker` crashing with negative relative value ([#1537](https://github.com/elastic/eui/pull/1537))
+- Make TSLint issues be warnings, not errors, when running `src-docs` ([#1537](https://github.com/elastic/eui/pull/1537))
 
 ## [`6.10.0`](https://github.com/elastic/eui/tree/v6.10.0)
 

--- a/src-docs/tslint.yaml
+++ b/src-docs/tslint.yaml
@@ -1,0 +1,2 @@
+extends: ../tslint.yaml
+defaultSeverity: warning

--- a/src-docs/webpack.config.js
+++ b/src-docs/webpack.config.js
@@ -64,7 +64,7 @@ module.exports = {
     // run TypeScript and tslint during webpack build
     new ForkTsCheckerWebpackPlugin({
       tsconfig: path.resolve(__dirname, '..', 'tsconfig.json'),
-      tslint: path.resolve(__dirname, '..', 'tslint.yaml'),
+      tslint: path.resolve(__dirname, 'tslint.yaml'),
       async: false, // makes errors more visible, but potentially less performant
     }),
   ],


### PR DESCRIPTION
### Summary

Now that we've merged #1529, all TypeScript files will trigger lint warnings if their formatting needs updating with Prettier (which can be done by fixing with the linter). So far, so good.

However, the Webpack config for `src-docs` pulls in the project's TypesScript and TSLint settings, meaning that Webpack won't compile any TS files that have lint problems. We don't need checking at this stage to be so strict, because the pre-commit hook and general lint task already check everything.

So, in order to stop docs development from being annoying, I've customised the TSLint settings when running `src-docs` so that lint problems are now warnings, instead of errors. They'll still have to get fixed before committing.

### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
