### PR TITLE
Update package.josn to match last seq release number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `17.1.3`.
+**Bug fixes**
+
+- Changed package.json version to match sure our build scripts release the correct sequential number.
 
 ## [`17.1.3`](https://github.com/elastic/eui/tree/v17.1.3)
+
+**NOTE: This release came out of order due to a release script error. It actually came after 17.2.0 and can be ignored in favor of 17.2.1**
 
 - Reverted docs changes in `17.2.0` that caused the build script to die ([#2672](https://github.com/elastic/eui/pull/2672))
 
 ## [`17.2.0`](https://github.com/elastic/eui/tree/v17.2.0)
+
+**NOTE: This release had an error in our documentation layer. Use 17.2.1 instead**
 
 - Improved a11y of `EuiNavDrawer` lock button state via `aria-pressed` ([#2643](https://github.com/elastic/eui/pull/2643))
 - Added exports for available types related to `EuiDataGrid` ([#2640](https://github.com/elastic/eui/pull/2640))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Bug fixes**
 
-- Changed package.json version to match sure our build scripts release the correct sequential number.
+- Changed package.json version to match sure our build scripts release the correct sequential number ([#2674](https://github.com/elastic/eui/pull/2674))
 
 ## [`17.1.3`](https://github.com/elastic/eui/tree/v17.1.3)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elastic/eui",
   "description": "Elastic UI Component Library",
-  "version": "17.1.3",
+  "version": "17.2.0",
   "license": "Apache-2.0",
   "main": "lib",
   "module": "es",


### PR DESCRIPTION
### Summary

This PR does nothing but change the package.json version back to `17.2.0` so that the next release will be `17.2.1` (which I will kickoff on merge). For some reason during the revert hub-bub, it made a release against `17.1.3`. Talking with @chandlerprall and @thompsongl we decided just producing a new release back on cadence (and properly notied things in the CL) was the easiest course of action.

### Checklist

- [ ] ~Checked in **dark mode**~
- [ ] ~Checked in **mobile**~
- [ ] ~Checked in **IE11** and **Firefox**~
- [ ] ~Props have proper **autodocs**~
- [ ] ~Added **documentation** examples~
- [ ] ~Added or updated **jest tests**~
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
