### PR TITLE
[Firefox] Remove `background-color` from transition property list of form control mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `10.4.0`
+**Bug fixes**
+
+- Fixed Firefox flash of unstyled select dropdown ([#1927](https://github.com/elastic/eui/pull/1927))
 
 ## [`10.4.0`](https://github.com/elastic/eui/tree/v10.4.0)
 

--- a/src/components/form/_mixins.scss
+++ b/src/components/form/_mixins.scss
@@ -93,9 +93,16 @@
 
   transition:
     box-shadow $euiAnimSpeedFast ease-in,
-    background-color $euiAnimSpeedFast ease-in,
     background-image $euiAnimSpeedFast ease-in,
-    background-size $euiAnimSpeedFast ease-in;
+    background-size $euiAnimSpeedFast ease-in,
+    background-color $euiAnimSpeedFast ease-in;
+
+  // Fixes bug in Firefox where adding a transition to the background-color
+  // caused a flash of differently styled dropdown.
+  @supports (-moz-appearance: none) { // sass-lint:disable-line no-vendor-prefixes
+    // List *must* be in the same order as the above.
+    transition-property: box-shadow, background-image, background-size;
+  }
 }
 
 @mixin euiFormControlFocusStyle($borderOnly: false) {


### PR DESCRIPTION
# Fixes #1385

For firefox only to fix the flash of unstyled dropdown.

## Before 

<img src="https://user-images.githubusercontent.com/809707/50233116-ffab7700-03b2-11e9-96f5-3784026f44db.gif" width="50%" />


## After

<img src="https://d.pr/free/i/KApkOt+" width="50%" />

### Checklist

- ~[ ] This was checked in mobile~
- ~[ ] This was checked in IE11~
- ~[ ] This was checked in dark mode~
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
