### PR TITLE
EuiComboBox: Sets focus back to the input element after each scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 **Bug fixes**
 
 - Fixed `EuiSwitch` clicking on disabled label ([#2575](https://github.com/elastic/eui/pull/2575))
-- Fixed `EuiComboBox` options list closing when clicking outside the component after scrolling ([#](https://github.com/elastic/eui/pull/))
+- Fixed `EuiComboBox` options list closing when clicking outside the component after scrolling ([#2589](https://github.com/elastic/eui/pull/2589))
 
 ## [`16.1.0`](https://github.com/elastic/eui/tree/v16.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 **Bug fixes**
 
 - Fixed `EuiSwitch` clicking on disabled label ([#2575](https://github.com/elastic/eui/pull/2575))
+- Fixed `EuiComboBox` options list closing when clicking outside the component after scrolling ([#](https://github.com/elastic/eui/pull/))
 
 ## [`16.1.0`](https://github.com/elastic/eui/tree/v16.1.0)
 

--- a/src/components/combo_box/__snapshots__/combo_box.test.js.snap
+++ b/src/components/combo_box/__snapshots__/combo_box.test.js.snap
@@ -466,6 +466,7 @@ exports[`props singleSelection selects existing option when opened 1`] = `
       onCloseList={[Function]}
       onOptionClick={[Function]}
       onOptionEnterKey={[Function]}
+      onScroll={[Function]}
       optionRef={[Function]}
       options={
         Array [

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -723,6 +723,7 @@ export class EuiComboBox extends Component {
             fullWidth={fullWidth}
             rootId={this.rootId}
             onCloseList={this.closeList}
+            onScroll={() => this.searchInput.focus()}
           />
         </EuiPortal>
       );


### PR DESCRIPTION
### Summary

Closes https://github.com/elastic/eui/issues/2583

In `EuiComboBox` sets focus back to the input element after each scroll. In order to do that I took advantage of the `onScroll` hook of the `List` component.

### Checklist

- [ ] Checked in **dark mode**
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [X] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
