### PR TITLE
[Accessibility] EuiBottomBar refers to the end of document.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Removed all `lodash` imports in `eui.d.ts` to avoid namespace pollution ([#1723](https://github.com/elastic/eui/pull/1723))
 - Prevent `EuiComboBox` from creating a custom option value when user clicks on a value in the dropdown ([#1728](https://github.com/elastic/eui/pull/1728))
+- Changed `EuiBottomBar` to refer to the end of document ([#1727](https://github.com/elastic/eui/pull/1727))
 
 ## [`9.3.0`](https://github.com/elastic/eui/tree/v9.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Adds missing type and fixes closure-scope problem for `SuperDatePicker`'s `onRefresh` callback ([#1732](https://github.com/elastic/eui/pull/1732))
+- Changed `EuiBottomBar` to refer to the end of document ([#1727](https://github.com/elastic/eui/pull/1727))
 
 ## [`9.4.0`](https://github.com/elastic/eui/tree/v9.4.0)
 
@@ -15,7 +16,6 @@
 
 - Removed all `lodash` imports in `eui.d.ts` to avoid namespace pollution ([#1723](https://github.com/elastic/eui/pull/1723))
 - Prevent `EuiComboBox` from creating a custom option value when user clicks on a value in the dropdown ([#1728](https://github.com/elastic/eui/pull/1728))
-- Changed `EuiBottomBar` to refer to the end of document ([#1727](https://github.com/elastic/eui/pull/1727))
 
 ## [`9.3.0`](https://github.com/elastic/eui/tree/v9.3.0)
 

--- a/src-docs/src/i18ntokens.json
+++ b/src-docs/src/i18ntokens.json
@@ -81,7 +81,7 @@
   },
   {
     "token": "euiBottomBar.screenReaderAnnouncement",
-    "defString": "There is a new menu opening with page level controls at the end of document.",
+    "defString": "There is a new menu opening with page level controls at the end of the document.",
     "highlighting": "string",
     "loc": {
       "start": {

--- a/src-docs/src/i18ntokens.json
+++ b/src-docs/src/i18ntokens.json
@@ -81,7 +81,7 @@
   },
   {
     "token": "euiBottomBar.screenReaderAnnouncement",
-    "defString": "There is a new menu opening with page level controls at the bottom of the document.",
+    "defString": "There is a new menu opening with page level controls at the end of document.",
     "highlighting": "string",
     "loc": {
       "start": {

--- a/src/components/bottom_bar/__snapshots__/bottom_bar.test.js.snap
+++ b/src/components/bottom_bar/__snapshots__/bottom_bar.test.js.snap
@@ -6,7 +6,7 @@ Array [
     aria-live="assertive"
     class="euiScreenReaderOnly"
   >
-    There is a new menu opening with page level controls at the bottom of the document.
+    There is a new menu opening with page level controls at the end of document.
   </p>,
   <div
     aria-label="aria-label"
@@ -24,7 +24,7 @@ Array [
     aria-live="assertive"
     class="euiScreenReaderOnly"
   >
-    There is a new menu opening with page level controls at the bottom of the document.
+    There is a new menu opening with page level controls at the end of document.
   </p>,
   <div
     class="euiBottomBar euiBottomBar--paddingLarge"
@@ -38,7 +38,7 @@ Array [
     aria-live="assertive"
     class="euiScreenReaderOnly"
   >
-    There is a new menu opening with page level controls at the bottom of the document.
+    There is a new menu opening with page level controls at the end of document.
   </p>,
   <div
     class="euiBottomBar euiBottomBar--paddingMedium"
@@ -52,7 +52,7 @@ Array [
     aria-live="assertive"
     class="euiScreenReaderOnly"
   >
-    There is a new menu opening with page level controls at the bottom of the document.
+    There is a new menu opening with page level controls at the end of document.
   </p>,
   <div
     class="euiBottomBar"
@@ -66,7 +66,7 @@ Array [
     aria-live="assertive"
     class="euiScreenReaderOnly"
   >
-    There is a new menu opening with page level controls at the bottom of the document.
+    There is a new menu opening with page level controls at the end of document.
   </p>,
   <div
     class="euiBottomBar euiBottomBar--paddingSmall"

--- a/src/components/bottom_bar/__snapshots__/bottom_bar.test.js.snap
+++ b/src/components/bottom_bar/__snapshots__/bottom_bar.test.js.snap
@@ -6,7 +6,7 @@ Array [
     aria-live="assertive"
     class="euiScreenReaderOnly"
   >
-    There is a new menu opening with page level controls at the end of document.
+    There is a new menu opening with page level controls at the end of the document.
   </p>,
   <div
     aria-label="aria-label"
@@ -24,7 +24,7 @@ Array [
     aria-live="assertive"
     class="euiScreenReaderOnly"
   >
-    There is a new menu opening with page level controls at the end of document.
+    There is a new menu opening with page level controls at the end of the document.
   </p>,
   <div
     class="euiBottomBar euiBottomBar--paddingLarge"
@@ -38,7 +38,7 @@ Array [
     aria-live="assertive"
     class="euiScreenReaderOnly"
   >
-    There is a new menu opening with page level controls at the end of document.
+    There is a new menu opening with page level controls at the end of the document.
   </p>,
   <div
     class="euiBottomBar euiBottomBar--paddingMedium"
@@ -52,7 +52,7 @@ Array [
     aria-live="assertive"
     class="euiScreenReaderOnly"
   >
-    There is a new menu opening with page level controls at the end of document.
+    There is a new menu opening with page level controls at the end of the document.
   </p>,
   <div
     class="euiBottomBar"
@@ -66,7 +66,7 @@ Array [
     aria-live="assertive"
     class="euiScreenReaderOnly"
   >
-    There is a new menu opening with page level controls at the end of document.
+    There is a new menu opening with page level controls at the end of the document.
   </p>,
   <div
     class="euiBottomBar euiBottomBar--paddingSmall"

--- a/src/components/bottom_bar/bottom_bar.js
+++ b/src/components/bottom_bar/bottom_bar.js
@@ -56,7 +56,7 @@ export class EuiBottomBar extends Component {
           <p aria-live="assertive">
             <EuiI18n
               token="euiBottomBar.screenReaderAnnouncement"
-              default="There is a new menu opening with page level controls at the bottom of the document."
+              default="There is a new menu opening with page level controls at the end of document."
             />
           </p>
         </EuiScreenReaderOnly>

--- a/src/components/bottom_bar/bottom_bar.js
+++ b/src/components/bottom_bar/bottom_bar.js
@@ -56,7 +56,7 @@ export class EuiBottomBar extends Component {
           <p aria-live="assertive">
             <EuiI18n
               token="euiBottomBar.screenReaderAnnouncement"
-              default="There is a new menu opening with page level controls at the end of document."
+              default="There is a new menu opening with page level controls at the end of the document."
             />
           </p>
         </EuiScreenReaderOnly>


### PR DESCRIPTION
### Summary

FIxes https://github.com/elastic/eui/issues/1696. EuiBottomBar uses non-visual language.

### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios
- [x] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
