### PR TITLE
Created compressed EuiButtonGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `14.1.1`.
+- Add `compressed` option to `buttonSize` prop of EuiButtonGroup ([#2343](https://github.com/elastic/eui/pull/2343))
 
 ## [`14.1.1`](https://github.com/elastic/eui/tree/v14.1.1)
 

--- a/src-docs/src/views/button/button_group.js
+++ b/src-docs/src/views/button/button_group.js
@@ -7,6 +7,7 @@ import {
 } from '../../../../src/components';
 
 import makeId from '../../../../src/components/form/form_row/make_id';
+import { EuiPanel } from '../../../../src/components/panel/panel';
 
 export default class extends Component {
   constructor(props) {
@@ -43,6 +44,21 @@ export default class extends Component {
       {
         id: `${idPrefix2}2`,
         label: 'Option 3',
+      },
+    ];
+
+    this.toggleButtonsCompressed = [
+      {
+        id: `${idPrefix2}3`,
+        label: 'fine',
+      },
+      {
+        id: `${idPrefix2}4`,
+        label: 'rough',
+      },
+      {
+        id: `${idPrefix2}5`,
+        label: 'coarse',
       },
     ];
 
@@ -98,6 +114,7 @@ export default class extends Component {
       },
       toggleIconIdSelected: `${idPrefix3}1`,
       toggleIconIdToSelectedMap: {},
+      toggleCompressedIdSelected: `${idPrefix2}4`,
     };
   }
 
@@ -123,6 +140,12 @@ export default class extends Component {
   onChangeIcons = optionId => {
     this.setState({
       toggleIconIdSelected: optionId,
+    });
+  };
+
+  onChangeCompressed = optionId => {
+    this.setState({
+      toggleCompressedIdSelected: optionId,
     });
   };
 
@@ -173,6 +196,7 @@ export default class extends Component {
           options={this.toggleButtons}
           idSelected={this.state.toggleIdSelected}
           onChange={this.onChange}
+          buttonSize="m"
           isDisabled
           isFullWidth
         />
@@ -184,7 +208,6 @@ export default class extends Component {
         <EuiButtonGroup
           legend="Text align"
           name="textAlign"
-          className="eui-displayInlineBlock"
           options={this.toggleButtonsIcons}
           idSelected={this.state.toggleIconIdSelected}
           onChange={this.onChangeIcons}
@@ -193,13 +216,47 @@ export default class extends Component {
         &nbsp;&nbsp;
         <EuiButtonGroup
           legend="Text style"
-          className="eui-displayInlineBlock"
           options={this.toggleButtonsIconsMulti}
           idToSelectedMap={this.state.toggleIconIdToSelectedMap}
           onChange={this.onChangeIconsMulti}
           type="multi"
           isIconOnly
         />
+        <EuiSpacer />
+        <EuiPanel style={{ maxWidth: 300 }}>
+          <EuiTitle size="xxxs">
+            <h3>
+              Compressed groups should always be primary and fullWidth so they
+              line up nicely in their small container.
+            </h3>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+          <EuiButtonGroup
+            legend="This is a basic group"
+            options={this.toggleButtonsCompressed}
+            idSelected={this.state.toggleCompressedIdSelected}
+            onChange={this.onChangeCompressed}
+            buttonSize="compressed"
+            isFullWidth
+            color="primary"
+          />
+          <EuiSpacer />
+          <EuiTitle size="xxxs">
+            <h3>Unless they are icon only</h3>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+          <EuiButtonGroup
+            legend="Text style"
+            className="eui-displayInlineBlock"
+            options={this.toggleButtonsIconsMulti}
+            idToSelectedMap={this.state.toggleIconIdToSelectedMap}
+            onChange={this.onChangeIconsMulti}
+            type="multi"
+            isIconOnly
+            buttonSize="compressed"
+            color="primary"
+          />
+        </EuiPanel>
       </Fragment>
     );
   }

--- a/src-docs/src/views/button/button_group.js
+++ b/src-docs/src/views/button/button_group.js
@@ -226,19 +226,19 @@ export default class extends Component {
         <EuiPanel style={{ maxWidth: 300 }}>
           <EuiTitle size="xxxs">
             <h3>
-              Compressed groups should always be primary and fullWidth so they
-              line up nicely in their small container.
+              Compressed groups should always be fullWidth so they line up
+              nicely in their small container.
             </h3>
           </EuiTitle>
           <EuiSpacer size="s" />
           <EuiButtonGroup
+            name="coarsness"
             legend="This is a basic group"
             options={this.toggleButtonsCompressed}
             idSelected={this.state.toggleCompressedIdSelected}
             onChange={this.onChangeCompressed}
             buttonSize="compressed"
             isFullWidth
-            color="primary"
           />
           <EuiSpacer />
           <EuiTitle size="xxxs">
@@ -246,15 +246,15 @@ export default class extends Component {
           </EuiTitle>
           <EuiSpacer size="s" />
           <EuiButtonGroup
+            name="textStyleCompressed"
             legend="Text style"
             className="eui-displayInlineBlock"
             options={this.toggleButtonsIconsMulti}
             idToSelectedMap={this.state.toggleIconIdToSelectedMap}
             onChange={this.onChangeIconsMulti}
             type="multi"
-            isIconOnly
             buttonSize="compressed"
-            color="primary"
+            isIconOnly
           />
         </EuiPanel>
       </Fragment>

--- a/src-docs/src/views/form_compressed/complex_example.js
+++ b/src-docs/src/views/form_compressed/complex_example.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 
 import {
+  EuiButtonGroup,
   EuiButtonIcon,
   EuiColorPicker,
   EuiColorPickerSwatch,
@@ -27,6 +28,8 @@ export default class extends Component {
   constructor(props) {
     super(props);
     const idPrefix = makeId;
+    const idPrefix2 = makeId;
+    const idPrefix3 = makeId;
 
     this.toggleButtons = [
       {
@@ -43,6 +46,48 @@ export default class extends Component {
       },
     ];
 
+    this.typeStyleToggleButtons = [
+      {
+        id: `${idPrefix3}3`,
+        label: 'Bold',
+        name: 'bold',
+        iconType: 'editorBold',
+      },
+      {
+        id: `${idPrefix3}4`,
+        label: 'Italic',
+        name: 'italic',
+        iconType: 'editorItalic',
+      },
+      {
+        id: `${idPrefix3}5`,
+        label: 'Underline',
+        name: 'underline',
+        iconType: 'editorUnderline',
+      },
+      {
+        id: `${idPrefix3}6`,
+        label: 'Strikethrough',
+        name: 'strikethrough',
+        iconType: 'editorStrike',
+      },
+    ];
+
+    this.granularityToggleButtons = [
+      {
+        id: `${idPrefix2}3`,
+        label: 'fine',
+      },
+      {
+        id: `${idPrefix2}4`,
+        label: 'rough',
+      },
+      {
+        id: `${idPrefix2}5`,
+        label: 'coarse',
+      },
+    ];
+
     this.state = {
       isSwitchChecked: false,
       opacityValue: '20',
@@ -51,6 +96,8 @@ export default class extends Component {
       borderValue: 3,
       popoverSliderValues: 16,
       dualValue: [5, 10],
+      typeStyleToggleButtonsIdToSelectedMap: {},
+      granularityToggleButtonsIdSelected: `${idPrefix2}4`,
     };
 
     this.selectTooltipContent =
@@ -92,6 +139,25 @@ export default class extends Component {
   onDualChange = value => {
     this.setState({
       dualValue: value,
+    });
+  };
+
+  onTypeStyleChange = optionId => {
+    const newTypeStyleToggleButtonsIdToSelectedMap = {
+      ...this.state.typeStyleToggleButtonsIdToSelectedMap,
+      ...{
+        [optionId]: !this.state.typeStyleToggleButtonsIdToSelectedMap[optionId],
+      },
+    };
+
+    this.setState({
+      typeStyleToggleButtonsIdToSelectedMap: newTypeStyleToggleButtonsIdToSelectedMap,
+    });
+  };
+
+  onGranularityChange = optionId => {
+    this.setState({
+      granularityToggleButtonsIdSelected: optionId,
     });
   };
 
@@ -153,6 +219,18 @@ export default class extends Component {
             ]}
             compressed
             aria-describedby="docsExampleSelectTooltipContent"
+          />
+        </EuiFormRow>
+
+        <EuiFormRow label="Granularity" display="columnCompressed">
+          <EuiButtonGroup
+            legend="Granulariy of zoom levels"
+            options={this.granularityToggleButtons}
+            idSelected={this.state.granularityToggleButtonsIdSelected}
+            onChange={this.onGranularityChange}
+            buttonSize="compressed"
+            isFullWidth
+            color="primary"
           />
         </EuiFormRow>
 
@@ -229,10 +307,8 @@ export default class extends Component {
 
         <EuiSpacer size="s" />
 
-        <EuiFormLabel htmlFor="docsExampleLabelFont">Label</EuiFormLabel>
-        <EuiSpacer size="xs" />
-        <EuiFlexGroup gutterSize="s" responsive={false} wrap>
-          <EuiFlexItem grow={3} style={{ minWidth: 160 }}>
+        <EuiFormRow label="Label" display="columnCompressed">
+          <div>
             <EuiSelect
               id="docsExampleLabelFont"
               options={[
@@ -242,21 +318,44 @@ export default class extends Component {
               ]}
               compressed
               prepend="Font"
+              aria-label="Label font family"
             />
-          </EuiFlexItem>
-          <EuiFlexItem style={{ minWidth: 80 }}>
-            <EuiRange
-              showInput="inputWithPopover"
-              min={7}
-              max={140}
-              value={this.state.popoverSliderValues}
-              onChange={this.onPopoverSliderValueChange}
-              compressed
-              append="px"
-              aria-label="Label font size in pixels"
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
+            <EuiSpacer size="xs" />
+            <EuiFlexGroup
+              gutterSize="s"
+              responsive={false}
+              wrap
+              justifyContent="flexEnd">
+              <EuiFlexItem>
+                <EuiRange
+                  showInput="inputWithPopover"
+                  min={7}
+                  max={140}
+                  value={this.state.popoverSliderValues}
+                  onChange={this.onPopoverSliderValueChange}
+                  compressed
+                  append="px"
+                  aria-label="Label font size in pixels"
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButtonGroup
+                  legend="Label text style"
+                  className="eui-displayInlineBlock"
+                  options={this.typeStyleToggleButtons}
+                  idToSelectedMap={
+                    this.state.typeStyleToggleButtonsIdToSelectedMap
+                  }
+                  onChange={this.onTypeStyleChange}
+                  type="multi"
+                  isIconOnly
+                  buttonSize="compressed"
+                  color="primary"
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </div>
+        </EuiFormRow>
 
         <EuiSpacer size="s" />
 

--- a/src-docs/src/views/form_compressed/complex_example.js
+++ b/src-docs/src/views/form_compressed/complex_example.js
@@ -230,7 +230,6 @@ export default class extends Component {
             onChange={this.onGranularityChange}
             buttonSize="compressed"
             isFullWidth
-            color="primary"
           />
         </EuiFormRow>
 
@@ -350,7 +349,6 @@ export default class extends Component {
                   type="multi"
                   isIconOnly
                   buttonSize="compressed"
-                  color="primary"
                 />
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/src/components/button/button_group/__snapshots__/button_group.test.tsx.snap
+++ b/src/components/button/button_group/__snapshots__/button_group.test.tsx.snap
@@ -11,3 +11,1654 @@ exports[`EuiButtonGroup is rendered 1`] = `
   />
 </fieldset>
 `;
+
+exports[`EuiButtonGroup props buttonSize compressed is rendered 1`] = `
+<fieldset
+  class="euiButtonGroup__fieldset"
+>
+  <div
+    class="euiButtonGroup euiButtonGroup--compressed"
+  >
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option one"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option one"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button00"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option one
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option two"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option two"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button01"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option two
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option three"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option three"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button02"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option three
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`EuiButtonGroup props buttonSize m is rendered 1`] = `
+<fieldset
+  class="euiButtonGroup__fieldset"
+>
+  <div
+    class="euiButtonGroup euiButtonGroup--m"
+  >
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option one"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option one"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButtonToggle euiButtonGroup__button"
+        id="button00"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option one
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option two"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option two"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButtonToggle euiButtonGroup__button"
+        id="button01"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option two
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option three"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option three"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButtonToggle euiButtonGroup__button"
+        id="button02"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option three
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`EuiButtonGroup props buttonSize s is rendered 1`] = `
+<fieldset
+  class="euiButtonGroup__fieldset"
+>
+  <div
+    class="euiButtonGroup euiButtonGroup--s"
+  >
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option one"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option one"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button00"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option one
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option two"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option two"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button01"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option two
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option three"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option three"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button02"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option three
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`EuiButtonGroup props color danger is rendered 1`] = `
+<fieldset
+  class="euiButtonGroup__fieldset"
+>
+  <div
+    class="euiButtonGroup euiButtonGroup--s"
+  >
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option one"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option one"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--danger euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button00"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option one
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option two"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option two"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--danger euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button01"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option two
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option three"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option three"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--danger euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button02"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option three
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`EuiButtonGroup props color ghost is rendered 1`] = `
+<fieldset
+  class="euiButtonGroup__fieldset"
+>
+  <div
+    class="euiButtonGroup euiButtonGroup--s"
+  >
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option one"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option one"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--ghost euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button00"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option one
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option two"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option two"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--ghost euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button01"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option two
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option three"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option three"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--ghost euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button02"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option three
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`EuiButtonGroup props color primary is rendered 1`] = `
+<fieldset
+  class="euiButtonGroup__fieldset"
+>
+  <div
+    class="euiButtonGroup euiButtonGroup--s"
+  >
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option one"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option one"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--primary euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button00"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option one
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option two"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option two"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--primary euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button01"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option two
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option three"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option three"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--primary euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button02"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option three
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`EuiButtonGroup props color secondary is rendered 1`] = `
+<fieldset
+  class="euiButtonGroup__fieldset"
+>
+  <div
+    class="euiButtonGroup euiButtonGroup--s"
+  >
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option one"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option one"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--secondary euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button00"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option one
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option two"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option two"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--secondary euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button01"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option two
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option three"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option three"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--secondary euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button02"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option three
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`EuiButtonGroup props color text is rendered 1`] = `
+<fieldset
+  class="euiButtonGroup__fieldset"
+>
+  <div
+    class="euiButtonGroup euiButtonGroup--s"
+  >
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option one"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option one"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button00"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option one
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option two"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option two"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button01"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option two
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option three"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option three"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button02"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option three
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`EuiButtonGroup props color warning is rendered 1`] = `
+<fieldset
+  class="euiButtonGroup__fieldset"
+>
+  <div
+    class="euiButtonGroup euiButtonGroup--s"
+  >
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option one"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option one"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--warning euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button00"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option one
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option two"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option two"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--warning euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button01"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option two
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option three"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option three"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--warning euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button02"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option three
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`EuiButtonGroup props idSelected is rendered 1`] = `
+<fieldset
+  class="euiButtonGroup__fieldset"
+>
+  <div
+    class="euiButtonGroup euiButtonGroup--s"
+  >
+    <div
+      class="euiToggle euiToggle--checked euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option one"
+        checked=""
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option one"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button euiButtonGroup__button--selected euiButton--fill"
+        id="button00"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option one
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option two"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option two"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button01"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option two
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option three"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option three"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button02"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option three
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`EuiButtonGroup props isDisabled is rendered 1`] = `
+<fieldset
+  class="euiButtonGroup__fieldset"
+>
+  <div
+    class="euiButtonGroup euiButtonGroup--s"
+  >
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonToggle--isDisabled euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option one"
+        class="euiToggle__input euiButtonToggle__input"
+        disabled=""
+        title="Option one"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        disabled=""
+        id="button00"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option one
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonToggle--isDisabled euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option two"
+        class="euiToggle__input euiButtonToggle__input"
+        disabled=""
+        title="Option two"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        disabled=""
+        id="button01"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option two
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonToggle--isDisabled euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option three"
+        class="euiToggle__input euiButtonToggle__input"
+        disabled=""
+        title="Option three"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        disabled=""
+        id="button02"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option three
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`EuiButtonGroup props isFullWidth is rendered 1`] = `
+<fieldset
+  class="euiButtonGroup__fieldset euiButtonGroup__fieldset--fullWidth"
+>
+  <div
+    class="euiButtonGroup euiButtonGroup--s euiButtonGroup--fullWidth"
+  >
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option one"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option one"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button00"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option one
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option two"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option two"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button01"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option two
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option three"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option three"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button02"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option three
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`EuiButtonGroup props isIconOnly is rendered 1`] = `
+<fieldset
+  class="euiButtonGroup__fieldset"
+>
+  <div
+    class="euiButtonGroup euiButtonGroup--s"
+  >
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option one"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option one"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonToggle--isIconOnly euiButtonGroup__button"
+        id="button00"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          />
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option two"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option two"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonToggle--isIconOnly euiButtonGroup__button"
+        id="button01"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          />
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option three"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option three"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonToggle--isIconOnly euiButtonGroup__button"
+        id="button02"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          />
+        </span>
+      </button>
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`EuiButtonGroup props legend is rendered 1`] = `
+<fieldset
+  class="euiButtonGroup__fieldset"
+>
+  <legend
+    class="euiScreenReaderOnly"
+  >
+    legend
+  </legend>
+  <div
+    class="euiButtonGroup euiButtonGroup--s"
+  >
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option one"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option one"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button00"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option one
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option two"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option two"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button01"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option two
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option three"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option three"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button02"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option three
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`EuiButtonGroup props name is rendered 1`] = `
+<fieldset
+  class="euiButtonGroup__fieldset"
+>
+  <div
+    class="euiButtonGroup euiButtonGroup--s"
+  >
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option one"
+        class="euiToggle__input euiButtonToggle__input"
+        name="name"
+        title="Option one"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button00"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option one
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option two"
+        class="euiToggle__input euiButtonToggle__input"
+        name="name"
+        title="Option two"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button01"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option two
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option three"
+        class="euiToggle__input euiButtonToggle__input"
+        name="name"
+        title="Option three"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button02"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option three
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`EuiButtonGroup props options are rendered 1`] = `
+<fieldset
+  class="euiButtonGroup__fieldset"
+>
+  <div
+    class="euiButtonGroup euiButtonGroup--s"
+  >
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option one"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option one"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button00"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option one
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option two"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option two"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button01"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option two
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option three"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option three"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button02"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option three
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`EuiButtonGroup props options can pass down data-test-subj 1`] = `
+<fieldset
+  class="euiButtonGroup__fieldset"
+>
+  <div
+    class="euiButtonGroup euiButtonGroup--s"
+  >
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option one"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option one"
+        type="radio"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        data-test-subj="test"
+        id="button00"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option one
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`EuiButtonGroup props type of multi idToSelectedMap is rendered 1`] = `
+<fieldset
+  class="euiButtonGroup__fieldset"
+>
+  <div
+    class="euiButtonGroup euiButtonGroup--s"
+  >
+    <div
+      class="euiToggle euiToggle--checked euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option one"
+        checked=""
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option one"
+        type="checkbox"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button euiButtonGroup__button--selected euiButton--fill"
+        id="button00"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option one
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiToggle--checked euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option two"
+        checked=""
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option two"
+        type="checkbox"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button euiButtonGroup__button--selected euiButton--fill"
+        id="button01"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option two
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option three"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option three"
+        type="checkbox"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button02"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option three
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`EuiButtonGroup props type of multi is rendered 1`] = `
+<fieldset
+  class="euiButtonGroup__fieldset"
+>
+  <div
+    class="euiButtonGroup euiButtonGroup--s"
+  >
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option one"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option one"
+        type="checkbox"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button00"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option one
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option two"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option two"
+        type="checkbox"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button01"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option two
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+    >
+      <input
+        aria-label="Option three"
+        class="euiToggle__input euiButtonToggle__input"
+        title="Option three"
+        type="checkbox"
+      />
+      <button
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        id="button02"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="euiButton__content"
+        >
+          <span
+            class="euiButton__text"
+          >
+            Option three
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</fieldset>
+`;

--- a/src/components/button/button_group/__snapshots__/button_group.test.tsx.snap
+++ b/src/components/button/button_group/__snapshots__/button_group.test.tsx.snap
@@ -1,10 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiButtonGroup is rendered 1`] = `
-<fieldset>
+<fieldset
+  class="euiButtonGroup__fieldset"
+>
   <div
     aria-label="aria-label"
-    class="euiButtonGroup testClass1 testClass2"
+    class="euiButtonGroup euiButtonGroup--s testClass1 testClass2"
     data-test-subj="test subject string"
   />
 </fieldset>

--- a/src/components/button/button_group/_button_group.scss
+++ b/src/components/button/button_group/_button_group.scss
@@ -103,7 +103,8 @@
     min-width: 0;
     border: none;
     border-radius: $euiBorderRadius;
-    // Offset the background color from the border by 1px
+    // Offset the background color from the border by 2px
+    // by clipping background to before the padding starts
     padding: 2px;
     background-clip: content-box;
 

--- a/src/components/button/button_group/_button_group.scss
+++ b/src/components/button/button_group/_button_group.scss
@@ -1,6 +1,17 @@
+@import '../../form/variables';
+
 .euiButtonGroup {
   max-width: 100%;
   display: flex;
+}
+
+.euiButtonGroup__fieldset {
+  display: inline-block;
+  max-width: 100%;
+
+  &--fullWidth {
+    display: block;
+  }
 }
 
 .euiButtonGroup--fullWidth {
@@ -41,10 +52,6 @@
     &:enabled {
       @include euiSlightShadow;
     }
-
-    @include euiButtonToggleStates {
-      @include euiSlightShadowHover;
-    }
   }
 
   &:first-child {
@@ -61,12 +68,69 @@
     border-bottom-right-radius: $euiBorderRadius;
   }
 
-  @include euiBreakpoint('xs', 's') {
+}
+
+@include euiBreakpoint('xs', 's') {
+  .euiButtonGroup__fieldset {
+    display: block;
+  }
+
+  .euiButtonGroup__toggle {
     flex: 1;
     min-width: 0;
 
     .euiButtonGroup__button {
       min-width: 0;
+    }
+  }
+}
+
+.euiButtonGroup--compressed {
+  .euiButtonGroup__button {
+    // sass-lint:disable-block no-important
+    box-shadow: none !important;
+    font-size: $euiFontSizeS;
+    min-width: 0;
+    height: $euiFormControlCompressedHeight;
+    border-color: $euiButtonToggleBorderColor !important; // for all states as this color encompasses the whole group
+    border-width: 1px 0;
+    // Offset the background color from the border by 1px
+    padding: 1px;
+    background-clip: content-box;
+
+    &:not(.euiButtonGroup__button--selected) {
+      color: $euiTextColor;
+    }
+
+    &--selected {
+      font-weight: $euiFontWeightSemiBold;
+      background-color: $euiColorLightestShade;
+    }
+
+    .euiButton__content {
+      padding-left: $euiSizeS;
+      padding-right: $euiSizeS;
+    }
+  }
+
+  .euiButtonGroup__toggle {
+    flex: 1;
+    min-width: 0;
+
+    &:first-child {
+      .euiButtonGroup__button {
+        border-left-width: 1px;
+        border-top-left-radius: $euiFormControlCompressedBorderRadius;
+        border-bottom-left-radius: $euiFormControlCompressedBorderRadius;
+      }
+    }
+
+    &:last-child {
+      .euiButtonGroup__button {
+        border-right-width: 1px;
+        border-top-right-radius: $euiFormControlCompressedBorderRadius;
+        border-bottom-right-radius: $euiFormControlCompressedBorderRadius;
+      }
     }
   }
 }

--- a/src/components/button/button_group/_button_group.scss
+++ b/src/components/button/button_group/_button_group.scss
@@ -43,6 +43,12 @@
     border-radius: 0;
     width: 100%;
 
+    // DO NOT Transform
+    // sass-lint:disable-block no-important
+    transition: none !important;
+    transform: none !important;
+    animation: none !important;
+
     // always the same border color unless it's selected
     &:not([class*='fill']) {
       border-color: $euiButtonToggleBorderColor;
@@ -86,25 +92,23 @@
 }
 
 .euiButtonGroup--compressed {
+  border: 1px solid $euiFormBorderColor;
+  border-radius: $euiFormControlCompressedBorderRadius;
+
   .euiButtonGroup__button {
+    height: $euiFormControlCompressedHeight - 2px;
     // sass-lint:disable-block no-important
     box-shadow: none !important;
     font-size: $euiFontSizeS;
     min-width: 0;
-    height: $euiFormControlCompressedHeight;
-    border-color: $euiButtonToggleBorderColor !important; // for all states as this color encompasses the whole group
-    border-width: 1px 0;
+    border: none;
+    border-radius: $euiBorderRadius;
     // Offset the background color from the border by 1px
-    padding: 1px;
+    padding: 2px;
     background-clip: content-box;
 
-    &:not(.euiButtonGroup__button--selected) {
-      color: $euiTextColor;
-    }
-
-    &--selected {
-      font-weight: $euiFontWeightSemiBold;
-      background-color: $euiColorLightestShade;
+    &:not(.euiButtonGroup__button--selected):not(:disabled) {
+      color: $euiColorDarkShade;
     }
 
     .euiButton__content {
@@ -116,21 +120,19 @@
   .euiButtonGroup__toggle {
     flex: 1;
     min-width: 0;
+  }
 
-    &:first-child {
-      .euiButtonGroup__button {
-        border-left-width: 1px;
-        border-top-left-radius: $euiFormControlCompressedBorderRadius;
-        border-bottom-left-radius: $euiFormControlCompressedBorderRadius;
-      }
-    }
+  .euiButtonToggle__input:enabled:hover + .euiButtonGroup__button,
+  .euiButtonToggle__input:enabled:focus + .euiButtonGroup__button {
+    background-color: transparentize($euiFormInputGroupLabelBackground, .5);
+  }
 
-    &:last-child {
-      .euiButtonGroup__button {
-        border-right-width: 1px;
-        border-top-right-radius: $euiFormControlCompressedBorderRadius;
-        border-bottom-right-radius: $euiFormControlCompressedBorderRadius;
-      }
-    }
+  .euiButtonToggle__input:enabled:focus + .euiButtonGroup__button {
+    outline: 2px solid $euiFocusRingColor;
+  }
+
+  .euiButtonGroup__button--selected {
+    font-weight: $euiFontWeightSemiBold;
+    background-color: $euiFormInputGroupLabelBackground;
   }
 }

--- a/src/components/button/button_group/button_group.test.tsx
+++ b/src/components/button/button_group/button_group.test.tsx
@@ -2,7 +2,25 @@ import React from 'react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../../test';
 
-import { EuiButtonGroup } from './button_group';
+import { EuiButtonGroup, GroupButtonSize } from './button_group';
+import { COLORS } from '../button';
+
+const SIZES: GroupButtonSize[] = ['s', 'm', 'compressed'];
+
+const options = [
+  {
+    id: 'button00',
+    label: 'Option one',
+  },
+  {
+    id: 'button01',
+    label: 'Option two',
+  },
+  {
+    id: 'button02',
+    label: 'Option three',
+  },
+];
 
 describe('EuiButtonGroup', () => {
   test('is rendered', () => {
@@ -11,5 +29,156 @@ describe('EuiButtonGroup', () => {
     );
 
     expect(component).toMatchSnapshot();
+  });
+
+  describe('props', () => {
+    describe('options', () => {
+      it('are rendered', () => {
+        const component = render(
+          <EuiButtonGroup onChange={() => {}} options={options} />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+
+      it('can pass down data-test-subj', () => {
+        const options2 = [
+          {
+            id: 'button00',
+            label: 'Option one',
+            'data-test-subj': 'test',
+          },
+        ];
+
+        const component = render(
+          <EuiButtonGroup onChange={() => {}} options={options2} />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+
+    describe('buttonSize', () => {
+      SIZES.forEach(size => {
+        test(`${size} is rendered`, () => {
+          const component = render(
+            <EuiButtonGroup
+              onChange={() => {}}
+              buttonSize={size}
+              options={options}
+            />
+          );
+
+          expect(component).toMatchSnapshot();
+        });
+      });
+    });
+
+    describe('isDisabled', () => {
+      it('is rendered', () => {
+        const component = render(
+          <EuiButtonGroup onChange={() => {}} isDisabled options={options} />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+
+    describe('isFullWidth', () => {
+      it('is rendered', () => {
+        const component = render(
+          <EuiButtonGroup onChange={() => {}} isFullWidth options={options} />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+
+    describe('isIconOnly', () => {
+      it('is rendered', () => {
+        const component = render(
+          <EuiButtonGroup onChange={() => {}} isIconOnly options={options} />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+
+    describe('color', () => {
+      COLORS.forEach(color => {
+        test(`${color} is rendered`, () => {
+          const component = render(
+            <EuiButtonGroup
+              onChange={() => {}}
+              color={color}
+              options={options}
+            />
+          );
+
+          expect(component).toMatchSnapshot();
+        });
+      });
+    });
+
+    describe('legend', () => {
+      it('is rendered', () => {
+        const component = render(
+          <EuiButtonGroup
+            onChange={() => {}}
+            legend="legend"
+            options={options}
+          />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+
+    describe('name', () => {
+      it('is rendered', () => {
+        const component = render(
+          <EuiButtonGroup onChange={() => {}} name="name" options={options} />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+
+    describe('idSelected', () => {
+      it('is rendered', () => {
+        const component = render(
+          <EuiButtonGroup
+            onChange={() => {}}
+            idSelected="button00"
+            options={options}
+          />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+
+    describe('type of multi', () => {
+      it('is rendered', () => {
+        const component = render(
+          <EuiButtonGroup onChange={() => {}} type="multi" options={options} />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+
+      it('idToSelectedMap is rendered', () => {
+        const component = render(
+          <EuiButtonGroup
+            onChange={() => {}}
+            type="multi"
+            idToSelectedMap={{ button00: true, button01: true }}
+            options={options}
+          />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/src/components/button/button_group/button_group.tsx
+++ b/src/components/button/button_group/button_group.tsx
@@ -3,24 +3,24 @@ import classNames from 'classnames';
 
 import { EuiScreenReaderOnly } from '../../accessibility';
 import { ToggleType } from '../../toggle';
-import { IconType } from '../../icon';
 
 import { EuiButtonToggle } from '../button_toggle';
-import { Omit } from '../../common';
+import { Omit, CommonProps } from '../../common';
 
 import { ButtonColor } from '../button';
+import { IconType } from '../../icon';
 
 export interface EuiButtonGroupIdToSelectedMap {
   [id: string]: boolean;
 }
 
-export type GroupButtonSize = 's' | 'm';
+export type GroupButtonSize = 's' | 'm' | 'compressed';
 
-export interface EuiButtonGroupOption {
+export interface EuiButtonGroupOption extends CommonProps {
   id: string;
+  name?: string;
   label: string;
   isDisabled?: boolean;
-  name?: string;
   value?: any;
   iconSide?: 'left' | 'right';
   iconType?: IconType;
@@ -28,7 +28,11 @@ export interface EuiButtonGroupOption {
 
 export interface EuiButtonGroupProps {
   options?: EuiButtonGroupOption[];
-  onChange: (id: string, value: any) => void;
+  onChange: (id: string, value?: any) => void;
+  /**
+   * Typical sizing is `s`. Medium `m` size should be reserved for major features.
+   * `compressed` is meant to be used alongside and within compressed forms.
+   */
   buttonSize?: GroupButtonSize;
   isDisabled?: boolean;
   isFullWidth?: boolean;
@@ -62,11 +66,16 @@ export const EuiButtonGroup: FunctionComponent<Props> = ({
 }) => {
   const classes = classNames(
     'euiButtonGroup',
+    [`euiButtonGroup--${buttonSize}`],
     {
       'euiButtonGroup--fullWidth': isFullWidth,
     },
     className
   );
+
+  const fieldsetClasses = classNames('euiButtonGroup__fieldset', {
+    'euiButtonGroup__fieldset--fullWidth': isFullWidth,
+  });
 
   let legendNode;
   if (legend) {
@@ -78,37 +87,56 @@ export const EuiButtonGroup: FunctionComponent<Props> = ({
   }
 
   return (
-    <fieldset>
+    <fieldset className={fieldsetClasses}>
       {legendNode}
 
       <div className={classes} {...rest}>
         {options.map((option, index) => {
+          const {
+            id,
+            name: optionName,
+            value,
+            isDisabled: optionDisabled,
+            className,
+            ...rest
+          } = option;
+
           let isSelectedState;
           if (type === 'multi') {
-            isSelectedState = idToSelectedMap[option.id] || false;
+            isSelectedState = idToSelectedMap[id] || false;
           } else {
-            isSelectedState = option.id === idSelected;
+            isSelectedState = id === idSelected;
           }
+
+          let fill;
+          if (buttonSize !== 'compressed') {
+            fill = isSelectedState;
+          }
+          const buttonClasses = classNames(
+            'euiButtonGroup__button',
+            {
+              'euiButtonGroup__button--selected': isSelectedState,
+            },
+            className
+          );
 
           return (
             <EuiButtonToggle
-              className="euiButtonGroup__button"
+              className={buttonClasses}
+              toggleClassName="euiButtonGroup__toggle"
+              id={id}
+              key={index}
+              value={value}
               color={color}
-              fill={isSelectedState}
-              iconSide={option.iconSide}
-              iconType={option.iconType}
-              id={option.id}
-              isDisabled={isDisabled || option.isDisabled}
+              fill={fill}
+              isDisabled={optionDisabled || isDisabled}
               isIconOnly={isIconOnly}
               isSelected={isSelectedState}
-              key={index}
-              label={option.label}
-              name={option.name || name}
-              onChange={() => onChange(option.id, option.value)}
-              size={buttonSize}
-              toggleClassName="euiButtonGroup__toggle"
+              name={optionName || name}
+              onChange={() => onChange(id, value)}
+              size={buttonSize === 'compressed' ? 's' : buttonSize}
               type={type}
-              value={option.value}
+              {...rest}
             />
           );
         })}

--- a/src/components/button/button_group/button_group.tsx
+++ b/src/components/button/button_group/button_group.tsx
@@ -18,8 +18,8 @@ export type GroupButtonSize = 's' | 'm' | 'compressed';
 
 export interface EuiButtonGroupOption extends CommonProps {
   id: string;
-  name?: string;
   label: string;
+  name?: string;
   isDisabled?: boolean;
   value?: any;
   iconSide?: 'left' | 'right';
@@ -38,11 +38,11 @@ export interface EuiButtonGroupProps {
   isFullWidth?: boolean;
   isIconOnly?: boolean;
   idSelected?: string;
-  idToSelectedMap?: EuiButtonGroupIdToSelectedMap;
   legend?: string;
   color?: ButtonColor;
-  type?: ToggleType;
   name?: string;
+  type?: ToggleType;
+  idToSelectedMap?: EuiButtonGroupIdToSelectedMap;
 }
 
 type Props = Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> &

--- a/src/components/button/button_toggle/index.ts
+++ b/src/components/button/button_toggle/index.ts
@@ -1,1 +1,1 @@
-export { EuiButtonToggle } from './button_toggle';
+export { EuiButtonToggle, EuiButtonToggleProps } from './button_toggle';

--- a/src/components/button/index.ts
+++ b/src/components/button/index.ts
@@ -8,7 +8,7 @@ export {
   EuiButtonIconPropsForButton,
 } from './button_icon';
 
-export { EuiButtonToggle } from './button_toggle';
+export { EuiButtonToggle, EuiButtonToggleProps } from './button_toggle';
 
 export {
   EuiButtonGroup,


### PR DESCRIPTION
### To match our new compressed form controls

EuiButtonGroup's `buttonSize` prop now also accepts `compressed`. Which creates the following.

<img src="https://d.pr/free/i/wtXbm2+" />

I also beefed up the tests for EuiButtonGroup that only had one in it.

### Checklist

- [x] Checked in **dark mode**
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [x] Props have proper **autodocs**
- [x] Added **documentation** examples
- [x] Added or updated **jest tests**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
