### PR TITLE
Adds possibility to disable checkboxes individually in an EuiCheckboxGroup component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Added `badge` prop and new styles `EuiHeaderAlert` ([#2506](https://github.com/elastic/eui/pull/2506))
 - Added `disabled` prop to the `EuiCheckboxGroup` definition ([#2545](https://github.com/elastic/eui/pull/2545))
-- Added `disabled` option to the `option` attribute of the `options` object that is passed to the `EuiCheckboxGroup` so that checkboxes in a group can be individually disabled ([#???](https://github.com/elastic/eui/pull/???))
+- Added `disabled` option to the `option` attribute of the `options` object that is passed to the `EuiCheckboxGroup` so that checkboxes in a group can be individually disabled ([#2548](https://github.com/elastic/eui/pull/2548))
 
 ## [`16.0.1`](https://github.com/elastic/eui/tree/v16.0.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added `badge` prop and new styles `EuiHeaderAlert` ([#2506](https://github.com/elastic/eui/pull/2506))
 - Added `disabled` prop to the `EuiCheckboxGroup` definition ([#2545](https://github.com/elastic/eui/pull/2545))
+- Added `disabled` option to the `option` attribute of the `options` object that is passed to the `EuiCheckboxGroup` so that checkboxes in a group can be individually disabled ([#???](https://github.com/elastic/eui/pull/???))
 
 ## [`16.0.1`](https://github.com/elastic/eui/tree/v16.0.1)
 

--- a/src-docs/src/views/form_controls/checkbox_group.js
+++ b/src-docs/src/views/form_controls/checkbox_group.js
@@ -33,12 +33,24 @@ export default class extends Component {
       return { ...checkbox, id: `${checkbox.id}_disabled` };
     });
 
+    this.checkboxesIndividuallyDisabled = this.checkboxes.map(checkbox => {
+      const isIndividuallyDisabled =
+        checkbox.id.charAt(checkbox.id.length - 1) === '1';
+      return {
+        ...checkbox,
+        id: `${checkbox.id}_individually_disabled`,
+        label: isIndividuallyDisabled
+          ? 'Option two is individually disabled'
+          : checkbox.label,
+        disabled: isIndividuallyDisabled,
+      };
+    });
+
     this.state = {
       checkboxIdToSelectedMap: {
         [`${idPrefix}1`]: true,
-      },
-      checkboxIdToSelectedMapDisabled: {
         [`${idPrefix}1_disabled`]: true,
+        [`${idPrefix}1_individually_disabled`]: true,
       },
     };
   }
@@ -75,9 +87,23 @@ export default class extends Component {
 
         <EuiCheckboxGroup
           options={this.checkboxesDisabled}
-          idToSelectedMap={this.state.checkboxIdToSelectedMapDisabled}
+          idToSelectedMap={this.state.checkboxIdToSelectedMap}
           onChange={this.onChange}
           disabled
+        />
+
+        <EuiSpacer size="m" />
+
+        <EuiTitle size="xxs">
+          <h3>Individually disabled checkbox</h3>
+        </EuiTitle>
+
+        <EuiSpacer size="s" />
+
+        <EuiCheckboxGroup
+          options={this.checkboxesIndividuallyDisabled}
+          idToSelectedMap={this.state.checkboxIdToSelectedMap}
+          onChange={this.onChange}
         />
       </Fragment>
     );

--- a/src/components/form/checkbox/__snapshots__/checkbox_group.test.js.snap
+++ b/src/components/form/checkbox/__snapshots__/checkbox_group.test.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiCheckboxGroup (mocked checkbox) individual disabled is rendered 1`] = `
+<div>
+  <eui_checkbox
+    checked=""
+    class="euiCheckboxGroup__item"
+    disabled=""
+    id="1"
+    label="kibana"
+  />
+  <eui_checkbox
+    class="euiCheckboxGroup__item"
+    id="2"
+    label="elastic"
+  />
+</div>
+`;
+
 exports[`EuiCheckboxGroup (mocked checkbox) disabled is rendered 1`] = `
 <div>
   <eui_checkbox

--- a/src/components/form/checkbox/checkbox_group.js
+++ b/src/components/form/checkbox/checkbox_group.js
@@ -21,7 +21,7 @@ export const EuiCheckboxGroup = ({
           id={option.id}
           checked={idToSelectedMap[option.id]}
           label={option.label}
-          disabled={disabled}
+          disabled={disabled || option.disabled}
           onChange={onChange.bind(null, option.id)}
           compressed={compressed}
         />

--- a/src/components/form/checkbox/checkbox_group.js
+++ b/src/components/form/checkbox/checkbox_group.js
@@ -35,6 +35,7 @@ EuiCheckboxGroup.propTypes = {
     PropTypes.shape({
       id: PropTypes.string.isRequired,
       label: PropTypes.node,
+      disabled: PropTypes.bool,
     })
   ).isRequired,
   idToSelectedMap: PropTypes.objectOf(PropTypes.bool).isRequired,

--- a/src/components/form/checkbox/checkbox_group.test.js
+++ b/src/components/form/checkbox/checkbox_group.test.js
@@ -56,4 +56,22 @@ describe('EuiCheckboxGroup (mocked checkbox)', () => {
 
     expect(component).toMatchSnapshot();
   });
+
+  test('individual disabled is rendered', () => {
+    const component = render(
+      <EuiCheckboxGroup
+        options={[
+          { id: '1', label: 'kibana', disabled: true },
+          { id: '2', label: 'elastic' },
+        ]}
+        idToSelectedMap={{
+          '1': true,
+          '2': false,
+        }}
+        onChange={() => {}}
+      />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
 });

--- a/src/components/form/checkbox/index.d.ts
+++ b/src/components/form/checkbox/index.d.ts
@@ -41,6 +41,7 @@ declare module '@elastic/eui' {
   export interface EuiCheckboxGroupOption {
     id: string;
     label?: ReactNode;
+    disabled?: boolean;
   }
 
   export interface EuiCheckboxGroupIdToSelectedMap {


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/eui/issues/2539

Added `disabled` option to the `option` attribute of the `options` object that is passed to the `EuiCheckboxGroup` so that checkboxes in a group can be individually disabled

### Checklist

- [ ] Checked in **dark mode**
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
