### PR TITLE
EuiGlobalToastList toasts title prop should accept a node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fixed environment setup for running `test-unit` script on Windows ([#1971](https://github.com/elastic/eui/pull/1971))
 - Fixed focus on single selection of EuiComboBox ([#1965](https://github.com/elastic/eui/pull/1965))
+- Fixed type mismatch between PropType and TypeScript def for `EuiGlobalToastList` toast `title` ([#1978](https://github.com/elastic/eui/pull/1978))
 
 ## [`11.2.1`](https://github.com/elastic/eui/tree/v11.2.1)
 

--- a/src/components/toast/global_toast_list.js
+++ b/src/components/toast/global_toast_list.js
@@ -35,7 +35,7 @@ export class EuiGlobalToastList extends Component {
       PropTypes.shape({
         id: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
           .isRequired,
-        title: PropTypes.string,
+        title: PropTypes.node,
         text: PropTypes.node,
         color: PropTypes.string,
         iconType: IconPropType,


### PR DESCRIPTION
Summary
Updates fix for #1957 to fix mismatch with defined toast prop type in EuiGlobalToastList.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
