### PR TITLE
Emit TypeScript type definitions for variables extracted from themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added documentation entry in `EuiPagination` for `activePage` prop. ([#1740](https://github.com/elastic/eui/pull/1740))
 - Changed `EuiButton` to use "m" as it's default `size` prop ([#1742](https://github.com/elastic/eui/pull/1742))
+- Enhanced the build process to emit TypeScript types for the variables extracted from the themes ([#1750](https://github.com/elastic/eui/pull/1750))
 
 ## [`9.4.2`](https://github.com/elastic/eui/tree/v9.4.2)
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test-docker": "docker pull $npm_package_docker_image && docker run --rm -i -e GIT_COMMITTER_NAME=test -e GIT_COMMITTER_EMAIL=test --user=$(id -u):$(id -g) -e HOME=/tmp -v $(pwd):/app -w /app $npm_package_docker_image bash -c 'npm config set spin false && /opt/yarn*/bin/yarn && npm run test && npm run build'",
     "sync-docs": "node ./scripts/docs-sync.js",
     "build-docs": "webpack --config=src-docs/webpack.config.js",
-    "build": "yarn extract-i18n-strings && node ./scripts/compile-clean.js && node ./scripts/compile-eui.js && node ./scripts/compile-scss.js",
+    "build": "yarn extract-i18n-strings && node ./scripts/compile-clean.js && node ./scripts/compile-eui.js && node ./scripts/compile-scss.js $npm_package_name",
     "extract-i18n-strings": "node ./scripts/babel/fetch-i18n-strings",
     "lint": "yarn lint-es && yarn lint-ts && yarn lint-sass && yarn lint-framer",
     "lint-fix": "yarn lint-es-fix && yarn lint-ts-fix",

--- a/scripts/compile-scss.js
+++ b/scripts/compile-scss.js
@@ -18,7 +18,7 @@ const postcssConfigurationWithMinification = {
   ...postcssConfiguration,
   plugins: [
     ...postcssConfiguration.plugins,
-    require('cssnano')({ preset: 'default' })
+    require('cssnano')({ preset: 'default' }),
   ],
 };
 
@@ -51,14 +51,25 @@ async function compileScssFiles(sourcePattern, destinationDirectory) {
             .join(', ')}`
         );
       } catch (error) {
-        console.log(chalk`{red ✗} Failed to compile {gray ${inputFilename}} with ${error.stack}`);
+        console.log(
+          chalk`{red ✗} Failed to compile {gray ${inputFilename}} with ${
+            error.stack
+          }`
+        );
       }
     })
   );
 }
 
-async function compileScssFile(inputFilename, outputCssFilename, outputVarsFilename) {
-  const outputCssMinifiedFilename = outputCssFilename.replace(/\.css$/, '.min.css');
+async function compileScssFile(
+  inputFilename,
+  outputCssFilename,
+  outputVarsFilename
+) {
+  const outputCssMinifiedFilename = outputCssFilename.replace(
+    /\.css$/,
+    '.min.css'
+  );
 
   const { css: renderedCss, vars: extractedVars } = await sassExtract.render(
     {
@@ -70,12 +81,17 @@ async function compileScssFile(inputFilename, outputCssFilename, outputVarsFilen
     }
   );
 
-  const { css: postprocessedCss } = await postcss(postcssConfiguration).process(renderedCss, {
-    from: outputCssFilename,
-    to: outputCssFilename,
-  });
+  const { css: postprocessedCss } = await postcss(postcssConfiguration).process(
+    renderedCss,
+    {
+      from: outputCssFilename,
+      to: outputCssFilename,
+    }
+  );
 
-  const { css: postprocessedMinifiedCss } = await postcss(postcssConfigurationWithMinification).process(renderedCss, {
+  const { css: postprocessedMinifiedCss } = await postcss(
+    postcssConfigurationWithMinification
+  ).process(renderedCss, {
     from: outputCssFilename,
     to: outputCssMinifiedFilename,
   });

--- a/scripts/derive-sass-variable-types.js
+++ b/scripts/derive-sass-variable-types.js
@@ -1,0 +1,75 @@
+const ts = require('typescript');
+const prettier = require('prettier');
+
+async function deriveSassVariableTypes(
+  extractedVars,
+  extractedVarsModuleName,
+  extractedVarTypesFilename
+) {
+  const extractedVarsModuleDeclaration = ts.createModuleDeclaration(
+    undefined,
+    [ts.createModifier(ts.SyntaxKind.DeclareKeyword)],
+    ts.createStringLiteral(extractedVarsModuleName),
+    ts.createModuleBlock([
+      ts.createVariableStatement(
+        undefined,
+        ts.createVariableDeclarationList(
+          [
+            ts.createVariableDeclaration(
+              'sassVariables',
+              deriveValueType(extractedVars)
+            ),
+          ],
+          ts.NodeFlags.Const
+        )
+      ),
+      ts.createExportAssignment(
+        undefined,
+        undefined,
+        undefined,
+        ts.createIdentifier('sassVariables')
+      ),
+    ]),
+    ts.NodeFlags.None
+  );
+
+  const moduleSource = ts
+    .createPrinter({ newLine: ts.NewLineKind.LineFeed })
+    .printNode(
+      ts.EmitHint.Unspecified,
+      extractedVarsModuleDeclaration,
+      ts.createSourceFile(extractedVarTypesFilename, '', ts.ScriptTarget.Latest)
+    );
+
+  const prettierOptions = await prettier.resolveConfig(extractedVarTypesFilename);
+  const prettifiedModuleSource = prettier.format(moduleSource, prettierOptions);
+
+  return prettifiedModuleSource;
+}
+
+function deriveValueType(extractedValue) {
+  switch (typeof extractedValue) {
+    case 'object':
+      return ts.createTypeLiteralNode(
+        Object.keys(extractedValue).map(key =>
+          ts.createPropertySignature(
+            undefined,
+            ts.createStringLiteral(key),
+            undefined,
+            deriveValueType(extractedValue[key]),
+            undefined
+          )
+        )
+      );
+    case 'string':
+      return ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword);
+    case 'number':
+      return ts.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword);
+    default:
+      return ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
+  }
+}
+
+module.exports = {
+  deriveSassVariableTypes,
+};


### PR DESCRIPTION
### Summary

This enhances the `compile-scss.js` build script to also emit TypeScript type definitions for the JSON files generated from the theme variables. These type definitions are stored as `.json.d.ts` files in `dist/` alongside the JSON files so the imports are typed correctly.

When imported in downstream projects like Kibana, the imported symbols will be typed appropriately, which would reduce the risk involved in making breaking changes to these variables like #1590 did.

Letting the TypeScript compiler derive the types automatically was attempted twice in Kibana (elastic/kibana#24425 and elastic/kibana#25516). Both attempts failed due to limitations Kibana's build process and the TypeScript compiler.

### Checklist

- ~~This was checked in mobile~~
- ~~This was checked in IE11~~
- ~~This was checked in dark mode~~
- ~~Any props added have proper autodocs~~
- ~~Documentation examples were added~~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- ~~Jest tests were updated or added to match the most common scenarios~~
- ~~This was checked against keyboard-only and screenreader scenarios~~
- ~~This required updates to Framer X components~~
