### PR TITLE
SelectableList: add optional `key` property to `options`

### DIFF
--- a/src-docs/src/views/selectable/selectable_example.js
+++ b/src-docs/src/views/selectable/selectable_example.js
@@ -91,7 +91,10 @@ export const SelectableExample = {
           <ul>
             <li>
               <EuiCode>label: string</EuiCode> <strong>required</strong> Must be
-              unique across items (todo: fix this)
+              unique across items if <EuiCode>key</EuiCode> is not passed
+            </li>
+            <li>
+              <EuiCode>key?: string</EuiCode> Must be unique across items
             </li>
             <li>
               <EuiCode>checked?: &apos;on&apos; | &apos;off&apos;</EuiCode>{' '}

--- a/src/components/selectable/types.tsx
+++ b/src/components/selectable/types.tsx
@@ -4,10 +4,11 @@ import { CommonProps } from '../common';
 export type OptionCheckedType = 'on' | 'off' | undefined;
 
 export interface Option extends CommonProps {
-  /**
-   * Must be unique across items (todo: fix this)
-   */
   label: string;
+  /**
+   * Must be unique across items
+   */
+  key?: string;
   /**
    * Leave off to indicate not selected,
    * 'on' to indicate inclusion and


### PR DESCRIPTION
### Summary

Fixes https://github.com/elastic/eui/issues/2605 

This is a proposed solution for fixing the React warning about duplicate keys for SelectableList if we pass two identical labels. The situation happens eg. for Index Pattern Chooser in Lens if index pattern was imported from Saved Object and the identically named index pattern existed in the app. 

Adding optional prop 'key' for Option Interface would allow having two different objects with identical labels. 

Still, the PR doesn't fix the problem of differentiating two identically labeled objects a user perspective. I'm counting on some suggestions! 🙏 

### Checklist

- [x] Checked in **dark mode**
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
