### PR TITLE
EuiAccordion: fixes rotation of icon when child of another EuiAccordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Added the same padding from `EuiSelectableListItem` to the heading to fix alignment ([#2585](https://github.com/elastic/eui/pull/2585))
 - Added exports for `EuiCheckboxType`, `EuiCheckboxGroupOption`, and `EuiCheckboxGroupIdToSelectedMap` types ([#2593](https://github.com/elastic/eui/pull/2593))
 - Fixed `.euiHeaderLinks__mobileList` in `EuiHeaderLinks` to only display it on mobile ([#2590](https://github.com/elastic/eui/pull/#2590))
-- Fixed `EuiAccordion` icon rotation when it is a child of another accordion so it doesn't inherits the rotation state of the parent ([#2595](https://github.com/elastic/eui/pull/#2595))
+- Fixed `EuiAccordion` icon rotation when it is a child of another accordion so it doesn't inherit the rotation state of the parent ([#2595](https://github.com/elastic/eui/pull/#2595))
 
 ## [`16.2.0`](https://github.com/elastic/eui/tree/v16.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Added the same padding from `EuiSelectableListItem` to the heading to fix alignment ([#2585](https://github.com/elastic/eui/pull/2585))
 - Added exports for `EuiCheckboxType`, `EuiCheckboxGroupOption`, and `EuiCheckboxGroupIdToSelectedMap` types ([#2593](https://github.com/elastic/eui/pull/2593))
 - Fixed `.euiHeaderLinks__mobileList` in `EuiHeaderLinks` to only display it on mobile ([#2590](https://github.com/elastic/eui/pull/#2590))
-- Fixed `EuiAccordion` icon rotation when it is a child of another accordion so it doesn't inherits the rotation state of the parent ([#](https://github.com/elastic/eui/pull/#))
+- Fixed `EuiAccordion` icon rotation when it is a child of another accordion so it doesn't inherits the rotation state of the parent ([#2595](https://github.com/elastic/eui/pull/#2595))
 
 ## [`16.2.0`](https://github.com/elastic/eui/tree/v16.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added the same padding from `EuiSelectableListItem` to the heading to fix alignment ([#2585](https://github.com/elastic/eui/pull/2585))
 - Added exports for `EuiCheckboxType`, `EuiCheckboxGroupOption`, and `EuiCheckboxGroupIdToSelectedMap` types ([#2593](https://github.com/elastic/eui/pull/2593))
 - Fixed `.euiHeaderLinks__mobileList` in `EuiHeaderLinks` to only display it on mobile ([#2590](https://github.com/elastic/eui/pull/#2590))
+- Fixed `EuiAccordion` icon rotation when it is a child of another accordion so it doesn't inherits the rotation state of the parent ([#](https://github.com/elastic/eui/pull/#))
 
 ## [`16.2.0`](https://github.com/elastic/eui/tree/v16.2.0)
 

--- a/src/components/accordion/__snapshots__/accordion.test.tsx.snap
+++ b/src/components/accordion/__snapshots__/accordion.test.tsx.snap
@@ -97,17 +97,17 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
           className="euiAccordion__iconWrapper"
         >
           <EuiIcon
-            className="euiAccordion__icon"
+            className="euiAccordion__icon euiAccordion__icon-isOpen"
             size="m"
             type="arrowRight"
           >
             <EuiIconEmpty
-              className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+              className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon euiAccordion__icon-isOpen"
               focusable="false"
               style={null}
             >
               <svg
-                className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+                className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon euiAccordion__icon-isOpen"
                 focusable="false"
                 height={16}
                 style={null}
@@ -344,7 +344,7 @@ exports[`EuiAccordion props initialIsOpen is rendered 1`] = `
         class="euiAccordion__iconWrapper"
       >
         <svg
-          class="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+          class="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon euiAccordion__icon-isOpen"
           focusable="false"
           height="16"
           viewBox="0 0 16 16"

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -35,6 +35,10 @@
     vertical-align: top;
     transition: transform $euiAnimSpeedNormal $euiAnimSlightResistance;
   }
+
+  .euiAccordion__icon-isOpen {
+    transform: rotate(90deg);
+  }
 }
 
 .euiAccordion__optionalAction {
@@ -73,9 +77,5 @@ $paddingSizes: (
     visibility: visible;
     opacity: 1;
     height: auto;
-  }
-
-  .euiAccordion__icon {
-    transform: rotate(90deg);
   }
 }

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -143,9 +143,11 @@ export class EuiAccordion extends Component<
 
     const buttonClasses = classNames('euiAccordion__button', buttonClassName);
 
-    const icon = (
-      <EuiIcon className="euiAccordion__icon" type="arrowRight" size="m" />
-    );
+    const iconClasses = this.state.isOpen
+      ? classNames('euiAccordion__icon', 'euiAccordion__icon-isOpen')
+      : classNames('euiAccordion__icon');
+
+    const icon = <EuiIcon className={iconClasses} type="arrowRight" size="m" />;
 
     let optionalAction = null;
 

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -143,9 +143,9 @@ export class EuiAccordion extends Component<
 
     const buttonClasses = classNames('euiAccordion__button', buttonClassName);
 
-    const iconClasses = this.state.isOpen
-      ? classNames('euiAccordion__icon', 'euiAccordion__icon-isOpen')
-      : classNames('euiAccordion__icon');
+    const iconClasses = classNames('euiAccordion__icon', {
+      'euiAccordion__icon-isOpen': this.state.isOpen,
+    });
 
     const icon = <EuiIcon className={iconClasses} type="arrowRight" size="m" />;
 


### PR DESCRIPTION
### Summary
Closes https://github.com/elastic/eui/issues/2591

Fixes `EuiAccordion` icon rotation when it is a child of another `EuiAccordion` (avoids inheritance of the opened state).

![Bildschirmfoto vom 2019-12-05 10-57-11](https://user-images.githubusercontent.com/23581855/70242662-f6482580-174f-11ea-9b15-9cb59748022a.png)

### Checklist

- [ ] Checked in **dark mode**
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [X] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
