### PR TITLE
Bump React Autosize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added new `euiControlBar` component for bottom-of-screen navigational elements. ([#2204](https://github.com/elastic/eui/pull/2204))
 - Convert `EuiFlyout` to TypeScript ([#2500](https://github.com/elastic/eui/pull/2500))
 - Added an animation to the arrow on `EuiAccordion` as it opens / closes ([#2507](https://github.com/elastic/eui/pull/2507))
+- Upgraded `react-input-autosize` to `2.2.2`
 
 **Bug fixes**
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react-ace": "^5.5.0",
     "react-beautiful-dnd": "^10.1.0",
     "react-focus-lock": "^1.17.7",
-    "react-input-autosize": "^2.2.1",
+    "react-input-autosize": "^2.2.2",
     "react-is": "~16.3.0",
     "react-virtualized": "^9.18.5",
     "resize-observer-polyfill": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11975,10 +11975,10 @@ react-focus-lock@^1.17.7:
     prop-types "^15.6.2"
     react-clientside-effect "^1.2.0"
 
-react-input-autosize@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.1.tgz#ec428fa15b1592994fb5f9aa15bb1eb6baf420f8"
-  integrity sha512-3+K4CD13iE4lQQ2WlF8PuV5htfmTRLH6MDnfndHM6LuBRszuXnuyIfE7nhSKt8AzRBZ50bu0sAhkNMeS5pxQQA==
+react-input-autosize@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.2.tgz#fcaa7020568ec206bc04be36f4eb68e647c4d8c2"
+  integrity sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==
   dependencies:
     prop-types "^15.5.8"
 


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/2513

Only change in `2.2.1..2.2.2` is renaming deprecated lifecycle methods [per CHANGELOG](https://github.com/JedWatson/react-input-autosize/blob/0aa6225fb4ae4e30d51a23f75b36b15e709efdd0/HISTORY.md#v222--2019-01-10)