### PR TITLE
Export missing type definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `14.5.0`.
+**Bug fixes**
+
+- Fixed missing misc. button and link type definition exports ([#2434](https://github.com/elastic/eui/pull/2434))
 
 ## [`14.5.0`](https://github.com/elastic/eui/tree/v14.5.0)
 

--- a/src/components/button/button_empty/button_empty.tsx
+++ b/src/components/button/button_empty/button_empty.tsx
@@ -42,6 +42,8 @@ const iconSideToClassNameMap = {
   right: 'euiButtonEmpty--iconRight',
 };
 
+export type EuiButtonEmptySizes = keyof typeof sizeToClassNameMap;
+
 export const ICON_SIDES = keysOf(iconSideToClassNameMap);
 
 const flushTypeToClassNameMap = {
@@ -55,7 +57,7 @@ interface CommonEuiButtonEmptyProps extends CommonProps {
   iconType?: IconType;
   iconSide?: keyof typeof iconSideToClassNameMap;
   color?: EuiButtonEmptyColor;
-  size?: keyof typeof sizeToClassNameMap;
+  size?: EuiButtonEmptySizes;
   flush?: keyof typeof flushTypeToClassNameMap;
   isDisabled?: boolean;
   href?: string;

--- a/src/components/button/button_empty/button_empty.tsx
+++ b/src/components/button/button_empty/button_empty.tsx
@@ -11,6 +11,7 @@ import {
 import { EuiLoadingSpinner } from '../../loading';
 import { getSecureRelForTarget } from '../../../services';
 import { IconType, EuiIcon } from '../../icon';
+import { ButtonIconSide } from '../button';
 
 export type EuiButtonEmptyColor =
   | 'primary'
@@ -37,12 +38,12 @@ const sizeToClassNameMap = {
 
 export const SIZES = keysOf(sizeToClassNameMap);
 
-const iconSideToClassNameMap = {
+export type EuiButtonEmptySizes = keyof typeof sizeToClassNameMap;
+
+const iconSideToClassNameMap: { [side in ButtonIconSide]: string } = {
   left: '',
   right: 'euiButtonEmpty--iconRight',
 };
-
-export type EuiButtonEmptySizes = keyof typeof sizeToClassNameMap;
 
 export const ICON_SIDES = keysOf(iconSideToClassNameMap);
 
@@ -55,7 +56,7 @@ export const FLUSH_TYPES = keysOf(flushTypeToClassNameMap);
 
 interface CommonEuiButtonEmptyProps extends CommonProps {
   iconType?: IconType;
-  iconSide?: keyof typeof iconSideToClassNameMap;
+  iconSide?: ButtonIconSide;
   color?: EuiButtonEmptyColor;
   size?: EuiButtonEmptySizes;
   flush?: keyof typeof flushTypeToClassNameMap;

--- a/src/components/button/button_empty/index.ts
+++ b/src/components/button/button_empty/index.ts
@@ -2,6 +2,7 @@ export {
   COLORS,
   ICON_SIDES,
   EuiButtonEmpty,
-  EuiButtonEmptyProps,
   EuiButtonEmptyColor,
+  EuiButtonEmptyProps,
+  EuiButtonEmptySizes,
 } from './button_empty';

--- a/src/components/button/button_group/button_group.tsx
+++ b/src/components/button/button_group/button_group.tsx
@@ -7,7 +7,7 @@ import { ToggleType } from '../../toggle';
 import { EuiButtonToggle } from '../button_toggle';
 import { Omit, CommonProps } from '../../common';
 
-import { ButtonColor } from '../button';
+import { ButtonColor, ButtonIconSide } from '../button';
 import { IconType } from '../../icon';
 
 export interface EuiButtonGroupIdToSelectedMap {
@@ -22,7 +22,7 @@ export interface EuiButtonGroupOption extends CommonProps {
   name?: string;
   isDisabled?: boolean;
   value?: any;
-  iconSide?: 'left' | 'right';
+  iconSide?: ButtonIconSide;
   iconType?: IconType;
 }
 

--- a/src/components/button/button_icon/button_icon.tsx
+++ b/src/components/button/button_icon/button_icon.tsx
@@ -19,7 +19,7 @@ import { IconType, IconSize, EuiIcon } from '../../icon';
 
 import { ButtonSize } from '../button';
 
-export type ButtonIconColor =
+export type EuiButtonIconColor =
   | 'danger'
   | 'disabled'
   | 'ghost'
@@ -31,7 +31,7 @@ export type ButtonIconColor =
 
 export interface EuiButtonIconProps extends CommonProps {
   iconType?: IconType;
-  color?: ButtonIconColor;
+  color?: EuiButtonIconColor;
   'aria-label'?: string;
   'aria-labelledby'?: string;
   isDisabled?: boolean;
@@ -58,7 +58,7 @@ type Props = ExclusiveUnion<
   EuiButtonIconPropsForButton
 >;
 
-const colorToClassNameMap: { [color in ButtonIconColor]: string } = {
+const colorToClassNameMap: { [color in EuiButtonIconColor]: string } = {
   danger: 'euiButtonIcon--danger',
   disabled: 'euiButtonIcon--disabled',
   ghost: 'euiButtonIcon--ghost',

--- a/src/components/button/button_icon/index.ts
+++ b/src/components/button/button_icon/index.ts
@@ -1,5 +1,6 @@
 export {
   EuiButtonIcon,
+  EuiButtonIconColor,
   EuiButtonIconProps,
   EuiButtonIconPropsForButton,
 } from './button_icon';

--- a/src/components/button/index.ts
+++ b/src/components/button/index.ts
@@ -1,6 +1,16 @@
-export { COLORS, ButtonColor, EuiButton, EuiButtonProps } from './button';
+export {
+  COLORS,
+  ButtonColor,
+  ButtonSize,
+  EuiButton,
+  EuiButtonProps,
+} from './button';
 
-export { EuiButtonEmpty, EuiButtonEmptyProps } from './button_empty';
+export {
+  EuiButtonEmpty,
+  EuiButtonEmptyColor,
+  EuiButtonEmptyProps,
+} from './button_empty';
 
 export {
   EuiButtonIcon,

--- a/src/components/button/index.ts
+++ b/src/components/button/index.ts
@@ -2,6 +2,7 @@ export {
   COLORS,
   ButtonColor,
   ButtonSize,
+  ButtonIconSide,
   EuiButton,
   EuiButtonProps,
 } from './button';
@@ -10,10 +11,12 @@ export {
   EuiButtonEmpty,
   EuiButtonEmptyColor,
   EuiButtonEmptyProps,
+  EuiButtonEmptySizes,
 } from './button_empty';
 
 export {
   EuiButtonIcon,
+  EuiButtonIconColor,
   EuiButtonIconProps,
   EuiButtonIconPropsForButton,
 } from './button_icon';

--- a/src/components/link/index.ts
+++ b/src/components/link/index.ts
@@ -1,6 +1,8 @@
 export {
   EuiLink,
+  EuiLinkColor,
   EuiLinkProps,
+  EuiLinkType,
   EuiLinkAnchorProps,
   EuiLinkButtonProps,
 } from './link';

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -9,8 +9,8 @@ import classNames from 'classnames';
 import { CommonProps, ExclusiveUnion, keysOf } from '../common';
 import { getSecureRelForTarget } from '../../services';
 
-type EuiLinkType = 'button' | 'reset' | 'submit';
-type EuiLinkColor =
+export type EuiLinkType = 'button' | 'reset' | 'submit';
+export type EuiLinkColor =
   | 'primary'
   | 'subdued'
   | 'secondary'


### PR DESCRIPTION
### Summary

Exports formerly exported types:

* `ButtonSize`
* `ButtonIconSide`
* `EmptyButtonColor` (now `EuiEmptyButtonColor`)
* `EmptyButtonSizes` (now `EuiEmptyButtonSizes`)
* `ButtonIconColor` (now `EuiButtonIconColor`)
* `EuiLinkColor`
* `EuiLinkType`

### Checklist

~~- [ ] Checked in **dark mode**~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
