### PR TITLE
Fixes bug in the `EuiCheckboxGroup` demo page and add `disabled` to TS defs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Added `badge` prop and new styles `EuiHeaderAlert` ([#2506](https://github.com/elastic/eui/pull/2506))
 
+**Bug fixes**
+
+- Fixed bug in the `EuiCheckboxGroup` demo page in which both enabled and disabled groups were using the same ids for their checkbox input components, which caused the disabled ones to be checkable
+
 ## [`16.0.1`](https://github.com/elastic/eui/tree/v16.0.1)
 
 **Bug fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added `badge` prop and new styles `EuiHeaderAlert` ([#2506](https://github.com/elastic/eui/pull/2506))
-
-**Bug fixes**
-
-- Fixed bug in the `EuiCheckboxGroup` demo page in which both enabled and disabled groups were using the same ids for their checkbox input components, which caused the disabled ones to be checkable
+- Added `disabled` prop to the `EuiCheckboxGroup` definition ([#2545](https://github.com/elastic/eui/pull/2545))
 
 ## [`16.0.1`](https://github.com/elastic/eui/tree/v16.0.1)
 

--- a/src-docs/src/views/form_controls/checkbox_group.js
+++ b/src-docs/src/views/form_controls/checkbox_group.js
@@ -37,6 +37,9 @@ export default class extends Component {
       checkboxIdToSelectedMap: {
         [`${idPrefix}1`]: true,
       },
+      checkboxIdToSelectedMapDisabled: {
+        [`${idPrefix}1_disabled`]: true,
+      },
     };
   }
 
@@ -72,7 +75,7 @@ export default class extends Component {
 
         <EuiCheckboxGroup
           options={this.checkboxesDisabled}
-          idToSelectedMap={this.state.checkboxIdToSelectedMap}
+          idToSelectedMap={this.state.checkboxIdToSelectedMapDisabled}
           onChange={this.onChange}
           disabled
         />

--- a/src-docs/src/views/form_controls/checkbox_group.js
+++ b/src-docs/src/views/form_controls/checkbox_group.js
@@ -29,6 +29,10 @@ export default class extends Component {
       },
     ];
 
+    this.checkboxesDisabled = this.checkboxes.map(checkbox => {
+      return { ...checkbox, id: `${checkbox}_disabled` };
+    });
+
     this.state = {
       checkboxIdToSelectedMap: {
         [`${idPrefix}1`]: true,
@@ -67,7 +71,7 @@ export default class extends Component {
         <EuiSpacer size="s" />
 
         <EuiCheckboxGroup
-          options={this.checkboxes}
+          options={this.checkboxesDisabled}
           idToSelectedMap={this.state.checkboxIdToSelectedMap}
           onChange={this.onChange}
           disabled

--- a/src-docs/src/views/form_controls/checkbox_group.js
+++ b/src-docs/src/views/form_controls/checkbox_group.js
@@ -30,7 +30,7 @@ export default class extends Component {
     ];
 
     this.checkboxesDisabled = this.checkboxes.map(checkbox => {
-      return { ...checkbox, id: `${checkbox}_disabled` };
+      return { ...checkbox, id: `${checkbox.id}_disabled` };
     });
 
     this.state = {

--- a/src/components/form/checkbox/index.d.ts
+++ b/src/components/form/checkbox/index.d.ts
@@ -52,6 +52,7 @@ declare module '@elastic/eui' {
     idToSelectedMap: EuiCheckboxGroupIdToSelectedMap;
     onChange: ChangeEventHandler<HTMLInputElement>;
     compressed?: boolean;
+    disabled?: boolean;
   }
 
   export const EuiCheckboxGroup: FunctionComponent<


### PR DESCRIPTION
Related to https://github.com/elastic/eui/issues/2538

Fixes bug in the `EuiCheckboxGroup` demo page in which both enabled and disabled groups were using the same ids for their checkbox input components, which caused the disabled ones to be checkable

### Checklist

- ~[ ] Checked in **dark mode**~
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **IE11** and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- [x] Added **documentation** examples
- ~[ ] Added or updated **jest tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
