### PR TITLE
[Icons] Updated APM app and solution logos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Made `aria-label` attribute equal to `title` of the the selection checkbox in table items (for each row) in `EuiBasicTable` ([#2043](https://github.com/elastic/eui/pull/2043))
-- Updated `EuiIconAppApm` with new updated icon ([#2084](https://github.com/elastic/eui/pull/2084))
+- Updated `appApm` and `logoAPM` with new updated icons ([#2084](https://github.com/elastic/eui/pull/2084))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Made `aria-label` attribute equal to `title` of the the selection checkbox in table items (for each row) in `EuiBasicTable` ([#2043](https://github.com/elastic/eui/pull/2043))
+- Updated `EuiIconAppApm` with new updated icon ([#2084](https://github.com/elastic/eui/pull/2084))
 
 **Bug fixes**
 

--- a/src/components/icon/__snapshots__/icon.test.tsx.snap
+++ b/src/components/icon/__snapshots__/icon.test.tsx.snap
@@ -607,20 +607,15 @@ exports[`EuiIcon props type apmApp is rendered 1`] = `
   class="euiIcon euiIcon--medium euiIcon--app euiIcon-isLoaded"
   focusable="false"
   height="32"
-  viewBox="0 0 32 32"
   width="32"
   xmlns="http://www.w3.org/2000/svg"
 >
   <path
-    class="euiIcon__fillSecondary"
-    d="M7 9v2H0V0h23v7h-2V2H2v7z"
-  />
-  <path
-    d="M32 9v12H20c-6.075 0-11-4.925-11-11V9h23zm-20.945 2c.497 4.5 4.312 8 8.945 8h10v-8H11.055z"
+    d="M3 10h4v2H1V1h30v6h-2V3H3v7zm26 19v-6h2v8H18v-8h2v6h9z"
   />
   <path
     class="euiIcon__fillSecondary"
-    d="M30 23h2v9H19v-9h2v7h9z"
+    d="M31 10H9v11h12c5.523 0 10-4.477 10-10v-1zm-10 9H11v-7h17.938A8.001 8.001 0 0 1 21 19z"
   />
 </svg>
 `;

--- a/src/components/icon/__snapshots__/icon.test.tsx.snap
+++ b/src/components/icon/__snapshots__/icon.test.tsx.snap
@@ -607,6 +607,7 @@ exports[`EuiIcon props type apmApp is rendered 1`] = `
   class="euiIcon euiIcon--medium euiIcon--app euiIcon-isLoaded"
   focusable="false"
   height="32"
+  viewBox="0 0 32 32"
   width="32"
   xmlns="http://www.w3.org/2000/svg"
 >
@@ -2940,6 +2941,7 @@ exports[`EuiIcon props type logoAPM is rendered 1`] = `
   class="euiIcon euiIcon--medium euiIcon-isLoaded"
   focusable="false"
   height="32"
+  viewBox="0 0 32 32"
   width="32"
   xmlns="http://www.w3.org/2000/svg"
 >

--- a/src/components/icon/__snapshots__/icon.test.tsx.snap
+++ b/src/components/icon/__snapshots__/icon.test.tsx.snap
@@ -2940,20 +2940,19 @@ exports[`EuiIcon props type logoAPM is rendered 1`] = `
   class="euiIcon euiIcon--medium euiIcon-isLoaded"
   focusable="false"
   height="32"
-  viewBox="0 0 32 32"
   width="32"
   xmlns="http://www.w3.org/2000/svg"
 >
   <path
-    d="M0 10.001h24V0H0z"
+    d="M0 0h32v10H0z"
     fill="#F04E98"
   />
   <path
     class="euiIcon__fillNegative"
-    d="M32 20H20c-5.522 0-10-4.478-10-10h22v10z"
+    d="M10 10h22a10 10 0 0 1-10 10H10V10z"
   />
   <path
-    d="M20 32h12v-9H20z"
+    d="M19 23h13v9H19z"
     fill="#0080D5"
   />
 </svg>

--- a/src/components/icon/assets/app_apm.js
+++ b/src/components/icon/assets/app_apm.js
@@ -1,7 +1,12 @@
 import React from 'react';
 
 const EuiIconAppApm = props => (
-  <svg width={32} height={32} xmlns="http://www.w3.org/2000/svg" {...props}>
+  <svg
+    width={32}
+    height={32}
+    viewBox="0 0 32 32"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}>
     <path d="M3 10h4v2H1V1h30v6h-2V3H3v7zm26 19v-6h2v8H18v-8h2v6h9z" />
     <path
       className="euiIcon__fillSecondary"

--- a/src/components/icon/assets/app_apm.js
+++ b/src/components/icon/assets/app_apm.js
@@ -1,15 +1,12 @@
 import React from 'react';
 
 const EuiIconAppApm = props => (
-  <svg
-    width={32}
-    height={32}
-    viewBox="0 0 32 32"
-    xmlns="http://www.w3.org/2000/svg"
-    {...props}>
-    <path className="euiIcon__fillSecondary" d="M7 9v2H0V0h23v7h-2V2H2v7z" />
-    <path d="M32 9v12H20c-6.075 0-11-4.925-11-11V9h23zm-20.945 2c.497 4.5 4.312 8 8.945 8h10v-8H11.055z" />
-    <path className="euiIcon__fillSecondary" d="M30 23h2v9H19v-9h2v7h9z" />
+  <svg width={32} height={32} xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path d="M3 10h4v2H1V1h30v6h-2V3H3v7zm26 19v-6h2v8H18v-8h2v6h9z" />
+    <path
+      className="euiIcon__fillSecondary"
+      d="M31 10H9v11h12c5.523 0 10-4.477 10-10v-1zm-10 9H11v-7h17.938A8.001 8.001 0 0 1 21 19z"
+    />
   </svg>
 );
 

--- a/src/components/icon/assets/app_apm.svg
+++ b/src/components/icon/assets/app_apm.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
   <g>
     <path d="M3 10h4v2H1V1h30v6h-2V3H3v7zm26 19v-6h2v8H18v-8h2v6h9z"/>
     <path class="euiIcon__fillSecondary" d="M31 10H9v11h12c5.523 0 10-4.477 10-10v-1zm-10 9H11v-7h17.938A8.001 8.001 0 0 1 21 19z"/>

--- a/src/components/icon/assets/app_apm.svg
+++ b/src/components/icon/assets/app_apm.svg
@@ -1,7 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <g>
-    <polygon class="euiIcon__fillSecondary" points="7 9 7 11 0 11 0 0 23 0 23 7 21 7 21 2 2 2 2 9"/>
-    <path d="M32,9 L32,21 L20,21 C13.9248678,21 9,16.0751322 9,10 L9,9 L32,9 Z M11.0549288,11 C11.5523731,15.4999505 15.3674463,19 20,19 L30,19 L30,11 L11.0549288,11 Z"/>
-    <polygon class="euiIcon__fillSecondary" points="30 23 32 23 32 32 19 32 19 23 21 23 21 30 30 30"/>
+    <path d="M3 10h4v2H1V1h30v6h-2V3H3v7zm26 19v-6h2v8H18v-8h2v6h9z"/>
+    <path class="euiIcon__fillSecondary" d="M31 10H9v11h12c5.523 0 10-4.477 10-10v-1zm-10 9H11v-7h17.938A8.001 8.001 0 0 1 21 19z"/>
   </g>
 </svg>

--- a/src/components/icon/assets/logo_apm.js
+++ b/src/components/icon/assets/logo_apm.js
@@ -1,18 +1,13 @@
 import React from 'react';
 
 const EuiIconLogoApm = props => (
-  <svg
-    width={32}
-    height={32}
-    viewBox="0 0 32 32"
-    xmlns="http://www.w3.org/2000/svg"
-    {...props}>
-    <path fill="#F04E98" d="M0 10.001h24V0H0z" />
+  <svg width={32} height={32} xmlns="http://www.w3.org/2000/svg" {...props}>
+    <path fill="#F04E98" d="M0 0h32v10H0z" />
     <path
       className="euiIcon__fillNegative"
-      d="M32 20H20c-5.522 0-10-4.478-10-10h22v10z"
+      d="M10 10h22a10 10 0 0 1-10 10H10V10z"
     />
-    <path fill="#0080D5" d="M20 32h12v-9H20z" />
+    <path fill="#0080D5" d="M19 23h13v9H19z" />
   </svg>
 );
 

--- a/src/components/icon/assets/logo_apm.js
+++ b/src/components/icon/assets/logo_apm.js
@@ -1,7 +1,12 @@
 import React from 'react';
 
 const EuiIconLogoApm = props => (
-  <svg width={32} height={32} xmlns="http://www.w3.org/2000/svg" {...props}>
+  <svg
+    width={32}
+    height={32}
+    viewBox="0 0 32 32"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}>
     <path fill="#F04E98" d="M0 0h32v10H0z" />
     <path
       className="euiIcon__fillNegative"

--- a/src/components/icon/assets/logo_apm.svg
+++ b/src/components/icon/assets/logo_apm.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
   <g>
     <path fill="#F04E98" d="M0 0h32v10H0z"/>
     <path class="euiIcon__fillNegative" d="M10 10h22a10 10 0 0 1-10 10H10V10z"/>

--- a/src/components/icon/assets/logo_apm.svg
+++ b/src/components/icon/assets/logo_apm.svg
@@ -1,7 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
   <g>
-    <polygon fill="#F04E98" points="0 10.001 24 10.001 24 0 0 0"/>
-    <path class="euiIcon__fillNegative" d="M32,20 L20,20 C14.478,20 10,15.522 10,10 L32,10 L32,20 Z"/>
-    <polygon fill="#0080D5" points="20 32 32 32 32 23 20 23"/>
+    <path fill="#F04E98" d="M0 0h32v10H0z"/>
+    <path class="euiIcon__fillNegative" d="M10 10h22a10 10 0 0 1-10 10H10V10z"/>
+    <path fill="#0080D5" d="M19 23h13v9H19z"/>
   </g>
 </svg>


### PR DESCRIPTION
### Summary

- Updated the APM app icon because we have a new revised icon.

<img width="248" alt="Screenshot 2019-07-01 at 10 17 50" src="https://user-images.githubusercontent.com/4104278/60422029-6247c000-9beb-11e9-8f3d-9821ac796685.png"><img width="240" alt="Screenshot 2019-07-01 at 10 17 58" src="https://user-images.githubusercontent.com/4104278/60422031-62e05680-9beb-11e9-9f30-39b8ad1099ec.png">

- Updated the APM solution logo

<img width="247" alt="Screenshot 2019-07-01 at 12 54 04" src="https://user-images.githubusercontent.com/4104278/60431150-5c5bda00-9bff-11e9-8891-b83ccb0d6e8a.png"><img width="236" alt="Screenshot 2019-07-01 at 12 54 12" src="https://user-images.githubusercontent.com/4104278/60431151-5c5bda00-9bff-11e9-85a9-543712654a47.png">


### Checklist

- [ ] ~~This was checked in mobile~~
- [ ] ~~This was checked in IE11~~
- [x] This was checked in dark mode
- [ ] ~~Any props added have proper autodocs~~
- [ ] ~~Documentation examples were added~~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] ~~This was checked for breaking changes and labeled appropriately~~
- [ ] ~~Jest tests were updated or added to match the most common scenarios~~
- [ ] ~~This was checked against keyboard-only and screenreader scenarios~~
- [ ] ~~This required updates to Framer X components~~
