### PR TITLE
Apply same top padding to EuiFormErrorText as EuiFormHelpText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `14.2.0`.
+**Bug fixes**
+
+- Fixed spacing of `EuiFormErrorText` to match `EuiFormHelpText` ([#2354](https://github.com/elastic/eui/pull/2354))
 
 ## [`14.2.0`](https://github.com/elastic/eui/tree/v14.2.0)
 
-- Add `compressed` option to `buttonSize` prop of EuiButtonGroup ([#2343](https://github.com/elastic/eui/pull/2343))
+- Added `compressed` option to `buttonSize` prop of EuiButtonGroup ([#2343](https://github.com/elastic/eui/pull/2343))
 - Added disabled states to `EuiCard`, `EuiKeyPadMenuItem` and `EuiKeyPadMenuItemButton`
  ([#2333](https://github.com/elastic/eui/pull/2340))
 - Added missing `compressed` TS definitions to `EuiComboBox`, `EuiCheckboxGroup`, `EuiCheckbox`, `EuiFieldSearch`, `EuiRadioGroup`, `EuiSwitch` ([#2338](https://github.com/elastic/eui/pull/2338))

--- a/src/components/form/form_error_text/_form_error_text.scss
+++ b/src/components/form/form_error_text/_form_error_text.scss
@@ -1,5 +1,5 @@
 .euiFormErrorText {
   @include euiFontSizeXS;
-  padding-top: $euiSizeS;
+  padding-top: $euiSizeXS;
   color: $euiColorDanger;
 }


### PR DESCRIPTION
### Fixes #2352 

**Before**
<img width="472" alt="Screen Shot 2019-09-19 at 14 40 39 PM" src="https://user-images.githubusercontent.com/549577/65272115-8204cb00-daec-11e9-9552-e4fb89d137ab.png">


**After**
<img width="470" alt="Screen Shot 2019-09-19 at 14 40 45 PM" src="https://user-images.githubusercontent.com/549577/65272133-86c97f00-daec-11e9-91ce-ec1e194643a8.png">


### Checklist

- ~[ ] Checked in **dark mode**~
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **IE11** and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **documentation** examples~
- ~[ ] Added or updated **jest tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
