### PR TITLE
Update TS error-guard's text to be meaningful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `13.1.0`.
+**Bug fixes**
+
+- Fixed error message when an I18n mapping is a formatting function with no values provided. ([#2182](https://github.com/elastic/eui/pull/2182))
 
 ## [`13.1.0`](https://github.com/elastic/eui/tree/v13.1.0)
 

--- a/src/components/i18n/i18n.tsx
+++ b/src/components/i18n/i18n.tsx
@@ -4,8 +4,10 @@ import { ExclusiveUnion } from '../common';
 import { I18nShape, Renderable, RenderableValues } from '../context/context';
 import { processStringToChildren } from './i18n_util';
 
-function throwError(): never {
-  throw new Error('asdf');
+function errorOnMissingValues(token: string): never {
+  throw new Error(
+    `I18n mapping for token "${token}" is a formatting function but no values were provided.`
+  );
 }
 
 function lookupToken<
@@ -23,7 +25,7 @@ function lookupToken<
 
   if (typeof renderable === 'function') {
     if (values === undefined) {
-      return throwError();
+      return errorOnMissingValues(token);
     } else {
       // @ts-ignore-next-line
       // TypeScript complains that `DEFAULT` doesn't have a call signature

--- a/src/components/stat/stat.tsx
+++ b/src/components/stat/stat.tsx
@@ -98,10 +98,7 @@ export const EuiStat: FunctionComponent<
   let titleText;
   if (isLoading) {
     titleText = (
-      // EuiI18n has trouble with the string setting
-      // @ts-ignore
       <EuiI18n token="euiStat.loadingText" default="Statistic is loading">
-        {/* // @ts-ignore */}
         {(loadingText: string) => <p aria-label={loadingText}>--</p>}
       </EuiI18n>
     );


### PR DESCRIPTION
### Summary

Provides a better error message when an i18n mapping is defined as a formatting function but no values were provided.

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
