### PR TITLE
Removed unnecessary conditional

### DIFF
--- a/src/components/steps/step_horizontal.tsx
+++ b/src/components/steps/step_horizontal.tsx
@@ -60,7 +60,7 @@ export const EuiStepHorizontal: FunctionComponent<
     status = 'complete';
   } else if (isSelected) {
     status = status;
-  } else if (!isComplete && !status) {
+  } else if (!status) {
     status = 'incomplete';
   }
 


### PR DESCRIPTION
### Summary

The negation of `isComplete` always evaluate to true because of this [line](https://github.com/elastic/eui/blob/aaa1b5c6799e301514423f4722e7a46e270c6d68/src/components/steps/step_horizontal.tsx#L59).


### Checklist

~~- [ ] Checked in **dark mode**~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
~~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~~
