### PR TITLE
Handle EuiIcon `type` prop updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `11.0.0`.
+**Bug fixes**
+
+- Reinstated `EuiIcon` component ability to handle `type` prop updates ([#1935](https://github.com/elastic/eui/pull/1935))
 
 ## [`11.0.0`](https://github.com/elastic/eui/tree/v11.0.0)
 

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -414,19 +414,13 @@ export class EuiIcon extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
-    const initialIcon = getInitialIcon(this.props.type);
+    const { type } = this.props;
+    const initialIcon = getInitialIcon(type);
     let isLoading = false;
 
-    if (isEuiIconType(this.props.type)) {
+    if (isEuiIconType(type)) {
       isLoading = true;
-      import('./assets/' + typeToPathMap[this.props.type] + '.js').then(
-        ({ icon }) => {
-          this.setState({
-            icon,
-            isLoading: false,
-          });
-        }
-      );
+      this.loadIconComponent(type);
     }
 
     this.state = {
@@ -434,6 +428,32 @@ export class EuiIcon extends Component<Props, State> {
       isLoading,
     };
   }
+
+  componentDidUpdate(prevProps: Props) {
+    const { type } = this.props;
+    if (type !== prevProps.type) {
+      if (isEuiIconType(type)) {
+        this.setState({
+          isLoading: true,
+        });
+        this.loadIconComponent(type);
+      } else {
+        this.setState({
+          icon: type == null ? undefined : type,
+          isLoading: false,
+        });
+      }
+    }
+  }
+
+  loadIconComponent = (iconType: EuiIconType) => {
+    import('./assets/' + typeToPathMap[iconType] + '.js').then(({ icon }) => {
+      this.setState({
+        icon,
+        isLoading: false,
+      });
+    });
+  };
 
   render() {
     const {

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -411,10 +411,11 @@ function getInitialIcon(icon: EuiIconProps['type']) {
 }
 
 export class EuiIcon extends Component<Props, State> {
+  isMounted = true;
   constructor(props: Props) {
     super(props);
 
-    const { type } = this.props;
+    const { type } = props;
     const initialIcon = getInitialIcon(type);
     let isLoading = false;
 
@@ -439,19 +440,25 @@ export class EuiIcon extends Component<Props, State> {
         this.loadIconComponent(type);
       } else {
         this.setState({
-          icon: type == null ? undefined : type,
+          icon: type,
           isLoading: false,
         });
       }
     }
   }
 
+  componentWillUnmount() {
+    this.isMounted = false;
+  }
+
   loadIconComponent = (iconType: EuiIconType) => {
     import('./assets/' + typeToPathMap[iconType] + '.js').then(({ icon }) => {
-      this.setState({
-        icon,
-        isLoading: false,
-      });
+      if (this.isMounted) {
+        this.setState({
+          icon,
+          isLoading: false,
+        });
+      }
     });
   };
 


### PR DESCRIPTION
### Summary

`EuiIcon` currently only dynamically imports the icon file once during the `constructor` phase, even if the `type` prop changes at a later time. This PR adds the ability to dynamically import new icon files as the `type` prop changes over the component lifecycle.

### Checklist

~~- [ ] This was checked in mobile~~
~~- [ ] This was checked in IE11~~
~~- [ ] This was checked in dark mode~~
~~- [ ] Any props added have proper autodocs~~
~~- [ ] Documentation examples were added~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately

~~- [ ] This was checked for breaking changes and labeled appropriately~~
~~- [ ] Jest tests were updated or added to match the most common scenarios~~
~~- [ ] This was checked against keyboard-only and screenreader scenarios~~
~~- [ ] This required updates to Framer X components~~
