### PR TITLE
Make "m" the default size of EuiButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Changed `EuiButton` to use "m" as it's default `size` prop ([#1742](https://github.com/elastic/eui/pull/1742))
+
 **Bug fixes**
 
 - Adds missing type and fixes closure-scope problem for `SuperDatePicker`'s `onRefresh` callback ([#1732](https://github.com/elastic/eui/pull/1732))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `9.4.2`.
-
 - Changed `EuiButton` to use "m" as it's default `size` prop ([#1742](https://github.com/elastic/eui/pull/1742))
 
 ## [`9.4.2`](https://github.com/elastic/eui/tree/v9.4.2)

--- a/src/components/button/__snapshots__/button.test.js.snap
+++ b/src/components/button/__snapshots__/button.test.js.snap
@@ -331,6 +331,21 @@ exports[`EuiButton props size l is rendered 1`] = `
 </button>
 `;
 
+exports[`EuiButton props size m is rendered 1`] = `
+<button
+  class="euiButton euiButton--primary"
+  type="button"
+>
+  <span
+    class="euiButton__content"
+  >
+    <span
+      class="euiButton__text"
+    />
+  </span>
+</button>
+`;
+
 exports[`EuiButton props size s is rendered 1`] = `
 <button
   class="euiButton euiButton--primary euiButton--small"

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -26,6 +26,7 @@ export const COLORS = Object.keys(colorToClassNameMap);
 
 const sizeToClassNameMap = {
   s: 'euiButton--small',
+  m: null,
   l: 'euiButton--large',
 };
 
@@ -198,6 +199,7 @@ EuiButton.propTypes = {
 };
 
 EuiButton.defaultProps = {
+  size: 'm',
   type: 'button',
   iconSide: 'left',
   color: 'primary',

--- a/src/components/button/button_group/button_group.js
+++ b/src/components/button/button_group/button_group.js
@@ -95,7 +95,7 @@ EuiButtonGroup.propTypes = {
 
   /**
    * Most button groups should be the small button size,
-   * but if you NEED to bump it to regular, change this to 'l'
+   * but if you NEED to bump it to regular, change this to 'm'
    */
   buttonSize: PropTypes.string,
 

--- a/src/components/button/button_group/button_group.js
+++ b/src/components/button/button_group/button_group.js
@@ -95,7 +95,7 @@ EuiButtonGroup.propTypes = {
 
   /**
    * Most button groups should be the small button size,
-   * but if you NEED to bump it to regular, change this to 'm'
+   * but if you NEED to bump it to regular, change this to 'l'
    */
   buttonSize: PropTypes.string,
 

--- a/src/components/button/index.d.ts
+++ b/src/components/button/index.d.ts
@@ -24,7 +24,7 @@ declare module '@elastic/eui' {
     | 'warning'
     | 'danger'
     | 'ghost';
-  export type ButtonSize = 's' | 'l';
+  export type ButtonSize = 's' | 'm' | 'l';
 
   export interface EuiButtonProps {
     iconType?: IconType;

--- a/src/components/button/index.d.ts
+++ b/src/components/button/index.d.ts
@@ -124,7 +124,7 @@ declare module '@elastic/eui' {
    */
 
   export type EuiButtonGroupIdToSelectedMap = { [id: string]: boolean };
-  export type GroupButtonSize = 's' | 'l';
+  export type GroupButtonSize = 's' | 'm';
 
   export interface EuiButtonGroupOption {
     id: string,

--- a/src/components/button/index.d.ts
+++ b/src/components/button/index.d.ts
@@ -124,7 +124,7 @@ declare module '@elastic/eui' {
    */
 
   export type EuiButtonGroupIdToSelectedMap = { [id: string]: boolean };
-  export type GroupButtonSize = 's' | 'm';
+  export type GroupButtonSize = 's' | 'l';
 
   export interface EuiButtonGroupOption {
     id: string,

--- a/src/components/date_picker/super_date_picker/__snapshots__/super_update_button.test.js.snap
+++ b/src/components/date_picker/super_date_picker/__snapshots__/super_update_button.test.js.snap
@@ -14,6 +14,7 @@ exports[`EuiSuperUpdateButton is rendered 1`] = `
     isDisabled={false}
     isLoading={false}
     onClick={[Function]}
+    size="m"
     textProps={
       Object {
         "className": "euiSuperUpdateButton__text",
@@ -41,6 +42,7 @@ exports[`EuiSuperUpdateButton isDisabled 1`] = `
     isDisabled={true}
     isLoading={false}
     onClick={[Function]}
+    size="m"
     textProps={
       Object {
         "className": "euiSuperUpdateButton__text",
@@ -67,6 +69,7 @@ exports[`EuiSuperUpdateButton isLoading 1`] = `
     isDisabled={false}
     isLoading={true}
     onClick={[Function]}
+    size="m"
     textProps={
       Object {
         "className": "euiSuperUpdateButton__text",
@@ -94,6 +97,7 @@ exports[`EuiSuperUpdateButton needsUpdate 1`] = `
     isDisabled={false}
     isLoading={false}
     onClick={[Function]}
+    size="m"
     textProps={
       Object {
         "className": "euiSuperUpdateButton__text",


### PR DESCRIPTION
### Summary

This updates the prop type comment for `EuiButtonGroup` and the TypeScript definition for `EuiButtonGroup`, this is to normalise a bit of drift between what `EuiButtonGroup` and `EuiButton` were declaring as valid button sizes, beforehand:

- `EuiButtonGroup` used "s" and mentioned "m" in the docs
- `EuiButtonGroup` TypeScript definitions defined size as "s" | "m"

However, once these props were passed down to `EuiButton` this would cause a console warning using "m" due to `EuiButton` [supporting "s" and "l" only](https://github.com/elastic/eui/blob/master/src/components/button/button.js#L27).

Given "m" and "l" both produce buttons of the same size, I've just removed the notion of "m" from `EuiButtonGroup` (hopefully this is okay - I've checked it against the docs site and Kibana).

### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [x] Any props added have proper autodocs
- [ ] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
