### PR TITLE
Fixes autofill coloring in dark mode

### DIFF
--- a/src/components/form/_mixins.scss
+++ b/src/components/form/_mixins.scss
@@ -180,6 +180,13 @@
     &[readOnly] {
       @include euiFormControlReadOnlyStyle;
     }
+
+    // Needs to be set for autofill in dark mode
+    // sass-lint:disable-block no-vendor-prefixes
+    &:-webkit-autofill {
+      -webkit-text-fill-color: $euiTextColor;
+    }
+
   }
 
 }


### PR DESCRIPTION
### Summary

Fixes https://github.com/elastic/eui/issues/827

Applies a similar fix as applied to cloud in https://github.com/elastic/cloud/pull/15106 but uses the correct coloring for the text.

### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
