### PR TITLE
Make EuiPopover's repositionOnScroll prop optional in TS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `9.2.0`.
+**Bug fixes**
+
+- Make `EuiPopover`'s repositionOnScroll prop optional in TS ([#1705](https://github.com/elastic/eui/pull/1705))
 
 ## [`9.2.0`](https://github.com/elastic/eui/tree/v9.2.0)
 

--- a/src/components/popover/index.d.ts
+++ b/src/components/popover/index.d.ts
@@ -40,7 +40,7 @@ declare module '@elastic/eui' {
     anchorPosition?: PopoverAnchorPosition;
     panelClassName?: string;
     panelPaddingSize?: PanelPaddingSize;
-    repositionOnScroll: boolean;
+    repositionOnScroll?: boolean;
   }
 
   export const EuiPopover: FunctionComponent<


### PR DESCRIPTION
### Summary

Make EuiPopover's repositionOnScroll prop optional in TS

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
