### PR TITLE
Change `render` signature to function from property

### DIFF
--- a/src/components/filter_group/index.d.ts
+++ b/src/components/filter_group/index.d.ts
@@ -64,6 +64,6 @@ declare module '@elastic/eui' {
       ButtonHTMLAttributes<HTMLButtonElement> &
       EuiFilterSelectItemProps
   > {
-    render: () => JSX.Element;
+    render(): JSX.Element;
   }
 }


### PR DESCRIPTION
### Summary

I am currently preparing the TS 3.7 upgrade in Kibana (https://github.com/elastic/kibana/pull/47188). There is currently one failure coming from EUI, that this PR fixes. It seems that newer TS versions make a difference between having a function (that `render` is in the base class) and an property assigned an arrow function, which we had in this typing. So TS 3.7 will [fail on this](https://kibana-ci.elastic.co/job/elastic+kibana+pipeline-pull-request/2162/console) on:

```
node_modules/@elastic/eui/eui.d.ts(2417,6): error TS2424: Class 'Component<CommonProps & ButtonHTMLAttributes<HTMLButtonElement> & EuiFilterSelectItemProps, {}, any>' defines instance member function 'render', but extended class 'EuiFilterSelectItem' defines it as instance member property.
```

Changing the typing here slightly (which should not have any other effect) prevents this error from happening. Since this should have no effect (except that you later might work with TS 3.7.0) I didn't add a changelog for that.

**Note:** There are a couple of more issues if you want to actually upgrade EUI to TS 3.7.0, that will need to be fixed, but this is the only one actually preventing consumers to upgrade to 3.7.0 later on, so I wanted to focus on this for now.

### Checklist

- ~[ ] Checked in **dark mode**~
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **IE11** and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **documentation** examples~
- ~[ ] Added or updated **jest tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
