### PR TITLE
add EuiListGroup and EuiListGroupItem type definitions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Adds type definitions for `EuiListGroup` and `EuiListGroupItem` ([#1737](https://github.com/elastic/eui/pull/1737))
+
 **Bug fixes**
 
 - Adds missing type and fixes closure-scope problem for `SuperDatePicker`'s `onRefresh` callback ([#1732](https://github.com/elastic/eui/pull/1732))

--- a/src/components/list_group/index.d.ts
+++ b/src/components/list_group/index.d.ts
@@ -51,7 +51,7 @@ declare module '@elastic/eui' {
           alwaysShow?: boolean;
         }
     >;
-    onClick?(): void;
+    onClick?: MouseEventHandler<HTMLButtonElement>;
     wrapText?: boolean;
   };
 

--- a/src/components/list_group/index.d.ts
+++ b/src/components/list_group/index.d.ts
@@ -1,7 +1,15 @@
 import { EuiButtonIconProps, EuiButtonPropsForButtonOrLink } from '@elastic/eui';
 import { IconType } from '../icon';
 import { CommonProps } from '../common';
-import { FunctionComponent, ReactNode, ReactPropTypes } from 'react';
+import {
+  AnchorHTMLAttributes,
+  ButtonHTMLAttributes,
+  FunctionComponent,
+  HTMLAttributes,
+  MouseEventHandler,
+  ReactElement,
+  ReactNode
+} from 'react';
 
 declare module '@elastic/eui' {
   /**
@@ -10,7 +18,7 @@ declare module '@elastic/eui' {
    * @see './list_group.js'
    */
 
-  type EuiListGroupProps = CommonProps & {
+  type EuiListGroupProps = CommonProps & HTMLAttributes<HTMLUListElement> & {
     bordered?: boolean;
     flush?: boolean;
     listItems?: FunctionComponent<EuiListGroupItemProps>[];
@@ -27,14 +35,14 @@ declare module '@elastic/eui' {
    * @see './list_group_item.js'
    */
 
-  type EuiListGroupItemProps = CommonProps & {
+  type EuiListGroupItemProps = {
     size?: 'xs' | 's' | 'm' | 'l';
     label: ReactNode;
     isActive?: boolean;
     isDisabled?: boolean;
     href?: string;
     iconType?: IconType;
-    icon?: ReactPropTypes['element'];
+    icon?: ReactElement;
     showToolTip?: boolean;
     extraAction?: EuiButtonPropsForButtonOrLink<
       CommonProps &
@@ -47,5 +55,16 @@ declare module '@elastic/eui' {
     wrapText?: boolean;
   };
 
-  export const EuiListGroupItem: FunctionComponent<EuiListGroupItemProps>;
+  type EuiListGroupItemExtendedProps = EuiListGroupItemProps & CommonProps & (
+    ({
+      onClick: MouseEventHandler<HTMLButtonElement>;
+    } & ButtonHTMLAttributes<HTMLButtonElement>) |
+    ({
+      href: string;
+      onClick: MouseEventHandler<HTMLAnchorElement>;
+    } & AnchorHTMLAttributes<HTMLAnchorElement>) |
+    HTMLAttributes<HTMLSpanElement>
+  );
+
+  export const EuiListGroupItem: FunctionComponent<EuiListGroupItemExtendedProps>;
 }

--- a/src/components/list_group/index.d.ts
+++ b/src/components/list_group/index.d.ts
@@ -1,4 +1,5 @@
-import { IconType } from '../icon'
+import { EuiButtonIconProps, EuiButtonPropsForButtonOrLink } from '@elastic/eui';
+import { IconType } from '../icon';
 import { CommonProps } from '../common';
 import { FunctionComponent, ReactNode, ReactPropTypes } from 'react';
 
@@ -35,10 +36,13 @@ declare module '@elastic/eui' {
     iconType?: IconType;
     icon?: ReactPropTypes['element'];
     showToolTip?: boolean;
-    extraAction?: {
-      iconType: IconType;
-      alwaysShow?: boolean;
-    };
+    extraAction?: EuiButtonPropsForButtonOrLink<
+      CommonProps &
+        EuiButtonIconProps & {
+          iconType: IconType;
+          alwaysShow?: boolean;
+        }
+    >;
     onClick?(): void;
     wrapText?: boolean;
   };

--- a/src/components/list_group/index.d.ts
+++ b/src/components/list_group/index.d.ts
@@ -1,5 +1,6 @@
+import { IconType } from '../icon'
 import { CommonProps } from '../common';
-import { FunctionComponent } from 'react';
+import { FunctionComponent, ReactNode, ReactPropTypes } from 'react';
 
 declare module '@elastic/eui' {
   /**
@@ -9,8 +10,38 @@ declare module '@elastic/eui' {
    */
 
   type EuiListGroupProps = CommonProps & {
-
+    bordered?: boolean;
+    flush?: boolean;
+    listItems?: FunctionComponent<EuiListGroupItemProps>[];
+    maxWidth?: boolean | number | string;
+    showToolTips?: boolean;
+    wrapText?: boolean;
   };
 
   export const EuiListGroup: FunctionComponent<EuiListGroupProps>;
+
+  /**
+   * list group item type defs
+   *
+   * @see './list_group_item.js'
+   */
+
+  type EuiListGroupItemProps = CommonProps & {
+    size?: 'xs' | 's' | 'm' | 'l';
+    label: ReactNode;
+    isActive?: boolean;
+    isDisabled?: boolean;
+    href?: string;
+    iconType?: IconType;
+    icon?: ReactPropTypes['element'];
+    showToolTip?: boolean;
+    extraAction?: {
+      iconType: IconType;
+      alwaysShow?: boolean;
+    };
+    onClick?(): void;
+    wrapText?: boolean;
+  };
+
+  export const EuiListGroupItem: FunctionComponent<EuiListGroupItemProps>;
 }

--- a/src/components/list_group/index.d.ts
+++ b/src/components/list_group/index.d.ts
@@ -1,6 +1,6 @@
 import { EuiButtonIconProps, EuiButtonPropsForButtonOrLink } from '@elastic/eui';
 import { IconType } from '../icon';
-import { CommonProps } from '../common';
+import { CommonProps, ExclusiveUnion } from '../common';
 import {
   AnchorHTMLAttributes,
   ButtonHTMLAttributes,
@@ -35,7 +35,7 @@ declare module '@elastic/eui' {
    * @see './list_group_item.js'
    */
 
-  type EuiListGroupItemProps = {
+  type EuiListGroupItemPropsBasics = {
     size?: 'xs' | 's' | 'm' | 'l';
     label: ReactNode;
     isActive?: boolean;
@@ -55,16 +55,15 @@ declare module '@elastic/eui' {
     wrapText?: boolean;
   };
 
-  type EuiListGroupItemExtendedProps = EuiListGroupItemProps & CommonProps & (
-    ({
-      onClick: MouseEventHandler<HTMLButtonElement>;
-    } & ButtonHTMLAttributes<HTMLButtonElement>) |
-    ({
-      href: string;
-      onClick: MouseEventHandler<HTMLAnchorElement>;
-    } & AnchorHTMLAttributes<HTMLAnchorElement>) |
+  type EuiListGroupItemProps = EuiListGroupItemPropsBasics &
+  CommonProps &
+  ExclusiveUnion<
+    ExclusiveUnion<
+      ButtonHTMLAttributes<HTMLButtonElement>,
+      AnchorHTMLAttributes<HTMLAnchorElement>
+    >,
     HTMLAttributes<HTMLSpanElement>
-  );
+  >;
 
-  export const EuiListGroupItem: FunctionComponent<EuiListGroupItemExtendedProps>;
+  export const EuiListGroupItem: FunctionComponent<EuiListGroupItemProps>;
 }

--- a/src/components/list_group/list_group.js
+++ b/src/components/list_group/list_group.js
@@ -76,15 +76,7 @@ export const EuiListGroup = ({
 };
 
 EuiListGroup.propTypes = {
-  listItems: PropTypes.arrayOf(PropTypes.shape({
-    label: PropTypes.node,
-    href: PropTypes.string,
-    extraAction: PropTypes.object,
-    iconType: PropTypes.string,
-    isActive: PropTypes.boolean,
-    isDisabled: PropTypes.boolean,
-    showToolTip: PropTypes.boolean,
-  })),
+  listItems: PropTypes.arrayOf(EuiListGroupItem.propTypes),
   children: PropTypes.node,
   className: PropTypes.string,
 

--- a/src/components/list_group/list_group.js
+++ b/src/components/list_group/list_group.js
@@ -76,7 +76,7 @@ export const EuiListGroup = ({
 };
 
 EuiListGroup.propTypes = {
-  listItems: PropTypes.arrayOf(EuiListGroupItem.propTypes),
+  listItems: PropTypes.arrayOf(PropTypes.shape(EuiListGroupItem.propTypes)),
   children: PropTypes.node,
   className: PropTypes.string,
 


### PR DESCRIPTION
### Summary

- Adds type definitions for `EuiListGroup` and `EuiListGroupItem`
- Changes the `propTypes` of `EuiListGroup` to reuse `EuiListGroupItem.propTypes` instead of redefining the shape.

### Checklist

~~- [ ] This was checked in mobile~~
~~- [ ] This was checked in IE11~~
~~- [ ] This was checked in dark mode~~
~~- [ ] Any props added have proper autodocs~~
~~- [ ] Documentation examples were added~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately

~~- [ ] This was checked for breaking changes and labeled appropriately~~
~~- [] Jest tests were updated or added to match the most common scenarios~~
~~- [ ] This was checked against keyboard-only and screenreader scenarios~~
~~- [ ] This required updates to Framer X components~~
