### PR TITLE
Fix EuiNavDrawer to not rely on managleable function names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added `"center"` as an acceptable value to `EuiBasicTable`'s `align` proptype ([#2158](https://github.com/elastic/eui/pull/2158))
 - Fixed `.eui-textBreakWord` utility class to be cross-browser compatible ([#2157](https://github.com/elastic/eui/pull/2157))
 - Fixed truncation and z-index of `EuiFilePicker` ([#2145](https://github.com/elastic/eui/pull/2145))
+- Fixed `EuiNavDrawer`'s support for flyout groups in production/minified builds ([#2178](https://github.com/elastic/eui/pull/2178))
 
 ## [`13.0.0`](https://github.com/elastic/eui/tree/v13.0.0)
 

--- a/src/components/nav_drawer/nav_drawer.js
+++ b/src/components/nav_drawer/nav_drawer.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { EuiListGroup, EuiListGroupItem } from '../list_group';
 import { EuiNavDrawerFlyout } from './nav_drawer_flyout';
+import { EuiNavDrawerGroup } from './nav_drawer_group';
 import { EuiOutsideClickDetector } from '../outside_click_detector';
 import { EuiI18n } from '../i18n';
 import { EuiFlexItem } from '../flex';
@@ -216,7 +217,7 @@ export class EuiNavDrawer extends Component {
     // 1. Loop through the EuiNavDrawer children (EuiListGroup, EuiHorizontalRules, etc)
     modifiedChildren = React.Children.map(this.props.children, child => {
       // 2. Check if child is an EuiNavDrawerGroup and if it does have a flyout, add the expand function
-      if (child.type.name === 'EuiNavDrawerGroup') {
+      if (child.type === EuiNavDrawerGroup) {
         const item = React.cloneElement(child, {
           flyoutMenuButtonClick: this.expandFlyout,
           showToolTips: this.state.toolTipsEnabled && showToolTips,


### PR DESCRIPTION
### Summary

Fixes #2175 

When minified, `EuiNavDrawerGroup`'s function name is shortened/mangled which caused the logic in `EuiNavDrawer` to break: `if (child.type.name === 'EuiNavDrawerGroup') {`

Instead of relying on the string name, this changes the logic to check for identity instead.

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
