### PR TITLE
`EuiCheckbox` and `EuiCheckboxGroup` type exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Fixed label wrapping of `EuiSwitch` ([#2585](https://github.com/elastic/eui/pull/2585))
 - Replaced `<p>` tag surrounding the label with a `<span>` tag in `EuiSwitch` to fix any inherited margin ([#2585](https://github.com/elastic/eui/pull/2585))
-- Add the same padding from `EuiSelectableListItem` to the heading to fix alignment ([#2585](https://github.com/elastic/eui/pull/2585))
+- Added the same padding from `EuiSelectableListItem` to the heading to fix alignment ([#2585](https://github.com/elastic/eui/pull/2585))
+- Added exports for `EuiCheckboxType`, `EuiCheckboxGroupOption`, and `EuiCheckboxGroupIdToSelectedMap` types ([#2593](https://github.com/elastic/eui/pull/2593))
 
 ## [`16.2.0`](https://github.com/elastic/eui/tree/v16.2.0)
 

--- a/src/components/form/checkbox/index.ts
+++ b/src/components/form/checkbox/index.ts
@@ -1,6 +1,7 @@
-export { EuiCheckbox, EuiCheckboxProps } from './checkbox';
+export { EuiCheckbox, EuiCheckboxProps, EuiCheckboxType } from './checkbox';
 export {
   EuiCheckboxGroup,
   EuiCheckboxGroupProps,
+  EuiCheckboxGroupOption,
   EuiCheckboxGroupIdToSelectedMap,
 } from './checkbox_group';

--- a/src/components/form/checkbox/index.ts
+++ b/src/components/form/checkbox/index.ts
@@ -1,2 +1,6 @@
 export { EuiCheckbox, EuiCheckboxProps } from './checkbox';
-export { EuiCheckboxGroup, EuiCheckboxGroupProps } from './checkbox_group';
+export {
+  EuiCheckboxGroup,
+  EuiCheckboxGroupProps,
+  EuiCheckboxGroupIdToSelectedMap,
+} from './checkbox_group';


### PR DESCRIPTION
### Summary

Completed exports:
* `EuiCheckboxType`
* `EuiCheckboxGroupOption`
* `EuiCheckboxGroupIdToSelectedMap`

### Checklist

~~- [ ] Checked in **dark mode**~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
