### PR TITLE
EuiDroppable now accepts multiple children (TypeScript)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed `EuiCodeEditor` custom mode file error by initializing with existing mode ([#2616](https://github.com/elastic/eui/pull/2616))
 - Removed `EuiIcon` default titles ([#2632](https://github.com/elastic/eui/pull/2632))
+- Fixed `EuiDroppable` not accepting multiple children when using TypeScript ([#2634](https://github.com/elastic/eui/pull/2634))
 
 ## [`17.1.1`](https://github.com/elastic/eui/tree/v17.1.1)
 

--- a/src/components/drag_and_drop/__snapshots__/droppable.test.tsx.snap
+++ b/src/components/drag_and_drop/__snapshots__/droppable.test.tsx.snap
@@ -13,6 +13,21 @@ exports[`EuiDroppable can be given ReactElement children 1`] = `
 </div>
 `;
 
+exports[`EuiDroppable can be given multiple ReactElement children 1`] = `
+<div
+  class="euiDroppable euiDroppable--noGrow"
+  data-react-beautiful-dnd-droppable="3"
+  data-test-subj="droppable"
+>
+  <div />
+  <div />
+  <div />
+  <div
+    class="euiDroppable__placeholder"
+  />
+</div>
+`;
+
 exports[`EuiDroppable is rendered 1`] = `
 <div
   class="euiDroppable euiDroppable--noGrow"

--- a/src/components/drag_and_drop/droppable.test.tsx
+++ b/src/components/drag_and_drop/droppable.test.tsx
@@ -32,6 +32,21 @@ describe('EuiDroppable', () => {
     expect(component).toMatchSnapshot();
   });
 
+  test('can be given multiple ReactElement children', () => {
+    const handler = jest.fn();
+    const component = render(
+      <EuiDragDropContext onDragEnd={handler} {...requiredProps}>
+        <EuiDroppable droppableId="testDroppable">
+          <div />
+          <div />
+          <div />
+        </EuiDroppable>
+      </EuiDragDropContext>
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
   describe('custom behavior', () => {
     describe('cloneDraggables', () => {
       const handler = jest.fn();

--- a/src/components/drag_and_drop/droppable.tsx
+++ b/src/components/drag_and_drop/droppable.tsx
@@ -21,7 +21,7 @@ export type EuiDroppableSpacing = keyof typeof spacingToClassNameMap;
 export interface EuiDroppableProps
   extends CommonProps,
     Omit<DroppableProps, 'children'> {
-  children: ReactElement | DroppableProps['children'];
+  children: ReactElement | ReactElement[] | DroppableProps['children'];
   className?: string;
   /**
    * Makes its items immutable. Dragging creates cloned items that can be dropped elsewhere.


### PR DESCRIPTION
### Summary

The type definitions for EuiDroppable don't seem to allow multiple children. You can't use examples from the docs, without surrounding multiple children in their own `<></>` fragment node - this change attempts to remedy that issue.

I'll be honest, I'm not sure if `ReactElement[]` is the best type for this, I did try to use `ReactNode`, but that prevented other parts of the type definition from working, whereas `ReactElement[]` didn't stop anything else from working.

A test case has been added.

### Checklist

~~- [x] Checked in **dark mode**~~
~~- [x] Checked in **mobile**~~
~~- [x] Checked in **IE11** and **Firefox**~~
~~- [x] Props have proper **autodocs**~~
~~- [x] Added **documentation** examples~~
~~- [x] Checked for **breaking changes** and labeled appropriately~~
~~- [x] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] Added or updated **jest tests**
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
