### PR TITLE
Allow SFC and FunctionComponent definitions to be indirected

### DIFF
--- a/scripts/babel/proptypes-from-ts-props/index.test.js
+++ b/scripts/babel/proptypes-from-ts-props/index.test.js
@@ -2053,6 +2053,30 @@ FooComponent.propTypes = {
 };`);
       });
 
+      it('annotates indirected FunctionComponent components', () => {
+        const result = transform(
+          `
+import React, { FunctionComponent } from 'react';
+type FooType = FunctionComponent<{foo: string, bar?: number}>;
+const FooComponent: FooType = () => {
+  return (<div>Hello World</div>);
+}`,
+          babelOptions
+        );
+
+        expect(result.code).toBe(`import React from 'react';
+import PropTypes from "prop-types";
+
+const FooComponent = () => {
+  return <div>Hello World</div>;
+};
+
+FooComponent.propTypes = {
+  foo: PropTypes.string.isRequired,
+  bar: PropTypes.number
+};`);
+      });
+
       it('annotates React.FunctionComponent components', () => {
         const result = transform(
           `


### PR DESCRIPTION
### Summary

Fixes #1698 - defs->proptypes resolver didn't know how to look further into the TS defs for `SFC` or `FunctionComponent` on a variable declaration.

```
const Foo: FunctionComponent<FooType> = () => {}
```

vs

```
type FooType = FunctionComponent<{}>;
const Foo: FooType = () => {}
```

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
- [x] Any props added have proper autodocs
~- [ ] Documentation examples were added~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
- [x] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
