### PR TITLE
Extract setState queuing into a service, re-use it in EuiIcon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added `euiTextBreakWord()` to `EuiToast` header ([#2549](https://github.com/elastic/eui/pull/2549))
 - Fixed `.eui-textBreakAll` on Firefox ([#2549](https://github.com/elastic/eui/pull/2549))
 - Fixed `EuiBetaBadge` accessibility with `tab-index=0` ([#2559](https://github.com/elastic/eui/pull/2559))
+- Improved `EuiIcon` loading performance ([#2565](https://github.com/elastic/eui/pull/2565))
 
 ## [`16.0.1`](https://github.com/elastic/eui/tree/v16.0.1)
 

--- a/src/components/context_menu/__snapshots__/context_menu.test.tsx.snap
+++ b/src/components/context_menu/__snapshots__/context_menu.test.tsx.snap
@@ -114,18 +114,13 @@ exports[`EuiContextMenu props panels and initialPanelId allows you to click the 
         class="euiContextMenu__itemLayout"
       >
         <svg
-          class="euiIcon euiIcon--medium euiIcon-isLoaded euiContextMenu__icon"
+          class="euiIcon euiIcon--medium euiIcon-isLoading euiContextMenu__icon"
           focusable="false"
           height="16"
           viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10.843 13.069L6.232 8.384a.546.546 0 0 1 0-.768l4.61-4.685a.552.552 0 0 0 0-.771.53.53 0 0 0-.759 0l-4.61 4.684a1.65 1.65 0 0 0 0 2.312l4.61 4.684a.53.53 0 0 0 .76 0 .552.552 0 0 0 0-.771z"
-            fill-rule="nonzero"
-          />
-        </svg>
+        />
         <span
           class="euiContextMenu__text"
         >
@@ -148,18 +143,13 @@ exports[`EuiContextMenu props panels and initialPanelId allows you to click the 
               2a
             </span>
             <svg
-              class="euiIcon euiIcon--medium euiIcon-isLoaded euiContextMenu__arrow"
+              class="euiIcon euiIcon--medium euiIcon-isLoading euiContextMenu__arrow"
               focusable="false"
               height="16"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M5.157 13.069l4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771z"
-                fill-rule="nonzero"
-              />
-            </svg>
+            />
           </span>
         </button>
         <button
@@ -175,18 +165,13 @@ exports[`EuiContextMenu props panels and initialPanelId allows you to click the 
               2b
             </span>
             <svg
-              class="euiIcon euiIcon--medium euiIcon-isLoaded euiContextMenu__arrow"
+              class="euiIcon euiIcon--medium euiIcon-isLoading euiContextMenu__arrow"
               focusable="false"
               height="16"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M5.157 13.069l4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771z"
-                fill-rule="nonzero"
-              />
-            </svg>
+            />
           </span>
         </button>
         <button
@@ -202,18 +187,13 @@ exports[`EuiContextMenu props panels and initialPanelId allows you to click the 
               2c
             </span>
             <svg
-              class="euiIcon euiIcon--medium euiIcon-isLoaded euiContextMenu__arrow"
+              class="euiIcon euiIcon--medium euiIcon-isLoading euiContextMenu__arrow"
               focusable="false"
               height="16"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M5.157 13.069l4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771z"
-                fill-rule="nonzero"
-              />
-            </svg>
+            />
           </span>
         </button>
       </div>

--- a/src/components/context_menu/__snapshots__/context_menu_panel.test.tsx.snap
+++ b/src/components/context_menu/__snapshots__/context_menu_panel.test.tsx.snap
@@ -114,18 +114,13 @@ exports[`EuiContextMenu props panels and initialPanelId allows you to click the 
         class="euiContextMenu__itemLayout"
       >
         <svg
-          class="euiIcon euiIcon--medium euiIcon-isLoaded euiContextMenu__icon"
+          class="euiIcon euiIcon--medium euiIcon-isLoading euiContextMenu__icon"
           focusable="false"
           height="16"
           viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10.843 13.069L6.232 8.384a.546.546 0 0 1 0-.768l4.61-4.685a.552.552 0 0 0 0-.771.53.53 0 0 0-.759 0l-4.61 4.684a1.65 1.65 0 0 0 0 2.312l4.61 4.684a.53.53 0 0 0 .76 0 .552.552 0 0 0 0-.771z"
-            fill-rule="nonzero"
-          />
-        </svg>
+        />
         <span
           class="euiContextMenu__text"
         >
@@ -148,18 +143,13 @@ exports[`EuiContextMenu props panels and initialPanelId allows you to click the 
               2a
             </span>
             <svg
-              class="euiIcon euiIcon--medium euiIcon-isLoaded euiContextMenu__arrow"
+              class="euiIcon euiIcon--medium euiIcon-isLoading euiContextMenu__arrow"
               focusable="false"
               height="16"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M5.157 13.069l4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771z"
-                fill-rule="nonzero"
-              />
-            </svg>
+            />
           </span>
         </button>
         <button
@@ -175,18 +165,13 @@ exports[`EuiContextMenu props panels and initialPanelId allows you to click the 
               2b
             </span>
             <svg
-              class="euiIcon euiIcon--medium euiIcon-isLoaded euiContextMenu__arrow"
+              class="euiIcon euiIcon--medium euiIcon-isLoading euiContextMenu__arrow"
               focusable="false"
               height="16"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M5.157 13.069l4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771z"
-                fill-rule="nonzero"
-              />
-            </svg>
+            />
           </span>
         </button>
         <button
@@ -202,18 +187,13 @@ exports[`EuiContextMenu props panels and initialPanelId allows you to click the 
               2c
             </span>
             <svg
-              class="euiIcon euiIcon--medium euiIcon-isLoaded euiContextMenu__arrow"
+              class="euiIcon euiIcon--medium euiIcon-isLoading euiContextMenu__arrow"
               focusable="false"
               height="16"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M5.157 13.069l4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771z"
-                fill-rule="nonzero"
-              />
-            </svg>
+            />
           </span>
         </button>
       </div>

--- a/src/components/datagrid/data_grid_inmemory_renderer.tsx
+++ b/src/components/datagrid/data_grid_inmemory_renderer.tsx
@@ -6,12 +6,13 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import { createPortal, unstable_batchedUpdates } from 'react-dom';
+import { createPortal } from 'react-dom';
 import {
   EuiDataGridCellValueElementProps,
   EuiDataGridCellProps,
 } from './data_grid_cell';
 import { EuiDataGridColumn, EuiDataGridInMemory } from './data_grid_types';
+import { enqueueStateChange } from '../../services/react';
 
 interface EuiDataGridInMemoryRendererProps {
   inMemory: EuiDataGridInMemory;
@@ -26,27 +27,6 @@ interface EuiDataGridInMemoryRendererProps {
 }
 
 function noop() {}
-
-const _queue: Function[] = [];
-
-function processQueue() {
-  // the queued functions trigger react setStates which, if unbatched,
-  // each cause a full update->render->dom pass _per function_
-  // instead, tell React to wait until all updates are finished before re-rendering
-  unstable_batchedUpdates(() => {
-    for (let i = 0; i < _queue.length; i++) {
-      _queue[i]();
-    }
-    _queue.length = 0;
-  });
-}
-
-function enqueue(fn: Function) {
-  if (_queue.length === 0) {
-    setTimeout(processQueue);
-  }
-  _queue.push(fn);
-}
 
 function getElementText(element: HTMLElement) {
   return 'innerText' in element
@@ -71,7 +51,9 @@ const ObservedCell: FunctionComponent<{
       onCellRender(i, column, getElementText(ref));
       const observer = new MutationObserver(() => {
         // onMutation callbacks aren't in the component lifecycle, intentionally batch any effects
-        enqueue(onCellRender.bind(null, i, column, getElementText(ref)));
+        enqueueStateChange(
+          onCellRender.bind(null, i, column, getElementText(ref))
+        );
       });
       observer.observe(ref, {
         characterData: true,

--- a/src/components/icon/icon.test.tsx
+++ b/src/components/icon/icon.test.tsx
@@ -10,14 +10,14 @@ const prettyHtml = cheerio.load('');
 
 function testIcon(props: PropsOf<EuiIcon>) {
   return () => {
-    const component = mount(<EuiIcon {...props} />);
-
+    expect.assertions(1);
     return new Promise(resolve => {
-      setTimeout(() => {
+      const onIconLoad = () => {
         component.update();
         expect(prettyHtml(component.html())).toMatchSnapshot();
         resolve();
-      }, 0);
+      };
+      const component = mount(<EuiIcon {...props} onIconLoad={onIconLoad} />);
     });
   };
 }

--- a/src/services/react.ts
+++ b/src/services/react.ts
@@ -1,0 +1,22 @@
+import { unstable_batchedUpdates } from 'react-dom';
+
+const _queue: Function[] = [];
+
+function processQueue() {
+  // the queued functions trigger react setStates which, if unbatched,
+  // each cause a full update->render->dom pass _per function_
+  // instead, tell React to wait until all updates are finished before re-rendering
+  unstable_batchedUpdates(() => {
+    for (let i = 0; i < _queue.length; i++) {
+      _queue[i]();
+    }
+    _queue.length = 0;
+  });
+}
+
+export function enqueueStateChange(fn: Function) {
+  if (_queue.length === 0) {
+    setTimeout(processQueue);
+  }
+  _queue.push(fn);
+}


### PR DESCRIPTION
### Summary

For performance reasons, EuiDataGrid utilizes `react-dom::unstable_batchedUpdates` to ensure setState calls are batched. EuiIcon suffers from not doing the same thing, which this PR resolves.

Shown in the screen shots below, the current performance is a 1.6s second UI-blocking back-to-back sequence of icon updates. The batched performance shows multiple frame renders and one consolidated React update operation.

I also added an `onIconLoad` prop to simplify the testing experience, as icon tests must now wait for the queued setState to finish in addition to the dynamic import resolving.

### Current EuiIcon performance (icon docs page)
![current performance](https://d.pr/i/fIiSMr.png)

### With batching
![updated performance](https://d.pr/i/BKZOoy.png)

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
- [x] Props have proper **autodocs**
~- [ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
