### PR TITLE
`EuiInputPopover` handle input size changes

### DIFF
--- a/src/components/popover/input_popover.js
+++ b/src/components/popover/input_popover.js
@@ -5,6 +5,7 @@ import tabbable from 'tabbable';
 
 import { EuiFocusTrap } from '../focus_trap';
 import { EuiPopover, EuiPopoverPropTypes } from './popover';
+import { EuiResizeObserver } from '../observer/resize_observer';
 import { cascadingMenuKeyCodes } from '../../services';
 
 export const EuiInputPopover = ({
@@ -25,12 +26,15 @@ export const EuiInputPopover = ({
       panelEl.style.width = `${inputElWidth}px`;
     }
   };
-  useEffect(() => {
+  const onResize = () => {
     if (inputEl) {
       const width = inputEl.getBoundingClientRect().width;
       setInputElWidth(width);
       setPanelWidth();
     }
+  };
+  useEffect(() => {
+    onResize();
   }, [inputEl]);
   useEffect(() => {
     setPanelWidth();
@@ -60,7 +64,11 @@ export const EuiInputPopover = ({
   return (
     <EuiPopover
       ownFocus={false}
-      button={input}
+      button={
+        <EuiResizeObserver onResize={onResize}>
+          {resizeRef => <div ref={resizeRef}>{input}</div>}
+        </EuiResizeObserver>
+      }
       buttonRef={inputRef}
       panelRef={panelRef}
       className={classes}


### PR DESCRIPTION
### Summary

For the case of inputs that change size/shape on focus (e.g., the in-progress `SuggestInput` component), this adds a resize handler to correctly size the popover.

### Checklist

~~- [ ] Checked in **dark mode**~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
