### PR TITLE
Added `autoFocus` option to `EuiTabbedContent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Changed `EuiNavDrawerFlyout` title from `h5` to `div` ([#2040](https://github.com/elastic/eui/pull/2040))
 - Added `magnifyWithMinus` and `magnifyWithPlus` glyphs to `EuiIcon` ([2056](https://github.com/elastic/eui/pull/2056))
 - Added a fully black (no matter the theme) color SASS variable `$euiColorInk` ([2060](https://github.com/elastic/eui/pull/2060))
+- Added `autoFocus` prop to `EuiTabbedContent` ([2062](https://github.com/elastic/eui/pull/2062))
 
 **Bug fixes**
 

--- a/src-docs/src/views/tabs/tabbed_content.js
+++ b/src-docs/src/views/tabs/tabbed_content.js
@@ -91,6 +91,7 @@ class EuiTabsExample extends Component {
       <EuiTabbedContent
         tabs={this.tabs}
         initialSelectedTab={this.tabs[1]}
+        autoFocus="selected"
         onTabClick={tab => {
           console.log('clicked tab', tab);
         }}

--- a/src/components/date_picker/super_date_picker/date_popover/date_popover_content.js
+++ b/src/components/date_picker/super_date_picker/date_popover/date_popover_content.js
@@ -91,6 +91,7 @@ export function EuiDatePopoverContent({
     <EuiTabbedContent
       className="euiDatePopoverContent"
       tabs={renderTabs()}
+      autoFocus="selected"
       initialSelectedTab={{ id: getDateMode(value) }}
       onTabClick={onTabClick}
       size="s"

--- a/src/components/tabs/index.d.ts
+++ b/src/components/tabs/index.d.ts
@@ -29,6 +29,8 @@ declare module '@elastic/eui' {
     content: ReactNode;
   }
 
+  type TABBED_CONTENT_AUTOFOCUS = 'initial' | 'selected';
+
   interface EuiTabbedContentProps {
     tabs: EuiTabbedContentTab[];
     onTabClick?: (tab: EuiTabbedContentTab) => void;
@@ -37,6 +39,7 @@ declare module '@elastic/eui' {
     size?: TAB_SIZES;
     display?: TAB_DISPLAYS;
     expand?: boolean;
+    autoFocus?: TABBED_CONTENT_AUTOFOCUS;
   }
 
   export const EuiTab: FunctionComponent<

--- a/src/components/tabs/tabbed_content/__snapshots__/tabbed_content.test.js.snap
+++ b/src/components/tabs/tabbed_content/__snapshots__/tabbed_content.test.js.snap
@@ -72,7 +72,6 @@ exports[`EuiTabbedContent behavior when uncontrolled, the selected tab should up
   }
 >
   <div
-    onBlur={[Function]}
     onFocus={[Function]}
   >
     <EuiTabs
@@ -157,6 +156,102 @@ exports[`EuiTabbedContent is rendered with required props and tabs 1`] = `
   class="testClass1 testClass2"
   data-test-subj="test subject string"
 >
+  <div
+    class="euiTabs"
+    role="tablist"
+  >
+    <button
+      aria-controls="42"
+      aria-selected="true"
+      class="euiTab euiTab-isSelected"
+      id="es"
+      role="tab"
+      type="button"
+    >
+      <span
+        class="euiTab__content"
+      >
+        Elasticsearch
+      </span>
+    </button>
+    <button
+      aria-controls="42"
+      aria-selected="false"
+      class="euiTab"
+      data-test-subj="kibanaTab"
+      id="kibana"
+      role="tab"
+      type="button"
+    >
+      <span
+        class="euiTab__content"
+      >
+        Kibana
+      </span>
+    </button>
+  </div>
+  <div
+    aria-labelledby="es"
+    id="42"
+    role="tabpanel"
+  >
+    <p>
+      Elasticsearch content
+    </p>
+  </div>
+</div>
+`;
+
+exports[`EuiTabbedContent props autoFocus initial is rendered 1`] = `
+<div>
+  <div
+    class="euiTabs"
+    role="tablist"
+  >
+    <button
+      aria-controls="42"
+      aria-selected="true"
+      class="euiTab euiTab-isSelected"
+      id="es"
+      role="tab"
+      type="button"
+    >
+      <span
+        class="euiTab__content"
+      >
+        Elasticsearch
+      </span>
+    </button>
+    <button
+      aria-controls="42"
+      aria-selected="false"
+      class="euiTab"
+      data-test-subj="kibanaTab"
+      id="kibana"
+      role="tab"
+      type="button"
+    >
+      <span
+        class="euiTab__content"
+      >
+        Kibana
+      </span>
+    </button>
+  </div>
+  <div
+    aria-labelledby="es"
+    id="42"
+    role="tabpanel"
+  >
+    <p>
+      Elasticsearch content
+    </p>
+  </div>
+</div>
+`;
+
+exports[`EuiTabbedContent props autoFocus selected is rendered 1`] = `
+<div>
   <div
     class="euiTabs"
     role="tablist"

--- a/src/components/tabs/tabbed_content/__snapshots__/tabbed_content.test.js.snap
+++ b/src/components/tabs/tabbed_content/__snapshots__/tabbed_content.test.js.snap
@@ -50,6 +50,7 @@ exports[`EuiTabbedContent behavior when selected tab state isn't controlled by t
 
 exports[`EuiTabbedContent behavior when uncontrolled, the selected tab should update if it receives new content 1`] = `
 <EuiTabbedContent
+  autoFocus="initial"
   tabs={
     Array [
       Object {
@@ -70,7 +71,10 @@ exports[`EuiTabbedContent behavior when uncontrolled, the selected tab should up
     ]
   }
 >
-  <div>
+  <div
+    onBlur={[Function]}
+    onFocus={[Function]}
+  >
     <EuiTabs
       display="default"
       expand={false}

--- a/src/components/tabs/tabbed_content/tabbed_content.js
+++ b/src/components/tabs/tabbed_content/tabbed_content.js
@@ -8,6 +8,8 @@ import { EuiTab } from '../tab';
 
 const makeId = htmlIdGenerator();
 
+export const AUTOFOCUS = ['initial', 'selected'];
+
 export class EuiTabbedContent extends Component {
   static propTypes = {
     className: PropTypes.string,
@@ -29,6 +31,12 @@ export class EuiTabbedContent extends Component {
      * Use this prop if you want to control selection state within the owner component
      */
     selectedTab: PropTypes.object,
+    /**
+     * When tabbing to into the tabs, set the focus on `initial` for the first tab,
+     * or `selected` for the currently selected tab. Best use case is for inside of
+     * overlay content like popovers or flyouts.
+     */
+    autoFocus: PropTypes.oneOf(AUTOFOCUS),
     size: PropTypes.oneOf(SIZES),
     /**
      * Each tab needs id and content properties, so we can associate it with its panel for accessibility.
@@ -51,13 +59,38 @@ export class EuiTabbedContent extends Component {
     this.rootId = makeId();
 
     // Only track selection state if it's not controlled externally.
+    let selectedTabId;
     if (!selectedTab) {
-      this.state = {
-        selectedTabId:
-          (initialSelectedTab && initialSelectedTab.id) || tabs[0].id,
-      };
+      selectedTabId =
+        (initialSelectedTab && initialSelectedTab.id) || tabs[0].id;
     }
+
+    this.state = {
+      selectedTabId,
+      inFocus: false,
+    };
   }
+
+  initializeFocus = () => {
+    console.log('THE FOCUS HAPPENED');
+
+    if (!this.state.inFocus && this.props.autoFocus === 'selected') {
+      console.log('Focusing selected tab');
+      document.getElementById(this.state.selectedTabId).focus();
+    }
+
+    this.setState({
+      inFocus: true,
+    });
+  };
+
+  removeFocus = () => {
+    console.log('THE BLUR HAPPENED');
+
+    this.setState({
+      // inFocus: false,
+    });
+  };
 
   onTabClick = selectedTab => {
     const { onTabClick, selectedTab: externalSelectedTab } = this.props;
@@ -82,6 +115,7 @@ export class EuiTabbedContent extends Component {
       selectedTab: externalSelectedTab,
       size,
       tabs,
+      autoFocus,
       ...rest
     } = this.props;
 
@@ -93,7 +127,11 @@ export class EuiTabbedContent extends Component {
     const { content: selectedTabContent, id: selectedTabId } = selectedTab;
 
     return (
-      <div className={className} {...rest}>
+      <div
+        className={className}
+        {...rest}
+        onFocus={this.initializeFocus}
+        onBlur={this.removeFocus}>
         <EuiTabs expand={expand} display={display} size={size}>
           {tabs.map(tab => {
             const {
@@ -125,3 +163,7 @@ export class EuiTabbedContent extends Component {
     );
   }
 }
+
+EuiTabbedContent.defaultProps = {
+  autoFocus: 'initial',
+};

--- a/src/components/tabs/tabbed_content/tabbed_content.js
+++ b/src/components/tabs/tabbed_content/tabbed_content.js
@@ -32,7 +32,7 @@ export class EuiTabbedContent extends Component {
      */
     selectedTab: PropTypes.object,
     /**
-     * When tabbing to into the tabs, set the focus on `initial` for the first tab,
+     * When tabbing into the tabs, set the focus on `initial` for the first tab,
      * or `selected` for the currently selected tab. Best use case is for inside of
      * overlay content like popovers or flyouts.
      */

--- a/src/components/tabs/tabbed_content/tabbed_content.test.js
+++ b/src/components/tabs/tabbed_content/tabbed_content.test.js
@@ -3,7 +3,7 @@ import { render, mount } from 'enzyme';
 import sinon from 'sinon';
 import { requiredProps, findTestSubject } from '../../../test';
 
-import { EuiTabbedContent } from './tabbed_content';
+import { EuiTabbedContent, AUTOFOCUS } from './tabbed_content';
 
 // Mock the htmlIdGenerator to generate predictable ids for snapshot tests
 jest.mock('../../../services/accessibility/html_id_generator', () => ({
@@ -79,6 +79,18 @@ describe('EuiTabbedContent', () => {
           <EuiTabbedContent display="condensed" tabs={tabs} />
         );
         expect(component).toMatchSnapshot();
+      });
+    });
+
+    describe('autoFocus', () => {
+      AUTOFOCUS.forEach(focusType => {
+        test(`${focusType} is rendered`, () => {
+          const component = render(
+            <EuiTabbedContent autoFocus={focusType} tabs={tabs} />
+          );
+
+          expect(component).toMatchSnapshot();
+        });
       });
     });
   });


### PR DESCRIPTION
The focus state of EuiTabs can confuse users since it's so prominent compared to the selected state. Some users thing the focus state **is** the selected state. This PR attempts to allow setting the initial focus of the tabbed items from `initial` (first tab) to `selected` (selected tab).

There are 2 issues with it at the moment:

- ~[ ] 1. If the selected tab is not the first, users have to <kbd>shift + tab</kbd> in order to get to the previous tabs.~ Got confirmation from most that this is not an issue.
- [x] 2. I'm currently using `document.getElementById()` to find the selected tab, which probably isn't great
- [x] 3. The way I have it setup is that when a user focuses in on the EuiTabbedContent, it sets the `state.focus` to `true` and then auto focuses on the selected tab. The problem is that I have to reset the state to `false` when a user tabs out of the control. However, it seems to cycle as `blur then focus` each <kbd>tab</tbd> press.

<img src="https://d.pr/free/i/8Snp8S+" />

--- 

Also fixes the second action item for the **EuiDatePicker** from GAH:

<img src="https://d.pr/free/i/GSoDNd+" width="50%" />

### Checklist

- ~[ ] This was checked in mobile~
- [x] This was checked in IE11
- ~[ ] This was checked in dark mode~
- [x] Any props added have proper autodocs
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- [x] Jest tests were updated or added to match the most common scenarios
- [x] This was checked against keyboard-only and screenreader scenarios
- ~[ ] This required updates to Framer X components~
