### PR TITLE
Removed duplicate propType

### DIFF
--- a/src-docs/src/views/form_controls/display_toggles.js
+++ b/src-docs/src/views/form_controls/display_toggles.js
@@ -204,7 +204,6 @@ DisplayToggles.propTypes = {
   canLoading: PropTypes.bool,
   canCompressed: PropTypes.bool,
   canFullWidth: PropTypes.bool,
-  canFullWidth: PropTypes.bool,
   canPrepend: PropTypes.bool,
   canAppend: PropTypes.bool,
   canInvalid: PropTypes.bool,


### PR DESCRIPTION
### Summary

Removed canFullWidth propType duplicate

### Checklist

- [x] Checked in **dark mode**
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [x] Props have proper **autodocs**
- [x] Added **documentation** examples
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
