### PR TITLE
Fix text wrapping utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug fixes**
 
 - Fixed invalid `aria-desribedby` values set by `EuiToolTip` ([#2156](https://github.com/elastic/eui/pull/2156))
+- Fixed `.eui-textBreakWord` utility class to be cross-browser compatible ([#2157](https://github.com/elastic/eui/pull/2157))
 
 ## [`13.0.0`](https://github.com/elastic/eui/tree/v13.0.0)
 

--- a/src-docs/src/views/guidelines/sass.js
+++ b/src-docs/src/views/guidelines/sass.js
@@ -762,7 +762,7 @@ export const SassGuidelines = ({ selectedTheme }) => {
                 <Link to="/utilities/css-utility-classes">
                   CSS utility class
                 </Link>{' '}
-                <EuiCode>.euiYScrollWithShadows</EuiCode>.
+                <EuiCode>.eui-yScrollWithShadows</EuiCode>.
               </p>
               <p>
                 <b>Example:</b>

--- a/src-docs/src/views/utility_classes/utility_classes.js
+++ b/src-docs/src/views/utility_classes/utility_classes.js
@@ -12,8 +12,36 @@ import {
 const longLink =
   'http://www.hithereimalongurl.com/dave_will_just_ramble_on_in_a_long_sentence_like_this/?ok=cool';
 
+const wrappingExampleStyle = {
+  width: 290,
+  padding: 16,
+  background: 'rgba(254, 228, 181, 0.5)',
+};
+
 export default () => (
   <EuiText>
+    <h4>Display</h4>
+
+    <EuiCode className="eui-displayBlock">.eui-displayBlock</EuiCode>
+
+    <EuiSpacer />
+
+    <EuiCode className="eui-displayInline">.eui-displayInline</EuiCode>
+
+    <EuiSpacer />
+
+    <EuiCode className="eui-displayInlineBlock">
+      .eui-displayInlineBlock
+    </EuiCode>
+
+    <EuiSpacer />
+
+    <EuiCode className="eui-fullWidth">
+      .eui-fullWidth (similar to eui-displayBlock but adds 100% width)
+    </EuiCode>
+
+    <EuiSpacer />
+
     <h4>Text</h4>
 
     <EuiSpacer />
@@ -38,102 +66,76 @@ export default () => (
 
     <EuiSpacer />
 
-    <div
-      style={{
-        width: 300,
-        padding: 16,
-        background: 'rgba(254, 228, 181, 0.5)',
-      }}
-      className="eui-textNoWrap">
+    <EuiSpacer />
+
+    <div style={wrappingExampleStyle} className="eui-textNoWrap">
       <EuiCode>.eui-textNoWrap</EuiCode> will force text not to wrap even in
       small containers.
     </div>
 
     <EuiSpacer />
 
-    <div
-      style={{
-        width: 300,
-        padding: 16,
-        background: 'rgba(254, 228, 181, 0.5)',
-      }}
-      className="eui-textTruncate">
+    <div style={wrappingExampleStyle} className="eui-textTruncate">
       <EuiCode>.eui-textTruncate</EuiCode> will ellipsis after a certain point.
     </div>
 
     <EuiSpacer />
-    <h4>Word breaking</h4>
-    <p>
-      We recommend using <EuiCode>.eui-textOverflowWrap</EuiCode> to break on
-      long words above all other options as it is supported by all major
-      browsers (except for IE11). The one caveat is that it does not work on{' '}
-      <EuiCode>display: flex</EuiCode> elements. To remedy, you can either add
-      another wrapper with this class or use{' '}
-      <EuiCode>.eui-textBreakWord</EuiCode> instead.
-    </p>
-    <EuiSpacer />
 
-    <div
-      style={{
-        width: 300,
-        padding: 16,
-        background: 'rgba(254, 228, 181, 0.5)',
-      }}
-      className="eui-textOverflowWrap">
-      <EuiCode>.eui-textOverflowWrap</EuiCode> will only break up at the end of
-      words. Long urls will still break
-      {longLink}.
-      <strong>
-        Falls back to <EuiCode>break-all</EuiCode> on IE11.
-      </strong>
-    </div>
-
-    <EuiSpacer />
-
-    <div
-      style={{
-        width: 300,
-        padding: 16,
-        background: 'rgba(254, 228, 181, 0.5)',
-      }}
-      className="eui-textBreakWord">
+    <div style={wrappingExampleStyle} className="eui-textBreakWord">
       <EuiCode>.eui-textBreakWord</EuiCode> will only break up at the end of
-      words. Long urls will still break
-      {longLink}.
-      <strong>
-        Falls back to <EuiCode>break-all</EuiCode> on Firefox and IE11.
-      </strong>
+      words. Long urls will still break {longLink}.
     </div>
 
     <EuiSpacer />
 
-    <div
-      style={{
-        width: 300,
-        padding: 16,
-        background: 'rgba(254, 228, 181, 0.5)',
-      }}
-      className="eui-textBreakAll">
+    <div style={wrappingExampleStyle} className="eui-textBreakAll">
       <EuiCode>.eui-textBreakAll</EuiCode> will break up anything. It is useful
-      for long urls like
-      {longLink}.
+      for long urls like {longLink}.
     </div>
 
     <EuiSpacer />
 
     <div
-      style={{
-        width: 300,
-        padding: 16,
-        background: 'rgba(254, 228, 181, 0.5)',
-      }}
+      style={wrappingExampleStyle}
       className="eui-textBreakWord eui-textBreakNormal">
       <EuiCode>.eui-textBreakNormal</EuiCode> revert back to not forcing word
-      breaks. It is <strong>not</strong> useful for long urls like
-      {longLink}.
+      breaks. It is <strong>not</strong> useful for long urls like {longLink}.
     </div>
 
     <EuiSpacer />
+
+    <h4>Overflows</h4>
+
+    <div className="guideSass__overflowShadows">
+      <EuiText className="guideSass__overflowShadowText" size="s">
+        <p>
+          It requires a wrapping element to control the height with{' '}
+          <EuiCode>overflow-y: hidden;</EuiCode> and the content to use the CSS
+          utility class <EuiCode>.eui-yScrollWithShadows</EuiCode>.
+        </p>
+        <p>
+          <b>Example:</b>
+        </p>
+        <EuiCodeBlock language="html" isCopyable paddingSize="s">
+          {`<BodyContent style={{ height: 200, overflowY: 'hidden' }}>
+  <BodyScroll className="eui-yScrollWithShadows" />
+</BodyContent>`}
+        </EuiCodeBlock>
+        <p>
+          Consequuntur atque nulla atque nemo tenetur numquam. Assumenda
+          aspernatur qui aut sit. Aliquam doloribus iure sint id. Possimus dolor
+          qui soluta cum id tempore ea illum. Facilis voluptatem aut aut ut
+          similique ut. Sed repellendus commodi iure officiis exercitationem
+          praesentium dolor. Ratione non ut nulla accusamus et. Optio laboriosam
+          id incidunt. Ipsam voluptate ab quia necessitatibus sequi earum
+          voluptate. Porro tempore et veritatis quo omnis. Eaque ut libero
+          tempore sit placeat maxime laudantium. Mollitia tempore minus qui
+          autem modi adipisci ad. Iste reprehenderit accusamus voluptatem velit.
+          Quidem delectus eos veritatis et vitae et nisi. Doloribus ut corrupti
+          voluptates qui exercitationem dolores.
+        </p>
+      </EuiText>
+    </div>
 
     <EuiSpacer />
     <h4>Vertical alignment</h4>
@@ -167,63 +169,6 @@ export default () => (
         className="eui-alignBaseline"
       />
       <EuiCode>.eui-alignBaseline</EuiCode>
-    </div>
-
-    <EuiSpacer />
-
-    <h4>Display</h4>
-
-    <EuiCode className="eui-displayBlock">.eui-displayBlock</EuiCode>
-
-    <EuiSpacer />
-
-    <EuiCode className="eui-displayInline">.eui-displayInline</EuiCode>
-
-    <EuiSpacer />
-
-    <EuiCode className="eui-displayInlineBlock">
-      .eui-displayInlineBlock
-    </EuiCode>
-
-    <EuiSpacer />
-
-    <EuiCode className="eui-fullWidth">
-      .eui-fullWidth (similar to eui-displayBlock but adds 100% width)
-    </EuiCode>
-
-    <EuiSpacer />
-
-    <h4>Overflows</h4>
-
-    <div className="guideSass__overflowShadows">
-      <EuiText className="guideSass__overflowShadowText" size="s">
-        <p>
-          It requires a wrapping element to control the height with{' '}
-          <EuiCode>overflow-y: hidden;</EuiCode> and the content to use the CSS
-          utility class <EuiCode>.euiYScrollWithShadows</EuiCode>.
-        </p>
-        <p>
-          <b>Example:</b>
-        </p>
-        <EuiCodeBlock language="html" isCopyable paddingSize="s">
-          {`<BodyContent style={{ height: 200, overflowY: 'hidden' }}>
-  <BodyScroll className="euiYScrollWithShadows" />
-</BodyContent>`}
-        </EuiCodeBlock>
-        <p>
-          Consequuntur atque nulla atque nemo tenetur numquam. Assumenda
-          aspernatur qui aut sit. Aliquam doloribus iure sint id. Possimus dolor
-          qui soluta cum id tempore ea illum. Facilis voluptatem aut aut ut
-          similique ut. Sed repellendus commodi iure officiis exercitationem
-          praesentium dolor. Ratione non ut nulla accusamus et. Optio laboriosam
-          id incidunt. Ipsam voluptate ab quia necessitatibus sequi earum
-          voluptate. Porro tempore et veritatis quo omnis. Eaque ut libero
-          tempore sit placeat maxime laudantium. Mollitia tempore minus qui
-          autem modi adipisci ad. Iste reprehenderit accusamus voluptatem velit.
-          Quidem delectus eos veritatis et vitae et nisi. Doloribus ut corrupti
-          voluptates qui exercitationem dolores.
-        </p>
-      </EuiText>
     </div>
 
     <EuiSpacer />

--- a/src/global_styling/utility/_utility.scss
+++ b/src/global_styling/utility/_utility.scss
@@ -24,12 +24,22 @@
 .eui-textNoWrap {white-space: nowrap !important;}
 .eui-textInheritColor {color: inherit !important;}
 
+// https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/
 .eui-textBreakWord {
-  word-break: break-all !important; // Fallback for FF and IE
-  word-break: break-word !important;
+  overflow-wrap: break-word !important; // makes sure the long string will wrap and not bust out of the container
+  word-wrap: break-word !important; // spec says, they are literally just alternate names for each other but some browsers support one and not the other
+  word-break: break-word; // IE doesn't understand but that's ok
 }
-.eui-textBreakAll {word-break: break-all !important;}
-.eui-textBreakNormal {word-break: normal !important;}
+
+.eui-textBreakAll {
+  word-break: break-all !important;
+}
+
+.eui-textBreakNormal {
+  overflow-wrap: normal !important;
+  word-wrap: normal !important;
+  word-break: normal !important;
+}
 
 .eui-textOverflowWrap {
   @include internetExplorerOnly {

--- a/src/global_styling/utility/_utility.scss
+++ b/src/global_styling/utility/_utility.scss
@@ -24,8 +24,8 @@
 .eui-textNoWrap {white-space: nowrap !important;}
 .eui-textInheritColor {color: inherit !important;}
 
-// https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/
 .eui-textBreakWord {
+  // https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/
   overflow-wrap: break-word !important; // makes sure the long string will wrap and not bust out of the container
   word-wrap: break-word !important; // spec says, they are literally just alternate names for each other but some browsers support one and not the other
   word-break: break-word; // IE doesn't understand but that's ok

--- a/src/global_styling/utility/_utility.scss
+++ b/src/global_styling/utility/_utility.scss
@@ -41,6 +41,7 @@
   word-break: normal !important;
 }
 
+// TODO: 7/23 DEPRECATE in favor of .eui-textBreakWord now that it's working as intended
 .eui-textOverflowWrap {
   @include internetExplorerOnly {
     word-break: break-all !important;


### PR DESCRIPTION
@markov00 pointed out that our fallback for IE in `.eui-textOverflowWrap` wasn't quite right. We were close with all our text-wrapping properties but not quite right.

`word-break` is just to indicate **how** to break words, but `word-wrap` tells browser if they **should** break. With some browsers, you can't really use the former without first setting the latter to `break-word`.

This PR fixes the original `.eui-textBreakWord` utility class to be more browser compatible.

**It now works on IE:**

<img src="https://d.pr/free/i/R8KbP6+" />

This also means that `.eui-textOverflowWrap` is now redundant to `.eui-textBreakWord` so I've set that for deprecation and removed it from the docs.

So now it's just back to the main 3 that work in **all** browsers similarly.

<img src="https://d.pr/free/i/juXxYJ+" />
<img src="https://d.pr/free/i/BVwGEe+" />

---

## Change to another utility class name:

`. euiYScrollWithShadows` --> `.eui-yScrollWithShadows` since the former didn't match our patterns. This class was introduced not too long ago, so I doubt there are really any usages yet.

### Checklist

- ~[ ] This was checked in mobile~
- [x] This was checked in IE11
- ~[ ] This was checked in dark mode~
- ~[ ] Any props added have proper autodocs~
- [x] Documentation examples were added
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- ~[ ] This was checked for breaking changes and labeled appropriately~
- ~[ ] Jest tests were updated or added to match the most common scenarios~
- ~[ ] This was checked against keyboard-only and screenreader scenarios~
- ~[ ] This required updates to Framer X components~
