### PR TITLE
`EuiSwitch` use `aria-labelledby`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug fixes**
 
 - Created `.euiTableCaption` with `position: relative` to avoid double border under header row ([#2484](https://github.com/elastic/eui/pull/2484))
+- Fixed `EuiSwitch` to use `aria-labelledby` ([#2522](https://github.com/elastic/eui/pull/2522))
 
 **Breaking changes**
 

--- a/src/components/form/switch/__snapshots__/switch.test.tsx.snap
+++ b/src/components/form/switch/__snapshots__/switch.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`EuiSwitch assigns automatically generated ID to label 1`] = `
 >
   <button
     aria-checked="false"
-    aria-describedby="generated-id"
+    aria-labelledby="generated-id"
     class="euiSwitch__button"
     id="generated-id"
     role="switch"
@@ -55,8 +55,8 @@ exports[`EuiSwitch is rendered 1`] = `
 >
   <button
     aria-checked="false"
-    aria-describedby="generated-id"
     aria-label="aria-label"
+    aria-labelledby="generated-id"
     class="euiSwitch__button"
     data-test-subj="test subject string"
     id="test"

--- a/src/components/form/switch/switch.tsx
+++ b/src/components/form/switch/switch.tsx
@@ -83,7 +83,7 @@ export const EuiSwitch: FunctionComponent<EuiSwitchProps> = ({
         disabled={disabled}
         onClick={onClick}
         aria-label={showLabel ? undefined : (label as string)}
-        aria-describedby={showLabel ? labelId : undefined}
+        aria-labelledby={showLabel ? labelId : undefined}
         {...rest}>
         <span className="euiSwitch__body">
           <span className="euiSwitch__thumb" />


### PR DESCRIPTION
### Summary

Per https://dequeuniversity.com/rules/axe/3.3/button-name?application=axeAPI, `EuiSwitch` should be using `aria-labelledby` instead of `aria-describedby`.

### Checklist

~~- [ ] Checked in **dark mode**~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~

- [x] Added or updated **jest tests**

~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
