### PR TITLE
[Docs] Remove duplicate sortable prop

### DIFF
--- a/src-docs/src/views/tables/sorting/sorting.js
+++ b/src-docs/src/views/tables/sorting/sorting.js
@@ -180,7 +180,6 @@ export class Table extends Component {
           const label = online ? 'Online' : 'Offline';
           return <EuiHealth color={color}>{label}</EuiHealth>;
         },
-        sortable: true,
       },
     ];
 


### PR DESCRIPTION
Fixes #2003

### Summary
*Docs-only fix so no CHANGELOG entry*

Remove duplicate `sortable: true` from sorting example in the tables docs.
