### PR TITLE
Remove potentially duplicate `EuiPopover` `id` attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed `EuiDroppable` not accepting multiple children when using TypeScript ([#2634](https://github.com/elastic/eui/pull/2634))
 - Fixed `EuiComboBox` from submitting parent `form` element when selecting options via `Enter` key ([#2642](https://github.com/elastic/eui/pull/2642))
 - Fixed `EuiNavDrawer` expand button from losing focus after click ([#2643](https://github.com/elastic/eui/pull/2643))
+- Fixed instances of potentially duplicate `EuiPopover` `id` attributes ([#2667](https://github.com/elastic/eui/pull/2667))
 
 ## [`17.1.2`](https://github.com/elastic/eui/tree/v17.1.2)
 

--- a/src/components/suggest/__snapshots__/suggest.test.js.snap
+++ b/src/components/suggest/__snapshots__/suggest.test.js.snap
@@ -7,7 +7,6 @@ exports[`EuiSuggest is rendered 1`] = `
   >
     <div
       class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiInputPopover--fullWidth"
-      id="popover"
     >
       <div
         class="euiPopover__anchor"

--- a/src/components/suggest/__snapshots__/suggest_input.test.js.snap
+++ b/src/components/suggest/__snapshots__/suggest_input.test.js.snap
@@ -6,7 +6,6 @@ exports[`EuiSuggestInput is rendered 1`] = `
 >
   <div
     class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiInputPopover--fullWidth"
-    id="popover"
   >
     <div
       class="euiPopover__anchor"

--- a/src/components/suggest/suggest_input.js
+++ b/src/components/suggest/suggest_input.js
@@ -100,7 +100,6 @@ export class EuiSuggestInput extends Component {
     return (
       <div className={classes}>
         <EuiInputPopover
-          id="popover"
           input={customInput}
           isOpen={this.state.isPopoverOpen}
           panelPaddingSize="none"

--- a/src/components/table/mobile/__snapshots__/table_sort_mobile.test.tsx.snap
+++ b/src/components/table/mobile/__snapshots__/table_sort_mobile.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`EuiTableSortMobile is rendered 1`] = `
     aria-label="aria-label"
     class="euiPopover euiPopover--anchorDownRight"
     data-test-subj="test subject string"
-    id="sortPopover"
   >
     <div
       class="euiPopover__anchor"

--- a/src/components/table/mobile/table_sort_mobile.tsx
+++ b/src/components/table/mobile/table_sort_mobile.tsx
@@ -63,7 +63,6 @@ export class EuiTableSortMobile extends Component<
 
     const mobileSortPopover = (
       <EuiPopover
-        id="sortPopover"
         ownFocus
         button={mobileSortButton}
         isOpen={this.state.isPopoverOpen}


### PR DESCRIPTION
### Summary

elastic/kibana#50992 highlights a case where duplicate `id` errors can occur with `EuiPopover`.
This removes the `id` attributes on cases where the value is not necessary and could produce such errors.

### Checklist

~~- [ ] Checked in **dark mode**~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~

- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately

~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~

- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
