### PR TITLE
EuiOverlayMask TS fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `10.2.1`.
+**Bug fixes**
+
+- Fixed `EuiOverlayMask` `children` element mismatch TS error ([#1900](https://github.com/elastic/eui/pull/1900))
 
 ## [`10.2.1`](https://github.com/elastic/eui/tree/v10.2.1)
 

--- a/src/components/overlay_mask/overlay_mask.tsx
+++ b/src/components/overlay_mask/overlay_mask.tsx
@@ -6,17 +6,14 @@
 import { Component, HTMLAttributes } from 'react';
 import { createPortal } from 'react-dom';
 import classNames from 'classnames';
-import { CommonProps, keysOf, Omit } from '../common';
+import { CommonProps, keysOf } from '../common';
 
 export interface EuiOverlayMaskProps {
   onClick?: () => void;
 }
 
 export type Props = CommonProps &
-  Omit<
-    Partial<Record<keyof HTMLAttributes<HTMLDivElement>, string>>,
-    keyof EuiOverlayMaskProps
-  > &
+  HTMLAttributes<HTMLDivElement> &
   EuiOverlayMaskProps;
 
 export class EuiOverlayMask extends Component<Props> {

--- a/src/components/overlay_mask/overlay_mask.tsx
+++ b/src/components/overlay_mask/overlay_mask.tsx
@@ -10,7 +10,7 @@ import { CommonProps, keysOf, Omit } from '../common';
 
 export interface EuiOverlayMaskProps {
   onClick?: () => void;
-  children?: ReactNode;
+  children: ReactNode;
 }
 
 export type Props = CommonProps &

--- a/src/components/overlay_mask/overlay_mask.tsx
+++ b/src/components/overlay_mask/overlay_mask.tsx
@@ -3,17 +3,21 @@
  * into portals.
  */
 
-import { Component, HTMLAttributes } from 'react';
+import { Component, HTMLAttributes, ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import classNames from 'classnames';
 import { CommonProps, keysOf, Omit } from '../common';
 
 export interface EuiOverlayMaskProps {
   onClick?: () => void;
+  children?: ReactNode;
 }
 
 export type Props = CommonProps &
-  Omit<HTMLAttributes<HTMLDivElement>, 'onClick'> &
+  Omit<
+    Partial<Record<keyof HTMLAttributes<HTMLDivElement>, string>>,
+    keyof EuiOverlayMaskProps
+  > &
   EuiOverlayMaskProps;
 
 export class EuiOverlayMask extends Component<Props> {

--- a/src/components/overlay_mask/overlay_mask.tsx
+++ b/src/components/overlay_mask/overlay_mask.tsx
@@ -6,14 +6,14 @@
 import { Component, HTMLAttributes } from 'react';
 import { createPortal } from 'react-dom';
 import classNames from 'classnames';
-import { CommonProps, keysOf } from '../common';
+import { CommonProps, keysOf, Omit } from '../common';
 
 export interface EuiOverlayMaskProps {
   onClick?: () => void;
 }
 
 export type Props = CommonProps &
-  HTMLAttributes<HTMLDivElement> &
+  Omit<HTMLAttributes<HTMLDivElement>, 'onClick'> &
   EuiOverlayMaskProps;
 
 export class EuiOverlayMask extends Component<Props> {


### PR DESCRIPTION
### Summary

Fixes `children` interface mismatches (below), which relates to the now-known #1890 about `children` element type restrictions/modifications. The type changes are not as well-defined as we'd like, but there is not good workaround yet.

```ts
Type 'Element' is not assignable to type 'string | ({} & string) | (ReactElement<any, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)> | null) | (new (props: any) => Component<any, any, any>)> & string) | (ReactNodeArray & string) | (ReactPortal & string) | undefined'.
  Type 'Element' is not assignable to type 'ReactPortal & string'.
    Type 'Element' is not assignable to type 'ReactPortal'.
```

### Checklist

~~- [ ] This was checked in mobile~~
~~- [ ] This was checked in IE11~~
~~- [ ] This was checked in dark mode~~
~~- [ ] Any props added have proper autodocs~~
~~- [ ] Documentation examples were added~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately

~~- [ ] This was checked for breaking changes and labeled appropriately~~
~~- [ ] Jest tests were updated or added to match the most common scenarios~~
~~- [ ] This was checked against keyboard-only and screenreader scenarios~~
~~- [ ] This required updates to Framer X components~~
