### PR TITLE
[DOCS] Update EUI writing guidelines to include title casing feature names

### DIFF
--- a/src-docs/src/views/guidelines/writing.js
+++ b/src-docs/src/views/guidelines/writing.js
@@ -26,6 +26,8 @@ import {
   EuiIcon,
   EuiFieldNumber,
   EuiLink,
+  EuiTabs,
+  EuiTab,
 } from '../../../../src/components';
 
 import makeId from '../../../../src/components/form/form_row/make_id';
@@ -93,15 +95,11 @@ export default () => (
       </EuiFlexItem>
     </EuiFlexGrid>
 
-    <GuideRuleTitle>Sentence case for all text</GuideRuleTitle>
-    <EuiText grow={false} className="guideSection__text">
-      <p>
-        This includes buttons, menus, and titles. In sentence case, only the
-        first word and proper names are capped.
-      </p>
-    </EuiText>
-
-    <GuideRule>
+    <GuideRuleTitle>Capitalization</GuideRuleTitle>
+    <GuideRule
+      heading="Sentence case for almost all text"
+      description="This includes buttons, menus, and titles. In sentence case, only the
+    first word and proper names are capped.">
       <GuideRuleExample
         type="do"
         text="Do. Sentence case makes titles easier to read.">
@@ -127,6 +125,27 @@ export default () => (
       </GuideRuleExample>
       <GuideRuleExample type="dont" text="Don't. Title case looks too formal.">
         <EuiButton>Set Up Index Pattern</EuiButton>
+      </GuideRuleExample>
+    </GuideRule>
+
+    <GuideRule
+      heading="Title case for feature titles"
+      description="Titles and tabs for specific features should capitalize all words in the name of the feature.">
+      <GuideRuleExample
+        type="do"
+        text="Do. Title case in tabs and titles for names of features.">
+        <EuiTabs>
+          <EuiTab>Inventory</EuiTab>
+          <EuiTab isSelected>Metrics Explorer</EuiTab>
+        </EuiTabs>
+      </GuideRuleExample>
+      <GuideRuleExample
+        type="dont"
+        text="Don't. Features are proper names, not sentences.">
+        <EuiTabs>
+          <EuiTab>Inventory</EuiTab>
+          <EuiTab isSelected>Metrics explorer</EuiTab>
+        </EuiTabs>
       </GuideRuleExample>
     </GuideRule>
 
@@ -493,7 +512,7 @@ export default () => (
               Cancel
             </EuiButtonEmpty>
             <EuiButton color="danger" size="s">
-              Delete Report
+              Delete report
             </EuiButton>
           </EuiFlexGroup>
         </EuiPanel>


### PR DESCRIPTION
### Summary

Addendum to https://github.com/elastic/kibana/issues/38734

Updates the section on "Sentence case for all text" to say this:
<img width="1002" alt="Screen Shot 2019-06-17 at 1 33 28 PM" src="https://user-images.githubusercontent.com/1445834/59628273-e129fc80-9105-11e9-9fe2-372916c509d6.png">


### Checklist

- [ ] ~This was checked in mobile~
- [ ] ~This was checked in IE11~
- [ ] ~This was checked in dark mode~
- [ ] ~Any props added have proper autodocs~
- [x] Documentation examples were added
- [ ] ~A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
- [ ] ~This was checked for breaking changes and labeled appropriately~
- [ ] ~Jest tests were updated or added to match the most common scenarios~
- [ ] ~This was checked against keyboard-only and screenreader scenarios~
- [ ] ~This required updates to Framer X components~
