### PR TITLE
Fixed license link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can find documentation around creating and submitting new components in [CON
 
 [Apache Licensed.][license] Read the [FAQ][faq] for details.
 
-[license]: LICENSE.md
+[license]: LICENSE
 [faq]: FAQ.md
 [consuming]: wiki/consuming.md
 [component-design]: wiki/component-design.md


### PR DESCRIPTION
### Summary

Removed .md extension from the link to LICENSE on the README file.
This was causing a redirect to 404 not found GitHub page when clicking the "Apache Licensed." link.

### Checklist

- [ ] Checked in **dark mode**
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
