### PR TITLE
Make EuiTableRowCell textOnly={false} when its an expanded row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added a `showMaxPopover` option for `EuiBreadcrumbs` to display all items when a `max` is set. ([#2342](https://github.com/elastic/eui/pull/2342))
 - Added `data-test-subj` support for basic and in-memory tables' actions ([#2353](https://github.com/elastic/eui/pull/2353))
 - Added `ip` icon to glyph set ([#2371](https://github.com/elastic/eui/pull/2371))
+- Set `textOnly={true}` for expanded rows in `EuiBasicTable` ([#2376](https://github.com/elastic/eui/pull/2376))
 
 **Bug fixes**
 

--- a/src/components/basic_table/__snapshots__/basic_table.test.js.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.js.snap
@@ -1040,6 +1040,7 @@ exports[`EuiBasicTable itemIdToExpandedRowMap renders an expanded row 1`] = `
         >
           <EuiTableRowCell
             colSpan={1}
+            textOnly={false}
           >
             <div>
               Expanded row

--- a/src/components/basic_table/basic_table.js
+++ b/src/components/basic_table/basic_table.js
@@ -801,7 +801,7 @@ export class EuiBasicTable extends Component {
         id={expandedRowId}
         isExpandedRow={true}
         isSelectable={isSelectable}>
-        <EuiTableRowCell colSpan={expandedRowColSpan}>
+        <EuiTableRowCell colSpan={expandedRowColSpan} textOnly={false}>
           {itemIdToExpandedRowMap[itemId]}
         </EuiTableRowCell>
       </EuiTableRow>


### PR DESCRIPTION
### Summary

Closes #2370. Hard codes `textOnly={false} on `EuiBasicTable`'s expanded rows. This allows the content to properly grow to the full width of the expanded row.

/cc @justinkambic 

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
