### PR TITLE
Fix readonly input groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed proptype for `EuiCopy`'s `children` ([#2048](https://github.com/elastic/eui/pull/2048))
 - Fixed `EuiInMemoryTable` to allow sorting on computed columns ([#2044](https://github.com/elastic/eui/pull/2044))
 - Fixed TypeScript `Toast` member export ([#2052](https://github.com/elastic/eui/pull/2052))
+- Fixed style of readOnly input groups via `EuiFormControlLayout` and `prepend`/`append` ([#2057](https://github.com/elastic/eui/pull/2057))
 
 ## [`12.0.0`](https://github.com/elastic/eui/tree/v12.0.0)
 

--- a/src-docs/src/views/form_controls/form_control_layout.js
+++ b/src-docs/src/views/form_controls/form_control_layout.js
@@ -93,6 +93,19 @@ export default () => (
     <EuiSpacer size="m" />
 
     <EuiFormControlLayout
+      readOnly
+      prepend={<EuiFormLabel htmlFor="textField19">Read only</EuiFormLabel>}>
+      <input
+        type="text"
+        className="euiFieldText euiFieldText--inGroup"
+        id="textField19"
+        readOnly
+      />
+    </EuiFormControlLayout>
+
+    <EuiSpacer size="m" />
+
+    <EuiFormControlLayout
       append={
         <EuiText size="xs">
           <strong>%</strong>

--- a/src-docs/src/views/form_controls/form_control_layout.js
+++ b/src-docs/src/views/form_controls/form_control_layout.js
@@ -94,11 +94,11 @@ export default () => (
 
     <EuiFormControlLayout
       readOnly
-      prepend={<EuiFormLabel htmlFor="textField19">Read only</EuiFormLabel>}>
+      prepend={<EuiFormLabel htmlFor="textField19a">Read only</EuiFormLabel>}>
       <input
         type="text"
         className="euiFieldText euiFieldText--inGroup"
-        id="textField19"
+        id="textField19a"
         readOnly
       />
     </EuiFormControlLayout>

--- a/src/components/color_picker/__snapshots__/color_picker.test.js.snap
+++ b/src/components/color_picker/__snapshots__/color_picker.test.js.snap
@@ -525,8 +525,7 @@ exports[`renders readOnly EuiColorPicker 1`] = `
     class="euiPopover__anchor euiColorPicker__popoverAnchor"
   >
     <div
-      class="euiFormControlLayout"
-      readonly=""
+      class="euiFormControlLayout euiFormControlLayout--readOnly"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
@@ -535,7 +534,7 @@ exports[`renders readOnly EuiColorPicker 1`] = `
           style="color:#ffeedd"
         >
           <div
-            class="euiFormControlLayout"
+            class="euiFormControlLayout euiFormControlLayout--readOnly"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"

--- a/src/components/form/_mixins.scss
+++ b/src/components/form/_mixins.scss
@@ -43,11 +43,11 @@
       height: $euiFormControlCompressedHeight;
     }
 
-    &--inGroup {
+    &--inGroup:not(:read-only) {
       height: $euiFormControlHeight - 2px; /* 2 */
     }
 
-    &--inGroup#{&}--compressed {
+    &--inGroup#{&}--compressed:not(:read-only) {
       height: $euiFormControlCompressedHeight - 2px; /* 2 */
     }
   }

--- a/src/components/form/_variables.scss
+++ b/src/components/form/_variables.scss
@@ -21,6 +21,7 @@ $euiFormBorderDisabledColor: transparentize($euiColorFullShade, .92) !default;
 $euiFormCustomControlDisabledIconColor: shadeOrTint($euiColorMediumShade, 38%, 48.5%) !default; // exact 508c foreground for $euiColorLightShade
 $euiFormControlDisabledColor: $euiColorMediumShade !default;
 $euiFormControlBoxShadow: 0 1px 1px -1px transparentize($euiShadowColor, .8), 0 3px 2px -2px transparentize($euiShadowColor, .8);
+$euiFormInputGroupLabelBackground: shadeOrTint($euiFormBackgroundDisabledColor, 0, 3%);
 
 //** DEPRECATED **//
 //** DEPRECATED **//

--- a/src/components/form/field_number/__snapshots__/field_number.test.js.snap
+++ b/src/components/form/field_number/__snapshots__/field_number.test.js.snap
@@ -71,6 +71,23 @@ exports[`EuiFieldNumber props isLoading is rendered 1`] = `
 </eui-form-control-layout>
 `;
 
+exports[`EuiFieldNumber props readOnly is rendered 1`] = `
+<eui-form-control-layout
+  compressed="false"
+  fullwidth="false"
+  isloading="false"
+  readonly="true"
+>
+  <eui-validatable-control>
+    <input
+      class="euiFieldNumber"
+      readonly=""
+      type="number"
+    />
+  </eui-validatable-control>
+</eui-form-control-layout>
+`;
+
 exports[`EuiFieldNumber props value no initial value 1`] = `
 <eui-form-control-layout
   compressed="false"

--- a/src/components/form/field_number/field_number.js
+++ b/src/components/form/field_number/field_number.js
@@ -22,6 +22,7 @@ export const EuiFieldNumber = ({
   prepend,
   append,
   inputRef,
+  readOnly,
   ...rest
 }) => {
   const classes = classNames('euiFieldNumber', className, {
@@ -38,6 +39,7 @@ export const EuiFieldNumber = ({
       fullWidth={fullWidth}
       isLoading={isLoading}
       compressed={compressed}
+      readOnly={readOnly}
       prepend={prepend}
       append={append}>
       <EuiValidatableControl isInvalid={isInvalid}>
@@ -49,6 +51,7 @@ export const EuiFieldNumber = ({
           name={name}
           value={value}
           placeholder={placeholder}
+          readOnly={readOnly}
           className={classes}
           ref={inputRef}
           {...rest}
@@ -91,6 +94,7 @@ EuiFieldNumber.propTypes = {
   isInvalid: PropTypes.bool,
   fullWidth: PropTypes.bool,
   isLoading: PropTypes.bool,
+  readOnly: PropTypes.bool,
   /**
    * when `true` creates a shorter height input
    */

--- a/src/components/form/field_number/field_number.test.js
+++ b/src/components/form/field_number/field_number.test.js
@@ -53,6 +53,12 @@ describe('EuiFieldNumber', () => {
       expect(component).toMatchSnapshot();
     });
 
+    test('readOnly is rendered', () => {
+      const component = render(<EuiFieldNumber readOnly />);
+
+      expect(component).toMatchSnapshot();
+    });
+
     describe('value', () => {
       test('value is number', () => {
         const component = render(

--- a/src/components/form/field_text/__snapshots__/field_text.test.js.snap
+++ b/src/components/form/field_text/__snapshots__/field_text.test.js.snap
@@ -68,3 +68,20 @@ exports[`EuiFieldText props isLoading is rendered 1`] = `
   </eui-validatable-control>
 </eui-form-control-layout>
 `;
+
+exports[`EuiFieldText props readOnly is rendered 1`] = `
+<eui-form-control-layout
+  compressed="false"
+  fullwidth="false"
+  isloading="false"
+  readonly="true"
+>
+  <eui-validatable-control>
+    <input
+      class="euiFieldText"
+      readonly=""
+      type="text"
+    />
+  </eui-validatable-control>
+</eui-form-control-layout>
+`;

--- a/src/components/form/field_text/field_text.js
+++ b/src/components/form/field_text/field_text.js
@@ -20,6 +20,7 @@ export const EuiFieldText = ({
   compressed,
   prepend,
   append,
+  readOnly,
   ...rest
 }) => {
   const classes = classNames('euiFieldText', className, {
@@ -36,6 +37,7 @@ export const EuiFieldText = ({
       fullWidth={fullWidth}
       isLoading={isLoading}
       compressed={compressed}
+      readOnly={readOnly}
       prepend={prepend}
       append={append}>
       <EuiValidatableControl isInvalid={isInvalid}>
@@ -47,6 +49,7 @@ export const EuiFieldText = ({
           className={classes}
           value={value}
           ref={inputRef}
+          readOnly={readOnly}
           {...rest}
         />
       </EuiValidatableControl>
@@ -64,6 +67,7 @@ EuiFieldText.propTypes = {
   inputRef: PropTypes.func,
   fullWidth: PropTypes.bool,
   isLoading: PropTypes.bool,
+  readOnly: PropTypes.bool,
   /**
    * when `true` creates a shorter height input
    */

--- a/src/components/form/field_text/field_text.test.js
+++ b/src/components/form/field_text/field_text.test.js
@@ -46,6 +46,12 @@ describe('EuiFieldText', () => {
       expect(component).toMatchSnapshot();
     });
 
+    test('readOnly is rendered', () => {
+      const component = render(<EuiFieldText readOnly />);
+
+      expect(component).toMatchSnapshot();
+    });
+
     test('isLoading is rendered', () => {
       const component = render(<EuiFieldText isLoading />);
 

--- a/src/components/form/form_control_layout/__snapshots__/form_control_layout.test.js.snap
+++ b/src/components/form/form_control_layout/__snapshots__/form_control_layout.test.js.snap
@@ -254,3 +254,13 @@ exports[`EuiFormControlLayout props one prepend is rendered 1`] = `
   />
 </div>
 `;
+
+exports[`EuiFormControlLayout props readOnly is rendered 1`] = `
+<div
+  class="euiFormControlLayout euiFormControlLayout--readOnly"
+>
+  <div
+    class="euiFormControlLayout__childrenWrapper"
+  />
+</div>
+`;

--- a/src/components/form/form_control_layout/_form_control_layout.scss
+++ b/src/components/form/form_control_layout/_form_control_layout.scss
@@ -85,7 +85,7 @@
 
     .euiFormControlLayout__prepend,
     .euiFormControlLayout__append {
-      height: $euiFormControlHeight; // Matchin input height, as euiFormControlSize() does not apply to the smaller height to readOnly states
+      height: $euiFormControlHeight; // Matching input height, as euiFormControlSize() does not apply to the smaller height to readOnly states
     }
   }
 }

--- a/src/components/form/form_control_layout/_form_control_layout.scss
+++ b/src/components/form/form_control_layout/_form_control_layout.scss
@@ -44,7 +44,7 @@
       margin-bottom: 0;
       padding: $euiFormControlPadding;
       border: none;
-      background-color: shadeOrTint($euiFormBackgroundDisabledColor, 0, 3%);
+      background-color: $euiFormInputGroupLabelBackground;
       line-height: $euiFontSize;
     }
   }
@@ -73,6 +73,19 @@
         padding-top: $euiFormControlCompressedPadding;
         padding-bottom: $euiFormControlCompressedPadding;
       }
+    }
+  }
+
+  //
+  // ReadOnly alterations
+  &.euiFormControlLayout--readOnly {
+    @include euiFormControlReadOnlyStyle;
+    padding: 0; /* 1 */
+    background-color: transparent; // Ensures the input and layout don't double up on background color
+
+    .euiFormControlLayout__prepend,
+    .euiFormControlLayout__append {
+      height: $euiFormControlHeight; // Matchin input height, as euiFormControlSize() does not apply to the smaller height to readOnly states
     }
   }
 }

--- a/src/components/form/form_control_layout/form_control_layout.js
+++ b/src/components/form/form_control_layout/form_control_layout.js
@@ -18,6 +18,7 @@ export class EuiFormControlLayout extends Component {
       className,
       prepend,
       append,
+      readOnly,
       ...rest
     } = this.props;
 
@@ -26,6 +27,7 @@ export class EuiFormControlLayout extends Component {
       {
         'euiFormControlLayout--fullWidth': fullWidth,
         'euiFormControlLayout--compressed': compressed,
+        'euiFormControlLayout--readOnly': readOnly,
         'euiFormControlLayout--group': prepend || append,
       },
       className

--- a/src/components/form/form_control_layout/form_control_layout.test.js
+++ b/src/components/form/form_control_layout/form_control_layout.test.js
@@ -117,6 +117,12 @@ describe('EuiFormControlLayout', () => {
       expect(component).toMatchSnapshot();
     });
 
+    test('readOnly is rendered', () => {
+      const component = render(<EuiFormControlLayout readOnly />);
+
+      expect(component).toMatchSnapshot();
+    });
+
     test('one prepend is rendered', () => {
       const component = render(
         <EuiFormControlLayout prepend={<span>1</span>} />

--- a/src/components/form/select/__snapshots__/select.test.js.snap
+++ b/src/components/form/select/__snapshots__/select.test.js.snap
@@ -119,6 +119,23 @@ exports[`EuiSelect props options are rendered 1`] = `
 </eui-form-control-layout>
 `;
 
+exports[`EuiSelect props readOnly is rendered 1`] = `
+<eui-form-control-layout
+  compressed="false"
+  fullwidth="false"
+  icon="[object Object]"
+  isloading="false"
+  readonly="true"
+>
+  <eui-validatable-control>
+    <select
+      class="euiSelect"
+      readonly=""
+    />
+  </eui-validatable-control>
+</eui-form-control-layout>
+`;
+
 exports[`EuiSelect props value option is rendered 1`] = `
 <eui-form-control-layout
   compressed="false"

--- a/src/components/form/select/select.js
+++ b/src/components/form/select/select.js
@@ -22,6 +22,7 @@ export const EuiSelect = ({
   prepend,
   append,
   onMouseUp,
+  readOnly,
   ...rest
 }) => {
   const handleMouseUp = e => {
@@ -71,6 +72,7 @@ export const EuiSelect = ({
       fullWidth={fullWidth}
       isLoading={isLoading}
       compressed={compressed}
+      readOnly={readOnly}
       prepend={prepend}
       append={append}>
       <EuiValidatableControl isInvalid={isInvalid}>
@@ -81,6 +83,7 @@ export const EuiSelect = ({
           ref={inputRef}
           defaultValue={selectDefaultValue}
           value={value}
+          readOnly={readOnly}
           onMouseUp={handleMouseUp}
           {...rest}>
           {emptyOptionNode}
@@ -119,6 +122,7 @@ EuiSelect.propTypes = {
    * when `true` creates a shorter height input
    */
   compressed: PropTypes.bool,
+  readOnly: PropTypes.bool,
   /**
    * Creates an input group with element(s) coming before select
    */

--- a/src/components/form/select/select.test.js
+++ b/src/components/form/select/select.test.js
@@ -52,6 +52,12 @@ describe('EuiSelect', () => {
       expect(component).toMatchSnapshot();
     });
 
+    test('readOnly is rendered', () => {
+      const component = render(<EuiSelect readOnly />);
+
+      expect(component).toMatchSnapshot();
+    });
+
     test('disabled options are rendered', () => {
       const component = render(
         <EuiSelect


### PR DESCRIPTION
While working on #2049, I noticed that we don't currently account for the readonly state when using prepend/append.

<img src="https://d.pr/free/i/L7h4mW+" width="50%" />

This PR, passes the `readOnly` to the EuiFormControlLayout and applies the correct styling. This means also having to explicitly state and use it as a prop for EuiFieldNumber, EuiFieldText, and EuiSelect. These are also the only ones that currently support prepend/append.

**Before**
<img width="433" alt="Screen Shot 2019-06-18 at 19 20 24 PM" src="https://user-images.githubusercontent.com/549577/59726187-a788ec80-91fe-11e9-83a9-c1bd9358ebe9.png">

**After**
<img width="436" alt="Screen Shot 2019-06-18 at 19 21 12 PM" src="https://user-images.githubusercontent.com/549577/59726191-ab1c7380-91fe-11e9-975e-2ab42f22f7ec.png">


### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
- [x] Any props added have proper autodocs
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- [x] Jest tests were updated or added to match the most common scenarios
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
