### PR TITLE
Add "Inline sass-extract-js plugin" to changelog as Breaking Change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Breaking changes**
 
 - `EuiBasicTable`'s select all checkbox appends a `makeId` string to the id ([#1462](https://github.com/elastic/eui/pull/1462))
+- Remove camel casing from exported JSON variables ([#1590](https://github.com/elastic/eui/pull/1590))
 
 ## [`8.0.0`](https://github.com/elastic/eui/tree/v8.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 **Breaking changes**
 
 - `EuiBasicTable`'s select all checkbox appends a `makeId` string to the id ([#1462](https://github.com/elastic/eui/pull/1462))
-- Remove camel casing from exported JSON variables ([#1590](https://github.com/elastic/eui/pull/1590))
+- Remove camel casing from exported JSON variables and preserve hex values instead of converting to rgb ([#1590](https://github.com/elastic/eui/pull/1590))
 
 ## [`8.0.0`](https://github.com/elastic/eui/tree/v8.0.0)
 


### PR DESCRIPTION
Missing changelog comments from https://github.com/elastic/eui/pull/1590

Variables affected by camel casing change:
- euiSizeXs -> euiSizeXS
- euiSizeXl -> euiSizeXL
- euiSizeXxl -> euiSizeXXL
- euiFontSizeXs -> euiFontSizeXS
- euiFontSizeXl -> euiFontSizeXL   
- euiFontSizeXxl -> euiFontSizeXXL

Full list of variable changes: https://www.diffchecker.com/ocT4Z4lA