### PR TITLE
Fix overflow of EuiModals in Chrome and Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `10.2.1`.
+**Bug fixes**
+
+- Fixed overflow scrolling of `EuiModal` and `EuiConfirmModal` for Chrome and Safari ([#1902](https://github.com/elastic/eui/pull/1902))
 
 ## [`10.2.1`](https://github.com/elastic/eui/tree/v10.2.1)
 

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -27,7 +27,6 @@
 }
 
 .euiModal--maxWidth-default {
-  width: 100%; // Needed for IE
   max-width: map-get($euiBreakpoints, 'm');
 }
 

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -27,6 +27,7 @@
 }
 
 .euiModal--maxWidth-default {
+  width: 100%; // Needed for IE
   max-width: map-get($euiBreakpoints, 'm');
 }
 
@@ -51,6 +52,9 @@
   @include euiOverflowShadow;
   flex-grow: 1;
   overflow: hidden;
+  // The below fixes scroll on Chrome and Safari
+  display: flex;
+  flex-direction: column;
 
   .euiModalBody__overflow {
     @include euiScrollBar;


### PR DESCRIPTION
Chrome 74 broke our implementation of overflow scrolling in modals. This adds an extra flex layer to ensure that scrolling works.

**Before**

<img width="1059" alt="Screen Shot 2019-04-30 at 12 24 44 PM" src="https://user-images.githubusercontent.com/549577/56977359-fdb4aa00-6b42-11e9-8440-5f9e1c4073db.png">


**After**

<img width="1059" alt="Screen Shot 2019-04-30 at 12 24 19 PM" src="https://user-images.githubusercontent.com/549577/56977362-00af9a80-6b43-11e9-9dff-4c3e07634b6d.png">

---


I have checked in:

**Mac 10.14**
- [x] Chrome 74
- [x] Safari 12
- [x] Firefox 66

**Windows 7**
- [x] IE11
- [x] Chrome 73

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- ~[ ] This was checked in dark mode~
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
