### PR TITLE
Export `Toast` TS member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Changed `EuiNavDrawerFlyout` title from `h5` to `div` ([#2040](https://github.com/elastic/eui/pull/2040))
+
+**Bug fixes**
+
 - Fixed proptype for `EuiCopy`'s `children` ([#2048](https://github.com/elastic/eui/pull/2048))
+- Fixed TypeScript `Toast` member export ([#2052](https://github.com/elastic/eui/pull/2052))
 
 ## [`12.0.0`](https://github.com/elastic/eui/tree/v12.0.0)
 

--- a/src/components/toast/index.ts
+++ b/src/components/toast/index.ts
@@ -1,5 +1,8 @@
 export { EuiToast } from './toast';
 
-export { EuiGlobalToastList } from './global_toast_list';
+export {
+  EuiGlobalToastList,
+  Toast as EuiGlobalToastListToast,
+} from './global_toast_list';
 
 export { EuiGlobalToastListItem } from './global_toast_list_item';


### PR DESCRIPTION
### Summary

`Toast` interface from `EuiGlobalToastList` is used/extended in Kibana, so we need to export it as a member of `@elastic/eui`.

Open to naming suggestions other than `EuiGlobalToastListToast`; `Toast` just seemed too generic.

### Checklist

~~- [ ] This was checked in mobile~~
~~- [ ] This was checked in IE11~~
~~- [ ] This was checked in dark mode~~
~~- [ ] Any props added have proper autodocs~~
~~- [ ] Documentation examples were added~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately

~~- [ ] This was checked for breaking changes and labeled appropriately~~
~~- [ ] Jest tests were updated or added to match the most common scenarios~~
~~- [ ] This was checked against keyboard-only and screenreader scenarios~~
~~- [ ] This required updates to Framer X components~~
