### PR TITLE
Wrap lodash functions to avoid exporting lodash type defs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Allow toasts in `EuiGlobalToastList` to override `toastLifeTimeMs` ([#1720](https://github.com/elastic/eui/pull/1720))
 
+**Bug fixes**
+
+- Removed all `lodash` imports in `eui.d.ts` to avoid namespace pollution ([#1723](https://github.com/elastic/eui/pull/1723))
+
 ## [`9.3.0`](https://github.com/elastic/eui/tree/v9.3.0)
 
 - Added `footerLink` and `showToolTips` to `EuiNavDrawer` and added `EuiNavDrawerGroup` ([#1701](https://github.com/elastic/eui/pull/1701))

--- a/src/services/objects.ts
+++ b/src/services/objects.ts
@@ -1,4 +1,11 @@
-import get from 'lodash/get';
-import omit from 'lodash/omit';
+import _get from 'lodash/get';
+import _omit from 'lodash/omit';
 
-export { get, omit };
+// wrap the lodash functions to avoid having lodash's TS type definition from being
+// exported, which can conflict with the lodash namespace if other versions are used
+
+export const get = (object: {}, path: string[] | string, defaultValue?: any) =>
+  _get(object, path, defaultValue);
+
+export const omit = (object: {} | null | undefined, paths: string[]) =>
+  _omit(object, paths);

--- a/src/services/predicate/lodash_predicates.ts
+++ b/src/services/predicate/lodash_predicates.ts
@@ -1,8 +1,17 @@
-import isFunction from 'lodash/isFunction';
-import isArray from 'lodash/isArray';
-import isString from 'lodash/isString';
-import isBoolean from 'lodash/isBoolean';
-import isNumber from 'lodash/isNumber';
-import isNaN from 'lodash/isNaN';
+import _isFunction from 'lodash/isFunction';
+import _isArray from 'lodash/isArray';
+import _isString from 'lodash/isString';
+import _isBoolean from 'lodash/isBoolean';
+import _isNumber from 'lodash/isNumber';
+import _isNaN from 'lodash/isNaN';
 
-export { isFunction, isArray, isString, isBoolean, isNumber, isNaN };
+// wrap the lodash functions to avoid having lodash's TS type definition from being
+// exported, which can conflict with the lodash namespace if other versions are used
+
+// tslint:disable-next-line:ban-types
+export const isFunction = (value: any): value is Function => _isFunction(value);
+export const isArray = (value: any): value is any[] => _isArray(value);
+export const isString = (value: any): value is string => _isString(value);
+export const isBoolean = (value: any): value is boolean => _isBoolean(value);
+export const isNumber = (value: any): value is number => _isNumber(value);
+export const isNaN = (value: any) => _isNaN(value);

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -1,7 +1,24 @@
-import times from 'lodash/times';
-import memoize from 'lodash/memoize';
+import _times from 'lodash/times';
+import _memoize from 'lodash/memoize';
 
-export { times, memoize };
+// wrap the lodash functions to avoid having lodash's TS type definition from being
+// exported, which can conflict with the lodash namespace if other versions are used
+
+export function times<T>(count: number): number[];
+export function times<T>(count: number, iteratee: (index: number) => T): T[];
+export function times<T>(count: number, iteratee?: (index: number) => T) {
+  if (iteratee === undefined) {
+    return _times(count);
+  }
+  return _times(count, iteratee);
+}
+
+export function memoize<T extends (...args: any[]) => any>(
+  func: T,
+  resolver?: (...args: any[]) => any
+): (...args: Parameters<T>) => ReturnType<T> {
+  return _memoize(func, resolver);
+}
 
 export const browserTick = (callback: FrameRequestCallback) => {
   requestAnimationFrame(callback);


### PR DESCRIPTION
### Summary

Required for https://github.com/elastic/kibana/pull/32746

If `eui.d.ts` imports anything from lodash, TS opens lodash's `index.d.ts` and loads its declarations into the lodash namespace. These conflict with the lodash 3 definitions used by Kibana.

Tested this by building `eui.d.ts` and copying it into the Kibana above branch, then running `node scripts/type_check.js`

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
