### PR TITLE
Fix global filter truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Fixed `EuiBadge` truncation and auto-applied `title` attribute with `innerText` ([#2190](https://github.com/elastic/eui/pull/2190))
+- Fixed `EuiBadge` truncation in IE and for the global filters pattern ([#2194](https://github.com/elastic/eui/pull/2194))
 
 ## [`13.1.1`](https://github.com/elastic/eui/tree/v13.1.1)
 

--- a/src-docs/src/views/header/_global_filter_group.scss
+++ b/src-docs/src/views/header/_global_filter_group.scss
@@ -17,3 +17,12 @@
   overflow: hidden;
   transition: height $euiAnimSpeedNormal $euiAnimSlightResistance;
 }
+
+.globalFilterGroup__filterFlexItem {
+  overflow: hidden;
+  padding-bottom: 2px; // Allow the shadows of the pills to show
+}
+
+.globalFilterBar__flexItem {
+  max-width: calc(100% - #{$euiSizeXS}); // Width minus margin around each flex itm
+}

--- a/src-docs/src/views/header/_global_filter_item.scss
+++ b/src-docs/src/views/header/_global_filter_item.scss
@@ -2,6 +2,7 @@
   line-height: $euiSizeL + $euiSizeXS;
   border: none;
   color: $euiTextColor;
+  max-width: calc(100% - #{$euiSizeS * 2}); // Padding plus border
 
   &:not(.globalFilterItem-isDisabled) {
     @include euiFormControlDefaultShadow;

--- a/src-docs/src/views/header/_global_filter_item.scss
+++ b/src-docs/src/views/header/_global_filter_item.scss
@@ -2,7 +2,6 @@
   line-height: $euiSizeL + $euiSizeXS;
   border: none;
   color: $euiTextColor;
-  max-width: calc(100% - #{$euiSizeS * 2}); // Padding plus border
 
   &:not(.globalFilterItem-isDisabled) {
     @include euiFormControlDefaultShadow;
@@ -27,5 +26,7 @@
     left: 0;
     width: $euiSizeXS;
     background-color: $euiColorVis0;
+    border-top-left-radius: $euiBorderRadius / 2;
+    border-bottom-left-radius: $euiBorderRadius / 2;
   }
 }

--- a/src-docs/src/views/header/global_filter_bar.js
+++ b/src-docs/src/views/header/global_filter_bar.js
@@ -13,7 +13,10 @@ export const GlobalFilterBar = ({ filters, className, ...rest }) => {
     .filter(filter => filter.isPinned)
     .map(filter => {
       return (
-        <EuiFlexItem key={filter.id} grow={false}>
+        <EuiFlexItem
+          key={filter.id}
+          grow={false}
+          className="globalFilterBar__flexItem">
           <GlobalFilterItem {...filter} />
         </EuiFlexItem>
       );
@@ -23,7 +26,10 @@ export const GlobalFilterBar = ({ filters, className, ...rest }) => {
     .filter(filter => !filter.isPinned)
     .map(filter => {
       return (
-        <EuiFlexItem key={filter.id} grow={false}>
+        <EuiFlexItem
+          key={filter.id}
+          grow={false}
+          className="globalFilterBar__flexItem">
           <GlobalFilterItem {...filter} />
         </EuiFlexItem>
       );

--- a/src-docs/src/views/header/global_filter_item.js
+++ b/src-docs/src/views/header/global_filter_item.js
@@ -188,7 +188,8 @@ export class GlobalFilterItem extends Component {
         closePopover={this.closePopover}
         button={button}
         anchorPosition="downCenter"
-        panelPaddingSize="none">
+        panelPaddingSize="none"
+        display="block">
         <EuiContextMenu
           initialPanelId={0}
           panels={flattenPanelTree(panelTree)}

--- a/src-docs/src/views/header/global_query.js
+++ b/src-docs/src/views/header/global_query.js
@@ -151,7 +151,7 @@ export default class extends Component {
                 <GlobalFilterOptions />
               </EuiFlexItem>
 
-              <EuiFlexItem>
+              <EuiFlexItem className="globalFilterGroup__filterFlexItem">
                 <GlobalFilterBar
                   className="globalFilterGroup__filterBar"
                   filters={this.state.filters}

--- a/src-docs/src/views/header/global_query.js
+++ b/src-docs/src/views/header/global_query.js
@@ -22,7 +22,8 @@ export default class extends Component {
           id: 'filter0',
           field: '@tags.keyword',
           operator: 'IS',
-          value: 'value',
+          value:
+            'This documents a visual pattern for the eventual replacement of Kibanas global query and filter bars. The filter bar has been broken down into multiple components. There are still bugs and not all the logic is well-formed.',
           isDisabled: false,
           isPinned: true,
           isExcluded: false,

--- a/src/components/badge/_badge.scss
+++ b/src/components/badge/_badge.scss
@@ -5,17 +5,15 @@
   font-size: $euiFontSizeXS;
   font-weight: $euiFontWeightMedium;
   line-height: $euiSize + 2px; /* 1 */
+  padding: 0 $euiSizeS;
   display: inline-block;
   text-decoration: none;
-  box-sizing: content-box;
   border-radius: $euiBorderRadius / 2;
   border: solid 1px transparent;
-  padding: 0 $euiSizeS;
   background-color: transparent;
   white-space: nowrap;
   vertical-align: middle;
-  overflow: hidden;
-  max-width: calc(100% - #{($euiSizeS * 2) + 2px}); // Padding plus border
+  max-width: 100%;
   // The badge will only ever be as wide as it's content
   // So, make the text left aligned to ensure all badges line up the same
   text-align: left;
@@ -26,7 +24,6 @@
 
   + .euiBadge {
     margin-left: $euiSizeXS;
-    max-width: calc(100% - #{($euiSizeS * 2) + 2px + $euiSizeXS}); // Padding plus border plus margin
   }
 
   .euiBadge__content {
@@ -37,8 +34,8 @@
 
   .euiBadge__childButton {
     @include euiTextTruncate;
-    max-width: calc(100% - #{$euiSizeM + $euiSizeXS}); // Subtract the icon and icon's margin
-    flex: 0 0 auto;
+    flex: 1 1 auto; // Must be 1 and 1 for IE to properly truncate
+    text-align: inherit;
     font-weight: inherit;
     line-height: inherit;
 


### PR DESCRIPTION
### Fixes the other half of #2189 and https://github.com/elastic/kibana/issues/35225

... also finishes the fixes in  #2190 for IE by:

## Removes `box-sizing: content-box` from EuiBadge

@snide If you can recall why that was in there I will try to find another solution. But that part of the styles was really conflicting with IE and forcing all those max-width calcs. Instead, I removed that to fallback to `border-box` and now just setting `max-width: 100%` accounts for all the extras.


## Fixes the truncation of global filters

**BEFORE**
<img width="966" alt="Screen Shot 2019-08-02 at 09 37 02 AM" src="https://user-images.githubusercontent.com/549577/62374083-2749ec80-b509-11e9-890a-bcac7f8537e3.png">


**AFTER**
<img width="659" alt="Screen Shot 2019-08-02 at 09 25 34 AM" src="https://user-images.githubusercontent.com/549577/62374095-2ca73700-b509-11e9-9b29-3518c60d91ce.png">

**Firefox**
<img width="682" alt="Screen Shot 2019-08-02 at 09 25 06 AM" src="https://user-images.githubusercontent.com/549577/62374119-392b8f80-b509-11e9-8d1c-7375e7074852.png">

**IE**
<img width="985" alt="Screen Shot 2019-08-02 at 09 24 20 AM" src="https://user-images.githubusercontent.com/549577/62374122-3af55300-b509-11e9-853f-d9700528618e.png">

----

Most of these fixes will need to be repeated in Kibana 😓 but atleast this diff will tell us exactly what to do and we'll need the badge fix in there first.

### Checklist

- ~[ ] Checked in **dark mode**~
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- ~[ ] Props have proper **autodocs**~
- [x] Added **documentation** examples
- ~[ ] Added or updated **jest tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
