### PR TITLE
Set some <button> elements to type="button"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Set `h1 through h6, p` tags font reset based on family, size, and weight ([#1760](https://github.com/elastic/eui/pull/1760))
 - Fixed `EuiButton` font size inheritence ([#1760](https://github.com/elastic/eui/pull/1760))
+- Updated button elements in `EuiFilePicker`, `EuiFormControlLayoutClearButton`, `EuiFormControlLayoutCustomIcon`, `EuiListGroupItem`, and `EuiSideNavItem` to type=button ([#1764](https://github.com/elastic/eui/pull/1764))
 
 ## [`9.5.0`](https://github.com/elastic/eui/tree/v9.5.0)
 

--- a/src/components/combo_box/__snapshots__/combo_box.test.js.snap
+++ b/src/components/combo_box/__snapshots__/combo_box.test.js.snap
@@ -42,6 +42,7 @@ exports[`EuiComboBox is rendered 1`] = `
           aria-label="Open list of options"
           class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
           data-test-subj="comboBoxToggleListButton"
+          type="button"
         >
           <svg
             aria-hidden="true"
@@ -276,6 +277,7 @@ exports[`props options list is rendered 1`] = `
           aria-label="Close list of options"
           class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
           data-test-subj="comboBoxToggleListButton"
+          type="button"
         >
           <svg
             aria-hidden="true"

--- a/src/components/form/file_picker/file_picker.js
+++ b/src/components/form/file_picker/file_picker.js
@@ -106,6 +106,7 @@ export class EuiFilePicker extends Component {
             if (compressed) {
               clearButton = (
                 <button
+                  type="button"
                   aria-label={clearSelectedFiles}
                   className="euiFilePicker__clearButton"
                   onClick={this.removeFiles}

--- a/src/components/form/form_control_layout/__snapshots__/form_control_layout.test.js.snap
+++ b/src/components/form/form_control_layout/__snapshots__/form_control_layout.test.js.snap
@@ -28,6 +28,7 @@ exports[`EuiFormControlLayout props clear onClick is rendered 1`] = `
         aria-label="Clear input"
         class="euiFormControlLayoutClearButton customClass"
         data-test-subj="clearButton"
+        type="button"
       >
         <svg
           class="euiIcon euiIcon--medium euiFormControlLayoutClearButton__icon"

--- a/src/components/form/form_control_layout/form_control_layout_clear_button.js
+++ b/src/components/form/form_control_layout/form_control_layout_clear_button.js
@@ -16,6 +16,7 @@ export const EuiFormControlLayoutClearButton = ({
     <EuiI18n token="euiFormControlLayoutClearButton.label" default="Clear input">
       {label => (
         <button
+          type="button"
           className={classes}
           onClick={onClick}
           aria-label={label}

--- a/src/components/form/form_control_layout/form_control_layout_custom_icon.js
+++ b/src/components/form/form_control_layout/form_control_layout_custom_icon.js
@@ -22,6 +22,7 @@ export const EuiFormControlLayoutCustomIcon = ({
   if (onClick) {
     return (
       <button
+        type="button"
         onClick={onClick}
         className={classes}
         ref={iconRef}

--- a/src/components/list_group/__snapshots__/list_group_item.test.js.snap
+++ b/src/components/list_group/__snapshots__/list_group_item.test.js.snap
@@ -152,6 +152,7 @@ exports[`EuiListGroupItem props onClick is rendered 1`] = `
 >
   <button
     class="euiListGroupItem__button"
+    type="button"
   >
     <span
       class="euiListGroupItem__label"
@@ -254,6 +255,7 @@ exports[`EuiListGroupItem renders a disabled button even if provided an href 1`]
   <button
     class="euiListGroupItem__button"
     disabled=""
+    type="button"
   >
     <span
       class="euiListGroupItem__label"
@@ -272,6 +274,7 @@ exports[`EuiListGroupItem renders a disabled button even if provided an href 2`]
   <button
     class="euiListGroupItem__button"
     disabled=""
+    type="button"
   >
     <span
       class="euiListGroupItem__label"

--- a/src/components/list_group/list_group_item.js
+++ b/src/components/list_group/list_group_item.js
@@ -104,6 +104,7 @@ export const EuiListGroupItem = ({
   } else if ((href && isDisabled) || onClick) {
     itemContent = (
       <button
+        type="button"
         className="euiListGroupItem__button"
         disabled={isDisabled}
         onClick={onClick}

--- a/src/components/side_nav/side_nav_item.js
+++ b/src/components/side_nav/side_nav_item.js
@@ -26,6 +26,7 @@ const defaultRenderItem = ({ href, onClick, className, children, ...rest }) => {
   if (onClick) {
     return (
       <button
+        type="button"
         className={className}
         onClick={onClick}
         role="menuitem"


### PR DESCRIPTION
### Summary

Fixes #1763 

These `button`s have been updated to type of _button_ instead of their default _submit_:

* [file_picker.js](https://github.com/elastic/eui/pull/1764/files#diff-295d2dd996a5ad6de97e0140a8968742R109)
* [form_control_layout_clear_button.js](https://github.com/elastic/eui/pull/1764/files#diff-a4e30e244a6ffafdf3f7f7e095add8fdR19)
* [form_control_layout_custom_icon.js](https://github.com/elastic/eui/pull/1764/files#diff-8066e73816f64cd183d72d5ba360b0adR25)
* [list_group_item.js](https://github.com/elastic/eui/pull/1764/files#diff-ae7a27bc6cec53a4dc2132b43eb4d135R107)
* [side_nav_item.js](https://github.com/elastic/eui/pull/1764/files#diff-2d3833502cf827812482433b557676ebR29)

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
~- [ ] Jest tests were updated or added to match the most common scenarios~
- [x] This was checked against keyboard-only and screenreader scenarios
~- [ ] This required updates to Framer X components~
