### PR TITLE
EuiColorPicker `onBlur` & `onFocus` fns are optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `11.3.0`.
+**Bug fixes**
+
+- Fixed optional definitions for `EuiColorPicker` `onBlur` and `onFocus` callbacks ([#1993](https://github.com/elastic/eui/pull/1993))
 
 ## [`11.3.0`](https://github.com/elastic/eui/tree/v11.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Bug fixes**
 
-- Fixed optional definitions for `EuiColorPicker` `onBlur` and `onFocus` callbacks ([#1993](https://github.com/elastic/eui/pull/1993))
+- Fixed optional TS definitions for `EuiColorPicker` `onBlur` and `onFocus` callbacks ([#1993](https://github.com/elastic/eui/pull/1993))
 
 ## [`11.3.0`](https://github.com/elastic/eui/tree/v11.3.0)
 

--- a/src/components/color_picker/index.d.ts
+++ b/src/components/color_picker/index.d.ts
@@ -26,9 +26,9 @@ declare module '@elastic/eui' {
    */
   interface HTMLDivElementOverrides {
     color: string;
-    onBlur: () => void;
+    onBlur?: () => void;
     onChange: (hex: string) => void;
-    onFocus: () => void;
+    onFocus?: () => void;
   }
   export type EuiColorPickerProps = CommonProps &
     Omit<HTMLAttributes<HTMLDivElement>, keyof HTMLDivElementOverrides> &


### PR DESCRIPTION
### Summary

Fixes incorrect type definitions. Optional `onBlur` and `onFocus`

### Checklist

~~- [ ] This was checked in mobile~~
~~- [ ] This was checked in IE11~~
~~- [ ] This was checked in dark mode~~
~~- [ ] Any props added have proper autodocs~~
~~- [ ] Documentation examples were added~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately

~~- [ ] This was checked for breaking changes and labeled appropriately~~
~~- [ ] Jest tests were updated or added to match the most common scenarios~~
~~- [ ] This was checked against keyboard-only and screenreader scenarios~~
~~- [ ] This required updates to Framer X components~~
