### PR TITLE
adding i18n tokens to EuiSuperDatePicker and EuiSuperUpdateButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `13.2.0`.
+- Added i18n tokens to `EuiSuperDatePicker` and `EuiSuperUpdateButton`
 
 ## [`13.2.0`](https://github.com/elastic/eui/tree/v13.2.0)
 

--- a/src-docs/src/i18ntokens.json
+++ b/src-docs/src/i18ntokens.json
@@ -416,6 +416,102 @@
     "filepath": "src/components/combo_box/combo_box_options_list/combo_box_options_list.js"
   },
   {
+    "token": "euiSuperDatePicker.showDatesButtonLabel",
+    "defString": "Show dates",
+    "highlighting": "string",
+    "loc": {
+      "start": {
+        "line": 329,
+        "column": 14
+      },
+      "end": {
+        "line": 332,
+        "column": 16
+      }
+    },
+    "filepath": "src/components/date_picker/super_date_picker/super_date_picker.js"
+  },
+  {
+    "token": "euiSuperUpdateButton.refreshButtonLabel",
+    "defString": "Refresh",
+    "highlighting": "string",
+    "loc": {
+      "start": {
+        "line": 77,
+        "column": 21
+      },
+      "end": {
+        "line": 80,
+        "column": 6
+      }
+    },
+    "filepath": "src/components/date_picker/super_date_picker/super_update_button.js"
+  },
+  {
+    "token": "euiSuperUpdateButton.updatingButtonLabel",
+    "defString": "Updating",
+    "highlighting": "string",
+    "loc": {
+      "start": {
+        "line": 83,
+        "column": 8
+      },
+      "end": {
+        "line": 86,
+        "column": 10
+      }
+    },
+    "filepath": "src/components/date_picker/super_date_picker/super_update_button.js"
+  },
+  {
+    "token": "euiSuperUpdateButton.updateButtonLabel",
+    "defString": "Update",
+    "highlighting": "string",
+    "loc": {
+      "start": {
+        "line": 86,
+        "column": 13
+      },
+      "end": {
+        "line": 89,
+        "column": 10
+      }
+    },
+    "filepath": "src/components/date_picker/super_date_picker/super_update_button.js"
+  },
+  {
+    "token": "euiSuperUpdateButton.cannotUpdateTooltip",
+    "defString": "Cannot update",
+    "highlighting": "string",
+    "loc": {
+      "start": {
+        "line": 94,
+        "column": 23
+      },
+      "end": {
+        "line": 97,
+        "column": 8
+      }
+    },
+    "filepath": "src/components/date_picker/super_date_picker/super_update_button.js"
+  },
+  {
+    "token": "euiSuperUpdateButton.clickToApplyTooltip",
+    "defString": "Click to apply",
+    "highlighting": "string",
+    "loc": {
+      "start": {
+        "line": 99,
+        "column": 23
+      },
+      "end": {
+        "line": 102,
+        "column": 8
+      }
+    },
+    "filepath": "src/components/date_picker/super_date_picker/super_update_button.js"
+  },
+  {
     "token": "euiFilterButton.filterBadge",
     "defString": "({\n  count,\n  hasActiveFilters\n}) => `${count} ${hasActiveFilters ? 'active' : 'available'} filters`;",
     "highlighting": "code",

--- a/src/components/date_picker/super_date_picker/__snapshots__/super_date_picker.test.js.snap
+++ b/src/components/date_picker/super_date_picker/__snapshots__/super_date_picker.test.js.snap
@@ -86,7 +86,10 @@ exports[`EuiSuperDatePicker is rendered 1`] = `
           <span
             className="euiSuperDatePicker__prettyFormatLink"
           >
-            Show dates
+            <EuiI18n
+              default="Show dates"
+              token="euiSuperDatePicker.showDatesButtonLabel"
+            />
           </span>
         </button>
       </EuiDatePickerRange>

--- a/src/components/date_picker/super_date_picker/__snapshots__/super_update_button.test.js.snap
+++ b/src/components/date_picker/super_date_picker/__snapshots__/super_update_button.test.js.snap
@@ -22,14 +22,22 @@ exports[`EuiSuperUpdateButton is rendered 1`] = `
     }
     type="button"
   >
-    Refresh
+    <EuiI18n
+      default="Refresh"
+      token="euiSuperUpdateButton.refreshButtonLabel"
+    />
   </EuiButton>
 </EuiToolTip>
 `;
 
 exports[`EuiSuperUpdateButton isDisabled 1`] = `
 <EuiToolTip
-  content="Cannot update"
+  content={
+    <EuiI18n
+      default="Cannot update"
+      token="euiSuperUpdateButton.cannotUpdateTooltip"
+    />
+  }
   delay="regular"
   position="bottom"
 >
@@ -50,7 +58,10 @@ exports[`EuiSuperUpdateButton isDisabled 1`] = `
     }
     type="button"
   >
-    Refresh
+    <EuiI18n
+      default="Refresh"
+      token="euiSuperUpdateButton.refreshButtonLabel"
+    />
   </EuiButton>
 </EuiToolTip>
 `;
@@ -77,14 +88,22 @@ exports[`EuiSuperUpdateButton isLoading 1`] = `
     }
     type="button"
   >
-    Updating
+    <EuiI18n
+      default="Updating"
+      token="euiSuperUpdateButton.updatingButtonLabel"
+    />
   </EuiButton>
 </EuiToolTip>
 `;
 
 exports[`EuiSuperUpdateButton needsUpdate 1`] = `
 <EuiToolTip
-  content="Click to apply"
+  content={
+    <EuiI18n
+      default="Click to apply"
+      token="euiSuperUpdateButton.clickToApplyTooltip"
+    />
+  }
   delay="regular"
   position="bottom"
 >
@@ -105,7 +124,10 @@ exports[`EuiSuperUpdateButton needsUpdate 1`] = `
     }
     type="button"
   >
-    Update
+    <EuiI18n
+      default="Update"
+      token="euiSuperUpdateButton.updateButtonLabel"
+    />
   </EuiButton>
 </EuiToolTip>
 `;

--- a/src/components/date_picker/super_date_picker/super_date_picker.js
+++ b/src/components/date_picker/super_date_picker/super_date_picker.js
@@ -23,6 +23,7 @@ import { EuiDatePickerRange } from '../date_picker_range';
 import { EuiFormControlLayout } from '../../form';
 import { EuiFlexGroup, EuiFlexItem } from '../../flex';
 import { AsyncInterval } from './async_interval';
+import { EuiI18n } from '../../i18n';
 
 export { prettyDuration, commonDurationRanges };
 
@@ -325,7 +326,10 @@ export class EuiSuperDatePicker extends Component {
               this.props.dateFormat
             )}
             <span className="euiSuperDatePicker__prettyFormatLink">
-              Show dates
+              <EuiI18n
+                token="euiSuperDatePicker.showDatesButtonLabel"
+                default="Show dates"
+              />
             </span>
           </button>
         </EuiDatePickerRange>

--- a/src/components/date_picker/super_date_picker/super_update_button.js
+++ b/src/components/date_picker/super_date_picker/super_update_button.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 
 import { EuiButton } from '../../button';
+import { EuiI18n } from '../../i18n';
 import { EuiToolTip } from '../../tool_tip';
 
 export class EuiSuperUpdateButton extends Component {
@@ -73,16 +74,41 @@ export class EuiSuperUpdateButton extends Component {
 
     const classes = classNames('euiSuperUpdateButton', className);
 
-    let buttonText = 'Refresh';
+    let buttonText = (
+      <EuiI18n
+        token="euiSuperUpdateButton.refreshButtonLabel"
+        default="Refresh"
+      />
+    );
     if (needsUpdate || isLoading) {
-      buttonText = isLoading ? 'Updating' : 'Update';
+      buttonText = isLoading ? (
+        <EuiI18n
+          token="euiSuperUpdateButton.updatingButtonLabel"
+          default="Updating"
+        />
+      ) : (
+        <EuiI18n
+          token="euiSuperUpdateButton.updateButtonLabel"
+          default="Update"
+        />
+      );
     }
 
     let tooltipContent;
     if (isDisabled) {
-      tooltipContent = 'Cannot update';
+      tooltipContent = (
+        <EuiI18n
+          token="euiSuperUpdateButton.cannotUpdateTooltip"
+          default="Cannot update"
+        />
+      );
     } else if (needsUpdate && !isLoading) {
-      tooltipContent = 'Click to apply';
+      tooltipContent = (
+        <EuiI18n
+          token="euiSuperUpdateButton.clickToApplyTooltip"
+          default="Click to apply"
+        />
+      );
     }
 
     return (


### PR DESCRIPTION
### Summary

This adds i18m tokens to EuiSuperDatePicker and EuiSuperUpdateButton so they can be properly localized.

### Checklist

- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
