### PR TITLE
add iconSize to ButtonIcon type definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added optional `Snippet` tab to docs and renamed demo tabs ([#1556](https://github.com/elastic/eui/pull/1556))
 - Expanded `getSecureRelForTarget` to handle elastic.co domains as a referrer whitelist ([#1565](https://github.com/elastic/eui/pull/1565))
 - New `url` utility for verifying if a URL is a referrer whitelist ([#1565](https://github.com/elastic/eui/pull/1565))
+- Add iconSize to ButtonIcon type definition ([#1568](https://github.com/elastic/eui/pull/1568))
 
 ## [`7.0.0`](https://github.com/elastic/eui/tree/v7.0.0)
 

--- a/src/components/button/index.d.ts
+++ b/src/components/button/index.d.ts
@@ -60,7 +60,7 @@ declare module '@elastic/eui' {
     'aria-labelledby'?: string;
     isDisabled?: boolean;
     size?: ButtonSize;
-    iconSize ?: IconSize
+    iconSize?: IconSize
   }
   export const EuiButtonIcon: SFC<
     EuiButtonPropsForButtonOrLink<CommonProps & EuiButtonIconProps>

--- a/src/components/button/index.d.ts
+++ b/src/components/button/index.d.ts
@@ -1,5 +1,5 @@
 import { CommonProps } from '../common';
-import { IconType } from '../icon'
+import { IconType, IconSize } from '../icon'
 
 import { SFC, ButtonHTMLAttributes, AnchorHTMLAttributes, MouseEventHandler, HTMLAttributes } from 'react';
 
@@ -60,6 +60,7 @@ declare module '@elastic/eui' {
     'aria-labelledby'?: string;
     isDisabled?: boolean;
     size?: ButtonSize;
+    iconSize ?: IconSize
   }
   export const EuiButtonIcon: SFC<
     EuiButtonPropsForButtonOrLink<CommonProps & EuiButtonIconProps>


### PR DESCRIPTION
### Summary

add iconSize to ButtonIcon type definition

### Checklist

- ~~[ ] This was checked in mobile~~
- ~~[ ] This was checked in IE11~~
- ~~[ ] This was checked in dark mode~~
- ~~[ ] Any props added have proper autodocs~~
- ~~[ ] Documentation examples were added~~
- ~~[ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~~
- ~~[ ] This was checked for breaking changes and labeled appropriately~~
- ~~[ ] Jest tests were updated or added to match the most common scenarios~~
- ~~[ ] This was checked against keyboard-only and screenreader scenarios~~
- ~~[ ] This required updates to Framer X components~~
