### PR TITLE
Make EuiTitle's docs list the components' props

### DIFF
--- a/src/components/title/title.js
+++ b/src/components/title/title.js
@@ -1,6 +1,4 @@
-import {
-  cloneElement,
-} from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
@@ -36,7 +34,7 @@ export const EuiTitle = ({ size, children, className, textTransform, ...rest }) 
     ...rest
   };
 
-  return cloneElement(children, props);
+  return React.cloneElement(children, props);
 };
 
 EuiTitle.propTypes = {


### PR DESCRIPTION
### Summary

Fixes #1692 - a component has props docs generated only if it returns JSX _or_ an explicit `React.*` function call.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
- [x] Any props added have proper autodocs
~- [ ] Documentation examples were added~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
