### PR TITLE
Upgrade sidenav search to include sub-section titles

### DIFF
--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -36,6 +36,10 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
     bottom: 0;
     top: 132px;
     overflow-y: auto;
+
+    &--inSearch {
+      color: $euiColorDarkShade;
+    }
   }
 }
 

--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -36,11 +36,11 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
     bottom: 0;
     top: 132px;
     overflow-y: auto;
-
-    &--inSearch {
-      color: $euiColorDarkShade;
-    }
   }
+}
+
+.guideSideNav__item--inSearch {
+  color: $euiColorDarkShade;
 }
 
 .guidePageContent {

--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -198,7 +198,7 @@ export class GuidePageChrome extends Component {
       if (searchTerm) {
         name = (
           <EuiHighlight
-            className="guideSideNav__content--inSearch"
+            className="guideSideNav__item--inSearch"
             search={searchTerm}>
             {title}
           </EuiHighlight>
@@ -250,7 +250,7 @@ export class GuidePageChrome extends Component {
         if (searchTerm) {
           visibleName = (
             <EuiHighlight
-              className="guideSideNav__content--inSearch"
+              className="guideSideNav__item--inSearch"
               search={searchTerm}>
               {name}
             </EuiHighlight>

--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -193,12 +193,25 @@ export class GuidePageChrome extends Component {
       return;
     }
 
-    return subSectionsWithTitles.map(({ title, id }) => ({
-      id: `subSection-${id}`,
-      name: <EuiHighlight search={searchTerm}>{title}</EuiHighlight>,
-      href,
-      onClick: this.onClickLink.bind(this, id),
-    }));
+    return subSectionsWithTitles.map(({ title, id }) => {
+      let name = title;
+      if (searchTerm) {
+        name = (
+          <EuiHighlight
+            className="guideSideNav__content--inSearch"
+            search={searchTerm}>
+            {title}
+          </EuiHighlight>
+        );
+      }
+
+      return {
+        id: `subSection-${id}`,
+        name,
+        href,
+        onClick: this.onClickLink.bind(this, id),
+      };
+    });
   };
 
   renderSideNav = sideNav => {
@@ -233,9 +246,20 @@ export class GuidePageChrome extends Component {
         const { name, path, sections } = item;
         const href = `#/${path}`;
 
+        let visibleName = name;
+        if (searchTerm) {
+          visibleName = (
+            <EuiHighlight
+              className="guideSideNav__content--inSearch"
+              search={searchTerm}>
+              {name}
+            </EuiHighlight>
+          );
+        }
+
         return {
           id: `${section.type}-${path}`,
-          name: <EuiHighlight search={searchTerm}>{name}</EuiHighlight>,
+          name: visibleName,
           href,
           onClick: this.onClickRoute.bind(this),
           items: this.renderSubSections(href, sections, searchTerm),

--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -20,6 +20,25 @@ import {
 import { GuideLocaleSelector } from '../guide_locale_selector';
 import { GuideThemeSelector } from '../guide_theme_selector';
 
+const scrollTo = position => {
+  $('html, body').animate(
+    {
+      scrollTop: position,
+    },
+    250
+  );
+};
+
+function scrollToSelector(selector, attempts = 5) {
+  const element = $(selector);
+
+  if (element.length) {
+    scrollTo(element.offset().top - 20);
+  } else if (attempts > 0) {
+    setTimeout(scrollToSelector.bind(null, selector, attempts - 1), 250);
+  }
+}
+
 export class GuidePageChrome extends Component {
   constructor(props) {
     super(props);
@@ -44,18 +63,9 @@ export class GuidePageChrome extends Component {
     });
   };
 
-  scrollTo = position => {
-    $('html, body').animate(
-      {
-        scrollTop: position,
-      },
-      250
-    );
-  };
-
   onClickLink = id => {
     // Scroll to element.
-    this.scrollTo($(`#${id}`).offset().top - 20);
+    scrollToSelector(`#${id}`);
 
     this.setState({
       search: '',
@@ -144,7 +154,7 @@ export class GuidePageChrome extends Component {
     );
   }
 
-  renderSubSections = (subSections = [], searchTerm = '') => {
+  renderSubSections = (href, subSections = [], searchTerm = '') => {
     const subSectionsWithTitles = subSections.filter(item => {
       if (!item.title) {
         return false;
@@ -165,6 +175,7 @@ export class GuidePageChrome extends Component {
     return subSectionsWithTitles.map(({ title, id }) => ({
       id: `subSection-${id}`,
       name: title,
+      href,
       onClick: this.onClickLink.bind(this, id),
     }));
   };
@@ -199,13 +210,14 @@ export class GuidePageChrome extends Component {
 
       const items = matchingItems.map(item => {
         const { name, path, sections } = item;
+        const href = `#/${path}`;
 
         return {
           id: `${section.type}-${path}`,
           name,
-          href: `#/${path}`,
+          href,
           onClick: this.onClickRoute.bind(this),
-          items: this.renderSubSections(sections, searchTerm),
+          items: this.renderSubSections(href, sections, searchTerm),
           isSelected: !!(
             name === this.props.currentRouteName ||
             (searchTerm && hasMatchingSubItem)

--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -63,21 +63,41 @@ export class GuidePageChrome extends Component {
     });
   };
 
+  scrollNavSectionIntoView = () => {
+    setTimeout(() => {
+      // wait a bit for react to blow away and re-create the DOM
+      // then scroll the selected nav section into view
+      const selectedButton = $('.euiSideNavItemButton-isSelected');
+      if (selectedButton.length) {
+        const root = selectedButton.parents('.euiSideNavItem--root');
+        if (root.length) {
+          root.get(0).scrollIntoView();
+        }
+      }
+    }, 250);
+  };
+
   onClickLink = id => {
     // Scroll to element.
     scrollToSelector(`#${id}`);
 
-    this.setState({
-      search: '',
-      isSideNavOpenOnMobile: false,
-    });
+    this.setState(
+      {
+        search: '',
+        isSideNavOpenOnMobile: false,
+      },
+      this.scrollNavSectionIntoView
+    );
   };
 
   onClickRoute = () => {
-    this.setState({
-      search: '',
-      isSideNavOpenOnMobile: false,
-    });
+    this.setState(
+      {
+        search: '',
+        isSideNavOpenOnMobile: false,
+      },
+      this.scrollNavSectionIntoView
+    );
   };
 
   onButtonClick() {

--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -19,6 +19,7 @@ import {
 
 import { GuideLocaleSelector } from '../guide_locale_selector';
 import { GuideThemeSelector } from '../guide_theme_selector';
+import { EuiHighlight } from '../../../../src/components/highlight';
 
 const scrollTo = position => {
   $('html, body').animate(
@@ -194,7 +195,7 @@ export class GuidePageChrome extends Component {
 
     return subSectionsWithTitles.map(({ title, id }) => ({
       id: `subSection-${id}`,
-      name: title,
+      name: <EuiHighlight search={searchTerm}>{title}</EuiHighlight>,
       href,
       onClick: this.onClickLink.bind(this, id),
     }));
@@ -234,14 +235,12 @@ export class GuidePageChrome extends Component {
 
         return {
           id: `${section.type}-${path}`,
-          name,
+          name: <EuiHighlight search={searchTerm}>{name}</EuiHighlight>,
           href,
           onClick: this.onClickRoute.bind(this),
           items: this.renderSubSections(href, sections, searchTerm),
-          isSelected: !!(
-            name === this.props.currentRouteName ||
-            (searchTerm && hasMatchingSubItem)
-          ),
+          isSelected: name === this.props.currentRouteName,
+          forceOpen: !!(searchTerm && hasMatchingSubItem),
         };
       });
 


### PR DESCRIPTION
### Summary

This has bugged me for a long time, also closes #2095. Enhances the docs' sidenav search to include subsections.

![subsection searching](https://5ac1221dfbed8d1ead68f66f8da2e3a0.s3-us-west-1.amazonaws.com/subsection_search.gif)

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
~- [ ] This was checked for breaking changes and labeled appropriately~
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
