### PR TITLE
Aligning switch semantics with aria role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `13.3.0`.
+- Fixed `EuiSwitch` semantics to align with aria roles ([#2193](https://github.com/elastic/eui/pull/2193))
+- Removed Firefox's focus ring to match other browsers ([#2193](https://github.com/elastic/eui/pull/2193))
 
 ## [`13.3.0`](https://github.com/elastic/eui/tree/v13.3.0)
 

--- a/src-docs/src/views/form_controls/switch.js
+++ b/src-docs/src/views/form_controls/switch.js
@@ -11,9 +11,9 @@ export default class extends Component {
     };
   }
 
-  onChange = e => {
+  onChange = () => {
     this.setState({
-      checked: e.target.checked,
+      checked: !this.state.checked,
     });
   };
 

--- a/src/components/form/_variables.scss
+++ b/src/components/form/_variables.scss
@@ -22,3 +22,4 @@ $euiFormCustomControlDisabledIconColor: shadeOrTint($euiColorMediumShade, 38%, 4
 $euiFormControlDisabledColor: $euiColorMediumShade !default;
 $euiFormControlBoxShadow: 0 1px 1px -1px transparentize($euiShadowColor, .8), 0 3px 2px -2px transparentize($euiShadowColor, .8);
 $euiFormInputGroupLabelBackground: shadeOrTint($euiFormBackgroundDisabledColor, 0, 3%);
+$euiSwitchOffColor: lightOrDarkTheme(transparentize($euiColorMediumShade, .8), transparentize($euiColorMediumShade, .3));

--- a/src/components/form/switch/__snapshots__/switch.test.js.snap
+++ b/src/components/form/switch/__snapshots__/switch.test.js.snap
@@ -4,38 +4,43 @@ exports[`EuiSwitch assigns automatically generated ID to label 1`] = `
 <div
   class="euiSwitch"
 >
-  <input
-    class="euiSwitch__input"
+  <button
+    class="euiSwitch__button"
     id="generated-id"
-    type="checkbox"
-  />
-  <span
-    class="euiSwitch__body"
+    role="switch"
   >
     <span
-      class="euiSwitch__thumb"
-    />
-    <span
-      class="euiSwitch__track"
+      class="euiSwitch__body"
     >
-      <svg
-        class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon"
-        focusable="false"
-        height="16"
-        viewBox="0 0 16 16"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
+      <span
+        class="euiSwitch__thumb"
       />
-      <svg
-        class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon euiSwitch__icon--checked"
-        focusable="false"
-        height="16"
-        viewBox="0 0 16 16"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+      <span
+        class="euiSwitch__track"
+      >
+        <svg
+          class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+        <svg
+          class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon euiSwitch__icon--checked"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+      </span>
     </span>
-  </span>
+  </button>
+  <label
+    class="euiSwitch__label"
+    for="generated-id"
+  />
 </div>
 `;
 
@@ -43,39 +48,44 @@ exports[`EuiSwitch is rendered 1`] = `
 <div
   class="euiSwitch testClass1 testClass2"
 >
-  <input
+  <button
     aria-label="aria-label"
-    class="euiSwitch__input"
+    class="euiSwitch__button"
     data-test-subj="test subject string"
     id="test"
-    type="checkbox"
-  />
-  <span
-    class="euiSwitch__body"
+    role="switch"
   >
     <span
-      class="euiSwitch__thumb"
-    />
-    <span
-      class="euiSwitch__track"
+      class="euiSwitch__body"
     >
-      <svg
-        class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon"
-        focusable="false"
-        height="16"
-        viewBox="0 0 16 16"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
+      <span
+        class="euiSwitch__thumb"
       />
-      <svg
-        class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon euiSwitch__icon--checked"
-        focusable="false"
-        height="16"
-        viewBox="0 0 16 16"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+      <span
+        class="euiSwitch__track"
+      >
+        <svg
+          class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+        <svg
+          class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon euiSwitch__icon--checked"
+          focusable="false"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        />
+      </span>
     </span>
-  </span>
+  </button>
+  <label
+    class="euiSwitch__label"
+    for="test"
+  />
 </div>
 `;

--- a/src/components/form/switch/_switch.scss
+++ b/src/components/form/switch/_switch.scss
@@ -4,29 +4,62 @@
   min-height: $euiSwitchHeight;
 
   .euiSwitch__label {
+    cursor: pointer;
     padding-left: $euiSizeS;
     line-height: $euiSwitchHeight;
     font-size: $euiFontSizeS;
     vertical-align: middle;
   }
 
-  /**
-   * 1. The input is "hidden" but still focusable.
-   * 2. Make sure it's still hidden when [disabled].
-   */
-  .euiSwitch__input,
-  .euiSwitch__input[disabled] /* 2 */ {
-    position: absolute;
-    opacity: 0; /* 1 */
-    width: 100%;
-    height: 100%;
-    cursor: pointer;
-  }
+  .euiSwitch__button {
+    line-height: 0; // ensures button takes height of switch inside
 
-  .euiSwitch__input:focus + .euiSwitch__body {
-
-    .euiSwitch__thumb {
+    &:focus .euiSwitch__thumb {
       @include euiCustomControlFocused;
+    }
+
+    &:disabled {
+      &:hover,
+      ~ .euiSwitch__label:hover {
+        cursor: not-allowed;
+      }
+
+      .euiSwitch__body {
+        background-color: $euiSwitchOffColor;
+      }
+
+      .euiSwitch__thumb {
+        @include euiCustomControlDisabled;
+        background-color: $euiSwitchOffColor;
+      }
+
+      .euiSwitch__icon {
+        fill: $euiFormCustomControlDisabledIconColor;
+      }
+
+      + .euiSwitch__label {
+        color: $euiFormControlDisabledColor;
+      }
+    }
+
+    &[aria-checked='false'] {
+      .euiSwitch__body {
+        background-color: $euiSwitchOffColor;
+      }
+
+      // When input is not checked, we shift around the positioning of the thumb and the icon
+      .euiSwitch__thumb { // move the thumb left
+        left: 0;
+      }
+
+      .euiSwitch__icon { // move the icon right
+        right: -$euiSizeS;
+
+        &.euiSwitch__icon--checked {
+          right: auto;
+          left: -($euiSwitchWidth - ($euiSwitchThumbSize / 2));
+        }
+      }
     }
   }
 
@@ -77,64 +110,13 @@
     fill: $euiColorEmptyShade;
   }
 
-  /**
-   * The thumb is slightly scaled when in use, unless it's disabled.
-   */
-  &:hover {
-    .euiSwitch__input:not(:disabled) ~ .euiSwitch__body {
-      .euiSwitch__thumb {
-        transform: scale(1.05);
-      }
+  &:hover .euiSwitch__button {
+    &:not(:disabled) .euiSwitch__thumb {
+      transform: scale(1.05);
     }
-  }
 
-  &:active {
-    .euiSwitch__thumb {
+    &:active .euiSwitch__thumb {
       transform: scale(.95);
-    }
-  }
-
-  .euiSwitch__input:disabled:hover {
-    cursor: not-allowed;
-  }
-
-  .euiSwitch__input:disabled ~ .euiSwitch__body,
-  .euiSwitch__input:checked:disabled ~ .euiSwitch__body {
-    background-color: lightOrDarkTheme(transparentize($euiColorMediumShade, .8), transparentize($euiColorMediumShade, .3));
-
-    .euiSwitch__thumb {
-      @include euiCustomControlDisabled;
-      background-color: lightOrDarkTheme(transparentize($euiColorMediumShade, .8), transparentize($euiColorMediumShade, .3));
-    }
-
-    .euiSwitch__icon {
-      fill: $euiFormCustomControlDisabledIconColor;
-    }
-
-    + label {
-      color: $euiFormControlDisabledColor;
-    }
-  }
-
-  .euiSwitch__input:not(:checked):not(:disabled) ~ .euiSwitch__body {
-    background-color: lightOrDarkTheme(transparentize($euiColorMediumShade, .8), transparentize($euiColorMediumShade, .3));
-  }
-
-  /**
-   * When input is not checked, we shift around the positioning of sibling/child selectors.
-   */
-  .euiSwitch__input:not(:checked) ~ .euiSwitch__body {
-    .euiSwitch__thumb {
-      left: 0;
-    }
-
-    .euiSwitch__icon {
-      right: -$euiSizeS;
-
-      &.euiSwitch__icon--checked {
-        right: auto;
-        left: -($euiSwitchWidth - ($euiSwitchThumbSize / 2));
-      }
     }
   }
 }

--- a/src/components/form/switch/index.d.ts
+++ b/src/components/form/switch/index.d.ts
@@ -1,14 +1,20 @@
 import { CommonProps } from '../../common';
 
-import { FunctionComponent, InputHTMLAttributes, ReactNode } from 'react';
+import { FunctionComponent, ButtonHTMLAttributes, ReactNode } from 'react';
 
 declare module '@elastic/eui' {
   /**
    * @see './switch.js'
    */
   export type EuiSwitchProps = CommonProps &
-    InputHTMLAttributes<HTMLInputElement> & {
-      label?: ReactNode;
+    ButtonHTMLAttributes<HTMLButtonElement> & {
+      label: ReactNode;
+      checked: boolean;
+      onChange: (
+        event: React.FormEvent<HTMLButtonElement & { checked: boolean }>
+      ) => void;
+      disabled?: boolean;
+      compressed?: boolean;
     };
 
   export const EuiSwitch: FunctionComponent<EuiSwitchProps>;

--- a/src/components/form/switch/switch.js
+++ b/src/components/form/switch/switch.js
@@ -15,6 +15,11 @@ export class EuiSwitch extends Component {
     };
   }
 
+  onClick = e => {
+    e.target.checked = !this.props.checked;
+    this.props.onChange(e);
+  };
+
   render() {
     const {
       label,
@@ -40,35 +45,31 @@ export class EuiSwitch extends Component {
 
     return (
       <div className={classes}>
-        <input
-          className="euiSwitch__input"
-          name={name}
+        <button
           id={switchId}
-          type="checkbox"
-          checked={checked}
+          aria-checked={checked}
+          className="euiSwitch__button"
+          role="switch"
           disabled={disabled}
-          onChange={onChange}
-          {...rest}
-        />
+          onClick={this.onClick}
+          {...rest}>
+          <span className="euiSwitch__body">
+            <span className="euiSwitch__thumb" />
+            <span className="euiSwitch__track">
+              <EuiIcon type="cross" size="m" className="euiSwitch__icon" />
 
-        <span className="euiSwitch__body">
-          <span className="euiSwitch__thumb" />
-          <span className="euiSwitch__track">
-            <EuiIcon type="cross" size="m" className="euiSwitch__icon" />
-
-            <EuiIcon
-              type="check"
-              size="m"
-              className="euiSwitch__icon euiSwitch__icon--checked"
-            />
+              <EuiIcon
+                type="check"
+                size="m"
+                className="euiSwitch__icon euiSwitch__icon--checked"
+              />
+            </span>
           </span>
-        </span>
+        </button>
 
-        {label && (
-          <label className="euiSwitch__label" htmlFor={switchId}>
-            {label}
-          </label>
-        )}
+        <label className="euiSwitch__label" htmlFor={switchId}>
+          {label}
+        </label>
       </div>
     );
   }

--- a/src/global_styling/reset/_reset.scss
+++ b/src/global_styling/reset/_reset.scss
@@ -71,6 +71,11 @@ body {
 
 *:focus {
   outline: none;
+
+  // sass-lint:disable no-vendor-prefixes
+  &::-moz-focus-inner {
+    border: none;
+  }
 }
 
 a {


### PR DESCRIPTION
### Summary

Kibana was [seeing issues with switches](https://github.com/elastic/kibana/issues/41522). Though we weren't able to figure out the root cause of the issue, switches have a unique aria role that they weren't taking advantage of. So, instead of continuing to dig, I thought I'd update the semantics skirting the issue a bit.

Following [Inclusive Component's recommendation](https://inclusive-components.design/toggle-button/) I've moved switches away from `<input type=checkbox />` to `<button role=switch aria-checked=true|false>`.

- [x] Made sure the deprecation flow of shimming the event object works in Chrome/FF/Safari/IE 11/ChromiumEdge 

### Checklist

- [x] Checked in **dark mode**
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
