### PR TITLE
Generate & display React.forwardRef components' props in docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "babel-plugin-dynamic-import-node": "^2.2.0",
     "babel-plugin-inline-react-svg": "^1.0.1",
     "babel-plugin-pegjs-inline-precompile": "^0.1.0",
-    "babel-plugin-react-docgen": "^2.0.0",
+    "babel-plugin-react-docgen": "^3.1.0",
     "babel-template": "^6.26.0",
     "cache-loader": "^2.0.1",
     "chai": "^4.1.2",

--- a/scripts/babel/proptypes-from-ts-props/index.js
+++ b/scripts/babel/proptypes-from-ts-props/index.js
@@ -9,15 +9,12 @@ const importedDefinitionsCache = new Map();
 
 // react-docgen does not understand typescript annotations
 function stripTypeScript(filename, ast) {
-  return babelCore.transform(
-    babelCore.transformFromAst(ast).code,
-    {
-      filename: filename,
-      babelrc: false,
-      presets: ['@babel/typescript'],
-      plugins: ['@babel/plugin-syntax-dynamic-import'],
-    }
-  ).code;
+  return babelCore.transform(babelCore.transformFromAst(ast).code, {
+    filename: filename,
+    babelrc: false,
+    presets: ['@babel/typescript'],
+    plugins: ['@babel/plugin-syntax-dynamic-import'],
+  }).code;
 }
 
 // .ts file could import types from a .tsx file, so force nested imports to parse JSX
@@ -64,15 +61,15 @@ function resolveArrayToPropTypes(node, state) {
     // Array with typed elements
     // PropTypes.arrayOf()
     // Array type only has one type argument
-    const { params: [arrayType] } = typeParameters;
+    const {
+      params: [arrayType],
+    } = typeParameters;
     return types.callExpression(
       types.memberExpression(
         types.identifier('PropTypes'),
         types.identifier('arrayOf')
       ),
-      [
-        getPropTypesForNode(arrayType, false, state)
-      ]
+      [getPropTypesForNode(arrayType, false, state)]
     );
   }
 }
@@ -101,9 +98,7 @@ function resolveArrayTypeToPropTypes(node, state) {
         types.identifier('PropTypes'),
         types.identifier('arrayOf')
       ),
-      [
-        getPropTypesForNode(elementType, false, state)
-      ]
+      [getPropTypesForNode(elementType, false, state)]
     );
   }
 }
@@ -138,7 +133,10 @@ function resolveIdentifierToPropTypes(node, state) {
   }
 
   // resolve React.* identifiers
-  if (identifier.type === 'TSQualifiedName' && identifier.left.name === 'React') {
+  if (
+    identifier.type === 'TSQualifiedName' &&
+    identifier.left.name === 'React'
+  ) {
     return resolveIdentifierToPropTypes(identifier.right, state);
   }
 
@@ -165,18 +163,32 @@ function resolveIdentifierToPropTypes(node, state) {
   }
 
   if (identifier.name === 'Array') return resolveArrayToPropTypes(node, state);
-  if (identifier.name === 'MouseEventHandler') return buildPropTypePrimitiveExpression(types, 'func');
-  if (identifier.name === 'Function') return buildPropTypePrimitiveExpression(types, 'func');
+  if (identifier.name === 'MouseEventHandler')
+    return buildPropTypePrimitiveExpression(types, 'func');
+  if (identifier.name === 'Function')
+    return buildPropTypePrimitiveExpression(types, 'func');
   if (identifier.name === 'ExclusiveUnion') {
     // We use ExclusiveUnion at the top level to exclusively discriminate between types
     // propTypes itself must be an object so merge the union sets together as an intersection
 
     // Any types that are optional or non-existant on one side must be optional after the union
-    const aPropType = getPropTypesForNode(node.typeParameters.params[0], true, state);
-    const bPropType = getPropTypesForNode(node.typeParameters.params[1], true, state);
+    const aPropType = getPropTypesForNode(
+      node.typeParameters.params[0],
+      true,
+      state
+    );
+    const bPropType = getPropTypesForNode(
+      node.typeParameters.params[1],
+      true,
+      state
+    );
 
-    const propsOnA = types.isCallExpression(aPropType) ? aPropType.arguments[0].properties : [];
-    const propsOnB = types.isCallExpression(bPropType) ? bPropType.arguments[0].properties : [];
+    const propsOnA = types.isCallExpression(aPropType)
+      ? aPropType.arguments[0].properties
+      : [];
+    const propsOnB = types.isCallExpression(bPropType)
+      ? bPropType.arguments[0].properties
+      : [];
 
     // optional props is any prop that is optional or non-existant on one side
     const optionalProps = new Set();
@@ -184,7 +196,8 @@ function resolveIdentifierToPropTypes(node, state) {
       const property = propsOnA[i];
       const propertyName = property.key.name;
       const isOptional = !isPropTypeRequired(types, property.value);
-      const existsOnB = propsOnB.find(property => property.key.name === propertyName) != null;
+      const existsOnB =
+        propsOnB.find(property => property.key.name === propertyName) != null;
       if (isOptional || !existsOnB) {
         optionalProps.add(propertyName);
       }
@@ -193,7 +206,8 @@ function resolveIdentifierToPropTypes(node, state) {
       const property = propsOnB[i];
       const propertyName = property.key.name;
       const isOptional = !isPropTypeRequired(types, property.value);
-      const existsOnA = propsOnA.find(property => property.key.name === propertyName) != null;
+      const existsOnA =
+        propsOnA.find(property => property.key.name === propertyName) != null;
       if (isOptional || !existsOnA) {
         optionalProps.add(propertyName);
       }
@@ -260,19 +274,18 @@ function buildPropTypePrimitiveExpression(types, typeName) {
 }
 
 function isPropTypeRequired(types, propType) {
-  return types.isMemberExpression(propType) &&
+  return (
+    types.isMemberExpression(propType) &&
     types.isIdentifier(propType.property) &&
-    propType.property.name === 'isRequired';
+    propType.property.name === 'isRequired'
+  );
 }
 
 function makePropTypeRequired(types, propType) {
   // can't make literals required no matter how hard we try
   if (types.isLiteral(propType) === true) return propType;
 
-  return types.memberExpression(
-    propType,
-    types.identifier('isRequired')
-  );
+  return types.memberExpression(propType, types.identifier('isRequired'));
 }
 
 function makePropTypeOptional(types, propType) {
@@ -284,16 +297,20 @@ function makePropTypeOptional(types, propType) {
 }
 
 function areExpressionsIdentical(a, b) {
-  const aCode = babelCore.transformFromAst(babelCore.types.program([
-    babelCore.types.expressionStatement(
-      babelCore.types.removeComments(babelCore.types.cloneDeep(a))
-    )
-  ])).code;
-  const bCode = babelCore.transformFromAst(babelCore.types.program([
-    babelCore.types.expressionStatement(
-      babelCore.types.removeComments(babelCore.types.cloneDeep(b))
-    )
-  ])).code;
+  const aCode = babelCore.transformFromAst(
+    babelCore.types.program([
+      babelCore.types.expressionStatement(
+        babelCore.types.removeComments(babelCore.types.cloneDeep(a))
+      ),
+    ])
+  ).code;
+  const bCode = babelCore.transformFromAst(
+    babelCore.types.program([
+      babelCore.types.expressionStatement(
+        babelCore.types.removeComments(babelCore.types.cloneDeep(b))
+      ),
+    ])
+  ).code;
   return aCode === bCode;
 }
 
@@ -307,9 +324,7 @@ function convertLiteralToOneOf(types, literalNode) {
       types.identifier('PropTypes'),
       types.identifier('oneOf')
     ),
-    [
-      types.arrayExpression([ literalNode ])
-    ]
+    [types.arrayExpression([literalNode])]
   );
 }
 
@@ -328,7 +343,7 @@ function getPropTypesForNode(node, optional, state) {
   if (node.isAlreadyResolved === true) return node;
 
   let propType;
-  switch(node.type) {
+  switch (node.type) {
     // a type value by identifier
     case 'TSTypeReference':
       propType = resolveIdentifierToPropTypes(node, state);
@@ -368,59 +383,62 @@ function getPropTypesForNode(node, optional, state) {
       });
 
       // merge the resolved proptypes for each intersection member into one object, mergedProperties
-      const mergedProperties = usableNodes.reduce(
-        (mergedProperties, node) => {
-          const nodePropTypes = getPropTypesForNode(node, true, state);
+      const mergedProperties = usableNodes.reduce((mergedProperties, node) => {
+        const nodePropTypes = getPropTypesForNode(node, true, state);
 
-          // iterate over this type's members, adding them (and their comments) to `mergedProperties`
-          const typeProperties = nodePropTypes.arguments[0].properties; // properties on the ObjectExpression passed to PropTypes.shape()
-          for (let i = 0; i < typeProperties.length; i++) {
-            const typeProperty = typeProperties[i];
-            // this member may be duplicated between two shapes, e.g. Foo = { buzz: string } & Bar = { buzz: string }
-            // either or both may have leading comments and we want to forward all comments to the generated prop type
-            const leadingComments = [
-              ...(typeProperty.leadingComments || []),
-              ...((mergedProperties[typeProperty.key.name] ? mergedProperties[typeProperty.key.name].leadingComments : null) || []),
-            ];
+        // iterate over this type's members, adding them (and their comments) to `mergedProperties`
+        const typeProperties = nodePropTypes.arguments[0].properties; // properties on the ObjectExpression passed to PropTypes.shape()
+        for (let i = 0; i < typeProperties.length; i++) {
+          const typeProperty = typeProperties[i];
+          // this member may be duplicated between two shapes, e.g. Foo = { buzz: string } & Bar = { buzz: string }
+          // either or both may have leading comments and we want to forward all comments to the generated prop type
+          const leadingComments = [
+            ...(typeProperty.leadingComments || []),
+            ...((mergedProperties[typeProperty.key.name]
+              ? mergedProperties[typeProperty.key.name].leadingComments
+              : null) || []),
+          ];
 
-            let propTypeValue = typeProperty.value;
-            if (types.isLiteral(propTypeValue)) {
-              // can't use a literal straight, wrap it with PropTypes.oneOf([ the_literal ])
-              propTypeValue = convertLiteralToOneOf(types, propTypeValue);
-            }
-
-            // if this property has already been found, the only action is to potentially change it to optional
-            if (mergedProperties.hasOwnProperty(typeProperty.key.name)) {
-              const existing = mergedProperties[typeProperty.key.name];
-              if (!areExpressionsIdentical(existing, typeProperty.value)) {
-                mergedProperties[typeProperty.key.name] = types.callExpression(
-                  types.memberExpression(
-                    types.identifier('PropTypes'),
-                    types.identifier('oneOfType'),
-                  ),
-                  [
-                    types.arrayExpression(
-                      [existing, propTypeValue]
-                    )
-                  ]
-                );
-
-                if (isPropTypeRequired(types, existing) && isPropTypeRequired(types, typeProperty.value)) {
-                  mergedProperties[typeProperty.key.name] = makePropTypeRequired(types, mergedProperties[typeProperty.key.name]);
-                }
-              }
-            } else {
-              // property hasn't been seen yet, add it
-              mergedProperties[typeProperty.key.name] = propTypeValue;
-            }
-
-            mergedProperties[typeProperty.key.name].leadingComments = leadingComments;
+          let propTypeValue = typeProperty.value;
+          if (types.isLiteral(propTypeValue)) {
+            // can't use a literal straight, wrap it with PropTypes.oneOf([ the_literal ])
+            propTypeValue = convertLiteralToOneOf(types, propTypeValue);
           }
 
-          return mergedProperties;
-        },
-        {}
-      );
+          // if this property has already been found, the only action is to potentially change it to optional
+          if (mergedProperties.hasOwnProperty(typeProperty.key.name)) {
+            const existing = mergedProperties[typeProperty.key.name];
+            if (!areExpressionsIdentical(existing, typeProperty.value)) {
+              mergedProperties[typeProperty.key.name] = types.callExpression(
+                types.memberExpression(
+                  types.identifier('PropTypes'),
+                  types.identifier('oneOfType')
+                ),
+                [types.arrayExpression([existing, propTypeValue])]
+              );
+
+              if (
+                isPropTypeRequired(types, existing) &&
+                isPropTypeRequired(types, typeProperty.value)
+              ) {
+                mergedProperties[typeProperty.key.name] = makePropTypeRequired(
+                  types,
+                  mergedProperties[typeProperty.key.name]
+                );
+              }
+            }
+          } else {
+            // property hasn't been seen yet, add it
+            mergedProperties[typeProperty.key.name] = propTypeValue;
+          }
+
+          mergedProperties[
+            typeProperty.key.name
+          ].leadingComments = leadingComments;
+        }
+
+        return mergedProperties;
+      }, {});
 
       const propertyKeys = Object.keys(mergedProperties);
       // if there is one or more members on `mergedProperties` then use PropTypes.shape,
@@ -433,19 +451,20 @@ function getPropTypesForNode(node, optional, state) {
             types.identifier('shape')
           ),
           [
-            types.objectExpression(propertyKeys.map(
-              propKey => {
+            types.objectExpression(
+              propertyKeys.map(propKey => {
                 const objectProperty = types.objectProperty(
                   types.identifier(propKey),
                   mergedProperties[propKey]
                 );
 
-                objectProperty.leadingComments = mergedProperties[propKey].leadingComments;
+                objectProperty.leadingComments =
+                  mergedProperties[propKey].leadingComments;
                 mergedProperties[propKey].leadingComments = null;
 
                 return objectProperty;
-              }
-            ))
+              })
+            ),
           ]
         );
       } else {
@@ -471,20 +490,33 @@ function getPropTypesForNode(node, optional, state) {
               // which don't translate to prop types.
               .filter(property => property.key != null)
               .map(property => {
-                const propertyPropType = property.type === 'TSMethodSignature'
-                  ? getPropTypesForNode({ type: 'TSFunctionType' }, property.optional, state)
-                  : getPropTypesForNode(property.typeAnnotation, property.optional, state);
+                const propertyPropType =
+                  property.type === 'TSMethodSignature'
+                    ? getPropTypesForNode(
+                        { type: 'TSFunctionType' },
+                        property.optional,
+                        state
+                      )
+                    : getPropTypesForNode(
+                        property.typeAnnotation,
+                        property.optional,
+                        state
+                      );
 
                 const objectProperty = types.objectProperty(
-                  types.identifier(property.key.name || `"${property.key.value}"`),
+                  types.identifier(
+                    property.key.name || `"${property.key.value}"`
+                  ),
                   propertyPropType
                 );
                 if (property.leadingComments != null) {
-                  objectProperty.leadingComments = property.leadingComments.map(({ type, value }) => ({ type, value }));
+                  objectProperty.leadingComments = property.leadingComments.map(
+                    ({ type, value }) => ({ type, value })
+                  );
                 }
                 return objectProperty;
               })
-          )
+          ),
         ]
       );
       break;
@@ -492,9 +524,13 @@ function getPropTypesForNode(node, optional, state) {
     // resolve a type operator (keyword) that operates on a value
     // currently only supporting `keyof typeof [object variable]`
     case 'TSTypeOperator':
-      if (node.operator === 'keyof' && node.typeAnnotation.type === 'TSTypeQuery') {
+      if (
+        node.operator === 'keyof' &&
+        node.typeAnnotation.type === 'TSTypeQuery'
+      ) {
         const typeDefinitions = state.get('typeDefinitions');
-        const typeDefinition = typeDefinitions[node.typeAnnotation.exprName.name];
+        const typeDefinition =
+          typeDefinitions[node.typeAnnotation.exprName.name];
         if (typeDefinition != null) {
           propType = getPropTypesForNode(typeDefinition, true, state);
         }
@@ -510,8 +546,12 @@ function getPropTypesForNode(node, optional, state) {
         ),
         [
           types.arrayExpression(
-            node.properties.map(property => types.stringLiteral(property.key.name || property.key.name || property.key.value))
-          )
+            node.properties.map(property =>
+              types.stringLiteral(
+                property.key.name || property.key.name || property.key.value
+              )
+            )
+          ),
         ]
       );
       break;
@@ -525,24 +565,39 @@ function getPropTypesForNode(node, optional, state) {
         ),
         [
           types.objectExpression(
-            node.members.map(property => {
-              // skip TS index signatures
-              if (types.isTSIndexSignature(property)) return null;
+            node.members
+              .map(property => {
+                // skip TS index signatures
+                if (types.isTSIndexSignature(property)) return null;
 
-              const propertyPropType = property.type === 'TSMethodSignature'
-                ? getPropTypesForNode({ type: 'TSFunctionType' }, property.optional, state)
-                : getPropTypesForNode(property.typeAnnotation, property.optional, state);
+                const propertyPropType =
+                  property.type === 'TSMethodSignature'
+                    ? getPropTypesForNode(
+                        { type: 'TSFunctionType' },
+                        property.optional,
+                        state
+                      )
+                    : getPropTypesForNode(
+                        property.typeAnnotation,
+                        property.optional,
+                        state
+                      );
 
-              const objectProperty = types.objectProperty(
-                types.identifier(property.key.name || `"${property.key.value}"`),
-                propertyPropType
-              );
-              if (property.leadingComments != null) {
-                objectProperty.leadingComments = property.leadingComments.map(({ type, value }) => ({ type, value }));
-              }
-              return objectProperty;
-            }).filter(x => x != null)
-          )
+                const objectProperty = types.objectProperty(
+                  types.identifier(
+                    property.key.name || `"${property.key.value}"`
+                  ),
+                  propertyPropType
+                );
+                if (property.leadingComments != null) {
+                  objectProperty.leadingComments = property.leadingComments.map(
+                    ({ type, value }) => ({ type, value })
+                  );
+                }
+                return objectProperty;
+              })
+              .filter(x => x != null)
+          ),
         ]
       );
       break;
@@ -552,7 +607,9 @@ function getPropTypesForNode(node, optional, state) {
     // literal values are extracted into a `oneOf`, if all members are literals this oneOf is used
     // otherwise `oneOfType` is used - if there are any literal values it contains the literals' `oneOf`
     case 'TSUnionType':
-      const tsUnionTypes = node.types.map(node => getPropTypesForNode(node, false, state));
+      const tsUnionTypes = node.types.map(node =>
+        getPropTypesForNode(node, false, state)
+      );
 
       // `tsUnionTypes` could be:
       // 1. all non-literal values (string | number)
@@ -562,7 +619,11 @@ function getPropTypesForNode(node, optional, state) {
 
       const reducedUnionTypes = tsUnionTypes.reduce(
         (foundTypes, tsUnionType) => {
-          if (types.isLiteral(tsUnionType) || (types.isIdentifier(tsUnionType) && tsUnionType.name === 'undefined')) {
+          if (
+            types.isLiteral(tsUnionType) ||
+            (types.isIdentifier(tsUnionType) &&
+              tsUnionType.name === 'undefined')
+          ) {
             if (foundTypes.oneOfPropType == null) {
               foundTypes.oneOfPropType = types.arrayExpression([]);
               foundTypes.unionTypes.push(
@@ -597,37 +658,34 @@ function getPropTypesForNode(node, optional, state) {
       //    PropTypes.oneOf([PropTypes.oneOf(['red', 'blue'])])
       //    ->
       //    PropTypes.oneOf(['red', 'blue'])
-      if (reducedUnionTypes.unionTypes.length === 1 && reducedUnionTypes.oneOfPropType != null) {
+      if (
+        reducedUnionTypes.unionTypes.length === 1 &&
+        reducedUnionTypes.oneOfPropType != null
+      ) {
         // the only proptype is a `oneOf`, use only that
         propType = reducedUnionTypes.unionTypes[0];
       } else {
         propType = types.callExpression(
           types.memberExpression(
             types.identifier('PropTypes'),
-            types.identifier('oneOfType'),
+            types.identifier('oneOfType')
           ),
-          [
-            types.arrayExpression(
-              reducedUnionTypes.unionTypes
-            )
-          ]
+          [types.arrayExpression(reducedUnionTypes.unionTypes)]
         );
       }
       break;
 
     // translate enum to PropTypes.oneOf
     case 'TSEnumDeclaration':
-      const memberTypes = node.members.map(member => getPropTypesForNode(member, true, state));
+      const memberTypes = node.members.map(member =>
+        getPropTypesForNode(member, true, state)
+      );
       propType = types.callExpression(
         types.memberExpression(
           types.identifier('PropTypes'),
-          types.identifier('oneOf'),
+          types.identifier('oneOf')
         ),
-        [
-          types.arrayExpression(
-            memberTypes
-          )
-        ]
+        [types.arrayExpression(memberTypes)]
       );
       break;
 
@@ -643,10 +701,7 @@ function getPropTypesForNode(node, optional, state) {
         propType = getPropTypesForNode(
           {
             type: 'TSIntersectionType',
-            types: [
-              body,
-              ...extensions
-            ]
+            types: [body, ...extensions],
           },
           true,
           state
@@ -704,27 +759,27 @@ function getPropTypesForNode(node, optional, state) {
       break;
 
     case 'StringLiteral':
-      propType =  types.stringLiteral(node.value);
+      propType = types.stringLiteral(node.value);
       optional = true; // cannot call `.isRequired` on a string literal
       break;
 
     case 'NumericLiteral':
-      propType =  types.numericLiteral(node.value);
+      propType = types.numericLiteral(node.value);
       optional = true; // cannot call `.isRequired` on a number literal
       break;
 
     case 'BooleanLiteral':
-      propType =  types.booleanLiteral(node.value);
+      propType = types.booleanLiteral(node.value);
       optional = true; // cannot call `.isRequired` on a boolean literal
       break;
 
     case 'TSNullKeyword':
-      propType =  types.nullLiteral();
+      propType = types.nullLiteral();
       optional = true; // cannot call `.isRequired` on a null literal
       break;
 
     case 'TSUndefinedKeyword':
-      propType =  types.identifier('undefined');
+      propType = types.identifier('undefined');
       optional = true; // cannot call `.isRequired` on an undefined literal
       break;
 
@@ -775,7 +830,6 @@ const typeDefinitionExtractors = {
 
     // only process relative imports for typescript definitions (avoid node_modules)
     if (isPathRelative) {
-
       // find the variable names being imported
       const importedTypeNames = node.specifiers.map(specifier => {
         switch (specifier.type) {
@@ -833,36 +887,34 @@ const typeDefinitionExtractors = {
       };
       for (let i = 0; i < ast.program.body.length; i++) {
         const bodyNode = ast.program.body[i];
-        Array.prototype.push.apply(definitions, extractTypeDefinition(bodyNode, subExtractionOptions) || []);
+        Array.prototype.push.apply(
+          definitions,
+          extractTypeDefinition(bodyNode, subExtractionOptions) || []
+        );
       }
 
       // temporarily override typeDefinitions so variable scope doesn't bleed between files
       const _typeDefinitions = state.get('typeDefinitions');
       state.set(
         'typeDefinitions',
-        definitions.reduce(
-          (typeDefinitions, definition) => {
-            if (definition) {
-              typeDefinitions[definition.name] = definition.definition;
-            }
+        definitions.reduce((typeDefinitions, definition) => {
+          if (definition) {
+            typeDefinitions[definition.name] = definition.definition;
+          }
 
-            return typeDefinitions;
-          },
-          {}
-        )
+          return typeDefinitions;
+        }, {})
       );
 
       // for each importedTypeName, fully resolve the type information
-      definitions.forEach(
-        ({ name, definition }) => {
-          if (importedTypeNames.includes(name)) {
-            // this type declaration is imported by the parent script
-            const propTypes = getPropTypesForNode(definition, true, state);
-            propTypes.isAlreadyResolved = true; // when getPropTypesForNode is called on this node later, tell it to skip processing
-            importedDefinitions.push({ name, definition: propTypes });
-          }
+      definitions.forEach(({ name, definition }) => {
+        if (importedTypeNames.includes(name)) {
+          // this type declaration is imported by the parent script
+          const propTypes = getPropTypesForNode(definition, true, state);
+          propTypes.isAlreadyResolved = true; // when getPropTypesForNode is called on this node later, tell it to skip processing
+          importedDefinitions.push({ name, definition: propTypes });
         }
-      );
+      });
 
       // reset typeDefinitions and continue processing the original file
       state.set('typeDefinitions', _typeDefinitions);
@@ -882,7 +934,11 @@ const typeDefinitionExtractors = {
     const { id } = node;
 
     if (id.type !== 'Identifier') {
-      throw new Error(`TSInterfaceDeclaration typeDefinitionExtract could not understand id type ${id.type}`);
+      throw new Error(
+        `TSInterfaceDeclaration typeDefinitionExtract could not understand id type ${
+          id.type
+        }`
+      );
     }
 
     return [{ name: id.name, definition: node }];
@@ -897,7 +953,11 @@ const typeDefinitionExtractors = {
     const { id, typeAnnotation } = node;
 
     if (id.type !== 'Identifier') {
-      throw new Error(`TSTypeAliasDeclaraction typeDefinitionExtract could not understand id type ${id.type}`);
+      throw new Error(
+        `TSTypeAliasDeclaraction typeDefinitionExtract could not understand id type ${
+          id.type
+        }`
+      );
     }
 
     return [{ name: id.name, definition: typeAnnotation }];
@@ -912,7 +972,11 @@ const typeDefinitionExtractors = {
     const { id } = node;
 
     if (id.type !== 'Identifier') {
-      throw new Error(`TSEnumDeclaration typeDefinitionExtract could not understand id type ${id.type}`);
+      throw new Error(
+        `TSEnumDeclaration typeDefinitionExtract could not understand id type ${
+          id.type
+        }`
+      );
     }
 
     return [{ name: id.name, definition: node }];
@@ -924,15 +988,15 @@ const typeDefinitionExtractors = {
    * @returns Array
    */
   VariableDeclaration: node => {
-    return node.declarations.reduce(
-      (declarations, declaration) => {
-        if (declaration.init.type === 'ObjectExpression') {
-          declarations.push({ name: declaration.id.name, definition: declaration.init });
-        }
-        return declarations;
-      },
-      []
-    );
+    return node.declarations.reduce((declarations, declaration) => {
+      if (declaration.init.type === 'ObjectExpression') {
+        declarations.push({
+          name: declaration.id.name,
+          definition: declaration.init,
+        });
+      }
+      return declarations;
+    }, []);
   },
 
   ExportNamedDeclaration: (node, extractionOptions) => {
@@ -940,7 +1004,10 @@ const typeDefinitionExtractors = {
     if (types.isStringLiteral(node.source)) {
       // export { variable } from './location'
       // for our needs, this node type overlaps an ImportDeclaration
-      return typeDefinitionExtractors.ImportDeclaration(node, extractionOptions);
+      return typeDefinitionExtractors.ImportDeclaration(
+        node,
+        extractionOptions
+      );
     }
     return extractTypeDefinition(node.declaration);
   },
@@ -949,7 +1016,9 @@ function extractTypeDefinition(node, opts) {
   if (node == null) {
     return null;
   }
-  return typeDefinitionExtractors.hasOwnProperty(node.type) ? typeDefinitionExtractors[node.type](node, opts) : null;
+  return typeDefinitionExtractors.hasOwnProperty(node.type)
+    ? typeDefinitionExtractors[node.type](node, opts)
+    : null;
 }
 
 /**
@@ -960,7 +1029,8 @@ function extractTypeDefinition(node, opts) {
  */
 function getVariableBinding(path, variableName) {
   while (path) {
-    if (path.scope.bindings[variableName]) return path.scope.bindings[variableName];
+    if (path.scope.bindings[variableName])
+      return path.scope.bindings[variableName];
     path = path.parentPath;
   }
   return null;
@@ -1004,7 +1074,11 @@ function processComponentDeclaration(typeDefinition, path, state) {
   const propTypesAST = getPropTypesForNode(typeDefinition, false, state);
 
   // if the resulting proptype is PropTypes.any don't bother setting the proptypes
-  if (types.isMemberExpression(propTypesAST.object) && propTypesAST.object.property.name === 'any') return;
+  if (
+    types.isMemberExpression(propTypesAST.object) &&
+    propTypesAST.object.property.name === 'any'
+  )
+    return;
 
   const propTypes = getPropTypesNodeFromAST(
     // `getPropTypesForNode` returns a PropTypes.shape representing the top-level object, we need to
@@ -1031,7 +1105,7 @@ function processComponentDeclaration(typeDefinition, path, state) {
     buildPropTypes({
       COMPONENT_NAME: types.identifier(path.node.id.name),
       PROP_TYPES: propTypes,
-    })
+    }),
   ]);
 
   // import PropTypes library if it isn't already
@@ -1068,7 +1142,11 @@ module.exports = function propTypesFromTypeScript({ types }) {
       Program: {
         enter: function visitProgram(programPath, state) {
           // only process typescript files
-          if (path.extname(state.file.opts.filename) !== '.ts' && path.extname(state.file.opts.filename) !== '.tsx') return;
+          if (
+            path.extname(state.file.opts.filename) !== '.ts' &&
+            path.extname(state.file.opts.filename) !== '.tsx'
+          )
+            return;
 
           // Extract any of the imported variables from 'react' (SFC, ReactNode, etc)
           // we do this here instead of resolving when the imported values are used
@@ -1084,7 +1162,7 @@ module.exports = function propTypesFromTypeScript({ types }) {
                     }
                   });
                 }
-              }
+              },
             },
             state
           );
@@ -1098,26 +1176,36 @@ module.exports = function propTypesFromTypeScript({ types }) {
           // extraction options are used to further resolve types imported from other files
           const extractionOptions = {
             state,
-            sourceFilename: path.resolve(process.cwd(), this.file.opts.filename),
+            sourceFilename: path.resolve(
+              process.cwd(),
+              this.file.opts.filename
+            ),
             fs: opts.fs || fs,
-            parse: code => babelCore.parse(code, forceTSXParsing(state.file.opts)),
+            parse: code =>
+              babelCore.parse(code, forceTSXParsing(state.file.opts)),
           };
 
           // collect named TS type definitions for later reference
           for (let i = 0; i < programPath.node.body.length; i++) {
             const bodyNode = programPath.node.body[i];
-            const extractedDefinitions = extractTypeDefinition(bodyNode, extractionOptions) || [];
+            const extractedDefinitions =
+              extractTypeDefinition(bodyNode, extractionOptions) || [];
             for (let i = 0; i < extractedDefinitions.length; i++) {
               const typeDefinition = extractedDefinitions[i];
               if (typeDefinition) {
-                typeDefinitions[typeDefinition.name] = typeDefinition.definition;
+                typeDefinitions[typeDefinition.name] =
+                  typeDefinition.definition;
               }
             }
           }
         },
         exit: function exitProgram(programPath, state) {
           // only process typescript files
-          if (path.extname(state.file.opts.filename) !== '.ts' && path.extname(state.file.opts.filename) !== '.tsx') return;
+          if (
+            path.extname(state.file.opts.filename) !== '.ts' &&
+            path.extname(state.file.opts.filename) !== '.tsx'
+          )
+            return;
 
           const types = state.get('types');
           const typeDefinitions = state.get('typeDefinitions');
@@ -1125,12 +1213,14 @@ module.exports = function propTypesFromTypeScript({ types }) {
           // remove any exported identifiers that are TS types or interfaces
           // this prevents TS-only identifiers from leaking into ES code
           programPath.traverse({
-            ExportNamedDeclaration: (path) => {
+            ExportNamedDeclaration: path => {
               const specifiers = path.get('specifiers');
               const source = path.get('source');
               specifiers.forEach(specifierPath => {
                 if (types.isExportSpecifier(specifierPath)) {
-                  const { node: { local } } = specifierPath;
+                  const {
+                    node: { local },
+                  } = specifierPath;
                   if (types.isIdentifier(local)) {
                     const { name } = local;
                     if (typeDefinitions.hasOwnProperty(name)) {
@@ -1156,9 +1246,9 @@ module.exports = function propTypesFromTypeScript({ types }) {
                   }
                 }
               });
-            }
+            },
           });
-        }
+        },
       },
 
       /**
@@ -1169,7 +1259,11 @@ module.exports = function propTypesFromTypeScript({ types }) {
        */
       ClassDeclaration: function visitClassDeclaration(nodePath, state) {
         // only process typescript files
-        if (path.extname(state.file.opts.filename) !== '.ts' && path.extname(state.file.opts.filename) !== '.tsx') return;
+        if (
+          path.extname(state.file.opts.filename) !== '.ts' &&
+          path.extname(state.file.opts.filename) !== '.tsx'
+        )
+          return;
 
         const types = state.get('types');
 
@@ -1179,12 +1273,18 @@ module.exports = function propTypesFromTypeScript({ types }) {
           if (types.isMemberExpression(nodePath.node.superClass)) {
             const objectName = nodePath.node.superClass.object.name;
             const propertyName = nodePath.node.superClass.property.name;
-            if (objectName === 'React' && (propertyName === 'Component' || propertyName === 'PureComponent')) {
+            if (
+              objectName === 'React' &&
+              (propertyName === 'Component' || propertyName === 'PureComponent')
+            ) {
               isReactComponent = true;
             }
           } else if (types.isIdentifier(nodePath.node.superClass)) {
             const identifierName = nodePath.node.superClass.name;
-            if (identifierName === 'Component' || identifierName === 'PureComponent') {
+            if (
+              identifierName === 'Component' ||
+              identifierName === 'PureComponent'
+            ) {
               if (state.get('importsFromReact').has(identifierName)) {
                 isReactComponent = true;
               }
@@ -1192,12 +1292,19 @@ module.exports = function propTypesFromTypeScript({ types }) {
           }
 
           if (isReactComponent && nodePath.node.superTypeParameters != null) {
-            processComponentDeclaration(nodePath.node.superTypeParameters.params[0], nodePath, state);
+            processComponentDeclaration(
+              nodePath.node.superTypeParameters.params[0],
+              nodePath,
+              state
+            );
 
             // babel-plugin-react-docgen passes `this.file.code` to react-docgen
             // instead of using the modified AST; to expose our changes to react-docgen
             // they need to be rendered to a string
-            this.file.code = stripTypeScript(this.file.opts.filename, this.file.ast);
+            this.file.code = stripTypeScript(
+              this.file.opts.filename,
+              this.file.ast
+            );
           }
         }
       },
@@ -1210,7 +1317,11 @@ module.exports = function propTypesFromTypeScript({ types }) {
        */
       VariableDeclarator: function visitVariableDeclarator(nodePath, state) {
         // only process typescript files
-        if (path.extname(state.file.opts.filename) !== '.ts' && path.extname(state.file.opts.filename) !== '.tsx') return;
+        if (
+          path.extname(state.file.opts.filename) !== '.ts' &&
+          path.extname(state.file.opts.filename) !== '.tsx'
+        )
+          return;
 
         const resolveVariableDeclarator = variableDeclarator => {
           const { id } = variableDeclarator;
@@ -1218,30 +1329,56 @@ module.exports = function propTypesFromTypeScript({ types }) {
           let fileCodeNeedsUpdating = false;
 
           if (
+            // this is a function call
             types.isCallExpression(variableDeclarator.init) &&
-            types.isIdentifier(variableDeclarator.init.callee) &&
-            variableDeclarator.init.callee.name === 'forwardRef' &&
-            variableDeclarator.init.typeParameters.params.length === 2
+            // is this forwardRef()
+            ((types.isIdentifier(variableDeclarator.init.callee) &&
+              variableDeclarator.init.callee.name === 'forwardRef' &&
+              variableDeclarator.init.typeParameters &&
+              variableDeclarator.init.typeParameters.params.length === 2) ||
+              // or is this React.forwardRef()
+              (types.isMemberExpression(variableDeclarator.init.callee) &&
+                types.isIdentifier(variableDeclarator.init.callee.object) &&
+                variableDeclarator.init.callee.object.name === 'React' &&
+                types.isIdentifier(variableDeclarator.init.callee.property) &&
+                variableDeclarator.init.callee.property.name === 'forwardRef')
+            )
           ) {
             // props for the component come from the second argument to the type params
-            const typeDefinition = variableDeclarator.init.typeParameters.params[1];
+            const typeDefinition =
+              variableDeclarator.init.typeParameters.params[1];
             fileCodeNeedsUpdating = true;
             processComponentDeclaration(typeDefinition, nodePath, state);
           } else if (idTypeAnnotation) {
             if (idTypeAnnotation.typeAnnotation.type === 'TSTypeReference') {
-              if (idTypeAnnotation.typeAnnotation.typeName.type === 'TSQualifiedName') {
-                const { left, right } = idTypeAnnotation.typeAnnotation.typeName;
+              if (
+                idTypeAnnotation.typeAnnotation.typeName.type ===
+                'TSQualifiedName'
+              ) {
+                const {
+                  left,
+                  right,
+                } = idTypeAnnotation.typeAnnotation.typeName;
 
                 if (left.name === 'React') {
                   const rightName = right.name;
-                  if (rightName === 'SFC' || rightName === 'FunctionComponent') {
-                    processComponentDeclaration(idTypeAnnotation.typeAnnotation.typeParameters.params[0], nodePath, state);
+                  if (
+                    rightName === 'SFC' ||
+                    rightName === 'FunctionComponent'
+                  ) {
+                    processComponentDeclaration(
+                      idTypeAnnotation.typeAnnotation.typeParameters.params[0],
+                      nodePath,
+                      state
+                    );
                     fileCodeNeedsUpdating = true;
                   } else {
                     // throw new Error(`Cannot process annotation id React.${right.name}`);
                   }
                 }
-              } else if (idTypeAnnotation.typeAnnotation.typeName.type === 'Identifier') {
+              } else if (
+                idTypeAnnotation.typeAnnotation.typeName.type === 'Identifier'
+              ) {
                 const typeName = idTypeAnnotation.typeAnnotation.typeName.name;
                 if (typeName === 'SFC' || typeName === 'FunctionComponent') {
                   if (state.get('importsFromReact').has(typeName)) {
@@ -1250,17 +1387,29 @@ module.exports = function propTypesFromTypeScript({ types }) {
                     // because the generic argument has a default of empty
                     // props.
                     if (idTypeAnnotation.typeAnnotation.typeParameters) {
-                      processComponentDeclaration(idTypeAnnotation.typeAnnotation.typeParameters.params[0], nodePath, state);
+                      processComponentDeclaration(
+                        idTypeAnnotation.typeAnnotation.typeParameters
+                          .params[0],
+                        nodePath,
+                        state
+                      );
                       fileCodeNeedsUpdating = true;
                     }
                   }
                 } else {
                   // reprocess this variable declaration but use the identifier lookup
-                  const nextTypeDefinition = state.get('typeDefinitions')[typeName];
+                  const nextTypeDefinition = state.get('typeDefinitions')[
+                    typeName
+                  ];
                   const types = state.get('types');
-                  if (nextTypeDefinition && types.isTSType(nextTypeDefinition)) {
+                  if (
+                    nextTypeDefinition &&
+                    types.isTSType(nextTypeDefinition)
+                  ) {
                     const newId = types.cloneDeep(id);
-                    newId.typeAnnotation = types.TSTypeAnnotation(nextTypeDefinition);
+                    newId.typeAnnotation = types.TSTypeAnnotation(
+                      nextTypeDefinition
+                    );
                     const newNode = types.VariableDeclarator(
                       newId,
                       variableDeclarator.init
@@ -1269,7 +1418,10 @@ module.exports = function propTypesFromTypeScript({ types }) {
                   }
                 }
               } else {
-                throw new Error('Cannot process annotation type of', idTypeAnnotation.typeAnnotation.id.type);
+                throw new Error(
+                  'Cannot process annotation type of',
+                  idTypeAnnotation.typeAnnotation.id.type
+                );
               }
             }
           }
@@ -1278,7 +1430,10 @@ module.exports = function propTypesFromTypeScript({ types }) {
             // babel-plugin-react-docgen passes `this.file.code` to react-docgen
             // instead of using the modified AST; to expose our changes to react-docgen
             // they need to be rendered to a string
-            this.file.code = stripTypeScript(this.file.opts.filename, this.file.ast);
+            this.file.code = stripTypeScript(
+              this.file.opts.filename,
+              this.file.ast
+            );
           }
         };
 
@@ -1291,4 +1446,4 @@ module.exports = function propTypesFromTypeScript({ types }) {
 
 module.exports.clearImportCache = function clearImportCache() {
   importedDefinitionsCache.clear();
-}
+};

--- a/scripts/babel/proptypes-from-ts-props/index.test.js
+++ b/scripts/babel/proptypes-from-ts-props/index.test.js
@@ -2447,6 +2447,31 @@ FooComponent.propTypes = {
   bar: PropTypes.number
 };`);
       });
+
+      it('attaches proptypes to components returned by React.forwardRef', () => {
+        const result = transform(
+          `
+import React from 'react';
+interface FooProps {
+  foo: string;
+  bar?: number;
+}
+const FooComponent = React.forwardRef<HTMLDivElement, FooProps>(() => {
+  return (<div>Hello World</div>);
+})`,
+          babelOptions
+        );
+
+        expect(result.code).toBe(`import React from 'react';
+import PropTypes from "prop-types";
+const FooComponent = React.forwardRef(() => {
+  return <div>Hello World</div>;
+});
+FooComponent.propTypes = {
+  foo: PropTypes.string.isRequired,
+  bar: PropTypes.number
+};`);
+      });
     });
 
   });

--- a/scripts/babel/proptypes-from-ts-props/index.test.js
+++ b/scripts/babel/proptypes-from-ts-props/index.test.js
@@ -2422,6 +2422,33 @@ FooComponent.propTypes = {
 
     });
 
+    describe('forwardRef', () => {
+      it('attaches proptypes to components returned by forwardRef', () => {
+        const result = transform(
+          `
+import React, { forwardRef } from 'react';
+interface FooProps {
+  foo: string;
+  bar?: number;
+}
+const FooComponent = forwardRef<HTMLDivElement, FooProps>(() => {
+  return (<div>Hello World</div>);
+})`,
+          babelOptions
+        );
+
+        expect(result.code).toBe(`import React, { forwardRef } from 'react';
+import PropTypes from "prop-types";
+const FooComponent = forwardRef(() => {
+  return <div>Hello World</div>;
+});
+FooComponent.propTypes = {
+  foo: PropTypes.string.isRequired,
+  bar: PropTypes.number
+};`);
+      });
+    });
+
   });
 
   describe('remove types from exports', () => {

--- a/src/components/flex/flex_group.tsx
+++ b/src/components/flex/flex_group.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, Ref, forwardRef } from 'react';
+import React, { HTMLAttributes, Ref } from 'react';
 import classNames from 'classnames';
 import { CommonProps, keysOf } from '../common';
 
@@ -65,7 +65,7 @@ const isValidElement = (
   return ['div', 'span'].includes(component);
 };
 
-const EuiFlexGroup = forwardRef<
+const EuiFlexGroup = React.forwardRef<
   HTMLDivElement | HTMLSpanElement,
   CommonProps &
     HTMLAttributes<HTMLDivElement | HTMLSpanElement> &

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,6 +26,33 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
+"@babel/code-frame@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
+  integrity sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==
+  dependencies:
+    "@babel/highlight" "^7.0.0"
+
+"@babel/core@^7.0.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.6.0.tgz#9b00f73554edd67bebc86df8303ef678be3d7b48"
+  integrity sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.6.0"
+    "@babel/helpers" "^7.6.0"
+    "@babel/parser" "^7.6.0"
+    "@babel/template" "^7.6.0"
+    "@babel/traverse" "^7.6.0"
+    "@babel/types" "^7.6.0"
+    convert-source-map "^1.1.0"
+    debug "^4.1.0"
+    json5 "^2.1.0"
+    lodash "^4.17.13"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/core@^7.1.0":
   version "7.3.3"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.3.3.tgz#d090d157b7c5060d05a05acaebc048bd2b037947"
@@ -116,6 +143,17 @@
     "@babel/types" "^7.4.0"
     jsesc "^2.5.1"
     lodash "^4.17.11"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+"@babel/generator@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.6.0.tgz#e2c21efbfd3293ad819a2359b448f002bfdfda56"
+  integrity sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==
+  dependencies:
+    "@babel/types" "^7.6.0"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
@@ -279,6 +317,13 @@
   dependencies:
     "@babel/types" "^7.4.0"
 
+"@babel/helper-split-export-declaration@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz#ff94894a340be78f53f06af038b205c49d993677"
+  integrity sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==
+  dependencies:
+    "@babel/types" "^7.4.4"
+
 "@babel/helper-wrap-function@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.1.0.tgz#8cf54e9190706067f016af8f75cb3df829cc8c66"
@@ -316,6 +361,15 @@
     "@babel/traverse" "^7.4.3"
     "@babel/types" "^7.4.0"
 
+"@babel/helpers@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.6.0.tgz#21961d16c6a3c3ab597325c34c465c0887d31c6e"
+  integrity sha512-W9kao7OBleOjfXtFGgArGRX6eCP0UEcA2ZWEWNkJdRZnHhW4eEbeswbG3EwaRsnQUAEGWYgMq1HsIXuNNNy2eQ==
+  dependencies:
+    "@babel/template" "^7.6.0"
+    "@babel/traverse" "^7.6.0"
+    "@babel/types" "^7.6.0"
+
 "@babel/highlight@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
@@ -324,11 +378,6 @@
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^4.0.0"
-
-"@babel/parser@7.0.0-beta.53":
-  version "7.0.0-beta.53"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.0.0-beta.53.tgz#1f45eb617bf9463d482b2c04d349d9e4edbf4892"
-  integrity sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=
 
 "@babel/parser@^7.0.0", "@babel/parser@^7.1.2", "@babel/parser@^7.1.3":
   version "7.1.3"
@@ -344,6 +393,11 @@
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.3.tgz#eb3ac80f64aa101c907d4ce5406360fe75b7895b"
   integrity sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==
+
+"@babel/parser@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.0.tgz#3e05d0647432a8326cb28d0de03895ae5a57f39b"
+  integrity sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==
 
 "@babel/plugin-proposal-async-generator-functions@^7.1.0":
   version "7.1.0"
@@ -832,6 +886,15 @@
     "@babel/parser" "^7.4.0"
     "@babel/types" "^7.4.0"
 
+"@babel/template@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.6.0.tgz#7f0159c7f5012230dad64cca42ec9bdb5c9536e6"
+  integrity sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.6.0"
+    "@babel/types" "^7.6.0"
+
 "@babel/traverse@^7.0.0", "@babel/traverse@^7.1.5", "@babel/traverse@^7.2.2":
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.2.3.tgz#7ff50cefa9c7c0bd2d81231fdac122f3957748d8"
@@ -877,6 +940,21 @@
     globals "^11.1.0"
     lodash "^4.17.11"
 
+"@babel/traverse@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.6.0.tgz#389391d510f79be7ce2ddd6717be66d3fed4b516"
+  integrity sha512-93t52SaOBgml/xY74lsmt7xOR4ufYvhb5c5qiM6lu4J/dWGMAfAh6eKw4PjLes6DI6nQgearoxnFJk60YchpvQ==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.6.0"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/parser" "^7.6.0"
+    "@babel/types" "^7.6.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/types@^7.0.0", "@babel/types@^7.1.2", "@babel/types@^7.1.3":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.1.3.tgz#3a767004567060c2f40fca49a304712c525ee37d"
@@ -902,6 +980,15 @@
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.11"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.4.4", "@babel/types@^7.6.0":
+  version "7.6.1"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.1.tgz#53abf3308add3ac2a2884d539151c57c4b3ac648"
+  integrity sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
 "@elastic/charts@^11.2.0":
@@ -1925,10 +2012,15 @@ ast-types-flow@0.0.7, ast-types-flow@^0.0.7:
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
   integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
 
-ast-types@0.11.5:
-  version "0.11.5"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.11.5.tgz#9890825d660c03c28339f315e9fa0a360e31ec28"
-  integrity sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw==
+ast-types@0.11.3:
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.11.3.tgz#c20757fe72ee71278ea0ff3d87e5c2ca30d9edf8"
+  integrity sha512-XA5o5dsNw8MhyW0Q7MWXJWc4oOzZKbdsEJq45h7c8q/d9DwWZ5F2ugUc1PuMLPGsUnphCt/cNDHu8JeBbxf1qA==
+
+ast-types@0.12.4:
+  version "0.12.4"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.12.4.tgz#71ce6383800f24efc9a1a3308f3a6e420a0974d1"
+  integrity sha512-ky/YVYCbtVAS8TdMIaTiPFHwEpRB5z1hctepJplTr3UW5q8TDrpIMCILyk8pmLxGtn2KCtC/lSn7zOsaI7nzDw==
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -2145,13 +2237,14 @@ babel-plugin-pegjs-inline-precompile@^0.1.0:
     babylon "^6.18.0"
     pegjs "^0.10.0"
 
-babel-plugin-react-docgen@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-react-docgen/-/babel-plugin-react-docgen-2.0.0.tgz#039d90f5a1a37131c8cc3015017eecafa8d78882"
-  integrity sha512-AaA6IPxCF1EkzpFG41GkVh/VGdoBejPF6oIub2K8E6AD3kwnTZ0DIKG7f20a7zmqBEeO8GkFWdM7tYd9Owkc+Q==
+babel-plugin-react-docgen@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-react-docgen/-/babel-plugin-react-docgen-3.1.0.tgz#14b02b363a38cc9e08c871df16960d27ef92030f"
+  integrity sha512-W6xqZnZIWjZuE9IjP7XolxxgFGB5Y9GZk4cLPSWKa10MrT86q7bX4ke9jbrNhFVIRhbmzL8wE1Sn++mIWoJLbw==
   dependencies:
-    lodash "^4.17.10"
-    react-docgen "^3.0.0-rc.1"
+    lodash "^4.17.11"
+    react-docgen "^4.1.0"
+    recast "^0.14.7"
 
 babel-preset-jest@^24.1.0:
   version "24.1.0"
@@ -2161,7 +2254,7 @@ babel-preset-jest@^24.1.0:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^24.1.0"
 
-babel-runtime@6.26.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0, babel-runtime@^6.9.0, babel-runtime@^6.9.2, babel-runtime@~6.26.0:
+babel-runtime@6.26.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0, babel-runtime@^6.9.0, babel-runtime@~6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
@@ -3372,7 +3465,7 @@ commander@2.12.x:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
   integrity sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==
 
-commander@^2.11.0:
+commander@^2.11.0, commander@^2.19.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -4481,7 +4574,7 @@ doctrine@1.5.0, doctrine@^1.2.2:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-doctrine@^2.0.0, doctrine@^2.1.0:
+doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
@@ -8938,6 +9031,11 @@ lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@^4.17.13:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 log-symbols@^1.0.1, log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
@@ -11590,7 +11688,7 @@ pretty-hrtime@^1.0.3:
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
-private@^0.1.6, private@~0.1.5:
+private@^0.1.6, private@^0.1.8, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
   integrity sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==
@@ -11986,18 +12084,18 @@ react-clientside-effect@^1.2.0:
     "@babel/runtime" "^7.0.0"
     shallowequal "^1.1.0"
 
-react-docgen@^3.0.0-rc.1:
-  version "3.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-3.0.0-rc.1.tgz#a4e33dba1454459294276afdec87ef3958167eb0"
-  integrity sha512-jOnu9qEqNlBx5Jrgx8mcHmG6FQcrBIpdZ5HTcZqW5hOkYsmCAPID0vEm66mkVbh3anli9+WWK2wL3AKK1ivNBA==
+react-docgen@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-4.1.1.tgz#8fef0212dbf14733e09edecef1de6b224d87219e"
+  integrity sha512-o1wdswIxbgJRI4pckskE7qumiFyqkbvCO++TylEDOo2RbMiueIOg8YzKU4X9++r0DjrbXePw/LHnh81GRBTWRw==
   dependencies:
-    "@babel/parser" "7.0.0-beta.53"
+    "@babel/core" "^7.0.0"
+    "@babel/runtime" "^7.0.0"
     async "^2.1.4"
-    babel-runtime "^6.9.2"
-    commander "^2.9.0"
-    doctrine "^2.0.0"
+    commander "^2.19.0"
+    doctrine "^3.0.0"
     node-dir "^0.1.10"
-    recast "^0.15.0"
+    recast "^0.17.3"
 
 react-dom@^16.8.0, react-dom@^16.8.3:
   version "16.8.6"
@@ -12335,14 +12433,24 @@ realpath-native@^1.0.2:
   dependencies:
     util.promisify "^1.0.0"
 
-recast@^0.15.0:
-  version "0.15.5"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.15.5.tgz#6871177ee26720be80d7624e4283d5c855a5cb0b"
-  integrity sha512-nkAYNqarh73cMWRKFiPQ8I9dOLFvFk6SnG8u/LUlOYfArDOD/EjsVRAs860TlBLrpxqAXHGET/AUAVjdEymL5w==
+recast@^0.14.7:
+  version "0.14.7"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.14.7.tgz#4f1497c2b5826d42a66e8e3c9d80c512983ff61d"
+  integrity sha512-/nwm9pkrcWagN40JeJhkPaRxiHXBRkXyRh/hgU088Z/v+qCy+zIHHY6bC6o7NaKAxPqtE6nD8zBH1LfU0/Wx6A==
   dependencies:
-    ast-types "0.11.5"
+    ast-types "0.11.3"
     esprima "~4.0.0"
     private "~0.1.5"
+    source-map "~0.6.1"
+
+recast@^0.17.3:
+  version "0.17.6"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.17.6.tgz#64ae98d0d2dfb10ff92ff5fb9ffb7371823b69fa"
+  integrity sha512-yoQRMRrK1lszNtbkGyM4kN45AwylV5hMiuEveUBlxytUViWevjvX6w+tzJt1LH4cfUhWt4NZvy3ThIhu6+m5wQ==
+  dependencies:
+    ast-types "0.12.4"
+    esprima "~4.0.0"
+    private "^0.1.8"
     source-map "~0.6.1"
 
 rechoir@^0.6.2:


### PR DESCRIPTION
### Summary

Fixes #2302 

* updated our babel plugin to generate proptypes for `forwardRef` and `React.forwardRef` components
* upgraded to latest `babel-plugin-react-docgen` & `react-docgen`, which understands `React.forwardRef`

**caveat**: Although our babel plugin works on calls to `forwardRef`, the docgen plugin only works when the method is fully-qualified: `React.forwardRef`

I double checked our other `forwardRef` uses, but those couple components are never exposed to the docs' props layer and are fine as is.

For testing, I generated the `es` build directory for master + this branch and diffed them. The changes to `EuiFlexGroup` were the only meaningful changes, but it does also remove the now-known React component methods like `getDerivedStateFromProps` from the resulting docgen.

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
- [x] Props have proper **autodocs**
~- [ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
