### PR TITLE
add component property to spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `10.0.0`.
+- `EuiLoadingSpinner` now accept a `component` prop which you can set to `span` or `div` (default).
 
 ## [`10.0.0`](https://github.com/elastic/eui/tree/v10.0.0)
 

--- a/src/components/loading/__snapshots__/loading_spinner.test.tsx.snap
+++ b/src/components/loading/__snapshots__/loading_spinner.test.tsx.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiLoadingSpinner component div is rendered 1`] = `
+<div
+  class="euiLoadingSpinner euiLoadingSpinner--medium"
+/>
+`;
+
+exports[`EuiLoadingSpinner component figure is rendered 1`] = `
+<figure
+  class="euiLoadingSpinner euiLoadingSpinner--medium"
+/>
+`;
+
+exports[`EuiLoadingSpinner component span is rendered 1`] = `
+<span
+  class="euiLoadingSpinner euiLoadingSpinner--medium"
+/>
+`;
+
 exports[`EuiLoadingSpinner is rendered 1`] = `
 <div
   aria-label="aria-label"

--- a/src/components/loading/loading_spinner.test.tsx
+++ b/src/components/loading/loading_spinner.test.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
 
-import { EuiLoadingSpinner, SIZES } from './loading_spinner';
+import {
+  EuiLoadingSpinner,
+  SIZES,
+  EuiLoadingSpinnerComponentType,
+} from './loading_spinner';
 
 describe('EuiLoadingSpinner', () => {
   test('is rendered', () => {
@@ -17,6 +21,30 @@ describe('EuiLoadingSpinner', () => {
         const component = render(<EuiLoadingSpinner size={size} />);
 
         expect(component).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('component', () => {
+    (['div', 'span', 'figure'] as EuiLoadingSpinnerComponentType[]).forEach(
+      value => {
+        test(`${value} is rendered`, () => {
+          const component = render(<EuiLoadingSpinner component={value} />);
+
+          expect(component).toMatchSnapshot();
+        });
+      }
+    );
+
+    ['h2'].forEach(value => {
+      test(`${value} is not rendered`, () => {
+        expect(() =>
+          render(
+            // intentionally passing an invalid value
+            // @ts-ignore
+            <EuiLoadingSpinner component={value} />
+          )
+        ).toThrow();
       });
     });
   });

--- a/src/components/loading/loading_spinner.tsx
+++ b/src/components/loading/loading_spinner.tsx
@@ -9,21 +9,26 @@ const sizeToClassNameMap = {
   xl: 'euiLoadingSpinner--xLarge',
 };
 
+export type EuiLoadingSpinnerComponentType = 'div' | 'span' | 'figure';
+
+interface EuiLoadingSpinnerComponentProps {
+  size?: EuiLoadingSpinnerSize;
+  component?: EuiLoadingSpinnerComponentType;
+}
+
 export const SIZES = keysOf(sizeToClassNameMap);
 
 export type EuiLoadingSpinnerSize = keyof typeof sizeToClassNameMap;
-
 export const EuiLoadingSpinner: FunctionComponent<
   CommonProps &
-    HTMLAttributes<HTMLDivElement> & {
-      size?: EuiLoadingSpinnerSize;
-    }
-> = ({ size = 'm', className, ...rest }) => {
+    HTMLAttributes<HTMLDivElement | HTMLSpanElement> &
+    EuiLoadingSpinnerComponentProps
+> = ({ size = 'm', className, component: Component = 'div', ...rest }) => {
   const classes = classNames(
     'euiLoadingSpinner',
     sizeToClassNameMap[size],
     className
   );
 
-  return <div className={classes} {...rest} />;
+  return <Component className={classes} {...rest} />;
 };


### PR DESCRIPTION
### Summary

I would like to put a `EuiLoadingSpinner` in the title of `EuiStat`, but it complains about the p element from Stat shouldn't wrap div element from the spinner. Therefor I made a PR to make spinner accept component prop, so user can set it to div (default) or span. Please let me know if there's other solutions, any suggestions are welcome. Thanks a lot!


<img width="1669" alt="Screenshot 2019-04-16 at 22 11 49" src="https://user-images.githubusercontent.com/6295984/56217731-4de93200-6096-11e9-9fb4-b6b6d4943f7d.png">
<img width="1673" alt="Screenshot 2019-04-16 at 22 13 23" src="https://user-images.githubusercontent.com/6295984/56217769-5b9eb780-6096-11e9-8b9c-176825b5395b.png">



### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
