### PR TITLE
Update EuiCodeBlock's children proptype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `13.8.1`.
+**Bug fixes**
+
+- Corrected `EuiCodeBlock`'s proptype for `children` to be string or array of strings. ([#2324](https://github.com/elastic/eui/pull/2324))
 
 ## [`13.8.1`](https://github.com/elastic/eui/tree/v13.8.1)
 

--- a/src-docs/src/views/responsive/responsive_example.js
+++ b/src-docs/src/views/responsive/responsive_example.js
@@ -26,7 +26,7 @@ function renderSizes(size, index) {
     code += ' +';
   }
 
-  return <div key={index}>{code}</div>;
+  return `${code}\n`;
 }
 
 export const ResponsiveExample = {


### PR DESCRIPTION
### Summary

Fixes #2322 

EuiCodeBlock's `children` proptype has been `node` when the component internally treated it as `string`. This PR aligns the proptype to the component's intent while maintaining backwards compatibility for any existing implementations passing malformed `children`.

The bugs:

* "copy" button expects the value to be a single string
* dynamic content does not get reflected

The component needs to operate on a single string, but this constrains the developer experience to working in a non-React way when "interpolating" variables

`<EuiCodeBlock>Hello {name}</EuiCodeBlock>` creates a children of `['Hello', name]`, and forcing children to be a single string would require `<EuiCodeBlock>{'Hello ' + name}</EuiCodeBlock>` or some other way to pre-compute the string.

To support the React Way™️, EuiCodeBlock now takes a string or array of strings which it concatenates together. The block of code doing this maintains backwards compatibility for instances which violate the proptype to avoid making this a breaking change with potentially very difficult broken cases to locate. When this is converted to TypeScript the invalid uses become compile-time errors and we can remove the backwards compatibility.

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
