### PR TITLE
Update docs on how to test local EUI in Kibana

### DIFF
--- a/wiki/component-development.md
+++ b/wiki/component-development.md
@@ -56,8 +56,7 @@ Note that `yarn link` currently does not work with Kibana. You'll need to manual
 2. In Kibana you have two choices:
     * Point your `package.json` files in Kibana to that file: `"@elastic/eui": "/path/to/elastic-eui-xx.x.x.tgz"` and run `yarn kbn bootstrap`.
     * Alternatively (and often easier), you can run `yarn kbn bootstrap` in Kibana first, then just unpack the `.tgz` file and paste its contents into an empty `/kibana/node_modules/@elastic/eui` folder. This method avoids having to edit all the various `package.json` files in Kibana if you need to run functional tests.
-
-If you feel like you're getting the old version, it's often helpful to launch Kibana with `FORCE_DLL_CREATION=true node scripts/kibana --dev` to make sure it doesn't reuse a cached version of EUI
+3. Regardless of the method you decide run Kibana with `FORCE_DLL_CREATION=true node scripts/kibana --dev` to make sure it doesn't use a previously cached version of EUI.
 
 ## Principles
 

--- a/wiki/component-development.md
+++ b/wiki/component-development.md
@@ -50,13 +50,14 @@ Refer to the [testing guide](testing.md) for guidelines on writing and designing
 
 ### Testing the component with Kibana
 
-1. In the `eui` folder, run `yarn link` to create the `@elastic/eui` link package.
+Note that `yarn link` currently does not work with Kibana. You'll need to manually pack and insert it into Kibana to test locally.
 
-2. In the `kibana` folder (and potentially the `x-pack` sub-folder as well, if you are working in x-pack code), run `yarn link @elastic/eui` to install the link package you just created.
+1. In the `eui` folder, run `npm pack`. This will create a `.tgz` file in your EUI directory. At this point you can move it anywhere.
+2. In `kibana` you have two choices:
+    * Point your `package.josn` files in Kibana to that file. `"@elastic/eui": "/path/to/elastic-eui-xx.x.x.tgz"` and run `yarn kbn bootstrap`
+    * Alternatively (and often easier), you can just unpack the `.tgz` file and paste its contents into an empty `/kibana/node_modules/@elastic/eui` folder. You should do this _after_ you've run `yarn kbn bootstrap`. This method avoids having to edit all the various `package.json` files in Kibana if you need to run functional tests.
 
-3. Start up the Kibana server.
-
-4. Back in the `eui` folder, run `yarn build`. Repeat (just) this step any time you make changes to your EUI component.
+If you feel like you're getting the old version, it's often helpful to launch Kibana with `FORCE_DLL_CREATION=true node scripts/kibana --dev` to make sure it doesn't reuse a cached version of EUI
 
 ## Principles
 

--- a/wiki/component-development.md
+++ b/wiki/component-development.md
@@ -53,8 +53,8 @@ Refer to the [testing guide](testing.md) for guidelines on writing and designing
 Note that `yarn link` currently does not work with Kibana. You'll need to manually pack and insert it into Kibana to test locally.
 
 1. In the `eui` folder, run `npm pack`. This will create a `.tgz` file in your EUI directory. At this point you can move it anywhere.
-2. In `kibana` you have two choices:
-    * Point your `package.josn` files in Kibana to that file. `"@elastic/eui": "/path/to/elastic-eui-xx.x.x.tgz"` and run `yarn kbn bootstrap`
+2. In Kibana you have two choices:
+    * Point your `package.json` files in Kibana to that file. `"@elastic/eui": "/path/to/elastic-eui-xx.x.x.tgz"` and run `yarn kbn bootstrap`
     * Alternatively (and often easier), you can just unpack the `.tgz` file and paste its contents into an empty `/kibana/node_modules/@elastic/eui` folder. You should do this _after_ you've run `yarn kbn bootstrap`. This method avoids having to edit all the various `package.json` files in Kibana if you need to run functional tests.
 
 If you feel like you're getting the old version, it's often helpful to launch Kibana with `FORCE_DLL_CREATION=true node scripts/kibana --dev` to make sure it doesn't reuse a cached version of EUI

--- a/wiki/component-development.md
+++ b/wiki/component-development.md
@@ -54,7 +54,7 @@ Note that `yarn link` currently does not work with Kibana. You'll need to manual
 
 1. In the `eui` folder, run `npm pack`. This will create a `.tgz` file in your EUI directory. At this point you can move it anywhere.
 2. In Kibana you have two choices:
-    * Point your `package.json` files in Kibana to that file. `"@elastic/eui": "/path/to/elastic-eui-xx.x.x.tgz"` and run `yarn kbn bootstrap`
+    * Point your `package.json` files in Kibana to that file: `"@elastic/eui": "/path/to/elastic-eui-xx.x.x.tgz"` and run `yarn kbn bootstrap`.
     * Alternatively (and often easier), you can run `yarn kbn bootstrap` in Kibana first, then just unpack the `.tgz` file and paste its contents into an empty `/kibana/node_modules/@elastic/eui` folder. This method avoids having to edit all the various `package.json` files in Kibana if you need to run functional tests.
 
 If you feel like you're getting the old version, it's often helpful to launch Kibana with `FORCE_DLL_CREATION=true node scripts/kibana --dev` to make sure it doesn't reuse a cached version of EUI

--- a/wiki/component-development.md
+++ b/wiki/component-development.md
@@ -55,7 +55,7 @@ Note that `yarn link` currently does not work with Kibana. You'll need to manual
 1. In the `eui` folder, run `npm pack`. This will create a `.tgz` file in your EUI directory. At this point you can move it anywhere.
 2. In Kibana you have two choices:
     * Point your `package.json` files in Kibana to that file. `"@elastic/eui": "/path/to/elastic-eui-xx.x.x.tgz"` and run `yarn kbn bootstrap`
-    * Alternatively (and often easier), you can just unpack the `.tgz` file and paste its contents into an empty `/kibana/node_modules/@elastic/eui` folder. You should do this _after_ you've run `yarn kbn bootstrap`. This method avoids having to edit all the various `package.json` files in Kibana if you need to run functional tests.
+    * Alternatively (and often easier), you can run `yarn kbn bootstrap` in Kibana first, then just unpack the `.tgz` file and paste its contents into an empty `/kibana/node_modules/@elastic/eui` folder. This method avoids having to edit all the various `package.json` files in Kibana if you need to run functional tests.
 
 If you feel like you're getting the old version, it's often helpful to launch Kibana with `FORCE_DLL_CREATION=true node scripts/kibana --dev` to make sure it doesn't reuse a cached version of EUI
 


### PR DESCRIPTION
### Summary

`yarn link` no longer works. Updated the docs to give people options for something that does.

### Checklist

- [ ] ~This was checked in mobile~
- [ ] ~This was checked in IE11~
- [ ] ~This was checked in dark mode~
- [ ] ~Any props added have proper autodocs~
- [ ] Documentation examples were added
- [ ] ~A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
- [ ] ~This was checked for breaking changes and labeled appropriately~
- [ ] ~Jest tests were updated or added to match the most common scenarios~
- [ ] ~This was checked against keyboard-only and screenreader scenarios~
- [ ] ~This required updates to Framer X components~
