### PR TITLE
Add pagination to EuiDataGrid

### DIFF
--- a/src-docs/src/views/datagrid/datagrid.js
+++ b/src-docs/src/views/datagrid/datagrid.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 
 import { EuiDataGrid } from '../../../../src/components/';
 
@@ -140,16 +140,43 @@ const data = [
   },
 ];
 
-export default () => {
-  return (
-    <div>
-      <EuiDataGrid
-        columns={columns}
-        rowCount={data.length}
-        renderCellValue={({ rowIndex, columnName }) =>
-          data[rowIndex][columnName]
-        }
-      />
-    </div>
-  );
-};
+export default class DataGrid extends Component {
+  state = {
+    pagination: {
+      pageIndex: 0,
+      pageSize: 10,
+    },
+  };
+
+  setPageIndex = pageIndex =>
+    this.setState(({ pagination }) => ({
+      pagination: { ...pagination, pageIndex },
+    }));
+
+  setPageSize = pageSize =>
+    this.setState(({ pagination }) => ({
+      pagination: { ...pagination, pageSize },
+    }));
+
+  render() {
+    const { pagination } = this.state;
+
+    return (
+      <div>
+        <EuiDataGrid
+          columns={columns}
+          rowCount={data.length}
+          renderCellValue={({ rowIndex, columnName }) =>
+            data[rowIndex][columnName]
+          }
+          pagination={{
+            ...pagination,
+            pageSizeOptions: [5, 10, 25],
+            onChangeItemsPerPage: this.setPageSize,
+            onChangePage: this.setPageIndex,
+          }}
+        />
+      </div>
+    );
+  }
+}

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.js.snap
@@ -319,6 +319,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                       button={
                         <EuiButtonEmpty
                           color="text"
+                          data-test-subj="tablePaginationPopoverButton"
                           iconSide="right"
                           iconType="arrowDown"
                           onClick={[Function]}
@@ -360,6 +361,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                           >
                             <EuiButtonEmpty
                               color="text"
+                              data-test-subj="tablePaginationPopoverButton"
                               iconSide="right"
                               iconType="arrowDown"
                               onClick={[Function]}
@@ -368,6 +370,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                             >
                               <button
                                 className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--iconRight"
+                                data-test-subj="tablePaginationPopoverButton"
                                 onClick={[Function]}
                                 type="button"
                               >

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -125,98 +125,105 @@ exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
   data-test-subj="test subject string"
 >
   <div
-    class="euiDataGridHeader"
-    data-test-subj="dataGridHeader"
+    class="euiDataGrid__content"
   >
     <div
-      class="euiDataGridHeaderCell"
-      data-test-subj="dataGridHeaderCell"
-      style="width:100px"
+      class="euiDataGridHeader"
+      data-test-subj="dataGridHeader"
     >
       <div
-        class="euiDataGridColumnResizer"
-        data-test-subj="dataGridColumnResizer"
-        style="margin-right:0px"
-      />
-      <div
-        class="euiDataGridHeaderCell__content"
+        class="euiDataGridHeaderCell"
+        data-test-subj="dataGridHeaderCell"
+        style="width:100px"
       >
-        A
+        <div
+          class="euiDataGridColumnResizer"
+          data-test-subj="dataGridColumnResizer"
+          style="margin-right:0px"
+        />
+        <div
+          class="euiDataGridHeaderCell__content"
+        >
+          A
+        </div>
+      </div>
+      <div
+        class="euiDataGridHeaderCell"
+        data-test-subj="dataGridHeaderCell"
+        style="width:100px"
+      >
+        <div
+          class="euiDataGridColumnResizer"
+          data-test-subj="dataGridColumnResizer"
+          style="margin-right:0px"
+        />
+        <div
+          class="euiDataGridHeaderCell__content"
+        >
+          B
+        </div>
       </div>
     </div>
     <div
-      class="euiDataGridHeaderCell"
-      data-test-subj="dataGridHeaderCell"
-      style="width:100px"
+      class="euiDataGridRow"
+      data-test-subj="dataGridRow"
     >
       <div
-        class="euiDataGridColumnResizer"
-        data-test-subj="dataGridColumnResizer"
-        style="margin-right:0px"
-      />
-      <div
-        class="euiDataGridHeaderCell__content"
+        class="euiDataGridRowCell"
+        data-test-subj="dataGridRowCell"
+        style="width:100px"
       >
-        B
+        0, A
+      </div>
+      <div
+        class="euiDataGridRowCell"
+        data-test-subj="dataGridRowCell"
+        style="width:100px"
+      >
+        0, B
+      </div>
+    </div>
+    <div
+      class="euiDataGridRow"
+      data-test-subj="dataGridRow"
+    >
+      <div
+        class="euiDataGridRowCell"
+        data-test-subj="dataGridRowCell"
+        style="width:100px"
+      >
+        1, A
+      </div>
+      <div
+        class="euiDataGridRowCell"
+        data-test-subj="dataGridRowCell"
+        style="width:100px"
+      >
+        1, B
+      </div>
+    </div>
+    <div
+      class="euiDataGridRow"
+      data-test-subj="dataGridRow"
+    >
+      <div
+        class="euiDataGridRowCell"
+        data-test-subj="dataGridRowCell"
+        style="width:100px"
+      >
+        2, A
+      </div>
+      <div
+        class="euiDataGridRowCell"
+        data-test-subj="dataGridRowCell"
+        style="width:100px"
+      >
+        2, B
       </div>
     </div>
   </div>
   <div
-    class="euiDataGridRow"
-    data-test-subj="dataGridRow"
-  >
-    <div
-      class="euiDataGridRowCell"
-      data-test-subj="dataGridRowCell"
-      style="width:100px"
-    >
-      0, A
-    </div>
-    <div
-      class="euiDataGridRowCell"
-      data-test-subj="dataGridRowCell"
-      style="width:100px"
-    >
-      0, B
-    </div>
-  </div>
-  <div
-    class="euiDataGridRow"
-    data-test-subj="dataGridRow"
-  >
-    <div
-      class="euiDataGridRowCell"
-      data-test-subj="dataGridRowCell"
-      style="width:100px"
-    >
-      1, A
-    </div>
-    <div
-      class="euiDataGridRowCell"
-      data-test-subj="dataGridRowCell"
-      style="width:100px"
-    >
-      1, B
-    </div>
-  </div>
-  <div
-    class="euiDataGridRow"
-    data-test-subj="dataGridRow"
-  >
-    <div
-      class="euiDataGridRowCell"
-      data-test-subj="dataGridRowCell"
-      style="width:100px"
-    >
-      2, A
-    </div>
-    <div
-      class="euiDataGridRowCell"
-      data-test-subj="dataGridRowCell"
-      style="width:100px"
-    >
-      2, B
-    </div>
-  </div>
+    class="euiSpacer euiSpacer--s"
+  />
 </div>
 `;

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -1,5 +1,123 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiDataGrid pagination renders 1`] = `
+<div
+  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+>
+  <div
+    class="euiFlexItem euiFlexItem--flexGrowZero"
+  >
+    <div
+      class="euiPopover euiPopover--anchorUpRight euiPopover--withTitle"
+      id="customizablePagination"
+    >
+      <div
+        class="euiPopover__anchor"
+      >
+        <button
+          class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--iconRight"
+          data-test-subj="tablePaginationPopoverButton"
+          type="button"
+        >
+          <span
+            class="euiButtonEmpty__content"
+          >
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiIcon-isLoading euiButtonEmpty__icon"
+              focusable="false"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            />
+            <span
+              class="euiButtonEmpty__text"
+            >
+              Rows per page: 6
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiFlexItem euiFlexItem--flexGrowZero"
+  >
+    <div
+      class="euiPagination"
+      role="group"
+    >
+      <button
+        aria-label="Previous page"
+        class="euiButtonIcon euiButtonIcon--text"
+        data-test-subj="pagination-button-previous"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiIcon-isLoading euiButtonIcon__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+      </button>
+      <button
+        aria-label="Page 1 of 2"
+        class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiPaginationButton euiPaginationButton--hideOnMobile"
+        data-test-subj="pagination-button-0"
+        type="button"
+      >
+        <span
+          class="euiButtonEmpty__content"
+        >
+          <span
+            class="euiButtonEmpty__text"
+          >
+            1
+          </span>
+        </span>
+      </button>
+      <button
+        aria-label="Page 2 of 2"
+        class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+        data-test-subj="pagination-button-1"
+        type="button"
+      >
+        <span
+          class="euiButtonEmpty__content"
+        >
+          <span
+            class="euiButtonEmpty__text"
+          >
+            2
+          </span>
+        </span>
+      </button>
+      <button
+        aria-label="Next page"
+        class="euiButtonIcon euiButtonIcon--text"
+        data-test-subj="pagination-button-next"
+        disabled=""
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiIcon-isLoading euiButtonIcon__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
 <div
   aria-label="aria-label"

--- a/src/components/datagrid/_data_grid.scss
+++ b/src/components/datagrid/_data_grid.scss
@@ -1,4 +1,4 @@
-.euiDataGrid {
+.euiDataGrid__content {
   @include euiScrollBar;
   font-feature-settings: 'tnum' 1; // Tabular numbers
   overflow-x: auto;

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from 'react';
 import { mount, ReactWrapper, render } from 'enzyme';
 import { EuiDataGrid } from './';
-import { findTestSubject, requiredProps } from '../../test';
+import {
+  findTestSubject,
+  requiredProps,
+  takeMountedSnapshot,
+} from '../../test';
 import { EuiDataGridColumnResizer } from './data_grid_column_resizer';
 
 function extractGridData(datagrid: ReactWrapper) {
@@ -75,6 +79,205 @@ Array [
   ],
 ]
 `);
+    });
+  });
+
+  describe('pagination', () => {
+    it('renders', () => {
+      const component = mount(
+        <EuiDataGrid
+          columns={[{ name: 'Column' }]}
+          rowCount={10}
+          renderCellValue={({ rowIndex }) => rowIndex}
+          pagination={{
+            pageIndex: 1,
+            pageSize: 6,
+            pageSizeOptions: [3, 6, 10],
+            onChangePage: () => {},
+            onChangeItemsPerPage: () => {},
+          }}
+        />
+      );
+
+      expect(
+        takeMountedSnapshot(component.find('EuiTablePagination'))
+      ).toMatchSnapshot();
+    });
+
+    describe('page navigation', () => {
+      it('next button pages through content', () => {
+        const component = mount(
+          <EuiDataGrid
+            columns={[{ name: 'Column' }]}
+            rowCount={8}
+            renderCellValue={({ rowIndex }) => rowIndex}
+            pagination={{
+              pageIndex: 0,
+              pageSize: 3,
+              pageSizeOptions: [3, 6, 10],
+              onChangePage: jest.fn(pageIndex => {
+                const pagination = component.props().pagination;
+                component.setProps({
+                  pagination: { ...pagination, pageIndex },
+                });
+              }),
+              onChangeItemsPerPage: jest.fn(),
+            }}
+          />
+        );
+
+        expect(extractGridData(component)).toEqual([
+          ['Column'],
+          ['0'],
+          ['1'],
+          ['2'],
+        ]);
+
+        findTestSubject(component, 'pagination-button-next').simulate('click');
+
+        expect(component.props().pagination.onChangePage).toHaveBeenCalledTimes(
+          1
+        );
+        const firstCallPageIndex = component.props().pagination.onChangePage
+          .mock.calls[0][0];
+        expect(firstCallPageIndex).toBe(1);
+
+        expect(extractGridData(component)).toEqual([
+          ['Column'],
+          ['3'],
+          ['4'],
+          ['5'],
+        ]);
+
+        findTestSubject(component, 'pagination-button-next').simulate('click');
+
+        expect(component.props().pagination.onChangePage).toHaveBeenCalledTimes(
+          2
+        );
+        const secondCallPageIndex = component.props().pagination.onChangePage
+          .mock.calls[1][0];
+        expect(secondCallPageIndex).toBe(2);
+
+        expect(extractGridData(component)).toEqual([['Column'], ['6'], ['7']]);
+      });
+
+      it('pages are navigatable through page links', () => {
+        const component = mount(
+          <EuiDataGrid
+            columns={[{ name: 'Column' }]}
+            rowCount={8}
+            renderCellValue={({ rowIndex }) => rowIndex}
+            pagination={{
+              pageIndex: 0,
+              pageSize: 3,
+              pageSizeOptions: [3, 6, 10],
+              onChangePage: jest.fn(pageIndex => {
+                const pagination = component.props().pagination;
+                component.setProps({
+                  pagination: { ...pagination, pageIndex },
+                });
+              }),
+              onChangeItemsPerPage: jest.fn(),
+            }}
+          />
+        );
+
+        expect(extractGridData(component)).toEqual([
+          ['Column'],
+          ['0'],
+          ['1'],
+          ['2'],
+        ]);
+
+        // goto page 3
+        findTestSubject(component, 'pagination-button-2').simulate('click');
+
+        expect(component.props().pagination.onChangePage).toHaveBeenCalledTimes(
+          1
+        );
+        const firstCallPageIndex = component.props().pagination.onChangePage
+          .mock.calls[0][0];
+        expect(firstCallPageIndex).toBe(2);
+
+        expect(extractGridData(component)).toEqual([['Column'], ['6'], ['7']]);
+
+        // goto page 2
+        findTestSubject(component, 'pagination-button-1').simulate('click');
+
+        expect(component.props().pagination.onChangePage).toHaveBeenCalledTimes(
+          2
+        );
+        const secondCallPageIndex = component.props().pagination.onChangePage
+          .mock.calls[1][0];
+        expect(secondCallPageIndex).toBe(1);
+
+        expect(extractGridData(component)).toEqual([
+          ['Column'],
+          ['3'],
+          ['4'],
+          ['5'],
+        ]);
+      });
+    });
+
+    it('changes the page size', () => {
+      const component = mount(
+        <EuiDataGrid
+          columns={[{ name: 'Column' }]}
+          rowCount={8}
+          renderCellValue={({ rowIndex }) => rowIndex}
+          pagination={{
+            pageIndex: 0,
+            pageSize: 3,
+            pageSizeOptions: [3, 6, 10],
+            onChangePage: jest.fn(),
+            onChangeItemsPerPage: jest.fn(pageSize => {
+              const pagination = component.props().pagination;
+              component.setProps({
+                pagination: { ...pagination, pageSize },
+              });
+            }),
+          }}
+        />
+      );
+
+      expect(extractGridData(component)).toEqual([
+        ['Column'],
+        ['0'],
+        ['1'],
+        ['2'],
+      ]);
+
+      findTestSubject(component, 'tablePaginationPopoverButton').simulate(
+        'click'
+      );
+      const rowButtons: NodeListOf<
+        HTMLButtonElement
+      > = document.body.querySelectorAll('.euiContextMenuItem');
+      expect(
+        Array.prototype.map.call(
+          rowButtons,
+          (button: HTMLDivElement) => button.textContent || ''
+        )
+      ).toEqual(['3 rows', '6 rows', '10 rows']);
+      rowButtons[1].click();
+
+      expect(
+        component.props().pagination.onChangeItemsPerPage
+      ).toHaveBeenCalledTimes(1);
+      const firstCallPageIndex = component.props().pagination
+        .onChangeItemsPerPage.mock.calls[0][0];
+      expect(firstCallPageIndex).toBe(6);
+
+      expect(extractGridData(component)).toEqual([
+        ['Column'],
+        ['0'],
+        ['1'],
+        ['2'],
+        ['3'],
+        ['4'],
+        ['5'],
+      ]);
     });
   });
 

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -6,11 +6,26 @@ import { Column, ColumnWidths } from './data_grid_types';
 import { EuiDataGridCellProps } from './data_grid_cell';
 import classNames from 'classnames';
 
+// @ts-ignore-next-line
+import { EuiTablePagination } from '../table/table_pagination';
+
+// ideally this would use a generic to enforce `pageSize` exists in `pageSizeOptions`,
+// but TypeScript's default understanding of an array is number[] unless `as const` is used
+// which defeats the generic's purpose & functionality as it would check for `number` in `number[]`
+interface PaginationProps {
+  pageIndex: number;
+  pageSize: number;
+  pageSizeOptions: number[];
+  onChangeItemsPerPage: (itemsPerPage: number) => void;
+  onChangePage: (pageIndex: number) => void;
+}
+
 type EuiDataGridProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {
     columns: Column[];
     rowCount: number;
     renderCellValue: EuiDataGridCellProps['renderCellValue'];
+    pagination?: PaginationProps;
   };
 
 interface EuiDataGridState {
@@ -18,11 +33,46 @@ interface EuiDataGridState {
   rows: ReactElement[];
 }
 
+function isPaginationDifferent(
+  prevPagination?: PaginationProps,
+  nextPagination?: PaginationProps
+) {
+  const prevPaginationExists = prevPagination != null;
+  const nextPaginationExists = nextPagination != null;
+
+  if (prevPaginationExists !== nextPaginationExists) {
+    return true;
+  }
+
+  // if either is null then both are null
+  // but TS doesn't understand that relation
+  if (prevPagination == null || nextPagination == null) {
+    return false;
+  }
+
+  const pageIndexDiffers =
+    prevPagination.pageIndex !== nextPagination.pageIndex;
+  const pageSizeDiffers = prevPagination.pageSize !== nextPagination.pageSize;
+
+  return pageIndexDiffers || pageSizeDiffers;
+}
+
 export class EuiDataGrid extends Component<EuiDataGridProps, EuiDataGridState> {
   state = {
     columnWidths: {},
     rows: this.renderRows(),
   };
+
+  componentDidUpdate(oldProps: EuiDataGridProps) {
+    const rowsNeedUpdate = isPaginationDifferent(
+      oldProps.pagination,
+      this.props.pagination
+    );
+
+    if (rowsNeedUpdate) {
+      this.updateRows();
+    }
+  }
 
   setColumnWidth = (columnName: string, width: number) => {
     this.setState(
@@ -41,10 +91,18 @@ export class EuiDataGrid extends Component<EuiDataGridProps, EuiDataGridState> {
 
   renderRows() {
     const { columnWidths = {} } = this.state || {};
-    const { columns, rowCount, renderCellValue } = this.props;
+    const { columns, rowCount, renderCellValue, pagination } = this.props;
+
+    const startRow = pagination
+      ? pagination.pageIndex * pagination.pageSize
+      : 0;
+    let endRow = pagination
+      ? (pagination.pageIndex + 1) * pagination.pageSize
+      : rowCount;
+    endRow = Math.min(endRow, rowCount);
 
     const rows = [];
-    for (let i = 0; i < rowCount; i++) {
+    for (let i = startRow; i < endRow; i++) {
       rows.push(
         <EuiDataGridDataRow
           key={i}
@@ -57,6 +115,34 @@ export class EuiDataGrid extends Component<EuiDataGridProps, EuiDataGridState> {
     }
 
     return rows;
+  }
+
+  renderPagination() {
+    const { pagination } = this.props;
+
+    if (pagination == null) {
+      return null;
+    }
+
+    const {
+      pageIndex,
+      pageSize,
+      pageSizeOptions,
+      onChangePage,
+      onChangeItemsPerPage,
+    } = pagination;
+    const pageCount = Math.ceil(this.props.rowCount / pageSize);
+
+    return (
+      <EuiTablePagination
+        activePage={pageIndex}
+        itemsPerPage={pageSize}
+        itemsPerPageOptions={pageSizeOptions}
+        pageCount={pageCount}
+        onChangePage={onChangePage}
+        onChangeItemsPerPage={onChangeItemsPerPage}
+      />
+    );
   }
 
   render() {
@@ -77,6 +163,7 @@ export class EuiDataGrid extends Component<EuiDataGridProps, EuiDataGridState> {
           setColumnWidth={this.setColumnWidth}
         />
         {rows}
+        {this.renderPagination()}
       </div>
     );
   }

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -1,121 +1,40 @@
-import React, { Component, HTMLAttributes, ReactElement } from 'react';
+import React, { Component, HTMLAttributes } from 'react';
 import { EuiDataGridHeaderRow } from './data_grid_header_row';
-import { EuiDataGridDataRow } from './data_grid_data_row';
 import { CommonProps } from '../common';
-import { Column, ColumnWidths } from './data_grid_types';
+import {
+  EuiDataGridColumn,
+  EuiDataGridColumnWidths,
+  EuiDataGridPaginationProps,
+} from './data_grid_types';
 import { EuiDataGridCellProps } from './data_grid_cell';
 import classNames from 'classnames';
 
 // @ts-ignore-next-line
 import { EuiTablePagination } from '../table/table_pagination';
-
-// ideally this would use a generic to enforce `pageSize` exists in `pageSizeOptions`,
-// but TypeScript's default understanding of an array is number[] unless `as const` is used
-// which defeats the generic's purpose & functionality as it would check for `number` in `number[]`
-interface PaginationProps {
-  pageIndex: number;
-  pageSize: number;
-  pageSizeOptions: number[];
-  onChangeItemsPerPage: (itemsPerPage: number) => void;
-  onChangePage: (pageIndex: number) => void;
-}
+import { EuiDataGridBody } from './grid_body';
 
 type EuiDataGridProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {
-    columns: Column[];
+    columns: EuiDataGridColumn[];
     rowCount: number;
     renderCellValue: EuiDataGridCellProps['renderCellValue'];
-    pagination?: PaginationProps;
+    pagination?: EuiDataGridPaginationProps;
   };
 
 interface EuiDataGridState {
-  columnWidths: ColumnWidths;
-  rows: ReactElement[];
-}
-
-function isPaginationDifferent(
-  prevPagination?: PaginationProps,
-  nextPagination?: PaginationProps
-) {
-  const prevPaginationExists = prevPagination != null;
-  const nextPaginationExists = nextPagination != null;
-
-  if (prevPaginationExists !== nextPaginationExists) {
-    return true;
-  }
-
-  // if either is null then both are null
-  // but TS doesn't understand that relation
-  if (prevPagination == null || nextPagination == null) {
-    return false;
-  }
-
-  const pageIndexDiffers =
-    prevPagination.pageIndex !== nextPagination.pageIndex;
-  const pageSizeDiffers = prevPagination.pageSize !== nextPagination.pageSize;
-
-  return pageIndexDiffers || pageSizeDiffers;
+  columnWidths: EuiDataGridColumnWidths;
 }
 
 export class EuiDataGrid extends Component<EuiDataGridProps, EuiDataGridState> {
   state = {
     columnWidths: {},
-    rows: this.renderRows(),
   };
-
-  componentDidUpdate(oldProps: EuiDataGridProps) {
-    const rowsNeedUpdate = isPaginationDifferent(
-      oldProps.pagination,
-      this.props.pagination
-    );
-
-    if (rowsNeedUpdate) {
-      this.updateRows();
-    }
-  }
 
   setColumnWidth = (columnName: string, width: number) => {
-    this.setState(
-      ({ columnWidths }) => ({
-        columnWidths: { ...columnWidths, [columnName]: width },
-      }),
-      this.updateRows
-    );
+    this.setState(({ columnWidths }) => ({
+      columnWidths: { ...columnWidths, [columnName]: width },
+    }));
   };
-
-  updateRows = () => {
-    this.setState({
-      rows: this.renderRows(),
-    });
-  };
-
-  renderRows() {
-    const { columnWidths = {} } = this.state || {};
-    const { columns, rowCount, renderCellValue, pagination } = this.props;
-
-    const startRow = pagination
-      ? pagination.pageIndex * pagination.pageSize
-      : 0;
-    let endRow = pagination
-      ? (pagination.pageIndex + 1) * pagination.pageSize
-      : rowCount;
-    endRow = Math.min(endRow, rowCount);
-
-    const rows = [];
-    for (let i = startRow; i < endRow; i++) {
-      rows.push(
-        <EuiDataGridDataRow
-          key={i}
-          rowIndex={i}
-          columns={columns}
-          renderCellValue={renderCellValue}
-          columnWidths={columnWidths}
-        />
-      );
-    }
-
-    return rows;
-  }
 
   renderPagination() {
     const { pagination } = this.props;
@@ -146,12 +65,13 @@ export class EuiDataGrid extends Component<EuiDataGridProps, EuiDataGridState> {
   }
 
   render() {
-    const { columnWidths, rows } = this.state;
+    const { columnWidths } = this.state;
     const {
       columns,
       rowCount,
       renderCellValue,
       className,
+      pagination,
       ...rest
     } = this.props;
 
@@ -162,7 +82,13 @@ export class EuiDataGrid extends Component<EuiDataGridProps, EuiDataGridState> {
           columnWidths={columnWidths}
           setColumnWidth={this.setColumnWidth}
         />
-        {rows}
+        <EuiDataGridBody
+          columnWidths={columnWidths}
+          columns={columns}
+          rowCount={rowCount}
+          renderCellValue={renderCellValue}
+          pagination={pagination}
+        />
         {this.renderPagination()}
       </div>
     );

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -11,6 +11,7 @@ import classNames from 'classnames';
 
 // @ts-ignore-next-line
 import { EuiTablePagination } from '../table/table_pagination';
+import { EuiSpacer } from '../spacer';
 import { EuiDataGridBody } from './grid_body';
 
 type EuiDataGridProps = CommonProps &
@@ -77,18 +78,21 @@ export class EuiDataGrid extends Component<EuiDataGridProps, EuiDataGridState> {
 
     return (
       <div {...rest} className={classNames(className, 'euiDataGrid')}>
-        <EuiDataGridHeaderRow
-          columns={columns}
-          columnWidths={columnWidths}
-          setColumnWidth={this.setColumnWidth}
-        />
-        <EuiDataGridBody
-          columnWidths={columnWidths}
-          columns={columns}
-          rowCount={rowCount}
-          renderCellValue={renderCellValue}
-          pagination={pagination}
-        />
+        <div className="euiDataGrid__content">
+          <EuiDataGridHeaderRow
+            columns={columns}
+            columnWidths={columnWidths}
+            setColumnWidth={this.setColumnWidth}
+          />
+          <EuiDataGridBody
+            columnWidths={columnWidths}
+            columns={columns}
+            rowCount={rowCount}
+            renderCellValue={renderCellValue}
+            pagination={pagination}
+          />
+        </div>
+        <EuiSpacer size="s" />
         {this.renderPagination()}
       </div>
     );

--- a/src/components/datagrid/data_grid_data_row.tsx
+++ b/src/components/datagrid/data_grid_data_row.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, HTMLAttributes } from 'react';
 import classnames from 'classnames';
-import { Column, ColumnWidths } from './data_grid_types';
+import { EuiDataGridColumn, EuiDataGridColumnWidths } from './data_grid_types';
 import { CommonProps } from '../common';
 
 import { DEFAULT_COLUMN_WIDTH } from './data_grid_header_row';
@@ -9,8 +9,8 @@ import { EuiDataGridCell, EuiDataGridCellProps } from './data_grid_cell';
 type EuiDataGridDataRowProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {
     rowIndex: number;
-    columns: Column[];
-    columnWidths: ColumnWidths;
+    columns: EuiDataGridColumn[];
+    columnWidths: EuiDataGridColumnWidths;
     renderCellValue: EuiDataGridCellProps['renderCellValue'];
   };
 

--- a/src/components/datagrid/data_grid_header_row.tsx
+++ b/src/components/datagrid/data_grid_header_row.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, HTMLAttributes } from 'react';
 import classnames from 'classnames';
-import { ColumnWidths, Column } from './data_grid_types';
+import { EuiDataGridColumnWidths, EuiDataGridColumn } from './data_grid_types';
 import { CommonProps } from '../common';
 import { EuiDataGridColumnResizer } from './data_grid_column_resizer';
 
@@ -8,8 +8,8 @@ export const DEFAULT_COLUMN_WIDTH = 100;
 
 type EuiDataGridHeaderRowProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {
-    columns: Column[];
-    columnWidths: ColumnWidths;
+    columns: EuiDataGridColumn[];
+    columnWidths: EuiDataGridColumnWidths;
     setColumnWidth: (columnName: string, width: number) => void;
   };
 

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -1,7 +1,18 @@
-export interface Column {
+export interface EuiDataGridColumn {
   name: string;
 }
 
-export interface ColumnWidths {
+export interface EuiDataGridColumnWidths {
   [key: string]: number;
+}
+
+// ideally this would use a generic to enforce `pageSize` exists in `pageSizeOptions`,
+// but TypeScript's default understanding of an array is number[] unless `as const` is used
+// which defeats the generic's purpose & functionality as it would check for `number` in `number[]`
+export interface EuiDataGridPaginationProps {
+  pageIndex: number;
+  pageSize: number;
+  pageSizeOptions: number[];
+  onChangeItemsPerPage: (itemsPerPage: number) => void;
+  onChangePage: (pageIndex: number) => void;
 }

--- a/src/components/datagrid/grid_body.tsx
+++ b/src/components/datagrid/grid_body.tsx
@@ -1,0 +1,53 @@
+import React, { Fragment, FunctionComponent, useMemo } from 'react';
+import {
+  EuiDataGridColumn,
+  EuiDataGridColumnWidths,
+  EuiDataGridPaginationProps,
+} from './data_grid_types';
+import { EuiDataGridCellProps } from './data_grid_cell';
+import { EuiDataGridDataRow } from './data_grid_data_row';
+
+interface EuiDataGridBodyProps {
+  columnWidths: EuiDataGridColumnWidths;
+  columns: EuiDataGridColumn[];
+  rowCount: number;
+  renderCellValue: EuiDataGridCellProps['renderCellValue'];
+  pagination?: EuiDataGridPaginationProps;
+}
+
+export const EuiDataGridBody: FunctionComponent<
+  EuiDataGridBodyProps
+> = props => {
+  const {
+    columnWidths,
+    columns,
+    rowCount,
+    renderCellValue,
+    pagination,
+  } = props;
+
+  const startRow = pagination ? pagination.pageIndex * pagination.pageSize : 0;
+  let endRow = pagination
+    ? (pagination.pageIndex + 1) * pagination.pageSize
+    : rowCount;
+  endRow = Math.min(endRow, rowCount);
+
+  const rows = useMemo(() => {
+    const rows = [];
+    for (let i = startRow; i < endRow; i++) {
+      rows.push(
+        <EuiDataGridDataRow
+          key={i}
+          rowIndex={i}
+          columns={columns}
+          renderCellValue={renderCellValue}
+          columnWidths={columnWidths}
+        />
+      );
+    }
+
+    return rows;
+  }, [startRow, endRow, columnWidths, columns, renderCellValue]);
+
+  return <Fragment>{rows}</Fragment>;
+};

--- a/src/components/table/table_pagination/__snapshots__/table_pagination.test.js.snap
+++ b/src/components/table/table_pagination/__snapshots__/table_pagination.test.js.snap
@@ -16,6 +16,7 @@ exports[`EuiTablePagination is rendered 1`] = `
       >
         <button
           class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--iconRight"
+          data-test-subj="tablePaginationPopoverButton"
           type="button"
         >
           <span

--- a/src/components/table/table_pagination/table_pagination.js
+++ b/src/components/table/table_pagination/table_pagination.js
@@ -46,6 +46,7 @@ export class EuiTablePagination extends Component {
         color="text"
         iconType="arrowDown"
         iconSide="right"
+        data-test-subj="tablePaginationPopoverButton"
         onClick={this.onButtonClick}>
         <EuiI18n
           token="euiTablePagination.rowsPerPage"

--- a/src/themes/eui/eui_colors_dark.scss
+++ b/src/themes/eui/eui_colors_dark.scss
@@ -1,28 +1,27 @@
 // Core
-$euiColorPrimary: #dc322f;
-$euiColorSecondary: #2aa198;
-$euiColorAccent: #d33682;
+$euiColorPrimary: #1BA9F5;
+$euiColorSecondary: #7DE2D1;
+$euiColorAccent: #F990C0;
 
 // These colors stay the same no matter the theme
 $euiColorGhost: #FFF;
 $euiColorInk: #000;
 
 // Status
-$euiColorSuccess: #859900;
-$euiColorWarning: #b58900;
-$euiColorDanger: #dc322f;
+$euiColorSuccess: $euiColorSecondary;
+$euiColorWarning: #FFCE7A;
+$euiColorDanger: #F66;
 
 // Grays
-$euiColorEmptyShade: #002b36;
-$euiColorLightestShade: #073642;
-$euiColorLightShade: #586e75;
-$euiColorMediumShade: #657b83;
-$euiColorDarkShade: #839496;
-$euiColorDarkestShade: #eee8d5;
-$euiColorFullShade: #fdf6e3;
+$euiColorEmptyShade: #1D1E24;
+$euiColorLightestShade: #25262E;
+$euiColorLightShade: #343741;
+$euiColorMediumShade: #535966;
+$euiColorDarkShade: #98A2B3;
+$euiColorDarkestShade: #D4DAE5;
+$euiColorFullShade: #FFF;
 
 // Variations from core
-
 $euiTextColor: #DFE5EF;
 $euiLinkColor: $euiColorPrimary;
 $euiFocusBackgroundColor: #232635;

--- a/src/themes/eui/eui_colors_dark.scss
+++ b/src/themes/eui/eui_colors_dark.scss
@@ -1,25 +1,25 @@
 // Core
-$euiColorPrimary: #1BA9F5;
-$euiColorSecondary: #7DE2D1;
-$euiColorAccent: #F990C0;
+$euiColorPrimary: #dc322f;
+$euiColorSecondary: #2aa198;
+$euiColorAccent: #d33682;
 
 // These colors stay the same no matter the theme
 $euiColorGhost: #FFF;
 $euiColorInk: #000;
 
 // Status
-$euiColorSuccess: $euiColorSecondary;
-$euiColorWarning: #FFCE7A;
-$euiColorDanger: #F66;
+$euiColorSuccess: #859900;
+$euiColorWarning: #b58900;
+$euiColorDanger: #dc322f;
 
 // Grays
-$euiColorEmptyShade: #1D1E24;
-$euiColorLightestShade: #25262E;
-$euiColorLightShade: #343741;
-$euiColorMediumShade: #535966;
-$euiColorDarkShade: #98A2B3;
-$euiColorDarkestShade: #D4DAE5;
-$euiColorFullShade: #FFF;
+$euiColorEmptyShade: #002b36;
+$euiColorLightestShade: #073642;
+$euiColorLightShade: #586e75;
+$euiColorMediumShade: #657b83;
+$euiColorDarkShade: #839496;
+$euiColorDarkestShade: #eee8d5;
+$euiColorFullShade: #fdf6e3;
 
 // Variations from core
 


### PR DESCRIPTION
### Summary

**This is not the full implementation for pagination (can't disable individual pages, etc), but is a definition of the pattern and the change set is already getting big**

![datagrid pagination](https://d.pr/i/ej1dwS+)

After the conversation on props vs. state for managing the grid's query, sorting, and pagination I went the route of pure props-driven, relying on the consuming component to hold and manage the state.

I also moved the row/body rendering into a separate component which cleaned out a _lot_ of code & logic from the top-level `EuiDataGrid`, using a `useMemo` hook to cache the processed rows instead of explicitly storing them on state.

In the future, user overrides may be held in the grid's internal state or may be expressed to the parent application in a way similar to this pagination.

@snide the overflow scrolling absolutely freaks out when interacting with the pagination buttons

### Checklist

- [ ] Checked in **dark mode**
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [x] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
