### PR TITLE
Add localization to EuiTablePagination's options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed `EuiComboBox` to not pass its `inputRef` prop down to the DOM ([#1867](https://github.com/elastic/eui/pull/1867))
 - Fixed `euiBreakpoint()` warning to give accurate feedback ([#1874](https://github.com/elastic/eui/pull/1874))
 - Fixed type definitions around `EuiI18n`'s `default` prop to better support use cases ([#1861](https://github.com/elastic/eui/pull/1861))
+- Localized `EuiTablePagination`'s row count selection ([#1883](https://github.com/elastic/eui/pull/1883))
 
 ## [`10.1.0`](https://github.com/elastic/eui/tree/v10.1.0)
 

--- a/src/components/table/table_pagination/table_pagination.js
+++ b/src/components/table/table_pagination/table_pagination.js
@@ -60,7 +60,7 @@ export class EuiTablePagination extends Component {
         icon={itemsPerPageOption === itemsPerPage ? 'check' : 'empty'}
         onClick={() => { this.closePopover(); onChangeItemsPerPage(itemsPerPageOption); }}
       >
-        {`${itemsPerPageOption} rows`}
+        <EuiI18n token="euiTablePagination.rowsPerPageOption" values={{ rowsPerPage: itemsPerPageOption }} default="{rowsPerPage} rows"/>
       </EuiContextMenuItem>
     ));
 


### PR DESCRIPTION
### Summary

Brought up in #1869 , `EuiTablePagination` was missing localization when selecting how many rows to display.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
