### PR TITLE
Adding a content block loading animation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## [`9.5.0`](https://github.com/elastic/eui/tree/v9.5.0)
 
 - Changed `EuiSuperDatePicker` to call `onRefresh` instead of `onTimeChanged` when user clicks "Refresh" button ([#1745](https://github.com/elastic/eui/pull/1745))
+- Added a new `EuiLoadingContent` component that displays blocks as placeholders for text. ([#1730](https://github.com/elastic/eui/pull/1730))
 - Added documentation entry in `EuiPagination` for `activePage` prop. ([#1740](https://github.com/elastic/eui/pull/1740))
 - Changed `EuiButton` to use "m" as it's default `size` prop ([#1742](https://github.com/elastic/eui/pull/1742))
 - Adds type definitions for `EuiListGroup` and `EuiListGroupItem` ([#1737](https://github.com/elastic/eui/pull/1737))

--- a/src-docs/src/views/loading/loading_content.tsx
+++ b/src-docs/src/views/loading/loading_content.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import { EuiLoadingContent } from '../../../../src/components/loading';
+
+export default () => (
+  <div>
+    <EuiLoadingContent lines={3} />
+  </div>
+);

--- a/src-docs/src/views/loading/loading_example.js
+++ b/src-docs/src/views/loading/loading_example.js
@@ -10,6 +10,7 @@ import {
   EuiLoadingKibana,
   EuiLoadingSpinner,
   EuiLoadingChart,
+  EuiLoadingContent,
 } from '../../../../src/components';
 
 import LoadingKibana from './loading_kibana';
@@ -23,6 +24,10 @@ const loadingChartHtml = renderToHtml(LoadingChart);
 import LoadingSpinner from './loading_spinner';
 const loadingSpinnerSource = require('!!raw-loader!./loading_spinner');
 const loadingSpinnerHtml = renderToHtml(LoadingSpinner);
+
+import LoadingContent from './loading_content';
+const loadingContentSource = require('!!raw-loader!./loading_content');
+const loadingContentHtml = renderToHtml(LoadingContent);
 
 export const LoadingExample = {
   title: 'Loading',
@@ -80,5 +85,20 @@ export const LoadingExample = {
     props: { EuiLoadingSpinner },
     demo: <LoadingSpinner />,
     snippet: `<EuiLoadingSpinner size="m" />`
+  }, {
+    title: 'Content',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: loadingContentSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: loadingContentHtml,
+    }],
+    text: (
+      <p>A simple loading animation for displaying placeholder content. You can pass in a number of lines — the default is 3.</p>
+    ),
+    props: { EuiLoadingContent },
+    demo: <LoadingContent />,
+    snippet: `<EuiLoadingContent lines={3} />`
   }],
 };

--- a/src-docs/src/views/loading/loading_example.js
+++ b/src-docs/src/views/loading/loading_example.js
@@ -7,6 +7,7 @@ import {
 } from '../../components';
 
 import {
+  EuiCode,
   EuiLoadingKibana,
   EuiLoadingSpinner,
   EuiLoadingChart,
@@ -86,7 +87,7 @@ export const LoadingExample = {
     demo: <LoadingSpinner />,
     snippet: `<EuiLoadingSpinner size="m" />`
   }, {
-    title: 'Content',
+    title: 'Text Content',
     source: [{
       type: GuideSectionTypes.JS,
       code: loadingContentSource,
@@ -95,7 +96,7 @@ export const LoadingExample = {
       code: loadingContentHtml,
     }],
     text: (
-      <p>A simple loading animation for displaying placeholder content. You can pass in a number of lines — the default is 3.</p>
+      <p>A simple loading animation for displaying placeholder text content. You can pass in a number of <EuiCode>lines</EuiCode> between 1 and 10.</p>
     ),
     props: { EuiLoadingContent },
     demo: <LoadingContent />,

--- a/src-docs/src/views/loading/loading_example.js
+++ b/src-docs/src/views/loading/loading_example.js
@@ -96,7 +96,10 @@ export const LoadingExample = {
       code: loadingContentHtml,
     }],
     text: (
-      <p>A simple loading animation for displaying placeholder text content. You can pass in a number of <EuiCode>lines</EuiCode> between 1 and 10.</p>
+      <p>
+        A simple loading animation for displaying placeholder text content.
+        You can pass in a number of <EuiCode>lines</EuiCode> between 1 and 10.
+      </p>
     ),
     props: { EuiLoadingContent },
     demo: <LoadingContent />,

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -200,6 +200,7 @@ export {
 export {
   EuiLoadingKibana,
   EuiLoadingChart,
+  EuiLoadingContent,
   EuiLoadingSpinner,
 } from './loading';
 

--- a/src/components/loading/__snapshots__/loading_content.test.tsx.snap
+++ b/src/components/loading/__snapshots__/loading_content.test.tsx.snap
@@ -1,0 +1,486 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiLoadingContent is rendered 1`] = `
+<div
+  aria-label="aria-label"
+  class="euiLoadingContent testClass1 testClass2"
+  data-test-subj="test subject string"
+>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiLoadingContent lines 1 is rendered 1`] = `
+<div
+  class="euiLoadingContent"
+>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiLoadingContent lines 2 is rendered 1`] = `
+<div
+  class="euiLoadingContent"
+>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiLoadingContent lines 3 is rendered 1`] = `
+<div
+  class="euiLoadingContent"
+>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiLoadingContent lines 4 is rendered 1`] = `
+<div
+  class="euiLoadingContent"
+>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiLoadingContent lines 5 is rendered 1`] = `
+<div
+  class="euiLoadingContent"
+>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiLoadingContent lines 6 is rendered 1`] = `
+<div
+  class="euiLoadingContent"
+>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiLoadingContent lines 7 is rendered 1`] = `
+<div
+  class="euiLoadingContent"
+>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiLoadingContent lines 8 is rendered 1`] = `
+<div
+  class="euiLoadingContent"
+>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiLoadingContent lines 9 is rendered 1`] = `
+<div
+  class="euiLoadingContent"
+>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiLoadingContent lines 10 is rendered 1`] = `
+<div
+  class="euiLoadingContent"
+>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+  <div
+    class="euiLoadingContent__singleLine"
+  >
+    <div
+      class="euiLoadingContent__singleLineBackground"
+    />
+  </div>
+</div>
+`;

--- a/src/components/loading/_index.scss
+++ b/src/components/loading/_index.scss
@@ -1,4 +1,5 @@
 @import 'mixins';
 @import 'loading_kibana';
 @import 'loading_chart';
+@import 'loading_content';
 @import 'loading_spinner';

--- a/src/components/loading/_index.scss
+++ b/src/components/loading/_index.scss
@@ -1,3 +1,4 @@
+@import 'variables';
 @import 'mixins';
 @import 'loading_kibana';
 @import 'loading_chart';

--- a/src/components/loading/_loading_content.scss
+++ b/src/components/loading/_loading_content.scss
@@ -1,30 +1,27 @@
-$gradientStartStop: shadeOrTint($euiColorLightestShade, 8%, 12%);
-$gradientMiddle: shadeOrTint($euiColorLightestShade, 2%, 4%);
-
 .euiLoadingContent__loader {
   width: 100%;
 }
 
-.euiLoadingContent__single-line {
+.euiLoadingContent__singleLine {
   height: $euiSize;
   margin-bottom: $euiSizeS;
   border-radius: $euiBorderRadius;
   width: 100%;
-  background-size: 200% 100% !important; // sass-lint:disable-line no-important
   background: linear-gradient(
     to right,
-    $gradientStartStop 8%,
-    $gradientMiddle 18%,
-    $gradientStartStop 33%,
-  );
-  animation: GradientLoad 1.5s $euiAnimSlightResistance infinite;
+    $euiGradientStartStop 8%,
+    $euiGradientMiddle 18%,
+    $euiGradientStartStop 33%,
+    );
+  background-size: 200% 100%;
+  animation: euiLoadingContentGradientLoad 1.5s $euiAnimSlightResistance infinite;
 
   &:last-child:not(:only-child) {
     width: 75%;
   }
 }
 
-@keyframes GradientLoad {
+@keyframes euiLoadingContentGradientLoad {
   0% {
     background-position: 100% 0%;
   }

--- a/src/components/loading/_loading_content.scss
+++ b/src/components/loading/_loading_content.scss
@@ -1,0 +1,20 @@
+.euiLoadingContent__loader {
+  width: 100%;
+}
+
+.euiLoadingContent__single-line {
+  width: 100%;
+  fill:shadeOrTint($euiColorLightShade, 0%, 15%);
+  &:last-child {
+    width: 75%;
+  }
+}
+
+.euiLoadingContent__gradient--start-end {
+  stop-color: shadeOrTint($euiColorLightShade, 0%, 15%);
+  stop-opacity: 1;
+}
+.euiLoadingContent__gradient--middle {
+  stop-color: shadeOrTint($euiColorLightestShade, 0%, 15%);
+  stop-opacity: 1;
+}

--- a/src/components/loading/_loading_content.scss
+++ b/src/components/loading/_loading_content.scss
@@ -12,10 +12,9 @@
   &:last-child:not(:only-child) {
     width: 75%;
   }
-
 }
 
-.euiLoadingContent__singleLine--background {
+.euiLoadingContent__singleLineBackground {
   width: 220%;
   height: 100%;
   background: linear-gradient(

--- a/src/components/loading/_loading_content.scss
+++ b/src/components/loading/_loading_content.scss
@@ -4,7 +4,8 @@
 
 .euiLoadingContent__single-line {
   width: 100%;
-  fill:shadeOrTint($euiColorLightShade, 0%, 15%);
+  fill: shadeOrTint($euiColorLightShade, 0%, 15%);
+
   &:last-child {
     width: 75%;
   }
@@ -14,6 +15,7 @@
   stop-color: shadeOrTint($euiColorLightShade, 0%, 15%);
   stop-opacity: 1;
 }
+
 .euiLoadingContent__gradient--middle {
   stop-color: shadeOrTint($euiColorLightestShade, 0%, 15%);
   stop-opacity: 1;

--- a/src/components/loading/_loading_content.scss
+++ b/src/components/loading/_loading_content.scss
@@ -3,31 +3,37 @@
 }
 
 .euiLoadingContent__singleLine {
+  width: 100%;
   height: $euiSize;
   margin-bottom: $euiSizeS;
   border-radius: $euiBorderRadius;
-  width: 100%;
-  background: linear-gradient(
-    to right,
-    $euiGradientStartStop 8%,
-    $euiGradientMiddle 18%,
-    $euiGradientStartStop 33%,
-    );
-  background-size: 200% 100%;
-  animation: euiLoadingContentGradientLoad 1.5s $euiAnimSlightResistance infinite;
+  overflow: hidden;
 
   &:last-child:not(:only-child) {
     width: 75%;
   }
+
+}
+
+.euiLoadingContent__singleLine--background {
+  width: 220%;
+  height: 100%;
+  background: linear-gradient(
+    to right,
+    $euiGradientStartStop 45%,
+    $euiGradientMiddle 50%,
+    $euiGradientStartStop 55%,
+    );
+  animation: euiLoadingContentGradientLoad 1.5s $euiAnimSlightResistance infinite;
 }
 
 @keyframes euiLoadingContentGradientLoad {
   0% {
-    background-position: 100% 0%;
+    transform: translateX(-53%);
   }
 
   100% {
-    background-position: -100% 0%;
+    transform: translateX(0);
   }
 }
 

--- a/src/components/loading/_loading_content.scss
+++ b/src/components/loading/_loading_content.scss
@@ -1,5 +1,5 @@
-$gradientStartStop: shadeOrTint($euiColorLightShade, 0%, 15%);
-$gradientMiddle: shadeOrTint($euiColorLightestShade, 0%, 5%);
+$gradientStartStop: shadeOrTint($euiColorLightestShade, 8%, 12%);
+$gradientMiddle: shadeOrTint($euiColorLightestShade, 2%, 4%);
 
 .euiLoadingContent__loader {
   width: 100%;
@@ -10,17 +10,14 @@ $gradientMiddle: shadeOrTint($euiColorLightestShade, 0%, 5%);
   margin-bottom: $euiSizeS;
   border-radius: $euiBorderRadius;
   width: 100%;
-  background-size: 400% 100% !important; // sass-lint:disable-line no-important
-  background-position: 0% 0%;
+  background-size: 200% 100% !important; // sass-lint:disable-line no-important
   background: linear-gradient(
-    90deg,
-    $gradientStartStop 0%,
-    $gradientStartStop 25%,
-    $gradientMiddle 50%,
-    $gradientStartStop 75%,
-    $gradientStartStop 100%,
+    to right,
+    $gradientStartStop 8%,
+    $gradientMiddle 18%,
+    $gradientStartStop 33%,
   );
-  animation: GradientLoad 1s $euiAnimSlightResistance infinite;
+  animation: GradientLoad 1.5s $euiAnimSlightResistance infinite;
 
   &:last-child:not(:only-child) {
     width: 75%;
@@ -33,6 +30,7 @@ $gradientMiddle: shadeOrTint($euiColorLightestShade, 0%, 5%);
   }
 
   100% {
-    background-position: 0% 0%;
+    background-position: -100% 0%;
   }
 }
+

--- a/src/components/loading/_loading_content.scss
+++ b/src/components/loading/_loading_content.scss
@@ -1,22 +1,38 @@
+$gradientStartStop: shadeOrTint($euiColorLightShade, 0%, 15%);
+$gradientMiddle: shadeOrTint($euiColorLightestShade, 0%, 5%);
+
 .euiLoadingContent__loader {
   width: 100%;
 }
 
 .euiLoadingContent__single-line {
+  height: $euiSize;
+  margin-bottom: $euiSizeS;
+  border-radius: $euiBorderRadius;
   width: 100%;
-  fill: shadeOrTint($euiColorLightShade, 0%, 15%);
+  background-size: 400% 100% !important; // sass-lint:disable-line no-important
+  background-position: 0% 0%;
+  background: linear-gradient(
+    90deg,
+    $gradientStartStop 0%,
+    $gradientStartStop 25%,
+    $gradientMiddle 50%,
+    $gradientStartStop 75%,
+    $gradientStartStop 100%,
+  );
+  animation: GradientLoad 1s $euiAnimSlightResistance infinite;
 
-  &:last-child {
+  &:last-child:not(:only-child) {
     width: 75%;
   }
 }
 
-.euiLoadingContent__gradient--start-end {
-  stop-color: shadeOrTint($euiColorLightShade, 0%, 35%);
-  stop-opacity: 1;
-}
+@keyframes GradientLoad {
+  0% {
+    background-position: 100% 0%;
+  }
 
-.euiLoadingContent__gradient--middle {
-  stop-color: shadeOrTint($euiColorLightestShade, 0%, 15%);
-  stop-opacity: 1;
+  100% {
+    background-position: 0% 0%;
+  }
 }

--- a/src/components/loading/_loading_content.scss
+++ b/src/components/loading/_loading_content.scss
@@ -12,7 +12,7 @@
 }
 
 .euiLoadingContent__gradient--start-end {
-  stop-color: shadeOrTint($euiColorLightShade, 0%, 15%);
+  stop-color: shadeOrTint($euiColorLightShade, 0%, 35%);
   stop-opacity: 1;
 }
 

--- a/src/components/loading/_variables.scss
+++ b/src/components/loading/_variables.scss
@@ -1,0 +1,2 @@
+$euiGradientStartStop: tintOrShade($euiColorLightShade, 5%, 12%);
+$euiGradientMiddle: tintOrShade($euiColorLightShade, 50%, 24%);

--- a/src/components/loading/index.ts
+++ b/src/components/loading/index.ts
@@ -1,3 +1,4 @@
 export { EuiLoadingKibana } from './loading_kibana';
 export { EuiLoadingChart } from './loading_chart';
+export { EuiLoadingContent } from './loading_content';
 export { EuiLoadingSpinner } from './loading_spinner';

--- a/src/components/loading/loading_content.test.tsx
+++ b/src/components/loading/loading_content.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render } from 'enzyme';
+import { requiredProps } from '../../test/required_props';
+
+import { EuiLoadingContent, LineRange } from './loading_content';
+
+const lines: LineRange[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+describe('EuiLoadingContent', () => {
+  test('is rendered', () => {
+    const component = render(<EuiLoadingContent {...requiredProps} />);
+
+    expect(component).toMatchSnapshot();
+  });
+
+  describe('lines', () => {
+    lines.forEach(line => {
+      test(`${line} is rendered`, () => {
+        const component = render(<EuiLoadingContent lines={line} />);
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/src/components/loading/loading_content.tsx
+++ b/src/components/loading/loading_content.tsx
@@ -1,0 +1,71 @@
+import React, { FunctionComponent, HTMLAttributes } from 'react';
+import classNames from 'classnames';
+import { CommonProps } from '../common';
+
+export const EuiLoadingContent: FunctionComponent<
+  CommonProps &
+    HTMLAttributes<HTMLDivElement> & {
+      lines?: number;
+    }
+> = ({ lines = 3, className, ...rest }) => {
+  const classes = classNames('euiLoadingContent', className);
+  // We need an array for mapping the lines
+  const newLineArray = Array(lines).fill(undefined);
+  return (
+    <div className={classes} {...rest}>
+      <svg
+        viewBox="0 0"
+        height={newLineArray.length * 32}
+        fill="none"
+        className="euiLoadingContent__loader">
+        <mask id="euiLoadingContent__mask">
+          {newLineArray.map((line: undefined, index) => {
+            return (
+              <rect
+                className="euiLoadingContent__single-line"
+                y={index * 32}
+                width={newLineArray.length === index + 1 ? '75%' : '100%'}
+                height="24"
+                rx="4"
+              />
+            );
+          })}
+        </mask>
+
+        <linearGradient
+          id="euiLoadingContent__gradient"
+          x1="0%"
+          x2="100%"
+          y1="38%"
+          y2="40%">
+          <stop
+            className="euiLoadingContent__gradient--start-end"
+            offset="0%"
+          />
+          <stop className="euiLoadingContent__gradient--middle" offset="50%" />
+          <stop
+            className="euiLoadingContent__gradient--start-end"
+            offset="100%"
+          />
+          <animate
+            attributeName="x2"
+            dur="900ms"
+            from="20%"
+            to="300%"
+            repeatCount="indefinite"
+          />
+        </linearGradient>
+
+        <rect
+          id="shimmer"
+          x="0"
+          y="0"
+          width="100%"
+          height="100%"
+          fill="url(#euiLoadingContent__gradient)"
+          mask="url(#euiLoadingContent__mask)"
+        />
+      </svg>
+    </div>
+  );
+};

--- a/src/components/loading/loading_content.tsx
+++ b/src/components/loading/loading_content.tsx
@@ -15,7 +15,7 @@ export const EuiLoadingContent: FunctionComponent<
 
   for (let i = 0; i < lines; i++) {
     lineElements.push(
-      <div key={i} className="euiLoadingContent__single-line" />
+      <div key={i} className="euiLoadingContent__singleLine" />
     );
   }
 

--- a/src/components/loading/loading_content.tsx
+++ b/src/components/loading/loading_content.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent, HTMLAttributes } from 'react';
 import classNames from 'classnames';
 import { CommonProps } from '../common';
 
-type LineRange = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
+export type LineRange = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
 
 export const EuiLoadingContent: FunctionComponent<
   CommonProps &

--- a/src/components/loading/loading_content.tsx
+++ b/src/components/loading/loading_content.tsx
@@ -1,75 +1,27 @@
 import React, { FunctionComponent, HTMLAttributes } from 'react';
 import classNames from 'classnames';
 import { CommonProps } from '../common';
-import { htmlIdGenerator } from '../../services';
 
-const getMaskId = htmlIdGenerator('euiLoadingContent__mask--');
+type LineRange = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
 
 export const EuiLoadingContent: FunctionComponent<
   CommonProps &
     HTMLAttributes<HTMLDivElement> & {
-      lines?: number;
+      lines?: LineRange;
     }
 > = ({ lines = 3, className, ...rest }) => {
   const classes = classNames('euiLoadingContent', className);
-  const maskId = getMaskId();
   const lineElements = [];
+
   for (let i = 0; i < lines; i++) {
     lineElements.push(
-      <rect
-        key={i}
-        className="euiLoadingContent__single-line"
-        y={i * 24}
-        width={lines === i + 1 ? '75%' : '100%'}
-        height="16"
-        rx="4"
-      />
+      <div key={i} className="euiLoadingContent__single-line" />
     );
   }
+
   return (
-    // TODO: Remove the styles! They're only there for 👇development
-    <div className={classes} {...rest} style={{ marginBottom: '800px' }}>
-      <svg
-        viewBox="0 0"
-        height={lineElements.length * 24}
-        fill="none"
-        className="euiLoadingContent__loader">
-        <mask id={maskId}>{lineElements}</mask>
-
-        <linearGradient
-          id="euiLoadingContent__gradient"
-          x1="0%"
-          x2="100%"
-          y1="38%"
-          y2="40%">
-          <stop
-            className="euiLoadingContent__gradient--start-end"
-            offset="0%"
-          />
-          <stop className="euiLoadingContent__gradient--middle" offset="50%" />
-          <stop
-            className="euiLoadingContent__gradient--start-end"
-            offset="100%"
-          />
-          <animate
-            attributeName="x2"
-            dur="900ms"
-            from="20%"
-            to="300%"
-            repeatCount="indefinite"
-          />
-        </linearGradient>
-
-        <rect
-          id="shimmer"
-          x="0"
-          y="0"
-          width="100%"
-          height="100%"
-          fill="url(#euiLoadingContent__gradient)"
-          mask={`url(#${maskId}`}
-        />
-      </svg>
+    <div className={classes} {...rest}>
+      {lineElements}
     </div>
   );
 };

--- a/src/components/loading/loading_content.tsx
+++ b/src/components/loading/loading_content.tsx
@@ -16,7 +16,7 @@ export const EuiLoadingContent: FunctionComponent<
   for (let i = 0; i < lines; i++) {
     lineElements.push(
       <div key={i} className="euiLoadingContent__singleLine">
-        <div className="euiLoadingContent__singleLine--background" />
+        <div className="euiLoadingContent__singleLineBackground" />
       </div>
     );
   }

--- a/src/components/loading/loading_content.tsx
+++ b/src/components/loading/loading_content.tsx
@@ -15,7 +15,9 @@ export const EuiLoadingContent: FunctionComponent<
 
   for (let i = 0; i < lines; i++) {
     lineElements.push(
-      <div key={i} className="euiLoadingContent__singleLine" />
+      <div key={i} className="euiLoadingContent__singleLine">
+        <div className="euiLoadingContent__singleLine--background" />
+      </div>
     );
   }
 

--- a/src/components/loading/loading_content.tsx
+++ b/src/components/loading/loading_content.tsx
@@ -1,6 +1,9 @@
 import React, { FunctionComponent, HTMLAttributes } from 'react';
 import classNames from 'classnames';
 import { CommonProps } from '../common';
+import { htmlIdGenerator } from '../../services';
+
+const getMaskId = htmlIdGenerator('euiLoadingContent__mask--');
 
 export const EuiLoadingContent: FunctionComponent<
   CommonProps &
@@ -9,28 +12,29 @@ export const EuiLoadingContent: FunctionComponent<
     }
 > = ({ lines = 3, className, ...rest }) => {
   const classes = classNames('euiLoadingContent', className);
-  // We need an array for mapping the lines
-  const newLineArray = Array(lines).fill(undefined);
+  const maskId = getMaskId();
+  const lineElements = [];
+  for (let i = 0; i < lines; i++) {
+    lineElements.push(
+      <rect
+        key={i}
+        className="euiLoadingContent__single-line"
+        y={i * 24}
+        width={lines === i + 1 ? '75%' : '100%'}
+        height="16"
+        rx="4"
+      />
+    );
+  }
   return (
-    <div className={classes} {...rest}>
+    // TODO: Remove the styles! They're only there for 👇development
+    <div className={classes} {...rest} style={{ marginBottom: '800px' }}>
       <svg
         viewBox="0 0"
-        height={newLineArray.length * 32}
+        height={lineElements.length * 24}
         fill="none"
         className="euiLoadingContent__loader">
-        <mask id="euiLoadingContent__mask">
-          {newLineArray.map((line: undefined, index) => {
-            return (
-              <rect
-                className="euiLoadingContent__single-line"
-                y={index * 32}
-                width={newLineArray.length === index + 1 ? '75%' : '100%'}
-                height="24"
-                rx="4"
-              />
-            );
-          })}
-        </mask>
+        <mask id={maskId}>{lineElements}</mask>
 
         <linearGradient
           id="euiLoadingContent__gradient"
@@ -63,7 +67,7 @@ export const EuiLoadingContent: FunctionComponent<
           width="100%"
           height="100%"
           fill="url(#euiLoadingContent__gradient)"
-          mask="url(#euiLoadingContent__mask)"
+          mask={`url(#${maskId}`}
         />
       </svg>
     </div>


### PR DESCRIPTION
### Summary

Creating a simple loading animation for content blocks. I'm open to ideas on this. I wanted to start with something dead simple and get some eyes on it.

![](https://cl.ly/8ecf97240b07/Image%2525202019-03-13%252520at%2525203.33.08%252520PM.png)

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
- [x] Any props added have proper autodocs
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios
- [ ] ~This was checked against keyboard-only and screenreader scenarios~
- [ ] ~This required updates to Framer X components~
