### PR TITLE
Adds @types/react-datepicker to the EUI peer dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `numActiveFilters` prop to `EuiFilterButton` ([#1589](https://github.com/elastic/eui/pull/1589))
 - Updated style of `EuiFilterButton` to match `EuiFacetButton` ([#1589](https://github.com/elastic/eui/pull/1589))
 - Added `size` and `color` props to `EuiNotificationBadge` ([#1589](https://github.com/elastic/eui/pull/1589))
+- Added `@types/react-datepicker` to peer dependencies
 
 **Bug fixes**
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Note that EUI itself has some dependencies itself mostly around management of da
 yarn add @elastic/eui @elastic/datemath moment
 ```
 
+Note: if you're using Typescript, you'll also need to install `@types/react-datepicker` version 1.8.0:
+```
+yarn add -D @types/react-datepicker@1.8.0
+```
+
 
 ## Running Locally
 

--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
   "peerDependencies": {
     "@elastic/datemath": "^5.0.2",
     "@types/react": "^16.8.0",
+    "@types/react-datepicker": "1.8.0",
     "moment": "^2.13.0",
     "prop-types": "^15.5.0",
     "react": "^16.8",

--- a/src-docs/src/views/guidelines/colors.js
+++ b/src-docs/src/views/guidelines/colors.js
@@ -161,7 +161,7 @@ export default class extends Component {
             those against a six-color grayscale. Variation beyond these colors is minimal and
             always dont with math manipulation against the original set.
           </p>
-      //Is the word "dont" correct in text above? Should it be "done" instead?
+          {/* Is the word "dont" correct in text above? Should it be "done" instead? */}
         </EuiText>
 
         <EuiSpacer />


### PR DESCRIPTION
I couldn't figure out how to get the types checked in, so I went with this as a 2nd best solution. :)