### PR TITLE
Bugfix/2361 euilink disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 - Fixed missing misc. button and link type definition exports ([#2434](https://github.com/elastic/eui/pull/2434))
 - Strip custom semantics from `EuiSideNav` ([#2429](https://github.com/elastic/eui/pull/2429))
+- Changed `EuiLink` to appear uninteractive when given the disabled prop and an onClick handler ([#2423](https://github.com/elastic/eui/pull/2423))
+
 
 ## [`14.5.0`](https://github.com/elastic/eui/tree/v14.5.0)
 
@@ -32,6 +34,7 @@
 - Added `keyboardShorcut` glyph to 'EuiIcon ([#2413](https://github.com/elastic/eui/pull/2413))
 - Improved a11y in `EuiNavDrawer` ([#2417](https://github.com/elastic/eui/pull/2417))
 - Improved a11y in `EuiSuperDatePicker` ([#2426](https://github.com/elastic/eui/pull/2426))
+
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added ability for `EuiColorStops` to accept user-defined range bounds ([#2396](https://github.com/elastic/eui/pull/2396))
 - Added `external` prop to `EuiLink` ([#2442](https://github.com/elastic/eui/pull/2442))
 - Added disabled state to `EuiBadge` ([#2440](https://github.com/elastic/eui/pull/2440))
+- Changed `EuiLink` to appear non interactive when passed the `disabled` prop and an `onClick` handler ([#2423](https://github.com/elastic/eui/pull/2423))
 
 **Bug fixes**
 
@@ -19,7 +20,6 @@
 
 - Fixed missing misc. button and link type definition exports ([#2434](https://github.com/elastic/eui/pull/2434))
 - Strip custom semantics from `EuiSideNav` ([#2429](https://github.com/elastic/eui/pull/2429))
-- Changed `EuiLink` to appear non interactive when passed the `disabled` prop and an `onClick` handler ([#2423](https://github.com/elastic/eui/pull/2423))
 
 ## [`14.5.0`](https://github.com/elastic/eui/tree/v14.5.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@
 - Improved a11y in `EuiNavDrawer` ([#2417](https://github.com/elastic/eui/pull/2417))
 - Improved a11y in `EuiSuperDatePicker` ([#2426](https://github.com/elastic/eui/pull/2426))
 
-
 **Bug fixes**
 
 - Fixed `EuiSelectable` to accept programmatic updates to its `options` prop ([#2390](https://github.com/elastic/eui/pull/2390))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,7 @@
 
 - Fixed missing misc. button and link type definition exports ([#2434](https://github.com/elastic/eui/pull/2434))
 - Strip custom semantics from `EuiSideNav` ([#2429](https://github.com/elastic/eui/pull/2429))
-- Changed `EuiLink` to appear uninteractive when given the disabled prop and an onClick handler ([#2423](https://github.com/elastic/eui/pull/2423))
-
+- Changed `EuiLink` to appear non interactive when passed the `disabled` prop and an `onClick` handler ([#2423](https://github.com/elastic/eui/pull/2423))
 
 ## [`14.5.0`](https://github.com/elastic/eui/tree/v14.5.0)
 

--- a/src-docs/src/views/link/link_disable.js
+++ b/src-docs/src/views/link/link_disable.js
@@ -1,0 +1,33 @@
+import React, { Component, Fragment } from 'react';
+import { EuiLink, EuiSwitch } from '../../../../src/components';
+
+export class LinkDisable extends Component {
+    constructor(props) {
+        super(props);
+        this.state = { 
+            disableLink: true
+        };
+    }
+
+    toggleLinkDisable = () => {
+        console.log(this.state.disableLink);
+        this.setState(prevState => ({ disableLink: !prevState.disableLink }));
+    };
+
+    render() {
+        return (
+            <Fragment>
+                <p>When links are disabled, they inherit the color of surrounding text.</p>
+                <EuiSwitch
+                    label="Toggle Disabled State"
+                    checked={this.state.disableLink}
+                    onChange={this.toggleLinkDisable}
+                />
+                <p>Lo and behold</p>
+                <EuiLink disabled={this.state.disableLink} onClick={() => window.alert('Button clicked')}>
+                    ghost
+                </EuiLink>
+            </Fragment>
+        );
+    }
+}   

--- a/src-docs/src/views/link/link_disable.js
+++ b/src-docs/src/views/link/link_disable.js
@@ -1,33 +1,62 @@
-import React, { Component, Fragment } from 'react';
-import { EuiLink, EuiSwitch } from '../../../../src/components';
+import React, { Component } from 'react';
+import {
+  EuiLink,
+  EuiSwitch,
+  EuiSpacer,
+  EuiTextColor,
+} from '../../../../src/components';
 
 export class LinkDisable extends Component {
-    constructor(props) {
-        super(props);
-        this.state = { 
-            disableLink: true
-        };
-    }
-
-    toggleLinkDisable = () => {
-        console.log(this.state.disableLink);
-        this.setState(prevState => ({ disableLink: !prevState.disableLink }));
+  constructor(props) {
+    super(props);
+    this.state = {
+      disableLink: true,
     };
+  }
 
-    render() {
-        return (
-            <Fragment>
-                <p>When links are disabled, they inherit the color of surrounding text.</p>
-                <EuiSwitch
-                    label="Toggle Disabled State"
-                    checked={this.state.disableLink}
-                    onChange={this.toggleLinkDisable}
-                />
-                <p>Lo and behold</p>
-                <EuiLink disabled={this.state.disableLink} onClick={() => window.alert('Button clicked')}>
-                    ghost
-                </EuiLink>
-            </Fragment>
-        );
-    }
-}   
+  toggleLinkDisable = () => {
+    console.log(this.state.disableLink);
+    this.setState(prevState => ({ disableLink: !prevState.disableLink }));
+  };
+
+  render() {
+    return (
+      <div>
+        <EuiSwitch
+          label="Disable Links"
+          checked={this.state.disableLink}
+          onChange={this.toggleLinkDisable}
+        />
+        <EuiSpacer size="m" />
+        <p>
+          This{' '}
+          <EuiLink
+            color="accent"
+            disabled={this.state.disableLink}
+            onClick={() => window.alert('Button clicked')}>
+            paragraph
+          </EuiLink>{' '}
+          has two{this.state.disableLink ? ' disabled ' : ' enabled '}
+          <EuiLink
+            color="warning"
+            disabled={this.state.disableLink}
+            onClick={() => window.alert('Button clicked')}>
+            links
+          </EuiLink>{' '}
+          in it.
+        </p>
+        <EuiSpacer size="m" />
+        <EuiTextColor color="accent">
+          When links are disabled, they inherit the{' '}
+          <EuiLink
+            color="secondary"
+            disabled={this.state.disableLink}
+            onClick={() => window.alert('Button clicked')}>
+            color
+          </EuiLink>{' '}
+          of surrounding text.
+        </EuiTextColor>
+      </div>
+    );
+  }
+}

--- a/src-docs/src/views/link/link_disable.js
+++ b/src-docs/src/views/link/link_disable.js
@@ -15,7 +15,6 @@ export class LinkDisable extends Component {
   }
 
   toggleLinkDisable = () => {
-    console.log(this.state.disableLink);
     this.setState(prevState => ({ disableLink: !prevState.disableLink }));
   };
 

--- a/src-docs/src/views/link/link_example.js
+++ b/src-docs/src/views/link/link_example.js
@@ -65,7 +65,10 @@ export const LinkExample = {
       ],
       text: (
         <p>
-          Holy moly
+          When an <EuiCode>EuiLink</EuiCode> is passed an onClick method, and is
+          not passed an <EuiCode>href</EuiCode> it can optionally be set to
+          <EuiCode>disabled</EuiCode> which disables the click behavior, and
+          hides the link.
         </p>
       ),
       props: { EuiLink },

--- a/src-docs/src/views/link/link_example.js
+++ b/src-docs/src/views/link/link_example.js
@@ -65,10 +65,11 @@ export const LinkExample = {
       ],
       text: (
         <p>
-          When an <EuiCode>EuiLink</EuiCode> is passed an onClick method, and is
-          not passed an <EuiCode>href</EuiCode>, it can optionally be set to
+          When an <EuiCode>EuiLink</EuiCode> is passed an{' '}
+          <EuiCode>onClick</EuiCode> method, and is not passed an{' '}
+          <EuiCode>href</EuiCode>, it can optionally be set to
           <EuiCode>disabled</EuiCode> which disables the click behavior, and
-          hides the link.
+          removes the link styling.
         </p>
       ),
       props: { EuiLink },

--- a/src-docs/src/views/link/link_example.js
+++ b/src-docs/src/views/link/link_example.js
@@ -7,8 +7,14 @@ import { GuideSectionTypes } from '../../components';
 import { EuiCode, EuiLink } from '../../../../src/components';
 
 import Link from './link';
+import { LinkDisable } from './link_disable';
+
 const linkSource = require('!!raw-loader!./link');
 const linkHtml = renderToHtml(Link);
+
+const linkDisableSource = require('!!raw-loader!./link_disable');
+const linkDisableHtml = renderToHtml(LinkDisable);
+
 const linkSnippet = [
   `<EuiLink href="#"><!-- Link text --></EuiLink>
 `,
@@ -44,6 +50,26 @@ export const LinkExample = {
       props: { EuiLink },
       snippet: linkSnippet,
       demo: <Link />,
+    },
+    {
+      title: 'Disabled Links',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: linkDisableSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: linkDisableHtml,
+        },
+      ],
+      text: (
+        <p>
+          Holy moly
+        </p>
+      ),
+      props: { EuiLink },
+      demo: <LinkDisable />,
     },
   ],
 };

--- a/src-docs/src/views/link/link_example.js
+++ b/src-docs/src/views/link/link_example.js
@@ -66,7 +66,7 @@ export const LinkExample = {
       text: (
         <p>
           When an <EuiCode>EuiLink</EuiCode> is passed an onClick method, and is
-          not passed an <EuiCode>href</EuiCode> it can optionally be set to
+          not passed an <EuiCode>href</EuiCode>, it can optionally be set to
           <EuiCode>disabled</EuiCode> which disables the click behavior, and
           hides the link.
         </p>

--- a/src/components/link/__snapshots__/link.test.tsx.snap
+++ b/src/components/link/__snapshots__/link.test.tsx.snap
@@ -103,6 +103,14 @@ exports[`EuiLink supports children 1`] = `
 </a>
 `;
 
+exports[`EuiLink supports disabled 1`] = `
+<button
+  class="euiLink euiLink-disabled"
+  disabled=""
+  type="button"
+/>
+`;
+
 exports[`EuiLink supports href 1`] = `
 <a
   class="euiLink euiLink--primary"

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -4,6 +4,7 @@
   .euiLink__externalIcon {
     margin-left: $euiSizeXS;
   }
+
 }
 
 $textColors: (
@@ -32,3 +33,9 @@ $textColors: (
     }
   }
 }
+
+.euiLink.euilink-disabled {
+  text-decoration: none;
+  cursor: text;
+}
+

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -1,12 +1,3 @@
-.euiLink {
-  @include euiLink;
-
-  .euiLink__externalIcon {
-    margin-left: $euiSizeXS;
-  }
-
-}
-
 $textColors: (
   subdued: $euiColorDarkShade,
   primary: $euiColorPrimary,
@@ -18,24 +9,33 @@ $textColors: (
   ghost: $euiColorGhost,
 );
 
-// Create color modifiers based on the map
-@each $name, $color in $textColors {
-  .euiLink.euiLink--#{$name} {
-    color: $color;
+.euiLink {
+  @include euiLink;
 
-    &:hover {
-      color: darken($color, 10%);
-    }
+  .euiLink__externalIcon {
+    margin-left: $euiSizeXS;
+  }
 
-    &:focus {
-      outline: solid 3px transparentize($color, .9);
-      background-color: transparentize($color, .9);
+  &.euiLink-disabled {
+    text-decoration: none;
+    cursor: default;
+  }
+
+  // Create color modifiers based on the map
+  @each $name, $color in $textColors {
+    &.euiLink--#{$name} {
+      color: $color;
+
+      &:hover {
+        color: darken($color, 10%);
+      }
+
+      &:focus {
+        outline: solid 3px transparentize($color, .9);
+        background-color: transparentize($color, .9);
+      }
     }
   }
 }
 
-.euiLink.euilink-disabled {
-  text-decoration: none;
-  cursor: text;
-}
 

--- a/src/components/link/link.test.tsx
+++ b/src/components/link/link.test.tsx
@@ -55,6 +55,13 @@ describe('EuiLink', () => {
     expect(component).toMatchSnapshot();
   });
 
+  test('supports disabled', () => {
+    const component = render(
+      <EuiLink disabled onClick={() => 'hello, world!'} />
+    );
+    expect(component).toMatchSnapshot();
+  });
+
   test('if href is not specified, it renders a button of type=button', () => {
     const component = render(<EuiLink />);
     expect(component).toMatchSnapshot();

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -81,7 +81,6 @@ const EuiLink = React.forwardRef<
     },
     ref
   ) => {
-
     const externalLinkIcon = external ? (
       <EuiI18n token="euiLink.external.ariaLabel" default="External link">
         {(ariaLabel: string) => (

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -76,13 +76,14 @@ const EuiLink = React.forwardRef<
       rel,
       type = 'button',
       onClick,
+      disabled,
       ...rest
     },
     ref
   ) => {
     const classes = classNames(
       'euiLink',
-      colorsToClassNameMap[color],
+      disabled ? 'euilink-disabled' : colorsToClassNameMap[color],
       className
     );
 
@@ -106,6 +107,7 @@ const EuiLink = React.forwardRef<
         className: classes,
         type,
         onClick,
+        disabled,
         ...rest,
       };
 

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -81,11 +81,6 @@ const EuiLink = React.forwardRef<
     },
     ref
   ) => {
-    const classes = classNames(
-      'euiLink',
-      disabled ? 'euilink-disabled' : colorsToClassNameMap[color],
-      className
-    );
 
     const externalLinkIcon = external ? (
       <EuiI18n token="euiLink.external.ariaLabel" default="External link">
@@ -104,7 +99,11 @@ const EuiLink = React.forwardRef<
 
     if (href === undefined) {
       const buttonProps = {
-        className: classes,
+        className: classNames(
+          'euiLink',
+          disabled ? 'euiLink-disabled' : colorsToClassNameMap[color],
+          className
+        ),
         type,
         onClick,
         disabled,
@@ -121,9 +120,8 @@ const EuiLink = React.forwardRef<
     }
 
     const secureRel = getSecureRelForTarget({ href, target, rel });
-
     const anchorProps = {
-      className: classes,
+      className: classNames('euiLink', colorsToClassNameMap[color], className),
       href,
       target,
       rel: secureRel,


### PR DESCRIPTION
### Summary

Fixes #2361 

Made the EuiLink component look non-interactive when it is given the disabled prop

### Checklist

- [X] Checked in **dark mode**
- [X] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [X] Added **documentation** examples
- [x] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
