### PR TITLE
[Docs] Fix buttons on colors guideline page

### DIFF
--- a/src-docs/src/views/guidelines/colors.js
+++ b/src-docs/src/views/guidelines/colors.js
@@ -283,7 +283,10 @@ color: $${color2};`;
                         beforeMessage={tooltipContent}
                         textToCopy={textToCopy}>
                         {copy => (
-                          <button type="button" onClick={copy}>
+                          <button
+                            type="button"
+                            onClick={copy}
+                            className="eui-fullWidth eui-textLeft">
                             <p
                               style={{
                                 backgroundColor: palette[color].rgba,

--- a/src-docs/src/views/guidelines/colors.js
+++ b/src-docs/src/views/guidelines/colors.js
@@ -286,17 +286,15 @@ color: $${color2};`;
                           <button
                             type="button"
                             onClick={copy}
-                            className="eui-fullWidth eui-textLeft">
-                            <p
-                              style={{
-                                backgroundColor: palette[color].rgba,
-                                color: palette[color2].rgba,
-                                padding: 6,
-                                marginBottom: 2,
-                                borderRadius: 4,
-                              }}>
-                              {contrastRating} &ensp; {color2}
-                            </p>
+                            className="eui-fullWidth eui-textLeft"
+                            style={{
+                              backgroundColor: palette[color].rgba,
+                              color: palette[color2].rgba,
+                              padding: 6,
+                              marginBottom: 2,
+                              borderRadius: 4,
+                            }}>
+                            {contrastRating} &ensp; {color2}
                           </button>
                         )}
                       </EuiCopy>


### PR DESCRIPTION
### Summary

We had a regression on the docs in https://github.com/elastic/eui/pull/1952 that made the color buttons not full width.

### Before


![image](https://user-images.githubusercontent.com/324519/59062077-d182fc00-8859-11e9-9b2e-51613bae3e89.png)

### After

![image](https://user-images.githubusercontent.com/324519/59061691-e4e19780-8858-11e9-8565-cd7e109d3146.png)

### Checklist

- ~[ ] This was checked in mobile~
- [ ] ~This was checked in IE11~
- [ ] This was checked in dark mode
- [ ] ~Any props added have proper autodocs~
- [ ] Documentation examples were added
- [ ] ~A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
- [ ] ~This was checked for breaking changes and labeled appropriately~
- [ ] ~Jest tests were updated or added to match the most common scenarios~
- [ ] ~This was checked against keyboard-only and screenreader scenarios~
- [ ] ~This required updates to Framer X components~
