### PR TITLE
Make the commit hook (via yarn lint-es) fail on lint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "extract-i18n-strings": "node ./scripts/babel/fetch-i18n-strings",
     "lint": "yarn tsc --noEmit && yarn lint-es && yarn lint-sass",
     "lint-fix": "yarn lint-es-fix",
-    "lint-es": "eslint --cache '{src,src-docs,src-framer}/**/*.{ts,tsx,js}'",
+    "lint-es": "eslint --cache '{src,src-docs,src-framer}/**/*.{ts,tsx,js}' --max-warnings 0",
     "lint-es-fix": "yarn lint-es --fix",
     "lint-sass": "sass-lint -v --max-warnings 0",
     "lint-sass-fix": "sass-lint-auto-fix -c ./.sass-lint-fix.yml",

--- a/src-docs/src/views/horizontal_rule/horizontal_rule_example.js
+++ b/src-docs/src/views/horizontal_rule/horizontal_rule_example.js
@@ -14,8 +14,8 @@ import HorizontalRuleMargin from './horizontal_rule_margin';
 const horizontalRuleMarginSource = require('!!raw-loader!./horizontal_rule_margin');
 const horizontalRuleMarginHtml = renderToHtml(HorizontalRuleMargin);
 
-const horizontalRuleSnippet = `<EuiHorizontalRule size="quarter" />`;
-const horizontalRuleMarginSnippet = `<EuiHorizontalRule margin="xs" />`;
+const horizontalRuleSnippet = '<EuiHorizontalRule size="quarter" />';
+const horizontalRuleMarginSnippet = '<EuiHorizontalRule margin="xs" />';
 
 export const HorizontalRuleExample = {
   title: 'Horizontal Rule',

--- a/src-docs/src/views/spacer/spacer_example.js
+++ b/src-docs/src/views/spacer/spacer_example.js
@@ -15,7 +15,7 @@ import Spacer from './spacer';
 const spacerSource = require('!!raw-loader!./spacer');
 const spacerHtml = renderToHtml(Spacer);
 
-const spacerSnippet = `<EuiSpacer size="xs" />`;
+const spacerSnippet = '<EuiSpacer size="xs" />';
 
 export const SpacerExample = {
   title: 'Spacer',


### PR DESCRIPTION
### Summary

It's useful to allow warnings in dev environments, but they're enabled for a reason and should break builds (& commits). We had a few warnings committed in master, this resolves them and prevents future warnings from being committed.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
