### PR TITLE
[EuiSuperDatePicker] Add `onRefresh` handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Added `onRefresh` option for `EuiSuperDatePicker` ([#1577](https://github.com/elastic/eui/pull/1577))
 - Converted `EuiToggle` to TypeScript ([#1570](https://github.com/elastic/eui/pull/1570))
 - Added type definitions for `EuiButtonGroup`,`EuiButtonToggle`, `EuiFilterButton`, `EuiFilterGroup`, and `EuiFilterSelectItem` ([#1570](https://github.com/elastic/eui/pull/1570))
 - Added `displayOnly` prop to EuiFormRow ([#1582](https://github.com/elastic/eui/pull/1582))

--- a/src-docs/src/views/date_picker/super_date_picker.js
+++ b/src-docs/src/views/date_picker/super_date_picker.js
@@ -26,8 +26,6 @@ function MyCustomQuickSelectPanel({ applyTime }) {
 export default class extends Component {
 
   state = {
-    refreshInterval: 1000,
-    isPaused: true,
     recentlyUsedRanges: [],
     isLoading: false,
     showUpdateButton: true,
@@ -54,9 +52,7 @@ export default class extends Component {
   }
 
   onRefresh = ({ start, end, refreshInterval }) => {
-    console.log('onRefresh was called');
     return new Promise((resolve) => {
-
       setTimeout(resolve, 100);
     }).then(() => {
       console.log(start, end, refreshInterval);

--- a/src-docs/src/views/date_picker/super_date_picker.js
+++ b/src-docs/src/views/date_picker/super_date_picker.js
@@ -26,6 +26,8 @@ function MyCustomQuickSelectPanel({ applyTime }) {
 export default class extends Component {
 
   state = {
+    refreshInterval: 1000,
+    isPaused: false,
     recentlyUsedRanges: [],
     isLoading: false,
     showUpdateButton: true,
@@ -52,7 +54,13 @@ export default class extends Component {
   }
 
   onRefresh = ({ start, end, refreshInterval }) => {
-    console.log(start, end, refreshInterval);
+    console.log('onRefresh was called');
+    return new Promise((resolve) => {
+
+      setTimeout(resolve, 100);
+    }).then(() => {
+      console.log(start, end, refreshInterval);
+    });
   }
 
   onStartInputChange = e => {

--- a/src-docs/src/views/date_picker/super_date_picker.js
+++ b/src-docs/src/views/date_picker/super_date_picker.js
@@ -27,7 +27,7 @@ export default class extends Component {
 
   state = {
     refreshInterval: 1000,
-    isPaused: false,
+    isPaused: true,
     recentlyUsedRanges: [],
     isLoading: false,
     showUpdateButton: true,

--- a/src-docs/src/views/date_picker/super_date_picker.js
+++ b/src-docs/src/views/date_picker/super_date_picker.js
@@ -51,6 +51,10 @@ export default class extends Component {
     }, this.startLoading);
   }
 
+  onRefresh = ({ start, end, refreshInterval }) => {
+    console.log(start, end, refreshInterval);
+  }
+
   onStartInputChange = e => {
     this.setState({
       start: e.target.value,
@@ -168,6 +172,7 @@ export default class extends Component {
           start={this.state.start}
           end={this.state.end}
           onTimeChange={this.onTimeChange}
+          onRefresh={this.onRefresh}
           isPaused={this.state.isPaused}
           refreshInterval={this.state.refreshInterval}
           onRefreshChange={this.onRefreshChange}

--- a/src/components/date_picker/super_date_picker/__snapshots__/super_date_picker.test.js.snap
+++ b/src/components/date_picker/super_date_picker/__snapshots__/super_date_picker.test.js.snap
@@ -21,6 +21,7 @@ exports[`EuiSuperDatePicker is rendered 1`] = `
       isLoading={false}
       prepend={
         <EuiQuickSelectPopover
+          applyRefreshInterval={[Function]}
           applyTime={[Function]}
           commonlyUsedRanges={
             Array [

--- a/src/components/date_picker/super_date_picker/__snapshots__/super_date_picker.test.js.snap
+++ b/src/components/date_picker/super_date_picker/__snapshots__/super_date_picker.test.js.snap
@@ -21,7 +21,7 @@ exports[`EuiSuperDatePicker is rendered 1`] = `
       isLoading={false}
       prepend={
         <EuiQuickSelectPopover
-          applyRefreshInterval={[Function]}
+          applyRefreshInterval={null}
           applyTime={[Function]}
           commonlyUsedRanges={
             Array [

--- a/src/components/date_picker/super_date_picker/async_interval.js
+++ b/src/components/date_picker/super_date_picker/async_interval.js
@@ -1,0 +1,22 @@
+export class AsyncInterval {
+  timeoutId = null;
+  isStopped = false;
+
+  constructor(fn, refreshInterval) {
+    this.setAsyncInterval(fn, refreshInterval);
+  }
+
+  setAsyncInterval = (fn, ms) => {
+    if (!this.isStopped) {
+      this.timeoutId = window.setTimeout(async () => {
+        this.__pendingFn = await fn();
+        this.setAsyncInterval(fn, ms);
+      }, ms);
+    }
+  };
+
+  stop = () => {
+    this.isStopped = true;
+    window.clearTimeout(this.timeoutId);
+  };
+}

--- a/src/components/date_picker/super_date_picker/async_interval.test.js
+++ b/src/components/date_picker/super_date_picker/async_interval.test.js
@@ -1,31 +1,95 @@
 import { AsyncInterval } from './async_interval';
+import { times } from 'lodash';
 
-jest.useFakeTimers();
-
-async function waitFor(instance, ms) {
-  jest.advanceTimersByTime(ms);
-  await instance.__pendingFn;
-}
-
-describe('AsyncInterval',  () => {
-  test('should call fn 3 times', async () => {
-    const spy = jest.fn();
-    const instance = new AsyncInterval(spy, 1000);
-    await waitFor(instance, 2000);
-    await waitFor(instance, 2000);
-    await waitFor(instance, 2000);
-
-    expect(spy).toHaveBeenCalledTimes(3);
+describe('AsyncInterval', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
   });
 
-  test('should not call fn after stop has been called', async () => {
-    const spy = jest.fn();
-    const instance = new AsyncInterval(spy, 1000);
-    await waitFor(instance, 2000);
-    instance.stop();
-    await waitFor(instance, 2000);
-    await waitFor(instance, 2000);
+  afterEach(() => {
+    jest.useRealTimers();
+  });
 
-    expect(spy).toHaveBeenCalledTimes(1);
+  // Advances time and awaits any pending promises after every 100ms
+  // This helper makes it easier to advance time without worrying
+  // whether tasks are still lingering on the event loop
+  async function andvanceTimerAndAwaitFn(instance, ms) {
+    const iterations = times(Math.floor(ms / 100));
+    const remainder = ms % 100;
+    // eslint-disable-next-line no-unused-vars
+    for (const item of iterations) {
+      await instance.__pendingFn;
+      jest.advanceTimersByTime(100);
+      await instance.__pendingFn;
+    }
+    jest.advanceTimersByTime(remainder);
+    await instance.__pendingFn;
+  }
+
+  describe('when creating a 1000ms interval', async () => {
+    let instance;
+    let spy;
+    beforeEach(() => {
+      spy = jest.fn();
+      instance = new AsyncInterval(spy, 1000);
+    });
+
+    it('should not call fn immediately', async () => {
+      await andvanceTimerAndAwaitFn(instance, 0);
+      expect(spy).toHaveBeenCalledTimes(0);
+    });
+
+    it('should have called fn once after 1000ms', async () => {
+      await andvanceTimerAndAwaitFn(instance, 1000);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should have called fn twice after 2000ms', async () => {
+      await andvanceTimerAndAwaitFn(instance, 2000);
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should have called fn three times after 3000ms', async () => {
+      await andvanceTimerAndAwaitFn(instance, 3000);
+      expect(spy).toHaveBeenCalledTimes(3);
+    });
+
+    it('should not call fn after stop has been invoked', async () => {
+      await andvanceTimerAndAwaitFn(instance, 1000);
+      expect(spy).toHaveBeenCalledTimes(1);
+      instance.stop();
+      await andvanceTimerAndAwaitFn(instance, 1000);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when creating a 1000ms interval that calls a fn that takes 2000ms to complete', async () => {
+    let instance;
+    let spy;
+    beforeEach(() => {
+      const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+      spy = jest.fn(async () => await sleep(2000));
+      instance = new AsyncInterval(spy, 1000);
+    });
+
+    it('should not call fn immediately', async () => {
+      await andvanceTimerAndAwaitFn(instance, 0);
+      expect(spy).toHaveBeenCalledTimes(0);
+    });
+
+    it('should have called fn once after 1000ms', async () => {
+      await andvanceTimerAndAwaitFn(instance, 1000);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should have called fn twice after 4000ms', async () => {
+      await andvanceTimerAndAwaitFn(instance, 4000);
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should have called fn tree times after 7000ms', async () => {
+      await andvanceTimerAndAwaitFn(instance, 7000);
+      expect(spy).toHaveBeenCalledTimes(3);
+    });
   });
 });

--- a/src/components/date_picker/super_date_picker/async_interval.test.js
+++ b/src/components/date_picker/super_date_picker/async_interval.test.js
@@ -1,0 +1,31 @@
+import { AsyncInterval } from './async_interval';
+
+jest.useFakeTimers();
+
+async function waitFor(instance, ms) {
+  jest.advanceTimersByTime(ms);
+  await instance.__pendingFn;
+}
+
+describe('AsyncInterval',  () => {
+  test('should call fn 3 times', async () => {
+    const spy = jest.fn();
+    const instance = new AsyncInterval(spy, 1000);
+    await waitFor(instance, 2000);
+    await waitFor(instance, 2000);
+    await waitFor(instance, 2000);
+
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  test('should not call fn after stop has been called', async () => {
+    const spy = jest.fn();
+    const instance = new AsyncInterval(spy, 1000);
+    await waitFor(instance, 2000);
+    instance.stop();
+    await waitFor(instance, 2000);
+    await waitFor(instance, 2000);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/date_picker/super_date_picker/super_date_picker.js
+++ b/src/components/date_picker/super_date_picker/super_date_picker.js
@@ -64,7 +64,9 @@ export class EuiSuperDatePicker extends Component {
     onRefreshChange: PropTypes.func,
 
     /**
-     * Callback for when the refresh interval is fired
+     * Callback for when the refresh interval is fired. Called with { start, end, refreshInterval }
+     * If a promise is returned, the next refresh interval will not start until the promise has resolved.
+     * If the promise rejects the refresh interval will stop and the error thrown
      */
     onRefresh: PropTypes.func,
 

--- a/src/components/date_picker/super_date_picker/super_date_picker.js
+++ b/src/components/date_picker/super_date_picker/super_date_picker.js
@@ -244,7 +244,9 @@ export class EuiSuperDatePicker extends Component {
     if(!isPaused) {
       this.startInterval(refreshInterval);
     }
-    this.props.onRefreshChange({ refreshInterval, isPaused });
+    if(this.props.onRefreshChange) {
+      this.props.onRefreshChange({ refreshInterval, isPaused });
+    }
   }
 
   stopInterval = () => {

--- a/src/components/date_picker/super_date_picker/super_date_picker.js
+++ b/src/components/date_picker/super_date_picker/super_date_picker.js
@@ -231,17 +231,25 @@ export class EuiSuperDatePicker extends Component {
     this.props.onRefreshChange({ refreshInterval, isPaused });
   }
 
+
+  setIntervalAsync = (fn, ms) => {
+    Promise.resolve(fn()).then(() => {
+      const nextAsyncHandler = () => this.setIntervalAsync(fn, ms);
+      this.timeoutId = window.setTimeout(nextAsyncHandler, ms);
+    });
+  };
+
   componentWillUnmount = () => {
-    window.clearInterval(this.intervalId);
+    window.clearTimeout(this.timeoutId);
   }
 
   resetInterval = ({ isPaused, refreshInterval }) => {
-    window.clearInterval(this.intervalId);
+    window.clearTimeout(this.timeoutId);
     if(!isPaused && this.props.onRefresh) {
-      this.intervalId = window.setInterval(() => {
+      this.setIntervalAsync(() => {
         const { start, end, onRefresh } = this.props;
         if(onRefresh) {
-          onRefresh({ start, end, refreshInterval });
+          return onRefresh({ start, end, refreshInterval });
         }
       }, refreshInterval);
     }

--- a/src/components/date_picker/super_date_picker/super_date_picker.js
+++ b/src/components/date_picker/super_date_picker/super_date_picker.js
@@ -63,6 +63,11 @@ export class EuiSuperDatePicker extends Component {
     onRefreshChange: PropTypes.func,
 
     /**
+     * Callback for when the refresh interval is fired
+     */
+    onRefresh: PropTypes.func,
+
+    /**
      * 'start' and 'end' must be string as either datemath (e.g.: now, now-15m, now-15m/m) or
      * absolute date in the format 'YYYY-MM-DDTHH:mm:ss.sssZ'
      */
@@ -221,6 +226,27 @@ export class EuiSuperDatePicker extends Component {
     this.setState({ isEndDatePopoverOpen: false });
   }
 
+  onRefreshChange = ({ refreshInterval, isPaused }) => {
+    this.resetInterval({ refreshInterval, isPaused });
+    this.props.onRefreshChange({ refreshInterval, isPaused });
+  }
+
+  componentWillUnmount = () => {
+    window.clearInterval(this.intervalId);
+  }
+
+  resetInterval = ({ isPaused, refreshInterval }) => {
+    window.clearInterval(this.intervalId);
+    if(!isPaused && this.props.onRefresh) {
+      this.intervalId = window.setInterval(() => {
+        const { start, end, onRefresh } = this.props;
+        if(onRefresh) {
+          onRefresh({ start, end, refreshInterval });
+        }
+      }, refreshInterval);
+    }
+  }
+
   renderDatePickerRange = () => {
     const {
       start,
@@ -329,7 +355,7 @@ export class EuiSuperDatePicker extends Component {
         applyTime={this.applyQuickTime}
         start={this.props.start}
         end={this.props.end}
-        applyRefreshInterval={this.props.onRefreshChange}
+        applyRefreshInterval={this.onRefreshChange}
         isPaused={this.props.isPaused}
         refreshInterval={this.props.refreshInterval}
         commonlyUsedRanges={this.props.commonlyUsedRanges}

--- a/src/components/date_picker/super_date_picker/super_date_picker.js
+++ b/src/components/date_picker/super_date_picker/super_date_picker.js
@@ -173,6 +173,10 @@ export class EuiSuperDatePicker extends Component {
     }
   }
 
+  componentWillUnmount = () => {
+    window.clearTimeout(this.timeoutId);
+  }
+
   setStart = (start) => {
     this.setTime({ start, end: this.state.end });
   }
@@ -227,10 +231,12 @@ export class EuiSuperDatePicker extends Component {
   }
 
   onRefreshChange = ({ refreshInterval, isPaused }) => {
-    this.resetInterval({ refreshInterval, isPaused });
+    window.clearTimeout(this.timeoutId);
+    if(!isPaused && this.props.onRefresh) {
+      this.startInterval(refreshInterval);
+    }
     this.props.onRefreshChange({ refreshInterval, isPaused });
   }
-
 
   setIntervalAsync = (fn, ms) => {
     Promise.resolve(fn()).then(() => {
@@ -239,20 +245,13 @@ export class EuiSuperDatePicker extends Component {
     });
   };
 
-  componentWillUnmount = () => {
-    window.clearTimeout(this.timeoutId);
-  }
-
-  resetInterval = ({ isPaused, refreshInterval }) => {
-    window.clearTimeout(this.timeoutId);
-    if(!isPaused && this.props.onRefresh) {
-      this.setIntervalAsync(() => {
-        const { start, end, onRefresh } = this.props;
-        if(onRefresh) {
-          return onRefresh({ start, end, refreshInterval });
-        }
-      }, refreshInterval);
-    }
+  startInterval = (refreshInterval) => {
+    this.setIntervalAsync(() => {
+      const { start, end, onRefresh } = this.props;
+      if(onRefresh) {
+        return onRefresh({ start, end, refreshInterval });
+      }
+    }, refreshInterval);
   }
 
   renderDatePickerRange = () => {

--- a/src/components/date_picker/super_date_picker/super_date_picker.js
+++ b/src/components/date_picker/super_date_picker/super_date_picker.js
@@ -246,7 +246,9 @@ export class EuiSuperDatePicker extends Component {
   }
 
   stopInterval = () => {
-    this.asyncInterval.stop();
+    if(this.asyncInterval) {
+      this.asyncInterval.stop();
+    }
   }
 
   startInterval = (refreshInterval) => {

--- a/src/components/date_picker/super_date_picker/super_date_picker.js
+++ b/src/components/date_picker/super_date_picker/super_date_picker.js
@@ -65,6 +65,7 @@ export class EuiSuperDatePicker extends Component {
 
     /**
      * Callback for when the refresh interval is fired. Called with { start, end, refreshInterval }
+     * EuiSuperDatePicker will only manage a refresh interval timer when onRefresh callback is supplied
      * If a promise is returned, the next refresh interval will not start until the promise has resolved.
      * If the promise rejects the refresh interval will stop and the error thrown
      */
@@ -371,7 +372,7 @@ export class EuiSuperDatePicker extends Component {
         applyTime={this.applyQuickTime}
         start={this.props.start}
         end={this.props.end}
-        applyRefreshInterval={this.onRefreshChange}
+        applyRefreshInterval={this.props.onRefreshChange ? this.onRefreshChange : null}
         isPaused={this.props.isPaused}
         refreshInterval={this.props.refreshInterval}
         commonlyUsedRanges={this.props.commonlyUsedRanges}


### PR DESCRIPTION
When setting the refresh rate on `EuiSuperDatePicker` it should keep track of the interval, and call the `onRefresh` handler whenever the interval fires.
This will save consumers the hassle of implementing this logic themselves.

### Checklist

- [x] Any props added have proper autodocs
- [ ] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios
