### PR TITLE
EuiInMemoryTable: maintain sort values through external item updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Bug fixes**
 
 - Fixed `EuiCallOut` header icon alignment ([#2006](https://github.com/elastic/eui/pull/2006))
+- Fixed `EuiInMemoryTable` sort value persistence through lifecycle updates ([#2035](https://github.com/elastic/eui/pull/2035))
 
 **Breaking changes**
 

--- a/src/components/basic_table/in_memory_table.js
+++ b/src/components/basic_table/in_memory_table.js
@@ -163,9 +163,8 @@ export class EuiInMemoryTable extends Component {
       // We have new items because an external search has completed, so reset pagination state.
       return {
         prevProps: {
+          ...prevState.prevProps,
           items: nextProps.items,
-          sortField: prevState.prevProps.sortField,
-          sortDirection: prevState.prevProps.sortDirection,
         },
         pageIndex: 0,
       };

--- a/src/components/basic_table/in_memory_table.js
+++ b/src/components/basic_table/in_memory_table.js
@@ -164,6 +164,8 @@ export class EuiInMemoryTable extends Component {
       return {
         prevProps: {
           items: nextProps.items,
+          sortField: prevState.prevProps.sortField,
+          sortDirection: prevState.prevProps.sortDirection,
         },
         pageIndex: 0,
       };


### PR DESCRIPTION
### Summary

Fixes a bug where `sorting` updates stop after `items` data is changed externally. This change persists the local values of sort properties through lifecycle changes.

### Checklist

~~- [ ] This was checked in mobile~~
~~- [ ] This was checked in IE11~~
~~- [ ] This was checked in dark mode~~
~~- [ ] Any props added have proper autodocs~~
~~- [ ] Documentation examples were added~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately

~~- [ ] This was checked for breaking changes and labeled appropriately~~
~~- [ ] Jest tests were updated or added to match the most common scenarios~~
~~- [ ] This was checked against keyboard-only and screenreader scenarios~~
~~- [ ] This required updates to Framer X components~~
