### PR TITLE
Process typedefs for FunctionComponent into propTypes

### DIFF
--- a/scripts/babel/proptypes-from-ts-props/index.js
+++ b/scripts/babel/proptypes-from-ts-props/index.js
@@ -1136,7 +1136,8 @@ module.exports = function propTypesFromTypeScript({ types }) {
               const { left, right } = idTypeAnnotation.typeAnnotation.typeName;
 
               if (left.name === 'React') {
-                if (right.name === 'SFC') {
+                const rightName = right.name;
+                if (rightName === 'SFC' || rightName === 'FunctionComponent') {
                   processComponentDeclaration(idTypeAnnotation.typeAnnotation.typeParameters.params[0], nodePath, state);
                   fileCodeNeedsUpdating = true;
                 } else {
@@ -1144,8 +1145,9 @@ module.exports = function propTypesFromTypeScript({ types }) {
                 }
               }
             } else if (idTypeAnnotation.typeAnnotation.typeName.type === 'Identifier') {
-              if (idTypeAnnotation.typeAnnotation.typeName.name === 'SFC') {
-                if (state.get('importsFromReact').has('SFC')) {
+              const typeName = idTypeAnnotation.typeAnnotation.typeName.name;
+              if (typeName === 'SFC' || typeName === 'FunctionComponent') {
+                if (state.get('importsFromReact').has(typeName)) {
                   processComponentDeclaration(idTypeAnnotation.typeAnnotation.typeParameters.params[0], nodePath, state);
                   fileCodeNeedsUpdating = true;
                 }

--- a/scripts/babel/proptypes-from-ts-props/index.test.js
+++ b/scripts/babel/proptypes-from-ts-props/index.test.js
@@ -1982,6 +1982,52 @@ FooComponent.propTypes = {
 };`);
       });
 
+      it('annotates FunctionComponent components', () => {
+        const result = transform(
+          `
+import React, { FunctionComponent } from 'react';
+const FooComponent: FunctionComponent<{foo: string, bar?: number}> = () => {
+  return (<div>Hello World</div>);
+}`,
+          babelOptions
+        );
+
+        expect(result.code).toBe(`import React from 'react';
+import PropTypes from "prop-types";
+
+const FooComponent = () => {
+  return <div>Hello World</div>;
+};
+
+FooComponent.propTypes = {
+  foo: PropTypes.string.isRequired,
+  bar: PropTypes.number
+};`);
+      });
+
+      it('annotates React.FunctionComponent components', () => {
+        const result = transform(
+          `
+import React from 'react';
+const FooComponent: React.FunctionComponent<{foo: string, bar?: number}> = () => {
+  return (<div>Hello World</div>);
+}`,
+          babelOptions
+        );
+
+        expect(result.code).toBe(`import React from 'react';
+import PropTypes from "prop-types";
+
+const FooComponent = () => {
+  return <div>Hello World</div>;
+};
+
+FooComponent.propTypes = {
+  foo: PropTypes.string.isRequired,
+  bar: PropTypes.number
+};`);
+      });
+
       it('annotates React.Component components', () => {
         const result = transform(
           `


### PR DESCRIPTION
### Summary

Component `propTypes` were not generated for `FunctionComponent`s. This fixes that.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
- [x] Any props added have proper autodocs
- [x] Documentation examples were added
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
~- [ ] This was checked for breaking changes and labeled appropriately~
- [x] Jest tests were updated or added to match the most common scenarios
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
