### PR TITLE
EuiDraggable, EuiDroppable should support the 'data-test-subj' property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Removed unused prop enum of `l` in `EuiButton` ([#1936](https://github.com/elastic/eui/pull/1936))
 - Fixed `EuiSelect` browser event inconsistencies by normalizing `mouseup` propagation ([#1926](https://github.com/elastic/eui/pull/1926))
 - Removed `children` as a required prop for `EuiOverlayMask` ([#1937](https://github.com/elastic/eui/pull/1937))
+- `EuiDraggable`, `EuiDroppable` should support the `data-test-subj` property ([#1943](https://github.com/elastic/eui/pull/1943))
 
 ## [`11.0.1`](https://github.com/elastic/eui/tree/v11.0.1)
 

--- a/src/components/drag_and_drop/draggable.tsx
+++ b/src/components/drag_and_drop/draggable.tsx
@@ -51,6 +51,7 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
   className,
   spacing = 'none',
   style,
+  'data-test-subj': dataTestSubj = 'draggable',
   ...rest
 }) => {
   const { cloneItems } = useContext(EuiDroppableContext);
@@ -85,7 +86,7 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
               {...provided.draggableProps}
               {...(!customDragHandle ? provided.dragHandleProps : {})}
               ref={provided.innerRef}
-              data-test-subj="draggable"
+              data-test-subj={dataTestSubj}
               className={classes}
               style={{ ...style, ...provided.draggableProps.style }}>
               {cloneElement(DraggableElement, {

--- a/src/components/drag_and_drop/droppable.tsx
+++ b/src/components/drag_and_drop/droppable.tsx
@@ -59,6 +59,7 @@ export const EuiDroppable: FunctionComponent<EuiDroppableProps> = ({
   type = 'EUI_DEFAULT',
   withPanel = false,
   grow = false,
+  'data-test-subj': dataTestSubj = 'droppable',
   ...rest
 }) => {
   const { isDraggingType } = useContext(EuiDragDropContextContext);
@@ -96,7 +97,7 @@ export const EuiDroppable: FunctionComponent<EuiDroppableProps> = ({
             {...provided.droppableProps}
             ref={provided.innerRef}
             style={style}
-            data-test-subj="droppable"
+            data-test-subj={dataTestSubj}
             className={classes}>
             <EuiDroppableContext.Provider
               value={{


### PR DESCRIPTION
Fix: #1898

### Summary

EuiDraggable, EuiDroppable should support the 'data-test-subj' property

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
- [x] Any props added have proper autodocs
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios
- [x] This was checked against keyboard-only and screenreader scenarios
- [x] This required updates to Framer X components
