### PR TITLE
Fix default docs moment locale

### DIFF
--- a/src-docs/src/components/guide_locale_selector/guide_locale_selector.js
+++ b/src-docs/src/components/guide_locale_selector/guide_locale_selector.js
@@ -14,6 +14,7 @@ moment.defineLocale('en-xa', {
   weekdaysMin: enConfig.weekdaysMin.map(translateUsingPseudoLocale),
   weekdaysShort: enConfig.weekdaysShort.map(translateUsingPseudoLocale),
 });
+moment.locale('en');
 
 import { EuiSwitch, EuiFormRow } from '../../../../src/components';
 

--- a/src-docs/src/components/guide_locale_selector/guide_locale_selector.js
+++ b/src-docs/src/components/guide_locale_selector/guide_locale_selector.js
@@ -14,6 +14,7 @@ moment.defineLocale('en-xa', {
   weekdaysMin: enConfig.weekdaysMin.map(translateUsingPseudoLocale),
   weekdaysShort: enConfig.weekdaysShort.map(translateUsingPseudoLocale),
 });
+// Reset default moment locale after using `defineLocale`
 moment.locale('en');
 
 import { EuiSwitch, EuiFormRow } from '../../../../src/components';


### PR DESCRIPTION
### Summary

#2518 added a babelfish moment config that can be enabled via a 'Doc Options' toggle (intended for dev only). Defining a new locale via `moment.defineLocale`, though, also sets the app's _default_ locale. As the locale was never reset to 'en' after defining 'en-xa', all components that do no use `EuiI18nConsumer` to consume the togglable locale have formatted dates displayed in babelfish. This also happens in the production build, as the babelfish locale is still defined.

This PR sets moment's default locale back to 'en' after defining 'en-xa'. The babelfish toggle still works in dev (see datepicker examples).

### Checklist

~~- [ ] Checked in **dark mode**~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
~~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~~
