### PR TITLE
 Added `display` prop to EuiPopover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added TypeScript definition for `EuiFormControlLayout` ([#2086](https://github.com/elastic/eui/pull/2086))
 - Changed SASS mixin `euiOverflowShadow()` to use `mask-image` instead of `box-shadow` ([#2088](https://github.com/elastic/eui/pull/2088))
 - Added SASS mixin and CSS utility `euiYScrollWithShadows` ([#2088](https://github.com/elastic/eui/pull/2088))
+- Added `display` prop to `EuiPopover` ([#2112](https://github.com/elastic/eui/pull/2112))
 
 **Bug fixes**
 

--- a/src-docs/src/views/popover/popover_block.js
+++ b/src-docs/src/views/popover/popover_block.js
@@ -1,0 +1,45 @@
+import React, { Component } from 'react';
+
+import { EuiButton, EuiPopover } from '../../../../src/components';
+
+export default class PopoverContainer extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isPopoverOpen: false,
+    };
+  }
+
+  onButtonClick = () => {
+    this.setState({
+      isPopoverOpen: !this.state.isPopoverOpen,
+    });
+  };
+
+  closePopover = () => {
+    this.setState({
+      isPopoverOpen: false,
+    });
+  };
+
+  setPanelRef = node => (this.panel = node);
+
+  render() {
+    const button = (
+      <EuiButton onClick={this.onButtonClick} fullWidth>
+        This button is expanded
+      </EuiButton>
+    );
+
+    return (
+      <EuiPopover
+        button={button}
+        isOpen={this.state.isPopoverOpen}
+        closePopover={this.closePopover}
+        display="block">
+        <div>This is a popover</div>
+      </EuiPopover>
+    );
+  }
+}

--- a/src-docs/src/views/popover/popover_example.js
+++ b/src-docs/src/views/popover/popover_example.js
@@ -47,6 +47,10 @@ import PopoverFixed from './popover_fixed';
 const popoverFixedSource = require('!!raw-loader!./popover_fixed');
 const popoverFixedHtml = renderToHtml(PopoverFixed);
 
+import PopoverBlock from './popover_block';
+const popoverBlockSource = require('!!raw-loader!./popover_block');
+const popoverBlockHtml = renderToHtml(PopoverBlock);
+
 const popOverSnippet = `<EuiPopover
   button={button}
   isOpen={this.state.isPopoverOpen}
@@ -112,6 +116,14 @@ const popoverFixedSnippet = `<EuiPopover
   closePopover={this.closePopover}
   repositionOnScroll={true}>
   <!-- Popover on a fixed element -->
+</EuiPopover>`;
+
+const popoverBlockSnippet = `<EuiPopover
+  button={button}
+  isOpen={this.state.isPopoverOpen}
+  closePopover={this.closePopover}
+  display="block">
+  <!-- Popover anchor is display block -->
 </EuiPopover>`;
 
 export const PopoverExample = {
@@ -348,6 +360,31 @@ export const PopoverExample = {
       ),
       snippet: popoverFixedSnippet,
       demo: <PopoverFixed />,
+    },
+    {
+      title: 'Popover as display block',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: popoverBlockSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: popoverBlockHtml,
+        },
+      ],
+      text: (
+        <div>
+          <p>
+            Popover anchors are forced to be{' '}
+            <EuiCode>display: inline-block</EuiCode> so they do not force block
+            display on inline triggers. If you do need to change this to block
+            display, just add <EuiCode>display=&quot;block&quot;</EuiCode>
+          </p>
+        </div>
+      ),
+      snippet: popoverBlockSnippet,
+      demo: <PopoverBlock />,
     },
   ],
 };

--- a/src-docs/src/views/popover/popover_example.js
+++ b/src-docs/src/views/popover/popover_example.js
@@ -362,7 +362,7 @@ export const PopoverExample = {
       demo: <PopoverFixed />,
     },
     {
-      title: 'Popover as display block',
+      title: 'Popover with block level display',
       source: [
         {
           type: GuideSectionTypes.JS,

--- a/src-docs/src/views/popover/popover_example.js
+++ b/src-docs/src/views/popover/popover_example.js
@@ -376,7 +376,7 @@ export const PopoverExample = {
       text: (
         <div>
           <p>
-            Popover anchors are forced to be{' '}
+            Popover anchors default to{' '}
             <EuiCode>display: inline-block</EuiCode> so they do not force block
             display on inline triggers. If you do need to change this to block
             display, just add <EuiCode>display=&quot;block&quot;</EuiCode>

--- a/src-docs/src/views/popover/popover_example.js
+++ b/src-docs/src/views/popover/popover_example.js
@@ -376,10 +376,10 @@ export const PopoverExample = {
       text: (
         <div>
           <p>
-            Popover anchors default to{' '}
-            <EuiCode>display: inline-block</EuiCode> so they do not force block
-            display on inline triggers. If you do need to change this to block
-            display, just add <EuiCode>display=&quot;block&quot;</EuiCode>
+            Popover anchors default to <EuiCode>display: inline-block</EuiCode>{' '}
+            so they do not force block display on inline triggers. If you do
+            need to change this to block display, just add{' '}
+            <EuiCode>display=&quot;block&quot;</EuiCode>
           </p>
         </div>
       ),

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
@@ -334,6 +334,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                         </EuiButtonEmpty>
                       }
                       closePopover={[Function]}
+                      display="inlineBlock"
                       hasArrow={true}
                       id="customizablePagination"
                       isOpen={false}

--- a/src/components/color_picker/__snapshots__/color_picker.test.js.snap
+++ b/src/components/color_picker/__snapshots__/color_picker.test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`renders EuiColorPicker 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownLeft euiColorPicker__popoverContainer"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock"
 >
   <div
-    class="euiPopover__anchor euiColorPicker__popoverAnchor"
+    class="euiPopover__anchor"
   >
     <div
       class="euiFormControlLayout"
@@ -76,10 +76,10 @@ exports[`renders EuiColorPicker 1`] = `
 
 exports[`renders EuiColorPicker with a color swatch when color is defined 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownLeft euiColorPicker__popoverContainer"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock"
 >
   <div
-    class="euiPopover__anchor euiColorPicker__popoverAnchor"
+    class="euiPopover__anchor"
   >
     <div
       class="euiFormControlLayout"
@@ -150,10 +150,10 @@ exports[`renders EuiColorPicker with a color swatch when color is defined 1`] = 
 
 exports[`renders EuiColorPicker with an empty swatch when color is "" 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownLeft euiColorPicker__popoverContainer"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock"
 >
   <div
-    class="euiPopover__anchor euiColorPicker__popoverAnchor"
+    class="euiPopover__anchor"
   >
     <div
       class="euiFormControlLayout"
@@ -223,10 +223,10 @@ exports[`renders EuiColorPicker with an empty swatch when color is "" 1`] = `
 
 exports[`renders EuiColorPicker with an empty swatch when color is null 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownLeft euiColorPicker__popoverContainer"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock"
 >
   <div
-    class="euiPopover__anchor euiColorPicker__popoverAnchor"
+    class="euiPopover__anchor"
   >
     <div
       class="euiFormControlLayout"
@@ -296,10 +296,10 @@ exports[`renders EuiColorPicker with an empty swatch when color is null 1`] = `
 
 exports[`renders compressed EuiColorPicker 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownLeft euiColorPicker__popoverContainer"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock"
 >
   <div
-    class="euiPopover__anchor euiColorPicker__popoverAnchor"
+    class="euiPopover__anchor"
   >
     <div
       class="euiFormControlLayout euiFormControlLayout--compressed"
@@ -370,10 +370,10 @@ exports[`renders compressed EuiColorPicker 1`] = `
 
 exports[`renders disabled EuiColorPicker 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownLeft euiColorPicker__popoverContainer"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock"
 >
   <div
-    class="euiPopover__anchor euiColorPicker__popoverAnchor"
+    class="euiPopover__anchor"
   >
     <div
       class="euiFormControlLayout"
@@ -445,10 +445,10 @@ exports[`renders disabled EuiColorPicker 1`] = `
 
 exports[`renders fullWidth EuiColorPicker 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownLeft euiColorPicker__popoverContainer"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock"
 >
   <div
-    class="euiPopover__anchor euiColorPicker__popoverAnchor"
+    class="euiPopover__anchor"
   >
     <div
       class="euiFormControlLayout euiFormControlLayout--fullWidth"
@@ -519,10 +519,10 @@ exports[`renders fullWidth EuiColorPicker 1`] = `
 
 exports[`renders readOnly EuiColorPicker 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownLeft euiColorPicker__popoverContainer"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock"
 >
   <div
-    class="euiPopover__anchor euiColorPicker__popoverAnchor"
+    class="euiPopover__anchor"
   >
     <div
       class="euiFormControlLayout euiFormControlLayout--readOnly"

--- a/src/components/color_picker/_color_picker.scss
+++ b/src/components/color_picker/_color_picker.scss
@@ -17,18 +17,6 @@
   padding-bottom: 0 !important;
 }
 
-.euiColorPicker__popoverContainer:not(.euiColorPicker__popoverContainer--customButton) {
-  // Override of EuiPopover display
-  // sass-lint:disable no-important
-  display: block !important;
-}
-
-.euiColorPicker__popoverAnchor:not(.euiColorPicker__popoverAnchor--customButton) {
-  // Override of EuiPopover display
-  // sass-lint:disable no-important
-  display: block !important;
-}
-
 .euiColorPicker__popoverPanel[class*='bottom']:not(.euiColorPicker__popoverPanel--customButton) {
   border-top-color: transparentize($euiBorderColor, .2);
   border-top-right-radius: 0;

--- a/src/components/color_picker/color_picker.js
+++ b/src/components/color_picker/color_picker.js
@@ -62,12 +62,6 @@ export const EuiColorPicker = ({
     'euiColorPicker__popoverPanel--pickerOnly': mode === 'picker',
     'euiColorPicker__popoverPanel--customButton': button,
   });
-  const popoverClasses = classNames('euiColorPicker__popoverContainer', {
-    'euiColorPicker__popoverContainer--customButton': button,
-  });
-  const anchorClasses = classNames('euiColorPicker__popoverAnchor', {
-    'euiColorPicker__popoverAnchor--customButton': button,
-  });
   const swatchClass = 'euiColorPicker__swatchSelect';
   const testSubjAnchor = 'colorPickerAnchor';
   const testSubjPopover = 'colorPickerPopover';
@@ -246,9 +240,8 @@ export const EuiColorPicker = ({
       isOpen={isColorSelectorShown}
       closePopover={handleFinalSelection}
       zIndex={popoverZIndex}
-      className={popoverClasses}
-      anchorClassName={anchorClasses}
       panelClassName={panelClasses}
+      display={button ? 'inlineBlock' : 'block'}
       attachToAnchor={button ? false : true}
       anchorPosition="downLeft"
       panelPaddingSize="s">

--- a/src/components/date_picker/super_date_picker/date_popover/_date_popover_button.scss
+++ b/src/components/date_picker/super_date_picker/date_popover/_date_popover_button.scss
@@ -1,7 +1,3 @@
-.euiDatePopoverButton__popover .euiDatePopoverButton__popoverAnchor {
-  display: block;
-}
-
 .euiDatePopoverButton {
   @include euiSuperDatePickerText;
   background-size: 100%; // For the bottom "border" via background-image

--- a/src/components/date_picker/super_date_picker/date_popover/date_popover_button.js
+++ b/src/components/date_picker/super_date_picker/date_popover/date_popover_button.js
@@ -53,12 +53,11 @@ export function EuiDatePopoverButton(props) {
 
   return (
     <EuiPopover
-      className="euiDatePopoverButton__popover"
       button={button}
       isOpen={isOpen}
       closePopover={onPopoverClose}
       anchorPosition={position === 'start' ? 'downLeft' : 'downRight'}
-      anchorClassName="euiDatePopoverButton__popoverAnchor"
+      display="block"
       panelPaddingSize="none"
       ownFocus
       {...rest}>

--- a/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select_popover.test.js.snap
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select_popover.test.js.snap
@@ -26,6 +26,7 @@ exports[`EuiQuickSelectPopover is rendered 1`] = `
     </EuiButtonEmpty>
   }
   closePopover={[Function]}
+  display="inlineBlock"
   hasArrow={true}
   id="QuickSelectPopover"
   isOpen={false}
@@ -111,6 +112,7 @@ exports[`EuiQuickSelectPopover isAutoRefreshOnly 1`] = `
     </EuiButtonEmpty>
   }
   closePopover={[Function]}
+  display="inlineBlock"
   hasArrow={true}
   id="QuickSelectPopover"
   isOpen={false}

--- a/src/components/form/super_select/__snapshots__/super_select.test.js.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.js.snap
@@ -469,6 +469,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
     }
     className="euiSuperSelect"
     closePopover={[Function]}
+    display="inlineBlock"
     hasArrow={false}
     isOpen={true}
     ownFocus={false}

--- a/src/components/form/super_select/__snapshots__/super_select.test.js.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`EuiSuperSelect is rendered 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
 >
   <div
-    class="euiPopover__anchor euiSuperSelect__popoverAnchor"
+    class="euiPopover__anchor"
   >
     <input
       type="hidden"
@@ -58,10 +58,10 @@ exports[`EuiSuperSelect is rendered 1`] = `
 
 exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
 >
   <div
-    class="euiPopover__anchor euiSuperSelect__popoverAnchor"
+    class="euiPopover__anchor"
   >
     <input
       type="hidden"
@@ -206,10 +206,10 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
 
 exports[`EuiSuperSelect props fullWidth is rendered 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiSuperSelect euiSuperSelect--fullWidth"
+  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect euiSuperSelect--fullWidth"
 >
   <div
-    class="euiPopover__anchor euiSuperSelect__popoverAnchor"
+    class="euiPopover__anchor"
   >
     <input
       type="hidden"
@@ -262,10 +262,10 @@ exports[`EuiSuperSelect props fullWidth is rendered 1`] = `
 
 exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
 >
   <div
-    class="euiPopover__anchor euiSuperSelect__popoverAnchor"
+    class="euiPopover__anchor"
   >
     <input
       type="hidden"
@@ -438,7 +438,6 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
   valueOfSelected="1"
 >
   <EuiPopover
-    anchorClassName="euiSuperSelect__popoverAnchor"
     anchorPosition="downCenter"
     button={
       <EuiSuperSelectControl
@@ -469,7 +468,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
     }
     className="euiSuperSelect"
     closePopover={[Function]}
-    display="inlineBlock"
+    display="block"
     hasArrow={false}
     isOpen={true}
     ownFocus={false}
@@ -482,7 +481,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
       onOutsideClick={[Function]}
     >
       <div
-        className="euiPopover euiPopover--anchorDownCenter euiSuperSelect"
+        className="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
         onKeyDown={[Function]}
         onMouseDown={[Function]}
         onMouseUp={[Function]}
@@ -490,7 +489,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
         onTouchStart={[Function]}
       >
         <div
-          className="euiPopover__anchor euiSuperSelect__popoverAnchor"
+          className="euiPopover__anchor"
         >
           <EuiSuperSelectControl
             className="euiSuperSelect--isOpen__button"
@@ -1097,10 +1096,10 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
 
 exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
 >
   <div
-    class="euiPopover__anchor euiSuperSelect__popoverAnchor"
+    class="euiPopover__anchor"
   >
     <input
       type="hidden"
@@ -1245,10 +1244,10 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
 
 exports[`EuiSuperSelect props select component is rendered 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
 >
   <div
-    class="euiPopover__anchor euiSuperSelect__popoverAnchor"
+    class="euiPopover__anchor"
   >
     <input
       type="hidden"
@@ -1299,10 +1298,10 @@ exports[`EuiSuperSelect props select component is rendered 1`] = `
 
 exports[`EuiSuperSelect props valueSelected is rendered 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
 >
   <div
-    class="euiPopover__anchor euiSuperSelect__popoverAnchor"
+    class="euiPopover__anchor"
   >
     <input
       type="hidden"

--- a/src/components/form/super_select/_super_select.scss
+++ b/src/components/form/super_select/_super_select.scss
@@ -5,15 +5,9 @@
  */
 
 .euiSuperSelect {
-  width: 100%;
-
   &:not(.euiSuperSelect--fullWidth) { /* 1 */
     // sass-lint:disable-block no-important
     max-width: $euiFormMaxWidth !important; // override default popover styles
-  }
-
-  .euiSuperSelect__popoverAnchor {
-    display: block;
   }
 }
 

--- a/src/components/form/super_select/super_select.js
+++ b/src/components/form/super_select/super_select.js
@@ -235,7 +235,7 @@ export class EuiSuperSelect extends Component {
     return (
       <EuiPopover
         className={popoverClasses}
-        anchorClassName="euiSuperSelect__popoverAnchor"
+        display="block"
         panelClassName={popoverPanelClasses}
         button={button}
         isOpen={isOpen || this.state.isPopoverOpen}

--- a/src/components/popover/__snapshots__/popover.test.js.snap
+++ b/src/components/popover/__snapshots__/popover.test.js.snap
@@ -80,6 +80,19 @@ exports[`EuiPopover props anchorPosition leftCenter is rendered 1`] = `
 </div>
 `;
 
+exports[`EuiPopover props display block is rendered 1`] = `
+<div
+  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+  id="2"
+>
+  <div
+    class="euiPopover__anchor"
+  >
+    <button />
+  </div>
+</div>
+`;
+
 exports[`EuiPopover props isOpen defaults to false 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter"
@@ -332,19 +345,6 @@ exports[`EuiPopover props panelPaddingSize is rendered 1`] = `
         tabindex="-1"
       />
     </div>
-  </div>
-</div>
-`;
-
-exports[`EuiPopover props withTitle is rendered 1`] = `
-<div
-  class="euiPopover euiPopover--anchorDownCenter euiPopover--withTitle"
-  id="2"
->
-  <div
-    class="euiPopover__anchor"
-  >
-    <button />
   </div>
 </div>
 `;

--- a/src/components/popover/_popover.scss
+++ b/src/components/popover/_popover.scss
@@ -15,6 +15,14 @@
   display: inline-block;
 }
 
+.euiPopover--displayBlock {
+  display: block;
+
+  .euiPopover__anchor {
+    display: block;
+  }
+}
+
 /**
  * 1. Can expand further, but it looks weird if it's smaller than the originating button.
  * 2. Animation happens on the panel.

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -72,6 +72,13 @@ const anchorPositionToClassNameMap = {
 
 export const ANCHOR_POSITIONS = Object.keys(anchorPositionToClassNameMap);
 
+const displayToClassNameMap = {
+  inlineBlock: undefined,
+  block: 'euiPopover--displayBlock',
+};
+
+export const DISPLAY = Object.keys(displayToClassNameMap);
+
 const DEFAULT_POPOVER_STYLES = {
   top: 50,
   left: 50,
@@ -413,12 +420,14 @@ export class EuiPopover extends Component {
       zIndex,
       initialFocus,
       attachToAnchor,
+      display,
       ...rest
     } = this.props;
 
     const classes = classNames(
       'euiPopover',
       anchorPositionToClassNameMap[anchorPosition],
+      displayToClassNameMap[display],
       {
         'euiPopover-isOpen': this.state.isOpening,
         'euiPopover--withTitle': withTitle,
@@ -553,6 +562,8 @@ EuiPopover.propTypes = {
   }),
   /** Style and position alteration for arrow-less, left-aligned attachment. Intended for use with inputs as anchors, à la EuiColorPicker */
   attachToAnchor: PropTypes.bool,
+  /** CSS display type for both the popover and anchor */
+  display: PropTypes.oneOf(DISPLAY),
 };
 
 EuiPopover.defaultProps = {
@@ -561,4 +572,5 @@ EuiPopover.defaultProps = {
   anchorPosition: 'downCenter',
   panelPaddingSize: 'm',
   hasArrow: true,
+  display: 'inlineBlock',
 };

--- a/src/components/popover/popover.test.js
+++ b/src/components/popover/popover.test.js
@@ -42,12 +42,12 @@ describe('EuiPopover', () => {
   });
 
   describe('props', () => {
-    describe('withTitle', () => {
+    describe('display block', () => {
       test('is rendered', () => {
         const component = render(
           <EuiPopover
             id={getId()}
-            withTitle
+            display="block"
             button={<button />}
             closePopover={() => {}}
           />

--- a/src/components/search_bar/filters/__snapshots__/field_value_selection_filter.test.js.snap
+++ b/src/components/search_bar/filters/__snapshots__/field_value_selection_filter.test.js.snap
@@ -17,6 +17,7 @@ exports[`FieldValueSelectionFilter active - field is global 1`] = `
     </EuiFilterButton>
   }
   closePopover={[Function]}
+  display="inlineBlock"
   hasArrow={true}
   id="field_value_selection_0"
   isOpen={false}
@@ -76,6 +77,7 @@ exports[`FieldValueSelectionFilter active - fields in options 1`] = `
     </EuiFilterButton>
   }
   closePopover={[Function]}
+  display="inlineBlock"
   hasArrow={true}
   id="field_value_selection_0"
   isOpen={false}
@@ -135,6 +137,7 @@ exports[`FieldValueSelectionFilter inactive - field is global 1`] = `
     </EuiFilterButton>
   }
   closePopover={[Function]}
+  display="inlineBlock"
   hasArrow={true}
   id="field_value_selection_0"
   isOpen={false}
@@ -193,6 +196,7 @@ exports[`FieldValueSelectionFilter inactive - fields in options 1`] = `
     </EuiFilterButton>
   }
   closePopover={[Function]}
+  display="inlineBlock"
   hasArrow={true}
   id="field_value_selection_0"
   isOpen={false}
@@ -251,6 +255,7 @@ exports[`FieldValueSelectionFilter render - all configurations 1`] = `
     </EuiFilterButton>
   }
   closePopover={[Function]}
+  display="inlineBlock"
   hasArrow={true}
   id="field_value_selection_0"
   isOpen={false}
@@ -296,6 +301,7 @@ exports[`FieldValueSelectionFilter render - fields in options 1`] = `
     </EuiFilterButton>
   }
   closePopover={[Function]}
+  display="inlineBlock"
   hasArrow={true}
   id="field_value_selection_0"
   isOpen={false}
@@ -354,6 +360,7 @@ exports[`FieldValueSelectionFilter render - multi-select OR 1`] = `
     </EuiFilterButton>
   }
   closePopover={[Function]}
+  display="inlineBlock"
   hasArrow={true}
   id="field_value_selection_0"
   isOpen={false}
@@ -399,6 +406,7 @@ exports[`FieldValueSelectionFilter render - options as a function 1`] = `
     </EuiFilterButton>
   }
   closePopover={[Function]}
+  display="inlineBlock"
   hasArrow={true}
   id="field_value_selection_0"
   isOpen={false}
@@ -444,6 +452,7 @@ exports[`FieldValueSelectionFilter render - options as an array 1`] = `
     </EuiFilterButton>
   }
   closePopover={[Function]}
+  display="inlineBlock"
   hasArrow={true}
   id="field_value_selection_0"
   isOpen={false}


### PR DESCRIPTION
### Summary

I got really tired of having to give the popover and the anchor a className in order to override the `display: inline-block` property. So I created a prop on the component so now you can easily pass down `display: "block"` and it will apply to both elements.

<img width="991" alt="Screen Shot 2019-07-11 at 18 58 58 PM" src="https://user-images.githubusercontent.com/549577/61090825-fa288380-a40d-11e9-91d2-7f42dc6bb20c.png">

### Also updated in the following usages

1. [EuiSuperSelect](https://github.com/elastic/eui/pull/2112/files#diff-d8c4f706b866af7a0c272f4128faf18f)
2. [EuiSuperDatePicker](https://github.com/elastic/eui/pull/2112/files#diff-fa55a3db8835f939a4d433388a88db4d)
3. [EuiColorPicker](https://github.com/elastic/eui/pull/2112/files#diff-5e645efd120e1f5ba28918bc84f8b7c0)

### Checklist

- ~[ ] This was checked in mobile~
- [x] This was checked in IE11
- ~[ ] This was checked in dark mode~
- [x] Any props added have proper autodocs
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- [x] Jest tests were updated or added to match the most common scenarios
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
