### PR TITLE
Attempting to fix with EuiFlyout maxWidth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Fixed `EuiComboBox`'s padding on the right ([#2135](https://github.com/elastic/eui/pull/2135))
 - Fixed `EuiAccordion` to correctly account for changing computed height of child elements ([#2136](https://github.com/elastic/eui/pull/2136))
+- Fixed some `EuiFlyout` sizing ([#2125](https://github.com/elastic/eui/pull/2125))
 
 **Breaking changes**
 

--- a/src-docs/src/views/flyout/flyout_example.js
+++ b/src-docs/src/views/flyout/flyout_example.js
@@ -217,7 +217,7 @@ export const FlyoutExample = {
       demo: <FlyoutLarge />,
     },
     {
-      title: 'maxWidth',
+      title: 'Max width',
       source: [
         {
           type: GuideSectionTypes.JS,
@@ -231,15 +231,20 @@ export const FlyoutExample = {
       text: (
         <Fragment>
           <p>
-            In this example, we set <EuiCode>maxWidth</EuiCode> to{' '}
-            <EuiCode>448px</EuiCode>, to set the width of the flyout at the
-            ideal width for a form.
+            By default, flyouts will continue to grow with the width of the
+            window. To stop this growth at an ideal width, set{' '}
+            <EuiCode>maxWidth</EuiCode> to <EuiCode>true</EuiCode>, or pass your
+            own custom size.
           </p>
-          <EuiCallOut title="Be sure to set the custom maxWidth value to a number larger than the minWidth otherwise the minWidth will supercede." />
+          <EuiCallOut
+            color="warning"
+            title="Note that there are some caveats to providing a maxWidth that is smaller than the minWidth."
+          />
         </Fragment>
       ),
       snippet: flyoutMaxWidthSnippet,
       demo: <FlyoutMaxWidth />,
+      props: { EuiFlyout },
     },
   ],
 };

--- a/src-docs/src/views/flyout/flyout_example.js
+++ b/src-docs/src/views/flyout/flyout_example.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 
 import { renderToHtml } from '../../services';
 
@@ -9,6 +9,7 @@ import {
   EuiFlyout,
   EuiFlyoutHeader,
   EuiFlyoutFooter,
+  EuiCallOut,
 } from '../../../../src/components';
 
 import { Flyout } from './flyout';
@@ -228,11 +229,14 @@ export const FlyoutExample = {
         },
       ],
       text: (
-        <p>
-          In this example, we set <EuiCode>maxWidth</EuiCode> to{' '}
-          <EuiCode>448px</EuiCode>, to set the width of the flyout at the ideal
-          width for a form.
-        </p>
+        <Fragment>
+          <p>
+            In this example, we set <EuiCode>maxWidth</EuiCode> to{' '}
+            <EuiCode>448px</EuiCode>, to set the width of the flyout at the
+            ideal width for a form.
+          </p>
+          <EuiCallOut title="Be sure to set the custom maxWidth value to a number larger than the minWidth otherwise the minWidth will supercede." />
+        </Fragment>
       ),
       snippet: flyoutMaxWidthSnippet,
       demo: <FlyoutMaxWidth />,

--- a/src-docs/src/views/flyout/flyout_max_width.js
+++ b/src-docs/src/views/flyout/flyout_max_width.js
@@ -4,7 +4,7 @@ import {
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutHeader,
-  EuiButton,
+  EuiLink,
   EuiText,
   EuiTitle,
   EuiFieldText,
@@ -22,26 +22,25 @@ export class FlyoutMaxWidth extends Component {
 
     this.state = {
       isFlyoutVisible: false,
-      isSwitchChecked: true,
+      flyoutSize: 'm',
+      flyoutMaxWidth: false,
     };
 
     this.closeFlyout = this.closeFlyout.bind(this);
     this.showFlyout = this.showFlyout.bind(this);
   }
 
-  onSwitchChange = () => {
-    this.setState({
-      isSwitchChecked: !this.state.isSwitchChecked,
-    });
-  };
-
   closeFlyout() {
     this.setState({ isFlyoutVisible: false });
   }
 
-  showFlyout() {
-    this.setState({ isFlyoutVisible: true });
-  }
+  showFlyout = (size = 'm', maxWidth = false) => {
+    this.setState({
+      flyoutSize: size,
+      flyoutMaxWidth: maxWidth,
+      isFlyoutVisible: true,
+    });
+  };
 
   render() {
     let flyout;
@@ -51,7 +50,8 @@ export class FlyoutMaxWidth extends Component {
         <EuiFlyout
           onClose={this.closeFlyout}
           aria-labelledby="flyoutMaxWidthTitle"
-          maxWidth={448}>
+          size={this.state.flyoutSize}
+          maxWidth={this.state.flyoutMaxWidth}>
           <EuiFlyoutHeader hasBorder>
             <EuiTitle size="m">
               <h2 id="flyoutMaxWidthTitle">448px wide flyout</h2>
@@ -101,7 +101,67 @@ export class FlyoutMaxWidth extends Component {
 
     return (
       <div>
-        <EuiButton onClick={this.showFlyout}>Show max-width flyout</EuiButton>
+        <EuiLink color="secondary" onClick={() => this.showFlyout('s')}>
+          Show <strong>small</strong> flyout with <strong>no max-width</strong>
+        </EuiLink>
+        <EuiSpacer size="s" />
+        <EuiLink color="secondary" onClick={() => this.showFlyout('s', true)}>
+          Show <strong>small</strong> flyout with{' '}
+          <strong>default max-width</strong>
+        </EuiLink>
+        <EuiSpacer size="s" />
+        <EuiLink color="secondary" onClick={() => this.showFlyout('s', 448)}>
+          Show <strong>small</strong> flyout with{' '}
+          <strong>larger custom max-width</strong>
+        </EuiLink>
+        <EuiSpacer size="s" />
+        <EuiLink color="danger" onClick={() => this.showFlyout('s', 200)}>
+          Show <strong>small</strong> flyout with{' '}
+          <strong>smaller custom max-width</strong> -- minWidth beats out except
+          for on small screens
+        </EuiLink>
+
+        <EuiSpacer />
+
+        <EuiLink color="secondary" onClick={() => this.showFlyout('m')}>
+          Show <strong>medium</strong> flyout with <strong>no max-width</strong>
+        </EuiLink>
+        <EuiSpacer size="s" />
+        <EuiLink color="secondary" onClick={() => this.showFlyout('m', true)}>
+          Show <strong>medium</strong> flyout with{' '}
+          <strong>default max-width</strong>
+        </EuiLink>
+        <EuiSpacer size="s" />
+        <EuiLink color="secondary" onClick={() => this.showFlyout('m', 900)}>
+          Show <strong>medium</strong> flyout with{' '}
+          <strong>larger custom max-width</strong>
+        </EuiLink>
+        <EuiSpacer size="s" />
+        <EuiLink color="danger" onClick={() => this.showFlyout('m', 200)}>
+          Show <strong>medium</strong> flyout with{' '}
+          <strong>smaller custom max-width</strong> -- minWidth beats out
+        </EuiLink>
+
+        <EuiSpacer />
+
+        <EuiLink color="secondary" onClick={() => this.showFlyout('l')}>
+          Show <strong>large</strong> flyout with <strong>no max-width</strong>
+        </EuiLink>
+        <EuiSpacer size="s" />
+        <EuiLink color="secondary" onClick={() => this.showFlyout('l', true)}>
+          Show <strong>large</strong> flyout with{' '}
+          <strong>default max-width</strong>
+        </EuiLink>
+        <EuiSpacer size="s" />
+        <EuiLink color="secondary" onClick={() => this.showFlyout('l', 1600)}>
+          Show <strong>large</strong> flyout with{' '}
+          <strong>larger custom max-width</strong>
+        </EuiLink>
+        <EuiSpacer size="s" />
+        <EuiLink color="danger" onClick={() => this.showFlyout('l', 200)}>
+          Show <strong>large</strong> flyout with{' '}
+          <strong>smaller custom max-width</strong> -- minWidth beats out
+        </EuiLink>
 
         {flyout}
       </div>

--- a/src-docs/src/views/flyout/flyout_max_width.js
+++ b/src-docs/src/views/flyout/flyout_max_width.js
@@ -137,9 +137,10 @@ export class FlyoutMaxWidth extends Component {
           <strong>larger custom max-width</strong>
         </EuiLink>
         <EuiSpacer size="s" />
-        <EuiLink color="danger" onClick={() => this.showFlyout('m', 200)}>
+        <EuiLink color="warning" onClick={() => this.showFlyout('m', 448)}>
           Show <strong>medium</strong> flyout with{' '}
-          <strong>smaller custom max-width</strong> -- minWidth beats out
+          <strong>smaller custom max-width</strong> -- full 100vw wins out on
+          small screens
         </EuiLink>
 
         <EuiSpacer />
@@ -158,9 +159,10 @@ export class FlyoutMaxWidth extends Component {
           <strong>larger custom max-width</strong>
         </EuiLink>
         <EuiSpacer size="s" />
-        <EuiLink color="danger" onClick={() => this.showFlyout('l', 200)}>
+        <EuiLink color="warning" onClick={() => this.showFlyout('l', 448)}>
           Show <strong>large</strong> flyout with{' '}
-          <strong>smaller custom max-width</strong> -- minWidth beats out
+          <strong>smaller custom max-width</strong> -- full 100vw wins out on
+          small screens
         </EuiLink>
 
         {flyout}

--- a/src-docs/src/views/flyout/flyout_max_width.js
+++ b/src-docs/src/views/flyout/flyout_max_width.js
@@ -46,6 +46,19 @@ export class FlyoutMaxWidth extends Component {
     let flyout;
 
     if (this.state.isFlyoutVisible) {
+      let maxWidthTitle;
+      switch (this.state.flyoutMaxWidth) {
+        case true:
+          maxWidthTitle = 'Default';
+          break;
+        case false:
+          maxWidthTitle = 'No';
+          break;
+        default:
+          maxWidthTitle = `${this.state.flyoutMaxWidth}px`;
+          break;
+      }
+
       flyout = (
         <EuiFlyout
           onClose={this.closeFlyout}
@@ -54,7 +67,7 @@ export class FlyoutMaxWidth extends Component {
           maxWidth={this.state.flyoutMaxWidth}>
           <EuiFlyoutHeader hasBorder>
             <EuiTitle size="m">
-              <h2 id="flyoutMaxWidthTitle">448px wide flyout</h2>
+              <h2 id="flyoutMaxWidthTitle">{maxWidthTitle} maxWidth</h2>
             </EuiTitle>
           </EuiFlyoutHeader>
           <EuiFlyoutBody>
@@ -110,15 +123,16 @@ export class FlyoutMaxWidth extends Component {
           <strong>default max-width</strong>
         </EuiLink>
         <EuiSpacer size="s" />
-        <EuiLink color="secondary" onClick={() => this.showFlyout('s', 448)}>
-          Show <strong>small</strong> flyout with{' '}
-          <strong>larger custom max-width</strong>
-        </EuiLink>
-        <EuiSpacer size="s" />
         <EuiLink color="danger" onClick={() => this.showFlyout('s', 200)}>
           Show <strong>small</strong> flyout with{' '}
-          <strong>smaller custom max-width</strong> -- minWidth beats out except
-          for on small screens
+          <strong>smaller custom max-width</strong> -- minWidth wins except for
+          on small screens
+        </EuiLink>
+        <EuiSpacer size="s" />
+        <EuiLink color="danger" onClick={() => this.showFlyout('s', 448)}>
+          Show <strong>small</strong> flyout with{' '}
+          <strong>larger custom max-width</strong> -- minWidth wins except for
+          on small screens
         </EuiLink>
 
         <EuiSpacer />
@@ -132,15 +146,15 @@ export class FlyoutMaxWidth extends Component {
           <strong>default max-width</strong>
         </EuiLink>
         <EuiSpacer size="s" />
+        <EuiLink color="danger" onClick={() => this.showFlyout('m', 448)}>
+          Show <strong>medium</strong> flyout with{' '}
+          <strong>smaller custom max-width</strong> -- minWidth wins and full
+          100vw wins on small screens
+        </EuiLink>
+        <EuiSpacer size="s" />
         <EuiLink color="secondary" onClick={() => this.showFlyout('m', 900)}>
           Show <strong>medium</strong> flyout with{' '}
           <strong>larger custom max-width</strong>
-        </EuiLink>
-        <EuiSpacer size="s" />
-        <EuiLink color="warning" onClick={() => this.showFlyout('m', 448)}>
-          Show <strong>medium</strong> flyout with{' '}
-          <strong>smaller custom max-width</strong> -- full 100vw wins out on
-          small screens
         </EuiLink>
 
         <EuiSpacer />
@@ -154,15 +168,15 @@ export class FlyoutMaxWidth extends Component {
           <strong>default max-width</strong>
         </EuiLink>
         <EuiSpacer size="s" />
+        <EuiLink color="danger" onClick={() => this.showFlyout('l', 448)}>
+          Show <strong>large</strong> flyout with{' '}
+          <strong>smaller custom max-width</strong> -- minWidth wins and full
+          100vw wins on small screens
+        </EuiLink>
+        <EuiSpacer size="s" />
         <EuiLink color="secondary" onClick={() => this.showFlyout('l', 1600)}>
           Show <strong>large</strong> flyout with{' '}
           <strong>larger custom max-width</strong>
-        </EuiLink>
-        <EuiSpacer size="s" />
-        <EuiLink color="warning" onClick={() => this.showFlyout('l', 448)}>
-          Show <strong>large</strong> flyout with{' '}
-          <strong>smaller custom max-width</strong> -- full 100vw wins out on
-          small screens
         </EuiLink>
 
         {flyout}

--- a/src-docs/src/views/flyout/flyout_max_width.js
+++ b/src-docs/src/views/flyout/flyout_max_width.js
@@ -179,6 +179,13 @@ export class FlyoutMaxWidth extends Component {
           <strong>larger custom max-width</strong>
         </EuiLink>
 
+        <EuiSpacer />
+
+        <EuiLink color="primary" onClick={() => this.showFlyout('m', 0)}>
+          Trick for forms: <strong>Medium</strong> flyout with{' '}
+          <strong>0 as max-width</strong>
+        </EuiLink>
+
         {flyout}
       </div>
     );

--- a/src-docs/src/views/not_found/not_found_view.js
+++ b/src-docs/src/views/not_found/not_found_view.js
@@ -7,9 +7,7 @@ export const NotFoundView = () => (
   <div className="guideContentPage">
     <div className="guideContentPage__content">
       <EuiText>
-        <h1 className="guideTitle">
-          404
-        </h1>
+        <h1 className="guideTitle">404</h1>
 
         <p className="guideText">
           You visited a page which doesn&rsquo;t exist, causing <em>this</em>{' '}

--- a/src-docs/src/views/not_found/not_found_view.js
+++ b/src-docs/src/views/not_found/not_found_view.js
@@ -8,7 +8,7 @@ export const NotFoundView = () => (
     <div className="guideContentPage__content">
       <EuiText>
         <h1 className="guideTitle">
-          Wow, a 404! You just created <em>something</em> from <em>nothing</em>.
+          404
         </h1>
 
         <p className="guideText">

--- a/src-docs/src/views/not_found/not_found_view.js
+++ b/src-docs/src/views/not_found/not_found_view.js
@@ -1,26 +1,29 @@
 import React from 'react';
 
 import { Link } from 'react-router';
+import { EuiText } from '../../../../src/components/text';
 
 export const NotFoundView = () => (
   <div className="guideContentPage">
     <div className="guideContentPage__content">
-      <h1 className="guideTitle">
-        Wow, a 404! You just created <em>something</em> from <em>nothing</em>.
-      </h1>
+      <EuiText>
+        <h1 className="guideTitle">
+          Wow, a 404! You just created <em>something</em> from <em>nothing</em>.
+        </h1>
 
-      <p className="guideText">
-        You visited a page which doesn&rsquo;t exist, causing <em>this</em> page
-        to exist. This page thanks you for summoning it into existence from the
-        raw fabric of reality, but it thinks you may find another page more
-        interesting. Might it suggest the{' '}
-        {
-          <Link className="guideLink" to="/">
-            home page
-          </Link>
-        }
-        ?
-      </p>
+        <p className="guideText">
+          You visited a page which doesn&rsquo;t exist, causing <em>this</em>{' '}
+          page to exist. This page thanks you for summoning it into existence
+          from the raw fabric of reality, but it thinks you may find another
+          page more interesting. Might it suggest the{' '}
+          {
+            <Link className="guideLink" to="/">
+              home page
+            </Link>
+          }
+          ?
+        </p>
+      </EuiText>
     </div>
   </div>
 );

--- a/src/components/flyout/__snapshots__/flyout.test.js.snap
+++ b/src/components/flyout/__snapshots__/flyout.test.js.snap
@@ -69,7 +69,7 @@ exports[`EuiFlyout max width can be set to a custom number 1`] = `
       <div
         class="euiFlyout euiFlyout--medium"
         role="dialog"
-        style="max-width:1024px"
+        style="max-width:1024px;min-width:0"
         tabindex="0"
       >
         <button
@@ -118,7 +118,7 @@ exports[`EuiFlyout max width can be set to a custom value and measurement 1`] = 
       <div
         class="euiFlyout euiFlyout--medium"
         role="dialog"
-        style="max-width:24rem"
+        style="max-width:24rem;min-width:0"
         tabindex="0"
       >
         <button

--- a/src/components/flyout/__snapshots__/flyout.test.js.snap
+++ b/src/components/flyout/__snapshots__/flyout.test.js.snap
@@ -69,7 +69,7 @@ exports[`EuiFlyout max width can be set to a custom number 1`] = `
       <div
         class="euiFlyout euiFlyout--medium"
         role="dialog"
-        style="max-width:1024px;min-width:0"
+        style="max-width:1024px"
         tabindex="0"
       >
         <button
@@ -118,7 +118,7 @@ exports[`EuiFlyout max width can be set to a custom value and measurement 1`] = 
       <div
         class="euiFlyout euiFlyout--medium"
         role="dialog"
-        style="max-width:24rem;min-width:0"
+        style="max-width:24rem"
         tabindex="0"
       >
         <button

--- a/src/components/flyout/_flyout.scss
+++ b/src/components/flyout/_flyout.scss
@@ -31,17 +31,17 @@
  */
 $flyoutSizes: (
   'small': (
-    min: map-get($euiBreakpoints, 'm') * .5, /* 1 */
+    min: round(map-get($euiBreakpoints, 'm') * .5), /* 1 */
     width: 25vw,
-    max: map-get($euiBreakpoints, 's') * .7,
+    max: round(map-get($euiBreakpoints, 's') * .7),
   ),
   'medium': (
-    min:  map-get($euiBreakpoints, 'm') * .7, /* 1 */
+    min:  round(map-get($euiBreakpoints, 'm') * .7), /* 1 */
     width: 50vw,
     max: map-get($euiBreakpoints, 'm'),
   ),
   'large': (
-    min:  map-get($euiBreakpoints, 'm') * .9, /* 1 */
+    min:  round(map-get($euiBreakpoints, 'm') * .9), /* 1 */
     width: 75vw,
     max: map-get($euiBreakpoints, 'l'),
   )

--- a/src/components/flyout/_flyout.scss
+++ b/src/components/flyout/_flyout.scss
@@ -1,3 +1,5 @@
+@import '../form/variables';
+
 .euiFlyout {
   border-left: $euiBorderThin;
   // The mixin augments the above
@@ -36,7 +38,8 @@ $flyoutSizes: (
     max: round(map-get($euiBreakpoints, 's') * .7),
   ),
   'medium': (
-    min:  round(map-get($euiBreakpoints, 'm') * .7), /* 1 */
+    // Calculated for forms plus padding
+    min: $euiFormMaxWidth + ($euiSizeM * 2),
     width: 50vw,
     max: map-get($euiBreakpoints, 'm'),
   ),

--- a/src/components/flyout/_flyout.scss
+++ b/src/components/flyout/_flyout.scss
@@ -33,7 +33,7 @@ $flyoutSizes: (
   'small': (
     min: map-get($euiBreakpoints, 'm') * .5, /* 1 */
     width: 25vw,
-    max: map-get($euiBreakpoints, 's'),
+    max: map-get($euiBreakpoints, 's') * .7,
   ),
   'medium': (
     min:  map-get($euiBreakpoints, 'm') * .7, /* 1 */
@@ -85,8 +85,8 @@ $flyoutSizes: (
   }
 
   .euiFlyout--small {
-    width: 80vw; // ensure that it's only partially showing the main content
+    width: 90vw; // ensure that it's only partially showing the main content
     min-width: 0; /* 1 */
-    max-width: 80vw !important; /* 2 */
+    max-width: map-get(map-get($flyoutSizes, 'small'), 'max');
   }
 }

--- a/src/components/flyout/flyout.js
+++ b/src/components/flyout/flyout.js
@@ -44,8 +44,7 @@ export class EuiFlyout extends Component {
       widthClassName = 'euiFlyout--maxWidth-default';
     } else if (maxWidth !== false) {
       const value = typeof maxWidth === 'number' ? `${maxWidth}px` : maxWidth;
-      const minWidth = size !== 's' ? { minWidth: 0 } : undefined;
-      newStyle = { ...style, maxWidth: value, ...minWidth };
+      newStyle = { ...style, maxWidth: value };
     }
 
     const classes = classnames(
@@ -124,8 +123,8 @@ EuiFlyout.propTypes = {
    * Sets the max-width of the page,
    * set to `true` to use the default size,
    * set to `false` to not restrict the width,
-   * set to a number for a custom width in px,
-   * set to a string for a custom width in custom measurement.
+   * set to a `number` for a custom width in `px`,
+   * set to a `string` for a custom width in a custom measurement.
    */
   maxWidth: PropTypes.oneOfType([
     PropTypes.bool,

--- a/src/components/flyout/flyout.js
+++ b/src/components/flyout/flyout.js
@@ -44,7 +44,8 @@ export class EuiFlyout extends Component {
       widthClassName = 'euiFlyout--maxWidth-default';
     } else if (maxWidth !== false) {
       const value = typeof maxWidth === 'number' ? `${maxWidth}px` : maxWidth;
-      newStyle = { ...style, maxWidth: value };
+      const minWidth = size !== 's' ? { minWidth: 0 } : undefined;
+      newStyle = { ...style, maxWidth: value, ...minWidth };
     }
 
     const classes = classnames(


### PR DESCRIPTION
### Fixes #2134 (kind of)

Really all I did was change the docs example to a) not be wrong, b) showcase all the permutations to show what works and what doesn't.

<img width="979" alt="Screen Shot 2019-07-17 at 14 32 22 PM" src="https://user-images.githubusercontent.com/549577/61401106-b61b0000-a89f-11e9-870b-c2822d3617e7.png">

But I also:

1. Rounded the SASS calculations so they don't come out as decimal points
2. Reduced the min width of the medium size so that it just fits our form width
3. Fixed the small flyout sizing on mobile

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- ~[ ] This was checked in dark mode~
- [x] Any props added have proper autodocs
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
