### PR TITLE
Use span for loaders and set width to kibana loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ No public interface changes since `10.0.1`.
 
 - Convert `EuiText`, `EuiTextColor` and `EuiTextAlign` to TS ([#1791](https://github.com/elastic/eui/pull/1791))
 - Updated `IconColor` type to better distinguish between accepted types ([#1842](https://github.com/elastic/eui/pull/1842))
-- Changed `EuiLoding` components to use spans instead of divs  ([#1845](https://github.com/elastic/eui/pull/1845))
+- Changed `EuiLoading` components to use spans instead of divs  ([#1845](https://github.com/elastic/eui/pull/1845))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ No public interface changes since `10.0.1`.
 
 - Convert `EuiText`, `EuiTextColor` and `EuiTextAlign` to TS ([#1791](https://github.com/elastic/eui/pull/1791))
 - Updated `IconColor` type to better distinguish between accepted types ([#1842](https://github.com/elastic/eui/pull/1842))
-- Changed `EuiLoading` components to use spans instead of divs  ([#1845](https://github.com/elastic/eui/pull/1845))
+- Changed `EuiLoadingKibana`, `EuiLoadingSpinner`, `EuiLoadingChart` and `EuiLoadingContent` components to use spans instead of divs  ([#1845](https://github.com/elastic/eui/pull/1845))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ No public interface changes since `10.0.1`.
 
 - Convert `EuiText`, `EuiTextColor` and `EuiTextAlign` to TS ([#1791](https://github.com/elastic/eui/pull/1791))
 - Updated `IconColor` type to better distinguish between accepted types ([#1842](https://github.com/elastic/eui/pull/1842))
+- Changed `EuiLoding` components to use spans instead of divs  ([#1845](https://github.com/elastic/eui/pull/1845))
+
+**Bug fixes**
+
+- Changed `EuiLoadingKibana` so it could better nest within `EuiFlexItem`  ([#1845](https://github.com/elastic/eui/pull/1845))
 
 ## [`10.0.0`](https://github.com/elastic/eui/tree/v10.0.0)
 

--- a/src/components/button/__snapshots__/button.test.js.snap
+++ b/src/components/button/__snapshots__/button.test.js.snap
@@ -306,7 +306,7 @@ exports[`EuiButton props isLoading is rendered 1`] = `
   <span
     class="euiButton__content"
   >
-    <div
+    <span
       class="euiLoadingSpinner euiLoadingSpinner--medium euiButton__spinner"
     />
     <span

--- a/src/components/facet/__snapshots__/facet_button.test.js.snap
+++ b/src/components/facet/__snapshots__/facet_button.test.js.snap
@@ -93,7 +93,7 @@ exports[`EuiFacetButton props isLoading is rendered 1`] = `
     >
       Content
     </span>
-    <div
+    <span
       class="euiLoadingSpinner euiLoadingSpinner--medium euiFacetButton__spinner"
     />
   </span>

--- a/src/components/form/form_control_layout/__snapshots__/form_control_layout.test.js.snap
+++ b/src/components/form/form_control_layout/__snapshots__/form_control_layout.test.js.snap
@@ -201,7 +201,7 @@ exports[`EuiFormControlLayout props isLoading is rendered 1`] = `
     <div
       class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
     >
-      <div
+      <span
         class="euiLoadingSpinner euiLoadingSpinner--medium"
       />
     </div>

--- a/src/components/form/super_select/__snapshots__/super_select_control.test.js.snap
+++ b/src/components/form/super_select/__snapshots__/super_select_control.test.js.snap
@@ -384,7 +384,7 @@ Array [
       <div
         class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
       >
-        <div
+        <span
           class="euiLoadingSpinner euiLoadingSpinner--medium"
         />
         <span

--- a/src/components/loading/__snapshots__/loading_chart.test.tsx.snap
+++ b/src/components/loading/__snapshots__/loading_chart.test.tsx.snap
@@ -1,98 +1,98 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiLoadingChart is rendered 1`] = `
-<div
+<span
   aria-label="aria-label"
   class="euiLoadingChart testClass1 testClass2 euiLoadingChart--medium"
   data-test-subj="test subject string"
 >
-  <div
+  <span
     class="euiLoadingChart__bar"
   />
-  <div
+  <span
     class="euiLoadingChart__bar"
   />
-  <div
+  <span
     class="euiLoadingChart__bar"
   />
-  <div
+  <span
     class="euiLoadingChart__bar"
   />
-</div>
+</span>
 `;
 
 exports[`EuiLoadingChart mono is rendered 1`] = `
-<div
+<span
   class="euiLoadingChart euiLoadingChart--mono euiLoadingChart--medium"
 >
-  <div
+  <span
     class="euiLoadingChart__bar"
   />
-  <div
+  <span
     class="euiLoadingChart__bar"
   />
-  <div
+  <span
     class="euiLoadingChart__bar"
   />
-  <div
+  <span
     class="euiLoadingChart__bar"
   />
-</div>
+</span>
 `;
 
 exports[`EuiLoadingChart size l is rendered 1`] = `
-<div
+<span
   class="euiLoadingChart euiLoadingChart--large"
 >
-  <div
+  <span
     class="euiLoadingChart__bar"
   />
-  <div
+  <span
     class="euiLoadingChart__bar"
   />
-  <div
+  <span
     class="euiLoadingChart__bar"
   />
-  <div
+  <span
     class="euiLoadingChart__bar"
   />
-</div>
+</span>
 `;
 
 exports[`EuiLoadingChart size m is rendered 1`] = `
-<div
+<span
   class="euiLoadingChart euiLoadingChart--medium"
 >
-  <div
+  <span
     class="euiLoadingChart__bar"
   />
-  <div
+  <span
     class="euiLoadingChart__bar"
   />
-  <div
+  <span
     class="euiLoadingChart__bar"
   />
-  <div
+  <span
     class="euiLoadingChart__bar"
   />
-</div>
+</span>
 `;
 
 exports[`EuiLoadingChart size xl is rendered 1`] = `
-<div
+<span
   class="euiLoadingChart euiLoadingChart--xLarge"
 >
-  <div
+  <span
     class="euiLoadingChart__bar"
   />
-  <div
+  <span
     class="euiLoadingChart__bar"
   />
-  <div
+  <span
     class="euiLoadingChart__bar"
   />
-  <div
+  <span
     class="euiLoadingChart__bar"
   />
-</div>
+</span>
 `;

--- a/src/components/loading/__snapshots__/loading_content.test.tsx.snap
+++ b/src/components/loading/__snapshots__/loading_content.test.tsx.snap
@@ -1,486 +1,486 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiLoadingContent is rendered 1`] = `
-<div
+<span
   aria-label="aria-label"
   class="euiLoadingContent testClass1 testClass2"
   data-test-subj="test subject string"
 >
-  <div
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-</div>
+  </span>
+</span>
 `;
 
 exports[`EuiLoadingContent lines 1 is rendered 1`] = `
-<div
+<span
   class="euiLoadingContent"
 >
-  <div
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-</div>
+  </span>
+</span>
 `;
 
 exports[`EuiLoadingContent lines 2 is rendered 1`] = `
-<div
+<span
   class="euiLoadingContent"
 >
-  <div
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-</div>
+  </span>
+</span>
 `;
 
 exports[`EuiLoadingContent lines 3 is rendered 1`] = `
-<div
+<span
   class="euiLoadingContent"
 >
-  <div
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-</div>
+  </span>
+</span>
 `;
 
 exports[`EuiLoadingContent lines 4 is rendered 1`] = `
-<div
+<span
   class="euiLoadingContent"
 >
-  <div
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-</div>
+  </span>
+</span>
 `;
 
 exports[`EuiLoadingContent lines 5 is rendered 1`] = `
-<div
+<span
   class="euiLoadingContent"
 >
-  <div
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-</div>
+  </span>
+</span>
 `;
 
 exports[`EuiLoadingContent lines 6 is rendered 1`] = `
-<div
+<span
   class="euiLoadingContent"
 >
-  <div
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-</div>
+  </span>
+</span>
 `;
 
 exports[`EuiLoadingContent lines 7 is rendered 1`] = `
-<div
+<span
   class="euiLoadingContent"
 >
-  <div
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-</div>
+  </span>
+</span>
 `;
 
 exports[`EuiLoadingContent lines 8 is rendered 1`] = `
-<div
+<span
   class="euiLoadingContent"
 >
-  <div
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-</div>
+  </span>
+</span>
 `;
 
 exports[`EuiLoadingContent lines 9 is rendered 1`] = `
-<div
+<span
   class="euiLoadingContent"
 >
-  <div
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-</div>
+  </span>
+</span>
 `;
 
 exports[`EuiLoadingContent lines 10 is rendered 1`] = `
-<div
+<span
   class="euiLoadingContent"
 >
-  <div
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-  <div
+  </span>
+  <span
     class="euiLoadingContent__singleLine"
   >
-    <div
+    <span
       class="euiLoadingContent__singleLineBackground"
     />
-  </div>
-</div>
+  </span>
+</span>
 `;

--- a/src/components/loading/__snapshots__/loading_kibana.test.tsx.snap
+++ b/src/components/loading/__snapshots__/loading_kibana.test.tsx.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiLoadingKibana is rendered 1`] = `
-<div
+<span
   aria-label="aria-label"
   class="euiLoadingKibana euiLoadingKibana--medium testClass1 testClass2"
   data-test-subj="test subject string"
 >
-  <div
+  <span
     class="euiLoadingKibana__icon"
   >
     <svg
@@ -35,15 +35,15 @@ exports[`EuiLoadingKibana is rendered 1`] = `
         />
       </g>
     </svg>
-  </div>
-</div>
+  </span>
+</span>
 `;
 
 exports[`EuiLoadingKibana size l is rendered 1`] = `
-<div
+<span
   class="euiLoadingKibana euiLoadingKibana--large"
 >
-  <div
+  <span
     class="euiLoadingKibana__icon"
   >
     <svg
@@ -72,15 +72,15 @@ exports[`EuiLoadingKibana size l is rendered 1`] = `
         />
       </g>
     </svg>
-  </div>
-</div>
+  </span>
+</span>
 `;
 
 exports[`EuiLoadingKibana size m is rendered 1`] = `
-<div
+<span
   class="euiLoadingKibana euiLoadingKibana--medium"
 >
-  <div
+  <span
     class="euiLoadingKibana__icon"
   >
     <svg
@@ -109,15 +109,15 @@ exports[`EuiLoadingKibana size m is rendered 1`] = `
         />
       </g>
     </svg>
-  </div>
-</div>
+  </span>
+</span>
 `;
 
 exports[`EuiLoadingKibana size xl is rendered 1`] = `
-<div
+<span
   class="euiLoadingKibana euiLoadingKibana--xLarge"
 >
-  <div
+  <span
     class="euiLoadingKibana__icon"
   >
     <svg
@@ -146,6 +146,6 @@ exports[`EuiLoadingKibana size xl is rendered 1`] = `
         />
       </g>
     </svg>
-  </div>
-</div>
+  </span>
+</span>
 `;

--- a/src/components/loading/__snapshots__/loading_spinner.test.tsx.snap
+++ b/src/components/loading/__snapshots__/loading_spinner.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiLoadingSpinner is rendered 1`] = `
-<div
+<span
   aria-label="aria-label"
   class="euiLoadingSpinner euiLoadingSpinner--medium testClass1 testClass2"
   data-test-subj="test subject string"
@@ -9,25 +9,25 @@ exports[`EuiLoadingSpinner is rendered 1`] = `
 `;
 
 exports[`EuiLoadingSpinner size l is rendered 1`] = `
-<div
+<span
   class="euiLoadingSpinner euiLoadingSpinner--large"
 />
 `;
 
 exports[`EuiLoadingSpinner size m is rendered 1`] = `
-<div
+<span
   class="euiLoadingSpinner euiLoadingSpinner--medium"
 />
 `;
 
 exports[`EuiLoadingSpinner size s is rendered 1`] = `
-<div
+<span
   class="euiLoadingSpinner euiLoadingSpinner--small"
 />
 `;
 
 exports[`EuiLoadingSpinner size xl is rendered 1`] = `
-<div
+<span
   class="euiLoadingSpinner euiLoadingSpinner--xLarge"
 />
 `;

--- a/src/components/loading/_loading_chart.scss
+++ b/src/components/loading/_loading_chart.scss
@@ -1,5 +1,5 @@
 .euiLoadingChart {
-  height: 32px;
+  height: $euiSizeXL;
   z-index: 500;
   overflow: hidden;
   display: inline-block;
@@ -7,11 +7,10 @@
 
 .euiLoadingChart__bar {
   height: 100%;
-  width: 8px;
+  width: $euiSizeS;
   display: inline-block;
-  float: left;
-  margin-bottom: -16px;
-  margin-left: 2px;
+  margin-bottom: -$euiSize;
+  margin-left: $euiSizeXS / 2;
   animation: euiLoadingChart 1s infinite;
 
   &:nth-child(1) {
@@ -57,7 +56,7 @@
 .euiLoadingChart--medium {
   height: $euiSize;
 
-  > div {
+  > span {
     width: $euiSizeXS / 2;
     margin-left: $euiSizeXS / 2;
     margin-bottom: $euiSizeS;
@@ -67,7 +66,7 @@
 .euiLoadingChart--large {
   height: $euiSizeL;
 
-  > div {
+  > span {
     width: $euiSizeXS;
     margin-left: $euiSizeXS / 2;
     margin-bottom: $euiSizeL / 2;
@@ -77,7 +76,7 @@
 .euiLoadingChart--xLarge {
   height: $euiSizeXL;
 
-  > div {
+  > span {
     width: $euiSizeS;
     margin-left: $euiSizeXS;
     margin-bottom: $euiSizeXL / 2;

--- a/src/components/loading/_loading_content.scss
+++ b/src/components/loading/_loading_content.scss
@@ -1,8 +1,10 @@
 .euiLoadingContent__loader {
+  display: block;
   width: 100%;
 }
 
 .euiLoadingContent__singleLine {
+  display: block;
   width: 100%;
   height: $euiSize;
   margin-bottom: $euiSizeS;
@@ -15,6 +17,7 @@
 }
 
 .euiLoadingContent__singleLineBackground {
+  display: block;
   width: 220%;
   height: 100%;
   background: linear-gradient(

--- a/src/components/loading/_loading_kibana.scss
+++ b/src/components/loading/_loading_kibana.scss
@@ -22,12 +22,18 @@
     background-color: $euiColorFullShade;
     animation: 1s euiLoadingKibanaPulsate $euiAnimSlightResistance infinite;
   }
+
+  .euiLoadingKibana__icon {
+    display: block;
+  }
 }
 
 /**
  * 1. Requires pixel math for animation.
  */
 .euiLoadingKibana--medium {
+  width: $euiSize;
+
   &:before,
   &:after {
     height: $euiSizeXS - 1; /* 1 */
@@ -44,6 +50,8 @@
  * 1. Requires pixel math for animation.
  */
 .euiLoadingKibana--large {
+  width: $euiSizeL;
+
   &:before,
   &:after {
     height: $euiSizeS - 2; /* 1 */
@@ -56,6 +64,8 @@
 }
 
 .euiLoadingKibana--xLarge {
+  width: $euiSizeXL;
+
   &:before,
   &:after {
     height: $euiSizeS;

--- a/src/components/loading/loading_chart.tsx
+++ b/src/components/loading/loading_chart.tsx
@@ -30,11 +30,11 @@ export const EuiLoadingChart: FunctionComponent<
   );
 
   return (
-    <div className={classes} {...rest}>
-      <div className="euiLoadingChart__bar" />
-      <div className="euiLoadingChart__bar" />
-      <div className="euiLoadingChart__bar" />
-      <div className="euiLoadingChart__bar" />
-    </div>
+    <span className={classes} {...rest}>
+      <span className="euiLoadingChart__bar" />
+      <span className="euiLoadingChart__bar" />
+      <span className="euiLoadingChart__bar" />
+      <span className="euiLoadingChart__bar" />
+    </span>
   );
 };

--- a/src/components/loading/loading_content.tsx
+++ b/src/components/loading/loading_content.tsx
@@ -15,15 +15,15 @@ export const EuiLoadingContent: FunctionComponent<
 
   for (let i = 0; i < lines; i++) {
     lineElements.push(
-      <div key={i} className="euiLoadingContent__singleLine">
-        <div className="euiLoadingContent__singleLineBackground" />
-      </div>
+      <span key={i} className="euiLoadingContent__singleLine">
+        <span className="euiLoadingContent__singleLineBackground" />
+      </span>
     );
   }
 
   return (
-    <div className={classes} {...rest}>
+    <span className={classes} {...rest}>
       {lineElements}
-    </div>
+    </span>
   );
 };

--- a/src/components/loading/loading_kibana.tsx
+++ b/src/components/loading/loading_kibana.tsx
@@ -25,10 +25,10 @@ export const EuiLoadingKibana: FunctionComponent<
   );
 
   return (
-    <div className={classes} {...rest}>
-      <div className="euiLoadingKibana__icon">
+    <span className={classes} {...rest}>
+      <span className="euiLoadingKibana__icon">
         <EuiIcon type="logoKibana" size={size} />
-      </div>
-    </div>
+      </span>
+    </span>
   );
 };

--- a/src/components/loading/loading_spinner.tsx
+++ b/src/components/loading/loading_spinner.tsx
@@ -25,5 +25,5 @@ export const EuiLoadingSpinner: FunctionComponent<
     className
   );
 
-  return <div className={classes} {...rest} />;
+  return <span className={classes} {...rest} />;
 };


### PR DESCRIPTION
### Summary

Replaces https://github.com/elastic/eui/pull/1840, fixes https://github.com/elastic/eui/issues/1834

Applies a width to the wrapping element for the Kibana loader. This also makes all of our loaders use spans instead of divs. I don't see any reason to also support divs, so this closes the PR mentioned above and removes the need for an extra prop.

![](http://snid.es/aa972ea5d07b/Screen%252520Recording%2525202019-04-16%252520at%25252003.31%252520PM.gif)

### Checklist

- [ ] ~This was checked in mobile~
- [ ] This was checked in IE11
- [x] This was checked in dark mode
- [ ] ~Any props added have proper autodocs~
- [ ] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] ~This was checked for breaking changes and labeled appropriately~
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] ~This was checked against keyboard-only and screenreader scenarios~
- [ ] ~This required updates to Framer X components~
