### PR TITLE
Mark EUI package as sideEffect free to enable webpack treeshaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "types": "eui.d.ts",
   "postcss": {},
   "docker_image": "node:8",
+  "sideEffects": false,
   "scripts": {
     "preinstall": "node ./preinstall_check",
     "start": "webpack-dev-server --port 8030 --inline --hot --config=src-docs/webpack.config.js",


### PR DESCRIPTION
### Summary

Supports the effort to break apart `EuiIcon` by allowing webpack to tree shake unused EUI components from the build.

Stats from the building with a `sideEffects: false` EUI -
```
Empty React "Hello World" - 117Kb
Include anything in EUI with no tree shaking - 3.6Mb
Including only EuiPanel with tree shaking - 767Kb
Including only EuiCodeEditor with tree shaking - 545Kb
```

To ensure all JS/TS/TSX files in EUI src are compatible with this change, looking for any usage of outside variables in the module's initiation. There are two cases:

* A few components have `PropTypes.instanceOf(HTMLElement)`, a passive reliance on a browser-like environment
* `EuiCodeEditor` imports `brace`, which requires the `window` object be present. This is fine for tree shaking as `brace` isn't needed unless `EuiCodeEditor` is brought in, and if `EuiCodeEditor` is imported then `brace` comes with it.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
