### PR TITLE
Fix EuiSearchBar's proptype docs around FieldValueToggleGroupFilter

### DIFF
--- a/src-docs/src/views/search_bar/props_info.js
+++ b/src-docs/src/views/search_bar/props_info.js
@@ -318,13 +318,36 @@ export const propsInfo = {
         items: {
           description: 'A list of field value filters that are part of this group',
           required: true,
-          type: { name: '#FieldValueToggleGroupItem[]' }
+          type: { name: '#FieldValueToggleGroupFilterItemType[]' }
         },
         available: {
           description: 'Called to check whether this filter is currently available. If not, it will not be shown',
           required: false,
           type: { name: '() => boolean' }
         }
+      }
+    }
+  },
+
+  FieldValueToggleGroupFilterItemType: {
+    __docgenInfo: {
+      _euiObjectType: 'type',
+      props: {
+        value: {
+          description: 'Value of the filter item',
+          required: true,
+          type: { name: 'string | number | boolean' }
+        },
+        name: {
+          description: 'Name rendered on the filter button',
+          required: true,
+          type: { name: 'string' }
+        },
+        negatedName: {
+          description: 'Name rendered on the filter button when its value is negated in the query',
+          required: false,
+          type: { name: 'string' }
+        },
       }
     }
   },

--- a/src-docs/src/views/search_bar/search_bar_example.js
+++ b/src-docs/src/views/search_bar/search_bar_example.js
@@ -109,11 +109,11 @@ export const SearchBarExample = {
             <EuiCode>created:&apos;2019-01-01&apos;</EuiCode>,&nbsp;
             <EuiCode>created&gt;=&apos;3rd January 2017&apos;</EuiCode>
           </p>
-          <p>
+          <div>
             Formats understood by the parser
             <ul>
               <li>
-                <p>relative</p>
+                relative
                 <ul>
                   <li><EuiCode>yesterday</EuiCode></li>
                   <li><EuiCode>today</EuiCode></li>
@@ -121,11 +121,9 @@ export const SearchBarExample = {
                 </ul>
               </li>
               <li>
-                <p>
-                  absolute (parsed by Moment.js&apos;s&nbsp;
-                  <EuiLink href="https://momentjs.com/docs/#/parsing/utc/" target="_blank">`utc` method</EuiLink>
-                  )
-                </p>
+                absolute (parsed by Moment.js&apos;s&nbsp;
+                <EuiLink href="https://momentjs.com/docs/#/parsing/utc/" target="_blank">`utc` method</EuiLink>
+                )
                 <ul>
                   <li><EuiCode>ddd</EuiCode></li>
                   <li><EuiCode>dddd</EuiCode></li>
@@ -145,7 +143,7 @@ export const SearchBarExample = {
                 </ul>
               </li>
             </ul>
-          </p>
+          </div>
         </div>
       ),
       props: propsInfo,


### PR DESCRIPTION
### Summary

Fixes #1547, updates the manual docgen values around `FieldValueToggleGroupFilter` & `FieldValueToggleGroupFilterItemType`

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
- [x] Documentation examples were added
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
