### PR TITLE
(Accessibility) Fix EuiNavDrawerFlyout using `<h5>` by replacing with `<div>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Fixed `EuiFlyout` scrolling in Safari ([#2033](https://github.com/elastic/eui/pull/2033))
 - Fixed `EuiCallOut` header icon alignment ([#2006](https://github.com/elastic/eui/pull/2006))
 - Fixed `EuiInMemoryTable` sort value persistence through lifecycle updates ([#2035](https://github.com/elastic/eui/pull/2035))
-- Fixed `EuiNavDrawerFlyout` heading ([#2040](https://github.com/elastic/eui/pull/2040))
+- Changed `EuiNavDrawerFlyout` title from `h2` to `div` ([#2040](https://github.com/elastic/eui/pull/2040))
 
 **Breaking changes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed `EuiFlyout` scrolling in Safari ([#2033](https://github.com/elastic/eui/pull/2033))
 - Fixed `EuiCallOut` header icon alignment ([#2006](https://github.com/elastic/eui/pull/2006))
 - Fixed `EuiInMemoryTable` sort value persistence through lifecycle updates ([#2035](https://github.com/elastic/eui/pull/2035))
+- Fixed `EuiNavDrawerFlyout` heading ([#2040](https://github.com/elastic/eui/pull/2040))
 
 **Breaking changes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@
 - Added `magnet` glyph to `EuiIcon` ([2010](https://github.com/elastic/eui/pull/2010))
 - Changed `logoAWS` SVG in `EuiIcon` to work better in dark mode ([#2036](https://github.com/elastic/eui/pull/2036))
 - Converted toast components to TypeScript ([#2032](https://github.com/elastic/eui/pull/2032))
+- Changed `EuiNavDrawerFlyout` title from `h5` to `div` ([#2040](https://github.com/elastic/eui/pull/2040))
 
 **Bug fixes**
 
 - Fixed `EuiFlyout` scrolling in Safari ([#2033](https://github.com/elastic/eui/pull/2033))
 - Fixed `EuiCallOut` header icon alignment ([#2006](https://github.com/elastic/eui/pull/2006))
 - Fixed `EuiInMemoryTable` sort value persistence through lifecycle updates ([#2035](https://github.com/elastic/eui/pull/2035))
-- Changed `EuiNavDrawerFlyout` title from `h2` to `div` ([#2040](https://github.com/elastic/eui/pull/2040))
 
 **Breaking changes**
 

--- a/src/components/nav_drawer/nav_drawer_flyout.js
+++ b/src/components/nav_drawer/nav_drawer_flyout.js
@@ -26,7 +26,7 @@ export const EuiNavDrawerFlyout = ({
   return (
     <div className={classes} aria-labelledby="navDrawerFlyoutTitle" {...rest}>
       <EuiTitle className="euiNavDrawerFlyout__title" tabIndex="-1" size="xxs">
-        <h5 id="navDrawerFlyoutTitle">{title}</h5>
+        <div id="navDrawerFlyoutTitle">{title}</div>
       </EuiTitle>
       <EuiNavDrawerGroup
         className="euiNavDrawerFlyout__listGroup"


### PR DESCRIPTION
Fixes #2039 
Associated issue: elastic/kibana#34995

### Summary
This PR replaces `<h5>` with `<div>` and that's it.

### Checklist

- ~~This was checked in mobile~~
- ~~This was checked in IE11~~
- ~~This was checked in dark mode~~
- ~~Any props added have proper autodocs~~
- ~~Documentation examples were added~~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~~This was checked for breaking changes and labeled appropriately~~
- ~~Jest tests were updated or added to match the most common scenarios~~
- [x] This was checked against keyboard-only and screenreader scenarios
- ~~This required updates to Framer X components~~
