### PR TITLE
`EuiComboBox` prevent form submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Fixed `EuiDroppable` not accepting multiple children when using TypeScript ([#2634](https://github.com/elastic/eui/pull/2634))
+- Fixed `EuiComboBox` from submitting parent `form` element when selecting options via `Enter` key ([#2642](https://github.com/elastic/eui/pull/2642)) 
 
 ## [`17.1.2`](https://github.com/elastic/eui/tree/v17.1.2)
 

--- a/src/components/combo_box/combo_box.js
+++ b/src/components/combo_box/combo_box.js
@@ -387,6 +387,7 @@ export class EuiComboBox extends Component {
         break;
 
       case comboBoxKeyCodes.ENTER:
+        e.preventDefault();
         e.stopPropagation();
         if (this.hasActiveOption()) {
           this.onAddOption(


### PR DESCRIPTION
### Summary

Fixes #2637, in which using <kbd>Enter</kbd> to select a list option could unintentionally trigger `form` submission.

### Checklist

~~- [ ] Checked in **dark mode**~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
