### PR TITLE
Added additional/base amount of z-index to popovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `14.1.1`.
+**Bug fixes**
+
+- Fixed default z-index of `EuiPopover` ([#2341](https://github.com/elastic/eui/pull/2341))
 
 ## [`14.1.1`](https://github.com/elastic/eui/tree/v14.1.1)
 
@@ -17,10 +19,6 @@ No public interface changes since `14.1.1`.
 - Added hover and focus states when `allowFullScreen` is true in `EuiImage`([#2287](https://github.com/elastic/eui/pull/2287))
 - Converted `EuiColorPicker` to TypeScript ([#2340](https://github.com/elastic/eui/pull/2340))
 - Added inline rendering option to `EuiColorPicker` ([#2340](https://github.com/elastic/eui/pull/2340))
-
-**Bug fixes**
-
-- Fixed default z-index of `EuiPopover` ([#2341](https://github.com/elastic/eui/pull/2341))
 
 ## [`14.0.0`](https://github.com/elastic/eui/tree/v14.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ No public interface changes since `14.1.1`.
 - Converted `EuiColorPicker` to TypeScript ([#2340](https://github.com/elastic/eui/pull/2340))
 - Added inline rendering option to `EuiColorPicker` ([#2340](https://github.com/elastic/eui/pull/2340))
 
+**Bug fixes**
+
+- Fixed default z-index of `EuiPopover` ([#2341](https://github.com/elastic/eui/pull/2341))
+
 ## [`14.0.0`](https://github.com/elastic/eui/tree/v14.0.0)
 
 ### Feature: Compressed Form Controls ([#2167](https://github.com/elastic/eui/pull/2167))

--- a/src-docs/src/views/form_controls/file_picker.js
+++ b/src-docs/src/views/form_controls/file_picker.js
@@ -8,6 +8,7 @@ import {
   EuiText,
   EuiSpacer,
   EuiSwitch,
+  EuiCheckboxGroup,
 } from '../../../../src/components';
 
 export class FilePicker extends Component {
@@ -80,6 +81,24 @@ export class FilePicker extends Component {
             </EuiText>
           </EuiFlexItem>
         </EuiFlexGroup>
+
+        <EuiCheckboxGroup
+          options={[
+            {
+              id: '0',
+              label: 'Option one',
+            },
+            {
+              id: '1',
+              label: 'Option two is checked by default',
+            },
+            {
+              id: '2',
+              label: 'Option three',
+            },
+          ]}
+          onChange={() => {}}
+        />
       </Fragment>
     );
   }

--- a/src-docs/src/views/form_controls/file_picker.js
+++ b/src-docs/src/views/form_controls/file_picker.js
@@ -8,7 +8,6 @@ import {
   EuiText,
   EuiSpacer,
   EuiSwitch,
-  EuiCheckboxGroup,
 } from '../../../../src/components';
 
 export class FilePicker extends Component {
@@ -81,24 +80,6 @@ export class FilePicker extends Component {
             </EuiText>
           </EuiFlexItem>
         </EuiFlexGroup>
-
-        <EuiCheckboxGroup
-          options={[
-            {
-              id: '0',
-              label: 'Option one',
-            },
-            {
-              id: '1',
-              label: 'Option two is checked by default',
-            },
-            {
-              id: '2',
-              label: 'Option three',
-            },
-          ]}
-          onChange={() => {}}
-        />
       </Fragment>
     );
   }

--- a/src-docs/src/views/popover/popover_fixed.js
+++ b/src-docs/src/views/popover/popover_fixed.js
@@ -50,7 +50,7 @@ export default class PopoverContainer extends Component {
             button={button}
             isOpen={this.state.isPopoverOpen}
             closePopover={this.closePopover}
-            style={{ position: 'fixed', bottom: 50, right: 50 }}
+            style={{ position: 'fixed', bottom: 50, right: 50, zIndex: 10 }}
             repositionOnScroll={true}>
             <div>This popover scrolls with the button element!</div>
           </EuiPopover>

--- a/src/components/form/super_select/__snapshots__/super_select.test.js.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.js.snap
@@ -181,7 +181,7 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
       <div
         aria-live="assertive"
         class="euiPanel euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
-        style="top: 8px; left: -22px; z-index: 0;"
+        style="top: 8px; left: -22px; z-index: 2000;"
       >
         <div
           class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -388,7 +388,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
       <div
         aria-live="assertive"
         class="euiPanel euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
-        style="top: 8px; left: -22px; z-index: 0;"
+        style="top: 8px; left: -22px; z-index: 2000;"
       >
         <div
           class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -755,7 +755,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                             <div
                               aria-live="assertive"
                               class="euiPanel euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
-                              style="top: 8px; left: -22px; z-index: 0;"
+                              style="top: 8px; left: -22px; z-index: 2000;"
                             >
                               <div
                                 class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -844,7 +844,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                               <div
                                 aria-live="assertive"
                                 class="euiPanel euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
-                                style="top: 8px; left: -22px; z-index: 0;"
+                                style="top: 8px; left: -22px; z-index: 2000;"
                               >
                                 <div
                                   class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -933,7 +933,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                           Object {
                             "left": -22,
                             "top": 8,
-                            "zIndex": 0,
+                            "zIndex": 2000,
                           }
                         }
                       >
@@ -944,7 +944,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                             Object {
                               "left": -22,
                               "top": 8,
-                              "zIndex": 0,
+                              "zIndex": 2000,
                             }
                           }
                         >
@@ -1202,7 +1202,7 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
       <div
         aria-live="assertive"
         class="euiPanel euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
-        style="top: 8px; left: -22px; z-index: 0;"
+        style="top: 8px; left: -22px; z-index: 2000;"
       >
         <div
           class="euiPopover__panelArrow euiPopover__panelArrow--bottom"

--- a/src/components/popover/__snapshots__/popover.test.tsx.snap
+++ b/src/components/popover/__snapshots__/popover.test.tsx.snap
@@ -134,7 +134,7 @@ exports[`EuiPopover props isOpen renders true 1`] = `
         <div
           aria-live="assertive"
           class="euiPanel euiPanel--paddingMedium euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
-          style="top: 16px; left: -22px; z-index: 0;"
+          style="top: 16px; left: -22px; z-index: 2000;"
         >
           <div
             class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -181,7 +181,7 @@ exports[`EuiPopover props ownFocus defaults to false 1`] = `
         <div
           aria-live="assertive"
           class="euiPanel euiPanel--paddingMedium euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
-          style="top: 16px; left: -22px; z-index: 0;"
+          style="top: 16px; left: -22px; z-index: 2000;"
         >
           <div
             class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -235,7 +235,7 @@ exports[`EuiPopover props ownFocus renders true 1`] = `
           aria-live="off"
           class="euiPanel euiPanel--paddingMedium euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
           data-autofocus="true"
-          style="top: 16px; left: -22px; z-index: 0;"
+          style="top: 16px; left: -22px; z-index: 2000;"
           tabindex="0"
         >
           <div
@@ -283,7 +283,7 @@ exports[`EuiPopover props panelClassName is rendered 1`] = `
         <div
           aria-live="assertive"
           class="euiPanel euiPanel--paddingMedium euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen test"
-          style="top: 16px; left: -22px; z-index: 0;"
+          style="top: 16px; left: -22px; z-index: 2000;"
         >
           <div
             class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -330,7 +330,7 @@ exports[`EuiPopover props panelPaddingSize is rendered 1`] = `
         <div
           aria-live="assertive"
           class="euiPanel euiPanel--paddingSmall euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
-          style="top: 16px; left: -22px; z-index: 0;"
+          style="top: 16px; left: -22px; z-index: 2000;"
         >
           <div
             class="euiPopover__panelArrow euiPopover__panelArrow--bottom"

--- a/src/components/popover/_popover.scss
+++ b/src/components/popover/_popover.scss
@@ -32,7 +32,6 @@
   // Ignore linting for legibility of transition property, and the mixin performs an overwrite
   // sass-lint:disable-block indentation, mixins-before-declarations
   position: absolute;
-  z-index: $euiZContentMenu;
   min-width: $euiButtonMinWidth; /* 1 */
   max-width: calc(100vw - #{$euiSizeXL}); /* 3 */
   backface-visibility: hidden;

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -458,7 +458,7 @@ export class EuiPopover extends Component<Props, State> {
     const { zIndex: zIndexProp } = this.props;
     const zIndex =
       zIndexProp == null
-        ? getElementZIndex(this.button, this.panel)
+        ? getElementZIndex(this.button, this.panel) + 2000
         : zIndexProp;
 
     const popoverStyles = {


### PR DESCRIPTION
### Fix EuiPopover base z-index

The z-index is based off of the parent and the triggering element. But if both are `0`, then so is the popover which causes anything with a z-index of `1` or more to show on top.

**Before**

<img width="345" alt="Screen Shot 2019-09-13 at 12 39 53 PM" src="https://user-images.githubusercontent.com/549577/64884380-9bf76700-d62f-11e9-8bc2-e10af2fdf927.png">

I've added an example in the File Picker docs section that will show:

**Before**
<img width="291" alt="Screen Shot 2019-09-13 at 14 10 37 PM" src="https://user-images.githubusercontent.com/549577/64884671-496a7a80-d630-11e9-9dab-461f8bb8d0df.png">


**After**
<img width="303" alt="Screen Shot 2019-09-13 at 14 10 13 PM" src="https://user-images.githubusercontent.com/549577/64884646-3fe11280-d630-11e9-8311-e41c848b8e9c.png">


I'll remove this before merge but allows for easy testing.

**And popovers in flyouts still work**

<img width="679" alt="Screen Shot 2019-09-13 at 13 02 42 PM" src="https://user-images.githubusercontent.com/549577/64884501-e4168980-d62f-11e9-813d-4244bf25be12.png">


### Checklist

- ~[ ] Checked in **dark mode**~
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **IE11** and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
