### PR TITLE
Add a webpack directive for naming icon chunks

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,4 +1,9 @@
 module.exports = {
+  // We need to preserve comments as they are used by webpack for
+  // naming chunks during code-splitting. The compression step during
+  // bundling will remove them later.
+  "comments": true,
+
   "presets": [
     ["@babel/env", {
       "targets": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Update `caniuse-lite` version resolution ([#1970](https://github.com/elastic/eui/pull/1970))
+- Add a webpack directive for naming icon chunks ([#1944])(https://github.com/elastic/eui/pull/1944))
 
 ## [`11.2.1`](https://github.com/elastic/eui/tree/v11.2.1)
 

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -452,7 +452,11 @@ export class EuiIcon extends Component<Props, State> {
   }
 
   loadIconComponent = (iconType: EuiIconType) => {
-    import('./assets/' + typeToPathMap[iconType] + '.js').then(({ icon }) => {
+    import(
+      /* webpackChunkName: "icon.[request]" */ './assets/' +
+        typeToPathMap[iconType] +
+        '.js'
+    ).then(({ icon }) => {
       if (this.isMounted) {
         this.setState({
           icon,


### PR DESCRIPTION
This PR adds a webpack directive (i.e. a comment) for naming icon chunks. The effect of this is obesrved in applications that use EUI and bundle through Webpack - instead of icon chunks such as e.g.

    233.longhashgoeshereomgitssolong.js

you get:

    icon.app-kibana-js.longhashgoeshereomgitssolong.js

It's a small thing, but if a dynamic download were to fail then it might make tracking down the problem fractionally easier.

I think it still works if you drop the file extension from the `import()`, which means you get a cleaner `[request]` value, but I thought I'd ask about that rather than just doing, since the `.js` assets live alongside the `.svg` assets.