### PR TITLE
Export used react-beautiful-dnd interfaces through EUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added `partial` glyph to `EuiIcon` ([#2152](https://github.com/elastic/eui/pull/2152))
 - Added `tall`, `fullWidth`, and `isInvalid` props to `EuiFilePicker` ([#2145](https://github.com/elastic/eui/pull/2145))
+- Added exports for `react-beautiful-dnd` interfaces used by EUI components ([#2173](https://github.com/elastic/eui/pull/2173))
 
 **Bug fixes**
 

--- a/src/components/drag_and_drop/index.ts
+++ b/src/components/drag_and_drop/index.ts
@@ -2,3 +2,15 @@ export { EuiDragDropContext } from './drag_drop_context';
 export { EuiDraggable } from './draggable';
 export { EuiDroppable } from './droppable';
 export { copy, move, reorder } from './services';
+
+// Interfaces in react-beautiful-dnd that EUI abstracts over
+// allows consumers to pull these from EUI instead of react-beautiful-dnd
+export {
+  DraggableLocation,
+  DraggableProps,
+  DragDropContextProps,
+  DragStart,
+  DroppableProps,
+  DropResult,
+  ResponderProvided,
+} from 'react-beautiful-dnd';


### PR DESCRIPTION
### Summary

Closes #2172, exports any interfaces EUI's drag&drop components imports from react-beautiful-dnd.

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
