### PR TITLE
Fix EuiToolTip text reflow on content changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `9.4.2`.
+**Bug fixes**
+
+- Fixed `EuiToolTip` potentially having incorrect position calculations near the window edge  ([#1744](https://github.com/elastic/eui/pull/1744)) 
 
 ## [`9.4.2`](https://github.com/elastic/eui/tree/v9.4.2)
 


### PR DESCRIPTION
### Summary

Fixes #1734, in which content changes near the right edge of the window caused longer text to wrap lines and result in incorrect, uncorrected positioning calculations.

* Uses `EuiResizeObserver` instead of `EuiMutationObserver`. The latter did not account for side effect updates and missed possible resize changes. (This is a more forward-looking change, getting at what I think we _actually_ want to observe).
* Calculates `EuiToolTip` x-axis position from the right if nearing the right edge of the window. This prevents text wrap/reflow, negating positioning correction.

### Checklist

~~- [ ] This was checked in mobile~~

- [x] This was checked in IE11

~~- [ ] This was checked in dark mode~~
~~- [ ] Any props added have proper autodocs~~
~~- [ ] Documentation examples were added~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately

~~- [ ] Jest tests were updated or added to match the most common scenarios~~
~~- [ ] This was checked against keyboard-only and screenreader scenarios~~
~~- [ ] This required updates to Framer X components~~
