### PR TITLE
[DATA GRID] EuiGridToolBar toolbar is now configurable through props

### DIFF
--- a/src-docs/src/views/datagrid/datagrid.js
+++ b/src-docs/src/views/datagrid/datagrid.js
@@ -238,6 +238,10 @@ export default () => {
         renderCellValue={renderCellValue}
         {...inMemoryProps}
         sorting={{ columns: sortingColumns, onSort }}
+        toolbarDisplay={{
+          showFullscrenSelector: false,
+          showSortSelector: true,
+        }}
         pagination={{
           ...pagination,
           pageSizeOptions: [10, 25, 50, 100],

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -178,6 +178,7 @@ Array [
     >
       <div
         class="euiDataGrid__controls"
+        data-test-sub="euiDataGrid__controls"
       >
         <div
           class="euiPopover euiPopover--anchorDownLeft"
@@ -245,6 +246,7 @@ Array [
         </div>
         <button
           class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiDataGrid__controlBtn testClass1 testClass2"
+          data-test-subj="euiDataGrid__showFullScrenButton"
           type="button"
         >
           <span
@@ -705,6 +707,7 @@ Array [
     >
       <div
         class="euiDataGrid__controls"
+        data-test-sub="euiDataGrid__controls"
       >
         <div
           class="euiPopover euiPopover--anchorDownLeft"
@@ -772,6 +775,7 @@ Array [
         </div>
         <button
           class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiDataGrid__controlBtn testClass1 testClass2"
+          data-test-subj="euiDataGrid__showFullScrenButton"
           type="button"
         >
           <span

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -178,7 +178,7 @@ Array [
     >
       <div
         class="euiDataGrid__controls"
-        data-test-sub="euiDataGrid__controls"
+        data-test-sub="dataGridControls"
       >
         <div
           class="euiPopover euiPopover--anchorDownLeft"
@@ -189,6 +189,7 @@ Array [
           >
             <button
               class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiDataGrid__controlBtn"
+              data-test-subj="dataGridColumnSelectorButton"
               type="button"
             >
               <span
@@ -221,6 +222,7 @@ Array [
           >
             <button
               class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiDataGrid__controlBtn"
+              data-test-subj="dataGridStyleSelectorButton"
               type="button"
             >
               <span
@@ -246,7 +248,7 @@ Array [
         </div>
         <button
           class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiDataGrid__controlBtn testClass1 testClass2"
-          data-test-subj="euiDataGrid__showFullScrenButton"
+          data-test-subj="dataGridFullScrenButton"
           type="button"
         >
           <span
@@ -707,7 +709,7 @@ Array [
     >
       <div
         class="euiDataGrid__controls"
-        data-test-sub="euiDataGrid__controls"
+        data-test-sub="dataGridControls"
       >
         <div
           class="euiPopover euiPopover--anchorDownLeft"
@@ -718,6 +720,7 @@ Array [
           >
             <button
               class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiDataGrid__controlBtn"
+              data-test-subj="dataGridColumnSelectorButton"
               type="button"
             >
               <span
@@ -750,6 +753,7 @@ Array [
           >
             <button
               class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiDataGrid__controlBtn"
+              data-test-subj="dataGridStyleSelectorButton"
               type="button"
             >
               <span
@@ -775,7 +779,7 @@ Array [
         </div>
         <button
           class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiDataGrid__controlBtn testClass1 testClass2"
-          data-test-subj="euiDataGrid__showFullScrenButton"
+          data-test-subj="dataGridFullScrenButton"
           type="button"
         >
           <span

--- a/src/components/datagrid/column_selector.tsx
+++ b/src/components/datagrid/column_selector.tsx
@@ -93,6 +93,7 @@ export const useColumnSelector = (
               iconType="eyeClosed"
               color="text"
               className={controlBtnClasses}
+              data-test-subj="dataGridColumnSelectorButton"
               onClick={() => setIsOpen(!isOpen)}>
               {numberOfHiddenFields > 0
                 ? `${numberOfHiddenFields} ${buttonActive}`

--- a/src/components/datagrid/column_sorting.tsx
+++ b/src/components/datagrid/column_sorting.tsx
@@ -112,6 +112,7 @@ export const useColumnSorting = (
               iconType="sortable"
               color="text"
               className={controlBtnClasses}
+              data-test-subj="dataGridColumnSortingButton"
               onClick={() => setIsOpen(!isOpen)}>
               {numberOfSortedFields > 0
                 ? `${numberOfSortedFields} ${buttonActive}`

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -630,9 +630,7 @@ Array [
       );
 
       // The toolbar should not show
-      expect(
-        component.find('div[data-test-subj="dataGridControls"]').length
-      ).toBe(0);
+      expect(findTestSubject(component, 'dataGridControls').length).toBe(0);
 
       // Check for false / true and unset values
       component.setProps({
@@ -644,31 +642,23 @@ Array [
       });
 
       // fullscreen selector
-      expect(
-        component.find(
-          'EuiButtonEmpty[data-test-subj="dataGridFullScrenButton"]'
-        ).length
-      ).toBe(0);
+      expect(findTestSubject(component, 'dataGridFullScrenButton').length).toBe(
+        0
+      );
 
       // sort selector
       expect(
-        component.find(
-          'EuiButtonEmpty[data-test-subj="dataGridColumnSortingButton"]'
-        ).length
+        findTestSubject(component, 'dataGridColumnSortingButton').length
       ).toBe(0);
 
       // style selector
       expect(
-        component.find(
-          'EuiButtonEmpty[data-test-subj="dataGridStyleSelectorButton"]'
-        ).length
+        findTestSubject(component, 'dataGridStyleSelectorButton').length
       ).toBe(1);
 
       // column selector
       expect(
-        component.find(
-          'EuiButtonEmpty[data-test-subj="dataGridColumnSelectorButton"]'
-        ).length
+        findTestSubject(component, 'dataGridColumnSelectorButton').length
       ).toBe(1);
     });
 

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -614,6 +614,49 @@ Array [
       ).toBe(2);
     });
 
+    it('can hide the toolbar', () => {
+      const component = mount(
+        <EuiDataGrid
+          {...requiredProps}
+          columns={[{ id: 'A' }, { id: 'B' }]}
+          columnVisibility={{
+            visibleColumns: ['A', 'B'],
+            setVisibleColumns: () => {},
+          }}
+          toolbarDisplay={false}
+          rowCount={1}
+          renderCellValue={() => 'value'}
+        />
+      );
+
+      // no columns are sorted, expect no aria-sort or aria-describedby attributes
+      expect(
+        component.find('[data-test-subj="euiDataGrid__controls"]').length
+      ).toBe(0);
+    });
+
+    it('can hide the full screen button', () => {
+      const component = mount(
+        <EuiDataGrid
+          {...requiredProps}
+          columns={[{ id: 'A' }, { id: 'B' }]}
+          columnVisibility={{
+            visibleColumns: ['A', 'B'],
+            setVisibleColumns: () => {},
+          }}
+          toolbarDisplay={{ showFullscrenSelector: false }}
+          rowCount={1}
+          renderCellValue={() => 'value'}
+        />
+      );
+
+      // no columns are sorted, expect no aria-sort or aria-describedby attributes
+      expect(
+        component.find('[data-test-subj="euiDataGrid__showFullScrenButton"]')
+          .length
+      ).toBe(0);
+    });
+
     describe('schema datatype classnames', () => {
       it('applies classnames from explicit datatypes', () => {
         const component = mount(

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -630,9 +630,9 @@ Array [
       );
 
       // The toolbar should not show
-      expect(component.find('[data-test-subj="dataGridControls"]').length).toBe(
-        0
-      );
+      expect(
+        component.find('div[data-test-subj="dataGridControls"]').length
+      ).toBe(0);
 
       // Check for false / true and unset values
       component.setProps({

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -629,32 +629,47 @@ Array [
         />
       );
 
-      // no columns are sorted, expect no aria-sort or aria-describedby attributes
-      expect(
-        component.find('[data-test-subj="euiDataGrid__controls"]').length
-      ).toBe(0);
-    });
-
-    it('can hide the full screen button', () => {
-      const component = mount(
-        <EuiDataGrid
-          {...requiredProps}
-          columns={[{ id: 'A' }, { id: 'B' }]}
-          columnVisibility={{
-            visibleColumns: ['A', 'B'],
-            setVisibleColumns: () => {},
-          }}
-          toolbarDisplay={{ showFullscrenSelector: false }}
-          rowCount={1}
-          renderCellValue={() => 'value'}
-        />
+      // The toolbar should not show
+      expect(component.find('[data-test-subj="dataGridControls"]').length).toBe(
+        0
       );
 
-      // no columns are sorted, expect no aria-sort or aria-describedby attributes
+      // Check for false / true and unset values
+      component.setProps({
+        toolbarDisplay: {
+          showFullscrenSelector: false,
+          showSortSelector: false,
+          showStyleSelector: true,
+        },
+      });
+
+      // fullscreen selector
       expect(
-        component.find('[data-test-subj="euiDataGrid__showFullScrenButton"]')
-          .length
+        component.find(
+          'EuiButtonEmpty[data-test-subj="dataGridFullScrenButton"]'
+        ).length
       ).toBe(0);
+
+      // sort selector
+      expect(
+        component.find(
+          'EuiButtonEmpty[data-test-subj="dataGridColumnSortingButton"]'
+        ).length
+      ).toBe(0);
+
+      // style selector
+      expect(
+        component.find(
+          'EuiButtonEmpty[data-test-subj="dataGridStyleSelectorButton"]'
+        ).length
+      ).toBe(1);
+
+      // column selector
+      expect(
+        component.find(
+          'EuiButtonEmpty[data-test-subj="dataGridColumnSelectorButton"]'
+        ).length
+      ).toBe(1);
     });
 
     describe('schema datatype classnames', () => {

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -495,7 +495,7 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
           iconType="fullScreen"
           color="text"
           className={controlBtnClasses}
-          data-test-subj="euiDataGrid__showFullScrenButton"
+          data-test-subj="dataGridFullScrenButton"
           onClick={() => setIsFullScreen(!isFullScreen)}>
           {isFullScreen ? fullScreenButtonActive : fullScreenButton}
         </EuiButtonEmpty>
@@ -512,7 +512,7 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
         {showToolbar ? (
           <div
             className="euiDataGrid__controls"
-            data-test-sub="euiDataGrid__controls">
+            data-test-sub="dataGridControls">
             {hasRoomForGridControls ? gridControls : null}
             {checkOrDefaultToolBarDiplayOptions(
               toolbarDisplay,

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -42,7 +42,7 @@ export interface EuiDataGridTooBarDisplayOptions {
 
 // ideally this would use a generic to enforce `pageSize` exists in `pageSizeOptions`,
 // but TypeScript's default understanding of an array is number[] unless `as const` is used
-// whickh defeats the generic's purpose & functionality as it would check for `number` in `number[]`
+// which defeats the generic's purpose & functionality as it would check for `number` in `number[]`
 export interface EuiDataGridPaginationProps {
   pageIndex: number;
   pageSize: number;

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -33,9 +33,16 @@ export interface EuiDataGridStyle {
   cellPadding?: EuiDataGridStyleCellPaddings;
 }
 
+export interface EuiDataGridTooBarDisplayOptions {
+  showColumnSelector?: boolean;
+  showStyleSelector?: boolean;
+  showSortSelector?: boolean;
+  showFullscrenSelector?: boolean;
+}
+
 // ideally this would use a generic to enforce `pageSize` exists in `pageSizeOptions`,
 // but TypeScript's default understanding of an array is number[] unless `as const` is used
-// which defeats the generic's purpose & functionality as it would check for `number` in `number[]`
+// whickh defeats the generic's purpose & functionality as it would check for `number` in `number[]`
 export interface EuiDataGridPaginationProps {
   pageIndex: number;
   pageSize: number;

--- a/src/components/datagrid/style_selector.tsx
+++ b/src/components/datagrid/style_selector.tsx
@@ -69,6 +69,7 @@ export const useStyleSelector = (
           iconType="tableDensityExpanded"
           className="euiDataGrid__controlBtn"
           color="text"
+          data-test-subj="dataGridStyleSelectorButton"
           onClick={() => setIsOpen(!isOpen)}>
           <EuiI18n token="euiStyleSelector.buttonText" default="Density" />
         </EuiButtonEmpty>


### PR DESCRIPTION
### Summary

Allows you to turn the toolbar on and off through a prop `toolbarDisplay`

`toolbarDiplay` can either take a boolean or object.
* If passed false, the entire toolbar does not show
* if passed an object, you can individually pass each toolbar control a false value to turn it off

I also changed some naming in here to be a little more clean. Tests added for turning the toolbar off and for turning one of the buttons off (which I think it good enough for the whole set)

### To test

Adjust `toolbarDisplay` options. I added some to `datagrid.js` for now, but I'll refactor this in my docs PR to be better.

### Checklist

- ~[ ] Checked in **dark mode**~
- [ ] ~Checked in **mobile**~
- [ ] ~Checked in **IE11** and **Firefox**~
- [ ] ~Props have proper **autodocs**~
- [x] Added **documentation** examples
- [x] Added or updated **jest tests**
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] ~A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
