### PR TITLE
Fix invalid aria-describedby values set by EuiToolTip (#1533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added `partial` glyph to `EuiIcon` ([#2152](https://github.com/elastic/eui/pull/2152))
+- Fixed invalid `aria-desribedby` values set by `EuiToolTip` ([#2156](https://github.com/elastic/eui/pull/2156))
 
 ## [`13.0.0`](https://github.com/elastic/eui/tree/v13.0.0)
 

--- a/src/components/tool_tip/__snapshots__/icon_tip.test.tsx.snap
+++ b/src/components/tool_tip/__snapshots__/icon_tip.test.tsx.snap
@@ -5,7 +5,6 @@ exports[`EuiIconTip is rendered 1`] = `
   class="euiToolTipAnchor"
 >
   <svg
-    aria-describedby="id"
     aria-label="aria-label"
     class="euiIcon euiIcon--medium euiIcon-isLoading"
     focusable="true"
@@ -23,7 +22,6 @@ exports[`EuiIconTip props color is rendered as the icon color 1`] = `
   class="euiToolTipAnchor"
 >
   <svg
-    aria-describedby="id"
     aria-label="Info"
     class="euiIcon euiIcon--medium euiIcon--warning euiIcon-isLoading"
     focusable="true"
@@ -41,7 +39,6 @@ exports[`EuiIconTip props size is rendered as the icon size 1`] = `
   class="euiToolTipAnchor"
 >
   <svg
-    aria-describedby="id"
     aria-label="Info"
     class="euiIcon euiIcon--xLarge euiIcon-isLoading"
     focusable="true"
@@ -59,7 +56,6 @@ exports[`EuiIconTip props type is rendered as the icon 1`] = `
   class="euiToolTipAnchor"
 >
   <svg
-    aria-describedby="id"
     aria-label="Info"
     class="euiIcon euiIcon--medium euiIcon-isLoading"
     focusable="true"

--- a/src/components/tool_tip/__snapshots__/tool_tip.test.tsx.snap
+++ b/src/components/tool_tip/__snapshots__/tool_tip.test.tsx.snap
@@ -4,8 +4,19 @@ exports[`EuiToolTip is rendered 1`] = `
 <span
   class="euiToolTipAnchor"
 >
+  <button>
+    Trigger
+  </button>
+</span>
+`;
+
+exports[`EuiToolTip shows tooltip on focus 1`] = `
+<span
+  class="euiToolTipAnchor"
+>
   <button
     aria-describedby="id"
+    data-test-subj="trigger"
   >
     Trigger
   </button>

--- a/src/components/tool_tip/tool_tip.test.tsx
+++ b/src/components/tool_tip/tool_tip.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test';
-
+import { render, mount } from 'enzyme';
+import {
+  requiredProps,
+  findTestSubject,
+  takeMountedSnapshot,
+} from '../../test';
 import { EuiToolTip } from './tool_tip';
 
 describe('EuiToolTip', () => {
@@ -13,5 +16,17 @@ describe('EuiToolTip', () => {
     );
 
     expect(component).toMatchSnapshot();
+  });
+
+  test('shows tooltip on focus', () => {
+    const component = mount(
+      <EuiToolTip title="title" id="id" content="content" {...requiredProps}>
+        <button data-test-subj="trigger">Trigger</button>
+      </EuiToolTip>
+    );
+
+    const trigger = findTestSubject(component, 'trigger');
+    trigger.simulate('focus');
+    expect(takeMountedSnapshot(component)).toMatchSnapshot();
   });
 });

--- a/src/components/tool_tip/tool_tip.tsx
+++ b/src/components/tool_tip/tool_tip.tsx
@@ -312,7 +312,7 @@ export class EuiToolTip extends Component<Props, State> {
         {cloneElement(children, {
           onFocus: this.showToolTip,
           onBlur: this.hideToolTip,
-          'aria-describedby': this.state.id,
+          ...(visible && { 'aria-describedby': this.state.id }),
         })}
       </span>
     );


### PR DESCRIPTION
### Summary

Tooltips have been adding their id to their anchor element as an `aria-describedby` attribute but that trips up a11y testing tools because the tooltips don't exist until after they're activated.

This change sets `aria-describedby` only when the tooltip is shown.

Closes #1533 

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
~- [ ] Any props added have proper autodocs~
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
~- [ ] This was checked for breaking changes and labeled appropriately~
- [x] Jest tests were updated or added to match the most common scenarios
- [x] This was checked against keyboard-only and screenreader scenarios
~- [ ] This required updates to Framer X components~