### PR TITLE
Close nav drawer when a link is clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `9.6.0`.
+- Changed `EuiNavDrawer` to close on any link click ([#1773](https://github.com/elastic/eui/pull/1773))
 
 ## [`9.6.0`](https://github.com/elastic/eui/tree/v9.6.0)
 

--- a/src/components/nav_drawer/nav_drawer.js
+++ b/src/components/nav_drawer/nav_drawer.js
@@ -124,6 +124,22 @@ export class EuiNavDrawer extends Component {
     this.collapseFlyout();
   }
 
+  handleDrawerMenuClick = e => {
+    // walk up e.target until either:
+    // 1. a[href] - close the menu
+    // 2. document.body - do nothing
+
+    let element = e.target;
+    while (element !== undefined && element !== document.body && (element.tagName !== 'A' || element.getAttribute('href') === undefined)) {
+      element = element.parentElement;
+    }
+
+    if (element !== document.body) {
+      // this is an anchor with an href
+      this.closeBoth();
+    }
+  }
+
   render() {
     const {
       children,
@@ -214,7 +230,7 @@ export class EuiNavDrawer extends Component {
           {...rest}
         >
           <EuiFlexItem grow={false}>
-            <div id="navDrawerMenu" className={menuClasses}>
+            <div id="navDrawerMenu" className={menuClasses} onClick={this.handleDrawerMenuClick}>
               {/* Put expand button first so it's first in tab order then on toggle starts the tabbing of the items from the top */}
               {/* TODO: Add a "skip navigation" keyboard only button */}
               {footerContent}


### PR DESCRIPTION
### Summary

This change will fix a Kibana issue https://github.com/elastic/kibana/issues/30331 where the expanded nav drawer will remain open if you navigate to the app that you are already viewing. In other words, there is no refresh so the menu doesn't get reloaded to the collapsed state. I noticed this can also happen with the flyout - if it's open and you click on an app icon in the main menu, the flyout stays open. This PR addresses both cases.

#### Reviewer note
This solution was the outcome of some discussion an initial PR - https://github.com/elastic/eui/pull/1770 

#### Demo

![close-drawer](https://user-images.githubusercontent.com/446285/55077860-c431e000-5066-11e9-9869-cbbe855abedb.gif)

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
- [x] Any props added have proper autodocs
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios
- [x] This was checked against keyboard-only and screenreader scenarios
- [ ] ~This required updates to Framer X components~
