### PR TITLE
remove postcss config from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "main": "lib",
   "module": "es",
   "types": "eui.d.ts",
-  "postcss": {},
   "docker_image": "node:8",
   "sideEffects": false,
   "scripts": {


### PR DESCRIPTION
### Summary

Fixes `docs` build by getting `postcss-loader` to use the correct config.
