### PR TITLE
[Wiki] react-router 4.x changes also apply to 5.x

### DIFF
--- a/wiki/react-router.md
+++ b/wiki/react-router.md
@@ -149,11 +149,11 @@ export const getRouterLinkProps = to => {
 };
 ```
 
-## react-router 4.x
+## react-router 4.x / 5.x
 
 ### Share `router` globally
 
-Setup is slightly different with `react-router` 4.x. To enable these techniques, you'll need to make
+Setup is slightly different with `react-router` 4.x and 5.x. To enable these techniques, you'll need to make
 the `router` instance available outside of React's `context`. One method for doing this is to assign
 it to a globally-available singleton within your app's root component.
 


### PR DESCRIPTION
`react-router` 5.0 came out recently and it's completely BWC version with `react-router` 4.x.