### PR TITLE
compile-icons checks SVGs for viewBox attribute

### DIFF
--- a/scripts/compile-icons.js
+++ b/scripts/compile-icons.js
@@ -2,6 +2,8 @@ const glob = require('glob');
 const svgr = require('@svgr/core').default;
 const path = require('path');
 const fs = require('fs');
+const os = require('os')
+const { execSync } = require('child_process');
 
 const rootDir = path.resolve(__dirname, '..');
 const srcDir = path.resolve(rootDir, 'src');
@@ -68,3 +70,11 @@ export const icon = ${componentName};
     process.exit(1);
   }
 });
+
+const results = execSync('find ./src -name "*.svg" -type f | xargs grep -L "viewBox"').toString();
+const filesMissingViewBox = results.split(os.EOL).filter(Boolean);
+if (filesMissingViewBox.length !== 0) {
+  console.error("All svg files should have a 'viewBox' attribute. Check the following:");
+  console.error(filesMissingViewBox.join(os.EOL));
+  process.exit(1);
+}

--- a/scripts/compile-icons.js
+++ b/scripts/compile-icons.js
@@ -2,8 +2,6 @@ const glob = require('glob');
 const svgr = require('@svgr/core').default;
 const path = require('path');
 const fs = require('fs');
-const os = require('os')
-const { execSync } = require('child_process');
 
 const rootDir = path.resolve(__dirname, '..');
 const srcDir = path.resolve(rootDir, 'src');
@@ -37,6 +35,11 @@ iconFiles.forEach(async filePath => {
   const svgSource = fs.readFileSync(filePath);
 
   try {
+    const viewBoxPosition = svgSource.toString().indexOf('viewBox');
+    if (viewBoxPosition === -1) {
+      throw new Error(`${filePath} is missing a 'viewBox' attribute`);
+    }
+
     const jsxSource = (await svgr(
       svgSource,
       {
@@ -70,11 +73,3 @@ export const icon = ${componentName};
     process.exit(1);
   }
 });
-
-const results = execSync('find ./src -name "*.svg" -type f | xargs grep -L "viewBox"').toString();
-const filesMissingViewBox = results.split(os.EOL).filter(Boolean);
-if (filesMissingViewBox.length !== 0) {
-  console.error("All svg files should have a 'viewBox' attribute. Check the following:");
-  console.error(filesMissingViewBox.join(os.EOL));
-  process.exit(1);
-}


### PR DESCRIPTION
### Summary

First pass at a check for the `viewBox` attribute.  Happy to learn a more appropriate place for it or to adjust the behavior/output.

re: [this comment](https://github.com/elastic/eui/issues/2227#issuecomment-521294491) in #2227 Added [the command](https://github.com/elastic/eui/issues/276#issuecomment-356420133) supplied in #276 to `yarn compile-icons` but altered to only look in `src` files.

When run in `master @ 0594cc1` (which had 3 files missing the attribute) it correctly fails with:

```
Error processing /Users/jfsiii/work/eui/src/components/icon/assets/logo_docker.svg
Error: /Users/jfsiii/work/eui/src/components/icon/assets/logo_docker.svg is missing a 'viewBox' attribute
    at iconFiles.forEach (/Users/jfsiii/work/eui/scripts/compile-icons.js:41:13)
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/Users/jfsiii/work/eui/scripts/compile-icons.js:34:11)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at startup (internal/bootstrap/node.js:283:19)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Those SVG's were fixed by #2240 

When run in [`jfsiii:2227-add-viewbox`](https://github.com/jfsiii/eui/tree/2227-add-viewbox) where all the SVGs have the `viewBox` attribute, the result is:

```
> yarn compile-icons
yarn run v1.17.3
$ node ./scripts/compile-icons.js && prettier --write --loglevel=warn "./src/components/icon/assets/**/*.js"
✨  Done in 5.96s.
```

### Checklist

- [ ] ~~Checked in **dark mode**~~
- [ ] ~~Checked in **mobile**~~
- [ ] ~~Checked in **IE11** and **Firefox**~~
- [ ] ~~Props have proper **autodocs**~~
- [ ] ~~Added **documentation** examples~~
- [ ] ~~Added or updated **jest tests**~~
- [ ] ~~Checked for **breaking changes** and labeled appropriately~~
- [ ] ~~Checked for **accessibility** including keyboard-only and screenreader modes~~
- [ ] ~~A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~~
