### PR TITLE
Added width to FlexItem when gutter in FlexGrid is set to none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Converted `pretty_interval` to TS ([#1920](https://github.com/elastic/eui/pull/1920))
 - Converted `relative_options` to TS ([#1921](https://github.com/elastic/eui/pull/1921))
-- Added width to `EUIFlexItem` when gutter in `EUIFlexGrid` is set to none. ([#1941](https://github.com/elastic/eui/pull/1941))
+- Added width to `EuiFlexItem` when gutter in `EuiFlexGrid` is set to none. ([#1941](https://github.com/elastic/eui/pull/1941))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Converted `pretty_interval` to TS ([#1920](https://github.com/elastic/eui/pull/1920))
 - Converted `relative_options` to TS ([#1921](https://github.com/elastic/eui/pull/1921))
+- Added width to `EUIFlexItem` when gutter in `EUIFlexGrid` is set to none. ([#1941](https://github.com/elastic/eui/pull/1941))
 
 **Bug fixes**
 

--- a/src/components/flex/__snapshots__/flex_grid.test.tsx.snap
+++ b/src/components/flex/__snapshots__/flex_grid.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`EuiFlexGrid props gutterSize m is rendered 1`] = `
 
 exports[`EuiFlexGrid props gutterSize none is rendered 1`] = `
 <div
-  class="euiFlexGrid euiFlexGrid--wrap euiFlexGrid--responsive"
+  class="euiFlexGrid euiFlexGrid--gutterNone euiFlexGrid--wrap euiFlexGrid--responsive"
 />
 `;
 

--- a/src/components/flex/_flex_grid.scss
+++ b/src/components/flex/_flex_grid.scss
@@ -15,6 +15,7 @@
 }
 
 $gutterTypes: (
+  // We're using calc which requires the px unit
   gutterNone: 0px, // sass-lint:disable-line zero-unit
   gutterSmall: $euiSizeS,
   gutterMedium: $euiSize,

--- a/src/components/flex/_flex_grid.scss
+++ b/src/components/flex/_flex_grid.scss
@@ -15,6 +15,7 @@
 }
 
 $gutterTypes: (
+  gutterNone: 0px, // sass-lint:disable-line zero-unit
   gutterSmall: $euiSizeS,
   gutterMedium: $euiSize,
   gutterLarge: $euiSizeL,

--- a/src/components/flex/flex_grid.tsx
+++ b/src/components/flex/flex_grid.tsx
@@ -13,7 +13,7 @@ export interface EuiFlexGridProps {
 }
 
 const gutterSizeToClassNameMap = {
-  none: null,
+  none: 'euiFlexGrid--gutterNone',
   s: 'euiFlexGrid--gutterSmall',
   m: 'euiFlexGrid--gutterMedium',
   l: 'euiFlexGrid--gutterLarge',


### PR DESCRIPTION
### Summary

Added width to `EUIFlexItem` when gutter in `EUIFlexGrid` is set to none. To fix #1493 

Before (2 columns)
![image](https://user-images.githubusercontent.com/4016496/57545719-145fbb80-7310-11e9-811d-ad417df6a450.png)
After (2 columns)
![image](https://user-images.githubusercontent.com/4016496/57545767-36f1d480-7310-11e9-8088-617786f5632c.png)


### Checklist

- ~[ ] This was checked in mobile~
- ~[ ] This was checked in IE11~
- ~[ ] This was checked in dark mode~
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
