### PR TITLE
Makes SuperDatePicker onRefresh prop optional, as it should be

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed `hexToRgb` from erroring on an incorrect string input ([#1741](https://github.com/elastic/eui/pull/1741))
 - Fixed `EuiBadge` custom `color` prop type ([#1741](https://github.com/elastic/eui/pull/1741))
+- Fixed inaccurately required `onRefresh` prop (should be optional) that was introduced in types in version 9.4.1 ([#1743](https://github.com/elastic/eui/pull/1743))
 
 ## [`9.4.1`](https://github.com/elastic/eui/tree/v9.4.1)
 

--- a/src/components/date_picker/index.d.ts
+++ b/src/components/date_picker/index.d.ts
@@ -71,7 +71,7 @@ declare module '@elastic/eui' {
     isPaused?: boolean;
     refreshInterval?: number;
     onTimeChange: (props: OnTimeChangeProps) => void;
-    onRefresh: (props: OnRefreshProps) => void;
+    onRefresh?: (props: OnRefreshProps) => void;
     onRefreshChange?: (props: OnRefreshChangeProps) => void;
     commonlyUsedRanges?: EuiSuperDatePickerCommonRange[];
     dateFormat?: string;


### PR DESCRIPTION
### Summary

The `EuiSuperDatePicker` component had an `onRefresh` prop added to its type files in 9.4.1, but it was accidentally made required. This makes it correctly optional.