### PR TITLE
EuiTreeView: fixed isExpanded property of Nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Reverted removal of `toggleOpen` method from `EuiNavDrawer` ([#2682](https://github.com/elastic/eui/pull/2682))
 - Improved `EuiDataGrid` update performance ([#2676](https://github.com/elastic/eui/pull/2676))
 - Fixed `EuiDatagrid` header top border when configured to have no toolbar ([#2619](https://github.com/elastic/eui/pull/#2619))
+- Fixed `isExpanded` property of nodes from `EuiTreeView` ([#](https://github.com/elastic/eui/pull/#))
 
 ## [`17.2.1`](https://github.com/elastic/eui/tree/v17.2.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Reverted removal of `toggleOpen` method from `EuiNavDrawer` ([#2682](https://github.com/elastic/eui/pull/2682))
 - Improved `EuiDataGrid` update performance ([#2676](https://github.com/elastic/eui/pull/2676))
 - Fixed `EuiDatagrid` header top border when configured to have no toolbar ([#2619](https://github.com/elastic/eui/pull/#2619))
-- Fixed `isExpanded` property of nodes from `EuiTreeView` ([#](https://github.com/elastic/eui/pull/#))
+- Fixed `isExpanded` property of nodes from `EuiTreeView` ([#2700](https://github.com/elastic/eui/pull/#2700))
 
 ## [`17.2.1`](https://github.com/elastic/eui/tree/v17.2.1)
 

--- a/src/components/tree_view/__snapshots__/tree_view.test.tsx.snap
+++ b/src/components/tree_view/__snapshots__/tree_view.test.tsx.snap
@@ -18,11 +18,11 @@ exports[`EuiTreeView is rendered 1`] = `
     id="htmlId"
   >
     <li
-      class="euiTreeView__node"
+      class="euiTreeView__node euiTreeView__node--expanded"
     >
       <button
         aria-controls="euiNestedTreeView-htmlId"
-        aria-expanded="false"
+        aria-expanded="true"
         class="euiTreeView__nodeInner"
         data-test-subj="euiTreeViewButton-htmlId"
         id="htmlId--0--node"
@@ -49,7 +49,120 @@ exports[`EuiTreeView is rendered 1`] = `
       </button>
       <div
         id="euiNestedTreeView-htmlId"
-      />
+      >
+        <div
+          class="euiText euiText--medium euiTreeView__wrapper"
+        >
+          <ul
+            aria-label="Item One child of aria-label"
+            class="euiTreeView"
+            id="htmlId"
+          >
+            <li
+              class="euiTreeView__node"
+            >
+              <button
+                aria-controls="euiNestedTreeView-htmlId"
+                aria-expanded="false"
+                class="euiTreeView__nodeInner"
+                data-test-subj="euiTreeViewButton-htmlId"
+                id="htmlId--0--node"
+              >
+                <span
+                  class="euiTreeView__iconWrapper"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="euiIcon euiIcon--medium euiIcon-isLoading"
+                    focusable="false"
+                    height="16"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  />
+                </span>
+                <span
+                  class="euiTreeView__nodeLabel"
+                >
+                  Item A
+                </span>
+              </button>
+              <div
+                id="euiNestedTreeView-htmlId"
+              />
+            </li>
+            <li
+              class="euiTreeView__node"
+            >
+              <button
+                aria-controls="euiNestedTreeView-htmlId"
+                aria-expanded="false"
+                class="euiTreeView__nodeInner"
+                data-test-subj="euiTreeViewButton-htmlId"
+                id="htmlId--1--node"
+              >
+                <span
+                  class="euiTreeView__iconWrapper"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="euiIcon euiIcon--medium euiIcon-isLoading"
+                    focusable="false"
+                    height="16"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  />
+                </span>
+                <span
+                  class="euiTreeView__nodeLabel"
+                >
+                  Item B
+                </span>
+              </button>
+              <div
+                id="euiNestedTreeView-htmlId"
+              />
+            </li>
+            <li
+              class="euiTreeView__node"
+            >
+              <button
+                aria-controls="euiNestedTreeView-htmlId"
+                aria-expanded="false"
+                class="euiTreeView__nodeInner"
+                data-test-subj="euiTreeViewButton-htmlId"
+                id="htmlId--2--node"
+              >
+                <span
+                  class="euiTreeView__iconWrapper"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="euiIcon euiIcon--medium euiIcon-isLoading"
+                    focusable="false"
+                    height="16"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  />
+                </span>
+                <span
+                  class="euiTreeView__nodeLabel"
+                >
+                  Item C
+                </span>
+              </button>
+              <div
+                id="euiNestedTreeView-htmlId"
+              />
+            </li>
+          </ul>
+        </div>
+      </div>
     </li>
     <li
       class="euiTreeView__node"

--- a/src/components/tree_view/tree_view.tsx
+++ b/src/components/tree_view/tree_view.tsx
@@ -98,7 +98,11 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
             children ? id : ((null as unknown) as string)
           )
           .filter(x => x != null)
-      : [],
+      : this.props.items
+          .map<string>(({ id, children, isExpanded }) =>
+            children && isExpanded ? id : ((null as unknown) as string)
+          )
+          .filter(x => x != null),
     activeItem: '',
     treeID: this.context || treeIdGenerator(),
     expandChildNodes: this.props.expandByDefault || false,
@@ -119,6 +123,8 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
     this.setState({
       expandChildNodes: false,
     });
+
+    node.isExpanded = !node.isExpanded;
 
     if (!ignoreCallback && node.callback !== undefined) {
       node.callback();


### PR DESCRIPTION
### Summary

Closes https://github.com/elastic/eui/issues/2699

Fixed `isExpanded` property of nodes of `EuiTreeView`.

![Bildschirmfoto vom 2019-12-19 09-05-49](https://user-images.githubusercontent.com/23581855/71174019-e433b000-2242-11ea-9459-d3967411a76a.png)

![Bildschirmfoto vom 2019-12-19 09-06-09](https://user-images.githubusercontent.com/23581855/71174024-e6960a00-2242-11ea-8e9c-41c8821bd857.png)


### Checklist

- [ ] Check against **all themes** for compatability in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [X] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
