### PR TITLE
adds background-color to compressed button group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Updated compressed styles for `EuiButtonGroup` to include a background color ([#2568](https://github.com/elastic/eui/pull/2568))
 - Added `heading` prop to `EuiCallOut` to allow for variance in the title tag ([#2357](https://github.com/elastic/eui/pull/2357))
 - Added `badge` prop and new styles `EuiHeaderAlert` ([#2506](https://github.com/elastic/eui/pull/2506))
 - Added new keyboard shortcuts for the data grid component: `Home` (same row, first column), `End` (same row, last column), `Ctrl+Home` (first row, first column), `Ctrl+End` (last row, last column), `Page Up` (next page) and `Page Down` (previous page) ([#2519](https://github.com/elastic/eui/pull/2519))

--- a/src/components/button/button_group/_button_group.scss
+++ b/src/components/button/button_group/_button_group.scss
@@ -94,6 +94,7 @@
 .euiButtonGroup--compressed {
   border: 1px solid $euiFormBorderColor;
   border-radius: $euiFormControlCompressedBorderRadius;
+  background-color: $euiFormBackgroundColor;
 
   .euiButtonGroup__button {
     height: $euiFormControlCompressedHeight - 2px;

--- a/src/components/form/_variables.scss
+++ b/src/components/form/_variables.scss
@@ -34,5 +34,5 @@ $euiFormCustomControlBorderColor: shadeOrTint($euiColorLightestShade, 18%, 30%) 
 $euiFormControlDisabledColor: $euiColorMediumShade !default;
 $euiFormControlBoxShadow: 0 1px 1px -1px transparentize($euiShadowColor, .8), 0 3px 2px -2px transparentize($euiShadowColor, .8) !default;
 $euiFormInputGroupLabelBackground: tintOrShade($euiColorLightShade, 50%, 40%) !default;
-$euiFormInputGroupBorder: 1px solid shadeOrTint($euiFormInputGroupLabelBackground, 6%, 8%) !default;
+$euiFormInputGroupBorder: 1px solid shadeOrTint($euiFormInputGroupLabelBackground, 2%, 4%) !default;
 $euiSwitchOffColor: lightOrDarkTheme(transparentize($euiColorMediumShade, .8), transparentize($euiColorMediumShade, .3)) !default;

--- a/src/components/form/_variables.scss
+++ b/src/components/form/_variables.scss
@@ -33,6 +33,6 @@ $euiFormCustomControlDisabledIconColor: shadeOrTint($euiColorMediumShade, 38%, 4
 $euiFormCustomControlBorderColor: shadeOrTint($euiColorLightestShade, 18%, 30%) !default;
 $euiFormControlDisabledColor: $euiColorMediumShade !default;
 $euiFormControlBoxShadow: 0 1px 1px -1px transparentize($euiShadowColor, .8), 0 3px 2px -2px transparentize($euiShadowColor, .8) !default;
-$euiFormInputGroupLabelBackground: tintOrShade($euiColorLightShade, 65%, 40%) !default;
+$euiFormInputGroupLabelBackground: tintOrShade($euiColorLightShade, 50%, 40%) !default;
 $euiFormInputGroupBorder: 1px solid shadeOrTint($euiFormInputGroupLabelBackground, 6%, 8%) !default;
 $euiSwitchOffColor: lightOrDarkTheme(transparentize($euiColorMediumShade, .8), transparentize($euiColorMediumShade, .3)) !default;


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/2564

### Summary

Adds background color to compressed button groups to prevent underlying background from showing through. Also, reduced the tint on 'selected' button background color for a touch more contrast.

As you'll see below, these minor changes result in the button groups also aligning better to the styles of the other compressed inputs.

### Before (left) and After (right)
![Artboard](https://user-images.githubusercontent.com/446285/69678688-e5baef80-106b-11ea-896d-71bee7aa7d16.png)

### With Canvas sidebar background color
<img width="447" alt="Screenshot 2019-11-26 16 37 56" src="https://user-images.githubusercontent.com/446285/69678695-ebb0d080-106b-11ea-9853-c2479fd1317d.png">

### Checklist

- [x] Checked in **dark mode**
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
