### PR TITLE
A few fixes required to get eui@8.x working in Kibana

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Bug fixes**
 
 - `EuiBasicTable` select all shows up on mobile ([#1462](https://github.com/elastic/eui/pull/1462))
+- Adds missing `hasActiveFilters` prop for `EuiFilterButton` type and fixes `onChange` signature for `EuiButtonGroup` ([#1603](https://github.com/elastic/eui/pull/1603))
 
 **Breaking changes**
 

--- a/src/components/button/button_group/button_group.js
+++ b/src/components/button/button_group/button_group.js
@@ -65,7 +65,7 @@ export const EuiButtonGroup = ({
               key={index}
               label={option.label}
               name={option.name || name}
-              onChange={onChange.bind(null, option.id, option.value)}
+              onChange={() => onChange(option.id, option.value)}
               size={buttonSize}
               toggleClassName="euiButtonGroup__toggle"
               type={type}

--- a/src/components/button/index.d.ts
+++ b/src/components/button/index.d.ts
@@ -1,4 +1,4 @@
-import { CommonProps } from '../common';
+import { CommonProps, Omit } from '../common';
 import { IconType, IconSize } from '../icon'
 import { ToggleType } from '../toggle'
 
@@ -146,6 +146,6 @@ declare module '@elastic/eui' {
     }
 
   export const EuiButtonGroup: FunctionComponent<
-    HTMLAttributes<HTMLDivElement> & EuiButtonGroupProps
+    Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> & EuiButtonGroupProps
   >;
 }

--- a/src/components/filter_group/index.d.ts
+++ b/src/components/filter_group/index.d.ts
@@ -1,5 +1,5 @@
 import { CommonProps } from '../common';
-import { IconType, IconSize } from '../icon'
+import { IconType, IconSize } from '../icon';
 /// <reference path="../button/index.d.ts" />
 
 import { Component, FunctionComponent, ButtonHTMLAttributes, HTMLAttributes } from 'react';
@@ -38,7 +38,7 @@ declare module '@elastic/eui' {
 
   export type FilterChecked = 'on' | 'off';
   export interface EuiFilterSelectItemProps {
-    checked?: FilterChecked
+    checked?: FilterChecked;
   }
 
   export const EuiFilterSelectItem: Component<CommonProps &

--- a/src/components/filter_group/index.d.ts
+++ b/src/components/filter_group/index.d.ts
@@ -14,6 +14,7 @@ declare module '@elastic/eui' {
   export interface EuiFilterButtonProps {
     numFilters?: number;
     numActiveFilters?: number;
+    hasActiveFilters?: boolean;
     isSelected?: boolean;
     isDisabled?: boolean;
     type?: string;


### PR DESCRIPTION
### Summary

* EuiFilterButton was missing props in the shipped types (it was only using `EuiEmptyButtonProps` but it accepts about 5 extra props)