### PR TITLE
`EuiContextMenu` `null` check for index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Updated TS def for `EuiFilterSelect` ([#2291](https://github.com/elastic/eui/pull/2291))
 - Fixed alignment of icons and label in `EuiSideNavItem` ([#2297](https://github.com/elastic/eui/pull/2297))
+- Fixed logic in `EuiContextMenu` to account for index of `0` ([#2304](https://github.com/elastic/eui/pull/2304))
 
 ## [`13.8.0`](https://github.com/elastic/eui/tree/v13.8.0)
 

--- a/src/components/context_menu/context_menu.tsx
+++ b/src/components/context_menu/context_menu.tsx
@@ -178,7 +178,7 @@ export class EuiContextMenu extends Component<EuiContextMenuProps, State> {
   }
 
   showNextPanel = (itemIndex?: number) => {
-    if (!itemIndex) {
+    if (itemIndex == null) {
       return;
     }
 


### PR DESCRIPTION
### Summary

Fixes a [bug introduced during TS conversion](https://github.com/elastic/eui/commit/1b7c29c4c0761ca50ee708d071dd820139993526#diff-43a73381f61128243de2427d64aba91dR181) where index of `0` isn't accounted for.

### Checklist

~~- [ ] Checked in **dark mode**~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
