### PR TITLE
`dist/eui_charts_theme` should be `.js`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Removed extra right side margin in `EuiSuperDatePicker` ([#2236](https://github.com/elastic/eui/pull/2236))
 - Fixed incorrect `onClick` type for `EuiButtonEmpty` ([#2282](https://github.com/elastic/eui/pull/2282))
 - Fixed compilation script to remove all TypeScript definition exports from built JS assets ([#2279](https://github.com/elastic/eui/pull/2279))
+- Fixed output extension for `dist` charts theme module ([#2294](https://github.com/elastic/eui/pull/2294))
 
 ## [`13.7.0`](https://github.com/elastic/eui/tree/v13.7.0)
 

--- a/scripts/compile-eui.js
+++ b/scripts/compile-eui.js
@@ -74,7 +74,7 @@ function compileBundle() {
 
   console.log('Building chart theme module...');
   execSync(
-    'webpack src/themes/charts/themes.ts -o dist/eui_charts_theme.ts --output-library-target="commonjs" --config=src/webpack.config.js',
+    'webpack src/themes/charts/themes.ts -o dist/eui_charts_theme.js --output-library-target="commonjs" --config=src/webpack.config.js',
     {
       stdio: 'inherit',
     }

--- a/scripts/compile-eui.js
+++ b/scripts/compile-eui.js
@@ -3,6 +3,7 @@ const chalk = require('chalk');
 const shell = require('shelljs');
 const path = require('path');
 const glob = require('glob');
+const dtsGenerator = require('dts-generator').default;
 
 function compileLib() {
   shell.mkdir(
@@ -43,7 +44,7 @@ function compileLib() {
     stdio: 'inherit',
   });
   // validate the generated eui.d.ts doesn't contain errors
-  execSync(`tsc --noEmit -p tsconfig-builttypes.json`, { stdio: 'inherit' });
+  execSync('tsc --noEmit -p tsconfig-builttypes.json', { stdio: 'inherit' });
   console.log(chalk.green('✔ Finished generating definitions'));
 
   // Also copy over SVGs. Babel has a --copy-files option but that brings over
@@ -79,6 +80,16 @@ function compileBundle() {
       stdio: 'inherit',
     }
   );
+  dtsGenerator({
+    name: '@elastic/eui/dist/eui_charts_theme',
+    out: 'dist/eui_charts_theme.d.ts',
+    baseDir: path.resolve(__dirname, '..', 'src/themes/charts/'),
+    files: ['themes.ts'],
+    resolveModuleId() {
+      return '@elastic/eui/dist/eui_charts_theme';
+    }
+  });
+  console.log(chalk.green('✔ Finished chart theme module'));
 }
 
 compileLib();


### PR DESCRIPTION
### Summary

Extra `.ts` snuck in before the merge.

### Checklist

~~- [ ] Checked in **dark mode**~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
