### PR TITLE
Move docs options into their own popover

### DIFF
--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -151,6 +151,10 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   outline: solid 2px $euiColorVis3;
 }
 
+.guideOptionsPopover {
+  width: $euiSize * 16;
+}
+
 
 
 @import '../views/guidelines/index';

--- a/src-docs/src/components/guide_locale_selector/guide_locale_selector.js
+++ b/src-docs/src/components/guide_locale_selector/guide_locale_selector.js
@@ -1,44 +1,26 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import {
   EuiSwitch,
+  EuiFormRow,
 } from '../../../../src/components';
 
-export class GuideLocaleSelector extends Component {
-  constructor(props) {
-    super(props);
+export const GuideLocaleSelector = ({ selectedLocale, onToggleLocale }) => {
 
-    this.state = {
-      isLocalePopoverOpen: false,
-    };
-  }
-
-  onLocaleButtonClick = () => {
-    this.setState({
-      isLocalePopoverOpen: !this.state.isLocalePopoverOpen,
-    });
-  };
-
-  closeLocalePopover = () => {
-    this.setState({
-      isLocalePopoverOpen: false,
-    });
-  };
-
-  render() {
-    const otherLocale = this.props.selectedLocale === 'en' ? 'en-xa' : 'en';
-
-    return (
+  return (
+    <EuiFormRow
+      label="Translations for development"
+    >
       <EuiSwitch
-        label="pseudo translation"
-        checked={this.props.selectedLocale === 'en-xa'}
-        onChange={() => this.props.onToggleLocale(otherLocale)}
+        label="Activate babelfish"
+        checked={selectedLocale === 'en-xa'}
+        onChange={() => onToggleLocale(selectedLocale === 'en' ? 'en-xa' : 'en')}
         compressed={true}
       />
-    );
-  }
-}
+    </EuiFormRow>
+  );
+};
 
 GuideLocaleSelector.propTypes = {
   onToggleLocale: PropTypes.func.isRequired,

--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -14,6 +14,9 @@ import {
   EuiSideNav,
   EuiSpacer,
   EuiText,
+  EuiButtonIcon,
+  EuiPopover,
+  EuiPopoverTitle,
 } from '../../../../src/components';
 
 import {
@@ -30,6 +33,7 @@ export class GuidePageChrome extends Component {
     this.state = {
       search: '',
       isSideNavOpenOnMobile: false,
+      isPopoverOpen: false,
     };
   }
 
@@ -69,41 +73,85 @@ export class GuidePageChrome extends Component {
     });
   };
 
+  onButtonClick() {
+    this.setState({
+      isPopoverOpen: !this.state.isPopoverOpen,
+    });
+  }
+
+  closePopover() {
+    this.setState({
+      isPopoverOpen: false,
+    });
+  }
+
   renderIdentity() {
-    const homeLink = (
-      <Link
-        to="/"
-        className="guideLogo"
-        aria-label="Go to home page"
-      >
-        <EuiIcon type="logoElastic" size="l" />
-      </Link>
+
+    const button = (
+      <EuiButtonIcon
+        iconType="gear"
+        onClick={this.onButtonClick.bind(this)}
+        aria-label="Open EUI options menu"
+        color="text"
+      />
     );
-
     return (
-      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap>
+      <EuiFlexGroup alignItems="center" gutterSize="s" justifyContent="spaceBetween" responsive={false} wrap>
         <EuiFlexItem grow={false}>
-          {homeLink}
+          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false} wrap>
+            <EuiFlexItem grow={false}>
+              <Link
+                to="/"
+                className="guideLogo"
+                aria-label="Go to home page"
+              >
+                <EuiIcon type="logoElastic" size="l" />
+              </Link>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <Link
+                to="/"
+                aria-label="Go to home page"
+                className="euiLink"
+              >
+                <strong>
+                  Elastic UI
+                </strong>
+              </Link>
+            </EuiFlexItem>
+          </EuiFlexGroup>
         </EuiFlexItem>
 
         <EuiFlexItem grow={false}>
-          <GuideThemeSelector
-            onToggleTheme={this.props.onToggleTheme}
-            selectedTheme={this.props.selectedTheme}
-          />
+
+          <EuiPopover
+            id="popover"
+            button={button}
+            isOpen={this.state.isPopoverOpen}
+            closePopover={this.closePopover.bind(this)}
+          >
+
+            <EuiPopoverTitle>Docs options</EuiPopoverTitle>
+            <div className="guideOptionsPopover">
+              <GuideThemeSelector
+                onToggleTheme={this.props.onToggleTheme}
+                selectedTheme={this.props.selectedTheme}
+              />
+              {
+                location.host === 'localhost:8030' // eslint-disable-line no-restricted-globals
+                  ? (
+                    <EuiFlexItem grow={false}>
+                      <GuideLocaleSelector
+                        onToggleLocale={this.props.onToggleLocale}
+                        selectedLocale={this.props.selectedLocale}
+                      />
+                    </EuiFlexItem>
+                  )
+                  : null
+              }
+            </div>
+          </EuiPopover>
         </EuiFlexItem>
-        {
-          location.host === 'localhost:8030' // eslint-disable-line no-restricted-globals
-            ? (
-              <EuiFlexItem grow={false}>
-                <GuideLocaleSelector
-                  onToggleLocale={this.props.onToggleLocale}
-                  selectedLocale={this.props.selectedLocale}
-                />
-              </EuiFlexItem>
-            )
-            : null
-        }
       </EuiFlexGroup>
     );
   }

--- a/src-docs/src/components/guide_theme_selector/guide_theme_selector.js
+++ b/src-docs/src/components/guide_theme_selector/guide_theme_selector.js
@@ -2,87 +2,55 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import {
-  EuiButtonEmpty,
-  EuiContextMenuItem,
-  EuiContextMenuPanel,
-  EuiPopover,
+  EuiSelect,
+  EuiFormRow
 } from '../../../../src/components';
 
 export class GuideThemeSelector extends Component {
   constructor(props) {
     super(props);
 
+    this.themeOptions = [
+      {
+        text: 'Light',
+        value: 'light',
+      }, {
+        text: 'Dark',
+        value: 'dark',
+      }, {
+        text: 'K6',
+        value: 'k6',
+      }, {
+        text: 'K6 dark',
+        value: 'k6_dark',
+      }
+    ];
+
     this.state = {
-      isThemePopoverOpen: false,
+      value: this.themeOptions[0].value,
     };
   }
 
-  onThemeButtonClick = () => {
+  onChange = e => {
     this.setState({
-      isThemePopoverOpen: !this.state.isThemePopoverOpen,
-    });
-  };
-
-  closeThemePopover = () => {
-    this.setState({
-      isThemePopoverOpen: false,
+      value: e.target.value,
     });
   };
 
   render() {
-    const themeButton = (
-      <EuiButtonEmpty
-        size="s"
-        color="text"
-        iconType="arrowDown"
-        iconSide="right"
-        onClick={this.onThemeButtonClick}
-        aria-label="Select a visual theme"
-      >
-        <strong>Elastic UI</strong> <span className="guideSideNav__theme"> ~ {this.props.selectedTheme}</span>
-      </EuiButtonEmpty>
-    );
-
-    const themeOptions = [{
-      name: 'Light',
-      value: 'light',
-    }, {
-      name: 'Dark',
-      value: 'dark',
-    }, {
-      name: 'K6',
-      value: 'k6',
-    }, {
-      name: 'K6 dark',
-      value: 'k6_dark',
-    }].map(option => {
-      const { name, value } = option;
-
-      return (
-        <EuiContextMenuItem
-          key={value}
-          icon={value === this.props.selectedTheme ? 'check' : 'empty'}
-          onClick={() => { this.closeThemePopover(); this.props.onToggleTheme(value); }}
-        >
-          {`${name}`}
-        </EuiContextMenuItem>
-      );
-    });
-
     return (
-      <EuiPopover
-        id="pageChromeThemePopover"
-        button={themeButton}
-        isOpen={this.state.isThemePopoverOpen}
-        closePopover={this.closeThemePopover}
-        panelPaddingSize="none"
-        anchorPosition="downRight"
+
+      <EuiFormRow
+        label="Theme"
       >
-        <EuiContextMenuPanel
-          style={{ width: '120px' }}
-          items={themeOptions}
+        <EuiSelect
+          options={this.themeOptions}
+          value={this.props.selectedTheme}
+          onChange={(e) => {this.props.onToggleTheme(e.target.value); }}
+          aria-label="Switch the theme"
         />
-      </EuiPopover>
+      </EuiFormRow>
+
     );
   }
 }

--- a/src-docs/src/views/package/i18n_tokens.js
+++ b/src-docs/src/views/package/i18n_tokens.js
@@ -1,28 +1,37 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import tokens from '../../i18ntokens';
 
-import { EuiCodeBlock, EuiInMemoryTable } from '../../../../src';
+import { EuiCodeBlock, EuiInMemoryTable, EuiLink } from '../../../../src';
 import { GuidePage } from '../../components/guide_page';
 
 const columns = [
-  { name: 'Token', field: 'token' },
   {
-    name: 'Default',
-    render({ defString, highlighting }) {
+    name: 'Token',
+    render({ filepath, loc, token }) {
       return (
-        <EuiCodeBlock language={highlighting === 'code' ? 'javascript' : 'text'}>{defString}</EuiCodeBlock>
+        <div>
+          <p><strong>{token}</strong></p>
+          <EuiLink target="_blank" color="subdued" href={`https://github.com/elastic/eui/blob/master/${filepath}#L${loc.start.line}`}>
+            {filepath}:{loc.start.line}:{loc.start.column}
+          </EuiLink>
+        </div>
       );
     }
   },
   {
-    name: 'File',
-    render({ filepath, loc }) {
+    name: 'Default',
+    render({ defString, highlighting }) {
       return (
-        <Fragment>
-          {filepath}:{loc.start.line}:{loc.start.column}
-        </Fragment>
+        <EuiCodeBlock
+          language={highlighting === 'code' ? 'javascript' : 'text'}
+          paddingSize="s"
+          transparentBackground
+          fontSize="s"
+        >
+          {defString}
+        </EuiCodeBlock>
       );
-    },
+    }
   },
 ];
 
@@ -41,8 +50,7 @@ export const I18nTokens = {
         items={tokens}
         columns={columns}
         search={search}
-        compressed={true}
-        pagination={true}
+        pagination={{ initialPageSize: 50 }}
       />
     </GuidePage>
   ),

--- a/src-docs/src/views/package/i18n_tokens.js
+++ b/src-docs/src/views/package/i18n_tokens.js
@@ -24,7 +24,7 @@ const columns = [
       return (
         <EuiCodeBlock
           language={highlighting === 'code' ? 'javascript' : 'text'}
-          paddingSize="s"
+          paddingSize="none"
           transparentBackground
           fontSize="s"
         >


### PR DESCRIPTION
### Summary

Moves the theming and translation options into their own "Docs options" popover. Figure we'll only have more of these kinds of things, and it will be a nice spot to drop docs versioning as well.

![](http://snid.es/8e8ec1e84f74/Screen%252520Recording%2525202019-02-13%252520at%25252004.36%252520PM.gif)

### Styles i18n page

Links to the correct line on github and styles up this page a little better

![image](http://snid.es/c99a07478b19/Screen%252520Recording%2525202019-02-13%252520at%25252005.19%252520PM.gif)

### Checklist

- [ ] This was checked in mobile
- [ ] ~This was checked in IE11~
- [x] This was checked in dark mode
- [ ] ~Any props added have proper autodocs~
- [ ] ~Documentation examples were added~
- [ ] ~A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
- [ ] ~This was checked for breaking changes and labeled appropriately~
- [ ] ~Jest tests were updated or added to match the most common scenarios~
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] ~This required updates to Framer X components~
