### PR TITLE
EuiToast title prop should accept a node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `11.2.0`.
+**Bug fixes**
+
+- Fixes type mismatch between PropType and TypeScript def for `EuiToast` `title` ([#1962](https://github.com/elastic/eui/pull/1962))
 
 ## [`11.2.0`](https://github.com/elastic/eui/tree/v11.2.0)
 

--- a/src/components/toast/index.d.ts
+++ b/src/components/toast/index.d.ts
@@ -2,7 +2,7 @@ import {
   EuiGlobalToastListItemProps as ToastListItemProps,
   EuiGlobalToastListItem as ToastListItem,
 } from './global_toast_list_item';
-import { CommonProps } from '../common';
+import { CommonProps, Omit } from '../common';
 import { IconType } from '../icon';
 
 import {
@@ -10,6 +10,7 @@ import {
   FunctionComponent,
   HTMLAttributes,
   ReactChild,
+  ReactNode,
 } from 'react';
 
 declare module '@elastic/eui' {
@@ -20,11 +21,11 @@ declare module '@elastic/eui' {
    */
   export interface EuiToastProps
     extends CommonProps,
-      HTMLAttributes<HTMLDivElement> {
-    title?: string,
-    color?: 'primary' | 'success' | 'warning' | 'danger',
-    iconType?: IconType,
-    onClose?: () => void,
+      Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
+    title?: ReactNode;
+    color?: 'primary' | 'success' | 'warning' | 'danger';
+    iconType?: IconType;
+    onClose?: () => void;
   }
 
   export const EuiToast: FunctionComponent<EuiToastProps>;


### PR DESCRIPTION
### Summary

Fixes #1957, which points out that we had a type mismatch for the `title` prop in EuiToast (PropType: `node`; d.ts: `string`). We've generally allowed for more flexibility, so TypeScript will now accept `ReactNode` instead of `string`.

### Checklist

~~- [ ] This was checked in mobile~~
~~- [ ] This was checked in IE11~~
~~- [ ] This was checked in dark mode~~
~~- [ ] Any props added have proper autodocs~~
~~- [ ] Documentation examples were added~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately

~~- [ ] Jest tests were updated or added to match the most common scenarios~~
~~- [ ] This was checked against keyboard-only and screenreader scenarios~~
~~- [ ] This required updates to Framer X components~~
