### PR TITLE
Add snippets to accordion docs

### DIFF
--- a/src-docs/src/views/accordion/accordion.js
+++ b/src-docs/src/views/accordion/accordion.js
@@ -4,7 +4,6 @@ import {
   EuiAccordion,
   EuiText,
   EuiCode,
-  EuiSpacer,
 } from '../../../../src/components';
 
 
@@ -16,23 +15,6 @@ export default () => (
     >
       <EuiText>
         <p>Any content inside of <EuiCode>EuiAccordion</EuiCode> will appear here.</p>
-      </EuiText>
-    </EuiAccordion>
-
-    <EuiSpacer size="l" />
-
-    <EuiAccordion
-      id="accordion2"
-      buttonContent="An accordion with some padding applied through props"
-      paddingSize="l"
-    >
-      <EuiText>
-        <p>The content inside can be of any height.</p>
-        <p>The content inside can be of any height.</p>
-        <p>The content inside can be of any height.</p>
-        <p>The content inside can be of any height.</p>
-        <p>The content inside can be of any height.</p>
-        <p>The content inside can be of any height.</p>
       </EuiText>
     </EuiAccordion>
   </div>

--- a/src-docs/src/views/accordion/accordion_example.js
+++ b/src-docs/src/views/accordion/accordion_example.js
@@ -17,20 +17,30 @@ import Accordion from './accordion';
 const accordionSource = require('!!raw-loader!./accordion');
 const accordionHtml = renderToHtml(Accordion);
 const accordionSnippet = `<EuiAccordion
-  id="accordion1"
-  buttonContent="Clickable title text for first accordion"
-  paddingSize="m"
+  id={accordionId}
+  buttonContent="Clickable title"
   >
-    <!-- Content for first accordion -->
+    <!-- Content to show when expanded -->
 </EuiAccordion>
-<!-- Optional, recommended spacer -->
-<EuiSpacer size="m" />
-<EuiAccordion
-  id="accordion2"
-  buttonContent="Clickable title text for second accordion"
-  paddingSize="m"
+`;
+
+import AccordionMultiple from './accordion_multiple';
+const accordionMultipleSource = require('!!raw-loader!./accordion');
+const accordionMultipleHtml = renderToHtml(Accordion);
+const accordionMultipleSnippet = `<EuiAccordion
+  id={accordionId}
+  buttonContent="Clickable title for first item"
+  paddingSize="l"
   >
-    <!-- Content for second accordion -->
+    <!-- Content to show when expanded -->
+</EuiAccordion>
+<EuiSpacer />
+<EuiAccordion
+  id={accordionId}
+  buttonContent="Clickable title for second item"
+  paddingSize="l"
+  >
+    <!-- Content to show when expanded -->
 </EuiAccordion>
 `;
 
@@ -42,12 +52,12 @@ import AccordionExtra from './accordion_extra';
 const accordionExtraSource = require('!!raw-loader!./accordion_extra');
 const accordionExtraHtml = renderToHtml(AccordionExtra);
 const accordionExtraSnippet = `<EuiAccordion
-  id="accordionExtra"
-  buttonContent="Click to open"
+  id={accordionId}
+  buttonContent="Clickable title"
   extraAction={<EuiButton size="s">Extra action!</EuiButton>}
   paddingSize="l"
   >
-    <!-- Content for accordion -->
+    <!-- Content to show when expanded -->
 </EuiAccordion>
 `;
 
@@ -55,11 +65,11 @@ import AccordionOpen from './accordion_open';
 const accordionOpenSource = require('!!raw-loader!./accordion_open');
 const accordionOpenHtml = renderToHtml(AccordionOpen);
 const accordionOpenSnippet = `<EuiAccordion
-  id="accordionOpen"
-  buttonContent="Click to toggle"
+  id={accordionId}
+  buttonContent="Clickable title"
   initialIsOpen={true}
   >
-    <!-- Content for accordion -->
+    <!-- Content to show when expanded -->
 </EuiAccordion>
 `;
 
@@ -109,8 +119,8 @@ export const AccordionExample = {
           based on the height of those children.
         </p>
         <p>
-          For styling needs, classes can be individually applied with
-          <EuiCode>className</EuiCode> (for the entire accordion),
+          For styling needs, classes can be individually applied
+          with <EuiCode>className</EuiCode> (for the entire accordion),
           and <EuiCode>buttonClassName</EuiCode> (for the clickable area).
         </p>
       </div>
@@ -118,6 +128,31 @@ export const AccordionExample = {
     props: { EuiAccordion },
     snippet: accordionSnippet,
     demo: <Accordion />,
+  }, {
+    title: 'Multiple accordions',
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: accordionMultipleSource,
+    }, {
+      type: GuideSectionTypes.HTML,
+      code: accordionMultipleHtml,
+    }],
+    text: (
+      <div>
+        <p>
+          Use any number of <EuiCode>EuiAccordion</EuiCode> elements to visually
+          display them as a group.
+        </p>
+        <p>
+          Due to the aforementioned bare styles, it is recommended to place
+          an <EuiCode>EuiSpacer</EuiCode> between accordion items. Padding
+          within each accordion item can be applied via
+          the <EuiCode>paddingSize</EuiCode> prop.
+        </p>
+      </div>
+    ),
+    snippet: accordionMultipleSnippet,
+    demo: <AccordionMultiple />,
   }, {
     title: 'Accordion can have extra actions',
     source: [{

--- a/src-docs/src/views/accordion/accordion_example.js
+++ b/src-docs/src/views/accordion/accordion_example.js
@@ -16,6 +16,23 @@ import {
 import Accordion from './accordion';
 const accordionSource = require('!!raw-loader!./accordion');
 const accordionHtml = renderToHtml(Accordion);
+const accordionSnippet = `<EuiAccordion
+  id="accordion1"
+  buttonContent="Clickable title text for first accordion"
+  paddingSize="m"
+  >
+    <!-- Content for first accordion -->
+</EuiAccordion>
+<!-- Optional, recommended spacer -->
+<EuiSpacer size="m" />
+<EuiAccordion
+  id="accordion2"
+  buttonContent="Clickable title text for second accordion"
+  paddingSize="m"
+  >
+    <!-- Content for second accordion -->
+</EuiAccordion>
+`;
 
 import AccordionForm from './accordion_form';
 const accordionFormSource = require('!!raw-loader!./accordion_form');
@@ -24,10 +41,27 @@ const accordionFormHtml = renderToHtml(AccordionForm);
 import AccordionExtra from './accordion_extra';
 const accordionExtraSource = require('!!raw-loader!./accordion_extra');
 const accordionExtraHtml = renderToHtml(AccordionExtra);
+const accordionExtraSnippet = `<EuiAccordion
+  id="accordionExtra"
+  buttonContent="Click to open"
+  extraAction={<EuiButton size="s">Extra action!</EuiButton>}
+  paddingSize="l"
+  >
+    <!-- Content for accordion -->
+</EuiAccordion>
+`;
 
 import AccordionOpen from './accordion_open';
 const accordionOpenSource = require('!!raw-loader!./accordion_open');
 const accordionOpenHtml = renderToHtml(AccordionOpen);
+const accordionOpenSnippet = `<EuiAccordion
+  id="accordionOpen"
+  buttonContent="Click to toggle"
+  initialIsOpen={true}
+  >
+    <!-- Content for accordion -->
+</EuiAccordion>
+`;
 
 import AccordionGrow from './accordion_grow';
 const accordionGrowSource = require('!!raw-loader!./accordion_grow');
@@ -82,6 +116,7 @@ export const AccordionExample = {
       </div>
     ),
     props: { EuiAccordion },
+    snippet: accordionSnippet,
     demo: <Accordion />,
   }, {
     title: 'Accordion can have extra actions',
@@ -101,6 +136,7 @@ export const AccordionExample = {
         it accessible.
       </p>
     ),
+    snippet: accordionExtraSnippet,
     demo: <AccordionExtra />,
   },  {
     title: 'Accordion can be opened on initial render',
@@ -116,6 +152,7 @@ export const AccordionExample = {
         Use the <EuiCode>initialIsOpen</EuiCode> prop to open the accordion when first rendered.
       </p>
     ),
+    snippet: accordionOpenSnippet,
     demo: <AccordionOpen />,
   }, {
     title: 'Accordion content can dynamically change height',

--- a/src-docs/src/views/accordion/accordion_example.js
+++ b/src-docs/src/views/accordion/accordion_example.js
@@ -108,10 +108,10 @@ export const AccordionExample = {
     text: (
       <div>
         <p>
-          <EuiCode>EuiAccordion</EuiCode> is purposely bare so that you can
-          put whatever styling you need on it (see the accordion form example). The only
-          styling we force on you is the caret, which gives the user an understanding
-          that the content will open up.
+          <EuiCode>EuiAccordion</EuiCode> has been purposely designed with
+          minimal styles, allowing you to visually enhance it as needed (see the
+          accordion form example). The only styling enforced by EUI is the
+          caret icon, which indicates to users that the item can be opened.
         </p>
         <p>
           A <EuiCode>buttonContent</EuiCode> prop defines the content of the
@@ -144,7 +144,7 @@ export const AccordionExample = {
           display them as a group.
         </p>
         <p>
-          Due to the aforementioned bare styles, it is recommended to place
+          Due to the previously mentioned bare styles, it is recommended to place
           an <EuiCode>EuiSpacer</EuiCode> between accordion items. Padding
           within each accordion item can be applied via
           the <EuiCode>paddingSize</EuiCode> prop.

--- a/src-docs/src/views/accordion/accordion_multiple.js
+++ b/src-docs/src/views/accordion/accordion_multiple.js
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import {
+  EuiAccordion,
+  EuiText,
+  EuiSpacer,
+} from '../../../../src/components';
+
+
+export default () => (
+  <div>
+    <EuiAccordion
+      id="accordion1"
+      buttonContent="An accordion with padding applied through props"
+      paddingSize="l"
+    >
+      <EuiText>
+        <p>The content inside can be of any height.</p>
+        <p>The content inside can be of any height.</p>
+        <p>The content inside can be of any height.</p>
+      </EuiText>
+    </EuiAccordion>
+
+    <EuiSpacer />
+
+    <EuiAccordion
+      id="accordion2"
+      buttonContent="A second accordion with padding"
+      paddingSize="l"
+    >
+      <EuiText>
+        <p>The content inside can be of any height.</p>
+        <p>The content inside can be of any height.</p>
+        <p>The content inside can be of any height.</p>
+        <p>The content inside can be of any height.</p>
+        <p>The content inside can be of any height.</p>
+        <p>The content inside can be of any height.</p>
+      </EuiText>
+    </EuiAccordion>
+  </div>
+);


### PR DESCRIPTION
### Summary

Tending garden 🥕, just adding some snippets to the `EuiAccordion` docs.

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
- [x] Any props added have proper autodocs
- [x] Documentation examples were added
- [ ] ~A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
- [ ] ~This was checked for breaking changes and labeled appropriately~
- [ ] ~Jest tests were updated or added to match the most common scenarios~
- [ ] ~This was checked against keyboard-only and screenreader scenarios~
- [ ] ~This required updates to Framer X components~
