### PR TITLE
Add `attributes` to `EuiAccordion` `MutationObserver` options

### DIFF
--- a/src/components/accordion/__snapshots__/accordion.test.tsx.snap
+++ b/src/components/accordion/__snapshots__/accordion.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
             "attributeFilter": Array [
               "style",
             ],
+            "attributes": true,
             "childList": true,
             "subtree": true,
           }
@@ -131,6 +132,7 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
             "attributeFilter": Array [
               "style",
             ],
+            "attributes": true,
             "childList": true,
             "subtree": true,
           }

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -185,6 +185,7 @@ export class EuiAccordion extends Component<
             observerOptions={{
               childList: true,
               subtree: true,
+              attributes: true,
               attributeFilter: MUTATION_ATTRIBUTE_FILTER,
             }}
             onMutation={this.onMutation}>


### PR DESCRIPTION
### Summary

The [MutationObserver polyfill used by Kibana](https://github.com/webmodules/mutation-observer/blob/master/index.js#L200-L201) does not allow for `attributesFilter` to be specified without `attributes: true` to also be present.
The [whatwg standard allows the absence](https://dom.spec.whatwg.org/#interface-mutationobserver), but we'll explicitly add it.

### Checklist

~~- [ ] This was checked in mobile~~
~~- [ ] This was checked in IE11~~
~~- [ ] This was checked in dark mode~~
~~- [ ] Any props added have proper autodocs~~
~~- [ ] Documentation examples were added~~

- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately

~~- [ ] This was checked for breaking changes and labeled appropriately~~
~~- [ ] Jest tests were updated or added to match the most common scenarios~~
~~- [ ] This was checked against keyboard-only and screenreader scenarios~~
~~- [ ] This required updates to Framer X components~~
