### PR TITLE
Fix PropType warning in docs

### DIFF
--- a/src-docs/src/views/context_menu/single_panel.js
+++ b/src-docs/src/views/context_menu/single_panel.js
@@ -32,7 +32,6 @@ export default class extends Component {
     const button = (
       <EuiButtonEmpty
         size="s"
-        type="text"
         iconType="arrowDown"
         iconSide="right"
         onClick={this.onButtonClick}>


### PR DESCRIPTION
### Summary

`type=text` was never a valid prop, but TS catches it now.

<img width="551" alt="Screen Shot 2019-08-28 at 2 11 33 PM" src="https://user-images.githubusercontent.com/2728212/63885365-d5787300-c99d-11e9-99ef-f8a4685bbe17.png">

### Checklist

~~- [ ] Checked in **dark mode**~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
~~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~~
