### PR TITLE
Added component prop to EuiPageBody

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added new `EuiColorStops` component ([#2360](https://github.com/elastic/eui/pull/2360))
 - Added `currency` glyph to 'EuiIcon' ([#2398](https://github.com/elastic/eui/pull/2398))
 - Migrate `EuiBreadcrumbs`, `EuiHeader` etc, and `EuiLink` to TypeScript ([#2391](https://github.com/elastic/eui/pull/2391))
+- Added `component` prop to `EuiPageBody` ([#2410](https://github.com/elastic/eui/pull/2410))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Added new `EuiColorStops` component ([#2360](https://github.com/elastic/eui/pull/2360))
 - Added `currency` glyph to 'EuiIcon' ([#2398](https://github.com/elastic/eui/pull/2398))
 - Migrate `EuiBreadcrumbs`, `EuiHeader` etc, and `EuiLink` to TypeScript ([#2391](https://github.com/elastic/eui/pull/2391))
-- Added `component` prop to `EuiPageBody` ([#2410](https://github.com/elastic/eui/pull/2410))
+- Added `component` prop to `EuiPageBody`, switching the default from `div` to `main` ([#2410](https://github.com/elastic/eui/pull/2410))
 
 **Bug fixes**
 

--- a/src/components/page/page_body/__snapshots__/page_body.test.js.snap
+++ b/src/components/page/page_body/__snapshots__/page_body.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiPageBody is rendered 1`] = `
-<div
+<main
   aria-label="aria-label"
   class="euiPageBody testClass1 testClass2"
   data-test-subj="test subject string"
@@ -9,7 +9,7 @@ exports[`EuiPageBody is rendered 1`] = `
 `;
 
 exports[`EuiPageBody restrict width can be set to a custom number 1`] = `
-<div
+<main
   aria-label="aria-label"
   class="euiPageBody euiPageBody--restrictWidth-custom testClass1 testClass2"
   data-test-subj="test subject string"
@@ -18,7 +18,7 @@ exports[`EuiPageBody restrict width can be set to a custom number 1`] = `
 `;
 
 exports[`EuiPageBody restrict width can be set to a custom value and measurement 1`] = `
-<div
+<main
   aria-label="aria-label"
   class="euiPageBody euiPageBody--restrictWidth-custom testClass1 testClass2"
   data-test-subj="test subject string"
@@ -27,7 +27,7 @@ exports[`EuiPageBody restrict width can be set to a custom value and measurement
 `;
 
 exports[`EuiPageBody restrict width can be set to a default 1`] = `
-<div
+<main
   aria-label="aria-label"
   class="euiPageBody euiPageBody--restrictWidth-default testClass1 testClass2"
   data-test-subj="test subject string"

--- a/src/components/page/page_body/page_body.js
+++ b/src/components/page/page_body/page_body.js
@@ -7,6 +7,7 @@ export const EuiPageBody = ({
   restrictWidth,
   style,
   className,
+  component,
   ...rest
 }) => {
   let widthClassname;
@@ -23,17 +24,19 @@ export const EuiPageBody = ({
 
   const classes = classNames('euiPageBody', widthClassname, className);
 
+  const OuterElement = component;
+
   return (
-    <div className={classes} style={newStyle || style} {...rest}>
+    <OuterElement className={classes} style={newStyle || style} {...rest}>
       {children}
-    </div>
+    </OuterElement>
   );
 };
 
 EuiPageBody.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
-
+  component: PropTypes.string,
   /**
    * Sets the max-width of the page,
    * set to `true` to use the default size,
@@ -50,4 +53,5 @@ EuiPageBody.propTypes = {
 
 EuiPageBody.defaultProps = {
   restrictWidth: false,
+  component: 'main',
 };

--- a/src/components/page/page_body/page_body.js
+++ b/src/components/page/page_body/page_body.js
@@ -36,6 +36,9 @@ export const EuiPageBody = ({
 EuiPageBody.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
+  /**
+   * Sets the HTML element for `EuiPageBody`.
+   */
   component: PropTypes.string,
   /**
    * Sets the max-width of the page,


### PR DESCRIPTION
### Summary

Added `component` prop to `EuiPageBody`. Default value is `main`, consumer can pass a different html tag if needed.

Covers #2359

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
-[X] Props have proper **autodocs**
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
-[X] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
