### PR TITLE
Passing name attribute into switch component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `16.0.0`.
+**Bug fixes**
+
+- `EuiSwitch` now passes `name` attribute into underlying `button` ([#2533](https://github.com/elastic/eui/pull/2533))
 
 ## [`16.0.0`](https://github.com/elastic/eui/tree/v16.0.0)
 
 - Made `EuiCard` more accessible ([#2521](https://github.com/elastic/eui/pull/2521))
 - Added ability to pass `children` to `EuiCard` ([#2521](https://github.com/elastic/eui/pull/2521))
 - Replaced root element in `EuiFlyout`, switching from `span` to `Fragment` ([#2527](https://github.com/elastic/eui/pull/2527))
-- Upgraded `react-virtualized` to `9.21.2`
+- Upgraded `react-virtualized` to `9.21.2` ([#2531](https://github.com/elastic/eui/pull/2531))
 
 **Bug fixes**
 
@@ -21,7 +23,7 @@ No public interface changes since `16.0.0`.
 ## [`15.0.0`](https://github.com/elastic/eui/tree/v15.0.0)
 
 - Converted `EuiShowFor` and `EuiHideFor` to TS ([#2503](https://github.com/elastic/eui/pull/2503))
-- Upgraded `react-ace` to `7.0.5`
+- Upgraded `react-ace` to `7.0.5` ([#2526](https://github.com/elastic/eui/pull/2526))
 
 **Bug fixes**
 
@@ -40,7 +42,7 @@ No public interface changes since `16.0.0`.
 - Added new `euiControlBar` component for bottom-of-screen navigational elements. ([#2204](https://github.com/elastic/eui/pull/2204))
 - Converted `EuiFlyout` to TypeScript ([#2500](https://github.com/elastic/eui/pull/2500))
 - Added an animation to the arrow on `EuiAccordion` as it opens / closes ([#2507](https://github.com/elastic/eui/pull/2507))
-- Upgraded `react-input-autosize` to `2.2.2`
+- Upgraded `react-input-autosize` to `2.2.2` ([#2514](https://github.com/elastic/eui/pull/2514))
 
 **Bug fixes**
 

--- a/src/components/form/switch/switch.tsx
+++ b/src/components/form/switch/switch.tsx
@@ -37,7 +37,6 @@ export type EuiSwitchProps = CommonProps &
 export const EuiSwitch: FunctionComponent<EuiSwitchProps> = ({
   label,
   id,
-  name,
   checked,
   disabled,
   compressed,


### PR DESCRIPTION
### Summary

The name prop is being de-structured in the switch component but it unused. Because of this it's pulled out of `...rest` being passed into the element attributes which we need in cloud as we use it in conjunction with Formik in some cases. Currently blocking https://github.com/elastic/cloud/pull/43440

### Checklist

~~- [ ] Checked in **dark mode**~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately

Not sure if I add this to the changelog or not as it's not part of the public API? Also unsure if it's done as a part of this PR or later on once we know which release it's a part of so I'd love to know for future reference.