### PR TITLE
Fix EuiNavDrawer collapse/expand button height issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 **Bug fixes**
 
 - Reenabled `width` property for `EuiTable` cell components ([#2452](https://github.com/elastic/eui/pull/2452))
+- Fixed `EuiNavDrawer` collapse/expand button height issue
+ ([#2463](https://github.com/elastic/eui/pull/2463))
 
 ## [`14.6.0`](https://github.com/elastic/eui/tree/v14.6.0)
 

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -37,8 +37,8 @@
       padding: $euiSizeM $euiSize;
     }
 
-    &:focus-within .navDrawerExpandButton-isCollapsed {
-      background-color: tintOrShade($euiColorLightestShade, 0%, 30%);
+    .navDrawerExpandButton-isCollapsed .euiListGroupItem__button {
+      max-width: 100%;
     }
   }
 

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -33,12 +33,12 @@
     transition: width $euiAnimSpeedExtraFast;
     z-index: $euiZHeader + 1;
 
-    .navDrawerExpandButton-isExpanded .euiListGroupItem__button {
+    .euiListGroupItem__button {
       padding: $euiSizeM $euiSize;
     }
 
-    .navDrawerExpandButton-isCollapsed .euiListGroupItem__button {
-      max-width: $euiSizeXL;
+    &:focus-within .navDrawerExpandButton-isCollapsed {
+      background-color: tintOrShade($euiColorLightestShade, 0%, 30%);
     }
   }
 

--- a/src/components/nav_drawer/nav_drawer.js
+++ b/src/components/nav_drawer/nav_drawer.js
@@ -229,7 +229,7 @@ export class EuiNavDrawer extends Component {
     let footerContent;
     if (showExpandButton) {
       footerContent = (
-        <EuiListGroup className="euiNavDrawer__expandButton">
+        <EuiListGroup className="euiNavDrawer__expandButton" flush>
           <EuiI18n
             tokens={[
               'euiNavDrawer.sideNavCollapse',
@@ -336,8 +336,8 @@ export class EuiNavDrawer extends Component {
                 onClick={this.handleDrawerMenuClick}>
                 {/* Put expand button first so it's first in tab order then on toggle starts the tabbing of the items from the top */}
                 {/* TODO: Add a "skip navigation" keyboard only button */}
-                {modifiedChildren}
                 {footerContent}
+                {modifiedChildren}
               </div>
             </EuiFlexItem>
             {flyoutContent}


### PR DESCRIPTION
### Summary

I reverted some changes introduced in #2417 and ended up with the original situation (i.e. a collapse/expand button with a weird focus behaviour). However, I think I've found a way to fix this using the `:focus-within` selector.

This is the behaviour now:

![newNawDrawer](https://user-images.githubusercontent.com/4016496/67249603-2cf80400-f460-11e9-9712-469414282016.gif)


Fixes #2456 

Note: I moved `footerContent` back to its original position (above `modifiedChildren`) as I had missed a comment we have explaining why we need to have it before `modifiedChildren`.

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
- [ ] Checked in **IE11** and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [X] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
