### PR TITLE
Added horizontal scroll mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Added disabled state to `EuiBadge` ([#2440](https://github.com/elastic/eui/pull/2440))
 - Changed `EuiLink` to appear non interactive when passed the `disabled` prop and an `onClick` handler ([#2423](https://github.com/elastic/eui/pull/2423))
 - Added `minimize` glyph to `EuiIcon` ([#2457](https://github.com/elastic/eui/pull/2457))
-- Added `euiXScrollWithShadows()` mixin and `.euiXScrollWithShadows` utility class ([#2458](https://github.com/elastic/eui/pull/2458))
+- Added `euiXScrollWithShadows()` mixin and `.eui-xScrollWithShadows` utility class ([#2458](https://github.com/elastic/eui/pull/2458))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Added disabled state to `EuiBadge` ([#2440](https://github.com/elastic/eui/pull/2440))
 - Changed `EuiLink` to appear non interactive when passed the `disabled` prop and an `onClick` handler ([#2423](https://github.com/elastic/eui/pull/2423))
 - Added `minimize` glyph to `EuiIcon` ([#2457](https://github.com/elastic/eui/pull/2457))
+- Added `euiXScrollWithShadows()` mixin and `.euiXScrollWithShadows` utility class ([#2458](https://github.com/elastic/eui/pull/2458))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Added `euiXScrollWithShadows()` mixin and `.eui-xScrollWithShadows` utility class ([#2458](https://github.com/elastic/eui/pull/2458))
+
 **Bug fixes**
 
 - Normalized button `moz-focus-inner` ([#2445](https://github.com/elastic/eui/pull/2445))
@@ -35,7 +37,6 @@
 - Added disabled state to `EuiBadge` ([#2440](https://github.com/elastic/eui/pull/2440))
 - Changed `EuiLink` to appear non interactive when passed the `disabled` prop and an `onClick` handler ([#2423](https://github.com/elastic/eui/pull/2423))
 - Added `minimize` glyph to `EuiIcon` ([#2457](https://github.com/elastic/eui/pull/2457))
-- Added `euiXScrollWithShadows()` mixin and `.eui-xScrollWithShadows` utility class ([#2458](https://github.com/elastic/eui/pull/2458))
 
 **Bug fixes**
 

--- a/src-docs/src/views/guidelines/index.scss
+++ b/src-docs/src/views/guidelines/index.scss
@@ -160,13 +160,22 @@
 
 .guideSass__overflowShadows {
   overflow-y: hidden;
-  margin-top: $euiSize;
-  border: 1px solid $euiColorLightestShade;
   height: 200px;
 
   .guideSass__overflowShadowText {
     @include euiYScrollWithShadows;
-    padding: $euiSize;
+    padding: $euiSizeS;
+  }
+}
+
+.guideSass__overflowShadowsX {
+  @include euiXScrollWithShadows;
+  padding-top: $euiSizeS;
+  padding-left: $euiSizeS;
+  padding-right: $euiSizeS;
+
+  .guideSass__overflowShadowTextX {
+    width: 150%;
   }
 }
 

--- a/src-docs/src/views/guidelines/index.scss
+++ b/src-docs/src/views/guidelines/index.scss
@@ -170,9 +170,7 @@
 
 .guideSass__overflowShadowsX {
   @include euiXScrollWithShadows;
-  padding-top: $euiSizeS;
-  padding-left: $euiSizeS;
-  padding-right: $euiSizeS;
+  padding: $euiSizeS $euiSizeS 0;
 
   .guideSass__overflowShadowTextX {
     width: 150%;

--- a/src-docs/src/views/guidelines/sass.js
+++ b/src-docs/src/views/guidelines/sass.js
@@ -22,6 +22,7 @@ import {
   EuiCode,
   EuiCodeBlock,
   EuiCallOut,
+  EuiPanel,
 } from '../../../../src/components';
 
 const euiColors = [
@@ -737,62 +738,6 @@ export const SassGuidelines = ({ selectedTheme }) => {
           {euiShadows.map(function(shadow, index) {
             return renderShadow(shadow, index);
           })}
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiTitle size="s">
-            <h4>Shadows to create graceful overflows</h4>
-          </EuiTitle>
-
-          <EuiText>
-            <p>
-              Primarily used in modals and flyouts, the overflow shadow masks
-              the top and bottom edges to indicate there is more content
-              below/above.
-            </p>
-          </EuiText>
-
-          <EuiSpacer />
-
-          <div className="guideSass__overflowShadows">
-            <EuiText className="guideSass__overflowShadowText" size="s">
-              <p>
-                It requires a wrapping element to control the height with{' '}
-                <EuiCode>overflow-y: hidden;</EuiCode> and the content to
-                <EuiCode>@include euiYScrollWithShadows;</EuiCode> or use the{' '}
-                <Link to="/utilities/css-utility-classes">
-                  CSS utility class
-                </Link>{' '}
-                <EuiCode>.eui-yScrollWithShadows</EuiCode>.
-              </p>
-              <p>
-                <b>Example:</b>
-              </p>
-              <EuiCodeBlock language="sass" isCopyable paddingSize="s">
-                {`.bodyContent {
-  height: 200px;
-  overflow-y: hidden;
-
-  .bodyContent__overflow {
-    @include euiYScrollWithShadows;
-  }
-}`}
-              </EuiCodeBlock>
-              <p>
-                Consequuntur atque nulla atque nemo tenetur numquam. Assumenda
-                aspernatur qui aut sit. Aliquam doloribus iure sint id. Possimus
-                dolor qui soluta cum id tempore ea illum. Facilis voluptatem aut
-                aut ut similique ut. Sed repellendus commodi iure officiis
-                exercitationem praesentium dolor. Ratione non ut nulla accusamus
-                et. Optio laboriosam id incidunt. Ipsam voluptate ab quia
-                necessitatibus sequi earum voluptate. Porro tempore et veritatis
-                quo omnis. Eaque ut libero tempore sit placeat maxime
-                laudantium. Mollitia tempore minus qui autem modi adipisci ad.
-                Iste reprehenderit accusamus voluptatem velit. Quidem delectus
-                eos veritatis et vitae et nisi. Doloribus ut corrupti voluptates
-                qui exercitationem dolores.
-              </p>
-            </EuiText>
-          </div>
 
           <EuiSpacer />
 
@@ -814,6 +759,103 @@ export const SassGuidelines = ({ selectedTheme }) => {
               @include euiBottomShadowLarge(desaturate($euiColorPrimary, 30%));
             </EuiCodeBlock>
           </div>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiTitle size="s">
+            <h4>Shadows to create graceful overflows</h4>
+          </EuiTitle>
+
+          <EuiText>
+            <p>
+              Primarily used in modals and flyouts, the overflow shadow masks
+              the edges to indicate there is more content.
+            </p>
+          </EuiText>
+
+          <EuiSpacer />
+
+          <EuiTitle size="xs">
+            <h5>
+              Vertical scrolling with <EuiCode>euiYScrollWithShadows</EuiCode>
+            </h5>
+          </EuiTitle>
+
+          <EuiSpacer size="s" />
+
+          <EuiPanel paddingSize="none" grow={false}>
+            <div className="guideSass__overflowShadows">
+              <EuiText className="guideSass__overflowShadowText" size="s">
+                <p>
+                  It requires a wrapping element to control the height with{' '}
+                  <EuiCode>overflow-y: hidden;</EuiCode> and the content to
+                  <EuiCode>@include euiYScrollWithShadows;</EuiCode> or use the{' '}
+                  <Link to="/utilities/css-utility-classes">
+                    CSS utility class
+                  </Link>{' '}
+                  <EuiCode>.euiYScrollWithShadows</EuiCode>.
+                </p>
+                <p>
+                  <b>Example:</b>
+                </p>
+                <EuiCodeBlock language="sass" isCopyable paddingSize="s">
+                  {`.overflowY {
+  height: 200px;
+  overflow-y: hidden;
+
+  .overflowY__content {
+    @include euiYScrollWithShadows;
+  }
+}`}
+                </EuiCodeBlock>
+                <p>
+                  Consequuntur atque nulla atque nemo tenetur numquam. Assumenda
+                  aspernatur qui aut sit. Aliquam doloribus iure sint id.
+                  Possimus dolor qui soluta cum id tempore ea illum. Facilis
+                  voluptatem aut aut ut similique ut. Sed repellendus commodi
+                  iure officiis exercitationem praesentium dolor. Ratione non ut
+                  nulla accusamus et. Optio laboriosam id incidunt. Ipsam
+                  voluptate ab quia necessitatibus sequi earum voluptate. Porro
+                  tempore et veritatis quo omnis. Eaque ut libero tempore sit
+                  placeat maxime laudantium. Mollitia tempore minus qui autem
+                  modi adipisci ad. Iste reprehenderit accusamus voluptatem
+                  velit. Quidem delectus eos veritatis et vitae et nisi.
+                  Doloribus ut corrupti voluptates qui exercitationem dolores.
+                </p>
+              </EuiText>
+            </div>
+          </EuiPanel>
+
+          <EuiSpacer />
+
+          <EuiTitle size="xs">
+            <h5>
+              Horizontal scrolling with <EuiCode>euiXScrollWithShadows</EuiCode>
+            </h5>
+          </EuiTitle>
+
+          <EuiSpacer size="s" />
+
+          <EuiPanel paddingSize="none" grow={false}>
+            <div className="guideSass__overflowShadowsX">
+              <EuiText className="guideSass__overflowShadowTextX" size="s">
+                <p>
+                  You may want to add at least <EuiCode>$euiSizeS</EuiCode>
+                  &apos;s worth of padding to the sides of your content so the
+                  mask doesn&apos;t overlay it.
+                </p>
+                <p>
+                  <b>Example:</b>
+                </p>
+                <EuiCodeBlock language="sass" isCopyable paddingSize="s">
+                  {`.overflowXContent {
+  @include euiXScrollWithShadows;
+  padding-left: $euiSizeS;
+  padding-right: $euiSizeS;
+}`}
+                </EuiCodeBlock>
+              </EuiText>
+            </div>
+          </EuiPanel>
         </EuiFlexItem>
       </EuiFlexGrid>
 

--- a/src-docs/src/views/guidelines/sass.js
+++ b/src-docs/src/views/guidelines/sass.js
@@ -792,7 +792,7 @@ export const SassGuidelines = ({ selectedTheme }) => {
                   <Link to="/utilities/css-utility-classes">
                     CSS utility class
                   </Link>{' '}
-                  <EuiCode>.euiYScrollWithShadows</EuiCode>.
+                  <EuiCode>.eui-yScrollWithShadows</EuiCode>.
                 </p>
                 <p>
                   <b>Example:</b>

--- a/src-docs/src/views/utility_classes/utility_classes.js
+++ b/src-docs/src/views/utility_classes/utility_classes.js
@@ -106,35 +106,51 @@ export default () => (
 
     <h4>Overflows</h4>
 
-    <div className="guideSass__overflowShadows">
-      <EuiText className="guideSass__overflowShadowText" size="s">
+    <div
+      style={{
+        height: 180,
+        overflowY: 'hidden',
+        background: wrappingExampleStyle.background,
+      }}>
+      <EuiText
+        className="euiYScrollWithShadows"
+        size="s"
+        style={{ padding: wrappingExampleStyle.padding }}>
         <p>
-          It requires a wrapping element to control the height with{' '}
-          <EuiCode>overflow-y: hidden;</EuiCode> and the content to use the CSS
-          utility class <EuiCode>.eui-yScrollWithShadows</EuiCode>.
+          The vertical utility requires a wrapping element to control the height
+          with <EuiCode>overflow-y: hidden;</EuiCode> and the content to use the
+          CSS utility class <EuiCode>.euiYScrollWithShadows</EuiCode>.
         </p>
         <p>
           <b>Example:</b>
         </p>
         <EuiCodeBlock language="html" isCopyable paddingSize="s">
           {`<BodyContent style={{ height: 200, overflowY: 'hidden' }}>
-  <BodyScroll className="eui-yScrollWithShadows" />
+  <BodyScroll className="euiYScrollWithShadows" />
 </BodyContent>`}
         </EuiCodeBlock>
-        <p>
-          Consequuntur atque nulla atque nemo tenetur numquam. Assumenda
-          aspernatur qui aut sit. Aliquam doloribus iure sint id. Possimus dolor
-          qui soluta cum id tempore ea illum. Facilis voluptatem aut aut ut
-          similique ut. Sed repellendus commodi iure officiis exercitationem
-          praesentium dolor. Ratione non ut nulla accusamus et. Optio laboriosam
-          id incidunt. Ipsam voluptate ab quia necessitatibus sequi earum
-          voluptate. Porro tempore et veritatis quo omnis. Eaque ut libero
-          tempore sit placeat maxime laudantium. Mollitia tempore minus qui
-          autem modi adipisci ad. Iste reprehenderit accusamus voluptatem velit.
-          Quidem delectus eos veritatis et vitae et nisi. Doloribus ut corrupti
-          voluptates qui exercitationem dolores.
-        </p>
       </EuiText>
+    </div>
+
+    <EuiSpacer />
+
+    <div
+      style={{
+        ...wrappingExampleStyle,
+        padding: 0,
+      }}>
+      <div
+        className="euiXScrollWithShadows"
+        style={{ padding: wrappingExampleStyle.padding }}>
+        <EuiText size="s" style={{ width: '150%' }}>
+          <p>
+            When using the horizontal utility{' '}
+            <EuiCode>.euiXScrollWithShadows</EuiCode>, you may want to add
+            padding to the sides of your content so the mask doesn&apos;t
+            overlay it.
+          </p>
+        </EuiText>
+      </div>
     </div>
 
     <EuiSpacer />

--- a/src-docs/src/views/utility_classes/utility_classes.js
+++ b/src-docs/src/views/utility_classes/utility_classes.js
@@ -113,20 +113,20 @@ export default () => (
         background: wrappingExampleStyle.background,
       }}>
       <EuiText
-        className="euiYScrollWithShadows"
+        className="eui-yScrollWithShadows"
         size="s"
         style={{ padding: wrappingExampleStyle.padding }}>
         <p>
           The vertical utility requires a wrapping element to control the height
           with <EuiCode>overflow-y: hidden;</EuiCode> and the content to use the
-          CSS utility class <EuiCode>.euiYScrollWithShadows</EuiCode>.
+          CSS utility class <EuiCode>.eui-yScrollWithShadows</EuiCode>.
         </p>
         <p>
           <b>Example:</b>
         </p>
         <EuiCodeBlock language="html" isCopyable paddingSize="s">
           {`<BodyContent style={{ height: 200, overflowY: 'hidden' }}>
-  <BodyScroll className="euiYScrollWithShadows" />
+  <BodyScroll className="eui-yScrollWithShadows" />
 </BodyContent>`}
         </EuiCodeBlock>
       </EuiText>
@@ -140,12 +140,12 @@ export default () => (
         padding: 0,
       }}>
       <div
-        className="euiXScrollWithShadows"
+        className="eui-xScrollWithShadows"
         style={{ padding: wrappingExampleStyle.padding }}>
         <EuiText size="s" style={{ width: '150%' }}>
           <p>
             When using the horizontal utility{' '}
-            <EuiCode>.euiXScrollWithShadows</EuiCode>, you may want to add
+            <EuiCode>.eui-xScrollWithShadows</EuiCode>, you may want to add
             padding to the sides of your content so the mask doesn&apos;t
             overlay it.
           </p>

--- a/src/global_styling/mixins/_helpers.scss
+++ b/src/global_styling/mixins/_helpers.scss
@@ -56,10 +56,16 @@
 
 // The full overflow shadow plus scrollbars
 @mixin euiYScrollWithShadows {
-  @include euiOverflowShadow;
   @include euiScrollBar;
+  @include euiOverflowShadow('y');
   height: 100%;
   overflow-y: auto;
+}
+
+@mixin euiXScrollWithShadows {
+  @include euiScrollBar;
+  @include euiOverflowShadow('x');
+  overflow-x: auto;
 }
 
 // Hiding elements offscreen to only be read by screen reader

--- a/src/global_styling/mixins/_shadow.scss
+++ b/src/global_styling/mixins/_shadow.scss
@@ -89,9 +89,9 @@
 @mixin euiOverflowShadow($direction: 'y') {
   $hideHeight: $euiScrollBarCorner * 1.25;
   $gradient: transparentize(red, .9) 0%,
-            transparentize(red, 0) $hideHeight,
-            transparentize(red, 0) calc(100% - #{$hideHeight}),
-            transparentize(red, .9) 100%;
+             transparentize(red, 0) $hideHeight,
+             transparentize(red, 0) calc(100% - #{$hideHeight}),
+             transparentize(red, .9) 100%;
 
   @if ($direction == 'y') {
     mask-image: linear-gradient(to bottom, #{$gradient});

--- a/src/global_styling/mixins/_shadow.scss
+++ b/src/global_styling/mixins/_shadow.scss
@@ -1,7 +1,7 @@
 // This file uses RGBA literal values responsibly
 // This file uses off-pattern indedentation to be more readible
 
-// sass-lint:disable no-color-literals, no-color-keywords, indentation
+// sass-lint:disable no-color-literals, no-color-keywords, indentation, quotes
 
 @mixin euiSlightShadow($color: $euiShadowColor, $opacity: .3) {
   box-shadow: 0 2px 2px -1px rgba($color, $opacity);
@@ -86,12 +86,18 @@
   @include euiSlightShadowHover($color, $opacity);
 }
 
-@mixin euiOverflowShadow {
+@mixin euiOverflowShadow($direction: 'y') {
   $hideHeight: $euiScrollBarCorner * 1.25;
-    mask-image: linear-gradient(to bottom,
-                  transparentize(red, .9) 0%,
-                  transparentize(red, 0) $hideHeight,
-                  transparentize(red, 0) calc(100% - #{$hideHeight}),
-                  transparentize(red, .9) 100%
-                );
+  $gradient: transparentize(red, .9) 0%,
+            transparentize(red, 0) $hideHeight,
+            transparentize(red, 0) calc(100% - #{$hideHeight}),
+            transparentize(red, .9) 100%;
+
+  @if ($direction == 'y') {
+    mask-image: linear-gradient(to bottom, #{$gradient});
+  } @else if ($direction == 'x') {
+    mask-image: linear-gradient(to right, #{$gradient});
+  } @else {
+    @warn "euiOverflowShadow() expects direction to be 'y' or 'x' but got '#{$direction}'";
+  }
 }

--- a/src/global_styling/utility/_utility.scss
+++ b/src/global_styling/utility/_utility.scss
@@ -90,3 +90,7 @@
 .euiYScrollWithShadows {
   @include euiYScrollWithShadows;
 }
+
+.euiXScrollWithShadows {
+  @include euiXScrollWithShadows;
+}

--- a/src/global_styling/utility/_utility.scss
+++ b/src/global_styling/utility/_utility.scss
@@ -87,10 +87,15 @@
 /**
   * Overflow scrolling
   */
-.euiYScrollWithShadows {
+.eui-yScrollWithShadows {
   @include euiYScrollWithShadows;
 }
 
-.euiXScrollWithShadows {
+.eui-xScrollWithShadows {
   @include euiXScrollWithShadows;
+}
+
+// TODO: 10/22 DEPRECATE in favor of the correctly formatted class .eui-yScrollWithShadows
+.euiYScrollWithShadows {
+  @include euiYScrollWithShadows;
 }


### PR DESCRIPTION
### Fixes #2215

This new mixin `euiXScrollWithShadows` and utility class `.euiXScrollWithShadows` compliment the already existing mixin `euiYScrollWithShadows` and utility class `.euiYScrollWithShadows`.

<img width="506" alt="Screen Shot 2019-10-21 at 16 46 29 PM" src="https://user-images.githubusercontent.com/549577/67242067-bdafef00-f422-11e9-93a8-3f4fcd45aa8e.png">

<img width="975" alt="Screen Shot 2019-10-21 at 16 44 32 PM" src="https://user-images.githubusercontent.com/549577/67242078-c30d3980-f422-11e9-992b-ba8b3f9ae769.png">

### Checklist

- [x] Checked in **dark mode**
- [x] Checked in **mobile**
- [x] Checked in ~**IE11**~ and **Firefox** (IE doesn't support masks, and we're ok with no fallback)
- ~[ ] Props have proper **autodocs**~
- [x] Added **documentation** examples
- ~[ ] Added or updated **jest tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
