### PR TITLE
[EuiColorStops] ignore empty values when getting range max and min

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added new `euiTreeView` component for rendering recursive objects such as folder structures. ([#2409](https://github.com/elastic/eui/pull/2409))
 - Added `euiXScrollWithShadows()` mixin and `.eui-xScrollWithShadows` utility class ([#2458](https://github.com/elastic/eui/pull/2458))
+- Fixed `EuiColorStops` where empty string values would cause range min or max to be NaN ()
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Added new `euiTreeView` component for rendering recursive objects such as folder structures. ([#2409](https://github.com/elastic/eui/pull/2409))
 - Added `euiXScrollWithShadows()` mixin and `.eui-xScrollWithShadows` utility class ([#2458](https://github.com/elastic/eui/pull/2458))
-- Fixed `EuiColorStops` where empty string values would cause range min or max to be NaN ()
+- Fixed `EuiColorStops` where empty string values would cause range min or max to be NaN ([#2496](https://github.com/elastic/eui/pull/2496))
 
 **Bug fixes**
 

--- a/src/components/color_picker/color_stops/color_stops.tsx
+++ b/src/components/color_picker/color_stops/color_stops.tsx
@@ -63,7 +63,7 @@ function sortStops(colorStops: ColorStop[]) {
 }
 
 function getValidStops(colorStops: ColorStop[]) {
-  return colorStops.map(el => el.stop).filter(stop => !isNaN(stop));
+  return colorStops.map(el => el.stop).filter(stop => stop !== '');
 }
 
 function getRangeMin(colorStops: ColorStop[], min?: number) {

--- a/src/components/color_picker/color_stops/color_stops.tsx
+++ b/src/components/color_picker/color_stops/color_stops.tsx
@@ -62,9 +62,13 @@ function sortStops(colorStops: ColorStop[]) {
     .sort((a, b) => a.stop - b.stop);
 }
 
+function getValidStops(colorStops: ColorStop[]) {
+  return colorStops.map(el => el.stop).filter(stop => !isNaN(stop));
+}
+
 function getRangeMin(colorStops: ColorStop[], min?: number) {
   const rangeMin = min || DEFAULT_MIN;
-  const stops = colorStops.map(el => el.stop);
+  const stops = getValidStops(colorStops);
   const first = Math.min.apply(Math, stops); // https://johnresig.com/blog/fast-javascript-maxmin/
 
   if (first < rangeMin) {
@@ -78,7 +82,7 @@ function getRangeMin(colorStops: ColorStop[], min?: number) {
 }
 function getRangeMax(colorStops: ColorStop[], max?: number) {
   const rangeMax = max || DEFAULT_MAX;
-  const stops = colorStops.map(el => el.stop);
+  const stops = getValidStops(colorStops);
   const last = Math.max.apply(Math, stops); // https://johnresig.com/blog/fast-javascript-maxmin/
 
   if (last > rangeMax) {

--- a/src/components/color_picker/color_stops/color_stops.tsx
+++ b/src/components/color_picker/color_stops/color_stops.tsx
@@ -63,7 +63,7 @@ function sortStops(colorStops: ColorStop[]) {
 }
 
 function getValidStops(colorStops: ColorStop[]) {
-  return colorStops.map(el => el.stop).filter(stop => stop !== '');
+  return colorStops.map(el => el.stop).filter(stop => !isNaN(stop));
 }
 
 function getRangeMin(colorStops: ColorStop[], min?: number) {


### PR DESCRIPTION

<img width="200" alt="Screen Shot 2019-10-28 at 12 30 45 PM" src="https://user-images.githubusercontent.com/373691/67707355-ee8ea780-f97f-11e9-98e7-458886571dc9.png">

Notice when the input is an empty string and then the markers are all messed up. This is because `getRangeMin` and `getRangeMax` do not handle empty string values and can return `NaN`.

<img width="200" alt="Screen Shot 2019-10-28 at 12 30 52 PM" src="https://user-images.githubusercontent.com/373691/67707374-f3ebf200-f97f-11e9-850d-7e67ff8b529d.png">

