### PR TITLE
Update ButtonIconColor type to match all available options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Converted `EuiFormErrorText` to TS ([#1772](https://github.com/elastic/eui/pull/1772))
 
+**Bug fixes**
+
+Update ButtonIconColor type to provide all available options ([#1783](https://github.com/elastic/eui/pull/1783))
+
 ## [`9.7.1`](https://github.com/elastic/eui/tree/v9.7.1)
 
 **Bug fixes**

--- a/src/components/button/index.d.ts
+++ b/src/components/button/index.d.ts
@@ -49,11 +49,14 @@ declare module '@elastic/eui' {
    */
 
   export type ButtonIconColor =
-    | 'primary'
     | 'danger'
     | 'disabled'
     | 'ghost'
-    | 'text';
+    | 'primary'
+    | 'subdued'
+    | 'success'
+    | 'text'
+    | 'warning';
 
   export interface EuiButtonIconProps {
     iconType?: IconType;


### PR DESCRIPTION
### Summary

Fixes #1780 by updating `ButtonIconColor` type to match available options.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
