### PR TITLE
Fix datagrid use of hooks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,8 +65,8 @@ module.exports = {
     "jsx-a11y/tabindex-no-positive": "error",
     "jsx-a11y/label-has-associated-control": "error",
 
-    // "react-hooks/rules-of-hooks": "error",
-    // "react-hooks/exhaustive-deps": "warn",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
 
     "@typescript-eslint/array-type": ["error", "array-simple"],
     "@typescript-eslint/camelcase": "off",

--- a/src-docs/src/views/datagrid/datagrid.js
+++ b/src-docs/src/views/datagrid/datagrid.js
@@ -101,12 +101,6 @@ export default () => {
     [setSortingColumns]
   );
 
-  // Sort data
-  const data = useMemo(() => {
-    // the grid itself is responsible for sorting if inMemory is `sorting`
-    return raw_data;
-  }, []);
-
   // Column visibility
   const [visibleColumns, setVisibleColumns] = useState(() =>
     columns.map(({ id }) => id)
@@ -114,15 +108,11 @@ export default () => {
 
   const renderCellValue = useMemo(() => {
     return ({ rowIndex, columnId, setCellProps }) => {
-      let adjustedRowIndex = rowIndex;
-
-      adjustedRowIndex = rowIndex - pagination.pageIndex * pagination.pageSize;
-
       useEffect(() => {
         if (columnId === 'amount') {
-          if (data.hasOwnProperty(adjustedRowIndex)) {
+          if (raw_data.hasOwnProperty(rowIndex)) {
             const numeric = parseFloat(
-              data[adjustedRowIndex][columnId].match(/\d+\.\d+/)[0],
+              raw_data[rowIndex][columnId].match(/\d+\.\d+/)[0],
               10
             );
             setCellProps({
@@ -132,13 +122,13 @@ export default () => {
             });
           }
         }
-      }, [adjustedRowIndex, columnId, setCellProps]);
+      }, [rowIndex, columnId, setCellProps]);
 
-      return data.hasOwnProperty(adjustedRowIndex)
-        ? data[adjustedRowIndex][columnId]
+      return raw_data.hasOwnProperty(rowIndex)
+        ? raw_data[rowIndex][columnId]
         : null;
     };
-  }, [data, pagination.pageIndex, pagination.pageSize]);
+  }, []);
 
   return (
     <EuiDataGrid

--- a/src-docs/src/views/datagrid/datagrid.js
+++ b/src-docs/src/views/datagrid/datagrid.js
@@ -105,7 +105,7 @@ export default () => {
   const data = useMemo(() => {
     // the grid itself is responsible for sorting if inMemory is `sorting`
     return raw_data;
-  }, [raw_data, sortingColumns]);
+  }, []);
 
   // Column visibility
   const [visibleColumns, setVisibleColumns] = useState(() =>
@@ -138,7 +138,7 @@ export default () => {
         ? data[adjustedRowIndex][columnId]
         : null;
     };
-  }, [data]);
+  }, [data, pagination.pageIndex, pagination.pageSize]);
 
   return (
     <EuiDataGrid

--- a/src-docs/src/views/datagrid/in_memory.js
+++ b/src-docs/src/views/datagrid/in_memory.js
@@ -88,7 +88,7 @@ export default () => {
 
       return 0;
     });
-  }, [raw_data, sortingColumns]);
+  }, [sortingColumns]);
 
   // Pagination
   data = useMemo(() => {
@@ -114,7 +114,7 @@ export default () => {
         ? data[adjustedRowIndex][columnId]
         : null;
     };
-  }, data);
+  }, [data, pagination.pageIndex, pagination.pageSize]);
 
   return (
     <EuiDataGrid

--- a/src-docs/src/views/datagrid/in_memory_enhancements.js
+++ b/src-docs/src/views/datagrid/in_memory_enhancements.js
@@ -89,7 +89,7 @@ export default () => {
 
       return 0;
     });
-  }, [raw_data, sortingColumns]);
+  }, [sortingColumns]);
 
   // Pagination
   data = useMemo(() => {
@@ -114,7 +114,7 @@ export default () => {
         ? data[adjustedRowIndex][columnId]
         : null;
     };
-  }, [data]);
+  }, [data, pagination.pageIndex, pagination.pageSize]);
 
   return (
     <div>

--- a/src-docs/src/views/datagrid/in_memory_pagination.js
+++ b/src-docs/src/views/datagrid/in_memory_pagination.js
@@ -87,7 +87,7 @@ export default () => {
 
       return 0;
     });
-  }, [raw_data, sortingColumns]);
+  }, [sortingColumns]);
 
   // Column visibility
   const [visibleColumns, setVisibleColumns] = useState(() =>

--- a/src-docs/src/views/datagrid/in_memory_sorting.js
+++ b/src-docs/src/views/datagrid/in_memory_sorting.js
@@ -84,7 +84,7 @@ export default () => {
         ? raw_data[rowIndex][columnId]
         : null;
     };
-  }, [raw_data]);
+  }, []);
 
   return (
     <EuiDataGrid

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -489,7 +489,7 @@ describe('EuiDataGrid', () => {
                 'data-test-subj': `cell-${rowIndex}-${columnId}`,
                 style: { color: columnId === 'A' ? 'red' : 'blue' },
               });
-            }, []);
+            }, [columnId, rowIndex, setCellProps]);
 
             return `${rowIndex}, ${columnId}`;
           }}

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -45,7 +45,7 @@ import { EuiFocusTrap } from '../focus_trap';
 import { EuiResizeObserver } from '../observer/resize_observer';
 import { EuiDataGridInMemoryRenderer } from './data_grid_inmemory_renderer';
 import {
-  getMergedSchema,
+  useMergedSchema,
   EuiDataGridSchemaDetector,
   useDetectSchema,
   schemaDetectors as providedSchemaDetectors,
@@ -465,7 +465,7 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
     allSchemaDetectors,
     inMemory != null
   );
-  const mergedSchema = getMergedSchema(detectedSchema, columns);
+  const mergedSchema = useMergedSchema(detectedSchema, columns);
 
   const [columnSelector, orderedVisibleColumns] = useColumnSelector(
     columns,

--- a/src/components/datagrid/data_grid_body.tsx
+++ b/src/components/datagrid/data_grid_body.tsx
@@ -201,7 +201,6 @@ export const EuiDataGridBody: FunctionComponent<
     schema,
     popoverContents,
     visibleRowIndices,
-    startRow,
     interactiveCellId,
   ]);
 

--- a/src/components/datagrid/data_grid_header_row.tsx
+++ b/src/components/datagrid/data_grid_header_row.tsx
@@ -210,24 +210,19 @@ const EuiDataGridHeaderCell: FunctionComponent<
         }
       }
 
+      const headerNode = headerRef.current;
       // @ts-ignore-next line TS doesn't have focusin
-      headerRef.current.addEventListener('focusin', onFocusIn);
-      headerRef.current.addEventListener('focusout', onFocusOut);
-      headerRef.current.addEventListener('keyup', onKeyUp);
+      headerNode.addEventListener('focusin', onFocusIn);
+      headerNode.addEventListener('focusout', onFocusOut);
+      headerNode.addEventListener('keyup', onKeyUp);
       return () => {
         // @ts-ignore-next line TS doesn't have focusin
-        headerRef.current!.removeEventListener('focusin', onFocusIn);
-        headerRef.current!.removeEventListener('focusout', onFocusOut);
-        headerRef.current!.removeEventListener('keyup', onKeyUp);
+        headerNode.removeEventListener('focusin', onFocusIn);
+        headerNode.removeEventListener('focusout', onFocusOut);
+        headerNode.removeEventListener('keyup', onKeyUp);
       };
     }
-  }, [
-    headerIsInteractive,
-    isFocused,
-    headerRef.current,
-    setIsCellEntered,
-    setFocusedCell,
-  ]);
+  }, [headerIsInteractive, isFocused, setIsCellEntered, setFocusedCell, index]);
 
   return (
     <div

--- a/src/components/datagrid/data_grid_inmemory_renderer.tsx
+++ b/src/components/datagrid/data_grid_inmemory_renderer.tsx
@@ -84,7 +84,7 @@ const ObservedCell: FunctionComponent<{
         observer.disconnect();
       };
     }
-  }, [ref]);
+  }, [column, i, onCellRender, ref]);
 
   const CellElement = renderCellValue as JSXElementConstructor<
     EuiDataGridCellValueElementProps
@@ -145,7 +145,7 @@ export const EuiDataGridInMemoryRenderer: FunctionComponent<
     }
 
     return rows;
-  }, [columns, rowCount, renderCellValue, onCellRender]);
+  }, [rowCount, columns, inMemory.skipColumns, renderCellValue, onCellRender]);
 
   return createPortal(
     <Fragment>{rows}</Fragment>,

--- a/src/components/datagrid/data_grid_schema.tsx
+++ b/src/components/datagrid/data_grid_schema.tsx
@@ -358,11 +358,11 @@ export function useDetectSchema(
       },
       {}
     );
-  }, [inMemoryValues, schemaDetectors]);
+  }, [autoDetectSchema, inMemoryValues, schemaDetectors]);
   return schema;
 }
 
-export function getMergedSchema(
+export function useMergedSchema(
   detectedSchema: EuiDataGridSchema,
   columns: EuiDataGridColumn[]
 ) {


### PR DESCRIPTION
### Summary

Second hooks PR, this fixes a number of hooks warnings & errors in src & docs. No functionality changes, but it does fix a bug in the docs' in-memory demo. This also enables the react hooks eslint rule.

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
