### PR TITLE
Fixed placeholder text color for more browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Removed time from default `dateFormat` of `EuiDatePicker` ([#1820](https://github.com/elastic/eui/pull/1820))
 - Fixed `EuiPopover` from catching and preventing propagation of keydown events when closed ([#2089](https://github.com/elastic/eui/pull/2089))
 - Fixed padding sizes between `EuiModal` header, body, and footer ([#2088](https://github.com/elastic/eui/pull/2088))
+- Fixed placeholder text color for more browsers ([#2113](https://github.com/elastic/eui/pull/2113))
 
 ## [`12.2.0`](https://github.com/elastic/eui/tree/v12.2.0)
 

--- a/src/components/form/_mixins.scss
+++ b/src/components/form/_mixins.scss
@@ -19,6 +19,24 @@
   line-height: 1em; // fixes text alignment in IE
   color: $euiTextColor;
 
+  // sass-lint:disable-block no-vendor-prefixes
+
+  &::-webkit-input-placeholder { /* Chrome/Opera/Safari */
+    color: $euiColorDarkShade;
+  }
+
+  &::-moz-placeholder { /* Firefox 19+ */
+    color: $euiColorDarkShade;
+  }
+
+  &:-ms-input-placeholder { /* IE 10+ */
+    color: $euiColorDarkShade;
+  }
+
+  &:-moz-placeholder { /* Firefox 18- */
+    color: $euiColorDarkShade;
+  }
+
   &::placeholder {
     color: $euiColorDarkShade;
   }

--- a/src/components/form/_mixins.scss
+++ b/src/components/form/_mixins.scss
@@ -1,3 +1,12 @@
+@mixin euiPlaceholderPerBrowser {
+  // sass-lint:disable-block no-vendor-prefixes
+  // Each prefix must be it's own content block
+  &::-webkit-input-placeholder { @content; }
+  &::-moz-placeholder { @content; }
+  &:-ms-input-placeholder { @content; }
+  &:-moz-placeholder { @content; }
+  &::placeholder { @content; }
+}
 
 @function euiFormControlGradient($color: $euiColorPrimary) {
   @return linear-gradient(to top,
@@ -19,25 +28,8 @@
   line-height: 1em; // fixes text alignment in IE
   color: $euiTextColor;
 
-  // sass-lint:disable-block no-vendor-prefixes
-
-  &::-webkit-input-placeholder { /* Chrome/Opera/Safari */
-    color: $euiColorDarkShade;
-  }
-
-  &::-moz-placeholder { /* Firefox 19+ */
-    color: $euiColorDarkShade;
-  }
-
-  &:-ms-input-placeholder { /* IE 10+ */
-    color: $euiColorDarkShade;
-  }
-
-  &:-moz-placeholder { /* Firefox 18- */
-    color: $euiColorDarkShade;
-  }
-
-  &::placeholder {
+  // sass-lint:disable-block mixins-before-declarations
+  @include euiPlaceholderPerBrowser {
     color: $euiColorDarkShade;
   }
 }
@@ -150,7 +142,8 @@
   background: $euiFormBackgroundDisabledColor;
   box-shadow: inset 0 0 0 1px $euiFormBorderDisabledColor;
 
-  &::placeholder {
+  // sass-lint:disable-block mixins-before-declarations
+  @include euiPlaceholderPerBrowser {
     color: $euiFormControlDisabledColor;
   }
 }


### PR DESCRIPTION
### Summary

It looks like our prefixer doesn't prefix pseudo elements so I added more browser prefixes for the form control placholder text color. The biggest offender was IE:

<img src="https://d.pr/free/i/uMKPMR+" />

### Checklist

- ~[ ] This was checked in mobile~
- [x] This was checked in IE11
- [x] This was checked in dark mode
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
