### PR TITLE
Headings, and <p>, need to inherit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `9.7.0`.
+**Bug fixes**
+
+- Fixed heading and paragraph tag font style inherits ([#1776](https://github.com/elastic/eui/pull/1776))
 
 ## [`9.7.0`](https://github.com/elastic/eui/tree/v9.7.0)
 
@@ -13,6 +15,8 @@ No public interface changes since `9.7.0`.
 - Enhanced the build process to emit TypeScript types for the variables extracted from the themes ([#1750](https://github.com/elastic/eui/pull/1750))
 
 **Bug fixes**
+
+**Note: this release creates a minor regression to text scales where paragraph and heading tags were no longer inheriting from their container. This is fixed in `master`.**
 
 - Set `h1 through h6, p` tags font reset based on family, size, and weight ([#1760](https://github.com/elastic/eui/pull/1760))
 - Fixed `EuiButton` font size inheritence ([#1760](https://github.com/elastic/eui/pull/1760))

--- a/src/global_styling/reset/_reset.scss
+++ b/src/global_styling/reset/_reset.scss
@@ -34,9 +34,9 @@ code, pre, kbd, samp {
 }
 
 h1, h2, h3, h4, h5, h6, p {
-  font-family: $euiFontFamily;
-  font-weight: $euiFontWeightRegular;
-  font-size: $euiFontSize;
+  font-family: inherit;
+  font-weight: inherit;
+  font-size: inherit;
 }
 
 input, textarea, select, button {


### PR DESCRIPTION
Fixing the previous fix of #1760 where setting the font size at the reset level was causing these tags not to inherit from their container. Even the text scales weren't working:

<img src="https://d.pr/free/i/9vBILs+" />

So now, all 3 properties are just set to inherit (which should be from the `html` tag which does set the size, family and weight.

**Now:**

<img src="https://d.pr/free/i/rc5xDc+"  />

_back to normal_

### Checklist

- [x] This was checked in Kibana
- ~[ ] This was checked in mobile~
- [x] This was checked in IE11
- ~[ ] This was checked in dark mode~
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
