### PR TITLE
Bug/1825 Fix sass warn feedback on breakpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Fixed `EuiComboBox` to not pass its `inputRef` prop down to the DOM ([#1867](https://github.com/elastic/eui/pull/1867))
+- Fixed `euiBreakpoint()` warning to give accurate feedback ([#1874](https://github.com/elastic/eui/pull/1874))
 
 ## [`10.1.0`](https://github.com/elastic/eui/tree/v10.1.0)
 

--- a/src/global_styling/mixins/_responsive.scss
+++ b/src/global_styling/mixins/_responsive.scss
@@ -46,7 +46,7 @@
       }
     // If it's not a known breakpoint, throw a warning
     } @else {
-      @warn "euiBreakpoint(): '#{$size}' is not a valid size in $euiBreakpoints.\nThe acceptable values are '#{$euiBreakpointKeys}'";
+      @warn "euiBreakpoint(): '#{$size}' is not a valid size in $euiBreakpoints. Accepted values are '#{$euiBreakpointKeys}'";
     }
   }
 }

--- a/src/global_styling/mixins/_responsive.scss
+++ b/src/global_styling/mixins/_responsive.scss
@@ -46,8 +46,7 @@
       }
     // If it's not a known breakpoint, throw a warning
     } @else {
-      @warn "euiBreakpoint(): '#{$size}' is not a valid size in $euiBreakpoints.
-        The acceptable values are '#{$euiBreakpointKeys}'";
+      @warn "euiBreakpoint(): '#{$size}' is not a valid size in $euiBreakpoints.\nThe acceptable values are '#{$euiBreakpointKeys}'";
     }
   }
 }


### PR DESCRIPTION
### Summary

Fixes https://github.com/elastic/eui/issues/1825. There was a feedback error with certain sass compilers.

![image](https://user-images.githubusercontent.com/324519/56599830-45b85780-65ac-11e9-9d6b-c33fbb9b187d.png)


### Checklist

- [ ] ~This was checked in mobile~
- [ ] ~This was checked in IE11~
- [ ] ~This was checked in dark mode~
- [ ] ~Any props added have proper autodocs~
- [ ] ~Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] ~This was checked for breaking changes and labeled appropriately~
- [ ] ~Jest tests were updated or added to match the most common scenarios~
- [ ] ~This was checked against keyboard-only and screenreader scenarios~
- [ ] ~This required updates to Framer X components~
