### PR TITLE
updates type for button size

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -30,7 +30,7 @@ export type ButtonColor =
   | 'ghost'
   | 'text';
 
-export type ButtonSize = 's' | 'm';
+export type ButtonSize = 'xs' | 's' | 'm';
 
 const colorToClassNameMap: { [color in ButtonColor]: string } = {
   primary: 'euiButton--primary',


### PR DESCRIPTION
the documentation uses `xs` https://elastic.github.io/eui/#/navigation/button

### Summary

The type for `ButtonSize` seems to not be complete (or, the source of truth).  Perhaps a small refactor is called for to get this value from the source?  That source appears to ultimately be here: https://github.com/elastic/eui/blob/master/src/components/button/button.tsx#L46 from what I can tell?

Perhaps a section documenting sizes, if small and medium are really the only sizes, would be best.  Let me know if so, I'd be happy to add it.

### Checklist

- [ ] Check against **all themes** for compatability in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
