### PR TITLE
Run only tests affected by changes in commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint-sass-fix": "sass-lint-auto-fix -c ./.sass-lint-fix.yml",
     "test": "yarn lint && yarn test-unit",
     "test-unit": "cross-env NODE_ENV=test jest --config ./scripts/jest/config.json",
+    "test-staged": "yarn lint && node scripts/test-staged.js",
     "start-test-server": "webpack-dev-server --config src-docs/webpack.config.js --port 9999",
     "test-visual": "wdio test/wdio.conf.js",
     "yo-component": "yo ./generator-eui/app/component.js",
@@ -40,6 +41,9 @@
     "type": "git",
     "url": "https://github.com/elastic/eui.git"
   },
+  "pre-commit": [
+    "test-staged"
+  ],
   "dependencies": {
     "@types/lodash": "^4.14.116",
     "@types/numeral": "^0.0.25",

--- a/scripts/test-staged.js
+++ b/scripts/test-staged.js
@@ -1,0 +1,11 @@
+const { execSync } = require('child_process');
+
+// find names of staged files
+const stagedFiles = execSync('git diff --cached --name-only --diff-filter=ACM')
+  .toString()
+  .split(/[\r\n]+/g);
+
+// execute tests related to the staged files
+execSync(`yarn test-unit --findRelatedTests ${stagedFiles.join(' ')}`, {
+  stdio: 'inherit',
+});


### PR DESCRIPTION
### Summary

Configures out existing `pre-commit` dependency to run a custom script on commit instead of `test`.

The custom hook gets the list of staged files from git and passes them to `jest --findRelatedTests` which only executes tests affected by the changes.

Note: this will only run tests affected by **staged** changes (those being included in the commit), it does **not** look at modified files outside the commit. I feel this best reflects the intention, but if people would prefer all uncommitted changes be used I can update.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
