### PR TITLE
Make EuiOverlayMask children optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Removed unused prop enum of `l` in `EuiButton` ([#1936](https://github.com/elastic/eui/pull/1936))
 - Fixed `EuiSelect` browser event inconsistencies by normalizing `mouseup` propagation ([#1926](https://github.com/elastic/eui/pull/1926))
+- Removed `children` as a required prop for `EuiOverlayMask` ([#1937](https://github.com/elastic/eui/pull/1937))
 
 ## [`11.0.1`](https://github.com/elastic/eui/tree/v11.0.1)
 

--- a/src/components/overlay_mask/overlay_mask.tsx
+++ b/src/components/overlay_mask/overlay_mask.tsx
@@ -10,7 +10,7 @@ import { CommonProps, keysOf, Omit } from '../common';
 
 export interface EuiOverlayMaskProps {
   onClick?: () => void;
-  children: ReactNode;
+  children?: ReactNode;
 }
 
 export type Props = CommonProps &


### PR DESCRIPTION
### Summary

React portals require `ReactNode`, which accepts `null` and `undefined`. `children` can be optional in `EuiOverlayMask` for this reason as it does nothing except pass to a portal.

### Checklist

~~- [ ] This was checked in mobile~~
~~- [ ] This was checked in IE11~~
~~- [ ] This was checked in dark mode~~
~~- [ ] Any props added have proper autodocs~~
~~- [ ] Documentation examples were added~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately

~~- [ ] This was checked for breaking changes and labeled appropriately~~
~~- [ ] Jest tests were updated or added to match the most common scenarios~~
~~- [ ] This was checked against keyboard-only and screenreader scenarios~~
~~- [ ] This required updates to Framer X components~~
