### PR TITLE
Adds onClear prop to EuiDatePicker to make it "clearable"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Converted `EuiFacetButton` to TypeScript ([#2226](https://github.com/elastic/eui/pull/2226))
-- Adds an optional onClose prop to the the EuiDatePicker component ([#2235](https://github.com/elastic/eui/pull/2235))
+- Adds an optional `onClear` prop to the the `EuiDatePicker` component ([#2235](https://github.com/elastic/eui/pull/2235))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Converted `EuiFacetButton` to TypeScript ([#2226](https://github.com/elastic/eui/pull/2226))
+- Adds an optional onClose prop to the the EuiDatePicker component ([#2235](https://github.com/elastic/eui/pull/2235))
 
 **Bug fixes**
 

--- a/src-docs/src/views/date_picker/states.js
+++ b/src-docs/src/views/date_picker/states.js
@@ -44,6 +44,16 @@ export default class extends Component {
           showTimeSelect
           selected={this.state.startDate}
           onChange={this.handleChange}
+          onClear={() => this.handleChange(null)}
+          placeholder="Clearable"
+        />
+
+        <EuiSpacer size="m" />
+
+        <EuiDatePicker
+          showTimeSelect
+          selected={this.state.startDate}
+          onChange={this.handleChange}
           disabled
           placeholder="Disabled"
         />

--- a/src/components/date_picker/__snapshots__/date_picker.test.js.snap
+++ b/src/components/date_picker/__snapshots__/date_picker.test.js.snap
@@ -6,6 +6,7 @@ exports[`EuiDatePicker is rendered 1`] = `
     className="euiDatePicker euiDatePicker--shadow"
   >
     <EuiFormControlLayout
+      clear={null}
       fullWidth={false}
       icon="calendar"
       isLoading={false}

--- a/src/components/date_picker/date_picker.js
+++ b/src/components/date_picker/date_picker.js
@@ -38,6 +38,7 @@ export class EuiDatePicker extends Component {
       minDate,
       minTime,
       onChange,
+      onClear,
       openToDate,
       placeholder,
       popperClassName,
@@ -127,6 +128,7 @@ export class EuiDatePicker extends Component {
           <EuiFormControlLayout
             icon={optionalIcon}
             fullWidth={fullWidth}
+            clear={selected && onClear ? { onClick: onClear } : null}
             isLoading={isLoading}>
             <EuiValidatableControl isInvalid={isInvalid}>
               <DatePicker
@@ -246,6 +248,10 @@ EuiDatePicker.propTypes = {
    * What to do when the input changes
    */
   onChange: PropTypes.func,
+  /**
+   * What to do when the input is cleared by the x icon
+   */
+  onClear: PropTypes.func,
   /**
    * Opens to this date (in moment format) on first press, regardless of selection
    */


### PR DESCRIPTION
### Summary

Adds an optional `onClose` prop to the the `EuiDatePicker` component. When present, it's passed to the `EuiFormControlLayout` that already wraps the date picker component, as its `onClick` method, so that the standard EUI close icon is applied.

![eui-clearable-date-picker](https://user-images.githubusercontent.com/159370/63189951-2a79c800-c033-11e9-878c-08f8be1ec095.gif)


### Checklist

- [ ] Checked in **dark mode**
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [x] Props have proper **autodocs**
- [x] Added **documentation** examples
- [x] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
