### PR TITLE
Fix some typoes in documentation/comments

### DIFF
--- a/packages/react-datepicker/test/datepicker_test.js
+++ b/packages/react-datepicker/test/datepicker_test.js
@@ -794,7 +794,7 @@ describe("DatePicker", () => {
   it("should correctly clear date with empty input string", () => {
     var cleared = false;
     function handleChange(d) {
-      // Internally DateInput calls it's onChange prop with null
+      // Internally DateInput calls its onChange prop with null
       // when the input value is an empty string
       if (d === null) {
         cleared = true;

--- a/src/components/avatar/_avatar.scss
+++ b/src/components/avatar/_avatar.scss
@@ -1,5 +1,5 @@
 .euiAvatar {
-  flex-shrink: 0; // Ensures it never scales down below it's intended size
+  flex-shrink: 0; // Ensures it never scales down below its intended size
   display: inline-block;
   background-size: cover;
   text-align: center;

--- a/src/components/badge/_badge.scss
+++ b/src/components/badge/_badge.scss
@@ -15,7 +15,7 @@
   vertical-align: middle;
   cursor: default;
   max-width: 100%;
-  // The badge will only ever be as wide as it's content
+  // The badge will only ever be as wide as its content
   // So, make the text left aligned to ensure all badges line up the same
   text-align: left;
 

--- a/src/components/badge/notification_badge/_notification_badge.scss
+++ b/src/components/badge/notification_badge/_notification_badge.scss
@@ -1,5 +1,5 @@
 .euiNotificationBadge {
-  flex-shrink: 0; // Ensures it never scales down below it's intended size
+  flex-shrink: 0; // Ensures it never scales down below its intended size
   display: inline-block;
   border-radius: $euiBorderRadius;
   background: $euiColorAccent;

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -6,7 +6,7 @@
 
 /**
  * 1. Footer is always at the bottom.
- * 2. Fix for IE where the image correctly resizes in width but doesn't collapse it's height
+ * 2. Fix for IE where the image correctly resizes in width but doesn't collapse its height
       (https://github.com/philipwalton/flexbugs/issues/75#issuecomment-134702421)
  * 3. Horizontal layouts should always top left align no matter the textAlign prop
  */

--- a/src/components/filter_group/filter_button.js
+++ b/src/components/filter_group/filter_button.js
@@ -136,7 +136,7 @@ EuiFilterButton.propTypes = {
    */
   type: PropTypes.string,
   /**
-   * Should the button grow to fill it's container, best used for dropdown buttons
+   * Should the button grow to fill its container, best used for dropdown buttons
    */
   grow: PropTypes.bool,
   /**

--- a/src/components/form/_mixins.scss
+++ b/src/components/form/_mixins.scss
@@ -1,6 +1,6 @@
 @mixin euiPlaceholderPerBrowser {
   // sass-lint:disable-block no-vendor-prefixes
-  // Each prefix must be it's own content block
+  // Each prefix must be its own content block
   &::-webkit-input-placeholder { @content; }
   &::-moz-placeholder { @content; }
   &:-ms-input-placeholder { @content; }

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -60,7 +60,7 @@
   * 1. Don't block the user from dropping files onto the filepicker.
   * 3. Ensure space for import icon, loading spinner, and clear button (only if it has files)
   * 4. Delay focus gradient or else it will only partially transition while file chooser opens
-  * 5. Static height so that it doesn't shift it's surrounding contents around
+  * 5. Static height so that it doesn't shift its surrounding contents around
   */
 .euiFilePicker__prompt {
   @include euiFormControlDefaultShadow;

--- a/src/components/icon/_icon.scss
+++ b/src/components/icon/_icon.scss
@@ -1,5 +1,5 @@
 .euiIcon {
-  flex-shrink: 0; // Ensures it never scales down below it's intended size
+  flex-shrink: 0; // Ensures it never scales down below its intended size
   display: inline-block;
   vertical-align: middle;
   fill: currentColor;

--- a/src/components/image/_image.scss
+++ b/src/components/image/_image.scss
@@ -1,5 +1,5 @@
 /**
- * 1. Fix for IE where the image correctly resizes in width but doesn't collapse it's height
+ * 1. Fix for IE where the image correctly resizes in width but doesn't collapse its height
       (https://github.com/philipwalton/flexbugs/issues/75#issuecomment-134702421)
  */
 
@@ -9,7 +9,7 @@
   max-width: 100%;
   position: relative;
   min-height: 1px; /* 1 */
-  line-height: 0; // Fixes cropping when image is resized by forcing it's height to be determined by the image not line-height
+  line-height: 0; // Fixes cropping when image is resized by forcing its height to be determined by the image not line-height
 
   &.euiImage--hasShadow {
     .euiImage__img {

--- a/src/components/loading/_loading_spinner.scss
+++ b/src/components/loading/_loading_spinner.scss
@@ -1,5 +1,5 @@
 .euiLoadingSpinner {
-  flex-shrink: 0; // Ensures it never scales down below it's intended size
+  flex-shrink: 0; // Ensures it never scales down below its intended size
   display: inline-block;
   width: $euiSizeXL;
   height: $euiSizeXL;

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -66,7 +66,7 @@
   justify-content: flex-end;
   padding: $euiSize $euiSizeL $euiSizeL;
   flex-grow: 0;
-  flex-shrink: 0; // ensure the height of the footer is based off it's contents and doesn't squish
+  flex-shrink: 0; // ensure the height of the footer is based off its contents and doesn't squish
 
   > * + * {
     margin-left: $euiSize;

--- a/src/components/nav_drawer/_nav_drawer_group.scss
+++ b/src/components/nav_drawer/_nav_drawer_group.scss
@@ -23,7 +23,7 @@
   @include size($euiSize);
   line-height: $euiSize;
   font-size: $euiSizeM;
-  flex-shrink: 0; // Ensures it never scales down below it's intended size
+  flex-shrink: 0; // Ensures it never scales down below its intended size
   display: inline-block;
   text-align: center;
   vertical-align: middle;

--- a/src/components/table/_responsive.scss
+++ b/src/components/table/_responsive.scss
@@ -138,7 +138,7 @@
         @include euiBottomShadowSmall;
         margin-top: -$euiTableCellContentPadding * 2;
         position: relative;
-        z-index: 2; // on top of it's parent/previous row
+        z-index: 2; // on top of its parent/previous row
         border-top: none;
         border-top-left-radius: 0;
         border-top-right-radius: 0;

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -218,7 +218,7 @@
   &.euiText--constrainedWidth {
     max-width: $euiTextConstrainedMaxWidth;
     // If the max-width is way too short of the width of the container,
-    // at least make it 2/3 of it's parent
+    // at least make it 2/3 of its parent
     min-width: 75%;
   }
 

--- a/src/components/tool_tip/_tool_tip.scss
+++ b/src/components/tool_tip/_tool_tip.scss
@@ -1,5 +1,5 @@
 /*
- * 1. Shift arrow 1px more than half it's size to account for border radius
+ * 1. Shift arrow 1px more than half its size to account for border radius
  */
 
 .euiToolTip {

--- a/src/global_styling/functions/_colors.scss
+++ b/src/global_styling/functions/_colors.scss
@@ -28,7 +28,7 @@
 }
 
 // Similar to above, but uses the light or dark color based
-// on whether it's the light or darkt theme
+// on whether it's the light or dark theme
 @function lightOrDarkTheme($lightColor, $darkColor) {
   @if (lightness($euiTextColor) < 50) {
     @return $lightColor;


### PR DESCRIPTION
### Summary

I went to fix a typo in some documentation and discovered several instances of the same typo, so I went through and replaced them all. Also fixed a misspelling.

Super low priority, but hopefully useful.

### Checklist

- [ ] Checked in **dark mode**
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
