### PR TITLE
Allow self-referencing/recursive ts types

### DIFF
--- a/scripts/babel/proptypes-from-ts-props/index.js
+++ b/scripts/babel/proptypes-from-ts-props/index.js
@@ -122,6 +122,7 @@ function resolveArrayTypeToPropTypes(node, state) {
 function resolveIdentifierToPropTypes(node, state) {
   const typeDefinitions = state.get('typeDefinitions');
   const types = state.get('types');
+  const inflightResolves = state.get('inflightResolves') || new Set();
 
   let identifier;
   switch (node.type) {
@@ -223,7 +224,21 @@ function resolveIdentifierToPropTypes(node, state) {
   const identifierDefinition = typeDefinitions[identifier.name];
 
   if (identifierDefinition) {
-    return getPropTypesForNode(identifierDefinition, true, state);
+    if (inflightResolves.has(identifier.name)) {
+      return types.memberExpression(
+        types.identifier('PropTypes'),
+        types.identifier('any')
+      );
+    }
+    inflightResolves.add(identifier.name);
+    state.set('inflightResolves', inflightResolves);
+
+    const propType = getPropTypesForNode(identifierDefinition, true, state);
+
+    inflightResolves.delete(identifier.name);
+    state.set('inflightResolves', inflightResolves);
+
+    return propType;
   } else {
     return null;
   }

--- a/scripts/babel/proptypes-from-ts-props/index.test.js
+++ b/scripts/babel/proptypes-from-ts-props/index.test.js
@@ -2361,6 +2361,64 @@ FooComponent.propTypes = {
 
     });
 
+    describe('self-referencing types', () => {
+
+      it(`doesn't explode on self-referencing interfaces`, () => {
+        const result = transform(
+          `
+import React, { SFC } from 'react';
+interface FooProps {
+  label: string;
+  children?: FooProps[];
+}
+const FooComponent: SFC<FooProps> = () => {
+  return (<div>Hello World</div>);
+}`,
+          babelOptions
+        );
+
+        expect(result.code).toBe(`import React from 'react';
+import PropTypes from "prop-types";
+
+const FooComponent = () => {
+  return <div>Hello World</div>;
+};
+
+FooComponent.propTypes = {
+  label: PropTypes.string.isRequired,
+  children: PropTypes.arrayOf(PropTypes.any.isRequired)
+};`);
+      });
+
+      it(`doesn't explode on self-referencing types`, () => {
+        const result = transform(
+          `
+import React, { SFC } from 'react';
+type FooProps = {
+  label: string;
+  children?: FooProps[];
+}
+const FooComponent: SFC<FooProps> = () => {
+  return (<div>Hello World</div>);
+}`,
+          babelOptions
+        );
+
+        expect(result.code).toBe(`import React from 'react';
+import PropTypes from "prop-types";
+
+const FooComponent = () => {
+  return <div>Hello World</div>;
+};
+
+FooComponent.propTypes = {
+  label: PropTypes.string.isRequired,
+  children: PropTypes.arrayOf(PropTypes.any.isRequired)
+};`);
+      });
+
+    });
+
   });
 
   describe('remove types from exports', () => {


### PR DESCRIPTION
### Summary

@daveyholler encountered this bug while working on a recursive tree component. The types->proptypes generator would infinite recurse if an interface or type referenced itself, e.g.

```
interface Foo {
  children: Foo[];
}
```

This adds a check to verify we don't follow recursive references - for now this is done by resolving to a `PropTypes.any` as the object we would want to refer to doesn't exist (the JS code can't self-reference).

I verified this doesn't impact any existing components' proptypes by diffing the `es` and `lib` directories before and after the change.

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
