### PR TITLE
Edit to JSDoc comment in bottom_bar.js

### DIFF
--- a/src/components/bottom_bar/bottom_bar.js
+++ b/src/components/bottom_bar/bottom_bar.js
@@ -75,7 +75,7 @@ export class EuiBottomBar extends Component {
 EuiBottomBar.propTypes = {
   children: PropTypes.node,
   /**
-   * Optional class applied to the bar iteself
+   * Optional class applied to the bar itself
    */
   className: PropTypes.string,
   /**


### PR DESCRIPTION
Fixed spelling in JSDoc comment.

I'm an editor rather than a developer, so I hope that this is the right place to make this change. If I understand correctly after some cursory Googling on /**, the JSDoc comments help to generate the HTML, in this case the table of properties shown in the Bottom Bar doc?