### PR TITLE
Get rid of negative margins in EuiFlexGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Get rid of negative margins in `EuiFlexGroup` ([#2142](https://github.com/elastic/eui/pull/2142))
 - Added support for negated or clauses to `EuiSearchBar` ([#2140](https://github.com/elastic/eui/pull/2140))
 
 **Bug fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Get rid of negative margins in `EuiFlexGroup` ([#2142](https://github.com/elastic/eui/pull/2142))
 - Added support for negated or clauses to `EuiSearchBar` ([#2140](https://github.com/elastic/eui/pull/2140))
 
 **Bug fixes**

--- a/src/components/flex/_flex_group.scss
+++ b/src/components/flex/_flex_group.scss
@@ -30,12 +30,16 @@ $gutterTypes: (
 @each $gutterName, $gutterSize in $gutterTypes {
   $halfGutterSize: $gutterSize * .5;
 
-  .euiFlexGroup--#{$gutterName} {
-    margin: -$halfGutterSize;
+  .euiFlexGroup--#{$gutterName} > .euiFlexItem {
+      margin: 0 $halfGutterSize;
 
-    & > .euiFlexItem {
-      margin: $halfGutterSize;
-    }
+      &:first-child {
+        margin-left: 0;
+      }
+
+      &:last-child {
+        margin-right: 0;
+      }
   }
 }
 

--- a/src/components/flex/_flex_group.scss
+++ b/src/components/flex/_flex_group.scss
@@ -30,16 +30,12 @@ $gutterTypes: (
 @each $gutterName, $gutterSize in $gutterTypes {
   $halfGutterSize: $gutterSize * .5;
 
-  .euiFlexGroup--#{$gutterName} > .euiFlexItem {
-      margin: 0 $halfGutterSize;
+  .euiFlexGroup--#{$gutterName} {
+    margin: -$halfGutterSize;
 
-      &:first-child {
-        margin-left: 0;
-      }
-
-      &:last-child {
-        margin-right: 0;
-      }
+    & > .euiFlexItem {
+      margin: $halfGutterSize;
+    }
   }
 }
 

--- a/src/components/flex/_flex_group.scss
+++ b/src/components/flex/_flex_group.scss
@@ -18,6 +18,12 @@
   }
 }
 
+.euiFlexGroup__wrapper {
+  display: flex;
+  flex-grow: 1;
+  overflow: hidden;
+}
+
 $gutterTypes: (
   gutterExtraSmall: $euiSizeXS,
   gutterSmall: $euiSizeS,

--- a/src/components/flex/flex_group.tsx
+++ b/src/components/flex/flex_group.tsx
@@ -89,8 +89,10 @@ export const EuiFlexGroup: FunctionComponent<
   );
 
   return (
-    <Component className={classes} {...rest}>
-      {children}
-    </Component>
+    <div className="euiFlexGroup__wrapper">
+      <Component className={classes} {...rest}>
+        {children}
+      </Component>
+    </div>
   );
 };


### PR DESCRIPTION
### Summary

It should fix #937 and other cases when negative margins cause problems with anything that has an overflow applied (like accordion).

![image](https://user-images.githubusercontent.com/31325372/61547331-d68bbb80-aa53-11e9-990a-0554f3998a3e.png)

![image](https://user-images.githubusercontent.com/31325372/61547354-e3101400-aa53-11e9-85fe-9d55b1bd3679.png)


### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in IE11
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios
- [ ] This required updates to Framer X components
