### PR TITLE
re-include all src scss files and packages/ dir in npm published build

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,6 @@ tmp/
 wiki/
 generator-eui/
 test/
-packages/
 src-docs/
 src-framer/
 packages/react-datepicker
@@ -17,7 +16,7 @@ types/
 # ignore everything in `scripts` except postinstall.js
 scripts/!(postinstall.js)
 
-src/!(*.scss)
+src/**/*.!(scss)
 
 .DS_Store
 .eslintcache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `12.3.0`.
+**Bug fixes**
+
+- Restored missing scss and react-datepicker files to the npm-published packaged ([#2119](https://github.com/elastic/eui/pull/2119))
 
 ## [`12.3.0`](https://github.com/elastic/eui/tree/v12.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [`12.3.0`](https://github.com/elastic/eui/tree/v12.3.0)
 
+**Note: this release contained a change which prevented necessary files from being published to npm, this was fixed in 12.3.1**
+
 - Added `logoSecurity`, `logoCode`, `logoMaps`, `logoUptime` and `logoLogging` to `EuiIcon` types ([#2111](https://github.com/elastic/eui/pull/2111))
 - Added a `column` direction option to `EuiFlexGrid` ([#2073](https://github.com/elastic/eui/pull/2073))
 - Updated `EuiSuperDatePicker`'s  commonly used date/times to display as columns. ([#2073](https://github.com/elastic/eui/pull/2073))


### PR DESCRIPTION
### Summary

Fixes an issue with the published contents of EUI on npm. This restores all of the `.scss` files and `package/` directory in the build. Verified this passes Kibana's jest & type tests (with some known snapshots and TS changes, unrelated to the package contents).

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
