### PR TITLE
remove menubar role from EuiSideNav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `14.5.0`.
+**Bug fixes**
+
+- Strip custom semantics from `EuiSideNav` ([#2429](https://github.com/elastic/eui/pull/2429))
 
 ## [`14.5.0`](https://github.com/elastic/eui/tree/v14.5.0)
 

--- a/src/components/side_nav/__snapshots__/side_nav.test.js.snap
+++ b/src/components/side_nav/__snapshots__/side_nav.test.js.snap
@@ -29,7 +29,6 @@ exports[`EuiSideNav is rendered 1`] = `
   </button>
   <div
     class="euiSideNav__content"
-    role="menubar"
   />
 </nav>
 `;
@@ -61,7 +60,6 @@ exports[`EuiSideNav props isOpenOnMobile defaults to false 1`] = `
   </button>
   <div
     class="euiSideNav__content"
-    role="menubar"
   />
 </nav>
 `;
@@ -93,7 +91,6 @@ exports[`EuiSideNav props isOpenOnMobile is rendered when specified as true 1`] 
   </button>
   <div
     class="euiSideNav__content"
-    role="menubar"
   />
 </nav>
 `;
@@ -125,13 +122,11 @@ exports[`EuiSideNav props items is rendered 1`] = `
   </button>
   <div
     class="euiSideNav__content"
-    role="menubar"
   >
     <div
       class="euiSideNavItem euiSideNavItem--root euiSideNavItem--hasChildItems"
     >
       <div
-        aria-label="[object Object]"
         class="euiSideNavItemButton"
       >
         <span
@@ -151,7 +146,6 @@ exports[`EuiSideNav props items is rendered 1`] = `
           class="euiSideNavItem euiSideNavItem--trunk"
         >
           <div
-            aria-label="[object Object]"
             class="euiSideNavItemButton"
           >
             <span
@@ -169,7 +163,6 @@ exports[`EuiSideNav props items is rendered 1`] = `
           class="euiSideNavItem euiSideNavItem--trunk"
         >
           <div
-            aria-label="[object Object]"
             class="euiSideNavItemButton"
           >
             <span
@@ -224,13 +217,11 @@ exports[`EuiSideNav props items renders items having { forceOpen: true } in open
   </button>
   <div
     class="euiSideNav__content"
-    role="menubar"
   >
     <div
       class="euiSideNavItem euiSideNavItem--root euiSideNavItem--hasChildItems"
     >
       <div
-        aria-label="[object Object]"
         class="euiSideNavItemButton"
       >
         <span
@@ -250,7 +241,6 @@ exports[`EuiSideNav props items renders items having { forceOpen: true } in open
           class="euiSideNavItem euiSideNavItem--trunk"
         >
           <div
-            aria-label="[object Object]"
             class="euiSideNavItemButton"
           >
             <span
@@ -268,7 +258,6 @@ exports[`EuiSideNav props items renders items having { forceOpen: true } in open
           class="euiSideNavItem euiSideNavItem--trunk euiSideNavItem--hasChildItems"
         >
           <div
-            aria-label="[object Object]"
             class="euiSideNavItemButton euiSideNavItemButton-isOpen"
           >
             <span
@@ -288,7 +277,6 @@ exports[`EuiSideNav props items renders items having { forceOpen: true } in open
               class="euiSideNavItem euiSideNavItem--branch euiSideNavItem--hasChildItems"
             >
               <div
-                aria-label="[object Object]"
                 class="euiSideNavItemButton euiSideNavItemButton-isOpen"
               >
                 <span
@@ -308,7 +296,6 @@ exports[`EuiSideNav props items renders items having { forceOpen: true } in open
                   class="euiSideNavItem euiSideNavItem--branch"
                 >
                   <div
-                    aria-label="[object Object]"
                     class="euiSideNavItemButton"
                   >
                     <span
@@ -359,7 +346,6 @@ exports[`EuiSideNav props items renders items using a specified callback 1`] = `
   </button>
   <div
     class="euiSideNav__content"
-    role="menubar"
   >
     <div
       class="euiSideNavItem euiSideNavItem--root euiSideNavItem--hasChildItems"
@@ -433,7 +419,6 @@ exports[`EuiSideNav props items renders items which are links 1`] = `
   </button>
   <div
     class="euiSideNav__content"
-    role="menubar"
   >
     <div
       class="euiSideNavItem euiSideNavItem--root euiSideNavItem--hasChildItems"
@@ -441,7 +426,6 @@ exports[`EuiSideNav props items renders items which are links 1`] = `
       <a
         class="euiSideNavItemButton euiSideNavItemButton--isClickable"
         href="http://www.elastic.co"
-        role="menuitem"
       >
         <span
           class="euiSideNavItemButton__content"
@@ -460,7 +444,6 @@ exports[`EuiSideNav props items renders items which are links 1`] = `
           class="euiSideNavItem euiSideNavItem--trunk"
         >
           <div
-            aria-label="[object Object]"
             class="euiSideNavItemButton"
           >
             <span
@@ -478,7 +461,6 @@ exports[`EuiSideNav props items renders items which are links 1`] = `
           class="euiSideNavItem euiSideNavItem--trunk"
         >
           <div
-            aria-label="[object Object]"
             class="euiSideNavItemButton"
           >
             <span
@@ -533,13 +515,11 @@ exports[`EuiSideNav props items renders selected item and automatically opens pa
   </button>
   <div
     class="euiSideNav__content"
-    role="menubar"
   >
     <div
       class="euiSideNavItem euiSideNavItem--root euiSideNavItem--hasChildItems"
     >
       <div
-        aria-label="[object Object]"
         class="euiSideNavItemButton"
       >
         <span
@@ -559,7 +539,6 @@ exports[`EuiSideNav props items renders selected item and automatically opens pa
           class="euiSideNavItem euiSideNavItem--trunk"
         >
           <div
-            aria-label="[object Object]"
             class="euiSideNavItemButton"
           >
             <span
@@ -577,7 +556,6 @@ exports[`EuiSideNav props items renders selected item and automatically opens pa
           class="euiSideNavItem euiSideNavItem--trunk euiSideNavItem--hasChildItems"
         >
           <div
-            aria-label="[object Object]"
             class="euiSideNavItemButton euiSideNavItemButton-isOpen"
           >
             <span
@@ -597,7 +575,6 @@ exports[`EuiSideNav props items renders selected item and automatically opens pa
               class="euiSideNavItem euiSideNavItem--branch"
             >
               <div
-                aria-label="[object Object]"
                 class="euiSideNavItemButton euiSideNavItemButton-isSelected"
               >
                 <span
@@ -615,7 +592,6 @@ exports[`EuiSideNav props items renders selected item and automatically opens pa
               class="euiSideNavItem euiSideNavItem--branch"
             >
               <div
-                aria-label="[object Object]"
                 class="euiSideNavItemButton"
               >
                 <span

--- a/src/components/side_nav/__snapshots__/side_nav_item.test.js.snap
+++ b/src/components/side_nav/__snapshots__/side_nav_item.test.js.snap
@@ -5,7 +5,6 @@ exports[`EuiSideNavItem is rendered 1`] = `
   class="euiSideNavItem"
 >
   <div
-    aria-label="[object Object]"
     class="euiSideNavItemButton"
   >
     <span
@@ -30,7 +29,6 @@ exports[`EuiSideNavItem isSelected defaults to false 1`] = `
   class="euiSideNavItem"
 >
   <div
-    aria-label="[object Object]"
     class="euiSideNavItemButton"
   >
     <span
@@ -51,7 +49,6 @@ exports[`EuiSideNavItem isSelected is rendered when specified as true 1`] = `
   class="euiSideNavItem"
 >
   <div
-    aria-label="[object Object]"
     class="euiSideNavItemButton euiSideNavItemButton-isSelected"
   >
     <span
@@ -72,7 +69,6 @@ exports[`EuiSideNavItem preserves child's classes 1`] = `
   class="euiSideNavItem"
 >
   <div
-    aria-label="[object Object]"
     class="euiSideNavItemButton"
   >
     <span

--- a/src/components/side_nav/side_nav.js
+++ b/src/components/side_nav/side_nav.js
@@ -106,9 +106,7 @@ export class EuiSideNav extends Component {
         </button>
 
         {/* Hidden from view in mobile, but toggled from the button above */}
-        <div className="euiSideNav__content" role="menubar">
-          {nav}
-        </div>
+        <div className="euiSideNav__content">{nav}</div>
       </nav>
     );
   }
@@ -160,6 +158,8 @@ EuiSideNav.propTypes = {
    * Overrides default navigation menu item rendering. When called, it should return a React node representing a replacement navigation item.
    */
   renderItem: PropTypes.func,
+
+  label: PropTypes.string,
 };
 
 EuiSideNav.defaultProps = {

--- a/src/components/side_nav/side_nav.js
+++ b/src/components/side_nav/side_nav.js
@@ -158,8 +158,6 @@ EuiSideNav.propTypes = {
    * Overrides default navigation menu item rendering. When called, it should return a React node representing a replacement navigation item.
    */
   renderItem: PropTypes.func,
-
-  label: PropTypes.string,
 };
 
 EuiSideNav.defaultProps = {

--- a/src/components/side_nav/side_nav_item.js
+++ b/src/components/side_nav/side_nav_item.js
@@ -7,12 +7,7 @@ import { EuiIcon } from '../icon';
 const defaultRenderItem = ({ href, onClick, className, children, ...rest }) => {
   if (href) {
     return (
-      <a
-        className={className}
-        href={href}
-        onClick={onClick}
-        role="menuitem"
-        {...rest}>
+      <a className={className} href={href} onClick={onClick} {...rest}>
         {children}
       </a>
     );
@@ -20,19 +15,14 @@ const defaultRenderItem = ({ href, onClick, className, children, ...rest }) => {
 
   if (onClick) {
     return (
-      <button
-        type="button"
-        className={className}
-        onClick={onClick}
-        role="menuitem"
-        {...rest}>
+      <button type="button" className={className} onClick={onClick} {...rest}>
         {children}
       </button>
     );
   }
 
   return (
-    <div className={className} aria-label={children} {...rest}>
+    <div className={className} {...rest}>
       {children}
     </div>
   );


### PR DESCRIPTION
### Summary

`EuiSideNav` was making a promise that it couldn't keep. (Metaphor explainer: a custom `role` is a promise that developer is making to the assistive tech on how something will work.) Better to ship a simpler structure that's not broken but could be better rather than ship broken semantics.

`EuiSideNav` can still be improved but this is a small, quick PR to make it just a bit better.

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
