### PR TITLE
[Feature branch] Compressed form rows

### DIFF
--- a/src-docs/src/components/guide_locale_selector/guide_locale_selector.js
+++ b/src-docs/src/components/guide_locale_selector/guide_locale_selector.js
@@ -12,7 +12,6 @@ export const GuideLocaleSelector = ({ selectedLocale, onToggleLocale }) => {
         onChange={() =>
           onToggleLocale(selectedLocale === 'en' ? 'en-xa' : 'en')
         }
-        compressed={true}
       />
     </EuiFormRow>
   );

--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -161,12 +161,10 @@ export class GuidePageChrome extends Component {
                 selectedTheme={this.props.selectedTheme}
               />
               {location.host === 'localhost:8030' ? ( // eslint-disable-line no-restricted-globals
-                <EuiFlexItem grow={false}>
-                  <GuideLocaleSelector
-                    onToggleLocale={this.props.onToggleLocale}
-                    selectedLocale={this.props.selectedLocale}
-                  />
-                </EuiFlexItem>
+                <GuideLocaleSelector
+                  onToggleLocale={this.props.onToggleLocale}
+                  selectedLocale={this.props.selectedLocale}
+                />
               ) : null}
             </div>
           </EuiPopover>

--- a/src-docs/src/views/color_picker/custom_button.js
+++ b/src-docs/src/views/color_picker/custom_button.js
@@ -5,6 +5,7 @@ import {
   EuiFormRow,
   EuiColorPickerSwatch,
   EuiBadge,
+  EuiSpacer,
 } from '../../../../src/components';
 
 import { isValidHex } from '../../../../src/services';
@@ -43,6 +44,7 @@ export class CustomButton extends Component {
             }
           />
         </EuiFormRow>
+        <EuiSpacer />
         <EuiColorPicker
           onChange={this.handleChange}
           color={this.state.color}

--- a/src-docs/src/views/combo_box/containers.js
+++ b/src-docs/src/views/combo_box/containers.js
@@ -161,6 +161,8 @@ export default class extends Component {
           {comboBox}
         </EuiFormRow>
 
+        <EuiSpacer />
+
         <EuiPopover
           id="popover"
           ownFocus

--- a/src-docs/src/views/context/context.js
+++ b/src-docs/src/views/context/context.js
@@ -85,6 +85,8 @@ export default class extends Component {
                   </EuiI18n>
                 </EuiFormRow>
 
+                <EuiSpacer />
+
                 <EuiButton>{action}</EuiButton>
               </Fragment>
             )}

--- a/src-docs/src/views/context_menu/context_menu.js
+++ b/src-docs/src/views/context_menu/context_menu.js
@@ -7,6 +7,7 @@ import {
   EuiIcon,
   EuiPopover,
   EuiSwitch,
+  EuiSpacer,
 } from '../../../../src/components';
 
 function flattenPanelTree(tree, array = []) {
@@ -87,6 +88,7 @@ export default class extends Component {
                           label="Current time range"
                         />
                       </EuiFormRow>
+                      <EuiSpacer />
                       <EuiButton fill>Copy iFrame code</EuiButton>
                     </div>
                   ),

--- a/src-docs/src/views/flyout/flyout_complicated.js
+++ b/src-docs/src/views/flyout/flyout_complicated.js
@@ -195,6 +195,7 @@ export class FlyoutComplicated extends Component {
                 <SuperSelectComplexExample />
               </EuiFormRow>
             </EuiForm>
+            <EuiSpacer />
             {flyoutContent}
             <EuiCodeBlock language="html">{htmlCode}</EuiCodeBlock>
           </EuiFlyoutBody>

--- a/src-docs/src/views/form_layouts/described_form_group.js
+++ b/src-docs/src/views/form_layouts/described_form_group.js
@@ -164,6 +164,7 @@ export default class extends Component {
               label="Should we do this?"
               checked={this.state.isSwitchChecked}
               onChange={this.onSwitchChange}
+              fullWidth
             />
           </EuiFormRow>
 

--- a/src-docs/src/views/form_layouts/described_form_group.js
+++ b/src-docs/src/views/form_layouts/described_form_group.js
@@ -164,7 +164,6 @@ export default class extends Component {
               label="Should we do this?"
               checked={this.state.isSwitchChecked}
               onChange={this.onSwitchChange}
-              fullWidth
             />
           </EuiFormRow>
 

--- a/src-docs/src/views/form_layouts/form_compressed.js
+++ b/src-docs/src/views/form_layouts/form_compressed.js
@@ -10,6 +10,7 @@ import {
   EuiFilePicker,
   EuiRange,
   EuiSelect,
+  EuiSpacer,
   EuiSwitch,
   EuiPanel,
 } from '../../../../src/components';
@@ -92,31 +93,35 @@ export default class extends Component {
           <EuiFormRow
             label="Text field"
             helpText="I am some friendly help text."
-            compressed>
-            <EuiFieldText name="first" isLoading />
+            compressed="horizontal">
+            <EuiFieldText name="first" isLoading compressed />
           </EuiFormRow>
 
-          <EuiFormRow label="Select" compressed>
+          <EuiFormRow label="Select" compressed="horizontal">
             <EuiSelect
               options={[
                 { value: 'option_one', text: 'Option one' },
                 { value: 'option_two', text: 'Option two' },
                 { value: 'option_three', text: 'Option three' },
               ]}
+              compressed
             />
           </EuiFormRow>
 
-          <EuiFormRow label="File picker" compressed>
-            <EuiFilePicker />
+          <EuiFormRow label="File picker" compressed="horizontal">
+            <EuiFilePicker compressed />
           </EuiFormRow>
 
-          <EuiFormRow label="Combo box" compressed>
+          <EuiFormRow
+            label="Comboboxwithalonglabelname"
+            compressed="horizontal">
             <EuiComboBox
               options={[
                 { label: 'Option one' },
                 { label: 'Option two' },
                 { label: 'Option three' },
               ]}
+              compressed
               selectedOptions={this.state.comboBoxSelectionOptions}
               onChange={comboBoxSelectionOptions =>
                 this.setState({ comboBoxSelectionOptions })
@@ -124,8 +129,15 @@ export default class extends Component {
             />
           </EuiFormRow>
 
-          <EuiFormRow label="Range" compressed>
-            <EuiRange min={0} max={100} name="range" id="range" />
+          <EuiFormRow label="Range" compressed="horizontal">
+            <EuiRange
+              min={0}
+              max={100}
+              name="range"
+              id="range"
+              showInput
+              compressed
+            />
           </EuiFormRow>
 
           <EuiFormRow
@@ -144,8 +156,11 @@ export default class extends Component {
               options={this.state.checkboxes}
               idToSelectedMap={this.state.checkboxIdToSelectedMap}
               onChange={this.onCheckboxChange}
+              compressed
             />
           </EuiFormRow>
+
+          <EuiSpacer size="s" />
 
           <EuiButton type="submit" size="s" fill>
             Save form

--- a/src-docs/src/views/form_layouts/form_compressed.js
+++ b/src-docs/src/views/form_layouts/form_compressed.js
@@ -100,11 +100,11 @@ export default class extends Component {
           <EuiFormRow
             label="Text field"
             helpText="I am some friendly help text."
-            compressed="horizontal">
+            display="compressedHorizontal">
             <EuiFieldText name="first" isLoading compressed />
           </EuiFormRow>
 
-          <EuiFormRow label="Select" compressed="horizontal">
+          <EuiFormRow label="Select" display="compressedHorizontal">
             <EuiSelect
               options={[
                 { value: 'option_one', text: 'Option one' },
@@ -115,13 +115,13 @@ export default class extends Component {
             />
           </EuiFormRow>
 
-          <EuiFormRow label="File picker" compressed="horizontal">
+          <EuiFormRow label="File picker" display="compressedHorizontal">
             <EuiFilePicker compressed display="default" />
           </EuiFormRow>
 
           <EuiFormRow
             label="Comboboxwithalonglabelname"
-            compressed="horizontal">
+            display="compressedHorizontal">
             <EuiComboBox
               options={[
                 { label: 'Option one' },
@@ -136,7 +136,7 @@ export default class extends Component {
             />
           </EuiFormRow>
 
-          <EuiFormRow label="Range" compressed="horizontal">
+          <EuiFormRow label="Range" display="compressedHorizontal">
             <EuiRange
               min={0}
               max={100}

--- a/src-docs/src/views/form_layouts/form_compressed.js
+++ b/src-docs/src/views/form_layouts/form_compressed.js
@@ -58,8 +58,15 @@ export default class extends Component {
       ],
       radioIdSelected: `${idPrefix}5`,
       comboBoxSelectionOptions: [],
+      value: '20',
     };
   }
+
+  onRangeChange = e => {
+    this.setState({
+      value: e.target.value,
+    });
+  };
 
   onSwitchChange = () => {
     this.setState({
@@ -137,6 +144,8 @@ export default class extends Component {
               id="range"
               showInput
               compressed
+              value={this.state.value}
+              onChange={this.onRangeChange}
             />
           </EuiFormRow>
 

--- a/src-docs/src/views/form_layouts/form_compressed.js
+++ b/src-docs/src/views/form_layouts/form_compressed.js
@@ -13,8 +13,6 @@ import {
   EuiSpacer,
   EuiSwitch,
   EuiPanel,
-  EuiText,
-  EuiLink,
 } from '../../../../src/components';
 
 import makeId from '../../../../src/components/form/form_row/make_id';
@@ -102,12 +100,7 @@ export default class extends Component {
           <EuiFormRow
             label="Text field"
             helpText="I am some friendly help text."
-            compressed="horizontal"
-            labelAppend={
-              <EuiText size="xs">
-                <EuiLink>Link to some help</EuiLink>
-              </EuiText>
-            }>
+            compressed="horizontal">
             <EuiFieldText name="first" isLoading compressed />
           </EuiFormRow>
 

--- a/src-docs/src/views/form_layouts/form_compressed.js
+++ b/src-docs/src/views/form_layouts/form_compressed.js
@@ -13,6 +13,8 @@ import {
   EuiSpacer,
   EuiSwitch,
   EuiPanel,
+  EuiText,
+  EuiLink,
 } from '../../../../src/components';
 
 import makeId from '../../../../src/components/form/form_row/make_id';
@@ -100,7 +102,12 @@ export default class extends Component {
           <EuiFormRow
             label="Text field"
             helpText="I am some friendly help text."
-            compressed="horizontal">
+            compressed="horizontal"
+            labelAppend={
+              <EuiText size="xs">
+                <EuiLink>Link to some help</EuiLink>
+              </EuiText>
+            }>
             <EuiFieldText name="first" isLoading compressed />
           </EuiFormRow>
 
@@ -116,7 +123,7 @@ export default class extends Component {
           </EuiFormRow>
 
           <EuiFormRow label="File picker" compressed="horizontal">
-            <EuiFilePicker compressed />
+            <EuiFilePicker compressed display="default" />
           </EuiFormRow>
 
           <EuiFormRow

--- a/src-docs/src/views/form_layouts/form_compressed.js
+++ b/src-docs/src/views/form_layouts/form_compressed.js
@@ -100,11 +100,11 @@ export default class extends Component {
           <EuiFormRow
             label="Text field"
             helpText="I am some friendly help text."
-            display="compressedHorizontal">
+            display="columnCompressed">
             <EuiFieldText name="first" isLoading compressed />
           </EuiFormRow>
 
-          <EuiFormRow label="Select" display="compressedHorizontal">
+          <EuiFormRow label="Select" display="columnCompressed">
             <EuiSelect
               options={[
                 { value: 'option_one', text: 'Option one' },
@@ -115,13 +115,13 @@ export default class extends Component {
             />
           </EuiFormRow>
 
-          <EuiFormRow label="File picker" display="compressedHorizontal">
+          <EuiFormRow label="File picker" display="columnCompressed">
             <EuiFilePicker compressed display="default" />
           </EuiFormRow>
 
           <EuiFormRow
             label="Comboboxwithalonglabelname"
-            display="compressedHorizontal">
+            display="columnCompressed">
             <EuiComboBox
               options={[
                 { label: 'Option one' },
@@ -136,7 +136,7 @@ export default class extends Component {
             />
           </EuiFormRow>
 
-          <EuiFormRow label="Range" display="compressedHorizontal">
+          <EuiFormRow label="Range" display="columnCompressed">
             <EuiRange
               min={0}
               max={100}
@@ -151,7 +151,7 @@ export default class extends Component {
 
           <EuiFormRow
             label="Use a switch instead of a single checkbox"
-            compressed>
+            display="rowCompressed">
             <EuiSwitch
               label="Should we do this?"
               name="switch"
@@ -160,7 +160,7 @@ export default class extends Component {
             />
           </EuiFormRow>
 
-          <EuiFormRow label="Checkboxes" compressed>
+          <EuiFormRow label="Checkboxes" display="rowCompressed">
             <EuiCheckboxGroup
               options={this.state.checkboxes}
               idToSelectedMap={this.state.checkboxIdToSelectedMap}

--- a/src-docs/src/views/form_layouts/form_layouts_example.js
+++ b/src-docs/src/views/form_layouts/form_layouts_example.js
@@ -122,10 +122,12 @@ export const FormLayoutsExample = {
       text: (
         <p>
           If the particular form is in an area with a small amount of real
-          estate, you can add the prop <EuiCode>compressed</EuiCode> to the{' '}
-          <EuiCode>EuiFormRow</EuiCode>s but you will also need to pass it to
-          the form controls. For editor style controls, pass{' '}
-          <EuiCode>compressed=&quot;horizontal&quot;</EuiCode> to align the
+          estate, you can pass{' '}
+          <EuiCode>display=&quot;rowCompressed&quot;</EuiCode> to the{' '}
+          <EuiCode>EuiFormRow</EuiCode>s but you will also need to pass{' '}
+          <EuiCode>compressed=true</EuiCode> to the form controls themselves.
+          For editor style controls, pass{' '}
+          <EuiCode>display=&quot;columnCompressed&quot;</EuiCode> to align the
           labels and inputs horizontally.
         </p>
       ),
@@ -136,13 +138,13 @@ export const FormLayoutsExample = {
       snippet: [
         `<EuiFormRow
   label="Text field"
-  compressed
+  display="rowCompressed"
 >
   <EuiFieldText compressed />
 </EuiFormRow>`,
         `<EuiFormRow
   label="Text field"
-  compressed="horizontal"
+  display="columnCompressed"
 >
   <EuiFieldText compressed />
 </EuiFormRow>`,

--- a/src-docs/src/views/form_layouts/form_layouts_example.js
+++ b/src-docs/src/views/form_layouts/form_layouts_example.js
@@ -123,8 +123,10 @@ export const FormLayoutsExample = {
         <p>
           If the particular form is in an area with a small amount of real
           estate, you can add the prop <EuiCode>compressed</EuiCode> to the{' '}
-          <EuiCode>EuiFormRow</EuiCode>s and it will pass down to the form
-          controls.
+          <EuiCode>EuiFormRow</EuiCode>s but you will also need to pass it to
+          the form controls. For editor style controls, pass{' '}
+          <EuiCode>compressed=&quot;horizontal&quot;</EuiCode> to align the
+          labels and inputs horizontally.
         </p>
       ),
       props: {

--- a/src-docs/src/views/form_layouts/form_layouts_example.js
+++ b/src-docs/src/views/form_layouts/form_layouts_example.js
@@ -108,7 +108,7 @@ export const FormLayoutsExample = {
 </EuiFormRow>`,
     },
     {
-      title: 'Compressed',
+      title: 'Compressed and horizontal',
       source: [
         {
           type: GuideSectionTypes.JS,

--- a/src-docs/src/views/form_layouts/form_layouts_example.js
+++ b/src-docs/src/views/form_layouts/form_layouts_example.js
@@ -133,12 +133,20 @@ export const FormLayoutsExample = {
         EuiFormRow,
       },
       demo: <FormCompressed />,
-      snippet: `<EuiFormRow
+      snippet: [
+        `<EuiFormRow
   label="Text field"
   compressed
 >
-  <EuiFieldText />
+  <EuiFieldText compressed />
 </EuiFormRow>`,
+        `<EuiFormRow
+  label="Text field"
+  compressed="horizontal"
+>
+  <EuiFieldText compressed />
+</EuiFormRow>`,
+      ],
     },
     {
       title: 'Described form groups',

--- a/src-docs/src/views/form_layouts/form_layouts_example.js
+++ b/src-docs/src/views/form_layouts/form_layouts_example.js
@@ -236,12 +236,16 @@ export const FormLayoutsExample = {
           <p>
             When supplying children to an EuiFormRow that is{' '}
             <strong>not</strong> a form control, and you need to the content to
-            vertically center with the other form controls, add the prop{' '}
-            <EuiCode>displayOnly</EuiCode>.
+            vertically center with the other form controls, change the{' '}
+            <EuiCode>display</EuiCode> prop to <EuiCode>center</EuiCode> or{' '}
+            <EuiCode>centerCompressed</EuiCode>.
           </p>
         </Fragment>
       ),
       demo: <InlineSizing />,
+      snippet: `<EuiFormRow label="Avatar" display="centerCompressed">
+  <EuiAvatar name="John Doe" size="s" />
+</EuiFormRow>`,
     },
     {
       title: 'In a popover',

--- a/src-docs/src/views/form_layouts/form_rows.js
+++ b/src-docs/src/views/form_layouts/form_rows.js
@@ -10,6 +10,7 @@ import {
   EuiLink,
   EuiRange,
   EuiSelect,
+  EuiSpacer,
   EuiSwitch,
   EuiText,
 } from '../../../../src/components';
@@ -134,6 +135,8 @@ export default class extends Component {
             onChange={this.onCheckboxChange}
           />
         </EuiFormRow>
+
+        <EuiSpacer />
 
         <EuiButton type="submit" fill>
           Save form

--- a/src-docs/src/views/form_layouts/form_rows.js
+++ b/src-docs/src/views/form_layouts/form_rows.js
@@ -88,16 +88,12 @@ export default class extends Component {
   render() {
     return (
       <EuiForm>
-        <EuiFormRow
-          compressed
-          label="Text field"
-          helpText="I am some friendly help text.">
-          <EuiFieldText name="first" compressed />
+        <EuiFormRow label="Text field" helpText="I am some friendly help text.">
+          <EuiFieldText name="first" />
         </EuiFormRow>
 
         <EuiFormRow
           label="Select (with no initial selection)"
-          compressed
           labelAppend={
             <EuiText size="xs">
               <EuiLink>Link to some help</EuiLink>
@@ -105,7 +101,6 @@ export default class extends Component {
           }>
           <EuiSelect
             hasNoInitialSelection
-            compressed
             options={[
               { value: 'option_one', text: 'Option one' },
               { value: 'option_two', text: 'Option two' },
@@ -114,35 +109,30 @@ export default class extends Component {
           />
         </EuiFormRow>
 
-        <EuiFormRow label="File picker" compressed>
-          <EuiFilePicker compressed />
+        <EuiFormRow label="File picker">
+          <EuiFilePicker />
         </EuiFormRow>
 
-        <EuiFormRow label="Range" compressed>
-          <EuiRange min={0} max={100} name="range" id="range" compressed />
+        <EuiFormRow label="Range">
+          <EuiRange min={0} max={100} name="range" id="range" />
         </EuiFormRow>
 
-        <EuiFormRow
-          label="Use a switch instead of a single checkbox"
-          compressed>
+        <EuiFormRow label="Use a switch instead of a single checkbox">
           <EuiSwitch
             name="switch"
             label="Should we do this?"
             checked={this.state.isSwitchChecked}
             onChange={this.onSwitchChange}
-            compressed
           />
         </EuiFormRow>
 
         <EuiFormRow
           label="Checkbox group labels should use a `legend` label type"
-          labelType="legend"
-          compressed>
+          labelType="legend">
           <EuiCheckboxGroup
             options={this.state.checkboxes}
             idToSelectedMap={this.state.checkboxIdToSelectedMap}
             onChange={this.onCheckboxChange}
-            compressed
           />
         </EuiFormRow>
 

--- a/src-docs/src/views/form_layouts/form_rows.js
+++ b/src-docs/src/views/form_layouts/form_rows.js
@@ -88,12 +88,16 @@ export default class extends Component {
   render() {
     return (
       <EuiForm>
-        <EuiFormRow label="Text field" helpText="I am some friendly help text.">
-          <EuiFieldText name="first" />
+        <EuiFormRow
+          compressed
+          label="Text field"
+          helpText="I am some friendly help text.">
+          <EuiFieldText name="first" compressed />
         </EuiFormRow>
 
         <EuiFormRow
           label="Select (with no initial selection)"
+          compressed
           labelAppend={
             <EuiText size="xs">
               <EuiLink>Link to some help</EuiLink>
@@ -101,6 +105,7 @@ export default class extends Component {
           }>
           <EuiSelect
             hasNoInitialSelection
+            compressed
             options={[
               { value: 'option_one', text: 'Option one' },
               { value: 'option_two', text: 'Option two' },
@@ -109,30 +114,35 @@ export default class extends Component {
           />
         </EuiFormRow>
 
-        <EuiFormRow label="File picker">
-          <EuiFilePicker />
+        <EuiFormRow label="File picker" compressed>
+          <EuiFilePicker compressed />
         </EuiFormRow>
 
-        <EuiFormRow label="Range">
-          <EuiRange min={0} max={100} name="range" id="range" />
+        <EuiFormRow label="Range" compressed>
+          <EuiRange min={0} max={100} name="range" id="range" compressed />
         </EuiFormRow>
 
-        <EuiFormRow label="Use a switch instead of a single checkbox">
+        <EuiFormRow
+          label="Use a switch instead of a single checkbox"
+          compressed>
           <EuiSwitch
             name="switch"
             label="Should we do this?"
             checked={this.state.isSwitchChecked}
             onChange={this.onSwitchChange}
+            compressed
           />
         </EuiFormRow>
 
         <EuiFormRow
           label="Checkbox group labels should use a `legend` label type"
-          labelType="legend">
+          labelType="legend"
+          compressed>
           <EuiCheckboxGroup
             options={this.state.checkboxes}
             idToSelectedMap={this.state.checkboxIdToSelectedMap}
             onChange={this.onCheckboxChange}
+            compressed
           />
         </EuiFormRow>
 

--- a/src-docs/src/views/form_layouts/full_width.js
+++ b/src-docs/src/views/form_layouts/full_width.js
@@ -15,10 +15,10 @@ export default () => (
   <Fragment>
     <EuiFlexGroup>
       <EuiFlexItem>
-        <EuiFieldSearch placeholder="Search..." fullWidth compressed />
+        <EuiFieldSearch placeholder="Search..." fullWidth />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiButton size="s">Search</EuiButton>
+        <EuiButton>Search</EuiButton>
       </EuiFlexItem>
     </EuiFlexGroup>
 
@@ -27,15 +27,13 @@ export default () => (
     <EuiFormRow
       label="Works on form rows too"
       fullWidth
-      helpText="Note that the fullWidth prop is not passed to the form row's child"
-      compressed>
-      <EuiRange fullWidth min={0} max={100} name="range" compressed />
+      helpText="Note that the fullWidth prop is not passed to the form row's child">
+      <EuiRange fullWidth min={0} max={100} name="range" />
     </EuiFormRow>
 
-    <EuiFormRow label="Often useful for text areas" fullWidth compressed>
+    <EuiFormRow label="Often useful for text areas" fullWidth>
       <EuiTextArea
         fullWidth
-        compressed
         placeholder="There is a reason we do not make forms ALWAYS 100% width.
           See how this text area becomes extremely hard to read when the individual
           lines get this long? It is much more readable when contained to a scannable max-width."

--- a/src-docs/src/views/form_layouts/full_width.js
+++ b/src-docs/src/views/form_layouts/full_width.js
@@ -15,10 +15,10 @@ export default () => (
   <Fragment>
     <EuiFlexGroup>
       <EuiFlexItem>
-        <EuiFieldSearch placeholder="Search..." fullWidth />
+        <EuiFieldSearch placeholder="Search..." fullWidth compressed />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiButton>Search</EuiButton>
+        <EuiButton size="s">Search</EuiButton>
       </EuiFlexItem>
     </EuiFlexGroup>
 
@@ -27,13 +27,15 @@ export default () => (
     <EuiFormRow
       label="Works on form rows too"
       fullWidth
-      helpText="Note that the fullWidth prop is not passed to the form row's child">
-      <EuiRange fullWidth min={0} max={100} name="range" />
+      helpText="Note that the fullWidth prop is not passed to the form row's child"
+      compressed>
+      <EuiRange fullWidth min={0} max={100} name="range" compressed />
     </EuiFormRow>
 
-    <EuiFormRow label="Often useful for text areas" fullWidth>
+    <EuiFormRow label="Often useful for text areas" fullWidth compressed>
       <EuiTextArea
         fullWidth
+        compressed
         placeholder="There is a reason we do not make forms ALWAYS 100% width.
           See how this text area becomes extremely hard to read when the individual
           lines get this long? It is much more readable when contained to a scannable max-width."

--- a/src-docs/src/views/form_layouts/inline.js
+++ b/src-docs/src/views/form_layouts/inline.js
@@ -11,21 +11,18 @@ import {
 export default () => (
   <EuiFlexGroup style={{ maxWidth: 600 }}>
     <EuiFlexItem>
-      <EuiFormRow
-        label="First name"
-        helpText="I am helpful help text!"
-        compressed>
-        <EuiFieldText compressed />
+      <EuiFormRow label="First name" helpText="I am helpful help text!">
+        <EuiFieldText />
       </EuiFormRow>
     </EuiFlexItem>
     <EuiFlexItem>
-      <EuiFormRow label="Last name" compressed>
-        <EuiFieldText compressed />
+      <EuiFormRow label="Last name">
+        <EuiFieldText />
       </EuiFormRow>
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
-      <EuiFormRow hasEmptyLabelSpace compressed>
-        <EuiButton size="s">Save</EuiButton>
+      <EuiFormRow hasEmptyLabelSpace>
+        <EuiButton>Save</EuiButton>
       </EuiFormRow>
     </EuiFlexItem>
   </EuiFlexGroup>

--- a/src-docs/src/views/form_layouts/inline.js
+++ b/src-docs/src/views/form_layouts/inline.js
@@ -11,18 +11,21 @@ import {
 export default () => (
   <EuiFlexGroup style={{ maxWidth: 600 }}>
     <EuiFlexItem>
-      <EuiFormRow label="First name" helpText="I am helpful help text!">
-        <EuiFieldText />
+      <EuiFormRow
+        label="First name"
+        helpText="I am helpful help text!"
+        compressed>
+        <EuiFieldText compressed />
       </EuiFormRow>
     </EuiFlexItem>
     <EuiFlexItem>
-      <EuiFormRow label="Last name">
-        <EuiFieldText />
+      <EuiFormRow label="Last name" compressed>
+        <EuiFieldText compressed />
       </EuiFormRow>
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
-      <EuiFormRow hasEmptyLabelSpace>
-        <EuiButton>Save</EuiButton>
+      <EuiFormRow hasEmptyLabelSpace compressed>
+        <EuiButton size="s">Save</EuiButton>
       </EuiFormRow>
     </EuiFlexItem>
   </EuiFlexGroup>

--- a/src-docs/src/views/form_layouts/inline_popover.js
+++ b/src-docs/src/views/form_layouts/inline_popover.js
@@ -10,6 +10,7 @@ import {
   EuiFlexItem,
   EuiFieldNumber,
   EuiRange,
+  EuiSpacer,
   EuiSwitch,
 } from '../../../../src/components';
 
@@ -125,6 +126,8 @@ export default class extends Component {
         <EuiFormRow label="Range" helpText="Some help text for the range">
           <EuiRange min={0} max={100} name="poprange" />
         </EuiFormRow>
+
+        <EuiSpacer />
         <EuiButton fullWidth>Save</EuiButton>
       </EuiForm>
     );

--- a/src-docs/src/views/form_layouts/inline_popover.js
+++ b/src-docs/src/views/form_layouts/inline_popover.js
@@ -79,18 +79,18 @@ export default class extends Component {
       <EuiForm>
         <EuiFlexGroup>
           <EuiFlexItem grow={false} style={{ width: 100 }}>
-            <EuiFormRow label="Age">
-              <EuiFieldNumber max={10} placeholder={42} />
+            <EuiFormRow label="Age" compressed>
+              <EuiFieldNumber max={10} placeholder={42} compressed />
             </EuiFormRow>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiFormRow label="Full name">
-              <EuiFieldText icon="user" placeholder="John Doe" />
+            <EuiFormRow label="Full name" compressed>
+              <EuiFieldText icon="user" placeholder="John Doe" compressed />
             </EuiFormRow>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiFormRow hasEmptyLabelSpace>
-              <EuiButton>Save</EuiButton>
+            <EuiFormRow hasEmptyLabelSpace compressed>
+              <EuiButton size="s">Save</EuiButton>
             </EuiFormRow>
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -109,7 +109,7 @@ export default class extends Component {
 
     const formSample2 = (
       <EuiForm>
-        <EuiFormRow>
+        <EuiFormRow compressed>
           <EuiSwitch
             id={makeId()}
             name="popswitch"
@@ -119,12 +119,15 @@ export default class extends Component {
           />
         </EuiFormRow>
 
-        <EuiFormRow label="A text field">
-          <EuiFieldText name="popfirst" />
+        <EuiFormRow label="A text field" compressed>
+          <EuiFieldText name="popfirst" compressed />
         </EuiFormRow>
 
-        <EuiFormRow label="Range" helpText="Some help text for the range">
-          <EuiRange min={0} max={100} name="poprange" />
+        <EuiFormRow
+          label="Range"
+          helpText="Some help text for the range"
+          compressed>
+          <EuiRange min={0} max={100} name="poprange" compressed />
         </EuiFormRow>
 
         <EuiSpacer />

--- a/src-docs/src/views/form_layouts/inline_popover.js
+++ b/src-docs/src/views/form_layouts/inline_popover.js
@@ -79,18 +79,18 @@ export default class extends Component {
       <EuiForm>
         <EuiFlexGroup>
           <EuiFlexItem grow={false} style={{ width: 100 }}>
-            <EuiFormRow label="Age" compressed>
-              <EuiFieldNumber max={10} placeholder={42} compressed />
+            <EuiFormRow label="Age">
+              <EuiFieldNumber max={10} placeholder={42} />
             </EuiFormRow>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiFormRow label="Full name" compressed>
-              <EuiFieldText icon="user" placeholder="John Doe" compressed />
+            <EuiFormRow label="Full name">
+              <EuiFieldText icon="user" placeholder="John Doe" />
             </EuiFormRow>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiFormRow hasEmptyLabelSpace compressed>
-              <EuiButton size="s">Save</EuiButton>
+            <EuiFormRow hasEmptyLabelSpace>
+              <EuiButton>Save</EuiButton>
             </EuiFormRow>
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -109,7 +109,7 @@ export default class extends Component {
 
     const formSample2 = (
       <EuiForm>
-        <EuiFormRow compressed>
+        <EuiFormRow>
           <EuiSwitch
             id={makeId()}
             name="popswitch"
@@ -119,15 +119,12 @@ export default class extends Component {
           />
         </EuiFormRow>
 
-        <EuiFormRow label="A text field" compressed>
-          <EuiFieldText name="popfirst" compressed />
+        <EuiFormRow label="A text field">
+          <EuiFieldText name="popfirst" />
         </EuiFormRow>
 
-        <EuiFormRow
-          label="Range"
-          helpText="Some help text for the range"
-          compressed>
-          <EuiRange min={0} max={100} name="poprange" compressed />
+        <EuiFormRow label="Range" helpText="Some help text for the range">
+          <EuiRange min={0} max={100} name="poprange" />
         </EuiFormRow>
 
         <EuiSpacer />

--- a/src-docs/src/views/form_layouts/inline_sizing.js
+++ b/src-docs/src/views/form_layouts/inline_sizing.js
@@ -13,23 +13,23 @@ import {
 export default () => (
   <EuiFlexGroup style={{ maxWidth: 600 }}>
     <EuiFlexItem grow={false} style={{ width: 100 }}>
-      <EuiFormRow label="Age" compressed>
-        <EuiFieldNumber max={10} placeholder={42} compressed />
+      <EuiFormRow label="Age">
+        <EuiFieldNumber max={10} placeholder={42} />
       </EuiFormRow>
     </EuiFlexItem>
     <EuiFlexItem>
-      <EuiFormRow label="Full name" compressed>
-        <EuiFieldText icon="user" placeholder="John Doe" compressed />
+      <EuiFormRow label="Full name">
+        <EuiFieldText icon="user" placeholder="John Doe" />
       </EuiFormRow>
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
-      <EuiFormRow label="Avatar" displayOnly compressed>
+      <EuiFormRow label="Avatar" displayOnly>
         <EuiAvatar name="John Doe" size="s" />
       </EuiFormRow>
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
-      <EuiFormRow hasEmptyLabelSpace compressed>
-        <EuiButton size="s">Save</EuiButton>
+      <EuiFormRow hasEmptyLabelSpace>
+        <EuiButton>Save</EuiButton>
       </EuiFormRow>
     </EuiFlexItem>
   </EuiFlexGroup>

--- a/src-docs/src/views/form_layouts/inline_sizing.js
+++ b/src-docs/src/views/form_layouts/inline_sizing.js
@@ -23,12 +23,12 @@ export default () => (
       </EuiFormRow>
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
-      <EuiFormRow label="Avatar" displayOnly compressed>
+      <EuiFormRow label="Avatar" display="centerCompressed">
         <EuiAvatar name="John Doe" size="s" />
       </EuiFormRow>
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
-      <EuiFormRow hasEmptyLabelSpace compressed>
+      <EuiFormRow hasEmptyLabelSpace displayOnly compressed>
         <EuiButton size="s">Save</EuiButton>
       </EuiFormRow>
     </EuiFlexItem>

--- a/src-docs/src/views/form_layouts/inline_sizing.js
+++ b/src-docs/src/views/form_layouts/inline_sizing.js
@@ -13,23 +13,23 @@ import {
 export default () => (
   <EuiFlexGroup style={{ maxWidth: 600 }}>
     <EuiFlexItem grow={false} style={{ width: 100 }}>
-      <EuiFormRow label="Age">
-        <EuiFieldNumber max={10} placeholder={42} />
+      <EuiFormRow label="Age" compressed>
+        <EuiFieldNumber max={10} placeholder={42} compressed />
       </EuiFormRow>
     </EuiFlexItem>
     <EuiFlexItem>
-      <EuiFormRow label="Full name">
-        <EuiFieldText icon="user" placeholder="John Doe" />
+      <EuiFormRow label="Full name" compressed>
+        <EuiFieldText icon="user" placeholder="John Doe" compressed />
       </EuiFormRow>
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
-      <EuiFormRow label="Avatar" displayOnly>
+      <EuiFormRow label="Avatar" displayOnly compressed>
         <EuiAvatar name="John Doe" size="s" />
       </EuiFormRow>
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
-      <EuiFormRow hasEmptyLabelSpace>
-        <EuiButton>Save</EuiButton>
+      <EuiFormRow hasEmptyLabelSpace compressed>
+        <EuiButton size="s">Save</EuiButton>
       </EuiFormRow>
     </EuiFlexItem>
   </EuiFlexGroup>

--- a/src-docs/src/views/form_layouts/inline_sizing.js
+++ b/src-docs/src/views/form_layouts/inline_sizing.js
@@ -13,22 +13,22 @@ import {
 export default () => (
   <EuiFlexGroup style={{ maxWidth: 600 }}>
     <EuiFlexItem grow={false} style={{ width: 100 }}>
-      <EuiFormRow label="Age" compressed>
-        <EuiFieldNumber max={10} placeholder={42} compressed />
+      <EuiFormRow label="Age">
+        <EuiFieldNumber max={10} placeholder={42} />
       </EuiFormRow>
     </EuiFlexItem>
     <EuiFlexItem>
-      <EuiFormRow label="Full name" compressed>
-        <EuiFieldText icon="user" placeholder="John Doe" compressed />
+      <EuiFormRow label="Full name">
+        <EuiFieldText icon="user" placeholder="John Doe" />
       </EuiFormRow>
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
-      <EuiFormRow label="Avatar" display="centerCompressed">
+      <EuiFormRow label="Avatar" display="center">
         <EuiAvatar name="John Doe" size="s" />
       </EuiFormRow>
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
-      <EuiFormRow hasEmptyLabelSpace displayOnly compressed>
+      <EuiFormRow hasEmptyLabelSpace display="center">
         <EuiButton size="s">Save</EuiButton>
       </EuiFormRow>
     </EuiFlexItem>

--- a/src-docs/src/views/form_validation/validation.js
+++ b/src-docs/src/views/form_validation/validation.js
@@ -7,6 +7,7 @@ import {
   EuiFormRow,
   EuiTextArea,
   EuiFieldText,
+  EuiSpacer,
 } from '../../../../src/components';
 
 export default class extends Component {
@@ -69,6 +70,8 @@ export default class extends Component {
               isInvalid={this.state.showErrors}
             />
           </EuiFormRow>
+
+          <EuiSpacer />
 
           {button}
         </EuiForm>

--- a/src-docs/src/views/popover/trap_focus.js
+++ b/src-docs/src/views/popover/trap_focus.js
@@ -4,6 +4,7 @@ import {
   EuiButton,
   EuiFormRow,
   EuiPopover,
+  EuiSpacer,
   EuiSwitch,
 } from '../../../../src/components';
 
@@ -53,6 +54,8 @@ export default class extends Component {
         <EuiFormRow label="Include the following in the embed" id="asdf2">
           <EuiSwitch name="switch" label="Current time range" />
         </EuiFormRow>
+
+        <EuiSpacer />
 
         <EuiButton fill>Copy IFRAME code</EuiButton>
       </EuiPopover>

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -98,6 +98,10 @@
       line-height: $euiFormControlCompressedHeight; /* 2 */
       padding-top: 0;
       padding-bottom: 0;
+
+      &.euiComboBox__inputWrap-isClearable {
+        @include euiFormControlLayoutPadding(2, $compressed: true); /* 2 */
+      }
     }
   }
 }

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -11,7 +11,7 @@
    */
 
   &--compressed,
-  .euiFormControlLayout--compressed {
+  .euiFormControlLayout {
     height: auto;
   }
 

--- a/src/components/date_picker/super_date_picker/date_popover/relative_tab.js
+++ b/src/components/date_picker/super_date_picker/date_popover/relative_tab.js
@@ -104,7 +104,7 @@ export class EuiRelativeTab extends Component {
             </EuiFormRow>
           </EuiFlexItem>
         </EuiFlexGroup>
-        <EuiSpacer size="s" />
+        <EuiSpacer size="m" />
         <EuiSwitch
           data-test-subj={'superDatePickerRelativeDateRoundSwitch'}
           label={`Round to the ${timeUnits[this.state.unit.substring(0, 1)]}`}

--- a/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select.test.js.snap
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select.test.js.snap
@@ -70,7 +70,7 @@ exports[`EuiQuickSelect is rendered 1`] = `
       >
         <EuiSelect
           aria-label="Quick time tense"
-          compressed={false}
+          compressed={true}
           fullWidth={false}
           hasNoInitialSelection={false}
           isLoading={false}
@@ -101,7 +101,7 @@ exports[`EuiQuickSelect is rendered 1`] = `
       >
         <EuiFieldNumber
           aria-label="Quick time value"
-          compressed={false}
+          compressed={true}
           fullWidth={false}
           isLoading={false}
           onChange={[Function]}
@@ -119,7 +119,7 @@ exports[`EuiQuickSelect is rendered 1`] = `
       >
         <EuiSelect
           aria-label="Quick time units"
-          compressed={false}
+          compressed={true}
           fullWidth={false}
           hasNoInitialSelection={false}
           isLoading={false}
@@ -260,7 +260,7 @@ exports[`EuiQuickSelect prevQuickSelect 1`] = `
       >
         <EuiSelect
           aria-label="Quick time tense"
-          compressed={false}
+          compressed={true}
           fullWidth={false}
           hasNoInitialSelection={false}
           isLoading={false}
@@ -291,7 +291,7 @@ exports[`EuiQuickSelect prevQuickSelect 1`] = `
       >
         <EuiFieldNumber
           aria-label="Quick time value"
-          compressed={false}
+          compressed={true}
           fullWidth={false}
           isLoading={false}
           onChange={[Function]}
@@ -309,7 +309,7 @@ exports[`EuiQuickSelect prevQuickSelect 1`] = `
       >
         <EuiSelect
           aria-label="Quick time units"
-          compressed={false}
+          compressed={true}
           fullWidth={false}
           hasNoInitialSelection={false}
           isLoading={false}

--- a/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select.test.js.snap
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select.test.js.snap
@@ -64,7 +64,7 @@ exports[`EuiQuickSelect is rendered 1`] = `
       <EuiFormRow
         compressed={true}
         describedByIds={Array []}
-        display="default"
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -96,7 +96,7 @@ exports[`EuiQuickSelect is rendered 1`] = `
       <EuiFormRow
         compressed={true}
         describedByIds={Array []}
-        display="default"
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -115,7 +115,7 @@ exports[`EuiQuickSelect is rendered 1`] = `
       <EuiFormRow
         compressed={true}
         describedByIds={Array []}
-        display="default"
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -168,7 +168,7 @@ exports[`EuiQuickSelect is rendered 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
-        display="default"
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -258,7 +258,7 @@ exports[`EuiQuickSelect prevQuickSelect 1`] = `
       <EuiFormRow
         compressed={true}
         describedByIds={Array []}
-        display="default"
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -290,7 +290,7 @@ exports[`EuiQuickSelect prevQuickSelect 1`] = `
       <EuiFormRow
         compressed={true}
         describedByIds={Array []}
-        display="default"
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -309,7 +309,7 @@ exports[`EuiQuickSelect prevQuickSelect 1`] = `
       <EuiFormRow
         compressed={true}
         describedByIds={Array []}
-        display="default"
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -362,7 +362,7 @@ exports[`EuiQuickSelect prevQuickSelect 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
-        display="default"
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"

--- a/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select.test.js.snap
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select.test.js.snap
@@ -64,6 +64,7 @@ exports[`EuiQuickSelect is rendered 1`] = `
       <EuiFormRow
         compressed={true}
         describedByIds={Array []}
+        display="default"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -95,6 +96,7 @@ exports[`EuiQuickSelect is rendered 1`] = `
       <EuiFormRow
         compressed={true}
         describedByIds={Array []}
+        display="default"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -113,6 +115,7 @@ exports[`EuiQuickSelect is rendered 1`] = `
       <EuiFormRow
         compressed={true}
         describedByIds={Array []}
+        display="default"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -165,6 +168,7 @@ exports[`EuiQuickSelect is rendered 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="default"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -254,6 +258,7 @@ exports[`EuiQuickSelect prevQuickSelect 1`] = `
       <EuiFormRow
         compressed={true}
         describedByIds={Array []}
+        display="default"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -285,6 +290,7 @@ exports[`EuiQuickSelect prevQuickSelect 1`] = `
       <EuiFormRow
         compressed={true}
         describedByIds={Array []}
+        display="default"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -303,6 +309,7 @@ exports[`EuiQuickSelect prevQuickSelect 1`] = `
       <EuiFormRow
         compressed={true}
         describedByIds={Array []}
+        display="default"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -355,6 +362,7 @@ exports[`EuiQuickSelect prevQuickSelect 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="default"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"

--- a/src/components/date_picker/super_date_picker/quick_select_popover/quick_select.js
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/quick_select.js
@@ -151,6 +151,7 @@ export class EuiQuickSelect extends Component {
                 value={this.state.timeTense}
                 options={timeTenseOptions}
                 onChange={this.onTimeTenseChange}
+                compressed
               />
             </EuiFormRow>
           </EuiFlexItem>
@@ -160,6 +161,7 @@ export class EuiQuickSelect extends Component {
                 aria-label="Quick time value"
                 value={this.state.timeValue}
                 onChange={this.onTimeValueChange}
+                compressed
               />
             </EuiFormRow>
           </EuiFlexItem>
@@ -170,6 +172,7 @@ export class EuiQuickSelect extends Component {
                 value={this.state.timeUnits}
                 options={timeUnitsOptions}
                 onChange={this.onTimeUnitsChange}
+                compressed
               />
             </EuiFormRow>
           </EuiFlexItem>

--- a/src/components/date_picker/super_date_picker/quick_select_popover/refresh_interval.js
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/refresh_interval.js
@@ -128,6 +128,7 @@ export class EuiRefreshInterval extends Component {
                 onChange={this.onValueChange}
                 aria-label="Refresh interval value"
                 data-test-subj="superDatePickerRefreshIntervalInput"
+                compressed
               />
             </EuiFormRow>
           </EuiFlexItem>
@@ -139,6 +140,7 @@ export class EuiRefreshInterval extends Component {
                 options={refreshUnitsOptions}
                 onChange={this.onUnitsChange}
                 data-test-subj="superDatePickerRefreshIntervalUnitsSelect"
+                compressed
               />
             </EuiFormRow>
           </EuiFlexItem>

--- a/src/components/expression/_expression.scss
+++ b/src/components/expression/_expression.scss
@@ -3,7 +3,7 @@
  *    but then wrap long words
  */
 .euiExpression {
-  @include euiTextOverflowWrap; /* 1 */
+  @include euiTextBreakWord; /* 1 */
   @include euiFontSizeS;
   @include euiCodeFont;
 

--- a/src/components/form/described_form_group/__snapshots__/described_form_group.test.js.snap
+++ b/src/components/form/described_form_group/__snapshots__/described_form_group.test.js.snap
@@ -330,6 +330,7 @@ exports[`EuiDescribedFormGroup ties together parts for accessibility 1`] = `
                 >
                   <EuiFormLabel
                     aria-invalid={true}
+                    className="euiFormRow__label"
                     htmlFor="generated-id"
                     isFocused={false}
                     isInvalid={true}
@@ -337,7 +338,7 @@ exports[`EuiDescribedFormGroup ties together parts for accessibility 1`] = `
                   >
                     <label
                       aria-invalid={true}
-                      className="euiFormLabel euiFormLabel-isInvalid"
+                      className="euiFormLabel euiFormRow__label euiFormLabel-isInvalid"
                       htmlFor="generated-id"
                     >
                       Label

--- a/src/components/form/described_form_group/__snapshots__/described_form_group.test.js.snap
+++ b/src/components/form/described_form_group/__snapshots__/described_form_group.test.js.snap
@@ -325,7 +325,9 @@ exports[`EuiDescribedFormGroup ties together parts for accessibility 1`] = `
                 className="euiFormRow"
                 id="generated-id-row"
               >
-                <div>
+                <div
+                  className="euiFormRow__labelWrapper"
+                >
                   <EuiFormLabel
                     aria-invalid={true}
                     htmlFor="generated-id"
@@ -342,49 +344,53 @@ exports[`EuiDescribedFormGroup ties together parts for accessibility 1`] = `
                     </label>
                   </EuiFormLabel>
                 </div>
-                <input
-                  aria-describedby="test-id generated-id-help generated-id-error-0 generated-id-error-1"
-                  id="generated-id"
-                  onBlur={[Function]}
-                  onFocus={[Function]}
-                />
-                <EuiFormErrorText
-                  className="euiFormRow__text"
-                  id="generated-id-error-0"
-                  key="Error one"
+                <div
+                  className="euiFormRow__fieldWrapper"
                 >
-                  <div
-                    aria-live="polite"
-                    className="euiFormErrorText euiFormRow__text"
+                  <input
+                    aria-describedby="test-id generated-id-help generated-id-error-0 generated-id-error-1"
+                    id="generated-id"
+                    onBlur={[Function]}
+                    onFocus={[Function]}
+                  />
+                  <EuiFormErrorText
+                    className="euiFormRow__text"
                     id="generated-id-error-0"
+                    key="Error one"
                   >
-                    Error one
-                  </div>
-                </EuiFormErrorText>
-                <EuiFormErrorText
-                  className="euiFormRow__text"
-                  id="generated-id-error-1"
-                  key="Error two"
-                >
-                  <div
-                    aria-live="polite"
-                    className="euiFormErrorText euiFormRow__text"
+                    <div
+                      aria-live="polite"
+                      className="euiFormErrorText euiFormRow__text"
+                      id="generated-id-error-0"
+                    >
+                      Error one
+                    </div>
+                  </EuiFormErrorText>
+                  <EuiFormErrorText
+                    className="euiFormRow__text"
                     id="generated-id-error-1"
+                    key="Error two"
                   >
-                    Error two
-                  </div>
-                </EuiFormErrorText>
-                <EuiFormHelpText
-                  className="euiFormRow__text"
-                  id="generated-id-help"
-                >
-                  <div
-                    className="euiFormHelpText euiFormRow__text"
+                    <div
+                      aria-live="polite"
+                      className="euiFormErrorText euiFormRow__text"
+                      id="generated-id-error-1"
+                    >
+                      Error two
+                    </div>
+                  </EuiFormErrorText>
+                  <EuiFormHelpText
+                    className="euiFormRow__text"
                     id="generated-id-help"
                   >
-                    Help text
-                  </div>
-                </EuiFormHelpText>
+                    <div
+                      className="euiFormHelpText euiFormRow__text"
+                      id="generated-id-help"
+                    >
+                      Help text
+                    </div>
+                  </EuiFormHelpText>
+                </div>
               </div>
             </EuiFormRow>
           </div>

--- a/src/components/form/described_form_group/__snapshots__/described_form_group.test.js.snap
+++ b/src/components/form/described_form_group/__snapshots__/described_form_group.test.js.snap
@@ -36,7 +36,7 @@ exports[`EuiDescribedFormGroup is rendered 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
-        display="default"
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -75,7 +75,7 @@ exports[`EuiDescribedFormGroup props description is not rendered when it's not p
     >
       <EuiFormRow
         describedByIds={Array []}
-        display="default"
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -123,7 +123,7 @@ exports[`EuiDescribedFormGroup props fullWidth is rendered 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
-        display="default"
+        display="row"
         fullWidth={true}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -171,7 +171,7 @@ exports[`EuiDescribedFormGroup props gutterSize is rendered 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
-        display="default"
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -219,7 +219,7 @@ exports[`EuiDescribedFormGroup props titleSize is rendered 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
-        display="default"
+        display="row"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -313,7 +313,7 @@ exports[`EuiDescribedFormGroup ties together parts for accessibility 1`] = `
                   "test-id",
                 ]
               }
-              display="default"
+              display="row"
               error={
                 Array [
                   "Error one",

--- a/src/components/form/described_form_group/__snapshots__/described_form_group.test.js.snap
+++ b/src/components/form/described_form_group/__snapshots__/described_form_group.test.js.snap
@@ -36,6 +36,7 @@ exports[`EuiDescribedFormGroup is rendered 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="default"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -74,6 +75,7 @@ exports[`EuiDescribedFormGroup props description is not rendered when it's not p
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="default"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -121,6 +123,7 @@ exports[`EuiDescribedFormGroup props fullWidth is rendered 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="default"
         fullWidth={true}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -168,6 +171,7 @@ exports[`EuiDescribedFormGroup props gutterSize is rendered 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="default"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -215,6 +219,7 @@ exports[`EuiDescribedFormGroup props titleSize is rendered 1`] = `
     >
       <EuiFormRow
         describedByIds={Array []}
+        display="default"
         fullWidth={false}
         hasEmptyLabelSpace={false}
         labelType="label"
@@ -308,6 +313,7 @@ exports[`EuiDescribedFormGroup ties together parts for accessibility 1`] = `
                   "test-id",
                 ]
               }
+              display="default"
               error={
                 Array [
                   "Error one",

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -44,6 +44,7 @@
 
   .euiFilePicker--compressed & {
     top: $euiSizeS;
+    left: $euiSizeS;
   }
 
   .euiFilePicker--large & {
@@ -76,7 +77,7 @@
 
   .euiFilePicker--compressed & {
     @include euiFormControlStyleCompressed($includeStates: false);
-    @include euiFormControlWithIcon; /* 2 */
+    @include euiFormControlWithIcon($compressed: true); /* 2 */
     height: $euiFormControlCompressedHeight;
   }
 

--- a/src/components/form/form_help_text/_form_help_text.scss
+++ b/src/components/form/form_help_text/_form_help_text.scss
@@ -1,5 +1,5 @@
 .euiFormHelpText {
   @include euiFontSizeXS;
-  padding-top: $euiSizeS;
+  padding-top: $euiSizeXS;
   color: $euiColorDarkShade;
 }

--- a/src/components/form/form_label/_form_label.scss
+++ b/src/components/form/form_label/_form_label.scss
@@ -4,7 +4,6 @@
 .euiFormLabel {
   @include euiFontSizeXS;
   display: inline-block;
-  margin-bottom: $euiSizeXS;
   transition: all $euiAnimSpeedFast $euiAnimSlightResistance;
   color: $euiTitleColor;
   font-weight: $euiFontWeightSemiBold;

--- a/src/components/form/form_row/__snapshots__/form_row.test.js.snap
+++ b/src/components/form/form_row/__snapshots__/form_row.test.js.snap
@@ -442,33 +442,19 @@ exports[`EuiFormRow props label append is rendered 1`] = `
   className="euiFormRow"
   id="generated-id-row"
 >
-  <EuiFlexGroup
-    gutterSize="xs"
-    justifyContent="spaceBetween"
-    responsive={false}
-    wrap={true}
+  <div
+    className="euiFormRow__labelWrapper"
   >
-    <EuiFlexItem
-      grow={false}
+    <EuiFormLabel
+      htmlFor="generated-id"
+      isFocused={false}
+      type="label"
     >
-      <div
-        className="euiFormRow__labelWrapper"
-      >
-        <EuiFormLabel
-          htmlFor="generated-id"
-          isFocused={false}
-          type="label"
-        >
-          label
-        </EuiFormLabel>
-      </div>
-    </EuiFlexItem>
-    <EuiFlexItem
-      grow={false}
-    >
-      append
-    </EuiFlexItem>
-  </EuiFlexGroup>
+      label
+    </EuiFormLabel>
+     
+    append
+  </div>
   <div
     className="euiFormRow__fieldWrapper"
   >

--- a/src/components/form/form_row/__snapshots__/form_row.test.js.snap
+++ b/src/components/form/form_row/__snapshots__/form_row.test.js.snap
@@ -215,7 +215,7 @@ exports[`EuiFormRow is rendered 1`] = `
 
 exports[`EuiFormRow props compressed is rendered 1`] = `
 <div
-  class="euiFormRow"
+  class="euiFormRow euiFormRow--compressed"
   id="generated-id-row"
 >
   <div
@@ -241,6 +241,36 @@ exports[`EuiFormRow props describedByIds is rendered 1`] = `
       id="generated-id"
       onBlur={[Function]}
       onFocus={[Function]}
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiFormRow props display type center is rendered 1`] = `
+<div
+  class="euiFormRow"
+  id="generated-id-row"
+>
+  <div
+    class="euiFormRow__fieldWrapper euiFormRow__fieldWrapperDisplayOnly"
+  >
+    <input
+      id="generated-id"
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiFormRow props display type centerCompressed is rendered 1`] = `
+<div
+  class="euiFormRow euiFormRow--compressed"
+  id="generated-id-row"
+>
+  <div
+    class="euiFormRow__fieldWrapper euiFormRow__fieldWrapperDisplayOnly"
+  >
+    <input
+      id="generated-id"
     />
   </div>
 </div>
@@ -297,17 +327,13 @@ exports[`EuiFormRow props displayOnly is rendered 1`] = `
   id="generated-id-row"
 >
   <div
-    class="euiFormRow__fieldWrapper"
+    class="euiFormRow__fieldWrapper euiFormRow__fieldWrapperDisplayOnly"
   >
-    <div
-      class="euiFormRow__displayOnlyWrapper"
+    <span
+      id="generated-id"
     >
-      <span
-        id="generated-id"
-      >
-        just some text
-      </span>
-    </div>
+      just some text
+    </span>
   </div>
 </div>
 `;

--- a/src/components/form/form_row/__snapshots__/form_row.test.js.snap
+++ b/src/components/form/form_row/__snapshots__/form_row.test.js.snap
@@ -16,7 +16,9 @@ exports[`EuiFormRow behavior onBlur is called in child 1`] = `
     className="euiFormRow"
     id="generated-id-row"
   >
-    <div>
+    <div
+      className="euiFormRow__labelWrapper"
+    >
       <EuiFormLabel
         htmlFor="generated-id"
         isFocused={false}
@@ -32,11 +34,15 @@ exports[`EuiFormRow behavior onBlur is called in child 1`] = `
         </label>
       </EuiFormLabel>
     </div>
-    <input
-      id="generated-id"
-      onBlur={[Function]}
-      onFocus={[Function]}
-    />
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <input
+        id="generated-id"
+        onBlur={[Function]}
+        onFocus={[Function]}
+      />
+    </div>
   </div>
 </EuiFormRow>
 `;
@@ -57,7 +63,9 @@ exports[`EuiFormRow behavior onBlur works in parent even if not in child 1`] = `
     className="euiFormRow"
     id="generated-id-row"
   >
-    <div>
+    <div
+      className="euiFormRow__labelWrapper"
+    >
       <EuiFormLabel
         htmlFor="generated-id"
         isFocused={false}
@@ -73,11 +81,15 @@ exports[`EuiFormRow behavior onBlur works in parent even if not in child 1`] = `
         </label>
       </EuiFormLabel>
     </div>
-    <input
-      id="generated-id"
-      onBlur={[Function]}
-      onFocus={[Function]}
-    />
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <input
+        id="generated-id"
+        onBlur={[Function]}
+        onFocus={[Function]}
+      />
+    </div>
   </div>
 </EuiFormRow>
 `;
@@ -98,7 +110,9 @@ exports[`EuiFormRow behavior onFocus is called in child 1`] = `
     className="euiFormRow"
     id="generated-id-row"
   >
-    <div>
+    <div
+      className="euiFormRow__labelWrapper"
+    >
       <EuiFormLabel
         htmlFor="generated-id"
         isFocused={true}
@@ -114,11 +128,15 @@ exports[`EuiFormRow behavior onFocus is called in child 1`] = `
         </label>
       </EuiFormLabel>
     </div>
-    <input
-      id="generated-id"
-      onBlur={[Function]}
-      onFocus={[Function]}
-    />
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <input
+        id="generated-id"
+        onBlur={[Function]}
+        onFocus={[Function]}
+      />
+    </div>
   </div>
 </EuiFormRow>
 `;
@@ -139,7 +157,9 @@ exports[`EuiFormRow behavior onFocus works in parent even if not in child 1`] = 
     className="euiFormRow"
     id="generated-id-row"
   >
-    <div>
+    <div
+      className="euiFormRow__labelWrapper"
+    >
       <EuiFormLabel
         htmlFor="generated-id"
         isFocused={true}
@@ -155,11 +175,15 @@ exports[`EuiFormRow behavior onFocus works in parent even if not in child 1`] = 
         </label>
       </EuiFormLabel>
     </div>
-    <input
-      id="generated-id"
-      onBlur={[Function]}
-      onFocus={[Function]}
-    />
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <input
+        id="generated-id"
+        onBlur={[Function]}
+        onFocus={[Function]}
+      />
+    </div>
   </div>
 </EuiFormRow>
 `;
@@ -171,9 +195,43 @@ exports[`EuiFormRow is rendered 1`] = `
   data-test-subj="test subject string"
   id="generated-id-row"
 >
-  <input
-    id="generated-id"
-  />
+  <div
+    class="euiFormRow__fieldWrapper"
+  >
+    <input
+      id="generated-id"
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiFormRow props compressed horizontally is rendered 1`] = `
+<div
+  class="euiFormRow euiFormRow--compressed euiFormRow--horizontal"
+  id="generated-id-row"
+>
+  <div
+    class="euiFormRow__fieldWrapper"
+  >
+    <input
+      id="generated-id"
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiFormRow props compressed is rendered 1`] = `
+<div
+  class="euiFormRow euiFormRow--compressed"
+  id="generated-id-row"
+>
+  <div
+    class="euiFormRow__fieldWrapper"
+  >
+    <input
+      id="generated-id"
+    />
+  </div>
 </div>
 `;
 
@@ -182,12 +240,16 @@ exports[`EuiFormRow props describedByIds is rendered 1`] = `
   className="euiFormRow"
   id="generated-id-row"
 >
-  <input
-    aria-describedby="generated-id-additional"
-    id="generated-id"
-    onBlur={[Function]}
-    onFocus={[Function]}
-  />
+  <div
+    className="euiFormRow__fieldWrapper"
+  >
+    <input
+      aria-describedby="generated-id-additional"
+      id="generated-id"
+      onBlur={[Function]}
+      onFocus={[Function]}
+    />
+  </div>
 </div>
 `;
 
@@ -197,13 +259,17 @@ exports[`EuiFormRow props displayOnly is rendered 1`] = `
   id="generated-id-row"
 >
   <div
-    class="euiFormRow__displayOnlyWrapper"
+    class="euiFormRow__fieldWrapper"
   >
-    <span
-      id="generated-id"
+    <div
+      class="euiFormRow__displayOnlyWrapper"
     >
-      just some text
-    </span>
+      <span
+        id="generated-id"
+      >
+        just some text
+      </span>
+    </div>
   </div>
 </div>
 `;
@@ -213,23 +279,27 @@ exports[`EuiFormRow props error as array is rendered 1`] = `
   class="euiFormRow"
   id="generated-id-row"
 >
-  <input
-    aria-describedby="generated-id-error-0 generated-id-error-1"
-    id="generated-id"
-  />
   <div
-    aria-live="polite"
-    class="euiFormErrorText euiFormRow__text"
-    id="generated-id-error-0"
+    class="euiFormRow__fieldWrapper"
   >
-    Error
-  </div>
-  <div
-    aria-live="polite"
-    class="euiFormErrorText euiFormRow__text"
-    id="generated-id-error-1"
-  >
-    Error2
+    <input
+      aria-describedby="generated-id-error-0 generated-id-error-1"
+      id="generated-id"
+    />
+    <div
+      aria-live="polite"
+      class="euiFormErrorText euiFormRow__text"
+      id="generated-id-error-0"
+    >
+      Error
+    </div>
+    <div
+      aria-live="polite"
+      class="euiFormErrorText euiFormRow__text"
+      id="generated-id-error-1"
+    >
+      Error2
+    </div>
   </div>
 </div>
 `;
@@ -239,16 +309,20 @@ exports[`EuiFormRow props error as string is rendered 1`] = `
   class="euiFormRow"
   id="generated-id-row"
 >
-  <input
-    aria-describedby="generated-id-error-0"
-    id="generated-id"
-  />
   <div
-    aria-live="polite"
-    class="euiFormErrorText euiFormRow__text"
-    id="generated-id-error-0"
+    class="euiFormRow__fieldWrapper"
   >
-    Error
+    <input
+      aria-describedby="generated-id-error-0"
+      id="generated-id"
+    />
+    <div
+      aria-live="polite"
+      class="euiFormErrorText euiFormRow__text"
+      id="generated-id-error-0"
+    >
+      Error
+    </div>
   </div>
 </div>
 `;
@@ -258,9 +332,13 @@ exports[`EuiFormRow props error is not rendered if isInvalid is false 1`] = `
   class="euiFormRow"
   id="generated-id-row"
 >
-  <input
-    id="generated-id"
-  />
+  <div
+    class="euiFormRow__fieldWrapper"
+  >
+    <input
+      id="generated-id"
+    />
+  </div>
 </div>
 `;
 
@@ -269,9 +347,13 @@ exports[`EuiFormRow props fullWidth is rendered 1`] = `
   class="euiFormRow euiFormRow--fullWidth"
   id="generated-id-row"
 >
-  <input
-    id="generated-id"
-  />
+  <div
+    class="euiFormRow__fieldWrapper"
+  >
+    <input
+      id="generated-id"
+    />
+  </div>
 </div>
 `;
 
@@ -280,9 +362,13 @@ exports[`EuiFormRow props hasEmptyLabelSpace is rendered 1`] = `
   class="euiFormRow euiFormRow--hasEmptyLabelSpace"
   id="generated-id-row"
 >
-  <input
-    id="generated-id"
-  />
+  <div
+    class="euiFormRow__fieldWrapper"
+  >
+    <input
+      id="generated-id"
+    />
+  </div>
 </div>
 `;
 
@@ -291,17 +377,21 @@ exports[`EuiFormRow props helpText is rendered 1`] = `
   class="euiFormRow"
   id="generated-id-row"
 >
-  <input
-    aria-describedby="generated-id-help"
-    id="generated-id"
-  />
   <div
-    class="euiFormHelpText euiFormRow__text"
-    id="generated-id-help"
+    class="euiFormRow__fieldWrapper"
   >
-    <span>
-      This is help text.
-    </span>
+    <input
+      aria-describedby="generated-id-help"
+      id="generated-id"
+    />
+    <div
+      class="euiFormHelpText euiFormRow__text"
+      id="generated-id-help"
+    >
+      <span>
+        This is help text.
+      </span>
+    </div>
   </div>
 </div>
 `;
@@ -311,9 +401,13 @@ exports[`EuiFormRow props id is rendered 1`] = `
   class="euiFormRow"
   id="id-row"
 >
-  <input
-    id="id"
-  />
+  <div
+    class="euiFormRow__fieldWrapper"
+  >
+    <input
+      id="id"
+    />
+  </div>
 </div>
 `;
 
@@ -322,7 +416,9 @@ exports[`EuiFormRow props isInvalid is rendered 1`] = `
   class="euiFormRow"
   id="generated-id-row"
 >
-  <div>
+  <div
+    class="euiFormRow__labelWrapper"
+  >
     <label
       aria-invalid="true"
       class="euiFormLabel euiFormLabel-isInvalid"
@@ -331,9 +427,13 @@ exports[`EuiFormRow props isInvalid is rendered 1`] = `
       label
     </label>
   </div>
-  <input
-    id="generated-id"
-  />
+  <div
+    class="euiFormRow__fieldWrapper"
+  >
+    <input
+      id="generated-id"
+    />
+  </div>
 </div>
 `;
 
@@ -351,7 +451,9 @@ exports[`EuiFormRow props label append is rendered 1`] = `
     <EuiFlexItem
       grow={false}
     >
-      <div>
+      <div
+        className="euiFormRow__labelWrapper"
+      >
         <EuiFormLabel
           htmlFor="generated-id"
           isFocused={false}
@@ -367,11 +469,15 @@ exports[`EuiFormRow props label append is rendered 1`] = `
       append
     </EuiFlexItem>
   </EuiFlexGroup>
-  <input
-    id="generated-id"
-    onBlur={[Function]}
-    onFocus={[Function]}
-  />
+  <div
+    className="euiFormRow__fieldWrapper"
+  >
+    <input
+      id="generated-id"
+      onBlur={[Function]}
+      onFocus={[Function]}
+    />
+  </div>
 </div>
 `;
 
@@ -380,7 +486,9 @@ exports[`EuiFormRow props label is rendered 1`] = `
   className="euiFormRow"
   id="generated-id-row"
 >
-  <div>
+  <div
+    className="euiFormRow__labelWrapper"
+  >
     <EuiFormLabel
       htmlFor="generated-id"
       isFocused={false}
@@ -389,11 +497,15 @@ exports[`EuiFormRow props label is rendered 1`] = `
       label
     </EuiFormLabel>
   </div>
-  <input
-    id="generated-id"
-    onBlur={[Function]}
-    onFocus={[Function]}
-  />
+  <div
+    className="euiFormRow__fieldWrapper"
+  >
+    <input
+      id="generated-id"
+      onBlur={[Function]}
+      onFocus={[Function]}
+    />
+  </div>
 </div>
 `;
 
@@ -403,7 +515,9 @@ exports[`EuiFormRow props label renders as a legend and subsquently a fieldset w
   className="euiFormRow"
   id="generated-id-row"
 >
-  <div>
+  <div
+    className="euiFormRow__labelWrapper"
+  >
     <EuiFormLabel
       id="generated-id-legend"
       isFocused={false}
@@ -412,10 +526,14 @@ exports[`EuiFormRow props label renders as a legend and subsquently a fieldset w
       label
     </EuiFormLabel>
   </div>
-  <input
-    id="generated-id"
-    onBlur={[Function]}
-    onFocus={[Function]}
-  />
+  <div
+    className="euiFormRow__fieldWrapper"
+  >
+    <input
+      id="generated-id"
+      onBlur={[Function]}
+      onFocus={[Function]}
+    />
+  </div>
 </fieldset>
 `;

--- a/src/components/form/form_row/__snapshots__/form_row.test.js.snap
+++ b/src/components/form/form_row/__snapshots__/form_row.test.js.snap
@@ -3,6 +3,7 @@
 exports[`EuiFormRow behavior onBlur is called in child 1`] = `
 <EuiFormRow
   describedByIds={Array []}
+  display="default"
   fullWidth={false}
   hasEmptyLabelSpace={false}
   label={
@@ -51,6 +52,7 @@ exports[`EuiFormRow behavior onBlur is called in child 1`] = `
 exports[`EuiFormRow behavior onBlur works in parent even if not in child 1`] = `
 <EuiFormRow
   describedByIds={Array []}
+  display="default"
   fullWidth={false}
   hasEmptyLabelSpace={false}
   label={
@@ -99,6 +101,7 @@ exports[`EuiFormRow behavior onBlur works in parent even if not in child 1`] = `
 exports[`EuiFormRow behavior onFocus is called in child 1`] = `
 <EuiFormRow
   describedByIds={Array []}
+  display="default"
   fullWidth={false}
   hasEmptyLabelSpace={false}
   label={
@@ -147,6 +150,7 @@ exports[`EuiFormRow behavior onFocus is called in child 1`] = `
 exports[`EuiFormRow behavior onFocus works in parent even if not in child 1`] = `
 <EuiFormRow
   describedByIds={Array []}
+  display="default"
   fullWidth={false}
   hasEmptyLabelSpace={false}
   label={
@@ -209,21 +213,6 @@ exports[`EuiFormRow is rendered 1`] = `
 </div>
 `;
 
-exports[`EuiFormRow props compressed horizontally is rendered 1`] = `
-<div
-  class="euiFormRow euiFormRow--compressed euiFormRow--horizontal"
-  id="generated-id-row"
->
-  <div
-    class="euiFormRow__fieldWrapper"
-  >
-    <input
-      id="generated-id"
-    />
-  </div>
-</div>
-`;
-
 exports[`EuiFormRow props compressed is rendered 1`] = `
 <div
   class="euiFormRow euiFormRow--compressed"
@@ -252,6 +241,51 @@ exports[`EuiFormRow props describedByIds is rendered 1`] = `
       id="generated-id"
       onBlur={[Function]}
       onFocus={[Function]}
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiFormRow props display type compressed is rendered 1`] = `
+<div
+  class="euiFormRow euiFormRow--compressed"
+  id="generated-id-row"
+>
+  <div
+    class="euiFormRow__fieldWrapper"
+  >
+    <input
+      id="generated-id"
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiFormRow props display type compressedHorizontal is rendered 1`] = `
+<div
+  class="euiFormRow euiFormRow--compressed euiFormRow--horizontal"
+  id="generated-id-row"
+>
+  <div
+    class="euiFormRow__fieldWrapper"
+  >
+    <input
+      id="generated-id"
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiFormRow props display type default is rendered 1`] = `
+<div
+  class="euiFormRow"
+  id="generated-id-row"
+>
+  <div
+    class="euiFormRow__fieldWrapper"
+  >
+    <input
+      id="generated-id"
     />
   </div>
 </div>

--- a/src/components/form/form_row/__snapshots__/form_row.test.js.snap
+++ b/src/components/form/form_row/__snapshots__/form_row.test.js.snap
@@ -20,12 +20,13 @@ exports[`EuiFormRow behavior onBlur is called in child 1`] = `
       className="euiFormRow__labelWrapper"
     >
       <EuiFormLabel
+        className="euiFormRow__label"
         htmlFor="generated-id"
         isFocused={false}
         type="label"
       >
         <label
-          className="euiFormLabel"
+          className="euiFormLabel euiFormRow__label"
           htmlFor="generated-id"
         >
           <span>
@@ -67,12 +68,13 @@ exports[`EuiFormRow behavior onBlur works in parent even if not in child 1`] = `
       className="euiFormRow__labelWrapper"
     >
       <EuiFormLabel
+        className="euiFormRow__label"
         htmlFor="generated-id"
         isFocused={false}
         type="label"
       >
         <label
-          className="euiFormLabel"
+          className="euiFormLabel euiFormRow__label"
           htmlFor="generated-id"
         >
           <span>
@@ -114,12 +116,13 @@ exports[`EuiFormRow behavior onFocus is called in child 1`] = `
       className="euiFormRow__labelWrapper"
     >
       <EuiFormLabel
+        className="euiFormRow__label"
         htmlFor="generated-id"
         isFocused={true}
         type="label"
       >
         <label
-          className="euiFormLabel euiFormLabel-isFocused"
+          className="euiFormLabel euiFormRow__label euiFormLabel-isFocused"
           htmlFor="generated-id"
         >
           <span>
@@ -161,12 +164,13 @@ exports[`EuiFormRow behavior onFocus works in parent even if not in child 1`] = 
       className="euiFormRow__labelWrapper"
     >
       <EuiFormLabel
+        className="euiFormRow__label"
         htmlFor="generated-id"
         isFocused={true}
         type="label"
       >
         <label
-          className="euiFormLabel euiFormLabel-isFocused"
+          className="euiFormLabel euiFormRow__label euiFormLabel-isFocused"
           htmlFor="generated-id"
         >
           <span>
@@ -421,7 +425,7 @@ exports[`EuiFormRow props isInvalid is rendered 1`] = `
   >
     <label
       aria-invalid="true"
-      class="euiFormLabel euiFormLabel-isInvalid"
+      class="euiFormLabel euiFormRow__label euiFormLabel-isInvalid"
       for="generated-id"
     >
       label
@@ -446,6 +450,7 @@ exports[`EuiFormRow props label append is rendered 1`] = `
     className="euiFormRow__labelWrapper"
   >
     <EuiFormLabel
+      className="euiFormRow__label"
       htmlFor="generated-id"
       isFocused={false}
       type="label"
@@ -476,6 +481,7 @@ exports[`EuiFormRow props label is rendered 1`] = `
     className="euiFormRow__labelWrapper"
   >
     <EuiFormLabel
+      className="euiFormRow__label"
       htmlFor="generated-id"
       isFocused={false}
       type="label"
@@ -505,6 +511,7 @@ exports[`EuiFormRow props label renders as a legend and subsquently a fieldset w
     className="euiFormRow__labelWrapper"
   >
     <EuiFormLabel
+      className="euiFormRow__label"
       id="generated-id-legend"
       isFocused={false}
       type="legend"

--- a/src/components/form/form_row/__snapshots__/form_row.test.js.snap
+++ b/src/components/form/form_row/__snapshots__/form_row.test.js.snap
@@ -3,7 +3,7 @@
 exports[`EuiFormRow behavior onBlur is called in child 1`] = `
 <EuiFormRow
   describedByIds={Array []}
-  display="default"
+  display="row"
   fullWidth={false}
   hasEmptyLabelSpace={false}
   label={
@@ -52,7 +52,7 @@ exports[`EuiFormRow behavior onBlur is called in child 1`] = `
 exports[`EuiFormRow behavior onBlur works in parent even if not in child 1`] = `
 <EuiFormRow
   describedByIds={Array []}
-  display="default"
+  display="row"
   fullWidth={false}
   hasEmptyLabelSpace={false}
   label={
@@ -101,7 +101,7 @@ exports[`EuiFormRow behavior onBlur works in parent even if not in child 1`] = `
 exports[`EuiFormRow behavior onFocus is called in child 1`] = `
 <EuiFormRow
   describedByIds={Array []}
-  display="default"
+  display="row"
   fullWidth={false}
   hasEmptyLabelSpace={false}
   label={
@@ -150,7 +150,7 @@ exports[`EuiFormRow behavior onFocus is called in child 1`] = `
 exports[`EuiFormRow behavior onFocus works in parent even if not in child 1`] = `
 <EuiFormRow
   describedByIds={Array []}
-  display="default"
+  display="row"
   fullWidth={false}
   hasEmptyLabelSpace={false}
   label={
@@ -215,7 +215,7 @@ exports[`EuiFormRow is rendered 1`] = `
 
 exports[`EuiFormRow props compressed is rendered 1`] = `
 <div
-  class="euiFormRow euiFormRow--compressed"
+  class="euiFormRow"
   id="generated-id-row"
 >
   <div
@@ -246,22 +246,7 @@ exports[`EuiFormRow props describedByIds is rendered 1`] = `
 </div>
 `;
 
-exports[`EuiFormRow props display type compressed is rendered 1`] = `
-<div
-  class="euiFormRow euiFormRow--compressed"
-  id="generated-id-row"
->
-  <div
-    class="euiFormRow__fieldWrapper"
-  >
-    <input
-      id="generated-id"
-    />
-  </div>
-</div>
-`;
-
-exports[`EuiFormRow props display type compressedHorizontal is rendered 1`] = `
+exports[`EuiFormRow props display type columnCompressed is rendered 1`] = `
 <div
   class="euiFormRow euiFormRow--compressed euiFormRow--horizontal"
   id="generated-id-row"
@@ -276,9 +261,24 @@ exports[`EuiFormRow props display type compressedHorizontal is rendered 1`] = `
 </div>
 `;
 
-exports[`EuiFormRow props display type default is rendered 1`] = `
+exports[`EuiFormRow props display type row is rendered 1`] = `
 <div
   class="euiFormRow"
+  id="generated-id-row"
+>
+  <div
+    class="euiFormRow__fieldWrapper"
+  >
+    <input
+      id="generated-id"
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiFormRow props display type rowCompressed is rendered 1`] = `
+<div
+  class="euiFormRow euiFormRow--compressed"
   id="generated-id-row"
 >
   <div

--- a/src/components/form/form_row/_form_row.scss
+++ b/src/components/form/form_row/_form_row.scss
@@ -18,7 +18,7 @@
 }
 
 .euiFormRow--hasEmptyLabelSpace {
-  margin-top: $euiFontSizeXS + $euiSizeM; /* 2 */
+  margin-top: ($euiFontSizeXS * $euiLineHeight) + $euiSizeXS; /* 2 */
   // the following ensure that contents that aren't inheritly the same height
   // as inputs will align to the vertical center
   min-height: $euiFormControlHeight;
@@ -26,13 +26,18 @@
   justify-content: center;
 }
 
+.euiFormRow__labelWrapper {
+  font-size: 0; // Ensures the wrapper doesn't create extra height
+}
+
 .euiFormRow--horizontal {
   flex-direction: row;
   align-items: stretch;
-  line-height: $euiFormControlHeight; // Lines up label with form control
 
   .euiFormRow__labelWrapper {
     @include euiTextBreakWord;
+    font-size: inherit; // Helps with alignment
+    line-height: $euiFormControlCompressedHeight - 1px; // The 1px less helps the alignment of the text baseline
     hyphens: auto;
     width: calc(33% - #{$euiSizeS});
     margin-right: $euiSizeS;
@@ -44,10 +49,6 @@
 
   .euiFormRow__fieldWrapper {
     width: 67%;
-  }
-
-  &.euiFormRow--compressed {
-    line-height: $euiFormControlCompressedHeight;
   }
 
   + .euiFormRow--horizontal {
@@ -69,7 +70,7 @@
   }
 
   &.euiFormRow--hasEmptyLabelSpace {
-    margin-top: $euiFontSizeXS + $euiSizeS; /* 2 */
+    min-height: $euiFormControlCompressedHeight;
   }
 
   .euiFormRow__displayOnlyWrapper {

--- a/src/components/form/form_row/_form_row.scss
+++ b/src/components/form/form_row/_form_row.scss
@@ -59,7 +59,7 @@
   }
 }
 
-.euiFormRow__displayOnlyWrapper {
+.euiFormRow__fieldWrapperDisplayOnly {
   min-height: $euiFormControlHeight;
   display: flex;
   align-items: center;
@@ -70,7 +70,7 @@
     min-height: $euiFormControlCompressedHeight;
   }
 
-  .euiFormRow__displayOnlyWrapper {
+  .euiFormRow__fieldWrapperDisplayOnly {
     min-height: $euiFormControlCompressedHeight;
   }
 }

--- a/src/components/form/form_row/_form_row.scss
+++ b/src/components/form/form_row/_form_row.scss
@@ -8,7 +8,7 @@
   max-width: $euiFormMaxWidth;
   padding-bottom: $euiSizeS;
 
-  + * {
+  + .euiFormRow {
     margin-top: $euiSize;
   }
 }
@@ -29,12 +29,37 @@
 .euiFormRow--compressed {
   padding-bottom: 0;
 
-  + * {
-    margin-top: $euiSizeS;
-  }
-
   .euiFormRow__text {
     padding-top: $euiSizeM / 2;
+  }
+}
+
+.euiFormRow--horizontal {
+  flex-direction: row;
+  align-items: stretch;
+  line-height: $euiFormControlHeight; // Lines up label with form control
+
+  .euiFormRow__labelWrapper {
+    @include euiTextBreakWord;
+    hyphens: auto;
+    width: calc(33% - #{$euiSizeS});
+    margin-right: $euiSizeS;
+  }
+
+  .euiFormLabel {
+    margin-bottom: 0;
+  }
+
+  .euiFormRow__fieldWrapper {
+    width: 67%;
+  }
+
+  &.euiFormRow--compressed {
+    line-height: $euiFormControlCompressedHeight;
+  }
+
+  + .euiFormRow--horizontal {
+    margin-top: $euiSizeS;
   }
 }
 

--- a/src/components/form/form_row/_form_row.scss
+++ b/src/components/form/form_row/_form_row.scss
@@ -18,20 +18,12 @@
 }
 
 .euiFormRow--hasEmptyLabelSpace {
-  margin-top: $euiFontSizeXS + $euiSizeS; /* 2 */
+  margin-top: $euiFontSizeXS + $euiSizeM; /* 2 */
   // the following ensure that contents that aren't inheritly the same height
   // as inputs will align to the vertical center
-  min-height: $euiSizeXXL;
+  min-height: $euiFormControlHeight;
   padding-bottom: 0;
   justify-content: center;
-}
-
-.euiFormRow--compressed {
-  padding-bottom: 0;
-
-  .euiFormRow__text {
-    padding-top: $euiSizeM / 2;
-  }
 }
 
 .euiFormRow--horizontal {
@@ -67,4 +59,20 @@
   min-height: $euiFormControlHeight;
   display: flex;
   align-items: center;
+}
+
+.euiFormRow--compressed {
+  padding-bottom: 0;
+
+  .euiFormRow__text {
+    padding-top: $euiSizeM / 2;
+  }
+
+  &.euiFormRow--hasEmptyLabelSpace {
+    margin-top: $euiFontSizeXS + $euiSizeS; /* 2 */
+  }
+
+  .euiFormRow__displayOnlyWrapper {
+    min-height: $euiFormControlCompressedHeight;
+  }
 }

--- a/src/components/form/form_row/_form_row.scss
+++ b/src/components/form/form_row/_form_row.scss
@@ -36,11 +36,15 @@
   flex-direction: row;
   align-items: stretch;
 
-  .euiFormRow__labelWrapper {
+  .euiFormRow__label {
     @include euiTextBreakWord;
+    hyphens: auto;
+    max-width: 100%; // Fixes IE
+  }
+
+  .euiFormRow__labelWrapper {
     display: block;
     line-height: $euiFormControlCompressedHeight - 1px; // The 1px less helps the alignment of the text baseline
-    hyphens: auto;
     width: calc(33% - #{$euiSizeS});
     margin-right: $euiSizeS;
     margin-bottom: 0;

--- a/src/components/form/form_row/_form_row.scss
+++ b/src/components/form/form_row/_form_row.scss
@@ -6,7 +6,6 @@
   display: flex; /* 1 */
   flex-direction: column; /* 1 */
   max-width: $euiFormMaxWidth;
-  padding-bottom: $euiSizeS;
 
   + .euiFormRow {
     margin-top: $euiSize;
@@ -27,7 +26,10 @@
 }
 
 .euiFormRow__labelWrapper {
-  font-size: 0; // Ensures the wrapper doesn't create extra height
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  margin-bottom: $euiSizeXS;
 }
 
 .euiFormRow--horizontal {
@@ -36,14 +38,11 @@
 
   .euiFormRow__labelWrapper {
     @include euiTextBreakWord;
-    font-size: inherit; // Helps with alignment
+    display: block;
     line-height: $euiFormControlCompressedHeight - 1px; // The 1px less helps the alignment of the text baseline
     hyphens: auto;
     width: calc(33% - #{$euiSizeS});
     margin-right: $euiSizeS;
-  }
-
-  .euiFormLabel {
     margin-bottom: 0;
   }
 
@@ -63,12 +62,6 @@
 }
 
 .euiFormRow--compressed {
-  padding-bottom: 0;
-
-  .euiFormRow__text {
-    padding-top: $euiSizeM / 2;
-  }
-
   &.euiFormRow--hasEmptyLabelSpace {
     min-height: $euiFormControlCompressedHeight;
   }

--- a/src/components/form/form_row/_form_row.scss
+++ b/src/components/form/form_row/_form_row.scss
@@ -27,6 +27,8 @@
 }
 
 .euiFormRow--compressed {
+  padding-bottom: 0;
+
   + * {
     margin-top: $euiSizeS;
   }

--- a/src/components/form/form_row/form_row.js
+++ b/src/components/form/form_row/form_row.js
@@ -8,7 +8,6 @@ import { withRequiredProp } from '../../../utils/prop_types/with_required_prop';
 import { EuiFormHelpText } from '../form_help_text';
 import { EuiFormErrorText } from '../form_error_text';
 import { EuiFormLabel } from '../form_label';
-import { EuiFlexGroup, EuiFlexItem } from '../../flex';
 
 import makeId from './make_id';
 
@@ -111,9 +110,8 @@ export class EuiFormRow extends Component {
     const isLegend = label && labelType === 'legend' ? true : false;
     const labelID = isLegend ? `${id}-${labelType}` : undefined;
 
-    if (label) {
+    if (label || labelAppend) {
       optionalLabel = (
-        // Outer div ensures the label is inline-block (only takes up as much room as it needs)
         <div className="euiFormRow__labelWrapper">
           <EuiFormLabel
             isFocused={!isLegend && this.state.isFocused}
@@ -124,20 +122,9 @@ export class EuiFormRow extends Component {
             id={labelID}>
             {label}
           </EuiFormLabel>
+          {labelAppend && ' '}
+          {labelAppend}
         </div>
-      );
-    }
-
-    if (labelAppend) {
-      optionalLabel = (
-        <EuiFlexGroup
-          responsive={false}
-          wrap={true}
-          gutterSize="xs"
-          justifyContent="spaceBetween">
-          <EuiFlexItem grow={false}>{optionalLabel}</EuiFlexItem>
-          <EuiFlexItem grow={false}>{labelAppend}</EuiFlexItem>
-        </EuiFlexGroup>
       );
     }
 

--- a/src/components/form/form_row/form_row.js
+++ b/src/components/form/form_row/form_row.js
@@ -12,9 +12,9 @@ import { EuiFormLabel } from '../form_label';
 import makeId from './make_id';
 
 const displayToClassNameMap = {
-  default: null,
-  compressed: 'euiFormRow--compressed',
-  compressedHorizontal: 'euiFormRow--compressed euiFormRow--horizontal',
+  row: null,
+  rowCompressed: 'euiFormRow--compressed',
+  columnCompressed: 'euiFormRow--compressed euiFormRow--horizontal',
 };
 
 export const DISPLAYS = Object.keys(displayToClassNameMap);
@@ -225,13 +225,12 @@ EuiFormRow.propTypes = {
   describedByIds: PropTypes.array,
   /**
    * **SET FOR DEPRECATION**
-   * When `true`, tightens up the spacing and sends down the
-   * compressed prop to the input;
+   * When `true`, tightens up the spacing.
    */
   compressed: PropTypes.bool,
   /**
-   * When `compressed`, tightens up the spacing and sends down the
-   * compressed prop to the input; Set to `'compressedHorizontal'` if compressed
+   * When `rowCompressed`, just tightens up the spacing;
+   * Set to `columnCompressed` if compressed
    * and horizontal layout is needed.
    */
   display: PropTypes.oneOf(DISPLAYS),
@@ -243,7 +242,7 @@ EuiFormRow.propTypes = {
 };
 
 EuiFormRow.defaultProps = {
-  display: 'default',
+  display: 'row',
   hasEmptyLabelSpace: false,
   fullWidth: false,
   describedByIds: [],

--- a/src/components/form/form_row/form_row.js
+++ b/src/components/form/form_row/form_row.js
@@ -75,6 +75,7 @@ export class EuiFormRow extends Component {
         'euiFormRow--hasEmptyLabelSpace': hasEmptyLabelSpace,
         'euiFormRow--fullWidth': fullWidth,
         'euiFormRow--compressed': compressed,
+        'euiFormRow--horizontal': compressed === 'horizontal',
       },
       className
     );
@@ -113,7 +114,7 @@ export class EuiFormRow extends Component {
     if (label) {
       optionalLabel = (
         // Outer div ensures the label is inline-block (only takes up as much room as it needs)
-        <div>
+        <div className="euiFormRow__labelWrapper">
           <EuiFormLabel
             isFocused={!isLegend && this.state.isFocused}
             isInvalid={isInvalid}
@@ -159,7 +160,6 @@ export class EuiFormRow extends Component {
       id,
       onFocus: this.onFocus,
       onBlur: this.onBlur,
-      compressed: compressed,
       ...optionalProps,
     });
 
@@ -177,9 +177,11 @@ export class EuiFormRow extends Component {
         aria-labelledby={labelID} // Only renders a string if label type is 'legend'
       >
         {optionalLabel}
-        {field}
-        {optionalErrors}
-        {optionalHelpText}
+        <div className="euiFormRow__fieldWrapper">
+          {field}
+          {optionalErrors}
+          {optionalHelpText}
+        </div>
       </Element>
     );
   }
@@ -222,7 +224,7 @@ EuiFormRow.propTypes = {
    * Tightens up the spacing and sends down the
    * compressed prop to the input
    */
-  compressed: PropTypes.bool,
+  compressed: PropTypes.oneOf([true, false, 'horizontal']),
   /**
    * Vertically centers non-input style content so it aligns
    * better with input style content.

--- a/src/components/form/form_row/form_row.js
+++ b/src/components/form/form_row/form_row.js
@@ -114,6 +114,7 @@ export class EuiFormRow extends Component {
       optionalLabel = (
         <div className="euiFormRow__labelWrapper">
           <EuiFormLabel
+            className="euiFormRow__label"
             isFocused={!isLegend && this.state.isFocused}
             isInvalid={isInvalid}
             aria-invalid={isInvalid}
@@ -208,8 +209,9 @@ EuiFormRow.propTypes = {
    */
   describedByIds: PropTypes.array,
   /**
-   * Tightens up the spacing and sends down the
-   * compressed prop to the input
+   * When `true`, tightens up the spacing and sends down the
+   * compressed prop to the input; Set to `'horizontal'` if compressed
+   * and horizontal layout is needed.
    */
   compressed: PropTypes.oneOf([true, false, 'horizontal']),
   /**

--- a/src/components/form/form_row/form_row.js
+++ b/src/components/form/form_row/form_row.js
@@ -11,6 +11,14 @@ import { EuiFormLabel } from '../form_label';
 
 import makeId from './make_id';
 
+const displayToClassNameMap = {
+  default: null,
+  compressed: 'euiFormRow--compressed',
+  compressedHorizontal: 'euiFormRow--compressed euiFormRow--horizontal',
+};
+
+export const DISPLAYS = Object.keys(displayToClassNameMap);
+
 export class EuiFormRow extends Component {
   constructor(props) {
     super(props);
@@ -62,20 +70,27 @@ export class EuiFormRow extends Component {
       className,
       describedByIds,
       compressed,
+      display,
       displayOnly,
       ...rest
     } = this.props;
 
     const { id } = this.state;
 
+    let shimDisplay;
+    if (compressed && display === 'default') {
+      shimDisplay = 'compressed';
+    } else {
+      shimDisplay = display;
+    }
+
     const classes = classNames(
       'euiFormRow',
       {
         'euiFormRow--hasEmptyLabelSpace': hasEmptyLabelSpace,
         'euiFormRow--fullWidth': fullWidth,
-        'euiFormRow--compressed': compressed,
-        'euiFormRow--horizontal': compressed === 'horizontal',
       },
+      displayToClassNameMap[shimDisplay],
       className
     );
 
@@ -209,11 +224,17 @@ EuiFormRow.propTypes = {
    */
   describedByIds: PropTypes.array,
   /**
+   * **SET FOR DEPRECATION**
    * When `true`, tightens up the spacing and sends down the
-   * compressed prop to the input; Set to `'horizontal'` if compressed
+   * compressed prop to the input;
+   */
+  compressed: PropTypes.bool,
+  /**
+   * When `compressed`, tightens up the spacing and sends down the
+   * compressed prop to the input; Set to `'compressedHorizontal'` if compressed
    * and horizontal layout is needed.
    */
-  compressed: PropTypes.oneOf([true, false, 'horizontal']),
+  display: PropTypes.oneOf(DISPLAYS),
   /**
    * Vertically centers non-input style content so it aligns
    * better with input style content.
@@ -222,6 +243,7 @@ EuiFormRow.propTypes = {
 };
 
 EuiFormRow.defaultProps = {
+  display: 'default',
   hasEmptyLabelSpace: false,
   fullWidth: false,
   describedByIds: [],

--- a/src/components/form/form_row/form_row.js
+++ b/src/components/form/form_row/form_row.js
@@ -15,6 +15,8 @@ const displayToClassNameMap = {
   row: null,
   rowCompressed: 'euiFormRow--compressed',
   columnCompressed: 'euiFormRow--compressed euiFormRow--horizontal',
+  center: null,
+  centerCompressed: 'euiFormRow--compressed',
 };
 
 export const DISPLAYS = Object.keys(displayToClassNameMap);
@@ -77,11 +79,23 @@ export class EuiFormRow extends Component {
 
     const { id } = this.state;
 
+    /**
+     * Remove when `compressed` is deprecated
+     */
     let shimDisplay;
-    if (compressed && display === 'default') {
-      shimDisplay = 'compressed';
+    if (compressed && display === 'row') {
+      shimDisplay = 'rowCompressed';
     } else {
       shimDisplay = display;
+    }
+
+    /**
+     * Remove when `displayOnly` is deprecated
+     */
+    if (compressed && displayOnly) {
+      shimDisplay = 'centerCompressed';
+    } else if (displayOnly && display === 'row') {
+      shimDisplay = 'center';
     }
 
     const classes = classNames(
@@ -159,16 +173,17 @@ export class EuiFormRow extends Component {
       optionalProps['aria-describedby'] = describingIds.join(' ');
     }
 
-    let field = cloneElement(Children.only(children), {
+    const field = cloneElement(Children.only(children), {
       id,
       onFocus: this.onFocus,
       onBlur: this.onBlur,
       ...optionalProps,
     });
 
-    if (displayOnly) {
-      field = <div className="euiFormRow__displayOnlyWrapper">{field}</div>;
-    }
+    const fieldWrapperClasses = classNames('euiFormRow__fieldWrapper', {
+      euiFormRow__fieldWrapperDisplayOnly:
+        displayOnly || display.startsWith('center'),
+    });
 
     const Element = labelType === 'legend' ? 'fieldset' : 'div';
 
@@ -180,7 +195,7 @@ export class EuiFormRow extends Component {
         aria-labelledby={labelID} // Only renders a string if label type is 'legend'
       >
         {optionalLabel}
-        <div className="euiFormRow__fieldWrapper">
+        <div className={fieldWrapperClasses}>
           {field}
           {optionalErrors}
           {optionalHelpText}
@@ -224,7 +239,7 @@ EuiFormRow.propTypes = {
    */
   describedByIds: PropTypes.array,
   /**
-   * **SET FOR DEPRECATION**
+   * **DEPRECATED: use `display: rowCompressed` instead.**
    * When `true`, tightens up the spacing.
    */
   compressed: PropTypes.bool,
@@ -232,9 +247,12 @@ EuiFormRow.propTypes = {
    * When `rowCompressed`, just tightens up the spacing;
    * Set to `columnCompressed` if compressed
    * and horizontal layout is needed.
+   * Set to `center` or `centerCompressed` to align non-input
+   * content better with inline rows.
    */
   display: PropTypes.oneOf(DISPLAYS),
   /**
+   * **DEPRECATED: use `display: center` instead.**
    * Vertically centers non-input style content so it aligns
    * better with input style content.
    */

--- a/src/components/form/form_row/form_row.test.js
+++ b/src/components/form/form_row/form_row.test.js
@@ -200,6 +200,28 @@ describe('EuiFormRow', () => {
 
       expect(component).toMatchSnapshot();
     });
+
+    describe('compressed', () => {
+      test('is rendered', () => {
+        const component = render(
+          <EuiFormRow compressed>
+            <input />
+          </EuiFormRow>
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+
+      test('horizontally is rendered', () => {
+        const component = render(
+          <EuiFormRow compressed="horizontal">
+            <input />
+          </EuiFormRow>
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
   });
 
   describe('behavior', () => {

--- a/src/components/form/form_row/form_row.test.js
+++ b/src/components/form/form_row/form_row.test.js
@@ -3,7 +3,7 @@ import { shallow, render, mount } from 'enzyme';
 import { requiredProps } from '../../../test';
 import sinon from 'sinon';
 
-import { EuiFormRow } from './form_row';
+import { EuiFormRow, DISPLAYS } from './form_row';
 
 jest.mock('./make_id', () => () => 'generated-id');
 
@@ -211,15 +211,19 @@ describe('EuiFormRow', () => {
 
         expect(component).toMatchSnapshot();
       });
+    });
 
-      test('horizontally is rendered', () => {
-        const component = render(
-          <EuiFormRow compressed="horizontal">
-            <input />
-          </EuiFormRow>
-        );
+    describe('display type', () => {
+      DISPLAYS.forEach(display => {
+        test(`${display} is rendered`, () => {
+          const component = render(
+            <EuiFormRow display={display}>
+              <input />
+            </EuiFormRow>
+          );
 
-        expect(component).toMatchSnapshot();
+          expect(component).toMatchSnapshot();
+        });
       });
     });
   });

--- a/src/components/form/form_row/index.d.ts
+++ b/src/components/form/form_row/index.d.ts
@@ -20,7 +20,7 @@ declare module '@elastic/eui' {
     label?: ReactNode;
     labelAppend?: ReactNode;
     describedByIds?: string[];
-    compressed?: boolean;
+    compressed?: boolean | 'horizontal';
     displayOnly?: boolean;
   };
 

--- a/src/components/form/form_row/index.d.ts
+++ b/src/components/form/form_row/index.d.ts
@@ -20,7 +20,8 @@ declare module '@elastic/eui' {
     label?: ReactNode;
     labelAppend?: ReactNode;
     describedByIds?: string[];
-    compressed?: boolean | 'horizontal';
+    compressed?: boolean;
+    display?: 'row' | 'rowCompressed' | 'columnCompressed';
     displayOnly?: boolean;
   };
 

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -138,7 +138,7 @@
 }
 
 .euiTableCellContent__text {
-  @include euiTextOverflowWrap; /* 4 */
+  @include euiTextBreakWord; /* 4 */
   min-width: 0;
   text-overflow: ellipsis;
 }

--- a/src/global_styling/mixins/_typography.scss
+++ b/src/global_styling/mixins/_typography.scss
@@ -1,4 +1,5 @@
 // sass-lint:disable no-vendor-prefixes
+// sass-lint:disable no-important
 
 // Our base fonts
 
@@ -96,13 +97,11 @@
   letter-spacing: -.03em;
 }
 
-// Overflow-wrap for breaking on word
-// Does not work on `display: flex` items
-@mixin euiTextOverflowWrap  {
-  @include internetExplorerOnly {
-    word-break: break-all;
-  }
-  overflow-wrap: break-word;
+@mixin euiTextBreakWord {
+  // https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/
+  overflow-wrap: break-word !important; // makes sure the long string will wrap and not bust out of the container
+  word-wrap: break-word !important; // spec says, they are literally just alternate names for each other but some browsers support one and not the other
+  word-break: break-word; // IE doesn't understand but that's ok
 }
 
 // Text truncation

--- a/src/global_styling/utility/_utility.scss
+++ b/src/global_styling/utility/_utility.scss
@@ -25,10 +25,7 @@
 .eui-textInheritColor {color: inherit !important;}
 
 .eui-textBreakWord {
-  // https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/
-  overflow-wrap: break-word !important; // makes sure the long string will wrap and not bust out of the container
-  word-wrap: break-word !important; // spec says, they are literally just alternate names for each other but some browsers support one and not the other
-  word-break: break-word; // IE doesn't understand but that's ok
+  @include euiTextBreakWord;
 }
 
 .eui-textBreakAll {


### PR DESCRIPTION
### feature/compressed-editor-controls

## Better spacing and alignment for EuiFormRow

### 1. Reduces padding, margins, etc when EuiFormRow is `compressed`

For both compressed and non-compressed, I [reduced the spacing between the form control and the help text below](https://github.com/elastic/eui/compare/feature/compressed-editor-controls...cchaos:into-feature/compressed-form-rows?expand=1#diff-3ddcbdd2ac6fda914a0ec0d93f1c794fR3) to be the same amount used for the form label. This condenses that space a bit but creates a clearer connection between the elements.

### 2. Adds `display="compressedHorizontal"` option for EuiFormRow

To allow laying out the label and control on the same line.

<img width="289" alt="Screen Shot 2019-07-30 at 18 14 17 PM" src="https://user-images.githubusercontent.com/549577/62169292-df06b080-b2f5-11e9-932f-4661f6c9294c.png">

I applied this as an option to the `compressed` prop because it should really only be used in conjunction with compressed controls. And while we can't know for sure if they're also passing a compressed control as the child, making this an option under the prop name "compressed" may deter people from using it outside of a compressed form.

### 3. Removed EuiFlexGroup dependency for label appends

And instead just [writing out the flex styles directly](https://github.com/elastic/eui/compare/feature/compressed-editor-controls...cchaos:into-feature/compressed-form-rows?expand=1#diff-ea77b7a95b86eb73bc5d79e4e49ec0fcR29). This also allowed for better calculation of spacing.

## Breaking

There are several "breaks" in this PR:

1. EuiFormRow no longer has bottom padding, nor does it add margin to **any** `+ *` siblings. Instead, it only [adds top margin to siblings of the same type](https://github.com/elastic/eui/compare/feature/compressed-editor-controls...cchaos:into-feature/compressed-form-rows?expand=1#diff-ea77b7a95b86eb73bc5d79e4e49ec0fcR10) `.euiFormRow + .euiFormRow` This means if layouts relied on margin being added to non-form row children, they'll need spacers added.

So you'll see a lot of `<EuiSpacer />` additions to files. I think this is a better approach as you never truly know what that universal selector will be attaching margins to. However, if someone feels **strongly** that we should not introduce a break like this, I should be able to easily revert.

2. [EuiFormRow no longer passes `compressed` down to its children](https://github.com/elastic/eui/compare/feature/compressed-editor-controls...cchaos:into-feature/compressed-form-rows?expand=1#diff-6dbd1b6e6d57ce4fe0ce8bbe47c1bb4dL162). This was not correct anyway but React wasn't complaining because the prop was fully lowercase. If the child didn't have a prop called `compressed` it was being passed down as an html attribute like `<input compressed />` which is invalid.

I finally removed this because it was causing an error when I added the third option of `horizontal`.

3. [Removed bottom margin from EuiFormLabel](https://github.com/elastic/eui/compare/feature/compressed-editor-controls...cchaos:into-feature/compressed-form-rows?expand=1#diff-1b63d85dbe95c25360dec47b45be6980L7), but added it back to the wrapping element inside of the EuiFormRow so there's still margin but just not on the plain element.

This means if anyone used EuiFormLabel by itself and relied on that margin, they'd need to add a spacer.

## Deprecations

1. EuiFormRow's `compressed` prop is now set for deprecation in favor of `display = "compressed"`.
1. EuiFormRow's `displayOnly` prop is now set for deprecation in favor of `display = "center"`.

## Docs

I'll be reverting all but the `Compressed and horizontal` section of the form layout docs

### Checklist

- [x] Checked in **dark mode**
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [x] Props have proper **autodocs**
- [x] Added **documentation** examples
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~ Will be adde via the feature branch
