### PR TITLE
Fixed console warning for disabled EuiBadge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `14.8.0`.
+**Bug fixes**
+
+* Fixed console warning in `EuiBadge`'s docs ([#2486](https://github.com/elastic/eui/pull/2486))
 
 ## [`14.8.0`](https://github.com/elastic/eui/tree/v14.8.0)
 

--- a/src-docs/src/views/badge/badge.js
+++ b/src-docs/src/views/badge/badge.js
@@ -16,17 +16,15 @@ const badges = [
   'danger',
   '#000',
   '#fea27f',
-  'disabled',
+  '0000FF',
 ];
 
 export default () => (
   <EuiFlexGroup wrap responsive={false} gutterSize="xs" style={{ width: 300 }}>
     {badges.map(badge => (
       <EuiFlexItem grow={false} key={badge}>
-        <EuiBadge
-          isDisabled={badge === 'disabled' ? true : false}
-          color={badge}>
-          {badge}
+        <EuiBadge isDisabled={badge === '0000FF' ? true : false} color={badge}>
+          {badge === '0000FF' ? 'disabled' : badge}
         </EuiBadge>
       </EuiFlexItem>
     ))}


### PR DESCRIPTION
### Summary

This removes a console warning that appears because we're passing "disabled" as a color in the docs for `EuiBadge` (introduced in #2440). I picked a random color to be the disabled badge. Let me know if you'd prefer to turn one of the existing colors into the disabled one. 

![image](https://user-images.githubusercontent.com/4016496/67510456-e5a28b00-f68c-11e9-8733-caaa248203a0.png)

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
