### PR TITLE
Upgrade typescript 3.3.3 -> 3.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 - Simplified `EuiColorStops` popover toggling ([#2505](https://github.com/elastic/eui/pull/2505))
 
+**Breaking changes**
+
+- Updated minimum TypeScript version to 3.5.3 ([#2510](https://github.com/elastic/eui/pull/2510))
+- Removed `Omit` type in favor of TypeScript's built-in ([#2510](https://github.com/elastic/eui/pull/2510))
+
 ## [`14.9.0`](https://github.com/elastic/eui/tree/v14.9.0)
 
 - Added new `euiTreeView` component for rendering recursive objects such as folder structures. ([#2409](https://github.com/elastic/eui/pull/2409))

--- a/package.json
+++ b/package.json
@@ -88,8 +88,8 @@
     "@types/resize-observer-browser": "^0.1.1",
     "@types/tabbable": "^3.1.0",
     "@types/uuid": "^3.4.4",
-    "@typescript-eslint/eslint-plugin": "^1.9.0",
-    "@typescript-eslint/parser": "^1.9.0",
+    "@typescript-eslint/eslint-plugin": "^1.13.0",
+    "@typescript-eslint/parser": "^1.13.0",
     "autoprefixer": "^7.1.5",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
@@ -175,7 +175,7 @@
     "sinon": "^4.4.8",
     "start-server-and-test": "^1.1.4",
     "style-loader": "^0.19.0",
-    "typescript": "^3.3.3",
+    "typescript": "3.5.3",
     "uglifyjs-webpack-plugin": "^2.0.1",
     "url-loader": "^1.0.1",
     "wdio-chromedriver-service": "^0.1.2",
@@ -199,6 +199,6 @@
     "prop-types": "^15.5.0",
     "react": "^16.8",
     "react-dom": "^16.8",
-    "typescript": "^3.3.3"
+    "typescript": "^3.5.3"
   }
 }

--- a/src/components/accessibility/keyboard_accessible.test.tsx
+++ b/src/components/accessibility/keyboard_accessible.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/tabindex-no-positive */
 import React from 'react';
 import { render, shallow } from 'enzyme';
 
@@ -145,10 +146,7 @@ describe('EuiKeyboardAccessible', () => {
     test('tabindex', () => {
       const $button = render(
         <EuiKeyboardAccessible>
-          <div
-            onClick={noop}
-            tabIndex={1} // eslint-disable-line jsx-a11y/tabindex-no-positive
-          />
+          <div onClick={noop} tabIndex={1} />
         </EuiKeyboardAccessible>
       );
 

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -5,7 +5,7 @@ import React, {
   ReactNode,
 } from 'react';
 import classNames from 'classnames';
-import { CommonProps, ExclusiveUnion, keysOf, PropsOf, Omit } from '../common';
+import { CommonProps, ExclusiveUnion, keysOf, PropsOf } from '../common';
 
 import { isColorDark, hexToRgb } from '../../services/color';
 import { EuiInnerText } from '../inner_text';

--- a/src/components/badge/notification_badge/badge_notification.tsx
+++ b/src/components/badge/notification_badge/badge_notification.tsx
@@ -1,6 +1,6 @@
 import React, { HTMLAttributes, ReactNode, FunctionComponent } from 'react';
 import classNames from 'classnames';
-import { CommonProps, Omit, keysOf } from '../../common';
+import { CommonProps, keysOf } from '../../common';
 
 const colorToClassMap: { [color: string]: string | null } = {
   accent: null,

--- a/src/components/button/button_group/button_group.tsx
+++ b/src/components/button/button_group/button_group.tsx
@@ -5,7 +5,7 @@ import { EuiScreenReaderOnly } from '../../accessibility';
 import { ToggleType } from '../../toggle';
 
 import { EuiButtonToggle } from '../button_toggle';
-import { Omit, CommonProps } from '../../common';
+import { CommonProps } from '../../common';
 
 import { ButtonColor, ButtonIconSide } from '../button';
 import { IconType } from '../../icon';

--- a/src/components/button/button_toggle/button_toggle.tsx
+++ b/src/components/button/button_toggle/button_toggle.tsx
@@ -8,7 +8,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { ExclusiveUnion, Omit } from '../../common';
+import { ExclusiveUnion } from '../../common';
 import { EuiToggle, ToggleType } from '../../toggle';
 import { EuiButton, EuiButtonProps } from '../button';
 import { useRenderToText } from '../../inner_text/render_to_text';

--- a/src/components/call_out/call_out.tsx
+++ b/src/components/call_out/call_out.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent, HTMLAttributes, ReactNode } from 'react';
 
 import classNames from 'classnames';
 
-import { CommonProps, Omit, keysOf } from '../common';
+import { CommonProps, keysOf } from '../common';
 import { IconType, EuiIcon } from '../icon';
 
 import { EuiText } from '../text';

--- a/src/components/color_picker/color_picker.tsx
+++ b/src/components/color_picker/color_picker.tsx
@@ -10,7 +10,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { CommonProps, Omit } from '../common';
+import { CommonProps } from '../common';
 
 import { EuiScreenReaderOnly } from '../accessibility';
 import { EuiColorPickerSwatch } from './color_picker_swatch';

--- a/src/components/color_picker/color_picker_swatch.tsx
+++ b/src/components/color_picker/color_picker_swatch.tsx
@@ -1,7 +1,7 @@
 import React, { ButtonHTMLAttributes, forwardRef } from 'react';
 import classNames from 'classnames';
 
-import { CommonProps, Omit } from '../common';
+import { CommonProps } from '../common';
 
 export type EuiColorPickerSwatchProps = CommonProps &
   Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'color'> & {

--- a/src/components/color_picker/hue.tsx
+++ b/src/components/color_picker/hue.tsx
@@ -4,7 +4,7 @@ import React, {
   FunctionComponent,
 } from 'react';
 import classNames from 'classnames';
-import { CommonProps, Omit } from '../common';
+import { CommonProps } from '../common';
 
 import { EuiScreenReaderOnly } from '../accessibility';
 import { EuiI18n } from '../i18n';

--- a/src/components/color_picker/saturation.tsx
+++ b/src/components/color_picker/saturation.tsx
@@ -8,7 +8,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { CommonProps, Omit } from '../common';
+import { CommonProps } from '../common';
 import { keyCodes } from '../../services';
 import { HSV } from '../../services/color';
 import { isNil } from '../../services/predicate';

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -2,6 +2,7 @@
  * Elements within EuiComboBox which would normally be tabbable (inputs, buttons) have been removed
  * from the tab order with tabindex="-1" so that we can control the keyboard navigation interface.
  */
+/* eslint-disable jsx-a11y/role-has-required-aria-props */
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
@@ -745,7 +746,7 @@ export class EuiComboBox extends Component {
         onKeyDown={this.onKeyDown}
         ref={this.comboBoxRef}
         data-test-subj={dataTestSubj}
-        role="combobox" // eslint-disable-line jsx-a11y/role-has-required-aria-props
+        role="combobox"
         aria-haspopup="listbox"
         aria-expanded={isListOpen}>
         <EuiComboBoxInput

--- a/src/components/combo_box/index.d.ts
+++ b/src/components/combo_box/index.d.ts
@@ -13,7 +13,7 @@ import {
   EuiComboBoxOptionsListProps,
   EuiComboBoxProps,
 } from '@elastic/eui'; // eslint-disable-line import/no-unresolved
-import { RefCallback, CommonProps, Omit } from '../common';
+import { RefCallback, CommonProps } from '../common';
 import { EuiPanelProps } from '../panel/panel';
 
 declare module '@elastic/eui' {

--- a/src/components/common.ts
+++ b/src/components/common.ts
@@ -21,8 +21,6 @@ export type RefCallback<Element extends HTMLElement | null> = (
 
 // utility types:
 
-export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
-
 /**
  * Wraps Object.keys with proper typescript definition of the resulting array
  */

--- a/src/components/context_menu/context_menu.tsx
+++ b/src/components/context_menu/context_menu.tsx
@@ -6,7 +6,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { CommonProps, Omit } from '../common';
+import { CommonProps } from '../common';
 import {
   EuiContextMenuPanel,
   EuiContextMenuPanelTransitionDirection,

--- a/src/components/context_menu/context_menu_item.tsx
+++ b/src/components/context_menu/context_menu_item.tsx
@@ -9,7 +9,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { CommonProps, keysOf, Omit } from '../common';
+import { CommonProps, keysOf } from '../common';
 import { EuiIcon } from '../icon';
 import { EuiToolTip, ToolTipPositions } from '../tool_tip';
 

--- a/src/components/context_menu/context_menu_panel.tsx
+++ b/src/components/context_menu/context_menu_panel.tsx
@@ -8,7 +8,7 @@ import React, {
 import classNames from 'classnames';
 import tabbable from 'tabbable';
 
-import { CommonProps, NoArgCallback, Omit } from '../common';
+import { CommonProps, NoArgCallback } from '../common';
 import { EuiIcon } from '../icon';
 import { EuiPopoverTitle } from '../popover';
 import { EuiResizeObserver } from '../observer/resize_observer';

--- a/src/components/control_bar/control_bar.tsx
+++ b/src/components/control_bar/control_bar.tsx
@@ -8,7 +8,6 @@ import classNames from 'classnames';
 import {
   CommonProps,
   ExclusiveUnion,
-  Omit,
   PropsForAnchor,
   PropsForButton,
 } from '../common';

--- a/src/components/copy/copy.tsx
+++ b/src/components/copy/copy.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, ReactNode } from 'react';
-import { CommonProps, Omit } from '../common';
+import { CommonProps } from '../common';
 import { copyToClipboard } from '../../services';
 import { EuiToolTip, EuiToolTipProps } from '../tool_tip';
 

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -210,11 +210,11 @@ function sortByColumn(
     );
     expect(sortButton.length).toBe(1);
     act(() =>
-      // @ts-ignore-next-line
-      sortButton
-        .parents('EuiButtonGroup')
-        .props()
-        .onChange(undefined, direction)
+      sortButton.parents('EuiButtonGroup').props().onChange!(
+        undefined,
+        // @ts-ignore TS wants to use react's onChange definition instead of the EuiButtonGroup one
+        direction
+      )
     );
   }
 

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -13,7 +13,7 @@ import classNames from 'classnames';
 import tabbable from 'tabbable';
 import { EuiI18n } from '../i18n';
 import { EuiDataGridHeaderRow } from './data_grid_header_row';
-import { CommonProps, Omit } from '../common';
+import { CommonProps } from '../common';
 import {
   EuiDataGridColumn,
   EuiDataGridColumnWidths,

--- a/src/components/datagrid/data_grid_cell.tsx
+++ b/src/components/datagrid/data_grid_cell.tsx
@@ -12,7 +12,7 @@ import React, {
 import classNames from 'classnames';
 import tabbable from 'tabbable';
 import { EuiPopover } from '../popover';
-import { CommonProps, Omit } from '../common';
+import { CommonProps } from '../common';
 import { EuiScreenReaderOnly } from '../accessibility';
 import { EuiI18n } from '../i18n';
 import { EuiButtonIcon } from '../button';

--- a/src/components/datagrid/data_grid_header_row.tsx
+++ b/src/components/datagrid/data_grid_header_row.tsx
@@ -13,7 +13,7 @@ import {
   EuiDataGridColumn,
   EuiDataGridSorting,
 } from './data_grid_types';
-import { CommonProps, Omit } from '../common';
+import { CommonProps } from '../common';
 import { EuiDataGridColumnResizer } from './data_grid_column_resizer';
 import { htmlIdGenerator } from '../../services/accessibility';
 import { EuiScreenReaderOnly } from '../accessibility';

--- a/src/components/drag_and_drop/draggable.tsx
+++ b/src/components/drag_and_drop/draggable.tsx
@@ -8,7 +8,7 @@ import React, {
 } from 'react';
 import { Draggable, DraggableProps } from 'react-beautiful-dnd';
 import classNames from 'classnames';
-import { CommonProps, Omit } from '../common';
+import { CommonProps } from '../common';
 import { EuiDroppableContext } from './droppable';
 
 const spacingToClassNameMap = {

--- a/src/components/drag_and_drop/droppable.tsx
+++ b/src/components/drag_and_drop/droppable.tsx
@@ -6,7 +6,7 @@ import React, {
 } from 'react';
 import { Droppable, DroppableProps } from 'react-beautiful-dnd';
 import classNames from 'classnames';
-import { CommonProps, Omit } from '../common';
+import { CommonProps } from '../common';
 import { EuiDragDropContextContext } from './drag_drop_context';
 
 const spacingToClassNameMap = {

--- a/src/components/empty_prompt/empty_prompt.tsx
+++ b/src/components/empty_prompt/empty_prompt.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { CommonProps, Omit } from '../common';
+import { CommonProps } from '../common';
 import { EuiTitle, EuiTitleSize } from '../title/title';
 import { EuiFlexGroup, EuiFlexItem } from '../flex';
 import { EuiSpacer } from '../spacer';

--- a/src/components/form/form_control_layout/form_control_layout_custom_icon.tsx
+++ b/src/components/form/form_control_layout/form_control_layout_custom_icon.tsx
@@ -6,7 +6,7 @@ import React, {
 import classNames from 'classnames';
 
 import { EuiIcon, IconType } from '../../icon';
-import { CommonProps, ExclusiveUnion, Omit } from '../../common';
+import { CommonProps, ExclusiveUnion } from '../../common';
 
 export type EuiFormControlLayoutCustomIconProps = CommonProps &
   ExclusiveUnion<

--- a/src/components/form/radio/radio.tsx
+++ b/src/components/form/radio/radio.tsx
@@ -5,7 +5,7 @@ import React, {
   ReactNode,
 } from 'react';
 import classNames from 'classnames';
-import { CommonProps, Omit } from '../../common';
+import { CommonProps } from '../../common';
 
 export interface RadioProps {
   autoFocus?: boolean;

--- a/src/components/form/radio/radio_group.tsx
+++ b/src/components/form/radio/radio_group.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, HTMLAttributes } from 'react';
-import { CommonProps, Omit } from '../../common';
+import { CommonProps } from '../../common';
 
 import { EuiRadio, RadioProps } from './radio';
 

--- a/src/components/form/range/index.d.ts
+++ b/src/components/form/range/index.d.ts
@@ -1,4 +1,4 @@
-import { CommonProps, Omit } from '../../common';
+import { CommonProps } from '../../common';
 
 import { ReactNode, FunctionComponent, InputHTMLAttributes } from 'react';
 

--- a/src/components/form/range/range_slider.tsx
+++ b/src/components/form/range/range_slider.tsx
@@ -1,8 +1,6 @@
 import React, {
   ChangeEventHandler,
-  FunctionComponent,
   InputHTMLAttributes,
-  Ref,
   forwardRef,
 } from 'react';
 import classNames from 'classnames';
@@ -25,9 +23,7 @@ export type EuiRangeSliderProps = InputHTMLAttributes<HTMLInputElement> &
     onChange?: ChangeEventHandler<HTMLInputElement>;
   };
 
-export const EuiRangeSlider: FunctionComponent<
-  EuiRangeSliderProps
-> = forwardRef(
+export const EuiRangeSlider = forwardRef<HTMLInputElement, EuiRangeSliderProps>(
   (
     {
       className,
@@ -47,7 +43,7 @@ export const EuiRangeSlider: FunctionComponent<
       compressed,
       ...rest
     },
-    ref: Ref<HTMLInputElement>
+    ref
   ) => {
     const classes = classNames(
       'euiRangeSlider',

--- a/src/components/form/range/range_thumb.tsx
+++ b/src/components/form/range/range_thumb.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, HTMLAttributes } from 'react';
 import classNames from 'classnames';
 
-import { CommonProps, ExclusiveUnion, Omit } from '../../common';
+import { CommonProps, ExclusiveUnion } from '../../common';
 
 interface BaseProps extends CommonProps {
   min: number;

--- a/src/components/form/range/range_ticks.tsx
+++ b/src/components/form/range/range_ticks.tsx
@@ -7,7 +7,6 @@ import React, {
 import classNames from 'classnames';
 import find from 'lodash/find';
 
-import { Omit } from '../../common';
 import { useInnerText } from '../../inner_text';
 
 export interface EuiRangeTick {

--- a/src/components/form/super_select/index.d.ts
+++ b/src/components/form/super_select/index.d.ts
@@ -1,4 +1,4 @@
-import { CommonProps, Omit } from '../../common';
+import { CommonProps } from '../../common';
 
 import { FunctionComponent, ReactNode, ButtonHTMLAttributes } from 'react';
 

--- a/src/components/form/switch/switch.tsx
+++ b/src/components/form/switch/switch.tsx
@@ -6,7 +6,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { CommonProps, Omit } from '../../common';
+import { CommonProps } from '../../common';
 import makeId from '../../form/form_row/make_id';
 import { EuiIcon } from '../../icon';
 

--- a/src/components/header/header_alert/header_alert.tsx
+++ b/src/components/header/header_alert/header_alert.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent, HTMLAttributes, ReactNode } from 'react';
 import classNames from 'classnames';
 
 import { EuiButtonIcon } from '../../button';
-import { CommonProps, Omit } from '../../common';
+import { CommonProps } from '../../common';
 
 import { EuiFlexGroup, EuiFlexItem } from '../../flex';
 

--- a/src/components/health/health.tsx
+++ b/src/components/health/health.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, HTMLAttributes } from 'react';
 import classNames from 'classnames';
-import { CommonProps, Omit } from '../common';
+import { CommonProps } from '../common';
 
 import { EuiIcon, IconColor } from '../icon';
 

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -7,7 +7,7 @@ import React, {
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { CommonProps, Omit, keysOf } from '../common';
+import { CommonProps, keysOf } from '../common';
 
 // @ts-ignore-next-line
 // not generating typescript files or definitions for the generated JS components

--- a/src/components/inner_text/inner_text.test.tsx
+++ b/src/components/inner_text/inner_text.test.tsx
@@ -150,7 +150,7 @@ describe('EuiInnerText', () => {
     const fallback = 'Fallback';
     const component = mount(
       <EuiInnerText {...requiredProps} fallback={fallback}>
-        {({}, innerText) => (
+        {(_, innerText) => (
           <span title={innerText} data-test-subj="span">
             {text}
           </span>

--- a/src/components/modal/index.d.ts
+++ b/src/components/modal/index.d.ts
@@ -1,4 +1,4 @@
-import { CommonProps, Omit } from '../common';
+import { CommonProps } from '../common';
 import { FocusTarget } from '../focus_trap';
 
 import { ReactNode, FunctionComponent, HTMLAttributes } from 'react';

--- a/src/components/overlay_mask/overlay_mask.tsx
+++ b/src/components/overlay_mask/overlay_mask.tsx
@@ -6,7 +6,7 @@
 import { Component, HTMLAttributes, ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import classNames from 'classnames';
-import { CommonProps, keysOf, Omit } from '../common';
+import { CommonProps, keysOf } from '../common';
 
 export interface EuiOverlayMaskProps {
   onClick?: () => void;

--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { CommonProps, ExclusiveUnion, Omit } from '../common';
+import { CommonProps, ExclusiveUnion } from '../common';
 import { EuiBetaBadge } from '../badge/beta_badge';
 
 export type PanelPaddingSize = 'none' | 's' | 'm' | 'l';

--- a/src/components/popover/input_popover.tsx
+++ b/src/components/popover/input_popover.tsx
@@ -7,7 +7,7 @@ import React, {
 import classnames from 'classnames';
 import tabbable from 'tabbable';
 
-import { CommonProps, Omit } from '../common';
+import { CommonProps } from '../common';
 import { EuiFocusTrap } from '../focus_trap';
 import { EuiPopover, EuiPopoverProps } from './popover';
 import { EuiResizeObserver } from '../observer/resize_observer';

--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -7,7 +7,7 @@ import React, {
   ReactElement,
 } from 'react';
 import classNames from 'classnames';
-import { CommonProps, Omit, ExclusiveUnion } from '../common';
+import { CommonProps, ExclusiveUnion } from '../common';
 import { EuiSelectableSearch } from './selectable_search';
 import { EuiSelectableMessage } from './selectable_message';
 import { EuiSelectableList } from './selectable_list';

--- a/src/components/selectable/selectable_message/selectable_message.tsx
+++ b/src/components/selectable/selectable_message/selectable_message.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLAttributes } from 'react';
-import { CommonProps, Omit } from '../../common';
+import { CommonProps } from '../../common';
 import classNames from 'classnames';
 import { EuiText } from '../../text';
 

--- a/src/components/selectable/selectable_search/selectable_search.tsx
+++ b/src/components/selectable/selectable_search/selectable_search.tsx
@@ -1,6 +1,6 @@
 import React, { Component, InputHTMLAttributes } from 'react';
 import classNames from 'classnames';
-import { CommonProps, Omit } from '../../common';
+import { CommonProps } from '../../common';
 // @ts-ignore
 import { EuiFieldSearch } from '../../form/field_search';
 import { getMatchingOptions } from '../matching_options';

--- a/src/components/stat/stat.tsx
+++ b/src/components/stat/stat.tsx
@@ -4,7 +4,7 @@ import React, {
   FunctionComponent,
   ReactNode,
 } from 'react';
-import { CommonProps, keysOf, Omit } from '../common';
+import { CommonProps, keysOf } from '../common';
 import classNames from 'classnames';
 
 import { EuiText } from '../text';

--- a/src/components/steps/steps.tsx
+++ b/src/components/steps/steps.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, HTMLAttributes } from 'react';
-import { CommonProps, Omit } from '../common';
+import { CommonProps } from '../common';
 import classNames from 'classnames';
 
 import { StandaloneEuiStepProps, EuiStep } from './step';

--- a/src/components/steps/steps_horizontal.tsx
+++ b/src/components/steps/steps_horizontal.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, HTMLAttributes } from 'react';
-import { CommonProps, Omit } from '../common';
+import { CommonProps } from '../common';
 import classNames from 'classnames';
 
 import { EuiStepHorizontalProps, EuiStepHorizontal } from './step_horizontal';

--- a/src/components/text/text.tsx
+++ b/src/components/text/text.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, HTMLAttributes } from 'react';
 import classNames from 'classnames';
-import { CommonProps, keysOf, Omit } from '../common';
+import { CommonProps, keysOf } from '../common';
 
 import { TextColor, EuiTextColor } from './text_color';
 

--- a/src/components/toast/toast.tsx
+++ b/src/components/toast/toast.tsx
@@ -6,7 +6,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { CommonProps, keysOf, Omit } from '../common';
+import { CommonProps, keysOf } from '../common';
 import { EuiScreenReaderOnly } from '../accessibility';
 import { EuiI18n } from '../i18n';
 

--- a/src/components/tool_tip/icon_tip.tsx
+++ b/src/components/tool_tip/icon_tip.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 
-import { Omit, PropsOf } from '../common';
+import { PropsOf } from '../common';
 import { EuiIcon, IconSize, IconType } from '../icon';
 import { EuiToolTip, Props as EuiToolTipProps } from './tool_tip';
 

--- a/src/components/tool_tip/tool_tip_popover.tsx
+++ b/src/components/tool_tip/tool_tip_popover.tsx
@@ -1,6 +1,6 @@
 import React, { HTMLAttributes, Component, ReactNode } from 'react';
 import classNames from 'classnames';
-import { CommonProps, Omit } from '../common';
+import { CommonProps } from '../common';
 
 type Props = CommonProps &
   Omit<HTMLAttributes<HTMLDivElement>, 'title'> & {

--- a/src/components/tree_view/tree_view.tsx
+++ b/src/components/tree_view/tree_view.tsx
@@ -1,6 +1,6 @@
 import React, { Component, HTMLAttributes, createContext } from 'react';
 import classNames from 'classnames';
-import { CommonProps, Omit } from '../common';
+import { CommonProps } from '../common';
 import { EuiI18n } from '../i18n';
 import { EuiIcon } from '../icon';
 import { EuiScreenReaderOnly } from '../accessibility';
@@ -260,7 +260,9 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
                     ariaLabel: hasAriaLabel(rest) ? rest['aria-label'] : '',
                   }}>
                   {(ariaLabel: string) => {
-                    const label = hasAriaLabel(rest)
+                    const label:
+                      | { 'aria-label': string }
+                      | { 'aria-labelledby': string } = hasAriaLabel(rest)
                       ? {
                           'aria-label': ariaLabel,
                         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1239,6 +1239,11 @@
     "@types/cheerio" "*"
     "@types/react" "*"
 
+"@types/eslint-visitor-keys@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
+  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
 "@types/jest-diff@*":
   version "20.0.1"
   resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
@@ -1250,6 +1255,11 @@
   integrity sha512-NE7FBG/F4cMDKdCBqgyd+Sa6JZ5GiMOyA5QwJdeS4Ii/Z9a18WgGbFrHbcr48/7I9HdnkaAYP+S2MmQ27qoqJA==
   dependencies:
     "@types/jest-diff" "*"
+
+"@types/json-schema@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
+  integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
 "@types/lodash@^4.14.116":
   version "4.14.118"
@@ -1357,40 +1367,40 @@
     "@types/unist" "*"
     "@types/vfile-message" "*"
 
-"@typescript-eslint/eslint-plugin@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.9.0.tgz#29d73006811bf2563b88891ceeff1c5ea9c8d9c6"
-  integrity sha512-FOgfBorxjlBGpDIw+0LaZIXRX6GEEUfzj8LXwaQIUCp+gDOvkI+1WgugJ7SmWiISqK9Vj5r8S7NDKO/LB+6X9A==
+"@typescript-eslint/eslint-plugin@^1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.13.0.tgz#22fed9b16ddfeb402fd7bcde56307820f6ebc49f"
+  integrity sha512-WQHCozMnuNADiqMtsNzp96FNox5sOVpU8Xt4meaT4em8lOG1SrOv92/mUbEHQVh90sldKSfcOc/I0FOb/14G1g==
   dependencies:
-    "@typescript-eslint/experimental-utils" "1.9.0"
-    "@typescript-eslint/parser" "1.9.0"
+    "@typescript-eslint/experimental-utils" "1.13.0"
     eslint-utils "^1.3.1"
     functional-red-black-tree "^1.0.1"
     regexpp "^2.0.1"
-    requireindex "^1.2.0"
     tsutils "^3.7.0"
 
-"@typescript-eslint/experimental-utils@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-1.9.0.tgz#a92777d0c92d7bc8627abd7cdb06cdbcaf2b39e8"
-  integrity sha512-1s2dY9XxBwtS9IlSnRIlzqILPyeMly5tz1bfAmQ84Ul687xBBve5YsH5A5EKeIcGurYYqY2w6RkHETXIwnwV0A==
+"@typescript-eslint/experimental-utils@1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz#b08c60d780c0067de2fb44b04b432f540138301e"
+  integrity sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==
   dependencies:
-    "@typescript-eslint/typescript-estree" "1.9.0"
-
-"@typescript-eslint/parser@1.9.0", "@typescript-eslint/parser@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.9.0.tgz#5796cbfcb9a3a5757aeb671c1ac88d7a94a95962"
-  integrity sha512-CWgC1XrQ34H/+LwAU7vY5xteZDkNqeAkeidEpJnJgkKu0yqQ3ZhQ7S+dI6MX4vmmM1TKRbOrKuXc6W0fIHhdbA==
-  dependencies:
-    "@typescript-eslint/experimental-utils" "1.9.0"
-    "@typescript-eslint/typescript-estree" "1.9.0"
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "1.13.0"
     eslint-scope "^4.0.0"
+
+"@typescript-eslint/parser@^1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.13.0.tgz#61ac7811ea52791c47dc9fd4dd4a184fae9ac355"
+  integrity sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "1.13.0"
+    "@typescript-eslint/typescript-estree" "1.13.0"
     eslint-visitor-keys "^1.0.0"
 
-"@typescript-eslint/typescript-estree@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.9.0.tgz#5d6d49be936e96fb0f859673480f89b070a5dd9b"
-  integrity sha512-7Eg0TEQpCkTsEwsl1lIzd6i7L3pJLQFWesV08dS87bNz0NeSjbL78gNAP1xCKaCejkds4PhpLnZkaAjx9SU8OA==
+"@typescript-eslint/typescript-estree@1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz#8140f17d0f60c03619798f1d628b8434913dc32e"
+  integrity sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"
@@ -12661,11 +12671,6 @@ require-uncached@^1.0.2:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
-requireindex@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
-  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
-
 requires-port@1.x.x, requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -14408,10 +14413,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3.tgz#f1657fc7daa27e1a8930758ace9ae8da31403221"
-  integrity sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==
+typescript@3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 ua-parser-js@^0.7.18, ua-parser-js@^0.7.9:
   version "0.7.18"


### PR DESCRIPTION
### Summary

This is a breaking change

* Upgraded typescript from 3.3.3 to 3.5.3, necessary for tables' typescript conversion (#2428)
* bumped `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` from 1.9.0 to 1.13.0
* Removed EUI's definition of `Omit` in favor of TS's now built-in version

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
