### PR TITLE
Fix `aira-modal` typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Normalized button `moz-focus-inner` ([#2445](https://github.com/elastic/eui/pull/2445))
+- Fixed typo to correct `aria-modal` attribute in`EuiPopover` ([#2488](https://github.com/elastic/eui/pull/2488))
 
 ## [`14.8.0`](https://github.com/elastic/eui/tree/v14.8.0)
 

--- a/src/components/form/super_select/__snapshots__/super_select.test.js.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.js.snap
@@ -179,9 +179,9 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aira-modal="true"
         aria-describedby="htmlId"
         aria-live="assertive"
+        aria-modal="true"
         class="euiPanel euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
         role="dialog"
         style="top: 8px; left: -22px; z-index: 2000;"
@@ -389,9 +389,9 @@ exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aira-modal="true"
         aria-describedby="htmlId"
         aria-live="assertive"
+        aria-modal="true"
         class="euiPanel euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
         role="dialog"
         style="top: 8px; left: -22px; z-index: 2000;"
@@ -763,9 +763,9 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                             data-focus-lock-disabled="disabled"
                           >
                             <div
-                              aira-modal="true"
                               aria-describedby="htmlId"
                               aria-live="assertive"
+                              aria-modal="true"
                               class="euiPanel euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
                               role="dialog"
                               style="top: 8px; left: -22px; z-index: 2000;"
@@ -855,9 +855,9 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                               data-focus-lock-disabled="disabled"
                             >
                               <div
-                                aira-modal="true"
                                 aria-describedby="htmlId"
                                 aria-live="assertive"
+                                aria-modal="true"
                                 class="euiPanel euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
                                 role="dialog"
                                 style="top: 8px; left: -22px; z-index: 2000;"
@@ -941,9 +941,9 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                         />
                       </SideEffect(FocusWatcher)>
                       <EuiPanel
-                        aira-modal="true"
                         aria-describedby="htmlId"
                         aria-live="assertive"
+                        aria-modal="true"
                         className="euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
                         paddingSize="none"
                         panelRef={[Function]}
@@ -957,9 +957,9 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
                         }
                       >
                         <div
-                          aira-modal="true"
                           aria-describedby="htmlId"
                           aria-live="assertive"
+                          aria-modal="true"
                           className="euiPanel euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
                           role="dialog"
                           style={
@@ -1222,9 +1222,9 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aira-modal="true"
         aria-describedby="htmlId"
         aria-live="assertive"
+        aria-modal="true"
         class="euiPanel euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
         role="dialog"
         style="top: 8px; left: -22px; z-index: 2000;"

--- a/src/components/popover/__snapshots__/popover.test.tsx.snap
+++ b/src/components/popover/__snapshots__/popover.test.tsx.snap
@@ -132,9 +132,9 @@ exports[`EuiPopover props isOpen renders true 1`] = `
         data-focus-lock-disabled="disabled"
       >
         <div
-          aira-modal="true"
           aria-describedby="htmlId"
           aria-live="assertive"
+          aria-modal="true"
           class="euiPanel euiPanel--paddingMedium euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
           role="dialog"
           style="top: 16px; left: -22px; z-index: 2000;"
@@ -182,9 +182,9 @@ exports[`EuiPopover props ownFocus defaults to false 1`] = `
         data-focus-lock-disabled="disabled"
       >
         <div
-          aira-modal="true"
           aria-describedby="htmlId"
           aria-live="assertive"
+          aria-modal="true"
           class="euiPanel euiPanel--paddingMedium euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
           role="dialog"
           style="top: 16px; left: -22px; z-index: 2000;"
@@ -232,9 +232,9 @@ exports[`EuiPopover props ownFocus renders true 1`] = `
         data-focus-lock-disabled="false"
       >
         <div
-          aira-modal="true"
           aria-describedby="htmlId"
           aria-live="off"
+          aria-modal="true"
           class="euiPanel euiPanel--paddingMedium euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
           data-autofocus="true"
           role="dialog"
@@ -290,9 +290,9 @@ exports[`EuiPopover props panelClassName is rendered 1`] = `
         data-focus-lock-disabled="disabled"
       >
         <div
-          aira-modal="true"
           aria-describedby="htmlId"
           aria-live="assertive"
+          aria-modal="true"
           class="euiPanel euiPanel--paddingMedium euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen test"
           role="dialog"
           style="top: 16px; left: -22px; z-index: 2000;"
@@ -340,9 +340,9 @@ exports[`EuiPopover props panelPaddingSize is rendered 1`] = `
         data-focus-lock-disabled="disabled"
       >
         <div
-          aira-modal="true"
           aria-describedby="htmlId"
           aria-live="assertive"
+          aria-modal="true"
           class="euiPanel euiPanel--paddingSmall euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
           role="dialog"
           style="top: 16px; left: -22px; z-index: 2000;"

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -642,7 +642,7 @@ export class EuiPopover extends Component<Props, State> {
               tabIndex={tabIndex}
               aria-live={ariaLive}
               role="dialog"
-              aira-modal="true"
+              aria-modal="true"
               aria-describedby={descriptionId}
               style={this.state.popoverStyles}>
               <div className={arrowClassNames} style={this.state.arrowStyles} />


### PR DESCRIPTION
### Summary

An a11y addition to `EuiPopover` during datagrid work had a small typo 😄 

### Checklist

~~- [ ] Checked in **dark mode**~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
