### PR TITLE
A few more dark mode fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `9.1.0`.
+- Adjusted the dark theme palette a bit more and adjusted a few components ([#1700](https://github.com/elastic/eui/pull/1700))
+
 
 ## [`9.1.0`](https://github.com/elastic/eui/tree/v9.1.0)
 
@@ -18,7 +19,6 @@ No public interface changes since `9.1.0`.
 **Bug fixes**
 
 - Fixed IE11 rendering issue in `EuiLoadingKibana` ([#1683](https://github.com/elastic/eui/pull/1683))
-
 - Fixed floating point arithmetic bug in `EuiRangeTrack`'s value validation ([#1687](https://github.com/elastic/eui/pull/1687))
 - Fixed `EuiComboBox` `activeOptonIndex` error with empty search results ([#1695](https://github.com/elastic/eui/pull/1695))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ No public interface changes since `9.1.0`.
 
 ## [`9.1.0`](https://github.com/elastic/eui/tree/v9.1.0)
 
-- Adjusted the dark theme palette to have a slight blue titn ([#1691](https://github.com/elastic/eui/pull/1691))
+- Adjusted the dark theme palette to have a slight blue tint ([#1691](https://github.com/elastic/eui/pull/1691))
 - Added `repositionOnScroll` property to the `EuiPopoverProps` type definition ([#1628](https://github.com/elastic/eui/pull/1628))
 - Added support to `findTestSubject` for an optional `matcher` argument, which defaults to `~=`, enabling it to identify an element based on one of multiple space-separated values within its `data-test-subj` attribute ([#1587](https://github.com/elastic/eui/pull/1587))
 - Converted `EuiFlexGrid`, `EuiFlexGroup`, `EuiFlexItem`, `EuiDescriptionList`, `EuiDescriptionListTitle`, and `EuiDescriptionListDescription` to TypeScript ([#1365](https://github.com/elastic/eui/pull/1365))
@@ -18,8 +18,6 @@ No public interface changes since `9.1.0`.
 **Bug fixes**
 
 - Fixed IE11 rendering issue in `EuiLoadingKibana` ([#1683](https://github.com/elastic/eui/pull/1683))
-
-**Bug fixes**
 
 - Fixed floating point arithmetic bug in `EuiRangeTrack`'s value validation ([#1687](https://github.com/elastic/eui/pull/1687))
 - Fixed `EuiComboBox` `activeOptonIndex` error with empty search results ([#1695](https://github.com/elastic/eui/pull/1695))

--- a/src/components/badge/_badge.scss
+++ b/src/components/badge/_badge.scss
@@ -62,11 +62,11 @@
 // Modifier naming and colors.
 $badgeTypes: (
   default: $euiColorLightShade,
-  primary: lighten(desaturate($euiColorPrimary, 30%), 30%),
-  secondary: lighten(desaturate($euiColorSecondary, 40%), 40%),
-  warning: lighten(desaturate($euiColorWarning, 30%), 20%),
-  danger: lighten(desaturate($euiColorDanger, 0%), 30%),
-  accent: lighten(desaturate($euiColorAccent, 40%), 40%),
+  primary: tintOrShade(desaturate($euiColorPrimary, 30%), 30%, 10%),
+  secondary: tintOrShade(desaturate($euiColorSecondary, 40%), 40%, 0%),
+  warning: tintOrShade(desaturate($euiColorWarning, 30%), 20%, 0%),
+  danger: tintOrShade(desaturate($euiColorDanger, 0%), 30%, 10%),
+  accent: tintOrShade(desaturate($euiColorAccent, 40%), 40%, 0%),
 );
 
 @each $name, $color in $badgeTypes {

--- a/src/components/badge/notification_badge/_notification_badge.scss
+++ b/src/components/badge/notification_badge/_notification_badge.scss
@@ -3,7 +3,7 @@
   display: inline-block;
   border-radius: $euiBorderRadius;
   background: $euiColorAccent;
-  color: lightOrDarkTheme($euiColorEmptyShade, $euiColorFullShade);
+  color: $euiColorEmptyShade;
   font-size: $euiFontSizeXS;
   font-weight: $euiFontWeightMedium;
   line-height: $euiSize;

--- a/src/components/bottom_bar/_bottom_bar.scss
+++ b/src/components/bottom_bar/_bottom_bar.scss
@@ -1,4 +1,5 @@
 .euiBottomBar {
+  @include euiBottomShadowFlat($euiShadowColorLarge);
   background: tintOrShade($euiColorFullShade, 25%, 90%);
   color: $euiColorEmptyShade;
   position: fixed;

--- a/src/components/bottom_bar/_bottom_bar.scss
+++ b/src/components/bottom_bar/_bottom_bar.scss
@@ -1,6 +1,6 @@
 .euiBottomBar {
   @include euiBottomShadowFlat($euiShadowColorLarge);
-  background: tintOrShade($euiColorFullShade, 25%, 90%);
+  background: tintOrShade($euiColorFullShade, 25%, 100%);
   color: $euiColorEmptyShade;
   position: fixed;
   bottom: 0;

--- a/src/components/call_out/_mixins.scss
+++ b/src/components/call_out/_mixins.scss
@@ -2,7 +2,7 @@
   @if (map-has-key($euiCallOutTypes, $type)) {
     $color: map-get($euiCallOutTypes, $type);
     $backgroundColor: tintOrShade($color, 90%, 70%);
-    $foregroundColor: makeHighContrastColor($color, $backgroundColor);
+    $foregroundColor: shadeOrTint(makeHighContrastColor($color, $backgroundColor), 0, 20%);
 
     @if ($returnBackgroundOrForeground == 'background') {
       @return $backgroundColor;

--- a/src/components/loading/_loading_chart.scss
+++ b/src/components/loading/_loading_chart.scss
@@ -41,15 +41,15 @@
     }
 
     &:nth-child(2) {
-      background-color: darken($euiColorLightShade, 4%);
+      background-color: shadeOrTint($euiColorLightShade, 4%, 4%);
     }
 
     &:nth-child(3) {
-      background-color: darken($euiColorLightShade, 8%);
+      background-color: shadeOrTint($euiColorLightShade, 8%, 8%);
     }
 
     &:nth-child(4) {
-      background-color: darken($euiColorLightShade, 12%);
+      background-color: shadeOrTint($euiColorLightShade, 12%, 12%);
     }
   }
 }

--- a/src/components/side_nav/_side_nav_item.scss
+++ b/src/components/side_nav/_side_nav_item.scss
@@ -11,7 +11,7 @@
   color: $euiColorFullShade; /* 2 */
 
   &.euiSideNavItemButton--isClickable {
-    &:hover {
+    &:hover .euiSideNavItemButton__label {
       text-decoration: underline;
     }
 
@@ -19,7 +19,6 @@
     &:focus {
       // sass-lint:disable-block no-important
       background-color: $euiFocusBackgroundColor !important;
-      color: $euiColorPrimary !important;
     }
   }
 

--- a/src/components/tool_tip/_mixins.scss
+++ b/src/components/tool_tip/_mixins.scss
@@ -1,7 +1,7 @@
 @mixin euiToolTipStyle($size: null) {
   @include euiBottomShadow($color: #000);
   border-radius: $euiBorderRadius;
-  background-color: tintOrShade($euiColorFullShade, 25%, 90%);
+  background-color: $euiTooltipBackgroundColor;
   color: $euiColorGhost;
   z-index: $euiZLevel9;
   max-width: 256px;

--- a/src/components/tool_tip/_tool_tip.scss
+++ b/src/components/tool_tip/_tool_tip.scss
@@ -23,7 +23,7 @@
     position: absolute;
     transform-origin: center;
     border-radius: 2px;
-    background-color: tintOrShade($euiColorFullShade, 25%, 90%);
+    background-color: $euiTooltipBackgroundColor;
     width: $arrowSize;
     height: $arrowSize;
 

--- a/src/components/tool_tip/_variables.scss
+++ b/src/components/tool_tip/_variables.scss
@@ -1,3 +1,5 @@
+$euiTooltipBackgroundColor: tintOrShade($euiColorFullShade, 25%, 100%);
+
 $euiTooltipAnimations: (
   top: euiToolTipTop,
   left: euiToolTipBottom,

--- a/src/themes/eui/eui_colors_dark.scss
+++ b/src/themes/eui/eui_colors_dark.scss
@@ -14,8 +14,8 @@ $euiColorEmptyShade: #1D1E24;
 $euiColorLightestShade: #25262E;
 $euiColorLightShade: #343741;
 $euiColorMediumShade: #535966;
-$euiColorDarkShade: #D4DAE5;
-$euiColorDarkestShade: #F5F7FA;
+$euiColorDarkShade: #98A2B3;
+$euiColorDarkestShade: #D4DAE5;
 $euiColorFullShade: #FFF;
 
 // Variations from core

--- a/src/themes/eui/eui_colors_dark.scss
+++ b/src/themes/eui/eui_colors_dark.scss
@@ -6,7 +6,7 @@ $euiColorGhost: #FFF;
 
 // Status
 $euiColorSuccess: $euiColorSecondary;
-$euiColorWarning: #FF977A;
+$euiColorWarning: #FFCE7A;
 $euiColorDanger: #F66;
 
 // Grays


### PR DESCRIPTION
A follow-up to @snide's dark colors update.

## Big-ish change

The lightest three colors euiColorDarkShade, euiColorDarkestShade, euiColorFullShade were way too similar that they were indistinguishable from each other (especially on the dark background). I altered the dark and darkest shades to be a tad darker (still using the same hex values from the light theme).

<img src="https://d.pr/free/i/RXdwXF+" width="50%" />

I noticed the difference when looking at subdued text, which didn't look subdued at all. So now it does.

<img src="https://d.pr/free/i/DEQ27M+"  />

## Badges

@snide Can you handle the update of these? You can push directly to this branch.

<img width="474" alt="screen shot 2019-03-07 at 21 54 55 pm" src="https://user-images.githubusercontent.com/549577/54006911-5eb89680-412d-11e9-808c-c987ee22ecb1.png">

But I did fix the notification badge:

<img width="44" alt="screen shot 2019-03-07 at 22 25 46 pm" src="https://user-images.githubusercontent.com/549577/54006948-8b6cae00-412d-11e9-9101-a5627a61621b.png"> --> <img width="50" alt="screen shot 2019-03-07 at 22 25 14 pm" src="https://user-images.githubusercontent.com/549577/54006951-8dcf0800-412d-11e9-87f8-165290f9c6af.png">

----

# Other changes

**Tooltips**
_before_
<img width="268" alt="screen shot 2019-03-07 at 23 07 05 pm" src="https://user-images.githubusercontent.com/549577/54006992-cb339580-412d-11e9-90ae-f8c571fa493f.png">
_after_
<img width="409" alt="screen shot 2019-03-07 at 22 34 04 pm" src="https://user-images.githubusercontent.com/549577/54006995-cc64c280-412d-11e9-8142-6a8bf5b58108.png">

**Callout titles**
They were just a tad on the saturated side, so I tinted them ever so slightly.

_before_
<img width="480" alt="screen shot 2019-03-07 at 22 35 12 pm" src="https://user-images.githubusercontent.com/549577/54007040-f3bb8f80-412d-11e9-9d37-08943459f30c.png">
_after_
<img width="432" alt="screen shot 2019-03-07 at 22 35 19 pm" src="https://user-images.githubusercontent.com/549577/54007043-f4542600-412d-11e9-8213-888d25e823ac.png">

**Bottom bar**

Added a shadow to try to distinguish it from the background ever so slightly.

_before_
<img width="1110" alt="screen shot 2019-03-07 at 22 37 17 pm" src="https://user-images.githubusercontent.com/549577/54007092-282f4b80-412e-11e9-9f67-8bdfe0fe8116.png">

_after_
<img width="1125" alt="screen shot 2019-03-07 at 22 38 48 pm" src="https://user-images.githubusercontent.com/549577/54007099-354c3a80-412e-11e9-80a0-9a9b678add33.png">


_it does also effect light theme_
<img width="1123" alt="screen shot 2019-03-07 at 22 38 59 pm" src="https://user-images.githubusercontent.com/549577/54007104-38472b00-412e-11e9-8c2e-5388e8fffbe1.png">

**Loading chart**

_before_
<img width="177" alt="screen shot 2019-03-07 at 22 50 35 pm" src="https://user-images.githubusercontent.com/549577/54007129-4d23be80-412e-11e9-8d1e-3c30fba74314.png">

_after_
<img width="154" alt="screen shot 2019-03-07 at 22 50 46 pm" src="https://user-images.githubusercontent.com/549577/54007131-4eed8200-412e-11e9-93cf-7bd7194e00f4.png">

**Sidenav underline color**

I fixed the focus/hover underline color of the side nav

_before_
<img width="220" alt="screen shot 2019-03-07 at 23 15 54 pm" src="https://user-images.githubusercontent.com/549577/54007304-0edacf00-412f-11e9-8ade-fc5f88822b7e.png">

_after_
<img width="227" alt="screen shot 2019-03-07 at 23 16 10 pm" src="https://user-images.githubusercontent.com/549577/54007306-10a49280-412f-11e9-9b71-da56b1160ba7.png">

---

# Still needs attention

Like I said, badges, but also the text colors of accent, warning and danger are **soo** similar, it's really hard to distinguish. Is it possible to go a littler more yellow with the warning color?

<img width="186" alt="screen shot 2019-03-07 at 22 53 43 pm" src="https://user-images.githubusercontent.com/549577/54007194-996efe80-412e-11e9-804c-86c21b01ae79.png">

@ryankeairns It seems something is not working with the subdued stat color?

<img width="292" alt="screen shot 2019-03-07 at 22 52 30 pm" src="https://user-images.githubusercontent.com/549577/54007207-a986de00-412e-11e9-9b3f-e7e670e6c038.png">


### Checklist

- ~[ ] This was checked in mobile~
- ~[ ] This was checked in IE11~
- [x] This was checked in dark mode
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
