### PR TITLE
exclude *.test.tsx? files from eui.d.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Reverted docs changes in `17.2.0` that caused the build script to die ([#2672](https://github.com/elastic/eui/pull/2672))
 
+**Bug fixes**
+
+- Removed TypeScript definitions in `*.test.tsx?` files from _eui.d.ts_ ([#2673](https://github.com/elastic/eui/pull/2673))
+
 ## [`17.2.0`](https://github.com/elastic/eui/tree/v17.2.0)
 
 - Improved a11y of `EuiNavDrawer` lock button state via `aria-pressed` ([#2643](https://github.com/elastic/eui/pull/2643))

--- a/scripts/dtsgenerator.js
+++ b/scripts/dtsgenerator.js
@@ -32,6 +32,8 @@ const generator = dtsGenerator({
     'node_modules/**/*.d.ts',
     '*/custom_typings/**/*.d.ts',
     'src-framer/**/*',
+    '**/*.test.ts',
+    '**/*.test.tsx',
   ],
   resolveModuleId(params) {
     if (


### PR DESCRIPTION
### Summary

Fixes #2671 

This excludes `*.test.tsx?` files when generating _eui.d.ts_. I verified this does not have unintended effects on Kibana by applying the change to eui@17.0.0 (Kibana's version of EUI in master), re-generating its _eui.d.ts_, and testing those type definitions in Kibana.

### Checklist

~- [ ] Checked in **dark mode**~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
