### PR TITLE
[EuiSuperDatePicker] Invoke `onRefresh` instead of `onTimeChanged` when clicking “Refresh” 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Changed callback handler for `EuiSuperDatePicker` to call `onRefresh` instead of `onTimeChanged` when user clicks "Refresh" ([#1745](https://github.com/elastic/eui/pull/1745))
+- Changed `EuiSuperDatePicker` to call `onRefresh` instead of `onTimeChanged` when user clicks "Refresh" button ([#1745](https://github.com/elastic/eui/pull/1745))
 - Added documentation entry in `EuiPagination` for `activePage` prop. ([#1740](https://github.com/elastic/eui/pull/1740))
 - Changed `EuiButton` to use "m" as it's default `size` prop ([#1742](https://github.com/elastic/eui/pull/1742))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `9.4.2`.
+- Fixed callback handler for `EuiSuperDatePicker` so `onRefresh` is called instead of `onTimeChanged` when clicking "Refresh" ([#1745](https://github.com/elastic/eui/pull/1745))
 
 ## [`9.4.2`](https://github.com/elastic/eui/tree/v9.4.2)
 

--- a/src/components/date_picker/super_date_picker/super_date_picker.js
+++ b/src/components/date_picker/super_date_picker/super_date_picker.js
@@ -351,6 +351,15 @@ export class EuiSuperDatePicker extends Component {
     );
   }
 
+  handleClickUpdateButton = () => {
+    if(!this.state.hasChanged && this.props.onRefresh) {
+      const { start, end, refreshInterval } = this.props;
+      this.props.onRefresh({ start, end, refreshInterval });
+    }else{
+      this.applyTime();
+    }
+  }
+
   renderUpdateButton = () => {
     if (!this.props.showUpdateButton || this.props.isAutoRefreshOnly) {
       return;
@@ -362,7 +371,7 @@ export class EuiSuperDatePicker extends Component {
           needsUpdate={this.state.hasChanged}
           isLoading={this.props.isLoading}
           isDisabled={this.state.isInvalid}
-          onClick={this.applyTime}
+          onClick={this.handleClickUpdateButton}
           data-test-subj="superDatePickerApplyTimeButton"
         />
       </EuiFlexItem>


### PR DESCRIPTION
Follow-up to https://github.com/elastic/eui/pull/1577

Since there is now an `onRefresh` callback, the update button should no longer call `onTimeChanged` when an actual refresh was performed (which doesn't change the time).
The ui of the button already distinguishes between the two states (update time range vs. manual refresh).
This is also the same callback that will be called, when the automatic refresh interval is fired.

![refresh-vs-update](https://user-images.githubusercontent.com/209966/54673858-7f082e00-4afb-11e9-8b08-4316b9172176.gif)

This is important because the consumer might want to have separate logic for when the time range was changed vs. when a refresh was invoked. 

To make this backwards compatible this change only take effect for consumers who have implemented the `onRefresh` callback (searching through Kibana this will only affect APM)
