### PR TITLE
Added focus state to EuiListGroupItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added new `EuiColorStops` component ([#2360](https://github.com/elastic/eui/pull/2360))
 - Added `currency` glyph to 'EuiIcon' ([#2398](https://github.com/elastic/eui/pull/2398))
 - Migrate `EuiBreadcrumbs`, `EuiHeader` etc, and `EuiLink` to TypeScript ([#2391](https://github.com/elastic/eui/pull/2391))
+- Added focus state to `EuiListGroupItem` ([#2406](https://github.com/elastic/eui/pull/2406))
 
 **Bug fixes**
 

--- a/src-docs/src/views/list_group/list_group.js
+++ b/src-docs/src/views/list_group/list_group.js
@@ -30,6 +30,9 @@ export default class extends Component {
 
   render() {
     const { flushWidth, showBorder } = this.state;
+    const handleOnClick = () => {
+      alert('Item was clicked');
+    };
 
     return (
       <Fragment>
@@ -61,13 +64,21 @@ export default class extends Component {
         <EuiSpacer size="l" />
 
         <EuiListGroup flush={flushWidth} bordered={showBorder}>
-          <EuiListGroupItem label="First item" />
+          <EuiListGroupItem onClick={handleOnClick} label="First item" />
 
-          <EuiListGroupItem label="Second item" />
+          <EuiListGroupItem onClick={handleOnClick} label="Second item" />
 
-          <EuiListGroupItem label="Third item" isActive />
+          <EuiListGroupItem
+            onClick={handleOnClick}
+            label="Third item"
+            isActive
+          />
 
-          <EuiListGroupItem label="Fourth item" isDisabled />
+          <EuiListGroupItem
+            onClick={handleOnClick}
+            label="Fourth item"
+            isDisabled
+          />
         </EuiListGroup>
       </Fragment>
     );

--- a/src-docs/src/views/list_group/list_group_extra.js
+++ b/src-docs/src/views/list_group/list_group_extra.js
@@ -2,13 +2,18 @@ import React from 'react';
 
 import { EuiListGroup, EuiListGroupItem } from '../../../../src/components';
 
+const handleOnClick = () => {
+  alert('Item was clicked');
+};
+
 export default () => (
   <EuiListGroup showToolTips>
-    <EuiListGroupItem label="First item" />
+    <EuiListGroupItem onClick={handleOnClick} label="First item" />
 
-    <EuiListGroupItem label="Second item" />
+    <EuiListGroupItem onClick={handleOnClick} label="Second item" />
 
     <EuiListGroupItem
+      onClick={handleOnClick}
       label={
         <span>
           Third very, very long item that <strong>will surely</strong> force
@@ -18,6 +23,7 @@ export default () => (
     />
 
     <EuiListGroupItem
+      onClick={handleOnClick}
       wrapText
       label="Fourth very, very long item with wrapping enabled that will not force truncation"
     />

--- a/src/components/list_group/_list_group_item.scss
+++ b/src/components/list_group/_list_group_item.scss
@@ -22,12 +22,6 @@
     text-decoration: underline;
   }
 
-
-  &.euiListGroupItem-isClickable:hover .euiListGroupItem__label,
-  &.euiListGroupItem-isClickable:focus .euiListGroupItem__label {
-    text-decoration: underline;
-  }
-
   // Style all disabled list items whether or not they are links or buttons
   &.euiListGroupItem-isDisabled,
   &.euiListGroupItem-isDisabled:hover,

--- a/src/components/list_group/_list_group_item.scss
+++ b/src/components/list_group/_list_group_item.scss
@@ -19,6 +19,7 @@
 
   &.euiListGroupItem-isClickable .euiListGroupItem__button:focus {
     background-color: tintOrShade($euiColorLightestShade, 0%, 30%);
+    text-decoration: underline;
   }
 
 

--- a/src/components/list_group/_list_group_item.scss
+++ b/src/components/list_group/_list_group_item.scss
@@ -13,10 +13,14 @@
   }
 
   &.euiListGroupItem-isActive,
-  &.euiListGroupItem-isClickable:hover,
-  &.euiListGroupItem-isClickable:focus {
+  &.euiListGroupItem-isClickable:hover {
     background-color: tintOrShade($euiColorLightestShade, 0%, 30%);
   }
+
+  &.euiListGroupItem-isClickable .euiListGroupItem__button:focus {
+    background-color: tintOrShade($euiColorLightestShade, 0%, 30%);
+  }
+
 
   &.euiListGroupItem-isClickable:hover .euiListGroupItem__label,
   &.euiListGroupItem-isClickable:focus .euiListGroupItem__label {


### PR DESCRIPTION
### Summary

Added focus state to `EuiListGroupItem` and updated some of the docs examples.

![a-ezgif com-video-to-gif](https://user-images.githubusercontent.com/4016496/66417979-c63a0b80-e9c6-11e9-8d4e-72fe249b4516.gif)

Covers #2266


### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [X] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
