### PR TITLE
Added missing union type for EuiPageContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Created `.euiTableCaption` with `position: relative` to avoid double border under header row ([#2484](https://github.com/elastic/eui/pull/2484))
 - Fixed `EuiSwitch` to use `aria-labelledby` ([#2522](https://github.com/elastic/eui/pull/2522))
+- Fixed `EuiPanelProps` type definition ([#2516](https://github.com/elastic/eui/pull/2516))
 
 **Breaking changes**
 

--- a/src/components/page/index.d.ts
+++ b/src/components/page/index.d.ts
@@ -58,7 +58,7 @@ declare module '@elastic/eui' {
   }
 
   export const EuiPageContent: FunctionComponent<
-    CommonProps & EuiPanelProps & EuiPageContentProps
+    CommonProps & HTMLAttributes<HTMLDivElement> & EuiPanelProps & EuiPageContentProps
   >;
 
   /**

--- a/src/components/page/index.d.ts
+++ b/src/components/page/index.d.ts
@@ -58,7 +58,7 @@ declare module '@elastic/eui' {
   }
 
   export const EuiPageContent: FunctionComponent<
-    CommonProps & HTMLAttributes<HTMLDivElement> & EuiPanelProps & EuiPageContentProps
+    CommonProps & EuiPanelProps & EuiPageContentProps
   >;
 
   /**

--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -12,7 +12,7 @@ import { EuiBetaBadge } from '../badge/beta_badge';
 
 export type PanelPaddingSize = 'none' | 's' | 'm' | 'l';
 
-export interface EuiPanelProps extends CommonProps {
+interface Props extends CommonProps {
   /**
    * If active, adds a deeper shadow to the panel
    */
@@ -45,14 +45,14 @@ export interface EuiPanelProps extends CommonProps {
 }
 
 interface Divlike
-  extends EuiPanelProps,
+  extends Props,
     Omit<HTMLAttributes<HTMLDivElement>, 'onClick'> {}
 
 interface Buttonlike
-  extends EuiPanelProps,
+  extends Props,
     ButtonHTMLAttributes<HTMLButtonElement> {}
 
-type Props = ExclusiveUnion<Divlike, Buttonlike>;
+export type EuiPanelProps = ExclusiveUnion<Divlike, Buttonlike>;
 
 const paddingSizeToClassNameMap = {
   none: null,
@@ -63,7 +63,7 @@ const paddingSizeToClassNameMap = {
 
 export const SIZES = Object.keys(paddingSizeToClassNameMap);
 
-export const EuiPanel: FunctionComponent<Props> = ({
+export const EuiPanel: FunctionComponent<EuiPanelProps> = ({
   children,
   className,
   paddingSize = 'm',

--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -48,9 +48,7 @@ interface Divlike
   extends Props,
     Omit<HTMLAttributes<HTMLDivElement>, 'onClick'> {}
 
-interface Buttonlike
-  extends Props,
-    ButtonHTMLAttributes<HTMLButtonElement> {}
+interface Buttonlike extends Props, ButtonHTMLAttributes<HTMLButtonElement> {}
 
 export type EuiPanelProps = ExclusiveUnion<Divlike, Buttonlike>;
 


### PR DESCRIPTION
### Summary

I added the `HTMLAttributes<HTMLDivElement>` type to EuiPageContent, because it seemed to be missing. 

I've noticed this because I tried to use the style prop, but it wasn't available and I had to //@ts-ignore the component.