### PR TITLE
[DataGrid] Fix cell focus on keyboard pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `17.0.0`.
+**Bug fixes**
+
+- Fixed UX/focus bug in `EuiDataGrid` when using keyboard shortcuts to paginate ([#2602](https://github.com/elastic/eui/pull/2602))
 
 ## [`17.0.0`](https://github.com/elastic/eui/tree/v17.0.0)
 

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -657,11 +657,6 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
       if (pagination) {
         const key = `${cell[0]}-${cell[1]}`;
 
-        // this intentionally and purposefully mutates the existing `cellsUpdateFocus` object as the
-        // value/state of `cellsUpdateFocus` must be up-to-date when `updateFocus`'s requestAnimationFrame fires
-        // there is likely a better pattern to use, but this is fine for now as the scope is known & limited
-        // cellsUpdateFocus.set(key, updateFocus);
-
         setCellsUpdateFocus(cellsUpdateFocus => {
           const nextCellsUpdateFocus = new Map(cellsUpdateFocus);
           nextCellsUpdateFocus.set(key, updateFocus);


### PR DESCRIPTION
### Summary

Resolves the UX bug mentioned in https://github.com/elastic/eui/pull/2519#issuecomment-555223888

This introduces a new hook that is used to wait for two of React's DOM flushes before updating the focus. This allows the `cellsUpdateFocus` state to avoid direct manipulation and better orchestrates the focus management. It's likely this hook is abstracted further to replace other instances of `requestAnimationFrame` in the future.

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
