### PR TITLE
Update README.md with example for react-router v5

### DIFF
--- a/wiki/react-router.md
+++ b/wiki/react-router.md
@@ -249,14 +249,14 @@ export const getRouterLinkProps = to => {
 ## react-router 5.x
 
 The React Context handling has changed in in 5.0 and we can't rely on it anymore. A solution is to create
-a `catchRouter` HOC that will intercept the router and send it to your custom handler.
+an `extractRouter` HOC that will intercept the router and send it to your custom handler.
 
 
 ```js
-// catchRouter.hoc.js
+// extractRouter.hoc.js
 import { withRouter } from 'react-router-dom';
 
-export const catchRouter = onRouter => WrappedComponent =>
+export const extractRouter = onRouter => WrappedComponent =>
   withRouter(
     class extends Component {
       componentDidMount() {
@@ -273,7 +273,7 @@ export const catchRouter = onRouter => WrappedComponent =>
 ```
 
 ```jsx
-import { catchRouter } from './hoc';
+import { extractRouter } from './hoc';
 import { registerRouter } from './routing';
 
 // App is your app's root component.
@@ -281,7 +281,7 @@ class App extends Component {
   ...
 }
 
-const AppMount = catchRouter(registerRouter)(App);
+const AppMount = extractRouter(registerRouter)(App);
 
 // <App> *must* be a child of <Router> because <App> depends on the context provided by <Router>
 ReactDOM.render(

--- a/wiki/react-router.md
+++ b/wiki/react-router.md
@@ -261,7 +261,8 @@ export const catchRouter = onRouter => WrappedComponent =>
     class extends Component {
       componentDidMount() {
         const { match, location, history } = this.props;
-        onRouter({ match, location, history });
+        const router = { route: { match, location }, history };
+        onRouter(router);
       }
 
       render() {

--- a/wiki/react-router.md
+++ b/wiki/react-router.md
@@ -248,13 +248,49 @@ export const getRouterLinkProps = to => {
 
 ## react-router 5.x
 
-`react-router` 5.0 was released and it was supposed to be completely backward compatible with
-4.x.
+The React Context handling has changed in in 5.0 and we can't rely on it anymore. A solution is to create
+a `catchRouter` HOC that will intercept the router and send it to your custom handler.
 
-However, they changed something about their React Context handling in 5.0, [which may be
-a bug](https://github.com/ReactTraining/react-router/issues/6672), but it completely breaks
-the 4.x variant of this code. Use [`react-router` 4.x](#react-router-4x) until this is
-clarified.
+
+```js
+// catchRouter.hoc.js
+import { withRouter } from 'react-router-dom';
+
+export const catchRouter = onRouter => WrappedComponent =>
+  withRouter(
+    class extends Component {
+      componentDidMount() {
+        const { match, location, history } = this.props;
+        onRouter({ match, location, history });
+      }
+
+      render() {
+        return <WrappedComponent {...this.props} />;
+      }
+    }
+  );
+```
+
+```jsx
+import { catchRouter } from './hoc';
+import { registerRouter } from './routing';
+
+// App is your app's root component.
+class App extends Component {
+  ...
+}
+
+const AppMount = catchRouter(registerRouter)(App);
+
+// <App> *must* be a child of <Router> because <App> depends on the context provided by <Router>
+ReactDOM.render(
+  <Router>
+    <AppMount />,
+  </Router>,
+  appRoot
+)
+```
+
 
 ## Techniques we don't recommend
 


### PR DESCRIPTION
This PR adds the documentation on how we can forward the router with `v5`. 

I found the solution while testing with `react-router 5.0.0` installed and had to make my tests pass.
You can see here the change I had to make: https://github.com/elastic/kibana/pull/36871/files#diff-45ba9f8ef2d45b26681f545635cb504dR24