### PR TITLE
Fix all non-datagrid hooks lint issues

### DIFF
--- a/src-docs/src/views/inner_text/inner_text.js
+++ b/src-docs/src/views/inner_text/inner_text.js
@@ -25,7 +25,7 @@ export default () => {
       setThing(newThing);
       setThingAndType([newThing, newType]);
     }, 5000);
-  }, [thing]);
+  }, [thing, type]);
 
   return (
     <EuiText size="s">

--- a/src/components/color_picker/color_picker.tsx
+++ b/src/components/color_picker/color_picker.tsx
@@ -122,7 +122,7 @@ export const EuiColorPicker: FunctionComponent<EuiColorPickerProps> = ({
       const newColorAsHsv = color ? hexToHsv(color) : hexToHsv('');
       setColorAsHsv(newColorAsHsv);
     }
-  }, [color]);
+  }, [color, lastHex]);
 
   const classes = classNames('euiColorPicker', className);
   const panelClasses = classNames('euiColorPicker__popoverPanel', {

--- a/src/components/color_picker/color_stops/color_stop_thumb.tsx
+++ b/src/components/color_picker/color_stops/color_stop_thumb.tsx
@@ -94,7 +94,7 @@ export const EuiColorStopThumb: FunctionComponent<EuiColorStopThumbProps> = ({
     if (isPopoverOpen && popoverRef && popoverRef.current) {
       popoverRef.current.positionPopoverFixed();
     }
-  }, [stop]);
+  }, [isPopoverOpen, stop]);
 
   const getStopFromMouseLocationFn = (location: { x: number; y: number }) => {
     // Guard against `null` ref in usage

--- a/src/components/color_picker/color_stops/color_stops.tsx
+++ b/src/components/color_picker/color_stops/color_stops.tsx
@@ -1,4 +1,10 @@
-import React, { FunctionComponent, useEffect, useMemo, useState } from 'react';
+import React, {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import classNames from 'classnames';
 
 import { CommonProps } from '../../common';
@@ -132,18 +138,6 @@ export const EuiColorStops: FunctionComponent<EuiColorStopsProps> = ({
     null
   );
 
-  useEffect(() => {
-    if (focusStopOnUpdate !== null) {
-      const toFocusIndex = sortedStops
-        .map(el => el.stop)
-        .indexOf(focusStopOnUpdate);
-      const toFocusId = toFocusIndex > -1 ? sortedStops[toFocusIndex].id : null;
-      onFocusStop(toFocusIndex);
-      setOpenedStopId(toFocusId);
-      setFocusStopOnUpdate(null);
-    }
-  }, [sortedStops]);
-
   const isNotInteractive = disabled || readOnly;
 
   const classes = classNames(
@@ -186,17 +180,32 @@ export const EuiColorStops: FunctionComponent<EuiColorStopsProps> = ({
     handleOnChange(newColorStops);
   };
 
-  const onFocusStop = (index: number) => {
-    if (disabled || !wrapperRef) return;
-    const toFocus = wrapperRef.querySelector<HTMLElement>(
-      `[data-index=${STOP_ATTR}${index}]`
-    );
-    if (toFocus) {
-      setHasFocus(false);
-      setFocusedStopIndex(index);
-      toFocus.focus();
+  const onFocusStop = useCallback(
+    (index: number) => {
+      if (disabled || !wrapperRef) return;
+      const toFocus = wrapperRef.querySelector<HTMLElement>(
+        `[data-index=${STOP_ATTR}${index}]`
+      );
+      if (toFocus) {
+        setHasFocus(false);
+        setFocusedStopIndex(index);
+        toFocus.focus();
+      }
+    },
+    [disabled, wrapperRef]
+  );
+
+  useEffect(() => {
+    if (focusStopOnUpdate !== null) {
+      const toFocusIndex = sortedStops
+        .map(el => el.stop)
+        .indexOf(focusStopOnUpdate);
+      const toFocusId = toFocusIndex > -1 ? sortedStops[toFocusIndex].id : null;
+      onFocusStop(toFocusIndex);
+      setOpenedStopId(toFocusId);
+      setFocusStopOnUpdate(null);
     }
-  };
+  }, [sortedStops, onFocusStop, setFocusStopOnUpdate, focusStopOnUpdate]);
 
   const onFocusWrapper = () => {
     setFocusedStopIndex(null);

--- a/src/components/color_picker/saturation.tsx
+++ b/src/components/color_picker/saturation.tsx
@@ -72,7 +72,7 @@ export const EuiSaturation = forwardRef<HTMLDivElement, EuiSaturationProps>(
           top: (1 - v) * height,
         });
       }
-    }, [color]);
+    }, [color, lastColor]);
 
     const calculateColor = ({
       top,

--- a/src/components/color_picker/utils.ts
+++ b/src/components/color_picker/utils.ts
@@ -52,7 +52,7 @@ export function useMouseMove<T = HTMLDivElement>(
 ] {
   useEffect(() => {
     return unbindEventListeners;
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
   const handleInteraction = (
     e: ReactMouseEvent<T> | TouchEvent<T>,
     isFirstInteraction?: boolean

--- a/src/components/form/range/range_ticks.tsx
+++ b/src/components/form/range/range_ticks.tsx
@@ -29,17 +29,57 @@ export type EuiRangeTicksProps = Omit<
   onChange?: MouseEventHandler<HTMLButtonElement>;
 };
 
-export const EuiRangeTicks: FunctionComponent<EuiRangeTicksProps> = ({
+const EuiTickValue: FunctionComponent<
+  EuiRangeTicksProps & { tickValue: any; percentageWidth: number }
+> = ({
   disabled,
-  onChange,
   ticks,
-  tickSequence,
-  value,
-  max,
   min,
-  interval = 1,
-  compressed,
+  max,
+  value,
+  onChange,
+  percentageWidth,
+  tickValue,
 }) => {
+  const tickStyle: { left?: string; width?: string } = {};
+  let customTick;
+  if (ticks) {
+    customTick = find(ticks, o => o.value === tickValue);
+
+    if (customTick) {
+      tickStyle.left = `${((customTick.value - min) / (max - min)) * 100}%`;
+    }
+  } else {
+    tickStyle.width = `${percentageWidth}%`;
+  }
+
+  const tickClasses = classNames('euiRangeTick', {
+    'euiRangeTick--selected': value === tickValue,
+    'euiRangeTick--isCustom': customTick,
+  });
+
+  const label = customTick ? customTick.label : tickValue;
+
+  const [ref, innerText] = useInnerText();
+
+  return (
+    <button
+      type="button"
+      className={tickClasses}
+      value={tickValue}
+      disabled={disabled}
+      onClick={onChange}
+      style={tickStyle}
+      tabIndex={-1}
+      ref={ref}
+      title={typeof label === 'string' ? label : innerText}>
+      {label}
+    </button>
+  );
+};
+
+export const EuiRangeTicks: FunctionComponent<EuiRangeTicksProps> = props => {
+  const { ticks, tickSequence, max, min, interval = 1, compressed } = props;
   // Calculate the width of each tick mark
   const percentageWidth = (interval / (max - min + interval)) * 100;
 
@@ -55,45 +95,14 @@ export const EuiRangeTicks: FunctionComponent<EuiRangeTicksProps> = ({
 
   return (
     <div className={classes} style={ticksStyle}>
-      {tickSequence.map(tickValue => {
-        const tickStyle: { left?: string; width?: string } = {};
-        let customTick;
-        if (ticks) {
-          customTick = find(ticks, o => o.value === tickValue);
-
-          if (customTick) {
-            tickStyle.left = `${((customTick.value - min) / (max - min)) *
-              100}%`;
-          }
-        } else {
-          tickStyle.width = `${percentageWidth}%`;
-        }
-
-        const tickClasses = classNames('euiRangeTick', {
-          'euiRangeTick--selected': value === tickValue,
-          'euiRangeTick--isCustom': customTick,
-        });
-
-        const label = customTick ? customTick.label : tickValue;
-
-        const [ref, innerText] = useInnerText();
-
-        return (
-          <button
-            type="button"
-            className={tickClasses}
-            key={tickValue}
-            value={tickValue}
-            disabled={disabled}
-            onClick={onChange}
-            style={tickStyle}
-            tabIndex={-1}
-            ref={ref}
-            title={typeof label === 'string' ? label : innerText}>
-            {label}
-          </button>
-        );
-      })}
+      {tickSequence.map(tickValue => (
+        <EuiTickValue
+          key={tickValue}
+          {...props}
+          percentageWidth={percentageWidth}
+          tickValue={tickValue}
+        />
+      ))}
     </div>
   );
 };

--- a/src/components/inner_text/render_to_text.tsx
+++ b/src/components/inner_text/render_to_text.tsx
@@ -15,7 +15,7 @@ export function useRenderToText(node: ReactNode, placeholder = ''): string {
         unmountComponentAtNode(hostNode);
       });
     };
-  }, [node]);
+  }, [node, ref]);
 
   return text || placeholder;
 }

--- a/src/components/popover/input_popover.tsx
+++ b/src/components/popover/input_popover.tsx
@@ -3,6 +3,7 @@ import React, {
   HTMLAttributes,
   useState,
   useEffect,
+  useCallback,
 } from 'react';
 import classnames from 'classnames';
 import tabbable from 'tabbable';
@@ -42,28 +43,31 @@ export const EuiInputPopover: FunctionComponent<Props> = ({
   const inputRef = (node: HTMLElement | null) => setInputEl(node);
   const panelRef = (node: HTMLElement | null) => setPanelEl(node);
 
-  const setPanelWidth = (width?: number) => {
-    if (panelEl && (!!inputElWidth || !!width)) {
-      const newWidth = !!width ? width : inputElWidth;
-      panelEl.style.width = `${newWidth}px`;
-      if (onPanelResize) {
-        onPanelResize(newWidth);
+  const setPanelWidth = useCallback(
+    (width?: number) => {
+      if (panelEl && (!!inputElWidth || !!width)) {
+        const newWidth = !!width ? width : inputElWidth;
+        panelEl.style.width = `${newWidth}px`;
+        if (onPanelResize) {
+          onPanelResize(newWidth);
+        }
       }
-    }
-  };
-  const onResize = () => {
+    },
+    [panelEl, inputElWidth, onPanelResize]
+  );
+  const onResize = useCallback(() => {
     if (inputEl) {
       const width = inputEl.getBoundingClientRect().width;
       setInputElWidth(width);
       setPanelWidth(width);
     }
-  };
+  }, [inputEl, setPanelWidth]);
   useEffect(() => {
     onResize();
-  }, [inputEl]);
+  }, [onResize]);
   useEffect(() => {
     setPanelWidth();
-  }, [panelEl]);
+  }, [setPanelWidth]);
 
   const onKeyDown = (e: React.KeyboardEvent) => {
     if (e.keyCode === cascadingMenuKeyCodes.TAB) {


### PR DESCRIPTION
### Summary

First of two PRs. This fixes all the non-datagrid hooks warnings & errors as reported by `react-hooks/rules-of-hooks` & `react-hooks/exhaustive-deps`. I'm following up with a PR for the datagrid ones, along with enabling that eslint rule.

I reviewed the hooks' logic & interaction, and spot-checked each component after the changes. I didn't notice any difference in their operation.

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
