### PR TITLE
Put charts theme files back

### DIFF
--- a/src-docs/src/theme_dark.scss
+++ b/src-docs/src/theme_dark.scss
@@ -5,3 +5,7 @@
 @import '../../src/theme_dark';
 @import './components/guide_components';
 @import './views/suggest/global_filter_group';
+
+// Elastic charts
+@import '~@elastic/charts/dist/theme';
+@import '../../src/themes/charts/theme';

--- a/src-docs/src/theme_light.scss
+++ b/src-docs/src/theme_light.scss
@@ -5,3 +5,7 @@
 @import '../../src/theme_light';
 @import './components/guide_components';
 @import './views/suggest/global_filter_group';
+
+// Elastic charts
+@import '~@elastic/charts/dist/theme';
+@import '../../src/themes/charts/theme';


### PR DESCRIPTION
### Summary

These got removed during a rebase or mege in #2270. Adding them back in fixes chart rendering in the docs. The EUI build assets in `14.1.0` are unaffected (charts theme is still usable).

### Checklist

~~- [ ] Checked in **dark mode**~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
~~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~~
