### PR TITLE
Fix EuiBadge truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `13.1.1`.
+**Bug fixes**
+
+- Fixed `EuiBadge` truncation and auto-applied `title` attribute with `innerText` ([#2190](https://github.com/elastic/eui/pull/2190))
 
 ## [`13.1.1`](https://github.com/elastic/eui/tree/v13.1.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `13.1.1`.
+**Bug fixes**
+
+- Fixed `EuiBadge` truncation and auto-applied `title` attribute with `innerText` ([#2190](https://github.com/elastic/eui/pull/2190))
 
 ## [`13.1.1`](https://github.com/elastic/eui/tree/v13.1.1)
 
@@ -739,7 +741,8 @@ No public interface changes since `13.1.1`.
 
 - Fixed `EuiSuperDatePicker` not updating derived `isInvalid` state on prop update ([#1483](https://github.com/elastic/eui/pull/1483))
 - Fixed `logoAPM` ([#1489](https://github.com/elastic/eui/pull/1489))
-- Remove Typescript type and interface definitions from ES and CJS exports ([#1486](https://github.com/elastic/eui/pull/1486))
+
+
 
 ## [`6.7.2`](https://github.com/elastic/eui/tree/v6.7.2)
 
@@ -1132,8 +1135,9 @@ No public interface changes since `13.1.1`.
 
 ## [`4.1.0`](https://github.com/elastic/eui/tree/v4.1.0)
 
-- Added `direction` to `EuiFlexGroup` prop types interface ([#1196](https://github.com/elastic/eui/pull/1196))
 - Made `description` prop optional for `EuiDescribedFormGroup` ([#1191](https://github.com/elastic/eui/pull/1191))
+
+**Bug fixes**
 - Fixed issue with unselected tabs and aria-controls attribute in EuiTabbedContent
 - Added `tag` icon ([#1188](https://github.com/elastic/eui/pull/1188))
 - Replaced `logging` app icon ([#1194](https://github.com/elastic/eui/pull/1194))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-**Bug fixes**
-
-- Fixed `EuiBadge` truncation and auto-applied `title` attribute with `innerText` ([#2190](https://github.com/elastic/eui/pull/2190))
+No public interface changes since `13.1.1`.
 
 ## [`13.1.1`](https://github.com/elastic/eui/tree/v13.1.1)
 
@@ -741,8 +739,7 @@
 
 - Fixed `EuiSuperDatePicker` not updating derived `isInvalid` state on prop update ([#1483](https://github.com/elastic/eui/pull/1483))
 - Fixed `logoAPM` ([#1489](https://github.com/elastic/eui/pull/1489))
-
-
+- Remove Typescript type and interface definitions from ES and CJS exports ([#1486](https://github.com/elastic/eui/pull/1486))
 
 ## [`6.7.2`](https://github.com/elastic/eui/tree/v6.7.2)
 
@@ -1135,9 +1132,8 @@
 
 ## [`4.1.0`](https://github.com/elastic/eui/tree/v4.1.0)
 
+- Added `direction` to `EuiFlexGroup` prop types interface ([#1196](https://github.com/elastic/eui/pull/1196))
 - Made `description` prop optional for `EuiDescribedFormGroup` ([#1191](https://github.com/elastic/eui/pull/1191))
-
-**Bug fixes**
 - Fixed issue with unselected tabs and aria-controls attribute in EuiTabbedContent
 - Added `tag` icon ([#1188](https://github.com/elastic/eui/pull/1188))
 - Replaced `logging` app icon ([#1194](https://github.com/elastic/eui/pull/1194))

--- a/src-docs/src/views/badge/badge_example.js
+++ b/src-docs/src/views/badge/badge_example.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 
 import { Link } from 'react-router';
 
@@ -33,6 +33,10 @@ const betaBadgeHtml = renderToHtml(BetaBadge);
 import NotificationBadge from './notification_badge';
 const notificationBadgeSource = require('!!raw-loader!./notification_badge');
 const notificationBadgeHtml = renderToHtml(NotificationBadge);
+
+import BadgeTruncate from './badge_truncate';
+const badgeTruncateSource = require('!!raw-loader!./badge_truncate');
+const badgeTruncateHtml = renderToHtml(BadgeTruncate);
 
 export const BadgeExample = {
   title: 'Badge',
@@ -147,6 +151,34 @@ export const BadgeExample = {
       ),
       props: { EuiBetaBadge },
       demo: <BetaBadge />,
+    },
+    {
+      title: 'Badge truncation',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: badgeTruncateSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: badgeTruncateHtml,
+        },
+      ],
+      text: (
+        <Fragment>
+          <p>
+            Badges, like buttons, will only every be a single line of text. This
+            means text will not wrap, but be truncated if the badge&apos;s width
+            reaches that of its parent&apos;s.
+          </p>
+          <p>
+            For this reason, badges also auto-apply the inner text of the badge
+            to the <EuiCode>title</EuiCode> attribute of the element to provide
+            default browser tooltips with the full badge text.
+          </p>
+        </Fragment>
+      ),
+      demo: <BadgeTruncate />,
     },
     {
       title: 'Notification badge type',

--- a/src-docs/src/views/badge/badge_example.js
+++ b/src-docs/src/views/badge/badge_example.js
@@ -114,6 +114,34 @@ export const BadgeExample = {
       demo: <BadgeButton />,
     },
     {
+      title: 'Badge truncation',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: badgeTruncateSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: badgeTruncateHtml,
+        },
+      ],
+      text: (
+        <Fragment>
+          <p>
+            Badges, like buttons, will only every be a single line of text. This
+            means text will not wrap, but be truncated if the badge&apos;s width
+            reaches that of its parent&apos;s.
+          </p>
+          <p>
+            For this reason, badges also auto-apply the inner text of the badge
+            to the <EuiCode>title</EuiCode> attribute of the element to provide
+            default browser tooltips with the full badge text.
+          </p>
+        </Fragment>
+      ),
+      demo: <BadgeTruncate />,
+    },
+    {
       title: 'Beta badge type',
       source: [
         {
@@ -151,34 +179,6 @@ export const BadgeExample = {
       ),
       props: { EuiBetaBadge },
       demo: <BetaBadge />,
-    },
-    {
-      title: 'Badge truncation',
-      source: [
-        {
-          type: GuideSectionTypes.JS,
-          code: badgeTruncateSource,
-        },
-        {
-          type: GuideSectionTypes.HTML,
-          code: badgeTruncateHtml,
-        },
-      ],
-      text: (
-        <Fragment>
-          <p>
-            Badges, like buttons, will only every be a single line of text. This
-            means text will not wrap, but be truncated if the badge&apos;s width
-            reaches that of its parent&apos;s.
-          </p>
-          <p>
-            For this reason, badges also auto-apply the inner text of the badge
-            to the <EuiCode>title</EuiCode> attribute of the element to provide
-            default browser tooltips with the full badge text.
-          </p>
-        </Fragment>
-      ),
-      demo: <BadgeTruncate />,
     },
     {
       title: 'Notification badge type',

--- a/src-docs/src/views/badge/badge_truncate.js
+++ b/src-docs/src/views/badge/badge_truncate.js
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import { EuiBadge, EuiPanel, EuiSpacer } from '../../../../src/components';
+
+export default () => (
+  <EuiPanel style={{ maxWidth: 200 }}>
+    <EuiBadge>Badge with simple text being truncated</EuiBadge>
+
+    <EuiSpacer size="s" />
+
+    <EuiBadge iconType="clock">Badge with icon being truncated</EuiBadge>
+
+    <EuiSpacer size="s" />
+
+    <EuiBadge onClick={() => {}} onClickAriaLabel="Click this badge to...">
+      Badge with onClick being truncated
+    </EuiBadge>
+
+    <EuiSpacer size="s" />
+
+    <EuiBadge
+      iconType="cross"
+      iconSide="right"
+      iconOnClick={() => {}}
+      iconOnClickAriaLabel="Click this icon to...">
+      Badge with iconOnClick being truncated
+    </EuiBadge>
+
+    <EuiSpacer size="s" />
+
+    <EuiBadge
+      iconType="cross"
+      iconSide="right"
+      onClick={() => {}}
+      onClickAriaLabel="Click this badge to..."
+      iconOnClick={() => {}}
+      iconOnClickAriaLabel="Click this icon to...">
+      Badge with both onClicks being truncated
+    </EuiBadge>
+  </EuiPanel>
+);

--- a/src/components/badge/__snapshots__/badge.test.tsx.snap
+++ b/src/components/badge/__snapshots__/badge.test.tsx.snap
@@ -63,7 +63,9 @@ exports[`EuiBadge is rendered with onClick provided 1`] = `
   <span
     class="euiBadge__content"
   >
-    <span>
+    <span
+      class="euiBadge__text"
+    >
       Content
     </span>
   </span>

--- a/src/components/badge/_badge.scss
+++ b/src/components/badge/_badge.scss
@@ -16,6 +16,7 @@
   vertical-align: middle;
   text-align: center;
   overflow: hidden;
+  max-width: 100%;
 
   &:focus-within {
     @include euiFocusRing('small');

--- a/src/components/badge/_badge.scss
+++ b/src/components/badge/_badge.scss
@@ -14,9 +14,11 @@
   background-color: transparent;
   white-space: nowrap;
   vertical-align: middle;
-  text-align: center;
   overflow: hidden;
   max-width: calc(100% - #{($euiSizeS * 2) + 2px}); // Padding plus border
+  // The badge will only ever be as wide as it's content
+  // So, make the text left aligned to ensure all badges line up the same
+  text-align: left;
 
   &:focus-within {
     @include euiFocusRing('small');
@@ -35,6 +37,7 @@
 
   .euiBadge__childButton {
     @include euiTextTruncate;
+    max-width: calc(100% - #{$euiSizeM + $euiSizeXS}); // Subtract the icon and icon's margin
     flex: 0 0 auto;
     font-weight: inherit;
     line-height: inherit;
@@ -65,6 +68,7 @@
   .euiBadge__text {
     @include euiTextTruncate;
     flex: 1 1 auto;
+    cursor: default;
   }
 
   .euiBadge__icon {
@@ -91,6 +95,10 @@
 
   &:focus {
     @include euiFocusRing('small');
+  }
+
+  .euiBadge__text {
+    cursor: inherit;
   }
 }
 

--- a/src/components/badge/_badge.scss
+++ b/src/components/badge/_badge.scss
@@ -16,7 +16,7 @@
   vertical-align: middle;
   text-align: center;
   overflow: hidden;
-  max-width: 100%;
+  max-width: calc(100% - #{($euiSizeS * 2) + 2px}); // Padding plus border
 
   &:focus-within {
     @include euiFocusRing('small');
@@ -24,6 +24,7 @@
 
   + .euiBadge {
     margin-left: $euiSizeXS;
+    max-width: calc(100% - #{($euiSizeS * 2) + 2px + $euiSizeXS}); // Padding plus border plus margin
   }
 
   .euiBadge__content {

--- a/src/components/badge/_badge.scss
+++ b/src/components/badge/_badge.scss
@@ -33,6 +33,7 @@
   }
 
   .euiBadge__childButton {
+    @include euiTextTruncate;
     flex: 0 0 auto;
     font-weight: inherit;
     line-height: inherit;
@@ -61,8 +62,7 @@
   }
 
   .euiBadge__text {
-    overflow: hidden;
-    text-overflow: ellipsis;
+    @include euiTextTruncate;
     flex: 1 1 auto;
   }
 

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -185,7 +185,7 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
         style={optionalCustomStyles}
         {...rest}>
         <span className="euiBadge__content">
-          <span>{children}</span>
+          <span className="euiBadge__text">{children}</span>
           {optionalIcon}
         </span>
       </button>

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -141,6 +141,7 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
         <button
           className="euiBadge__iconButton"
           aria-label={iconOnClickAriaLabel}
+          title={iconOnClickAriaLabel}
           onClick={iconOnClick}>
           <EuiIcon
             type={iconType}
@@ -206,18 +207,21 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
     );
   } else {
     return (
-      <span className={classes} style={optionalCustomStyles} {...rest}>
-        <span className="euiBadge__content">
-          <EuiInnerText>
-            {(ref, innerText) => (
-              <span className="euiBadge__text" ref={ref} title={innerText}>
-                {children}
-              </span>
-            )}
-          </EuiInnerText>
-          {optionalIcon}
-        </span>
-      </span>
+      <EuiInnerText>
+        {(ref, innerText) => (
+          <span
+            className={classes}
+            style={optionalCustomStyles}
+            ref={ref}
+            title={innerText}
+            {...rest}>
+            <span className="euiBadge__content">
+              <span className="euiBadge__text">{children}</span>
+              {optionalIcon}
+            </span>
+          </span>
+        )}
+      </EuiInnerText>
     );
   }
 };

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -2,11 +2,13 @@ import React, {
   FunctionComponent,
   MouseEventHandler,
   HTMLAttributes,
+  ReactNode,
 } from 'react';
 import classNames from 'classnames';
 import { CommonProps, ExclusiveUnion, keysOf, PropsOf, Omit } from '../common';
 
 import { isColorDark, hexToRgb } from '../../services/color';
+import { EuiInnerText } from '../inner_text';
 
 import { EuiIcon, IconColor, IconType } from '../icon';
 
@@ -97,7 +99,7 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
   checkValidColor(color);
 
   let optionalColorClass = null;
-  let optionalCustomStyles = undefined;
+  let optionalCustomStyles: object | undefined = undefined;
   let textColor = null;
 
   if (COLORS.indexOf(color) > -1) {
@@ -127,7 +129,7 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
     closeButtonProps && closeButtonProps.className
   );
 
-  let optionalIcon = null;
+  let optionalIcon: ReactNode = null;
   if (iconType) {
     if (iconOnClick) {
       if (!iconOnClickAriaLabel) {
@@ -165,36 +167,54 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
     return (
       <span className={classes} style={optionalCustomStyles}>
         <span className="euiBadge__content">
-          <button
-            className="euiBadge__childButton"
-            aria-label={onClickAriaLabel}
-            onClick={onClick}
-            {...rest}>
-            {children}
-          </button>
+          <EuiInnerText>
+            {(ref, innerText) => (
+              <button
+                className="euiBadge__childButton"
+                aria-label={onClickAriaLabel}
+                onClick={onClick}
+                ref={ref}
+                title={innerText}
+                {...rest}>
+                {children}
+              </button>
+            )}
+          </EuiInnerText>
           {optionalIcon}
         </span>
       </span>
     );
   } else if (onClick) {
     return (
-      <button
-        aria-label={onClickAriaLabel}
-        className={classes}
-        onClick={onClick}
-        style={optionalCustomStyles}
-        {...rest}>
-        <span className="euiBadge__content">
-          <span className="euiBadge__text">{children}</span>
-          {optionalIcon}
-        </span>
-      </button>
+      <EuiInnerText>
+        {(ref, innerText) => (
+          <button
+            aria-label={onClickAriaLabel}
+            className={classes}
+            onClick={onClick}
+            style={optionalCustomStyles}
+            ref={ref}
+            title={innerText}
+            {...rest}>
+            <span className="euiBadge__content">
+              <span className="euiBadge__text">{children}</span>
+              {optionalIcon}
+            </span>
+          </button>
+        )}
+      </EuiInnerText>
     );
   } else {
     return (
       <span className={classes} style={optionalCustomStyles} {...rest}>
         <span className="euiBadge__content">
-          <span className="euiBadge__text">{children}</span>
+          <EuiInnerText>
+            {(ref, innerText) => (
+              <span className="euiBadge__text" ref={ref} title={innerText}>
+                {children}
+              </span>
+            )}
+          </EuiInnerText>
           {optionalIcon}
         </span>
       </span>


### PR DESCRIPTION
## Fixes https://github.com/elastic/eui/issues/2189

Luckily it was mostly a matter of a missing class and missing truncation mixin. I also needed to add a `max-width: 100%` otherwise it wouldn't stop at the container's width.

### **Before -- no max-width**

It wouldn't even truncate at all
<img width="605" alt="Screen Shot 2019-08-01 at 12 10 05 PM" src="https://user-images.githubusercontent.com/549577/62309769-20ae6d00-b456-11e9-924f-046f8b915d0a.png">

### **Before -- with max-width**

When it **did** truncate, it didn't do so correctly
<img width="574" alt="Screen Shot 2019-08-01 at 12 10 25 PM" src="https://user-images.githubusercontent.com/549577/62309874-505d7500-b456-11e9-9cab-284756c320b9.png">

### After

Now it truncates no matter the contents. I also added the `innerText` to the `title` attribute of the surrounding content so that consumers don't have to worry about adding this or tooltips to show the full text.

<img width="578" alt="Screen Shot 2019-08-01 at 12 09 06 PM" src="https://user-images.githubusercontent.com/549577/62309950-784cd880-b456-11e9-9dae-3fc4d72e610c.png">




### Checklist

- ~[ ] Checked in **dark mode**~
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
