### PR TITLE
Fix SuperDatePicker isPaused prop update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `13.5.0`.
+- Fixed `EuiSuperDatePicker` to update `asyncInterval.isStopped` on a `isPaused` prop change. ([#2250](https://github.com/elastic/eui/pull/2250))
 
 ## [`13.5.0`](https://github.com/elastic/eui/tree/v13.5.0)
 

--- a/src/components/date_picker/super_date_picker/super_date_picker.js
+++ b/src/components/date_picker/super_date_picker/super_date_picker.js
@@ -192,6 +192,14 @@ export class EuiSuperDatePicker extends Component {
     }
   };
 
+  componentDidUpdate = () => {
+    if (this.props.isPaused) {
+      this.stopInterval();
+    } else {
+      this.startInterval(this.props.refreshInterval);
+    }
+  };
+
   componentWillUnmount = () => {
     this.stopInterval();
   };

--- a/src/components/date_picker/super_date_picker/super_date_picker.test.js
+++ b/src/components/date_picker/super_date_picker/super_date_picker.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
 import { EuiSuperDatePicker } from './super_date_picker';
 
@@ -10,5 +10,42 @@ describe('EuiSuperDatePicker', () => {
     const component = shallow(<EuiSuperDatePicker onTimeChange={noop} />);
 
     expect(component).toMatchSnapshot();
+  });
+
+  test('updates refresh interval on isPaused prop update', () => {
+    // By default we expect `asyncInterval` to be not set.
+    const componentPaused = mount(<EuiSuperDatePicker onTimeChange={noop} />);
+    const instancePaused = componentPaused.instance();
+    expect(instancePaused.asyncInterval).toBe(undefined);
+    expect(componentPaused.prop('isPaused')).toBe(true);
+
+    // If refresh is enabled via `isPaused/onRefresh` we expect
+    // `asyncInterval` to be present and `asyncInterval.isStopped` to be `false`.
+    const onRefresh = jest.fn();
+    const componentRefresh = mount(
+      <EuiSuperDatePicker
+        onTimeChange={noop}
+        isPaused={false}
+        onRefresh={onRefresh}
+      />
+    );
+    const instanceRefresh = componentRefresh.instance();
+    expect(typeof instanceRefresh.asyncInterval).toBe('object');
+    expect(instanceRefresh.asyncInterval.isStopped).toBe(false);
+    expect(componentRefresh.prop('isPaused')).toBe(false);
+
+    // If we update the prop `isPaused` we expect the interval to be stopped too.
+    componentRefresh.setProps({ isPaused: true });
+    const instanceUpdatedPaused = componentRefresh.instance();
+    expect(typeof instanceUpdatedPaused.asyncInterval).toBe('object');
+    expect(instanceUpdatedPaused.asyncInterval.isStopped).toBe(true);
+    expect(componentRefresh.prop('isPaused')).toBe(true);
+
+    // Let's start refresh again for a final sanity check.
+    componentRefresh.setProps({ isPaused: false });
+    const instanceUpdatedRefresh = componentRefresh.instance();
+    expect(typeof instanceUpdatedRefresh.asyncInterval).toBe('object');
+    expect(instanceUpdatedRefresh.asyncInterval.isStopped).toBe(false);
+    expect(componentRefresh.prop('isPaused')).toBe(false);
   });
 });

--- a/src/components/date_picker/super_date_picker/super_date_picker.test.js
+++ b/src/components/date_picker/super_date_picker/super_date_picker.test.js
@@ -12,13 +12,15 @@ describe('EuiSuperDatePicker', () => {
     expect(component).toMatchSnapshot();
   });
 
-  test('updates refresh interval on isPaused prop update', () => {
+  test('refresh is disabled by default', () => {
     // By default we expect `asyncInterval` to be not set.
     const componentPaused = mount(<EuiSuperDatePicker onTimeChange={noop} />);
     const instancePaused = componentPaused.instance();
     expect(instancePaused.asyncInterval).toBe(undefined);
     expect(componentPaused.prop('isPaused')).toBe(true);
+  });
 
+  test('updates refresh interval on isPaused prop update', () => {
     // If refresh is enabled via `isPaused/onRefresh` we expect
     // `asyncInterval` to be present and `asyncInterval.isStopped` to be `false`.
     const onRefresh = jest.fn();


### PR DESCRIPTION
### Summary

Fixes a bug where a prop change of `isPaused` for SuperDatePicker is not reflected in the refresh interval.

### Checklist

- ~~Checked in **dark mode**~~ doesn't touch DOM
- ~~Checked in **mobile**~~ doesn't touch DOM
- ~~Checked in **IE11** and **Firefox**~~  doesn't touch DOM
- ~~Props have proper **autodocs**~~ doesn't touch props
- ~~Added **documentation** examples~~ doesn't change features
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
- ~~Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
