### PR TITLE
[Docs]: Allow multiple snippets

### DIFF
--- a/src-docs/src/components/guide_section/guide_section.js
+++ b/src-docs/src/components/guide_section/guide_section.js
@@ -158,14 +158,28 @@ export class GuideSection extends Component {
       return;
     }
 
-    return [
-      <Fragment key="snippet">
-        <EuiSpacer size="m" />
-        <EuiCodeBlock language="html" fontSize="m" paddingSize="m" isCopyable>
-          {snippet}
-        </EuiCodeBlock>
-      </Fragment>
-    ];
+    let snippetCode;
+    if (typeof snippet === 'string') {
+      snippetCode = (
+        <Fragment key="snippet">
+          <EuiSpacer size="m" />
+          <EuiCodeBlock language="html" fontSize="m" paddingSize="m" isCopyable>
+            {snippet}
+          </EuiCodeBlock>
+        </Fragment>
+      );
+    } else {
+      snippetCode = snippet.map((snip, index) => (
+        <Fragment key={`snippet${index}`}>
+          <EuiSpacer size="m" />
+          <EuiCodeBlock language="html" fontSize="m" paddingSize="m" isCopyable>
+            {snip}
+          </EuiCodeBlock>
+        </Fragment>
+      ));
+    }
+
+    return snippetCode;
   }
 
   renderPropsForComponent = (componentName, component) => {
@@ -413,7 +427,10 @@ GuideSection.propTypes = {
   title: PropTypes.string,
   id: PropTypes.string,
   source: PropTypes.array,
-  snippet: PropTypes.string,
+  snippet: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]),
   children: PropTypes.any,
   toggleTheme: PropTypes.func.isRequired,
   theme: PropTypes.string.isRequired,

--- a/src-docs/src/views/icon/icon_example.js
+++ b/src-docs/src/views/icon/icon_example.js
@@ -31,17 +31,15 @@ const iconsSnippet = `<EuiIcon type="alert" />`;
 
 import Tokens from './tokens';
 const tokensSource = require('!!raw-loader!./tokens');
-const tokensSnippet = `<EuiToken type="tokenAnnotation" />
-
-<EuiToken
+const tokensSnippet = [`<EuiToken type="tokenAnnotation" />`,
+  `<EuiToken
   iconType="visMapCoordinate"
   displayOptions={{
     color: 'tokenTint05',
     shape: 'circle',
   }}
-/>
-
-<EuiToken
+/>`,
+  `<EuiToken
   iconType="tokenElement"
   size="l"
   displayOptions={{
@@ -49,7 +47,7 @@ const tokensSnippet = `<EuiToken type="tokenAnnotation" />
     shape: 'rectangle',
     hideBorder: true
   }}
-/>`;
+/>`];
 
 
 import Apps from './apps';
@@ -74,23 +72,18 @@ const iconSizesSnippet = `<EuiIcon type="logoElasticStack" size="xl" />`;
 
 import IconColors from './icon_colors';
 const iconColorsSource = require('!!raw-loader!./icon_colors');
-const iconColorsSnippet = `<EuiIcon type="brush" color="primary" />
-
-<EuiIcon type="brush" color="#F98510" />`;
+const iconColorsSnippet = [`<EuiIcon type="brush" color="primary" />`,
+  `<EuiIcon type="brush" color="#F98510" />`];
 
 import Accessibility from './accessibility';
 const accessibilitySource = require('!!raw-loader!./accessibility');
 
 import IconTypes from './icon_types';
 const iconTypesSource = require('!!raw-loader!./icon_types');
-const iconTypesSnippet = `<EuiIcon type="logoElastic" size="xl" />
-
-<EuiIcon type={reactSVGElement} size="xl" />
-
-<EuiIcon type="https://upload.wikimedia.org/wikipedia/commons/9/9f/Vimlogo.svg" size="xl" />
-
-<EuiButton iconType={reactSVGElement}>Works in other components too</EuiButton>
-`;
+const iconTypesSnippet = [`<EuiIcon type="logoElastic" size="xl" />`,
+  `<EuiIcon type={reactSVGElement} size="xl" />`,
+  `<EuiIcon type="https://upload.wikimedia.org/wikipedia/commons/9/9f/Vimlogo.svg" size="xl" />`,
+  `<EuiButton iconType={reactSVGElement}>Works in other components too</EuiButton>`];
 
 export const IconExample = {
   title: 'Icons',


### PR DESCRIPTION
You can now also pass an array of strings to break the snippets into multiples. This is helpful for copy and pasting single snippets. It renders like so:

<img width="963" alt="Screen Shot 2019-05-01 at 11 16 38 AM" src="https://user-images.githubusercontent.com/549577/57037003-f0232100-6c23-11e9-8676-7b521cda5971.png">
