### PR TITLE
add license to package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 - Added `text` as a color option for `EuiLink` ([#1571](https://github.com/elastic/eui/pull/1571))
 - Added `EuiResizeObserver` to expose ResizeObserver API to React components; falls back to MutationObserver API in unsupported browsers ([#1559](https://github.com/elastic/eui/pull/1559))
-- Added Apache-2.0 license field to package.json ([#1579](https://github.com/elastic/eui/pull/1579))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added `text` as a color option for `EuiLink` ([#1571](https://github.com/elastic/eui/pull/1571))
 - Added `EuiResizeObserver` to expose ResizeObserver API to React components; falls back to MutationObserver API in unsupported browsers ([#1559](https://github.com/elastic/eui/pull/1559))
+- Added Apache-2.0 license field to package.json ([#1579](https://github.com/elastic/eui/pull/1579))
 
 **Bug fixes**
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@elastic/eui",
   "description": "Elastic UI Component Library",
   "version": "7.1.0",
+  "license": "Apache-2.0",
   "main": "lib",
   "module": "es",
   "types": "eui.d.ts",


### PR DESCRIPTION
### Summary

Fixes #1578. Adds `"license": "Apache-2.0"` to `package.json`

### Checklist

~~- [ ] This was checked in mobile~~
~~- [ ] This was checked in IE11~~
~~- [ ] This was checked in dark mode~~
~~- [ ] Any props added have proper autodocs~~
~~- [ ] Documentation examples were added~~
~~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~~
~~- [ ] This was checked for breaking changes and labeled appropriately~~
~~- [ ] Jest tests were updated or added to match the most common scenarios~~
~~- [ ] This was checked against keyboard-only and screenreader scenarios~~
~~- [ ] This required updates to Framer X components~~
