### PR TITLE
Fix onRefresh for SuperDatePicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `9.4.0`.
+**Bug fixes**
+
+- Adds missing type and fixes closure-scope problem for `SuperDatePicker`'s `onRefresh` callback ([#1732](https://github.com/elastic/eui/pull/1732))
 
 ## [`9.4.0`](https://github.com/elastic/eui/tree/v9.4.0)
 

--- a/src/components/date_picker/index.d.ts
+++ b/src/components/date_picker/index.d.ts
@@ -1,7 +1,9 @@
 import React from 'react';
 import { CommonProps } from '../common';
 import { IconType } from '../icon';
-import _ReactDatePicker, { ReactDatePickerProps as _ReactDatePickerProps } from './react-datepicker';
+import _ReactDatePicker, {
+  ReactDatePickerProps as _ReactDatePickerProps,
+} from './react-datepicker';
 import { Moment } from 'moment';
 
 declare module '@elastic/eui' {
@@ -10,6 +12,12 @@ declare module '@elastic/eui' {
     end: string;
     isInvalid: boolean;
     isQuickSelection: boolean;
+  }
+
+  interface OnRefreshProps {
+    start: string;
+    end: string;
+    refreshInterval: number;
   }
 
   interface OnRefreshChangeProps {
@@ -63,6 +71,7 @@ declare module '@elastic/eui' {
     isPaused?: boolean;
     refreshInterval?: number;
     onTimeChange: (props: OnTimeChangeProps) => void;
+    onRefresh: (props: OnRefreshProps) => void;
     onRefreshChange?: (props: OnRefreshChangeProps) => void;
     commonlyUsedRanges?: EuiSuperDatePickerCommonRange[];
     dateFormat?: string;

--- a/src/components/date_picker/super_date_picker/super_date_picker.js
+++ b/src/components/date_picker/super_date_picker/super_date_picker.js
@@ -257,9 +257,12 @@ export class EuiSuperDatePicker extends Component {
   }
 
   startInterval = (refreshInterval) => {
-    const { start, end, onRefresh } = this.props;
+    const { onRefresh } = this.props;
     if(onRefresh) {
-      const handler = () => onRefresh({ start, end, refreshInterval });
+      const handler = () => {
+        const { start, end } = this.props;
+        onRefresh({ start, end, refreshInterval });
+      };
       this.asyncInterval = new AsyncInterval(handler, refreshInterval);
     }
   }


### PR DESCRIPTION
### Summary

The SuperDatePicker was missing the `onRefresh` callback prop in the types file. I added it so that it can be used in a TS file without complaints.

Once I did that, I was able to test out the new `onRefresh` prop and it didn't _quite_ work. If you started refreshing and then changed the start/end values, each refresh would _reset_ them back where they were because of the closure where the refresh handler was created. 

This PR makes the handler grab start and end from props on each refresh so that the refresh callback is given the most up to date start and end values.

### Checklist

- ~[ ] This was checked in mobile~
- ~[ ] This was checked in IE11~
- ~[ ] This was checked in dark mode~
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
