### PR TITLE
Fixed `EuiSwitch` clicking on disabled label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 **Bug fixes**
 
-- Fixed `EuiSwitch` clicking on disabled label, positioning (regression) ([#2575](https://github.com/elastic/eui/pull/2575))
+- Fixed `EuiSwitch` clicking on disabled label ([#2575](https://github.com/elastic/eui/pull/2575))
 - Fixed `EuiDataGrid` schema detection on already defined column schemas ([#2550](https://github.com/elastic/eui/pull/2550))
 - Added `euiTextBreakWord()` to `EuiToast` header ([#2549](https://github.com/elastic/eui/pull/2549))
 - Fixed `.eui-textBreakAll` on Firefox ([#2549](https://github.com/elastic/eui/pull/2549))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 **Bug fixes**
 
+- Fixed `EuiSwitch` clicking on disabled label, positioning (regression) ([#2574](https://github.com/elastic/eui/pull/2574))
 - Fixed `EuiDataGrid` schema detection on already defined column schemas ([#2550](https://github.com/elastic/eui/pull/2550))
 - Added `euiTextBreakWord()` to `EuiToast` header ([#2549](https://github.com/elastic/eui/pull/2549))
 - Fixed `.eui-textBreakAll` on Firefox ([#2549](https://github.com/elastic/eui/pull/2549))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 **Bug fixes**
 
-- Fixed `EuiSwitch` clicking on disabled label, positioning (regression) ([#2574](https://github.com/elastic/eui/pull/2574))
+- Fixed `EuiSwitch` clicking on disabled label, positioning (regression) ([#2575](https://github.com/elastic/eui/pull/2575))
 - Fixed `EuiDataGrid` schema detection on already defined column schemas ([#2550](https://github.com/elastic/eui/pull/2550))
 - Added `euiTextBreakWord()` to `EuiToast` header ([#2549](https://github.com/elastic/eui/pull/2549))
 - Fixed `.eui-textBreakAll` on Firefox ([#2549](https://github.com/elastic/eui/pull/2549))

--- a/src/components/form/switch/_switch.scss
+++ b/src/components/form/switch/_switch.scss
@@ -1,6 +1,6 @@
 .euiSwitch {
   position: relative;
-  display: flex;
+  display: inline-block;
   min-height: $euiSwitchHeight;
 
   .euiSwitch__label {

--- a/src/components/form/switch/_switch.scss
+++ b/src/components/form/switch/_switch.scss
@@ -1,6 +1,6 @@
 .euiSwitch {
   position: relative;
-  display: inline-block;
+  display: flex;
   min-height: $euiSwitchHeight;
 
   .euiSwitch__label {

--- a/src/components/form/switch/switch.tsx
+++ b/src/components/form/switch/switch.tsx
@@ -3,6 +3,7 @@ import React, {
   FunctionComponent,
   ReactNode,
   useState,
+  useCallback,
 } from 'react';
 import classNames from 'classnames';
 
@@ -49,13 +50,18 @@ export const EuiSwitch: FunctionComponent<EuiSwitchProps> = ({
   const [switchId] = useState(id || makeId());
   const [labelId] = useState(makeId());
 
-  const onClick = (
-    e: React.MouseEvent<HTMLButtonElement | HTMLParagraphElement>
-  ) => {
-    const event = (e as unknown) as EuiSwitchEvent;
-    event.target.checked = !checked;
-    onChange(event);
-  };
+  const onClick = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement | HTMLParagraphElement>) => {
+      if (disabled) {
+        return;
+      }
+
+      const event = (e as unknown) as EuiSwitchEvent;
+      event.target.checked = !checked;
+      onChange(event);
+    },
+    [checked, disabled, onChange]
+  );
 
   const classes = classNames(
     'euiSwitch',


### PR DESCRIPTION
### Summary

This fixes the regression of `EuiSwitch` component:

 - The switch is clickable even in `disabled` state if click on label:


![switch_disabled](https://user-images.githubusercontent.com/31325372/69807893-7b36ba80-11f7-11ea-808d-cef039ae754f.gif)


 - Label displays under the switch button if there is not enough space:

![image](https://user-images.githubusercontent.com/31325372/69808036-c3ee7380-11f7-11ea-9cca-d9c8a6faf078.png)

Found in kibana:

![switch](https://user-images.githubusercontent.com/31325372/69808237-25164700-11f8-11ea-80ea-afc412fd9e26.png)


Using flex box it looks better: 

![image](https://user-images.githubusercontent.com/31325372/69808284-36f7ea00-11f8-11ea-9dec-ac9018e2a77d.png)


### Checklist

- [ ] Checked in **dark mode**
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
