### PR TITLE
Compressed Fixes  Round 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `14.1.1`.
+- Added missing `compressed` TS definitions to `EuiComboBox`, `EuiCheckboxGroup`, `EuiCheckbox`, `EuiFieldSearch`, `EuiRadioGroup`, `EuiSwitch` ([#2338](https://github.com/elastic/eui/pull/2338))
+
+**Bug fixes**
+
+- Fixed styling for `prepend` and `append` nodes that may be popovers or tooltips ([#2338](https://github.com/elastic/eui/pull/2338))
 
 ## [`14.1.1`](https://github.com/elastic/eui/tree/v14.1.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added missing `compressed` TS definitions to `EuiComboBox`, `EuiCheckboxGroup`, `EuiCheckbox`, `EuiFieldSearch`, `EuiRadioGroup`, `EuiSwitch` ([#2338](https://github.com/elastic/eui/pull/2338))
+- Added auto-margin between `EuiFormRow` and `EuiButton` ([#2338](https://github.com/elastic/eui/pull/2338))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added missing `compressed` TS definitions to `EuiComboBox`, `EuiCheckboxGroup`, `EuiCheckbox`, `EuiFieldSearch`, `EuiRadioGroup`, `EuiSwitch` ([#2338](https://github.com/elastic/eui/pull/2338))
 - Added auto-margin between `EuiFormRow` and `EuiButton` ([#2338](https://github.com/elastic/eui/pull/2338))
+- Added border to `[readOnly]` inputs ([#2338](https://github.com/elastic/eui/pull/2338))
 
 **Bug fixes**
 

--- a/src-docs/src/views/form_controls/form_controls_example.js
+++ b/src-docs/src/views/form_controls/form_controls_example.js
@@ -75,6 +75,10 @@ import Switch from './switch';
 const switchSource = require('!!raw-loader!./switch');
 const switchHtml = renderToHtml(Switch);
 
+import PrependAppend from './prepend_append';
+const PrependAppendSource = require('!!raw-loader!./prepend_append');
+const PrependAppendHtml = renderToHtml(PrependAppend);
+
 import FormControlLayout from './form_control_layout';
 const formControlLayoutSource = require('!!raw-loader!./form_control_layout');
 const formControlLayoutHtml = renderToHtml(FormControlLayout);
@@ -314,6 +318,59 @@ export const FormControlsExample = {
         EuiSwitch,
       },
       demo: <Switch />,
+    },
+    {
+      title: 'Prepend and Append',
+      text: (
+        <Fragment>
+          <p>
+            Most form controls accept a <EuiCode>prepend</EuiCode> and{' '}
+            <EuiCode>append</EuiCode> prop that allows passing a single
+            node/string or an array of nodes/strings. Strings will be converted
+            into form labels and connected to the input via{' '}
+            <EuiCode>htmlFor</EuiCode> for accessibility.
+          </p>
+          <p>
+            These are great for demarcating the input&apos;s metric like
+            &quot;px&quot; or &quot;ms&quot;. You can also pass buttons for
+            input settings or additional filters. Just be sure to use
+            <EuiCode>&lt;EuiButtonEmpty size=&quot;xs&quot; /&gt;</EuiCode>.
+          </p>
+        </Fragment>
+      ),
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: PrependAppendSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: PrependAppendHtml,
+        },
+      ],
+      demo: <PrependAppend />,
+      snippet: [
+        `<EuiFieldText
+  prepend="Label"
+  append="px"
+/>`,
+        `<EuiFieldText
+  prepend={
+    <EuiPopover
+      button={
+        <EuiButtonEmpty size="xs" iconType="arrowDown" iconSide="right">
+          Popover
+        </EuiButtonEmpty>
+      }
+      closePopover={() => {}}
+    />
+  }
+  append={[
+    <EuiButtonIcon iconType="gear" />,
+    "Label",
+  ]}
+/>`,
+      ],
     },
     {
       title: 'Form control layout',

--- a/src-docs/src/views/form_controls/prepend_append.js
+++ b/src-docs/src/views/form_controls/prepend_append.js
@@ -1,0 +1,171 @@
+import React, { Fragment, useState } from 'react';
+
+import {
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiFieldText,
+  EuiIcon,
+  EuiIconTip,
+  EuiPopover,
+  EuiSpacer,
+  EuiSwitch,
+  EuiText,
+  EuiToolTip,
+} from '../../../../src/components';
+
+export default () => {
+  const [isCompressed, setCompressed] = useState(false);
+  const [isDisabled, setDisabled] = useState(false);
+  const [isReadOnly, setReadOnly] = useState(false);
+
+  return (
+    <Fragment>
+      <EuiSwitch
+        label="compressed"
+        checked={isCompressed}
+        onChange={e => setCompressed(e.target.checked)}
+      />
+      &emsp;
+      <EuiSwitch
+        label="disabled"
+        checked={isDisabled}
+        onChange={e => setDisabled(e.target.checked)}
+      />
+      &emsp;
+      <EuiSwitch
+        label="readOnly"
+        checked={isReadOnly}
+        onChange={e => setReadOnly(e.target.checked)}
+      />
+      <EuiSpacer />
+      <EuiFieldText
+        placeholder="String & text in a tooltip"
+        prepend="String"
+        append={
+          <EuiToolTip content="content">
+            <EuiText size="s">Tooltip</EuiText>
+          </EuiToolTip>
+        }
+        compressed={isCompressed}
+        disabled={isDisabled}
+        readOnly={isReadOnly}
+      />
+      <EuiSpacer />
+      <EuiFieldText
+        placeholder="XS empty button in a popover & tooltip"
+        prepend={
+          <EuiPopover
+            button={
+              <EuiButtonEmpty size="xs" iconType="arrowDown" iconSide="right">
+                Popover
+              </EuiButtonEmpty>
+            }
+            closePopover={() => {}}
+          />
+        }
+        append={
+          <EuiToolTip content="content">
+            <EuiButtonEmpty size="xs">Tooltip</EuiButtonEmpty>
+          </EuiToolTip>
+        }
+        compressed={isCompressed}
+        disabled={isDisabled}
+        readOnly={isReadOnly}
+      />
+      <EuiSpacer />
+      <EuiFieldText
+        placeholder="XS empty buttons with icons"
+        prepend={
+          <EuiButtonEmpty size="xs" iconType="arrowDown" iconSide="right">
+            <EuiIcon type="calendar" />
+          </EuiButtonEmpty>
+        }
+        append={
+          <EuiButtonEmpty size="xs" iconType="gear">
+            Tooltip
+          </EuiButtonEmpty>
+        }
+        compressed={isCompressed}
+        disabled={isDisabled}
+        readOnly={isReadOnly}
+      />
+      <EuiSpacer />
+      <EuiFieldText
+        placeholder="Icon & button icon"
+        prepend={<EuiIcon type="vector" />}
+        append={<EuiButtonIcon iconType="gear" aria-label="Gear this" />}
+        compressed={isCompressed}
+        disabled={isDisabled}
+        readOnly={isReadOnly}
+      />
+      <EuiSpacer />
+      <EuiFieldText
+        placeholder="Icons in buttons and popovers and tooltips"
+        prepend={[
+          <EuiIcon type="vector" />,
+          <EuiButtonIcon iconType="gear" aria-label="Gear this" />,
+        ]}
+        append={[
+          <EuiPopover
+            button={<EuiButtonIcon iconType="gear" aria-label="Gear this" />}
+            closePopover={() => {}}
+          />,
+          <EuiIconTip content="content" />,
+        ]}
+        compressed={isCompressed}
+        disabled={isDisabled}
+        readOnly={isReadOnly}
+      />
+      <EuiSpacer />
+      <EuiFieldText
+        placeholder="Icon button in popover & tooltip"
+        append={
+          <EuiPopover
+            button={<EuiButtonIcon iconType="arrowDown" aria-label="Popover" />}
+            closePopover={() => {}}
+          />
+        }
+        prepend={
+          <EuiToolTip content="content">
+            <EuiButtonIcon iconType="gear" aria-label="Gear this" />
+          </EuiToolTip>
+        }
+        compressed={isCompressed}
+        disabled={isDisabled}
+        readOnly={isReadOnly}
+      />
+      <EuiSpacer />
+      <EuiFieldText
+        placeholder="Icon and string & string and icon button"
+        prepend={[<EuiIcon type="vector" />, 'String']}
+        append={[
+          'String',
+          <EuiButtonIcon iconType="gear" aria-label="Gear this" />,
+        ]}
+        compressed={isCompressed}
+        disabled={isDisabled}
+        readOnly={isReadOnly}
+      />
+      <EuiSpacer />
+      <EuiFieldText
+        placeholder="String and button icon in tooltip & button icon in popover and string "
+        prepend={[
+          'String',
+          <EuiToolTip content="content">
+            <EuiButtonIcon iconType="gear" aria-label="Gear this" />
+          </EuiToolTip>,
+        ]}
+        append={[
+          <EuiPopover
+            button={<EuiButtonIcon iconType="gear" aria-label="Gear this" />}
+            closePopover={() => {}}
+          />,
+          'String',
+        ]}
+        compressed={isCompressed}
+        disabled={isDisabled}
+        readOnly={isReadOnly}
+      />
+    </Fragment>
+  );
+};

--- a/src/components/combo_box/index.d.ts
+++ b/src/components/combo_box/index.d.ts
@@ -79,6 +79,7 @@ declare module '@elastic/eui' {
   export interface EuiComboBoxProps<T> {
     id?: string;
     isDisabled?: boolean;
+    compressed?: boolean;
     className?: string;
     placeholder?: string;
     isLoading?: boolean;

--- a/src/components/date_picker/_date_picker_range.scss
+++ b/src/components/date_picker/_date_picker_range.scss
@@ -48,6 +48,7 @@
   }
 
   > .euiDatePickerRange__delimeter {
+    background-color: transparent !important; // override .euiFormControlLayout--group .euiText
     line-height: 1 !important;
     flex: 0 0 auto;
     padding-left: $euiFormControlPadding / 2;

--- a/src/components/form/_mixins.scss
+++ b/src/components/form/_mixins.scss
@@ -151,7 +151,7 @@
   // Use transparency since there is no border and in case form is on a non-white background
   background: $euiFormBackgroundReadOnlyColor;
   border-color: transparent;
-  box-shadow: none;
+  box-shadow: inset 0 0 0 1px $euiFormBorderDisabledColor;
 }
 
 /**

--- a/src/components/form/_mixins.scss
+++ b/src/components/form/_mixins.scss
@@ -149,7 +149,7 @@
 @mixin euiFormControlReadOnlyStyle {
   cursor: default;
   // Use transparency since there is no border and in case form is on a non-white background
-  background: transparentize(lightOrDarkTheme($euiColorLightShade, $euiColorInk), .88);
+  background: $euiFormBackgroundReadOnlyColor;
   border-color: transparent;
   box-shadow: none;
 }

--- a/src/components/form/_variables.scss
+++ b/src/components/form/_variables.scss
@@ -21,11 +21,13 @@ $euiSwitchThumbSizeCompressed: $euiSwitchHeightCompressed !default;
 // Coloring
 $euiFormBackgroundColor: tintOrShade($euiColorLightestShade, 60%, 40%) !default;
 $euiFormBackgroundDisabledColor: darken($euiColorLightestShade, 2%) !default;
+$euiFormBackgroundReadOnlyColor: transparentize(lightOrDarkTheme($euiColorLightShade, $euiColorInk), .88) !default;
 $euiFormBorderOpaqueColor: shadeOrTint(desaturate(adjust-hue($euiColorPrimary, 22), 22.95), 26%, 60%) !default;
 $euiFormBorderColor: transparentize($euiFormBorderOpaqueColor, .9) !default;
 $euiFormBorderDisabledColor: transparentize($euiFormBorderOpaqueColor, .9) !default;
 $euiFormCustomControlDisabledIconColor: shadeOrTint($euiColorMediumShade, 38%, 48.5%) !default; // exact 508c foreground for $euiColorLightShade
 $euiFormCustomControlBorderColor: shadeOrTint($euiColorLightestShade, 18%, 30%) !default;
 $euiFormControlDisabledColor: $euiColorMediumShade !default;
-$euiFormControlBoxShadow: 0 1px 1px -1px transparentize($euiShadowColor, .8), 0 3px 2px -2px transparentize($euiShadowColor, .8);
-$euiFormInputGroupLabelBackground: shadeOrTint($euiFormBackgroundDisabledColor, 0, 3%);
+$euiFormControlBoxShadow: 0 1px 1px -1px transparentize($euiShadowColor, .8), 0 3px 2px -2px transparentize($euiShadowColor, .8) !default;
+$euiFormInputGroupLabelBackground: transparentize(lightOrDarkTheme($euiColorLightShade, $euiColorInk), .75) !default;
+$euiFormInputGroupBorder: 1px solid shadeOrTint($euiFormInputGroupLabelBackground, 6%, 10%) !default;

--- a/src/components/form/_variables.scss
+++ b/src/components/form/_variables.scss
@@ -22,12 +22,12 @@ $euiSwitchThumbSizeCompressed: $euiSwitchHeightCompressed !default;
 $euiFormBackgroundColor: tintOrShade($euiColorLightestShade, 60%, 40%) !default;
 $euiFormBackgroundDisabledColor: darken($euiColorLightestShade, 2%) !default;
 $euiFormBackgroundReadOnlyColor: transparentize(lightOrDarkTheme($euiColorLightShade, $euiColorInk), .88) !default;
-$euiFormBorderOpaqueColor: shadeOrTint(desaturate(adjust-hue($euiColorPrimary, 22), 22.95), 26%, 60%) !default;
+$euiFormBorderOpaqueColor: shadeOrTint(desaturate(adjust-hue($euiColorPrimary, 22), 22.95), 26%, 100%) !default;
 $euiFormBorderColor: transparentize($euiFormBorderOpaqueColor, .9) !default;
 $euiFormBorderDisabledColor: transparentize($euiFormBorderOpaqueColor, .9) !default;
 $euiFormCustomControlDisabledIconColor: shadeOrTint($euiColorMediumShade, 38%, 48.5%) !default; // exact 508c foreground for $euiColorLightShade
 $euiFormCustomControlBorderColor: shadeOrTint($euiColorLightestShade, 18%, 30%) !default;
 $euiFormControlDisabledColor: $euiColorMediumShade !default;
 $euiFormControlBoxShadow: 0 1px 1px -1px transparentize($euiShadowColor, .8), 0 3px 2px -2px transparentize($euiShadowColor, .8) !default;
-$euiFormInputGroupLabelBackground: transparentize(lightOrDarkTheme($euiColorLightShade, $euiColorInk), .75) !default;
-$euiFormInputGroupBorder: 1px solid shadeOrTint($euiFormInputGroupLabelBackground, 6%, 10%) !default;
+$euiFormInputGroupLabelBackground: transparentize(lightOrDarkTheme($euiColorLightShade, $euiColorLightShade), .75) !default;
+$euiFormInputGroupBorder: 1px solid shadeOrTint($euiFormInputGroupLabelBackground, 6%, 8%) !default;

--- a/src/components/form/_variables.scss
+++ b/src/components/form/_variables.scss
@@ -29,5 +29,5 @@ $euiFormCustomControlDisabledIconColor: shadeOrTint($euiColorMediumShade, 38%, 4
 $euiFormCustomControlBorderColor: shadeOrTint($euiColorLightestShade, 18%, 30%) !default;
 $euiFormControlDisabledColor: $euiColorMediumShade !default;
 $euiFormControlBoxShadow: 0 1px 1px -1px transparentize($euiShadowColor, .8), 0 3px 2px -2px transparentize($euiShadowColor, .8) !default;
-$euiFormInputGroupLabelBackground: transparentize(lightOrDarkTheme($euiColorLightShade, $euiColorLightShade), .75) !default;
+$euiFormInputGroupLabelBackground: tintOrShade($euiColorLightShade, 65%, 40%) !default;
 $euiFormInputGroupBorder: 1px solid shadeOrTint($euiFormInputGroupLabelBackground, 6%, 8%) !default;

--- a/src/components/form/_variables.scss
+++ b/src/components/form/_variables.scss
@@ -21,7 +21,7 @@ $euiSwitchThumbSizeCompressed: $euiSwitchHeightCompressed !default;
 // Coloring
 $euiFormBackgroundColor: tintOrShade($euiColorLightestShade, 60%, 40%) !default;
 $euiFormBackgroundDisabledColor: darken($euiColorLightestShade, 2%) !default;
-$euiFormBackgroundReadOnlyColor: transparentize(lightOrDarkTheme($euiColorLightShade, $euiColorInk), .88) !default;
+$euiFormBackgroundReadOnlyColor: transparentize(lightOrDarkTheme($euiColorLightShade, $euiColorInk), .95) !default;
 $euiFormBorderOpaqueColor: shadeOrTint(desaturate(adjust-hue($euiColorPrimary, 22), 22.95), 26%, 100%) !default;
 $euiFormBorderColor: transparentize($euiFormBorderOpaqueColor, .9) !default;
 $euiFormBorderDisabledColor: transparentize($euiFormBorderOpaqueColor, .9) !default;

--- a/src/components/form/checkbox/index.d.ts
+++ b/src/components/form/checkbox/index.d.ts
@@ -51,6 +51,7 @@ declare module '@elastic/eui' {
     options: EuiCheckboxGroupOption[];
     idToSelectedMap: EuiCheckboxGroupIdToSelectedMap;
     onChange: ChangeEventHandler<HTMLInputElement>;
+    compressed?: boolean;
   }
 
   export const EuiCheckboxGroup: FunctionComponent<

--- a/src/components/form/checkbox/index.d.ts
+++ b/src/components/form/checkbox/index.d.ts
@@ -24,6 +24,7 @@ declare module '@elastic/eui' {
     label?: ReactNode;
     type?: EuiCheckboxType;
     disabled?: boolean;
+    compressed?: boolean;
     indeterminate?: boolean;
   }
 

--- a/src/components/form/field_search/index.d.ts
+++ b/src/components/form/field_search/index.d.ts
@@ -1,6 +1,6 @@
 import { CommonProps } from '../../common';
 
-import { FunctionComponent, InputHTMLAttributes } from 'react';
+import { FunctionComponent, InputHTMLAttributes, Ref } from 'react';
 
 declare module '@elastic/eui' {
   /**
@@ -17,8 +17,10 @@ declare module '@elastic/eui' {
     isInvalid?: boolean;
     fullWidth?: boolean;
     isLoading?: boolean;
-    incremental?: boolean;
     onSearch?: (value: string) => void;
+    incremental?: boolean;
+    compressed?: boolean;
+    inputRef?: Ref<HTMLInputElement>;
   }
 
   export const EuiFieldSearch: FunctionComponent<

--- a/src/components/form/form_control_layout/_form_control_layout.scss
+++ b/src/components/form/form_control_layout/_form_control_layout.scss
@@ -21,6 +21,16 @@
   align-items: stretch;
   padding: 1px; /* 1 */
 
+  // Force the stretch of any children so they expand the full height of the control
+  > *,
+  .euiPopover__anchor,
+  .euiButtonEmpty,
+  .euiText,
+  .euiFormLabel,
+  .euiButtonIcon {
+    height: 100%;
+  }
+
   .euiFormControlLayout__childrenWrapper {
     flex-grow: 1;
   }
@@ -30,79 +40,86 @@
     @include euiTextTruncate;
     flex-shrink: 0;
     height: 100%;
-    line-height: $euiFontSize - 1px; // The 1px less aligns the icons better
-    border: none; // remove any border in case it exists
     border-radius: 0;
 
-    &:first-child {
-      border-top-left-radius: $euiFormControlLayoutGroupInputCompressedBorderRadius;
-      border-bottom-left-radius: $euiFormControlLayoutGroupInputCompressedBorderRadius;
-    }
+    // ICONS
 
-    &:last-child {
-      border-top-right-radius: $euiFormControlLayoutGroupInputCompressedBorderRadius;
-      border-bottom-right-radius: $euiFormControlLayoutGroupInputCompressedBorderRadius;
-    }
+    &.euiIcon,
+    .euiIcon {
+      padding: 0 $euiSizeS;
+      width: $euiSizeXL;
+      border-radius: 0;
 
-    &:disabled {
-      background-color: $euiFormBackgroundDisabledColor;
-      color: $euiFormControlDisabledColor; // ensures established contrast
-    }
-
-    // sass-lint:disable-block no-important
-    // This is the only way to target specific components to override styling
-    &.euiFormLabel,
-    &.euiText,
-    &.euiButtonIcon,
-    &.euiIcon {
-      background-color: $euiFormInputGroupLabelBackground;
-
-      & + .euiFormControlLayout__prepend,
-      & + .euiFormControlLayout__append {
-        padding-left: 0 !important;
-
-        &.euiButtonIcon,
-        &.euiIcon {
-          width: $euiSizeL;
-        }
+      &:not(:focus) {
+        background-color: $euiFormInputGroupLabelBackground;
       }
     }
 
-    &.euiFormLabel,
-    &.euiText {
-      max-width: 50%;
-      white-space: nowrap;
-      margin-bottom: 0;
-      padding: $euiFormControlPadding;
-      border: none;
-      line-height: $euiFontSize;
-    }
 
     &.euiButtonIcon,
-    &.euiIcon {
-      padding: 0 $euiSizeS;
-      width: $euiSizeXL;
-      border: none;
+    &.euiButtonEmpty,
+    .euiButtonIcon,
+    .euiButtonEmpty {
       transform: none !important;
+
+      // Undo sizing from icons inside buttons
+      .euiIcon {
+        background: none !important;
+        padding: 0;
+        width: $euiSize;
+      }
     }
   }
 
-  // In case a tooltip was passed as a pre/append
-  // The cloned element's classname would have been passed to the tooltip not the anchor
-  .euiToolTipAnchor {
-    padding: $euiSizeXS;
+  .euiButtonIcon {
+    padding: 0 $euiSizeS;
+    width: $euiSizeXL;
+    border-radius: 0;
+
+    &:not(:focus) {
+      background-color: $euiFormInputGroupLabelBackground;
+    }
+  }
+
+  .euiToolTipAnchor > .euiIcon {
+    height: 100%;
     background-color: $euiFormInputGroupLabelBackground;
+    padding: 0 $euiSizeS;
+    width: $euiSizeXL;
+    border-radius: 0;
+  }
+
+  > .euiFormControlLayout__prepend,
+  > .euiFormControlLayout__append {
+    max-width: 50%; // Make sure max-width only applies to the outer most append/prepend element
+  }
+
+  // sass-lint:disable-block no-important
+  // This is the only way to target specific components to override styling
+
+  // TEXT
+
+  .euiFormLabel,
+  .euiText {
+    background-color: $euiFormInputGroupLabelBackground;
+    padding: $euiFormControlPadding;
+    line-height: $euiFontSize !important;
+    cursor: default !important; // pointer cursor on some form labels but not others is confusing
   }
 
   //
-  // Borders
+  // BORDERS on buttons only
 
-  .euiFormControlLayout__prepend {
-    border-right: 1px solid $euiFormBorderColor;
+  .euiButtonEmpty {
+    border-right: $euiFormInputGroupBorder;
   }
 
-  .euiFormControlLayout__append {
-    border-left: 1px solid $euiFormBorderColor;
+  // Any buttons after the children wrapper or inside any elements after the children wrapper
+  // Need to swap border sides
+  .euiFormControlLayout__childrenWrapper ~ .euiButtonEmpty,
+  .euiFormControlLayout__childrenWrapper ~ * .euiButtonEmpty {
+    border-right: none;
+    border-left: $euiFormInputGroupBorder;
   }
 
   //
@@ -111,23 +128,12 @@
   &.euiFormControlLayout--compressed {
     @include euiFormControlDefaultShadow($borderOnly: true);
     border-radius: $euiBorderRadius / 2;
+    overflow: hidden; // Keeps backgrounds inside border radius
 
-    .euiFormControlLayout__prepend,
-    .euiFormControlLayout__append {
-      &:first-child {
-        border-top-left-radius: $euiFormControlLayoutGroupInputCompressedBorderRadius;
-        border-bottom-left-radius: $euiFormControlLayoutGroupInputCompressedBorderRadius;
-      }
-
-      &:last-child {
-        border-top-right-radius: $euiFormControlLayoutGroupInputCompressedBorderRadius;
-        border-bottom-right-radius: $euiFormControlLayoutGroupInputCompressedBorderRadius;
-      }
-
-      &.euiFormLabel,
-      &.euiText {
-        padding: $euiFormControlCompressedPadding;
-      }
+    // Padding
+    .euiFormLabel,
+    .euiText {
+      padding: $euiFormControlCompressedPadding;
     }
   }
 
@@ -141,22 +147,4 @@
       background-color: transparent; // Ensures the input and layout don't double up on background color
     }
   }
-
-  //
-  // ReadOnly-Compressed alterations
-
-  &.euiFormControlLayout--compressed.euiFormControlLayout--readOnly {
-    .euiFormControlLayout__prepend,
-    .euiFormControlLayout__append {
-      height: $euiFormControlCompressedHeight;
-      border-top-left-radius: $euiFormControlCompressedBorderRadius;
-      border-bottom-left-radius: $euiFormControlCompressedBorderRadius;
-    }
-  }
-}
-
-.euiFormControlLayout-isDisabled,
-.euiFormControlLayout-isDisabled .euiDatePickerRange--inGroup {
-  background-color: $euiFormBackgroundDisabledColor;
-  color: $euiColorDarkShade;
 }

--- a/src/components/form/form_control_layout/_form_control_layout.scss
+++ b/src/components/form/form_control_layout/_form_control_layout.scss
@@ -105,6 +105,19 @@
     padding: $euiFormControlPadding;
     line-height: $euiFontSize !important;
     cursor: default !important; // pointer cursor on some form labels but not others is confusing
+
+    // If the next sibiling is not the input, pull it closer to the text to reduce space
+    + *:not(.euiFormControlLayout__childrenWrapper) {
+      margin-left: -$euiFormControlPadding;
+    }
+  }
+
+  // If any child that is not the input has a next sibling that is text, pull it closer to the text to reduce space
+  > *:not(.euiFormControlLayout__childrenWrapper) {
+    + .euiFormLabel,
+    + .euiText {
+      margin-left: -$euiFormControlPadding;
+    }
   }
 
   //
@@ -134,6 +147,19 @@
     .euiFormLabel,
     .euiText {
       padding: $euiFormControlCompressedPadding;
+
+      // If the next sibiling is not the input, pull it closer to the text to reduce space
+      + *:not(.euiFormControlLayout__childrenWrapper) {
+        margin-left: -$euiFormControlCompressedPadding;
+      }
+    }
+
+    // If any child that is not the input has a next sibling that is text, pull it closer to the text to reduce space
+    > *:not(.euiFormControlLayout__childrenWrapper) {
+      + .euiFormLabel,
+      + .euiText {
+        margin-left: -$euiFormControlCompressedPadding;
+      }
     }
   }
 

--- a/src/components/form/form_control_layout/_form_control_layout.scss
+++ b/src/components/form/form_control_layout/_form_control_layout.scss
@@ -165,7 +165,6 @@
   // ReadOnly alterations
   &.euiFormControlLayout--readOnly {
     @include euiFormControlReadOnlyStyle;
-    padding: 0; /* 1 */
 
     input {
       background-color: transparent; // Ensures the input and layout don't double up on background color

--- a/src/components/form/form_control_layout/_form_control_layout.scss
+++ b/src/components/form/form_control_layout/_form_control_layout.scss
@@ -49,10 +49,7 @@
       padding: 0 $euiSizeS;
       width: $euiSizeXL;
       border-radius: 0;
-
-      &:not(:focus) {
-        background-color: $euiFormInputGroupLabelBackground;
-      }
+      background-color: $euiFormInputGroupLabelBackground;
     }
 
 
@@ -75,9 +72,10 @@
     padding: 0 $euiSizeS;
     width: $euiSizeXL;
     border-radius: 0;
+    background-color: $euiFormInputGroupLabelBackground;
 
-    &:not(:focus) {
-      background-color: $euiFormInputGroupLabelBackground;
+    &:focus {
+      box-shadow: inset 0 0 0 2px $euiFocusRingColor;
     }
   }
 

--- a/src/components/form/form_control_layout/_form_control_layout_delimited.scss
+++ b/src/components/form/form_control_layout/_form_control_layout_delimited.scss
@@ -83,8 +83,8 @@
 
 .euiFormControlLayoutDelimited__delimeter {
   // sass-lint:disable-block no-important
-  // Override EuiText line-height
-  line-height: 1 !important;
+  background-color: transparent !important; // Override .euiFormControlLayout--group > .euiFormLabel
+  line-height: 1 !important; // Override EuiText line-height
   flex: 0 0 auto;
   padding-left: $euiFormControlPadding / 2;
   padding-right: $euiFormControlPadding / 2;

--- a/src/components/form/form_row/_form_row.scss
+++ b/src/components/form/form_row/_form_row.scss
@@ -7,7 +7,8 @@
   flex-direction: column; /* 1 */
   max-width: $euiFormMaxWidth;
 
-  + .euiFormRow {
+  + .euiFormRow,
+  + .euiButton {
     margin-top: $euiSize;
   }
 }

--- a/src/components/form/form_row/index.d.ts
+++ b/src/components/form/form_row/index.d.ts
@@ -20,7 +20,6 @@ declare module '@elastic/eui' {
     label?: ReactNode;
     labelAppend?: ReactNode;
     describedByIds?: string[];
-    compressed?: boolean;
     display?:
       | 'row'
       | 'rowCompressed'
@@ -28,6 +27,9 @@ declare module '@elastic/eui' {
       | 'center'
       | 'centerCompressed'
       | 'columnCompressedSwitch';
+    // **DEPRECATED: use `display: rowCompressed` instead.**
+    compressed?: boolean;
+    // **DEPRECATED: use `display: center` instead.**
     displayOnly?: boolean;
   };
 

--- a/src/components/form/radio/index.d.ts
+++ b/src/components/form/radio/index.d.ts
@@ -21,6 +21,7 @@ declare module '@elastic/eui' {
   export type EuiRadioGroupProps = CommonProps &
     Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> & {
       disabled?: boolean;
+      compressed?: boolean;
       name?: string;
       options?: EuiRadioGroupOption[];
       idSelected?: string;

--- a/src/components/form/switch/index.d.ts
+++ b/src/components/form/switch/index.d.ts
@@ -9,6 +9,7 @@ declare module '@elastic/eui' {
   export type EuiSwitchProps = CommonProps &
     InputHTMLAttributes<HTMLInputElement> & {
       label?: ReactNode;
+      compressed?: boolean;
     };
 
   export const EuiSwitch: FunctionComponent<EuiSwitchProps>;

--- a/src/components/suggest/__snapshots__/suggest_input.test.js.snap
+++ b/src/components/suggest/__snapshots__/suggest_input.test.js.snap
@@ -27,10 +27,10 @@ exports[`EuiSuggestInput is rendered 1`] = `
             />
           </div>
           <span
-            class="euiToolTipAnchor euiSuggestInput__statusIcon"
+            class="euiToolTipAnchor"
           >
             <svg
-              class="euiIcon euiIcon--medium euiIcon--accent euiIcon-isLoading"
+              class="euiIcon euiIcon--medium euiIcon--accent euiIcon-isLoading euiSuggestInput__statusIcon"
               focusable="false"
               height="16"
               viewBox="0 0 16 16"

--- a/src/components/suggest/_suggest_input.scss
+++ b/src/components/suggest/_suggest_input.scss
@@ -2,13 +2,8 @@
   font-size: $euiFontSizeS;
   color: $euiColorPrimary;
 
-  .euiLoadingSpinner {
-    margin-right: $euiSizeS;
-  }
-
   .euiSuggestInput__statusIcon {
-    padding-left: $euiSizeS;
-    padding-right: $euiSizeS;
+    // sass-lint:disable-block no-important
+    background-color: transparent !important; // Override typical append coloring
   }
-
 }

--- a/src/components/suggest/suggest_input.js
+++ b/src/components/suggest/suggest_input.js
@@ -71,9 +71,12 @@ export class EuiSuggestInput extends Component {
     const statusElement = (status === 'saved' || status === 'unsaved') && (
       <EuiToolTip
         position="left"
-        content={tooltipContent || statusMap[status].tooltip}
-        anchorClassName="euiSuggestInput__statusIcon">
-        <EuiIcon color={color} type={icon} />
+        content={tooltipContent || statusMap[status].tooltip}>
+        <EuiIcon
+          className="euiSuggestInput__statusIcon"
+          color={color}
+          type={icon}
+        />
       </EuiToolTip>
     );
 


### PR DESCRIPTION
### Fixing some initial issues found while updating Kibana

# Added TS defs where missing

There were some `compressed` props missing from the TS def files of some controls.

# Added a doc section for `append` and `prepend`

... and fixed up some styling especially if consumer was passing a popover or tooltip. These types of elements didn't get proper styling because the className wasn't being passed down to the right element it would have needed to be pass as the `anchorClassName`. The docs section is pretty robust showing lots of different types of elements being passed in.

<img width="979" alt="Screen Shot 2019-09-12 at 22 54 46 PM" src="https://user-images.githubusercontent.com/549577/64834669-de2d9380-d5b0-11e9-98cc-93b0015dd149.png">


### Checklist

- [x] Checked in **dark mode**
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- ~[ ] Props have proper **autodocs**~
- [x] Added **documentation** examples
- ~[ ] Added or updated **jest tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
