### PR TITLE
Remove EuiFlexGroup dependency from EuiAccordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added `EuiSuggestItem` component ([#2090](https://github.com/elastic/eui/pull/2090))
 - Added support for negated or clauses to `EuiSearchBar` ([#2140](https://github.com/elastic/eui/pull/2140))
 - Added `transition` utility services to help create timeouts that account for CSS transition durations and delays ([#2136](https://github.com/elastic/eui/pull/2136))
+- Removed `EuiFlexGroup` dependency from `EuiAccordion` ([#2143](https://github.com/elastic/eui/pull/2143))
 
 **Bug fixes**
 

--- a/src-docs/src/views/accordion/accordion_form.js
+++ b/src-docs/src/views/accordion/accordion_form.js
@@ -45,7 +45,7 @@ const repeatableForm = (
 
 const buttonContent = (
   <div>
-    <EuiFlexGroup gutterSize="s" alignItems="center">
+    <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
       <EuiFlexItem grow={false}>
         <EuiIcon type="logoWebhook" size="m" />
       </EuiFlexItem>

--- a/src-docs/src/views/accordion/accordion_multiple.js
+++ b/src-docs/src/views/accordion/accordion_multiple.js
@@ -6,8 +6,7 @@ export default () => (
   <div>
     <EuiAccordion
       id="accordion1"
-      buttonContent="An accordion with padding applied through props and a very long title that should truncate because of eui-textTruncate"
-      buttonContentClassName="eui-textTruncate"
+      buttonContent="An accordion with padding applied through props"
       paddingSize="l">
       <EuiText>
         <p>The content inside can be of any height.</p>
@@ -20,7 +19,8 @@ export default () => (
 
     <EuiAccordion
       id="accordion2"
-      buttonContent="A second accordion with padding"
+      buttonContent="A second accordion with padding  and a very long title that should truncate because of eui-textTruncate"
+      buttonContentClassName="eui-textTruncate"
       paddingSize="l">
       <EuiText>
         <p>The content inside can be of any height.</p>

--- a/src-docs/src/views/accordion/accordion_multiple.js
+++ b/src-docs/src/views/accordion/accordion_multiple.js
@@ -7,6 +7,7 @@ export default () => (
     <EuiAccordion
       id="accordion1"
       buttonContent="An accordion with padding applied through props"
+      buttonContentClassName="eui-textTruncate"
       paddingSize="l">
       <EuiText>
         <p>The content inside can be of any height.</p>

--- a/src-docs/src/views/accordion/accordion_multiple.js
+++ b/src-docs/src/views/accordion/accordion_multiple.js
@@ -19,7 +19,7 @@ export default () => (
 
     <EuiAccordion
       id="accordion2"
-      buttonContent="A second accordion with padding  and a very long title that should truncate because of eui-textTruncate"
+      buttonContent="A second accordion with padding and a very long title that should truncate because of eui-textTruncate"
       buttonContentClassName="eui-textTruncate"
       paddingSize="l">
       <EuiText>

--- a/src-docs/src/views/accordion/accordion_multiple.js
+++ b/src-docs/src/views/accordion/accordion_multiple.js
@@ -6,7 +6,7 @@ export default () => (
   <div>
     <EuiAccordion
       id="accordion1"
-      buttonContent="An accordion with padding applied through props"
+      buttonContent="An accordion with padding applied through props and a very long title that should truncate because of eui-textTruncate"
       buttonContentClassName="eui-textTruncate"
       paddingSize="l">
       <EuiText>

--- a/src/components/accordion/__snapshots__/accordion.test.tsx.snap
+++ b/src/components/accordion/__snapshots__/accordion.test.tsx.snap
@@ -27,52 +27,34 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
               onClick={[Function]}
               type="button"
             >
-              <EuiFlexGroup
-                alignItems="center"
-                gutterSize="s"
-                responsive={false}
+              <span
+                className="euiAccordion__iconWrapper"
               >
-                <div
-                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                <EuiIcon
+                  className="euiAccordion__icon"
+                  size="m"
+                  type="arrowRight"
                 >
-                  <EuiFlexItem
-                    className="euiAccordion__iconWrapper"
-                    grow={false}
+                  <EuiIconEmpty
+                    className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+                    focusable="false"
+                    style={null}
                   >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero euiAccordion__iconWrapper"
-                    >
-                      <EuiIcon
-                        size="m"
-                        type="arrowRight"
-                      >
-                        <EuiIconEmpty
-                          className="euiIcon euiIcon--medium euiIcon-isLoading"
-                          focusable="false"
-                          style={null}
-                        >
-                          <svg
-                            className="euiIcon euiIcon--medium euiIcon-isLoading"
-                            focusable="false"
-                            height={16}
-                            style={null}
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          />
-                        </EuiIconEmpty>
-                      </EuiIcon>
-                    </div>
-                  </EuiFlexItem>
-                  <EuiFlexItem
-                    className="euiAccordion__buttonContent"
-                  >
-                    <div
-                      className="euiFlexItem euiAccordion__buttonContent"
+                    <svg
+                      className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+                      focusable="false"
+                      height={16}
+                      style={null}
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
                     />
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
+                  </EuiIconEmpty>
+                </EuiIcon>
+              </span>
+              <span
+                className="euiAccordion__buttonContent"
+              />
             </button>
           </div>
         </EuiFlexItem>
@@ -132,52 +114,34 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
               onClick={[Function]}
               type="button"
             >
-              <EuiFlexGroup
-                alignItems="center"
-                gutterSize="s"
-                responsive={false}
+              <span
+                className="euiAccordion__iconWrapper"
               >
-                <div
-                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                <EuiIcon
+                  className="euiAccordion__icon"
+                  size="m"
+                  type="arrowDown"
                 >
-                  <EuiFlexItem
-                    className="euiAccordion__iconWrapper"
-                    grow={false}
+                  <EuiIconEmpty
+                    className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+                    focusable="false"
+                    style={null}
                   >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero euiAccordion__iconWrapper"
-                    >
-                      <EuiIcon
-                        size="m"
-                        type="arrowDown"
-                      >
-                        <EuiIconEmpty
-                          className="euiIcon euiIcon--medium euiIcon-isLoading"
-                          focusable="false"
-                          style={null}
-                        >
-                          <svg
-                            className="euiIcon euiIcon--medium euiIcon-isLoading"
-                            focusable="false"
-                            height={16}
-                            style={null}
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          />
-                        </EuiIconEmpty>
-                      </EuiIcon>
-                    </div>
-                  </EuiFlexItem>
-                  <EuiFlexItem
-                    className="euiAccordion__buttonContent"
-                  >
-                    <div
-                      className="euiFlexItem euiAccordion__buttonContent"
+                    <svg
+                      className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+                      focusable="false"
+                      height={16}
+                      style={null}
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
                     />
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
+                  </EuiIconEmpty>
+                </EuiIcon>
+              </span>
+              <span
+                className="euiAccordion__buttonContent"
+              />
             </button>
           </div>
         </EuiFlexItem>
@@ -228,25 +192,21 @@ exports[`EuiAccordion is rendered 1`] = `
         class="euiAccordion__button"
         type="button"
       >
-        <div
-          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+        <span
+          class="euiAccordion__iconWrapper"
         >
-          <div
-            class="euiFlexItem euiFlexItem--flexGrowZero euiAccordion__iconWrapper"
-          >
-            <svg
-              class="euiIcon euiIcon--medium euiIcon-isLoading"
-              focusable="false"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            />
-          </div>
-          <div
-            class="euiFlexItem euiAccordion__buttonContent"
+          <svg
+            class="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           />
-        </div>
+        </span>
+        <span
+          class="euiAccordion__buttonContent"
+        />
       </button>
     </div>
   </div>
@@ -279,29 +239,25 @@ exports[`EuiAccordion props buttonContent is rendered 1`] = `
         class="euiAccordion__button"
         type="button"
       >
-        <div
-          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+        <span
+          class="euiAccordion__iconWrapper"
         >
-          <div
-            class="euiFlexItem euiFlexItem--flexGrowZero euiAccordion__iconWrapper"
-          >
-            <svg
-              class="euiIcon euiIcon--medium euiIcon-isLoading"
-              focusable="false"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            />
+          <svg
+            class="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+        </span>
+        <span
+          class="euiAccordion__buttonContent"
+        >
+          <div>
+            Button content
           </div>
-          <div
-            class="euiFlexItem euiAccordion__buttonContent"
-          >
-            <div>
-              Button content
-            </div>
-          </div>
-        </div>
+        </span>
       </button>
     </div>
   </div>
@@ -334,25 +290,21 @@ exports[`EuiAccordion props buttonContentClassName is rendered 1`] = `
         class="euiAccordion__button"
         type="button"
       >
-        <div
-          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+        <span
+          class="euiAccordion__iconWrapper"
         >
-          <div
-            class="euiFlexItem euiFlexItem--flexGrowZero euiAccordion__iconWrapper"
-          >
-            <svg
-              class="euiIcon euiIcon--medium euiIcon-isLoading"
-              focusable="false"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            />
-          </div>
-          <div
-            class="euiFlexItem euiAccordion__buttonContent button content class name"
+          <svg
+            class="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           />
-        </div>
+        </span>
+        <span
+          class="euiAccordion__buttonContent button content class name"
+        />
       </button>
     </div>
   </div>
@@ -385,25 +337,21 @@ exports[`EuiAccordion props extraAction is rendered 1`] = `
         class="euiAccordion__button"
         type="button"
       >
-        <div
-          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+        <span
+          class="euiAccordion__iconWrapper"
         >
-          <div
-            class="euiFlexItem euiFlexItem--flexGrowZero euiAccordion__iconWrapper"
-          >
-            <svg
-              class="euiIcon euiIcon--medium euiIcon-isLoading"
-              focusable="false"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            />
-          </div>
-          <div
-            class="euiFlexItem euiAccordion__buttonContent"
+          <svg
+            class="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           />
-        </div>
+        </span>
+        <span
+          class="euiAccordion__buttonContent"
+        />
       </button>
     </div>
     <div
@@ -443,25 +391,21 @@ exports[`EuiAccordion props initialIsOpen is rendered 1`] = `
         class="euiAccordion__button"
         type="button"
       >
-        <div
-          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+        <span
+          class="euiAccordion__iconWrapper"
         >
-          <div
-            class="euiFlexItem euiFlexItem--flexGrowZero euiAccordion__iconWrapper"
-          >
-            <svg
-              class="euiIcon euiIcon--medium euiIcon-isLoading"
-              focusable="false"
-              height="16"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            />
-          </div>
-          <div
-            class="euiFlexItem euiAccordion__buttonContent"
+          <svg
+            class="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           />
-        </div>
+        </span>
+        <span
+          class="euiAccordion__buttonContent"
+        />
       </button>
     </div>
   </div>

--- a/src/components/accordion/__snapshots__/accordion.test.tsx.snap
+++ b/src/components/accordion/__snapshots__/accordion.test.tsx.snap
@@ -9,57 +9,46 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
   <div
     className="euiAccordion"
   >
-    <EuiFlexGroup
-      alignItems="center"
-      gutterSize="none"
+    <div
+      className="euiAccordion__triggerWrapper"
     >
-      <div
-        className="euiFlexGroup euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+      <button
+        aria-controls="6"
+        aria-expanded={false}
+        className="euiAccordion__button"
+        onClick={[Function]}
+        type="button"
       >
-        <EuiFlexItem>
-          <div
-            className="euiFlexItem"
+        <span
+          className="euiAccordion__iconWrapper"
+        >
+          <EuiIcon
+            className="euiAccordion__icon"
+            size="m"
+            type="arrowRight"
           >
-            <button
-              aria-controls="6"
-              aria-expanded={false}
-              className="euiAccordion__button"
-              onClick={[Function]}
-              type="button"
+            <EuiIconEmpty
+              className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+              focusable="false"
+              style={null}
             >
-              <span
-                className="euiAccordion__iconWrapper"
-              >
-                <EuiIcon
-                  className="euiAccordion__icon"
-                  size="m"
-                  type="arrowRight"
-                >
-                  <EuiIconEmpty
-                    className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
-                    focusable="false"
-                    style={null}
-                  >
-                    <svg
-                      className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
-                      focusable="false"
-                      height={16}
-                      style={null}
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </EuiIconEmpty>
-                </EuiIcon>
-              </span>
-              <span
-                className="euiAccordion__buttonContent"
+              <svg
+                className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+                focusable="false"
+                height={16}
+                style={null}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
               />
-            </button>
-          </div>
-        </EuiFlexItem>
-      </div>
-    </EuiFlexGroup>
+            </EuiIconEmpty>
+          </EuiIcon>
+        </span>
+        <span
+          className="euiAccordion__buttonContent"
+        />
+      </button>
+    </div>
     <div
       className="euiAccordion__childWrapper"
       id="6"
@@ -96,57 +85,46 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
   <div
     className="euiAccordion euiAccordion-isOpen"
   >
-    <EuiFlexGroup
-      alignItems="center"
-      gutterSize="none"
+    <div
+      className="euiAccordion__triggerWrapper"
     >
-      <div
-        className="euiFlexGroup euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+      <button
+        aria-controls="5"
+        aria-expanded={true}
+        className="euiAccordion__button"
+        onClick={[Function]}
+        type="button"
       >
-        <EuiFlexItem>
-          <div
-            className="euiFlexItem"
+        <span
+          className="euiAccordion__iconWrapper"
+        >
+          <EuiIcon
+            className="euiAccordion__icon"
+            size="m"
+            type="arrowDown"
           >
-            <button
-              aria-controls="5"
-              aria-expanded={true}
-              className="euiAccordion__button"
-              onClick={[Function]}
-              type="button"
+            <EuiIconEmpty
+              className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+              focusable="false"
+              style={null}
             >
-              <span
-                className="euiAccordion__iconWrapper"
-              >
-                <EuiIcon
-                  className="euiAccordion__icon"
-                  size="m"
-                  type="arrowDown"
-                >
-                  <EuiIconEmpty
-                    className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
-                    focusable="false"
-                    style={null}
-                  >
-                    <svg
-                      className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
-                      focusable="false"
-                      height={16}
-                      style={null}
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </EuiIconEmpty>
-                </EuiIcon>
-              </span>
-              <span
-                className="euiAccordion__buttonContent"
+              <svg
+                className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+                focusable="false"
+                height={16}
+                style={null}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
               />
-            </button>
-          </div>
-        </EuiFlexItem>
-      </div>
-    </EuiFlexGroup>
+            </EuiIconEmpty>
+          </EuiIcon>
+        </span>
+        <span
+          className="euiAccordion__buttonContent"
+        />
+      </button>
+    </div>
     <div
       className="euiAccordion__childWrapper"
       id="5"
@@ -181,34 +159,30 @@ exports[`EuiAccordion is rendered 1`] = `
   data-test-subj="test subject string"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiAccordion__triggerWrapper"
   >
-    <div
-      class="euiFlexItem"
+    <button
+      aria-controls="0"
+      aria-expanded="false"
+      class="euiAccordion__button"
+      type="button"
     >
-      <button
-        aria-controls="0"
-        aria-expanded="false"
-        class="euiAccordion__button"
-        type="button"
+      <span
+        class="euiAccordion__iconWrapper"
       >
-        <span
-          class="euiAccordion__iconWrapper"
-        >
-          <svg
-            class="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
-            focusable="false"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          />
-        </span>
-        <span
-          class="euiAccordion__buttonContent"
+        <svg
+          class="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
         />
-      </button>
-    </div>
+      </span>
+      <span
+        class="euiAccordion__buttonContent"
+      />
+    </button>
   </div>
   <div
     class="euiAccordion__childWrapper"
@@ -228,38 +202,34 @@ exports[`EuiAccordion props buttonContent is rendered 1`] = `
   class="euiAccordion"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiAccordion__triggerWrapper"
   >
-    <div
-      class="euiFlexItem"
+    <button
+      aria-controls="2"
+      aria-expanded="false"
+      class="euiAccordion__button"
+      type="button"
     >
-      <button
-        aria-controls="2"
-        aria-expanded="false"
-        class="euiAccordion__button"
-        type="button"
+      <span
+        class="euiAccordion__iconWrapper"
       >
-        <span
-          class="euiAccordion__iconWrapper"
-        >
-          <svg
-            class="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
-            focusable="false"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          />
-        </span>
-        <span
-          class="euiAccordion__buttonContent"
-        >
-          <div>
-            Button content
-          </div>
-        </span>
-      </button>
-    </div>
+        <svg
+          class="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+      </span>
+      <span
+        class="euiAccordion__buttonContent"
+      >
+        <div>
+          Button content
+        </div>
+      </span>
+    </button>
   </div>
   <div
     class="euiAccordion__childWrapper"
@@ -279,34 +249,30 @@ exports[`EuiAccordion props buttonContentClassName is rendered 1`] = `
   class="euiAccordion"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiAccordion__triggerWrapper"
   >
-    <div
-      class="euiFlexItem"
+    <button
+      aria-controls="1"
+      aria-expanded="false"
+      class="euiAccordion__button"
+      type="button"
     >
-      <button
-        aria-controls="1"
-        aria-expanded="false"
-        class="euiAccordion__button"
-        type="button"
+      <span
+        class="euiAccordion__iconWrapper"
       >
-        <span
-          class="euiAccordion__iconWrapper"
-        >
-          <svg
-            class="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
-            focusable="false"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          />
-        </span>
-        <span
-          class="euiAccordion__buttonContent button content class name"
+        <svg
+          class="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
         />
-      </button>
-    </div>
+      </span>
+      <span
+        class="euiAccordion__buttonContent button content class name"
+      />
+    </button>
   </div>
   <div
     class="euiAccordion__childWrapper"
@@ -326,36 +292,32 @@ exports[`EuiAccordion props extraAction is rendered 1`] = `
   class="euiAccordion"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiAccordion__triggerWrapper"
   >
-    <div
-      class="euiFlexItem"
+    <button
+      aria-controls="3"
+      aria-expanded="false"
+      class="euiAccordion__button"
+      type="button"
     >
-      <button
-        aria-controls="3"
-        aria-expanded="false"
-        class="euiAccordion__button"
-        type="button"
+      <span
+        class="euiAccordion__iconWrapper"
       >
-        <span
-          class="euiAccordion__iconWrapper"
-        >
-          <svg
-            class="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
-            focusable="false"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          />
-        </span>
-        <span
-          class="euiAccordion__buttonContent"
+        <svg
+          class="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
         />
-      </button>
-    </div>
+      </span>
+      <span
+        class="euiAccordion__buttonContent"
+      />
+    </button>
     <div
-      class="euiFlexItem euiFlexItem--flexGrowZero"
+      class="euiAccordion__optionalAction"
     >
       <button>
         Extra action
@@ -380,34 +342,30 @@ exports[`EuiAccordion props initialIsOpen is rendered 1`] = `
   class="euiAccordion euiAccordion-isOpen"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiAccordion__triggerWrapper"
   >
-    <div
-      class="euiFlexItem"
+    <button
+      aria-controls="4"
+      aria-expanded="true"
+      class="euiAccordion__button"
+      type="button"
     >
-      <button
-        aria-controls="4"
-        aria-expanded="true"
-        class="euiAccordion__button"
-        type="button"
+      <span
+        class="euiAccordion__iconWrapper"
       >
-        <span
-          class="euiAccordion__iconWrapper"
-        >
-          <svg
-            class="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
-            focusable="false"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          />
-        </span>
-        <span
-          class="euiAccordion__buttonContent"
+        <svg
+          class="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
         />
-      </button>
-    </div>
+      </span>
+      <span
+        class="euiAccordion__buttonContent"
+      />
+    </button>
   </div>
   <div
     class="euiAccordion__childWrapper"

--- a/src/components/accordion/__snapshots__/accordion.test.tsx.snap
+++ b/src/components/accordion/__snapshots__/accordion.test.tsx.snap
@@ -44,9 +44,7 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
             </EuiIconEmpty>
           </EuiIcon>
         </span>
-        <span
-          className="euiAccordion__buttonContent"
-        />
+        <span />
       </button>
     </div>
     <div
@@ -120,9 +118,7 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
             </EuiIconEmpty>
           </EuiIcon>
         </span>
-        <span
-          className="euiAccordion__buttonContent"
-        />
+        <span />
       </button>
     </div>
     <div
@@ -179,9 +175,7 @@ exports[`EuiAccordion is rendered 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         />
       </span>
-      <span
-        class="euiAccordion__buttonContent"
-      />
+      <span />
     </button>
   </div>
   <div
@@ -222,9 +216,7 @@ exports[`EuiAccordion props buttonContent is rendered 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         />
       </span>
-      <span
-        class="euiAccordion__buttonContent"
-      >
+      <span>
         <div>
           Button content
         </div>
@@ -270,7 +262,7 @@ exports[`EuiAccordion props buttonContentClassName is rendered 1`] = `
         />
       </span>
       <span
-        class="euiAccordion__buttonContent button content class name"
+        class="button content class name"
       />
     </button>
   </div>
@@ -312,9 +304,7 @@ exports[`EuiAccordion props extraAction is rendered 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         />
       </span>
-      <span
-        class="euiAccordion__buttonContent"
-      />
+      <span />
     </button>
     <div
       class="euiAccordion__optionalAction"
@@ -362,9 +352,7 @@ exports[`EuiAccordion props initialIsOpen is rendered 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         />
       </span>
-      <span
-        class="euiAccordion__buttonContent"
-      />
+      <span />
     </button>
   </div>
   <div

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -1,6 +1,13 @@
+.euiAccordion__triggerWrapper {
+  display: flex;
+  align-items: center;
+}
+
 .euiAccordion__button {
+  @include euiFontSize;
   text-align: left;
   width: 100%;
+  flex-grow: 1;
   display: flex;
   align-items: center;
 
@@ -12,7 +19,6 @@
   &:focus {
     .euiAccordion__iconWrapper {
       @include euiFocusRing;
-
       color: $euiColorPrimary;
     }
   }
@@ -26,23 +32,25 @@
 
   // Nested to override EuiIcon
   .euiAccordion__icon {
-    vertical-align: initial;
+    vertical-align: top;
   }
 }
 
+.euiAccordion__optionalAction {
+  flex-shrink: 0;
+}
 
 .euiAccordion__childWrapper {
   visibility: hidden;
   height: 0;
   opacity: 0;
-  overflow-y: hidden;
+  overflow: hidden;
   transform: translatez(0);
   // sass-lint:disable-block indentation
   transition:
     height $euiAnimSpeedNormal $euiAnimSlightResistance,
     opacity $euiAnimSpeedNormal $euiAnimSlightResistance;
 }
-
 
 $paddingSizes: (
   xs: $euiSizeXS,
@@ -54,7 +62,6 @@ $paddingSizes: (
 
 // Create button modifiders based upon the map.
 @each $name, $size in $paddingSizes {
-
   .euiAccordion__padding--#{$name} {
     padding: $size;
   }

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -1,6 +1,8 @@
 .euiAccordion__button {
   text-align: left;
   width: 100%;
+  display: flex;
+  align-items: center;
 
   &:hover {
     text-decoration: underline;
@@ -12,11 +14,22 @@
       @include euiFocusRing;
 
       color: $euiColorPrimary;
-      border-radius: $euiBorderRadius;
     }
   }
-
 }
+
+.euiAccordion__iconWrapper {
+  @include size($euiSize);
+  border-radius: $euiBorderRadius;
+  margin-right: $euiSizeS;
+  flex-shrink: 0;
+
+  // Nested to override EuiIcon
+  .euiAccordion__icon {
+    vertical-align: initial;
+  }
+}
+
 
 .euiAccordion__childWrapper {
   visibility: hidden;

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -4,7 +4,6 @@ import classNames from 'classnames';
 import { CommonProps, keysOf } from '../common';
 
 import { EuiIcon } from '../icon';
-import { EuiFlexGroup, EuiFlexItem } from '../flex';
 import { EuiMutationObserver } from '../observer/mutation_observer';
 import { getDurationAndPerformOnFrame } from '../../services';
 
@@ -160,26 +159,26 @@ export class EuiAccordion extends Component<
     let optionalAction = null;
 
     if (extraAction) {
-      optionalAction = <EuiFlexItem grow={false}>{extraAction}</EuiFlexItem>;
+      optionalAction = (
+        <div className="euiAccordion__optionalAction">{extraAction}</div>
+      );
     }
 
     return (
       <div className={classes} {...rest}>
-        <EuiFlexGroup gutterSize="none" alignItems="center">
-          <EuiFlexItem>
-            <button
-              aria-controls={id}
-              aria-expanded={!!this.state.isOpen}
-              onClick={this.onToggle}
-              className={buttonClasses}
-              type="button">
-              <span className="euiAccordion__iconWrapper">{icon}</span>
-              <span className={buttonContentClasses}>{buttonContent}</span>
-            </button>
-          </EuiFlexItem>
+        <div className="euiAccordion__triggerWrapper">
+          <button
+            aria-controls={id}
+            aria-expanded={!!this.state.isOpen}
+            onClick={this.onToggle}
+            className={buttonClasses}
+            type="button">
+            <span className="euiAccordion__iconWrapper">{icon}</span>
+            <span className={buttonContentClasses}>{buttonContent}</span>
+          </button>
 
           {optionalAction}
-        </EuiFlexGroup>
+        </div>
 
         <div
           className="euiAccordion__childWrapper"

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -143,11 +143,6 @@ export class EuiAccordion extends Component<
 
     const buttonClasses = classNames('euiAccordion__button', buttonClassName);
 
-    const buttonContentClasses = classNames(
-      'euiAccordion__buttonContent',
-      buttonContentClassName
-    );
-
     const icon = (
       <EuiIcon
         className="euiAccordion__icon"
@@ -174,7 +169,7 @@ export class EuiAccordion extends Component<
             className={buttonClasses}
             type="button">
             <span className="euiAccordion__iconWrapper">{icon}</span>
-            <span className={buttonContentClasses}>{buttonContent}</span>
+            <span className={buttonContentClassName}>{buttonContent}</span>
           </button>
 
           {optionalAction}

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -150,7 +150,11 @@ export class EuiAccordion extends Component<
     );
 
     const icon = (
-      <EuiIcon type={this.state.isOpen ? 'arrowDown' : 'arrowRight'} size="m" />
+      <EuiIcon
+        className="euiAccordion__icon"
+        type={this.state.isOpen ? 'arrowDown' : 'arrowRight'}
+        size="m"
+      />
     );
 
     let optionalAction = null;
@@ -169,18 +173,8 @@ export class EuiAccordion extends Component<
               onClick={this.onToggle}
               className={buttonClasses}
               type="button">
-              <EuiFlexGroup
-                gutterSize="s"
-                alignItems="center"
-                responsive={false}>
-                <EuiFlexItem grow={false} className="euiAccordion__iconWrapper">
-                  {icon}
-                </EuiFlexItem>
-
-                <EuiFlexItem className={buttonContentClasses}>
-                  {buttonContent}
-                </EuiFlexItem>
-              </EuiFlexGroup>
+              <span className="euiAccordion__iconWrapper">{icon}</span>
+              <span className={buttonContentClasses}>{buttonContent}</span>
             </button>
           </EuiFlexItem>
 


### PR DESCRIPTION
Based on the issues stemming from negative margins and all the different options from EuiFlexGroup and wild nesting, I've removed this dependency for just applying `display: flex` in CSS.

### Ref: #2141 

Fixes the failed responsiveness when using the `extraAction` prop

<img width="510" alt="Screen Shot 2019-07-19 at 11 23 02 AM" src="https://user-images.githubusercontent.com/549577/61549187-6cf0ba80-aa1d-11e9-869b-138f15f00d5f.png">

I also added an example of how to truncate the text properly

<img width="357" alt="Screen Shot 2019-07-19 at 11 23 16 AM" src="https://user-images.githubusercontent.com/549577/61549205-7712b900-aa1d-11e9-8b0c-4ff2ff68d53a.png">


cc @sulemanof @maryia-lapata 

### Checklist

- [x] This was checked in Kibana
- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
- [x] Any props added have proper autodocs
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- [x] Jest tests were updated or added to match the most common scenarios
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
