### PR TITLE
Fix EuiComboBox's call to onBlur prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Adds missing type and fixes closure-scope problem for `SuperDatePicker`'s `onRefresh` callback ([#1732](https://github.com/elastic/eui/pull/1732))
 - Changed `EuiBottomBar` to refer to the end of document ([#1727](https://github.com/elastic/eui/pull/1727))
+- Fixed `EuiComboBox`'s calls to its `onBlur` prop ([#1739](https://github.com/elastic/eui/pull/1739))
 
 ## [`9.4.0`](https://github.com/elastic/eui/tree/v9.4.0)
 

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -286,19 +286,20 @@ export class EuiComboBox extends Component {
     const focusedInInput = this.comboBox && this.comboBox.contains(e.relatedTarget);
     if (!focusedInOptionsList && !focusedInInput) {
       this.closeList();
-    }
 
-    // If the user tabs away or changes focus to another element, take whatever input they've
-    // typed and convert it into a pill, to prevent the combo box from looking like a text input.
-    if (!this.hasActiveOption() && !focusedInInput && !focusedInOptionsList) {
-      this.addCustomOption();
+      if (this.props.onBlur) {
+        this.props.onBlur();
+      }
+
+      // If the user tabs away or changes focus to another element, take whatever input they've
+      // typed and convert it into a pill, to prevent the combo box from looking like a text input.
+      if (!this.hasActiveOption()) {
+        this.addCustomOption();
+      }
     }
   }
 
   onComboBoxBlur = () => {
-    if (this.props.onBlur) {
-      this.props.onBlur();
-    }
     this.setState({ hasFocus: false });
   }
 
@@ -571,6 +572,7 @@ export class EuiComboBox extends Component {
       onChange, // eslint-disable-line no-unused-vars
       onSearchChange, // eslint-disable-line no-unused-vars
       async, // eslint-disable-line no-unused-vars
+      onBlur, // eslint-disable-line no-unused-vars
       isInvalid,
       rowHeight,
       isClearable,


### PR DESCRIPTION
### Summary

Fixes #1736. Makes `EuiComboBox`'s call its `onBlur` prop only when the entire combo box element loses focus i.e. text input, pills, dropdown, clear button no longer trigger it.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
