### PR TITLE
Add data-test-subj support to non-custom table actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Added `data-test-subj` support for basic and in-memory tables' actions ([#2353](https://github.com/elastic/eui/pull/2353))
+
 **Bug fixes**
 
 - Fixed spacing of `EuiFormErrorText` to match `EuiFormHelpText` ([#2354](https://github.com/elastic/eui/pull/2354))
@@ -12,7 +14,6 @@
 - Added missing `compressed` TS definitions to `EuiComboBox`, `EuiCheckboxGroup`, `EuiCheckbox`, `EuiFieldSearch`, `EuiRadioGroup`, `EuiSwitch` ([#2338](https://github.com/elastic/eui/pull/2338))
 - Added auto-margin between `EuiFormRow` and `EuiButton` ([#2338](https://github.com/elastic/eui/pull/2338))
 - Added border to `[readOnly]` inputs ([#2338](https://github.com/elastic/eui/pull/2338))
-- Added `data-test-subj` support for basic and in-memory tables' actions ([#2353](https://github.com/elastic/eui/pull/2353))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ No public interface changes since `14.2.0`.
 - Added missing `compressed` TS definitions to `EuiComboBox`, `EuiCheckboxGroup`, `EuiCheckbox`, `EuiFieldSearch`, `EuiRadioGroup`, `EuiSwitch` ([#2338](https://github.com/elastic/eui/pull/2338))
 - Added auto-margin between `EuiFormRow` and `EuiButton` ([#2338](https://github.com/elastic/eui/pull/2338))
 - Added border to `[readOnly]` inputs ([#2338](https://github.com/elastic/eui/pull/2338))
+- Added `data-test-subj` support for basic and in-memory tables' actions ([#2353](https://github.com/elastic/eui/pull/2353))
 
 **Bug fixes**
 

--- a/src-docs/src/views/tables/actions/actions.js
+++ b/src-docs/src/views/tables/actions/actions.js
@@ -163,6 +163,7 @@ export class Table extends Component {
               description: 'Clone this user',
               icon: 'copy',
               onClick: this.cloneUser,
+              'data-test-subj': 'action-clone',
             },
             {
               name: 'Delete',
@@ -172,6 +173,7 @@ export class Table extends Component {
               type: 'icon',
               onClick: this.deleteUser,
               isPrimary: true,
+              'data-test-subj': 'action-delete',
             },
             {
               name: 'Edit',
@@ -180,6 +182,7 @@ export class Table extends Component {
               icon: 'pencil',
               type: 'icon',
               onClick: () => {},
+              'data-test-subj': 'action-edit',
             },
             {
               name: 'Share',
@@ -188,6 +191,7 @@ export class Table extends Component {
               icon: 'share',
               type: 'icon',
               onClick: () => {},
+              'data-test-subj': 'action-share',
             },
           ];
     } else {
@@ -212,6 +216,7 @@ export class Table extends Component {
               type: 'icon',
               href: 'https://elastic.co',
               target: '_blank',
+              'data-test-subj': 'action-outboundlink',
             },
           ];
     }

--- a/src-docs/src/views/tables/basic/props_info.js
+++ b/src-docs/src/views/tables/basic/props_info.js
@@ -404,6 +404,12 @@ export const propsInfo = {
           required: false,
           type: { name: 'string (must be one of the supported button colors)' },
         },
+        'data-test-subj': {
+          description:
+            "Applies a data-test-subj attribute to the action's DOM node",
+          required: false,
+          type: { name: 'string' },
+        },
       },
     },
   },

--- a/src/components/basic_table/__snapshots__/collapsed_item_actions.test.js.snap
+++ b/src/components/basic_table/__snapshots__/collapsed_item_actions.test.js.snap
@@ -14,6 +14,7 @@ exports[`CollapsedItemActions render 1`] = `
       <button
         aria-label="All actions"
         class="euiButtonIcon euiButtonIcon--text"
+        data-test-subj="euiCollapsedItemActions"
         type="button"
       >
         <svg

--- a/src/components/basic_table/__snapshots__/collapsed_item_actions.test.js.snap
+++ b/src/components/basic_table/__snapshots__/collapsed_item_actions.test.js.snap
@@ -14,7 +14,7 @@ exports[`CollapsedItemActions render 1`] = `
       <button
         aria-label="All actions"
         class="euiButtonIcon euiButtonIcon--text"
-        data-test-subj="euiCollapsedItemActions"
+        data-test-subj="euiCollapsedItemActionsButton"
         type="button"
       >
         <svg

--- a/src/components/basic_table/basic_table.js
+++ b/src/components/basic_table/basic_table.js
@@ -86,6 +86,7 @@ const DefaultItemActionType = PropTypes.shape({
     PropTypes.oneOf(BUTTON_ICON_COLORS),
     PropTypes.func, // (item) => oneOf(ICON_BUTTON_COLORS)
   ]),
+  'data-test-subj': PropTypes.string,
 });
 
 const CustomItemActionType = PropTypes.shape({

--- a/src/components/basic_table/collapsed_item_actions.js
+++ b/src/components/basic_table/collapsed_item_actions.js
@@ -114,7 +114,7 @@ export class CollapsedItemActions extends Component {
             isDisabled={allDisabled}
             onClick={this.togglePopover.bind(this)}
             onFocus={onFocus}
-            data-test-subj="euiCollapsedItemActions"
+            data-test-subj="euiCollapsedItemActionsButton"
           />
         )}
       </EuiI18n>

--- a/src/components/basic_table/collapsed_item_actions.js
+++ b/src/components/basic_table/collapsed_item_actions.js
@@ -91,6 +91,7 @@ export class CollapsedItemActions extends Component {
             key={key}
             disabled={!enabled}
             icon={action.icon}
+            data-test-subj={action['data-test-subj']}
             onClick={this.onClickItem.bind(
               null,
               action.onClick.bind(null, item)
@@ -113,6 +114,7 @@ export class CollapsedItemActions extends Component {
             isDisabled={allDisabled}
             onClick={this.togglePopover.bind(this)}
             onFocus={onFocus}
+            data-test-subj="euiCollapsedItemActions"
           />
         )}
       </EuiI18n>

--- a/src/components/basic_table/default_item_action.js
+++ b/src/components/basic_table/default_item_action.js
@@ -44,6 +44,7 @@ export class DefaultItemAction extends Component {
           onClick={onClick}
           href={action.href}
           target={action.target}
+          data-test-subj={action['data-test-subj']}
         />
       );
     } else {
@@ -57,6 +58,7 @@ export class DefaultItemAction extends Component {
           onClick={onClick}
           href={action.href}
           target={action.target}
+          data-test-subj={action['data-test-subj']}
           flush="right">
           {action.name}
         </EuiButtonEmpty>


### PR DESCRIPTION
### Summary

Closes #1807 

I added a `data-test-subj` to the collapsed actions button and allowed properties on default action types (non-custom actions can already specify the data-test-subj however they'd like). The `Adding actions to BasicTable` doc section was updated to include `data-test-subj`s and can be used to verify they are applied to the DOM in the three non-custom action locations:

* single action
* multiple actions, not in popover
* multiple actions, in popover 

/cc @lizozom @pheyos 

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
- [x] Props have proper **autodocs**
- [x] Added **documentation** examples
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
