### PR TITLE
[EuiDataGrid] Base layer Sass

### DIFF
--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
 <div
   aria-label="aria-label"
-  class="euiDataGrid"
+  class="testClass1 testClass2 euiDataGrid"
   data-test-subj="test subject string"
 >
   <div
@@ -44,64 +44,60 @@ exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
     </div>
   </div>
   <div
-    class="dataGridBody"
+    class="euiDataGridRow"
+    data-test-subj="dataGridRow"
   >
     <div
-      class="euiDataGridRow"
-      data-test-subj="dataGridRow"
+      class="euiDataGridRowCell"
+      data-test-subj="dataGridRowCell"
+      style="width:100px"
     >
-      <div
-        class="euiDataGridRowCell"
-        data-test-subj="dataGridRowCell"
-        style="width:100px"
-      >
-        0, A
-      </div>
-      <div
-        class="euiDataGridRowCell"
-        data-test-subj="dataGridRowCell"
-        style="width:100px"
-      >
-        0, B
-      </div>
+      0, A
     </div>
     <div
-      class="euiDataGridRow"
-      data-test-subj="dataGridRow"
+      class="euiDataGridRowCell"
+      data-test-subj="dataGridRowCell"
+      style="width:100px"
     >
-      <div
-        class="euiDataGridRowCell"
-        data-test-subj="dataGridRowCell"
-        style="width:100px"
-      >
-        1, A
-      </div>
-      <div
-        class="euiDataGridRowCell"
-        data-test-subj="dataGridRowCell"
-        style="width:100px"
-      >
-        1, B
-      </div>
+      0, B
+    </div>
+  </div>
+  <div
+    class="euiDataGridRow"
+    data-test-subj="dataGridRow"
+  >
+    <div
+      class="euiDataGridRowCell"
+      data-test-subj="dataGridRowCell"
+      style="width:100px"
+    >
+      1, A
     </div>
     <div
-      class="euiDataGridRow"
-      data-test-subj="dataGridRow"
+      class="euiDataGridRowCell"
+      data-test-subj="dataGridRowCell"
+      style="width:100px"
     >
-      <div
-        class="euiDataGridRowCell"
-        data-test-subj="dataGridRowCell"
-        style="width:100px"
-      >
-        2, A
-      </div>
-      <div
-        class="euiDataGridRowCell"
-        data-test-subj="dataGridRowCell"
-        style="width:100px"
-      >
-        2, B
-      </div>
+      1, B
+    </div>
+  </div>
+  <div
+    class="euiDataGridRow"
+    data-test-subj="dataGridRow"
+  >
+    <div
+      class="euiDataGridRowCell"
+      data-test-subj="dataGridRowCell"
+      style="width:100px"
+    >
+      2, A
+    </div>
+    <div
+      class="euiDataGridRowCell"
+      data-test-subj="dataGridRowCell"
+      style="width:100px"
+    >
+      2, B
     </div>
   </div>
 </div>

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
 <div
   aria-label="aria-label"
-  class="testClass1 testClass2"
+  class="euiDataGrid"
   data-test-subj="test subject string"
 >
   <div

--- a/src/components/datagrid/_data_grid.scss
+++ b/src/components/datagrid/_data_grid.scss
@@ -2,4 +2,6 @@
   @include euiScrollBar;
   font-feature-settings: 'tnum' 1; // Tabular numbers
   overflow-x: auto;
+  max-width: 100%;
+  width: 100%;
 }

--- a/src/components/datagrid/_data_grid.scss
+++ b/src/components/datagrid/_data_grid.scss
@@ -1,0 +1,5 @@
+.euiDataGrid {
+  @include euiScrollBar;
+  font-feature-settings: 'tnum' 1; // Tabular numbers
+  overflow-x: auto;
+}

--- a/src/components/datagrid/_data_grid_column_resizer.scss
+++ b/src/components/datagrid/_data_grid_column_resizer.scss
@@ -1,9 +1,27 @@
+  // Resizer straddles the column border and is an invisible hitzone for dragging
 .euiDataGridColumnResizer {
   position: absolute;
   top: 0;
-  right: 0;
+  right: -$euiSizeS;
   height: 100%;
-  width: 3px;
-  background-color: $euiColorDarkestShade;
+  width: $euiSize;
   cursor: ew-resize;
+  opacity: 0;
+  z-index: 2;
+
+  // Center a vertical line within the button above
+  &:after {
+    content: '';
+    position: absolute;
+    left: $euiSizeS - 1px;
+    top: 0;
+    bottom: 0;
+    width: $euiDataGridColumnResizerWidth;
+    background-color: $euiColorPrimary;
+  }
+
+  &:hover,
+  &:active {
+    opacity: 1;
+  }
 }

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -1,12 +1,15 @@
 .euiDataGridRow {
-  white-space: nowrap;
+  display: inline-flex;
+  min-width: 100%;
 }
 
 .euiDataGridRowCell {
-  display: inline-block;
-  padding: $euiSize;
-  border: $euiBorderThin;
-  border-left-width: 0;
+  @include euiFontSizeXS;
+  @include euiTextTruncate;
+
+  padding: $euiSizeM / 2;
+  border-right: $euiBorderThin;
+  border-bottom: $euiBorderThin;
   overflow: hidden;
   white-space: nowrap;
 

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -12,6 +12,7 @@
   border-bottom: $euiBorderThin;
   overflow: hidden;
   white-space: nowrap;
+  flex: 0 0 auto;
 
   &:first-of-type {
     border-left: $euiBorderThin;

--- a/src/components/datagrid/_data_grid_header_row.scss
+++ b/src/components/datagrid/_data_grid_header_row.scss
@@ -12,6 +12,7 @@
   position: relative;
   background: $euiColorLightestShade;
   user-select: none;
+  flex: 0 0 auto;
 
 
   &:first-of-type {

--- a/src/components/datagrid/_data_grid_header_row.scss
+++ b/src/components/datagrid/_data_grid_header_row.scss
@@ -11,7 +11,6 @@
   border-left: none;
   position: relative;
   background: $euiColorLightestShade;
-  user-select: none;
   flex: 0 0 auto;
 
 

--- a/src/components/datagrid/_data_grid_header_row.scss
+++ b/src/components/datagrid/_data_grid_header_row.scss
@@ -1,9 +1,18 @@
+.euiDataGridHeader {
+  display: inline-flex;
+  min-width: 100%;
+}
+
 .euiDataGridHeaderCell {
-  display: inline-block;
-  padding: $euiSize;
+  @include euiFontSizeXS;
+
+  padding: $euiSizeM / 2;
   border: $euiBorderThin;
-  border-left-width: 0;
+  border-left: none;
   position: relative;
+  background: $euiColorLightestShade;
+  user-select: none;
+
 
   &:first-of-type {
     border-left: $euiBorderThin;

--- a/src/components/datagrid/_index.scss
+++ b/src/components/datagrid/_index.scss
@@ -1,3 +1,6 @@
+@import 'variables';
+@import 'mixins';
+@import 'data_grid';
 @import 'data_grid_header_row';
 @import 'data_grid_column_resizer';
 @import 'data_grid_data_row';

--- a/src/components/datagrid/_variables.scss
+++ b/src/components/datagrid/_variables.scss
@@ -1,0 +1,1 @@
+$euiDataGridColumnResizerWidth: 3px; // Odd number because it straddles a border

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -63,7 +63,7 @@ export class EuiDataGrid extends Component<EuiDataGridProps, EuiDataGridState> {
     const { columns, rowCount, renderCellValue, ...rest } = this.props;
 
     return (
-      <div {...rest}>
+      <div {...rest} className="euiDataGrid">
         <EuiDataGridHeaderRow
           columns={columns}
           columnWidths={columnWidths}

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -4,6 +4,7 @@ import { EuiDataGridDataRow } from './data_grid_data_row';
 import { CommonProps } from '../common';
 import { Column, ColumnWidths } from './data_grid_types';
 import { EuiDataGridCellProps } from './data_grid_cell';
+import classNames from 'classnames';
 
 type EuiDataGridProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {
@@ -60,16 +61,22 @@ export class EuiDataGrid extends Component<EuiDataGridProps, EuiDataGridState> {
 
   render() {
     const { columnWidths, rows } = this.state;
-    const { columns, rowCount, renderCellValue, ...rest } = this.props;
+    const {
+      columns,
+      rowCount,
+      renderCellValue,
+      className,
+      ...rest
+    } = this.props;
 
     return (
-      <div {...rest} className="euiDataGrid">
+      <div {...rest} className={classNames(className, 'euiDataGrid')}>
         <EuiDataGridHeaderRow
           columns={columns}
           columnWidths={columnWidths}
           setColumnWidth={this.setColumnWidth}
         />
-        <div className="dataGridBody">{rows}</div>
+        {rows}
       </div>
     );
   }


### PR DESCRIPTION
### Summary

This is a really simple PR that just adds some basic Sass. It's just meant to make things mostly usable and isn't a deep dive into how we should necessarily do things.

I'm going to attempt to make these PRs frequent and small so that they are reviewable. All that said, early on a lot of this stuff is knowingly temporary as we build up the component. For example, I'm not concentrating too much on style yet since that will have it's own configuration layer.

### TODO

- [x] Fix IE11 issue with grid overflow

### Uses `inline-flex` + a wrapping max width container to allow for overflows when it gets too big.

![](http://snid.es/ec2ef8f7665b/Screen%252520Recording%2525202019-07-26%252520at%25252012.43%252520AM.gif)

### Sets up very basic truncation and tabular numbers

This will likely change once node type content is passed in, but for now it works. We'll likely want to apply auto styling to certain data types so this is what too heavy handed.

![image](https://user-images.githubusercontent.com/324519/61935106-a4d89000-af3e-11e9-9a7a-683957fefa76.png)

### Reworked hit/drag zones for column resizing

* Made this stuff a lot easier to handle with a fat, invisible hitzone.
* Turned off `user-select` on the text in the header only (which it think should be ok long term) because it gets in the way with dragging.

![](http://snid.es/ad1839623c9a/Screen%252520Recording%2525202019-07-26%252520at%25252012.46%252520AM.gif)

### Works in mobile / dark mode better

Will need to figure out how to do the drag bits. The don't work because of the reliance on hover. Later PR.

![](http://snid.es/6556f3c3dab2/Screen%252520Recording%2525202019-07-26%252520at%25252012.56%252520AM.gif)

### Works in IE11

![](http://snid.es/fa2e071bf11d/Screen%252520Recording%2525202019-07-26%252520at%25252008.26%252520AM.gif)

### Checklist

- [x] Checked in **dark mode**
- [x] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] ~Props have proper **autodocs**~
- [x] Added **documentation** examples
- [x] Added or updated **jest tests**
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] ~A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
