### PR TITLE
Revamp EuiSuperDatePicker docs

### DIFF
--- a/src-docs/src/routes.js
+++ b/src-docs/src/routes.js
@@ -177,6 +177,8 @@ import { StepsExample } from './views/steps/steps_example';
 
 import { SuggestExample } from './views/suggest/suggest_example';
 
+import { SuperDatePickerExample } from './views/super_date_picker/super_date_picker_example';
+
 import { TableExample } from './views/tables/tables_example';
 
 import { TabsExample } from './views/tabs/tabs_example';
@@ -379,6 +381,7 @@ const navigation = [
       SearchBarExample,
       SelectableExample,
       SuggestExample,
+      SuperDatePickerExample,
     ].map(example => createExample(example)),
   },
   {

--- a/src-docs/src/views/date_picker/date_picker_example.js
+++ b/src-docs/src/views/date_picker/date_picker_example.js
@@ -6,12 +6,9 @@ import { GuideSectionTypes } from '../../components';
 
 import {
   EuiCode,
-  EuiCodeBlock,
   EuiLink,
   EuiDatePicker,
   EuiDatePickerRange,
-  EuiSuperDatePicker,
-  EuiSuperUpdateButton,
 } from '../../../../src/components';
 
 import DatePicker from './date_picker';
@@ -57,10 +54,6 @@ const customInputHtml = renderToHtml(CustomInput);
 import Utc from './utc';
 const utcSource = require('!!raw-loader!./utc');
 const utcHtml = renderToHtml(Utc);
-
-import SuperDatePicker from './super_date_picker';
-const superDatePickerSource = require('!!raw-loader!./super_date_picker');
-const superDatePickerHtml = renderToHtml(SuperDatePicker);
 
 export const DatePickerExample = {
   title: 'Date Picker',
@@ -323,82 +316,6 @@ export const DatePickerExample = {
         </div>
       ),
       demo: <Classes />,
-    },
-    {
-      title: 'Super date picker',
-      source: [
-        {
-          type: GuideSectionTypes.JS,
-          code: superDatePickerSource,
-        },
-        {
-          type: GuideSectionTypes.HTML,
-          code: superDatePickerHtml,
-        },
-      ],
-      text: (
-        <div>
-          <p>
-            <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> date times are
-            passed as strings in either datemath format (e.g.: now, now-15m,
-            now-15m/m) or as absolute date in the format{' '}
-            <EuiCode>YYYY-MM-DDTHH:mm:ss.SSSZ</EuiCode>. Use{' '}
-            <EuiLink href="https://github.com/elastic/datemath-js">
-              datemath
-            </EuiLink>{' '}
-            to convert start and end strings into moment objects.
-          </p>
-          <EuiCodeBlock paddingSize="none" isCopyable>
-            {`
-import dateMath from '@elastic/datemath';
-
-const startMoment = dateMath.parse(start);
-// dateMath.parse is inconsistent with unparsable strings.
-// Sometimes undefined is returned, other times an invalid moment is returned
-if (!startMoment || !startMoment.isValid()) {
-  throw new Error('Unable to parse start string');
-}
-
-// Pass roundUp when parsing end string
-const endMoment = dateMath.parse(end, { roundUp: true });
-if (!endMoment || !endMoment.isValid()) {
-  throw new Error('Unable to parse end string');
-}
-          `}
-          </EuiCodeBlock>
-          <p>
-            <EuiCode>onTimeChange</EuiCode> will be immediately invoked when{' '}
-            <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> change from
-            interactions with <strong> Quick select</strong>,{' '}
-            <strong>Commonly used</strong>, or{' '}
-            <strong>Recently used date ranges</strong> since these interactions
-            set both <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> in a
-            single event.
-          </p>
-          <p>
-            <EuiCode>onTimeChange</EuiCode> will <strong>not</strong> be invoked
-            when
-            <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> change from
-            interactions with <strong>Absolute</strong>,{' '}
-            <strong>Relative</strong>, and <strong>Now</strong> tabs.{' '}
-            <EuiCode>onTimeChange</EuiCode> will be invoked when the user clicks
-            the <strong>Update</strong> button. This gives users the ability to
-            set both <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> before
-            triggering <EuiCode>onTimeChange</EuiCode>. Set{' '}
-            <EuiCode>showUpdateButton</EuiCode> to <EuiCode>false</EuiCode> to
-            immediately invoke <EuiCode>onTimeChange</EuiCode> for all{' '}
-            <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> changes.
-          </p>
-          <p>
-            Set <EuiCode>isAutoRefreshOnly</EuiCode> to <EuiCode>true </EuiCode>{' '}
-            to limit the component to only display auto refresh content. This is
-            useful in cases where there is no time data but auto-refresh
-            configuration is still desired.
-          </p>
-        </div>
-      ),
-      demo: <SuperDatePicker />,
-      props: { EuiSuperDatePicker, EuiSuperUpdateButton },
     },
   ],
 };

--- a/src-docs/src/views/super_date_picker/super_date_picker.js
+++ b/src-docs/src/views/super_date_picker/super_date_picker.js
@@ -3,8 +3,8 @@ import React, { Component, Fragment } from 'react';
 import {
   EuiSuperDatePicker,
   EuiSpacer,
-  EuiFormRow,
-  EuiFieldText,
+  EuiFormControlLayoutDelimited,
+  EuiFormLabel,
   EuiPanel,
   EuiText,
 } from '../../../../src/components';
@@ -83,22 +83,28 @@ export default class extends Component {
             can try to break it with unexpected values here.
           </EuiText>
           <EuiSpacer />
-          <EuiFormRow
-            label="start"
-            helpText="Start date. Try to break EuiSuperDatePicker with unexpected values">
-            <EuiFieldText
-              onChange={this.onStartInputChange}
-              value={this.state.start}
-            />
-          </EuiFormRow>
-          <EuiFormRow
-            label="end"
-            helpText="End date. Try to break EuiSuperDatePicker with unexpected values">
-            <EuiFieldText
-              onChange={this.onEndInputChange}
-              value={this.state.end}
-            />
-          </EuiFormRow>
+          <EuiFormControlLayoutDelimited
+            prepend={<EuiFormLabel>Dates</EuiFormLabel>}
+            startControl={
+              <input
+                onChange={this.onStartInputChange}
+                type="text"
+                value={this.state.start}
+                placeholder="start"
+                label="start"
+                className="euiFieldText"
+              />
+            }
+            endControl={
+              <input
+                onChange={this.onEndInputChange}
+                type="text"
+                placeholder="end"
+                value={this.state.end}
+                className="euiFieldText"
+              />
+            }
+          />
         </EuiPanel>
       </Fragment>
     );
@@ -108,7 +114,6 @@ export default class extends Component {
     return (
       <Fragment>
         <EuiSuperDatePicker
-          isDisabled={this.state.isDisabled}
           isLoading={this.state.isLoading}
           start={this.state.start}
           end={this.state.end}

--- a/src-docs/src/views/super_date_picker/super_date_picker.js
+++ b/src-docs/src/views/super_date_picker/super_date_picker.js
@@ -91,7 +91,6 @@ export default class extends Component {
                 type="text"
                 value={this.state.start}
                 placeholder="start"
-                label="start"
                 className="euiFieldText"
               />
             }

--- a/src-docs/src/views/super_date_picker/super_date_picker.js
+++ b/src-docs/src/views/super_date_picker/super_date_picker.js
@@ -1,0 +1,121 @@
+import React, { Component, Fragment } from 'react';
+
+import {
+  EuiSuperDatePicker,
+  EuiSpacer,
+  EuiFormRow,
+  EuiFieldText,
+  EuiPanel,
+} from '../../../../src/components';
+
+export default class extends Component {
+  state = {
+    recentlyUsedRanges: [],
+    isLoading: false,
+    start: 'now-30m',
+    end: 'now',
+  };
+
+  onTimeChange = ({ start, end }) => {
+    this.setState(prevState => {
+      const recentlyUsedRanges = prevState.recentlyUsedRanges.filter(
+        recentlyUsedRange => {
+          const isDuplicate =
+            recentlyUsedRange.start === start && recentlyUsedRange.end === end;
+          return !isDuplicate;
+        }
+      );
+      recentlyUsedRanges.unshift({ start, end });
+      return {
+        start,
+        end,
+        recentlyUsedRanges:
+          recentlyUsedRanges.length > 10
+            ? recentlyUsedRanges.slice(0, 9)
+            : recentlyUsedRanges,
+        isLoading: true,
+      };
+    }, this.startLoading);
+  };
+
+  onRefresh = ({ start, end, refreshInterval }) => {
+    return new Promise(resolve => {
+      setTimeout(resolve, 100);
+    }).then(() => {
+      console.log(start, end, refreshInterval);
+    });
+  };
+
+  onStartInputChange = e => {
+    this.setState({
+      start: e.target.value,
+    });
+  };
+
+  onEndInputChange = e => {
+    this.setState({
+      end: e.target.value,
+    });
+  };
+
+  startLoading = () => {
+    setTimeout(this.stopLoading, 1000);
+  };
+
+  stopLoading = () => {
+    this.setState({ isLoading: false });
+  };
+
+  onRefreshChange = ({ isPaused, refreshInterval }) => {
+    this.setState({
+      isPaused,
+      refreshInterval,
+    });
+  };
+
+  renderTimeRange = () => {
+    return (
+      <Fragment>
+        <EuiPanel paddingSize="m">
+          <EuiFormRow
+            label="start"
+            helpText="EuiSuperDatePicker should be resilient to invalid start values. Try to break it with unexpected values">
+            <EuiFieldText
+              onChange={this.onStartInputChange}
+              value={this.state.start}
+            />
+          </EuiFormRow>
+          <EuiFormRow
+            label="end"
+            helpText="EuiSuperDatePicker should be resilient to invalid end values. Try to break it with unexpected values">
+            <EuiFieldText
+              onChange={this.onEndInputChange}
+              value={this.state.end}
+            />
+          </EuiFormRow>
+        </EuiPanel>
+      </Fragment>
+    );
+  };
+
+  render() {
+    return (
+      <Fragment>
+        <EuiSuperDatePicker
+          isDisabled={this.state.isDisabled}
+          isLoading={this.state.isLoading}
+          start={this.state.start}
+          end={this.state.end}
+          onTimeChange={this.onTimeChange}
+          onRefresh={this.onRefresh}
+          isPaused={this.state.isPaused}
+          refreshInterval={this.state.refreshInterval}
+          onRefreshChange={this.onRefreshChange}
+          recentlyUsedRanges={this.state.recentlyUsedRanges}
+        />
+        <EuiSpacer />
+        {this.renderTimeRange()}
+      </Fragment>
+    );
+  }
+}

--- a/src-docs/src/views/super_date_picker/super_date_picker_config.js
+++ b/src-docs/src/views/super_date_picker/super_date_picker_config.js
@@ -2,17 +2,17 @@ import React, { Component, Fragment } from 'react';
 
 import {
   EuiSuperDatePicker,
+  EuiSwitch,
   EuiSpacer,
-  EuiFormRow,
-  EuiFieldText,
-  EuiPanel,
-  EuiText,
 } from '../../../../src/components';
 
 export default class extends Component {
   state = {
     recentlyUsedRanges: [],
+    isDisabled: false,
     isLoading: false,
+    showUpdateButton: true,
+    isAutoRefreshOnly: false,
     start: 'now-30m',
     end: 'now',
   };
@@ -47,18 +47,6 @@ export default class extends Component {
     });
   };
 
-  onStartInputChange = e => {
-    this.setState({
-      start: e.target.value,
-    });
-  };
-
-  onEndInputChange = e => {
-    this.setState({
-      end: e.target.value,
-    });
-  };
-
   startLoading = () => {
     setTimeout(this.stopLoading, 1000);
   };
@@ -74,39 +62,46 @@ export default class extends Component {
     });
   };
 
-  renderTimeRange = () => {
-    return (
-      <Fragment>
-        <EuiPanel paddingSize="m">
-          <EuiText size="s">
-            EuiSuperDatePicker should be resilient to invalid date values. You
-            can try to break it with unexpected values here.
-          </EuiText>
-          <EuiSpacer />
-          <EuiFormRow
-            label="start"
-            helpText="Start date. Try to break EuiSuperDatePicker with unexpected values">
-            <EuiFieldText
-              onChange={this.onStartInputChange}
-              value={this.state.start}
-            />
-          </EuiFormRow>
-          <EuiFormRow
-            label="end"
-            helpText="End date. Try to break EuiSuperDatePicker with unexpected values">
-            <EuiFieldText
-              onChange={this.onEndInputChange}
-              value={this.state.end}
-            />
-          </EuiFormRow>
-        </EuiPanel>
-      </Fragment>
-    );
+  toggleDisabled = () => {
+    this.setState(prevState => ({
+      isDisabled: !prevState.isDisabled,
+    }));
+  };
+
+  toggleShowApplyButton = () => {
+    this.setState(prevState => ({
+      showUpdateButton: !prevState.showUpdateButton,
+    }));
+  };
+
+  toggleShowRefreshOnly = () => {
+    this.setState(prevState => ({
+      isAutoRefreshOnly: !prevState.isAutoRefreshOnly,
+    }));
   };
 
   render() {
     return (
       <Fragment>
+        <EuiSwitch
+          label="Show update button"
+          onChange={this.toggleShowApplyButton}
+          checked={!this.state.isAutoRefreshOnly && this.state.showUpdateButton}
+          disabled={this.state.isAutoRefreshOnly}
+        />
+        &emsp;
+        <EuiSwitch
+          label="Is auto-refresh only"
+          onChange={this.toggleShowRefreshOnly}
+          checked={this.state.isAutoRefreshOnly}
+        />
+        &emsp;
+        <EuiSwitch
+          label="Is disabled"
+          onChange={this.toggleDisabled}
+          checked={this.state.isDisabled}
+        />
+        <EuiSpacer />
         <EuiSuperDatePicker
           isDisabled={this.state.isDisabled}
           isLoading={this.state.isLoading}
@@ -118,9 +113,10 @@ export default class extends Component {
           refreshInterval={this.state.refreshInterval}
           onRefreshChange={this.onRefreshChange}
           recentlyUsedRanges={this.state.recentlyUsedRanges}
+          showUpdateButton={this.state.showUpdateButton}
+          isAutoRefreshOnly={this.state.isAutoRefreshOnly}
         />
         <EuiSpacer />
-        {this.renderTimeRange()}
       </Fragment>
     );
   }

--- a/src-docs/src/views/super_date_picker/super_date_picker_custom_quick_select.js
+++ b/src-docs/src/views/super_date_picker/super_date_picker_custom_quick_select.js
@@ -4,8 +4,6 @@ import {
   EuiSuperDatePicker,
   EuiSwitch,
   EuiSpacer,
-  EuiFormRow,
-  EuiFieldText,
   EuiLink,
 } from '../../../../src/components';
 
@@ -22,11 +20,8 @@ function MyCustomQuickSelectPanel({ applyTime }) {
 export default class extends Component {
   state = {
     recentlyUsedRanges: [],
-    isDisabled: false,
     isLoading: false,
-    showUpdateButton: true,
-    isAutoRefreshOnly: false,
-    showCustomQuickSelectPanel: false,
+    showCustomQuickSelectPanel: true,
     start: 'now-30m',
     end: 'now',
   };
@@ -61,18 +56,6 @@ export default class extends Component {
     });
   };
 
-  onStartInputChange = e => {
-    this.setState({
-      start: e.target.value,
-    });
-  };
-
-  onEndInputChange = e => {
-    this.setState({
-      end: e.target.value,
-    });
-  };
-
   startLoading = () => {
     setTimeout(this.stopLoading, 1000);
   };
@@ -88,55 +71,10 @@ export default class extends Component {
     });
   };
 
-  toggleDisabled = () => {
-    this.setState(prevState => ({
-      isDisabled: !prevState.isDisabled,
-    }));
-  };
-
-  toggleShowApplyButton = () => {
-    this.setState(prevState => ({
-      showUpdateButton: !prevState.showUpdateButton,
-    }));
-  };
-
-  toggleShowRefreshOnly = () => {
-    this.setState(prevState => ({
-      isAutoRefreshOnly: !prevState.isAutoRefreshOnly,
-    }));
-  };
-
   toggleShowCustomQuickSelectPanel = () => {
     this.setState(prevState => ({
       showCustomQuickSelectPanel: !prevState.showCustomQuickSelectPanel,
     }));
-  };
-
-  renderTimeRange = () => {
-    if (this.state.isAutoRefreshOnly) {
-      return null;
-    }
-
-    return (
-      <Fragment>
-        <EuiFormRow
-          label="start"
-          helpText="EuiSuperDatePicker should be resilient to invalid start values. Try to break it with unexpected values">
-          <EuiFieldText
-            onChange={this.onStartInputChange}
-            value={this.state.start}
-          />
-        </EuiFormRow>
-        <EuiFormRow
-          label="end"
-          helpText="EuiSuperDatePicker should be resilient to invalid end values. Try to break it with unexpected values">
-          <EuiFieldText
-            onChange={this.onEndInputChange}
-            value={this.state.end}
-          />
-        </EuiFormRow>
-      </Fragment>
-    );
   };
 
   render() {
@@ -152,32 +90,13 @@ export default class extends Component {
     return (
       <Fragment>
         <EuiSwitch
-          label="Show apply button"
-          onChange={this.toggleShowApplyButton}
-          checked={!this.state.isAutoRefreshOnly && this.state.showUpdateButton}
-          disabled={this.state.isAutoRefreshOnly}
-        />
-        &emsp;
-        <EuiSwitch
-          label="Is auto-refresh only"
-          onChange={this.toggleShowRefreshOnly}
-          checked={this.state.isAutoRefreshOnly}
-        />
-        &emsp;
-        <EuiSwitch
-          label="Show custom quick select panel"
+          label="Show custom quick menu panel"
           onChange={this.toggleShowCustomQuickSelectPanel}
           checked={this.state.showCustomQuickSelectPanel}
         />
         &emsp;
-        <EuiSwitch
-          label="Is disabled"
-          onChange={this.toggleDisabled}
-          checked={this.state.isDisabled}
-        />
         <EuiSpacer />
         <EuiSuperDatePicker
-          isDisabled={this.state.isDisabled}
           isLoading={this.state.isLoading}
           start={this.state.start}
           end={this.state.end}
@@ -187,12 +106,9 @@ export default class extends Component {
           refreshInterval={this.state.refreshInterval}
           onRefreshChange={this.onRefreshChange}
           recentlyUsedRanges={this.state.recentlyUsedRanges}
-          showUpdateButton={this.state.showUpdateButton}
-          isAutoRefreshOnly={this.state.isAutoRefreshOnly}
           customQuickSelectPanels={customQuickSelectPanels}
         />
         <EuiSpacer />
-        {this.renderTimeRange()}
       </Fragment>
     );
   }

--- a/src-docs/src/views/super_date_picker/super_date_picker_example.js
+++ b/src-docs/src/views/super_date_picker/super_date_picker_example.js
@@ -29,6 +29,19 @@ const superDatePickerSnippet = `<EuiSuperDatePicker
 />
 `;
 
+const superDatePickerCustomQuickSelectSnippet = `customQuickSelectPanels = [
+  {
+    title: 'My custom panel',
+    content: <MyCustomQuickSelectPanel />,
+  },
+];
+
+<EuiSuperDatePicker
+  onTimeChange={this.onTimeChange}
+  customQuickSelectPanels={customQuickSelectPanels}
+/>
+`;
+
 export const SuperDatePickerExample = {
   title: 'Super Date Picker',
   sections: [
@@ -51,24 +64,24 @@ export const SuperDatePickerExample = {
             <strong>Quick select menu</strong>{' '}
             <EuiCode>
               <EuiIcon type="calendar" color="primary" />
-            </EuiCode>
+            </EuiCode>{' '}
             which includes <strong>Commonly used dates</strong>,{' '}
             <strong>Recently used date ranges</strong> and{' '}
             <strong>Set refresh</strong> features.
           </p>
           <p>
-            <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> date times are
-            passed as strings in either datemath format (e.g.: now, now-15m,
-            now-15m/m) or as absolute date in the format{' '}
+            Pass <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> date times
+            as strings in either datemath format (e.g.: <EuiCode>now</EuiCode>,{' '}
+            <EuiCode>now-15m</EuiCode>, <EuiCode>now-15m/m</EuiCode>) or as
+            absolute date in the format{' '}
             <EuiCode>YYYY-MM-DDTHH:mm:ss.SSSZ</EuiCode>. Use{' '}
             <EuiLink href="https://github.com/elastic/datemath-js">
               datemath
             </EuiLink>{' '}
             to convert start and end strings into moment objects.
           </p>
-          <EuiCodeBlock paddingSize="none" isCopyable>
-            {`
-import dateMath from '@elastic/datemath';
+          <EuiCodeBlock language="js" paddingSize="none" isCopyable>
+            {`import dateMath from '@elastic/datemath';
 
 const startMoment = dateMath.parse(start);
 // dateMath.parse is inconsistent with unparsable strings.
@@ -81,8 +94,7 @@ if (!startMoment || !startMoment.isValid()) {
 const endMoment = dateMath.parse(end, { roundUp: true });
 if (!endMoment || !endMoment.isValid()) {
   throw new Error('Unable to parse end string');
-}
-          `}
+}`}
           </EuiCodeBlock>
         </div>
       ),
@@ -105,24 +117,24 @@ if (!endMoment || !endMoment.isValid()) {
       text: (
         <div>
           <p>
-            <EuiCode>onTimeChange</EuiCode> will be immediately invoked when{' '}
-            <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> change from
+            When <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> change from
             interactions with <strong> Quick select</strong>,{' '}
             <strong>Commonly used</strong>, or{' '}
-            <strong>Recently used date ranges</strong> since these interactions
-            set both <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> in a
-            single event.
+            <strong>Recently used date ranges</strong>,
+            <EuiCode>onTimeChange</EuiCode> will be immediately invoked. This is
+            because these interactions set both <EuiCode>start</EuiCode> and{' '}
+            <EuiCode>end</EuiCode> in a single event.
           </p>
           <p>
-            <EuiCode>onTimeChange</EuiCode> will <strong>not</strong> be invoked
-            when
-            <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> change from
+            When <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> change from
             interactions with <strong>Absolute</strong>,{' '}
-            <strong>Relative</strong>, and <strong>Now</strong> tabs.{' '}
-            <EuiCode>onTimeChange</EuiCode> will be invoked when the user clicks
-            the <strong>Update</strong> button. This gives users the ability to
-            set both <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> before
-            triggering <EuiCode>onTimeChange</EuiCode>. Set{' '}
+            <strong>Relative</strong>, and <strong>Now</strong> tabs,
+            <EuiCode>onTimeChange</EuiCode> will <strong>not</strong> be
+            invoked. In these cases,<EuiCode>onTimeChange</EuiCode> will be
+            invoked when the user clicks the <strong>Update</strong> button.
+            This gives users the ability to set both <EuiCode>start</EuiCode>{' '}
+            and <EuiCode>end</EuiCode> before triggering{' '}
+            <EuiCode>onTimeChange</EuiCode>. Set{' '}
             <EuiCode>showUpdateButton</EuiCode> to <EuiCode>false</EuiCode> to
             immediately invoke <EuiCode>onTimeChange</EuiCode> for all{' '}
             <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> changes.
@@ -158,6 +170,7 @@ if (!endMoment || !endMoment.isValid()) {
           </p>
         </div>
       ),
+      snippet: superDatePickerCustomQuickSelectSnippet,
       demo: <SuperDatePickerCustomQuickSelect />,
     },
   ],

--- a/src-docs/src/views/super_date_picker/super_date_picker_example.js
+++ b/src-docs/src/views/super_date_picker/super_date_picker_example.js
@@ -7,63 +7,30 @@ import { GuideSectionTypes } from '../../components';
 import {
   EuiCode,
   EuiCodeBlock,
+  EuiIcon,
   EuiLink,
   EuiSuperDatePicker,
 } from '../../../../src/components';
-
-// import Suggest from './suggest';
-// const suggestSource = require('!!raw-loader!./suggest');
-// const suggestHtml = renderToHtml(Suggest);
 
 import SuperDatePicker from './super_date_picker';
 const superDatePickerSource = require('!!raw-loader!./super_date_picker');
 const superDatePickerHtml = renderToHtml(SuperDatePicker);
 
-// import SavedQueries from './saved_queries';
-// const savedQueriesSource = require('!!raw-loader!./saved_queries');
-// const savedQueriesHtml = renderToHtml(SavedQueries);
+import SuperDatePickerConfig from './super_date_picker_config';
+const superDatePickerConfigSource = require('!!raw-loader!./super_date_picker_config');
+const superDatePickerConfigHtml = renderToHtml(SuperDatePicker);
 
-// import SuggestItem from './suggest_item';
-// const suggestItemSource = require('!!raw-loader!./suggest_item');
-// const suggestItemHtml = renderToHtml(SuggestItem);
-const suggestItemSnippet = [
-  `<EuiSuggestItem
-  type={sampleItem.type}
-  label={sampleItem.label}
-  description={sampleItem.description}
+import SuperDatePickerCustomQuickSelect from './super_date_picker_custom_quick_select';
+const superDatePickerCustomQuickSelectSource = require('!!raw-loader!./super_date_picker_custom_quick_select');
+const superDatePickerCustomQuickSelectHtml = renderToHtml(SuperDatePicker);
+
+const superDatePickerSnippet = `<EuiSuperDatePicker
+  onTimeChange={this.onTimeChange}
 />
-`,
-  `<EuiSuggestItem
-  type={sampleItem.type}
-  label={sampleItem.label}
-  description={sampleItem.description}
-  labelDisplay="expand"
-/>`,
-];
-
-const suggestSnippet = [
-  `<EuiSuggest
-  status={this.state.status}
-  tooltipContent={this.state.tooltipContent}
-  onInputChange={this.getInputValue}
-  onItemClick={this.onItemClick}
-  suggestions={[
-    {
-      type: { iconType: 'kqlField', color: 'tint4' },
-      label: 'Field sample',
-      description: 'This is the description',
-    },
-    {
-      type: { iconType: 'kqlValue', color: 'tint0' },
-      label: 'Value sample',
-      description: 'This is the description',
-    },
-  ]}
-/>`,
-];
+`;
 
 export const SuperDatePickerExample = {
-  title: 'SuperDatePicker',
+  title: 'Super Date Picker',
   sections: [
     {
       source: [
@@ -78,6 +45,17 @@ export const SuperDatePickerExample = {
       ],
       text: (
         <div>
+          <p>
+            <EuiCode>EuiSuperDatePicker</EuiCode> is a date picker that supports
+            relative and absolute dates. It offers a convenient{' '}
+            <strong>Quick select menu</strong>{' '}
+            <EuiCode>
+              <EuiIcon type="calendar" color="primary" />
+            </EuiCode>
+            which includes <strong>Commonly used dates</strong>,{' '}
+            <strong>Recently used date ranges</strong> and{' '}
+            <strong>Set refresh</strong> features.
+          </p>
           <p>
             <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> date times are
             passed as strings in either datemath format (e.g.: now, now-15m,
@@ -106,6 +84,26 @@ if (!endMoment || !endMoment.isValid()) {
 }
           `}
           </EuiCodeBlock>
+        </div>
+      ),
+      props: { EuiSuperDatePicker },
+      snippet: superDatePickerSnippet,
+      demo: <SuperDatePicker />,
+    },
+    {
+      title: 'Configurations',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: superDatePickerConfigSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: superDatePickerConfigHtml,
+        },
+      ],
+      text: (
+        <div>
           <p>
             <EuiCode>onTimeChange</EuiCode> will be immediately invoked when{' '}
             <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> change from
@@ -137,9 +135,30 @@ if (!endMoment || !endMoment.isValid()) {
           </p>
         </div>
       ),
-      props: { EuiSuperDatePicker },
-      // snippet: suggestSnippet,
-      demo: <SuperDatePicker />,
+      demo: <SuperDatePickerConfig />,
+    },
+    {
+      title: 'Custom quick select panel',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: superDatePickerCustomQuickSelectSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: superDatePickerCustomQuickSelectHtml,
+        },
+      ],
+      text: (
+        <div>
+          <p>
+            <EuiCode>EuiSuperDatePicker</EuiCode>&apos;s quick select menu also
+            supports <strong>custom panels</strong>. These panels can have their
+            own title and perform custom actions on the date picker.
+          </p>
+        </div>
+      ),
+      demo: <SuperDatePickerCustomQuickSelect />,
     },
   ],
 };

--- a/src-docs/src/views/super_date_picker/super_date_picker_example.js
+++ b/src-docs/src/views/super_date_picker/super_date_picker_example.js
@@ -1,0 +1,145 @@
+import React from 'react';
+
+import { renderToHtml } from '../../services';
+
+import { GuideSectionTypes } from '../../components';
+
+import {
+  EuiCode,
+  EuiCodeBlock,
+  EuiLink,
+  EuiSuperDatePicker,
+} from '../../../../src/components';
+
+// import Suggest from './suggest';
+// const suggestSource = require('!!raw-loader!./suggest');
+// const suggestHtml = renderToHtml(Suggest);
+
+import SuperDatePicker from './super_date_picker';
+const superDatePickerSource = require('!!raw-loader!./super_date_picker');
+const superDatePickerHtml = renderToHtml(SuperDatePicker);
+
+// import SavedQueries from './saved_queries';
+// const savedQueriesSource = require('!!raw-loader!./saved_queries');
+// const savedQueriesHtml = renderToHtml(SavedQueries);
+
+// import SuggestItem from './suggest_item';
+// const suggestItemSource = require('!!raw-loader!./suggest_item');
+// const suggestItemHtml = renderToHtml(SuggestItem);
+const suggestItemSnippet = [
+  `<EuiSuggestItem
+  type={sampleItem.type}
+  label={sampleItem.label}
+  description={sampleItem.description}
+/>
+`,
+  `<EuiSuggestItem
+  type={sampleItem.type}
+  label={sampleItem.label}
+  description={sampleItem.description}
+  labelDisplay="expand"
+/>`,
+];
+
+const suggestSnippet = [
+  `<EuiSuggest
+  status={this.state.status}
+  tooltipContent={this.state.tooltipContent}
+  onInputChange={this.getInputValue}
+  onItemClick={this.onItemClick}
+  suggestions={[
+    {
+      type: { iconType: 'kqlField', color: 'tint4' },
+      label: 'Field sample',
+      description: 'This is the description',
+    },
+    {
+      type: { iconType: 'kqlValue', color: 'tint0' },
+      label: 'Value sample',
+      description: 'This is the description',
+    },
+  ]}
+/>`,
+];
+
+export const SuperDatePickerExample = {
+  title: 'SuperDatePicker',
+  sections: [
+    {
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: superDatePickerSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: superDatePickerHtml,
+        },
+      ],
+      text: (
+        <div>
+          <p>
+            <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> date times are
+            passed as strings in either datemath format (e.g.: now, now-15m,
+            now-15m/m) or as absolute date in the format{' '}
+            <EuiCode>YYYY-MM-DDTHH:mm:ss.SSSZ</EuiCode>. Use{' '}
+            <EuiLink href="https://github.com/elastic/datemath-js">
+              datemath
+            </EuiLink>{' '}
+            to convert start and end strings into moment objects.
+          </p>
+          <EuiCodeBlock paddingSize="none" isCopyable>
+            {`
+import dateMath from '@elastic/datemath';
+
+const startMoment = dateMath.parse(start);
+// dateMath.parse is inconsistent with unparsable strings.
+// Sometimes undefined is returned, other times an invalid moment is returned
+if (!startMoment || !startMoment.isValid()) {
+  throw new Error('Unable to parse start string');
+}
+
+// Pass roundUp when parsing end string
+const endMoment = dateMath.parse(end, { roundUp: true });
+if (!endMoment || !endMoment.isValid()) {
+  throw new Error('Unable to parse end string');
+}
+          `}
+          </EuiCodeBlock>
+          <p>
+            <EuiCode>onTimeChange</EuiCode> will be immediately invoked when{' '}
+            <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> change from
+            interactions with <strong> Quick select</strong>,{' '}
+            <strong>Commonly used</strong>, or{' '}
+            <strong>Recently used date ranges</strong> since these interactions
+            set both <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> in a
+            single event.
+          </p>
+          <p>
+            <EuiCode>onTimeChange</EuiCode> will <strong>not</strong> be invoked
+            when
+            <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> change from
+            interactions with <strong>Absolute</strong>,{' '}
+            <strong>Relative</strong>, and <strong>Now</strong> tabs.{' '}
+            <EuiCode>onTimeChange</EuiCode> will be invoked when the user clicks
+            the <strong>Update</strong> button. This gives users the ability to
+            set both <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> before
+            triggering <EuiCode>onTimeChange</EuiCode>. Set{' '}
+            <EuiCode>showUpdateButton</EuiCode> to <EuiCode>false</EuiCode> to
+            immediately invoke <EuiCode>onTimeChange</EuiCode> for all{' '}
+            <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> changes.
+          </p>
+          <p>
+            Set <EuiCode>isAutoRefreshOnly</EuiCode> to <EuiCode>true </EuiCode>{' '}
+            to limit the component to only display auto refresh content. This is
+            useful in cases where there is no time data but auto-refresh
+            configuration is still desired.
+          </p>
+        </div>
+      ),
+      props: { EuiSuperDatePicker },
+      // snippet: suggestSnippet,
+      demo: <SuperDatePicker />,
+    },
+  ],
+};


### PR DESCRIPTION
### Summary

This PR gives `EuiSuperDatePicker` its own section in EUI docs. 
Following the original ticket, I've added the main example and two other sections (1) configurations and 2) quick select custom panel.

I also added a brief description in which I highlight the quick select menu and its sections.

Screenshot - New description

![image](https://user-images.githubusercontent.com/4016496/70736043-4da44380-1cc4-11ea-8a40-06bce1786817.png)

Screenshot - Main example 
![image](https://user-images.githubusercontent.com/4016496/70735972-29486700-1cc4-11ea-8741-fb9ad49b7145.png)


Fixes #2584 

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
- [x] Added **documentation** examples
~- [ ] Added or updated **jest tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
