### PR TITLE
Fix changelog mistake made in #1750

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `9.5.0`.
+- Enhanced the build process to emit TypeScript types for the variables extracted from the themes ([#1750](https://github.com/elastic/eui/pull/1750))
 
 ## [`9.5.0`](https://github.com/elastic/eui/tree/v9.5.0)
 
@@ -8,7 +8,6 @@ No public interface changes since `9.5.0`.
 - Added documentation entry in `EuiPagination` for `activePage` prop. ([#1740](https://github.com/elastic/eui/pull/1740))
 - Changed `EuiButton` to use "m" as it's default `size` prop ([#1742](https://github.com/elastic/eui/pull/1742))
 - Adds type definitions for `EuiListGroup` and `EuiListGroupItem` ([#1737](https://github.com/elastic/eui/pull/1737))
-- Enhanced the build process to emit TypeScript types for the variables extracted from the themes ([#1750](https://github.com/elastic/eui/pull/1750))
 
 **Bug fixes**
 


### PR DESCRIPTION
### Summary

This fixes an incorrect merge conflict resolution in the changelog of #1750.

### Checklist

- ~~This was checked in mobile~~
- ~~This was checked in IE11~~
- ~~This was checked in dark mode~~
- ~~Any props added have proper autodocs~~
- ~~Documentation examples were added~~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~~This was checked for breaking changes and labeled appropriately~~
- ~~Jest tests were updated or added to match the most common scenarios~~
- ~~This was checked against keyboard-only and screenreader scenarios~~
- ~~This required updates to Framer X components~~
