### PR TITLE
Add third party icon for ActiveMQ

### DIFF
--- a/src-docs/src/views/icon/logos_third.js
+++ b/src-docs/src/views/icon/logos_third.js
@@ -21,6 +21,7 @@ import {
 } from '../../../../src/components';
 
 const iconTypes = [
+  'logoActivemq',
   'logoAerospike',
   'logoApache',
   'logoAWS',

--- a/src/components/icon/assets/logo_activemq.js
+++ b/src/components/icon/assets/logo_activemq.js
@@ -1,0 +1,37 @@
+import React from 'react';
+
+const EuiIconLogoActivemq = props => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={32} height={32} viewBox="0 0 128 128">
+    <defs>
+      <filter id="a" colorInterpolationFilters="sRGB">
+        <feFlood floodOpacity=".498" floodColor="#000" result="flood" />
+        <feComposite in="flood" in2="SourceGraphic" operator="in" result="composite1" />
+        <feGaussianBlur in="composite1" stdDeviation=".2" result="blur" />
+        <feOffset dx="1" dy="1" result="offset" />
+        <feComposite in="SourceGraphic" in2="offset" result="composite2" />
+      </filter>
+    </defs>
+    <g filter="url(#a)" fill="#fff" transform="matrix(2.8 0 0 2.8 -90 -305)">
+      <path d="M64.697 153.552l-8.352-.05-4.133-7.257 4.218-7.208 8.352.049 4.134 7.257z" />
+      <path d="M52.632 146.553l-8.352-.049-4.133-7.257 4.218-7.209 8.352.05 4.134 7.257z" />
+      <path d="M64.771 139.589l-8.352-.05-4.133-7.257 4.218-7.208 8.352.05 4.134 7.257z" />
+      <path d="M64.765 125.702l-8.351-.049-4.134-7.257 4.219-7.209 8.352.05 4.133 7.257z" />
+      <path d="M52.696 132.676l-8.352-.049-4.133-7.257 4.218-7.209 8.352.05 4.133 7.257z" />
+    </g>
+    <g transform="matrix(2.8 0 0 2.8 -90 -305)">
+      <path d="M64.266 138.661l-7.296-.022-3.628-6.33L57.009 126l7.297.023 3.628 6.33z" fill="#c12766" />
+      <path d="M52.127 145.626l-7.296-.023-3.628-6.33 3.667-6.307 7.296.022 3.629 6.33z" fill="#3e489f" />
+      <path d="M64.19 152.624l-7.295-.023-3.629-6.33 3.668-6.307 7.296.023 3.629 6.33z" fill="#714099" />
+      <path d="M52.191 131.749l-7.296-.023-3.629-6.33 3.668-6.307 7.296.022 3.629 6.33z" fill="#78932c" />
+      <path d="M64.26 124.775l-7.296-.023-3.628-6.33 3.668-6.307 7.296.022 3.628 6.33z" fill="#cf242a" />
+      <circle cy="146.294" cx="60.564" r="1.6" fill="#fff" />
+      <path d="M61.748 117.71l-14.267 8.174M48.514 124.197l.048 16.442M47.525 138.715l14.136 8.397M60.59 117.133l.048 16.442M60.657 131.093l.048 16.442M61.766 131.708l-14.267 8.174M47.564 124.84l14.136 8.398" fill="none" stroke="#fff" strokeWidth=".524" />
+      <circle cy="139.242" cx="48.334" r="1.6" fill="#fff" />
+      <circle cy="132.486" cx="60.901" r="1.6" fill="#fff" />
+      <circle cy="125.419" cx="48.563" r="1.6" fill="#fff" />
+      <circle cy="118.445" cx="60.632" r="1.6" fill="#fff" />
+    </g>
+  </svg>
+);
+
+export const icon = EuiIconLogoActivemq;

--- a/src/components/icon/assets/logo_activemq.svg
+++ b/src/components/icon/assets/logo_activemq.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 128 128">
+  <defs>
+    <filter id="a" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity=".498" flood-color="#000" result="flood" />
+      <feComposite in="flood" in2="SourceGraphic" operator="in" result="composite1" />
+      <feGaussianBlur in="composite1" stdDeviation=".2" result="blur" />
+      <feOffset dx="1" dy="1" result="offset" />
+      <feComposite in="SourceGraphic" in2="offset" result="composite2" />
+    </filter>
+  </defs>
+  <g filter="url(#a)" fill="#fff" transform="matrix(2.8 0 0 2.8 -90 -305)">
+    <path d="M64.697 153.552l-8.352-.05-4.133-7.257 4.218-7.208 8.352.049 4.134 7.257z" />
+    <path d="M52.632 146.553l-8.352-.049-4.133-7.257 4.218-7.209 8.352.05 4.134 7.257z" />
+    <path d="M64.771 139.589l-8.352-.05-4.133-7.257 4.218-7.208 8.352.05 4.134 7.257z" />
+    <path d="M64.765 125.702l-8.351-.049-4.134-7.257 4.219-7.209 8.352.05 4.133 7.257z" />
+    <path d="M52.696 132.676l-8.352-.049-4.133-7.257 4.218-7.209 8.352.05 4.133 7.257z" />
+  </g>
+  <g transform="matrix(2.8 0 0 2.8 -90 -305)">
+    <path d="M64.266 138.661l-7.296-.022-3.628-6.33L57.009 126l7.297.023 3.628 6.33z" fill="#c12766" />
+    <path d="M52.127 145.626l-7.296-.023-3.628-6.33 3.667-6.307 7.296.022 3.629 6.33z" fill="#3e489f" />
+    <path d="M64.19 152.624l-7.295-.023-3.629-6.33 3.668-6.307 7.296.023 3.629 6.33z" fill="#714099" />
+    <path d="M52.191 131.749l-7.296-.023-3.629-6.33 3.668-6.307 7.296.022 3.629 6.33z" fill="#78932c" />
+    <path d="M64.26 124.775l-7.296-.023-3.628-6.33 3.668-6.307 7.296.022 3.628 6.33z" fill="#cf242a" />
+    <circle cy="146.294" cx="60.564" r="1.6" fill="#fff" />
+    <path d="M61.748 117.71l-14.267 8.174M48.514 124.197l.048 16.442M47.525 138.715l14.136 8.397M60.59 117.133l.048 16.442M60.657 131.093l.048 16.442M61.766 131.708l-14.267 8.174M47.564 124.84l14.136 8.398" fill="none" stroke="#fff" stroke-width=".524" />
+    <circle cy="139.242" cx="48.334" r="1.6" fill="#fff" />
+    <circle cy="132.486" cx="60.901" r="1.6" fill="#fff" />
+    <circle cy="125.419" cx="48.563" r="1.6" fill="#fff" />
+    <circle cy="118.445" cx="60.632" r="1.6" fill="#fff" />
+  </g>
+</svg>

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -162,6 +162,7 @@ const typeToPathMap = {
   lock: 'lock',
   lockOpen: 'lockOpen',
   logsApp: 'app_logs',
+  logoActivemq: 'logo_activemq',
   logoAerospike: 'logo_aerospike',
   logoApache: 'logo_apache',
   logoAPM: 'logo_apm',


### PR DESCRIPTION
### Summary

This PR adds new icon for the third party application - ActiveMQ.

Master issue: https://github.com/elastic/beats/issues/14510

### Checklist

- [x] Checked in **dark mode**
- [x] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately

### Screenshots
<img width="391" alt="Zrzut ekranu 2019-11-26 o 10 35 11" src="https://user-images.githubusercontent.com/14044910/69617552-a921d080-1038-11ea-9c26-5c07c495e520.png">
<img width="962" alt="Zrzut ekranu 2019-11-26 o 10 34 06" src="https://user-images.githubusercontent.com/14044910/69617537-a2935900-1038-11ea-95f9-dcbbe2a390e0.png">
<img width="1029" alt="Zrzut ekranu 2019-11-26 o 10 26 49" src="https://user-images.githubusercontent.com/14044910/69617593-b6d75600-1038-11ea-841b-768f280f14fd.png">

