### PR TITLE
Add a responsiveHeader prop to the EuiAccordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Added responsiveHeader prop to `EuiAccordion` ([#2141](https://github.com/elastic/eui/pull/2141))
 - Added support for negated or clauses to `EuiSearchBar` ([#2140](https://github.com/elastic/eui/pull/2140))
 
 **Bug fixes**

--- a/src-docs/src/views/accordion/accordion_form.js
+++ b/src-docs/src/views/accordion/accordion_form.js
@@ -90,7 +90,8 @@ export default () => (
       buttonClassName="euiAccordionForm__button"
       buttonContent={buttonContent}
       extraAction={extraAction}
-      paddingSize="l">
+      paddingSize="l"
+      responsiveHeader={false}>
       {repeatableForm}
     </EuiAccordion>
 

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -50,6 +50,10 @@ export type EuiAccordionProps = HTMLAttributes<HTMLDivElement> &
      * The padding around the exposed accordion content.
      */
     paddingSize: EuiAccordionSize;
+    /**
+     * Set the responsive to the header container.
+     */
+    responsiveHeader?: boolean;
   };
 
 export class EuiAccordion extends Component<
@@ -113,6 +117,7 @@ export class EuiAccordion extends Component<
       extraAction,
       paddingSize,
       initialIsOpen,
+      responsiveHeader,
       ...rest
     } = this.props;
 
@@ -145,7 +150,10 @@ export class EuiAccordion extends Component<
 
     return (
       <div className={classes} {...rest}>
-        <EuiFlexGroup gutterSize="none" alignItems="center">
+        <EuiFlexGroup
+          gutterSize="none"
+          alignItems="center"
+          responsive={responsiveHeader}>
           <EuiFlexItem>
             <button
               aria-controls={id}


### PR DESCRIPTION
### Summary

While using the accordion on small screens there could be a necessity not to wrap buttons on the right side: 

![eui_responsive](https://user-images.githubusercontent.com/31325372/61535001-c5ce4c00-aa39-11e9-9a58-3aad004975b4.gif)

Such a necessity was caused in kibana default vis editor (in the metric `euiFlexGroup--responsive` is deleted to show the desired behavior):

![kibana_responsive](https://user-images.githubusercontent.com/31325372/61535547-3cb81480-aa3b-11e9-9d21-943f39485ef6.gif)


### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
