### PR TITLE
Prevent calculation on null childNode during resize observation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 **Bug fixes**
 
-Update ButtonIconColor type to provide all available options ([#1783](https://github.com/elastic/eui/pull/1783))
+- Update ButtonIconColor type to provide all available options ([#1783](https://github.com/elastic/eui/pull/1783))
+- Prevent calculation on `null` ref during `EuiResizeObserver` observation ([#1784](https://github.com/elastic/eui/pull/1784))
 
 ## [`9.7.1`](https://github.com/elastic/eui/tree/v9.7.1)
 

--- a/src/components/observer/observer.js
+++ b/src/components/observer/observer.js
@@ -24,13 +24,13 @@ class EuiObserver extends Component {
   updateChildNode = ref => {
     if (this.childNode === ref) return; // node hasn't changed
 
-    this.childNode = ref;
-
     // if there's an existing observer disconnect it
     if (this.observer != null) {
       this.observer.disconnect();
       this.observer = null;
     }
+
+    this.childNode = ref;
 
     if (this.childNode != null) {
       this.beginObserve();

--- a/src/components/observer/resize_observer/resize_observer.js
+++ b/src/components/observer/resize_observer/resize_observer.js
@@ -11,12 +11,14 @@ class EuiResizeObserver extends EuiObserver {
   }
 
   onResize = () => {
-    // Eventually use `clientRect` on the `entries[]` returned natively
-    const { height, width } = this.childNode.getBoundingClientRect();
-    this.props.onResize({
-      height,
-      width
-    });
+    if (this.childNode != null) {
+      // Eventually use `clientRect` on the `entries[]` returned natively
+      const { height, width } = this.childNode.getBoundingClientRect();
+      this.props.onResize({
+        height,
+        width
+      });
+    }
   }
 
   beginObserve = () => {


### PR DESCRIPTION
### Summary

elastic/kibana#34271 raises the case where `EuiResizeObserver` using the fallback `MutationObserver` API results in errors when the observed element is removed.

Two possible scenarios where `this.childNode` ref becomes `null` but `onResize` can still occur:
1)  prior to the initialization `requestAnimationFrame`
2) prior to `observer.disconnect()` but `onResize` is already queued

Changes address the two above by calling `disconnect` before changing the `childNode` ref, and preventing calculations when `childNode` is `null`

### Checklist

~~- [ ] This was checked in mobile~~
~~- [ ] This was checked in IE11~~
~~- [ ] This was checked in dark mode~~
~~- [ ] Any props added have proper autodocs~~
~~- [ ] Documentation examples were added~~

- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately

~~- [ ] This was checked for breaking changes and labeled appropriately~~
~~- [ ] Jest tests were updated or added to match the most common scenarios~~
~~- [ ] This was checked against keyboard-only and screenreader scenarios~~
~~- [ ] This required updates to Framer X components~~
