### PR TITLE
Fix EuiIcon so webpack can build dynamic require contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Fixed optional TS definitions for `EuiColorPicker` `onBlur` and `onFocus` callbacks ([#1993](https://github.com/elastic/eui/pull/1993))
+- Fixed `EuiIcon` again so that webpack can build dynamic require contexts ([#1998](https://github.com/elastic/eui/pull/1998))
 
 ## [`11.3.0`](https://github.com/elastic/eui/tree/v11.3.0)
 

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -457,9 +457,11 @@ export class EuiIcon extends Component<Props, State> {
 
   loadIconComponent = (iconType: EuiIconType) => {
     import(
-      /* webpackChunkName: "icon.[request]" */ `./assets/${
-        typeToPathMap[iconType]
-      }.js`
+      /* webpackChunkName: "icon.[request]" */
+      // It's important that we don't use a template string here, it
+      // stops webpack from building a dynamic require context.
+      // eslint-disable-next-line prefer-template
+      './assets/' + typeToPathMap[iconType] + '.js'
     ).then(({ icon }) => {
       if (this.isMounted) {
         this.setState({


### PR DESCRIPTION
### Summary

The work to remove TSLint in favour of ESLint has the side effect of "fixing" a lint failure in `EuiIcon`. It changed a plain string concatenation into a string template. Normally this would be fine, but this particular string concatenation is used to load icons dynamically, and Webpack can't build a dynamic require context from the compiled version of the template string.

Revert the change and add a lint directive to stop it recurring.

I built and linked the package, and tried it out in Cloud UI to ensure it was working as expected.

### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
