### PR TITLE
[Feature branch] Updated form control border color

### DIFF
--- a/src/components/form/_mixins.scss
+++ b/src/components/form/_mixins.scss
@@ -112,12 +112,12 @@
   background-size: 100% 100%; /* 3 */
 
   @if ($borderOnly) {
-    box-shadow: inset 0 0 0 1px transparentize($euiColorFullShade, .84);
+    box-shadow: inset 0 0 0 1px $euiFormBorderColor;
   } @else {
     box-shadow:
       0 1px 1px -1px transparentize($euiShadowColor, .8),
       0 4px 4px -2px transparentize($euiShadowColor, .8),
-      inset 0 0 0 1px transparentize($euiColorFullShade, .84);
+      inset 0 0 0 1px $euiFormBorderColor;
   }
 }
 

--- a/src/components/form/_variables.scss
+++ b/src/components/form/_variables.scss
@@ -16,9 +16,9 @@ $euiSwitchIconHeight: $euiSize !default;
 // Coloring
 $euiFormBackgroundColor: tintOrShade($euiColorLightestShade, 60%, 40%) !default;
 $euiFormBackgroundDisabledColor: darken($euiColorLightestShade, 2%) !default;
-$euiFormBorderSolidColor: shade(desaturate(adjust-hue($euiColorPrimary, 22), 22.95), 26%) !default;
-$euiFormBorderColor: transparentize($euiFormBorderSolidColor, .9) !default;
-$euiFormBorderDisabledColor: transparentize($euiFormBorderSolidColor, .9) !default;
+$euiFormBorderOpaqueColor: shade(desaturate(adjust-hue($euiColorPrimary, 22), 22.95), 26%) !default;
+$euiFormBorderColor: transparentize($euiFormBorderOpaqueColor, .9) !default;
+$euiFormBorderDisabledColor: transparentize($euiFormBorderOpaqueColor, .9) !default;
 $euiFormCustomControlDisabledIconColor: shadeOrTint($euiColorMediumShade, 38%, 48.5%) !default; // exact 508c foreground for $euiColorLightShade
 $euiFormControlDisabledColor: $euiColorMediumShade !default;
 $euiFormControlBoxShadow: 0 1px 1px -1px transparentize($euiShadowColor, .8), 0 3px 2px -2px transparentize($euiShadowColor, .8);

--- a/src/components/form/_variables.scss
+++ b/src/components/form/_variables.scss
@@ -17,7 +17,7 @@ $euiSwitchIconHeight: $euiSize !default;
 $euiFormBackgroundColor: tintOrShade($euiColorLightestShade, 60%, 40%) !default;
 $euiFormBackgroundDisabledColor: darken($euiColorLightestShade, 2%) !default;
 $euiFormBorderSolidColor: shade(desaturate(adjust-hue($euiColorPrimary, 22), 22.95), 26%) !default;
-$euiFormBorderColor: transparentize($euiFormBorderSolidColor, .84) !default;
+$euiFormBorderColor: transparentize($euiFormBorderSolidColor, .9) !default;
 $euiFormBorderDisabledColor: transparentize($euiFormBorderSolidColor, .9) !default;
 $euiFormCustomControlDisabledIconColor: shadeOrTint($euiColorMediumShade, 38%, 48.5%) !default; // exact 508c foreground for $euiColorLightShade
 $euiFormControlDisabledColor: $euiColorMediumShade !default;

--- a/src/components/form/_variables.scss
+++ b/src/components/form/_variables.scss
@@ -16,8 +16,9 @@ $euiSwitchIconHeight: $euiSize !default;
 // Coloring
 $euiFormBackgroundColor: tintOrShade($euiColorLightestShade, 60%, 40%) !default;
 $euiFormBackgroundDisabledColor: darken($euiColorLightestShade, 2%) !default;
-$euiFormBorderColor: transparentize($euiColorFullShade, .9) !default;
-$euiFormBorderDisabledColor: transparentize($euiColorFullShade, .92) !default;
+$euiFormBorderSolidColor: shade(desaturate(adjust-hue($euiColorPrimary, 22), 22.95), 26%) !default;
+$euiFormBorderColor: transparentize($euiFormBorderSolidColor, .84) !default;
+$euiFormBorderDisabledColor: transparentize($euiFormBorderSolidColor, .9) !default;
 $euiFormCustomControlDisabledIconColor: shadeOrTint($euiColorMediumShade, 38%, 48.5%) !default; // exact 508c foreground for $euiColorLightShade
 $euiFormControlDisabledColor: $euiColorMediumShade !default;
 $euiFormControlBoxShadow: 0 1px 1px -1px transparentize($euiShadowColor, .8), 0 3px 2px -2px transparentize($euiShadowColor, .8);


### PR DESCRIPTION
### This is the first (of some, not many) PR's that will go into the compressed editor style controls feature branch 

## Updates the color of the form control border to be more "blue"

When playing around in sketch, I noticed that the border color is light transparency of one of our dark grays which when more transparent becomes less "blue". It's a very subtle difference, but now it looks like our horizontal rule and other border colors.

It needs to stay as a transparent inner shadow because it will overlap the background image which creates the thickened primary bottom border for the focus and invalid states.

<img src="https://d.pr/free/i/IrzgLR+" />

You can see the difference if you compare the border color to the bottom border of the tabs above it.

### Checklist

- ~[ ] This was checked in mobile~
- ~[ ] This was checked in IE11~
- [x] This was checked in dark mode
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- ~[ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
