### PR TITLE
Prevent an empty badge color from blowing things up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `9.4.1`.
+**Bug fixes**
+
+- Fixed `hexToRgb` from erroring on an incorrect string input ([#1741](https://github.com/elastic/eui/pull/1741))
+- Fixed `EuiBadge` custom `color` prop type ([#1741](https://github.com/elastic/eui/pull/1741))
 
 ## [`9.4.1`](https://github.com/elastic/eui/tree/v9.4.1)
 

--- a/src/components/badge/badge.js
+++ b/src/components/badge/badge.js
@@ -135,7 +135,7 @@ export const EuiBadge = ({
 
 function checkValidColor(props, propName, componentName) {
   const validHex = /(^#[0-9A-F]{6}$)|(^#[0-9A-F]{3}$)/i.test(props.color);
-  if (props.color && !validHex && !COLORS.includes(props.color)) {
+  if (props.color != null && !validHex && !COLORS.includes(props.color)) {
     throw new Error(
       `${componentName} needs to pass a valid color. This can either be a three ` +
       `or six character hex value or one of the following: ${COLORS}`

--- a/src/services/color/hex_to_rgb.ts
+++ b/src/services/color/hex_to_rgb.ts
@@ -16,8 +16,8 @@ export function hexToRgb(hex: string): rgbDef {
   if (result) {
     const [, r, g, b] = result;
     return [parseInt(r, 16), parseInt(g, 16), parseInt(b, 16)];
-  } else {
-    // fallback to prevent errors
-    return [0, 0, 0];
   }
+
+  // fallback to prevent errors
+  return [0, 0, 0];
 }

--- a/src/services/color/hex_to_rgb.ts
+++ b/src/services/color/hex_to_rgb.ts
@@ -11,6 +11,13 @@ export function hexToRgb(hex: string): rgbDef {
     (m, r1, g1, b1) => r1 + r1 + g1 + g1 + b1 + b1
   );
 
-  const [, r, g, b] = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)!;
-  return [parseInt(r, 16), parseInt(g, 16), parseInt(b, 16)];
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)!;
+
+  if (result) {
+    const [, r, g, b] = result;
+    return [parseInt(r, 16), parseInt(g, 16), parseInt(b, 16)];
+  } else {
+    // fallback to prevent errors
+    return [0, 0, 0];
+  }
 }


### PR DESCRIPTION
### Summary

Makes `EuiBadge` resilient to an empty string passed into `color`

* adds a check in `hexToRgb` to prevent destructuring a `null`
* corrects the custom prop type in `EuiBadge` to properly warn when `color` is empty

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
