### PR TITLE
Remove TS types from exports when they come from node_modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `13.1.1`.
+**Bug fixes**
+
+- Remove exported TypeScript type and interface exports from built artifacts when they originate from `node_modules` ([#2191](https://github.com/elastic/eui/pull/2191))
 
 ## [`13.1.1`](https://github.com/elastic/eui/tree/v13.1.1)
 

--- a/scripts/babel/proptypes-from-ts-props/index.js
+++ b/scripts/babel/proptypes-from-ts-props/index.js
@@ -1100,7 +1100,6 @@ module.exports = function propTypesFromTypeScript({ types }) {
           // this prevents TS-only identifiers from leaking into ES code
           programPath.traverse({
             ExportNamedDeclaration: (path) => {
-              debugger;
               const specifiers = path.get('specifiers');
               const source = path.get('source');
               specifiers.forEach(specifierPath => {
@@ -1121,7 +1120,7 @@ module.exports = function propTypesFromTypeScript({ types }) {
                         // comes from a 3rd-party library
                         // best way to reliably check if this is
                         // a type or value is to require the
-                        // library and check it's exports
+                        // library and check its exports
                         const library = require(libraryName);
                         if (library.hasOwnProperty(name) === false) {
                           specifierPath.remove();

--- a/scripts/babel/proptypes-from-ts-props/index.js
+++ b/scripts/babel/proptypes-from-ts-props/index.js
@@ -1100,15 +1100,33 @@ module.exports = function propTypesFromTypeScript({ types }) {
           // this prevents TS-only identifiers from leaking into ES code
           programPath.traverse({
             ExportNamedDeclaration: (path) => {
+              debugger;
               const specifiers = path.get('specifiers');
+              const source = path.get('source');
               specifiers.forEach(specifierPath => {
                 if (types.isExportSpecifier(specifierPath)) {
                   const { node: { local } } = specifierPath;
                   if (types.isIdentifier(local)) {
                     const { name } = local;
-                    const def = typeDefinitions[name];
-                    if (isTSType(def)) {
-                      specifierPath.remove();
+                    if (typeDefinitions.hasOwnProperty(name)) {
+                      // this is a locally-known value
+                      const def = typeDefinitions[name];
+                      if (isTSType(def)) {
+                        specifierPath.remove();
+                      }
+                    } else if (types.isStringLiteral(source)) {
+                      const libraryName = source.get('value').node;
+                      const isRelativeSource = libraryName.startsWith('.');
+                      if (isRelativeSource === false) {
+                        // comes from a 3rd-party library
+                        // best way to reliably check if this is
+                        // a type or value is to require the
+                        // library and check it's exports
+                        const library = require(libraryName);
+                        if (library.hasOwnProperty(name) === false) {
+                          specifierPath.remove();
+                        }
+                      }
                     }
                   }
                 }

--- a/scripts/babel/proptypes-from-ts-props/index.test.js
+++ b/scripts/babel/proptypes-from-ts-props/index.test.js
@@ -2485,6 +2485,19 @@ export type Foo = string;
 
       expect(result.code).toBe('');
     });
+
+    it('removes 3rd-party type exports', () => {
+      const result = transform(
+        `
+export { DraggableLocation, Draggable, DragDropContextProps } from 'react-beautiful-dnd';
+`,
+        babelOptions
+      );
+
+      expect(result.code).toBe(
+        `export { Draggable } from 'react-beautiful-dnd';`
+      );
+    });
   });
 
 });


### PR DESCRIPTION
### Summary

Fixes #2185 by filtering out non-value exports from `node_modules` during build/babel. I tested by:

* diffing the `es` directory before-and-after this change, only components/drag_and_drop/index.js had changes
* created a new CRA repo and included and built with an `npm pack`ed version of EUI with these changes

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
