### PR TITLE
Dark mode redux, fix dark mode docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Adjusted the dark theme palette to have a slight blue titn ([#1691](https://github.com/elastic/eui/pull/1691))
 - Added `repositionOnScroll` property to the `EuiPopoverProps` type definition ([#1628](https://github.com/elastic/eui/pull/1628))
 - Added support to `findTestSubject` for an optional `matcher` argument, which defaults to `~=`, enabling it to identify an element based on one of multiple space-separated values within its `data-test-subj` attribute ([#1587](https://github.com/elastic/eui/pull/1587))
 - Converted `EuiFlexGrid`, `EuiFlexGroup`, `EuiFlexItem`, `EuiDescriptionList`, `EuiDescriptionListTitle`, and `EuiDescriptionListDescription` to TypeScript ([#1365](https://github.com/elastic/eui/pull/1365))

--- a/src-docs/src/routes.js
+++ b/src-docs/src/routes.js
@@ -25,7 +25,7 @@ import ColorGuidelines
 import ModalGuidelines
   from './views/guidelines/modals';
 
-import SassGuidelines
+import { SassGuidelines }
   from './views/guidelines/sass';
 
 import TextScales

--- a/src-docs/src/views/app_view.js
+++ b/src-docs/src/views/app_view.js
@@ -80,7 +80,7 @@ export class AppView extends Component {
 
           <div className="guidePageContent">
             <EuiContext i18n={i18n}>
-              {children}
+              {React.cloneElement(children, { selectedTheme: theme })}
             </EuiContext>
           </div>
         </EuiPageBody>

--- a/src-docs/src/views/guidelines/colors.js
+++ b/src-docs/src/views/guidelines/colors.js
@@ -5,6 +5,7 @@ import {
 } from 'react-router';
 
 import lightColors from '!!sass-vars-to-js-loader!../../../../src/global_styling/variables/_colors.scss';
+import darkColors from '!!sass-vars-to-js-loader!../../../../src/themes/eui/eui_colors_dark.scss';
 import { calculateContrast, rgbToHex } from '../../../../src/services';
 
 import {
@@ -60,14 +61,14 @@ const ratingAA = <EuiBadge color="#333">AA</EuiBadge>;
 
 const ratingAA18 = <EuiBadge color="#666">AA18</EuiBadge>;
 
-function renderPaletteColor(color, index) {
+function renderPaletteColor(palette, color, index) {
   return (
     <EuiFlexItem key={index}>
       <EuiFlexGroup responsive={false} alignItems="center">
         <EuiFlexItem grow={false}>
           <EuiCopy beforeMessage="Click to copy color name" textToCopy={color}>
             {(copy) => (
-              <EuiIcon onClick={copy} size="xl" type="stopFilled" color={rgbToHex(lightColors[color].rgba)} />
+              <EuiIcon onClick={copy} size="xl" type="stopFilled" color={rgbToHex(palette[color].rgba)} />
             )}
           </EuiCopy>
         </EuiFlexItem>
@@ -78,13 +79,13 @@ function renderPaletteColor(color, index) {
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiText size="s" color="subdued">
-            <p><code>{rgbToHex(lightColors[color].rgba).toUpperCase()}</code></p>
+            <p><code>{rgbToHex(palette[color].rgba).toUpperCase()}</code></p>
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiText size="s" color="subdued">
             <p>
-              <code>rgb({lightColors[color].r}, {lightColors[color].g}, {lightColors[color].b})</code>
+              <code>rgb({palette[color].r}, {palette[color].g}, {palette[color].b})</code>
             </p>
           </EuiText>
         </EuiFlexItem>
@@ -146,6 +147,7 @@ export default class extends Component {
   };
 
   render() {
+    const palette = (this.props.selectedTheme === 'light') ? lightColors : darkColors;
     const { value } = this.state;
 
     return (
@@ -167,7 +169,7 @@ export default class extends Component {
 
         <EuiFlexGroup direction="column" gutterSize="s">
           {allowedColors.map(function (color, index) {
-            return renderPaletteColor(color, index);
+            return renderPaletteColor(palette, color, index);
           })}
         </EuiFlexGroup>
 
@@ -230,8 +232,8 @@ export default class extends Component {
                   {allowedColors.map(function (color2, index) {
                     const contrast = (
                       calculateContrast(
-                        [lightColors[color].r, lightColors[color].g, lightColors[color].b],
-                        [lightColors[color2].r, lightColors[color2].g, lightColors[color2].b],
+                        [palette[color].r, palette[color].g, palette[color].b],
+                        [palette[color2].r, palette[color2].g, palette[color2].b],
                       )
                     );
 
@@ -275,8 +277,8 @@ color: $${color2};`
                           <p
                             onClick={copy}
                             style={{
-                              backgroundColor: lightColors[color].rgba,
-                              color: lightColors[color2].rgba,
+                              backgroundColor: palette[color].rgba,
+                              color: palette[color2].rgba,
                               padding: 6,
                               marginBottom: 2,
                               borderRadius: 4
@@ -312,7 +314,7 @@ color: $${color2};`
 
         <EuiFlexGroup direction="column" gutterSize="s">
           {visColors.map(function (color, index) {
-            return renderPaletteColor(color, index);
+            return renderPaletteColor(palette, color, index);
           })}
         </EuiFlexGroup>
       </GuidePage>

--- a/src-docs/src/views/guidelines/sass.js
+++ b/src-docs/src/views/guidelines/sass.js
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { Component } from 'react';
 import lightColors from '!!sass-vars-to-js-loader?preserveKeys=true!../../../../src/global_styling/variables/_colors.scss';
+import darkColors from '!!sass-vars-to-js-loader!../../../../src/themes/eui/eui_colors_dark.scss';
 import sizes from '!!sass-vars-to-js-loader?preserveKeys=true!../../../../src/global_styling/variables/_size.scss';
 import zindexs from '!!sass-vars-to-js-loader?preserveKeys=true!../../../../src/global_styling/variables/_z_index.scss';
 import animations from '!!sass-vars-to-js-loader?preserveKeys=true!../../../../src/global_styling/variables/_animations.scss';
@@ -116,7 +117,7 @@ const euiOverFlowShadows = [
 
 const euiBreakPoints = Object.getOwnPropertyNames(breakpoints.euiBreakpoints);
 
-function renderPaletteColor(color) {
+function renderPaletteColor(palette, color) {
   let optionalDefault;
   if (color === 'euiTextColor') {
     optionalDefault = (
@@ -129,7 +130,7 @@ function renderPaletteColor(color) {
   return (
     <EuiFlexGroup responsive={false} alignItems="center" gutterSize="s" className="guideSass__swatchItem"  key={color}>
       <EuiFlexItem grow={false}>
-        <div className="guideSass__swatch" style={{ background: rgbToHex(lightColors[color].rgba).toUpperCase() }} />
+        <div className="guideSass__swatch" style={{ background: rgbToHex(palette[color].rgba).toUpperCase() }} />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiCode>${color}</EuiCode>
@@ -331,604 +332,614 @@ const contrastExample = (`// Make sure text passes a contrast check
 }
 `);
 
-export default() => (
+export default class extends Component {
+  constructor(props) {
+    super(props);
+  }
 
-  <GuidePage title="Sass guidelines">
+  render() {
+
+    const palette = (this.props.selectedTheme === 'light') ? lightColors : darkColors;
+
+    return (
+      <GuidePage title="Sass guidelines">
 
 
-    <EuiTitle>
-      <h2>Core variables</h2>
-    </EuiTitle>
-
-    <EuiSpacer size="xxl" />
-
-    <EuiFlexGrid columns={2}>
-      <EuiFlexItem>
-        <div>
-          <EuiTitle size="s">
-            <h4>Sizing</h4>
-          </EuiTitle>
-
-          <EuiSpacer />
-
-          {euiSizes.map(function (size, index) {
-            return renderSize(size, index);
-          })}
-
-          <EuiSpacer />
-
-          <EuiTitle size="s">
-            <h4>Z-index</h4>
-          </EuiTitle>
-
-          <EuiSpacer />
-
-          {euiLevels.map(function (level, index) {
-            return renderLevel(level, index);
-          })}
-        </div>
-
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiTitle size="s">
-          <h4>Color</h4>
+        <EuiTitle>
+          <h2>Core variables</h2>
         </EuiTitle>
 
-        <EuiSpacer />
-
-        {euiColors.map(function (color, index) {
-          return renderPaletteColor(color, index);
-        })}
-
-      </EuiFlexItem>
-    </EuiFlexGrid>
-
-    <EuiSpacer size="xxl"/>
-
-    <GuideRuleTitle>Going beyond the provided colors</GuideRuleTitle>
-
-    <EuiSpacer size="xxl"/>
-
-    <EuiFlexGrid columns={2}>
-      <EuiFlexItem>
-        <EuiTitle size="s">
-          <h4>Theming patterns</h4>
-        </EuiTitle>
-
-        <EuiSpacer />
-        <EuiText>
-          <p>
-            Often you need to go beyond the provided color set. When doing so <strong>always</strong> use
-            color functions to modify the base set. Here are some examples.
-          </p>
-        </EuiText>
-        <EuiSpacer />
-
-        <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
-          <EuiFlexItem grow={false}>
-            <div className="guideSass__swatch guideSass__swatch--danger" />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiCode>$euiCodeDanger</EuiCode>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-        <EuiSpacer />
-        <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
-          <EuiFlexItem grow={false}>
-            <div className="guideSass__swatch guideSass__swatch--dangerTint" />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiCode>tint($euiCodeDanger, 30%)</EuiCode>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-        <EuiSpacer />
-        <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
-          <EuiFlexItem grow={false}>
-            <div className="guideSass__swatch guideSass__swatch--dangerShade" />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiCode>shade($euiCodeDanger, 30%)</EuiCode>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-
-        <EuiSpacer />
-        <EuiText>
-          <p>
-            Remember that EUI provides dark and light mode theming support. Sometimes the traditional
-            color functions don&apos;t give enough flexibility for both modes.
-          </p>
-          <p>
-            For example, depending upon what theme you use <EuiCode>$EuiColorPrimary</EuiCode> will be a different
-            hex value.
-          </p>
-        </EuiText>
-        <EuiSpacer />
-
-        <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
-          <EuiFlexItem grow={false} style={{ background: '#FFF', padding: 8 }}>
-            <div className="guideSass__swatch guideSass__swatch--primaryLight" />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiCode>$euiColorPrimary</EuiCode>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiText size="s">
-              <p>
-                is #0079A5 in the light theme
-              </p>
-            </EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-        <EuiSpacer />
-        <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
-          <EuiFlexItem grow={false} style={{ background: '#222', padding: 8 }}>
-            <div className="guideSass__swatch guideSass__swatch--primaryDark" />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiCode>$euiColorPrimary</EuiCode>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiText size="s">
-              <p>
-                is #4da1c0 in the dark theme
-              </p>
-            </EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-
-        <EuiSpacer />
-        <EuiText>
-          <p>
-            Taking the default primary color above we want to tint the color
-            in the light mode, but shade it in the dark mode. This makes the
-            background color more subtle in both use cases.
-          </p>
-        </EuiText>
-
-        <EuiSpacer />
-
-        <EuiCodeBlock language="scss" transparentBackground paddingSize="none">{tintOrShadeExample}</EuiCodeBlock>
-
-        <EuiSpacer />
+        <EuiSpacer size="xxl" />
 
         <EuiFlexGrid columns={2}>
-          <EuiFlexItem style={{ background: '#FFF', padding: 16 }}>
-            <div className="guideSass__themedBox guideSass__themedBox--light">Light theme</div>
+          <EuiFlexItem>
+            <div>
+              <EuiTitle size="s">
+                <h4>Sizing</h4>
+              </EuiTitle>
+
+              <EuiSpacer />
+
+              {euiSizes.map(function (size, index) {
+                return renderSize(size, index);
+              })}
+
+              <EuiSpacer />
+
+              <EuiTitle size="s">
+                <h4>Z-index</h4>
+              </EuiTitle>
+
+              <EuiSpacer />
+
+              {euiLevels.map(function (level, index) {
+                return renderLevel(level, index);
+              })}
+            </div>
+
           </EuiFlexItem>
-          <EuiFlexItem style={{ background: '#222', padding: 16 }}>
-            <div className="guideSass__themedBox guideSass__themedBox--dark">Dark theme</div>
+          <EuiFlexItem>
+            <EuiTitle size="s">
+              <h4>Color</h4>
+            </EuiTitle>
+
+            <EuiSpacer />
+
+            {euiColors.map(function (color, index) {
+              return renderPaletteColor(palette, color, index);
+            })}
+
           </EuiFlexItem>
         </EuiFlexGrid>
 
-      </EuiFlexItem>
-
-      <EuiFlexItem>
-        <EuiTitle size="s">
-          <h4>Color contrast patterns</h4>
-        </EuiTitle>
-
-        <EuiSpacer />
-
-        <EuiText>
-          <p>
-            EUI provides some nifty color functions for auto-adjusting color to pass AA contrast checks.
-            Often this is needed when using the base colors on top of each other. Here is an example
-            similar to our callouts with a pesky orange.
-          </p>
-        </EuiText>
-
-        <EuiSpacer />
-
-        <EuiCodeBlock language="scss" transparentBackground paddingSize="none">{contrastExample}</EuiCodeBlock>
-
-        <EuiSpacer />
-
-        <div className="guideSass__contrastExample">
-          This orange text now passes a contrast check!
-        </div>
-
-        <EuiSpacer />
-
-        <EuiTitle size="s">
-          <h4>More on color contrast</h4>
-        </EuiTitle>
-
-        <EuiSpacer />
-
-        <EuiText>
-          <p>
-            Consult the larger <Link to="/guidelines/colors">color guidelines</Link> page
-            for a better explanation about passing color contrast.
-          </p>
-        </EuiText>
-
-
-        <EuiSpacer />
-      </EuiFlexItem>
-    </EuiFlexGrid>
-
-    <GuideRuleTitle>Typography</GuideRuleTitle>
-
-    <EuiText grow={false} className="guideSection__text">
-      <p>
-        View the <EuiLink href="https://github.com/elastic/eui/blob/master/src/global_styling/variables/_typography.scss">variable</EuiLink>
-        {' '} and <EuiLink href="https://github.com/elastic/eui/blob/master/src/global_styling/mixins/_typography.scss">mixins</EuiLink>
-        {' '}Sass code for typography.
-        For most of your components we recommend using <Link to="/display/text">EuiText</Link> or
-        {' '}<Link to="/display/title">EuiTitle</Link> instead of these Sass variables.
-      </p>
-    </EuiText>
-
-    <EuiSpacer />
-    <EuiCallOut
-      size="s"
-      color="warning"
-      title={
-        <span>
-          It is more common to use these as a mixin (e.g. <EuiCode language="css">@include euiFontSizeS;</EuiCode>)
-          to automatically apply line-height as well as size.
-        </span>
-      }
-    />
-
-    <EuiSpacer />
-    <EuiFlexGrid columns={2}>
-      <EuiFlexItem>
-        <EuiTitle size="s">
-          <h4>Text sizes</h4>
-        </EuiTitle>
-
-        <EuiSpacer />
-        {euiFontSizes.map(function (size, index) {
-          return renderFontSize(size, index);
-        })}
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <div>
-          <EuiTitle size="s">
-            <h4>Text colors</h4>
-          </EuiTitle>
-
-          <EuiSpacer />
-
-          {euiTextColors.map(function (color, index) {
-            return renderPaletteColor(color, index);
-          })}
-
-          <EuiSpacer />
-
-          <EuiTitle>
-            <h4>Font families</h4>
-          </EuiTitle>
-
-          <EuiSpacer />
-
-          <EuiFlexGroup responsive={false} alignItems="center">
-            <EuiFlexItem grow={false} className="guideSass__fontFamily">
-              Abc
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiCode language="css">@include euiFont;</EuiCode>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-
-          <EuiFlexGroup responsive={false} alignItems="center">
-            <EuiFlexItem grow={false} className="guideSass__fontFamily guideSass__fontFamily--code">
-              Abc
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiCode language="css">@include euiCodeFont;</EuiCode>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </div>
-      </EuiFlexItem>
-    </EuiFlexGrid>
-
-    <EuiSpacer size="xxl"/>
-
-    <GuideRuleTitle>Borders</GuideRuleTitle>
-
-    <EuiSpacer size="xxl"/>
-
-    <EuiText grow={false}>
-      <p>EUI provides some helper variables for setting common border types.</p>
-    </EuiText>
-
-    <EuiSpacer />
-
-    <EuiFlexGrid columns={3}>
-      {euiBorders.map(function (border, index) {
-        return renderBorder(border, index);
-      })}
-    </EuiFlexGrid>
-
-    <EuiSpacer />
-
-    <EuiText grow={false}>
-      <p>In addition, you can utilize <EuiCode>$euiBorderRadius</EuiCode> to round the corners.</p>
-    </EuiText>
-
-    <EuiSpacer />
-
-    <EuiFlexGrid columns={3}>
-      <EuiFlexItem className="guideSass__border guideSass__border--radius">
-        <EuiCodeBlock language="scss" transparentBackground paddingSize="none">
-          {borderRadiusExample}
-        </EuiCodeBlock>
-      </EuiFlexItem>
-    </EuiFlexGrid>
-
-    <GuideRuleTitle>Shadow and Depth</GuideRuleTitle>
-
-    <EuiFlexGrid columns={2}>
-      <EuiFlexItem>
-
-        <EuiTitle size="s">
-          <h4>Use mixins for shadows</h4>
-        </EuiTitle>
-
-        <EuiText>
-          <p>
-            <EuiLink href="https://github.com/elastic/eui/blob/master/src/global_styling/mixins/_shadow.scss">View the Sass code for shadow mixins</EuiLink>.
-          </p>
-        </EuiText>
-
-        <EuiSpacer />
-
-        {euiShadows.map(function (shadow, index) {
-          return renderShadow(shadow, index);
-        })}
-      </EuiFlexItem>
-      <EuiFlexItem>
-
-        <EuiTitle size="s">
-          <h4>Shadows to create graceful overflows</h4>
-        </EuiTitle>
-
-        <EuiText>
-          <p>
-            Primarily used in modals and flyouts, the overflow shadows add a white
-            glow to subtly hide the content they float above.
-          </p>
-        </EuiText>
-
-        <EuiSpacer />
-
-        <div className="guideSass__overflowShadows">
-          <EuiText className="guideSass__overflowShadowText" size="s">
-            <p>
-              Minima reprehenderit aperiam at in ea. Veniam nihil quod tempore.
-              Dolores sit quo expedita voluptate libero.
-              Consequuntur atque nulla atque nemo tenetur numquam.
-              Assumenda aspernatur qui aut sit. Aliquam doloribus iure sint id.
-              Possimus dolor qui soluta cum id tempore ea illum.
-              Facilis voluptatem aut aut ut similique ut.
-              Sed repellendus commodi iure officiis exercitationem praesentium
-              dolor. Ratione non ut nulla accusamus et. Optio laboriosam id
-              incidunt. Ipsam voluptate ab quia necessitatibus sequi earum
-              voluptate. Porro tempore et veritatis quo omnis. Eaque ut libero
-              tempore sit placeat maxime laudantium.
-              Mollitia tempore minus qui autem modi adipisci ad. Iste reprehenderit
-              accusamus voluptatem velit. Quidem delectus eos veritatis et vitae
-              et nisi. Doloribus ut corrupti voluptates qui exercitationem dolores.
-            </p>
-          </EuiText>
-          {euiOverFlowShadows.map(function (shadow, index) {
-            return renderShadow(shadow, index);
-          })}
-        </div>
-
-        <EuiSpacer />
-
-        <EuiTitle size="s">
-          <h4>Adding color to shadows</h4>
-        </EuiTitle>
-
-        <EuiText>
-          <p>Most shadow mixins can also accept color.</p>
-        </EuiText>
-
-        <EuiSpacer />
-
-        <div className="guideSass__shadow guideSass__shadow--color eui-textBreakAll">
-          <EuiCodeBlock
-            language="scss"
-            paddingSize="none"
-            transparentBackground
-          >
-              @include euiBottomShadowLarge(desaturate($euiColorPrimary, 30%));
-          </EuiCodeBlock>
-        </div>
-      </EuiFlexItem>
-    </EuiFlexGrid>
-
-    <EuiSpacer size="xxl"/>
-
-    <GuideRuleTitle>Media queries and breakpoints</GuideRuleTitle>
-
-    <EuiText className="guideSection__text">
-      <p>
-        <EuiLink href="https://github.com/elastic/eui/blob/master/src/global_styling/mixins/_responsive.scss">View the Sass code for media queries</EuiLink>.
-      </p>
-      <p>
-        Breakpoints in EUI are provided through the use of a Sass
-        mixin <EuiCode>@include euiBreakpoint()</EuiCode> that
-        accepts an array of sizes.
-      </p>
-    </EuiText>
-
-    <EuiSpacer />
-    <div className="guideSass__breakpointExample" />
-    <EuiSpacer />
-
-    <EuiFlexGrid columns={2}>
-      <EuiFlexItem>
-        <div>
-          <EuiTitle size="s">
-            <h4>Breakpoint sizing</h4>
-          </EuiTitle>
-
-          <EuiSpacer />
-
-          {euiBreakPoints.map(function (size, index) {
-            return renderBreakpoint(size, index);
-          })}
-
-
-        </div>
-
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiTitle size="s">
-          <h4>Mixin usage</h4>
-        </EuiTitle>
-
-        <EuiSpacer />
-
-        <EuiText><p>Target mobile devices only</p></EuiText>
-        <EuiCodeBlock language="scss" transparentBackground paddingSize="s">
-          {'@include euiBreakpoint(\'xs\',\'s\') {...}'}
-        </EuiCodeBlock>
-
-        <EuiSpacer />
-
-        <EuiText><p>Target mobile and tablets</p></EuiText>
-        <EuiCodeBlock language="scss" transparentBackground paddingSize="s">
-          {'@include euiBreakpoint(\'xs\', \'s\', \'m\') {...}'}
-        </EuiCodeBlock>
-
-        <EuiSpacer />
-
-        <EuiText><p>Target tablets only</p></EuiText>
-        <EuiCodeBlock language="scss" transparentBackground paddingSize="s">
-          {'@include euiBreakpoint(\'m\') {...}'}
-        </EuiCodeBlock>
-
-        <EuiSpacer />
-
-        <EuiText><p>Target very wide displays only</p></EuiText>
-        <EuiCodeBlock language="scss" transparentBackground paddingSize="s">
-          {'@include euiBreakpoint(\'xl\') {...}'}
-        </EuiCodeBlock>
-
-        <EuiSpacer />
-      </EuiFlexItem>
-    </EuiFlexGrid>
-
-    <EuiSpacer size="xxl"/>
-
-    <GuideRuleTitle>Animation</GuideRuleTitle>
-    <EuiText grow={false} className="guideSection__text">
-      <p>
-        <EuiLink href="https://github.com/elastic/eui/blob/master/src/global_styling/variables/_animation.scss">View the Sass code for animation</EuiLink>.
-      </p>
-      <p>
-        EUI utilizes the following constants to maintain a similar &apos;bounce&apos; to its animations.
-        That said, animations are tricky, and if they aren&apos;t working for your specific application
-        this is the one place where we think it&apos;s OK to come up with your own rules.
-      </p>
-    </EuiText>
-    <EuiSpacer />
-    <EuiFlexGrid columns={2}>
-      <EuiFlexItem>
-        <EuiTitle size="s">
-          <h4>Speed</h4>
-        </EuiTitle>
-
-        <EuiSpacer />
-
-        {euiAnimationSpeeds.map(function (speed, index) {
-          return renderAnimationSpeed(speed, index);
-        })}
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiTitle size="s">
-          <h4>Timing</h4>
-        </EuiTitle>
-
-        <EuiSpacer />
-
-        {euiAnimationTimings.map(function (speed, index) {
-          return renderAnimationTiming(speed, index);
-        })}
-      </EuiFlexItem>
-    </EuiFlexGrid>
-
-    <EuiSpacer size="xl" />
-
-    <GuideRuleTitle>Sass best practices</GuideRuleTitle>
-
-    <EuiSpacer size="xl" />
-
-    <EuiFlexGrid columns={2}>
-      <EuiFlexItem>
-        <EuiText>
-          <h3>Component based naming</h3>
-          <p>
-            EUI is written in a <EuiLink href="http://getbem.com/introduction/">BEM</EuiLink>ish style with the addition of verb states (ex: <EuiCode>*-isLoading</EuiCode>).
-            Below is an example of proper formatting.
-          </p>
-        </EuiText>
-        <EuiSpacer />
-        <EuiCodeBlock language="scss" transparentBackground paddingSize="none">{bemExample}</EuiCodeBlock>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiText grow={false} className="guideSection__text">
-          <h3>Writing Sass the EUI way</h3>
-          <p>
-            In general, when writing new SCSS in a project that installs EUI as a dependency
-            try to follow these best practices:
-          </p>
-        </EuiText>
-        <EuiSpacer />
-        <EuiText size="s" grow={false} className="guideSection__text">
-          <ul>
-            <li>Utilize color variables and functions rather than hard-coded values</li>
-            <li>Utilize the sizing variables for padding and margins</li>
-            <li>Utilize the animation variables for animations when possible</li>
-            <li>Utilize the responsive mixins for all screen width calculations</li>
-            <li>Utilize the typography mixins and variables for all font family, weight, and sizing</li>
-            <li>Utilize the shadow mixins and z-index variables to manage depth</li>
-            <li>Utilize the border and border-radius variable to handle border usage</li>
-            <li>Minimize your overwrites and try to make new Sass additive in nature</li>
-          </ul>
-        </EuiText>
-
-        <EuiSpacer />
-
-        <EuiTitle size="s">
-          <h3>Importing EUI global Sass</h3>
-        </EuiTitle>
-
-        <EuiSpacer />
+        <EuiSpacer size="xxl"/>
+
+        <GuideRuleTitle>Going beyond the provided colors</GuideRuleTitle>
+
+        <EuiSpacer size="xxl"/>
+
+        <EuiFlexGrid columns={2}>
+          <EuiFlexItem>
+            <EuiTitle size="s">
+              <h4>Theming patterns</h4>
+            </EuiTitle>
+
+            <EuiSpacer />
+            <EuiText>
+              <p>
+                Often you need to go beyond the provided color set. When doing so <strong>always</strong> use
+                color functions to modify the base set. Here are some examples.
+              </p>
+            </EuiText>
+            <EuiSpacer />
+
+            <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
+              <EuiFlexItem grow={false}>
+                <div className="guideSass__swatch guideSass__swatch--danger" />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiCode>$euiCodeDanger</EuiCode>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer />
+            <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
+              <EuiFlexItem grow={false}>
+                <div className="guideSass__swatch guideSass__swatch--dangerTint" />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiCode>tint($euiCodeDanger, 30%)</EuiCode>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer />
+            <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
+              <EuiFlexItem grow={false}>
+                <div className="guideSass__swatch guideSass__swatch--dangerShade" />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiCode>shade($euiCodeDanger, 30%)</EuiCode>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+
+            <EuiSpacer />
+            <EuiText>
+              <p>
+                Remember that EUI provides dark and light mode theming support. Sometimes the traditional
+                color functions don&apos;t give enough flexibility for both modes.
+              </p>
+              <p>
+                For example, depending upon what theme you use <EuiCode>$EuiColorPrimary</EuiCode> will be a different
+                hex value.
+              </p>
+            </EuiText>
+            <EuiSpacer />
+
+            <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
+              <EuiFlexItem grow={false} style={{ background: '#FFF', padding: 8 }}>
+                <div className="guideSass__swatch guideSass__swatch--primaryLight" />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiCode>$euiColorPrimary</EuiCode>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiText size="s">
+                  <p>
+                    is #0079A5 in the light theme
+                  </p>
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer />
+            <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
+              <EuiFlexItem grow={false} style={{ background: '#222', padding: 8 }}>
+                <div className="guideSass__swatch guideSass__swatch--primaryDark" />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiCode>$euiColorPrimary</EuiCode>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiText size="s">
+                  <p>
+                    is #4da1c0 in the dark theme
+                  </p>
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+
+            <EuiSpacer />
+            <EuiText>
+              <p>
+                Taking the default primary color above we want to tint the color
+                in the light mode, but shade it in the dark mode. This makes the
+                background color more subtle in both use cases.
+              </p>
+            </EuiText>
+
+            <EuiSpacer />
+
+            <EuiCodeBlock language="scss" transparentBackground paddingSize="none">{tintOrShadeExample}</EuiCodeBlock>
+
+            <EuiSpacer />
+
+            <EuiFlexGrid columns={2}>
+              <EuiFlexItem style={{ background: '#FFF', padding: 16 }}>
+                <div className="guideSass__themedBox guideSass__themedBox--light">Light theme</div>
+              </EuiFlexItem>
+              <EuiFlexItem style={{ background: '#222', padding: 16 }}>
+                <div className="guideSass__themedBox guideSass__themedBox--dark">Dark theme</div>
+              </EuiFlexItem>
+            </EuiFlexGrid>
+
+          </EuiFlexItem>
+
+          <EuiFlexItem>
+            <EuiTitle size="s">
+              <h4>Color contrast patterns</h4>
+            </EuiTitle>
+
+            <EuiSpacer />
+
+            <EuiText>
+              <p>
+                EUI provides some nifty color functions for auto-adjusting color to pass AA contrast checks.
+                Often this is needed when using the base colors on top of each other. Here is an example
+                similar to our callouts with a pesky orange.
+              </p>
+            </EuiText>
+
+            <EuiSpacer />
+
+            <EuiCodeBlock language="scss" transparentBackground paddingSize="none">{contrastExample}</EuiCodeBlock>
+
+            <EuiSpacer />
+
+            <div className="guideSass__contrastExample">
+              This orange text now passes a contrast check!
+            </div>
+
+            <EuiSpacer />
+
+            <EuiTitle size="s">
+              <h4>More on color contrast</h4>
+            </EuiTitle>
+
+            <EuiSpacer />
+
+            <EuiText>
+              <p>
+                Consult the larger <Link to="/guidelines/colors">color guidelines</Link> page
+                for a better explanation about passing color contrast.
+              </p>
+            </EuiText>
+
+
+            <EuiSpacer />
+          </EuiFlexItem>
+        </EuiFlexGrid>
+
+        <GuideRuleTitle>Typography</GuideRuleTitle>
 
         <EuiText grow={false} className="guideSection__text">
           <p>
-            Most EUI based projects should already import the EUI global
-            scope. For example, Kibana has its own
-            liner that will give you everything on this page.
+            View the <EuiLink href="https://github.com/elastic/eui/blob/master/src/global_styling/variables/_typography.scss">variable</EuiLink>
+            {' '} and <EuiLink href="https://github.com/elastic/eui/blob/master/src/global_styling/mixins/_typography.scss">mixins</EuiLink>
+            {' '}Sass code for typography.
+            For most of your components we recommend using <Link to="/display/text">EuiText</Link> or
+            {' '}<Link to="/display/title">EuiTitle</Link> instead of these Sass variables.
           </p>
         </EuiText>
+
         <EuiSpacer />
-        <EuiCodeBlock language="scss" transparentBackground paddingSize="none">
-          {importKibanaExample}
-        </EuiCodeBlock>
+        <EuiCallOut
+          size="s"
+          color="warning"
+          title={
+            <span>
+              It is more common to use these as a mixin (e.g. <EuiCode language="css">@include euiFontSizeS;</EuiCode>)
+              to automatically apply line-height as well as size.
+            </span>
+          }
+        />
+
         <EuiSpacer />
+        <EuiFlexGrid columns={2}>
+          <EuiFlexItem>
+            <EuiTitle size="s">
+              <h4>Text sizes</h4>
+            </EuiTitle>
+
+            <EuiSpacer />
+            {euiFontSizes.map(function (size, index) {
+              return renderFontSize(size, index);
+            })}
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <div>
+              <EuiTitle size="s">
+                <h4>Text colors</h4>
+              </EuiTitle>
+
+              <EuiSpacer />
+
+              {euiTextColors.map(function (color, index) {
+                return renderPaletteColor(palette, color, index);
+              })}
+
+              <EuiSpacer />
+
+              <EuiTitle>
+                <h4>Font families</h4>
+              </EuiTitle>
+
+              <EuiSpacer />
+
+              <EuiFlexGroup responsive={false} alignItems="center">
+                <EuiFlexItem grow={false} className="guideSass__fontFamily">
+                  Abc
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiCode language="css">@include euiFont;</EuiCode>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+
+              <EuiFlexGroup responsive={false} alignItems="center">
+                <EuiFlexItem grow={false} className="guideSass__fontFamily guideSass__fontFamily--code">
+                  Abc
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiCode language="css">@include euiCodeFont;</EuiCode>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </div>
+          </EuiFlexItem>
+        </EuiFlexGrid>
+
+        <EuiSpacer size="xxl"/>
+
+        <GuideRuleTitle>Borders</GuideRuleTitle>
+
+        <EuiSpacer size="xxl"/>
+
+        <EuiText grow={false}>
+          <p>EUI provides some helper variables for setting common border types.</p>
+        </EuiText>
+
+        <EuiSpacer />
+
+        <EuiFlexGrid columns={3}>
+          {euiBorders.map(function (border, index) {
+            return renderBorder(border, index);
+          })}
+        </EuiFlexGrid>
+
+        <EuiSpacer />
+
+        <EuiText grow={false}>
+          <p>In addition, you can utilize <EuiCode>$euiBorderRadius</EuiCode> to round the corners.</p>
+        </EuiText>
+
+        <EuiSpacer />
+
+        <EuiFlexGrid columns={3}>
+          <EuiFlexItem className="guideSass__border guideSass__border--radius">
+            <EuiCodeBlock language="scss" transparentBackground paddingSize="none">
+              {borderRadiusExample}
+            </EuiCodeBlock>
+          </EuiFlexItem>
+        </EuiFlexGrid>
+
+        <GuideRuleTitle>Shadow and Depth</GuideRuleTitle>
+
+        <EuiFlexGrid columns={2}>
+          <EuiFlexItem>
+
+            <EuiTitle size="s">
+              <h4>Use mixins for shadows</h4>
+            </EuiTitle>
+
+            <EuiText>
+              <p>
+                <EuiLink href="https://github.com/elastic/eui/blob/master/src/global_styling/mixins/_shadow.scss">View the Sass code for shadow mixins</EuiLink>.
+              </p>
+            </EuiText>
+
+            <EuiSpacer />
+
+            {euiShadows.map(function (shadow, index) {
+              return renderShadow(shadow, index);
+            })}
+          </EuiFlexItem>
+          <EuiFlexItem>
+
+            <EuiTitle size="s">
+              <h4>Shadows to create graceful overflows</h4>
+            </EuiTitle>
+
+            <EuiText>
+              <p>
+                Primarily used in modals and flyouts, the overflow shadows add a white
+                glow to subtly hide the content they float above.
+              </p>
+            </EuiText>
+
+            <EuiSpacer />
+
+            <div className="guideSass__overflowShadows">
+              <EuiText className="guideSass__overflowShadowText" size="s">
+                <p>
+                  Minima reprehenderit aperiam at in ea. Veniam nihil quod tempore.
+                  Dolores sit quo expedita voluptate libero.
+                  Consequuntur atque nulla atque nemo tenetur numquam.
+                  Assumenda aspernatur qui aut sit. Aliquam doloribus iure sint id.
+                  Possimus dolor qui soluta cum id tempore ea illum.
+                  Facilis voluptatem aut aut ut similique ut.
+                  Sed repellendus commodi iure officiis exercitationem praesentium
+                  dolor. Ratione non ut nulla accusamus et. Optio laboriosam id
+                  incidunt. Ipsam voluptate ab quia necessitatibus sequi earum
+                  voluptate. Porro tempore et veritatis quo omnis. Eaque ut libero
+                  tempore sit placeat maxime laudantium.
+                  Mollitia tempore minus qui autem modi adipisci ad. Iste reprehenderit
+                  accusamus voluptatem velit. Quidem delectus eos veritatis et vitae
+                  et nisi. Doloribus ut corrupti voluptates qui exercitationem dolores.
+                </p>
+              </EuiText>
+              {euiOverFlowShadows.map(function (shadow, index) {
+                return renderShadow(shadow, index);
+              })}
+            </div>
+
+            <EuiSpacer />
+
+            <EuiTitle size="s">
+              <h4>Adding color to shadows</h4>
+            </EuiTitle>
+
+            <EuiText>
+              <p>Most shadow mixins can also accept color.</p>
+            </EuiText>
+
+            <EuiSpacer />
+
+            <div className="guideSass__shadow guideSass__shadow--color eui-textBreakAll">
+              <EuiCodeBlock
+                language="scss"
+                paddingSize="none"
+                transparentBackground
+              >
+                  @include euiBottomShadowLarge(desaturate($euiColorPrimary, 30%));
+              </EuiCodeBlock>
+            </div>
+          </EuiFlexItem>
+        </EuiFlexGrid>
+
+        <EuiSpacer size="xxl"/>
+
+        <GuideRuleTitle>Media queries and breakpoints</GuideRuleTitle>
+
+        <EuiText className="guideSection__text">
+          <p>
+            <EuiLink href="https://github.com/elastic/eui/blob/master/src/global_styling/mixins/_responsive.scss">View the Sass code for media queries</EuiLink>.
+          </p>
+          <p>
+            Breakpoints in EUI are provided through the use of a Sass
+            mixin <EuiCode>@include euiBreakpoint()</EuiCode> that
+            accepts an array of sizes.
+          </p>
+        </EuiText>
+
+        <EuiSpacer />
+        <div className="guideSass__breakpointExample" />
+        <EuiSpacer />
+
+        <EuiFlexGrid columns={2}>
+          <EuiFlexItem>
+            <div>
+              <EuiTitle size="s">
+                <h4>Breakpoint sizing</h4>
+              </EuiTitle>
+
+              <EuiSpacer />
+
+              {euiBreakPoints.map(function (size, index) {
+                return renderBreakpoint(size, index);
+              })}
+
+
+            </div>
+
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiTitle size="s">
+              <h4>Mixin usage</h4>
+            </EuiTitle>
+
+            <EuiSpacer />
+
+            <EuiText><p>Target mobile devices only</p></EuiText>
+            <EuiCodeBlock language="scss" transparentBackground paddingSize="s">
+              {'@include euiBreakpoint(\'xs\',\'s\') {...}'}
+            </EuiCodeBlock>
+
+            <EuiSpacer />
+
+            <EuiText><p>Target mobile and tablets</p></EuiText>
+            <EuiCodeBlock language="scss" transparentBackground paddingSize="s">
+              {'@include euiBreakpoint(\'xs\', \'s\', \'m\') {...}'}
+            </EuiCodeBlock>
+
+            <EuiSpacer />
+
+            <EuiText><p>Target tablets only</p></EuiText>
+            <EuiCodeBlock language="scss" transparentBackground paddingSize="s">
+              {'@include euiBreakpoint(\'m\') {...}'}
+            </EuiCodeBlock>
+
+            <EuiSpacer />
+
+            <EuiText><p>Target very wide displays only</p></EuiText>
+            <EuiCodeBlock language="scss" transparentBackground paddingSize="s">
+              {'@include euiBreakpoint(\'xl\') {...}'}
+            </EuiCodeBlock>
+
+            <EuiSpacer />
+          </EuiFlexItem>
+        </EuiFlexGrid>
+
+        <EuiSpacer size="xxl"/>
+
+        <GuideRuleTitle>Animation</GuideRuleTitle>
         <EuiText grow={false} className="guideSection__text">
           <p>
-            If you want to construct your own import, you would just need to
-            import the following core files into a fresh Sass project.
+            <EuiLink href="https://github.com/elastic/eui/blob/master/src/global_styling/variables/_animation.scss">View the Sass code for animation</EuiLink>.
+          </p>
+          <p>
+            EUI utilizes the following constants to maintain a similar &apos;bounce&apos; to its animations.
+            That said, animations are tricky, and if they aren&apos;t working for your specific application
+            this is the one place where we think it&apos;s OK to come up with your own rules.
           </p>
         </EuiText>
-
         <EuiSpacer />
+        <EuiFlexGrid columns={2}>
+          <EuiFlexItem>
+            <EuiTitle size="s">
+              <h4>Speed</h4>
+            </EuiTitle>
 
-        <EuiCodeBlock language="scss" transparentBackground paddingSize="none">
-          {importOutsideExample}
-        </EuiCodeBlock>
+            <EuiSpacer />
 
-      </EuiFlexItem>
-    </EuiFlexGrid>
+            {euiAnimationSpeeds.map(function (speed, index) {
+              return renderAnimationSpeed(speed, index);
+            })}
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiTitle size="s">
+              <h4>Timing</h4>
+            </EuiTitle>
 
-  </GuidePage>
-);
+            <EuiSpacer />
+
+            {euiAnimationTimings.map(function (speed, index) {
+              return renderAnimationTiming(speed, index);
+            })}
+          </EuiFlexItem>
+        </EuiFlexGrid>
+
+        <EuiSpacer size="xl" />
+
+        <GuideRuleTitle>Sass best practices</GuideRuleTitle>
+
+        <EuiSpacer size="xl" />
+
+        <EuiFlexGrid columns={2}>
+          <EuiFlexItem>
+            <EuiText>
+              <h3>Component based naming</h3>
+              <p>
+                EUI is written in a <EuiLink href="http://getbem.com/introduction/">BEM</EuiLink>ish style with the addition of verb states (ex: <EuiCode>*-isLoading</EuiCode>).
+                Below is an example of proper formatting.
+              </p>
+            </EuiText>
+            <EuiSpacer />
+            <EuiCodeBlock language="scss" transparentBackground paddingSize="none">{bemExample}</EuiCodeBlock>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText grow={false} className="guideSection__text">
+              <h3>Writing Sass the EUI way</h3>
+              <p>
+                In general, when writing new SCSS in a project that installs EUI as a dependency
+                try to follow these best practices:
+              </p>
+            </EuiText>
+            <EuiSpacer />
+            <EuiText size="s" grow={false} className="guideSection__text">
+              <ul>
+                <li>Utilize color variables and functions rather than hard-coded values</li>
+                <li>Utilize the sizing variables for padding and margins</li>
+                <li>Utilize the animation variables for animations when possible</li>
+                <li>Utilize the responsive mixins for all screen width calculations</li>
+                <li>Utilize the typography mixins and variables for all font family, weight, and sizing</li>
+                <li>Utilize the shadow mixins and z-index variables to manage depth</li>
+                <li>Utilize the border and border-radius variable to handle border usage</li>
+                <li>Minimize your overwrites and try to make new Sass additive in nature</li>
+              </ul>
+            </EuiText>
+
+            <EuiSpacer />
+
+            <EuiTitle size="s">
+              <h3>Importing EUI global Sass</h3>
+            </EuiTitle>
+
+            <EuiSpacer />
+
+            <EuiText grow={false} className="guideSection__text">
+              <p>
+                Most EUI based projects should already import the EUI global
+                scope. For example, Kibana has its own
+                liner that will give you everything on this page.
+              </p>
+            </EuiText>
+            <EuiSpacer />
+            <EuiCodeBlock language="scss" transparentBackground paddingSize="none">
+              {importKibanaExample}
+            </EuiCodeBlock>
+            <EuiSpacer />
+            <EuiText grow={false} className="guideSection__text">
+              <p>
+                If you want to construct your own import, you would just need to
+                import the following core files into a fresh Sass project.
+              </p>
+            </EuiText>
+
+            <EuiSpacer />
+
+            <EuiCodeBlock language="scss" transparentBackground paddingSize="none">
+              {importOutsideExample}
+            </EuiCodeBlock>
+
+          </EuiFlexItem>
+        </EuiFlexGrid>
+
+      </GuidePage>
+    );
+  }
+}

--- a/src-docs/src/views/guidelines/sass.js
+++ b/src-docs/src/views/guidelines/sass.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import lightColors from '!!sass-vars-to-js-loader?preserveKeys=true!../../../../src/global_styling/variables/_colors.scss';
 import darkColors from '!!sass-vars-to-js-loader!../../../../src/themes/eui/eui_colors_dark.scss';
 import sizes from '!!sass-vars-to-js-loader?preserveKeys=true!../../../../src/global_styling/variables/_size.scss';
@@ -332,614 +332,609 @@ const contrastExample = (`// Make sure text passes a contrast check
 }
 `);
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
-  }
+export const SassGuidelines = ({
+  selectedTheme
+}) => {
 
-  render() {
+  const palette = (selectedTheme === 'light') ? lightColors : darkColors;
 
-    const palette = (this.props.selectedTheme === 'light') ? lightColors : darkColors;
+  return (
+    <GuidePage title="Sass guidelines">
 
-    return (
-      <GuidePage title="Sass guidelines">
+      <EuiTitle>
+        <h2>Core variables</h2>
+      </EuiTitle>
 
+      <EuiSpacer size="xxl" />
 
-        <EuiTitle>
-          <h2>Core variables</h2>
-        </EuiTitle>
-
-        <EuiSpacer size="xxl" />
-
-        <EuiFlexGrid columns={2}>
-          <EuiFlexItem>
-            <div>
-              <EuiTitle size="s">
-                <h4>Sizing</h4>
-              </EuiTitle>
-
-              <EuiSpacer />
-
-              {euiSizes.map(function (size, index) {
-                return renderSize(size, index);
-              })}
-
-              <EuiSpacer />
-
-              <EuiTitle size="s">
-                <h4>Z-index</h4>
-              </EuiTitle>
-
-              <EuiSpacer />
-
-              {euiLevels.map(function (level, index) {
-                return renderLevel(level, index);
-              })}
-            </div>
-
-          </EuiFlexItem>
-          <EuiFlexItem>
+      <EuiFlexGrid columns={2}>
+        <EuiFlexItem>
+          <div>
             <EuiTitle size="s">
-              <h4>Color</h4>
+              <h4>Sizing</h4>
             </EuiTitle>
 
             <EuiSpacer />
 
-            {euiColors.map(function (color, index) {
+            {euiSizes.map(function (size, index) {
+              return renderSize(size, index);
+            })}
+
+            <EuiSpacer />
+
+            <EuiTitle size="s">
+              <h4>Z-index</h4>
+            </EuiTitle>
+
+            <EuiSpacer />
+
+            {euiLevels.map(function (level, index) {
+              return renderLevel(level, index);
+            })}
+          </div>
+
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiTitle size="s">
+            <h4>Color</h4>
+          </EuiTitle>
+
+          <EuiSpacer />
+
+          {euiColors.map(function (color, index) {
+            return renderPaletteColor(palette, color, index);
+          })}
+
+        </EuiFlexItem>
+      </EuiFlexGrid>
+
+      <EuiSpacer size="xxl"/>
+
+      <GuideRuleTitle>Going beyond the provided colors</GuideRuleTitle>
+
+      <EuiSpacer size="xxl"/>
+
+      <EuiFlexGrid columns={2}>
+        <EuiFlexItem>
+          <EuiTitle size="s">
+            <h4>Theming patterns</h4>
+          </EuiTitle>
+
+          <EuiSpacer />
+          <EuiText>
+            <p>
+              Often you need to go beyond the provided color set. When doing so <strong>always</strong> use
+              color functions to modify the base set. Here are some examples.
+            </p>
+          </EuiText>
+          <EuiSpacer />
+
+          <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
+            <EuiFlexItem grow={false}>
+              <div className="guideSass__swatch guideSass__swatch--danger" />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiCode>$euiCodeDanger</EuiCode>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiSpacer />
+          <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
+            <EuiFlexItem grow={false}>
+              <div className="guideSass__swatch guideSass__swatch--dangerTint" />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiCode>tint($euiCodeDanger, 30%)</EuiCode>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiSpacer />
+          <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
+            <EuiFlexItem grow={false}>
+              <div className="guideSass__swatch guideSass__swatch--dangerShade" />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiCode>shade($euiCodeDanger, 30%)</EuiCode>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+
+          <EuiSpacer />
+          <EuiText>
+            <p>
+              Remember that EUI provides dark and light mode theming support. Sometimes the traditional
+              color functions don&apos;t give enough flexibility for both modes.
+            </p>
+            <p>
+              For example, depending upon what theme you use <EuiCode>$EuiColorPrimary</EuiCode> will be a different
+              hex value.
+            </p>
+          </EuiText>
+          <EuiSpacer />
+
+          <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
+            <EuiFlexItem grow={false} style={{ background: '#FFF', padding: 8 }}>
+              <div className="guideSass__swatch guideSass__swatch--primaryLight" />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiCode>$euiColorPrimary</EuiCode>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiText size="s">
+                <p>
+                  is #0079A5 in the light theme
+                </p>
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiSpacer />
+          <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
+            <EuiFlexItem grow={false} style={{ background: '#222', padding: 8 }}>
+              <div className="guideSass__swatch guideSass__swatch--primaryDark" />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiCode>$euiColorPrimary</EuiCode>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiText size="s">
+                <p>
+                  is #4da1c0 in the dark theme
+                </p>
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+
+          <EuiSpacer />
+          <EuiText>
+            <p>
+              Taking the default primary color above we want to tint the color
+              in the light mode, but shade it in the dark mode. This makes the
+              background color more subtle in both use cases.
+            </p>
+          </EuiText>
+
+          <EuiSpacer />
+
+          <EuiCodeBlock language="scss" transparentBackground paddingSize="none">{tintOrShadeExample}</EuiCodeBlock>
+
+          <EuiSpacer />
+
+          <EuiFlexGrid columns={2}>
+            <EuiFlexItem style={{ background: '#FFF', padding: 16 }}>
+              <div className="guideSass__themedBox guideSass__themedBox--light">Light theme</div>
+            </EuiFlexItem>
+            <EuiFlexItem style={{ background: '#222', padding: 16 }}>
+              <div className="guideSass__themedBox guideSass__themedBox--dark">Dark theme</div>
+            </EuiFlexItem>
+          </EuiFlexGrid>
+
+        </EuiFlexItem>
+
+        <EuiFlexItem>
+          <EuiTitle size="s">
+            <h4>Color contrast patterns</h4>
+          </EuiTitle>
+
+          <EuiSpacer />
+
+          <EuiText>
+            <p>
+              EUI provides some nifty color functions for auto-adjusting color to pass AA contrast checks.
+              Often this is needed when using the base colors on top of each other. Here is an example
+              similar to our callouts with a pesky orange.
+            </p>
+          </EuiText>
+
+          <EuiSpacer />
+
+          <EuiCodeBlock language="scss" transparentBackground paddingSize="none">{contrastExample}</EuiCodeBlock>
+
+          <EuiSpacer />
+
+          <div className="guideSass__contrastExample">
+            This orange text now passes a contrast check!
+          </div>
+
+          <EuiSpacer />
+
+          <EuiTitle size="s">
+            <h4>More on color contrast</h4>
+          </EuiTitle>
+
+          <EuiSpacer />
+
+          <EuiText>
+            <p>
+              Consult the larger <Link to="/guidelines/colors">color guidelines</Link> page
+              for a better explanation about passing color contrast.
+            </p>
+          </EuiText>
+
+
+          <EuiSpacer />
+        </EuiFlexItem>
+      </EuiFlexGrid>
+
+      <GuideRuleTitle>Typography</GuideRuleTitle>
+
+      <EuiText grow={false} className="guideSection__text">
+        <p>
+          View the <EuiLink href="https://github.com/elastic/eui/blob/master/src/global_styling/variables/_typography.scss">variable</EuiLink>
+          {' '} and <EuiLink href="https://github.com/elastic/eui/blob/master/src/global_styling/mixins/_typography.scss">mixins</EuiLink>
+          {' '}Sass code for typography.
+          For most of your components we recommend using <Link to="/display/text">EuiText</Link> or
+          {' '}<Link to="/display/title">EuiTitle</Link> instead of these Sass variables.
+        </p>
+      </EuiText>
+
+      <EuiSpacer />
+      <EuiCallOut
+        size="s"
+        color="warning"
+        title={
+          <span>
+            It is more common to use these as a mixin (e.g. <EuiCode language="css">@include euiFontSizeS;</EuiCode>)
+            to automatically apply line-height as well as size.
+          </span>
+        }
+      />
+
+      <EuiSpacer />
+      <EuiFlexGrid columns={2}>
+        <EuiFlexItem>
+          <EuiTitle size="s">
+            <h4>Text sizes</h4>
+          </EuiTitle>
+
+          <EuiSpacer />
+          {euiFontSizes.map(function (size, index) {
+            return renderFontSize(size, index);
+          })}
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <div>
+            <EuiTitle size="s">
+              <h4>Text colors</h4>
+            </EuiTitle>
+
+            <EuiSpacer />
+
+            {euiTextColors.map(function (color, index) {
               return renderPaletteColor(palette, color, index);
             })}
 
-          </EuiFlexItem>
-        </EuiFlexGrid>
-
-        <EuiSpacer size="xxl"/>
-
-        <GuideRuleTitle>Going beyond the provided colors</GuideRuleTitle>
-
-        <EuiSpacer size="xxl"/>
-
-        <EuiFlexGrid columns={2}>
-          <EuiFlexItem>
-            <EuiTitle size="s">
-              <h4>Theming patterns</h4>
-            </EuiTitle>
-
-            <EuiSpacer />
-            <EuiText>
-              <p>
-                Often you need to go beyond the provided color set. When doing so <strong>always</strong> use
-                color functions to modify the base set. Here are some examples.
-              </p>
-            </EuiText>
             <EuiSpacer />
 
-            <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
-              <EuiFlexItem grow={false}>
-                <div className="guideSass__swatch guideSass__swatch--danger" />
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiCode>$euiCodeDanger</EuiCode>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-            <EuiSpacer />
-            <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
-              <EuiFlexItem grow={false}>
-                <div className="guideSass__swatch guideSass__swatch--dangerTint" />
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiCode>tint($euiCodeDanger, 30%)</EuiCode>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-            <EuiSpacer />
-            <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
-              <EuiFlexItem grow={false}>
-                <div className="guideSass__swatch guideSass__swatch--dangerShade" />
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiCode>shade($euiCodeDanger, 30%)</EuiCode>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-
-            <EuiSpacer />
-            <EuiText>
-              <p>
-                Remember that EUI provides dark and light mode theming support. Sometimes the traditional
-                color functions don&apos;t give enough flexibility for both modes.
-              </p>
-              <p>
-                For example, depending upon what theme you use <EuiCode>$EuiColorPrimary</EuiCode> will be a different
-                hex value.
-              </p>
-            </EuiText>
-            <EuiSpacer />
-
-            <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
-              <EuiFlexItem grow={false} style={{ background: '#FFF', padding: 8 }}>
-                <div className="guideSass__swatch guideSass__swatch--primaryLight" />
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiCode>$euiColorPrimary</EuiCode>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiText size="s">
-                  <p>
-                    is #0079A5 in the light theme
-                  </p>
-                </EuiText>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-            <EuiSpacer />
-            <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
-              <EuiFlexItem grow={false} style={{ background: '#222', padding: 8 }}>
-                <div className="guideSass__swatch guideSass__swatch--primaryDark" />
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiCode>$euiColorPrimary</EuiCode>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiText size="s">
-                  <p>
-                    is #4da1c0 in the dark theme
-                  </p>
-                </EuiText>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-
-            <EuiSpacer />
-            <EuiText>
-              <p>
-                Taking the default primary color above we want to tint the color
-                in the light mode, but shade it in the dark mode. This makes the
-                background color more subtle in both use cases.
-              </p>
-            </EuiText>
-
-            <EuiSpacer />
-
-            <EuiCodeBlock language="scss" transparentBackground paddingSize="none">{tintOrShadeExample}</EuiCodeBlock>
-
-            <EuiSpacer />
-
-            <EuiFlexGrid columns={2}>
-              <EuiFlexItem style={{ background: '#FFF', padding: 16 }}>
-                <div className="guideSass__themedBox guideSass__themedBox--light">Light theme</div>
-              </EuiFlexItem>
-              <EuiFlexItem style={{ background: '#222', padding: 16 }}>
-                <div className="guideSass__themedBox guideSass__themedBox--dark">Dark theme</div>
-              </EuiFlexItem>
-            </EuiFlexGrid>
-
-          </EuiFlexItem>
-
-          <EuiFlexItem>
-            <EuiTitle size="s">
-              <h4>Color contrast patterns</h4>
+            <EuiTitle>
+              <h4>Font families</h4>
             </EuiTitle>
 
             <EuiSpacer />
 
-            <EuiText>
-              <p>
-                EUI provides some nifty color functions for auto-adjusting color to pass AA contrast checks.
-                Often this is needed when using the base colors on top of each other. Here is an example
-                similar to our callouts with a pesky orange.
-              </p>
-            </EuiText>
+            <EuiFlexGroup responsive={false} alignItems="center">
+              <EuiFlexItem grow={false} className="guideSass__fontFamily">
+                Abc
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiCode language="css">@include euiFont;</EuiCode>
+              </EuiFlexItem>
+            </EuiFlexGroup>
 
-            <EuiSpacer />
+            <EuiFlexGroup responsive={false} alignItems="center">
+              <EuiFlexItem grow={false} className="guideSass__fontFamily guideSass__fontFamily--code">
+                Abc
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiCode language="css">@include euiCodeFont;</EuiCode>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </div>
+        </EuiFlexItem>
+      </EuiFlexGrid>
 
-            <EuiCodeBlock language="scss" transparentBackground paddingSize="none">{contrastExample}</EuiCodeBlock>
+      <EuiSpacer size="xxl"/>
 
-            <EuiSpacer />
+      <GuideRuleTitle>Borders</GuideRuleTitle>
 
-            <div className="guideSass__contrastExample">
-              This orange text now passes a contrast check!
-            </div>
+      <EuiSpacer size="xxl"/>
 
-            <EuiSpacer />
+      <EuiText grow={false}>
+        <p>EUI provides some helper variables for setting common border types.</p>
+      </EuiText>
 
-            <EuiTitle size="s">
-              <h4>More on color contrast</h4>
-            </EuiTitle>
+      <EuiSpacer />
 
-            <EuiSpacer />
+      <EuiFlexGrid columns={3}>
+        {euiBorders.map(function (border, index) {
+          return renderBorder(border, index);
+        })}
+      </EuiFlexGrid>
 
-            <EuiText>
-              <p>
-                Consult the larger <Link to="/guidelines/colors">color guidelines</Link> page
-                for a better explanation about passing color contrast.
-              </p>
-            </EuiText>
+      <EuiSpacer />
 
+      <EuiText grow={false}>
+        <p>In addition, you can utilize <EuiCode>$euiBorderRadius</EuiCode> to round the corners.</p>
+      </EuiText>
 
-            <EuiSpacer />
-          </EuiFlexItem>
-        </EuiFlexGrid>
+      <EuiSpacer />
 
-        <GuideRuleTitle>Typography</GuideRuleTitle>
+      <EuiFlexGrid columns={3}>
+        <EuiFlexItem className="guideSass__border guideSass__border--radius">
+          <EuiCodeBlock language="scss" transparentBackground paddingSize="none">
+            {borderRadiusExample}
+          </EuiCodeBlock>
+        </EuiFlexItem>
+      </EuiFlexGrid>
 
-        <EuiText grow={false} className="guideSection__text">
-          <p>
-            View the <EuiLink href="https://github.com/elastic/eui/blob/master/src/global_styling/variables/_typography.scss">variable</EuiLink>
-            {' '} and <EuiLink href="https://github.com/elastic/eui/blob/master/src/global_styling/mixins/_typography.scss">mixins</EuiLink>
-            {' '}Sass code for typography.
-            For most of your components we recommend using <Link to="/display/text">EuiText</Link> or
-            {' '}<Link to="/display/title">EuiTitle</Link> instead of these Sass variables.
-          </p>
-        </EuiText>
+      <GuideRuleTitle>Shadow and Depth</GuideRuleTitle>
 
-        <EuiSpacer />
-        <EuiCallOut
-          size="s"
-          color="warning"
-          title={
-            <span>
-              It is more common to use these as a mixin (e.g. <EuiCode language="css">@include euiFontSizeS;</EuiCode>)
-              to automatically apply line-height as well as size.
-            </span>
-          }
-        />
+      <EuiFlexGrid columns={2}>
+        <EuiFlexItem>
 
-        <EuiSpacer />
-        <EuiFlexGrid columns={2}>
-          <EuiFlexItem>
-            <EuiTitle size="s">
-              <h4>Text sizes</h4>
-            </EuiTitle>
+          <EuiTitle size="s">
+            <h4>Use mixins for shadows</h4>
+          </EuiTitle>
 
-            <EuiSpacer />
-            {euiFontSizes.map(function (size, index) {
-              return renderFontSize(size, index);
-            })}
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <div>
-              <EuiTitle size="s">
-                <h4>Text colors</h4>
-              </EuiTitle>
+          <EuiText>
+            <p>
+              <EuiLink href="https://github.com/elastic/eui/blob/master/src/global_styling/mixins/_shadow.scss">View the Sass code for shadow mixins</EuiLink>.
+            </p>
+          </EuiText>
 
-              <EuiSpacer />
+          <EuiSpacer />
 
-              {euiTextColors.map(function (color, index) {
-                return renderPaletteColor(palette, color, index);
-              })}
-
-              <EuiSpacer />
-
-              <EuiTitle>
-                <h4>Font families</h4>
-              </EuiTitle>
-
-              <EuiSpacer />
-
-              <EuiFlexGroup responsive={false} alignItems="center">
-                <EuiFlexItem grow={false} className="guideSass__fontFamily">
-                  Abc
-                </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiCode language="css">@include euiFont;</EuiCode>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-
-              <EuiFlexGroup responsive={false} alignItems="center">
-                <EuiFlexItem grow={false} className="guideSass__fontFamily guideSass__fontFamily--code">
-                  Abc
-                </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiCode language="css">@include euiCodeFont;</EuiCode>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </div>
-          </EuiFlexItem>
-        </EuiFlexGrid>
-
-        <EuiSpacer size="xxl"/>
-
-        <GuideRuleTitle>Borders</GuideRuleTitle>
-
-        <EuiSpacer size="xxl"/>
-
-        <EuiText grow={false}>
-          <p>EUI provides some helper variables for setting common border types.</p>
-        </EuiText>
-
-        <EuiSpacer />
-
-        <EuiFlexGrid columns={3}>
-          {euiBorders.map(function (border, index) {
-            return renderBorder(border, index);
+          {euiShadows.map(function (shadow, index) {
+            return renderShadow(shadow, index);
           })}
-        </EuiFlexGrid>
+        </EuiFlexItem>
+        <EuiFlexItem>
 
-        <EuiSpacer />
+          <EuiTitle size="s">
+            <h4>Shadows to create graceful overflows</h4>
+          </EuiTitle>
 
-        <EuiText grow={false}>
-          <p>In addition, you can utilize <EuiCode>$euiBorderRadius</EuiCode> to round the corners.</p>
-        </EuiText>
+          <EuiText>
+            <p>
+              Primarily used in modals and flyouts, the overflow shadows add a white
+              glow to subtly hide the content they float above.
+            </p>
+          </EuiText>
 
-        <EuiSpacer />
+          <EuiSpacer />
 
-        <EuiFlexGrid columns={3}>
-          <EuiFlexItem className="guideSass__border guideSass__border--radius">
-            <EuiCodeBlock language="scss" transparentBackground paddingSize="none">
-              {borderRadiusExample}
-            </EuiCodeBlock>
-          </EuiFlexItem>
-        </EuiFlexGrid>
-
-        <GuideRuleTitle>Shadow and Depth</GuideRuleTitle>
-
-        <EuiFlexGrid columns={2}>
-          <EuiFlexItem>
-
-            <EuiTitle size="s">
-              <h4>Use mixins for shadows</h4>
-            </EuiTitle>
-
-            <EuiText>
+          <div className="guideSass__overflowShadows">
+            <EuiText className="guideSass__overflowShadowText" size="s">
               <p>
-                <EuiLink href="https://github.com/elastic/eui/blob/master/src/global_styling/mixins/_shadow.scss">View the Sass code for shadow mixins</EuiLink>.
+                Minima reprehenderit aperiam at in ea. Veniam nihil quod tempore.
+                Dolores sit quo expedita voluptate libero.
+                Consequuntur atque nulla atque nemo tenetur numquam.
+                Assumenda aspernatur qui aut sit. Aliquam doloribus iure sint id.
+                Possimus dolor qui soluta cum id tempore ea illum.
+                Facilis voluptatem aut aut ut similique ut.
+                Sed repellendus commodi iure officiis exercitationem praesentium
+                dolor. Ratione non ut nulla accusamus et. Optio laboriosam id
+                incidunt. Ipsam voluptate ab quia necessitatibus sequi earum
+                voluptate. Porro tempore et veritatis quo omnis. Eaque ut libero
+                tempore sit placeat maxime laudantium.
+                Mollitia tempore minus qui autem modi adipisci ad. Iste reprehenderit
+                accusamus voluptatem velit. Quidem delectus eos veritatis et vitae
+                et nisi. Doloribus ut corrupti voluptates qui exercitationem dolores.
               </p>
             </EuiText>
-
-            <EuiSpacer />
-
-            {euiShadows.map(function (shadow, index) {
+            {euiOverFlowShadows.map(function (shadow, index) {
               return renderShadow(shadow, index);
             })}
-          </EuiFlexItem>
-          <EuiFlexItem>
+          </div>
 
+          <EuiSpacer />
+
+          <EuiTitle size="s">
+            <h4>Adding color to shadows</h4>
+          </EuiTitle>
+
+          <EuiText>
+            <p>Most shadow mixins can also accept color.</p>
+          </EuiText>
+
+          <EuiSpacer />
+
+          <div className="guideSass__shadow guideSass__shadow--color eui-textBreakAll">
+            <EuiCodeBlock
+              language="scss"
+              paddingSize="none"
+              transparentBackground
+            >
+                @include euiBottomShadowLarge(desaturate($euiColorPrimary, 30%));
+            </EuiCodeBlock>
+          </div>
+        </EuiFlexItem>
+      </EuiFlexGrid>
+
+      <EuiSpacer size="xxl"/>
+
+      <GuideRuleTitle>Media queries and breakpoints</GuideRuleTitle>
+
+      <EuiText className="guideSection__text">
+        <p>
+          <EuiLink href="https://github.com/elastic/eui/blob/master/src/global_styling/mixins/_responsive.scss">View the Sass code for media queries</EuiLink>.
+        </p>
+        <p>
+          Breakpoints in EUI are provided through the use of a Sass
+          mixin <EuiCode>@include euiBreakpoint()</EuiCode> that
+          accepts an array of sizes.
+        </p>
+      </EuiText>
+
+      <EuiSpacer />
+      <div className="guideSass__breakpointExample" />
+      <EuiSpacer />
+
+      <EuiFlexGrid columns={2}>
+        <EuiFlexItem>
+          <div>
             <EuiTitle size="s">
-              <h4>Shadows to create graceful overflows</h4>
-            </EuiTitle>
-
-            <EuiText>
-              <p>
-                Primarily used in modals and flyouts, the overflow shadows add a white
-                glow to subtly hide the content they float above.
-              </p>
-            </EuiText>
-
-            <EuiSpacer />
-
-            <div className="guideSass__overflowShadows">
-              <EuiText className="guideSass__overflowShadowText" size="s">
-                <p>
-                  Minima reprehenderit aperiam at in ea. Veniam nihil quod tempore.
-                  Dolores sit quo expedita voluptate libero.
-                  Consequuntur atque nulla atque nemo tenetur numquam.
-                  Assumenda aspernatur qui aut sit. Aliquam doloribus iure sint id.
-                  Possimus dolor qui soluta cum id tempore ea illum.
-                  Facilis voluptatem aut aut ut similique ut.
-                  Sed repellendus commodi iure officiis exercitationem praesentium
-                  dolor. Ratione non ut nulla accusamus et. Optio laboriosam id
-                  incidunt. Ipsam voluptate ab quia necessitatibus sequi earum
-                  voluptate. Porro tempore et veritatis quo omnis. Eaque ut libero
-                  tempore sit placeat maxime laudantium.
-                  Mollitia tempore minus qui autem modi adipisci ad. Iste reprehenderit
-                  accusamus voluptatem velit. Quidem delectus eos veritatis et vitae
-                  et nisi. Doloribus ut corrupti voluptates qui exercitationem dolores.
-                </p>
-              </EuiText>
-              {euiOverFlowShadows.map(function (shadow, index) {
-                return renderShadow(shadow, index);
-              })}
-            </div>
-
-            <EuiSpacer />
-
-            <EuiTitle size="s">
-              <h4>Adding color to shadows</h4>
-            </EuiTitle>
-
-            <EuiText>
-              <p>Most shadow mixins can also accept color.</p>
-            </EuiText>
-
-            <EuiSpacer />
-
-            <div className="guideSass__shadow guideSass__shadow--color eui-textBreakAll">
-              <EuiCodeBlock
-                language="scss"
-                paddingSize="none"
-                transparentBackground
-              >
-                  @include euiBottomShadowLarge(desaturate($euiColorPrimary, 30%));
-              </EuiCodeBlock>
-            </div>
-          </EuiFlexItem>
-        </EuiFlexGrid>
-
-        <EuiSpacer size="xxl"/>
-
-        <GuideRuleTitle>Media queries and breakpoints</GuideRuleTitle>
-
-        <EuiText className="guideSection__text">
-          <p>
-            <EuiLink href="https://github.com/elastic/eui/blob/master/src/global_styling/mixins/_responsive.scss">View the Sass code for media queries</EuiLink>.
-          </p>
-          <p>
-            Breakpoints in EUI are provided through the use of a Sass
-            mixin <EuiCode>@include euiBreakpoint()</EuiCode> that
-            accepts an array of sizes.
-          </p>
-        </EuiText>
-
-        <EuiSpacer />
-        <div className="guideSass__breakpointExample" />
-        <EuiSpacer />
-
-        <EuiFlexGrid columns={2}>
-          <EuiFlexItem>
-            <div>
-              <EuiTitle size="s">
-                <h4>Breakpoint sizing</h4>
-              </EuiTitle>
-
-              <EuiSpacer />
-
-              {euiBreakPoints.map(function (size, index) {
-                return renderBreakpoint(size, index);
-              })}
-
-
-            </div>
-
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiTitle size="s">
-              <h4>Mixin usage</h4>
+              <h4>Breakpoint sizing</h4>
             </EuiTitle>
 
             <EuiSpacer />
 
-            <EuiText><p>Target mobile devices only</p></EuiText>
-            <EuiCodeBlock language="scss" transparentBackground paddingSize="s">
-              {'@include euiBreakpoint(\'xs\',\'s\') {...}'}
-            </EuiCodeBlock>
-
-            <EuiSpacer />
-
-            <EuiText><p>Target mobile and tablets</p></EuiText>
-            <EuiCodeBlock language="scss" transparentBackground paddingSize="s">
-              {'@include euiBreakpoint(\'xs\', \'s\', \'m\') {...}'}
-            </EuiCodeBlock>
-
-            <EuiSpacer />
-
-            <EuiText><p>Target tablets only</p></EuiText>
-            <EuiCodeBlock language="scss" transparentBackground paddingSize="s">
-              {'@include euiBreakpoint(\'m\') {...}'}
-            </EuiCodeBlock>
-
-            <EuiSpacer />
-
-            <EuiText><p>Target very wide displays only</p></EuiText>
-            <EuiCodeBlock language="scss" transparentBackground paddingSize="s">
-              {'@include euiBreakpoint(\'xl\') {...}'}
-            </EuiCodeBlock>
-
-            <EuiSpacer />
-          </EuiFlexItem>
-        </EuiFlexGrid>
-
-        <EuiSpacer size="xxl"/>
-
-        <GuideRuleTitle>Animation</GuideRuleTitle>
-        <EuiText grow={false} className="guideSection__text">
-          <p>
-            <EuiLink href="https://github.com/elastic/eui/blob/master/src/global_styling/variables/_animation.scss">View the Sass code for animation</EuiLink>.
-          </p>
-          <p>
-            EUI utilizes the following constants to maintain a similar &apos;bounce&apos; to its animations.
-            That said, animations are tricky, and if they aren&apos;t working for your specific application
-            this is the one place where we think it&apos;s OK to come up with your own rules.
-          </p>
-        </EuiText>
-        <EuiSpacer />
-        <EuiFlexGrid columns={2}>
-          <EuiFlexItem>
-            <EuiTitle size="s">
-              <h4>Speed</h4>
-            </EuiTitle>
-
-            <EuiSpacer />
-
-            {euiAnimationSpeeds.map(function (speed, index) {
-              return renderAnimationSpeed(speed, index);
+            {euiBreakPoints.map(function (size, index) {
+              return renderBreakpoint(size, index);
             })}
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiTitle size="s">
-              <h4>Timing</h4>
-            </EuiTitle>
 
-            <EuiSpacer />
 
-            {euiAnimationTimings.map(function (speed, index) {
-              return renderAnimationTiming(speed, index);
-            })}
-          </EuiFlexItem>
-        </EuiFlexGrid>
+          </div>
 
-        <EuiSpacer size="xl" />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiTitle size="s">
+            <h4>Mixin usage</h4>
+          </EuiTitle>
 
-        <GuideRuleTitle>Sass best practices</GuideRuleTitle>
+          <EuiSpacer />
 
-        <EuiSpacer size="xl" />
+          <EuiText><p>Target mobile devices only</p></EuiText>
+          <EuiCodeBlock language="scss" transparentBackground paddingSize="s">
+            {'@include euiBreakpoint(\'xs\',\'s\') {...}'}
+          </EuiCodeBlock>
 
-        <EuiFlexGrid columns={2}>
-          <EuiFlexItem>
-            <EuiText>
-              <h3>Component based naming</h3>
-              <p>
-                EUI is written in a <EuiLink href="http://getbem.com/introduction/">BEM</EuiLink>ish style with the addition of verb states (ex: <EuiCode>*-isLoading</EuiCode>).
-                Below is an example of proper formatting.
-              </p>
-            </EuiText>
-            <EuiSpacer />
-            <EuiCodeBlock language="scss" transparentBackground paddingSize="none">{bemExample}</EuiCodeBlock>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiText grow={false} className="guideSection__text">
-              <h3>Writing Sass the EUI way</h3>
-              <p>
-                In general, when writing new SCSS in a project that installs EUI as a dependency
-                try to follow these best practices:
-              </p>
-            </EuiText>
-            <EuiSpacer />
-            <EuiText size="s" grow={false} className="guideSection__text">
-              <ul>
-                <li>Utilize color variables and functions rather than hard-coded values</li>
-                <li>Utilize the sizing variables for padding and margins</li>
-                <li>Utilize the animation variables for animations when possible</li>
-                <li>Utilize the responsive mixins for all screen width calculations</li>
-                <li>Utilize the typography mixins and variables for all font family, weight, and sizing</li>
-                <li>Utilize the shadow mixins and z-index variables to manage depth</li>
-                <li>Utilize the border and border-radius variable to handle border usage</li>
-                <li>Minimize your overwrites and try to make new Sass additive in nature</li>
-              </ul>
-            </EuiText>
+          <EuiSpacer />
 
-            <EuiSpacer />
+          <EuiText><p>Target mobile and tablets</p></EuiText>
+          <EuiCodeBlock language="scss" transparentBackground paddingSize="s">
+            {'@include euiBreakpoint(\'xs\', \'s\', \'m\') {...}'}
+          </EuiCodeBlock>
 
-            <EuiTitle size="s">
-              <h3>Importing EUI global Sass</h3>
-            </EuiTitle>
+          <EuiSpacer />
 
-            <EuiSpacer />
+          <EuiText><p>Target tablets only</p></EuiText>
+          <EuiCodeBlock language="scss" transparentBackground paddingSize="s">
+            {'@include euiBreakpoint(\'m\') {...}'}
+          </EuiCodeBlock>
 
-            <EuiText grow={false} className="guideSection__text">
-              <p>
-                Most EUI based projects should already import the EUI global
-                scope. For example, Kibana has its own
-                liner that will give you everything on this page.
-              </p>
-            </EuiText>
-            <EuiSpacer />
-            <EuiCodeBlock language="scss" transparentBackground paddingSize="none">
-              {importKibanaExample}
-            </EuiCodeBlock>
-            <EuiSpacer />
-            <EuiText grow={false} className="guideSection__text">
-              <p>
-                If you want to construct your own import, you would just need to
-                import the following core files into a fresh Sass project.
-              </p>
-            </EuiText>
+          <EuiSpacer />
 
-            <EuiSpacer />
+          <EuiText><p>Target very wide displays only</p></EuiText>
+          <EuiCodeBlock language="scss" transparentBackground paddingSize="s">
+            {'@include euiBreakpoint(\'xl\') {...}'}
+          </EuiCodeBlock>
 
-            <EuiCodeBlock language="scss" transparentBackground paddingSize="none">
-              {importOutsideExample}
-            </EuiCodeBlock>
+          <EuiSpacer />
+        </EuiFlexItem>
+      </EuiFlexGrid>
 
-          </EuiFlexItem>
-        </EuiFlexGrid>
+      <EuiSpacer size="xxl"/>
 
-      </GuidePage>
-    );
-  }
-}
+      <GuideRuleTitle>Animation</GuideRuleTitle>
+      <EuiText grow={false} className="guideSection__text">
+        <p>
+          <EuiLink href="https://github.com/elastic/eui/blob/master/src/global_styling/variables/_animation.scss">View the Sass code for animation</EuiLink>.
+        </p>
+        <p>
+          EUI utilizes the following constants to maintain a similar &apos;bounce&apos; to its animations.
+          That said, animations are tricky, and if they aren&apos;t working for your specific application
+          this is the one place where we think it&apos;s OK to come up with your own rules.
+        </p>
+      </EuiText>
+      <EuiSpacer />
+      <EuiFlexGrid columns={2}>
+        <EuiFlexItem>
+          <EuiTitle size="s">
+            <h4>Speed</h4>
+          </EuiTitle>
+
+          <EuiSpacer />
+
+          {euiAnimationSpeeds.map(function (speed, index) {
+            return renderAnimationSpeed(speed, index);
+          })}
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiTitle size="s">
+            <h4>Timing</h4>
+          </EuiTitle>
+
+          <EuiSpacer />
+
+          {euiAnimationTimings.map(function (speed, index) {
+            return renderAnimationTiming(speed, index);
+          })}
+        </EuiFlexItem>
+      </EuiFlexGrid>
+
+      <EuiSpacer size="xl" />
+
+      <GuideRuleTitle>Sass best practices</GuideRuleTitle>
+
+      <EuiSpacer size="xl" />
+
+      <EuiFlexGrid columns={2}>
+        <EuiFlexItem>
+          <EuiText>
+            <h3>Component based naming</h3>
+            <p>
+              EUI is written in a <EuiLink href="http://getbem.com/introduction/">BEM</EuiLink>ish style with the addition of verb states (ex: <EuiCode>*-isLoading</EuiCode>).
+              Below is an example of proper formatting.
+            </p>
+          </EuiText>
+          <EuiSpacer />
+          <EuiCodeBlock language="scss" transparentBackground paddingSize="none">{bemExample}</EuiCodeBlock>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiText grow={false} className="guideSection__text">
+            <h3>Writing Sass the EUI way</h3>
+            <p>
+              In general, when writing new SCSS in a project that installs EUI as a dependency
+              try to follow these best practices:
+            </p>
+          </EuiText>
+          <EuiSpacer />
+          <EuiText size="s" grow={false} className="guideSection__text">
+            <ul>
+              <li>Utilize color variables and functions rather than hard-coded values</li>
+              <li>Utilize the sizing variables for padding and margins</li>
+              <li>Utilize the animation variables for animations when possible</li>
+              <li>Utilize the responsive mixins for all screen width calculations</li>
+              <li>Utilize the typography mixins and variables for all font family, weight, and sizing</li>
+              <li>Utilize the shadow mixins and z-index variables to manage depth</li>
+              <li>Utilize the border and border-radius variable to handle border usage</li>
+              <li>Minimize your overwrites and try to make new Sass additive in nature</li>
+            </ul>
+          </EuiText>
+
+          <EuiSpacer />
+
+          <EuiTitle size="s">
+            <h3>Importing EUI global Sass</h3>
+          </EuiTitle>
+
+          <EuiSpacer />
+
+          <EuiText grow={false} className="guideSection__text">
+            <p>
+              Most EUI based projects should already import the EUI global
+              scope. For example, Kibana has its own
+              liner that will give you everything on this page.
+            </p>
+          </EuiText>
+          <EuiSpacer />
+          <EuiCodeBlock language="scss" transparentBackground paddingSize="none">
+            {importKibanaExample}
+          </EuiCodeBlock>
+          <EuiSpacer />
+          <EuiText grow={false} className="guideSection__text">
+            <p>
+              If you want to construct your own import, you would just need to
+              import the following core files into a fresh Sass project.
+            </p>
+          </EuiText>
+
+          <EuiSpacer />
+
+          <EuiCodeBlock language="scss" transparentBackground paddingSize="none">
+            {importOutsideExample}
+          </EuiCodeBlock>
+
+        </EuiFlexItem>
+      </EuiFlexGrid>
+
+    </GuidePage>
+  );
+};

--- a/src/components/form/_mixins.scss
+++ b/src/components/form/_mixins.scss
@@ -101,7 +101,7 @@
 
 @mixin euiFormControlFocusStyle($borderOnly: false) {
   // sass-lint:disable-block indentation, empty-args
-  background-color: tintOrShade($euiColorEmptyShade, 0%, 50%);
+  background-color: tintOrShade($euiColorEmptyShade, 0%, 40%);
   background-image: euiFormControlGradient();
   background-size: 100% 100%; /* 3 */
 

--- a/src/components/form/_variables.scss
+++ b/src/components/form/_variables.scss
@@ -14,7 +14,7 @@ $euiSwitchThumbSize: $euiSwitchHeight !default;
 $euiSwitchIconHeight: $euiSize !default;
 
 // Coloring
-$euiFormBackgroundColor: tintOrShade($euiColorLightestShade, 60%, 25%) !default;
+$euiFormBackgroundColor: tintOrShade($euiColorLightestShade, 60%, 40%) !default;
 $euiFormBackgroundDisabledColor: darken($euiColorLightestShade, 2%) !default;
 $euiFormBorderColor: transparentize($euiColorFullShade, .9) !default;
 $euiFormBorderDisabledColor: transparentize($euiColorFullShade, .92) !default;

--- a/src/global_styling/variables/_colors.scss
+++ b/src/global_styling/variables/_colors.scss
@@ -26,7 +26,7 @@ $euiTextColor: $euiColorDarkestShade !default;
 $euiTitleColor: shadeOrTint($euiTextColor, 50%, 0%) !default;
 $euiLinkColor: $euiColorPrimary !default;
 $euiFocusBackgroundColor: tintOrShade($euiColorPrimary, 90%, 50%) !default;
-$euiPageBackgroundColor: tintOrShade($euiColorLightestShade, 50%, 25%) !default;
+$euiPageBackgroundColor: tintOrShade($euiColorLightestShade, 50%, 30%) !default;
 
 // Visualization colors
 

--- a/src/themes/eui/eui_colors_dark.scss
+++ b/src/themes/eui/eui_colors_dark.scss
@@ -14,7 +14,7 @@ $euiColorAccent: #F990C0;
 $euiColorDanger: #F66;
 $euiColorSuccess: $euiColorSecondary;
 $euiColorGhost: #FFF;
-$euiTextColor: #DDD;
+$euiTextColor: #DFE5EF;
 $euiLinkColor: $euiColorPrimary;
 
 $euiFocusBackgroundColor: #232635;

--- a/src/themes/eui/eui_colors_dark.scss
+++ b/src/themes/eui/eui_colors_dark.scss
@@ -1,29 +1,24 @@
 // Dark theme overides
 
-$euiColorEmptyShade: #222;
-$euiColorLightestShade: #242424;
-$euiColorLightShade: #333;
-$euiColorMediumShade: #444;
-$euiColorDarkShade: #8A8A8A;
-$euiColorDarkestShade: #F5F5F5;
+$euiColorEmptyShade: #1D1E24;
+$euiColorLightestShade: #25262E;
+$euiColorLightShade: #343741;
+$euiColorMediumShade: #535966;
+$euiColorDarkShade: #D4DAE5;
+$euiColorDarkestShade: #F5F7FA;
 $euiColorFullShade: #FFF;
-$euiColorMediumShade: #494E51;
-$euiColorPrimary: #4DA1C0;
-$euiColorWarning: #C06C4C;
-$euiColorDanger: #BF4D4D;
+$euiColorPrimary: #1BA9F5;
+$euiColorSecondary: #7DE2D1;
+$euiColorWarning: #FF977A;
+$euiColorDanger: #F990C0;
 $euiTextColor: #DDD;
 
-$euiFocusBackgroundColor: #191919;
+$euiFocusBackgroundColor: #232635;
 $euiShadowColor: #000;
 $euiShadowColorLarge: #000;
-$euiModalBorderColor: $euiColorLightShade;
-$euiFlyoutBorderColor: $euiColorLightShade;
 
 // Code
 
-$euiCodeBlockBackgroundColor: #2B2B2D;
-$euiCodeBlockColor: #CDD3D8;
-$euiCodeBlockSelectedBackgroundColor: #3E4451;
 $euiCodeBlockCommentColor: #656565;
 $euiCodeBlockSelectorTagColor: #C792EA;
 $euiCodeBlockStringColor: #C3E88D;

--- a/src/themes/eui/eui_colors_dark.scss
+++ b/src/themes/eui/eui_colors_dark.scss
@@ -10,12 +10,29 @@ $euiColorFullShade: #FFF;
 $euiColorPrimary: #1BA9F5;
 $euiColorSecondary: #7DE2D1;
 $euiColorWarning: #FF977A;
-$euiColorDanger: #F990C0;
+$euiColorAccent: #F990C0;
+$euiColorDanger: #F66;
+$euiColorSuccess: $euiColorSecondary;
+$euiColorGhost: #FFF;
 $euiTextColor: #DDD;
+$euiLinkColor: $euiColorPrimary;
 
 $euiFocusBackgroundColor: #232635;
 $euiShadowColor: #000;
 $euiShadowColorLarge: #000;
+
+// Visualization colors
+
+$euiColorVis0: #00B3A4 !default;
+$euiColorVis1: #3185FC !default;
+$euiColorVis2: #DB1374 !default;
+$euiColorVis3: #490092 !default;
+$euiColorVis4: #FEB6DB !default;
+$euiColorVis5: #E6C220 !default;
+$euiColorVis6: #BFA180 !default;
+$euiColorVis7: #F98510 !default;
+$euiColorVis8: #461A0A !default;
+$euiColorVis9: #920000 !default;
 
 // Code
 

--- a/src/themes/eui/eui_colors_dark.scss
+++ b/src/themes/eui/eui_colors_dark.scss
@@ -23,16 +23,16 @@ $euiShadowColorLarge: #000;
 
 // Visualization colors
 
-$euiColorVis0: #00B3A4 !default;
-$euiColorVis1: #3185FC !default;
-$euiColorVis2: #DB1374 !default;
-$euiColorVis3: #490092 !default;
-$euiColorVis4: #FEB6DB !default;
-$euiColorVis5: #E6C220 !default;
-$euiColorVis6: #BFA180 !default;
-$euiColorVis7: #F98510 !default;
-$euiColorVis8: #461A0A !default;
-$euiColorVis9: #920000 !default;
+$euiColorVis0: #00B3A4;
+$euiColorVis1: #3185FC;
+$euiColorVis2: #DB1374;
+$euiColorVis3: #490092;
+$euiColorVis4: #FEB6DB;
+$euiColorVis5: #E6C220;
+$euiColorVis6: #BFA180;
+$euiColorVis7: #F98510;
+$euiColorVis8: #461A0A;
+$euiColorVis9: #920000;
 
 // Code
 

--- a/src/themes/eui/eui_colors_dark.scss
+++ b/src/themes/eui/eui_colors_dark.scss
@@ -1,5 +1,15 @@
-// Dark theme overides
+// Code
+$euiColorPrimary: #1BA9F5;
+$euiColorSecondary: #7DE2D1;
+$euiColorAccent: #F990C0;
+$euiColorGhost: #FFF;
 
+// Status
+$euiColorSuccess: $euiColorSecondary;
+$euiColorWarning: #FF977A;
+$euiColorDanger: #F66;
+
+// Grays
 $euiColorEmptyShade: #1D1E24;
 $euiColorLightestShade: #25262E;
 $euiColorLightShade: #343741;
@@ -7,21 +17,17 @@ $euiColorMediumShade: #535966;
 $euiColorDarkShade: #D4DAE5;
 $euiColorDarkestShade: #F5F7FA;
 $euiColorFullShade: #FFF;
-$euiColorPrimary: #1BA9F5;
-$euiColorSecondary: #7DE2D1;
-$euiColorWarning: #FF977A;
-$euiColorAccent: #F990C0;
-$euiColorDanger: #F66;
-$euiColorSuccess: $euiColorSecondary;
-$euiColorGhost: #FFF;
+
+// Variations from core
+
 $euiTextColor: #DFE5EF;
 $euiLinkColor: $euiColorPrimary;
-
 $euiFocusBackgroundColor: #232635;
 $euiShadowColor: #000;
 $euiShadowColorLarge: #000;
 
 // Visualization colors
+// Currently this is the same as light. It is required to list them for our docs to work
 
 $euiColorVis0: #00B3A4;
 $euiColorVis1: #3185FC;


### PR DESCRIPTION
### Summary

Fixes https://github.com/elastic/eui/issues/605


Figured this was one of the few things we could try and get in before RC1.

Updates the dark mode color scheme to get blue hues. I brightened up the colors but have yet to do a full contrast audit other than to see that things generally work. I've tried to steal colors from the upcoming marketing designs as much as I could here so that we match against some of the things they are planning.

I also went ahead and fixed the docs pages to better account for the dark mode palettes. Because of the way they were imported, this required me to duplicate some vars in the `eui_theme_dark.scss` file (like the viz colors or ghost) that were unchanged between themes. I think it's ok to have them there, but would be nice to have a better solution.

![](http://snid.es/52ef67fda215/Screen%252520Recording%2525202019-03-06%252520at%25252009.28%252520PM.gif)

@cchaos tag you're it. Feel free to commit to this PR directly and adjust whatever you see fit, then pass it to @ryankeairns next.

### In Kibana

If you want to try this in Kibana you'll need to run a build of KUI there to generate matching CSS. Assuming we go forward with this, we'll need a PR there to adjust the colors in KUI and bootstrap (neither of which should be too difficult)

Some screens from there

![image](https://user-images.githubusercontent.com/324519/53935826-afac8a00-405c-11e9-91ac-a46cccfec4a9.png)

![image](https://user-images.githubusercontent.com/324519/53935833-b5a26b00-405c-11e9-849f-87d968ae12b0.png)

![image](https://user-images.githubusercontent.com/324519/53935842-b9ce8880-405c-11e9-983c-543adfa19209.png)

![image](https://user-images.githubusercontent.com/324519/53935850-c05d0000-405c-11e9-9c23-feacb1fafd39.png)


### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [x] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
