### PR TITLE
SelectableList: Fixes React warning when  two items with same key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Fixed UX/focus bug in `EuiDataGrid` when using keyboard shortcuts to paginate ([#2602](https://github.com/elastic/eui/pull/2602))
+- Fixed React warning when `SelectableList` has two items with same key ([#](https://github.com/elastic/eui/pull/))
 
 ## [`17.0.0`](https://github.com/elastic/eui/tree/v17.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 **Bug fixes**
 
 - Fixed UX/focus bug in `EuiDataGrid` when using keyboard shortcuts to paginate ([#2602](https://github.com/elastic/eui/pull/2602))
-- Fixed React warning when `SelectableList` has two items with same key ([#](https://github.com/elastic/eui/pull/))
+- Fixed React warning when `SelectableList` has two items with same key ([#2610](https://github.com/elastic/eui/pull/2610))
 
 ## [`17.0.0`](https://github.com/elastic/eui/tree/v17.0.0)
 

--- a/src/components/selectable/selectable_list/selectable_list.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.tsx
@@ -183,7 +183,7 @@ export class EuiSelectableList extends Component<EuiSelectableListProps> {
                   <EuiSelectableListItem
                     id={this.rootId(`_option-${index}`)}
                     style={style}
-                    key={option.label.toLowerCase()}
+                    key={`${option.label.toLowerCase()}-${index}`}
                     onClick={() => this.onAddOrRemoveOption(option)}
                     ref={ref ? ref.bind(null, index) : undefined}
                     isFocused={activeOptionIndex === index}


### PR DESCRIPTION
### Summary

Closes https://github.com/elastic/eui/issues/2605

Fixes React warning when `SelectableList` has two items with same key. Just concatenated the items label with the iteration `index`.

### Checklist

- [ ] Checked in **dark mode**
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [X] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
