### PR TITLE
Allow EuiFormRow to pass `fullWidth` to it’s children

### DIFF
--- a/src-docs/src/views/form_layouts/full_width.js
+++ b/src-docs/src/views/form_layouts/full_width.js
@@ -28,12 +28,11 @@ export default () => (
       label="Works on form rows too"
       fullWidth
       helpText="Note that the fullWidth prop is not passed to the form row's child">
-      <EuiRange fullWidth min={0} max={100} name="range" />
+      <EuiRange min={0} max={100} name="range" />
     </EuiFormRow>
 
     <EuiFormRow label="Often useful for text areas" fullWidth>
       <EuiTextArea
-        fullWidth
         placeholder="There is a reason we do not make forms ALWAYS 100% width.
           See how this text area becomes extremely hard to read when the individual
           lines get this long? It is much more readable when contained to a scannable max-width."

--- a/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select.test.js.snap
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select.test.js.snap
@@ -64,7 +64,6 @@ exports[`EuiQuickSelect is rendered 1`] = `
       <EuiFormRow
         compressed={true}
         describedByIds={Array []}
-        fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
       >
@@ -95,7 +94,6 @@ exports[`EuiQuickSelect is rendered 1`] = `
       <EuiFormRow
         compressed={true}
         describedByIds={Array []}
-        fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
       >
@@ -113,7 +111,6 @@ exports[`EuiQuickSelect is rendered 1`] = `
       <EuiFormRow
         compressed={true}
         describedByIds={Array []}
-        fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
       >
@@ -165,7 +162,6 @@ exports[`EuiQuickSelect is rendered 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
-        fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
       >
@@ -254,7 +250,6 @@ exports[`EuiQuickSelect prevQuickSelect 1`] = `
       <EuiFormRow
         compressed={true}
         describedByIds={Array []}
-        fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
       >
@@ -285,7 +280,6 @@ exports[`EuiQuickSelect prevQuickSelect 1`] = `
       <EuiFormRow
         compressed={true}
         describedByIds={Array []}
-        fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
       >
@@ -303,7 +297,6 @@ exports[`EuiQuickSelect prevQuickSelect 1`] = `
       <EuiFormRow
         compressed={true}
         describedByIds={Array []}
-        fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
       >
@@ -355,7 +348,6 @@ exports[`EuiQuickSelect prevQuickSelect 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
-        fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
       >

--- a/src/components/form/described_form_group/__snapshots__/described_form_group.test.js.snap
+++ b/src/components/form/described_form_group/__snapshots__/described_form_group.test.js.snap
@@ -36,7 +36,6 @@ exports[`EuiDescribedFormGroup is rendered 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
-        fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
       >
@@ -74,7 +73,6 @@ exports[`EuiDescribedFormGroup props description is not rendered when it's not p
     >
       <EuiFormRow
         describedByIds={Array []}
-        fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
       >
@@ -168,7 +166,6 @@ exports[`EuiDescribedFormGroup props gutterSize is rendered 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
-        fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
       >
@@ -215,7 +212,6 @@ exports[`EuiDescribedFormGroup props titleSize is rendered 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
-        fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
       >
@@ -314,7 +310,6 @@ exports[`EuiDescribedFormGroup ties together parts for accessibility 1`] = `
                   "Error two",
                 ]
               }
-              fullWidth={false}
               hasEmptyLabelSpace={false}
               helpText="Help text"
               isInvalid={true}

--- a/src/components/form/form_row/__snapshots__/form_row.test.js.snap
+++ b/src/components/form/form_row/__snapshots__/form_row.test.js.snap
@@ -3,7 +3,6 @@
 exports[`EuiFormRow behavior onBlur is called in child 1`] = `
 <EuiFormRow
   describedByIds={Array []}
-  fullWidth={false}
   hasEmptyLabelSpace={false}
   label={
     <span>
@@ -44,7 +43,6 @@ exports[`EuiFormRow behavior onBlur is called in child 1`] = `
 exports[`EuiFormRow behavior onBlur works in parent even if not in child 1`] = `
 <EuiFormRow
   describedByIds={Array []}
-  fullWidth={false}
   hasEmptyLabelSpace={false}
   label={
     <span>
@@ -85,7 +83,6 @@ exports[`EuiFormRow behavior onBlur works in parent even if not in child 1`] = `
 exports[`EuiFormRow behavior onFocus is called in child 1`] = `
 <EuiFormRow
   describedByIds={Array []}
-  fullWidth={false}
   hasEmptyLabelSpace={false}
   label={
     <span>
@@ -126,7 +123,6 @@ exports[`EuiFormRow behavior onFocus is called in child 1`] = `
 exports[`EuiFormRow behavior onFocus works in parent even if not in child 1`] = `
 <EuiFormRow
   describedByIds={Array []}
-  fullWidth={false}
   hasEmptyLabelSpace={false}
   label={
     <span>

--- a/src/components/form/form_row/form_row.js
+++ b/src/components/form/form_row/form_row.js
@@ -160,6 +160,7 @@ export class EuiFormRow extends Component {
       onFocus: this.onFocus,
       onBlur: this.onBlur,
       compressed: compressed,
+      fullWidth: fullWidth,
       ...optionalProps,
     });
 
@@ -232,7 +233,6 @@ EuiFormRow.propTypes = {
 
 EuiFormRow.defaultProps = {
   hasEmptyLabelSpace: false,
-  fullWidth: false,
   describedByIds: [],
   labelType: 'label',
 };


### PR DESCRIPTION
### Summary

EuiFormRow currently passes `compressed` but it doesn't pass `fullWidth` so any time you add this prop to a form row you also have to add it to the child input.

I'm trying to add this as a prop to pass down and it works, but the tests fail when using `<input>` instead of an EUI form control. I get this error:

<img width="421" alt="Screen Shot 2019-07-12 at 10 46 35 AM" src="https://user-images.githubusercontent.com/549577/61136997-96946980-a492-11e9-9cd1-e8bfaa00d775.png">


### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
