### PR TITLE
Fix EuiNavDrawer scroll overflow issue on Firefrox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added `adjustDateOnChange` prop to date pickers, enabling month and year changes to trigger `onChange` ([#1817](https://github.com/elastic/eui/pull/1817))
 - Updated the overflow shadows for `EuiModal` and `EuiFlyout` ([#1829](https://github.com/elastic/eui/pull/1829))
 - Added `confirmButtonDisabled` prop to `EuiConfirmModal` ([#1829](https://github.com/elastic/eui/pull/1829))
+- Fixed `EuiNavDrawer` overflow scroll behavior on Firefox ([#1837](https://github.com/elastic/eui/pull/1837))
 
 **Bug fixes**
 
@@ -21,8 +22,8 @@
 **Bug fixes**
 
 - Added `isLoading` prop typedef to `EuiSuperDatePickerProps` ([#1812](https://github.com/elastic/eui/pull/1812))
-- Fix `EuiSearchBox` query input resetting on prop updates ([#1823](https://github.com/elastic/eui/pull/1823))
-- Fix `EuiSearchBar` filter button highlighting ([#1824](https://github.com/elastic/eui/pull/1824))
+- Fixed `EuiSearchBox` query input resetting on prop updates ([#1823](https://github.com/elastic/eui/pull/1823))
+- Fixed `EuiSearchBar` filter button highlighting ([#1824](https://github.com/elastic/eui/pull/1824))
 
 ## [`9.9.0`](https://github.com/elastic/eui/tree/v9.9.0)
 

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -20,7 +20,7 @@
     height: 100%;
 
     &-hasFooter {
-      padding-bottom: $euiSizeXXL;
+      margin-bottom: $euiSizeXXL;
     }
   }
 
@@ -106,7 +106,7 @@
     // No expand toggle on mobile
 
     .euiNavDrawerMenu-hasFooter {
-      padding-bottom: 0;
+      margin-bottom: 0;
     }
 
     .euiNavDrawer__expandButton {


### PR DESCRIPTION
### Summary

Fixes an issue that was opened in the Kibana repo: https://github.com/elastic/kibana/issues/35083

It seems this comes down to difference of interpretation for the overflow spec. The Mozilla team seems to have taken a slightly different approach (than other browsers) with regards to where they apply bottom padding when there is overflow: https://bugzilla.mozilla.org/show_bug.cgi?id=748518

There were several kludge solution, but simply changing this from `padding-bottom` to `margin-bottom` did the trick.

Tested EUI docs and Kibana on FF, Chrome, and IE.

#### Firefox recording

![ff-nav-scroll](https://user-images.githubusercontent.com/446285/56151825-c3121580-5f77-11e9-895c-0d4ac4e147ba.gif)

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [ ] ~This was checked in dark mode~
- [ ] ~Any props added have proper autodocs~
- [ ] ~Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [ ] ~Jest tests were updated or added to match the most common scenarios~
- [x] This was checked against keyboard-only and screenreader scenarios
- [ ] ~This required updates to Framer X components~
