### PR TITLE
Add DistributivePick and DistributiveOmit, update EuiFormControlLayoutIcons to use DistributiveOmit

### DIFF
--- a/src/components/common.ts
+++ b/src/components/common.ts
@@ -32,6 +32,20 @@ export type PropsOf<C> = C extends SFC<infer SFCProps>
   : never;
 
 /*
+https://github.com/Microsoft/TypeScript/issues/28339
+Problem: Pick and Omit do not distribute over union types, which manifests when
+optional values become required after a Pick or Omit operation. These
+Distributive forms correctly operate on union types, preseving optionality.
+ */
+type UnionKeys<T> = T extends any ? keyof T : never;
+export type DistributivePick<T, K extends UnionKeys<T>> = T extends any
+  ? Pick<T, Extract<keyof T, K>>
+  : never;
+export type DistributiveOmit<T, K extends UnionKeys<T>> = T extends any
+  ? Omit<T, Extract<keyof T, K>>
+  : never;
+
+/*
 TypeScript's discriminated unions are overly permissive: as long as one type of the union is satisfied
 the other types are not validated against. For example:
 

--- a/src/components/form/form_control_layout/form_control_layout_icons.tsx
+++ b/src/components/form/form_control_layout/form_control_layout_icons.tsx
@@ -10,12 +10,13 @@ import {
   EuiFormControlLayoutCustomIconProps,
 } from './form_control_layout_custom_icon';
 import { IconType } from '../../icon';
-import { Omit } from '../../common';
+import { DistributiveOmit } from '../../common';
 
 export const ICON_SIDES: ['left', 'right'] = ['left', 'right'];
 
-type IconShape = Partial<
-  Omit<EuiFormControlLayoutCustomIconProps, 'type' | 'iconRef'>
+type IconShape = DistributiveOmit<
+  EuiFormControlLayoutCustomIconProps,
+  'type' | 'iconRef'
 > & {
   type: IconType;
   side?: typeof ICON_SIDES[number];


### PR DESCRIPTION
### Summary

I've hit this a few times when typing complex prop interactions where `Omit` and `Pick` will transform optional props into required ones. In the past I've re-worked the types to get around the issue or (as was the case with EuiFormControlLayoutIcons) simply wrapped the result with a `Partial`. Stumbled upon a TypeScript github issue with distributed forms of those operations which solves the problem.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
