### PR TITLE
Improved logic for generating i18n changelog entries

### DIFF
--- a/scripts/update-token-changelog.js
+++ b/scripts/update-token-changelog.js
@@ -90,14 +90,7 @@ async function getDirtyFiles(repo) {
   const diff = await git.Diff.indexToWorkdir(repo, null, { FLAGS: git.Diff.OPTION.INCLUDE_UNTRACKED });
   const patches = await diff.patches();
 
-  return patches.reduce(
-    (dirtyFiles, patch) => {
-      dirtyFiles.add(patch.oldFile().path());
-
-      return dirtyFiles;
-    },
-    new Set()
-  );
+  return new Set(patches.map(patch => patch.oldFile().path()));
 }
 
 async function commitTokenChanges(repo) {
@@ -126,13 +119,13 @@ async function commitTokenChanges(repo) {
 
     const userSignature = await repo.defaultSignature();
 
-    return await repo.createCommit('HEAD', userSignature, userSignature, 'update i18ntokens', oid, [parent]);
+    return repo.createCommit('HEAD', userSignature, userSignature, 'update i18ntokens', oid, [parent]);
   }
 }
 
 async function getCommitForTagName(repo, tagname) {
   const tag = await repo.getTagByName(tagname);
-  return await git.Commit.lookup(repo, tag.targetId());
+  return git.Commit.lookup(repo, tag.targetId());
 }
 
 async function main() {

--- a/scripts/update-token-changelog.js
+++ b/scripts/update-token-changelog.js
@@ -86,55 +86,80 @@ function getTokenChanges(oldTokenInstances, newTokenInstances) {
   return changes;
 }
 
+async function getDirtyFiles(repo) {
+  const diff = await git.Diff.indexToWorkdir(repo, null, { FLAGS: git.Diff.OPTION.INCLUDE_UNTRACKED });
+  const patches = await diff.patches();
+
+  return patches.reduce(
+    (dirtyFiles, patch) => {
+      dirtyFiles.add(patch.oldFile().path());
+
+      return dirtyFiles;
+    },
+    new Set()
+  );
+}
+
 async function commitTokenChanges(repo) {
-  // two files to add to git and commit: i18ntokens.json and i18ntokens_changelog.json
+  // add i18ntokens.json and i18ntokens_changelog.json if modified, and commit
   // https://github.com/nodegit/nodegit/blob/master/examples/add-and-commit.js
+  const dirtyFiles = await getDirtyFiles(repo);
+  let createCommit = false;
+
   const index = await repo.refreshIndex();
-  await index.addByPath('src-docs/src/i18ntokens.json');
-  await index.addByPath('src-docs/src/i18ntokens_changelog.json');
-  await index.write();
-  const oid = await index.writeTree();
-  const head = await git.Reference.nameToId(repo, 'HEAD');
-  const parent = await repo.getCommit(head);
 
-  const userSignature = await repo.defaultSignature();
+  if (dirtyFiles.has('src-docs/src/i18ntokens.json')) {
+    createCommit = true;
+    await index.addByPath('src-docs/src/i18ntokens.json');
+  }
 
-  return await repo.createCommit('HEAD', userSignature, userSignature, 'update i18ntokens', oid, [parent]);
+  if (dirtyFiles.has('src-docs/src/i18ntokens_changelog.json')) {
+    createCommit = true;
+    await index.addByPath('src-docs/src/i18ntokens_changelog.json');
+  }
+
+  if (createCommit) {
+    await index.write();
+    const oid = await index.writeTree();
+    const head = await git.Reference.nameToId(repo, 'HEAD');
+    const parent = await repo.getCommit(head);
+
+    const userSignature = await repo.defaultSignature();
+
+    return await repo.createCommit('HEAD', userSignature, userSignature, 'update i18ntokens', oid, [parent]);
+  }
+}
+
+async function getCommitForTagName(repo, tagname) {
+  const tag = await repo.getTagByName(tagname);
+  return await git.Commit.lookup(repo, tag.targetId());
 }
 
 async function main() {
   const repo = await git.Repository.open(repoDir);
-  const head = await repo.getHeadCommit();
-  const diff = await git.Diff.indexToWorkdir(repo, null, { FLAGS: git.Diff.OPTION.INCLUDE_UNTRACKED });
-  const patches = await diff.patches();
+  const previousVersionCommit = await getCommitForTagName(repo, `v${oldPackageVersion}`);
 
-  while (patches.length > 0) {
-    const patch = patches.pop();
+  // check for i18n token differences between the current file & the most recent EUI version
+  const originalTokens = JSON.parse(await getFileContentsFromCommit(previousVersionCommit, 'src-docs/src/i18ntokens.json'));
+  const newTokens = require(tokensPath);
 
-    // iterate through git workspace changes looking for i18ntokens.json
-    if (patch.oldFile().path() === 'src-docs/src/i18ntokens.json') {
-      // i18n tokens has changed, load the previous version
-      const originalTokens = JSON.parse(await getFileContentsFromCommit(head, 'src-docs/src/i18ntokens.json'));
-      const newTokens = require(tokensPath);
+  const changes = getTokenChanges(originalTokens, newTokens);
 
-      const changes = getTokenChanges(originalTokens, newTokens);
-
-      // it's possible that no meaningful changes occurred
-      if (changes.length > 0) {
-        const changeLog = require(tokensChangelogPath);
-        changeLog.unshift({
-          version: newPackageVersion,
-          changes,
-        });
-        fs.writeFileSync(tokensChangelogPath, JSON.stringify(changeLog, null, 2));
-      }
-
-      // always commit changes to i18ntokens.json
-      await commitTokenChanges(repo);
-
-      // stop iterating over workspace changes
-      return;
-    }
+  // it's possible that no meaningful changes occurred
+  if (changes.length > 0) {
+    const changeLog = require(tokensChangelogPath);
+    changeLog.unshift({
+      version: newPackageVersion,
+      changes,
+    });
+    fs.writeFileSync(tokensChangelogPath, JSON.stringify(changeLog, null, 2));
   }
+
+  // commit pending changes to i18ntokens.json or i18ntokens_changelog.json
+  await commitTokenChanges(repo);
 }
-main();
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
### Summary

The current setup for detecting changes to i18n tokens relies on changes to *i18n_tokens.json* not be manually committed, instead allowing the release script to generate & commit the new file. This process breaks if someone does a build, notices *i18n_tokens.json* was updated, and commits those changes.

This PR modifies the release process to check if the tokens have changed _since the last release_ instead of if there are unstaged changes.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
