### PR TITLE
[Feature branch] Compressed EuiSuperSelect dropdown

### DIFF
--- a/src-docs/src/views/super_select/super_select.js
+++ b/src-docs/src/views/super_select/super_select.js
@@ -19,8 +19,11 @@ export default class extends Component {
       },
       {
         value: 'option_three',
-        inputDisplay:
-          'Option three has a super long text to see if it will truncate or what',
+        inputDisplay: (
+          <span className="eui-textTruncate eui-displayBlock">
+            Option three has a super long text and added truncation
+          </span>
+        ),
       },
     ];
 

--- a/src-docs/src/views/super_select/super_select_complex.js
+++ b/src-docs/src/views/super_select/super_select_complex.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react';
 
-import { EuiSuperSelect, EuiSpacer, EuiText } from '../../../../src/components';
+import { EuiSuperSelect, EuiText } from '../../../../src/components';
 
 export default class extends Component {
   constructor(props) {
@@ -13,7 +13,6 @@ export default class extends Component {
         dropdownDisplay: (
           <Fragment>
             <strong>Option one</strong>
-            <EuiSpacer size="xs" />
             <EuiText size="s" color="subdued">
               <p className="euiTextColor--subdued">
                 Has a short description giving more detail to the option.
@@ -28,7 +27,6 @@ export default class extends Component {
         dropdownDisplay: (
           <Fragment>
             <strong>Option two</strong>
-            <EuiSpacer size="xs" />
             <EuiText size="s" color="subdued">
               <p className="euiTextColor--subdued">
                 Has a short description giving more detail to the option.
@@ -43,7 +41,6 @@ export default class extends Component {
         dropdownDisplay: (
           <Fragment>
             <strong>Option three</strong>
-            <EuiSpacer size="xs" />
             <EuiText size="s" color="subdued">
               <p className="euiTextColor--subdued">
                 Has a short description giving more detail to the option.

--- a/src/components/context_menu/_context_menu_item.scss
+++ b/src/components/context_menu/_context_menu_item.scss
@@ -31,6 +31,7 @@
 
 .euiContextMenuItem__text {
   flex-grow: 1;
+  overflow: hidden; // allows for text truncation
 }
 
 .euiContextMenuItem__arrow {

--- a/src/components/form/super_select/__snapshots__/super_select.test.js.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.js.snap
@@ -58,10 +58,10 @@ exports[`EuiSuperSelect is rendered 1`] = `
 
 exports[`EuiSuperSelect props compressed is rendered 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
 >
   <div
-    class="euiPopover__anchor euiSuperSelect__popoverAnchor"
+    class="euiPopover__anchor"
   >
     <input
       type="hidden"
@@ -194,6 +194,7 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
             You are in a form selector of 2 items and must select a single option. Use the up and down keys to navigate or escape to close.
           </p>
           <div
+            class="euiSuperSelect__listbox"
             role="listbox"
             tabindex="0"
           >
@@ -401,6 +402,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
           </p>
           <div
             aria-activedescendant="1"
+            class="euiSuperSelect__listbox"
             role="listbox"
             tabindex="0"
           >
@@ -767,6 +769,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                                 </p>
                                 <div
                                   aria-activedescendant="1"
+                                  class="euiSuperSelect__listbox"
                                   role="listbox"
                                   tabindex="0"
                                 >
@@ -855,6 +858,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                                   </p>
                                   <div
                                     aria-activedescendant="1"
+                                    class="euiSuperSelect__listbox"
                                     role="listbox"
                                     tabindex="0"
                                   >
@@ -982,7 +986,13 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                               </EuiScreenReaderOnly>
                               <div
                                 aria-activedescendant="1"
+                                className="euiSuperSelect__listbox"
                                 role="listbox"
+                                style={
+                                  Object {
+                                    "width": null,
+                                  }
+                                }
                                 tabIndex="0"
                               >
                                 <EuiContextMenuItem
@@ -997,11 +1007,6 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
                                   role="option"
-                                  style={
-                                    Object {
-                                      "width": null,
-                                    }
-                                  }
                                   toolTipPosition="right"
                                 >
                                   <button
@@ -1012,11 +1017,6 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                                     onClick={[Function]}
                                     onKeyDown={[Function]}
                                     role="option"
-                                    style={
-                                      Object {
-                                        "width": null,
-                                      }
-                                    }
                                     type="button"
                                   >
                                     <span
@@ -1063,11 +1063,6 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
                                   role="option"
-                                  style={
-                                    Object {
-                                      "width": null,
-                                    }
-                                  }
                                   toolTipPosition="right"
                                 >
                                   <button
@@ -1078,11 +1073,6 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                                     onClick={[Function]}
                                     onKeyDown={[Function]}
                                     role="option"
-                                    style={
-                                      Object {
-                                        "width": null,
-                                      }
-                                    }
                                     type="button"
                                   >
                                     <span
@@ -1232,6 +1222,7 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
             You are in a form selector of 2 items and must select a single option. Use the up and down keys to navigate or escape to close.
           </p>
           <div
+            class="euiSuperSelect__listbox"
             role="listbox"
             tabindex="0"
           >

--- a/src/components/form/super_select/__snapshots__/super_select.test.js.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.js.snap
@@ -56,6 +56,62 @@ exports[`EuiSuperSelect is rendered 1`] = `
 </div>
 `;
 
+exports[`EuiSuperSelect props compressed is rendered 1`] = `
+<div
+  class="euiPopover euiPopover--anchorDownCenter euiSuperSelect"
+>
+  <div
+    class="euiPopover__anchor euiSuperSelect__popoverAnchor"
+  >
+    <input
+      type="hidden"
+      value=""
+    />
+    <div
+      class="euiFormControlLayout euiFormControlLayout--compressed"
+    >
+      <div
+        class="euiFormControlLayout__childrenWrapper"
+      >
+        <span
+          class="euiScreenReaderOnly"
+          id="generated-id"
+        >
+          Select an option: , is selected
+        </span>
+        <button
+          aria-haspopup="true"
+          aria-label="aria-label"
+          aria-labelledby="undefined generated-id"
+          aria-selected="true"
+          class="euiSuperSelectControl euiSuperSelectControl--compressed testClass1 testClass2"
+          data-test-subj="test subject string"
+          role="option"
+          type="button"
+        />
+        <div
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+        >
+          <span
+            class="euiFormControlLayoutCustomIcon"
+          >
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+              focusable="false"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"

--- a/src/components/form/super_select/_super_select.scss
+++ b/src/components/form/super_select/_super_select.scss
@@ -36,3 +36,8 @@
 .euiSuperSelect__item--hasDividers:not(:last-of-type) {
   border-bottom: $euiBorderThin;
 }
+
+.euiSuperSelect__item--compressed {
+  padding: $euiSizeS;
+  font-size: $euiFontSizeS;
+}

--- a/src/components/form/super_select/_super_select.scss
+++ b/src/components/form/super_select/_super_select.scss
@@ -36,10 +36,14 @@
   @include euiFontSizeS;
   padding: $euiSizeS;
 
-  &:hover,
+  &:hover:not(:disabled),
   &:focus {
     text-decoration: none;
     background-color: $euiFocusBackgroundColor;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
   }
 }
 

--- a/src/components/form/super_select/_super_select.scss
+++ b/src/components/form/super_select/_super_select.scss
@@ -11,6 +11,12 @@
   }
 }
 
+.euiSuperSelect__listbox {
+  @include euiScrollBar;
+  max-height: 300px;
+  overflow: hidden auto;
+}
+
 .euiSuperSelect__popoverPanel[class*='bottom'] { /* 3 */
   border-top-color: transparentize($euiBorderColor, .2);
   border-top-right-radius: 0; /* 2 */
@@ -26,6 +32,9 @@
 }
 
 .euiSuperSelect__item {
+  @include euiFontSizeS;
+  padding: $euiSizeS;
+
   &:hover,
   &:focus {
     text-decoration: none;
@@ -35,9 +44,4 @@
 
 .euiSuperSelect__item--hasDividers:not(:last-of-type) {
   border-bottom: $euiBorderThin;
-}
-
-.euiSuperSelect__item--compressed {
-  padding: $euiSizeS;
-  font-size: $euiFontSizeS;
 }

--- a/src/components/form/super_select/_super_select.scss
+++ b/src/components/form/super_select/_super_select.scss
@@ -14,7 +14,8 @@
 .euiSuperSelect__listbox {
   @include euiScrollBar;
   max-height: 300px;
-  overflow: hidden auto;
+  overflow: hidden;
+  overflow-y: auto;
 }
 
 .euiSuperSelect__popoverPanel[class*='bottom'] { /* 3 */

--- a/src/components/form/super_select/super_select.js
+++ b/src/components/form/super_select/super_select.js
@@ -165,6 +165,7 @@ export class EuiSuperSelect extends Component {
       itemLayoutAlign,
       fullWidth,
       popoverClassName,
+      compressed,
       ...rest
     } = this.props;
 
@@ -191,6 +192,7 @@ export class EuiSuperSelect extends Component {
       'euiSuperSelect__item',
       {
         'euiSuperSelect__item--hasDividers': hasDividers,
+        'euiSuperSelect__item--compressed': compressed,
       },
       itemClassName
     );
@@ -206,6 +208,7 @@ export class EuiSuperSelect extends Component {
         className={buttonClasses}
         fullWidth={fullWidth}
         isInvalid={isInvalid}
+        compressed={compressed}
         {...rest}
       />
     );

--- a/src/components/form/super_select/super_select.js
+++ b/src/components/form/super_select/super_select.js
@@ -192,7 +192,6 @@ export class EuiSuperSelect extends Component {
       'euiSuperSelect__item',
       {
         'euiSuperSelect__item--hasDividers': hasDividers,
-        'euiSuperSelect__item--compressed': compressed,
       },
       itemClassName
     );

--- a/src/components/form/super_select/super_select.js
+++ b/src/components/form/super_select/super_select.js
@@ -225,7 +225,6 @@ export class EuiSuperSelect extends Component {
           onKeyDown={this.onItemKeyDown}
           layoutAlign={itemLayoutAlign}
           buttonRef={node => this.setItemNode(node, index)}
-          style={{ width: this.state.menuWidth }}
           role="option"
           id={value}
           aria-selected={valueOfSelected === value}
@@ -259,8 +258,10 @@ export class EuiSuperSelect extends Component {
           </p>
         </EuiScreenReaderOnly>
         <div
+          className="euiSuperSelect__listbox"
           role="listbox"
           aria-activedescendant={valueOfSelected}
+          style={{ width: this.state.menuWidth }}
           tabIndex="0">
           {items}
         </div>

--- a/src/components/form/super_select/super_select.test.js
+++ b/src/components/form/super_select/super_select.test.js
@@ -42,6 +42,19 @@ describe('EuiSuperSelect', () => {
       expect(component).toMatchSnapshot();
     });
 
+    test('compressed is rendered', () => {
+      const component = render(
+        <EuiSuperSelect
+          {...requiredProps}
+          options={options}
+          onChange={() => {}}
+          compressed
+        />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
     test('select component is rendered', () => {
       const component = render(
         <EuiSuperSelect


### PR DESCRIPTION
The EuiSuperSelect's dropdown was way too big. It used the standard 16px font, but the input itself was still just 14px. This PR reduces the default font-size (and the padding) to create a more compact but still spacious dropdown.

<img src="https://d.pr/free/i/GJ63sH+" />

^^ In the above "after" example, I also add a docs example for forcing truncation (this isn't the default).

**Complex example** looks better as well:

<img src="https://d.pr/free/i/T0bqjF+" />

**Compressed especially looks better**

<img src="https://d.pr/free/i/W1rjHc+" />

---

### Max Height

I also added a max-height of `300px` which is 100px taller than the EuiComboBox, since we want to try to display more of the complex style items.

<img src="https://d.pr/free/i/84MWA1+" />

---

### Disabled item

Disabled items were grayed out but they were still getting the blue background on hover. This removes that hover state and adds the `not-allowed` cursor.

<img src="https://d.pr/free/i/XKWIfg+" width="50%" />

### Checklist

- [x] This was checked in mobile
- [x] This was checked in IE11
- [x] This was checked in dark mode
- ~[ ] Any props added have proper autodocs~
- ~[ ] Documentation examples were added~
- ~[ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~ Will get added via the Feature Branch
- ~[ ] This was checked for breaking changes and labeled appropriately~
- [x] Jest tests were updated or added to match the most common scenarios
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
