### PR TITLE
Fix search box query resetting on prop updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Re-enable installation of `@elastic/eui` via npm ([#1811](https://github.com/elastic/eui/pull/1811))
 
+**Bug fixes**
+
+- Fix `EuiSearchBox` query input resetting on prop updates ([#1823](https://github.com/elastic/eui/pull/1823))
+
 ## [`9.9.0`](https://github.com/elastic/eui/tree/v9.9.0)
 
 - Add `initialPageIndex` pagination prop to `EuiInMemoryTable` ([#1798](https://github.com/elastic/eui/pull/1798))

--- a/src/components/search_bar/search_box.js
+++ b/src/components/search_bar/search_box.js
@@ -33,8 +33,10 @@ export class EuiSearchBox extends Component {
     super(props);
   }
 
-  componentDidUpdate() {
-    this.inputElement.value = this.props.query;
+  componentDidUpdate(oldProps) {
+    if (oldProps.query !== this.props.query) {
+      this.inputElement.value = this.props.query;
+    }
   }
 
   render() {


### PR DESCRIPTION
This one has been grinding our gears for as long as I can remember

Fixes https://github.com/elastic/cloud/issues/22906