### PR TITLE
Use `EuiInnerText` in `EuiBreadcrumbs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Added new `EuiColorStops` component ([#2360](https://github.com/elastic/eui/pull/2360))
 - Added `currency` glyph to 'EuiIcon' ([#2398](https://github.com/elastic/eui/pull/2398))
 - Migrate `EuiBreadcrumbs`, `EuiHeader` etc, and `EuiLink` to TypeScript ([#2391](https://github.com/elastic/eui/pull/2391))
-- Added `hasChildLabel` prop to `EuiFormRow` to avoid duplicate labels ([#2390](https://github.com/elastic/eui/pull/2390))
+- Added `hasChildLabel` prop to `EuiFormRow` to avoid duplicate labels ([#2411](https://github.com/elastic/eui/pull/2411))
 - Added `component` prop to `EuiPageBody`, switching the default from `div` to `main` ([#2410](https://github.com/elastic/eui/pull/2410))
 - Added focus state to `EuiListGroupItem` ([#2406](https://github.com/elastic/eui/pull/2406))
 - Added `keyboardShorcut` glyph to 'EuiIcon ([#2413](https://github.com/elastic/eui/pull/2413))
@@ -12,9 +12,10 @@
 **Bug fixes**
 
 - Fixed `EuiSelectable` to accept programmatic updates to its `options` prop ([#2390](https://github.com/elastic/eui/pull/2390))
-- Fixed poor labeling in `EuiSuperDatePicker` ([#2390](https://github.com/elastic/eui/pull/2411))
-- Fixed `EuiCodeEditor`'s ID to be dynamic between renders ([#2390](https://github.com/elastic/eui/pull/2411))
-- Fixed `EuiCodeEditor` to not render multiple labels for some inputs ([#2390](https://github.com/elastic/eui/pull/2411))
+- Fixed poor labeling in `EuiSuperDatePicker` ([#2411](https://github.com/elastic/eui/pull/2411))
+- Fixed `EuiCodeEditor`'s ID to be dynamic between renders ([#2411](https://github.com/elastic/eui/pull/2411))
+- Fixed `EuiCodeEditor` to not render multiple labels for some inputs ([#2411](https://github.com/elastic/eui/pull/2411))
+- Fixed `EuiBreadcrumbs` improper use of `useInnerText` hook ([#2425](https://github.com/elastic/eui/pull/2425))
 
 ## [`14.4.0`](https://github.com/elastic/eui/tree/v14.4.0)
 

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import { CommonProps } from '../common';
 import { EuiBadge } from '../badge';
 import { EuiI18n } from '../i18n';
-import { useInnerText } from '../inner_text';
+import { EuiInnerText } from '../inner_text';
 import { EuiLink } from '../link';
 import { EuiPopover } from '../popover';
 
@@ -174,31 +174,38 @@ export const EuiBreadcrumbs: FunctionComponent<EuiBreadcrumbsProps> = ({
     });
 
     let link;
-    const [setRef, innerText] = useInnerText();
 
     if (isLastBreadcrumb && !href) {
       link = (
-        <span
-          ref={setRef}
-          className={breadcrumbClasses}
-          title={innerText}
-          aria-current="page"
-          {...breadcrumbRest}>
-          {text}
-        </span>
+        <EuiInnerText>
+          {(ref, innerText) => (
+            <span
+              ref={ref}
+              className={breadcrumbClasses}
+              title={innerText}
+              aria-current="page"
+              {...breadcrumbRest}>
+              {text}
+            </span>
+          )}
+        </EuiInnerText>
       );
     } else {
       link = (
-        <EuiLink
-          ref={setRef}
-          color={isLastBreadcrumb ? 'text' : 'subdued'}
-          onClick={onClick}
-          href={href}
-          className={breadcrumbClasses}
-          title={innerText}
-          {...breadcrumbRest}>
-          {text}
-        </EuiLink>
+        <EuiInnerText>
+          {(ref, innerText) => (
+            <EuiLink
+              ref={ref}
+              color={isLastBreadcrumb ? 'text' : 'subdued'}
+              onClick={onClick}
+              href={href}
+              className={breadcrumbClasses}
+              title={innerText}
+              {...breadcrumbRest}>
+              {text}
+            </EuiLink>
+          )}
+        </EuiInnerText>
       );
     }
 


### PR DESCRIPTION
### Summary

Fixes a React hooks [invariant violation](https://reactjs.org/warnings/invalid-hook-call-warning.html) in Kibana related to the use of `useInnerText` in `EuiBreadcrumbs`. The hook was improperly used inside of a `.map` callback, although caused no errors in the EUI docs.
The fix is to use the pass-through `EuiInnerText` component instead.

### Checklist

~~- [ ] Checked in **dark mode**~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
