### PR TITLE
Fix EuiFilePicker's prompt to properly reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `10.2.1`.
+**Bug fixes**
+
+- Fixed prompt text rendering in `EuiFilePicker` when a React element is passed ([#1903](https://github.com/elastic/eui/pull/1903))
 
 ## [`10.2.1`](https://github.com/elastic/eui/tree/v10.2.1)
 

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -115,7 +115,7 @@
       .euiFilePicker--compressed#{&} {
         @include euiFormControlLayoutClearIcon('.euiFilePicker__clearIcon');
         position: absolute;
-        top: $euiSizeM / 2;
+        top: $euiSizeS;
         right: $euiSizeM;
       }
     }

--- a/src/components/form/file_picker/file_picker.js
+++ b/src/components/form/file_picker/file_picker.js
@@ -35,7 +35,7 @@ export class EuiFilePicker extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      promptText: this.props.initialPromptText,
+      promptText: null,
       isHoveringDrop: false,
     };
   }
@@ -44,7 +44,7 @@ export class EuiFilePicker extends Component {
     if (this.fileInput.files && this.fileInput.files.length > 1) {
       this.setState({ promptText: `${this.fileInput.files.length} ${filesSelected}` });
     } else if (this.fileInput.files.length === 0) {
-      this.setState({ promptText: this.props.initialPromptText });
+      this.setState({ promptText: null });
     } else {
       this.setState({ promptText: this.fileInput.value.split('\\').pop() });
     }
@@ -91,18 +91,20 @@ export class EuiFilePicker extends Component {
             ...rest
           } = this.props;
 
+          const isOverridingInitialPrompt = this.state.promptText != null;
+
           const classes = classNames(
             'euiFilePicker',
             {
               'euiFilePicker__showDrop': this.state.isHoveringDrop,
               'euiFilePicker--compressed': compressed,
-              'euiFilePicker-hasFiles': this.state.promptText !== initialPromptText,
+              'euiFilePicker-hasFiles': isOverridingInitialPrompt,
             },
             className
           );
 
           let clearButton;
-          if (this.state.promptText !== initialPromptText) {
+          if (isOverridingInitialPrompt) {
             if (compressed) {
               clearButton = (
                 <button
@@ -161,7 +163,7 @@ export class EuiFilePicker extends Component {
                   <div
                     className="euiFilePicker__promptText"
                   >
-                    {this.state.promptText}
+                    {this.state.promptText || initialPromptText}
                   </div>
                   {clearButton}
                 </div>


### PR DESCRIPTION
### Summary

Fixes #1897 

`EuiFilePicker` would store `initialPromptText` in state, updating the value when the file selection changed. This introduced two bugs:

* If `initialPromptText` prop changed, the rendered text wouldn't update
* The component considered a selection to exist if the its prompt state did not match the initial prompt. This works when comparing primitive values like strings, but when provided a React element it would get confused on the next render as the element representation is an object resulting from `React.createElement`. This is reproducible by passing `initialPromptText={<span>Select or drag and drop multiple files</span>}`.

The fix is to avoid storing the initial prompt in state. Always pulling it from props keeps the rendered text up to date and allows it to know when the prompt text is being overridden.

I attempted to write a unit test to cover but couldn't get JSDOM to accept a FileList on the input element. This comment (related thread) got the closest https://github.com/jsdom/jsdom/issues/1272#issuecomment-486088445

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
