### PR TITLE
add `@elastic/eslint-plugin-eui` package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,6 +8,7 @@ test/
 src-docs/
 src-framer/
 packages/react-datepicker
+packages/eslint-plugin
 .nvmrc
 
 # typescript output

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "cross-env": "^5.2.0",
     "css-loader": "^0.28.7",
     "cssnano": "^4.0.5",
+    "dedent": "^0.7.0",
     "dts-generator": "^2.1.0",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",

--- a/packages/eslint-plugin/.npmignore
+++ b/packages/eslint-plugin/.npmignore
@@ -1,0 +1,1 @@
+rules/*.test.js

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -1,0 +1,25 @@
+# `@elastic/eslint-plugin-eui`
+
+This package contains an eslint plugin that enforces some default rules for using EUI.
+
+## Setup
+
+1. install `@elastic/eslint-plugin-eui` as a dev dependency
+2. extend `plugin:@elastic/eui/recommended` in your eslint config
+
+## Rules
+
+### `@elastic/eui/href-or-on-click`
+
+`<EuiButton />` should either be a button or a link, for a11y purposes. When given an `href` the button behaves as a link, otherwise an `onClick` handler is expected and it will behave as a button.
+
+In some cases it makes sense to disable this rule locally, such as when <kbd>cmd</kbd>+click should open the link in a new tab, but a standard click should use the `history.pushState()` API to change the URL without triggering a full page load.
+
+## Publishing
+
+This package is published separately from the rest of EUI, as required by eslint. The code is not transpiled, so make sure to use `require()` statements rather than `import`, and once the code is updated run:
+
+1. `npm version patch|minor|major`
+2. commit version bump
+3. `npm publish` in this directory 
+4. push the version bump upstream

--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module.exports = {
+  rules: {
+    'href-or-on-click': require('./rules/href_or_on_click'),
+  },
+  configs: {
+    recommended: {
+      plugins: ['@elastic/eslint-plugin-eui'],
+      rules: {
+        '@elastic/eui/href-or-on-click': 'error',
+      },
+    },
+  },
+};

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -2,6 +2,11 @@
   "name": "@elastic/eslint-plugin-eui",
   "version": "0.0.1",
   "license": "Apache-2.0",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/elastic/eui.git"
+  },
+  "homepage": "https://github.com/elastic/eui/blob/master/packages/eslint-plugin",
   "peerDependencies": {
     "eslint": "^5.0.0"
   }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@elastic/eslint-plugin-eui",
+  "version": "0.0.1",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "eslint": "^5.0.0"
+  }
+}

--- a/packages/eslint-plugin/rules/href_or_on_click.js
+++ b/packages/eslint-plugin/rules/href_or_on_click.js
@@ -1,0 +1,31 @@
+module.exports = {
+  meta: {
+    fixable: null,
+  },
+  create(context) {
+    return {
+      JSXOpeningElement(node) {
+        if (
+          node.name.type !== 'JSXIdentifier' ||
+          node.name.name !== 'EuiButton'
+        ) {
+          return;
+        }
+
+        const hasHref = node.attributes.some(
+          attr => attr.type === 'JSXAttribute' && attr.name.name === 'href'
+        );
+        const hasOnClick = node.attributes.some(
+          attr => attr.type === 'JSXAttribute' && attr.name.name === 'onClick'
+        );
+
+        if (hasHref && hasOnClick) {
+          context.report(
+            node,
+            '<EuiButton> accepts either `href` or `onClick`, not both.'
+          );
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/rules/href_or_on_click.js
+++ b/packages/eslint-plugin/rules/href_or_on_click.js
@@ -1,3 +1,5 @@
+const componentNames = ['EuiButton', 'EuiButtonEmpty', 'EuiLink'];
+
 module.exports = {
   meta: {
     fixable: null,
@@ -7,7 +9,7 @@ module.exports = {
       JSXOpeningElement(node) {
         if (
           node.name.type !== 'JSXIdentifier' ||
-          node.name.name !== 'EuiButton'
+          !componentNames.includes(node.name.name)
         ) {
           return;
         }
@@ -22,7 +24,9 @@ module.exports = {
         if (hasHref && hasOnClick) {
           context.report(
             node,
-            '<EuiButton> accepts either `href` or `onClick`, not both.'
+            `<${
+              node.name.name
+            }> accepts either \`href\` or \`onClick\`, not both.`
           );
         }
       },

--- a/packages/eslint-plugin/rules/href_or_on_click.test.js
+++ b/packages/eslint-plugin/rules/href_or_on_click.test.js
@@ -51,7 +51,6 @@ ruleTester.run('@elastic/eui/href-or-on-click', rule, {
   ],
 
   invalid: [
-    // both href and onClick
     {
       code: dedent(`
         module.export = () => (
@@ -62,6 +61,33 @@ ruleTester.run('@elastic/eui/href-or-on-click', rule, {
       errors: [
         {
           message: '<EuiButton> accepts either `href` or `onClick`, not both.',
+        },
+      ],
+    },
+    {
+      code: dedent(`
+        module.export = () => (
+          <EuiButtonEmpty href="/" onClick={fooBar} />
+        )
+      `),
+
+      errors: [
+        {
+          message:
+            '<EuiButtonEmpty> accepts either `href` or `onClick`, not both.',
+        },
+      ],
+    },
+    {
+      code: dedent(`
+        module.export = () => (
+          <EuiLink href="/" onClick={fooBar} />
+        )
+      `),
+
+      errors: [
+        {
+          message: '<EuiLink> accepts either `href` or `onClick`, not both.',
         },
       ],
     },

--- a/packages/eslint-plugin/rules/href_or_on_click.test.js
+++ b/packages/eslint-plugin/rules/href_or_on_click.test.js
@@ -1,0 +1,69 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+const { RuleTester } = require('eslint');
+const rule = require('./href_or_on_click');
+const dedent = require('dedent');
+
+const ruleTester = new RuleTester({
+  parser: 'babel-eslint',
+  parserOptions: {
+    ecmaVersion: 2018,
+  },
+});
+
+ruleTester.run('@elastic/eui/href-or-on-click', rule, {
+  valid: [
+    {
+      code: dedent(`
+        module.export = () => (
+          <EuiButton />
+        )
+      `),
+    },
+    {
+      code: dedent(`
+        module.export = () => (
+          <EuiButton href="/" />
+        )
+      `),
+    },
+    {
+      code: dedent(`
+        module.export = () => (
+          <EuiButton href={'/' + 'home'} />
+        )
+      `),
+    },
+    {
+      code: dedent(`
+        module.export = () => (
+          <EuiButton onClick={executeAction} />
+        )
+      `),
+    },
+    {
+      code: dedent(`
+        module.export = () => (
+          <EuiButton onClick={() => executeAction()} />
+        )
+      `),
+    },
+  ],
+
+  invalid: [
+    // both href and onClick
+    {
+      code: dedent(`
+        module.export = () => (
+          <EuiButton href="/" onClick={fooBar} />
+        )
+      `),
+
+      errors: [
+        {
+          message: '<EuiButton> accepts either `href` or `onClick`, not both.',
+        },
+      ],
+    },
+  ],
+});

--- a/scripts/jest/config.json
+++ b/scripts/jest/config.json
@@ -2,7 +2,8 @@
   "rootDir": "../../",
   "roots": [
     "<rootDir>/src/",
-    "<rootDir>/scripts/babel"
+    "<rootDir>/scripts/babel",
+    "<rootDir>/packages/eslint-plugin"
   ],
   "collectCoverageFrom": [
     "src/components/**/*.js",

--- a/wiki/releasing-versions.md
+++ b/wiki/releasing-versions.md
@@ -20,6 +20,6 @@ That's it. The latest changes were published to GitHub, a new `git` tag now exis
 
 ## `@elastic/eslint-plugin-eui`
 
-For information on releasing the eslint plugin checkout the readme in [packages/eslint-plugin/README.md](packages/eslint-plugin/README.md)
+For information on releasing the eslint plugin checkout the readme in [packages/eslint-plugin/README.md](../packages/eslint-plugin/README.md)
 
 [docs]: https://elastic.github.io/eui/

--- a/wiki/releasing-versions.md
+++ b/wiki/releasing-versions.md
@@ -18,4 +18,8 @@ That's it. The latest changes were published to GitHub, a new `git` tag now exis
 
 <sup>_\* GitHub Pages sites are cached aggressively and can sometimes take a couple of minutes to update._</sup>
 
+## `@elastic/eslint-plugin-eui`
+
+For information on releasing the eslint plugin checkout the readme in [packages/eslint-plugin/README.md](packages/eslint-plugin/README.md)
+
 [docs]: https://elastic.github.io/eui/

--- a/yarn.lock
+++ b/yarn.lock
@@ -4112,6 +4112,11 @@ decompress-response@^3.2.0:
   dependencies:
     mimic-response "^1.0.0"
 
+dedent@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
+  integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
+
 deep-eql@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"


### PR DESCRIPTION
### Summary

In order to enforce rules like "only pass href, or onClick to `<EuiButton />`" outside of the library implementation, in a way that can be ignored on a case-by-case basis.

Failure:
![image](https://user-images.githubusercontent.com/1329312/62875889-ae048380-bcd8-11e9-875e-67ff23977f00.png)

### Checklist

- [x] ~~Checked in **dark mode**~~
- [x] ~~Checked in **mobile**~~
- [x] ~~Checked in **IE11** and **Firefox**~~
- [x] ~~Props have proper **autodocs**~~
- [x] ~~Added **documentation** examples~~
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] ~~Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] ~~A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~~
