### PR TITLE
Removed extra footer cell from docs

### DIFF
--- a/src-docs/src/views/tables/custom/custom.js
+++ b/src-docs/src/views/tables/custom/custom.js
@@ -492,7 +492,6 @@ export default class extends Component {
         );
       }
     });
-
     return headers.length ? headers : null;
   }
 
@@ -644,7 +643,7 @@ export default class extends Component {
 
     this.columns.forEach(column => {
       const footer = this.getColumnFooter(column, { items, pagination });
-      if (column.isMobileHeader) {
+      if (column.mobileOptions && column.mobileOptions.only) {
         return; // exclude columns that only exist for mobile headers
       }
 
@@ -666,7 +665,6 @@ export default class extends Component {
         );
       }
     });
-
     return footers;
   }
 


### PR DESCRIPTION
### Summary

Removed extra footer cell from "Build a custom table from individual components" example. 
Covers #2407.

![image](https://user-images.githubusercontent.com/4016496/66446721-54d37a80-ea11-11e9-9d9b-0b5c1a4a46d9.png)

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
