### PR TITLE
Adds ability to copy EuiCodeBlock and adds snippet prop to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Added optional `copy` button to `EuiCode` blocks ([#1556](https://github.com/elastic/eui/pull/1556))
+- Added `isCopyable` prop to `EuiCodeBlock` ([#1556](https://github.com/elastic/eui/pull/1556))
 - Added optional `Snippet` tab to docs and renamed demo tabs ([#1556](https://github.com/elastic/eui/pull/1556))
 
 ## [`7.0.0`](https://github.com/elastic/eui/tree/v7.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `7.0.0`.
+- Added optional `copy` button to `EuiCode` blocks ([#1556](https://github.com/elastic/eui/pull/1556))
+- Added optional `Snippet` tab to docs and renamed demo tabs ([#1556](https://github.com/elastic/eui/pull/1556))
 
 ## [`7.0.0`](https://github.com/elastic/eui/tree/v7.0.0)
 

--- a/src-docs/src/components/guide_section/guide_section.js
+++ b/src-docs/src/components/guide_section/guide_section.js
@@ -86,20 +86,33 @@ export class GuideSection extends Component {
     super(props);
 
     this.componentNames = Object.keys(props.props);
+    this.hasSnippet = 'snippet' in props;
 
     this.tabs = [{
-      name: 'Demo',
+      name: 'demo',
+      displayName: 'Demo',
     }, {
-      name: 'JavaScript',
+      name: 'javascript',
+      displayName: 'Demo JS',
       isCode: true,
     }, {
-      name: 'HTML',
+      name: 'html',
+      displayName: 'Demo HTML',
       isCode: true,
     }];
 
+    if (this.hasSnippet) {
+      this.tabs.push({
+        name: 'snippet',
+        displayName: 'Snippet',
+        isCode: true,
+      });
+    }
+
     if (this.componentNames.length) {
       this.tabs.push({
-        name: 'Props',
+        name: 'props',
+        displayName: 'Props',
       });
     }
 
@@ -121,7 +134,7 @@ export class GuideSection extends Component {
         isSelected={tab === this.state.selectedTab}
         key={tab.name}
       >
-        {tab.name}
+        {tab.displayName}
       </EuiTab>
     ));
   }
@@ -312,7 +325,6 @@ export class GuideSection extends Component {
         <div className="guideSection__text">
           {title}
           {this.renderText()}
-          {this.renderSnippet()}
         </div>
 
         <EuiSpacer size="m" />
@@ -326,8 +338,8 @@ export class GuideSection extends Component {
 
   renderCode(name) {
     const nameToCodeClassMap = {
-      JavaScript: 'javascript',
-      HTML: 'html',
+      javascript: 'javascript',
+      html: 'html',
     };
 
     const codeClass = nameToCodeClassMap[name];
@@ -351,6 +363,14 @@ export class GuideSection extends Component {
   }
 
   renderContent() {
+    if (this.state.selectedTab.name === 'snippet') {
+      return (
+        <EuiErrorBoundary>
+          {this.renderSnippet()}
+        </EuiErrorBoundary>
+      );
+    }
+
     if (this.state.selectedTab.isCode) {
       return (
         <EuiErrorBoundary>
@@ -359,7 +379,7 @@ export class GuideSection extends Component {
       );
     }
 
-    if (this.state.selectedTab.name === 'Props') {
+    if (this.state.selectedTab.name === 'props') {
       return (
         <EuiErrorBoundary>
           {this.renderProps()}

--- a/src-docs/src/components/guide_section/guide_section.js
+++ b/src-docs/src/components/guide_section/guide_section.js
@@ -86,7 +86,7 @@ export class GuideSection extends Component {
     super(props);
 
     this.componentNames = Object.keys(props.props);
-    this.hasSnippet = 'snippet' in props;
+    const hasSnippet = 'snippet' in props;
 
     this.tabs = [{
       name: 'demo',
@@ -101,7 +101,7 @@ export class GuideSection extends Component {
       isCode: true,
     }];
 
-    if (this.hasSnippet) {
+    if (hasSnippet) {
       this.tabs.push({
         name: 'snippet',
         displayName: 'Snippet',

--- a/src-docs/src/components/guide_section/guide_section.js
+++ b/src-docs/src/components/guide_section/guide_section.js
@@ -138,6 +138,23 @@ export class GuideSection extends Component {
     ];
   }
 
+  renderSnippet() {
+    const { snippet } = this.props;
+
+    if (!snippet) {
+      return;
+    }
+
+    return [
+      <Fragment key="snippet">
+        <EuiSpacer size="m" />
+        <EuiCodeBlock language="html" fontSize="m" paddingSize="m" isCopyable>
+          {snippet}
+        </EuiCodeBlock>
+      </Fragment>
+    ];
+  }
+
   renderPropsForComponent = (componentName, component) => {
     if (!component.__docgenInfo) {
       return;
@@ -295,6 +312,7 @@ export class GuideSection extends Component {
         <div className="guideSection__text">
           {title}
           {this.renderText()}
+          {this.renderSnippet()}
         </div>
 
         <EuiSpacer size="m" />
@@ -375,6 +393,7 @@ GuideSection.propTypes = {
   title: PropTypes.string,
   id: PropTypes.string,
   source: PropTypes.array,
+  snippet: PropTypes.string,
   children: PropTypes.any,
   toggleTheme: PropTypes.func.isRequired,
   theme: PropTypes.string.isRequired,

--- a/src-docs/src/components/guide_section/guide_section_types.js
+++ b/src-docs/src/components/guide_section/guide_section_types.js
@@ -1,4 +1,4 @@
 export const GuideSectionTypes = {
-  JS: 'JavaScript',
-  HTML: 'HTML',
+  JS: 'javascript',
+  HTML: 'html',
 };

--- a/src-docs/src/views/code/code_block.js
+++ b/src-docs/src/views/code/code_block.js
@@ -7,7 +7,7 @@ import {
 
 const htmlCode = `<!--I'm an example of HTML-->
 <div>
-  asdf
+  <h1>Title</h1>
 </div>
 `;
 
@@ -21,7 +21,7 @@ export default () => (
 
     <EuiSpacer />
 
-    <EuiCodeBlock language="js" fontSize="l" paddingSize="s" color="dark" overflowHeight={300} isCopyable>
+    <EuiCodeBlock language="js" fontSize="m" paddingSize="m" color="dark" overflowHeight={300} isCopyable>
       {jsCode}
     </EuiCodeBlock>
 

--- a/src-docs/src/views/code/code_block.js
+++ b/src-docs/src/views/code/code_block.js
@@ -21,7 +21,7 @@ export default () => (
 
     <EuiSpacer />
 
-    <EuiCodeBlock language="js" fontSize="l" paddingSize="s" color="dark" overflowHeight={300}>
+    <EuiCodeBlock language="js" fontSize="l" paddingSize="s" color="dark" overflowHeight={300} isCopyable>
       {jsCode}
     </EuiCodeBlock>
 

--- a/src-docs/src/views/code/code_example.js
+++ b/src-docs/src/views/code/code_example.js
@@ -14,10 +14,15 @@ import {
 import Code from './code';
 const codeSource = require('!!raw-loader!./code');
 const codeHtml = renderToHtml(Code);
+const codeSnippet = '<EuiCode>Text to be formatted</EuiCode>';
 
 import CodeBlock from './code_block';
 const codeBlockSource = require('!!raw-loader!./code_block');
 const codeBlockHtml = renderToHtml(CodeBlock);
+const codeBlockSnippet = `<EuiCodeBlock language="html" paddingSize="s" isCopyable>
+  { \`<h1>Title</h1>\` }
+</EuiCodeBlock>
+`;
 
 export const CodeExample = {
   title: 'Code',
@@ -36,6 +41,7 @@ export const CodeExample = {
         within or next to bodies of text.
       </p>
     ),
+    snippet: codeSnippet,
     demo: <Code />,
   }, {
     title: 'CodeBlock',
@@ -48,9 +54,13 @@ export const CodeExample = {
     }],
     text: (
       <p>
-        <EuiCode>EuiCodeBlock</EuiCode> can be used to create multi-line code blocks.
+        <EuiCode>EuiCodeBlock</EuiCode> can be used to create multi-line code
+        blocks. Copy and fullscreen buttons can be enabled via the
+        <EuiCode>isCopyable</EuiCode> and <EuiCode>overflowHeight</EuiCode>
+        props, respectively.
       </p>
     ),
+    snippet: codeBlockSnippet,
     props: { EuiCodeBlockImpl },
     demo: <CodeBlock />,
   }],

--- a/src-docs/src/views/progress/progress.js
+++ b/src-docs/src/views/progress/progress.js
@@ -5,5 +5,5 @@ import {
 } from '../../../../src/components';
 
 export default () => (
-  <EuiProgress size="xs" />
+  <EuiProgress size="xs" color="accent" />
 );

--- a/src-docs/src/views/progress/progress.js
+++ b/src-docs/src/views/progress/progress.js
@@ -5,5 +5,7 @@ import {
 } from '../../../../src/components';
 
 export default () => (
-  <EuiProgress size="xs" color="accent" />
+  <div>
+    <EuiProgress size="xs" color="accent" />
+  </div>
 );

--- a/src-docs/src/views/progress/progress_example.js
+++ b/src-docs/src/views/progress/progress_example.js
@@ -7,8 +7,11 @@ import {
 } from '../../components';
 
 import {
+  EuiCallOut,
   EuiCode,
+  EuiCodeBlock,
   EuiProgress,
+  EuiSpacer,
 } from '../../../../src/components';
 
 import Progress from './progress';
@@ -26,6 +29,10 @@ const progressFixedHtml = renderToHtml(ProgressFixed);
 import ProgressSizeColor from './progress_size_color';
 const progressSizeColorSource = require('!!raw-loader!./progress_size_color');
 const progressSizeColorHtml = renderToHtml(ProgressSizeColor);
+
+const htmlCode = `<EuiPortal>
+  <EuiProgress size="xs" color="accent" position="fixed" />
+</EuiPortal>`;
 
 export const ProgressExample = {
   title: 'Progress',
@@ -84,15 +91,23 @@ export const ProgressExample = {
           absolute option, make sure that your wrapping element
           has <EuiCode>position: relative</EuiCode> applied.
         </p>
-
-        <p>
-          Using <EuiCode>EuiProgress</EuiCode> with
-          a <EuiCode>fixed</EuiCode> position may result in it being overlayed
-          when its parent wrapper has a <EuiCode>z-index</EuiCode> value lower
-          than another fixed element, such as <EuiCode>EuiHeader</EuiCode>. In
-          that case, wrap <EuiCode>EuiProgress</EuiCode> in
-          an <EuiCode>EuiPortal</EuiCode>.
-        </p>
+        <EuiCallOut
+          title="Note about progress bars over fixed headers"
+          iconType="iInCircle"
+        >
+          <p>
+            Using <EuiCode>EuiProgress</EuiCode> with
+            a <EuiCode>fixed</EuiCode> position may result in it being overlayed
+            when its parent wrapper has a <EuiCode>z-index</EuiCode> value lower
+            than another fixed element, such as <EuiCode>EuiHeader</EuiCode>. In
+            that case, wrap <EuiCode>EuiProgress</EuiCode> in
+            an <EuiCode>EuiPortal</EuiCode>.
+          </p>
+        </EuiCallOut>
+        <EuiSpacer size="s" />
+        <EuiCodeBlock language="html" paddingSize="m" isCopyable>
+          {htmlCode}
+        </EuiCodeBlock>
       </div>
     ),
     demo: <ProgressFixed />,

--- a/src-docs/src/views/progress/progress_example.js
+++ b/src-docs/src/views/progress/progress_example.js
@@ -9,9 +9,7 @@ import {
 import {
   EuiCallOut,
   EuiCode,
-  EuiCodeBlock,
   EuiProgress,
-  EuiSpacer,
 } from '../../../../src/components';
 
 import Progress from './progress';
@@ -27,7 +25,11 @@ const progressValueSnippet = '<EuiProgress value={22} max={100} size="xs" />';
 import ProgressFixed from './progress_fixed';
 const progressFixedSource = require('!!raw-loader!./progress_fixed');
 const progressFixedHtml = renderToHtml(ProgressFixed);
-const progressFixedSnippet = `<EuiPortal>
+const progressFixedSnippet = `<!-- Position at top of parent container -->
+<EuiProgress size="xs" color="accent" position="absolute" />
+
+<!-- Position at top of screen, above global header -->
+<EuiPortal>
   <EuiProgress size="xs" color="accent" position="fixed" />
 </EuiPortal>`;
 
@@ -104,15 +106,12 @@ export const ProgressExample = {
             when its parent wrapper has a <EuiCode>z-index</EuiCode> value lower
             than another fixed element, such as <EuiCode>EuiHeader</EuiCode>. In
             that case, wrap <EuiCode>EuiProgress</EuiCode> in
-            an <EuiCode>EuiPortal</EuiCode>.
+            an <EuiCode>EuiPortal</EuiCode> as seen on the Snippet tab.
           </p>
         </EuiCallOut>
-        <EuiSpacer size="s" />
-        <EuiCodeBlock language="html" paddingSize="m" isCopyable>
-          {progressFixedSnippet}
-        </EuiCodeBlock>
       </div>
     ),
+    snippet: progressFixedSnippet,
     demo: <ProgressFixed />,
   }, {
     title: 'Progress has a range of sizes and colors',

--- a/src-docs/src/views/progress/progress_example.js
+++ b/src-docs/src/views/progress/progress_example.js
@@ -17,22 +17,23 @@ import {
 import Progress from './progress';
 const progressSource = require('!!raw-loader!./progress');
 const progressHtml = renderToHtml(Progress);
+const progressSnippet = `<EuiProgress size="xs" color="accent" />`;
 
 import ProgressValue from './progress_value';
 const progressValueSource = require('!!raw-loader!./progress_value');
 const progressValueHtml = renderToHtml(ProgressValue);
+const progressValueSnippet = '<EuiProgress value={22} max={100} size="xs" />';
 
 import ProgressFixed from './progress_fixed';
 const progressFixedSource = require('!!raw-loader!./progress_fixed');
 const progressFixedHtml = renderToHtml(ProgressFixed);
+const progressFixedSnippet = `<EuiPortal>
+  <EuiProgress size="xs" color="accent" position="fixed" />
+</EuiPortal>`;
 
 import ProgressSizeColor from './progress_size_color';
 const progressSizeColorSource = require('!!raw-loader!./progress_size_color');
 const progressSizeColorHtml = renderToHtml(ProgressSizeColor);
-
-const htmlCode = `<EuiPortal>
-  <EuiProgress size="xs" color="accent" position="fixed" />
-</EuiPortal>`;
 
 export const ProgressExample = {
   title: 'Progress',
@@ -53,6 +54,7 @@ export const ProgressExample = {
         always strech <EuiCode>100%</EuiCode> to its container.
       </p>
     ),
+    snippet: progressSnippet,
     props: { EuiProgress },
     demo: <Progress />,
   }, {
@@ -71,6 +73,7 @@ export const ProgressExample = {
         using an HTML5 <EuiCode>progress</EuiCode> tag.
       </p>
     ),
+    snippet: progressValueSnippet,
     demo: <ProgressValue />,
   }, {
     title: 'Progress can have absolute or fixed positions',
@@ -106,7 +109,7 @@ export const ProgressExample = {
         </EuiCallOut>
         <EuiSpacer size="s" />
         <EuiCodeBlock language="html" paddingSize="m" isCopyable>
-          {htmlCode}
+          {progressFixedSnippet}
         </EuiCodeBlock>
       </div>
     ),

--- a/src/components/code/_code_block.js
+++ b/src/components/code/_code_block.js
@@ -152,17 +152,21 @@ export class EuiCodeBlockImpl extends Component {
       copyButton = (
         // TODO add i18n
         <div className="euiCodeBlock__copyButton">
-          <EuiCopy textToCopy={children}>
-            {(copy) => (
-              <EuiButtonIcon
-                size="s"
-                onClick={copy}
-                iconType="copy"
-                color="text"
-                aria-label="Copy"
-              />
+          <EuiI18n token="euiCodeBlock.copyButton" default="Copy">
+            {copyButton => (
+              <EuiCopy textToCopy={children}>
+                {(copy) => (
+                  <EuiButtonIcon
+                    size="s"
+                    onClick={copy}
+                    iconType="copy"
+                    color="text"
+                    aria-label={copyButton}
+                  />
+                )}
+              </EuiCopy>
             )}
-          </EuiCopy>
+          </EuiI18n>
         </div>
       );
     }
@@ -194,8 +198,8 @@ export class EuiCodeBlockImpl extends Component {
     if (copyButton || fullScreenButton) {
       codeBlockControls = (
         <div className="euiCodeBlock__controls">
-          {copyButton}
           {fullScreenButton}
+          {copyButton}
         </div>
       );
     }
@@ -277,7 +281,7 @@ EuiCodeBlockImpl.propTypes = {
   inline: PropTypes.bool,
 
   /**
-   * Displays an icon button that copies the code snippet to your clipboard.
+   * Displays an icon button to copy the code snippet to the clipboard.
    */
   isCopyable: PropTypes.bool,
 };

--- a/src/components/code/_code_block.js
+++ b/src/components/code/_code_block.js
@@ -150,7 +150,6 @@ export class EuiCodeBlockImpl extends Component {
 
     if (isCopyable) {
       copyButton = (
-        // TODO add i18n
         <div className="euiCodeBlock__copyButton">
           <EuiI18n token="euiCodeBlock.copyButton" default="Copy">
             {copyButton => (

--- a/src/components/code/_code_block.js
+++ b/src/components/code/_code_block.js
@@ -159,10 +159,8 @@ export class EuiCodeBlockImpl extends Component {
                 onClick={copy}
                 iconType="copy"
                 color="text"
-                aria-label="Copy code block to clipboard"
-              >
-                Copy
-              </EuiButtonIcon>
+                aria-label="Copy"
+              />
             )}
           </EuiCopy>
         </div>
@@ -279,7 +277,7 @@ EuiCodeBlockImpl.propTypes = {
   inline: PropTypes.bool,
 
   /**
-   * Displays a 'Copy' button that copies the provided code snippet.
+   * Displays an icon button that copies the code snippet to your clipboard.
    */
   isCopyable: PropTypes.bool,
 };

--- a/src/components/code/_code_block.js
+++ b/src/components/code/_code_block.js
@@ -7,6 +7,10 @@ import FocusTrap from 'focus-trap-react';
 import hljs from 'highlight.js';
 
 import {
+  EuiCopy,
+} from '../copy';
+
+import {
   EuiButtonIcon,
 } from '../button';
 
@@ -95,6 +99,7 @@ export class EuiCodeBlockImpl extends Component {
       overflowHeight,
       paddingSize,
       transparentBackground,
+      isCopyable,
       ...otherProps
     } = this.props;
 
@@ -105,6 +110,7 @@ export class EuiCodeBlockImpl extends Component {
       {
         'euiCodeBlock--transparentBackground': transparentBackground,
         'euiCodeBlock--inline': inline,
+        'euiCodeBlock-isCopyable': isCopyable,
       },
       className
     );
@@ -140,6 +146,29 @@ export class EuiCodeBlockImpl extends Component {
       );
     }
 
+    let copyButton;
+
+    if (isCopyable) {
+      copyButton = (
+        // TODO add i18n
+        <div className="euiCodeBlock__copyButton">
+          <EuiCopy textToCopy={children}>
+            {(copy) => (
+              <EuiButtonIcon
+                size="s"
+                onClick={copy}
+                iconType="copy"
+                color="text"
+                aria-label="Copy code block to clipboard"
+              >
+                Copy
+              </EuiButtonIcon>
+            )}
+          </EuiCopy>
+        </div>
+      );
+    }
+
     let fullScreenButton;
 
     if (!inline && overflowHeight) {
@@ -159,6 +188,17 @@ export class EuiCodeBlockImpl extends Component {
             />
           )}
         </EuiI18n>
+      );
+    }
+
+    let codeBlockControls;
+
+    if (copyButton || fullScreenButton) {
+      codeBlockControls = (
+        <div className="euiCodeBlock__controls">
+          {copyButton}
+          {fullScreenButton}
+        </div>
       );
     }
 
@@ -196,7 +236,7 @@ export class EuiCodeBlockImpl extends Component {
                 </code>
               </pre>
 
-              {fullScreenButton}
+              {codeBlockControls}
             </div>
           </EuiOverlayMask>
         </FocusTrap>
@@ -213,7 +253,7 @@ export class EuiCodeBlockImpl extends Component {
           If the below fullScreen code renders, it actually attaches to the body because of
           EuiOverlayMask's React portal usage.
         */}
-        {fullScreenButton}
+        {codeBlockControls}
         {fullScreenDisplay}
       </div>
     );
@@ -237,10 +277,16 @@ EuiCodeBlockImpl.propTypes = {
    * Displays the passed code in an inline format. Also removes any margins set.
    */
   inline: PropTypes.bool,
+
+  /**
+   * Displays a 'Copy' button that copies the provided code snippet.
+   */
+  isCopyable: PropTypes.bool,
 };
 
 EuiCodeBlockImpl.defaultProps = {
   transparentBackground: false,
   paddingSize: 'l',
   fontSize: 's',
+  isCopyable: false,
 };

--- a/src/components/code/_code_block.scss
+++ b/src/components/code/_code_block.scss
@@ -25,7 +25,7 @@
   .euiCodeBlock__controls {
     position: absolute;
     top: $euiSizeM;
-    right: $euiSizeL;
+    right: $euiSize;
   }
 
   .euiCodeBlock__copyButton,

--- a/src/components/code/_code_block.scss
+++ b/src/components/code/_code_block.scss
@@ -25,10 +25,6 @@
     margin-top: $euiSizeXS;
   }
 
-  .euiCodeBlock__copyButton {
-    background-color: $euiColorLightestShade;
-  }
-
   .euiCodeBlock__controls {
     position: absolute;
     top: $euiSizeM;

--- a/src/components/code/_code_block.scss
+++ b/src/components/code/_code_block.scss
@@ -18,10 +18,19 @@
     font-weight: $euiFontWeightRegular;
   }
 
-  .euiCodeBlock__fullScreenButton {
+  .euiCodeBlock__copyButton {
+    background-color: $euiColorLightestShade;
+  }
+
+  .euiCodeBlock__controls {
     position: absolute;
     top: $euiSizeM;
     right: $euiSizeL;
+  }
+
+  .euiCodeBlock__copyButton,
+  .euiCodeBlock__fullScreenButton {
+    display: inline-block;
   }
 
   &.euiCodeBlock-isFullScreen {

--- a/src/components/code/_code_block.scss
+++ b/src/components/code/_code_block.scss
@@ -5,10 +5,13 @@
   color: $euiCodeBlockColor;
 
   .euiCodeBlock__pre {
+    @include euiScrollBar;
     height: 100%;
     overflow: auto;
     display: block;
     white-space: pre-wrap;
+    // sass-lint:disable-block no-important
+    padding-right: $euiSizeXXL !important; // Space for controls
   }
 
   .euiCodeBlock__code {
@@ -16,6 +19,10 @@
     display: block;
     line-height: $euiLineHeight;
     font-weight: $euiFontWeightRegular;
+  }
+
+  .euiCodeBlock__fullScreenButton + .euiCodeBlock__copyButton {
+    margin-top: $euiSizeXS;
   }
 
   .euiCodeBlock__copyButton {
@@ -28,11 +35,6 @@
     right: $euiSize;
   }
 
-  .euiCodeBlock__copyButton,
-  .euiCodeBlock__fullScreenButton {
-    display: inline-block;
-  }
-
   &.euiCodeBlock-isFullScreen {
     position: fixed;
     top: 0;
@@ -41,7 +43,8 @@
     bottom: 0;
 
     .euiCodeBlock__pre {
-      padding: $euiSizeXL !important; // sass-lint:disable-line no-important
+      // sass-lint:disable-block no-important
+      padding: $euiSizeXL !important;
     }
   }
 

--- a/src/components/code/index.d.ts
+++ b/src/components/code/index.d.ts
@@ -24,6 +24,7 @@ declare module '@elastic/eui' {
     overflowHeight?: number;
     fontSize?: FontSize;
     transparentBackground?: boolean;
+    isCopyable?: boolean;
   }
 
 

--- a/src/components/progress/progress.js
+++ b/src/components/progress/progress.js
@@ -74,9 +74,11 @@ EuiProgress.propTypes = {
   color: PropTypes.oneOf(COLORS),
   position: PropTypes.oneOf(POSITIONS),
   max: PropTypes.number,
+  value: PropTypes.number,
 };
 
 EuiProgress.defaultProps = {
+  value: null,
   max: null,
   size: 'm',
   color: 'secondary',


### PR DESCRIPTION
### Summary

This PR has two related objectives:
1. Add an optional 'copy' icon button to `EuiCodeBlock` via an `isCopyable` prop.
2. Add a `snippet` prop to `GuideSection` that optionally displays a new Snippet tab. This essentially allows an EUI docs user to copy code without having to wade through all the demo code in the Javascript tab. It won't be appropriate for all components, but likely for the majority. See it in action on the Code and Progress pages.

#### Add copy button
<img width="936" alt="screenshot 2019-02-12 11 59 43" src="https://user-images.githubusercontent.com/446285/52657188-b6ad0600-2ebd-11e9-9b83-46c6afa1e61e.png">

#### Works with fullscreen too
<img width="936" alt="screenshot 2019-02-12 12 00 39" src="https://user-images.githubusercontent.com/446285/52657243-d8a68880-2ebd-11e9-9b45-909d5f14b4e8.png">

#### Copyable snippet
<img width="971" alt="screenshot 2019-02-13 09 55 26" src="https://user-images.githubusercontent.com/446285/52724743-89239380-2f75-11e9-8026-b9bc48aec2a3.png">

^ Something to consider is that what we provide in the snippet may be proliferated. In other words, we should likely put the preferred settings in there. The catch to that is we'd like to demonstrate some available props which, in the preferred state, commonly use the defaults. The moral of the story is to be thoughtful with what we put into the Snippet tab. 

### Snippets in EUI docs
By using a prop on `GuideSection`, we can add a snippet easily in the `*_example.js` file and produce consistent output (i.e. the same size, padding, copy button, etc., on the `EuiCodeBlock`):

```
const codeSource = require('!!raw-loader!./code');
const codeHtml = renderToHtml(Code);
const codeSnippet = '<EuiCode>Text to be formatted</EuiCode>';
```

```
...
    text: (
      <p>
        <EuiCode>Code</EuiCode> is for making inline code snippets that can work
        within or next to bodies of text.
      </p>
    ),
    snippet: codeSnippet,
...
```

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
- [x] Any props added have proper autodocs
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [ ] ~Jest tests were updated or added to match the most common scenarios~
- [x] This was checked against keyboard-only and screenreader scenarios
- [ ] ~This required updates to Framer X components~
