### PR TITLE
Fix Flyout scrolling in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **Bug fixes**
 
+- Fixed Flyout scrolling in Safari ([#2033](https://github.com/elastic/eui/pull/2033))
 - Fixed `EuiCallOut` header icon alignment ([#2006](https://github.com/elastic/eui/pull/2006))
 
 **Breaking changes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 **Bug fixes**
 
-- Fixed Flyout scrolling in Safari ([#2033](https://github.com/elastic/eui/pull/2033))
+- Fixed `EuiFlyout` scrolling in Safari ([#2033](https://github.com/elastic/eui/pull/2033))
 - Fixed `EuiCallOut` header icon alignment ([#2006](https://github.com/elastic/eui/pull/2006))
 
 **Breaking changes**

--- a/src/components/flyout/_flyout.scss
+++ b/src/components/flyout/_flyout.scss
@@ -7,6 +7,7 @@
   top: 0;
   bottom: 0;
   right: 0;
+  height: 100%;
   z-index: $euiZModal;
   background: $euiColorEmptyShade;
   animation: euiFlyout $euiAnimSpeedNormal $euiAnimSlightResistance;

--- a/src/components/flyout/_flyout_body.scss
+++ b/src/components/flyout/_flyout_body.scss
@@ -2,6 +2,7 @@
   @include euiOverflowShadow;
   flex-grow: 1;
   overflow-y: hidden;
+  height: 100%;
 
   .euiFlyoutBody__overflow {
     @include euiScrollBar;


### PR DESCRIPTION
### Summary

This issue was [originally picked up in the Logs UI](https://github.com/elastic/kibana/issues/37699). The changes here allow the body of the Flyout component to scroll in Safari, currently in `master` it won't scroll at all. My understanding is that, according to the Flebox spec, for `height` to take effect it needs to be present throughout the whole Flex hierarchy (so Safari was doing the right thing 😭).

However, these changes do seem to introduce the classic body scrolling issue, which on `master` currently only exists in IE11. By body scrolling issue I mean that when the scrollable area of the flyout is exhausted the body will start to scroll. In the past I've generally solved this with a `noscroll` class on the `body` when the component is open, or hovered (depending on the scenario). Do EUI have a standard way of handling this? 

(Aside: there will also be a Kibana PR to update the legacy style for `.header-global-wrapper + .app-wrapper:not(.hidden-chrome) .euiFlyout`, I'll open that once this PR is merged.).  

### Checklist

- [ ] This was checked in mobile
- [x] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
