### PR TITLE
[Draft] Memoize EuiIcon

### DIFF
--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -3,7 +3,7 @@ import React, {
   HTMLAttributes,
   ReactElement,
   SVGAttributes,
-  memo,
+  // memo,
 } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -445,7 +445,7 @@ function getInitialIcon(icon: EuiIconProps['type']) {
   return icon;
 }
 
-class RawEuiIcon extends Component<EuiIconProps, State> {
+export class EuiIcon extends Component<EuiIconProps, State> {
   isMounted = true;
   constructor(props: EuiIconProps) {
     super(props);
@@ -582,6 +582,6 @@ class RawEuiIcon extends Component<EuiIconProps, State> {
   }
 }
 
-export const EuiIcon = memo(RawEuiIcon);
+// export const EuiIcon = memo(RawEuiIcon);
 
-export type EuiIcon = RawEuiIcon;
+// export type EuiIcon = RawEuiIcon;

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -3,6 +3,7 @@ import React, {
   HTMLAttributes,
   ReactElement,
   SVGAttributes,
+  memo,
 } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -444,7 +445,7 @@ function getInitialIcon(icon: EuiIconProps['type']) {
   return icon;
 }
 
-export class EuiIcon extends Component<EuiIconProps, State> {
+class RawEuiIcon extends Component<EuiIconProps, State> {
   isMounted = true;
   constructor(props: EuiIconProps) {
     super(props);
@@ -580,3 +581,7 @@ export class EuiIcon extends Component<EuiIconProps, State> {
     }
   }
 }
+
+export const EuiIcon = memo(RawEuiIcon);
+
+export type EuiIcon = RawEuiIcon;


### PR DESCRIPTION
### Summary

Memoize EuiIcon. The icon is relatively expensive to render, and in a Kibana app (Lens), icon rendering had noticeable performance implications. Memoizing the icons went a long way towards alleviating our performance issues, so I thought it made sense to do the memoization in eui itself.

### Checklist

- [ ] Checked in **dark mode**
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
