### PR TITLE
Reset borders of append/prepend items in EuiFormControlLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `11.3.0`.
+**Bug fixes**
+
+- Fixed double borders on prepend/append items in `EuiFormControlLayout` ([#1996](https://github.com/elastic/eui/pull/1996))
 
 ## [`11.3.0`](https://github.com/elastic/eui/tree/v11.3.0)
 

--- a/src/components/form/form_control_layout/_form_control_layout.scss
+++ b/src/components/form/form_control_layout/_form_control_layout.scss
@@ -30,6 +30,7 @@
     flex-shrink: 0;
     height: $euiFormControlHeight - 2px; /* 1 */
     line-height: $euiFontSize;
+    border: none; // remove any border in case it exists
 
     &:disabled {
       background-color: $euiFormBackgroundDisabledColor;


### PR DESCRIPTION
#1849 Caused a regression with prepend/append items in EuiFormControlLayout when using a EuiFilterButton in either position because the PR added borders to the individual buttons that did not previously exist.

`EuiFormControlLayout` made the assumption that anything being put into prepend/append was not coming with borders and so it only added a dividing border but left any surrounding borders.

**Before**

<img width="143" alt="Screen Shot 2019-06-04 at 18 12 33 PM" src="https://user-images.githubusercontent.com/549577/58917609-26593200-86f5-11e9-8f88-253981648794.png">

This PR just resets/clears any borders for any prepend/append items that may be passed.

**After**

<img width="117" alt="Screen Shot 2019-06-04 at 18 13 23 PM" src="https://user-images.githubusercontent.com/549577/58917640-41c43d00-86f5-11e9-8edc-e16620447519.png">


### Checklist

- ~[ ] This was checked in mobile~
- ~[ ] This was checked in IE11~
- ~[ ] This was checked in dark mode~
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
