### PR TITLE
use correct source to color stops range examples

### DIFF
--- a/src-docs/src/views/color_picker/color_picker_example.js
+++ b/src-docs/src/views/color_picker/color_picker_example.js
@@ -54,7 +54,7 @@ const colorStopsSnippetFixed = `<EuiColorStops
 `;
 
 import { ColorStopsRange } from './color_stops_range';
-const colorStopsRangeSource = require('!!raw-loader!./color_stops');
+const colorStopsRangeSource = require('!!raw-loader!./color_stops_range');
 const colorStopsRangeHtml = renderToHtml(ColorStopsRange);
 const colorPickerRangeSnippet = `<EuiColorStops
   label="Free-range color stops"


### PR DESCRIPTION
`Free-range color stops` docs load the wrong source so `Demo JS` does not contain the correct code that is being used in the examples.

This PR just loads the correct source code for the docs