### PR TITLE
Use requestAnimationFrame on EuiComboBox singleSelection close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Corrected `EuiCodeBlock`'s proptype for `children` to be string or array of strings. ([#2324](https://github.com/elastic/eui/pull/2324))
+- Fixed `EuiComboBox` list reopening after closing on option selection in IE11 ([#2326](https://github.com/elastic/eui/pull/2326))
 
 ## [`13.8.1`](https://github.com/elastic/eui/tree/v13.8.1)
 

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -437,7 +437,7 @@ export class EuiComboBox extends Component {
     }
 
     if (singleSelection) {
-      this.closeList();
+      setTimeout(this.closeList, 50);
     }
   };
 

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -437,7 +437,7 @@ export class EuiComboBox extends Component {
     }
 
     if (singleSelection) {
-      setTimeout(this.closeList, 50);
+      requestAnimationFrame(this.closeList);
     }
   };
 


### PR DESCRIPTION
### Summary

Closes #2303, which is an IE11 bug caused by a focus event and `setState` mistiming. IE11 needs a tick between calling `focus()` and `setState` so that the latter always happens second and prevents re-opening of the list.

### Checklist

~~- [ ] Checked in **dark mode**~~
~~- [ ] Checked in **mobile**~~

- [x] Checked in **IE11** and **Firefox**

~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
