### PR TITLE
Update EuiBasicTable's column proptype to support 'center' value for align

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug fixes**
 
 - Fixed invalid `aria-desribedby` values set by `EuiToolTip` ([#2156](https://github.com/elastic/eui/pull/2156))
+- Added `"center"` as an acceptable value to `EuiBasicTable`'s `align` proptype ([#2158](https://github.com/elastic/eui/pull/2158))
 
 ## [`13.0.0`](https://github.com/elastic/eui/tree/v13.0.0)
 

--- a/src-docs/src/views/tables/basic/props_info.js
+++ b/src-docs/src/views/tables/basic/props_info.js
@@ -250,7 +250,7 @@ export const propsInfo = {
             value: '"right"',
             comment: 'May change when "dataType" is defined',
           },
-          type: { name: '"left" | "right"' },
+          type: { name: '"left" | "center" | "right"' },
         },
         truncateText: {
           description:

--- a/src/components/basic_table/basic_table.js
+++ b/src/components/basic_table/basic_table.js
@@ -8,8 +8,9 @@ import {
   formatNumber,
   formatText,
   LEFT_ALIGNMENT,
-  PropertySortType,
+  CENTER_ALIGNMENT,
   RIGHT_ALIGNMENT,
+  PropertySortType,
   SortDirection,
 } from '../../services';
 import { isFunction } from '../../services/predicate';
@@ -113,7 +114,7 @@ export const FieldDataColumnTypeShape = {
   dataType: PropTypes.oneOf(DATA_TYPES),
   width: PropTypes.string,
   sortable: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
-  align: PropTypes.oneOf([LEFT_ALIGNMENT, RIGHT_ALIGNMENT]),
+  align: PropTypes.oneOf([LEFT_ALIGNMENT, CENTER_ALIGNMENT, RIGHT_ALIGNMENT]),
   truncateText: PropTypes.bool,
   render: PropTypes.func, // ((value, record) => PropTypes.node (also see [services/value_renderer] for basic implementations)
   footer: PropTypes.oneOfType([


### PR DESCRIPTION
### Summary

Closes #2153 , small addition of `"center"` to the table's column align proptype. `"center"` is supported by the table header, footer, and cell components.

### Checklist

~- [ ] This was checked in mobile~
~- [ ] This was checked in IE11~
~- [ ] This was checked in dark mode~
- [x] Any props added have proper autodocs
~- [ ] Documentation examples were added~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [x] This was checked for breaking changes and labeled appropriately
~- [ ] Jest tests were updated or added to match the most common scenarios~
~- [ ] This was checked against keyboard-only and screenreader scenarios~
~- [ ] This required updates to Framer X components~
