### PR TITLE
[EuiDataGrid] Automatic column schema detection

### DIFF
--- a/src-docs/src/views/datagrid/datagrid.js
+++ b/src-docs/src/views/datagrid/datagrid.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component, Fragment, useEffect } from 'react';
 import { fake } from 'faker';
 
 import {
@@ -124,10 +124,25 @@ export default class DataGridContainer extends Component {
 
     return (
       <EuiDataGrid
-        aria-label="Top EUI contributors"
+        aria-label="Data grid demo"
         columns={columns}
         rowCount={data.length}
-        renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
+        renderCellValue={({ rowIndex, columnId, setCellProps }) => {
+          useEffect(() => {
+            if (columnId === 'amount') {
+              const numeric = parseFloat(
+                data[rowIndex][columnId].match(/\d+\.\d+/)[0],
+                10
+              );
+              setCellProps({
+                style: {
+                  backgroundColor: `rgba(0, ${(numeric / 1000) * 255}, 0, 0.2)`,
+                },
+              });
+            }
+          }, [rowIndex, columnId, setCellProps]);
+          return data[rowIndex][columnId];
+        }}
         sorting={{ columns: sortingColumns, onSort: this.setSorting }}
         pagination={{
           ...pagination,

--- a/src-docs/src/views/datagrid/datagrid_example.js
+++ b/src-docs/src/views/datagrid/datagrid_example.js
@@ -19,7 +19,7 @@ const dataGridStylingHtml = renderToHtml(DataGridStyling);
 
 import InMemoryDataGrid from './in_memory';
 const inMemoryDataGridSource = require('!!raw-loader!./in_memory');
-const inMemoryDataGridHtml = renderToHtml(DataGridStyling);
+const inMemoryDataGridHtml = renderToHtml(InMemoryDataGrid);
 
 export const DataGridExample = {
   title: 'Data grid',

--- a/src-docs/src/views/datagrid/datagrid_example.js
+++ b/src-docs/src/views/datagrid/datagrid_example.js
@@ -17,6 +17,10 @@ import DataGridStyling from './styling';
 const dataGridStylingSource = require('!!raw-loader!./styling');
 const dataGridStylingHtml = renderToHtml(DataGridStyling);
 
+import DataGridSchema from './schema';
+const dataGridSchemaSource = require('!!raw-loader!./schema');
+const dataGridSchemaHtml = renderToHtml(DataGridSchema);
+
 import InMemoryDataGrid from './in_memory';
 const inMemoryDataGridSource = require('!!raw-loader!./in_memory');
 const inMemoryDataGridHtml = renderToHtml(InMemoryDataGrid);
@@ -87,6 +91,24 @@ export const DataGridExample = {
       components: { DataGridStyling },
       demo: <DataGridStyling />,
       props: { EuiDataGrid },
+    },
+    {
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: dataGridSchemaSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: dataGridSchemaHtml,
+        },
+      ],
+      title: 'Schema',
+      text: (
+        <p>Column type information can be included on the column definition.</p>
+      ),
+      components: { DataGridSchema },
+      demo: <DataGridSchema />,
     },
     {
       source: [

--- a/src-docs/src/views/datagrid/in_memory.js
+++ b/src-docs/src/views/datagrid/in_memory.js
@@ -1,17 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import { fake } from 'faker';
 
-import {
-  EuiDataGrid,
-  EuiButtonGroup,
-  EuiSpacer,
-  EuiFormRow,
-  EuiPopover,
-  EuiButton,
-  EuiButtonIcon,
-  EuiLink,
-} from '../../../../src/components/';
-import { iconTypes } from '../icon/icons';
+import { EuiDataGrid, EuiLink } from '../../../../src/components/';
 
 const columns = [
   {
@@ -38,9 +28,6 @@ const columns = [
   {
     id: 'version',
   },
-  {
-    id: 'actions',
-  },
 ];
 
 const data = [];
@@ -62,112 +49,14 @@ for (let i = 1; i < 100; i++) {
     amount: fake('{{finance.currencySymbol}}{{finance.amount}}'),
     phone: fake('{{phone.phoneNumber}}'),
     version: fake('{{system.semver}}'),
-    actions: (
-      <Fragment>
-        <EuiButtonIcon
-          aria-label="dummy icon"
-          iconType={iconTypes[Math.floor(Math.random() * iconTypes.length)]}
-        />
-        <EuiButtonIcon
-          aria-label="dummy icon"
-          iconType={iconTypes[Math.floor(Math.random() * iconTypes.length)]}
-        />
-      </Fragment>
-    ),
   });
 }
 
 export default class InMemoryDataGrid extends Component {
   constructor(props) {
     super(props);
-    this.borderOptions = [
-      {
-        id: 'all',
-        label: 'All',
-      },
-      {
-        id: 'horizontal',
-        label: 'Horizontal only',
-      },
-      {
-        id: 'none',
-        label: 'None',
-      },
-    ];
-
-    this.fontSizeOptions = [
-      {
-        id: 's',
-        label: 'Small',
-      },
-      {
-        id: 'm',
-        label: 'Medium',
-      },
-      {
-        id: 'l',
-        label: 'Large',
-      },
-    ];
-
-    this.cellPaddingOptions = [
-      {
-        id: 's',
-        label: 'Small',
-      },
-      {
-        id: 'm',
-        label: 'Medium',
-      },
-      {
-        id: 'l',
-        label: 'Large',
-      },
-    ];
-
-    this.stripeOptions = [
-      {
-        id: 'true',
-        label: 'Stripes on',
-      },
-      {
-        id: 'false',
-        label: 'Stripes off',
-      },
-    ];
-
-    this.rowHoverOptions = [
-      {
-        id: 'none',
-        label: 'None',
-      },
-      {
-        id: 'highlight',
-        label: 'Highlight',
-      },
-    ];
-
-    this.headerOptions = [
-      {
-        id: 'shade',
-        label: 'Shade',
-      },
-      {
-        id: 'underline',
-        label: 'Underline',
-      },
-    ];
 
     this.state = {
-      borderSelected: 'all',
-      fontSizeSelected: 'm',
-      cellPaddingSelected: 'm',
-      stripes: false,
-      stripesSelected: 'false',
-      rowHoverSelected: 'highlight',
-      isPopoverOpen: false,
-      headerSelected: 'shade',
-
       data,
       sortingColumns: [{ id: 'contributions', direction: 'asc' }],
 
@@ -176,55 +65,6 @@ export default class InMemoryDataGrid extends Component {
         pageSize: 10,
       },
     };
-  }
-
-  onBorderChange = optionId => {
-    this.setState({
-      borderSelected: optionId,
-    });
-  };
-
-  onFontSizeChange = optionId => {
-    this.setState({
-      fontSizeSelected: optionId,
-    });
-  };
-
-  onCellPaddingChange = optionId => {
-    this.setState({
-      cellPaddingSelected: optionId,
-    });
-  };
-
-  onStripesChange = optionId => {
-    this.setState({
-      stripesSelected: optionId,
-      stripes: !this.state.stripes,
-    });
-  };
-
-  onRowHoverChange = optionId => {
-    this.setState({
-      rowHoverSelected: optionId,
-    });
-  };
-
-  onHeaderChange = optionId => {
-    this.setState({
-      headerSelected: optionId,
-    });
-  };
-
-  onPopoverButtonClick() {
-    this.setState({
-      isPopoverOpen: !this.state.isPopoverOpen,
-    });
-  }
-
-  closePopover() {
-    this.setState({
-      isPopoverOpen: false,
-    });
   }
 
   setSorting = sortingColumns => this.setState({ sortingColumns });
@@ -239,141 +79,27 @@ export default class InMemoryDataGrid extends Component {
       pagination: { ...pagination, pageSize },
     }));
 
-  dummyIcon = () => (
-    <EuiButtonIcon
-      aria-label="dummy icon"
-      iconType={iconTypes[Math.floor(Math.random() * iconTypes.length)]}
-    />
-  );
-
   render() {
     const { data, pagination, sortingColumns } = this.state;
 
-    const button = (
-      <EuiButton
-        iconType="arrowDown"
-        iconSide="right"
-        onClick={this.onPopoverButtonClick.bind(this)}>
-        Table styling
-      </EuiButton>
-    );
-
     return (
-      <div>
-        <EuiPopover
-          id="popover"
-          button={button}
-          isOpen={this.state.isPopoverOpen}
-          anchorPosition="rightUp"
-          zIndex={2}
-          closePopover={this.closePopover.bind(this)}>
-          <div>
-            <EuiFormRow label="Border">
-              <EuiButtonGroup
-                legend="Border"
-                options={this.borderOptions}
-                idSelected={this.state.borderSelected}
-                onChange={this.onBorderChange}
-              />
-            </EuiFormRow>
-
-            <EuiFormRow label="Cell padding">
-              <EuiButtonGroup
-                legend="Cell padding"
-                options={this.cellPaddingOptions}
-                idSelected={this.state.cellPaddingSelected}
-                onChange={this.onCellPaddingChange}
-              />
-            </EuiFormRow>
-
-            <EuiFormRow label="Font size">
-              <EuiButtonGroup
-                legend="Fornt size"
-                options={this.fontSizeOptions}
-                idSelected={this.state.fontSizeSelected}
-                onChange={this.onFontSizeChange}
-              />
-            </EuiFormRow>
-
-            <EuiFormRow label="Stripes">
-              <EuiButtonGroup
-                legend="Stripes"
-                options={this.stripeOptions}
-                idSelected={this.state.stripesSelected}
-                onChange={this.onStripesChange}
-              />
-            </EuiFormRow>
-
-            <EuiFormRow label="Hover row">
-              <EuiButtonGroup
-                legend="Hover row"
-                options={this.rowHoverOptions}
-                idSelected={this.state.rowHoverSelected}
-                onChange={this.onRowHoverChange}
-              />
-            </EuiFormRow>
-
-            <EuiFormRow label="Header">
-              <EuiButtonGroup
-                legend="Header"
-                options={this.headerOptions}
-                idSelected={this.state.headerSelected}
-                onChange={this.onHeaderChange}
-              />
-            </EuiFormRow>
-          </div>
-        </EuiPopover>
-
-        <EuiSpacer />
-
-        <EuiDataGrid
-          aria-label="Top EUI contributors"
-          columns={columns}
-          rowCount={data.length}
-          gridStyle={{
-            border: this.state.borderSelected,
-            fontSize: this.state.fontSizeSelected,
-            cellPadding: this.state.cellPaddingSelected,
-            stripes: this.state.stripes,
-            rowHover: this.state.rowHoverSelected,
-            header: this.state.headerSelected,
-          }}
-          renderCellValue={({ rowIndex, columnId }) => {
-            const value = data[rowIndex][columnId];
-
-            if (columnId === 'actions') {
-              return (
-                <>
-                  {this.dummyIcon()}
-                  {this.dummyIcon()}
-                </>
-              );
-            }
-
-            if (columnId === 'url') {
-              return <EuiLink href={value}>{value}</EuiLink>;
-            }
-
-            if (columnId === 'avatar_url') {
-              return (
-                <p>
-                  Avatar: <EuiLink href={value}>{value}</EuiLink>
-                </p>
-              );
-            }
-
-            return value;
-          }}
-          inMemory="sorting"
-          sorting={{ columns: sortingColumns, onSort: this.setSorting }}
-          pagination={{
-            ...pagination,
-            pageSizeOptions: [5, 10, 25],
-            onChangeItemsPerPage: this.setPageSize,
-            onChangePage: this.setPageIndex,
-          }}
-        />
-      </div>
+      <EuiDataGrid
+        aria-label="Top EUI contributors"
+        columns={columns}
+        rowCount={data.length}
+        renderCellValue={({ rowIndex, columnId }) => {
+          const value = data[rowIndex][columnId];
+          return value;
+        }}
+        inMemory="sorting"
+        sorting={{ columns: sortingColumns, onSort: this.setSorting }}
+        pagination={{
+          ...pagination,
+          pageSizeOptions: [5, 10, 25],
+          onChangeItemsPerPage: this.setPageSize,
+          onChangePage: this.setPageIndex,
+        }}
+      />
     );
   }
 }

--- a/src-docs/src/views/datagrid/in_memory.js
+++ b/src-docs/src/views/datagrid/in_memory.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
+import { fake } from 'faker';
 
 import {
   EuiDataGrid,
@@ -17,141 +18,64 @@ const columns = [
     id: 'name',
   },
   {
-    id: 'avatar_url',
+    id: 'email',
   },
   {
-    id: 'url',
+    id: 'location',
   },
   {
-    id: 'contributions',
+    id: 'account',
+  },
+  {
+    id: 'date',
+  },
+  {
+    id: 'amount',
+  },
+  {
+    id: 'phone',
+  },
+  {
+    id: 'version',
   },
   {
     id: 'actions',
   },
 ];
 
-const data = [
-  {
-    name: 'cjcenizal',
-    avatar_url: 'https://avatars2.githubusercontent.com/u/1238659?v=4',
-    url: 'https://api.github.com/users/cjcenizal',
-    contributions: 392,
-  },
-  {
-    name: 'snide',
-    avatar_url: 'https://avatars3.githubusercontent.com/u/324519?v=4',
-    url: 'https://api.github.com/users/snide',
-    contributions: 361,
-  },
-  {
-    name: 'chandlerprall',
-    avatar_url: 'https://avatars3.githubusercontent.com/u/313125?v=4',
-    url: 'https://api.github.com/users/chandlerprall',
-    contributions: 274,
-  },
-  {
-    name: 'cchaos',
-    avatar_url: 'https://avatars3.githubusercontent.com/u/549577?v=4',
-    url: 'https://api.github.com/users/cchaos',
-    contributions: 156,
-  },
-  {
-    name: 'bevacqua',
-    avatar_url: 'https://avatars3.githubusercontent.com/u/934293?v=4',
-    url: 'https://api.github.com/users/bevacqua',
-    contributions: 128,
-  },
-  {
-    name: 'thompsongl',
-    avatar_url: 'https://avatars0.githubusercontent.com/u/2728212?v=4',
-    url: 'https://api.github.com/users/thompsongl',
-    contributions: 106,
-  },
-  {
-    name: 'pugnascotia',
-    avatar_url: 'https://avatars1.githubusercontent.com/u/8696382?v=4',
-    url: 'https://api.github.com/users/pugnascotia',
-    contributions: 82,
-  },
-  {
-    name: 'nreese',
-    avatar_url: 'https://avatars0.githubusercontent.com/u/373691?v=4',
-    url: 'https://api.github.com/users/nreese',
-    contributions: 58,
-  },
-  {
-    name: 'dmeiss',
-    avatar_url: 'https://avatars3.githubusercontent.com/u/45879454?v=4',
-    url: 'https://api.github.com/users/dmeiss',
-    contributions: 52,
-  },
-  {
-    name: 'ryankeairns',
-    avatar_url: 'https://avatars2.githubusercontent.com/u/446285?v=4',
-    url: 'https://api.github.com/users/ryankeairns',
-    contributions: 32,
-  },
-  {
-    name: 'stacey-gammon',
-    avatar_url: 'https://avatars3.githubusercontent.com/u/16563603?v=4',
-    url: 'https://api.github.com/users/stacey-gammon',
-    contributions: 24,
-  },
-  {
-    name: 'theodesp',
-    avatar_url: 'https://avatars0.githubusercontent.com/u/328805?v=4',
-    url: 'https://api.github.com/users/theodesp',
-    contributions: 22,
-  },
-  {
-    name: 'uboness',
-    avatar_url: 'https://avatars3.githubusercontent.com/u/211019?v=4',
-    url: 'https://api.github.com/users/uboness',
-    contributions: 17,
-  },
-  {
-    name: 'weltenwort',
-    avatar_url: 'https://avatars3.githubusercontent.com/u/973741?v=4',
-    url: 'https://api.github.com/users/weltenwort',
-    contributions: 16,
-  },
-  {
-    name: 'jen-huang',
-    avatar_url: 'https://avatars0.githubusercontent.com/u/1965714?v=4',
-    url: 'https://api.github.com/users/jen-huang',
-    contributions: 13,
-  },
-  {
-    name: 'PopradiArpad',
-    avatar_url: 'https://avatars3.githubusercontent.com/u/4144816?v=4',
-    url: 'https://api.github.com/users/PopradiArpad',
-    contributions: 11,
-  },
-  {
-    name: 'chrisronline',
-    avatar_url: 'https://avatars1.githubusercontent.com/u/56682?v=4',
-    url: 'https://api.github.com/users/chrisronline',
-    contributions: 10,
-  },
-  {
-    name: 'timroes',
-    avatar_url: 'https://avatars0.githubusercontent.com/u/877229?v=4',
-    url: 'https://api.github.com/users/timroes',
-    contributions: 10,
-  },
-  {
-    name: 'daveyholler',
-    avatar_url: 'https://avatars2.githubusercontent.com/u/739960?v=4',
-    url: 'https://api.github.com/users/daveyholler',
-    contributions: 9,
-  },
-  {
-    name: 'sqren',
-    avatar_url: 'https://avatars3.githubusercontent.com/u/209966?v=4',
-    url: 'https://api.github.com/users/sqren',
-    contributions: 9,
-  },
-];
+const data = [];
+
+for (let i = 1; i < 100; i++) {
+  data.push({
+    name: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
+    email: <EuiLink href="">{fake('{{internet.email}}')}</EuiLink>,
+    location: (
+      <Fragment>
+        {`${fake('{{address.city}}')}, `}
+        <EuiLink href="https://google.com">
+          {fake('{{address.country}}')}
+        </EuiLink>
+      </Fragment>
+    ),
+    date: fake('{{date.past}}'),
+    account: fake('{{finance.account}}'),
+    amount: fake('{{finance.currencySymbol}}{{finance.amount}}'),
+    phone: fake('{{phone.phoneNumber}}'),
+    version: fake('{{system.semver}}'),
+    actions: (
+      <Fragment>
+        <EuiButtonIcon
+          aria-label="dummy icon"
+          iconType={iconTypes[Math.floor(Math.random() * iconTypes.length)]}
+        />
+        <EuiButtonIcon
+          aria-label="dummy icon"
+          iconType={iconTypes[Math.floor(Math.random() * iconTypes.length)]}
+        />
+      </Fragment>
+    ),
+  });
+}
 
 export default class InMemoryDataGrid extends Component {
   constructor(props) {

--- a/src-docs/src/views/datagrid/schema.js
+++ b/src-docs/src/views/datagrid/schema.js
@@ -1,0 +1,380 @@
+import React, { Component, Fragment } from 'react';
+import { fake } from 'faker';
+
+import {
+  EuiDataGrid,
+  EuiButtonGroup,
+  EuiSpacer,
+  EuiFormRow,
+  EuiPopover,
+  EuiButton,
+  EuiButtonIcon,
+  EuiLink,
+} from '../../../../src/components/';
+import { iconTypes } from '../icon/icons';
+
+const columns = [
+  {
+    id: 'name',
+  },
+  {
+    id: 'email',
+  },
+  {
+    id: 'location',
+  },
+  {
+    id: 'account',
+    dataType: 'numeric',
+  },
+  {
+    id: 'date',
+  },
+  {
+    id: 'amount',
+    dataType: 'currency',
+  },
+  {
+    id: 'phone',
+  },
+  {
+    id: 'version',
+  },
+  {
+    id: 'actions',
+  },
+];
+
+const data = [];
+
+for (let i = 1; i < 100; i++) {
+  data.push({
+    name: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
+    email: <EuiLink href="">{fake('{{internet.email}}')}</EuiLink>,
+    location: (
+      <Fragment>
+        {`${fake('{{address.city}}')}, `}
+        <EuiLink href="https://google.com">
+          {fake('{{address.country}}')}
+        </EuiLink>
+      </Fragment>
+    ),
+    date: fake('{{date.past}}'),
+    account: fake('{{finance.account}}'),
+    amount: fake('{{finance.currencySymbol}}{{finance.amount}}'),
+    phone: fake('{{phone.phoneNumber}}'),
+    version: fake('{{system.semver}}'),
+    actions: (
+      <Fragment>
+        <EuiButtonIcon
+          aria-label="dummy icon"
+          iconType={iconTypes[Math.floor(Math.random() * iconTypes.length)]}
+        />
+        <EuiButtonIcon
+          aria-label="dummy icon"
+          iconType={iconTypes[Math.floor(Math.random() * iconTypes.length)]}
+        />
+      </Fragment>
+    ),
+  });
+}
+
+export default class InMemoryDataGrid extends Component {
+  constructor(props) {
+    super(props);
+    this.borderOptions = [
+      {
+        id: 'all',
+        label: 'All',
+      },
+      {
+        id: 'horizontal',
+        label: 'Horizontal only',
+      },
+      {
+        id: 'none',
+        label: 'None',
+      },
+    ];
+
+    this.fontSizeOptions = [
+      {
+        id: 's',
+        label: 'Small',
+      },
+      {
+        id: 'm',
+        label: 'Medium',
+      },
+      {
+        id: 'l',
+        label: 'Large',
+      },
+    ];
+
+    this.cellPaddingOptions = [
+      {
+        id: 's',
+        label: 'Small',
+      },
+      {
+        id: 'm',
+        label: 'Medium',
+      },
+      {
+        id: 'l',
+        label: 'Large',
+      },
+    ];
+
+    this.stripeOptions = [
+      {
+        id: 'true',
+        label: 'Stripes on',
+      },
+      {
+        id: 'false',
+        label: 'Stripes off',
+      },
+    ];
+
+    this.rowHoverOptions = [
+      {
+        id: 'none',
+        label: 'None',
+      },
+      {
+        id: 'highlight',
+        label: 'Highlight',
+      },
+    ];
+
+    this.headerOptions = [
+      {
+        id: 'shade',
+        label: 'Shade',
+      },
+      {
+        id: 'underline',
+        label: 'Underline',
+      },
+    ];
+
+    this.state = {
+      borderSelected: 'all',
+      fontSizeSelected: 'm',
+      cellPaddingSelected: 'm',
+      stripes: false,
+      stripesSelected: 'false',
+      rowHoverSelected: 'highlight',
+      isPopoverOpen: false,
+      headerSelected: 'shade',
+
+      data,
+      sortingColumns: [{ id: 'contributions', direction: 'asc' }],
+
+      pagination: {
+        pageIndex: 0,
+        pageSize: 10,
+      },
+    };
+  }
+
+  onBorderChange = optionId => {
+    this.setState({
+      borderSelected: optionId,
+    });
+  };
+
+  onFontSizeChange = optionId => {
+    this.setState({
+      fontSizeSelected: optionId,
+    });
+  };
+
+  onCellPaddingChange = optionId => {
+    this.setState({
+      cellPaddingSelected: optionId,
+    });
+  };
+
+  onStripesChange = optionId => {
+    this.setState({
+      stripesSelected: optionId,
+      stripes: !this.state.stripes,
+    });
+  };
+
+  onRowHoverChange = optionId => {
+    this.setState({
+      rowHoverSelected: optionId,
+    });
+  };
+
+  onHeaderChange = optionId => {
+    this.setState({
+      headerSelected: optionId,
+    });
+  };
+
+  onPopoverButtonClick() {
+    this.setState({
+      isPopoverOpen: !this.state.isPopoverOpen,
+    });
+  }
+
+  closePopover() {
+    this.setState({
+      isPopoverOpen: false,
+    });
+  }
+
+  setSorting = sortingColumns => this.setState({ sortingColumns });
+
+  setPageIndex = pageIndex =>
+    this.setState(({ pagination }) => ({
+      pagination: { ...pagination, pageIndex },
+    }));
+
+  setPageSize = pageSize =>
+    this.setState(({ pagination }) => ({
+      pagination: { ...pagination, pageSize },
+    }));
+
+  dummyIcon = () => (
+    <EuiButtonIcon
+      aria-label="dummy icon"
+      iconType={iconTypes[Math.floor(Math.random() * iconTypes.length)]}
+    />
+  );
+
+  render() {
+    const { data, pagination, sortingColumns } = this.state;
+
+    const button = (
+      <EuiButton
+        iconType="arrowDown"
+        iconSide="right"
+        onClick={this.onPopoverButtonClick.bind(this)}>
+        Table styling
+      </EuiButton>
+    );
+
+    return (
+      <div>
+        <EuiPopover
+          id="popover"
+          button={button}
+          isOpen={this.state.isPopoverOpen}
+          anchorPosition="rightUp"
+          zIndex={2}
+          closePopover={this.closePopover.bind(this)}>
+          <div>
+            <EuiFormRow label="Border">
+              <EuiButtonGroup
+                legend="Border"
+                options={this.borderOptions}
+                idSelected={this.state.borderSelected}
+                onChange={this.onBorderChange}
+              />
+            </EuiFormRow>
+
+            <EuiFormRow label="Cell padding">
+              <EuiButtonGroup
+                legend="Cell padding"
+                options={this.cellPaddingOptions}
+                idSelected={this.state.cellPaddingSelected}
+                onChange={this.onCellPaddingChange}
+              />
+            </EuiFormRow>
+
+            <EuiFormRow label="Font size">
+              <EuiButtonGroup
+                legend="Fornt size"
+                options={this.fontSizeOptions}
+                idSelected={this.state.fontSizeSelected}
+                onChange={this.onFontSizeChange}
+              />
+            </EuiFormRow>
+
+            <EuiFormRow label="Stripes">
+              <EuiButtonGroup
+                legend="Stripes"
+                options={this.stripeOptions}
+                idSelected={this.state.stripesSelected}
+                onChange={this.onStripesChange}
+              />
+            </EuiFormRow>
+
+            <EuiFormRow label="Hover row">
+              <EuiButtonGroup
+                legend="Hover row"
+                options={this.rowHoverOptions}
+                idSelected={this.state.rowHoverSelected}
+                onChange={this.onRowHoverChange}
+              />
+            </EuiFormRow>
+
+            <EuiFormRow label="Header">
+              <EuiButtonGroup
+                legend="Header"
+                options={this.headerOptions}
+                idSelected={this.state.headerSelected}
+                onChange={this.onHeaderChange}
+              />
+            </EuiFormRow>
+          </div>
+        </EuiPopover>
+
+        <EuiSpacer />
+
+        <EuiDataGrid
+          aria-label="Top EUI contributors"
+          columns={columns}
+          rowCount={data.length}
+          gridStyle={{
+            border: this.state.borderSelected,
+            fontSize: this.state.fontSizeSelected,
+            cellPadding: this.state.cellPaddingSelected,
+            stripes: this.state.stripes,
+            rowHover: this.state.rowHoverSelected,
+            header: this.state.headerSelected,
+          }}
+          renderCellValue={({ rowIndex, columnId }) => {
+            const value = data[rowIndex][columnId];
+
+            if (columnId === 'actions') {
+              return (
+                <>
+                  {this.dummyIcon()}
+                  {this.dummyIcon()}
+                </>
+              );
+            }
+
+            if (columnId === 'url') {
+              return <EuiLink href={value}>{value}</EuiLink>;
+            }
+
+            if (columnId === 'avatar_url') {
+              return (
+                <p>
+                  Avatar: <EuiLink href={value}>{value}</EuiLink>
+                </p>
+              );
+            }
+
+            return value;
+          }}
+          sorting={{ columns: sortingColumns, onSort: this.setSorting }}
+          pagination={{
+            ...pagination,
+            pageSizeOptions: [5, 10, 25],
+            onChangeItemsPerPage: this.setPageSize,
+            onChangePage: this.setPageIndex,
+          }}
+        />
+      </div>
+    );
+  }
+}

--- a/src-docs/src/views/datagrid/schema.js
+++ b/src-docs/src/views/datagrid/schema.js
@@ -3,11 +3,6 @@ import { fake } from 'faker';
 
 import {
   EuiDataGrid,
-  EuiButtonGroup,
-  EuiSpacer,
-  EuiFormRow,
-  EuiPopover,
-  EuiButton,
   EuiButtonIcon,
   EuiLink,
 } from '../../../../src/components/';
@@ -40,14 +35,11 @@ const columns = [
   {
     id: 'version',
   },
-  {
-    id: 'actions',
-  },
 ];
 
 const data = [];
 
-for (let i = 1; i < 100; i++) {
+for (let i = 1; i < 5; i++) {
   data.push({
     name: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
     email: <EuiLink href="">{fake('{{internet.email}}')}</EuiLink>,
@@ -61,115 +53,17 @@ for (let i = 1; i < 100; i++) {
     ),
     date: fake('{{date.past}}'),
     account: fake('{{finance.account}}'),
-    amount: fake('{{finance.currencySymbol}}{{finance.amount}}'),
+    amount: fake('${{finance.amount}}'),
     phone: fake('{{phone.phoneNumber}}'),
     version: fake('{{system.semver}}'),
-    actions: (
-      <Fragment>
-        <EuiButtonIcon
-          aria-label="dummy icon"
-          iconType={iconTypes[Math.floor(Math.random() * iconTypes.length)]}
-        />
-        <EuiButtonIcon
-          aria-label="dummy icon"
-          iconType={iconTypes[Math.floor(Math.random() * iconTypes.length)]}
-        />
-      </Fragment>
-    ),
   });
 }
 
 export default class InMemoryDataGrid extends Component {
   constructor(props) {
     super(props);
-    this.borderOptions = [
-      {
-        id: 'all',
-        label: 'All',
-      },
-      {
-        id: 'horizontal',
-        label: 'Horizontal only',
-      },
-      {
-        id: 'none',
-        label: 'None',
-      },
-    ];
-
-    this.fontSizeOptions = [
-      {
-        id: 's',
-        label: 'Small',
-      },
-      {
-        id: 'm',
-        label: 'Medium',
-      },
-      {
-        id: 'l',
-        label: 'Large',
-      },
-    ];
-
-    this.cellPaddingOptions = [
-      {
-        id: 's',
-        label: 'Small',
-      },
-      {
-        id: 'm',
-        label: 'Medium',
-      },
-      {
-        id: 'l',
-        label: 'Large',
-      },
-    ];
-
-    this.stripeOptions = [
-      {
-        id: 'true',
-        label: 'Stripes on',
-      },
-      {
-        id: 'false',
-        label: 'Stripes off',
-      },
-    ];
-
-    this.rowHoverOptions = [
-      {
-        id: 'none',
-        label: 'None',
-      },
-      {
-        id: 'highlight',
-        label: 'Highlight',
-      },
-    ];
-
-    this.headerOptions = [
-      {
-        id: 'shade',
-        label: 'Shade',
-      },
-      {
-        id: 'underline',
-        label: 'Underline',
-      },
-    ];
 
     this.state = {
-      borderSelected: 'all',
-      fontSizeSelected: 'm',
-      cellPaddingSelected: 'm',
-      stripes: false,
-      stripesSelected: 'false',
-      rowHoverSelected: 'highlight',
-      isPopoverOpen: false,
-      headerSelected: 'shade',
-
       data,
       sortingColumns: [{ id: 'contributions', direction: 'asc' }],
 
@@ -178,55 +72,6 @@ export default class InMemoryDataGrid extends Component {
         pageSize: 10,
       },
     };
-  }
-
-  onBorderChange = optionId => {
-    this.setState({
-      borderSelected: optionId,
-    });
-  };
-
-  onFontSizeChange = optionId => {
-    this.setState({
-      fontSizeSelected: optionId,
-    });
-  };
-
-  onCellPaddingChange = optionId => {
-    this.setState({
-      cellPaddingSelected: optionId,
-    });
-  };
-
-  onStripesChange = optionId => {
-    this.setState({
-      stripesSelected: optionId,
-      stripes: !this.state.stripes,
-    });
-  };
-
-  onRowHoverChange = optionId => {
-    this.setState({
-      rowHoverSelected: optionId,
-    });
-  };
-
-  onHeaderChange = optionId => {
-    this.setState({
-      headerSelected: optionId,
-    });
-  };
-
-  onPopoverButtonClick() {
-    this.setState({
-      isPopoverOpen: !this.state.isPopoverOpen,
-    });
-  }
-
-  closePopover() {
-    this.setState({
-      isPopoverOpen: false,
-    });
   }
 
   setSorting = sortingColumns => this.setState({ sortingColumns });
@@ -251,130 +96,23 @@ export default class InMemoryDataGrid extends Component {
   render() {
     const { data, pagination, sortingColumns } = this.state;
 
-    const button = (
-      <EuiButton
-        iconType="arrowDown"
-        iconSide="right"
-        onClick={this.onPopoverButtonClick.bind(this)}>
-        Table styling
-      </EuiButton>
-    );
-
     return (
-      <div>
-        <EuiPopover
-          id="popover"
-          button={button}
-          isOpen={this.state.isPopoverOpen}
-          anchorPosition="rightUp"
-          zIndex={2}
-          closePopover={this.closePopover.bind(this)}>
-          <div>
-            <EuiFormRow label="Border">
-              <EuiButtonGroup
-                legend="Border"
-                options={this.borderOptions}
-                idSelected={this.state.borderSelected}
-                onChange={this.onBorderChange}
-              />
-            </EuiFormRow>
-
-            <EuiFormRow label="Cell padding">
-              <EuiButtonGroup
-                legend="Cell padding"
-                options={this.cellPaddingOptions}
-                idSelected={this.state.cellPaddingSelected}
-                onChange={this.onCellPaddingChange}
-              />
-            </EuiFormRow>
-
-            <EuiFormRow label="Font size">
-              <EuiButtonGroup
-                legend="Fornt size"
-                options={this.fontSizeOptions}
-                idSelected={this.state.fontSizeSelected}
-                onChange={this.onFontSizeChange}
-              />
-            </EuiFormRow>
-
-            <EuiFormRow label="Stripes">
-              <EuiButtonGroup
-                legend="Stripes"
-                options={this.stripeOptions}
-                idSelected={this.state.stripesSelected}
-                onChange={this.onStripesChange}
-              />
-            </EuiFormRow>
-
-            <EuiFormRow label="Hover row">
-              <EuiButtonGroup
-                legend="Hover row"
-                options={this.rowHoverOptions}
-                idSelected={this.state.rowHoverSelected}
-                onChange={this.onRowHoverChange}
-              />
-            </EuiFormRow>
-
-            <EuiFormRow label="Header">
-              <EuiButtonGroup
-                legend="Header"
-                options={this.headerOptions}
-                idSelected={this.state.headerSelected}
-                onChange={this.onHeaderChange}
-              />
-            </EuiFormRow>
-          </div>
-        </EuiPopover>
-
-        <EuiSpacer />
-
-        <EuiDataGrid
-          aria-label="Top EUI contributors"
-          columns={columns}
-          rowCount={data.length}
-          gridStyle={{
-            border: this.state.borderSelected,
-            fontSize: this.state.fontSizeSelected,
-            cellPadding: this.state.cellPaddingSelected,
-            stripes: this.state.stripes,
-            rowHover: this.state.rowHoverSelected,
-            header: this.state.headerSelected,
-          }}
-          renderCellValue={({ rowIndex, columnId }) => {
-            const value = data[rowIndex][columnId];
-
-            if (columnId === 'actions') {
-              return (
-                <>
-                  {this.dummyIcon()}
-                  {this.dummyIcon()}
-                </>
-              );
-            }
-
-            if (columnId === 'url') {
-              return <EuiLink href={value}>{value}</EuiLink>;
-            }
-
-            if (columnId === 'avatar_url') {
-              return (
-                <p>
-                  Avatar: <EuiLink href={value}>{value}</EuiLink>
-                </p>
-              );
-            }
-
-            return value;
-          }}
-          sorting={{ columns: sortingColumns, onSort: this.setSorting }}
-          pagination={{
-            ...pagination,
-            pageSizeOptions: [5, 10, 25],
-            onChangeItemsPerPage: this.setPageSize,
-            onChangePage: this.setPageIndex,
-          }}
-        />
-      </div>
+      <EuiDataGrid
+        aria-label="Top EUI contributors"
+        columns={columns}
+        rowCount={data.length}
+        renderCellValue={({ rowIndex, columnId }) => {
+          const value = data[rowIndex][columnId];
+          return value;
+        }}
+        sorting={{ columns: sortingColumns, onSort: this.setSorting }}
+        pagination={{
+          ...pagination,
+          pageSizeOptions: [5, 10, 25],
+          onChangeItemsPerPage: this.setPageSize,
+          onChangePage: this.setPageIndex,
+        }}
+      />
     );
   }
 }

--- a/src/components/datagrid/_data_grid.scss
+++ b/src/components/datagrid/_data_grid.scss
@@ -25,8 +25,10 @@
 
 .euiDataGrid__content {
   @include euiScrollBar;
-  @include euiYScrollWithShadows;
+  @include euiScrollBar;
 
+  height: 100%;
+  overflow-y: auto;
   font-feature-settings: 'tnum' 1; // Tabular numbers
   overflow-x: auto;
   scroll-padding: 0;

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -41,6 +41,14 @@
     // Needed because the focus state adds a border, which needs to be subtracted from padding
     padding-left: $euiDataGridCellPaddingM - 1px;
   }
+
+  &.euiDataGridRowCell__columnType--numeric {
+    font-family: monospace;
+  }
+
+  &.euiDataGridRowCell__columnType--currency {
+    color: $euiCodeBlockRegexpColor;
+  }
 }
 
 .euiDataGridRowCell__content {

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -18,6 +18,7 @@
   // Hack to allow for all the focus guard stuff
   > * {
     max-width: 100%;
+    width: 100%;
   }
 
   &:first-of-type {
@@ -42,12 +43,12 @@
     padding-left: $euiDataGridCellPaddingM - 1px;
   }
 
-  &.euiDataGridRowCell__columnType--numeric {
-    font-family: monospace;
+  &.euiDataGridRowCell--numeric {
+    text-align: right;
   }
 
-  &.euiDataGridRowCell__columnType--currency {
-    color: $euiCodeBlockRegexpColor;
+  &.euiDataGridRowCell--currency {
+    text-align: right;
   }
 }
 
@@ -80,7 +81,8 @@
 // Border alternates
 @include euiDataGridStyles(bordersNone) {
   @include euiDataGridRowCell {
-    border-color: transparent;
+    // sass-lint:disable-block no-important
+    border-color: transparent !important;
   }
 }
 

--- a/src/components/datagrid/_data_grid_header_row.scss
+++ b/src/components/datagrid/_data_grid_header_row.scss
@@ -14,6 +14,14 @@
   .euiDataGridHeaderCell__content {
     @include euiTextTruncate;
   }
+
+  &.euiDataGridHeaderCell--numeric {
+    text-align: right;
+  }
+
+  &.euiDataGridHeaderCell--currency {
+    text-align: right;
+  }
 }
 
 // Header alternates

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -307,6 +307,98 @@ describe('EuiDataGrid', () => {
         expect($element.children().length).toBe(allCells.length);
       });
     });
+
+    describe('schema datatype classnames', () => {
+      it('applies classnames from explicit datatypes', () => {
+        const component = mount(
+          <EuiDataGrid
+            {...requiredProps}
+            columns={[
+              { id: 'A', dataType: 'numeric' },
+              { id: 'B', dataType: 'customFormatName' },
+            ]}
+            rowCount={3}
+            renderCellValue={({ rowIndex, columnId }) =>
+              `${rowIndex}, ${columnId}`
+            }
+          />
+        );
+
+        const gridCellClassNames = component
+          .find('[className*="euiDataGridRowCell__columnType--"]')
+          .map(x => x.props().className);
+        expect(gridCellClassNames).toMatchInlineSnapshot(`
+Array [
+  "euiDataGridRowCell euiDataGridRowCell__columnType--numeric",
+  "euiDataGridRowCell euiDataGridRowCell__columnType--customFormatName",
+  "euiDataGridRowCell euiDataGridRowCell__columnType--numeric",
+  "euiDataGridRowCell euiDataGridRowCell__columnType--customFormatName",
+  "euiDataGridRowCell euiDataGridRowCell__columnType--numeric",
+  "euiDataGridRowCell euiDataGridRowCell__columnType--customFormatName",
+]
+`);
+      });
+
+      it('automatically detects column types and applies classnames', () => {
+        const component = mount(
+          <EuiDataGrid
+            {...requiredProps}
+            columns={[{ id: 'A' }, { id: 'B' }, { id: 'C' }]}
+            inMemory="pagination"
+            rowCount={2}
+            renderCellValue={({ columnId }) => {
+              if (columnId === 'A') {
+                return 5.5;
+              } else if (columnId === 'B') {
+                return 'true';
+              } else {
+                return 'asdf';
+              }
+            }}
+          />
+        );
+
+        const gridCellClassNames = component
+          .find('[className~="euiDataGridRowCell"]')
+          .map(x => x.props().className);
+        expect(gridCellClassNames).toMatchInlineSnapshot(`
+Array [
+  "euiDataGridRowCell euiDataGridRowCell__columnType--numeric",
+  "euiDataGridRowCell euiDataGridRowCell__columnType--boolean",
+  "euiDataGridRowCell",
+  "euiDataGridRowCell euiDataGridRowCell__columnType--numeric",
+  "euiDataGridRowCell euiDataGridRowCell__columnType--boolean",
+  "euiDataGridRowCell",
+]
+`);
+      });
+
+      it('overrides automatically detected column types with supplied schema', () => {
+        const component = mount(
+          <EuiDataGrid
+            {...requiredProps}
+            columns={[{ id: 'A' }, { id: 'B', dataType: 'alphanumeric' }]}
+            inMemory="pagination"
+            rowCount={2}
+            renderCellValue={({ columnId }) =>
+              columnId === 'A' ? 5.5 : 'true'
+            }
+          />
+        );
+
+        const gridCellClassNames = component
+          .find('[className~="euiDataGridRowCell"]')
+          .map(x => x.props().className);
+        expect(gridCellClassNames).toMatchInlineSnapshot(`
+Array [
+  "euiDataGridRowCell euiDataGridRowCell__columnType--numeric",
+  "euiDataGridRowCell euiDataGridRowCell__columnType--alphanumeric",
+  "euiDataGridRowCell euiDataGridRowCell__columnType--numeric",
+  "euiDataGridRowCell euiDataGridRowCell__columnType--alphanumeric",
+]
+`);
+      });
+    });
   });
 
   describe('cell rendering', () => {

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -308,6 +308,80 @@ describe('EuiDataGrid', () => {
       });
     });
 
+    it('renders and applies custom props', () => {
+      const component = mount(
+        <EuiDataGrid
+          {...requiredProps}
+          columns={[{ id: 'A' }, { id: 'B' }]}
+          rowCount={2}
+          renderCellValue={({ rowIndex, columnId, setCellProps }) => {
+            setCellProps({
+              className: 'customClass',
+              'data-test-subj': `cell-${rowIndex}-${columnId}`,
+              style: { color: columnId === 'A' ? 'red' : 'blue' },
+            });
+
+            return `${rowIndex}, ${columnId}`;
+          }}
+        />
+      );
+
+      expect(
+        component.find('.euiDataGridRowCell').map(cell => {
+          const props = cell.props();
+          delete props.children;
+          return props;
+        })
+      ).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "className": "euiDataGridRowCell customClass",
+    "data-test-subj": "dataGridRowCell",
+    "onFocus": [Function],
+    "role": "gridcell",
+    "style": Object {
+      "color": "red",
+      "width": "100px",
+    },
+    "tabIndex": 0,
+  },
+  Object {
+    "className": "euiDataGridRowCell customClass",
+    "data-test-subj": "dataGridRowCell",
+    "onFocus": [Function],
+    "role": "gridcell",
+    "style": Object {
+      "color": "blue",
+      "width": "100px",
+    },
+    "tabIndex": -1,
+  },
+  Object {
+    "className": "euiDataGridRowCell customClass",
+    "data-test-subj": "dataGridRowCell",
+    "onFocus": [Function],
+    "role": "gridcell",
+    "style": Object {
+      "color": "red",
+      "width": "100px",
+    },
+    "tabIndex": -1,
+  },
+  Object {
+    "className": "euiDataGridRowCell customClass",
+    "data-test-subj": "dataGridRowCell",
+    "onFocus": [Function],
+    "role": "gridcell",
+    "style": Object {
+      "color": "blue",
+      "width": "100px",
+    },
+    "tabIndex": -1,
+  },
+]
+`);
+    });
+
     describe('schema datatype classnames', () => {
       it('applies classnames from explicit datatypes', () => {
         const component = mount(

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -398,6 +398,42 @@ Array [
 ]
 `);
       });
+
+      it('detects all of the supported types', () => {
+        const values: { [key: string]: string } = {
+          A: '-5.80',
+          B: 'false',
+          C: '$-5.80',
+          E: '2019-09-18T12:31:28',
+          F: '2019-09-18T12:31:28Z',
+          G: '2019-09-18T12:31:28.234',
+          H: '2019-09-18T12:31:28.234+0300',
+        };
+        const component = mount(
+          <EuiDataGrid
+            {...requiredProps}
+            columns={Object.keys(values).map(id => ({ id }))}
+            inMemory="pagination"
+            rowCount={1}
+            renderCellValue={({ columnId }) => values[columnId]}
+          />
+        );
+
+        const gridCellClassNames = component
+          .find('[className~="euiDataGridRowCell"]')
+          .map(x => x.props().className);
+        expect(gridCellClassNames).toMatchInlineSnapshot(`
+Array [
+  "euiDataGridRowCell euiDataGridRowCell__columnType--numeric",
+  "euiDataGridRowCell euiDataGridRowCell__columnType--boolean",
+  "euiDataGridRowCell euiDataGridRowCell__columnType--currency",
+  "euiDataGridRowCell euiDataGridRowCell__columnType--datetime",
+  "euiDataGridRowCell euiDataGridRowCell__columnType--datetime",
+  "euiDataGridRowCell euiDataGridRowCell__columnType--datetime",
+  "euiDataGridRowCell euiDataGridRowCell__columnType--datetime",
+]
+`);
+      });
     });
   });
 

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -327,16 +327,7 @@ describe('EuiDataGrid', () => {
         const gridCellClassNames = component
           .find('[className*="euiDataGridRowCell__columnType--"]')
           .map(x => x.props().className);
-        expect(gridCellClassNames).toMatchInlineSnapshot(`
-Array [
-  "euiDataGridRowCell euiDataGridRowCell__columnType--numeric",
-  "euiDataGridRowCell euiDataGridRowCell__columnType--customFormatName",
-  "euiDataGridRowCell euiDataGridRowCell__columnType--numeric",
-  "euiDataGridRowCell euiDataGridRowCell__columnType--customFormatName",
-  "euiDataGridRowCell euiDataGridRowCell__columnType--numeric",
-  "euiDataGridRowCell euiDataGridRowCell__columnType--customFormatName",
-]
-`);
+        expect(gridCellClassNames).toMatchInlineSnapshot(`Array []`);
       });
 
       it('automatically detects column types and applies classnames', () => {
@@ -363,11 +354,11 @@ Array [
           .map(x => x.props().className);
         expect(gridCellClassNames).toMatchInlineSnapshot(`
 Array [
-  "euiDataGridRowCell euiDataGridRowCell__columnType--numeric",
-  "euiDataGridRowCell euiDataGridRowCell__columnType--boolean",
+  "euiDataGridRowCell euiDataGridRowCell--numeric",
+  "euiDataGridRowCell euiDataGridRowCell--boolean",
   "euiDataGridRowCell",
-  "euiDataGridRowCell euiDataGridRowCell__columnType--numeric",
-  "euiDataGridRowCell euiDataGridRowCell__columnType--boolean",
+  "euiDataGridRowCell euiDataGridRowCell--numeric",
+  "euiDataGridRowCell euiDataGridRowCell--boolean",
   "euiDataGridRowCell",
 ]
 `);
@@ -391,10 +382,10 @@ Array [
           .map(x => x.props().className);
         expect(gridCellClassNames).toMatchInlineSnapshot(`
 Array [
-  "euiDataGridRowCell euiDataGridRowCell__columnType--numeric",
-  "euiDataGridRowCell euiDataGridRowCell__columnType--alphanumeric",
-  "euiDataGridRowCell euiDataGridRowCell__columnType--numeric",
-  "euiDataGridRowCell euiDataGridRowCell__columnType--alphanumeric",
+  "euiDataGridRowCell euiDataGridRowCell--numeric",
+  "euiDataGridRowCell euiDataGridRowCell--alphanumeric",
+  "euiDataGridRowCell euiDataGridRowCell--numeric",
+  "euiDataGridRowCell euiDataGridRowCell--alphanumeric",
 ]
 `);
       });
@@ -424,13 +415,13 @@ Array [
           .map(x => x.props().className);
         expect(gridCellClassNames).toMatchInlineSnapshot(`
 Array [
-  "euiDataGridRowCell euiDataGridRowCell__columnType--numeric",
-  "euiDataGridRowCell euiDataGridRowCell__columnType--boolean",
-  "euiDataGridRowCell euiDataGridRowCell__columnType--currency",
-  "euiDataGridRowCell euiDataGridRowCell__columnType--datetime",
-  "euiDataGridRowCell euiDataGridRowCell__columnType--datetime",
-  "euiDataGridRowCell euiDataGridRowCell__columnType--datetime",
-  "euiDataGridRowCell euiDataGridRowCell__columnType--datetime",
+  "euiDataGridRowCell euiDataGridRowCell--numeric",
+  "euiDataGridRowCell euiDataGridRowCell--boolean",
+  "euiDataGridRowCell euiDataGridRowCell--currency",
+  "euiDataGridRowCell euiDataGridRowCell--datetime",
+  "euiDataGridRowCell euiDataGridRowCell--datetime",
+  "euiDataGridRowCell euiDataGridRowCell--datetime",
+  "euiDataGridRowCell euiDataGridRowCell--datetime",
 ]
 `);
       });
@@ -465,8 +456,8 @@ Array [
           .map(x => x.props().className);
         expect(gridCellClassNames).toMatchInlineSnapshot(`
 Array [
-  "euiDataGridRowCell euiDataGridRowCell__columnType--numeric",
-  "euiDataGridRowCell euiDataGridRowCell__columnType--ipaddress",
+  "euiDataGridRowCell euiDataGridRowCell--numeric",
+  "euiDataGridRowCell euiDataGridRowCell--ipaddress",
 ]
 `);
       });

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -434,6 +434,42 @@ Array [
 ]
 `);
       });
+
+      it('accepts extra detectors', () => {
+        const values: { [key: string]: string } = {
+          A: '-5.80',
+          B: '127.0.0.1',
+        };
+        const component = mount(
+          <EuiDataGrid
+            {...requiredProps}
+            columns={Object.keys(values).map(id => ({ id }))}
+            schemaDetectors={[
+              {
+                type: 'ipaddress',
+                detector(value: string) {
+                  return value.match(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/)
+                    ? 1
+                    : 0;
+                },
+              },
+            ]}
+            inMemory="pagination"
+            rowCount={1}
+            renderCellValue={({ columnId }) => values[columnId]}
+          />
+        );
+
+        const gridCellClassNames = component
+          .find('[className~="euiDataGridRowCell"]')
+          .map(x => x.props().className);
+        expect(gridCellClassNames).toMatchInlineSnapshot(`
+Array [
+  "euiDataGridRowCell euiDataGridRowCell__columnType--numeric",
+  "euiDataGridRowCell euiDataGridRowCell__columnType--ipaddress",
+]
+`);
+      });
     });
   });
 

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -325,9 +325,18 @@ describe('EuiDataGrid', () => {
         );
 
         const gridCellClassNames = component
-          .find('[className*="euiDataGridRowCell__columnType--"]')
+          .find('[className*="euiDataGridRowCell--"]')
           .map(x => x.props().className);
-        expect(gridCellClassNames).toMatchInlineSnapshot(`Array []`);
+        expect(gridCellClassNames).toMatchInlineSnapshot(`
+Array [
+  "euiDataGridRowCell euiDataGridRowCell--numeric",
+  "euiDataGridRowCell euiDataGridRowCell--customFormatName",
+  "euiDataGridRowCell euiDataGridRowCell--numeric",
+  "euiDataGridRowCell euiDataGridRowCell--customFormatName",
+  "euiDataGridRowCell euiDataGridRowCell--numeric",
+  "euiDataGridRowCell euiDataGridRowCell--customFormatName",
+]
+`);
       });
 
       it('automatically detects column types and applies classnames', () => {

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -40,7 +40,11 @@ import { EuiFocusTrap } from '../focus_trap';
 import { EuiResizeObserver } from '../observer/resize_observer';
 import { CELL_CONTENTS_ATTR } from './utils';
 import { EuiDataGridInMemoryRenderer } from './data_grid_inmemory_renderer';
-import { getMergedSchema, useDetectSchema } from './data_grid_schema';
+import {
+  getMergedSchema,
+  SchemaDetector,
+  useDetectSchema,
+} from './data_grid_schema';
 
 // When below this number the grid only shows the full screen button
 const MINIMUM_WIDTH_FOR_GRID_CONTROLS = 479;
@@ -48,6 +52,7 @@ const MINIMUM_WIDTH_FOR_GRID_CONTROLS = 479;
 type CommonGridProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {
     columns: EuiDataGridColumn[];
+    schemaDetectors?: SchemaDetector[];
     rowCount: number;
     renderCellValue: EuiDataGridCellProps['renderCellValue'];
     gridStyle?: EuiDataGridStyle;
@@ -377,6 +382,7 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
 
   const {
     columns,
+    schemaDetectors,
     rowCount,
     renderCellValue,
     className,
@@ -425,7 +431,11 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
 
   const [inMemoryValues, onCellRender] = useInMemoryValues();
 
-  const detectedSchema = useDetectSchema(inMemoryValues, inMemory !== false);
+  const detectedSchema = useDetectSchema(
+    inMemoryValues,
+    schemaDetectors,
+    inMemory !== false
+  );
   const mergedSchema = getMergedSchema(detectedSchema, columns);
 
   // These grid controls will only show when there is room. Check the resize observer callback

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -313,14 +313,12 @@ const schemaDetectors = [
   },
 ];
 
-export type EuiDataGridSchemaType = typeof schemaDetectors[number]['type'];
-
 export interface EuiDataGridSchema {
-  [columnId: string]: { columnType: EuiDataGridSchemaType | null };
+  [columnId: string]: { columnType: string | null };
 }
 
 interface SchemaTypeScore {
-  type: EuiDataGridSchemaType;
+  type: string;
   score: number;
 }
 
@@ -427,6 +425,7 @@ function useDetectSchema(
 
           const summary = { minScore, maxScore, mean, sd };
 
+          // the mean-standard_deviation calculation is fairly arbitrary but fits the patterns I've thrown at it
           const score = summary.mean - summary.sd;
           if (score > MINIMUM_SCORE_MATCH) {
             if (bestType == null || score > bestScore) {

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -528,6 +528,7 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
                     columnWidths={columnWidths}
                     defaultColumnWidth={defaultColumnWidth}
                     setColumnWidth={setColumnWidth}
+                    schema={mergedSchema}
                   />
                   <EuiDataGridBody
                     columnWidths={columnWidths}

--- a/src/components/datagrid/data_grid_body.tsx
+++ b/src/components/datagrid/data_grid_body.tsx
@@ -17,7 +17,7 @@ import {
   EuiDataGridDataRow,
   EuiDataGridDataRowProps,
 } from './data_grid_data_row';
-import { EuiDataGridSchema } from './data_grid';
+import { EuiDataGridSchema } from './data_grid_schema';
 
 interface EuiDataGridBodyProps {
   columnWidths: EuiDataGridColumnWidths;

--- a/src/components/datagrid/data_grid_body.tsx
+++ b/src/components/datagrid/data_grid_body.tsx
@@ -17,11 +17,13 @@ import {
   EuiDataGridDataRow,
   EuiDataGridDataRowProps,
 } from './data_grid_data_row';
+import { EuiDataGridSchema } from './data_grid';
 
 interface EuiDataGridBodyProps {
   columnWidths: EuiDataGridColumnWidths;
   defaultColumnWidth?: number | null;
   columns: EuiDataGridColumn[];
+  schema: EuiDataGridSchema;
   focusedCell: EuiDataGridDataRowProps['focusedCell'];
   onCellFocus: EuiDataGridDataRowProps['onCellFocus'];
   rowCount: number;
@@ -41,6 +43,7 @@ export const EuiDataGridBody: FunctionComponent<
     columnWidths,
     defaultColumnWidth,
     columns,
+    schema,
     focusedCell,
     onCellFocus,
     rowCount,
@@ -137,6 +140,7 @@ export const EuiDataGridBody: FunctionComponent<
         <EuiDataGridDataRow
           key={rowIndex}
           columns={columns}
+          schema={schema}
           columnWidths={columnWidths}
           defaultColumnWidth={defaultColumnWidth}
           focusedCell={focusedCell}

--- a/src/components/datagrid/data_grid_cell.tsx
+++ b/src/components/datagrid/data_grid_cell.tsx
@@ -17,7 +17,7 @@ import { EuiMutationObserver } from '../observer/mutation_observer';
 export interface CellValueElementProps {
   rowIndex: number;
   columnId: string;
-  setCellProps: (props: HTMLAttributes<HTMLDivElement>) => void;
+  setCellProps: (props: CommonProps & HTMLAttributes<HTMLDivElement>) => void;
 }
 
 export interface EuiDataGridCellProps {
@@ -207,7 +207,7 @@ export class EuiDataGridCell extends Component<
       [`euiDataGridRowCell--${columnType}`]: columnType,
     });
 
-    const cellProps: CommonProps & HTMLAttributes<HTMLDivElement> = {
+    const cellProps = {
       ...this.state.cellProps,
       'data-test-subj': classnames(
         'dataGridRowCell',

--- a/src/components/datagrid/data_grid_cell.tsx
+++ b/src/components/datagrid/data_grid_cell.tsx
@@ -191,7 +191,7 @@ export class EuiDataGridCell extends Component<
     };
 
     const className = classnames('euiDataGridRowCell', {
-      [`euiDataGridRowCell__columnType--${columnType}`]: columnType,
+      [`euiDataGridRowCell--${columnType}`]: columnType,
     });
 
     return (

--- a/src/components/datagrid/data_grid_cell.tsx
+++ b/src/components/datagrid/data_grid_cell.tsx
@@ -42,7 +42,7 @@ type EuiDataGridCellValueProps = Omit<
 >;
 
 const EuiDataGridCellContent: FunctionComponent<
-  Omit<EuiDataGridCellValueProps, 'columnType'>
+  EuiDataGridCellValueProps
 > = memo(props => {
   const { renderCellValue, ...rest } = props;
 
@@ -221,7 +221,7 @@ export class EuiDataGridCell extends Component<
                   {...isInteractiveCell}
                   ref={this.cellContentsRef}
                   className="euiDataGridRowCell__content">
-                  <EuiDataGridCellContent {...rest} />
+                  <EuiDataGridCellContent {...rest} columnType={columnType} />
                 </div>
               </div>
             )}

--- a/src/components/datagrid/data_grid_cell.tsx
+++ b/src/components/datagrid/data_grid_cell.tsx
@@ -12,7 +12,6 @@ import { EuiFocusTrap } from '../focus_trap';
 import { Omit } from '../common';
 import { getTabbables, CELL_CONTENTS_ATTR } from './utils';
 import { EuiMutationObserver } from '../observer/mutation_observer';
-import { EuiDataGridSchemaType } from './data_grid';
 
 export interface CellValueElementProps {
   rowIndex: number;
@@ -23,7 +22,7 @@ export interface EuiDataGridCellProps {
   rowIndex: number;
   colIndex: number;
   columnId: string;
-  columnType?: EuiDataGridSchemaType | null;
+  columnType?: string | null;
   width?: number;
   isFocusable: boolean;
   onCellFocus: Function;

--- a/src/components/datagrid/data_grid_cell.tsx
+++ b/src/components/datagrid/data_grid_cell.tsx
@@ -6,11 +6,13 @@ import React, {
   ReactNode,
   createRef,
 } from 'react';
+import classnames from 'classnames';
 // @ts-ignore
 import { EuiFocusTrap } from '../focus_trap';
 import { Omit } from '../common';
 import { getTabbables, CELL_CONTENTS_ATTR } from './utils';
 import { EuiMutationObserver } from '../observer/mutation_observer';
+import { EuiDataGridSchemaType } from './data_grid';
 
 export interface CellValueElementProps {
   rowIndex: number;
@@ -21,6 +23,7 @@ export interface EuiDataGridCellProps {
   rowIndex: number;
   colIndex: number;
   columnId: string;
+  columnType?: EuiDataGridSchemaType | null;
   width?: number;
   isFocusable: boolean;
   onCellFocus: Function;
@@ -39,7 +42,7 @@ type EuiDataGridCellValueProps = Omit<
 >;
 
 const EuiDataGridCellContent: FunctionComponent<
-  EuiDataGridCellValueProps
+  Omit<EuiDataGridCellValueProps, 'columnType'>
 > = memo(props => {
   const { renderCellValue, ...rest } = props;
 
@@ -179,6 +182,7 @@ export class EuiDataGridCell extends Component<
       isFocusable,
       isGridNavigationEnabled,
       interactiveCellId,
+      columnType,
       ...rest
     } = this.props;
     const { colIndex, rowIndex, onCellFocus } = rest;
@@ -187,13 +191,17 @@ export class EuiDataGridCell extends Component<
       [CELL_CONTENTS_ATTR]: isInteractive,
     };
 
+    const className = classnames('euiDataGridRowCell', {
+      [`euiDataGridRowCell__columnType--${columnType}`]: columnType,
+    });
+
     return (
       <div
         role="gridcell"
         {...isInteractive && { 'aria-describedby': interactiveCellId }}
         tabIndex={isFocusable ? 0 : -1}
         ref={this.cellRef}
-        className="euiDataGridRowCell"
+        className={className}
         data-test-subj="dataGridRowCell"
         onFocus={() => onCellFocus([colIndex, rowIndex])}
         style={width != null ? { width: `${width}px` } : {}}>

--- a/src/components/datagrid/data_grid_data_row.tsx
+++ b/src/components/datagrid/data_grid_data_row.tsx
@@ -4,11 +4,13 @@ import { EuiDataGridColumn, EuiDataGridColumnWidths } from './data_grid_types';
 import { CommonProps } from '../common';
 
 import { EuiDataGridCell, EuiDataGridCellProps } from './data_grid_cell';
+import { EuiDataGridSchema } from './data_grid';
 
 export type EuiDataGridDataRowProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {
     rowIndex: number;
     columns: EuiDataGridColumn[];
+    schema: EuiDataGridSchema;
     columnWidths: EuiDataGridColumnWidths;
     defaultColumnWidth?: number | null;
     focusedCell: [number, number];
@@ -24,6 +26,7 @@ const EuiDataGridDataRow: FunctionComponent<
 > = props => {
   const {
     columns,
+    schema,
     columnWidths,
     defaultColumnWidth,
     className,
@@ -57,6 +60,7 @@ const EuiDataGridDataRow: FunctionComponent<
             rowIndex={rowIndex}
             colIndex={i}
             columnId={id}
+            columnType={schema[id]}
             width={width || undefined}
             renderCellValue={renderCellValue}
             onCellFocus={onCellFocus}

--- a/src/components/datagrid/data_grid_data_row.tsx
+++ b/src/components/datagrid/data_grid_data_row.tsx
@@ -4,7 +4,7 @@ import { EuiDataGridColumn, EuiDataGridColumnWidths } from './data_grid_types';
 import { CommonProps } from '../common';
 
 import { EuiDataGridCell, EuiDataGridCellProps } from './data_grid_cell';
-import { EuiDataGridSchema } from './data_grid';
+import { EuiDataGridSchema } from './data_grid_schema';
 
 export type EuiDataGridDataRowProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {

--- a/src/components/datagrid/data_grid_data_row.tsx
+++ b/src/components/datagrid/data_grid_data_row.tsx
@@ -60,7 +60,7 @@ const EuiDataGridDataRow: FunctionComponent<
             rowIndex={rowIndex}
             colIndex={i}
             columnId={id}
-            columnType={schema[id]}
+            columnType={schema[id] ? schema[id].columnType : null}
             width={width || undefined}
             renderCellValue={renderCellValue}
             onCellFocus={onCellFocus}

--- a/src/components/datagrid/data_grid_header_row.tsx
+++ b/src/components/datagrid/data_grid_header_row.tsx
@@ -9,11 +9,13 @@ import { CommonProps } from '../common';
 import { EuiDataGridColumnResizer } from './data_grid_column_resizer';
 import { htmlIdGenerator } from '../../services/accessibility';
 import { EuiScreenReaderOnly } from '../accessibility';
+import { EuiDataGridSchema } from './data_grid_schema';
 
 type EuiDataGridHeaderRowProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {
     columns: EuiDataGridColumn[];
     columnWidths: EuiDataGridColumnWidths;
+    schema: EuiDataGridSchema;
     defaultColumnWidth?: number | null;
     setColumnWidth: (columnId: string, width: number) => void;
     sorting?: EuiDataGridSorting;
@@ -24,6 +26,7 @@ const EuiDataGridHeaderRow: FunctionComponent<
 > = props => {
   const {
     columns,
+    schema,
     columnWidths,
     defaultColumnWidth,
     className,
@@ -77,12 +80,18 @@ const EuiDataGridHeaderRow: FunctionComponent<
           }
         }
 
+        const columnType = schema[id] ? schema[id].columnType : null;
+
+        const classes = classnames('euiDataGridHeaderCell', {
+          [`euiDataGridHeaderCell--${columnType}`]: columnType,
+        });
+
         return (
           <div
             role="columnheader"
             {...ariaProps}
             key={id}
-            className="euiDataGridHeaderCell"
+            className={classes}
             data-test-subj={`dataGridHeaderCell-${id}`}
             style={width != null ? { width: `${width}px` } : {}}>
             {width ? (

--- a/src/components/datagrid/data_grid_inmemory_renderer.tsx
+++ b/src/components/datagrid/data_grid_inmemory_renderer.tsx
@@ -22,6 +22,8 @@ interface EuiDataGridInMemoryRendererProps {
   ) => void;
 }
 
+function noop() {}
+
 export const EuiDataGridInMemoryRenderer: FunctionComponent<
   EuiDataGridInMemoryRendererProps
 > = ({ columns, rowCount, renderCellValue, onCellRender }) => {
@@ -48,7 +50,11 @@ export const EuiDataGridInMemoryRenderer: FunctionComponent<
                   }, [text]);
                   return (
                     <div ref={ref}>
-                      <CellElement rowIndex={i} columnId={column.id} />
+                      <CellElement
+                        rowIndex={i}
+                        columnId={column.id}
+                        setCellProps={noop}
+                      />
                     </div>
                   );
                 }}

--- a/src/components/datagrid/data_grid_schema.ts
+++ b/src/components/datagrid/data_grid_schema.ts
@@ -19,8 +19,11 @@ const schemaDetectors: SchemaDetector[] = [
   {
     type: 'currency',
     detector(value: string) {
-      const matchLength = (value.match(/[$-(]*[\d,]+(\.\d*)?[$)]*/) || [''])[0]
-        .length;
+      const matchLength = (value.match(
+        // currency prefers starting with 1-3 characters for the currency symbol
+        // then it matches against numerical data + $
+        /(^[^-(]{1,3})?[$-(]*[\d,]+(\.\d*)?[$)]*/
+      ) || [''])[0].length;
 
       // if there is no currency symbol then reduce the score
       const hasCurrency = value.indexOf('$') !== -1;

--- a/src/components/datagrid/data_grid_schema.ts
+++ b/src/components/datagrid/data_grid_schema.ts
@@ -1,0 +1,213 @@
+import { useMemo } from 'react';
+import {
+  EuiDataGridColumn,
+  EuiDataGridInMemoryValues,
+} from './data_grid_types';
+
+const schemaDetectors = [
+  {
+    type: 'boolean',
+    detector(value: string) {
+      return value === 'true' || value === 'false' ? 1 : 0;
+    },
+  },
+  {
+    type: 'currency',
+    detector(value: string) {
+      const matchLength = (value.match(/[$-(]*[\d,]+(\.\d*)?[$)]*/) || [''])[0]
+        .length;
+
+      // if there is no currency symbol then reduce the score
+      const hasCurrency = value.indexOf('$') !== -1;
+      const currencyAdjustment = hasCurrency ? 1 : 0.75;
+
+      return (matchLength / value.length) * currencyAdjustment || 0;
+    },
+  },
+  {
+    type: 'datetime',
+    detector(value: string) {
+      // matches the most common forms of ISO-8601
+      const isoTimestampMatch = value.match(
+        // 2019 - 09    - 17     T 12     : 18    : 32      .853     Z or -0600
+        /^\d{2,4}-\d{1,2}-\d{1,2}(T?\d{1,2}:\d{1,2}:\d{1,2}(\.\d{3})?(Z|[+-]\d{4})?)?/
+      );
+
+      // matches 9 digits (seconds) or 13 digits (milliseconds) since unix epoch
+      const unixTimestampMatch = value.match(/^(\d{9}|\d{13})$/);
+
+      const isoMatchLength = isoTimestampMatch
+        ? isoTimestampMatch[0].length
+        : 0;
+
+      // reduce the confidence of a unix timestamp match to 75%
+      // (a column of all unix timestamps should be numeric instead)
+      const unixMatchLength = unixTimestampMatch
+        ? unixTimestampMatch[0].length * 0.75
+        : 0;
+
+      return Math.max(isoMatchLength, unixMatchLength) / value.length || 0;
+    },
+  },
+  {
+    type: 'numeric',
+    detector(value: string) {
+      const matchLength = (value.match(/[%-(]*[\d,]+(\.\d*)?[%)]*/) || [''])[0]
+        .length;
+      return matchLength / value.length || 0;
+    },
+  },
+];
+
+export interface EuiDataGridSchema {
+  [columnId: string]: { columnType: string | null };
+}
+
+interface SchemaTypeScore {
+  type: string;
+  score: number;
+}
+
+function scoreValueBySchemaType(value: string) {
+  const scores: SchemaTypeScore[] = [];
+
+  for (let i = 0; i < schemaDetectors.length; i++) {
+    const { type, detector } = schemaDetectors[i];
+    const score = detector(value);
+    scores.push({ type, score });
+  }
+
+  return scores;
+}
+
+// completely arbitrary minimum match I came up with
+// represents lowest score a type detector can have to be considered valid
+const MINIMUM_SCORE_MATCH = 0.2;
+
+export function useDetectSchema(
+  inMemoryValues: EuiDataGridInMemoryValues,
+  autoDetectSchema: boolean
+) {
+  const schema = useMemo(() => {
+    const schema: EuiDataGridSchema = {};
+    if (autoDetectSchema === false) {
+      return schema;
+    }
+
+    const columnSchemas: {
+      [columnId: string]: { [type: string]: number[] };
+    } = {};
+
+    const rowIndices = Object.keys(inMemoryValues);
+    for (let i = 0; i < rowIndices.length; i++) {
+      const rowIndex = rowIndices[i];
+      const rowData = inMemoryValues[rowIndex];
+      const columnIds = Object.keys(rowData);
+
+      for (let j = 0; j < columnIds.length; j++) {
+        const columnId = columnIds[j];
+
+        const schemaColumn = (columnSchemas[columnId] =
+          columnSchemas[columnId] || {});
+
+        const columnValue = rowData[columnId].trim();
+        const valueScores = scoreValueBySchemaType(columnValue);
+
+        for (let k = 0; k < valueScores.length; k++) {
+          const valueScore = valueScores[k];
+          if (schemaColumn.hasOwnProperty(valueScore.type)) {
+            const existingScore = schemaColumn[valueScore.type];
+            existingScore.push(valueScore.score);
+          } else {
+            // first entry for this column
+            schemaColumn[valueScore.type] = [valueScore.score];
+          }
+        }
+      }
+    }
+
+    return Object.keys(columnSchemas).reduce<EuiDataGridSchema | any>(
+      (schema, columnId) => {
+        const columnScores = columnSchemas[columnId];
+        const typeIds = Object.keys(columnScores);
+
+        //
+        const typeSummaries: {
+          [type: string]: {
+            minScore: number;
+            maxScore: number;
+            mean: number;
+            sd: number;
+          };
+        } = {};
+
+        let bestType = null;
+        let bestScore = 0;
+
+        for (let i = 0; i < typeIds.length; i++) {
+          const typeId = typeIds[i];
+
+          const typeScores = columnScores[typeId];
+
+          let minScore = 1;
+          let maxScore = 0;
+
+          let totalScore = 0;
+          for (let j = 0; j < typeScores.length; j++) {
+            const score = typeScores[j];
+            totalScore += score;
+            minScore = Math.min(minScore, score);
+            maxScore = Math.max(maxScore, score);
+          }
+          const mean = totalScore / typeScores.length;
+
+          let sdSum = 0;
+          for (let j = 0; j < typeScores.length; j++) {
+            const score = typeScores[j];
+            sdSum += (score - mean) * (score - mean);
+          }
+          // console.log(sdSum, typeScores.length - 1);
+          const sd = Math.sqrt(sdSum / typeScores.length);
+
+          const summary = { minScore, maxScore, mean, sd };
+
+          // the mean-standard_deviation calculation is fairly arbitrary but fits the patterns I've thrown at it
+          const score = summary.mean - summary.sd;
+          if (score > MINIMUM_SCORE_MATCH) {
+            if (bestType == null || score > bestScore) {
+              bestType = typeId;
+              bestScore = score;
+            }
+          }
+
+          typeSummaries[typeId] = summary;
+        }
+        schema[columnId] = { columnType: bestType };
+
+        return schema;
+      },
+      {}
+    );
+  }, [inMemoryValues]);
+  return schema;
+}
+
+export function getMergedSchema(
+  detectedSchema: EuiDataGridSchema,
+  columns: EuiDataGridColumn[]
+) {
+  const mergedSchema = { ...detectedSchema };
+
+  for (let i = 0; i < columns.length; i++) {
+    const { id, dataType } = columns[i];
+    if (dataType != null) {
+      if (detectedSchema.hasOwnProperty(id)) {
+        mergedSchema[id] = { ...detectedSchema[id], columnType: dataType };
+      } else {
+        mergedSchema[id] = { columnType: dataType };
+      }
+    }
+  }
+
+  return mergedSchema;
+}

--- a/src/components/datagrid/data_grid_schema.ts
+++ b/src/components/datagrid/data_grid_schema.ts
@@ -24,9 +24,9 @@ const schemaDetectors: SchemaDetector[] = [
 
       // if there is no currency symbol then reduce the score
       const hasCurrency = value.indexOf('$') !== -1;
-      const currencyAdjustment = hasCurrency ? 1 : 0.75;
+      const confidenceAdjustment = hasCurrency ? 1 : 0.95;
 
-      return (matchLength / value.length) * currencyAdjustment || 0;
+      return (matchLength / value.length) * confidenceAdjustment || 0;
     },
   },
   {

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -1,9 +1,9 @@
-import { EuiDataGridSchema } from './data_grid';
+import { EuiDataGridSchema } from './data_grid_schema';
 
 export interface EuiDataGridColumn {
   id: string;
   // allow devs to pass arbitrary dataType strings, but internally keep the code matching against the known types
-  dataType?: EuiDataGridSchema['schema']['columnType'] | string;
+  dataType?: EuiDataGridSchema['*']['columnType'];
 }
 
 export interface EuiDataGridColumnWidths {

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -2,7 +2,8 @@ import { EuiDataGridSchema } from './data_grid';
 
 export interface EuiDataGridColumn {
   id: string;
-  dataType?: EuiDataGridSchema['schema']['columnType'];
+  // allow devs to pass arbitrary dataType strings, but internally keep the code matching against the known types
+  dataType?: EuiDataGridSchema['schema']['columnType'] | string;
 }
 
 export interface EuiDataGridColumnWidths {

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -1,5 +1,8 @@
+import { EuiDataGridSchema } from './data_grid';
+
 export interface EuiDataGridColumn {
   id: string;
+  dataType?: EuiDataGridSchema['schema']['columnType'];
 }
 
 export interface EuiDataGridColumnWidths {

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -54,7 +54,7 @@ service / in-memory boundary can be used. Thus there are four states for in-memo
 * "filtering" - all operations are performed in-memory, no service calls
  */
 export type EuiDataGridInMemory =
-  | false
+  | boolean
   | 'pagination'
   | 'sorting'
   | 'filtering';


### PR DESCRIPTION
### Summary

Adds a schema-detection pass to EuiDataGrid. The detection looks at the rendered content and scores each value against each type. A column's type scores are then aggregated by taking the `mean - standard_deviation`, and the best resulting type score wins.

Additional schema detectors can also be passed as a prop to EuiDataGrid.

@snide I threw the SCSS changes in to verify things were working, feel free to fix them up directly on this branch.

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
- [x] Added **documentation** examples
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
