### PR TITLE
Fix EuiIconTip TS types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `11.0.0`.
+**Bug fixes**
+
+- Fixed `EuiIconTip`'s typescript definition ([#1934](https://github.com/elastic/eui/pull/1934))
 
 ## [`11.0.0`](https://github.com/elastic/eui/tree/v11.0.0)
 

--- a/src/components/tool_tip/index.d.ts
+++ b/src/components/tool_tip/index.d.ts
@@ -1,6 +1,6 @@
 export { EuiToolTipPopover } from './tool_tip_popover';
 import { ReactElement, ReactNode, FunctionComponent } from 'react';
-import { EuiIcon } from '../icon';
+import { EuiIcon, IconType } from '../icon';
 import { Omit, PropsOf } from '../common';
 
 declare module '@elastic/eui' {
@@ -28,10 +28,15 @@ declare module '@elastic/eui' {
 
   export interface EuiIconTipProps {
     color?: string;
-    type?: string;
+    type?: IconType;
     size?: string;
     'aria-label'?: string;
-    iconProps?: PropsOf<typeof EuiIcon>;
+
+    // EuiIconTip's `type` is passed to EuiIcon, so we want to exclude `type` from
+    // iconProps; however, due to TS's bivariant function arguments `type` could be
+    // passed without any error/feedback so we explicitly set it to `never` type
+    iconProps?: Omit<PropsOf<EuiIcon>, 'type'> & { type?: never };
   }
+
   export const EuiIconTip: FunctionComponent<Omit<EuiToolTipProps, 'children'> & EuiIconTipProps>;
 }


### PR DESCRIPTION
### Summary

The expansion of EuiIcon's _IconType_ made the EuiIconTip definition unhappy. I've tested this change in Kibana locally and verified that its type_check script completes successfully.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
