### PR TITLE
Fixed EuiComboBox padding on the right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `12.4.0`.
+**Bug fixes**
+
+- Fixed `EuiComboBox`'s padding on the right ([#2135](https://github.com/elastic/eui/pull/2135))
 
 ## [`12.4.0`](https://github.com/elastic/eui/tree/v12.4.0)
 

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -23,6 +23,7 @@
     display: flex; /* 1 */
 
     // sass-lint:disable-block mixins-before-declarations
+    // to override the padding added above
     @include euiFormControlLayoutPadding(1); /* 2 */
 
     &:not(.euiComboBox__inputWrap--noWrap) {

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -1,3 +1,5 @@
+@import '../form/form_control_layout/mixins';
+
 .euiComboBox {
   @include euiFormControlSize(auto, $includeAlternates: true);
   position: relative;
@@ -18,17 +20,15 @@
     @include euiFormControlWithIcon($isIconOptional: true);
     @include euiFormControlSize(auto, $includeAlternates: true);
     padding: $euiSizeXS $euiSizeS;
+    display: flex; /* 1 */
+
     // sass-lint:disable-block mixins-before-declarations
     @include euiFormControlLayoutPadding(1); /* 2 */
 
-    display: flex; /* 1 */
-
-    &.euiComboBox__inputWrap-isClearable {
-      @include euiFormControlLayoutPadding(2); /* 2 */
-    }
-
     &:not(.euiComboBox__inputWrap--noWrap) {
-      padding: $euiSizeXS;
+      padding-top: $euiSizeXS;
+      padding-bottom: $euiSizeXS;
+      padding-left: $euiSizeXS;
       height: auto;  /* 3 */
       flex-wrap: wrap; /* 1 */
       align-content: flex-start;
@@ -36,6 +36,10 @@
       &:hover {
         cursor: text;
       }
+    }
+
+    &.euiComboBox__inputWrap-isClearable {
+      @include euiFormControlLayoutPadding(2); /* 2 */
     }
   }
 


### PR DESCRIPTION
## Fixes #2126

The right-hand  padding for EuiComboBox was being overrided further down the selector. This fixes that.

**before** 
<img width="455" alt="Screen Shot 2019-07-10 at 12 47 08 PM" src="https://user-images.githubusercontent.com/549577/61403615-adc4c400-a8a3-11e9-9dd7-d550dbc828b3.png">


**after**

<img width="417" alt="Screen Shot 2019-07-17 at 15 03 15 PM" src="https://user-images.githubusercontent.com/549577/61403777-072cf300-a8a4-11e9-83dc-f55f09c28033.png">


### Checklist

- ~[ ] This was checked in mobile~
- ~[ ] This was checked in IE11~
- ~[ ] This was checked in dark mode~
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
