### PR TITLE
EuiComboBox keyboard navigation: tab exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 **Bug fixes**
 
 - Fixed content cut off in `EuiContextMenuPanel` when height changes dynamically ([#1559](https://github.com/elastic/eui/pull/1559))
+- Fixed `EuiComboBox` to allow keyboard tab to exit single selection box ([#1576](https://github.com/elastic/eui/pull/1576))
 
 ## [`7.1.0`](https://github.com/elastic/eui/tree/v7.1.0)
 

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -343,7 +343,7 @@ export class EuiComboBox extends Component {
 
       case TAB:
         // Disallow tabbing when the user is navigating the options.
-        if (this.hasActiveOption()) {
+        if (this.hasActiveOption() && this.state.isListOpen) {
           e.preventDefault();
           e.stopPropagation();
         }


### PR DESCRIPTION
### Summary

Fixes #1451 by adding a bit more logic to determine whether to allow or disallow `tab` from exiting `EuiComboBox` focus.
Note that the bug only impacted the single select variation of the combo box.

Testing/reproduction can be done in the EUI docs site (Combo Box > Single Selection):
* Tab into the combo box
* Use arrow keys to select an option
* Hit enter
* Hit tab; caret should have focus
* Hit tab again; focus should move to the next relevant element

Previously, the last step would never move focus off the caret

### Checklist

~~- [ ] This was checked in mobile~~
~~- [ ] This was checked in IE11~~
~~- [ ] This was checked in dark mode~~
~~- [ ] Any props added have proper autodocs~~
~~- [ ] Documentation examples were added~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately

~~- [ ] This was checked for breaking changes and labeled appropriately~~
~~- [ ] Jest tests were updated or added to match the most common scenarios~~

- [x] This was checked against keyboard-only and screenreader scenarios

~~- [ ] This required updates to Framer X components~~
