### PR TITLE
[EuiDataGrid] Export useRenderToText

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -150,7 +150,7 @@ export { ICON_TYPES, EuiIcon } from './icon';
 
 export { EuiImage } from './image';
 
-export { useInnerText, EuiInnerText } from './inner_text';
+export { useInnerText, EuiInnerText, useRenderToText } from './inner_text';
 
 export { EuiI18n, EuiI18nNumber } from './i18n';
 

--- a/src/components/inner_text/index.ts
+++ b/src/components/inner_text/index.ts
@@ -1,1 +1,2 @@
 export { useInnerText, EuiInnerText } from './inner_text';
+export { useRenderToText } from './render_to_text';


### PR DESCRIPTION
### Summary

#2392 introduced a new `useRenderToText` hook but didn't export it outside of EUI. This PR corrects that.