### PR TITLE
Change date formatting docs from .sssZ to .SSSZ

### DIFF
--- a/src-docs/src/views/date_picker/date_picker_example.js
+++ b/src-docs/src/views/date_picker/date_picker_example.js
@@ -342,7 +342,7 @@ export const DatePickerExample = {
             <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> date times are
             passed as strings in either datemath format (e.g.: now, now-15m,
             now-15m/m) or as absolute date in the format{' '}
-            <EuiCode>YYYY-MM-DDTHH:mm:ss.sssZ</EuiCode>. Use{' '}
+            <EuiCode>YYYY-MM-DDTHH:mm:ss.SSSZ</EuiCode>. Use{' '}
             <EuiLink href="https://github.com/elastic/datemath-js">
               datemath
             </EuiLink>{' '}

--- a/src/components/date_picker/super_date_picker/super_date_picker.js
+++ b/src/components/date_picker/super_date_picker/super_date_picker.js
@@ -47,12 +47,12 @@ export class EuiSuperDatePicker extends Component {
     isLoading: PropTypes.bool,
     /**
      * String as either datemath (e.g.: now, now-15m, now-15m/m) or
-     * absolute date in the format 'YYYY-MM-DDTHH:mm:ss.sssZ'
+     * absolute date in the format 'YYYY-MM-DDTHH:mm:ss.SSSZ'
      */
     start: PropTypes.string,
     /**
      * String as either datemath (e.g.: now, now-15m, now-15m/m) or
-     * absolute date in the format 'YYYY-MM-DDTHH:mm:ss.sssZ'
+     * absolute date in the format 'YYYY-MM-DDTHH:mm:ss.SSSZ'
      */
     end: PropTypes.string,
     /**
@@ -80,13 +80,13 @@ export class EuiSuperDatePicker extends Component {
 
     /**
      * 'start' and 'end' must be string as either datemath (e.g.: now, now-15m, now-15m/m) or
-     * absolute date in the format 'YYYY-MM-DDTHH:mm:ss.sssZ'
+     * absolute date in the format 'YYYY-MM-DDTHH:mm:ss.SSSZ'
      */
     commonlyUsedRanges: PropTypes.arrayOf(commonlyUsedRangeShape),
     dateFormat: PropTypes.string,
     /**
      * 'start' and 'end' must be string as either datemath (e.g.: now, now-15m, now-15m/m) or
-     * absolute date in the format 'YYYY-MM-DDTHH:mm:ss.sssZ'
+     * absolute date in the format 'YYYY-MM-DDTHH:mm:ss.SSSZ'
      */
     recentlyUsedRanges: PropTypes.arrayOf(recentlyUsedRangeShape),
     /**


### PR DESCRIPTION
### Summary

Fixes #2014, corrects docs typo in recommended moment/date formatting. No changelog as this is a docs-only change.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
- [x] Documentation examples were added
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
