### PR TITLE
Strip TS type exports even when they are being renamed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed `EuiInMemoryTable` to allow sorting on computed columns ([#2044](https://github.com/elastic/eui/pull/2044))
 - Fixed TypeScript `Toast` member export ([#2052](https://github.com/elastic/eui/pull/2052))
 - Fixed style of readOnly input groups via `EuiFormControlLayout` and `prepend`/`append` ([#2057](https://github.com/elastic/eui/pull/2057))
+- Removed TS types from ES exports when the exported name differs from the imported one ([#2069](https://github.com/elastic/eui/pull/2069))
 
 ## [`12.0.0`](https://github.com/elastic/eui/tree/v12.0.0)
 

--- a/scripts/babel/proptypes-from-ts-props/index.js
+++ b/scripts/babel/proptypes-from-ts-props/index.js
@@ -765,7 +765,7 @@ const typeDefinitionExtractors = {
           case 'ImportSpecifier':
             return specifier.imported.name;
           case 'ExportSpecifier':
-            return specifier.exported.name;
+            return specifier.local.name;
 
           // default:
           //   throw new Error(`Unable to process import specifier type ${specifier.type}`);
@@ -1103,9 +1103,9 @@ module.exports = function propTypesFromTypeScript({ types }) {
               const specifiers = path.get('specifiers');
               specifiers.forEach(specifierPath => {
                 if (types.isExportSpecifier(specifierPath)) {
-                  const { node: { exported } } = specifierPath;
-                  if (types.isIdentifier(exported)) {
-                    const { name } = exported;
+                  const { node: { local } } = specifierPath;
+                  if (types.isIdentifier(local)) {
+                    const { name } = local;
                     const def = typeDefinitions[name];
                     if (isTSType(def)) {
                       specifierPath.remove();


### PR DESCRIPTION
### Summary

Cleans up renamed exports of TS types, such as [Toast as EuiGlobalToastListToast,](https://github.com/elastic/eui/commit/7de5b206163582e630145cf1c2d01f6b7a2c3ad3#diff-b5b09f81465c2c17912687397b176515R5) in _toast/index.ts_. There were two instances of the same bug, where the value being exported was observed instead of the local variable name.

After applying the fix & re-running babel on _toast/index.ts_ the new output is 

```
export { EuiToast } from './toast';
export { EuiGlobalToastList } from './global_toast_list';
export { EuiGlobalToastListItem } from './global_toast_list_item';
```

I also ran `icon/index.ts` to confirm this did not affect the existing type removal when the variable is not renamed.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
