### PR TITLE
Add missing TS definition for EuiFieldText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Added missing TypeScript definition for `EuiFieldText`'s `compressed` prop. ([#1977](https://github.com/elastic/eui/pull/1977))
+- Added missing TypeScript definition for `EuiFieldText`'s `compressed` prop ([#1977](https://github.com/elastic/eui/pull/1977))
 - Converted `EuiTableRowCellCheckbox` to TS ([#1964](https://github.com/elastic/eui/pull/1964))
 - Update `caniuse-lite` version resolution ([#1970](https://github.com/elastic/eui/pull/1970))
 - Add a webpack directive for naming icon chunks ([#1944])(https://github.com/elastic/eui/pull/1944))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Add missing TypeScript definition for `EuiFieldText`'s `compressed` prop. ([#1977](https://github.com/elastic/eui/pull/1977))
+- Added missing TypeScript definition for `EuiFieldText`'s `compressed` prop. ([#1977](https://github.com/elastic/eui/pull/1977))
 - Converted `EuiTableRowCellCheckbox` to TS ([#1964](https://github.com/elastic/eui/pull/1964))
 - Update `caniuse-lite` version resolution ([#1970](https://github.com/elastic/eui/pull/1970))
 - Add a webpack directive for naming icon chunks ([#1944])(https://github.com/elastic/eui/pull/1944))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Add missing TypeScript definition for `EuiFieldText`'s `compressed` prop. ([#1977](https://github.com/elastic/eui/pull/1977))
 - Converted `EuiTableRowCellCheckbox` to TS ([#1964](https://github.com/elastic/eui/pull/1964))
 - Update `caniuse-lite` version resolution ([#1970](https://github.com/elastic/eui/pull/1970))
 - Add a webpack directive for naming icon chunks ([#1944])(https://github.com/elastic/eui/pull/1944))

--- a/src/components/form/field_text/index.d.ts
+++ b/src/components/form/field_text/index.d.ts
@@ -17,6 +17,7 @@ declare module '@elastic/eui' {
     isLoading?: boolean;
     prepend?: React.ReactNode;
     append?: React.ReactNode;
+    compressed?: boolean;
   }
 
   export const EuiFieldText: FunctionComponent<


### PR DESCRIPTION
### Summary

Add missing TypeScript definition for `EuiFieldText`'s `compressed` prop.

This changes are needed for the PR https://github.com/elastic/kibana/pull/37476

### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
