### PR TITLE
Fix typo in icon docs

### DIFF
--- a/src-docs/src/views/icon/icon_example.js
+++ b/src-docs/src/views/icon/icon_example.js
@@ -346,7 +346,7 @@ export const IconExample = {
       text: (
         <p>
           You can title the SVG by passing the <EuiCode>aria-label</EuiCode>{' '}
-          prop to <EuiCode>EuiCode</EuiCode>. No value is set by default.
+          prop to <EuiCode>EuiIcon</EuiCode>. No value is set by default.
         </p>
       ),
       demo: <Accessibility />,


### PR DESCRIPTION
Fix an a11y typo in the icon docs that has been annoying me for ages.