### PR TITLE
Fixed `EuiButtonToggle` passes data-test-subj attribute to the parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 **Bug fixes**
 
+- Fixed `EuiButtonToggle` passes data-test-subj attribute to the parent ([#2576](https://github.com/elastic/eui/pull/2576))
 - Fixed `EuiDataGrid` schema detection on already defined column schemas ([#2550](https://github.com/elastic/eui/pull/2550))
 - Added `euiTextBreakWord()` to `EuiToast` header ([#2549](https://github.com/elastic/eui/pull/2549))
 - Fixed `.eui-textBreakAll` on Firefox ([#2549](https://github.com/elastic/eui/pull/2549))

--- a/src/components/button/button_toggle/button_toggle.tsx
+++ b/src/components/button/button_toggle/button_toggle.tsx
@@ -70,6 +70,7 @@ type Props = ExclusiveUnion<
 export const EuiButtonToggle: FunctionComponent<Props> = ({
   className,
   color = 'primary',
+  'data-test-subj': dataTestSubj = '',
   isDisabled,
   isEmpty,
   isIconOnly,
@@ -108,6 +109,7 @@ export const EuiButtonToggle: FunctionComponent<Props> = ({
   return (
     <EuiToggle
       className={wrapperClasses}
+      data-test-subj={dataTestSubj}
       inputClassName="euiButtonToggle__input"
       checked={isSelected}
       isDisabled={isDisabled}


### PR DESCRIPTION
### Summary

This change is necessary for functional tests because of intercepted click event:

![image](https://user-images.githubusercontent.com/31325372/69813487-5e07e900-1203-11ea-9f50-2f0a5aa7947b.png)

### Checklist

- [ ] Checked in **dark mode**
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
