### PR TITLE
EuiRange and EuiDualRange fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 - Converted `EuiToggle` to TypeScript ([#1570](https://github.com/elastic/eui/pull/1570))
 - Added type definitions for `EuiButtonGroup`,`EuiButtonToggle`, `EuiFilterButton`, `EuiFilterGroup`, and `EuiFilterSelectItem` ([#1570](https://github.com/elastic/eui/pull/1570))
 
+**Bug fixes**
+
+- Fixed several bugs with `EuiRange` and `EuiDualRange` including sizing of inputs, tick placement, and the handling of invalid values ([#1580](https://github.com/elastic/eui/pull/1580))
+
 ## [`7.2.0`](https://github.com/elastic/eui/tree/v7.2.0)
 
 - Added `text` as a color option for `EuiLink` ([#1571](https://github.com/elastic/eui/pull/1571))

--- a/src-docs/src/views/range/dual_range.js
+++ b/src-docs/src/views/range/dual_range.js
@@ -96,6 +96,7 @@ export default class extends Component {
           onChange={this.onChange}
           aria-label="Use aria labels when no actual label is in use"
           aria-describedby="levelsHelp"
+          showLabels
           showInput
           compressed
           levels={this.levels}

--- a/src-docs/src/views/range/dual_range.js
+++ b/src-docs/src/views/range/dual_range.js
@@ -17,19 +17,22 @@ export default class extends Component {
 
     this.levels = [
       {
-        min: 0,
-        max: 600,
+        min: 100,
+        max: 140,
         color: 'danger'
       },
       {
-        min: 600,
-        max: 2000,
+        min: 140,
+        max: 180,
         color: 'success'
       }
     ];
 
     this.state = {
-      value: [120, 480]
+      value: ['', ''],
+      min: 100,
+      max: 200,
+      step: 10,
     };
   }
 
@@ -45,8 +48,8 @@ export default class extends Component {
 
         <EuiDualRange
           id={makeId()}
-          min={0}
-          max={2000}
+          min={this.state.min}
+          max={this.state.max}
           value={this.state.value}
           onChange={this.onChange}
           aria-label="Use aria labels when no actual label is in use"
@@ -58,8 +61,8 @@ export default class extends Component {
 
         <EuiDualRange
           id={makeId()}
-          min={0}
-          max={2000}
+          min={this.state.min}
+          max={this.state.max}
           value={this.state.value}
           onChange={this.onChange}
           disabled
@@ -71,63 +74,61 @@ export default class extends Component {
 
         <EuiDualRange
           id={makeId()}
-          min={0}
-          max={2000}
+          min={this.state.min}
+          max={this.state.max}
           value={this.state.value}
           onChange={this.onChange}
           aria-label="Use aria labels when no actual label is in use"
-          showLabels
           showInput
           showRange
+          showTicks
+          tickInterval={20}
         />
 
         <EuiSpacer size="xl" />
 
         <EuiDualRange
           id={makeId()}
-          min={0}
-          max={2000}
-          step={50}
+          min={this.state.min}
+          max={this.state.max}
+          step={this.state.step}
           value={this.state.value}
           onChange={this.onChange}
           aria-label="Use aria labels when no actual label is in use"
           aria-describedby="levelsHelp"
-          showLabels
           showInput
           compressed
           levels={this.levels}
         />
-        <EuiFormHelpText id="levelsHelp">Recommended levels are 600 and above.</EuiFormHelpText>
+        <EuiFormHelpText id="levelsHelp">Recommended levels are 120 and above.</EuiFormHelpText>
 
         <EuiSpacer size="xl" />
 
         <EuiDualRange
           id={makeId()}
-          min={0}
-          max={2000}
-          step={50}
+          min={this.state.min}
+          max={this.state.max}
+          step={this.state.step}
           value={this.state.value}
           onChange={this.onChange}
           aria-label="Use aria labels when no actual label is in use"
           showTicks
-          showRange
-          tickInterval={300}
         />
 
         <EuiSpacer size="xl" />
 
         <EuiDualRange
           id={makeId()}
-          min={0}
-          max={2000}
-          step={50}
+          min={this.state.min}
+          max={this.state.max}
+          step={this.state.step}
           value={this.state.value}
           onChange={this.onChange}
           aria-label="Use aria labels when no actual label is in use"
           aria-describedby="levelsHelp"
           showTicks
+          ticks={[{ value: this.state.min, label: this.state.min }, { value: this.state.max, label: this.state.max }]}
           showInput
-          tickInterval={500}
           levels={this.levels}
         />
       </Fragment>

--- a/src-docs/src/views/range/dual_range.js
+++ b/src-docs/src/views/range/dual_range.js
@@ -31,7 +31,7 @@ export default class extends Component {
 
         <EuiDualRange
           id={makeId()}
-          min={100}
+          min={-100}
           max={200}
           step={10}
           value={this.state.value}
@@ -43,7 +43,7 @@ export default class extends Component {
 
         <EuiDualRange
           id={makeId()}
-          min={100}
+          min={-100}
           max={200}
           step={10}
           value={this.state.value}

--- a/src-docs/src/views/range/dual_range.js
+++ b/src-docs/src/views/range/dual_range.js
@@ -1,11 +1,9 @@
 import React, {
   Component,
-  Fragment,
 } from 'react';
 
 import {
   EuiDualRange,
-  EuiSpacer,
 } from '../../../../src/components';
 
 import makeId from '../../../../src/components/form/form_row/make_id';
@@ -27,30 +25,15 @@ export default class extends Component {
 
   render() {
     return (
-      <Fragment>
-
-        <EuiDualRange
-          id={makeId()}
-          min={-100}
-          max={200}
-          step={10}
-          value={this.state.value}
-          onChange={this.onChange}
-          showLabels
-        />
-
-        <EuiSpacer size="xl" />
-
-        <EuiDualRange
-          id={makeId()}
-          min={-100}
-          max={200}
-          step={10}
-          value={this.state.value}
-          onChange={this.onChange}
-          showInput
-        />
-      </Fragment>
+      <EuiDualRange
+        id={makeId()}
+        min={-100}
+        max={200}
+        step={10}
+        value={this.state.value}
+        onChange={this.onChange}
+        showLabels
+      />
     );
   }
 }

--- a/src-docs/src/views/range/input.js
+++ b/src-docs/src/views/range/input.js
@@ -4,8 +4,9 @@ import React, {
 } from 'react';
 
 import {
-  EuiDualRange,
+  EuiRange,
   EuiSpacer,
+  EuiDualRange,
 } from '../../../../src/components';
 
 import makeId from '../../../../src/components/form/form_row/make_id';
@@ -15,39 +16,39 @@ export default class extends Component {
     super(props);
 
     this.state = {
-      value: ['', ''],
+      value: '20',
+      dualValue: [20, 100],
     };
   }
 
-  onChange = (value) => {
+  onChange = e => {
     this.setState({
-      value
+      value: e.target.value,
+    });
+  };
+
+  onDualChange = (value) => {
+    this.setState({
+      dualValue: value
     });
   };
 
   render() {
     return (
       <Fragment>
-
-        <EuiDualRange
+        <EuiRange
           id={makeId()}
-          min={100}
-          max={200}
-          step={10}
           value={this.state.value}
           onChange={this.onChange}
-          showLabels
+          showInput
         />
 
         <EuiSpacer size="xl" />
 
         <EuiDualRange
           id={makeId()}
-          min={100}
-          max={200}
-          step={10}
-          value={this.state.value}
-          onChange={this.onChange}
+          value={this.state.dualValue}
+          onChange={this.onDualChange}
           showInput
         />
       </Fragment>

--- a/src-docs/src/views/range/levels.js
+++ b/src-docs/src/views/range/levels.js
@@ -1,0 +1,80 @@
+import React, {
+  Component,
+  Fragment,
+} from 'react';
+
+import {
+  EuiRange,
+  EuiSpacer,
+  EuiFormHelpText,
+  EuiDualRange,
+} from '../../../../src/components';
+
+import makeId from '../../../../src/components/form/form_row/make_id';
+
+export default class extends Component {
+  constructor(props) {
+    super(props);
+
+    this.levels = [
+      {
+        min: 0,
+        max: 20,
+        color: 'danger'
+      },
+      {
+        min: 20,
+        max: 100,
+        color: 'success'
+      }
+    ];
+
+    this.state = {
+      value: '20',
+      dualValue: [20, 100],
+    };
+  }
+
+  onChange = e => {
+    this.setState({
+      value: e.target.value,
+    });
+  };
+
+  onDualChange = (value) => {
+    this.setState({
+      dualValue: value
+    });
+  };
+
+  render() {
+    return (
+      <Fragment>
+        <EuiRange
+          id={makeId()}
+          value={this.state.value}
+          onChange={this.onChange}
+          showTicks
+          tickInterval={20}
+          levels={this.levels}
+          aria-describedby="levelsHelp2"
+        />
+        <EuiFormHelpText id="levelsHelp2">Recommended levels are {this.levels[1].min} and above.</EuiFormHelpText>
+
+        <EuiSpacer size="xl" />
+
+        <EuiDualRange
+          id={makeId()}
+          value={this.state.dualValue}
+          onChange={this.onDualChange}
+          showTicks
+          ticks={[{ label: '20kb', value: 20 }, { label: '100kb', value: 100 }]}
+          showInput
+          levels={this.levels}
+          aria-describedby="levelsHelp3"
+        />
+        <EuiFormHelpText id="levelsHelp3">Recommended size is {this.levels[1].min}kb and above.</EuiFormHelpText>
+      </Fragment>
+    );
+  }
+}

--- a/src-docs/src/views/range/range.js
+++ b/src-docs/src/views/range/range.js
@@ -17,13 +17,13 @@ export default class extends Component {
 
     this.levels = [
       {
-        min: 0,
-        max: 600,
+        min: 100,
+        max: 140,
         color: 'danger'
       },
       {
-        min: 600,
-        max: 2000,
+        min: 140,
+        max: 180,
         color: 'success'
       }
     ];
@@ -76,18 +76,19 @@ export default class extends Component {
           value={this.state.value}
           onChange={this.onChange}
           aria-label="Use aria labels when no actual label is in use"
-          showLabels
           showInput
           showRange
+          showTicks
+          tickInterval={20}
         />
 
         <EuiSpacer size="xl" />
 
         <EuiRange
           id={makeId()}
-          min={0}
-          max={2000}
-          step={50}
+          min={100}
+          max={200}
+          step={10}
           value={this.state.value}
           onChange={this.onChange}
           aria-label="Use aria labels when no actual label is in use"
@@ -103,32 +104,29 @@ export default class extends Component {
 
         <EuiRange
           id={makeId()}
-          min={0}
-          max={2000}
-          step={50}
+          min={100}
+          max={200}
+          step={10}
           value={this.state.value}
           onChange={this.onChange}
           aria-label="Use aria labels when no actual label is in use"
           showTicks
           showRange
-          showValue
-          tickInterval={300}
         />
 
         <EuiSpacer size="xl" />
 
         <EuiRange
           id={makeId()}
-          min={0}
-          max={2000}
-          step={50}
+          min={100}
+          max={200}
           value={this.state.value}
           onChange={this.onChange}
           aria-label="Use aria labels when no actual label is in use"
           aria-describedby="levelsHelp"
           showTicks
+          ticks={[{ label: 100, value: 100 }, { label: 200, value: 200 }]}
           showInput
-          tickInterval={500}
           levels={this.levels}
         />
       </Fragment>

--- a/src-docs/src/views/range/range.js
+++ b/src-docs/src/views/range/range.js
@@ -18,12 +18,12 @@ export default class extends Component {
     this.levels = [
       {
         min: 100,
-        max: 140,
+        max: 120,
         color: 'danger'
       },
       {
-        min: 140,
-        max: 180,
+        min: 120,
+        max: 200,
         color: 'success'
       }
     ];

--- a/src-docs/src/views/range/range_example.js
+++ b/src-docs/src/views/range/range_example.js
@@ -10,8 +10,23 @@ import {
   EuiCallOut,
   EuiDualRange,
   EuiRange,
-  EuiSpacer
+  EuiSpacer,
+  EuiCode,
 } from '../../../../src/components';
+
+import {
+  EuiRangeLevels,
+  LEVEL_COLORS,
+} from '../../../../src/components/form/range/range_levels';
+
+import {
+  EuiRangeTicks,
+} from '../../../../src/components/form/range/range_ticks';
+
+
+import {
+  EuiRangeInput,
+} from '../../../../src/components/form/range/range_input';
 
 import DualRangeExample from './dual_range';
 const dualRangeSource = require('!!raw-loader!./dual_range');
@@ -21,28 +36,69 @@ import RangeExample from './range';
 const rangeSource = require('!!raw-loader!./range');
 const rangeHtml = renderToHtml(RangeExample);
 
+import InputExample from './input';
+const inputSource = require('!!raw-loader!./input');
+const inputHtml = renderToHtml(InputExample);
+
+import TicksExample from './ticks';
+const ticksSource = require('!!raw-loader!./ticks');
+const ticksHtml = renderToHtml(TicksExample);
+
+import LevelsExample from './levels';
+const levelsSource = require('!!raw-loader!./levels');
+const levelsHtml = renderToHtml(LevelsExample);
+
+import StatesExample from './states';
+const statesSource = require('!!raw-loader!./states');
+const statesHtml = renderToHtml(StatesExample);
+
 export const RangeControlExample = {
-  title: 'Range',
+  title: 'Range sliders',
   intro: (
     <Fragment>
       <EuiCallOut color="warning" title="Understanding precision">
         <p>
         Range sliders should only be used
         when <strong>the precise value is not considered important</strong>. If
-        the precise value does matter, add the <code>showInput</code> prop or use
-        a <code>EuiFieldNumber</code> instead.
-        </p>
-        <p>
-        While currently considered optional, the <code>showLabels</code> property should
-        be added to explicitly state the range to the user.
+        the precise value does matter, add the <EuiCode>showInput</EuiCode> prop or use
+        a <EuiCode>EuiFieldNumber</EuiCode> instead.
         </p>
       </EuiCallOut>
-      <EuiSpacer size="l" />
+      <EuiSpacer />
     </Fragment>
   ),
   sections: [
     {
-      title: 'Range',
+      title: 'Single range',
+      text: (
+        <Fragment>
+          <h3>Required</h3>
+          <ul>
+            <li><EuiCode>min, max</EuiCode>:
+              Sets the range values.
+            </li>
+            <li><EuiCode>step</EuiCode>:
+              Technically not required because the default is <EuiCode>1</EuiCode>.
+            </li>
+            <li><EuiCode>value, onChange</EuiCode></li>
+          </ul>
+          <h3>Optional</h3>
+          <ul>
+            <li><EuiCode>showLabels</EuiCode>:
+              While currently considered optional, the property should
+              be added to explicitly state the range to the user.
+            </li>
+            <li><EuiCode>showValue</EuiCode>:
+              Displays a tooltip style indicator of the selected value. You can
+              add <EuiCode>valuePrepend</EuiCode> and/or <EuiCode>valueAppend</EuiCode> to
+              bookend the value with custom content.
+            </li>
+            <li><EuiCode>showRange</EuiCode>:
+              Displays a thickened line from the minimum value to the selected value.
+            </li>
+          </ul>
+        </Fragment>
+      ),
       source: [{
         type: GuideSectionTypes.JS,
         code: rangeSource,
@@ -54,28 +110,61 @@ export const RangeControlExample = {
         EuiRange,
       },
       demo: <RangeExample />,
+      snippet: `<EuiRange
+  min={100}
+  max={200}
+  value={this.state.value}
+  onChange={this.onChange}
+  showLabels
+/>
+
+// Show tooltip
+<EuiRange
+  min={100}
+  max={200}
+  value={this.state.value}
+  onChange={this.onChange}
+  showLabels
+  showValue
+/>
+
+// Show thickened range and prepend a string to the tooltip
+<EuiRange
+  min={100}
+  max={200}
+  value={this.state.value}
+  onChange={this.onChange}
+  showLabels
+  showRange
+  showValue
+  valuePrepend="100 - "
+/>`,
     },
     {
-      title: 'DualRange',
+      title: 'Dual range',
       text: (
         <Fragment>
+          <p>
+            The EuiDualRange accepts almost all the same props as the regular EuiRange, with
+            the exception of <EuiCode>showRange</EuiCode> which is on by default, and <EuiCode>showValue</EuiCode> since
+            tooltips don&apos;t fit properly when there are two.
+          </p>
           <EuiCallOut color="warning" title="Retrieving field values">
             <p>
-            Two-value <code>input[type=range]</code> elements are not part of the HTML5 specification.
-            Because of this support gap, <code>EuiDualRange</code> cannot expose a native <code>value</code> property
-            for native <code>form</code> to consumption.
+              Two-value <EuiCode>input[type=range]</EuiCode> elements are not part of the HTML5 specification.
+            Because of this support gap, EuiDualRange cannot expose a native <EuiCode>value</EuiCode> property
+            for native form to consumption.
               <strong>
-                The React <code>onChange</code> prop is the recommended method
+                The React <EuiCode>onChange</EuiCode> prop is the recommended method
                 for retrieving the upper and lower values.
               </strong>
             </p>
             <p>
-              <code>EuiDualRange</code> does use native <code>input</code>s to help validate step values
-            and range limits. These may be used as <code>form</code> values when <code>showInput</code> is in use.
-            The alternative is to store values in <code>input[type=hidden]</code>.
+              EuiDualRange does use native inputs to help validate step values
+            and range limits. These may be used as form values when <EuiCode>showInput</EuiCode> is in use.
+            The alternative is to store values in <EuiCode>input[type=hidden]</EuiCode>.
             </p>
           </EuiCallOut>
-          <EuiSpacer size="l" />
         </Fragment>
       ),
       source: [{
@@ -89,6 +178,171 @@ export const RangeControlExample = {
         EuiDualRange,
       },
       demo: <DualRangeExample />,
-    }
+      snippet: `<EuiDualRange
+  min={100}
+  max={200}
+  step={10}
+  value={this.state.value}
+  onChange={this.onChange}
+  showLabels
+/>`,
+    },
+    {
+      title: 'Inputs',
+      text: (
+        <Fragment>
+          <p>
+            The <EuiCode>showInput</EuiCode> prop, will append or bookend the range slider with number type inputs.
+            This is important for allowing precise values to be entered by the user.
+          </p>
+          <p>
+            Passing empty strings as the <EuiCode>value</EuiCode> to the ranges, will allow the inputs to be blank, though
+            the range handles will show at the min (or max and min) positions.
+          </p>
+        </Fragment>
+      ),
+      source: [{
+        type: GuideSectionTypes.JS,
+        code: inputSource,
+      }, {
+        type: GuideSectionTypes.HTML,
+        code: inputHtml,
+      }],
+      demo: <InputExample />,
+      props: { EuiRangeInput },
+      snippet: `<EuiRange showInput />
+
+<EuiDualRange showInput />`,
+    },
+    {
+      title: 'Tick marks',
+      text: (
+        <Fragment>
+          <p>
+            To show clickable tick marks and labels at a given interval, add the prop <EuiCode>showTicks</EuiCode>.
+            By default, tick mark interval is bound to the <EuiCode>step</EuiCode> prop, however, you can set a custom
+            interval without changing the actual steps allowed by passing a number to the <EuiCode>tickInterval</EuiCode> prop.
+          </p>
+          <p>
+            To pass completely custom tick marks, you can pass an array of objects that
+            require a <EuiCode>value</EuiCode> and <EuiCode>label</EuiCode>. The value must be included in the range of values
+            (min-max), though the label may be anythin you choose.
+          </p>
+          <EuiCallOut color="warning" title="Maximum of 20 ticks allowed">
+            <p>Spacing can get quite cramped with lots of ticks so we max out the number to 20.</p>
+          </EuiCallOut>
+        </Fragment>
+      ),
+      source: [{
+        type: GuideSectionTypes.JS,
+        code: ticksSource,
+      }, {
+        type: GuideSectionTypes.HTML,
+        code: ticksHtml,
+      }],
+      demo: <TicksExample />,
+      props: { EuiRangeTicks },
+      snippet: `<EuiRange step={10} showTicks />
+
+<EuiRange showTicks tickInterval={20} />
+
+<EuiDualRange
+  showTicks
+  ticks={[
+    { label: '20kb', value: 20 },
+    { label: '100kb', value: 100 }
+  ]}
+/>`,
+    },
+    {
+      title: 'Levels',
+      text: (
+        <Fragment>
+          <p>
+            To create colored indicators for certain intervals, pass an array of objects that
+            include a <EuiCode>min</EuiCode>, <EuiCode>max</EuiCode> and <EuiCode>color</EuiCode>.
+            Color options are <EuiCode>{JSON.stringify(LEVEL_COLORS, null, 2)}</EuiCode>.
+          </p>
+          <p>
+            Be sure to then add an <EuiCode>aria-describedby</EuiCode> and match it to the
+            id of a <EuiCode>EuiFormHelpText</EuiCode>.
+          </p>
+        </Fragment>
+      ),
+      source: [{
+        type: GuideSectionTypes.JS,
+        code: levelsSource,
+      }, {
+        type: GuideSectionTypes.HTML,
+        code: levelsHtml,
+      }],
+      demo: <LevelsExample />,
+      props: { EuiRangeLevels },
+      snippet: `<EuiRange
+  levels={[
+    {min: 0, max: 20, color: 'danger'},
+    {min: 20, max: 100, color: 'success'}
+  ]}
+  aria-describedby=""
+/>
+
+<EuiDualRange
+  levels={[
+    {min: 0, max: 20, color: 'danger'},
+    {min: 20, max: 100, color: 'success'}
+  ]}
+  aria-describedby=""
+/>`,
+    },
+    {
+      title: 'Kitchen sink',
+      text: (
+        <Fragment>
+          <p>
+            Other alterations you can add to the range are <EuiCode>compressed</EuiCode>, <EuiCode>fullWidth</EuiCode>,
+            and <EuiCode>disabled</EuiCode>.
+          </p>
+        </Fragment>
+      ),
+      source: [{
+        type: GuideSectionTypes.JS,
+        code: statesSource,
+      }, {
+        type: GuideSectionTypes.HTML,
+        code: statesHtml,
+      }],
+      demo: <StatesExample />,
+      snippet: `<EuiRange
+  id=""
+  value={}
+  onChange={() => {}}
+  compressed
+  fullWidth
+  disabled
+  showTicks
+  showInput
+  showLabels
+  showValue
+  showRange
+  tickInterval={}
+  levels={[]}
+  aria-describedby=""
+/>
+
+<EuiDualRange
+  id=""
+  value={}
+  onChange={() => {}}
+  compressed
+  fullWidth
+  disabled
+  showLabels
+  showInput
+  showTicks
+  ticks={[]}
+  levels={[]}
+  aria-describedby=""
+/>`,
+    },
   ]
 };

--- a/src-docs/src/views/range/range_example.js
+++ b/src-docs/src/views/range/range_example.js
@@ -283,7 +283,7 @@ export const RangeControlExample = {
     {min: 0, max: 20, color: 'danger'},
     {min: 20, max: 100, color: 'success'}
   ]}
-  aria-describedby=""
+  aria-describedBy={replaceWithID}
 />
 
 <EuiDualRange
@@ -291,7 +291,7 @@ export const RangeControlExample = {
     {min: 0, max: 20, color: 'danger'},
     {min: 20, max: 100, color: 'success'}
   ]}
-  aria-describedby=""
+  aria-describedBy={replaceWithID}
 />`,
     },
     {
@@ -326,7 +326,7 @@ export const RangeControlExample = {
   showRange
   tickInterval={}
   levels={[]}
-  aria-describedby=""
+  aria-describedBy={replaceWithID}
 />
 
 <EuiDualRange
@@ -341,7 +341,7 @@ export const RangeControlExample = {
   showTicks
   ticks={[]}
   levels={[]}
-  aria-describedby=""
+  aria-describedBy={replaceWithID}
 />`,
     },
   ]

--- a/src-docs/src/views/range/states.js
+++ b/src-docs/src/views/range/states.js
@@ -1,0 +1,91 @@
+import React, {
+  Component,
+  Fragment,
+} from 'react';
+
+import {
+  EuiRange,
+  EuiSpacer,
+  EuiFormHelpText,
+  EuiDualRange,
+} from '../../../../src/components';
+
+import makeId from '../../../../src/components/form/form_row/make_id';
+
+export default class extends Component {
+  constructor(props) {
+    super(props);
+
+    this.levels = [
+      {
+        min: 0,
+        max: 20,
+        color: 'danger'
+      },
+      {
+        min: 20,
+        max: 100,
+        color: 'success'
+      }
+    ];
+
+    this.state = {
+      value: '20',
+      dualValue: [20, 100],
+    };
+  }
+
+  onChange = e => {
+    this.setState({
+      value: e.target.value,
+    });
+  };
+
+  onDualChange = (value) => {
+    this.setState({
+      dualValue: value
+    });
+  };
+
+  render() {
+    return (
+      <Fragment>
+        <EuiRange
+          id={makeId()}
+          value={this.state.value}
+          onChange={this.onChange}
+          compressed
+          fullWidth
+          disabled
+          showTicks
+          showInput
+          showLabels
+          showValue
+          showRange
+          tickInterval={20}
+          levels={this.levels}
+          aria-describedby="levelsHelp4"
+        />
+        <EuiFormHelpText id="levelsHelp4">Recommended levels are {this.levels[1].min} and above.</EuiFormHelpText>
+
+        <EuiSpacer size="xl" />
+
+        <EuiDualRange
+          id={makeId()}
+          value={this.state.dualValue}
+          onChange={this.onDualChange}
+          compressed
+          fullWidth
+          disabled
+          showLabels
+          showInput
+          showTicks
+          ticks={[{ label: '20kb', value: 20 }, { label: '100kb', value: 100 }]}
+          levels={this.levels}
+          aria-describedby="levelsHelp5"
+        />
+        <EuiFormHelpText id="levelsHelp5">Recommended size is {this.levels[1].min}kb and above.</EuiFormHelpText>
+      </Fragment>
+    );
+  }
+}

--- a/src-docs/src/views/range/ticks.js
+++ b/src-docs/src/views/range/ticks.js
@@ -6,6 +6,8 @@ import React, {
 import {
   EuiRange,
   EuiSpacer,
+  EuiTitle,
+  EuiDualRange,
 } from '../../../../src/components';
 
 import makeId from '../../../../src/components/form/form_row/make_id';
@@ -15,7 +17,8 @@ export default class extends Component {
     super(props);
 
     this.state = {
-      value: '120'
+      value: '20',
+      dualValue: [20, 100],
     };
   }
 
@@ -25,42 +28,52 @@ export default class extends Component {
     });
   };
 
+  onDualChange = (value) => {
+    this.setState({
+      dualValue: value
+    });
+  };
+
   render() {
     return (
       <Fragment>
         <EuiRange
           id={makeId()}
-          min={100}
-          max={200}
+          step={10}
           value={this.state.value}
           onChange={this.onChange}
-          showLabels
+          showTicks
         />
 
         <EuiSpacer size="xl" />
 
-        <EuiRange
-          id={makeId()}
-          min={100}
-          max={200}
-          value={this.state.value}
-          onChange={this.onChange}
-          showLabels
-          showValue
-        />
+        <EuiTitle size="xxs"><h3>Custom tick interval</h3></EuiTitle>
 
-        <EuiSpacer size="xl" />
+        <EuiSpacer size="l" />
 
         <EuiRange
           id={makeId()}
-          min={100}
-          max={200}
           value={this.state.value}
           onChange={this.onChange}
-          showLabels
+          showInput
           showRange
-          showValue
-          valuePrepend="100 - "
+          showTicks
+          tickInterval={20}
+        />
+
+        <EuiSpacer size="xl" />
+
+        <EuiTitle size="xxs"><h3>Custom ticks object</h3></EuiTitle>
+
+        <EuiSpacer size="l" />
+
+        <EuiDualRange
+          id={makeId()}
+          value={this.state.dualValue}
+          onChange={this.onDualChange}
+          showTicks
+          ticks={[{ label: '20kb', value: 20 }, { label: '100kb', value: 100 }]}
+          showInput
         />
       </Fragment>
     );

--- a/src/components/form/range/__snapshots__/dual_range.test.js.snap
+++ b/src/components/form/range/__snapshots__/dual_range.test.js.snap
@@ -9,9 +9,10 @@ exports[`EuiDualRange allows value prop to accept numbers 1`] = `
   >
     <input
       aria-hidden="true"
-      class="euiRangeSlider euiDualRange__slider"
+      class="euiRangeSlider euiRangeSlider--hasRange euiDualRange__slider"
       max="100"
-      min="1"
+      min="0"
+      step="1"
       tabindex="-1"
       type="range"
     />
@@ -20,7 +21,7 @@ exports[`EuiDualRange allows value prop to accept numbers 1`] = `
     >
       <div
         class="euiRangeHighlight__progress"
-        style="margin-left:0%;width:7.07070707070707%"
+        style="margin-left:1%;width:7.000000000000001%"
       />
     </div>
   </div>
@@ -29,7 +30,7 @@ exports[`EuiDualRange allows value prop to accept numbers 1`] = `
 
 exports[`EuiDualRange is rendered 1`] = `
 <div
-  class="euiRangeWrapper euiDualRange"
+  class="euiRangeWrapper euiDualRange testClass1 testClass2"
 >
   <div
     class="euiRangeTrack"
@@ -37,12 +38,13 @@ exports[`EuiDualRange is rendered 1`] = `
     <input
       aria-hidden="true"
       aria-label="aria-label"
-      class="euiRangeSlider euiDualRange__slider testClass1 testClass2"
+      class="euiRangeSlider euiRangeSlider--hasRange euiDualRange__slider"
       data-test-subj="test subject string"
       id="id"
       max="10"
       min="1"
       name="name"
+      step="1"
       tabindex="-1"
       type="range"
     />
@@ -67,9 +69,10 @@ exports[`EuiDualRange props compressed should render 1`] = `
   >
     <input
       aria-hidden="true"
-      class="euiRangeSlider euiDualRange__slider"
+      class="euiRangeSlider euiRangeSlider--hasRange euiDualRange__slider"
       max="100"
-      min="1"
+      min="0"
+      step="1"
       tabindex="-1"
       type="range"
     />
@@ -94,9 +97,10 @@ exports[`EuiDualRange props fullWidth should render 1`] = `
   >
     <input
       aria-hidden="true"
-      class="euiRangeSlider euiDualRange__slider"
+      class="euiRangeSlider euiRangeSlider--hasRange euiDualRange__slider"
       max="100"
-      min="1"
+      min="0"
+      step="1"
       tabindex="-1"
       type="range"
     />
@@ -114,7 +118,7 @@ exports[`EuiDualRange props fullWidth should render 1`] = `
 
 exports[`EuiDualRange props inputs should render 1`] = `
 <div
-  class="euiRangeWrapper euiDualRange"
+  class="euiRangeWrapper euiDualRange testClass1 testClass2"
 >
   <div
     class="euiFormControlLayout"
@@ -128,7 +132,8 @@ exports[`EuiDualRange props inputs should render 1`] = `
         max="8"
         min="1"
         name="name-minValue"
-        style="width:4em"
+        step="1"
+        style="width:3.6em"
         type="number"
         value="1"
       />
@@ -140,12 +145,13 @@ exports[`EuiDualRange props inputs should render 1`] = `
     <input
       aria-hidden="true"
       aria-label="aria-label"
-      class="euiRangeSlider euiDualRange__slider testClass1 testClass2"
+      class="euiRangeSlider euiRangeSlider--hasRange euiDualRange__slider"
       data-test-subj="test subject string"
       id="id"
       max="10"
       min="1"
       name="name"
+      step="1"
       tabindex="-1"
       type="range"
     />
@@ -170,7 +176,8 @@ exports[`EuiDualRange props inputs should render 1`] = `
         max="10"
         min="1"
         name="name-maxValue"
-        style="width:4em"
+        step="1"
+        style="width:3.6em"
         type="number"
         value="8"
       />
@@ -186,16 +193,17 @@ exports[`EuiDualRange props labels should render 1`] = `
   <label
     class="euiRangeLabel euiRangeLabel--min"
   >
-    1
+    0
   </label>
   <div
     class="euiRangeTrack"
   >
     <input
       aria-hidden="true"
-      class="euiRangeSlider euiDualRange__slider"
+      class="euiRangeSlider euiRangeSlider--hasRange euiDualRange__slider"
       max="100"
-      min="1"
+      min="0"
+      step="1"
       tabindex="-1"
       type="range"
     />
@@ -225,9 +233,10 @@ exports[`EuiDualRange props levels should render 1`] = `
   >
     <input
       aria-hidden="true"
-      class="euiRangeSlider euiDualRange__slider"
+      class="euiRangeSlider euiRangeSlider--hasRange euiDualRange__slider"
       max="100"
-      min="1"
+      min="0"
+      step="1"
       tabindex="-1"
       type="range"
     />
@@ -244,11 +253,11 @@ exports[`EuiDualRange props levels should render 1`] = `
     >
       <span
         class="euiRangeLevel euiRangeLevel--danger"
-        style="width:606.060606060606%"
+        style="width:19%"
       />
       <span
         class="euiRangeLevel euiRangeLevel--success"
-        style="width:1414.141414141414%"
+        style="width:80%"
       />
     </div>
   </div>
@@ -264,9 +273,10 @@ exports[`EuiDualRange props range should render 1`] = `
   >
     <input
       aria-hidden="true"
-      class="euiRangeSlider euiDualRange__slider"
+      class="euiRangeSlider euiRangeSlider--hasRange euiDualRange__slider"
       max="100"
-      min="1"
+      min="0"
+      step="1"
       tabindex="-1"
       type="range"
     />
@@ -275,7 +285,7 @@ exports[`EuiDualRange props range should render 1`] = `
     >
       <div
         class="euiRangeHighlight__progress"
-        style="margin-left:0%;width:7.07070707070707%"
+        style="margin-left:1%;width:7.000000000000001%"
       />
     </div>
   </div>
@@ -288,12 +298,14 @@ exports[`EuiDualRange props ticks should render 1`] = `
 >
   <div
     class="euiRangeTrack"
+    style="margin-right:0.6em"
   >
     <input
       aria-hidden="true"
-      class="euiRangeSlider euiRangeSlider--hasTicks euiDualRange__slider"
+      class="euiRangeSlider euiRangeSlider--hasTicks euiRangeSlider--hasRange euiDualRange__slider"
       max="100"
-      min="1"
+      min="0"
+      step="1"
       tabindex="-1"
       type="range"
     />
@@ -307,52 +319,67 @@ exports[`EuiDualRange props ticks should render 1`] = `
     </div>
     <div
       class="euiRangeTicks"
-      style="margin:0 -8.403361344537815%;left:0;right:0"
+      style="margin:0 -8.333333333333332%;left:0;right:0"
     >
       <button
         class="euiRangeTick"
-        style="width:16.80672268907563%"
+        style="width:16.666666666666664%"
         tabindex="-1"
+        title="0"
         type="button"
-        value="1"
+        value="0"
       >
-        1
+        0
       </button>
       <button
         class="euiRangeTick"
-        style="width:16.80672268907563%"
+        style="width:16.666666666666664%"
         tabindex="-1"
+        title="20"
         type="button"
-        value="21"
+        value="20"
       >
-        21
+        20
       </button>
       <button
         class="euiRangeTick"
-        style="width:16.80672268907563%"
+        style="width:16.666666666666664%"
         tabindex="-1"
+        title="40"
         type="button"
-        value="41"
+        value="40"
       >
-        41
+        40
       </button>
       <button
         class="euiRangeTick"
-        style="width:16.80672268907563%"
+        style="width:16.666666666666664%"
         tabindex="-1"
+        title="60"
         type="button"
-        value="61"
+        value="60"
       >
-        61
+        60
       </button>
       <button
         class="euiRangeTick"
-        style="width:16.80672268907563%"
+        style="width:16.666666666666664%"
         tabindex="-1"
+        title="80"
         type="button"
-        value="81"
+        value="80"
       >
-        81
+        80
+      </button>
+      <button
+        class="euiRangeTick"
+        style="width:16.666666666666664%"
+        tabindex="-1"
+        title="100"
+        type="button"
+        value="100"
+      >
+        100
       </button>
     </div>
   </div>

--- a/src/components/form/range/__snapshots__/dual_range.test.js.snap
+++ b/src/components/form/range/__snapshots__/dual_range.test.js.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiDualRange allows value prop to accept empty strings 1`] = `
+<div
+  class="euiRangeWrapper euiDualRange"
+>
+  <div
+    class="euiRangeTrack"
+  >
+    <input
+      aria-hidden="true"
+      class="euiRangeSlider euiRangeSlider--hasRange euiDualRange__slider"
+      max="100"
+      min="0"
+      step="1"
+      tabindex="-1"
+      type="range"
+    />
+  </div>
+</div>
+`;
+
 exports[`EuiDualRange allows value prop to accept numbers 1`] = `
 <div
   class="euiRangeWrapper euiDualRange"
@@ -70,6 +90,88 @@ exports[`EuiDualRange props compressed should render 1`] = `
     <input
       aria-hidden="true"
       class="euiRangeSlider euiRangeSlider--hasRange euiDualRange__slider"
+      max="100"
+      min="0"
+      step="1"
+      tabindex="-1"
+      type="range"
+    />
+    <div
+      class="euiRangeHighlight"
+    >
+      <div
+        class="euiRangeHighlight__progress"
+        style="margin-left:0%;width:100%"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiDualRange props custom ticks should render 1`] = `
+<div
+  class="euiRangeWrapper euiDualRange"
+>
+  <div
+    class="euiRangeTrack"
+    style="margin-right:0.6em"
+  >
+    <input
+      aria-hidden="true"
+      class="euiRangeSlider euiRangeSlider--hasTicks euiRangeSlider--hasRange euiDualRange__slider"
+      max="100"
+      min="0"
+      step="1"
+      tabindex="-1"
+      type="range"
+    />
+    <div
+      class="euiRangeHighlight euiRangeHighlight--hasTicks"
+    >
+      <div
+        class="euiRangeHighlight__progress"
+        style="margin-left:0%;width:100%"
+      />
+    </div>
+    <div
+      class="euiRangeTicks"
+    >
+      <button
+        class="euiRangeTick euiRangeTick--isCustom"
+        style="left:20%"
+        tabindex="-1"
+        title="20kb"
+        type="button"
+        value="20"
+      >
+        20kb
+      </button>
+      <button
+        class="euiRangeTick euiRangeTick--isCustom"
+        style="left:100%"
+        tabindex="-1"
+        title="100kb"
+        type="button"
+        value="100"
+      >
+        100kb
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiDualRange props disabled should render 1`] = `
+<div
+  class="euiRangeWrapper euiDualRange"
+>
+  <div
+    class="euiRangeTrack euiRangeTrack--disabled"
+  >
+    <input
+      aria-hidden="true"
+      class="euiRangeSlider euiRangeSlider--hasRange euiDualRange__slider"
+      disabled=""
       max="100"
       min="0"
       step="1"

--- a/src/components/form/range/__snapshots__/dual_range.test.js.snap
+++ b/src/components/form/range/__snapshots__/dual_range.test.js.snap
@@ -253,7 +253,7 @@ exports[`EuiDualRange props levels should render 1`] = `
     >
       <span
         class="euiRangeLevel euiRangeLevel--danger"
-        style="width:19%"
+        style="width:20%"
       />
       <span
         class="euiRangeLevel euiRangeLevel--success"

--- a/src/components/form/range/__snapshots__/range.test.js.snap
+++ b/src/components/form/range/__snapshots__/range.test.js.snap
@@ -320,7 +320,7 @@ exports[`EuiRange props value should render 1`] = `
     >
       <output
         class="euiRangeTooltip__value euiRangeTooltip__value--left"
-        style="left:100%"
+        style="right:0%"
       />
     </div>
   </div>

--- a/src/components/form/range/__snapshots__/range.test.js.snap
+++ b/src/components/form/range/__snapshots__/range.test.js.snap
@@ -10,7 +10,7 @@ exports[`EuiRange allows value prop to accept a number 1`] = `
     <input
       class="euiRangeSlider"
       max="100"
-      min="1"
+      min="0"
       step="1"
       type="range"
       value="8"
@@ -20,7 +20,7 @@ exports[`EuiRange allows value prop to accept a number 1`] = `
     >
       <output
         class="euiRangeTooltip__value euiRangeTooltip__value--right"
-        style="left:7.07070707070707%"
+        style="left:8%"
       >
         8
       </output>
@@ -62,7 +62,7 @@ exports[`EuiRange props compressed should render 1`] = `
     <input
       class="euiRangeSlider"
       max="100"
-      min="1"
+      min="0"
       step="1"
       type="range"
     />
@@ -124,7 +124,7 @@ exports[`EuiRange props fullWidth should render 1`] = `
     <input
       class="euiRangeSlider"
       max="100"
-      min="1"
+      min="0"
       step="1"
       type="range"
     />
@@ -139,7 +139,7 @@ exports[`EuiRange props labels should render 1`] = `
   <label
     class="euiRangeLabel euiRangeLabel--min"
   >
-    1
+    0
   </label>
   <div
     class="euiRangeTrack"
@@ -147,7 +147,7 @@ exports[`EuiRange props labels should render 1`] = `
     <input
       class="euiRangeSlider"
       max="100"
-      min="1"
+      min="0"
       step="1"
       type="range"
     />
@@ -170,7 +170,7 @@ exports[`EuiRange props levels should render 1`] = `
     <input
       class="euiRangeSlider"
       max="100"
-      min="1"
+      min="0"
       step="1"
       type="range"
     />
@@ -179,11 +179,11 @@ exports[`EuiRange props levels should render 1`] = `
     >
       <span
         class="euiRangeLevel euiRangeLevel--danger"
-        style="width:19.19191919191919%"
+        style="width:20%"
       />
       <span
         class="euiRangeLevel euiRangeLevel--success"
-        style="width:80.8080808080808%"
+        style="width:80%"
       />
     </div>
   </div>
@@ -200,7 +200,7 @@ exports[`EuiRange props range should render 1`] = `
     <input
       class="euiRangeSlider euiRangeSlider--hasRange"
       max="100"
-      min="1"
+      min="0"
       step="1"
       type="range"
       value="8"
@@ -210,7 +210,7 @@ exports[`EuiRange props range should render 1`] = `
     >
       <div
         class="euiRangeHighlight__progress"
-        style="margin-left:0%;width:7.07070707070707%"
+        style="margin-left:0%;width:8%"
       />
     </div>
   </div>
@@ -223,67 +223,78 @@ exports[`EuiRange props ticks should render 1`] = `
 >
   <div
     class="euiRangeTrack"
+    style="margin-right:0.6em"
   >
     <input
       class="euiRangeSlider euiRangeSlider--hasTicks"
       max="100"
-      min="1"
+      min="0"
       step="1"
       type="range"
     />
     <div
       class="euiRangeTicks"
-      style="margin:0 -8.403361344537815%;left:0;right:0"
+      style="margin:0 -8.333333333333332%;left:0;right:0"
     >
       <button
         class="euiRangeTick"
-        style="width:16.80672268907563%"
+        style="width:16.666666666666664%"
         tabindex="-1"
-        title="1"
+        title="0"
         type="button"
-        value="1"
+        value="0"
       >
-        1
+        0
       </button>
       <button
         class="euiRangeTick"
-        style="width:16.80672268907563%"
+        style="width:16.666666666666664%"
         tabindex="-1"
-        title="21"
+        title="20"
         type="button"
-        value="21"
+        value="20"
       >
-        21
+        20
       </button>
       <button
         class="euiRangeTick"
-        style="width:16.80672268907563%"
+        style="width:16.666666666666664%"
         tabindex="-1"
-        title="41"
+        title="40"
         type="button"
-        value="41"
+        value="40"
       >
-        41
+        40
       </button>
       <button
         class="euiRangeTick"
-        style="width:16.80672268907563%"
+        style="width:16.666666666666664%"
         tabindex="-1"
-        title="61"
+        title="60"
         type="button"
-        value="61"
+        value="60"
       >
-        61
+        60
       </button>
       <button
         class="euiRangeTick"
-        style="width:16.80672268907563%"
+        style="width:16.666666666666664%"
         tabindex="-1"
-        title="81"
+        title="80"
         type="button"
-        value="81"
+        value="80"
       >
-        81
+        80
+      </button>
+      <button
+        class="euiRangeTick"
+        style="width:16.666666666666664%"
+        tabindex="-1"
+        title="100"
+        type="button"
+        value="100"
+      >
+        100
       </button>
     </div>
   </div>
@@ -300,7 +311,7 @@ exports[`EuiRange props value should render 1`] = `
     <input
       class="euiRangeSlider"
       max="100"
-      min="1"
+      min="0"
       step="1"
       type="range"
     />

--- a/src/components/form/range/__snapshots__/range.test.js.snap
+++ b/src/components/form/range/__snapshots__/range.test.js.snap
@@ -29,6 +29,25 @@ exports[`EuiRange allows value prop to accept a number 1`] = `
 </div>
 `;
 
+exports[`EuiRange allows value prop to accept empty string 1`] = `
+<div
+  class="euiRangeWrapper euiRange"
+>
+  <div
+    class="euiRangeTrack"
+  >
+    <input
+      class="euiRangeSlider"
+      max="100"
+      min="0"
+      step="1"
+      type="range"
+      value=""
+    />
+  </div>
+</div>
+`;
+
 exports[`EuiRange is rendered 1`] = `
 <div
   class="euiRangeWrapper euiRange testClass1 testClass2"
@@ -70,7 +89,87 @@ exports[`EuiRange props compressed should render 1`] = `
 </div>
 `;
 
-exports[`EuiRange props extra input should render 1`] = `
+exports[`EuiRange props custom ticks should render 1`] = `
+<div
+  class="euiRangeWrapper euiRange"
+>
+  <div
+    class="euiRangeTrack"
+    style="margin-right:0.6em"
+  >
+    <input
+      class="euiRangeSlider euiRangeSlider--hasTicks"
+      max="100"
+      min="0"
+      step="1"
+      type="range"
+    />
+    <div
+      class="euiRangeTicks"
+    >
+      <button
+        class="euiRangeTick euiRangeTick--isCustom"
+        style="left:20%"
+        tabindex="-1"
+        title="20kb"
+        type="button"
+        value="20"
+      >
+        20kb
+      </button>
+      <button
+        class="euiRangeTick euiRangeTick--isCustom"
+        style="left:100%"
+        tabindex="-1"
+        title="100kb"
+        type="button"
+        value="100"
+      >
+        100kb
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiRange props disabled should render 1`] = `
+<div
+  class="euiRangeWrapper euiRange"
+>
+  <div
+    class="euiRangeTrack euiRangeTrack--disabled"
+  >
+    <input
+      class="euiRangeSlider"
+      disabled=""
+      max="100"
+      min="0"
+      step="1"
+      type="range"
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiRange props fullWidth should render 1`] = `
+<div
+  class="euiRangeWrapper euiRangeWrapper--fullWidth euiRange"
+>
+  <div
+    class="euiRangeTrack"
+  >
+    <input
+      class="euiRangeSlider"
+      max="100"
+      min="0"
+      step="1"
+      type="range"
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiRange props input should render 1`] = `
 <div
   class="euiRangeWrapper euiRange testClass1 testClass2"
 >
@@ -110,24 +209,6 @@ exports[`EuiRange props extra input should render 1`] = `
         value="8"
       />
     </div>
-  </div>
-</div>
-`;
-
-exports[`EuiRange props fullWidth should render 1`] = `
-<div
-  class="euiRangeWrapper euiRangeWrapper--fullWidth euiRange"
->
-  <div
-    class="euiRangeTrack"
-  >
-    <input
-      class="euiRangeSlider"
-      max="100"
-      min="0"
-      step="1"
-      type="range"
-    />
   </div>
 </div>
 `;
@@ -314,6 +395,7 @@ exports[`EuiRange props value should render 1`] = `
       min="0"
       step="1"
       type="range"
+      value="200"
     />
     <div
       class="euiRangeTooltip"
@@ -321,7 +403,9 @@ exports[`EuiRange props value should render 1`] = `
       <output
         class="euiRangeTooltip__value euiRangeTooltip__value--left"
         style="right:0%"
-      />
+      >
+        before200after
+      </output>
     </div>
   </div>
 </div>

--- a/src/components/form/range/__snapshots__/range.test.js.snap
+++ b/src/components/form/range/__snapshots__/range.test.js.snap
@@ -11,6 +11,7 @@ exports[`EuiRange allows value prop to accept a number 1`] = `
       class="euiRangeSlider"
       max="100"
       min="1"
+      step="1"
       type="range"
       value="8"
     />
@@ -30,19 +31,20 @@ exports[`EuiRange allows value prop to accept a number 1`] = `
 
 exports[`EuiRange is rendered 1`] = `
 <div
-  class="euiRangeWrapper euiRange"
+  class="euiRangeWrapper euiRange testClass1 testClass2"
 >
   <div
     class="euiRangeTrack"
   >
     <input
       aria-label="aria-label"
-      class="euiRangeSlider testClass1 testClass2"
+      class="euiRangeSlider"
       data-test-subj="test subject string"
       id="id"
       max="10"
       min="1"
       name="name"
+      step="1"
       type="range"
       value="8"
     />
@@ -61,6 +63,7 @@ exports[`EuiRange props compressed should render 1`] = `
       class="euiRangeSlider"
       max="100"
       min="1"
+      step="1"
       type="range"
     />
   </div>
@@ -69,19 +72,20 @@ exports[`EuiRange props compressed should render 1`] = `
 
 exports[`EuiRange props extra input should render 1`] = `
 <div
-  class="euiRangeWrapper euiRange"
+  class="euiRangeWrapper euiRange testClass1 testClass2"
 >
   <div
     class="euiRangeTrack"
   >
     <input
       aria-label="aria-label"
-      class="euiRangeSlider testClass1 testClass2"
+      class="euiRangeSlider"
       data-test-subj="test subject string"
       id="id"
       max="10"
       min="1"
       name="name"
+      step="1"
       tabindex="-1"
       type="range"
       value="8"
@@ -100,7 +104,8 @@ exports[`EuiRange props extra input should render 1`] = `
         max="10"
         min="1"
         name="name"
-        style="width:4em"
+        step="1"
+        style="width:3.6em"
         type="number"
         value="8"
       />
@@ -120,6 +125,7 @@ exports[`EuiRange props fullWidth should render 1`] = `
       class="euiRangeSlider"
       max="100"
       min="1"
+      step="1"
       type="range"
     />
   </div>
@@ -142,6 +148,7 @@ exports[`EuiRange props labels should render 1`] = `
       class="euiRangeSlider"
       max="100"
       min="1"
+      step="1"
       type="range"
     />
   </div>
@@ -164,6 +171,7 @@ exports[`EuiRange props levels should render 1`] = `
       class="euiRangeSlider"
       max="100"
       min="1"
+      step="1"
       type="range"
     />
     <div
@@ -171,11 +179,11 @@ exports[`EuiRange props levels should render 1`] = `
     >
       <span
         class="euiRangeLevel euiRangeLevel--danger"
-        style="width:606.060606060606%"
+        style="width:19.19191919191919%"
       />
       <span
         class="euiRangeLevel euiRangeLevel--success"
-        style="width:1414.141414141414%"
+        style="width:80.8080808080808%"
       />
     </div>
   </div>
@@ -190,9 +198,10 @@ exports[`EuiRange props range should render 1`] = `
     class="euiRangeTrack"
   >
     <input
-      class="euiRangeSlider"
+      class="euiRangeSlider euiRangeSlider--hasRange"
       max="100"
       min="1"
+      step="1"
       type="range"
       value="8"
     />
@@ -219,6 +228,7 @@ exports[`EuiRange props ticks should render 1`] = `
       class="euiRangeSlider euiRangeSlider--hasTicks"
       max="100"
       min="1"
+      step="1"
       type="range"
     />
     <div
@@ -229,6 +239,7 @@ exports[`EuiRange props ticks should render 1`] = `
         class="euiRangeTick"
         style="width:16.80672268907563%"
         tabindex="-1"
+        title="1"
         type="button"
         value="1"
       >
@@ -238,6 +249,7 @@ exports[`EuiRange props ticks should render 1`] = `
         class="euiRangeTick"
         style="width:16.80672268907563%"
         tabindex="-1"
+        title="21"
         type="button"
         value="21"
       >
@@ -247,6 +259,7 @@ exports[`EuiRange props ticks should render 1`] = `
         class="euiRangeTick"
         style="width:16.80672268907563%"
         tabindex="-1"
+        title="41"
         type="button"
         value="41"
       >
@@ -256,6 +269,7 @@ exports[`EuiRange props ticks should render 1`] = `
         class="euiRangeTick"
         style="width:16.80672268907563%"
         tabindex="-1"
+        title="61"
         type="button"
         value="61"
       >
@@ -265,6 +279,7 @@ exports[`EuiRange props ticks should render 1`] = `
         class="euiRangeTick"
         style="width:16.80672268907563%"
         tabindex="-1"
+        title="81"
         type="button"
         value="81"
       >
@@ -286,6 +301,7 @@ exports[`EuiRange props value should render 1`] = `
       class="euiRangeSlider"
       max="100"
       min="1"
+      step="1"
       type="range"
     />
     <div

--- a/src/components/form/range/__snapshots__/range_levels.test.js.snap
+++ b/src/components/form/range/__snapshots__/range_levels.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiRangeLevels is rendered 1`] = `
+<div
+  class="euiRangeLevels euiRangeLevels--hasTicks"
+>
+  <span
+    class="euiRangeLevel euiRangeLevel--danger"
+    style="width:20%"
+  />
+  <span
+    class="euiRangeLevel euiRangeLevel--success"
+    style="width:80%"
+  />
+</div>
+`;
+
+exports[`EuiRangeLevels should throw error if \`level.max\` is higher than \`max\` 1`] = `"The level max of 200 is higher than the max value of 100."`;
+
+exports[`EuiRangeLevels should throw error if \`level.min\` is lower than \`min\` 1`] = `"The level min of -10 is lower than the min value of 0."`;

--- a/src/components/form/range/__snapshots__/range_track.test.js.snap
+++ b/src/components/form/range/__snapshots__/range_track.test.js.snap
@@ -1,0 +1,136 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiRangeTrack is rendered 1`] = `
+<div
+  class="euiRangeTrack"
+  style="margin-right:0.6em"
+>
+  <div
+    class="euiRangeTicks"
+    style="margin:0 -4.545454545454546%;left:0;right:0"
+  >
+    <button
+      class="euiRangeTick"
+      style="width:9.090909090909092%"
+      tabindex="-1"
+      title="0"
+      type="button"
+      value="0"
+    >
+      0
+    </button>
+    <button
+      class="euiRangeTick"
+      style="width:9.090909090909092%"
+      tabindex="-1"
+      title="10"
+      type="button"
+      value="10"
+    >
+      10
+    </button>
+    <button
+      class="euiRangeTick"
+      style="width:9.090909090909092%"
+      tabindex="-1"
+      title="20"
+      type="button"
+      value="20"
+    >
+      20
+    </button>
+    <button
+      class="euiRangeTick"
+      style="width:9.090909090909092%"
+      tabindex="-1"
+      title="30"
+      type="button"
+      value="30"
+    >
+      30
+    </button>
+    <button
+      class="euiRangeTick"
+      style="width:9.090909090909092%"
+      tabindex="-1"
+      title="40"
+      type="button"
+      value="40"
+    >
+      40
+    </button>
+    <button
+      class="euiRangeTick"
+      style="width:9.090909090909092%"
+      tabindex="-1"
+      title="50"
+      type="button"
+      value="50"
+    >
+      50
+    </button>
+    <button
+      class="euiRangeTick"
+      style="width:9.090909090909092%"
+      tabindex="-1"
+      title="60"
+      type="button"
+      value="60"
+    >
+      60
+    </button>
+    <button
+      class="euiRangeTick"
+      style="width:9.090909090909092%"
+      tabindex="-1"
+      title="70"
+      type="button"
+      value="70"
+    >
+      70
+    </button>
+    <button
+      class="euiRangeTick"
+      style="width:9.090909090909092%"
+      tabindex="-1"
+      title="80"
+      type="button"
+      value="80"
+    >
+      80
+    </button>
+    <button
+      class="euiRangeTick"
+      style="width:9.090909090909092%"
+      tabindex="-1"
+      title="90"
+      type="button"
+      value="90"
+    >
+      90
+    </button>
+    <button
+      class="euiRangeTick"
+      style="width:9.090909090909092%"
+      tabindex="-1"
+      title="100"
+      type="button"
+      value="100"
+    >
+      100
+    </button>
+  </div>
+</div>
+`;
+
+exports[`EuiRangeTrack should throw error if \`max\` does not line up with \`step\` interval 1`] = `"The value of 105 is not included in the possible sequence provided by the step of 10."`;
+
+exports[`EuiRangeTrack should throw error if \`tickInterval\` is off sequence from \`step\` 1`] = `"The value of 3 is not included in the possible sequence provided by the step of 10."`;
+
+exports[`EuiRangeTrack should throw error if custom tick value is higher than \`max\` 1`] = `"The value of 200 is higher than the max value of 100."`;
+
+exports[`EuiRangeTrack should throw error if custom tick value is lower than \`min\` 1`] = `"The value of -100 is lower than the min value of 0."`;
+
+exports[`EuiRangeTrack should throw error if custom tick value is off sequence from \`step\` 1`] = `"The value of 10 is not included in the possible sequence provided by the step of 50."`;
+
+exports[`EuiRangeTrack should throw error if there are too many ticks to render 1`] = `"The number of ticks to render is too high (22), reduce the interval."`;

--- a/src/components/form/range/_range_input.scss
+++ b/src/components/form/range/_range_input.scss
@@ -1,11 +1,6 @@
-/*
- * 1. Align extra input slightly better with slider labels, in an IE compliant way.
- */
-
 .euiRangeInput {
   width: auto;
-  position: relative; /* 1 */
-  top: -2px; /* 1 */
+  min-width: $euiSize * 4;
 
   &--min {
     margin-right: $euiSize;

--- a/src/components/form/range/_range_slider.scss
+++ b/src/components/form/range/_range_slider.scss
@@ -36,19 +36,14 @@
 
   @include euiRangeThumbPerBrowser {
     @include euiCustomControl($type: 'round');
-
     @include euiRangeThumbStyle;
   }
 
   @include euiRangeTrackPerBrowser {
     @include euiRangeTrackSize;
-
     background: $euiRangeTrackColor;
     border: $euiRangeTrackBorderWidth solid $euiRangeTrackBorderColor;
     border-radius: $euiRangeTrackRadius;
-
-    background-color: transparentize($euiRangeTrackColor, .6);
-    border-color: transparentize($euiRangeTrackBorderColor, .6);
   }
 
   &:focus,
@@ -94,7 +89,6 @@
 
   &::-ms-track {
     @include euiRangeTrackSize;
-
     background: transparent;
     border-color: transparent;
     border-width: ($euiRangeThumbHeight / 2) 0;
@@ -104,5 +98,13 @@
   // States
   &--hasTicks {
     height: $euiFormControlHeight / 2; // Adjust vertical alignment based on extras
+  }
+}
+
+// Lighten the track when showing the range
+.euiRangeSlider--hasRange {
+  @include euiRangeTrackPerBrowser {
+    background-color: transparentize($euiRangeTrackColor, .6);
+    border-color: transparentize($euiRangeTrackBorderColor, .6);
   }
 }

--- a/src/components/form/range/_range_slider.scss
+++ b/src/components/form/range/_range_slider.scss
@@ -64,12 +64,9 @@
     ~ .euiRangeTooltip .euiRangeTooltip__value {
       @include euiBottomShadowMedium;
 
-      &.euiRangeTooltip__value--right {
-        transform: translateX(0) translateY(-50%) scale(1.1);
-      }
-
+      &.euiRangeTooltip__value--right,
       &.euiRangeTooltip__value--left {
-        transform: translateX(-100%) translateY(-50%) scale(1.1);
+        transform: translateX(0) translateY(-50%) scale(1.1);
       }
     }
   }

--- a/src/components/form/range/_range_slider.scss
+++ b/src/components/form/range/_range_slider.scss
@@ -32,6 +32,13 @@
       background-color: $euiRangeThumbBorderColor;
       box-shadow: none;
     }
+
+    ~ .euiRangeThumb {
+      cursor: not-allowed;
+      border-color: $euiRangeThumbBorderColor;
+      background-color: $euiRangeThumbBorderColor;
+      box-shadow: none;
+    }
   }
 
   @include euiRangeThumbPerBrowser {
@@ -50,6 +57,10 @@
   &--hasFocus {
     @include euiRangeThumbPerBrowser {
       @include euiCustomControlFocused;
+    }
+
+    ~ .euiRangeThumb {
+      border-color: $euiColorPrimary;
     }
 
     @include euiRangeTrackPerBrowser {

--- a/src/components/form/range/_range_tooltip.scss
+++ b/src/components/form/range/_range_tooltip.scss
@@ -49,14 +49,11 @@
 
   // Positions the arrow
   &.euiRangeTooltip__value--right {
-    transform: translateX(0) translateY(-50%);
     margin-left: $euiSizeL;
 
     &:before,
     &:after {
-      bottom: 50%;
       left: $arrowMinusSize;
-      transform: translateY(50%) rotateZ(45deg);
     }
 
     &::before {
@@ -65,19 +62,27 @@
   }
 
   &.euiRangeTooltip__value--left {
-    transform: translateX(-100%) translateY(-50%);
-    margin-left: -$euiSizeL;
+    margin-right: $euiSizeL;
 
     &:before,
     &:after {
-      bottom: 50%;
       left: auto;
       right: $arrowMinusSize;
-      transform: translateY(50%) rotateZ(45deg);
     }
 
     &::before {
       margin-right: -1px;
+    }
+  }
+
+  &.euiRangeTooltip__value--right,
+  &.euiRangeTooltip__value--left {
+    transform: translateX(0) translateY(-50%);
+
+    &:before,
+    &:after {
+      bottom: 50%;
+      transform: translateY(50%) rotateZ(45deg);
     }
   }
 

--- a/src/components/form/range/dual_range.js
+++ b/src/components/form/range/dual_range.js
@@ -28,10 +28,10 @@ export class EuiDualRange extends Component {
   }
 
   get lowerValue() {
-    return this.props.value && this.props.value !== '' ? this.props.value[0] : this.props.min;
+    return this.props.value ? this.props.value[0] : this.props.min;
   }
   get upperValue() {
-    return this.props.value && this.props.value !== '' ? this.props.value[1] : this.props.max;
+    return this.props.value ? this.props.value[1] : this.props.max;
   }
   get lowerValueIsValid() {
     return isWithinRange(this.props.min, this.upperValue, this.lowerValue);

--- a/src/components/form/range/dual_range.js
+++ b/src/components/form/range/dual_range.js
@@ -29,10 +29,10 @@ export class EuiDualRange extends Component {
   }
 
   get lowerValue() {
-    return this.props.value ? this.props.value[0] : this.props.min;
+    return this.props.value && this.props.value !== '' ? this.props.value[0] : this.props.min;
   }
   get upperValue() {
-    return this.props.value ? this.props.value[1] : this.props.max;
+    return this.props.value && this.props.value !== '' ? this.props.value[1] : this.props.max;
   }
   get isValid() {
     return isWithinRange(this.props.min, this.upperValue, this.lowerValue)
@@ -208,7 +208,7 @@ export class EuiDualRange extends Component {
       showInput,
       showTicks,
       tickInterval,
-      ticks, // eslint-disable-line no-unused-vars
+      ticks,
       levels,
       onChange, // eslint-disable-line no-unused-vars
       showRange,
@@ -217,11 +217,11 @@ export class EuiDualRange extends Component {
       ...rest
     } = this.props;
 
-    const sliderClasses = classNames('euiDualRange__slider', className);
+    const classes = classNames('euiDualRange', className);
 
     return (
       <EuiRangeWrapper
-        className="euiDualRange"
+        className={classes}
         fullWidth={fullWidth}
       >
         {showInput && (
@@ -254,10 +254,10 @@ export class EuiDualRange extends Component {
           value={value}
         >
           <EuiRangeSlider
+            className="euiDualRange__slider"
             ref={this.handleRangeSliderRefUpdate}
             id={id}
             name={name}
-            className={sliderClasses}
             min={min}
             max={max}
             step={step}
@@ -268,6 +268,7 @@ export class EuiDualRange extends Component {
             hasFocus={this.state.hasFocus}
             aria-hidden={true}
             tabIndex={'-1'}
+            showRange={showRange}
             {...rest}
           />
 
@@ -283,7 +284,7 @@ export class EuiDualRange extends Component {
                 onKeyDown={this.handleLowerKeyDown}
                 onFocus={() => this.toggleHasFocus(true)}
                 onBlur={() => this.toggleHasFocus(false)}
-                style={this.calculateThumbPositionStyle(this.lowerValue)}
+                style={this.calculateThumbPositionStyle(this.lowerValue || min)}
                 aria-describedby={this.props['aria-describedby']}
                 aria-label={this.props['aria-label']}
               />
@@ -297,7 +298,7 @@ export class EuiDualRange extends Component {
                 onKeyDown={this.handleUpperKeyDown}
                 onFocus={() => this.toggleHasFocus(true)}
                 onBlur={() => this.toggleHasFocus(false)}
-                style={this.calculateThumbPositionStyle(this.upperValue)}
+                style={this.calculateThumbPositionStyle(this.upperValue || max)}
                 aria-describedby={this.props['aria-describedby']}
                 aria-label={this.props['aria-label']}
               />
@@ -394,8 +395,9 @@ EuiDualRange.propTypes = {
 };
 
 EuiDualRange.defaultProps = {
-  min: 1,
+  min: 0,
   max: 100,
+  step: 1,
   fullWidth: false,
   compressed: false,
   showLabels: false,

--- a/src/components/form/range/dual_range.js
+++ b/src/components/form/range/dual_range.js
@@ -185,6 +185,7 @@ export class EuiDualRange extends Component {
     } = this.props;
 
     const classes = classNames('euiDualRange', className);
+    const digitTolerance = Math.max(String(min).length, String(max).length);
 
     return (
       <EuiRangeWrapper
@@ -193,10 +194,10 @@ export class EuiDualRange extends Component {
       >
         {showInput && (
           <EuiRangeInput
+            digitTolerance={digitTolerance}
             side="min"
             min={min}
             max={Number(this.upperValue)}
-            digits={String(max).length}
             step={step}
             value={this.lowerValue}
             disabled={disabled}
@@ -286,9 +287,10 @@ export class EuiDualRange extends Component {
         {showLabels && <EuiRangeLabel disabled={disabled}>{max}</EuiRangeLabel>}
         {showInput && (
           <EuiRangeInput
+            digitTolerance={digitTolerance}
+            side="max"
             min={Number(this.lowerValue)}
             max={max}
-            digits={String(max).length}
             step={step}
             value={this.upperValue}
             disabled={disabled}

--- a/src/components/form/range/dual_range.js
+++ b/src/components/form/range/dual_range.js
@@ -33,19 +33,29 @@ export class EuiDualRange extends Component {
   get upperValue() {
     return this.props.value && this.props.value !== '' ? this.props.value[1] : this.props.max;
   }
+  get lowerValueIsValid() {
+    return isWithinRange(this.props.min, this.upperValue, this.lowerValue);
+  }
+  get upperValueIsValid() {
+    return isWithinRange(this.lowerValue, this.props.max, this.upperValue);
+  }
   get isValid() {
-    return isWithinRange(this.props.min, this.upperValue, this.lowerValue)
-      && isWithinRange(this.lowerValue, this.props.max, this.upperValue);
+    return this.lowerValueIsValid && this.upperValueIsValid;
   }
 
   _determineInvalidThumbMovement = (newVal, lower, upper, e) => {
     // If the values are invalid, find whether the new value is in the upper
     // or lower half and move the appropriate handle to the new value,
-    // while the other handle gets moved to the opposite bound
+    // while the other handle gets moved to the opposite bound (if invalid)
     const lowerHalf = (Math.abs(this.props.max - this.props.min) / 2) + this.props.min;
     const newValIsLow = isWithinRange(this.props.min, lowerHalf, newVal);
-    lower = newValIsLow ? newVal : this.props.min;
-    upper = !newValIsLow ? newVal : this.props.max;
+    if (newValIsLow) {
+      lower = newVal;
+      upper = !this.upperValueIsValid ? this.props.max : upper;
+    } else {
+      lower = !this.lowerValueIsValid ? this.props.min : lower;
+      upper = newVal;
+    }
     this._handleOnChange(lower, upper, e);
   }
 

--- a/src/components/form/range/dual_range.js
+++ b/src/components/form/range/dual_range.js
@@ -349,6 +349,7 @@ EuiDualRange.propTypes = {
   value: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
   fullWidth: PropTypes.bool,
   compressed: PropTypes.bool,
+  disabled: PropTypes.bool,
   /**
    * Shows static min/max labels on the sides of the range slider
    */

--- a/src/components/form/range/dual_range.js
+++ b/src/components/form/range/dual_range.js
@@ -44,6 +44,7 @@ export class EuiDualRange extends Component {
     const isUnbound = Number(upper) < this.props.min || Number(lower) > this.props.max;
     const isLow = lower < this.props.min;
     const isHigh = upper > this.props.max;
+    console.log(isBackwards, isUnbound);
     if (isBackwards || isUnbound) {
       // Scenerio in which we cannot reasonably infer intention via click location due to current invalid thumb positions.
       // Reset both values in the proximity of the click.
@@ -65,6 +66,7 @@ export class EuiDualRange extends Component {
       (newVal === upper || (newVal < upper && thumbsAreEquidistant))
       && this.state.lastThumbInteraction === 'lower'
     ) {
+      console.log('Lower thumb nearing swap with upper thumb');
       lower = newVal;
     }
     // Upper thumb nearing swap with lower thumb
@@ -72,6 +74,7 @@ export class EuiDualRange extends Component {
       (newVal === lower || (newVal > lower && thumbsAreEquidistant))
       && this.state.lastThumbInteraction === 'upper'
     ) {
+      console.log('Upper thumb nearing swap with lower thumb');
       upper = newVal;
     }
     // Lower thumb targeted or right-moving swap has occured
@@ -79,6 +82,7 @@ export class EuiDualRange extends Component {
       Math.abs(lower - newVal) < Math.abs(upper - newVal)
       || (thumbsAreEquidistant && this.state.lastThumbInteraction === 'upper')
     ) {
+      console.log('Lower thumb targeted or right-moving swap has occured');
       this.setState({
         lastThumbInteraction: 'lower'
       });
@@ -86,6 +90,7 @@ export class EuiDualRange extends Component {
     }
     // Upper thumb targeted or left-moving swap has occured
     else {
+      console.log('Upper thumb targeted or left-moving swap has occured');
       this.setState({
         lastThumbInteraction: 'upper'
       });
@@ -108,6 +113,9 @@ export class EuiDualRange extends Component {
   _handleOnChange = (lower, upper, e) => {
     const isValid = isWithinRange(this.props.min, upper, lower) && isWithinRange(lower, this.props.max, upper);
     this.props.onChange([lower, upper], isValid, e);
+    this.setState({
+      lastThumbInteraction: null
+    });
   }
 
   handleSliderChange = (e) => {

--- a/src/components/form/range/dual_range.test.js
+++ b/src/components/form/range/dual_range.test.js
@@ -91,7 +91,7 @@ describe('EuiDualRange', () => {
         <EuiDualRange
           levels={[
             {
-              min: 1,
+              min: 0,
               max: 20,
               color: 'danger'
             },

--- a/src/components/form/range/dual_range.test.js
+++ b/src/components/form/range/dual_range.test.js
@@ -91,13 +91,13 @@ describe('EuiDualRange', () => {
         <EuiDualRange
           levels={[
             {
-              min: 0,
-              max: 600,
+              min: 1,
+              max: 20,
               color: 'danger'
             },
             {
-              min: 600,
-              max: 2000,
+              min: 20,
+              max: 100,
               color: 'success'
             }
           ]}

--- a/src/components/form/range/dual_range.test.js
+++ b/src/components/form/range/dual_range.test.js
@@ -23,6 +23,15 @@ describe('EuiDualRange', () => {
   });
 
   describe('props', () => {
+    test('disabled should render', () => {
+      const component = render(
+        <EuiDualRange disabled/>
+      );
+
+      expect(component)
+        .toMatchSnapshot();
+    });
+
     test('fullWidth should render', () => {
       const component = render(
         <EuiDualRange fullWidth/>
@@ -53,6 +62,21 @@ describe('EuiDualRange', () => {
     test('ticks should render', () => {
       const component = render(
         <EuiDualRange showTicks tickInterval={20}/>
+      );
+
+      expect(component)
+        .toMatchSnapshot();
+    });
+
+    test('custom ticks should render', () => {
+      const component = render(
+        <EuiDualRange
+          showTicks
+          ticks={[
+            { label: '20kb', value: 20 },
+            { label: '100kb', value: 100 }
+          ]}
+        />
       );
 
       expect(component)
@@ -113,6 +137,18 @@ describe('EuiDualRange', () => {
     const component = render(
       <EuiDualRange
         value={[1, 8]}
+        onChange={() => {}}
+      />
+    );
+
+    expect(component)
+      .toMatchSnapshot();
+  });
+
+  test('allows value prop to accept empty strings', () => {
+    const component = render(
+      <EuiDualRange
+        value={['', '']}
         onChange={() => {}}
       />
     );

--- a/src/components/form/range/range.js
+++ b/src/components/form/range/range.js
@@ -52,6 +52,7 @@ export class EuiRange extends Component {
     } = this.props;
 
     const classes = classNames('euiRange', className);
+    const digitTolerance = Math.max(String(min).length, String(max).length);
 
     return (
       <EuiRangeWrapper
@@ -114,6 +115,7 @@ export class EuiRange extends Component {
           <EuiRangeInput
             min={min}
             max={max}
+            digitTolerance={digitTolerance}
             step={step}
             value={value}
             disabled={disabled}

--- a/src/components/form/range/range.js
+++ b/src/components/form/range/range.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 import { isWithinRange } from '../../../services/number';
 
@@ -49,9 +50,11 @@ export class EuiRange extends Component {
       ...rest
     } = this.props;
 
+    const classes = classNames('euiRange', className);
+
     return (
       <EuiRangeWrapper
-        className="euiRange"
+        className={classes}
         fullWidth={fullWidth}
       >
         {showLabels && <EuiRangeLabel side="min" disabled={disabled}>{min}</EuiRangeLabel>}
@@ -70,7 +73,6 @@ export class EuiRange extends Component {
           <EuiRangeSlider
             id={id}
             name={name}
-            className={className}
             min={min}
             max={max}
             step={step}
@@ -79,6 +81,7 @@ export class EuiRange extends Component {
             onChange={this.handleOnChange}
             style={style}
             showTicks={showTicks}
+            showRange={showRange}
             tabIndex={showInput ? '-1' : (tabIndex || null)}
             {...rest}
           />
@@ -187,6 +190,7 @@ EuiRange.propTypes = {
 EuiRange.defaultProps = {
   min: 1,
   max: 100,
+  step: 1,
   fullWidth: false,
   compressed: false,
   showLabels: false,

--- a/src/components/form/range/range.js
+++ b/src/components/form/range/range.js
@@ -43,6 +43,7 @@ export class EuiRange extends Component {
       showRange,
       showValue,
       valueAppend, // eslint-disable-line no-unused-vars
+      valuePrepend, // eslint-disable-line no-unused-vars
       onChange, // eslint-disable-line no-unused-vars
       value,
       style,
@@ -93,6 +94,8 @@ export class EuiRange extends Component {
               min={min}
               name={name}
               showTicks={showTicks}
+              valuePrepend={valuePrepend}
+              valueAppend={valueAppend}
             />
           )}
 
@@ -134,6 +137,7 @@ EuiRange.propTypes = {
   value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   fullWidth: PropTypes.bool,
   compressed: PropTypes.bool,
+  disabled: PropTypes.bool,
   /**
    * Shows static min/max labels on the sides of the range slider
    */
@@ -182,13 +186,17 @@ EuiRange.propTypes = {
    */
   showValue: PropTypes.bool,
   /**
-   * Shows a tooltip styled value
+   * Appends to the tooltip
    */
   valueAppend: PropTypes.node,
+  /**
+   * Prepends to the tooltip
+   */
+  valuePrepend: PropTypes.node,
 };
 
 EuiRange.defaultProps = {
-  min: 1,
+  min: 0,
   max: 100,
   step: 1,
   fullWidth: false,

--- a/src/components/form/range/range.test.js
+++ b/src/components/form/range/range.test.js
@@ -100,13 +100,13 @@ describe('EuiRange', () => {
         <EuiRange
           levels={[
             {
-              min: 0,
-              max: 600,
+              min: 1,
+              max: 20,
               color: 'danger'
             },
             {
-              min: 600,
-              max: 2000,
+              min: 20,
+              max: 100,
               color: 'success'
             }
           ]}

--- a/src/components/form/range/range.test.js
+++ b/src/components/form/range/range.test.js
@@ -23,6 +23,15 @@ describe('EuiRange', () => {
   });
 
   describe('props', () => {
+    test('disabled should render', () => {
+      const component = render(
+        <EuiRange disabled/>
+      );
+
+      expect(component)
+        .toMatchSnapshot();
+    });
+
     test('fullWidth should render', () => {
       const component = render(
         <EuiRange fullWidth/>
@@ -59,6 +68,21 @@ describe('EuiRange', () => {
         .toMatchSnapshot();
     });
 
+    test('custom ticks should render', () => {
+      const component = render(
+        <EuiRange
+          showTicks
+          ticks={[
+            { label: '20kb', value: 20 },
+            { label: '100kb', value: 100 }
+          ]}
+        />
+      );
+
+      expect(component)
+        .toMatchSnapshot();
+    });
+
     test('range should render', () => {
       const component = render(
         <EuiRange showRange value="8" />
@@ -70,14 +94,19 @@ describe('EuiRange', () => {
 
     test('value should render', () => {
       const component = render(
-        <EuiRange showValue />
+        <EuiRange
+          value="200"
+          showValue
+          valuePrepend="before"
+          valueAppend="after"
+        />
       );
 
       expect(component)
         .toMatchSnapshot();
     });
 
-    test('extra input should render', () => {
+    test('input should render', () => {
       const component = render(
         <EuiRange
           name="name"
@@ -124,6 +153,18 @@ describe('EuiRange', () => {
         value={8}
         onChange={() => {}}
         showValue
+      />
+    );
+
+    expect(component)
+      .toMatchSnapshot();
+  });
+
+  test('allows value prop to accept empty string', () => {
+    const component = render(
+      <EuiRange
+        value={''}
+        onChange={() => {}}
       />
     );
 

--- a/src/components/form/range/range.test.js
+++ b/src/components/form/range/range.test.js
@@ -100,7 +100,7 @@ describe('EuiRange', () => {
         <EuiRange
           levels={[
             {
-              min: 1,
+              min: 0,
               max: 20,
               color: 'danger'
             },

--- a/src/components/form/range/range_input.js
+++ b/src/components/form/range/range_input.js
@@ -21,7 +21,7 @@ export const EuiRangeInput = ({
   // Calculate the width of the input based on highest number of characters.
   // Add 2 to accomodate for input stepper
   const digitTolerance = !!digits ? digits : Math.max(String(min).length, String(max).length);
-  const widthStyle = { width: `${digitTolerance + 2}em` };
+  const widthStyle = { width: `${(digitTolerance / 1.25) + 2}em` };
 
   return (
     <EuiFieldNumber

--- a/src/components/form/range/range_input.js
+++ b/src/components/form/range/range_input.js
@@ -13,15 +13,15 @@ export const EuiRangeInput = ({
   onChange,
   name,
   side,
-  digits,
+  digitTolerance,
   ...rest
 }) => {
 
   // Chrome will properly size the input based on the max value, but FF & IE do not.
   // Calculate the width of the input based on highest number of characters.
   // Add 2 to accomodate for input stepper
-  const digitTolerance = !!digits ? digits : Math.max(String(min).length, String(max).length);
   const widthStyle = { width: `${(digitTolerance / 1.25) + 2}em` };
+  console.log(digitTolerance);
 
   return (
     <EuiFieldNumber
@@ -48,7 +48,7 @@ EuiRangeInput.propTypes = {
   compressed: PropTypes.bool,
   onChange: PropTypes.func,
   name: PropTypes.string,
-  digits: PropTypes.number,
+  digitTolerance: PropTypes.number.isRequired,
   side: PropTypes.oneOf(['min', 'max'])
 };
 EuiRangeInput.defaultProps = {

--- a/src/components/form/range/range_input.js
+++ b/src/components/form/range/range_input.js
@@ -21,7 +21,6 @@ export const EuiRangeInput = ({
   // Calculate the width of the input based on highest number of characters.
   // Add 2 to accomodate for input stepper
   const widthStyle = { width: `${(digitTolerance / 1.25) + 2}em` };
-  console.log(digitTolerance);
 
   return (
     <EuiFieldNumber

--- a/src/components/form/range/range_levels.js
+++ b/src/components/form/range/range_levels.js
@@ -5,12 +5,23 @@ import classNames from 'classnames';
 export const LEVEL_COLORS = ['primary', 'success', 'warning', 'danger'];
 
 export const EuiRangeLevels = ({ levels, max, min, showTicks }) => {
+  const validateLevelIsInRange = (level) => {
+    if (level.min < min) {
+      throw new Error(`The level min of ${level.min} is lower than the min value of ${min}.`);
+    }
+    if (level.max > max) {
+      throw new Error(`The level max of ${level.max} is higher than the max value of ${max}.`);
+    }
+  };
+
   const classes = classNames('euiRangeLevels', {
     'euiRangeLevels--hasTicks': showTicks
   });
+
   return (
     <div className={classes}>
       {levels.map((level, index) => {
+        validateLevelIsInRange(level);
         const range = level.max - level.min;
         const width = (range / (max - min)) * 100;
 

--- a/src/components/form/range/range_levels.js
+++ b/src/components/form/range/range_levels.js
@@ -36,9 +36,9 @@ export const EuiRangeLevels = ({ levels, max, min, showTicks }) => {
 EuiRangeLevels.propTypes = {
   levels: PropTypes.arrayOf(
     PropTypes.shape({
-      min: PropTypes.number,
-      max: PropTypes.number,
-      color: PropTypes.oneOf(LEVEL_COLORS),
+      min: PropTypes.number.isRequired,
+      max: PropTypes.number.isRequired,
+      color: PropTypes.oneOf(LEVEL_COLORS).isRequired,
     }),
   ),
   max: PropTypes.number.isRequired,

--- a/src/components/form/range/range_levels.test.js
+++ b/src/components/form/range/range_levels.test.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render } from 'enzyme';
+import { requiredProps } from '../../../test/required_props';
+
+import { EuiRangeLevels } from './range_levels';
+
+describe('EuiRangeLevels', () => {
+  test('is rendered', () => {
+    const component = render(
+      <EuiRangeLevels
+        min={0}
+        max={100}
+        showTicks
+        levels={[
+          {
+            min: 0,
+            max: 20,
+            color: 'danger'
+          },
+          {
+            min: 20,
+            max: 100,
+            color: 'success'
+          }
+        ]}
+        {...requiredProps}
+      />
+    );
+
+    expect(component)
+      .toMatchSnapshot();
+  });
+
+  test('should throw error if `level.min` is lower than `min`', () => {
+    const component = () => render(
+      <EuiRangeLevels
+        min={0}
+        max={100}
+        levels={[
+          {
+            min: -10,
+            max: 20,
+            color: 'danger'
+          },
+        ]}
+      />
+    );
+
+    expect(component).toThrowErrorMatchingSnapshot();
+  });
+
+  test('should throw error if `level.max` is higher than `max`', () => {
+    const component = () => render(
+      <EuiRangeLevels
+        min={0}
+        max={100}
+        levels={[
+          {
+            min: 20,
+            max: 200,
+            color: 'danger'
+          },
+        ]}
+      />
+    );
+
+    expect(component).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/components/form/range/range_slider.js
+++ b/src/components/form/range/range_slider.js
@@ -15,12 +15,14 @@ export const EuiRangeSlider = React.forwardRef(({
   value,
   style,
   showTicks,
+  showRange,
   hasFocus,
   ...rest
 }, ref) => {
   const classes = classNames('euiRangeSlider', {
     'euiRangeSlider--hasTicks': showTicks,
-    'euiRangeSlider--hasFocus': hasFocus
+    'euiRangeSlider--hasFocus': hasFocus,
+    'euiRangeSlider--hasRange': showRange,
   }, className);
   return (
     <input
@@ -55,5 +57,6 @@ EuiRangeSlider.propTypes = {
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string]))
   ]),
-  hasFocus: PropTypes.bool
+  hasFocus: PropTypes.bool,
+  showRange: PropTypes.bool,
 };

--- a/src/components/form/range/range_ticks.js
+++ b/src/components/form/range/range_ticks.js
@@ -8,20 +8,24 @@ export const EuiRangeTicks = ({
   disabled,
   onChange,
   ticks,
-  tickObject,
+  tickSequence,
   value,
   max,
   min,
+  interval,
 }) => {
+  // Calculate the width of each tick mark
+  const percentageWidth = (interval / ((max - min) + interval)) * 100;
+
   // Align with item labels across the range by adding
   // left and right negative margins that is half of the tick marks
   const ticksStyle = !!ticks
     ? undefined
-    : { margin: `0 ${tickObject.percentageWidth / -2}%`, left: 0, right: 0 };
+    : { margin: `0 ${percentageWidth / -2}%`, left: 0, right: 0 };
 
   return (
     <div className="euiRangeTicks" style={ticksStyle}>
-      {tickObject.sequence.map(tickValue => {
+      {tickSequence.map(tickValue => {
         const tickStyle = {};
         let customTick;
         if (ticks) {
@@ -31,7 +35,7 @@ export const EuiRangeTicks = ({
             tickStyle.left = `${((customTick.value - min) / (max - min)) * 100}%`;
           }
         } else {
-          tickStyle.width = `${tickObject.percentageWidth}%`;
+          tickStyle.width = `${percentageWidth}%`;
         }
 
         const tickClasses = classNames('euiRangeTick', {
@@ -70,10 +74,7 @@ EuiRangeTicks.propTypes = {
       label: PropTypes.node.isRequired,
     })
   ),
-  tickObject: PropTypes.shape({
-    percentageWidth: PropTypes.number,
-    sequence: PropTypes.arrayOf(PropTypes.number),
-  }).isRequired,
+  tickSequence: PropTypes.arrayOf(PropTypes.number).isRequired,
   value: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string,
@@ -83,4 +84,5 @@ EuiRangeTicks.propTypes = {
   ]),
   min: PropTypes.number.isRequired,
   max: PropTypes.number.isRequired,
+  interval: PropTypes.number,
 };

--- a/src/components/form/range/range_ticks.js
+++ b/src/components/form/range/range_ticks.js
@@ -4,35 +4,42 @@ import classNames from 'classnames';
 
 import find from 'lodash/find';
 
-export const EuiRangeTicks = ({ disabled, onChange, ticks, tickObject, value, max }) => {
+export const EuiRangeTicks = ({
+  disabled,
+  onChange,
+  ticks,
+  tickObject,
+  value,
+  max,
+  min,
+}) => {
   // Align with item labels across the range by adding
   // left and right negative margins that is half of the tick marks
-  const ticksStyle = !!ticks ? undefined : { margin: `0 ${tickObject.percentageWidth / -2}%`, left: 0, right: 0 };
+  const ticksStyle = !!ticks
+    ? undefined
+    : { margin: `0 ${tickObject.percentageWidth / -2}%`, left: 0, right: 0 };
 
   return (
     <div className="euiRangeTicks" style={ticksStyle}>
-      {tickObject.sequence.map((tickValue) => {
+      {tickObject.sequence.map(tickValue => {
         const tickStyle = {};
         let customTick;
         if (ticks) {
           customTick = find(ticks, o => o.value === tickValue);
 
-          if (customTick == null) {
-            return;
-          } else {
-            tickStyle.left = `${(customTick.value / max) * 100}%`;
+          if (customTick) {
+            tickStyle.left = `${((customTick.value - min) / (max - min)) * 100}%`;
           }
         } else {
           tickStyle.width = `${tickObject.percentageWidth}%`;
         }
 
-        const tickClasses = classNames(
-          'euiRangeTick',
-          {
-            'euiRangeTick--selected': value === tickValue,
-            'euiRangeTick--isCustom': customTick,
-          }
-        );
+        const tickClasses = classNames('euiRangeTick', {
+          'euiRangeTick--selected': value === tickValue,
+          'euiRangeTick--isCustom': customTick,
+        });
+
+        const label = customTick ? customTick.label : tickValue;
 
         return (
           <button
@@ -43,10 +50,10 @@ export const EuiRangeTicks = ({ disabled, onChange, ticks, tickObject, value, ma
             disabled={disabled}
             onClick={onChange}
             style={tickStyle}
-
             tabIndex="-1"
+            title={label}
           >
-            {customTick ? customTick.label : tickValue}
+            {label}
           </button>
         );
       })}
@@ -61,17 +68,19 @@ EuiRangeTicks.propTypes = {
     PropTypes.shape({
       value: PropTypes.number.isRequired,
       label: PropTypes.node.isRequired,
-    }),
+    })
   ),
   tickObject: PropTypes.shape({
-    decimalWidth: PropTypes.number,
     percentageWidth: PropTypes.number,
     sequence: PropTypes.arrayOf(PropTypes.number),
   }).isRequired,
   value: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string,
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string]))
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+    ),
   ]),
-  max: PropTypes.number.isRequired
+  min: PropTypes.number.isRequired,
+  max: PropTypes.number.isRequired,
 };

--- a/src/components/form/range/range_tooltip.js
+++ b/src/components/form/range/range_tooltip.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-export const EuiRangeTooltip = ({ value, valueAppend, max, min, name, showTicks }) => {
+export const EuiRangeTooltip = ({ value, valueAppend, valuePrepend, max, min, name, showTicks }) => {
   // Calculate the left position based on value
   const decimal = (value - min) / (max - min);
   // Must be between 0-100%
@@ -30,7 +30,7 @@ export const EuiRangeTooltip = ({ value, valueAppend, max, min, name, showTicks 
   return (
     <div className="euiRangeTooltip">
       <output className={valueClasses} htmlFor={name} style={valuePositionStyle}>
-        {value}{valueAppend}
+        {valuePrepend}{value}{valueAppend}
       </output>
     </div>
   );
@@ -38,7 +38,8 @@ export const EuiRangeTooltip = ({ value, valueAppend, max, min, name, showTicks 
 
 EuiRangeTooltip.propTypes = {
   value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  valueAppend: PropTypes.string,
+  valueAppend: PropTypes.node,
+  valuePrepend: PropTypes.node,
   max: PropTypes.number.isRequired,
   min: PropTypes.number.isRequired,
   name: PropTypes.string

--- a/src/components/form/range/range_tooltip.js
+++ b/src/components/form/range/range_tooltip.js
@@ -10,13 +10,14 @@ export const EuiRangeTooltip = ({ value, valueAppend, valuePrepend, max, min, na
   valuePosition = valuePosition >= 0 ? valuePosition : 0;
 
   let valuePositionSide;
+  let valuePositionStyle;
   if (valuePosition > .5) {
     valuePositionSide = 'left';
+    valuePositionStyle = { right: `${(1 - valuePosition) * 100}%` };
   } else {
     valuePositionSide = 'right';
+    valuePositionStyle = { left: `${valuePosition * 100}%` };
   }
-
-  const valuePositionStyle = { left: `${valuePosition * 100}%` };
 
   // Change left/right position based on value (half way point)
   const valueClasses = classNames(

--- a/src/components/form/range/range_track.js
+++ b/src/components/form/range/range_track.js
@@ -11,15 +11,13 @@ export { LEVEL_COLORS };
 
 export class EuiRangeTrack extends Component {
   validateValueIsInStep = (value) => {
-    // Error out if the max value is not included in the sequence
     if (value < this.props.min) {
       throw new Error(`The value of ${value} is lower than the min value of ${this.props.min}.`);
     }
-    // Error out if the max value is not included in the sequence
     if (value > this.props.max) {
       throw new Error(`The value of ${value} is higher than the max value of ${this.props.max}.`);
     }
-    // Error out if the max value is not included in the sequence
+    // Error out if the value doesn't line up with the sequence of steps
     if ((value - this.props.min) % this.props.step > 0) {
       throw new Error(`The value of ${value} is not included in the possible sequence provided by the step of ${this.props.step}.`);
     }
@@ -106,7 +104,7 @@ export class EuiRangeTrack extends Component {
     return (
       <div className={trackClasses} style={inputWrapperStyle}>
         {children}
-        {!!levels.length && (
+        {levels && !!levels.length && (
           <EuiRangeLevels
             levels={levels}
             max={max}

--- a/src/components/form/range/range_track.js
+++ b/src/components/form/range/range_track.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import range from 'lodash/range';
+import find from 'lodash/find';
 
 import { EuiRangeLevels, LEVEL_COLORS } from './range_levels';
 import { EuiRangeTicks } from './range_ticks';
@@ -11,21 +12,57 @@ export { LEVEL_COLORS };
 
 export class EuiRangeTrack extends Component {
 
-  calculateTicksObject = (min, max, interval) => {
-    // Calculate the width of each tick mark
-    const tickWidthDecimal = (interval / ((max - min) + interval));
-    const tickWidthPercentage = tickWidthDecimal * 100;
-
-    // Loop from min to max, creating ticks at each interval
+  calculateSequence = (min, max, interval) => {
+    // Loop from min to max, creating adding values at each interval
     // (adds a very small number to the max since `range` is not inclusive of the max value)
     const toBeInclusive = .000000001;
     const sequence = range(min, max + toBeInclusive, interval);
 
+    // Error out if the max value is not included in the sequence
+    if (!find(sequence, o => o === max)) {
+      console.error(max, sequence);
+      throw new Error(`The max value of ${max} is not included in the possible sequence.`);
+    }
+
+    // If no problems, return the sequence
+    return sequence;
+  }
+
+  calculateTicksObject = (sequence, tickSequence, customTicks) => {
+    let ticks = sequence;
+
+    if (customTicks) {
+      // If custom values were passed, use those for the sequence
+      // But make sure they align with the possible sequence
+      ticks = customTicks.map(o => {
+        if (find(sequence, value => value === o.value) !== undefined) {
+          return o.value;
+        } else {
+          console.error(o.value, sequence);
+          throw new Error(`Custom tick value of ${o.value} does not exist among the possible sequence.`);
+        }
+      });
+    } else if (tickSequence) {
+      // If a custom interval was passed, use those for the sequence
+      // But make sure they align with the possible sequence
+      ticks = tickSequence.map(o => {
+        if (find(sequence, value => value === o) !== undefined) {
+          return o;
+        } else {
+          console.error(o, sequence);
+          throw new Error(`Tick interval value of ${o} does not exist among the possible sequence.`);
+        }
+      });
+    }
+
+    // Error out if there are too many ticks to render
+    if (ticks.length > 20) {
+      throw new Error(`The number of ticks to render is too high (${ticks.length}), reduce the interval.`);
+    }
+
     return (
       {
-        decimalWidth: tickWidthDecimal,
-        percentageWidth: tickWidthPercentage,
-        sequence: sequence,
+        sequence: ticks,
       }
     );
   }
@@ -39,16 +76,25 @@ export class EuiRangeTrack extends Component {
       step,
       showTicks,
       tickInterval,
-      ticks, // eslint-disable-line no-unused-vars
+      ticks,
       levels,
       onChange,
       value
     } = this.props;
 
+    // TODO: Move these to only re-calculate if no-value props have changed
+    const interval = step || 1;
+    const sequence = this.calculateSequence(min, max, interval);
+
     let tickObject;
     const inputWrapperStyle = {};
     if (showTicks) {
-      tickObject = this.calculateTicksObject(min, max, tickInterval || step || 1);
+      const tickSequence = tickInterval ? this.calculateSequence(min, max, tickInterval) : sequence;
+      tickObject = this.calculateTicksObject(sequence, tickSequence, ticks);
+
+      // Calculate the width of each tick mark
+      const calcWidthBy = tickInterval || step;
+      tickObject.percentageWidth = (calcWidthBy / ((max - min) + calcWidthBy)) * 100;
 
       // Calculate if any extra margin should be added to the inputWrapper
       // because of longer tick labels on the ends
@@ -78,13 +124,14 @@ export class EuiRangeTrack extends Component {
             showTicks={showTicks}
           />
         )}
-        {showTicks && (
+        {tickObject && (
           <EuiRangeTicks
             disabled={disabled}
             onChange={onChange}
             ticks={ticks}
             tickObject={tickObject}
             value={value}
+            min={min}
             max={max}
           />
         )}

--- a/src/components/form/range/range_track.js
+++ b/src/components/form/range/range_track.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import range from 'lodash/range';
-import find from 'lodash/find';
 
 import { EuiRangeLevels, LEVEL_COLORS } from './range_levels';
 import { EuiRangeTicks } from './range_ticks';
@@ -11,47 +10,48 @@ import { EuiRangeTicks } from './range_ticks';
 export { LEVEL_COLORS };
 
 export class EuiRangeTrack extends Component {
+  validateValueIsInStep = (value) => {
+    // Error out if the max value is not included in the sequence
+    if (value < this.props.min) {
+      throw new Error(`The value of ${value} is lower than the min value of ${this.props.min}.`);
+    }
+    // Error out if the max value is not included in the sequence
+    if (value > this.props.max) {
+      throw new Error(`The value of ${value} is higher than the max value of ${this.props.max}.`);
+    }
+    // Error out if the max value is not included in the sequence
+    if ((value - this.props.min) % this.props.step > 0) {
+      throw new Error(`The value of ${value} is not included in the possible sequence provided by the step of ${this.props.step}.`);
+    }
+    // Return the value if nothing fails
+    return value;
+  }
+
 
   calculateSequence = (min, max, interval) => {
     // Loop from min to max, creating adding values at each interval
     // (adds a very small number to the max since `range` is not inclusive of the max value)
     const toBeInclusive = .000000001;
-    const sequence = range(min, max + toBeInclusive, interval);
-
-    // Error out if the max value is not included in the sequence
-    if (!find(sequence, o => o === max)) {
-      console.error(max, sequence);
-      throw new Error(`The max value of ${max} is not included in the possible sequence.`);
-    }
-
-    // If no problems, return the sequence
-    return sequence;
+    return range(min, max + toBeInclusive, interval);
   }
 
-  calculateTicksObject = (sequence, tickSequence, customTicks) => {
-    let ticks = sequence;
+  calculateTicks = (min, max, step, tickInterval, customTicks) => {
+    let ticks;
 
     if (customTicks) {
       // If custom values were passed, use those for the sequence
       // But make sure they align with the possible sequence
-      ticks = customTicks.map(o => {
-        if (find(sequence, value => value === o.value) !== undefined) {
-          return o.value;
-        } else {
-          console.error(o.value, sequence);
-          throw new Error(`Custom tick value of ${o.value} does not exist among the possible sequence.`);
-        }
+      ticks = customTicks.map(tick => {
+        return this.validateValueIsInStep(tick.value);
       });
-    } else if (tickSequence) {
+    } else {
       // If a custom interval was passed, use those for the sequence
       // But make sure they align with the possible sequence
-      ticks = tickSequence.map(o => {
-        if (find(sequence, value => value === o) !== undefined) {
-          return o;
-        } else {
-          console.error(o, sequence);
-          throw new Error(`Tick interval value of ${o} does not exist among the possible sequence.`);
-        }
+      const interval = tickInterval || step;
+      const tickSequence = this.calculateSequence(min, max, interval);
+
+      ticks = tickSequence.map(tick => {
+        return this.validateValueIsInStep(tick);
       });
     }
 
@@ -60,11 +60,7 @@ export class EuiRangeTrack extends Component {
       throw new Error(`The number of ticks to render is too high (${ticks.length}), reduce the interval.`);
     }
 
-    return (
-      {
-        sequence: ticks,
-      }
-    );
+    return ticks;
   }
 
   render() {
@@ -83,24 +79,18 @@ export class EuiRangeTrack extends Component {
     } = this.props;
 
     // TODO: Move these to only re-calculate if no-value props have changed
-    const interval = step || 1;
-    const sequence = this.calculateSequence(min, max, interval);
+    this.validateValueIsInStep(max);
 
-    let tickObject;
+    let tickSequence;
     const inputWrapperStyle = {};
     if (showTicks) {
-      const tickSequence = tickInterval ? this.calculateSequence(min, max, tickInterval) : sequence;
-      tickObject = this.calculateTicksObject(sequence, tickSequence, ticks);
-
-      // Calculate the width of each tick mark
-      const calcWidthBy = tickInterval || step;
-      tickObject.percentageWidth = (calcWidthBy / ((max - min) + calcWidthBy)) * 100;
+      tickSequence = this.calculateTicks(min, max, step, tickInterval, ticks);
 
       // Calculate if any extra margin should be added to the inputWrapper
       // because of longer tick labels on the ends
-      const lengthOfMinLabel = String(tickObject.sequence[0]).length;
-      const lenghtOfMaxLabel = String(tickObject.sequence[tickObject.sequence.length - 1]).length;
-      const isLastTickTheMax = tickObject.sequence[tickObject.sequence.length - 1] === max;
+      const lengthOfMinLabel = String(tickSequence[0]).length;
+      const lenghtOfMaxLabel = String(tickSequence[tickSequence.length - 1]).length;
+      const isLastTickTheMax = tickSequence[tickSequence.length - 1] === max;
       if (lengthOfMinLabel > 2) {
         inputWrapperStyle.marginLeft = `${(lengthOfMinLabel / 5)}em`;
       }
@@ -124,15 +114,16 @@ export class EuiRangeTrack extends Component {
             showTicks={showTicks}
           />
         )}
-        {tickObject && (
+        {tickSequence && (
           <EuiRangeTicks
             disabled={disabled}
             onChange={onChange}
             ticks={ticks}
-            tickObject={tickObject}
+            tickSequence={tickSequence}
             value={value}
             min={min}
             max={max}
+            interval={tickInterval || step}
           />
         )}
       </div>

--- a/src/components/form/range/range_track.test.js
+++ b/src/components/form/range/range_track.test.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import { render } from 'enzyme';
+import { requiredProps } from '../../../test/required_props';
+
+import { EuiRangeTrack } from './range_track';
+
+describe('EuiRangeTrack', () => {
+  test('is rendered', () => {
+    const component = render(
+      <EuiRangeTrack
+        min={0}
+        max={100}
+        step={10}
+        showTicks
+        value="10"
+        onChange={() => {}}
+        {...requiredProps}
+      />
+    );
+
+    expect(component)
+      .toMatchSnapshot();
+  });
+
+  test('should throw error if `max` does not line up with `step` interval', () => {
+    const component = () => render(
+      <EuiRangeTrack
+        min={0}
+        max={105}
+        step={10}
+      />
+    );
+
+    expect(component).toThrowErrorMatchingSnapshot();
+  });
+
+  test('should throw error if there are too many ticks to render', () => {
+    const component = () => render(
+      <EuiRangeTrack
+        min={0}
+        max={21}
+        showTicks
+      />
+    );
+
+    expect(component).toThrowErrorMatchingSnapshot();
+  });
+
+  test('should throw error if `tickInterval` is off sequence from `step`', () => {
+    const component = () => render(
+      <EuiRangeTrack
+        min={0}
+        max={100}
+        step={10}
+        showTicks
+        tickInterval={3}
+      />
+    );
+
+    expect(component).toThrowErrorMatchingSnapshot();
+  });
+
+  test('should throw error if custom tick value is lower than `min`', () => {
+    const component = () => render(
+      <EuiRangeTrack
+        min={0}
+        max={100}
+        showTicks
+        ticks={[
+          { label: '-100', value: -100 },
+        ]}
+      />
+    );
+
+    expect(component).toThrowErrorMatchingSnapshot();
+  });
+
+  test('should throw error if custom tick value is higher than `max`', () => {
+    const component = () => render(
+      <EuiRangeTrack
+        min={0}
+        max={100}
+        showTicks
+        ticks={[
+          { label: '200', value: 200 },
+        ]}
+      />
+    );
+
+    expect(component).toThrowErrorMatchingSnapshot();
+  });
+
+  test('should throw error if custom tick value is off sequence from `step`', () => {
+    const component = () => render(
+      <EuiRangeTrack
+        min={0}
+        max={100}
+        step={50}
+        showTicks
+        ticks={[
+          { label: '10', value: 10 },
+        ]}
+      />
+    );
+
+    expect(component).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/components/icon/__snapshots__/icon.test.tsx.snap
+++ b/src/components/icon/__snapshots__/icon.test.tsx.snap
@@ -2594,23 +2594,18 @@ exports[`EuiIcon props type logoAPM is rendered 1`] = `
   width="32"
   xmlns="http://www.w3.org/2000/svg"
 >
-  <g
-    fill="none"
-    fill-rule="evenodd"
-  >
-    <path
-      d="M0 10.001h24V0H0z"
-      fill="#F04E98"
-    />
-    <path
-      d="M32 20H20c-5.522 0-10-4.478-10-10h22v10z"
-      fill="#343741"
-    />
-    <path
-      d="M20 32h12v-9H20z"
-      fill="#0080D5"
-    />
-  </g>
+  <path
+    d="M0 10.001h24V0H0z"
+    fill="#F04E98"
+  />
+  <path
+    class="euiIcon__fillNegative"
+    d="M32 20H20c-5.522 0-10-4.478-10-10h22v10z"
+  />
+  <path
+    d="M20 32h12v-9H20z"
+    fill="#0080D5"
+  />
 </svg>
 `;
 
@@ -2922,23 +2917,18 @@ exports[`EuiIcon props type logoAppSearch is rendered 1`] = `
   width="32"
   xmlns="http://www.w3.org/2000/svg"
 >
-  <g
-    fill="none"
-    fill-rule="evenodd"
-  >
-    <path
-      d="M19.5.938a7.002 7.002 0 0 0-7 0l-8 4.619A7 7 0 0 0 1 11.62v9.237a7 7 0 0 0 3.5 6.062l7.5 4.33V17.979a7 7 0 0 1 3.5-6.062L27 5.276 19.5.939z"
-      fill="#0080D5"
-    />
-    <path
-      d="M19.5.938a7.002 7.002 0 0 0-7 0L5 5.277l11 6.35 11-6.35-7.5-4.34z"
-      fill="#343741"
-    />
-    <path
-      d="M28.435 7.76l-10.026 5.79a6.994 6.994 0 0 1 1.59 4.428v13.27l7.5-4.33a7 7 0 0 0 3.5-6.061v-9.238a6.992 6.992 0 0 0-1.586-4.422l-.978.564z"
-      fill="#FA744E"
-    />
-  </g>
+  <path
+    d="M19.5.938a7.002 7.002 0 0 0-7 0l-8 4.619A7 7 0 0 0 1 11.62v9.237a7 7 0 0 0 3.5 6.062l7.5 4.33V17.979a7 7 0 0 1 3.5-6.062L27 5.276 19.5.939z"
+    fill="#0080D5"
+  />
+  <path
+    class="euiIcon__fillNegative"
+    d="M19.5.938a7.002 7.002 0 0 0-7 0L5 5.277l11 6.35 11-6.35-7.5-4.34z"
+  />
+  <path
+    d="M28.435 7.76l-10.026 5.79a6.994 6.994 0 0 1 1.59 4.428v13.27l7.5-4.33a7 7 0 0 0 3.5-6.061v-9.238a6.992 6.992 0 0 0-1.586-4.422l-.978.564z"
+    fill="#FA744E"
+  />
 </svg>
 `;
 
@@ -2951,23 +2941,18 @@ exports[`EuiIcon props type logoBeats is rendered 1`] = `
   width="32"
   xmlns="http://www.w3.org/2000/svg"
 >
-  <g
-    fill="none"
-    fill-rule="evenodd"
-  >
-    <path
-      d="M15 20H4V0h11c5.522 0 10 4.478 10 10s-4.478 10-10 10"
-      fill="#0080D5"
-    />
-    <path
-      d="M26.702 15.624C24.6 19.979 20.152 23 15 23H4v9h15c5.522 0 10-4.478 10-10a9.952 9.952 0 0 0-2.298-6.376"
-      fill="#00C2B3"
-    />
-    <path
-      d="M24.338 13.554A9.942 9.942 0 0 0 19 12H4v8h11c4.27 0 7.903-2.68 9.338-6.446"
-      fill="#343741"
-    />
-  </g>
+  <path
+    d="M15 20H4V0h11c5.522 0 10 4.478 10 10s-4.478 10-10 10"
+    fill="#0080D5"
+  />
+  <path
+    d="M26.702 15.624C24.6 19.979 20.152 23 15 23H4v9h15c5.522 0 10-4.478 10-10a9.952 9.952 0 0 0-2.298-6.376"
+    fill="#00C2B3"
+  />
+  <path
+    class="euiIcon__fillNegative"
+    d="M24.338 13.554A9.942 9.942 0 0 0 19 12H4v8h11c4.27 0 7.903-2.68 9.338-6.446"
+  />
 </svg>
 `;
 
@@ -2989,8 +2974,8 @@ exports[`EuiIcon props type logoBusinessAnalytics is rendered 1`] = `
       fill="#00BFB3"
     />
     <path
+      class="euiIcon__fillNegative"
       d="M10 12v10h10c0-5.522-4.478-10-10-10"
-      fill="#343741"
     />
     <path
       d="M10 0v9c7.168 0 13 5.832 13 13h9C32 9.85 22.15 0 10 0"
@@ -3034,8 +3019,8 @@ exports[`EuiIcon props type logoCloud is rendered 1`] = `
     fill-rule="evenodd"
   >
     <path
+      class="euiIcon__fillNegative"
       d="M12.37 18.352c.032-.01.066-.014.1-.023A6 6 0 0 1 18 10V0C9.163 0 2 7.164 2 16c0 2.793.72 5.417 1.976 7.702a18.947 18.947 0 0 1 8.393-5.349"
-      fill="#343741"
     />
     <path
       d="M18 0A15.959 15.959 0 0 0 5.717 5.75a16.006 16.006 0 0 0 7.541 5.032c.71.22 1.477.135 2.146-.188A5.94 5.94 0 0 1 18 10a5.94 5.94 0 0 1 2.596.594c.669.323 1.436.408 2.146.188a16.01 16.01 0 0 0 7.541-5.032A15.959 15.959 0 0 0 18 0"
@@ -3063,8 +3048,8 @@ exports[`EuiIcon props type logoCloudEnterprise is rendered 1`] = `
     fill-rule="evenodd"
   >
     <path
+      class="euiIcon__fillNegative"
       d="M11.37 18.352c.032-.01.066-.014.1-.023A6 6 0 0 1 17 10V0C8.163 0 1 7.164 1 16c0 2.793.72 5.417 1.976 7.702a18.947 18.947 0 0 1 8.393-5.349"
-      fill="#343741"
     />
     <path
       d="M17 0A15.959 15.959 0 0 0 4.717 5.75a16.006 16.006 0 0 0 7.541 5.032c.71.22 1.477.135 2.146-.188A5.94 5.94 0 0 1 17 10a5.94 5.94 0 0 1 2.596.594c.669.323 1.436.408 2.146.188a16.01 16.01 0 0 0 7.541-5.032A15.959 15.959 0 0 0 17 0"
@@ -3075,8 +3060,8 @@ exports[`EuiIcon props type logoCloudEnterprise is rendered 1`] = `
       fill="#00AEFA"
     />
     <path
+      class="euiIcon__fillNegative"
       d="M20 16a3 3 0 1 1-6 0 3 3 0 0 1 6 0"
-      fill="#343741"
     />
   </g>
 </svg>
@@ -3237,8 +3222,8 @@ exports[`EuiIcon props type logoElasticsearch is rendered 1`] = `
     fill-rule="evenodd"
   >
     <path
+      class="euiIcon__fillNegative"
       d="M2 16c0 1.384.194 2.72.524 4H22a4 4 0 0 0 0-8H2.524A15.984 15.984 0 0 0 2 16"
-      fill="#343741"
     />
     <path
       d="M28.924 7.662A15.381 15.381 0 0 0 30.48 6C27.547 2.346 23.05 0 18 0 11.679 0 6.239 3.678 3.644 9H25.51a5.039 5.039 0 0 0 3.413-1.338"
@@ -3274,8 +3259,8 @@ exports[`EuiIcon props type logoEnterpriseSearch is rendered 1`] = `
       fill="#FEC514"
     />
     <path
+      class="euiIcon__fillNegative"
       d="M16 8h-2.152A15.877 15.877 0 0 1 16 16c0 2.918-.786 5.647-2.152 8H16a8 8 0 0 0 0-16"
-      fill="#343741"
     />
   </g>
 </svg>
@@ -3692,8 +3677,8 @@ exports[`EuiIcon props type logoKibana is rendered 1`] = `
       fill="#F04E98"
     />
     <path
+      class="euiIcon__fillNegative"
       d="M4 12v16.789l11.906-13.738A24.721 24.721 0 0 0 4 12"
-      fill="#343741"
     />
     <path
       d="M18.479 16.664L6.268 30.754l-1.073 1.237h23.191c-1.252-6.292-4.883-11.719-9.908-15.327"
@@ -3727,26 +3712,18 @@ exports[`EuiIcon props type logoLogstash is rendered 1`] = `
   width="32"
   xmlns="http://www.w3.org/2000/svg"
 >
-  <g
-    fill="none"
-  >
-    <path
-      d="M6.966.412h-4.67v17.126h14.012V9.754A9.55 9.55 0 0 0 6.966.412z"
-      fill="#FDD10D"
-    />
-    <path
-      d="M2.295 19.49c0 6.768 7.231 12.067 14.013 12.067V17.538H2.295v1.951z"
-      fill="#231F20"
-    />
-    <path
-      d="M19.422 17.538h9.342V31.55h-9.342z"
-      fill="#20BBB1"
-    />
-    <path
-      d="M16.308 17.538h3.114V31.55h-3.114z"
-      fill="#009B90"
-    />
-  </g>
+  <path
+    d="M19 32h11V20H19z"
+    fill="#3EBEB0"
+  />
+  <path
+    d="M4 0H3v20h13v-8C16 5.373 10.627 0 4 0"
+    fill="#FEC514"
+  />
+  <path
+    class="euiIcon__fillNegative"
+    d="M3 20c0 6.627 5.373 12 12 12h1V20H3z"
+  />
 </svg>
 `;
 
@@ -3878,8 +3855,8 @@ exports[`EuiIcon props type logoMetrics is rendered 1`] = `
       fill="#F04E98"
     />
     <path
+      class="euiIcon__fillNegative"
       d="M16.465 13.535l-3.536 3.536a9.965 9.965 0 0 0 7.07 2.93 9.965 9.965 0 0 0 7.072-2.93l-3.536-3.536a5 5 0 0 0-7.07 0"
-      fill="#343741"
     />
     <path
       d="M14.343 11.414A7.951 7.951 0 0 1 20 9.071c2.137 0 4.146.832 5.657 2.343l3.207 3.207A9.955 9.955 0 0 0 30 10.001c0-5.524-4.477-10-10-10-5.522 0-10 4.476-10 10 0 1.667.414 3.237 1.137 4.62l3.206-3.207z"
@@ -4304,8 +4281,8 @@ exports[`EuiIcon props type logoSiteSearch is rendered 1`] = `
       fill="#00BFB3"
     />
     <path
+      class="euiIcon__fillNegative"
       d="M2.533 10L.428 14.211C-.903 16.871 1.032 20 4.005 20h7.35l5-10H2.533z"
-      fill="#343741"
     />
   </g>
 </svg>
@@ -4441,8 +4418,8 @@ exports[`EuiIcon props type logoXpack is rendered 1`] = `
       fill="#17A8E0"
     />
     <path
+      class="euiIcon__fillNegative"
       d="M21.143 15.691a8.823 8.823 0 0 0-12.474 0l-1.04 1.04L14.909 24l7.28-7.269-1.046-1.04z"
-      fill="#353535"
     />
     <path
       d="M28.429 22.966l-4.16-4.16-7.28 7.28 4.154 4.16a4.411 4.411 0 0 0 6.24 0l1.04-1.04a4.411 4.411 0 0 0 .006-6.24z"

--- a/src/components/icon/__snapshots__/icon.test.tsx.snap
+++ b/src/components/icon/__snapshots__/icon.test.tsx.snap
@@ -2594,18 +2594,23 @@ exports[`EuiIcon props type logoAPM is rendered 1`] = `
   width="32"
   xmlns="http://www.w3.org/2000/svg"
 >
-  <path
-    d="M0 10.001h24V0H0z"
-    fill="#F04E98"
-  />
-  <path
-    class="euiIcon__fillNegative"
-    d="M32 20H20c-5.522 0-10-4.478-10-10h22v10z"
-  />
-  <path
-    d="M20 32h12v-9H20z"
-    fill="#0080D5"
-  />
+  <g
+    fill="none"
+    fill-rule="evenodd"
+  >
+    <path
+      d="M0 10.001h24V0H0z"
+      fill="#F04E98"
+    />
+    <path
+      d="M32 20H20c-5.522 0-10-4.478-10-10h22v10z"
+      fill="#343741"
+    />
+    <path
+      d="M20 32h12v-9H20z"
+      fill="#0080D5"
+    />
+  </g>
 </svg>
 `;
 
@@ -2917,18 +2922,23 @@ exports[`EuiIcon props type logoAppSearch is rendered 1`] = `
   width="32"
   xmlns="http://www.w3.org/2000/svg"
 >
-  <path
-    d="M19.5.938a7.002 7.002 0 0 0-7 0l-8 4.619A7 7 0 0 0 1 11.62v9.237a7 7 0 0 0 3.5 6.062l7.5 4.33V17.979a7 7 0 0 1 3.5-6.062L27 5.276 19.5.939z"
-    fill="#0080D5"
-  />
-  <path
-    class="euiIcon__fillNegative"
-    d="M19.5.938a7.002 7.002 0 0 0-7 0L5 5.277l11 6.35 11-6.35-7.5-4.34z"
-  />
-  <path
-    d="M28.435 7.76l-10.026 5.79a6.994 6.994 0 0 1 1.59 4.428v13.27l7.5-4.33a7 7 0 0 0 3.5-6.061v-9.238a6.992 6.992 0 0 0-1.586-4.422l-.978.564z"
-    fill="#FA744E"
-  />
+  <g
+    fill="none"
+    fill-rule="evenodd"
+  >
+    <path
+      d="M19.5.938a7.002 7.002 0 0 0-7 0l-8 4.619A7 7 0 0 0 1 11.62v9.237a7 7 0 0 0 3.5 6.062l7.5 4.33V17.979a7 7 0 0 1 3.5-6.062L27 5.276 19.5.939z"
+      fill="#0080D5"
+    />
+    <path
+      d="M19.5.938a7.002 7.002 0 0 0-7 0L5 5.277l11 6.35 11-6.35-7.5-4.34z"
+      fill="#343741"
+    />
+    <path
+      d="M28.435 7.76l-10.026 5.79a6.994 6.994 0 0 1 1.59 4.428v13.27l7.5-4.33a7 7 0 0 0 3.5-6.061v-9.238a6.992 6.992 0 0 0-1.586-4.422l-.978.564z"
+      fill="#FA744E"
+    />
+  </g>
 </svg>
 `;
 
@@ -2941,18 +2951,23 @@ exports[`EuiIcon props type logoBeats is rendered 1`] = `
   width="32"
   xmlns="http://www.w3.org/2000/svg"
 >
-  <path
-    d="M15 20H4V0h11c5.522 0 10 4.478 10 10s-4.478 10-10 10"
-    fill="#0080D5"
-  />
-  <path
-    d="M26.702 15.624C24.6 19.979 20.152 23 15 23H4v9h15c5.522 0 10-4.478 10-10a9.952 9.952 0 0 0-2.298-6.376"
-    fill="#00C2B3"
-  />
-  <path
-    class="euiIcon__fillNegative"
-    d="M24.338 13.554A9.942 9.942 0 0 0 19 12H4v8h11c4.27 0 7.903-2.68 9.338-6.446"
-  />
+  <g
+    fill="none"
+    fill-rule="evenodd"
+  >
+    <path
+      d="M15 20H4V0h11c5.522 0 10 4.478 10 10s-4.478 10-10 10"
+      fill="#0080D5"
+    />
+    <path
+      d="M26.702 15.624C24.6 19.979 20.152 23 15 23H4v9h15c5.522 0 10-4.478 10-10a9.952 9.952 0 0 0-2.298-6.376"
+      fill="#00C2B3"
+    />
+    <path
+      d="M24.338 13.554A9.942 9.942 0 0 0 19 12H4v8h11c4.27 0 7.903-2.68 9.338-6.446"
+      fill="#343741"
+    />
+  </g>
 </svg>
 `;
 
@@ -2974,8 +2989,8 @@ exports[`EuiIcon props type logoBusinessAnalytics is rendered 1`] = `
       fill="#00BFB3"
     />
     <path
-      class="euiIcon__fillNegative"
       d="M10 12v10h10c0-5.522-4.478-10-10-10"
+      fill="#343741"
     />
     <path
       d="M10 0v9c7.168 0 13 5.832 13 13h9C32 9.85 22.15 0 10 0"
@@ -3019,8 +3034,8 @@ exports[`EuiIcon props type logoCloud is rendered 1`] = `
     fill-rule="evenodd"
   >
     <path
-      class="euiIcon__fillNegative"
       d="M12.37 18.352c.032-.01.066-.014.1-.023A6 6 0 0 1 18 10V0C9.163 0 2 7.164 2 16c0 2.793.72 5.417 1.976 7.702a18.947 18.947 0 0 1 8.393-5.349"
+      fill="#343741"
     />
     <path
       d="M18 0A15.959 15.959 0 0 0 5.717 5.75a16.006 16.006 0 0 0 7.541 5.032c.71.22 1.477.135 2.146-.188A5.94 5.94 0 0 1 18 10a5.94 5.94 0 0 1 2.596.594c.669.323 1.436.408 2.146.188a16.01 16.01 0 0 0 7.541-5.032A15.959 15.959 0 0 0 18 0"
@@ -3048,8 +3063,8 @@ exports[`EuiIcon props type logoCloudEnterprise is rendered 1`] = `
     fill-rule="evenodd"
   >
     <path
-      class="euiIcon__fillNegative"
       d="M11.37 18.352c.032-.01.066-.014.1-.023A6 6 0 0 1 17 10V0C8.163 0 1 7.164 1 16c0 2.793.72 5.417 1.976 7.702a18.947 18.947 0 0 1 8.393-5.349"
+      fill="#343741"
     />
     <path
       d="M17 0A15.959 15.959 0 0 0 4.717 5.75a16.006 16.006 0 0 0 7.541 5.032c.71.22 1.477.135 2.146-.188A5.94 5.94 0 0 1 17 10a5.94 5.94 0 0 1 2.596.594c.669.323 1.436.408 2.146.188a16.01 16.01 0 0 0 7.541-5.032A15.959 15.959 0 0 0 17 0"
@@ -3060,8 +3075,8 @@ exports[`EuiIcon props type logoCloudEnterprise is rendered 1`] = `
       fill="#00AEFA"
     />
     <path
-      class="euiIcon__fillNegative"
       d="M20 16a3 3 0 1 1-6 0 3 3 0 0 1 6 0"
+      fill="#343741"
     />
   </g>
 </svg>
@@ -3222,8 +3237,8 @@ exports[`EuiIcon props type logoElasticsearch is rendered 1`] = `
     fill-rule="evenodd"
   >
     <path
-      class="euiIcon__fillNegative"
       d="M2 16c0 1.384.194 2.72.524 4H22a4 4 0 0 0 0-8H2.524A15.984 15.984 0 0 0 2 16"
+      fill="#343741"
     />
     <path
       d="M28.924 7.662A15.381 15.381 0 0 0 30.48 6C27.547 2.346 23.05 0 18 0 11.679 0 6.239 3.678 3.644 9H25.51a5.039 5.039 0 0 0 3.413-1.338"
@@ -3259,8 +3274,8 @@ exports[`EuiIcon props type logoEnterpriseSearch is rendered 1`] = `
       fill="#FEC514"
     />
     <path
-      class="euiIcon__fillNegative"
       d="M16 8h-2.152A15.877 15.877 0 0 1 16 16c0 2.918-.786 5.647-2.152 8H16a8 8 0 0 0 0-16"
+      fill="#343741"
     />
   </g>
 </svg>
@@ -3677,8 +3692,8 @@ exports[`EuiIcon props type logoKibana is rendered 1`] = `
       fill="#F04E98"
     />
     <path
-      class="euiIcon__fillNegative"
       d="M4 12v16.789l11.906-13.738A24.721 24.721 0 0 0 4 12"
+      fill="#343741"
     />
     <path
       d="M18.479 16.664L6.268 30.754l-1.073 1.237h23.191c-1.252-6.292-4.883-11.719-9.908-15.327"
@@ -3712,18 +3727,26 @@ exports[`EuiIcon props type logoLogstash is rendered 1`] = `
   width="32"
   xmlns="http://www.w3.org/2000/svg"
 >
-  <path
-    d="M19 32h11V20H19z"
-    fill="#3EBEB0"
-  />
-  <path
-    d="M4 0H3v20h13v-8C16 5.373 10.627 0 4 0"
-    fill="#FEC514"
-  />
-  <path
-    class="euiIcon__fillNegative"
-    d="M3 20c0 6.627 5.373 12 12 12h1V20H3z"
-  />
+  <g
+    fill="none"
+  >
+    <path
+      d="M6.966.412h-4.67v17.126h14.012V9.754A9.55 9.55 0 0 0 6.966.412z"
+      fill="#FDD10D"
+    />
+    <path
+      d="M2.295 19.49c0 6.768 7.231 12.067 14.013 12.067V17.538H2.295v1.951z"
+      fill="#231F20"
+    />
+    <path
+      d="M19.422 17.538h9.342V31.55h-9.342z"
+      fill="#20BBB1"
+    />
+    <path
+      d="M16.308 17.538h3.114V31.55h-3.114z"
+      fill="#009B90"
+    />
+  </g>
 </svg>
 `;
 
@@ -3855,8 +3878,8 @@ exports[`EuiIcon props type logoMetrics is rendered 1`] = `
       fill="#F04E98"
     />
     <path
-      class="euiIcon__fillNegative"
       d="M16.465 13.535l-3.536 3.536a9.965 9.965 0 0 0 7.07 2.93 9.965 9.965 0 0 0 7.072-2.93l-3.536-3.536a5 5 0 0 0-7.07 0"
+      fill="#343741"
     />
     <path
       d="M14.343 11.414A7.951 7.951 0 0 1 20 9.071c2.137 0 4.146.832 5.657 2.343l3.207 3.207A9.955 9.955 0 0 0 30 10.001c0-5.524-4.477-10-10-10-5.522 0-10 4.476-10 10 0 1.667.414 3.237 1.137 4.62l3.206-3.207z"
@@ -4281,8 +4304,8 @@ exports[`EuiIcon props type logoSiteSearch is rendered 1`] = `
       fill="#00BFB3"
     />
     <path
-      class="euiIcon__fillNegative"
       d="M2.533 10L.428 14.211C-.903 16.871 1.032 20 4.005 20h7.35l5-10H2.533z"
+      fill="#343741"
     />
   </g>
 </svg>
@@ -4418,8 +4441,8 @@ exports[`EuiIcon props type logoXpack is rendered 1`] = `
       fill="#17A8E0"
     />
     <path
-      class="euiIcon__fillNegative"
       d="M21.143 15.691a8.823 8.823 0 0 0-12.474 0l-1.04 1.04L14.909 24l7.28-7.269-1.046-1.04z"
+      fill="#353535"
     />
     <path
       d="M28.429 22.966l-4.16-4.16-7.28 7.28 4.154 4.16a4.411 4.411 0 0 0 6.24 0l1.04-1.04a4.411 4.411 0 0 0 .006-6.24z"

--- a/src/components/loading/__snapshots__/loading_kibana.test.js.snap
+++ b/src/components/loading/__snapshots__/loading_kibana.test.js.snap
@@ -26,8 +26,8 @@ exports[`EuiLoadingKibana is rendered 1`] = `
           fill="#F04E98"
         />
         <path
-          class="euiIcon__fillNegative"
           d="M4 12v16.789l11.906-13.738A24.721 24.721 0 0 0 4 12"
+          fill="#343741"
         />
         <path
           d="M18.479 16.664L6.268 30.754l-1.073 1.237h23.191c-1.252-6.292-4.883-11.719-9.908-15.327"

--- a/src/components/loading/__snapshots__/loading_kibana.test.js.snap
+++ b/src/components/loading/__snapshots__/loading_kibana.test.js.snap
@@ -26,8 +26,8 @@ exports[`EuiLoadingKibana is rendered 1`] = `
           fill="#F04E98"
         />
         <path
+          class="euiIcon__fillNegative"
           d="M4 12v16.789l11.906-13.738A24.721 24.721 0 0 0 4 12"
-          fill="#343741"
         />
         <path
           d="M18.479 16.664L6.268 30.754l-1.073 1.237h23.191c-1.252-6.292-4.883-11.719-9.908-15.327"


### PR DESCRIPTION
## Bug fixing
- Gave the inputs a min-width in case of single digits. And remove shifting of inputs because they then don’t line up with other form rows
- Custom tick values now properly account for minimum value
- Fix styling of track color when not showing the range
- Top level `className` now applied to the top level wrapper
- Fixed prepend/append of value
- Moved dual range handles to min **and max** positions if the values are empty
- Dual range inputs account for both min and max for sizing

## Added validations

The [EuiRangeTrack](https://github.com/elastic/eui/compare/master...cchaos:dual-range-css-fixes?expand=1#diff-ba1a2287cccb3dc491b2faa5ad592ffe) and [EuiRangeLevels](https://github.com/elastic/eui/compare/master...cchaos:dual-range-css-fixes?expand=1#diff-c3982e95736ab0d1909eff527618ee6b) now handle some errors of invalid steps/ticks.

## Split up the docs page into more sections

<img width="198" alt="screen shot 2019-02-20 at 14 33 08 pm" src="https://user-images.githubusercontent.com/549577/53118998-75030780-351c-11e9-80cd-31db8f4b6d0c.png">

## Todo:

- [x] Fix some state coloring of the dual range

@thompsongl I could use your help on the following

- [x] Fix starting click on dual range if the value is `['', '']`
<img src="https://d.pr/free/i/Pt4LHs+" width="50%" />

- [x] Fix dragging of handles on dual range where it doesn't seem to allow clicking on a different handle
<img src="https://d.pr/free/i/YSeabS+" width="50%" />

- [x] Value tooltip gets narrow towards max value
<img width="445" alt="screen shot 2019-02-20 at 14 15 30 pm" src="https://user-images.githubusercontent.com/549577/53119354-446f9d80-351d-11e9-983d-d1ae46fd122b.png">




### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
- [x] Any props added have proper autodocs
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios
- ~[ ] This was checked against keyboard-only and screenreader scenarios~ Crossing this one off because it's a bit out of scope for this PR. There is basic keyboard-only interactions though they could probably be enhanced.
- ~[ ] This required updates to Framer X components~
