### PR TITLE
Preserve elasticsearch order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Added support for `preserveSearchResultOrder` prop to `EuiInMemoryTable`, which in conjunction with `allowNeutralSort`, allows showing search results in the order they are returned from ES.  
 - Added support to `findTestSubject` for an optional `matcher` argument, which defaults to `~=`, enabling it to identify an element based on one of multiple space-separated values within its `data-test-subj` attribute ([#1587](https://github.com/elastic/eui/pull/1587))
 - Converted `EuiFlexGrid`, `EuiFlexGroup`, `EuiFlexItem`, `EuiDescriptionList`, `EuiDescriptionListTitle`, and `EuiDescriptionListDescription` to TypeScript ([#1365](https://github.com/elastic/eui/pull/1365))
 - Converted `EuiAvatar` to Typescript ([#1654](https://github.com/elastic/eui/pull/1654))

--- a/src-docs/src/views/tables/in_memory/props_info.js
+++ b/src-docs/src/views/tables/in_memory/props_info.js
@@ -48,6 +48,11 @@ export const propsInfo = {
           required: false,
           type: { name: 'boolean' }
         },
+        preserveSearchResultOrder: {
+          description: 'Enables/disables preserving search results order.',
+          required: false,
+          type: { name: 'boolean' }
+        },
         search: {
           description: 'Configures a search bar for the table',
           required: false,

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`EuiInMemoryTable behavior pagination 1`] = `
 <EuiInMemoryTable
+  allowNeutralSort={true}
   aria-label="aria-label"
   className="testClass1 testClass2"
   columns={

--- a/src/components/basic_table/in_memory_table.js
+++ b/src/components/basic_table/in_memory_table.js
@@ -77,11 +77,11 @@ const InMemoryTablePropTypes = {
    */
   allowNeutralSort: PropTypes.bool,
   /**
-   * Set `shouldSearchClearSort` to true to show results in the "neutral" order they are returned, when searching.
-   * If initial sorting was provided, clearing the search query, will restore it.
+   * Set `preserveSearchResultOrder` to true to show search results in the original order they are returned.
+   * If initial sorting is provided, clearing the search query, will restore it.
    * This flag does not apply if `allowNeutralSort` is disabled.
    */
-  shouldSearchClearSort: PropTypes.bool,
+  preserveSearchResultOrder: PropTypes.bool,
   selection: SelectionType,
   itemId: ItemIdType,
   rowProps: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
@@ -173,7 +173,7 @@ export class EuiInMemoryTable extends Component {
   constructor(props) {
     super(props);
 
-    const { search, pagination, sorting, allowNeutralSort, shouldSearchClearSort } = props;
+    const { search, pagination, sorting, allowNeutralSort, preserveSearchResultOrder } = props;
     const { pageIndex, pageSize, pageSizeOptions, hidePerPageOptions } = getInitialPagination(pagination);
     const { sortField, sortDirection } = getInitialSorting(sorting);
 
@@ -188,7 +188,7 @@ export class EuiInMemoryTable extends Component {
       sortField,
       sortDirection,
       allowNeutralSort: (allowNeutralSort === false) ? false : true,
-      shouldSearchClearSort,
+      preserveSearchResultOrder,
       hidePerPageOptions
     };
   }
@@ -227,8 +227,8 @@ export class EuiInMemoryTable extends Component {
 
   getSortOnSearch(queryText) {
     const isQueryEmpty = !queryText;
-    const { allowNeutralSort, shouldSearchClearSort } = this.state;
-    const shouldClear = allowNeutralSort && shouldSearchClearSort;
+    const { allowNeutralSort, preserveSearchResultOrder } = this.state;
+    const shouldClear = allowNeutralSort && preserveSearchResultOrder;
     const sorting = this.props.sorting;
     if (!shouldClear) {
       return {};
@@ -370,7 +370,7 @@ export class EuiInMemoryTable extends Component {
       onTableChange, // eslint-disable-line no-unused-vars
       executeQueryOptions, // eslint-disable-line no-unused-vars
       allowNeutralSort, // eslint-disable-line no-unused-vars
-      shouldSearchClearSort, // eslint-disable-line no-unused-vars
+      preserveSearchResultOrder, // eslint-disable-line no-unused-vars
       ...rest
     } = this.props;
 


### PR DESCRIPTION
### Summary

Now that we've added the ability to unsort a talbe, we need to be able to use InMemoryTable to show search results in the order defined by ElasticSearch.

To achieve that, I added the preserveSearchResultOrder flag, which in conjunction with allowNeutralSort, will clear existing sorting upon search.

If initial sorting is provided, it's restored when the query is cleared.

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
- [x] Any props added have proper autodocs
- [ ] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
~~[ ] Jest tests were updated or added to match the most common scenarios~~
- [x] This was checked against keyboard-only and screenreader scenarios
~~ [ ] This required updates to Framer X components~~
