### PR TITLE
Prevent unmounted EuiGlobalToastList from causing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - `EuiBasicTable` select all shows up on mobile ([#1462](https://github.com/elastic/eui/pull/1462))
 - Adds missing `hasActiveFilters` prop for `EuiFilterButton` type and fixes `onChange` signature for `EuiButtonGroup` ([#1603](https://github.com/elastic/eui/pull/1603))
+- Prevent `EuiGlobalToastList` from attempting calculations on `null` DOM elements ([#1606](https://github.com/elastic/eui/pull/1606))
 
 **Breaking changes**
 

--- a/src/components/toast/global_toast_list.js
+++ b/src/components/toast/global_toast_list.js
@@ -23,6 +23,9 @@ export class EuiGlobalToastList extends Component {
 
     this.isScrollingToBottom = false;
     this.isScrolledToBottom = true;
+
+    this.isScrollingAnimationFrame;
+    this.startScrollingAnimationFrame;
   }
 
   static propTypes = {
@@ -40,6 +43,7 @@ export class EuiGlobalToastList extends Component {
     this.isScrollingToBottom = true;
 
     const scrollToBottom = () => {
+      if (!this.listElement) return;
       const position = this.listElement.scrollTop;
       const destination = this.listElement.scrollHeight - this.listElement.clientHeight;
       const distanceToDestination = destination - position;
@@ -54,11 +58,11 @@ export class EuiGlobalToastList extends Component {
       this.listElement.scrollTop = position + distanceToDestination * 0.25;
 
       if (this.isScrollingToBottom) {
-        window.requestAnimationFrame(scrollToBottom);
+        this.isScrollingAnimationFrame = window.requestAnimationFrame(scrollToBottom);
       }
     };
 
-    window.requestAnimationFrame(scrollToBottom);
+    this.startScrollingAnimationFrame = window.requestAnimationFrame(scrollToBottom);
   }
 
   onMouseEnter = () => {
@@ -162,6 +166,8 @@ export class EuiGlobalToastList extends Component {
   }
 
   componentWillUnmount() {
+    window.cancelAnimationFrame(this.isScrollingAnimationFrame);
+    window.cancelAnimationFrame(this.startScrollingAnimationFrame);
     this.listElement.removeEventListener('scroll', this.onScroll);
     this.listElement.removeEventListener('mouseenter', this.onMouseEnter);
     this.listElement.removeEventListener('mouseleave', this.onMouseLeave);

--- a/src/components/toast/global_toast_list.js
+++ b/src/components/toast/global_toast_list.js
@@ -24,8 +24,10 @@ export class EuiGlobalToastList extends Component {
     this.isScrollingToBottom = false;
     this.isScrolledToBottom = true;
 
-    this.isScrollingAnimationFrame;
-    this.startScrollingAnimationFrame;
+    // See [Return Value](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame#Return_value)
+    // for information on initial value of 0
+    this.isScrollingAnimationFrame = 0;
+    this.startScrollingAnimationFrame = 0;
   }
 
   static propTypes = {
@@ -169,8 +171,12 @@ export class EuiGlobalToastList extends Component {
   }
 
   componentWillUnmount() {
-    window.cancelAnimationFrame(this.isScrollingAnimationFrame);
-    window.cancelAnimationFrame(this.startScrollingAnimationFrame);
+    if (this.isScrollingAnimationFrame !== 0) {
+      window.cancelAnimationFrame(this.isScrollingAnimationFrame);
+    }
+    if (this.startScrollingAnimationFrame !== 0) {
+      window.cancelAnimationFrame(this.startScrollingAnimationFrame);
+    }
     this.listElement.removeEventListener('scroll', this.onScroll);
     this.listElement.removeEventListener('mouseenter', this.onMouseEnter);
     this.listElement.removeEventListener('mouseleave', this.onMouseLeave);

--- a/src/components/toast/global_toast_list.js
+++ b/src/components/toast/global_toast_list.js
@@ -43,7 +43,10 @@ export class EuiGlobalToastList extends Component {
     this.isScrollingToBottom = true;
 
     const scrollToBottom = () => {
+      // Although we cancel the requestAnimationFrame in componentWillUnmount,
+      // it's possible for this.listElement to become null in the meantime
       if (!this.listElement) return;
+
       const position = this.listElement.scrollTop;
       const destination = this.listElement.scrollHeight - this.listElement.clientHeight;
       const distanceToDestination = destination - position;


### PR DESCRIPTION
### Summary

Fixes #1595, in which attempts to do calculations on a element that had become `null` caused errors.
* Cancel `requestAnimationFrame` updates in `componentWillUnmount`
* Prevent accessing properties on a `null`ed DOM element

### Checklist

~~- [ ] This was checked in mobile~~
~~- [ ] This was checked in IE11~~
~~- [ ] This was checked in dark mode~~
~~- [ ] Any props added have proper autodocs~~
~~- [ ] Documentation examples were added~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately

~~- [ ] This was checked for breaking changes and labeled appropriately~~
~~- [ ] Jest tests were updated or added to match the most common scenarios~~
~~- [ ] This was checked against keyboard-only and screenreader scenarios~~
~~- [ ] This required updates to Framer X components~~
