### PR TITLE
Small accessibility fixes to toasts and combo box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 **Bug fixes**
 
 - Fixed issue where toasts would dismiss when they have focus ([#1803](https://github.com/elastic/eui/pull/1803))
+- Fixed issue where placeholder was not read with combo box ([#1803](https://github.com/elastic/eui/pull/1803))
 
 ## [`9.8.0`](https://github.com/elastic/eui/tree/v9.8.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 **Bug fixes**
 
 - Fixed issue where toasts would dismiss when they have focus ([#1803](https://github.com/elastic/eui/pull/1803))
-- Fixed issue where placeholder was not read with combo box ([#1803](https://github.com/elastic/eui/pull/1803))
+- Fixed issue where `EuiComboBox` placeholder was not read by screen readers ([#1803](https://github.com/elastic/eui/pull/1803))
 
 ## [`9.8.0`](https://github.com/elastic/eui/tree/v9.8.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - Added `menuLeft` and `menuRight` icons ([#1797](https://github.com/elastic/eui/pull/1797))
 - Updated EuiNavDrawer’s collapse/expand button to use `menuLeft` and `menuRight` icons ([#1797](https://github.com/elastic/eui/pull/1797))
 
+**Bug fixes**
+
+- Fixed issue where toasts would dismiss when they have focus ([#1803](https://github.com/elastic/eui/pull/1803))
+
 ## [`9.8.0`](https://github.com/elastic/eui/tree/v9.8.0)
 
 - **[Beta]** Added new `EuiSelectable` component  ([#1699](https://github.com/elastic/eui/pull/1699))

--- a/src/components/combo_box/combo_box_input/combo_box_input.js
+++ b/src/components/combo_box/combo_box_input/combo_box_input.js
@@ -143,12 +143,12 @@ export class EuiComboBoxInput extends Component {
     let removeOptionMessageId;
 
     if (this.state.hasFocus) {
-      const readPlaceholder = (placeholder ? `The placeholder for the input says ${placeholder}` : null);
+      const readPlaceholder = (placeholder ? `The placeholder for the input says ${placeholder}.` : '');
       const removeOptionMessageContent =
         `Combo box. Selected. ${
           searchValue ? `${searchValue}. Selected. ` : ''
         }${selectedOptions.length ? `${value}. Press Backspace to delete ${selectedOptions[selectedOptions.length - 1].label}. ` : ''
-        }You are currently on a combo box. ${readPlaceholder}. Type some text or, to display a list of choices, press Down Arrow. ` +
+        }You are currently on a combo box. ${readPlaceholder} Type some text or, to display a list of choices, press Down Arrow. ` +
         `To exit the list of choices, press Escape.`;
 
       removeOptionMessageId = makeId();

--- a/src/components/combo_box/combo_box_input/combo_box_input.js
+++ b/src/components/combo_box/combo_box_input/combo_box_input.js
@@ -143,11 +143,12 @@ export class EuiComboBoxInput extends Component {
     let removeOptionMessageId;
 
     if (this.state.hasFocus) {
+      const readPlaceholder = (placeholder ? `The placeholder for the input says ${placeholder}` : null);
       const removeOptionMessageContent =
         `Combo box. Selected. ${
           searchValue ? `${searchValue}. Selected. ` : ''
         }${selectedOptions.length ? `${value}. Press Backspace to delete ${selectedOptions[selectedOptions.length - 1].label}. ` : ''
-        }You are currently on a combo box. Type text or, to display a list of choices, press Down Arrow. ` +
+        }You are currently on a combo box. ${readPlaceholder}. Type some text or, to display a list of choices, press Down Arrow. ` +
         `To exit the list of choices, press Escape.`;
 
       removeOptionMessageId = makeId();

--- a/src/components/combo_box/combo_box_input/combo_box_input.js
+++ b/src/components/combo_box/combo_box_input/combo_box_input.js
@@ -143,12 +143,12 @@ export class EuiComboBoxInput extends Component {
     let removeOptionMessageId;
 
     if (this.state.hasFocus) {
-      const readPlaceholder = (placeholder ? `The placeholder for the input says ${placeholder}.` : '');
+      const readPlaceholder = (placeholder ? `${placeholder}.` : '');
       const removeOptionMessageContent =
         `Combo box. Selected. ${
           searchValue ? `${searchValue}. Selected. ` : ''
         }${selectedOptions.length ? `${value}. Press Backspace to delete ${selectedOptions[selectedOptions.length - 1].label}. ` : ''
-        }You are currently on a combo box. ${readPlaceholder} Type some text or, to display a list of choices, press Down Arrow. ` +
+        }Combo box input. ${readPlaceholder} Type some text or, to display a list of choices, press Down Arrow. ` +
         `To exit the list of choices, press Escape.`;
 
       removeOptionMessageId = makeId();

--- a/src/components/toast/_toast.scss
+++ b/src/components/toast/_toast.scss
@@ -10,7 +10,7 @@
   width: 100%;
 
   &:hover .euiToast__closeButton,
-  &:focus .euiToast__closeButton, {
+  &:focus .euiToast__closeButton {
     opacity: 1;
   }
 }

--- a/src/components/toast/global_toast_list.js
+++ b/src/components/toast/global_toast_list.js
@@ -220,6 +220,8 @@ export class EuiGlobalToastList extends Component {
         >
           <EuiToast
             onClose={this.dismissToast.bind(this, toast)}
+            onFocus={this.onMouseEnter}
+            onBlur={this.onMouseLeave}
             {...rest}
           >
             {text}


### PR DESCRIPTION
### Summary

Easy one while I was cleaning out the backlog. As long as an item within a toast has focus, it will stick around. When you tab out, it will resume the countdown, similar to mouse actions.

Fixes https://github.com/elastic/eui/issues/717

![](http://snid.es/493907a56091/Screen%252520Recording%2525202019-04-05%252520at%25252007.43%252520PM.gif)

Also added a fixes https://github.com/elastic/eui/issues/1343. Given how direct the combo box is with instruction it seemed like the best thing to do was announce the placeholder in the same way.

![image](https://user-images.githubusercontent.com/324519/55664165-d2a69700-57de-11e9-85ac-7c4ce09d5c9b.png)

### Checklist

- [ ] ~This was checked in mobile~
- [x] This was checked in IE11
- [ ] ~This was checked in dark mode~
- [ ] ~Any props added have proper autodocs~
- [x] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] ~This was checked for breaking changes and labeled appropriately~
- [ ] ~Jest tests were updated or added to match the most common scenarios~
- [x] This was checked against keyboard-only and screenreader scenarios
- [ ] ~This required updates to Framer X components~
