### PR TITLE
Fix `EuiPanel` `onClick` def

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Corrected `EuiCodeBlock`'s proptype for `children` to be string or array of strings. ([#2324](https://github.com/elastic/eui/pull/2324))
+- Fixed `onClick` TypeScript definition for `EuiPanel` ([#2330](https://github.com/elastic/eui/pull/2330))
 
 ## [`13.8.1`](https://github.com/elastic/eui/tree/v13.8.1)
 

--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -2,7 +2,6 @@ import React, {
   ButtonHTMLAttributes,
   FunctionComponent,
   HTMLAttributes,
-  MouseEventHandler,
   ReactNode,
   Ref,
 } from 'react';
@@ -13,7 +12,7 @@ import { EuiBetaBadge } from '../badge/beta_badge';
 
 export type PanelPaddingSize = 'none' | 's' | 'm' | 'l';
 
-export interface EuiPanelProps {
+export interface EuiPanelProps extends CommonProps {
   /**
    * If active, adds a deeper shadow to the panel
    */
@@ -45,13 +44,15 @@ export interface EuiPanelProps {
   betaBadgeTitle?: string;
 }
 
-type Divlike = Omit<HTMLAttributes<HTMLDivElement>, 'onClick'>;
+interface Divlike
+  extends EuiPanelProps,
+    Omit<HTMLAttributes<HTMLDivElement>, 'onClick'> {}
 
-interface Buttonlike {
-  onClick?: MouseEventHandler<HTMLButtonElement>;
-}
+interface Buttonlike
+  extends EuiPanelProps,
+    ButtonHTMLAttributes<HTMLButtonElement> {}
 
-type Props = CommonProps & EuiPanelProps & ExclusiveUnion<Divlike, Buttonlike>;
+type Props = ExclusiveUnion<Divlike, Buttonlike>;
 
 const paddingSizeToClassNameMap = {
   none: null,
@@ -115,8 +116,10 @@ export const EuiPanel: FunctionComponent<Props> = ({
   }
 
   return (
-    // ts-ignore seems to be some div / button confusion here
-    <div ref={panelRef} className={classes} {...rest}>
+    <div
+      ref={panelRef as Ref<HTMLDivElement>}
+      className={classes}
+      {...rest as HTMLAttributes<HTMLDivElement>}>
       {optionalBetaBadge}
       {children}
     </div>


### PR DESCRIPTION
### Summary

Closes #2329, which reports that the `onClick` def for `EuiPanel` isn't quite right. The `ExlusiveUnion` wasn't set up to be fully exclusive, so the def was ambiguous.

### Checklist

~~- [ ] Checked in **dark mode**~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
