### PR TITLE
Allow ESC to propagate if `EuiPopover` is not open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added TS defs for `EuiComboBox`'s props spreading onto a `div` ([#2080](https://github.com/elastic/eui/pull/2080))
 - Fixed responsive display of inline `EuiDatePicker` ([#1820](https://github.com/elastic/eui/pull/1820))
 - Removed time from default `dateFormat` of `EuiDatePicker` ([#1820](https://github.com/elastic/eui/pull/1820))
+- Fixed `EuiPopover` from catching and preventing propagation of keydown events when closed ([#2089](https://github.com/elastic/eui/pull/2089))
 
 ## [`12.2.0`](https://github.com/elastic/eui/tree/v12.2.0)
 

--- a/src/components/color_picker/color_picker.test.js
+++ b/src/components/color_picker/color_picker.test.js
@@ -3,13 +3,7 @@ import { render, mount } from 'enzyme';
 
 import { EuiColorPicker } from './color_picker';
 import { VISUALIZATION_COLORS, keyCodes } from '../../services';
-import { requiredProps, findTestSubject } from '../../test';
-
-function pause(ms) {
-  return new Promise(resolve => {
-    setTimeout(resolve, ms);
-  });
-}
+import { requiredProps, findTestSubject, sleep } from '../../test';
 
 jest.mock('../portal', () => ({
   EuiPortal: ({ children }) => children,
@@ -135,7 +129,7 @@ test('popover color selector is hidden when the ESC key pressed', async () => {
   );
 
   findTestSubject(colorPicker, 'colorPickerAnchor').simulate('click');
-  await pause(50);
+  await sleep();
   findTestSubject(colorPicker, 'colorPickerPopover').simulate('keydown', {
     keyCode: keyCodes.ESCAPE,
   });

--- a/src/components/color_picker/color_picker.test.js
+++ b/src/components/color_picker/color_picker.test.js
@@ -5,6 +5,12 @@ import { EuiColorPicker } from './color_picker';
 import { VISUALIZATION_COLORS, keyCodes } from '../../services';
 import { requiredProps, findTestSubject } from '../../test';
 
+function pause(ms) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
 jest.mock('../portal', () => ({
   EuiPortal: ({ children }) => children,
 }));
@@ -117,7 +123,7 @@ test('popover color selector is shown when the input is clicked', () => {
   expect(colorSelector.length).toBe(1);
 });
 
-test('popover color selector is hidden when the ESC key pressed', () => {
+test('popover color selector is hidden when the ESC key pressed', async () => {
   const onBlurHandler = jest.fn();
   const colorPicker = mount(
     <EuiColorPicker
@@ -129,6 +135,7 @@ test('popover color selector is hidden when the ESC key pressed', () => {
   );
 
   findTestSubject(colorPicker, 'colorPickerAnchor').simulate('click');
+  await pause(50);
   findTestSubject(colorPicker, 'colorPickerPopover').simulate('keydown', {
     keyCode: keyCodes.ESCAPE,
   });

--- a/src/components/date_picker/super_date_picker/async_interval.test.js
+++ b/src/components/date_picker/super_date_picker/async_interval.test.js
@@ -1,5 +1,6 @@
 import { AsyncInterval } from './async_interval';
 import { times } from 'lodash';
+import { sleep } from '../../../test';
 
 describe('AsyncInterval', () => {
   beforeEach(() => {
@@ -67,7 +68,6 @@ describe('AsyncInterval', () => {
     let instance;
     let spy;
     beforeEach(() => {
-      const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
       spy = jest.fn(async () => await sleep(2000));
       instance = new AsyncInterval(spy, 1000);
     });

--- a/src/components/observer/mutation_observer/mutation_observer.test.tsx
+++ b/src/components/observer/mutation_observer/mutation_observer.test.tsx
@@ -1,12 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import { mount } from 'enzyme';
 import { EuiMutationObserver } from './mutation_observer';
-
-async function sleep(duration: number) {
-  return new Promise(resolve => {
-    setTimeout(resolve, duration);
-  });
-}
+import { sleep } from '../../../test';
 
 export async function waitforMutationObserver(period = 30) {
   // `period` defaults to 30 because its the delay used by the MutationObserver polyfill

--- a/src/components/observer/resize_observer/resize_observer.test.tsx
+++ b/src/components/observer/resize_observer/resize_observer.test.tsx
@@ -1,12 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import { mount } from 'enzyme';
 import { EuiResizeObserver } from './resize_observer';
-
-async function sleep(duration: number) {
-  return new Promise(resolve => {
-    setTimeout(resolve, duration);
-  });
-}
+import { sleep } from '../../../test';
 
 export async function waitforResizeObserver(period = 30) {
   // `period` defaults to 30 because its the delay used by the ResizeObserver polyfill

--- a/src/components/popover/__snapshots__/popover.test.js.snap
+++ b/src/components/popover/__snapshots__/popover.test.js.snap
@@ -44,7 +44,7 @@ exports[`EuiPopover props anchorClassName is rendered 1`] = `
 exports[`EuiPopover props anchorPosition defaults to centerDown 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
-  id="5"
+  id="6"
 >
   <div
     class="euiPopover__anchor"
@@ -57,7 +57,7 @@ exports[`EuiPopover props anchorPosition defaults to centerDown 1`] = `
 exports[`EuiPopover props anchorPosition downRight is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownRight"
-  id="7"
+  id="8"
 >
   <div
     class="euiPopover__anchor"
@@ -70,7 +70,7 @@ exports[`EuiPopover props anchorPosition downRight is rendered 1`] = `
 exports[`EuiPopover props anchorPosition leftCenter is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorLeftCenter"
-  id="6"
+  id="7"
 >
   <div
     class="euiPopover__anchor"
@@ -83,7 +83,7 @@ exports[`EuiPopover props anchorPosition leftCenter is rendered 1`] = `
 exports[`EuiPopover props isOpen defaults to false 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
-  id="8"
+  id="9"
 >
   <div
     class="euiPopover__anchor"
@@ -94,53 +94,6 @@ exports[`EuiPopover props isOpen defaults to false 1`] = `
 `;
 
 exports[`EuiPopover props isOpen renders true 1`] = `
-<div>
-  <div
-    class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
-    id="9"
-  >
-    <div
-      class="euiPopover__anchor"
-    >
-      <button />
-    </div>
-    <div>
-      <div
-        data-focus-guard="true"
-        style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-        tabindex="-1"
-      />
-      <div
-        data-focus-guard="true"
-        style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-        tabindex="-1"
-      />
-      <div
-        data-focus-lock-disabled="disabled"
-      >
-        <div
-          aria-live="assertive"
-          class="euiPanel euiPanel--paddingMedium euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
-          style="top: 16px; left: -22px; z-index: 0;"
-        >
-          <div
-            class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
-            style="left: 10px; top: 0px;"
-          />
-          <div />
-        </div>
-      </div>
-      <div
-        data-focus-guard="true"
-        style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-        tabindex="-1"
-      />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`EuiPopover props ownFocus defaults to false 1`] = `
 <div>
   <div
     class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
@@ -187,11 +140,58 @@ exports[`EuiPopover props ownFocus defaults to false 1`] = `
 </div>
 `;
 
-exports[`EuiPopover props ownFocus renders true 1`] = `
+exports[`EuiPopover props ownFocus defaults to false 1`] = `
 <div>
   <div
     class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
     id="11"
+  >
+    <div
+      class="euiPopover__anchor"
+    >
+      <button />
+    </div>
+    <div>
+      <div
+        data-focus-guard="true"
+        style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+        tabindex="-1"
+      />
+      <div
+        data-focus-guard="true"
+        style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+        tabindex="-1"
+      />
+      <div
+        data-focus-lock-disabled="disabled"
+      >
+        <div
+          aria-live="assertive"
+          class="euiPanel euiPanel--paddingMedium euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
+          style="top: 16px; left: -22px; z-index: 0;"
+        >
+          <div
+            class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
+            style="left: 10px; top: 0px;"
+          />
+          <div />
+        </div>
+      </div>
+      <div
+        data-focus-guard="true"
+        style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+        tabindex="-1"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiPopover props ownFocus renders true 1`] = `
+<div>
+  <div
+    class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
+    id="12"
   >
     <div
       class="euiPopover__anchor"
@@ -246,7 +246,7 @@ exports[`EuiPopover props panelClassName is rendered 1`] = `
 <div>
   <div
     class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
-    id="12"
+    id="13"
   >
     <div
       class="euiPopover__anchor"
@@ -293,7 +293,7 @@ exports[`EuiPopover props panelPaddingSize is rendered 1`] = `
 <div>
   <div
     class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
-    id="13"
+    id="14"
   >
     <div
       class="euiPopover__anchor"

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -149,9 +149,11 @@ export class EuiPopover extends Component {
 
   onKeyDown = e => {
     if (e.keyCode === cascadingMenuKeyCodes.ESCAPE) {
-      e.preventDefault();
-      e.stopPropagation();
-      this.props.closePopover();
+      if (this.state.isOpenStable || this.state.isOpening) {
+        e.preventDefault();
+        e.stopPropagation();
+        this.props.closePopover();
+      }
     }
   };
 

--- a/src/components/popover/popover.test.js
+++ b/src/components/popover/popover.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render, mount } from 'enzyme';
-import sinon from 'sinon';
 import { requiredProps } from '../../test/required_props';
 
 import {
@@ -75,7 +74,7 @@ describe('EuiPopover', () => {
 
     describe('closePopover', () => {
       it('is called when ESC key is hit and the popover is open', () => {
-        const closePopoverHandler = sinon.stub();
+        const closePopoverHandler = jest.fn();
 
         const component = mount(
           <EuiPopover
@@ -88,7 +87,24 @@ describe('EuiPopover', () => {
         );
 
         component.simulate('keydown', { keyCode: keyCodes.ESCAPE });
-        sinon.assert.calledOnce(closePopoverHandler);
+        expect(closePopoverHandler).toBeCalledTimes(1);
+      });
+
+      it('is not called when ESC key is hit and the popover is closed', () => {
+        const closePopoverHandler = jest.fn();
+
+        const component = mount(
+          <EuiPopover
+            id={getId()}
+            withTitle
+            button={<button />}
+            closePopover={closePopoverHandler}
+            isOpen={false}
+          />
+        );
+
+        component.simulate('keydown', { keyCode: keyCodes.ESCAPE });
+        expect(closePopoverHandler).not.toBeCalled();
       });
     });
 

--- a/src/components/popover/popover.test.js
+++ b/src/components/popover/popover.test.js
@@ -74,7 +74,7 @@ describe('EuiPopover', () => {
     });
 
     describe('closePopover', () => {
-      it('is called when ESC key is hit', () => {
+      it('is called when ESC key is hit and the popover is open', () => {
         const closePopoverHandler = sinon.stub();
 
         const component = mount(
@@ -83,6 +83,7 @@ describe('EuiPopover', () => {
             withTitle
             button={<button />}
             closePopover={closePopoverHandler}
+            isOpen
           />
         );
 

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -5,3 +5,4 @@ export {
   startThrowingReactWarnings,
   stopThrowingReactWarnings,
 } from './react_warnings';
+export { sleep } from './sleep';

--- a/src/test/sleep.ts
+++ b/src/test/sleep.ts
@@ -1,0 +1,6 @@
+// async timeout function for awaiting state or DOM updates
+export function sleep(ms: number = 50) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}


### PR DESCRIPTION
### Summary

Fixes #2042, in which a _closed_ `EuiPopover` inside of an _open_ `EuiPopover` will catch the `ESC` key press and prevent event propagation, preventing the open `EuiPopover` from closing.
More generally, this solution will allow propagation regardless of nesting/location if the `EuiPopover` is not open.

### Checklist

~~- [ ] This was checked in mobile~~
~~- [ ] This was checked in IE11~~
~~- [ ] This was checked in dark mode~~
~~- [ ] Any props added have proper autodocs~~
~~- [ ] Documentation examples were added~~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
- [x] Jest tests were updated or added to match the most common scenarios

~~- [ ] This was checked against keyboard-only and screenreader scenarios~~
~~- [ ] This required updates to Framer X components~~
