### PR TITLE
Fix toggle pointer events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed type mismatch between PropType and TypeScript def for `EuiGlobalToastList` toast `title` ([#1978](https://github.com/elastic/eui/pull/1978))
 - Fixed missing Typescript definition for `EuiButton`'s `color="text"` option ([#1980](https://github.com/elastic/eui/pull/1980))
 - Fixed Prettier formatting lint error in `EuiTable` TS def file ([#1986](https://github.com/elastic/eui/pull/1986))
+- Fixed `EuiToggle` pointer events for those using icons only ([#1991](https://github.com/elastic/eui/pull/1991))
 
 ## [`11.2.1`](https://github.com/elastic/eui/tree/v11.2.1)
 

--- a/src/components/toggle/_toggle.scss
+++ b/src/components/toggle/_toggle.scss
@@ -5,6 +5,7 @@
 
   .euiToggle__input {
     @include euiHiddenSelectableInput;
+    z-index: 1; // Increase z-index to ensure the input receives the pointer events
 
     &:disabled {
       cursor: not-allowed;


### PR DESCRIPTION
### Fixes #1990 

Setting the z-index to 1 ensures the hidden input for the toggle is the top most element and is the one to receive the pointer events.

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- ~[ ] This was checked in dark mode~
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
