### PR TITLE
Align Filter and Facet button styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `8.0.0`.
+- Added `displayOnly` prop to `EuiFormRow` ([#1582](https://github.com/elastic/eui/pull/1582))
+- Added `numActiveFilters` prop to `EuiFilterButton` ([#1589](https://github.com/elastic/eui/pull/1589))
+- Updated style of `EuiFilterButton` to match `EuiFacetButton` ([#1589](https://github.com/elastic/eui/pull/1589))
+- Added `size` and `color` props to `EuiNotificationBadge` ([#1589](https://github.com/elastic/eui/pull/1589))
 
 ## [`8.0.0`](https://github.com/elastic/eui/tree/v8.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,26 @@ No public interface changes since `8.0.0`.
 
 - Made `or` a reserved keyword in `EuiQuery`'s syntax ([#1204](https://github.com/elastic/eui/pull/1204))
 
+## [`6.10.4`](https://github.com/elastic/eui/tree/v6.10.4)
+
+**Note: this release is a backport containing changes originally made in `7.3.0`**
+
+- Added an index.d.ts file for the date picker components, including `EuiDatePicker`, `EuiDatePickerRange`, and `EuiSuperDatePicker` ([#1574](https://github.com/elastic/eui/pull/1574))
+
+## [`6.10.3`](https://github.com/elastic/eui/tree/v6.10.3)
+
+**Note: this release is a backport containing changes originally made in `7.1.0`**
+
+- Added `append` prop to `EuiFieldText` ([#1567](https://github.com/elastic/eui/pull/1567))
+
+## [`6.10.2`](https://github.com/elastic/eui/tree/v6.10.2)
+
+**Note: this release is a backport containing changes originally made in `7.1.0`**
+
+- Adjusted set of Elastic Logos in `EuiIcon` to look better in dark mode. ([#1562](https://github.com/elastic/eui/pull/1562))
+- Expanded `getSecureRelForTarget` to handle elastic.co domains as a referrer whitelist ([#1565](https://github.com/elastic/eui/pull/1565))
+- New `url` utility for verifying if a URL is a referrer whitelist ([#1565](https://github.com/elastic/eui/pull/1565))
+
 ## [`6.10.1`](https://github.com/elastic/eui/tree/v6.10.1)
 
 **Note: this release is a backport containing changes originally made in `7.0.0`**

--- a/src-docs/src/views/facet/facet_example.js
+++ b/src-docs/src/views/facet/facet_example.js
@@ -69,6 +69,9 @@ export const FacetExample = {
       ),
       props: { EuiFacetGroup },
       demo: <FacetLayout />,
+      snippet: `<EuiFacetGroup style={{ maxWidth: 200 }}>{facets}</EuiFacetGroup>
+
+<EuiFacetGroup layout="horizontal">{facets}</EuiFacetGroup>`,
     },
   ],
 };

--- a/src-docs/src/views/facet/facet_example.js
+++ b/src-docs/src/views/facet/facet_example.js
@@ -69,8 +69,10 @@ export const FacetExample = {
       ),
       props: { EuiFacetGroup },
       demo: <FacetLayout />,
-      snippet: `<EuiFacetGroup style={{ maxWidth: 200 }}>{facets}</EuiFacetGroup>
+      snippet: `// Restrict the width of default (vertical) if not restricted by parent
+<EuiFacetGroup style={{ maxWidth: 200 }}>{facets}</EuiFacetGroup>
 
+// Horizontal
 <EuiFacetGroup layout="horizontal">{facets}</EuiFacetGroup>`,
     },
   ],

--- a/src-docs/src/views/facet/facet_example.js
+++ b/src-docs/src/views/facet/facet_example.js
@@ -69,9 +69,6 @@ export const FacetExample = {
       ),
       props: { EuiFacetGroup },
       demo: <FacetLayout />,
-      snippet: `<EuiFacetGroup style={{ maxWidth: 200 }}>{facets}</EuiFacetGroup>
-
-<EuiFacetGroup layout="horizontal">{facets}</EuiFacetGroup>`,
     },
   ],
 };

--- a/src-docs/src/views/filter_group/filter_group.js
+++ b/src-docs/src/views/filter_group/filter_group.js
@@ -88,8 +88,9 @@ export default class extends Component {
         iconType="arrowDown"
         onClick={this.onButtonClick.bind(this)}
         isSelected={this.state.isPopoverOpen}
+        numFilters={items.length}
         hasActiveFilters={true}
-        numFilters={2}
+        numActiveFilters={2}
         grow={true}
       >
         Composers

--- a/src-docs/src/views/filter_group/filter_group_example.js
+++ b/src-docs/src/views/filter_group/filter_group_example.js
@@ -1,9 +1,5 @@
 import React, { Fragment } from 'react';
 
-import {
-  Link,
-} from 'react-router';
-
 import { renderToHtml } from '../../services';
 
 import {
@@ -35,7 +31,7 @@ export const FilterGroupExample = {
           This documents a visual pattern used for filtering (usually page heads next to search).
           The individual components themselves are very simple
           and do not have much functionality on their own. If you are looking for expanded usage
-          examples please check out the <Link to="/forms/search-bar">Search Bar</Link> component which uses this more fully and
+          examples please check out the Table of Records component which uses this more fully and
           can give you a better example of its usage when applied to filtering.
         </p>
       </EuiCallOut>

--- a/src-docs/src/views/filter_group/filter_group_example.js
+++ b/src-docs/src/views/filter_group/filter_group_example.js
@@ -1,5 +1,9 @@
 import React, { Fragment } from 'react';
 
+import {
+  Link,
+} from 'react-router';
+
 import { renderToHtml } from '../../services';
 
 import {
@@ -31,7 +35,7 @@ export const FilterGroupExample = {
           This documents a visual pattern used for filtering (usually page heads next to search).
           The individual components themselves are very simple
           and do not have much functionality on their own. If you are looking for expanded usage
-          examples please check out the Table of Records component which uses this more fully and
+          examples please check out the <Link to="/forms/search-bar">Search Bar</Link> component which uses this more fully and
           can give you a better example of its usage when applied to filtering.
         </p>
       </EuiCallOut>

--- a/src/components/avatar/_avatar.scss
+++ b/src/components/avatar/_avatar.scss
@@ -1,10 +1,11 @@
 .euiAvatar {
+  flex-shrink: 0; // Ensures it never scales down below it's intended size
   display: inline-block;
   background-size: cover;
   text-align: center;
   vertical-align: middle;
   overflow-x: hidden;
-  font-weight: $euiFontWeightRegular; // Explicitly state so it doesn't get overridden by inheritence
+  font-weight: $euiFontWeightMedium; // Explicitly state so it doesn't get overridden by inheritence
 }
 
 .euiAvatar--user {
@@ -21,7 +22,7 @@
 $avatarSizing: (
   s: (
     size: $euiSizeL,
-    font-size: $euiSizeM*.9
+    font-size: $euiSizeM
   ),
   m: (
     size: $euiSizeXL,

--- a/src/components/badge/notification_badge/__snapshots__/badge_notification.test.tsx.snap
+++ b/src/components/badge/notification_badge/__snapshots__/badge_notification.test.tsx.snap
@@ -5,5 +5,39 @@ exports[`EuiNotificationBadge is rendered 1`] = `
   aria-label="aria-label"
   class="euiNotificationBadge testClass1 testClass2"
   data-test-subj="test subject string"
-/>
+>
+  5
+</span>
+`;
+
+exports[`EuiNotificationBadge props color accent is rendered 1`] = `
+<span
+  class="euiNotificationBadge"
+>
+  5
+</span>
+`;
+
+exports[`EuiNotificationBadge props color subdued is rendered 1`] = `
+<span
+  class="euiNotificationBadge euiNotificationBadge--subdued"
+>
+  5
+</span>
+`;
+
+exports[`EuiNotificationBadge props size m is rendered 1`] = `
+<span
+  class="euiNotificationBadge euiNotificationBadge--medium"
+>
+  5
+</span>
+`;
+
+exports[`EuiNotificationBadge props size s is rendered 1`] = `
+<span
+  class="euiNotificationBadge"
+>
+  5
+</span>
 `;

--- a/src/components/badge/notification_badge/_notification_badge.scss
+++ b/src/components/badge/notification_badge/_notification_badge.scss
@@ -1,4 +1,5 @@
 .euiNotificationBadge {
+  flex-shrink: 0; // Ensures it never scales down below it's intended size
   display: inline-block;
   border-radius: $euiBorderRadius;
   background: $euiColorAccent;
@@ -12,4 +13,18 @@
   padding-right: $euiSizeXS;
   vertical-align: middle;
   text-align: center;
+  transition: all $euiAnimSpeedFast ease-in;
+}
+
+.euiNotificationBadge--medium {
+  // Increase the default size a bit
+  $size: $euiSize + $euiSizeXS;
+  line-height: $size;
+  height: $size;
+  min-width: $euiSizeL;
+}
+
+.euiNotificationBadge--subdued {
+  background-color: tint($euiColorLightShade, 30%);
+  color: $euiColorFullShade;
 }

--- a/src/components/badge/notification_badge/badge_notification.test.tsx
+++ b/src/components/badge/notification_badge/badge_notification.test.tsx
@@ -2,12 +2,40 @@ import React from 'react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
 
-import { EuiNotificationBadge } from './badge_notification';
+import { EuiNotificationBadge, COLORS, SIZES } from './badge_notification';
 
 describe('EuiNotificationBadge', () => {
   test('is rendered', () => {
-    const component = render(<EuiNotificationBadge {...requiredProps} />);
+    const component = render(
+      <EuiNotificationBadge {...requiredProps}>5</EuiNotificationBadge>
+    );
 
     expect(component).toMatchSnapshot();
+  });
+
+  describe('props', () => {
+    describe('color', () => {
+      COLORS.forEach(color => {
+        test(`${color} is rendered`, () => {
+          const component = render(
+            <EuiNotificationBadge color={color}>5</EuiNotificationBadge>
+          );
+
+          expect(component).toMatchSnapshot();
+        });
+      });
+    });
+
+    describe('size', () => {
+      SIZES.forEach(size => {
+        test(`${size} is rendered`, () => {
+          const component = render(
+            <EuiNotificationBadge size={size}>5</EuiNotificationBadge>
+          );
+
+          expect(component).toMatchSnapshot();
+        });
+      });
+    });
   });
 });

--- a/src/components/badge/notification_badge/badge_notification.tsx
+++ b/src/components/badge/notification_badge/badge_notification.tsx
@@ -1,17 +1,40 @@
 import React, { HTMLAttributes, ReactNode, FunctionComponent } from 'react';
 import classNames from 'classnames';
-import { CommonProps } from '../../common';
+import { CommonProps, keysOf } from '../../common';
+
+const colorToClassMap: { [color: string]: string | null } = {
+  accent: null,
+  subdued: 'euiNotificationBadge--subdued',
+};
+
+export const COLORS: BadgeNotificationColor[] = keysOf(colorToClassMap);
+export type BadgeNotificationColor = keyof typeof colorToClassMap;
+
+const sizeToClassNameMap = {
+  s: null,
+  m: 'euiNotificationBadge--medium',
+};
+
+export const SIZES: BadgeNotificationSize[] = keysOf(sizeToClassNameMap);
+export type BadgeNotificationSize = keyof typeof sizeToClassNameMap;
 
 export interface EuiNotificationBadgeProps
   extends CommonProps,
     HTMLAttributes<HTMLSpanElement> {
   children?: ReactNode;
+  size?: BadgeNotificationSize;
+  color?: BadgeNotificationColor;
 }
 
 export const EuiNotificationBadge: FunctionComponent<
   EuiNotificationBadgeProps
-> = ({ children, className, ...rest }) => {
-  const classes = classNames('euiNotificationBadge', className);
+> = ({ children, className, size = 's', color = 'accent', ...rest }) => {
+  const classes = classNames(
+    'euiNotificationBadge',
+    sizeToClassNameMap[size],
+    colorToClassMap[color],
+    className
+  );
 
   return (
     <span className={classes} {...rest}>

--- a/src/components/badge/notification_badge/badge_notification.tsx
+++ b/src/components/badge/notification_badge/badge_notification.tsx
@@ -21,7 +21,7 @@ export type BadgeNotificationSize = keyof typeof sizeToClassNameMap;
 export interface EuiNotificationBadgeProps
   extends CommonProps,
     HTMLAttributes<HTMLSpanElement> {
-  children?: ReactNode;
+  children: ReactNode;
   size?: BadgeNotificationSize;
   color?: BadgeNotificationColor;
 }

--- a/src/components/facet/__snapshots__/facet_button.test.js.snap
+++ b/src/components/facet/__snapshots__/facet_button.test.js.snap
@@ -12,6 +12,7 @@ exports[`EuiFacetButton is rendered 1`] = `
   >
     <span
       class="euiFacetButton__text"
+      data-text="Content"
     >
       Content
     </span>
@@ -117,7 +118,7 @@ exports[`EuiFacetButton props quantity is rendered 1`] = `
       class="euiFacetButton__text"
     />
     <span
-      class="euiNotificationBadge euiFacetButton__quantity"
+      class="euiNotificationBadge euiNotificationBadge--medium euiNotificationBadge--subdued euiFacetButton__quantity"
     >
       60
     </span>

--- a/src/components/facet/__snapshots__/facet_button.test.js.snap
+++ b/src/components/facet/__snapshots__/facet_button.test.js.snap
@@ -51,7 +51,10 @@ exports[`EuiFacetButton props icon is rendered 1`] = `
     </svg>
     <span
       class="euiFacetButton__text"
-    />
+      data-text="Content"
+    >
+      Content
+    </span>
   </span>
 </button>
 `;
@@ -67,7 +70,10 @@ exports[`EuiFacetButton props isDisabled is rendered 1`] = `
   >
     <span
       class="euiFacetButton__text"
-    />
+      data-text="Content"
+    >
+      Content
+    </span>
   </span>
 </button>
 `;
@@ -83,7 +89,10 @@ exports[`EuiFacetButton props isLoading is rendered 1`] = `
   >
     <span
       class="euiFacetButton__text"
-    />
+      data-text="Content"
+    >
+      Content
+    </span>
     <div
       class="euiLoadingSpinner euiLoadingSpinner--medium euiFacetButton__spinner"
     />
@@ -101,7 +110,10 @@ exports[`EuiFacetButton props isSelected is rendered 1`] = `
   >
     <span
       class="euiFacetButton__text"
-    />
+      data-text="Content"
+    >
+      Content
+    </span>
   </span>
 </button>
 `;
@@ -116,7 +128,10 @@ exports[`EuiFacetButton props quantity is rendered 1`] = `
   >
     <span
       class="euiFacetButton__text"
-    />
+      data-text="Content"
+    >
+      Content
+    </span>
     <span
       class="euiNotificationBadge euiNotificationBadge--medium euiNotificationBadge--subdued euiFacetButton__quantity"
     >

--- a/src/components/facet/_facet_button.scss
+++ b/src/components/facet/_facet_button.scss
@@ -14,43 +14,7 @@
   animation: none !important; /* 1 */
   transition-timing-function: ease-in; /* 2 */
   transition-duration: $euiAnimSpeedFast; /* 2 */
-
-  .euiFacetButton__content {
-    @include euiButtonContent;
-  }
-
-  .euiFacetButton__text {
-    flex-grow: 1;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    line-height: $euiButtonHeight; // For better alignment with icon/quantity
-  }
-
-  .euiFacetButton__spinner,
-  .euiFacetButton__quantity,
-  .euiFacetButton__icon {
-    flex-shrink: 0; // Ensures they don't scale down below their intended size
-  }
-
-  .euiFacetButton__quantity,
-  .euiFacetButton__icon {
-    transition: all $euiAnimSpeedFast ease-in;
-  }
-
-  .euiFacetButton__quantity {
-    // Increase the default size a bit
-    $size: $euiSize + $euiSizeXS;
-    line-height: $size;
-    height: $size;
-    min-width: $euiSizeL;
-  }
-
-  &.euiFacetButton--unSelected .euiFacetButton__quantity,
-  &:disabled .euiFacetButton__quantity {
-    // Change the default coloring when it's not selected
-    background-color: tint($euiColorLightShade, 30%);
-    color: $euiColorFullShade;
-  }
+  transition: all $euiAnimSpeedFast ease-in;
 
   &:hover,
   &:focus {
@@ -91,6 +55,21 @@
   }
 }
 
-.euiFacetButton--isSelected .euiFacetButton__text {
-  font-weight: $euiFontWeightBold;
+.euiFacetButton__content {
+  @include euiButtonContent;
+}
+
+.euiFacetButton__text {
+  @include euiTextShift;
+  @include euiTextTruncate;
+  flex-grow: 1;
+  vertical-align: middle;
+
+  .euiFacetButton--isSelected & {
+    font-weight: $euiFontWeightBold;
+  }
+}
+
+.euiFacetButton__icon {
+  transition: all $euiAnimSpeedFast ease-in;
 }

--- a/src/components/facet/_facet_button.scss
+++ b/src/components/facet/_facet_button.scss
@@ -12,9 +12,7 @@
   border: none;
   transform: none !important; /* 1 */
   animation: none !important; /* 1 */
-  transition-timing-function: ease-in; /* 2 */
-  transition-duration: $euiAnimSpeedFast; /* 2 */
-  transition: all $euiAnimSpeedFast ease-in;
+  transition: all $euiAnimSpeedFast ease-in; /* 2 */
 
   &:hover,
   &:focus {

--- a/src/components/facet/_index.scss
+++ b/src/components/facet/_index.scss
@@ -1,5 +1,6 @@
 @import '../button/variables';
 @import '../button/mixins';
+@import 'mixins';
 
 @import 'facet_button';
 @import 'facet_group';

--- a/src/components/facet/_index.scss
+++ b/src/components/facet/_index.scss
@@ -1,6 +1,5 @@
 @import '../button/variables';
 @import '../button/mixins';
-@import 'mixins';
 
 @import 'facet_button';
 @import 'facet_group';

--- a/src/components/facet/facet_button.js
+++ b/src/components/facet/facet_button.js
@@ -89,16 +89,11 @@ export const EuiFacetButton = ({
 };
 
 EuiFacetButton.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   className: PropTypes.string,
+  icon: PropTypes.node,
   isDisabled: PropTypes.bool,
   onClick: PropTypes.func,
-  buttonRef: PropTypes.func,
-
-  /**
-   * Any node, but preferrably a `EuiIcon` or `EuiAvatar`
-   */
-  icon: PropTypes.node,
 
   /**
    * Adds/swaps for loading spinner & disables
@@ -114,6 +109,8 @@ EuiFacetButton.propTypes = {
    * Adds a notification indicator for displaying the quantity provided
    */
   quantity: PropTypes.number,
+
+  buttonRef: PropTypes.func,
 };
 
 EuiFacetButton.defaultProps = {

--- a/src/components/facet/facet_button.js
+++ b/src/components/facet/facet_button.js
@@ -89,11 +89,16 @@ export const EuiFacetButton = ({
 };
 
 EuiFacetButton.propTypes = {
-  children: PropTypes.node,
+  children: PropTypes.node.isRequired,
   className: PropTypes.string,
-  icon: PropTypes.node,
   isDisabled: PropTypes.bool,
   onClick: PropTypes.func,
+  buttonRef: PropTypes.func,
+
+  /**
+   * Any node, but preferrably a `EuiIcon` or `EuiAvatar`
+   */
+  icon: PropTypes.node,
 
   /**
    * Adds/swaps for loading spinner & disables
@@ -109,8 +114,6 @@ EuiFacetButton.propTypes = {
    * Adds a notification indicator for displaying the quantity provided
    */
   quantity: PropTypes.number,
-
-  buttonRef: PropTypes.func,
 };
 
 EuiFacetButton.defaultProps = {

--- a/src/components/facet/facet_button.js
+++ b/src/components/facet/facet_button.js
@@ -48,6 +48,8 @@ export const EuiFacetButton = ({
     buttonQuantity = (
       <EuiNotificationBadge
         className="euiFacetButton__quantity"
+        size="m"
+        color={!isSelected || isDisabled ? 'subdued' : 'accent'}
       >
         {quantity}
       </EuiNotificationBadge>
@@ -64,18 +66,22 @@ export const EuiFacetButton = ({
     );
   }
 
+  let dataText;
+  if (typeof children === 'string') {
+    dataText = children;
+  }
 
   return (
     <button
-      disabled={isDisabled}
       className={classes}
+      disabled={isDisabled}
       type="button"
       ref={buttonRef}
       {...rest}
     >
       <span className="euiFacetButton__content">
         {buttonIcon}
-        <span className="euiFacetButton__text">{children}</span>
+        <span data-text={dataText} className="euiFacetButton__text">{children}</span>
         {buttonQuantity}
       </span>
     </button>

--- a/src/components/facet/facet_button.test.js
+++ b/src/components/facet/facet_button.test.js
@@ -21,7 +21,7 @@ describe('EuiFacetButton', () => {
     describe('isDisabled', () => {
       it('is rendered', () => {
         const component = render(
-          <EuiFacetButton isDisabled />
+          <EuiFacetButton isDisabled>Content</EuiFacetButton>
         );
 
         expect(component)
@@ -32,7 +32,7 @@ describe('EuiFacetButton', () => {
     describe('isLoading', () => {
       it('is rendered', () => {
         const component = render(
-          <EuiFacetButton isLoading />
+          <EuiFacetButton isLoading>Content</EuiFacetButton>
         );
 
         expect(component)
@@ -43,7 +43,7 @@ describe('EuiFacetButton', () => {
     describe('isSelected', () => {
       it('is rendered', () => {
         const component = render(
-          <EuiFacetButton isSelected />
+          <EuiFacetButton isSelected>Content</EuiFacetButton>
         );
 
         expect(component)
@@ -54,7 +54,7 @@ describe('EuiFacetButton', () => {
     describe('quantity', () => {
       it('is rendered', () => {
         const component = render(
-          <EuiFacetButton quantity={60} />
+          <EuiFacetButton quantity={60}>Content</EuiFacetButton>
         );
 
         expect(component)
@@ -65,7 +65,7 @@ describe('EuiFacetButton', () => {
     describe('icon', () => {
       it('is rendered', () => {
         const component = render(
-          <EuiFacetButton icon={<EuiIcon type="dot" />} />
+          <EuiFacetButton icon={<EuiIcon type="dot" />}>Content</EuiFacetButton>
         );
 
         expect(component)
@@ -77,7 +77,7 @@ describe('EuiFacetButton', () => {
       it('supports onClick', () => {
         const handler = jest.fn();
         const component = mount(
-          <EuiFacetButton onClick={handler} />
+          <EuiFacetButton onClick={handler}>Content</EuiFacetButton>
         );
         component.find('button').simulate('click');
         expect(handler.mock.calls.length).toEqual(1);

--- a/src/components/facet/index.d.ts
+++ b/src/components/facet/index.d.ts
@@ -1,0 +1,44 @@
+import React, {
+  ButtonHTMLAttributes,
+  HTMLAttributes,
+  ReactNode,
+  MouseEventHandler,
+  SFC,
+} from 'react';
+import { CommonProps, RefCallback } from '../common';
+/// <reference path="../flex/index.d.ts" />
+
+declare module '@elastic/eui' {
+  /**
+   * Facet button type defs
+   *
+   * @see './facet_button.js'
+   */
+
+  export interface EuiFacetButtonProps {
+    children: ReactNode;
+    icon?: ReactNode;
+    isDisabled?: boolean;
+    onClick?: MouseEventHandler<HTMLButtonElement>;
+    isLoading?: boolean;
+    isSelected?: boolean;
+    quantity: number;
+    buttonRef: RefCallback<HTMLButtonElement>;
+  }
+  export const EuiFacetButton: SFC<
+    CommonProps & ButtonHTMLAttributes<HTMLButtonElement>> & EuiFacetButtonProps;
+
+  /**
+   * Facet group type defs
+   *
+   * @see './facet_group.js'
+   */
+
+  export type FacetGroupLayouts = 'vertical' | 'horizontal';
+  export interface EuiFacetGroupProps {
+    layout?: FacetGroupLayouts
+  }
+
+  export const EuiFacetGroup: SFC<
+    CommonProps & HTMLAttributes<HTMLDivElement>> & EuiFacetGroupProps;
+}

--- a/src/components/facet/index.d.ts
+++ b/src/components/facet/index.d.ts
@@ -3,7 +3,7 @@ import React, {
   HTMLAttributes,
   ReactNode,
   MouseEventHandler,
-  SFC,
+  FunctionComponent,
 } from 'react';
 import { CommonProps, RefCallback } from '../common';
 /// <reference path="../flex/index.d.ts" />
@@ -25,7 +25,7 @@ declare module '@elastic/eui' {
     quantity: number;
     buttonRef: RefCallback<HTMLButtonElement>;
   }
-  export const EuiFacetButton: SFC<
+  export const EuiFacetButton: FunctionComponent<
     CommonProps & ButtonHTMLAttributes<HTMLButtonElement>> & EuiFacetButtonProps;
 
   /**
@@ -39,6 +39,6 @@ declare module '@elastic/eui' {
     layout?: FacetGroupLayouts
   }
 
-  export const EuiFacetGroup: SFC<
+  export const EuiFacetGroup: FunctionComponent<
     CommonProps & HTMLAttributes<HTMLDivElement>> & EuiFacetGroupProps;
 }

--- a/src/components/facet/index.d.ts
+++ b/src/components/facet/index.d.ts
@@ -26,7 +26,7 @@ declare module '@elastic/eui' {
     buttonRef: RefCallback<HTMLButtonElement>;
   }
   export const EuiFacetButton: FunctionComponent<CommonProps &
-    ButtonHTMLAttributes<HTMLButtonElement>> & EuiFacetButtonProps;
+    ButtonHTMLAttributes<HTMLButtonElement> & EuiFacetButtonProps>;
 
   /**
    * Facet group type defs
@@ -40,5 +40,5 @@ declare module '@elastic/eui' {
   }
 
   export const EuiFacetGroup: FunctionComponent<CommonProps &
-    HTMLAttributes<HTMLDivElement>> & EuiFacetGroupProps;
+    HTMLAttributes<HTMLDivElement> & EuiFacetGroupProps>;
 }

--- a/src/components/facet/index.d.ts
+++ b/src/components/facet/index.d.ts
@@ -25,8 +25,8 @@ declare module '@elastic/eui' {
     quantity: number;
     buttonRef: RefCallback<HTMLButtonElement>;
   }
-  export const EuiFacetButton: FunctionComponent<
-    CommonProps & ButtonHTMLAttributes<HTMLButtonElement>> & EuiFacetButtonProps;
+  export const EuiFacetButton: FunctionComponent<CommonProps &
+    ButtonHTMLAttributes<HTMLButtonElement>> & EuiFacetButtonProps;
 
   /**
    * Facet group type defs
@@ -39,6 +39,6 @@ declare module '@elastic/eui' {
     layout?: FacetGroupLayouts
   }
 
-  export const EuiFacetGroup: FunctionComponent<
-    CommonProps & HTMLAttributes<HTMLDivElement>> & EuiFacetGroupProps;
+  export const EuiFacetGroup: FunctionComponent<CommonProps &
+    HTMLAttributes<HTMLDivElement>> & EuiFacetGroupProps;
 }

--- a/src/components/filter_group/__snapshots__/filter_button.test.js.snap
+++ b/src/components/filter_group/__snapshots__/filter_button.test.js.snap
@@ -21,6 +21,184 @@ exports[`EuiFilterButton is rendered 1`] = `
 </button>
 `;
 
+exports[`EuiFilterButton props grow is rendered 1`] = `
+<button
+  class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--iconRight euiFilterButton euiFilterButton--grow"
+  type="button"
+>
+  <span
+    class="euiButtonEmpty__content"
+  >
+    <span
+      class="euiButtonEmpty__text"
+    >
+      <span
+        class="euiFilterButton__textShift"
+      />
+    </span>
+  </span>
+</button>
+`;
+
+exports[`EuiFilterButton props iconType and iconSide is rendered 1`] = `
+<button
+  class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--iconRight euiFilterButton"
+  type="button"
+>
+  <span
+    class="euiButtonEmpty__content"
+  >
+    <svg
+      aria-hidden="true"
+      class="euiIcon euiIcon--medium euiButtonEmpty__icon"
+      focusable="false"
+      height="18"
+      viewBox="0 0 18 18"
+      width="18"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill-rule="evenodd"
+      >
+        <path
+          d="M13.689 11.132c1.155 1.222 1.953 2.879 2.183 4.748a1.007 1.007 0 0 1-1 1.12H3.007a1.005 1.005 0 0 1-1-1.12c.23-1.87 1.028-3.526 2.183-4.748.247.228.505.442.782.633-1.038 1.069-1.765 2.55-1.972 4.237L14.872 16c-.204-1.686-.93-3.166-1.966-4.235a7.01 7.01 0 0 0 .783-.633zM8.939 1c1.9 0 3 2 4.38 2.633a2.483 2.483 0 0 1-1.88.867c-.298 0-.579-.06-.844-.157A3.726 3.726 0 0 1 7.69 5.75c-1.395 0-3.75.25-3.245-1.903C5.94 3 6.952 1 8.94 1z"
+        />
+        <path
+          d="M8.94 2c2.205 0 4 1.794 4 4s-1.795 4-4 4c-2.207 0-4-1.794-4-4s1.793-4 4-4m0 9A5 5 0 1 0 8.937.999 5 5 0 0 0 8.94 11"
+        />
+      </g>
+    </svg>
+    <span
+      class="euiButtonEmpty__text"
+    >
+      <span
+        class="euiFilterButton__textShift"
+      />
+    </span>
+  </span>
+</button>
+`;
+
+exports[`EuiFilterButton props isDisabled is rendered 1`] = `
+<button
+  class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--iconRight euiFilterButton"
+  disabled=""
+  type="button"
+>
+  <span
+    class="euiButtonEmpty__content"
+  >
+    <span
+      class="euiButtonEmpty__text"
+    >
+      <span
+        class="euiFilterButton__textShift"
+      />
+    </span>
+  </span>
+</button>
+`;
+
+exports[`EuiFilterButton props isSelected is rendered 1`] = `
+<button
+  class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--iconRight euiFilterButton euiFilterButton-isSelected"
+  type="button"
+>
+  <span
+    class="euiButtonEmpty__content"
+  >
+    <span
+      class="euiButtonEmpty__text"
+    >
+      <span
+        class="euiFilterButton__textShift"
+      />
+    </span>
+  </span>
+</button>
+`;
+
+exports[`EuiFilterButton props noDivider is rendered 1`] = `
+<button
+  class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--iconRight euiFilterButton euiFilterButton--noDivider"
+  type="button"
+>
+  <span
+    class="euiButtonEmpty__content"
+  >
+    <span
+      class="euiButtonEmpty__text"
+    >
+      <span
+        class="euiFilterButton__textShift"
+      />
+    </span>
+  </span>
+</button>
+`;
+
+exports[`EuiFilterButton props numActiveFilters and hasActiveFilters is rendered 1`] = `
+<button
+  class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--iconRight euiFilterButton euiFilterButton-hasActiveFilters"
+  type="button"
+>
+  <span
+    class="euiButtonEmpty__content"
+  >
+    <span
+      class="euiButtonEmpty__text"
+    >
+      <span
+        class="euiFilterButton__textShift"
+      />
+    </span>
+  </span>
+</button>
+`;
+
+exports[`EuiFilterButton props numFilters is rendered 1`] = `
+<button
+  class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--iconRight euiFilterButton"
+  type="button"
+>
+  <span
+    class="euiButtonEmpty__content"
+  >
+    <span
+      class="euiButtonEmpty__text euiFilterButton__text-hasNotification"
+    >
+      <span
+        class="euiFilterButton__textShift"
+      />
+      <span
+        class="euiNotificationBadge euiNotificationBadge--medium euiNotificationBadge--subdued euiFilterButton__notification"
+      >
+        5
+      </span>
+    </span>
+  </span>
+</button>
+`;
+
+exports[`EuiFilterButton props type is rendered 1`] = `
+<button
+  class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--iconRight euiFilterButton"
+  type="button"
+>
+  <span
+    class="euiButtonEmpty__content"
+  >
+    <span
+      class="euiButtonEmpty__text"
+    >
+      <span
+        class="euiFilterButton__textShift"
+      />
+    </span>
+  </span>
+</button>
+`;
+
 exports[`EuiFilterButton renders zero properly 1`] = `
 <button
   aria-label="aria-label"

--- a/src/components/filter_group/__snapshots__/filter_button.test.js.snap
+++ b/src/components/filter_group/__snapshots__/filter_button.test.js.snap
@@ -38,7 +38,7 @@ exports[`EuiFilterButton renders zero properly 1`] = `
         class="euiFilterButton__textShift"
       />
       <span
-        class="euiNotificationBadge euiFilterButton__notification"
+        class="euiNotificationBadge euiNotificationBadge--medium euiNotificationBadge--subdued euiFilterButton__notification"
       >
         0
       </span>

--- a/src/components/filter_group/_filter_button.scss
+++ b/src/components/filter_group/_filter_button.scss
@@ -16,11 +16,16 @@
   }
 
   &:disabled {
-    font-style: italic;
+    color: $euiButtonColorDisabled;
+    pointer-events: none;
+
+    .euiFilterButton__notification {
+      opacity: .5;
+    }
   }
 
   &:hover:not(:disabled),
-  &:focus {
+  &:focus:not(:disabled) {
     // Remove underline from whole button so notifications don't get the underline
     text-decoration: none;
 
@@ -29,26 +34,34 @@
       text-decoration: underline;
     }
   }
+}
 
-  &.euiFilterButton--grow {
-    flex-grow: 1;
-    width: 100%;
-    text-align: left;
+.euiFilterButton--grow {
+  flex-grow: 1;
+  width: 100%;
+  text-align: left;
 
-    // Force content to space out icon
-    .euiButtonEmpty__content {
-      justify-content: space-between;
-    }
+  // Force content to space out icon
+  .euiButtonEmpty__content {
+    justify-content: space-between;
   }
+}
 
-  &.euiFilterButton-hasActiveFilters {
-    font-weight: $euiFontWeightMedium;
-  }
+.euiFilterButton-hasActiveFilters {
+  font-weight: $euiFontWeightBold;
+}
 
-  .euiFilterButton__notification {
-    margin-left: $euiSizeS;
-    vertical-align: text-bottom;
-  }
+.euiFilterButton__notification {
+  margin-left: $euiSizeS;
+  vertical-align: text-bottom;
+}
+
+.euiFilterButton--noDivider + .euiFilterButton {
+  margin-left: $euiSizeXS * -1;
+}
+
+.euiFilterButton-isSelected {
+  background-color: $euiColorLightestShade;
 }
 
 .euiFilterButton__text-hasNotification {
@@ -57,14 +70,6 @@
 }
 
 .euiFilterButton__textShift {
+  @include euiTextShift;
   vertical-align: middle;
-
-  &::after {
-    display: block;
-    content: attr(data-text);
-    font-weight: $euiFontWeightBold;
-    height: 0;
-    overflow: hidden;
-    visibility: hidden;
-  }
 }

--- a/src/components/filter_group/filter_button.js
+++ b/src/components/filter_group/filter_button.js
@@ -22,6 +22,7 @@ export const EuiFilterButton = ({
   color,
   hasActiveFilters,
   numFilters,
+  numActiveFilters,
   isDisabled,
   isSelected,
   type,
@@ -49,13 +50,24 @@ export const EuiFilterButton = ({
     textProps && textProps.className,
   );
 
+  let dataText;
+  if (typeof children === 'string') {
+    dataText = children;
+  }
+
   const buttonContents = (
     <Fragment>
-      <span className="euiFilterButton__textShift" data-text={children}>
+      <span className="euiFilterButton__textShift" data-text={dataText}>
         {children}
       </span>
       {numFiltersDefined &&
-        <EuiNotificationBadge className="euiFilterButton__notification">{numFilters}</EuiNotificationBadge>
+        <EuiNotificationBadge
+          className="euiFilterButton__notification"
+          size="m"
+          color={isDisabled || !hasActiveFilters ? 'subdued' : 'accent'}
+        >
+          {numActiveFilters || numFilters}
+        </EuiNotificationBadge>
       }
     </Fragment>
   );
@@ -94,6 +106,7 @@ EuiFilterButton.propTypes = {
    * Adds a notification with number
    */
   numFilters: PropTypes.number,
+  numActiveFilters: PropTypes.number,
   /**
    * Applies a visual state to the button useful when using with a popover.
    */

--- a/src/components/filter_group/filter_button.js
+++ b/src/components/filter_group/filter_button.js
@@ -103,9 +103,14 @@ EuiFilterButton.propTypes = {
    */
   hasActiveFilters: PropTypes.bool,
   /**
-   * Adds a notification with number
+   * Pass the total number of filters available and it will
+   * add a subdued notification badge showing the number
    */
   numFilters: PropTypes.number,
+  /**
+   * Pass the number of selected filters and it will
+   * add a bright notification badge showing the number
+   */
   numActiveFilters: PropTypes.number,
   /**
    * Applies a visual state to the button useful when using with a popover.

--- a/src/components/filter_group/filter_button.test.js
+++ b/src/components/filter_group/filter_button.test.js
@@ -21,4 +21,94 @@ describe('EuiFilterButton', () => {
 
     expect(component).toMatchSnapshot();
   });
+
+  describe('props', () => {
+    describe('iconType and iconSide', () => {
+      it('is rendered', () => {
+        const component = render(
+          <EuiFilterButton iconType="user" iconSide="right" />
+        );
+
+        expect(component)
+          .toMatchSnapshot();
+      });
+    });
+
+    describe('numFilters', () => {
+      it('is rendered', () => {
+        const component = render(
+          <EuiFilterButton numFilters={5} />
+        );
+
+        expect(component)
+          .toMatchSnapshot();
+      });
+    });
+
+    describe('numActiveFilters and hasActiveFilters', () => {
+      it('is rendered', () => {
+        const component = render(
+          <EuiFilterButton numActiveFilters={5} hasActiveFilters />
+        );
+
+        expect(component)
+          .toMatchSnapshot();
+      });
+    });
+
+    describe('isSelected', () => {
+      it('is rendered', () => {
+        const component = render(
+          <EuiFilterButton isSelected />
+        );
+
+        expect(component)
+          .toMatchSnapshot();
+      });
+    });
+
+    describe('isDisabled', () => {
+      it('is rendered', () => {
+        const component = render(
+          <EuiFilterButton isDisabled />
+        );
+
+        expect(component)
+          .toMatchSnapshot();
+      });
+    });
+
+    describe('type', () => {
+      it('is rendered', () => {
+        const component = render(
+          <EuiFilterButton type="button" />
+        );
+
+        expect(component)
+          .toMatchSnapshot();
+      });
+    });
+
+    describe('grow', () => {
+      it('is rendered', () => {
+        const component = render(
+          <EuiFilterButton grow />
+        );
+
+        expect(component)
+          .toMatchSnapshot();
+      });
+    });
+
+    describe('noDivider', () => {
+      it('is rendered', () => {
+        const component = render(
+          <EuiFilterButton noDivider />
+        );
+
+        expect(component)
+          .toMatchSnapshot();
+      });
+    });
+  });
 });

--- a/src/components/filter_group/index.d.ts
+++ b/src/components/filter_group/index.d.ts
@@ -2,7 +2,7 @@ import { CommonProps } from '../common';
 import { IconType, IconSize } from '../icon'
 /// <reference path="../button/index.d.ts" />
 
-import { SFC, ButtonHTMLAttributes, HTMLAttributes } from 'react';
+import { SFC, ButtonHTMLAttributes, HTMLAttributes, MouseEventHandler } from 'react';
 
 declare module '@elastic/eui' {
   /**
@@ -11,7 +11,18 @@ declare module '@elastic/eui' {
    * @see './filter_button.js'
    */
 
-  export const EuiFilterButton: SFC<EuiButtonEmptyProps>;
+  export interface EuiFilterButtonProps {
+    onClick?: MouseEventHandler<HTMLButtonElement>;
+    hasActiveFilters?: boolean;
+    numFilters?: number;
+    numActiveFilters?: number;
+    isSelected?: boolean;
+    isDisabled?: boolean;
+    type?: string;
+    grow?: boolean;
+    noDivider?: boolean;
+  }
+  export const EuiFilterButton: SFC<CommonProps & EuiButtonEmptyProps> & EuiFilterButtonProps;
 
   /**
    * Filter group type defs

--- a/src/components/filter_group/index.d.ts
+++ b/src/components/filter_group/index.d.ts
@@ -2,7 +2,7 @@ import { CommonProps } from '../common';
 import { IconType, IconSize } from '../icon'
 /// <reference path="../button/index.d.ts" />
 
-import { SFC, ButtonHTMLAttributes, HTMLAttributes } from 'react';
+import { Component, FunctionComponent, ButtonHTMLAttributes, HTMLAttributes } from 'react';
 
 declare module '@elastic/eui' {
   /**
@@ -20,7 +20,7 @@ declare module '@elastic/eui' {
     grow?: boolean;
     noDivider?: boolean;
   }
-  export const EuiFilterButton: SFC<EuiButtonEmptyProps> & EuiFilterButtonProps;
+  export const EuiFilterButton: FunctionComponent<EuiButtonEmptyProps> & EuiFilterButtonProps;
 
   /**
    * Filter group type defs
@@ -28,7 +28,7 @@ declare module '@elastic/eui' {
    * @see './filter_group.js'
    */
 
-  export const EuiFilterGroup: SFC<CommonProps & HTMLAttributes<HTMLDivElement>>;
+  export const EuiFilterGroup: FunctionComponent<CommonProps & HTMLAttributes<HTMLDivElement>>;
 
   /**
    * Filter select item type defs
@@ -41,7 +41,7 @@ declare module '@elastic/eui' {
     checked?: FilterChecked
   }
 
-  export const EuiFilterSelectItem: SFC<CommonProps &
+  export const EuiFilterSelectItem: Component<CommonProps &
     ButtonHTMLAttributes<HTMLButtonElement> & EuiFilterSelectItemProps
   >;
 }

--- a/src/components/filter_group/index.d.ts
+++ b/src/components/filter_group/index.d.ts
@@ -42,6 +42,5 @@ declare module '@elastic/eui' {
   }
 
   export const EuiFilterSelectItem: Component<CommonProps &
-    ButtonHTMLAttributes<HTMLButtonElement> & EuiFilterSelectItemProps
-  >;
+    ButtonHTMLAttributes<HTMLButtonElement> & EuiFilterSelectItemProps>;
 }

--- a/src/components/filter_group/index.d.ts
+++ b/src/components/filter_group/index.d.ts
@@ -2,7 +2,7 @@ import { CommonProps } from '../common';
 import { IconType, IconSize } from '../icon'
 /// <reference path="../button/index.d.ts" />
 
-import { SFC, ButtonHTMLAttributes, HTMLAttributes, MouseEventHandler } from 'react';
+import { SFC, ButtonHTMLAttributes, HTMLAttributes } from 'react';
 
 declare module '@elastic/eui' {
   /**
@@ -12,8 +12,6 @@ declare module '@elastic/eui' {
    */
 
   export interface EuiFilterButtonProps {
-    onClick?: MouseEventHandler<HTMLButtonElement>;
-    hasActiveFilters?: boolean;
     numFilters?: number;
     numActiveFilters?: number;
     isSelected?: boolean;
@@ -22,7 +20,7 @@ declare module '@elastic/eui' {
     grow?: boolean;
     noDivider?: boolean;
   }
-  export const EuiFilterButton: SFC<CommonProps & EuiButtonEmptyProps> & EuiFilterButtonProps;
+  export const EuiFilterButton: SFC<EuiButtonEmptyProps> & EuiFilterButtonProps;
 
   /**
    * Filter group type defs

--- a/src/components/filter_group/index.d.ts
+++ b/src/components/filter_group/index.d.ts
@@ -20,7 +20,7 @@ declare module '@elastic/eui' {
     grow?: boolean;
     noDivider?: boolean;
   }
-  export const EuiFilterButton: FunctionComponent<EuiButtonEmptyProps> & EuiFilterButtonProps;
+  export const EuiFilterButton: FunctionComponent<EuiButtonEmptyProps & EuiFilterButtonProps>;
 
   /**
    * Filter group type defs

--- a/src/components/icon/_icon.scss
+++ b/src/components/icon/_icon.scss
@@ -1,4 +1,5 @@
 .euiIcon {
+  flex-shrink: 0; // Ensures it never scales down below it's intended size
   display: inline-block;
   vertical-align: middle;
   fill: currentColor;

--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -11,6 +11,7 @@
 /// <reference path="./description_list/index.d.ts" />
 /// <reference path="./empty_prompt/index.d.ts" />
 /// <reference path="./error_boundary/index.d.ts" />
+/// <reference path="./facet/index.d.ts" />
 /// <reference path="./filter_group/index.d.ts" />
 /// <reference path="./flex/index.d.ts" />
 /// <reference path="./flyout/index.d.ts" />

--- a/src/components/loading/_loading_spinner.scss
+++ b/src/components/loading/_loading_spinner.scss
@@ -1,4 +1,5 @@
 .euiLoadingSpinner {
+  flex-shrink: 0; // Ensures it never scales down below it's intended size
   display: inline-block;
   width: $euiSizeXL;
   height: $euiSizeXL;

--- a/src/global_styling/mixins/_typography.scss
+++ b/src/global_styling/mixins/_typography.scss
@@ -127,3 +127,22 @@
 @mixin euiNumberFormat {
   font-feature-settings: $euiFontFeatureSettings, 'tnum' 1; // Fixed-width numbers for tabular data
 }
+
+
+// Text weight shifting
+//
+// When changing the font-weight based the state of the component
+// this mixin will ensure that the sizing is dependent on the boldest
+// weight so it doesn't shifter sibling content.
+
+@mixin euiTextShift($fontWeight: $euiFontWeightBold, $attr: 'data-text') {
+  &::after {
+    display: block;
+    content: attr(#{$attr});
+    font-weight: $fontWeight;
+    height: 0;
+    overflow: hidden;
+    visibility: hidden;
+  }
+}
+


### PR DESCRIPTION
## Fixes #1511

Essentially, this PR aligns the EuiFilterButton styles too look similar to the EuiFacetButton. It also means allowing to pass the "total available filters" when none are selected:
<img src="https://d.pr/free/i/4jhdOe+" />

As well as highlight when there are selected filters:
<img src="https://d.pr/free/i/3I0PVR+" />

Which meant adding `numActiveFilters` to EuiFilterButton.

As a reference, this is what the facet buttons look like
<img src="https://d.pr/free/i/zQqksj+" width="50%" />


---

## Typescript

I had originally attempted to convert them to TS, but because they each imported a non-TS'd component or the props of one, I couldn't do it. Maybe someone with better TS chops than me can. But I did make sure the TS def's were up to date so it will be easier to convert down the line.

---

## Other

Added some extra props to `EuiNotificationBadge`:
- `size`: s, m (default: s)
- `color`: accent, subdued (default: accent)

I also did some quick updates to EuiAvatar (thicker font weight and font size adjustment) and to EuiIcon so that both do never shrink because of flex.

I also added a global mixin for the text-weight-shifting stuff since we're seeing it more often.

---

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
- [x] Any props added have proper autodocs
- ~[ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- [x] Jest tests were updated or added to match the most common scenarios
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
