### PR TITLE
Updated tooltip docs

### DIFF
--- a/src-docs/src/views/tool_tip/tool_tip_example.js
+++ b/src-docs/src/views/tool_tip/tool_tip_example.js
@@ -40,8 +40,7 @@ export const ToolTipExample = {
         Wrap <EuiCode>EuiToolTip</EuiCode> around any item that you need a
         tooltip for. The <EuiCode>position</EuiCode> prop will take a suggested
         position, but will change it if the tooltip gets too close to the edge
-        of the screen. You can use the <EuiCode>clickOnly</EuiCode> prop to tell
-        the tooltip to only appear on click rather than on hover.
+        of the screen.
       </EuiText>
 
       <EuiSpacer size="l" />


### PR DESCRIPTION
### Summary

Removed reference to `clickOnly` prop from docs. Covers #2248 
### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
