### PR TITLE
[EuiSuperDatePicker] relative tab, timestamp: Use roundUp, switch pos with "Round To"  btn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Converted `EuiStat` to TS ([#1848](https://github.com/elastic/eui/pull/1848))
 - Added `isLoading` prop to `EuiStat` ([#1848](https://github.com/elastic/eui/pull/1848))
+- Added `roundUp` prop to relative tab of `EuiSuperDatePicker` ([#1827](https://github.com/elastic/eui/pull/1827))
+- Changed position of `EuiSwitch` for date rounding used at relative tab of `EuiSuperDatePicker` ([#1827](https://github.com/elastic/eui/pull/1827))
 
 **Bug fixes**
 

--- a/src/components/date_picker/super_date_picker/date_popover/date_popover_button.js
+++ b/src/components/date_picker/super_date_picker/date_popover/date_popover_button.js
@@ -48,7 +48,7 @@ export function EuiDatePopoverButton(props) {
       data-test-subj={`superDatePicker${position}DatePopoverButton`}
       {...buttonProps}
     >
-      {formatTimeString(value, dateFormat, roundUp)}
+      {formatTimeString(value, dateFormat)}
     </button>
   );
 

--- a/src/components/date_picker/super_date_picker/date_popover/date_popover_button.js
+++ b/src/components/date_picker/super_date_picker/date_popover/date_popover_button.js
@@ -48,7 +48,7 @@ export function EuiDatePopoverButton(props) {
       data-test-subj={`superDatePicker${position}DatePopoverButton`}
       {...buttonProps}
     >
-      {formatTimeString(value, dateFormat)}
+      {formatTimeString(value, dateFormat, roundUp)}
     </button>
   );
 

--- a/src/components/date_picker/super_date_picker/date_popover/date_popover_content.js
+++ b/src/components/date_picker/super_date_picker/date_popover/date_popover_content.js
@@ -52,6 +52,7 @@ export function EuiDatePopoverContent({ value, roundUp, onChange, dateFormat }) 
             dateFormat={dateFormat}
             value={value}
             onChange={onChange}
+            roundUp={roundUp}
           />
         ),
         'data-test-subj': 'superDatePickerRelativeTab',

--- a/src/components/date_picker/super_date_picker/date_popover/relative_tab.js
+++ b/src/components/date_picker/super_date_picker/date_popover/relative_tab.js
@@ -55,7 +55,7 @@ export class EuiRelativeTab extends Component {
 
   render() {
     const isInvalid = this.state.count < 0;
-    const parsedValue = dateMath.parse(this.props.value);
+    const parsedValue = dateMath.parse(this.props.value, { roundUp: this.props.roundUp });
     const formatedValue = isInvalid || !parsedValue || !parsedValue.isValid()
       ? ''
       : parsedValue.format(this.props.dateFormat);
@@ -107,4 +107,5 @@ EuiRelativeTab.propTypes = {
   dateFormat: PropTypes.string.isRequired,
   value: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
+  roundUp: PropTypes.bool
 };

--- a/src/components/date_picker/super_date_picker/date_popover/relative_tab.js
+++ b/src/components/date_picker/super_date_picker/date_popover/relative_tab.js
@@ -88,15 +88,15 @@ export class EuiRelativeTab extends Component {
           </EuiFlexItem>
         </EuiFlexGroup>
         <EuiFormRow>
-          <EuiFieldText value={formatedValue} readOnly />
-        </EuiFormRow>
-        <EuiFormRow>
           <EuiSwitch
             data-test-subj={`superDatePickerRelativeDateRoundSwitch`}
             label={`Round to the ${timeUnits[this.state.unit.substring(0, 1)]}`}
             checked={this.state.round}
             onChange={this.onRoundChange}
           />
+        </EuiFormRow>
+        <EuiFormRow>
+          <EuiFieldText value={formatedValue} readOnly />
         </EuiFormRow>
       </EuiForm>
     );

--- a/src/components/date_picker/super_date_picker/date_popover/relative_tab.js
+++ b/src/components/date_picker/super_date_picker/date_popover/relative_tab.js
@@ -12,6 +12,7 @@ import {
   EuiFieldText,
   EuiSwitch
 } from '../../../form';
+import { EuiSpacer } from '../../../spacer';
 
 import { timeUnits } from '../time_units';
 import { relativeOptions } from '../relative_options';
@@ -87,17 +88,15 @@ export class EuiRelativeTab extends Component {
             </EuiFormRow>
           </EuiFlexItem>
         </EuiFlexGroup>
-        <EuiFormRow>
-          <EuiSwitch
-            data-test-subj={`superDatePickerRelativeDateRoundSwitch`}
-            label={`Round to the ${timeUnits[this.state.unit.substring(0, 1)]}`}
-            checked={this.state.round}
-            onChange={this.onRoundChange}
-          />
-        </EuiFormRow>
-        <EuiFormRow>
-          <EuiFieldText value={formatedValue} readOnly />
-        </EuiFormRow>
+        <EuiSpacer size="s" />
+        <EuiSwitch
+          data-test-subj={`superDatePickerRelativeDateRoundSwitch`}
+          label={`Round to the ${timeUnits[this.state.unit.substring(0, 1)]}`}
+          checked={this.state.round}
+          onChange={this.onRoundChange}
+        />
+        <EuiSpacer size="m" />
+        <EuiFieldText value={formatedValue} readOnly />
       </EuiForm>
     );
   }
@@ -107,5 +106,5 @@ EuiRelativeTab.propTypes = {
   dateFormat: PropTypes.string.isRequired,
   value: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
-  roundUp: PropTypes.bool
+  roundUp: PropTypes.bool,
 };


### PR DESCRIPTION
### Summary

So when you set e.g. 70 years ago in the To field of the date
range with "Round to the year" active, the To field's value is rounded
up. So instead of:

Jan 1, 1949 @ 00:00:00.000

It's

Jan 1, 1949 @ 23:59:59.999

Since now this date is less then 70 years in the past, moment.js fromNow
displays 69 years

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
~~- [ ] Any props added have proper autodocs~~
~~- [ ] Documentation examples were added~~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
~~- [ ] This was checked for breaking changes and labeled appropriately~~
~~- [ ] Jest tests were updated or added to match the most common scenarios~~
~~- [ ] This was checked against keyboard-only and screenreader scenarios~~
~~- [ ] This required updates to Framer X components~~