### PR TITLE
Allow EuiListGroupItem to pass a custom element as the icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Allow toasts in `EuiGlobalToastList` to override `toastLifeTimeMs` ([#1720](https://github.com/elastic/eui/pull/1720))
+- Allow `EuiListGroupItem` to pass a custom element as the `icon` ([#1726](https://github.com/elastic/eui/pull/1726))
 
 ## [`9.3.0`](https://github.com/elastic/eui/tree/v9.3.0)
 

--- a/src/components/list_group/__snapshots__/list_group_item.test.js.snap
+++ b/src/components/list_group/__snapshots__/list_group_item.test.js.snap
@@ -17,7 +17,39 @@ exports[`EuiListGroupItem is rendered 1`] = `
 </li>
 `;
 
-exports[`EuiListGroupItem renders href 1`] = `
+exports[`EuiListGroupItem props extraAction is rendered 1`] = `
+<li
+  class="euiListGroupItem euiListGroupItem--medium euiListGroupItem-hasExtraAction"
+>
+  <span
+    class="euiListGroupItem__text"
+  >
+    <span
+      class="euiListGroupItem__label"
+      title="Label"
+    >
+      Label
+    </span>
+  </span>
+  <button
+    aria-label="label"
+    class="euiButtonIcon euiButtonIcon--primary euiListGroupItem__extraAction euiListGroupItem__extraAction-alwaysShow"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="euiIcon euiIcon--medium euiButtonIcon__icon"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+  </button>
+</li>
+`;
+
+exports[`EuiListGroupItem props href is rendered 1`] = `
 <li
   class="euiListGroupItem euiListGroupItem--medium euiListGroupItem-isClickable"
 >
@@ -31,6 +63,261 @@ exports[`EuiListGroupItem renders href 1`] = `
     >
       Label
     </span>
+  </a>
+</li>
+`;
+
+exports[`EuiListGroupItem props icon is rendered 1`] = `
+<li
+  class="euiListGroupItem euiListGroupItem--medium"
+>
+  <span
+    class="euiListGroupItem__text"
+  >
+    <span
+      class="euiListGroupItem__icon"
+    />
+    <span
+      class="euiListGroupItem__label"
+      title="Label"
+    >
+      Label
+    </span>
+  </span>
+</li>
+`;
+
+exports[`EuiListGroupItem props iconType is rendered 1`] = `
+<li
+  class="euiListGroupItem euiListGroupItem--medium"
+>
+  <span
+    class="euiListGroupItem__text"
+  >
+    <svg
+      class="euiIcon euiIcon--medium euiListGroupItem__icon"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+    <span
+      class="euiListGroupItem__label"
+      title="Label"
+    >
+      Label
+    </span>
+  </span>
+</li>
+`;
+
+exports[`EuiListGroupItem props isActive is rendered 1`] = `
+<li
+  class="euiListGroupItem euiListGroupItem--medium euiListGroupItem-isActive"
+>
+  <span
+    class="euiListGroupItem__text"
+  >
+    <span
+      class="euiListGroupItem__label"
+      title="Label"
+    >
+      Label
+    </span>
+  </span>
+</li>
+`;
+
+exports[`EuiListGroupItem props isDisabled is rendered 1`] = `
+<li
+  class="euiListGroupItem euiListGroupItem--medium euiListGroupItem-isDisabled"
+>
+  <span
+    class="euiListGroupItem__text"
+  >
+    <span
+      class="euiListGroupItem__label"
+      title="Label"
+    >
+      Label
+    </span>
+  </span>
+</li>
+`;
+
+exports[`EuiListGroupItem props onClick is rendered 1`] = `
+<li
+  class="euiListGroupItem euiListGroupItem--medium euiListGroupItem-isClickable"
+>
+  <button
+    class="euiListGroupItem__button"
+  >
+    <span
+      class="euiListGroupItem__label"
+      title="Label"
+    >
+      Label
+    </span>
+  </button>
+</li>
+`;
+
+exports[`EuiListGroupItem props size l is rendered 1`] = `
+<li
+  class="euiListGroupItem euiListGroupItem--large"
+>
+  <span
+    class="euiListGroupItem__text"
+  >
+    <span
+      class="euiListGroupItem__label"
+      title="Label"
+    >
+      Label
+    </span>
+  </span>
+</li>
+`;
+
+exports[`EuiListGroupItem props size m is rendered 1`] = `
+<li
+  class="euiListGroupItem euiListGroupItem--medium"
+>
+  <span
+    class="euiListGroupItem__text"
+  >
+    <span
+      class="euiListGroupItem__label"
+      title="Label"
+    >
+      Label
+    </span>
+  </span>
+</li>
+`;
+
+exports[`EuiListGroupItem props size s is rendered 1`] = `
+<li
+  class="euiListGroupItem euiListGroupItem--small"
+>
+  <span
+    class="euiListGroupItem__text"
+  >
+    <span
+      class="euiListGroupItem__label"
+      title="Label"
+    >
+      Label
+    </span>
+  </span>
+</li>
+`;
+
+exports[`EuiListGroupItem props size xs is rendered 1`] = `
+<li
+  class="euiListGroupItem euiListGroupItem--xSmall"
+>
+  <span
+    class="euiListGroupItem__text"
+  >
+    <span
+      class="euiListGroupItem__label"
+      title="Label"
+    >
+      Label
+    </span>
+  </span>
+</li>
+`;
+
+exports[`EuiListGroupItem props wrapText is rendered 1`] = `
+<li
+  class="euiListGroupItem euiListGroupItem--medium euiListGroupItem--wrapText"
+>
+  <span
+    class="euiListGroupItem__text"
+  >
+    <span
+      class="euiListGroupItem__label"
+    >
+      Label
+    </span>
+  </span>
+</li>
+`;
+
+exports[`EuiListGroupItem renders a disabled button even if provided an href 1`] = `
+<li
+  class="euiListGroupItem euiListGroupItem--medium euiListGroupItem-isDisabled euiListGroupItem-isClickable"
+>
+  <button
+    class="euiListGroupItem__button"
+    disabled=""
+  >
+    <span
+      class="euiListGroupItem__label"
+      title="Label"
+    >
+      Label
+    </span>
+  </button>
+</li>
+`;
+
+exports[`EuiListGroupItem renders a disabled button even if provided an href 2`] = `
+<li
+  class="euiListGroupItem euiListGroupItem--medium euiListGroupItem-isDisabled euiListGroupItem-isClickable"
+>
+  <button
+    class="euiListGroupItem__button"
+    disabled=""
+  >
+    <span
+      class="euiListGroupItem__label"
+      title="Label"
+    >
+      Label
+    </span>
+  </button>
+</li>
+`;
+
+exports[`EuiListGroupItem throws an warning if both iconType and icon are provided but still renders 1`] = `
+<li
+  class="euiListGroupItem euiListGroupItem--medium"
+>
+  <span
+    class="euiListGroupItem__text"
+  >
+    <svg
+      class="euiIcon euiIcon--medium euiListGroupItem__icon"
+      focusable="false"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    />
+    <span
+      class="euiListGroupItem__label"
+      title=""
+    />
+  </span>
+</li>
+`;
+
+exports[`EuiListGroupItem throws an warning if both onClick and href are provided but still renders 1`] = `
+<li
+  class="euiListGroupItem euiListGroupItem--medium euiListGroupItem-isClickable"
+>
+  <a
+    class="euiListGroupItem__button"
+    href="#"
+  >
+    <span
+      class="euiListGroupItem__label"
+      title=""
+    />
   </a>
 </li>
 `;

--- a/src/components/list_group/_list_group_item.scss
+++ b/src/components/list_group/_list_group_item.scss
@@ -18,8 +18,8 @@
     background-color: tintOrShade($euiColorLightestShade, 0%, 30%);
   }
 
-  &.euiListGroupItem-isClickable:hover,
-  &.euiListGroupItem-isClickable:focus {
+  &.euiListGroupItem-isClickable:hover .euiListGroupItem__label,
+  &.euiListGroupItem-isClickable:focus .euiListGroupItem__label {
     text-decoration: underline;
   }
 
@@ -54,10 +54,6 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.euiListGroupItem__button:focus {
-  text-decoration: underline;
 }
 
 .euiListGroupItem__extraAction {

--- a/src/components/list_group/list_group_item.js
+++ b/src/components/list_group/list_group_item.js
@@ -22,6 +22,7 @@ export const EuiListGroupItem = ({
   href,
   className,
   iconType,
+  icon,
   extraAction,
   onClick,
   size,
@@ -48,6 +49,13 @@ export const EuiListGroupItem = ({
     iconNode = (
       <EuiIcon className="euiListGroupItem__icon" type={iconType} />
     );
+
+    if (icon) {
+      console.warn('Both `iconType` and `icon` were passed to EuiListGroupItem but only one can exist. The `iconType` was used.');
+    }
+  } else if (icon) {
+    iconNode = React.cloneElement(icon,
+      { className: classNames('euiListGroupItem__icon', icon.props.className) });
   }
 
   let extraActionNode;
@@ -89,6 +97,10 @@ export const EuiListGroupItem = ({
         {labelContent}
       </a>
     );
+
+    if (onClick) {
+      console.warn('Both `href` and `onClick` were passed to EuiListGroupItem but only one can exist. The `href` was used.');
+    }
   } else if ((href && isDisabled) || onClick) {
     itemContent = (
       <button
@@ -167,9 +179,15 @@ EuiListGroupItem.propTypes = {
   href: PropTypes.string,
 
   /**
-   * See `EuiIcon`
+   * Adds `EuiIcon` of `EuiIcon.type`
    */
   iconType: PropTypes.oneOf(ICON_TYPES),
+
+  /**
+   * Custom node to pass as the icon. Cannot be used in conjunction
+   * with `iconType`.
+   */
+  icon: PropTypes.element,
 
   /**
    * Display tooltip on list item

--- a/src/components/list_group/list_group_item.test.js
+++ b/src/components/list_group/list_group_item.test.js
@@ -3,6 +3,7 @@ import { render } from 'enzyme';
 
 import {
   EuiListGroupItem,
+  SIZES,
 } from './list_group_item';
 
 describe('EuiListGroupItem', () => {
@@ -15,12 +16,168 @@ describe('EuiListGroupItem', () => {
       .toMatchSnapshot();
   });
 
-  test('renders href', () => {
+  describe('props', () => {
+    describe('size', () => {
+      SIZES.forEach(size => {
+        test(`${size} is rendered`, () => {
+          const component = render(<EuiListGroupItem label="Label" size={size} />);
+
+          expect(component).toMatchSnapshot();
+        });
+      });
+    });
+
+    describe('isActive', () => {
+      test('is rendered', () => {
+        const component = render(
+          <EuiListGroupItem label="Label" isActive />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+
+    describe('isDisabled', () => {
+      test('is rendered', () => {
+        const component = render(
+          <EuiListGroupItem label="Label" isDisabled />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+
+    describe('iconType', () => {
+      test('is rendered', () => {
+        const component = render(
+          <EuiListGroupItem label="Label" iconType="empty" />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+
+    describe('icon', () => {
+      test('is rendered', () => {
+        const component = render(
+          <EuiListGroupItem label="Label" icon={<span/>} />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+
+    // TODO: This keeps re-rendering differently because of fake id creation
+    // describe('showToolTip', () => {
+    //   test('is rendered', () => {
+    //     const component = render(
+    //       <EuiListGroupItem label="Label" showToolTip />
+    //     );
+
+    //     expect(component).toMatchSnapshot();
+    //   });
+    // });
+
+    describe('wrapText', () => {
+      test('is rendered', () => {
+        const component = render(
+          <EuiListGroupItem label="Label" wrapText />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+
+    describe('extraAction', () => {
+      test('is rendered', () => {
+        const component = render(
+          <EuiListGroupItem
+            label="Label"
+            extraAction={{ iconType: 'empty', alwaysShow: true, 'aria-label': 'label' }}
+          />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+
+    describe('href', () => {
+      test('is rendered', () => {
+        const component = render(
+          <EuiListGroupItem label="Label" href="#" />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+
+    describe('onClick', () => {
+      test('is rendered', () => {
+        const component = render(
+          <EuiListGroupItem label="Label" onClick={() => {}} />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+
+  });
+
+  test('renders a disabled button even if provided an href', () => {
     const component = render(
-      <EuiListGroupItem label="Label" href="#" />
+      <EuiListGroupItem label="Label" isDisabled href="#" />
     );
 
     expect(component)
       .toMatchSnapshot();
+  });
+
+  test('renders a disabled button even if provided an href', () => {
+    const component = render(
+      <EuiListGroupItem label="Label" isDisabled href="#" />
+    );
+
+    expect(component)
+      .toMatchSnapshot();
+  });
+
+  describe('throws an warning', () => {
+    const oldConsoleError = console.warn;
+    let consoleStub;
+
+    beforeEach(() => {
+      // We don't use jest.spyOn() here, because EUI's tests apply a global
+      // console.error() override that throws an exception. For these
+      // tests, we just want to know if console.error() was called.
+      console.warn = consoleStub = jest.fn();
+    });
+
+    afterEach(() => {
+      console.warn = oldConsoleError;
+    });
+
+    test('if both onClick and href are provided but still renders', () => {
+      const component = render(
+        <EuiListGroupItem label="" onClick={() => {}} href="#" />
+      );
+
+      expect(consoleStub).toBeCalled();
+      expect(consoleStub.mock.calls[0][0]).toMatch(
+        '`href` and `onClick` were passed'
+      );
+      expect(component).toMatchSnapshot();
+    });
+
+    test('if both iconType and icon are provided but still renders', () => {
+      const component = render(
+        <EuiListGroupItem label="" iconType="empty" icon={<span/>} />
+      );
+
+      expect(consoleStub).toBeCalled();
+      expect(consoleStub.mock.calls[0][0]).toMatch(
+        '`iconType` and `icon` were passed'
+      );
+      expect(component).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
This is required for the nav in Kibana where plugins can provide their own (non-EuiIcon icon type) icon/image.

Example using an avatar:
<img src="https://d.pr/free/i/wNhZVg+"  />

Also beefed up the test cases.

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
- [x] Any props added have proper autodocs
- ~[ ] Documentation examples were added~ I specifically didn't add an example as it's a very low use case
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- [x] Jest tests were updated or added to match the most common scenarios
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
