### PR TITLE
Fix docs console warning

### DIFF
--- a/src-docs/src/views/badge/badge.js
+++ b/src-docs/src/views/badge/badge.js
@@ -21,12 +21,17 @@ const badges = [
 
 export default () => (
   <EuiFlexGroup wrap responsive={false} gutterSize="xs" style={{ width: 300 }}>
-    {badges.map(badge => (
-      <EuiFlexItem grow={false} key={badge}>
-        <EuiBadge isDisabled={badge === '0000FF' ? true : false} color={badge}>
-          {badge === '0000FF' ? 'disabled' : badge}
-        </EuiBadge>
-      </EuiFlexItem>
-    ))}
+    {badges.map(badge => {
+      const isDisabled = badge === '0000FF';
+      return (
+        <EuiFlexItem grow={false} key={badge}>
+          <EuiBadge
+            isDisabled={isDisabled ? true : false}
+            color={isDisabled ? undefined : badge}>
+            {isDisabled ? 'disabled' : badge}
+          </EuiBadge>
+        </EuiFlexItem>
+      );
+    })}
   </EuiFlexGroup>
 );

--- a/src-docs/src/views/badge/badge.js
+++ b/src-docs/src/views/badge/badge.js
@@ -16,22 +16,17 @@ const badges = [
   'danger',
   '#000',
   '#fea27f',
-  '0000FF',
 ];
 
 export default () => (
   <EuiFlexGroup wrap responsive={false} gutterSize="xs" style={{ width: 300 }}>
-    {badges.map(badge => {
-      const isDisabled = badge === '0000FF';
-      return (
-        <EuiFlexItem grow={false} key={badge}>
-          <EuiBadge
-            isDisabled={isDisabled ? true : false}
-            color={isDisabled ? undefined : badge}>
-            {isDisabled ? 'disabled' : badge}
-          </EuiBadge>
-        </EuiFlexItem>
-      );
-    })}
+    {badges.map(badge => (
+      <EuiFlexItem grow={false} key={badge}>
+        <EuiBadge color={badge}>{badge}</EuiBadge>
+      </EuiFlexItem>
+    ))}
+    <EuiFlexItem grow={false}>
+      <EuiBadge isDisabled={true}>disabled</EuiBadge>
+    </EuiFlexItem>
   </EuiFlexGroup>
 );


### PR DESCRIPTION
### Summary

`EuiBadge` example was logging a warning due to an invalid hex value.

### Checklist

~~- [ ] Checked in **dark mode**~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
~~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~~
