### PR TITLE
Fixed EuiBetaBadge a11y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 **Bug fixes**
 
 - Fixed `EuiDataGrid` schema detection on already defined column schemas ([#2550](https://github.com/elastic/eui/pull/2550))
+- Fixed `EuiBetaBadge` accessibility with `tab-index=0` ([#2559](https://github.com/elastic/eui/pull/2559))
 
 ## [`16.0.1`](https://github.com/elastic/eui/tree/v16.0.1)
 

--- a/src/components/badge/beta_badge/_beta_badge.scss
+++ b/src/components/badge/beta_badge/_beta_badge.scss
@@ -12,8 +12,11 @@
   line-height: $euiSizeL;
   text-align: center;
   white-space: nowrap;
-
   cursor: default;
+
+  &:focus {
+    @include euiFocusRing;
+  }
 }
 
 // When it's just an icon, make it a circle

--- a/src/components/badge/beta_badge/beta_badge.tsx
+++ b/src/components/badge/beta_badge/beta_badge.tsx
@@ -93,7 +93,7 @@ export const EuiBetaBadge: FunctionComponent<EuiBetaBadgeProps> = ({
         position={tooltipPosition}
         content={tooltipContent}
         title={title || label}>
-        <span className={classes} {...rest}>
+        <span tabIndex={0} className={classes} {...rest}>
           {icon || label}
         </span>
       </EuiToolTip>

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -294,7 +294,6 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
 
   return (
     <div className={classes} onClick={outerOnClick} {...rest}>
-      {optionalBetaBadge}
       {optionalCardTop}
 
       <div className="euiCard__content">
@@ -311,6 +310,9 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
 
         {children}
       </div>
+
+      {/* Beta badge should always be after the title/description but before any footer buttons */}
+      {optionalBetaBadge}
 
       {layout === 'vertical' && footer && (
         <div className="euiCard__footer">{footer}</div>


### PR DESCRIPTION
### Summary

Since EuiBetaBadge's don't actually have any clickability to them, they were ignored from the tab order and therefore, the description which only shows on hover could never be read by a screenreader. This PR basically just adds `tab-index=0` to the element putting it into the focus order of the DOM. We handle this the same way for EuiIconTip.

![Screen Recording 2019-11-25 at 12 39 PM](https://user-images.githubusercontent.com/549577/69564270-b1b6d000-0f80-11ea-9cc8-350a35c3beb1.gif)

<img width="506" alt="Screen Shot 2019-11-21 at 11 53 23 AM" src="https://user-images.githubusercontent.com/549577/69564360-e2970500-0f80-11ea-9592-e03d21927e2f.png">


This also then required moving the DOM order of the beta badge in EuiCard so that it didn't come before the title of the card.

![Screen Recording 2019-11-21 at 12 01 PM](https://user-images.githubusercontent.com/549577/69564339-d9a63380-0f80-11ea-9f3d-dc6fc50dbd96.gif)


### Checklist

- ~[ ] Checked in **dark mode**~
- ~[ ] Checked in **mobile**~
- [x] Checked in **IE11** and **Firefox**
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **documentation** examples~
- ~[ ] Added or updated **jest tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
