### PR TITLE
Don't create a custom combobox option if user clicked on an option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug fixes**
 
 - Removed all `lodash` imports in `eui.d.ts` to avoid namespace pollution ([#1723](https://github.com/elastic/eui/pull/1723))
+- Prevent `EuiComboBox` from creating a custom option value when user clicks on a value in the dropdown ([#1728](https://github.com/elastic/eui/pull/1728))
 
 ## [`9.3.0`](https://github.com/elastic/eui/tree/v9.3.0)
 

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -290,7 +290,7 @@ export class EuiComboBox extends Component {
 
     // If the user tabs away or changes focus to another element, take whatever input they've
     // typed and convert it into a pill, to prevent the combo box from looking like a text input.
-    if (!this.hasActiveOption() && !focusedInInput) {
+    if (!this.hasActiveOption() && !focusedInInput && !focusedInOptionsList) {
       this.addCustomOption();
     }
   }


### PR DESCRIPTION
### Summary

Fixes #1721 . Doesn't add a custom option if the user is clicking on an option.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
