### PR TITLE
Work around for IE11 sidenav navigation bug

### DIFF
--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -92,13 +92,18 @@ export class GuidePageChrome extends Component {
   };
 
   onClickRoute = () => {
-    this.setState(
-      {
-        search: '',
-        isSideNavOpenOnMobile: false,
-      },
-      this.scrollNavSectionIntoView
-    );
+    // timeout let's IE11 do its thing and update the url
+    // allowing react-router to navigate to the route
+    // otherwise IE11 somehow kills the navigation
+    setTimeout(() => {
+      this.setState(
+        {
+          search: '',
+          isSideNavOpenOnMobile: false,
+        },
+        this.scrollNavSectionIntoView
+      );
+    }, 0);
   };
 
   onButtonClick() {


### PR DESCRIPTION
### Summary

Fixes #2183 

I couldn't find a root cause for IE11 to not update the URL, and thereby preventing routing. Apparently delaying the search state reset avoids the issue.

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
- [x] Checked in **IE11** and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
