### PR TITLE
Fix EuiCallOut icon alignment in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `11.3.1`.
+**Bug fixes**
+
+- Fixed `EuiCallOut` header icon alignment ([#2006](https://github.com/elastic/eui/pull/2006))
 
 ## [`11.3.1`](https://github.com/elastic/eui/tree/v11.3.1)
 

--- a/src/components/call_out/_call_out.scss
+++ b/src/components/call_out/_call_out.scss
@@ -5,6 +5,12 @@
   &.euiCallOut--small {
     padding: $euiSizeS;
   }
+
+  .euiCallOutHeader__icon {
+    flex: 0 0 auto;
+    // Vertically center icon with first line of title
+    transform: translateY(2px);
+  }
 }
 
 // Create callout modifiders based upon the map.
@@ -45,12 +51,4 @@
   .euiCallOut--small & {
     @include euiCallOutTitle('s');
   }
-}
-
-/**
-  * 1. Vertically center icon with first line of title.
-  */
-.euiCallOutHeader__icon {
-  flex: 0 0 auto;
-  transform: translateY(2px) !important; /* 1 */ // sass-lint:disable-line no-important
 }

--- a/src/components/call_out/_call_out.scss
+++ b/src/components/call_out/_call_out.scss
@@ -52,5 +52,5 @@
   */
 .euiCallOutHeader__icon {
   flex: 0 0 auto;
-  transform: translateY(2px); /* 1 */
+  transform: translateY(2px) !important; /* 1 */ // sass-lint:disable-line no-important
 }


### PR DESCRIPTION
`.euiIcon` has a transform applied to it that is overriding  the transform placed on the `.euiCallOutHeader__icon` because the icon file is loaded after the callout file.

<img src="https://d.pr/free/i/1Xqihx+" width="50%" />

Causing:

<img src="https://d.pr/free/i/cp8x7H+" width="50%" />

This PR moves the `.euiCallOutHeader__icon` declaration inside of `.euiCallOutHeader` to increase specificity to override the `.euiIcon` property.

So now:

<img src="https://d.pr/free/i/Bsv6hT+" width="50%" />


### Checklist

- ~[ ] This was checked in mobile~
- ~[ ] This was checked in IE11~
- ~[ ] This was checked in dark mode~
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
