### PR TITLE
Allow keyboard navigation of single select combobox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 **Bug fixes**
 
+- Fixes keyboard navigation of `EuiComboBox` items in single selection mode ([#1619](https://github.com/elastic/eui/pull/1619))
 - `EuiBasicTable` select all shows up on mobile ([#1462](https://github.com/elastic/eui/pull/1462))
 - Adds missing `hasActiveFilters` prop for `EuiFilterButton` type and fixes `onChange` signature for `EuiButtonGroup` ([#1603](https://github.com/elastic/eui/pull/1603))
 - Prevent `EuiGlobalToastList` from attempting calculations on `null` DOM elements ([#1606](https://github.com/elastic/eui/pull/1606))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 **Bug fixes**
 
-- Fixes keyboard navigation of `EuiComboBox` items in single selection mode ([#1619](https://github.com/elastic/eui/pull/1619))
+- Fixed keyboard navigation and UI of `EuiComboBox` items in single selection mode ([#1619](https://github.com/elastic/eui/pull/1619))
 - `EuiBasicTable` select all shows up on mobile ([#1462](https://github.com/elastic/eui/pull/1462))
 - Adds missing `hasActiveFilters` prop for `EuiFilterButton` type and fixes `onChange` signature for `EuiButtonGroup` ([#1603](https://github.com/elastic/eui/pull/1603))
 - Prevent `EuiGlobalToastList` from attempting calculations on `null` DOM elements ([#1606](https://github.com/elastic/eui/pull/1606))

--- a/src/components/combo_box/__snapshots__/combo_box.test.js.snap
+++ b/src/components/combo_box/__snapshots__/combo_box.test.js.snap
@@ -379,7 +379,7 @@ exports[`props singleSelection is rendered 1`] = `
   <EuiComboBoxInput
     autoSizeInputRef={[Function]}
     compressed={false}
-    focusedOptionId="htmlid__option-2"
+    focusedOptionId={null}
     fullWidth={false}
     hasSelectedOptions={true}
     inputRef={[Function]}
@@ -421,7 +421,7 @@ exports[`props singleSelection selects existing option when opened 1`] = `
   <EuiComboBoxInput
     autoSizeInputRef={[Function]}
     compressed={false}
-    focusedOptionId="htmlid__option-2"
+    focusedOptionId={null}
     fullWidth={false}
     hasSelectedOptions={true}
     inputRef={[Function]}
@@ -451,7 +451,6 @@ exports[`props singleSelection selects existing option when opened 1`] = `
   />
   <EuiPortal>
     <EuiComboBoxOptionsList
-      activeOptionIndex={2}
       areAllOptionsSelected={false}
       data-test-subj=""
       fullWidth={false}
@@ -533,7 +532,6 @@ exports[`props singleSelection selects existing option when opened 1`] = `
       position="bottom"
       rootId={[Function]}
       rowHeight={27}
-      scrollToIndex={2}
       searchValue=""
       selectedOptions={
         Array [

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -17,9 +17,9 @@
     @include euiFormControlStyle($includeStates: false, $includeSizes: false);
     @include euiFormControlWithIcon($isIconOptional: true);
     @include euiFormControlSize(auto, $includeAlternates: true);
-    padding: $euiSizeXS;
+    padding: $euiSizeXS $euiSizeS;
     // sass-lint:disable-block mixins-before-declarations
-    @include euiFormControlLayoutPadding(1); /* 2 */ //
+    @include euiFormControlLayoutPadding(1); /* 2 */
 
     display: flex; /* 1 */
 
@@ -28,6 +28,7 @@
     }
 
     &:not(.euiComboBox__inputWrap--noWrap) {
+      padding: $euiSizeXS;
       height: auto;  /* 3 */
       flex-wrap: wrap; /* 1 */
       align-content: flex-start;

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -491,13 +491,19 @@ export class EuiComboBox extends Component {
 
   static getDerivedStateFromProps(nextProps, prevState) {
     const { options, selectedOptions, singleSelection } = nextProps;
-    const { searchValue } = prevState;
+    const { activeOptionIndex, searchValue } = prevState;
 
     // Calculate and cache the options which match the searchValue, because we use this information
     // in multiple places and it would be expensive to calculate repeatedly.
     const matchingOptions = getMatchingOptions(options, selectedOptions, searchValue, nextProps.async, singleSelection);
 
-    return { matchingOptions };
+    const stateUpdate = { matchingOptions };
+
+    if (activeOptionIndex >= matchingOptions.length) {
+      stateUpdate.activeOptionIndex = undefined;
+    }
+
+    return stateUpdate;
   }
 
   updateMatchingOptionsIfDifferent(newMatchingOptions) {

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -77,13 +77,6 @@ export class EuiComboBox extends Component {
       hasFocus: false,
     };
 
-    // ensure that the currently selected single option is active if it is in the matchingOptions
-    if (singleSelection && selectedOptions.length === 1) {
-      if (this.state.matchingOptions.includes(selectedOptions[0])) {
-        this.state.activeOptionIndex = this.state.matchingOptions.indexOf(selectedOptions[0]);
-      }
-    }
-
     this.rootId = htmlIdGenerator();
 
     // Refs.
@@ -95,19 +88,9 @@ export class EuiComboBox extends Component {
   }
 
   openList = () => {
-    const { selectedOptions, singleSelection } = this.props;
-    const { matchingOptions } = this.state;
-
-    const stateUpdate = { isListOpen: true };
-
-    // ensure that the currently selected single option is active if it is in the matchingOptions
-    if (singleSelection && selectedOptions.length === 1) {
-      if (matchingOptions.includes(selectedOptions[0])) {
-        stateUpdate.activeOptionIndex = matchingOptions.indexOf(selectedOptions[0]);
-      }
-    }
-
-    this.setState(stateUpdate);
+    this.setState({
+      isListOpen: true,
+    });
   };
 
   closeList = () => {

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -74,6 +74,7 @@ export class EuiComboBox extends Component {
       isListOpen: false,
       listPosition: 'bottom',
       activeOptionIndex: undefined,
+      hasFocus: false,
     };
 
     // ensure that the currently selected single option is active if it is in the matchingOptions
@@ -287,6 +288,7 @@ export class EuiComboBox extends Component {
       this.props.onFocus();
     }
     this.openList();
+    this.setState({ hasFocus: true });
   }
 
   onContainerBlur = (e) => {
@@ -308,6 +310,7 @@ export class EuiComboBox extends Component {
     if (this.props.onBlur) {
       this.props.onBlur();
     }
+    this.setState({ hasFocus: false });
   }
 
   onKeyDown = (e) => {
@@ -581,12 +584,13 @@ export class EuiComboBox extends Component {
       'data-test-subj': dataTestSubj,
       ...rest
     } = this.props;
+    const { hasFocus, searchValue, isListOpen, listPosition, width, activeOptionIndex } = this.state;
 
-    const { searchValue, isListOpen, listPosition, width, activeOptionIndex } = this.state;
+    const markAsInvalid = isInvalid || (hasFocus === false && searchValue);
 
     const classes = classNames('euiComboBox', className, {
       'euiComboBox-isOpen': isListOpen,
-      'euiComboBox-isInvalid': isInvalid,
+      'euiComboBox-isInvalid': markAsInvalid,
       'euiComboBox-isDisabled': isDisabled,
       'euiComboBox--fullWidth': fullWidth,
       'euiComboBox--compressed': compressed,

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -430,7 +430,7 @@ export class EuiComboBox extends Component {
     this.setState(
       { searchValue },
       () => {
-        if (this.state.isListOpen === false) this.openList();
+        if (searchValue && this.state.isListOpen === false) this.openList();
       }
     );
   };

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -94,9 +94,19 @@ export class EuiComboBox extends Component {
   }
 
   openList = () => {
-    this.setState({
-      isListOpen: true,
-    });
+    const { selectedOptions, singleSelection } = this.props;
+    const { matchingOptions } = this.state;
+
+    const stateUpdate = { isListOpen: true };
+
+    // ensure that the currently selected single option is active if it is in the matchingOptions
+    if (singleSelection && selectedOptions.length === 1) {
+      if (matchingOptions.includes(selectedOptions[0])) {
+        stateUpdate.activeOptionIndex = matchingOptions.indexOf(selectedOptions[0]);
+      }
+    }
+
+    this.setState(stateUpdate);
   };
 
   closeList = () => {
@@ -186,7 +196,7 @@ export class EuiComboBox extends Component {
   };
 
   hasActiveOption = () => {
-    return this.state.activeOptionIndex != null;
+    return this.state.activeOptionIndex != null && this.state.activeOptionIndex < this.state.matchingOptions.length;
   };
 
   clearActiveOption = () => {
@@ -486,14 +496,6 @@ export class EuiComboBox extends Component {
     // Calculate and cache the options which match the searchValue, because we use this information
     // in multiple places and it would be expensive to calculate repeatedly.
     const matchingOptions = getMatchingOptions(options, selectedOptions, searchValue, nextProps.async, singleSelection);
-    // ensure that the currently selected single option is active if it is in the matchingOptions
-    if (singleSelection && selectedOptions.length === 1) {
-      let nextActiveOptionIndex;
-      if (matchingOptions.includes(selectedOptions[0])) {
-        nextActiveOptionIndex = matchingOptions.indexOf(selectedOptions[0]);
-      }
-      return { matchingOptions, activeOptionIndex: nextActiveOptionIndex };
-    }
 
     return { matchingOptions };
   }

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -132,6 +132,12 @@ export class EuiComboBox extends Component {
       return;
     }
 
+    // it's possible that updateListPosition is called when listElement is becoming visible, but isn't yet
+    const listElementBounds = listElement.getBoundingClientRect();
+    if (listElementBounds.width === 0 || listElementBounds.height === 0) {
+      return;
+    }
+
     const comboBoxBounds = this.comboBox.getBoundingClientRect();
 
     const { position, top } = findPopoverPosition({
@@ -437,7 +443,13 @@ export class EuiComboBox extends Component {
     if (this.props.onSearchChange) {
       this.props.onSearchChange(searchValue);
     }
-    this.setState({ searchValue });
+
+    this.setState(
+      { searchValue },
+      () => {
+        if (this.state.isListOpen === false) this.openList();
+      }
+    );
   };
 
   comboBoxRef = node => {

--- a/src/components/combo_box/combo_box_input/_combo_box_pill.scss
+++ b/src/components/combo_box/combo_box_input/_combo_box_pill.scss
@@ -11,7 +11,7 @@
 
     line-height: $euiSizeL;
     font-size: $euiFontSizeS;
-    padding: 0 $euiSizeXS;
+    padding: 0;
     color: $euiTextColor;
     vertical-align: middle;
     display: inline-block;

--- a/src/components/combo_box/combo_box_input/combo_box_input.js
+++ b/src/components/combo_box/combo_box_input/combo_box_input.js
@@ -215,7 +215,7 @@ export class EuiComboBoxInput extends Component {
           tabIndex="-1" // becomes onBlur event's relatedTarget, otherwise relatedTarget is null when clicking on this div
           data-test-subj="comboBoxInput"
         >
-          {pills}
+          {!singleSelection || !searchValue ? pills : null}
           {placeholderMessage}
           <AutosizeInput
             role="textbox"


### PR DESCRIPTION
### Summary

Fixes #1615. Moves the highlighting-of-active-single-selection logic to the list open action instead of on any prop/state change. This allows controlling the active item via keyboard arrows.

`EuiComboBox` should get another pass in the future to get a better way of tracking & managing the current active item, there's a lot of interwoven logic in here.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
~- [ ] Jest tests were updated or added to match the most common scenarios~
- [x] This was checked against keyboard-only and screenreader scenarios
~- [ ] This required updates to Framer X components~
