### PR TITLE
Fix missing typescript for EuiButton color="text"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed environment setup for running `test-unit` script on Windows ([#1971](https://github.com/elastic/eui/pull/1971))
 - Fixed focus on single selection of EuiComboBox ([#1965](https://github.com/elastic/eui/pull/1965))
 - Fixed type mismatch between PropType and TypeScript def for `EuiGlobalToastList` toast `title` ([#1978](https://github.com/elastic/eui/pull/1978))
+- Fixed missing Typescript definition for `EuiBUtton`'s `color="text"` option
 
 ## [`11.2.1`](https://github.com/elastic/eui/tree/v11.2.1)
 

--- a/src/components/button/index.d.ts
+++ b/src/components/button/index.d.ts
@@ -23,7 +23,8 @@ declare module '@elastic/eui' {
     | 'secondary'
     | 'warning'
     | 'danger'
-    | 'ghost';
+    | 'ghost'
+    | 'text';
   export type ButtonSize = 's' | 'm' | 'l';
 
   export interface EuiButtonProps {


### PR DESCRIPTION
### Summary

I found that this type definition was missing when trying to use `<EuiButton color="text">` in a typescript file.

### Checklist

- ~[ ] This was checked in mobile~
- ~[ ] This was checked in IE11~
- ~[ ] This was checked in dark mode~
- [x] Any props added have proper autodocs
- ~[ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
