### PR TITLE
Fix font reset for headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 - Converted `EuiCardGraphic` to TS ([#1751](https://github.com/elastic/eui/pull/1751))
 - Enhanced the build process to emit TypeScript types for the variables extracted from the themes ([#1750](https://github.com/elastic/eui/pull/1750))
 
+**Bug fixes**
+
+- Set `h1 through h6, p` tags font reset based on family, size, and weight ([#1760](https://github.com/elastic/eui/pull/1760))
+- Fixed `EuiButton` font size inheritence ([#1760](https://github.com/elastic/eui/pull/1760))
+
 ## [`9.5.0`](https://github.com/elastic/eui/tree/v9.5.0)
 
 - Changed `EuiSuperDatePicker` to call `onRefresh` instead of `onTimeChanged` when user clicks "Refresh" button ([#1745](https://github.com/elastic/eui/pull/1745))
@@ -12,7 +17,7 @@
 
 **Bug fixes**
 
-- Fixed `EuiToolTip` potentially having incorrect position calculations near the window edge  ([#1744](https://github.com/elastic/eui/pull/1744)) 
+- Fixed `EuiToolTip` potentially having incorrect position calculations near the window edge  ([#1744](https://github.com/elastic/eui/pull/1744))
 
 ## [`9.4.2`](https://github.com/elastic/eui/tree/v9.4.2)
 

--- a/src/components/button/_mixins.scss
+++ b/src/components/button/_mixins.scss
@@ -1,5 +1,6 @@
 @mixin euiButton {
   @include euiFont;
+  @include euiFontSize;
 
   display: inline-block;
   appearance: none;

--- a/src/global_styling/reset/_reset.scss
+++ b/src/global_styling/reset/_reset.scss
@@ -33,11 +33,14 @@ code, pre, kbd, samp {
   font-family: $euiCodeFontFamily;
 }
 
-h1, h2, h3, h4, h5, h6, p,
-input, textarea, select, button {
+h1, h2, h3, h4, h5, h6, p {
   font-family: $euiFontFamily;
   font-weight: $euiFontWeightRegular;
   font-size: $euiFontSize;
+}
+
+input, textarea, select, button {
+  font-family: $euiFontFamily;
 }
 
 em {

--- a/src/global_styling/reset/_reset.scss
+++ b/src/global_styling/reset/_reset.scss
@@ -29,12 +29,15 @@ time, mark, audio, video {
   vertical-align: baseline;
 }
 
-code, pre {
+code, pre, kbd, samp {
   font-family: $euiCodeFontFamily;
 }
 
+h1, h2, h3, h4, h5, h6, p,
 input, textarea, select, button {
   font-family: $euiFontFamily;
+  font-weight: $euiFontWeightRegular;
+  font-size: $euiFontSize;
 }
 
 em {
@@ -96,7 +99,6 @@ button {
   padding: 0;
   margin: 0;
   outline: none;
-  font-size: $euiFontSize;
   font-size: inherit;
   color: inherit;
   border-radius: 0;


### PR DESCRIPTION
This now targets h1-h6 and p tags to reset the family, weight and size to be similar to the base. This fixes #1714 where plain headings outside of EuiText were getting the browser's default applied which doesn't match our EuiText or EuiTitle styles.

## Before
<img src="https://d.pr/free/i/PyM2PQ+" />

## After
<img width="562" alt="Screen Shot 2019-03-18 at 13 27 30 PM" src="https://user-images.githubusercontent.com/549577/54831607-076c0780-4c91-11e9-8ae1-73f92b60fac5.png">

---

# Buttons

I also added a font-size declaration for EuiButton's since they were getting inherited from their container, even though the overall size of the button was staying the same.

For example in tables:

## Before

<img width="566" alt="Screen Shot 2019-03-18 at 13 33 31 PM" src="https://user-images.githubusercontent.com/549577/54831667-28345d00-4c91-11e9-818d-54061860ea90.png">


## After

<img width="561" alt="Screen Shot 2019-03-18 at 13 33 28 PM" src="https://user-images.githubusercontent.com/549577/54831701-3d10f080-4c91-11e9-89b5-220242e7ef6f.png">


### Checklist

- ~[ ] This was checked in mobile~
- [x] This was checked in IE11
- ~[ ] This was checked in dark mode~
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~

---

cc @zumwalt @gjones @formgeist 

Even though this reset stopped existing only for a short while, I just wanted everyone to be alerted.
