### PR TITLE
Fix variable naming error in testing.md doc

### DIFF
--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -68,7 +68,7 @@ describe('YourComponent', () => {
       });
 
       test('is called when the button is clicked', () => {
-        const onCloseHandler = sinon.stub();
+        const onClickHandler = sinon.stub();
 
         const component = mount(
           <YourComponent onClick={onClickHandler} />
@@ -77,7 +77,7 @@ describe('YourComponent', () => {
         // NOTE: This is the only way to find this button.
         component.find('button').simulate('click');
 
-        sinon.assert.calledOnce(onCloseHandler);
+        sinon.assert.calledOnce(onClickHandler);
       });
     });
   });


### PR DESCRIPTION
### Summary

A test contained a variable named "onCloseHandler", however the component below tried to use "onClickHandler". Renamed variable to "onClickHandler" to better match the purpose of the test and fix this error.

### Checklist

- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
