### PR TITLE
Update combobox option's value TS definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@
 **Bug fixes**
 
 - Added requirement that `EuiFormRow` has exactly one child element [#2054](https://github.com/elastic/eui/pull/2054)
-
-**Breaking changes**
-
 - Widened `EuiComboBox`'s `options[].value` / `EuiComboBoxOptionProps.value` TypeScript definition ([#2080](https://github.com/elastic/eui/pull/2080))
 
 ## [`12.1.0`](https://github.com/elastic/eui/tree/v12.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added requirement that `EuiFormRow` has exactly one child element [#2054](https://github.com/elastic/eui/pull/2054)
 - Widened `EuiComboBox`'s `options[].value` / `EuiComboBoxOptionProps.value` TypeScript definition ([#2080](https://github.com/elastic/eui/pull/2080))
+- Added TS defs for `EuiComboBox`'s props spreading onto a `div` ([#2080](https://github.com/elastic/eui/pull/2080))
 
 ## [`12.1.0`](https://github.com/elastic/eui/tree/v12.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added requirement that `EuiFormRow` has exactly one child element [#2054](https://github.com/elastic/eui/pull/2054)
 
+**Breaking changes**
+
+- Widened `EuiComboBox`'s `options[].value` / `EuiComboBoxOptionProps.value` TypeScript definition ([#2080](https://github.com/elastic/eui/pull/2080))
+
 ## [`12.1.0`](https://github.com/elastic/eui/tree/v12.1.0)
 
 - Changed `EuiNavDrawerFlyout` title from `h5` to `div` ([#2040](https://github.com/elastic/eui/pull/2040))

--- a/src/components/combo_box/index.d.ts
+++ b/src/components/combo_box/index.d.ts
@@ -10,49 +10,51 @@ import {
   EuiComboBoxOptionProps,
   EuiComboBoxOptionsListPosition,
   EuiComboBoxOptionsListProps,
+  EuiComboBoxProps,
 } from '@elastic/eui'; // eslint-disable-line import/no-unresolved
-import { RefCallback, CommonProps } from '../common';
+import { RefCallback, CommonProps, Omit } from '../common';
 
 declare module '@elastic/eui' {
-  export type EuiComboBoxOptionProps = CommonProps &
-    ButtonHTMLAttributes<HTMLButtonElement> & {
+  export type EuiComboBoxOptionProps<T> = CommonProps &
+    Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'value'> & {
       label: string;
       isGroupLabelOption?: boolean;
-      options?: EuiComboBoxOptionProps[];
+      options?: Array<EuiComboBoxOptionProps<T>>;
+      value?: T;
     };
 
   export type EuiComboBoxOptionsListPosition = 'top' | 'bottom';
 
-  export interface EuiComboBoxOption {
-    option: EuiComboBoxOptionProps;
+  export interface EuiComboBoxOption<T> {
+    option: EuiComboBoxOptionProps<T>;
     children?: ReactNode;
     className?: string;
     optionRef?: RefCallback<HTMLButtonElement>;
-    onClick: (option: EuiComboBoxOptionProps) => any;
-    onEnterKey: (option: EuiComboBoxOptionProps) => any;
+    onClick: (option: EuiComboBoxOptionProps<T>) => any;
+    onEnterKey: (option: EuiComboBoxOptionProps<T>) => any;
     disabled?: boolean;
   }
 
-  export interface EuiComboBoxOptionsListProps {
-    options?: EuiComboBoxOptionProps[];
+  export interface EuiComboBoxOptionsListProps<T> {
+    options?: Array<EuiComboBoxOptionProps<T>>;
     isLoading?: boolean;
     selectedOptions?: any[];
     onCreateOption?: any;
     searchValue?: string;
-    matchingOptions?: EuiComboBoxOptionProps[];
-    optionRef?: EuiComboBoxOption['optionRef'];
-    onOptionClick?: EuiComboBoxOption['onClick'];
-    onOptionEnterKey?: EuiComboBoxOption['onEnterKey'];
+    matchingOptions?: Array<EuiComboBoxOptionProps<T>>;
+    optionRef?: EuiComboBoxOption<T>['optionRef'];
+    onOptionClick?: EuiComboBoxOption<T>['onClick'];
+    onOptionEnterKey?: EuiComboBoxOption<T>['onEnterKey'];
     areAllOptionsSelected?: boolean;
     getSelectedOptionForSearchValue?: (
       searchValue: string,
       selectedOptions: any[]
-    ) => EuiComboBoxOptionProps;
+    ) => EuiComboBoxOptionProps<T>;
     updatePosition: (parameter?: UIEvent | EuiPanelProps['panelRef']) => any;
     position?: EuiComboBoxOptionsListPosition;
     listRef: EuiPanelProps['panelRef'];
     renderOption?: (
-      option: EuiComboBoxOptionProps,
+      option: EuiComboBoxOptionProps<T>,
       searchValue: string,
       OPTION_CONTENT_CLASSNAME: string
     ) => ReactNode;
@@ -62,15 +64,15 @@ declare module '@elastic/eui' {
     rowHeight?: number;
     fullWidth?: boolean;
   }
-  export const EuiComboBoxOptionsList: FunctionComponent<
-    EuiComboBoxOptionsListProps
-  >;
+  export function EuiComboBoxOptionsList<T>(
+    props: EuiComboBoxOptionsListProps<T>
+  ): ReturnType<FunctionComponent<EuiComboBoxOptionsListProps<T>>>;
 
   export interface EuiComboBoxSingleSelectionShape {
     asPlainText?: boolean;
   }
 
-  export interface EuiComboBoxProps {
+  export interface EuiComboBoxProps<T> {
     id?: string;
     isDisabled?: boolean;
     className?: string;
@@ -79,19 +81,22 @@ declare module '@elastic/eui' {
     async?: boolean;
     singleSelection?: EuiComboBoxSingleSelectionShape | boolean;
     noSuggestions?: boolean;
-    options?: EuiComboBoxOptionsListProps['options'];
-    selectedOptions?: EuiComboBoxOptionsListProps['selectedOptions'];
+    options?: EuiComboBoxOptionsListProps<T>['options'];
+    selectedOptions?: EuiComboBoxOptionsListProps<T>['selectedOptions'];
     onBlur?: FocusEventHandler<HTMLInputElement>;
-    onChange?: (options: EuiComboBoxOptionProps[]) => any;
+    onChange?: (options: Array<EuiComboBoxOptionProps<T>>) => any;
     onFocus?: FocusEventHandler<HTMLInputElement>;
     onSearchChange?: (searchValue: string) => any;
-    onCreateOption?: EuiComboBoxOptionsListProps['onCreateOption'];
-    renderOption?: EuiComboBoxOptionsListProps['renderOption'];
+    onCreateOption?: EuiComboBoxOptionsListProps<T>['onCreateOption'];
+    renderOption?: EuiComboBoxOptionsListProps<T>['renderOption'];
     isInvalid?: boolean;
     rowHeight?: number;
     isClearable?: boolean;
     fullWidth?: boolean;
     inputRef?: (element: HTMLInputElement) => void;
   }
-  export const EuiComboBox: FunctionComponent<EuiComboBoxProps>;
+
+  export function EuiComboBox<T>(
+    props: EuiComboBoxProps<T>
+  ): ReturnType<FunctionComponent<EuiComboBoxProps<T>>>;
 }

--- a/src/components/combo_box/index.d.ts
+++ b/src/components/combo_box/index.d.ts
@@ -1,5 +1,6 @@
 import {
   ButtonHTMLAttributes,
+  HTMLAttributes,
   ReactNode,
   FunctionComponent,
   FocusEventHandler,
@@ -15,7 +16,9 @@ import {
 import { RefCallback, CommonProps, Omit } from '../common';
 
 declare module '@elastic/eui' {
-  export type EuiComboBoxOptionProps<T> = CommonProps &
+  export type EuiComboBoxOptionProps<
+    T = string | number | string[] | undefined
+  > = CommonProps &
     Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'value'> & {
       label: string;
       isGroupLabelOption?: boolean;
@@ -97,6 +100,7 @@ declare module '@elastic/eui' {
   }
 
   export function EuiComboBox<T>(
-    props: EuiComboBoxProps<T>
+    props: EuiComboBoxProps<T> &
+      Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>
   ): ReturnType<FunctionComponent<EuiComboBoxProps<T>>>;
 }

--- a/src/components/combo_box/matching_options.test.ts
+++ b/src/components/combo_box/matching_options.test.ts
@@ -5,7 +5,7 @@ import {
   getMatchingOptions,
 } from './matching_options';
 
-const options: EuiComboBoxOptionProps[] = [
+const options = [
   {
     label: 'Titan',
     'data-test-subj': 'titanOption',
@@ -51,7 +51,7 @@ describe('flattenOptionGroups', () => {
 describe('getSelectedOptionForSearchValue', () => {
   test('gets the first matching selected option for search value', () => {
     // Assemble
-    const expected: EuiComboBoxOptionProps = {
+    const expected = {
       label: 'Saturn',
       'data-test-subj': 'saturnOption',
     };
@@ -71,7 +71,7 @@ describe('getSelectedOptionForSearchValue', () => {
   });
   test('gets the first matching selected option for search value', () => {
     // Assemble
-    const expected: EuiComboBoxOptionProps = {
+    const expected = {
       label: 'Saturn',
       'data-test-subj': 'saturnOption',
     };
@@ -82,16 +82,18 @@ describe('getSelectedOptionForSearchValue', () => {
   });
 });
 
-interface GetMatchingOptionsTestCase {
-  options: EuiComboBoxOptionProps[];
-  selectedOptions: EuiComboBoxOptionProps[];
+interface GetMatchingOptionsTestCase<T> {
+  options: Array<EuiComboBoxOptionProps<T>>;
+  selectedOptions: Array<EuiComboBoxOptionProps<T>>;
   searchValue: string;
   isPreFiltered: boolean;
   showPrevSelected: boolean;
-  expected: EuiComboBoxOptionProps[];
+  expected: Array<EuiComboBoxOptionProps<T>>;
 }
 
-const testCases: GetMatchingOptionsTestCase[] = [
+const testCases: Array<
+  GetMatchingOptionsTestCase<{ [key: string]: string }>
+> = [
   {
     options,
     selectedOptions: [
@@ -156,7 +158,7 @@ const testCases: GetMatchingOptionsTestCase[] = [
 describe('getMatchingOptions', () => {
   test.each(testCases)(
     '.getMatchingOptions(%o)',
-    (testCase: GetMatchingOptionsTestCase) => {
+    (testCase: typeof testCases[number]) => {
       expect(
         getMatchingOptions(
           testCase.options,

--- a/src/components/combo_box/matching_options.ts
+++ b/src/components/combo_box/matching_options.ts
@@ -1,12 +1,12 @@
 import { EuiComboBoxOptionProps } from '@elastic/eui'; // eslint-disable-line import/no-unresolved
 
-export const flattenOptionGroups = (
-  optionsOrGroups: EuiComboBoxOptionProps[]
+export const flattenOptionGroups = <T>(
+  optionsOrGroups: Array<EuiComboBoxOptionProps<T>>
 ) => {
   return optionsOrGroups.reduce(
     (
-      options: EuiComboBoxOptionProps[],
-      optionOrGroup: EuiComboBoxOptionProps
+      options: Array<EuiComboBoxOptionProps<T>>,
+      optionOrGroup: EuiComboBoxOptionProps<T>
     ) => {
       if (optionOrGroup.options) {
         options.push(...optionOrGroup.options);
@@ -19,9 +19,9 @@ export const flattenOptionGroups = (
   );
 };
 
-export const getSelectedOptionForSearchValue = (
+export const getSelectedOptionForSearchValue = <T>(
   searchValue: string,
-  selectedOptions: EuiComboBoxOptionProps[]
+  selectedOptions: Array<EuiComboBoxOptionProps<T>>
 ) => {
   const normalizedSearchValue = searchValue.toLowerCase();
   return selectedOptions.find(
@@ -29,10 +29,10 @@ export const getSelectedOptionForSearchValue = (
   );
 };
 
-const collectMatchingOption = (
-  accumulator: EuiComboBoxOptionProps[],
-  option: EuiComboBoxOptionProps,
-  selectedOptions: EuiComboBoxOptionProps[],
+const collectMatchingOption = <T>(
+  accumulator: Array<EuiComboBoxOptionProps<T>>,
+  option: EuiComboBoxOptionProps<T>,
+  selectedOptions: Array<EuiComboBoxOptionProps<T>>,
   normalizedSearchValue: string,
   isPreFiltered: boolean,
   showPrevSelected: boolean
@@ -63,20 +63,20 @@ const collectMatchingOption = (
   }
 };
 
-export const getMatchingOptions = (
-  options: EuiComboBoxOptionProps[],
-  selectedOptions: EuiComboBoxOptionProps[],
+export const getMatchingOptions = <T>(
+  options: Array<EuiComboBoxOptionProps<T>>,
+  selectedOptions: Array<EuiComboBoxOptionProps<T>>,
   searchValue: string,
   isPreFiltered: boolean,
   showPrevSelected: boolean
 ) => {
   const normalizedSearchValue = searchValue.trim().toLowerCase();
-  const matchingOptions: EuiComboBoxOptionProps[] = [];
+  const matchingOptions: Array<EuiComboBoxOptionProps<T>> = [];
 
   options.forEach(option => {
     if (option.options) {
-      const matchingOptionsForGroup: EuiComboBoxOptionProps[] = [];
-      option.options.forEach((groupOption: EuiComboBoxOptionProps) => {
+      const matchingOptionsForGroup: Array<EuiComboBoxOptionProps<T>> = [];
+      option.options.forEach((groupOption: EuiComboBoxOptionProps<T>) => {
         collectMatchingOption(
           matchingOptionsForGroup,
           groupOption,


### PR DESCRIPTION
### Summary

Fixes #2078 by updating the typescript definition for EuiComboBox's options' `value`.

I tested these changes in a new project to verify the generic was understood properly -
![understood generic](https://d.pr/i/Ux3Ho1.png)

I also dropped the resulting _eui.d.ts_ file into Kibana and ran the typecheck script, there are two instances in _x-pack/legacy/plugins/siem/public/components/edit_data_provider/index.tsx_ where `EuiComboBox` is used through `styled-components` which interprets the generic as `{}` which is invalid. Both cases are solved by moving the css style onto `EuiComboBox` as a prop.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
