### PR TITLE
More EuiFilePicker styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added `partial` glyph to `EuiIcon` ([#2152](https://github.com/elastic/eui/pull/2152))
+- Added `tall`, `fullWidth`, and `isInvalid` props to `EuiFilePicker` ([#2145](https://github.com/elastic/eui/pull/2145))
 
 **Bug fixes**
 
 - Fixed invalid `aria-desribedby` values set by `EuiToolTip` ([#2156](https://github.com/elastic/eui/pull/2156))
+- Fixed truncation and z-index of `EuiFilePicker` ([#2145](https://github.com/elastic/eui/pull/2145))
 
 ## [`13.0.0`](https://github.com/elastic/eui/tree/v13.0.0)
 

--- a/src-docs/src/views/form_controls/file_picker.js
+++ b/src-docs/src/views/form_controls/file_picker.js
@@ -72,6 +72,18 @@ export class FilePicker extends Component {
         <EuiFilePicker
           id="asdf2"
           multiple
+          tall={false}
+          initialPromptText="Select some files"
+          onChange={files => {
+            this.onChange(files);
+          }}
+        />
+
+        <EuiSpacer size="m" />
+
+        <EuiFilePicker
+          id="asdf2"
+          multiple
           compressed
           initialPromptText="Select some files"
           onChange={files => {

--- a/src-docs/src/views/form_controls/file_picker.js
+++ b/src-docs/src/views/form_controls/file_picker.js
@@ -70,9 +70,7 @@ export class FilePicker extends Component {
         <EuiSpacer size="m" />
 
         <EuiFilePicker
-          id="asdf2"
-          multiple
-          tall={false}
+          display="default"
           initialPromptText="Select some files"
           onChange={files => {
             this.onChange(files);
@@ -82,8 +80,6 @@ export class FilePicker extends Component {
         <EuiSpacer size="m" />
 
         <EuiFilePicker
-          id="asdf2"
-          multiple
           compressed
           initialPromptText="Select some files"
           onChange={files => {

--- a/src/components/form/file_picker/__snapshots__/file_picker.test.js.snap
+++ b/src/components/form/file_picker/__snapshots__/file_picker.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`EuiFilePicker is rendered 1`] = `
 <div
-  class="euiFilePicker testClass1 testClass2"
+  class="euiFilePicker euiFilePicker--large testClass1 testClass2"
 >
   <div
     class="euiFilePicker__wrap"

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -1,253 +1,199 @@
 @import '../form_control_layout/mixins';
 
+/**
+  * REMEMBER: --large modifiers must come last to override --compressed
+  */
+
 .euiFilePicker {
-  .euiFilePicker__wrap {
-    // Auto means the height isn't set to a fixed size
-    @include euiFormControlSize(auto);
+  @include euiFormControlSize;
+  position: relative;
 
-    position: relative;
-    display: inline-block;
-
-    @at-root {
-      .euiFilePicker--notTall#{&} {
-        height: $euiFormControlHeight;
-      }
-
-      .euiFilePicker--compressed#{&} {
-        height: $euiFormControlCompressedHeight;
-      }
-
-      .euiFilePicker--fullWidth#{&} {
-        max-width: 100%;
-      }
-    }
+  &.euiFilePicker--fullWidth {
+    max-width: 100%;
   }
 
-  // The input is an invisiable dropzone / button
-  .euiFilePicker__input {
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    opacity: 0;
-    overflow: hidden;
+  &.euiFilePicker--large {
+    height: auto;
+  }
+}
 
-    &:hover {
-      cursor: pointer;
-    }
+// The input is an invisiable dropzone / button
+.euiFilePicker__input {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  overflow: hidden;
 
-    &:hover:disabled {
-      cursor: not-allowed;
-    }
-
-    &:disabled ~ .euiFilePicker__prompt {
-      color: $euiColorMediumShade;
-    }
+  &:hover {
+    cursor: pointer;
   }
 
-  .euiFilePicker__icon {
+  &:hover:disabled {
+    cursor: not-allowed;
+  }
+
+  &:disabled ~ .euiFilePicker__prompt {
+    color: $euiColorMediumShade;
+  }
+}
+
+.euiFilePicker__icon {
+  position: absolute;
+  left: $euiSizeM;
+  top: $euiSizeM;
+  transition: transform $euiAnimSpeedFast $euiAnimSlightResistance;
+
+  .euiFilePicker--compressed & {
+    top: $euiSizeS;
+  }
+
+  .euiFilePicker--large & {
+    position: static;
     margin-bottom: $euiSize;
-    transition: transform $euiAnimSpeedFast $euiAnimSlightResistance;
+  }
+}
 
-    @at-root {
-      .euiFilePicker--notTall#{&},
-      .euiFilePicker--compressed#{&} {
-        // sass-lint:disable-block no-important
-        position: absolute;
-        left: $euiSizeM;
-        transform: scale(1) !important; // don't scale icon on hover
-      }
+/**
+  * 1. Don't block the user from dropping files onto the filepicker.
+  * 3. Ensure space for import icon, loading spinner, and clear button (only if it has files)
+  * 4. Delay focus gradient or else it will only partially transition while file chooser opens
+  * 5. Static height so that it doesn't shift it's surrounding contents around
+  */
+.euiFilePicker__prompt {
+  @include euiFormControlDefaultShadow;
+  @include euiFormControlWithIcon; /* 3 */
+  height: $euiFormControlHeight;
+  padding-top: $euiFormControlPadding;
+  padding-right: $euiFormControlPadding;
+  padding-bottom: $euiFormControlPadding;
+  pointer-events: none; /* 1 */
 
-      .euiFilePicker--notTall#{&} {
-        top: $euiSizeM;
-      }
+  // sass-lint:disable-block indentation
+  transition:
+    box-shadow $euiAnimSpeedFast ease-in,
+    background-color $euiAnimSpeedFast ease-in,
+    background-image $euiAnimSpeedFast ease-in,
+    background-size $euiAnimSpeedFast ease-in $euiAnimSpeedFast; /* 4 */
 
-      .euiFilePicker--compressed#{&} {
-        top: $euiSizeS;
-      }
-    }
+  .euiFilePicker--compressed & {
+    height: $euiFormControlCompressedHeight;
+    padding-top: $euiFormControlCompressedPadding;
+    padding-right: $euiFormControlCompressedPadding;
+    padding-bottom: $euiFormControlCompressedPadding;
   }
 
-  /**
-   * 1. Don't block the user from dropping files onto the filepicker.
-   * 3. Ensure space for import icon, loading spinner, and clear button (only if it has files)
-   * 4. Delay focus gradient or else it will only partially transition while file chooser opens
-   * 5. Static height so that it doesn't shift it's surrounding contents around
-   */
-  .euiFilePicker__prompt {
-    @include euiFormControlDefaultShadow;
-
+  .euiFilePicker--large & {
     height: $euiFilePickerTallHeight; /* 5 */
-    pointer-events: none; /* 1 */
-    position: relative; /* 2 */
+    padding: 0 $euiSizeL;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding: 0 $euiSizeL;
-
-    // sass-lint:disable-block indentation
-    transition:
-      box-shadow $euiAnimSpeedFast ease-in,
-      background-color $euiAnimSpeedFast ease-in,
-      background-image $euiAnimSpeedFast ease-in,
-      background-size $euiAnimSpeedFast ease-in $euiAnimSpeedFast; /* 4 */
-
-    // sass-lint:disable-block mixins-before-declarations
-    @at-root {
-      .euiFilePicker--notTall#{&} {
-        height: $euiFormControlHeight;
-        padding: $euiFormControlPadding;
-      }
-
-      .euiFilePicker--compressed#{&} {
-        height: $euiFormControlCompressedHeight;
-        padding: $euiFormControlCompressedPadding;
-      }
-
-      .euiFilePicker--notTall#{&},
-      .euiFilePicker--compressed#{&} {
-        @include euiFormControlWithIcon; /* 3 */
-        display: block;
-      }
-
-      .euiFilePicker-isInvalid#{&} {
-        @include euiFormControlInvalidStyle;
-      }
-    }
   }
 
-  .euiFilePicker__promptText {
-    @include euiFontSizeS;
-    @include euiTextTruncate;
-    display: block;
+  .euiFilePicker-isInvalid & {
+    @include euiFormControlInvalidStyle;
+  }
+}
 
-    @at-root {
-      // make compressed prompt look like placeholder
-      .euiFilePicker--notTall#{&},
-      .euiFilePicker--compressed#{&} {
-        color: $euiColorMediumShade;
-        line-height: $euiSize;
-      }
-    }
+.euiFilePicker__promptText {
+  @include euiFontSizeS;
+  @include euiTextTruncate;
+  line-height: $euiSize;
+  display: block;
+
+  // make normal sized prompt look like placeholder
+  .euiFilePicker:not(.euiFilePicker--large):not(.euiFilePicker-hasFiles) & {
+    color: $euiColorMediumShade;
+  }
+}
+
+.euiFilePicker__clearButton,
+.euiFilePicker__loadingSpinner {
+  position: absolute;
+  right: $euiSizeM;
+  top: $euiSizeM;
+
+  .euiFilePicker--compressed & {
+    top: $euiSizeS;
+  }
+}
+
+/**
+  * 1. Undo the pointer-events: none applied to the enclosing prompt.
+  */
+.euiFilePicker__clearButton {
+  pointer-events: auto; /* 1 */
+
+  .euiFilePicker:not(.euiFilePicker--large) & {
+    @include euiFormControlLayoutClearIcon('.euiFilePicker__clearIcon');
   }
 
-  /**
-   * 1. Undo the pointer-events: none applied to the enclosing prompt.
-   */
-  .euiFilePicker__clearButton {
-    pointer-events: auto; /* 1 */
-
-    @at-root {
-      .euiFilePicker--notTall#{&},
-      .euiFilePicker--compressed#{&} {
-        @include euiFormControlLayoutClearIcon('.euiFilePicker__clearIcon');
-        position: absolute;
-        right: $euiSizeM;
-      }
-
-      .euiFilePicker--notTall#{&} {
-        top: $euiSizeM;
-      }
-
-      .euiFilePicker--compressed#{&} {
-        top: $euiSizeS;
-      }
-    }
+  .euiFilePicker--large & {
+    position: relative;
+    top: 0;
+    right: 0;
   }
+}
 
-  .euiFilePicker__loadingSpinner {
-    @at-root {
-      .euiFilePicker--notTall#{&},
-      .euiFilePicker--compressed#{&} {
-        position: absolute;
-        right: $euiSizeM;
-      }
+// Focus
+.euiFilePicker__showDrop .euiFilePicker__prompt,
+.euiFilePicker__input:focus + .euiFilePicker__prompt {
+  @include euiFormControlFocusStyle;
+}
 
-      .euiFilePicker--notTall#{&} {
-        top: $euiSizeM;
-      }
+// Disabled
+.euiFilePicker__input:disabled + .euiFilePicker__prompt {
+  @include euiFormControlDisabledStyle;
+}
 
-      .euiFilePicker--compressed#{&} {
-        top: $euiSizeS;
-      }
-    }
-  }
-
-  // sass-lint:disable-block no-mergeable-selectors
-  // Not actually mergeable because of where the & lies
-  .euiFilePicker__clearButton {
-    @at-root {
-      .euiFilePicker--notTall#{&},
-      .euiFilePicker--compressed#{&} {
-        position: absolute;
-        right: $euiSizeM;
-      }
-
-      .euiFilePicker--notTall#{&} {
-        top: $euiSizeM;
-      }
-
-      .euiFilePicker--compressed#{&} {
-        top: $euiSizeS;
-      }
-    }
-  }
-
-  // Hover and focus
-  .euiFilePicker__input:hover:not(:disabled) + .euiFilePicker__prompt,
-  .euiFilePicker__input:focus + .euiFilePicker__prompt {
-    .euiFilePicker__promptText {
-      // Adding the underline to the prompt text ensures the underline
-      // color is the same as the current text color
-      text-decoration: underline;
-    }
-
-    .euiFilePicker__icon {
-      transform: scale(1.1);
-    }
-  }
-
-  // Focus
-  .euiFilePicker__input:focus + .euiFilePicker__prompt {
-    @include euiFormControlFocusStyle;
-  }
-
-  // Disabled
-  .euiFilePicker__input:disabled + .euiFilePicker__prompt {
-    @include euiFormControlDisabledStyle;
-  }
-
-  &.euiFilePicker-isLoading.euiFilePicker--notTall .euiFilePicker__prompt,
-  &.euiFilePicker-isLoading.euiFilePicker--compressed .euiFilePicker__prompt,
-  &.euiFilePicker-hasFiles.euiFilePicker--notTall .euiFilePicker__prompt,
-  &.euiFilePicker-hasFiles.euiFilePicker--compressed .euiFilePicker__prompt {
+// Make space for the icons on the right
+.euiFilePicker:not(.euiFilePicker--large) {
+  &.euiFilePicker-isLoading .euiFilePicker__prompt,
+  &.euiFilePicker-hasFiles .euiFilePicker__prompt {
     @include euiFormControlWithIcon(false, 'right'); /* 3 */
   }
+}
 
-  // When the filepicker has files in it, but not in compressed mode
-  &:not(.euiFilePicker--compressed):not(.euiFilePicker--notTall).euiFilePicker-hasFiles .euiFilePicker__promptText {
-    font-weight: $euiFontWeightBold;
+// When the filepicker has files in it
+.euiFilePicker-hasFiles .euiFilePicker__promptText {
+  color: $euiTextColor;
+}
+
+// Large styles only
+.euiFilePicker--large {
+  // sass-lint:disable-block nesting-depth
+  // Hover and focus
+  .euiFilePicker__input:hover:not(:disabled),
+  .euiFilePicker__input:focus {
+    + .euiFilePicker__prompt {
+      .euiFilePicker__promptText {
+        // Adding the underline to the prompt text ensures the underline
+        // color is the same as the current text color
+        text-decoration: underline;
+      }
+
+      .euiFilePicker__icon {
+        transform: scale(1.1);
+      }
+    }
   }
 
-  // When the filepicker has files in it, AND in compressed mode
-  &.euiFilePicker--notTall.euiFilePicker-hasFiles .euiFilePicker__promptText,
-  &.euiFilePicker--compressed.euiFilePicker-hasFiles .euiFilePicker__promptText {
-    color: $euiTextColor;
-  }
-
-  // When you are dragging files over the dropzone
+  // While dragging files over the dropzone
   &.euiFilePicker__showDrop .euiFilePicker__prompt {
-    @include euiFormControlFocusStyle;
-
     .euiFilePicker__promptText {
       text-decoration: underline;
     }
 
     .euiFilePicker__icon {
       transform: scale(1.1);
-      color: $euiColorPrimary;
     }
+  }
+
+  &.euiFilePicker-hasFiles .euiFilePicker__promptText {
+    font-weight: $euiFontWeightBold;
   }
 }

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -191,8 +191,7 @@
   }
 
   // When the filepicker has files in it, but not in compressed mode
-  &:not(.euiFilePicker--notTall).euiFilePicker-hasFiles .euiFilePicker__promptText,
-  &:not(.euiFilePicker--compressed).euiFilePicker-hasFiles .euiFilePicker__promptText {
+  &:not(.euiFilePicker--compressed):not(.euiFilePicker--notTall).euiFilePicker-hasFiles .euiFilePicker__promptText {
     font-weight: $euiFontWeightBold;
   }
 

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -26,7 +26,6 @@
   // The input is an invisiable dropzone / button
   .euiFilePicker__input {
     position: absolute;
-    z-index: 0;
     left: 0;
     top: 0;
     width: 100%;
@@ -72,7 +71,6 @@
 
   /**
    * 1. Don't block the user from dropping files onto the filepicker.
-   * 2. Put prompt on top of input, so the clear button can intercept the click.
    * 3. Ensure space for import icon and clear button (only if it has files)
    * 4. Delay focus gradient or else it will only partially transition while file chooser opens
    * 5. Static height so that it doesn't shift it's surrounding contents around
@@ -83,7 +81,6 @@
     height: $euiFilePickerTallHeight; /* 5 */
     pointer-events: none; /* 1 */
     position: relative; /* 2 */
-    z-index: 1; /* 2 */
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -12,6 +12,10 @@
       .euiFilePicker--compressed#{&} {
         height: $euiSizeXL;
       }
+
+      .euiFilePicker--fullWidth#{&} {
+        max-width: 100%;
+      }
     }
   }
 
@@ -80,10 +84,16 @@
     // sass-lint:disable-block mixins-before-declarations
     @at-root {
       .euiFilePicker--compressed#{&} {
+        @include euiFormControlDefaultShadow($borderOnly: true);
+        border-radius: $euiBorderRadius / 2;
         height: $euiFormControlCompressedHeight;
         padding: $euiFormControlCompressedPadding;
         @include euiFormControlWithIcon; /* 3 */
         text-align: left;
+      }
+
+      .euiFilePicker-isInvalid#{&} {
+        @include euiFormControlInvalidStyle;
       }
     }
   }

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -71,7 +71,7 @@
 
   /**
    * 1. Don't block the user from dropping files onto the filepicker.
-   * 3. Ensure space for import icon and clear button (only if it has files)
+   * 3. Ensure space for import icon, loading spinner, and clear button (only if it has files)
    * 4. Delay focus gradient or else it will only partially transition while file chooser opens
    * 5. Static height so that it doesn't shift it's surrounding contents around
    */
@@ -139,11 +139,48 @@
   .euiFilePicker__clearButton {
     pointer-events: auto; /* 1 */
 
-    // sass-lint:disable-block mixins-before-declarations
     @at-root {
       .euiFilePicker--notTall#{&},
       .euiFilePicker--compressed#{&} {
         @include euiFormControlLayoutClearIcon('.euiFilePicker__clearIcon');
+        position: absolute;
+        right: $euiSizeM;
+      }
+
+      .euiFilePicker--notTall#{&} {
+        top: $euiSizeM;
+      }
+
+      .euiFilePicker--compressed#{&} {
+        top: $euiSizeS;
+      }
+    }
+  }
+
+  .euiFilePicker__loadingSpinner {
+    @at-root {
+      .euiFilePicker--notTall#{&},
+      .euiFilePicker--compressed#{&} {
+        position: absolute;
+        right: $euiSizeM;
+      }
+
+      .euiFilePicker--notTall#{&} {
+        top: $euiSizeM;
+      }
+
+      .euiFilePicker--compressed#{&} {
+        top: $euiSizeS;
+      }
+    }
+  }
+
+  // sass-lint:disable-block no-mergeable-selectors
+  // Not actually mergeable because of where the & lies
+  .euiFilePicker__clearButton {
+    @at-root {
+      .euiFilePicker--notTall#{&},
+      .euiFilePicker--compressed#{&} {
         position: absolute;
         right: $euiSizeM;
       }
@@ -182,6 +219,8 @@
     @include euiFormControlDisabledStyle;
   }
 
+  &.euiFilePicker-isLoading.euiFilePicker--notTall .euiFilePicker__prompt,
+  &.euiFilePicker-isLoading.euiFilePicker--compressed .euiFilePicker__prompt,
   &.euiFilePicker-hasFiles.euiFilePicker--notTall .euiFilePicker__prompt,
   &.euiFilePicker-hasFiles.euiFilePicker--compressed .euiFilePicker__prompt {
     @include euiFormControlWithIcon(false, 'right'); /* 3 */

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -85,7 +85,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding: $euiSizeL;
+    padding: 0 $euiSizeL;
 
     // sass-lint:disable-block indentation
     transition:

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -75,16 +75,20 @@
    * 2. Put prompt on top of input, so the clear button can intercept the click.
    * 3. Ensure space for import icon and clear button (only if it has files)
    * 4. Delay focus gradient or else it will only partially transition while file chooser opens
+   * 5. Static height so that it doesn't shift it's surrounding contents around
    */
   .euiFilePicker__prompt {
     @include euiFormControlDefaultShadow;
 
+    height: $euiFilePickerTallHeight; /* 5 */
     pointer-events: none; /* 1 */
     position: relative; /* 2 */
     z-index: 1; /* 2 */
-    display: block;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
     padding: $euiSizeL;
-    text-align: center;
 
     // sass-lint:disable-block indentation
     transition:
@@ -108,7 +112,7 @@
       .euiFilePicker--notTall#{&},
       .euiFilePicker--compressed#{&} {
         @include euiFormControlWithIcon; /* 3 */
-        text-align: left;
+        display: block;
       }
 
       .euiFilePicker-isInvalid#{&} {
@@ -119,10 +123,8 @@
 
   .euiFilePicker__promptText {
     @include euiFontSizeS;
+    @include euiTextTruncate;
     display: block;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
 
     @at-root {
       // make compressed prompt look like placeholder

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -9,8 +9,12 @@
     display: inline-block;
 
     @at-root {
+      .euiFilePicker--notTall#{&} {
+        height: $euiFormControlHeight;
+      }
+
       .euiFilePicker--compressed#{&} {
-        height: $euiSizeXL;
+        height: $euiFormControlCompressedHeight;
       }
 
       .euiFilePicker--fullWidth#{&} {
@@ -48,12 +52,20 @@
     transition: transform $euiAnimSpeedFast $euiAnimSlightResistance;
 
     @at-root {
+      .euiFilePicker--notTall#{&},
       .euiFilePicker--compressed#{&} {
         // sass-lint:disable-block no-important
         position: absolute;
-        top: $euiSizeS;
         left: $euiSizeM;
         transform: scale(1) !important; // don't scale icon on hover
+      }
+
+      .euiFilePicker--notTall#{&} {
+        top: $euiSizeM;
+      }
+
+      .euiFilePicker--compressed#{&} {
+        top: $euiSizeS;
       }
     }
   }
@@ -83,11 +95,18 @@
 
     // sass-lint:disable-block mixins-before-declarations
     @at-root {
+      .euiFilePicker--notTall#{&} {
+        height: $euiFormControlHeight;
+        padding: $euiFormControlPadding;
+      }
+
       .euiFilePicker--compressed#{&} {
-        @include euiFormControlDefaultShadow($borderOnly: true);
-        border-radius: $euiBorderRadius / 2;
         height: $euiFormControlCompressedHeight;
         padding: $euiFormControlCompressedPadding;
+      }
+
+      .euiFilePicker--notTall#{&},
+      .euiFilePicker--compressed#{&} {
         @include euiFormControlWithIcon; /* 3 */
         text-align: left;
       }
@@ -107,6 +126,7 @@
 
     @at-root {
       // make compressed prompt look like placeholder
+      .euiFilePicker--notTall#{&},
       .euiFilePicker--compressed#{&} {
         color: $euiColorMediumShade;
         line-height: $euiSize;
@@ -122,11 +142,19 @@
 
     // sass-lint:disable-block mixins-before-declarations
     @at-root {
+      .euiFilePicker--notTall#{&},
       .euiFilePicker--compressed#{&} {
         @include euiFormControlLayoutClearIcon('.euiFilePicker__clearIcon');
         position: absolute;
-        top: $euiSizeS;
         right: $euiSizeM;
+      }
+
+      .euiFilePicker--notTall#{&} {
+        top: $euiSizeM;
+      }
+
+      .euiFilePicker--compressed#{&} {
+        top: $euiSizeS;
       }
     }
   }
@@ -155,16 +183,19 @@
     @include euiFormControlDisabledStyle;
   }
 
+  &.euiFilePicker-hasFiles.euiFilePicker--notTall .euiFilePicker__prompt,
   &.euiFilePicker-hasFiles.euiFilePicker--compressed .euiFilePicker__prompt {
     @include euiFormControlWithIcon(false, 'right'); /* 3 */
   }
 
   // When the filepicker has files in it, but not in compressed mode
+  &:not(.euiFilePicker--notTall).euiFilePicker-hasFiles .euiFilePicker__promptText,
   &:not(.euiFilePicker--compressed).euiFilePicker-hasFiles .euiFilePicker__promptText {
     font-weight: $euiFontWeightBold;
   }
 
   // When the filepicker has files in it, AND in compressed mode
+  &.euiFilePicker--notTall.euiFilePicker-hasFiles .euiFilePicker__promptText,
   &.euiFilePicker--compressed.euiFilePicker-hasFiles .euiFilePicker__promptText {
     color: $euiTextColor;
   }

--- a/src/components/form/file_picker/_index.scss
+++ b/src/components/form/file_picker/_index.scss
@@ -1,1 +1,2 @@
+@import 'variables';
 @import 'file_picker';

--- a/src/components/form/file_picker/_variables.scss
+++ b/src/components/form/file_picker/_variables.scss
@@ -1,0 +1,1 @@
+$euiFilePickerTallHeight: $euiSize * 8;

--- a/src/components/form/file_picker/file_picker.js
+++ b/src/components/form/file_picker/file_picker.js
@@ -24,6 +24,10 @@ export class EuiFilePicker extends Component {
      * Reduces the size to a typical (compressed) input
      */
     compressed: PropTypes.bool,
+    /**
+     * Uses the taller multi-line version
+     */
+    tall: PropTypes.bool,
     fullWidth: PropTypes.bool,
     isInvalid: PropTypes.bool,
   };
@@ -31,6 +35,7 @@ export class EuiFilePicker extends Component {
   static defaultProps = {
     initialPromptText: 'Select or drag and drop a file',
     compressed: false,
+    tall: true,
   };
 
   constructor(props) {
@@ -95,6 +100,7 @@ export class EuiFilePicker extends Component {
             onChange,
             isInvalid,
             fullWidth,
+            tall,
             ...rest
           } = this.props;
 
@@ -106,15 +112,18 @@ export class EuiFilePicker extends Component {
               euiFilePicker__showDrop: this.state.isHoveringDrop,
               'euiFilePicker--compressed': compressed,
               'euiFilePicker--fullWidth': fullWidth,
+              'euiFilePicker--notTall': !tall,
               'euiFilePicker-isInvalid': isInvalid,
               'euiFilePicker-hasFiles': isOverridingInitialPrompt,
             },
             className
           );
 
+          const normalFormControl = compressed || !tall;
+
           let clearButton;
           if (isOverridingInitialPrompt) {
-            if (compressed) {
+            if (normalFormControl) {
               clearButton = (
                 <button
                   type="button"
@@ -163,7 +172,7 @@ export class EuiFilePicker extends Component {
                   <EuiIcon
                     className="euiFilePicker__icon"
                     type="importAction"
-                    size={compressed ? 'm' : 'l'}
+                    size={normalFormControl ? 'm' : 'l'}
                     aria-hidden="true"
                   />
                   <div className="euiFilePicker__promptText">

--- a/src/components/form/file_picker/file_picker.js
+++ b/src/components/form/file_picker/file_picker.js
@@ -4,8 +4,10 @@ import classNames from 'classnames';
 
 import { EuiValidatableControl } from '../validatable_control';
 import { EuiButtonEmpty } from '../../button';
+import { EuiProgress } from '../../progress';
 import { EuiIcon } from '../../icon';
 import { EuiI18n } from '../../i18n';
+import { EuiLoadingSpinner } from '../../loading';
 
 export class EuiFilePicker extends Component {
   static propTypes = {
@@ -30,6 +32,7 @@ export class EuiFilePicker extends Component {
     tall: PropTypes.bool,
     fullWidth: PropTypes.bool,
     isInvalid: PropTypes.bool,
+    isLoading: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -100,6 +103,7 @@ export class EuiFilePicker extends Component {
             onChange,
             isInvalid,
             fullWidth,
+            isLoading,
             tall,
             ...rest
           } = this.props;
@@ -115,6 +119,7 @@ export class EuiFilePicker extends Component {
               'euiFilePicker--notTall': !tall,
               'euiFilePicker-isInvalid': isInvalid,
               'euiFilePicker-hasFiles': isOverridingInitialPrompt,
+              'euiFilePicker-isLoading': isLoading,
             },
             className
           );
@@ -122,7 +127,12 @@ export class EuiFilePicker extends Component {
           const normalFormControl = compressed || !tall;
 
           let clearButton;
-          if (isOverridingInitialPrompt) {
+          if (isLoading && normalFormControl) {
+            // Override clear button with loading spinner if it is in loading state
+            clearButton = (
+              <EuiLoadingSpinner className="euiFilePicker__loadingSpinner" />
+            );
+          } else if (isOverridingInitialPrompt) {
             if (normalFormControl) {
               clearButton = (
                 <button
@@ -147,6 +157,10 @@ export class EuiFilePicker extends Component {
           } else {
             clearButton = null;
           }
+
+          const loader = !normalFormControl && isLoading && (
+            <EuiProgress size="xs" color="accent" position="absolute" />
+          );
 
           return (
             <div className={classes}>
@@ -179,6 +193,7 @@ export class EuiFilePicker extends Component {
                     {this.state.promptText || initialPromptText}
                   </div>
                   {clearButton}
+                  {loader}
                 </div>
               </div>
             </div>

--- a/src/components/form/file_picker/file_picker.js
+++ b/src/components/form/file_picker/file_picker.js
@@ -9,6 +9,13 @@ import { EuiIcon } from '../../icon';
 import { EuiI18n } from '../../i18n';
 import { EuiLoadingSpinner } from '../../loading';
 
+const displayToClassNameMap = {
+  default: null,
+  large: 'euiFilePicker--large',
+};
+
+export const DISPLAYS = Object.keys(displayToClassNameMap);
+
 export class EuiFilePicker extends Component {
   static propTypes = {
     id: PropTypes.string,
@@ -27,9 +34,11 @@ export class EuiFilePicker extends Component {
      */
     compressed: PropTypes.bool,
     /**
-     * Uses the taller multi-line version
+     * Size or type of display;
+     * `default` for normal height, similar to other controls;
+     * `large` for taller size
      */
-    tall: PropTypes.bool,
+    display: PropTypes.oneOf(DISPLAYS),
     fullWidth: PropTypes.bool,
     isInvalid: PropTypes.bool,
     isLoading: PropTypes.bool,
@@ -38,7 +47,7 @@ export class EuiFilePicker extends Component {
   static defaultProps = {
     initialPromptText: 'Select or drag and drop a file',
     compressed: false,
-    tall: true,
+    display: 'large',
   };
 
   constructor(props) {
@@ -104,27 +113,33 @@ export class EuiFilePicker extends Component {
             isInvalid,
             fullWidth,
             isLoading,
-            tall,
+            display,
             ...rest
           } = this.props;
 
           const isOverridingInitialPrompt = this.state.promptText != null;
 
+          /**
+           * BWC: Force display to be default in case compressed is passed,
+           *      but `display: default` is not. This can be removed once
+           *      we support the new compressed styles and make this breaking change.
+           */
+          const calculatedDisplay = compressed ? 'default' : display;
+          const normalFormControl = calculatedDisplay === 'default';
+
           const classes = classNames(
             'euiFilePicker',
+            displayToClassNameMap[calculatedDisplay],
             {
               euiFilePicker__showDrop: this.state.isHoveringDrop,
               'euiFilePicker--compressed': compressed,
               'euiFilePicker--fullWidth': fullWidth,
-              'euiFilePicker--notTall': !tall,
               'euiFilePicker-isInvalid': isInvalid,
-              'euiFilePicker-hasFiles': isOverridingInitialPrompt,
               'euiFilePicker-isLoading': isLoading,
+              'euiFilePicker-hasFiles': isOverridingInitialPrompt,
             },
             className
           );
-
-          const normalFormControl = compressed || !tall;
 
           let clearButton;
           if (isLoading && normalFormControl) {

--- a/src/components/form/file_picker/file_picker.js
+++ b/src/components/form/file_picker/file_picker.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+import { EuiValidatableControl } from '../validatable_control';
 import { EuiButtonEmpty } from '../../button';
 import { EuiIcon } from '../../icon';
 import { EuiI18n } from '../../i18n';
@@ -23,6 +24,8 @@ export class EuiFilePicker extends Component {
      * Reduces the size to a typical (compressed) input
      */
     compressed: PropTypes.bool,
+    fullWidth: PropTypes.bool,
+    isInvalid: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -90,6 +93,8 @@ export class EuiFilePicker extends Component {
             disabled,
             compressed,
             onChange,
+            isInvalid,
+            fullWidth,
             ...rest
           } = this.props;
 
@@ -100,6 +105,8 @@ export class EuiFilePicker extends Component {
             {
               euiFilePicker__showDrop: this.state.isHoveringDrop,
               'euiFilePicker--compressed': compressed,
+              'euiFilePicker--fullWidth': fullWidth,
+              'euiFilePicker-isInvalid': isInvalid,
               'euiFilePicker-hasFiles': isOverridingInitialPrompt,
             },
             className
@@ -135,21 +142,23 @@ export class EuiFilePicker extends Component {
           return (
             <div className={classes}>
               <div className="euiFilePicker__wrap">
-                <input
-                  type="file"
-                  id={id}
-                  name={name}
-                  className="euiFilePicker__input"
-                  onChange={() => this.handleChange(filesSelected)}
-                  ref={input => {
-                    this.fileInput = input;
-                  }}
-                  onDragOver={this.showDrop}
-                  onDragLeave={this.hideDrop}
-                  onDrop={this.hideDrop}
-                  disabled={disabled}
-                  {...rest}
-                />
+                <EuiValidatableControl isInvalid={isInvalid}>
+                  <input
+                    type="file"
+                    id={id}
+                    name={name}
+                    className="euiFilePicker__input"
+                    onChange={() => this.handleChange(filesSelected)}
+                    ref={input => {
+                      this.fileInput = input;
+                    }}
+                    onDragOver={this.showDrop}
+                    onDragLeave={this.hideDrop}
+                    onDrop={this.hideDrop}
+                    disabled={disabled}
+                    {...rest}
+                  />
+                </EuiValidatableControl>
                 <div className="euiFilePicker__prompt">
                   <EuiIcon
                     className="euiFilePicker__icon"


### PR DESCRIPTION
This adds some more versions of the file picker since there were a few missing.

## 1. Not `large` aka `display='default'` Fixes https://github.com/elastic/eui/issues/1484

~I'm not thrilled with this name, I just was having trouble finding the appropriate name. In actuality we should allow the `compressed` prop to accept a boolean or some string that means "normal". Suggestions welcome.~ UPDATED

<img src="https://d.pr/free/i/64EPQH+" width="50%" />

The main reason I created this one is because I've seen consumers use the "compressed" version when they just wanted the normal height/style input. But this is technically wrong, so this is more appropriate.

### Making sure the `:focus` / `selected` states works

<img width="426" alt="Screen Shot 2019-07-19 at 19 45 21 PM" src="https://user-images.githubusercontent.com/549577/61570917-d4c6f580-aa5d-11e9-875c-ec9c7fc13c03.png">

_This also fixed an issue where truncation wasn't working._

**And with multiple files**

<img width="439" alt="Screen Shot 2019-07-19 at 19 33 41 PM" src="https://user-images.githubusercontent.com/549577/61570666-3ede9b00-aa5c-11e9-92df-7f13ea131e59.png">


## 2. `fullWidth` was missing

<img width="958" alt="Screen Shot 2019-07-19 at 19 30 41 PM" src="https://user-images.githubusercontent.com/549577/61570585-bd870880-aa5b-11e9-88b3-f84236775ff2.png">


## 3. `isInvalid` was missing

<img width="425" alt="Screen Shot 2019-07-19 at 19 31 28 PM" src="https://user-images.githubusercontent.com/549577/61570611-dc859a80-aa5b-11e9-8818-a0d9c8ec0461.png">

## 4. Removed z-indexes

There was a clash if popovers were anywhere near:

**Before**
<img width="639" alt="Screen Shot 2019-07-19 at 19 47 18 PM" src="https://user-images.githubusercontent.com/549577/61571023-ad245d00-aa5e-11e9-9513-e92a54eef8e9.png">

The z-indexes weren't really necessary anyway since the input is first in DOM order.

**After**
<img width="525" alt="Screen Shot 2019-07-19 at 19 50 47 PM" src="https://user-images.githubusercontent.com/549577/61571039-c75e3b00-aa5e-11e9-8553-afeb215597aa.png">

## 5. `isLoading` was missing

For the large form, I just used the animated progress indicator at the top, though I supposed we could also swap out the import icon for the loading spinner. But I do use the loading spinner for the smaller sizes. I also don't display the clear button when it's in a loading state. Simplifies the icons overload.

<img width="440" alt="Screen Shot 2019-07-19 at 20 23 48 PM with a reall long name" src="https://user-images.githubusercontent.com/549577/61571853-d21bce80-aa64-11e9-8688-783f82c17288.png">
<img width="441" alt="Screen Shot 2019-07-19 at 20 31 38 PM" src="https://user-images.githubusercontent.com/549577/61571854-d47e2880-aa64-11e9-91b0-27256218ae55.png">


---

# Height

One other big thing I changed was to set a static height on the tall version. I wasn't a fan that when selecting files it would increase in height, bumping the surrounding elements around.

**Before**
<img src="https://d.pr/free/i/88bIM7+" width="50%" />

Since the line denoting the file name/number of files would only every be a single line, I decided to calculate the height at that moment and set it as the static height. Using flex box and column layout I'm able to keep the contents of the input vertically centered.

**After**

<img src="https://d.pr/free/i/4Kvy0a+" width="50%" />

---

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
- [x] Any props added have proper autodocs
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
