### PR TITLE
Adds more complex focus control for DataGrid

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react-is": "~16.3.0",
     "react-virtualized": "^9.18.5",
     "resize-observer-polyfill": "^1.5.0",
-    "tabbable": "^1.1.0",
+    "tabbable": "^3.0.0",
     "uuid": "^3.1.0"
   },
   "devDependencies": {
@@ -85,6 +85,7 @@
     "@types/react-is": "~16.3.0",
     "@types/react-virtualized": "^9.18.6",
     "@types/resize-observer-browser": "^0.1.1",
+    "@types/tabbable": "^3.1.0",
     "@types/uuid": "^3.4.4",
     "@typescript-eslint/eslint-plugin": "^1.9.0",
     "@typescript-eslint/parser": "^1.9.0",

--- a/src-docs/src/views/datagrid/datagrid.js
+++ b/src-docs/src/views/datagrid/datagrid.js
@@ -7,7 +7,10 @@ import {
   EuiFormRow,
   EuiPopover,
   EuiButton,
+  EuiButtonIcon,
+  EuiLink,
 } from '../../../../src/components/';
+import { iconTypes } from '../../../../src-docs/src/views/icon/icons';
 
 const columns = [
   {
@@ -21,6 +24,9 @@ const columns = [
   },
   {
     id: 'contributions',
+  },
+  {
+    id: 'actions',
   },
 ];
 
@@ -304,6 +310,13 @@ export default class DataGrid extends Component {
       pagination: { ...pagination, pageSize },
     }));
 
+  dummyIcon = () => (
+    <EuiButtonIcon
+      aria-label="dummy icon"
+      iconType={iconTypes[Math.floor(Math.random() * iconTypes.length)]}
+    />
+  );
+
   render() {
     const { pagination } = this.state;
 
@@ -396,7 +409,32 @@ export default class DataGrid extends Component {
             rowHover: this.state.rowHoverSelected,
             header: this.state.headerSelected,
           }}
-          renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
+          renderCellValue={({ rowIndex, columnId }) => {
+            const value = data[rowIndex][columnId];
+
+            if (columnId === 'actions') {
+              return (
+                <>
+                  {this.dummyIcon()}
+                  {this.dummyIcon()}
+                </>
+              );
+            }
+
+            if (columnId === 'url') {
+              return <EuiLink href={value}>{value}</EuiLink>;
+            }
+
+            if (columnId === 'avatar_url') {
+              return (
+                <p>
+                  Avatar: <EuiLink href={value}>{value}</EuiLink>
+                </p>
+              );
+            }
+
+            return value;
+          }}
           pagination={{
             ...pagination,
             pageSizeOptions: [5, 10, 25],

--- a/src-docs/src/views/icon/icons.js
+++ b/src-docs/src/views/icon/icons.js
@@ -20,7 +20,7 @@ import {
   EuiCopy,
 } from '../../../../src/components';
 
-const iconTypes = [
+export const iconTypes = [
   'alert',
   'apmTrace',
   'apps',

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -1,5 +1,200 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiDataGrid keyboard controls allows user to enter and exit grid navigation 1`] = `
+<div
+  class="euiDataGrid__controls"
+>
+  <div
+    class="euiPopover euiPopover--anchorDownLeft"
+    data-test-subj="dataGridColumnSelectorPopover"
+  >
+    <div
+      class="euiPopover__anchor"
+    >
+      <button
+        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
+        type="button"
+      >
+        <span
+          class="euiButtonEmpty__content"
+        >
+          <svg
+            aria-hidden="true"
+            class="euiIcon euiIcon--medium euiIcon-isLoading euiButtonEmpty__icon"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+          <span
+            class="euiButtonEmpty__text"
+          >
+            Columns
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiDataGrid keyboard controls allows user to enter and exit grid navigation 2`] = `
+<div
+  class="euiDataGrid__controls"
+>
+  <div
+    class="euiPopover euiPopover--anchorDownLeft"
+    data-test-subj="dataGridColumnSelectorPopover"
+  >
+    <div
+      class="euiPopover__anchor"
+    >
+      <button
+        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
+        type="button"
+      >
+        <span
+          class="euiButtonEmpty__content"
+        >
+          <svg
+            aria-hidden="true"
+            class="euiIcon euiIcon--medium euiIcon-isLoading euiButtonEmpty__icon"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+          <span
+            class="euiButtonEmpty__text"
+          >
+            Columns
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiDataGrid keyboard controls allows user to enter and exit grid navigation 3`] = `
+<div
+  class="euiDataGrid__controls"
+>
+  <div
+    class="euiPopover euiPopover--anchorDownLeft"
+    data-test-subj="dataGridColumnSelectorPopover"
+  >
+    <div
+      class="euiPopover__anchor"
+    >
+      <button
+        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
+        type="button"
+      >
+        <span
+          class="euiButtonEmpty__content"
+        >
+          <svg
+            aria-hidden="true"
+            class="euiIcon euiIcon--medium euiIcon-isLoading euiButtonEmpty__icon"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+          <span
+            class="euiButtonEmpty__text"
+          >
+            Columns
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiDataGrid keyboard controls allows user to enter and exit grid navigation 4`] = `
+<div
+  class="euiDataGrid__controls"
+>
+  <div
+    class="euiPopover euiPopover--anchorDownLeft"
+    data-test-subj="dataGridColumnSelectorPopover"
+  >
+    <div
+      class="euiPopover__anchor"
+    >
+      <button
+        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
+        type="button"
+      >
+        <span
+          class="euiButtonEmpty__content"
+        >
+          <svg
+            aria-hidden="true"
+            class="euiIcon euiIcon--medium euiIcon-isLoading euiButtonEmpty__icon"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+          <span
+            class="euiButtonEmpty__text"
+          >
+            Columns
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiDataGrid keyboard controls allows user to enter and exit grid navigation 5`] = `
+<div
+  class="euiDataGrid__controls"
+>
+  <div
+    class="euiPopover euiPopover--anchorDownLeft"
+    data-test-subj="dataGridColumnSelectorPopover"
+  >
+    <div
+      class="euiPopover__anchor"
+    >
+      <button
+        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
+        type="button"
+      >
+        <span
+          class="euiButtonEmpty__content"
+        >
+          <svg
+            aria-hidden="true"
+            class="euiIcon euiIcon--medium euiIcon-isLoading euiButtonEmpty__icon"
+            focusable="false"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+          <span
+            class="euiButtonEmpty__text"
+          >
+            Columns
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EuiDataGrid pagination renders 1`] = `
 <div
   class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
@@ -163,113 +358,254 @@ Array [
     role="grid"
   >
     <div
-      class="euiDataGrid__content"
+      class="euiDataGridHeader"
+      data-test-subj="dataGridHeader"
+      role="row"
     >
       <div
-        class="euiDataGridHeader"
-        data-test-subj="dataGridHeader"
+        class="euiDataGridHeaderCell"
+        data-test-subj="dataGridHeaderCell-A"
+        role="columnheader"
+        style="width:undefinedpx"
       >
         <div
-          class="euiDataGridHeaderCell"
-          data-test-subj="dataGridHeaderCell-A"
-          role="columnheader"
-          style="width:undefinedpx"
+          class="euiDataGridHeaderCell__content"
         >
-          <div
-            class="euiDataGridHeaderCell__content"
-          >
-            A
-          </div>
-        </div>
-        <div
-          class="euiDataGridHeaderCell"
-          data-test-subj="dataGridHeaderCell-B"
-          role="columnheader"
-          style="width:undefinedpx"
-        >
-          <div
-            class="euiDataGridHeaderCell__content"
-          >
-            B
-          </div>
+          A
         </div>
       </div>
       <div
-        class="euiDataGridRow"
-        data-test-subj="dataGridRow"
-        role="row"
+        class="euiDataGridHeaderCell"
+        data-test-subj="dataGridHeaderCell-B"
+        role="columnheader"
+        style="width:undefinedpx"
       >
         <div
-          class="euiDataGridRowCell"
-          data-test-subj="dataGridRowCell"
-          role="gridcell"
-          style="width:undefinedpx"
-          tabindex="0"
+          class="euiDataGridHeaderCell__content"
         >
-          0, A
-        </div>
-        <div
-          class="euiDataGridRowCell"
-          data-test-subj="dataGridRowCell"
-          role="gridcell"
-          style="width:undefinedpx"
-          tabindex="-1"
-        >
-          0, B
-        </div>
-      </div>
-      <div
-        class="euiDataGridRow"
-        data-test-subj="dataGridRow"
-        role="row"
-      >
-        <div
-          class="euiDataGridRowCell"
-          data-test-subj="dataGridRowCell"
-          role="gridcell"
-          style="width:undefinedpx"
-          tabindex="-1"
-        >
-          1, A
-        </div>
-        <div
-          class="euiDataGridRowCell"
-          data-test-subj="dataGridRowCell"
-          role="gridcell"
-          style="width:undefinedpx"
-          tabindex="-1"
-        >
-          1, B
-        </div>
-      </div>
-      <div
-        class="euiDataGridRow"
-        data-test-subj="dataGridRow"
-        role="row"
-      >
-        <div
-          class="euiDataGridRowCell"
-          data-test-subj="dataGridRowCell"
-          role="gridcell"
-          style="width:undefinedpx"
-          tabindex="-1"
-        >
-          2, A
-        </div>
-        <div
-          class="euiDataGridRowCell"
-          data-test-subj="dataGridRowCell"
-          role="gridcell"
-          style="width:undefinedpx"
-          tabindex="-1"
-        >
-          2, B
+          B
         </div>
       </div>
     </div>
     <div
-      class="euiSpacer euiSpacer--s"
-    />
+      class="euiDataGridRow"
+      data-test-subj="dataGridRow"
+      role="row"
+    >
+      <div
+        class="euiDataGridRowCell"
+        data-test-subj="dataGridRowCell"
+        role="gridcell"
+        style="width:undefinedpx"
+        tabindex="0"
+      >
+        <div
+          data-focus-guard="true"
+          style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+          tabindex="-1"
+        />
+        <div
+          data-focus-guard="true"
+          style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+          tabindex="-1"
+        />
+        <div
+          data-focus-lock-disabled="disabled"
+        >
+          <div
+            data-js-cell-contents-container="false"
+          >
+            0, A
+          </div>
+        </div>
+        <div
+          data-focus-guard="true"
+          style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+          tabindex="-1"
+        />
+      </div>
+      <div
+        class="euiDataGridRowCell"
+        data-test-subj="dataGridRowCell"
+        role="gridcell"
+        style="width:undefinedpx"
+        tabindex="-1"
+      >
+        <div
+          data-focus-guard="true"
+          style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+          tabindex="-1"
+        />
+        <div
+          data-focus-guard="true"
+          style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+          tabindex="-1"
+        />
+        <div
+          data-focus-lock-disabled="disabled"
+        >
+          <div
+            data-js-cell-contents-container="false"
+          >
+            0, B
+          </div>
+        </div>
+        <div
+          data-focus-guard="true"
+          style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+          tabindex="-1"
+        />
+      </div>
+    </div>
+    <div
+      class="euiDataGridRow"
+      data-test-subj="dataGridRow"
+      role="row"
+    >
+      <div
+        class="euiDataGridRowCell"
+        data-test-subj="dataGridRowCell"
+        role="gridcell"
+        style="width:undefinedpx"
+        tabindex="-1"
+      >
+        <div
+          data-focus-guard="true"
+          style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+          tabindex="-1"
+        />
+        <div
+          data-focus-guard="true"
+          style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+          tabindex="-1"
+        />
+        <div
+          data-focus-lock-disabled="disabled"
+        >
+          <div
+            data-js-cell-contents-container="false"
+          >
+            1, A
+          </div>
+        </div>
+        <div
+          data-focus-guard="true"
+          style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+          tabindex="-1"
+        />
+      </div>
+      <div
+        class="euiDataGridRowCell"
+        data-test-subj="dataGridRowCell"
+        role="gridcell"
+        style="width:undefinedpx"
+        tabindex="-1"
+      >
+        <div
+          data-focus-guard="true"
+          style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+          tabindex="-1"
+        />
+        <div
+          data-focus-guard="true"
+          style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+          tabindex="-1"
+        />
+        <div
+          data-focus-lock-disabled="disabled"
+        >
+          <div
+            data-js-cell-contents-container="false"
+          >
+            1, B
+          </div>
+        </div>
+        <div
+          data-focus-guard="true"
+          style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+          tabindex="-1"
+        />
+      </div>
+    </div>
+    <div
+      class="euiDataGridRow"
+      data-test-subj="dataGridRow"
+      role="row"
+    >
+      <div
+        class="euiDataGridRowCell"
+        data-test-subj="dataGridRowCell"
+        role="gridcell"
+        style="width:undefinedpx"
+        tabindex="-1"
+      >
+        <div
+          data-focus-guard="true"
+          style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+          tabindex="-1"
+        />
+        <div
+          data-focus-guard="true"
+          style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+          tabindex="-1"
+        />
+        <div
+          data-focus-lock-disabled="disabled"
+        >
+          <div
+            data-js-cell-contents-container="false"
+          >
+            2, A
+          </div>
+        </div>
+        <div
+          data-focus-guard="true"
+          style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+          tabindex="-1"
+        />
+      </div>
+      <div
+        class="euiDataGridRowCell"
+        data-test-subj="dataGridRowCell"
+        role="gridcell"
+        style="width:undefinedpx"
+        tabindex="-1"
+      >
+        <div
+          data-focus-guard="true"
+          style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+          tabindex="-1"
+        />
+        <div
+          data-focus-guard="true"
+          style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+          tabindex="-1"
+        />
+        <div
+          data-focus-lock-disabled="disabled"
+        >
+          <div
+            data-js-cell-contents-container="false"
+          >
+            2, B
+          </div>
+        </div>
+        <div
+          data-focus-guard="true"
+          style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+          tabindex="-1"
+        />
+      </div>
+    </div>
   </div>,
+  <div
+    class="euiSpacer euiSpacer--s"
+  />,
+  <p
+    hidden=""
+    id="htmlId"
+  >
+    Cell contains interactive content.
+  </p>,
 ]
 `;

--- a/src/components/datagrid/_data_grid.scss
+++ b/src/components/datagrid/_data_grid.scss
@@ -1,4 +1,4 @@
-.euiDataGrid__content {
+.euiDataGrid {
   @include euiScrollBar;
   font-feature-settings: 'tnum' 1; // Tabular numbers
   overflow-x: auto;

--- a/src/components/datagrid/data_grid_body.tsx
+++ b/src/components/datagrid/data_grid_body.tsx
@@ -18,6 +18,8 @@ interface EuiDataGridBodyProps {
   rowCount: number;
   renderCellValue: EuiDataGridCellProps['renderCellValue'];
   pagination?: EuiDataGridPaginationProps;
+  isGridNavigationEnabled: EuiDataGridCellProps['isGridNavigationEnabled'];
+  interactiveCellId: EuiDataGridCellProps['interactiveCellId'];
 }
 
 export const EuiDataGridBody: FunctionComponent<
@@ -31,6 +33,8 @@ export const EuiDataGridBody: FunctionComponent<
     rowCount,
     renderCellValue,
     pagination,
+    isGridNavigationEnabled,
+    interactiveCellId,
   } = props;
 
   const startRow = pagination ? pagination.pageIndex * pagination.pageSize : 0;
@@ -51,6 +55,8 @@ export const EuiDataGridBody: FunctionComponent<
           onCellFocus={onCellFocus}
           renderCellValue={renderCellValue}
           rowIndex={i}
+          isGridNavigationEnabled={isGridNavigationEnabled}
+          interactiveCellId={interactiveCellId}
         />
       );
     }
@@ -64,6 +70,8 @@ export const EuiDataGridBody: FunctionComponent<
     onCellFocus,
     renderCellValue,
     startRow,
+    isGridNavigationEnabled,
+    interactiveCellId,
   ]);
 
   return <Fragment>{rows}</Fragment>;

--- a/src/components/datagrid/data_grid_cell.tsx
+++ b/src/components/datagrid/data_grid_cell.tsx
@@ -6,7 +6,10 @@ import React, {
   ReactNode,
   createRef,
 } from 'react';
+// @ts-ignore
+import { EuiFocusTrap } from '../focus_trap';
 import { Omit } from '../common';
+import { getTabbables, CELL_CONTENTS_ATTR } from './utils';
 
 interface CellValueElementProps {
   rowIndex: number;
@@ -20,6 +23,8 @@ export interface EuiDataGridCellProps {
   width?: number;
   isFocusable: boolean;
   onCellFocus: Function;
+  isGridNavigationEnabled: boolean;
+  interactiveCellId: string;
   renderCellValue:
     | JSXElementConstructor<CellValueElementProps>
     | ((props: CellValueElementProps) => ReactNode);
@@ -29,7 +34,7 @@ interface EuiDataGridCellState {}
 
 type EuiDataGridCellValueProps = Omit<
   EuiDataGridCellProps,
-  'width' | 'isFocusable'
+  'width' | 'isFocusable' | 'isGridNavigationEnabled' | 'interactiveCellId'
 >;
 
 const EuiDataGridCellContent: FunctionComponent<
@@ -45,36 +50,138 @@ const EuiDataGridCellContent: FunctionComponent<
   return <CellElement {...rest} />;
 });
 
+const IS_TABBABLE_ATTR = 'data-is-tabbable';
+
 export class EuiDataGridCell extends Component<
   EuiDataGridCellProps,
   EuiDataGridCellState
 > {
   cellRef = createRef<HTMLDivElement>();
+  cellContentsRef = createRef<HTMLDivElement>();
+
+  isInteractiveCell() {
+    const cellContents = this.cellContentsRef.current;
+
+    if (!cellContents) {
+      return false;
+    }
+
+    const tabbables = getTabbables(cellContents);
+
+    return (
+      tabbables.length > 1 ||
+      (tabbables.length === 1 && this.hasNotTabbables(cellContents))
+    );
+  }
 
   updateFocus() {
-    if (this.cellRef.current && this.props.isFocusable) {
-      this.cellRef.current.focus();
+    const cell = this.cellRef.current;
+    const cellContents = this.cellContentsRef.current;
+    const { isFocusable, isGridNavigationEnabled } = this.props;
+
+    if (cell && isFocusable && cellContents) {
+      const tabbables = getTabbables(cellContents);
+      const isASimpleInteractiveCell =
+        tabbables.length === 1 && !this.hasNotTabbables(cellContents);
+
+      if (
+        !isGridNavigationEnabled ||
+        (isGridNavigationEnabled && isASimpleInteractiveCell)
+      ) {
+        (tabbables[0] as HTMLElement).focus();
+      } else {
+        cell.focus();
+      }
     }
   }
 
-  componentDidUpdate() {
-    this.updateFocus();
+  setTabbablesTabIndex() {
+    const cellContents = this.cellContentsRef.current;
+
+    if (cellContents) {
+      const { isFocusable, isGridNavigationEnabled } = this.props;
+      const areContentsFocusable = isFocusable && !isGridNavigationEnabled;
+
+      getTabbables(cellContents).forEach(element => {
+        element.setAttribute('tabIndex', areContentsFocusable ? '0' : '-1');
+        element.setAttribute(IS_TABBABLE_ATTR, 'true');
+      });
+    }
+  }
+
+  hasNotTabbables(cellContents: Element) {
+    const clone = cellContents.cloneNode(true) as HTMLElement;
+
+    // has to exist because we set the `IS_TABBABLE_ATTR` attribute on it
+    const tabbableElement = clone.querySelector(`[${IS_TABBABLE_ATTR}]`)!;
+
+    // IE 11 doesn't support remove
+    if (tabbableElement.remove) {
+      tabbableElement.remove();
+    } else {
+      tabbableElement.parentNode!.removeChild(tabbableElement);
+    }
+
+    // textContent includes not human readable text
+    // but innerText causes a page reflow
+    // so, only force a reflow if we have a strong signal that we should
+    if (clone.textContent && clone.textContent.length > 0) {
+      // Fallback to innerText if textContent isn't available
+      // Only documented to fallback in tests; all officially supported browsers support innerText
+      if (typeof clone.innerText === 'undefined') {
+        return clone.textContent.length > 0;
+      }
+
+      return clone.innerText.length > 0;
+    }
+
+    return false;
+  }
+
+  componentDidMount() {
+    this.setTabbablesTabIndex();
+  }
+
+  componentDidUpdate(prevProps: EuiDataGridCellProps) {
+    const didFocusChange = prevProps.isFocusable !== this.props.isFocusable;
+    const didNavigationChange =
+      prevProps.isGridNavigationEnabled !== this.props.isGridNavigationEnabled;
+
+    if (didFocusChange || didNavigationChange) {
+      this.updateFocus();
+      this.setTabbablesTabIndex();
+    }
   }
 
   render() {
-    const { width, isFocusable, ...rest } = this.props;
+    const {
+      width,
+      isFocusable,
+      isGridNavigationEnabled,
+      interactiveCellId,
+      ...rest
+    } = this.props;
     const { colIndex, rowIndex, onCellFocus } = rest;
+    const isInteractive = this.isInteractiveCell();
+    const isInteractiveCell = {
+      [CELL_CONTENTS_ATTR]: isInteractive,
+    };
 
     return (
       <div
         role="gridcell"
+        {...isInteractive && { 'aria-describedby': interactiveCellId }}
         tabIndex={isFocusable ? 0 : -1}
         ref={this.cellRef}
         className="euiDataGridRowCell"
         data-test-subj="dataGridRowCell"
-        onFocus={() => onCellFocus(colIndex, rowIndex)}
+        onFocus={() => onCellFocus([colIndex, rowIndex])}
         style={{ width: `${width}px` }}>
-        <EuiDataGridCellContent {...rest} />
+        <EuiFocusTrap disabled={!(isFocusable && !isGridNavigationEnabled)}>
+          <div {...isInteractiveCell} ref={this.cellContentsRef}>
+            <EuiDataGridCellContent {...rest} />
+          </div>
+        </EuiFocusTrap>
       </div>
     );
   }

--- a/src/components/datagrid/data_grid_data_row.tsx
+++ b/src/components/datagrid/data_grid_data_row.tsx
@@ -12,7 +12,9 @@ export type EuiDataGridDataRowProps = CommonProps &
     columnWidths: EuiDataGridColumnWidths;
     focusedCell: [number, number];
     renderCellValue: EuiDataGridCellProps['renderCellValue'];
+    isGridNavigationEnabled: EuiDataGridCellProps['isGridNavigationEnabled'];
     onCellFocus: Function;
+    interactiveCellId: EuiDataGridCellProps['interactiveCellId'];
   };
 
 const EuiDataGridDataRow: FunctionComponent<
@@ -26,6 +28,8 @@ const EuiDataGridDataRow: FunctionComponent<
     rowIndex,
     focusedCell,
     onCellFocus,
+    isGridNavigationEnabled,
+    interactiveCellId,
     'data-test-subj': _dataTestSubj,
     ...rest
   } = props;
@@ -52,6 +56,8 @@ const EuiDataGridDataRow: FunctionComponent<
             renderCellValue={renderCellValue}
             onCellFocus={onCellFocus}
             isFocusable={isFocusable}
+            isGridNavigationEnabled={isGridNavigationEnabled}
+            interactiveCellId={interactiveCellId}
           />
         );
       })}

--- a/src/components/datagrid/data_grid_header_row.tsx
+++ b/src/components/datagrid/data_grid_header_row.tsx
@@ -27,7 +27,7 @@ const EuiDataGridHeaderRow: FunctionComponent<
   const dataTestSubj = classnames('dataGridHeader', _dataTestSubj);
 
   return (
-    <div className={classes} data-test-subj={dataTestSubj} {...rest}>
+    <div role="row" className={classes} data-test-subj={dataTestSubj} {...rest}>
       {columns.map(props => {
         const { id } = props;
 

--- a/src/components/datagrid/utils.tsx
+++ b/src/components/datagrid/utils.tsx
@@ -1,0 +1,8 @@
+import tabbable from 'tabbable';
+
+export const getTabbables = (element: Element) => [
+  ...tabbable(element),
+  ...Array.from(element.querySelectorAll('[tabIndex="-1"]')),
+];
+
+export const CELL_CONTENTS_ATTR = 'data-js-cell-contents-container';

--- a/src/services/key_codes.ts
+++ b/src/services/key_codes.ts
@@ -3,6 +3,7 @@ export const SPACE = 32;
 export const ESCAPE = 27;
 export const TAB = 9;
 export const BACKSPACE = 8;
+export const F2 = 113;
 
 // Arrow keys
 export const DOWN = 40;
@@ -16,6 +17,7 @@ export enum keyCodes {
   ESCAPE = 27,
   TAB = 9,
   BACKSPACE = 8,
+  F2 = 113,
 
   DOWN = 40,
   UP = 38,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1156,6 +1156,11 @@
   resolved "https://registry.yarnpkg.com/@types/resize-observer-browser/-/resize-observer-browser-0.1.1.tgz#9b7cdae9cdc8b1a7020ca7588018dac64c770866"
   integrity sha512-5/bJS/uGB5kmpRrrAWXQnmyKlv+4TlPn4f+A2NBa93p+mt6Ht+YcNGkQKf8HMx28a9hox49ZXShtbGqZkk41Sw==
 
+"@types/tabbable@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/tabbable/-/tabbable-3.1.0.tgz#540d4c2729872560badcc220e73c9412c1d2bffe"
+  integrity sha512-LL0q/bTlzseaXQ8j91eZ+Z8FQUzo0nwkng00B8365qULvFyiSOWylxV8m31Gmee3QuidkDqR72a9NRfR8s4qTw==
+
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
@@ -13988,10 +13993,10 @@ sync-exec@^0.6.2:
   resolved "https://registry.yarnpkg.com/sync-exec/-/sync-exec-0.6.2.tgz#717d22cc53f0ce1def5594362f3a89a2ebb91105"
   integrity sha1-cX0izFPwzh3vVZQ2LzqJouu5EQU=
 
-tabbable@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-1.1.2.tgz#b171680aea6e0a3e9281ff23532e2e5de11c0d94"
-  integrity sha512-77oqsKEPrxIwgRcXUwipkj9W5ItO97L6eUT1Ar7vh+El16Zm4M6V+YU1cbipHEa6q0Yjw8O3Hoh8oRgatV5s7A==
+tabbable@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-3.1.2.tgz#f2d16cccd01f400e38635c7181adfe0ad965a4a2"
+  integrity sha512-wjB6puVXTYO0BSFtCmWQubA/KIn7Xvajw0x0l6eJUudMG/EAiJvIUnyNX6xO4NpGrJ16lbD0eUseB9WxW0vlpQ==
 
 table@^3.7.8:
   version "3.8.3"


### PR DESCRIPTION
### Summary

Improved focus management for more complex cell contents. From the [a11y spec](https://docs.google.com/document/d/16Bje5R00cybqXeCvA0tLM4v8Dl3GwJG6o4etPCiChRM/edit?usp=sharing), this covers: 

- if a cell has one focusable element, default focus can go directly to the element
- if a cell has more than one focusable element or 1 focusable element with other content, the cell should receive focus but make it clear there is interactive content
- on [enter] if a cell contains one or more widgets, disables grid navigation and places focus on the first widget
- on [F2] same as enter; pressing [F2] again restores grid navigation
- [esc] restore grid navigation; if content was being edited, it may undo/cancel
- if grid navigation is disabled, [shift+tab/tab] can now navigate through widgets inside a cell which is now a focus trap

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
- [x] Checked in **IE11** 
- [x] Checked in **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
~- [ ] Checked for **breaking changes** and labeled appropriately~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~