### PR TITLE
Fix overflowHeight in EuiCodeBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Normalized button `moz-focus-inner` ([#2445](https://github.com/elastic/eui/pull/2445))
+- Fixed `overflowHeight` in `EuiCodeBlock` ([#2487](https://github.com/elastic/eui/pull/2487))
 
 ## [`14.8.0`](https://github.com/elastic/eui/tree/v14.8.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 **Bug fixes**
 
 - Normalized button `moz-focus-inner` ([#2445](https://github.com/elastic/eui/pull/2445))
-- Fixed `overflowHeight` in `EuiCodeBlock` ([#2487](https://github.com/elastic/eui/pull/2487))
+- Changed `EuiCodeBlock` so that `overflowHeight` now applies a `maxHeight` instead of a `height` on the block ([#2487](https://github.com/elastic/eui/pull/2487))
 
 ## [`14.8.0`](https://github.com/elastic/eui/tree/v14.8.0)
 

--- a/src/components/code/_code_block.js
+++ b/src/components/code/_code_block.js
@@ -128,11 +128,9 @@ export class EuiCodeBlockImpl extends Component {
     const codeClasses = classNames('euiCodeBlock__code', language);
 
     const optionalStyles = {};
-    const preOptionalStyles = {};
 
     if (overflowHeight) {
       optionalStyles.maxHeight = overflowHeight;
-      preOptionalStyles.maxHeight = overflowHeight;
     }
 
     const codeSnippet = (
@@ -257,7 +255,7 @@ export class EuiCodeBlockImpl extends Component {
 
     return (
       <div {...wrapperProps}>
-        <pre style={preOptionalStyles} className="euiCodeBlock__pre">
+        <pre style={optionalStyles} className="euiCodeBlock__pre">
           {codeSnippet}
         </pre>
 

--- a/src/components/code/_code_block.js
+++ b/src/components/code/_code_block.js
@@ -128,9 +128,11 @@ export class EuiCodeBlockImpl extends Component {
     const codeClasses = classNames('euiCodeBlock__code', language);
 
     const optionalStyles = {};
+    const preOptionalStyles = {};
 
     if (overflowHeight) {
-      optionalStyles.height = overflowHeight;
+      optionalStyles.maxHeight = overflowHeight;
+      preOptionalStyles.maxHeight = overflowHeight;
     }
 
     const codeSnippet = (
@@ -255,7 +257,9 @@ export class EuiCodeBlockImpl extends Component {
 
     return (
       <div {...wrapperProps}>
-        <pre className="euiCodeBlock__pre">{codeSnippet}</pre>
+        <pre style={preOptionalStyles} className="euiCodeBlock__pre">
+          {codeSnippet}
+        </pre>
 
         {/*
           If the below fullScreen code renders, it actually attaches to the body because of


### PR DESCRIPTION
### Summary

Fixing issue where `EuiCodeBlock` always expands to given `overflowHeight` even when content does not require it. Fixes #2435

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
- [x] Checked in **IE11** and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
