### PR TITLE
Fix license link

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -8,7 +8,7 @@ The Elastic UI Framework (EUI) is a design library in use at Elastic to build Re
 
 ## Can I use EUI?
 
-Yes, but be aware of the [license](LICENSE.md) as always. Although the roadmap and priorities are directed by our own usage within Elastic, we do attempt to make the platform generically useful for any React application and try to test for it.
+Yes, but be aware of the [license](LICENSE) as always. Although the roadmap and priorities are directed by our own usage within Elastic, we do attempt to make the platform generically useful for any React application and try to test for it.
 
 ## What is the versioning, releases and upgrade strategy?
 


### PR DESCRIPTION
The license link is broken. (removed .MD)

### Summary

Fixed broken license link in FAQ page.
### Checklist

- [x] Checked in **dark mode**
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [x] Props have proper **autodocs**
- [x] Added **documentation** examples
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
