### PR TITLE
EuiDataGrid column visibility & ordering

### DIFF
--- a/src-docs/src/views/datagrid/datagrid.js
+++ b/src-docs/src/views/datagrid/datagrid.js
@@ -323,6 +323,7 @@ export default class DataGrid extends Component {
           button={button}
           isOpen={this.state.isPopoverOpen}
           anchorPosition="rightUp"
+          zIndex={2}
           closePopover={this.closePopover.bind(this)}>
           <div>
             <EuiFormRow label="Border">

--- a/src-docs/src/views/datagrid/datagrid.js
+++ b/src-docs/src/views/datagrid/datagrid.js
@@ -11,16 +11,16 @@ import {
 
 const columns = [
   {
-    name: 'name',
+    id: 'name',
   },
   {
-    name: 'avatar_url',
+    id: 'avatar_url',
   },
   {
-    name: 'url',
+    id: 'url',
   },
   {
-    name: 'contributions',
+    id: 'contributions',
   },
 ];
 
@@ -395,9 +395,7 @@ export default class DataGrid extends Component {
             rowHover: this.state.rowHoverSelected,
             header: this.state.headerSelected,
           }}
-          renderCellValue={({ rowIndex, columnName }) =>
-            data[rowIndex][columnName]
-          }
+          renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
           pagination={{
             ...pagination,
             pageSizeOptions: [5, 10, 25],

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -126,6 +126,37 @@ exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
   role="grid"
 >
   <div
+    class="euiPopover euiPopover--anchorDownCenter"
+  >
+    <div
+      class="euiPopover__anchor"
+    >
+      <button
+        class="euiButton euiButton--primary"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <svg
+            aria-hidden="true"
+            class="euiIcon euiIcon--medium euiIcon-isLoading euiButton__icon"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+          <span
+            class="euiButton__text"
+          >
+            Columns
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+  <div
     class="euiDataGrid__content"
   >
     <div
@@ -134,7 +165,7 @@ exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
     >
       <div
         class="euiDataGridHeaderCell"
-        data-test-subj="dataGridHeaderCell"
+        data-test-subj="dataGridHeaderCell-A"
         role="columnheader"
         style="width:100px"
       >
@@ -151,7 +182,7 @@ exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
       </div>
       <div
         class="euiDataGridHeaderCell"
-        data-test-subj="dataGridHeaderCell"
+        data-test-subj="dataGridHeaderCell-B"
         role="columnheader"
         style="width:100px"
       >

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -119,161 +119,157 @@ exports[`EuiDataGrid pagination renders 1`] = `
 `;
 
 exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
-<div
-  aria-label="aria-label"
-  class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--rowHoverHighlight testClass1 testClass2"
-  data-test-subj="test subject string"
-  role="grid"
->
+Array [
   <div
-    class="euiPopover euiPopover--anchorDownCenter"
-    data-test-subj="dataGridColumnSelectorPopover"
+    class="euiDataGrid__controls"
   >
     <div
-      class="euiPopover__anchor"
+      class="euiPopover euiPopover--anchorDownLeft"
+      data-test-subj="dataGridColumnSelectorPopover"
     >
-      <button
-        class="euiButton euiButton--primary"
-        type="button"
+      <div
+        class="euiPopover__anchor"
       >
-        <span
-          class="euiButton__content"
+        <button
+          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
+          type="button"
         >
-          <svg
-            aria-hidden="true"
-            class="euiIcon euiIcon--medium euiIcon-isLoading euiButton__icon"
-            focusable="false"
-            height="16"
-            viewBox="0 0 16 16"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          />
           <span
-            class="euiButton__text"
+            class="euiButtonEmpty__content"
           >
-            Columns
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiIcon-isLoading euiButtonEmpty__icon"
+              focusable="false"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            />
+            <span
+              class="euiButtonEmpty__text"
+            >
+              Columns
+            </span>
           </span>
-        </span>
-      </button>
+        </button>
+      </div>
     </div>
-  </div>
+  </div>,
   <div
-    class="euiDataGrid__content"
+    aria-label="aria-label"
+    class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--rowHoverHighlight testClass1 testClass2"
+    data-test-subj="test subject string"
+    role="grid"
   >
     <div
-      class="euiDataGridHeader"
-      data-test-subj="dataGridHeader"
+      class="euiDataGrid__content"
     >
       <div
-        class="euiDataGridHeaderCell"
-        data-test-subj="dataGridHeaderCell-A"
-        role="columnheader"
-        style="width:100px"
+        class="euiDataGridHeader"
+        data-test-subj="dataGridHeader"
       >
         <div
-          class="euiDataGridColumnResizer"
-          data-test-subj="dataGridColumnResizer"
-          style="margin-right:0px"
-        />
-        <div
-          class="euiDataGridHeaderCell__content"
+          class="euiDataGridHeaderCell"
+          data-test-subj="dataGridHeaderCell-A"
+          role="columnheader"
+          style="width:undefinedpx"
         >
-          A
+          <div
+            class="euiDataGridHeaderCell__content"
+          >
+            A
+          </div>
+        </div>
+        <div
+          class="euiDataGridHeaderCell"
+          data-test-subj="dataGridHeaderCell-B"
+          role="columnheader"
+          style="width:undefinedpx"
+        >
+          <div
+            class="euiDataGridHeaderCell__content"
+          >
+            B
+          </div>
         </div>
       </div>
       <div
-        class="euiDataGridHeaderCell"
-        data-test-subj="dataGridHeaderCell-B"
-        role="columnheader"
-        style="width:100px"
+        class="euiDataGridRow"
+        data-test-subj="dataGridRow"
+        role="row"
       >
         <div
-          class="euiDataGridColumnResizer"
-          data-test-subj="dataGridColumnResizer"
-          style="margin-right:0px"
-        />
-        <div
-          class="euiDataGridHeaderCell__content"
+          class="euiDataGridRowCell"
+          data-test-subj="dataGridRowCell"
+          role="gridcell"
+          style="width:undefinedpx"
+          tabindex="0"
         >
-          B
+          0, A
+        </div>
+        <div
+          class="euiDataGridRowCell"
+          data-test-subj="dataGridRowCell"
+          role="gridcell"
+          style="width:undefinedpx"
+          tabindex="-1"
+        >
+          0, B
+        </div>
+      </div>
+      <div
+        class="euiDataGridRow"
+        data-test-subj="dataGridRow"
+        role="row"
+      >
+        <div
+          class="euiDataGridRowCell"
+          data-test-subj="dataGridRowCell"
+          role="gridcell"
+          style="width:undefinedpx"
+          tabindex="-1"
+        >
+          1, A
+        </div>
+        <div
+          class="euiDataGridRowCell"
+          data-test-subj="dataGridRowCell"
+          role="gridcell"
+          style="width:undefinedpx"
+          tabindex="-1"
+        >
+          1, B
+        </div>
+      </div>
+      <div
+        class="euiDataGridRow"
+        data-test-subj="dataGridRow"
+        role="row"
+      >
+        <div
+          class="euiDataGridRowCell"
+          data-test-subj="dataGridRowCell"
+          role="gridcell"
+          style="width:undefinedpx"
+          tabindex="-1"
+        >
+          2, A
+        </div>
+        <div
+          class="euiDataGridRowCell"
+          data-test-subj="dataGridRowCell"
+          role="gridcell"
+          style="width:undefinedpx"
+          tabindex="-1"
+        >
+          2, B
         </div>
       </div>
     </div>
     <div
-      class="euiDataGridRow"
-      data-test-subj="dataGridRow"
-      role="row"
-    >
-      <div
-        class="euiDataGridRowCell"
-        data-test-subj="dataGridRowCell"
-        role="gridcell"
-        style="width:100px"
-        tabindex="0"
-      >
-        0, A
-      </div>
-      <div
-        class="euiDataGridRowCell"
-        data-test-subj="dataGridRowCell"
-        role="gridcell"
-        style="width:100px"
-        tabindex="-1"
-      >
-        0, B
-      </div>
-    </div>
-    <div
-      class="euiDataGridRow"
-      data-test-subj="dataGridRow"
-      role="row"
-    >
-      <div
-        class="euiDataGridRowCell"
-        data-test-subj="dataGridRowCell"
-        role="gridcell"
-        style="width:100px"
-        tabindex="-1"
-      >
-        1, A
-      </div>
-      <div
-        class="euiDataGridRowCell"
-        data-test-subj="dataGridRowCell"
-        role="gridcell"
-        style="width:100px"
-        tabindex="-1"
-      >
-        1, B
-      </div>
-    </div>
-    <div
-      class="euiDataGridRow"
-      data-test-subj="dataGridRow"
-      role="row"
-    >
-      <div
-        class="euiDataGridRowCell"
-        data-test-subj="dataGridRowCell"
-        role="gridcell"
-        style="width:100px"
-        tabindex="-1"
-      >
-        2, A
-      </div>
-      <div
-        class="euiDataGridRowCell"
-        data-test-subj="dataGridRowCell"
-        role="gridcell"
-        style="width:100px"
-        tabindex="-1"
-      >
-        2, B
-      </div>
-    </div>
-  </div>
-  <div
-    class="euiSpacer euiSpacer--s"
-  />
-</div>
+      class="euiSpacer euiSpacer--s"
+    />
+  </div>,
+]
 `;

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -127,6 +127,7 @@ exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
 >
   <div
     class="euiPopover euiPopover--anchorDownCenter"
+    data-test-subj="dataGridColumnSelectorPopover"
   >
     <div
       class="euiPopover__anchor"

--- a/src/components/datagrid/_data_grid.scss
+++ b/src/components/datagrid/_data_grid.scss
@@ -2,6 +2,18 @@
   @include euiScrollBar;
   font-feature-settings: 'tnum' 1; // Tabular numbers
   overflow-x: auto;
+  scroll-padding: 0;
   max-width: 100%;
-  width: 100%;
+  width: auto;
+  background: $euiColorLightestShade;
+}
+
+.euiDataGrid__controls {
+  @include euiBottomShadowSmall;
+
+  position: relative;
+  z-index: 2;
+  border-top: $euiBorderThin;
+  border-right: $euiBorderThin;
+  border-left: $euiBorderThin;
 }

--- a/src/components/datagrid/_data_grid.scss
+++ b/src/components/datagrid/_data_grid.scss
@@ -4,7 +4,7 @@
   overflow-x: auto;
   scroll-padding: 0;
   max-width: 100%;
-  width: auto;
+  width: 100%;
   background: $euiColorLightestShade;
 }
 

--- a/src/components/datagrid/_data_grid_column_resizer.scss
+++ b/src/components/datagrid/_data_grid_column_resizer.scss
@@ -28,6 +28,21 @@
       user-select: none;
     }
   }
+}
 
+// This is important. Because the resizer sits in the negative space to the right of the column
+// it can cause the full grid to be a few pixels longer than it actually is. So for the last one
+// we don't use negative positioning and the borders from the cell will match the container.
+@include euiDataGridHeaderCell {
+  &:last-child {
 
+    .euiDataGridColumnResizer {
+      right: 0;
+
+      &:after {
+        left: auto;
+        right: 0;
+      }
+    }
+  }
 }

--- a/src/components/datagrid/_data_grid_column_selector.scss
+++ b/src/components/datagrid/_data_grid_column_selector.scss
@@ -1,3 +1,4 @@
+// sass-lint:disable-block no-empty-rulesets
 .euiDataGridColumnSelector {
   // sass-lint:disable-block no-important
   // background: $euiColorEmptyShade !important; // No need for droppable coloring

--- a/src/components/datagrid/_data_grid_column_selector.scss
+++ b/src/components/datagrid/_data_grid_column_selector.scss
@@ -1,0 +1,20 @@
+.euiDataGridColumnSelector {
+  // sass-lint:disable-block no-important
+  // background: $euiColorEmptyShade !important; // No need for droppable coloring
+}
+
+.euiDataGridColumnSelector__item {
+  background: $euiColorEmptyShade;
+  padding: $euiSizeXS;
+
+  &-isDragging {
+    @include euiBottomShadow;
+  }
+}
+
+// TODO: Find a better solution for how to deal with fix position draggables inside the transformed popover
+.euiDataGridColumnSelectorPopover {
+  // sass-lint:disable-block no-important
+  transform: none !important;
+  margin-top: -$euiSizeS;
+}

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -13,6 +13,7 @@
   overflow: hidden;
   white-space: nowrap;
   flex: 0 0 auto;
+  background: $euiColorEmptyShade;
 
   &:first-of-type {
     border-left: $euiBorderThin;

--- a/src/components/datagrid/_index.scss
+++ b/src/components/datagrid/_index.scss
@@ -4,3 +4,4 @@
 @import 'data_grid_header_row';
 @import 'data_grid_column_resizer';
 @import 'data_grid_data_row';
+@import 'data_grid_column_selector';

--- a/src/components/datagrid/column_selector.tsx
+++ b/src/components/datagrid/column_selector.tsx
@@ -27,7 +27,10 @@ export const useColumnSelector = (
 
   const [isOpen, setIsOpen] = useState(false);
 
-  function fn({ source: { index: sourceIndex }, destination }: DropResult) {
+  function onDragEnd({
+    source: { index: sourceIndex },
+    destination,
+  }: DropResult) {
     const destinationIndex = destination!.index;
     const nextSortedColumns = [...sortedColumns];
 
@@ -44,6 +47,7 @@ export const useColumnSelector = (
 
   const ColumnSelector = () => (
     <EuiPopover
+      data-test-subj="dataGridColumnSelectorPopover"
       isOpen={isOpen}
       closePopover={() => setIsOpen(false)}
       button={
@@ -53,7 +57,7 @@ export const useColumnSelector = (
           </EuiButton>
         </Fragment>
       }>
-      <EuiDragDropContext onDragEnd={fn}>
+      <EuiDragDropContext onDragEnd={onDragEnd}>
         <EuiDroppable droppableId="columnOrder">
           <div>
             {sortedColumns.map(({ id }, index) => (

--- a/src/components/datagrid/column_selector.tsx
+++ b/src/components/datagrid/column_selector.tsx
@@ -1,9 +1,10 @@
 import React, { Fragment, FunctionComponent, useState } from 'react';
 import { EuiDataGridColumn } from './data_grid_types';
 // @ts-ignore-next-line
-import { EuiPopover } from '../popover';
+import { EuiPopover, EuiPopoverFooter } from '../popover';
 // @ts-ignore-next-line
-import { EuiButton } from '../button';
+import { EuiButtonEmpty } from '../button';
+import { EuiFlexGroup, EuiFlexItem } from '../flex';
 // @ts-ignore-next-line
 import { EuiSwitch } from '../form';
 import {
@@ -50,48 +51,79 @@ export const useColumnSelector = (
       data-test-subj="dataGridColumnSelectorPopover"
       isOpen={isOpen}
       closePopover={() => setIsOpen(false)}
+      anchorPosition="downLeft"
+      panelPaddingSize="s"
+      panelClassName="euiDataGridColumnSelectorPopover"
       button={
         <Fragment>
-          <EuiButton iconType="apps" onClick={() => setIsOpen(!isOpen)}>
+          <EuiButtonEmpty
+            size="s"
+            iconType="list"
+            onClick={() => setIsOpen(!isOpen)}>
             Columns
-          </EuiButton>
+          </EuiButtonEmpty>
         </Fragment>
       }>
       <EuiDragDropContext onDragEnd={onDragEnd}>
-        <EuiDroppable droppableId="columnOrder">
-          <div>
+        <EuiDroppable
+          droppableId="columnOrder"
+          className="euiDataGridColumnSelector">
+          <Fragment>
             {sortedColumns.map(({ id }, index) => (
               <EuiDraggable key={id} draggableId={id} index={index}>
-                {provided => (
-                  <Fragment>
-                    <div {...provided.dragHandleProps}>
-                      <EuiIcon type="grab" />
-                    </div>
-                    <EuiSwitch
-                      name={id}
-                      label={id}
-                      checked={visibleColumnIds.has(id)}
-                      onChange={({
-                        currentTarget: { checked },
-                      }: React.FormEvent<HTMLInputElement>) => {
-                        const nextVisibleColumns = sortedColumns.filter(
-                          ({ id: columnId }) =>
-                            checked
-                              ? visibleColumnIds.has(columnId) ||
-                                id === columnId
-                              : visibleColumnIds.has(columnId) &&
-                                id !== columnId
-                        );
-                        setVisibleColumns(nextVisibleColumns);
-                      }}
-                    />
-                  </Fragment>
+                {(provided, state) => (
+                  <div
+                    className={`euiDataGridColumnSelector__item ${state.isDragging &&
+                      'euiDataGridColumnSelector__item-isDragging'}`}>
+                    <EuiFlexGroup gutterSize="m" alignItems="center">
+                      <EuiFlexItem>
+                        <EuiSwitch
+                          name={id}
+                          label={id}
+                          checked={visibleColumnIds.has(id)}
+                          compressed
+                          onChange={({
+                            currentTarget: { checked },
+                          }: React.FormEvent<HTMLInputElement>) => {
+                            const nextVisibleColumns = sortedColumns.filter(
+                              ({ id: columnId }) =>
+                                checked
+                                  ? visibleColumnIds.has(columnId) ||
+                                    id === columnId
+                                  : visibleColumnIds.has(columnId) &&
+                                    id !== columnId
+                            );
+                            setVisibleColumns(nextVisibleColumns);
+                          }}
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false} {...provided.dragHandleProps}>
+                        <div {...provided.dragHandleProps}>
+                          <EuiIcon type="grab" color="subdued" />
+                        </div>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  </div>
                 )}
               </EuiDraggable>
             ))}
-          </div>
+          </Fragment>
         </EuiDroppable>
       </EuiDragDropContext>
+      <EuiPopoverFooter>
+        <EuiFlexGroup gutterSize="s" justifyContent="spaceBetween">
+          <EuiFlexItem>
+            <EuiButtonEmpty size="xs" flush="left">
+              Show all
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiButtonEmpty size="xs" flush="right">
+              Hide all
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPopoverFooter>
     </EuiPopover>
   );
 

--- a/src/components/datagrid/column_selector.tsx
+++ b/src/components/datagrid/column_selector.tsx
@@ -1,0 +1,95 @@
+import React, { Fragment, FunctionComponent, useState } from 'react';
+import { EuiDataGridColumn } from './data_grid_types';
+// @ts-ignore-next-line
+import { EuiPopover } from '../popover';
+// @ts-ignore-next-line
+import { EuiButton } from '../button';
+// @ts-ignore-next-line
+import { EuiSwitch } from '../form';
+import {
+  EuiDragDropContext,
+  EuiDraggable,
+  EuiDroppable,
+} from '../drag_and_drop';
+import { DropResult } from 'react-beautiful-dnd';
+import { EuiIcon } from '../icon';
+
+export const useColumnSelector = (
+  availableColumns: EuiDataGridColumn[]
+): [FunctionComponent<any>, EuiDataGridColumn[]] => {
+  const [sortedColumns, setSortedColumns] = useState(availableColumns);
+
+  const [visibleColumns, setVisibleColumns] = useState(availableColumns);
+  const visibleColumnIds = visibleColumns.reduce((visibleColumnIds, { id }) => {
+    visibleColumnIds.add(id);
+    return visibleColumnIds;
+  }, new Set());
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  function fn({ source: { index: sourceIndex }, destination }: DropResult) {
+    const destinationIndex = destination!.index;
+    const nextSortedColumns = [...sortedColumns];
+
+    nextSortedColumns[sourceIndex] = sortedColumns[destinationIndex];
+    nextSortedColumns[destinationIndex] = sortedColumns[sourceIndex];
+
+    setSortedColumns(nextSortedColumns);
+
+    const nextVisibleColumns = nextSortedColumns.filter(({ id }) =>
+      visibleColumnIds.has(id)
+    );
+    setVisibleColumns(nextVisibleColumns);
+  }
+
+  const ColumnSelector = () => (
+    <EuiPopover
+      isOpen={isOpen}
+      closePopover={() => setIsOpen(false)}
+      button={
+        <Fragment>
+          <EuiButton iconType="apps" onClick={() => setIsOpen(!isOpen)}>
+            Columns
+          </EuiButton>
+        </Fragment>
+      }>
+      <EuiDragDropContext onDragEnd={fn}>
+        <EuiDroppable droppableId="columnOrder">
+          <div>
+            {sortedColumns.map(({ id }, index) => (
+              <EuiDraggable key={id} draggableId={id} index={index}>
+                {provided => (
+                  <Fragment>
+                    <div {...provided.dragHandleProps}>
+                      <EuiIcon type="grab" />
+                    </div>
+                    <EuiSwitch
+                      name={id}
+                      label={id}
+                      checked={visibleColumnIds.has(id)}
+                      onChange={({
+                        currentTarget: { checked },
+                      }: React.FormEvent<HTMLInputElement>) => {
+                        const nextVisibleColumns = sortedColumns.filter(
+                          ({ id: columnId }) =>
+                            checked
+                              ? visibleColumnIds.has(columnId) ||
+                                id === columnId
+                              : visibleColumnIds.has(columnId) &&
+                                id !== columnId
+                        );
+                        setVisibleColumns(nextVisibleColumns);
+                      }}
+                    />
+                  </Fragment>
+                )}
+              </EuiDraggable>
+            ))}
+          </div>
+        </EuiDroppable>
+      </EuiDragDropContext>
+    </EuiPopover>
+  );
+
+  return [ColumnSelector, visibleColumns];
+};

--- a/src/components/datagrid/column_selector.tsx
+++ b/src/components/datagrid/column_selector.tsx
@@ -113,12 +113,18 @@ export const useColumnSelector = (
       <EuiPopoverFooter>
         <EuiFlexGroup gutterSize="s" justifyContent="spaceBetween">
           <EuiFlexItem>
-            <EuiButtonEmpty size="xs" flush="left">
+            <EuiButtonEmpty
+              size="xs"
+              flush="left"
+              onClick={() => setVisibleColumns(sortedColumns)}>
               Show all
             </EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiButtonEmpty size="xs" flush="right">
+            <EuiButtonEmpty
+              size="xs"
+              flush="right"
+              onClick={() => setVisibleColumns([])}>
               Hide all
             </EuiButtonEmpty>
           </EuiFlexItem>

--- a/src/components/datagrid/column_selector.tsx
+++ b/src/components/datagrid/column_selector.tsx
@@ -53,6 +53,7 @@ export const useColumnSelector = (
       closePopover={() => setIsOpen(false)}
       anchorPosition="downLeft"
       panelPaddingSize="s"
+      ownFocus
       panelClassName="euiDataGridColumnSelectorPopover"
       button={
         <Fragment>

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
   useRef,
   useEffect,
+  Fragment,
 } from 'react';
 import classNames from 'classnames';
 import { EuiDataGridHeaderRow } from './data_grid_header_row';
@@ -230,34 +231,36 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
   return (
     // Unsure why this element causes errors as focus follows spec
     // eslint-disable-next-line jsx-a11y/interactive-supports-focus
-    <div
-      role="grid"
-      onKeyDown={handleKeyDown}
-      ref={gridRef}
-      // {...label}
-      {...rest}
-      className={classes}>
+    <Fragment>
       <div className="euiDataGrid__controls">
         <ColumnSelector />
       </div>
-      <div className="euiDataGrid__content">
-        <EuiDataGridHeaderRow
-          columns={visibleColumns}
-          columnWidths={columnWidths}
-          setColumnWidth={setColumnWidth}
-        />
-        <EuiDataGridBody
-          columnWidths={columnWidths}
-          columns={visibleColumns}
-          focusedCell={focusedCell}
-          onCellFocus={onCellFocus}
-          pagination={pagination}
-          renderCellValue={renderCellValue}
-          rowCount={rowCount}
-        />
+      <div
+        role="grid"
+        onKeyDown={handleKeyDown}
+        ref={gridRef}
+        // {...label}
+        {...rest}
+        className={classes}>
+        <div className="euiDataGrid__content">
+          <EuiDataGridHeaderRow
+            columns={visibleColumns}
+            columnWidths={columnWidths}
+            setColumnWidth={setColumnWidth}
+          />
+          <EuiDataGridBody
+            columnWidths={columnWidths}
+            columns={visibleColumns}
+            focusedCell={focusedCell}
+            onCellFocus={onCellFocus}
+            pagination={pagination}
+            renderCellValue={renderCellValue}
+            rowCount={rowCount}
+          />
+        </div>
+        <EuiSpacer size="s" />
+        {renderPagination(props)}
       </div>
-      <EuiSpacer size="s" />
-      {renderPagination(props)}
-    </div>
+    </Fragment>
   );
 };

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -4,6 +4,8 @@ import React, {
   KeyboardEvent,
   useCallback,
   useState,
+  useRef,
+  useEffect,
 } from 'react';
 import classNames from 'classnames';
 import { EuiDataGridHeaderRow } from './data_grid_header_row';
@@ -131,6 +133,26 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
     setColumnWidths({ ...columnWidths, [columnId]: width });
   };
 
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    console.log(gridRef.current);
+    if (gridRef.current != null) {
+      const gridWidth = Math.max(
+        gridRef.current!.clientWidth / props.columns.length,
+        100
+      );
+      const columnWidths = props.columns.reduce(
+        (columnWidths, column) => {
+          columnWidths[column.id] = gridWidth;
+          return columnWidths;
+        },
+        {} as EuiDataGridColumnWidths
+      );
+      setColumnWidths(columnWidths);
+    }
+  }, []);
+
   const [focusedCell, setFocusedCell] = useState<[number, number]>(ORIGIN);
   const onCellFocus = useCallback(
     (x: number, y: number) => {
@@ -211,6 +233,7 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
     <div
       role="grid"
       onKeyDown={handleKeyDown}
+      ref={gridRef}
       // {...label}
       {...rest}
       className={classes}>

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -137,18 +137,17 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
   const gridRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    console.log(gridRef.current);
     if (gridRef.current != null) {
       const gridWidth = Math.max(
         gridRef.current!.clientWidth / props.columns.length,
         100
       );
       const columnWidths = props.columns.reduce(
-        (columnWidths, column) => {
+        (columnWidths: EuiDataGridColumnWidths, column) => {
           columnWidths[column.id] = gridWidth;
           return columnWidths;
         },
-        {} as EuiDataGridColumnWidths
+        {}
       );
       setColumnWidths(columnWidths);
     }

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -229,12 +229,12 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
   const [ColumnSelector, visibleColumns] = useColumnSelector(columns);
 
   return (
-    // Unsure why this element causes errors as focus follows spec
-    // eslint-disable-next-line jsx-a11y/interactive-supports-focus
     <Fragment>
       <div className="euiDataGrid__controls">
         <ColumnSelector />
       </div>
+      {/* Unsure why this element causes errors as focus follows spec */}
+      {/* eslint-disable-next-line jsx-a11y/interactive-supports-focus */}
       <div
         role="grid"
         onKeyDown={handleKeyDown}

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -214,7 +214,9 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
       // {...label}
       {...rest}
       className={classes}>
-      <ColumnSelector />
+      <div className="euiDataGrid__controls">
+        <ColumnSelector />
+      </div>
       <div className="euiDataGrid__content">
         <EuiDataGridHeaderRow
           columns={visibleColumns}

--- a/src/components/datagrid/data_grid_cell.tsx
+++ b/src/components/datagrid/data_grid_cell.tsx
@@ -17,7 +17,7 @@ export interface EuiDataGridCellProps {
   rowIndex: number;
   colIndex: number;
   columnId: string;
-  width: number;
+  width?: number;
   isFocusable: boolean;
   onCellFocus: Function;
   renderCellValue:

--- a/src/components/datagrid/data_grid_cell.tsx
+++ b/src/components/datagrid/data_grid_cell.tsx
@@ -10,13 +10,13 @@ import { Omit } from '../common';
 
 interface CellValueElementProps {
   rowIndex: number;
-  columnName: string;
+  columnId: string;
 }
 
 export interface EuiDataGridCellProps {
   rowIndex: number;
   colIndex: number;
-  columnName: string;
+  columnId: string;
   width: number;
   isFocusable: boolean;
   onCellFocus: Function;
@@ -27,7 +27,10 @@ export interface EuiDataGridCellProps {
 
 interface EuiDataGridCellState {}
 
-type EuiDataGridCellValueProps = Omit<EuiDataGridCellProps, 'width'>;
+type EuiDataGridCellValueProps = Omit<
+  EuiDataGridCellProps,
+  'width' | 'isFocusable'
+>;
 
 const EuiDataGridCellContent: FunctionComponent<
   EuiDataGridCellValueProps
@@ -59,8 +62,8 @@ export class EuiDataGridCell extends Component<
   }
 
   render() {
-    const { width, ...rest } = this.props;
-    const { colIndex, rowIndex, onCellFocus, isFocusable } = rest;
+    const { width, isFocusable, ...rest } = this.props;
+    const { colIndex, rowIndex, onCellFocus } = rest;
 
     return (
       <div

--- a/src/components/datagrid/data_grid_column_resizer.tsx
+++ b/src/components/datagrid/data_grid_column_resizer.tsx
@@ -3,9 +3,9 @@ import React, { Component } from 'react';
 const MINIMUM_COLUMN_WIDTH = 40;
 
 interface EuiDataGridColumnResizerProps {
-  columnName: string;
+  columnId: string;
   columnWidth: number;
-  setColumnWidth: (columnName: string, width: number) => void;
+  setColumnWidth: (columnId: string, width: number) => void;
 }
 
 interface EuiDataGridColumnResizerState {
@@ -34,9 +34,9 @@ export class EuiDataGridColumnResizer extends Component<
 
   onMouseUp = () => {
     const { offset } = this.state;
-    const { columnName, columnWidth, setColumnWidth } = this.props;
+    const { columnId, columnWidth, setColumnWidth } = this.props;
     setColumnWidth(
-      columnName,
+      columnId,
       Math.max(MINIMUM_COLUMN_WIDTH, columnWidth + offset)
     );
 

--- a/src/components/datagrid/data_grid_data_row.tsx
+++ b/src/components/datagrid/data_grid_data_row.tsx
@@ -37,20 +37,20 @@ const EuiDataGridDataRow: FunctionComponent<
   return (
     <div role="row" className={classes} data-test-subj={dataTestSubj} {...rest}>
       {columns.map((props, i) => {
-        const { name } = props;
+        const { id } = props;
 
-        const width = columnWidths.hasOwnProperty(name)
-          ? columnWidths[name]
+        const width = columnWidths.hasOwnProperty(id)
+          ? columnWidths[id]
           : DEFAULT_COLUMN_WIDTH;
 
         const isFocusable = focusedCell[0] === i && focusedCell[1] === rowIndex;
 
         return (
           <EuiDataGridCell
-            key={name}
+            key={id}
             rowIndex={rowIndex}
             colIndex={i}
-            columnName={name}
+            columnId={id}
             width={width}
             renderCellValue={renderCellValue}
             onCellFocus={onCellFocus}

--- a/src/components/datagrid/data_grid_data_row.tsx
+++ b/src/components/datagrid/data_grid_data_row.tsx
@@ -3,7 +3,6 @@ import classnames from 'classnames';
 import { EuiDataGridColumn, EuiDataGridColumnWidths } from './data_grid_types';
 import { CommonProps } from '../common';
 
-import { DEFAULT_COLUMN_WIDTH } from './data_grid_header_row';
 import { EuiDataGridCell, EuiDataGridCellProps } from './data_grid_cell';
 
 export type EuiDataGridDataRowProps = CommonProps &
@@ -39,9 +38,7 @@ const EuiDataGridDataRow: FunctionComponent<
       {columns.map((props, i) => {
         const { id } = props;
 
-        const width = columnWidths.hasOwnProperty(id)
-          ? columnWidths[id]
-          : DEFAULT_COLUMN_WIDTH;
+        const width = columnWidths[id];
 
         const isFocusable = focusedCell[0] === i && focusedCell[1] === rowIndex;
 

--- a/src/components/datagrid/data_grid_header_row.tsx
+++ b/src/components/datagrid/data_grid_header_row.tsx
@@ -10,7 +10,7 @@ type EuiDataGridHeaderRowProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {
     columns: EuiDataGridColumn[];
     columnWidths: EuiDataGridColumnWidths;
-    setColumnWidth: (columnName: string, width: number) => void;
+    setColumnWidth: (columnId: string, width: number) => void;
   };
 
 const EuiDataGridHeaderRow: FunctionComponent<
@@ -31,25 +31,25 @@ const EuiDataGridHeaderRow: FunctionComponent<
   return (
     <div className={classes} data-test-subj={dataTestSubj} {...rest}>
       {columns.map(props => {
-        const { name } = props;
+        const { id } = props;
 
-        const width = columnWidths.hasOwnProperty(name)
-          ? columnWidths[name]
+        const width = columnWidths.hasOwnProperty(id)
+          ? columnWidths[id]
           : DEFAULT_COLUMN_WIDTH;
 
         return (
           <div
             role="columnheader"
-            key={name}
+            key={id}
             className="euiDataGridHeaderCell"
-            data-test-subj="dataGridHeaderCell"
+            data-test-subj={`dataGridHeaderCell-${id}`}
             style={{ width: `${width}px` }}>
             <EuiDataGridColumnResizer
-              columnName={name}
+              columnId={id}
               columnWidth={width}
               setColumnWidth={setColumnWidth}
             />
-            <div className="euiDataGridHeaderCell__content">{name}</div>
+            <div className="euiDataGridHeaderCell__content">{id}</div>
           </div>
         );
       })}

--- a/src/components/datagrid/data_grid_header_row.tsx
+++ b/src/components/datagrid/data_grid_header_row.tsx
@@ -4,8 +4,6 @@ import { EuiDataGridColumnWidths, EuiDataGridColumn } from './data_grid_types';
 import { CommonProps } from '../common';
 import { EuiDataGridColumnResizer } from './data_grid_column_resizer';
 
-export const DEFAULT_COLUMN_WIDTH = 100;
-
 type EuiDataGridHeaderRowProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {
     columns: EuiDataGridColumn[];
@@ -33,9 +31,7 @@ const EuiDataGridHeaderRow: FunctionComponent<
       {columns.map(props => {
         const { id } = props;
 
-        const width = columnWidths.hasOwnProperty(id)
-          ? columnWidths[id]
-          : DEFAULT_COLUMN_WIDTH;
+        const width = columnWidths[id];
 
         return (
           <div
@@ -44,11 +40,14 @@ const EuiDataGridHeaderRow: FunctionComponent<
             className="euiDataGridHeaderCell"
             data-test-subj={`dataGridHeaderCell-${id}`}
             style={{ width: `${width}px` }}>
-            <EuiDataGridColumnResizer
-              columnId={id}
-              columnWidth={width}
-              setColumnWidth={setColumnWidth}
-            />
+            {width ? (
+              <EuiDataGridColumnResizer
+                columnId={id}
+                columnWidth={width}
+                setColumnWidth={setColumnWidth}
+              />
+            ) : null}
+
             <div className="euiDataGridHeaderCell__content">{id}</div>
           </div>
         );

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -1,5 +1,5 @@
 export interface EuiDataGridColumn {
-  name: string;
+  id: string;
 }
 
 export interface EuiDataGridColumnWidths {

--- a/src/components/form/switch/_switch.scss
+++ b/src/components/form/switch/_switch.scss
@@ -137,4 +137,43 @@
       }
     }
   }
+
+  &.euiSwitch--compressed {
+    min-height: $euiSwitchHeight * .5;
+
+    .euiSwitch__label {
+      line-height: $euiSwitchHeight * .5;
+      font-size: $euiFontSizeXS;
+    }
+
+    .euiSwitch__body {
+      pointer-events: none;
+      width: $euiSwitchWidth * .5;
+      height: $euiSwitchHeight * .5;
+      border-radius: $euiSwitchHeight * .5;
+    }
+
+    .euiSwitch__thumb {
+      @include euiCustomControl($type: 'round', $size: ($euiSwitchThumbSize * .5) - 2px);
+
+      left: ($euiSwitchWidth * .5) - (($euiSwitchThumbSize * .5) - 2px) - 1px;
+      top: 1px;
+      border-color: $euiColorPrimary;
+    }
+
+    .euiSwitch__track {
+      border-radius: $euiSwitchHeight * .5;
+    }
+
+    .euiSwitch__icon {
+      display: none;
+    }
+
+    .euiSwitch__input:not(:checked) ~ .euiSwitch__body {
+      .euiSwitch__thumb {
+        left: 1px;
+        border-color: $euiColorMediumShade;
+      }
+    }
+  }
 }

--- a/src/components/form/switch/_switch.scss
+++ b/src/components/form/switch/_switch.scss
@@ -159,6 +159,7 @@
       left: ($euiSwitchWidth * .5) - (($euiSwitchThumbSize * .5) - 2px) - 1px;
       top: 1px;
       border-color: $euiColorPrimary;
+      transition: border-color $euiAnimSpeedNormal $euiAnimSlightBounce, background-color $euiAnimSpeedNormal $euiAnimSlightBounce, left $euiAnimSpeedNormal $euiAnimSlightBounce, transform $euiAnimSpeedNormal $euiAnimSlightBounce;
     }
 
     .euiSwitch__track {

--- a/src/components/popover/_popover_footer.scss
+++ b/src/components/popover/_popover_footer.scss
@@ -9,7 +9,7 @@
 
   @each $modifier, $amount in $euiPanelPaddingModifiers {
     .euiPopover__panel.euiPanel--#{$modifier} & {
-      padding: $euiSizeM $amount;
+      padding: $amount;
       margin: $amount ($amount * -1) ($amount * -1);
     }
   }

--- a/src/test/find_test_subject.ts
+++ b/src/test/find_test_subject.ts
@@ -2,7 +2,8 @@ import { ReactWrapper, ShallowWrapper } from 'enzyme';
 
 type FindTestSubject<T extends ShallowWrapper | ReactWrapper> = (
   mountedComponent: T,
-  testSubjectSelector: string
+  testSubjectSelector: string,
+  matcher?: '=' | '~=' | '|=' | '^=' | '$=' | '*='
 ) => ReturnType<T['find']>;
 
 /**


### PR DESCRIPTION
### Summary

Adds column visibility and ordering options to EuiDataGrid.

I refactored `EuiDataGrid` from a class to a function component so it could use hooks. Implemented the column selector component as a hook, inspired by a conversation with @myasonik about child components reporting their data to parents in a tight feedback loop: `const [ColumnSelector, visibleColumns] = useColumnSelector(columns);`

![datagrid column visibility & ordering](https://d.pr/i/UZMfxG+)

### Checklist

- [ ] Checked in **dark mode**
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [x] Added or updated **jest tests**
~- [ ] Checked for **breaking changes** and labeled appropriately~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
