### PR TITLE
`EuiColorStops` thumb drag performance

### DIFF
--- a/src/components/color_picker/color_stops/color_stop_thumb.tsx
+++ b/src/components/color_picker/color_stops/color_stop_thumb.tsx
@@ -120,10 +120,16 @@ export const EuiColorStopThumb: FunctionComponent<EuiColorStopThumbProps> = ({
     }
   };
 
+  const setHasFocusTrue = () => setHasFocus(true);
+  const setHasFocusFalse = () => setHasFocus(false);
+
   const handleColorChange = (value: ColorStop['color']) => {
     setColorIsInvalid(isColorInvalid(value));
     onChange({ stop, color: value });
   };
+
+  const handleColorInputChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+    handleColorChange(e.target.value);
 
   const handleStopChange = (value: ColorStop['stop']) => {
     const willBeInvalid = value > localMax || value < localMin;
@@ -140,7 +146,9 @@ export const EuiColorStopThumb: FunctionComponent<EuiColorStopThumbProps> = ({
     onChange({ stop: value, color });
   };
 
-  const handleStopInputChange = (value: ColorStop['stop']) => {
+  const handleStopInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    let value = parseFloat(e.target.value);
+
     const willBeInvalid = value > globalMax || value < globalMin;
 
     if (willBeInvalid) {
@@ -200,10 +208,14 @@ export const EuiColorStopThumb: FunctionComponent<EuiColorStopThumbProps> = ({
     openPopover();
   };
 
-  const handleTouchStart = (e: React.TouchEvent<HTMLButtonElement>) => {
+  const handleTouchInteraction = (e: React.TouchEvent<HTMLButtonElement>) => {
     if (!readOnly) {
       handleInteraction(e);
     }
+  };
+
+  const handleTouchStart = (e: React.TouchEvent<HTMLButtonElement>) => {
+    handleTouchInteraction(e);
     openPopover();
   };
 
@@ -214,6 +226,8 @@ export const EuiColorStopThumb: FunctionComponent<EuiColorStopThumbProps> = ({
     },
     className
   );
+
+  // console.log('render', stop);
 
   return (
     <EuiPopover
@@ -252,13 +266,13 @@ export const EuiColorStopThumb: FunctionComponent<EuiColorStopThumbProps> = ({
                 max={localMax}
                 value={stop}
                 onFocus={handleFocus}
-                onBlur={() => setHasFocus(false)}
-                onMouseOver={() => setHasFocus(true)}
-                onMouseOut={() => setHasFocus(false)}
+                onBlur={setHasFocusFalse}
+                onMouseOver={setHasFocusTrue}
+                onMouseOut={setHasFocusFalse}
                 onKeyDown={handleKeyDown}
                 onMouseDown={handleOnMouseDown}
                 onTouchStart={handleTouchStart}
-                onTouchMove={readOnly ? undefined : handleInteraction}
+                onTouchMove={handleTouchInteraction}
                 aria-valuetext={ariaValueText}
                 aria-label={ariaLabel}
                 title={title}
@@ -307,9 +321,7 @@ export const EuiColorStopThumb: FunctionComponent<EuiColorStopThumbProps> = ({
                     max={isRangeMax || max == null ? null : localMax}
                     value={isStopInvalid(stop) ? '' : stop}
                     isInvalid={stopIsInvalid}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                      handleStopInputChange(parseFloat(e.target.value))
-                    }
+                    onChange={handleStopInputChange}
                   />
                 </EuiFormRow>
               )}
@@ -370,9 +382,7 @@ export const EuiColorStopThumb: FunctionComponent<EuiColorStopThumbProps> = ({
                     readOnly={readOnly}
                     value={color}
                     isInvalid={colorIsInvalid}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                      handleColorChange(e.target.value)
-                    }
+                    onChange={handleColorInputChange}
                   />
                 </EuiFormRow>
               )}

--- a/src/components/color_picker/color_stops/color_stops.tsx
+++ b/src/components/color_picker/color_stops/color_stops.tsx
@@ -205,6 +205,16 @@ export const EuiColorStops: FunctionComponent<EuiColorStopsProps> = ({
     }
   };
 
+  const setWrapperHasFocus = (e: React.FocusEvent) => {
+    if (e.target === wrapperRef) {
+      setHasFocus(true);
+    }
+  };
+
+  const removeWrapperFocus = () => {
+    setHasFocus(false);
+  };
+
   const onAdd = () => {
     const stops = sortedStops.map(({ color, stop }) => {
       return {
@@ -223,6 +233,16 @@ export const EuiColorStops: FunctionComponent<EuiColorStopsProps> = ({
 
     onFocusWrapper();
     handleOnChange(newColorStops);
+  };
+
+  const disableHover = () => {
+    if (disabled) return;
+    setIsHoverDisabled(true);
+  };
+
+  const enableHover = () => {
+    if (disabled) return;
+    setIsHoverDisabled(false);
   };
 
   const handleAddHover = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -298,46 +318,52 @@ export const EuiColorStops: FunctionComponent<EuiColorStopsProps> = ({
     }
   };
 
-  const thumbs = sortedStops.map((colorStop, index) => (
-    <EuiColorStopThumb
-      isRangeMin={min == null && colorStop.stop === rangeMin}
-      isRangeMax={max == null && colorStop.stop === rangeMax}
-      data-index={`${STOP_ATTR}${index}`}
-      key={colorStop.id}
-      globalMin={min || rangeMin}
-      globalMax={max || rangeMax}
-      min={min}
-      max={max}
-      localMin={index === 0 ? min || rangeMin : sortedStops[index - 1].stop + 1}
-      localMax={
-        index === sortedStops.length - 1
-          ? max || rangeMax
-          : sortedStops[index + 1].stop - 1
-      }
-      stop={colorStop.stop}
-      color={colorStop.color}
-      onRemove={
-        sortedStops.length > 1 ? () => onRemove(colorStop.id) : undefined
-      }
-      onChange={stop => handleStopChange(stop, colorStop.id)}
-      onFocus={() => setFocusedStopIndex(index)}
-      parentRef={wrapperRef}
-      colorPickerMode={mode}
-      colorPickerSwatches={swatches}
-      disabled={disabled}
-      readOnly={readOnly}
-      aria-valuetext={`Stop: ${colorStop.stop}, Color: ${
-        colorStop.color
-      } (${index + 1} of ${colorStops.length})`}
-      isPopoverOpen={colorStop.id === openedStopId}
-      openPopover={() => {
-        setOpenedStopId(colorStop.id);
-      }}
-      closePopover={() => {
-        setOpenedStopId(null);
-      }}
-    />
-  ));
+  const thumbs = useMemo(
+    () =>
+      sortedStops.map((colorStop, index) => (
+        <EuiColorStopThumb
+          isRangeMin={min == null && colorStop.stop === rangeMin}
+          isRangeMax={max == null && colorStop.stop === rangeMax}
+          data-index={`${STOP_ATTR}${index}`}
+          key={colorStop.id}
+          globalMin={min || rangeMin}
+          globalMax={max || rangeMax}
+          min={min}
+          max={max}
+          localMin={
+            index === 0 ? min || rangeMin : sortedStops[index - 1].stop + 1
+          }
+          localMax={
+            index === sortedStops.length - 1
+              ? max || rangeMax
+              : sortedStops[index + 1].stop - 1
+          }
+          stop={colorStop.stop}
+          color={colorStop.color}
+          onRemove={
+            sortedStops.length > 1 ? () => onRemove(colorStop.id) : undefined
+          }
+          onChange={stop => handleStopChange(stop, colorStop.id)}
+          onFocus={() => setFocusedStopIndex(index)}
+          parentRef={wrapperRef}
+          colorPickerMode={mode}
+          colorPickerSwatches={swatches}
+          disabled={disabled}
+          readOnly={readOnly}
+          aria-valuetext={`Stop: ${colorStop.stop}, Color: ${
+            colorStop.color
+          } (${index + 1} of ${colorStops.length})`}
+          isPopoverOpen={colorStop.id === openedStopId}
+          openPopover={() => {
+            setOpenedStopId(colorStop.id);
+          }}
+          closePopover={() => {
+            setOpenedStopId(null);
+          }}
+        />
+      )),
+    [sortedStops, rangeMin, rangeMax, wrapperRef, openedStopId]
+  );
 
   const positions = wrapperRef
     ? sortedStops.map(({ stop }) => getPositionFromStopFn(stop))
@@ -372,16 +398,12 @@ export const EuiColorStops: FunctionComponent<EuiColorStopsProps> = ({
       className={classes}
       fullWidth={fullWidth}
       tabIndex={disabled ? -1 : 0}
-      onMouseDown={() => !disabled && setIsHoverDisabled(true)}
-      onMouseUp={() => !disabled && setIsHoverDisabled(false)}
-      onMouseLeave={() => !disabled && setIsHoverDisabled(false)}
+      onMouseDown={disableHover}
+      onMouseUp={enableHover}
+      onMouseLeave={enableHover}
       onKeyDown={handleKeyDown}
-      onFocus={e => {
-        if (e.target === wrapperRef) {
-          setHasFocus(true);
-        }
-      }}
-      onBlur={() => setHasFocus(false)}>
+      onFocus={setWrapperHasFocus}
+      onBlur={removeWrapperFocus}>
       <EuiScreenReaderOnly>
         <p aria-live="polite">
           <EuiI18n


### PR DESCRIPTION
### Summary

Closes #2498. Thumb rerendering causes some visual lag when dragging. Some changes:

* useMemo on the array of renderable thumbs
* Minimize new arrow function creation inside of props

### Checklist

~~- [ ] Checked in **dark mode**~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~

- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
