### PR TITLE
Properly render an example's html output in the  Demo HTML tab

### DIFF
--- a/src-docs/src/services/string/render_to_html.js
+++ b/src-docs/src/services/string/render_to_html.js
@@ -8,13 +8,20 @@ import html from 'html';
 
 configure({ adapter: new EnzymeAdapter() });
 
-export function renderToHtml(componentReference, props = {}) {
+export function renderToHtml(ComponentReference, props = {}) {
   // If there's a failure, just return an empty string. The actual component itself should
   // trip an error boundary in the UI when it fails.
   try {
     // Create the React element, render it and get its HTML, then format it prettily.
-    const element = React.createElement(componentReference, props);
-    const htmlString = render(element).html();
+    // the .html() call below renders the contents of the first node, so wrap everything in a div
+    const element = (
+      <div>
+        <ComponentReference {...props} />
+      </div>
+    );
+    const renderedNodes = render(element);
+
+    const htmlString = renderedNodes.html();
     return html.prettyPrint(htmlString, {
       indent_size: 2,
       unformatted: [], // Expand all tags, including spans


### PR DESCRIPTION
### Summary

Fixes #2713 and fixes #2711

Two issues I found:

* Any example source that returns a `<Fragment>` (e.g. [list_group.js](https://github.com/elastic/eui/blob/9985aadf7f316f5b7f81873fee5afe6a2f0bc100/src-docs/src/views/list_group/list_group.js#L38-L83) only rendered the first child's html
* The rendered content didn't include the root node's HTML, so **every** `Demo HTML` tab in our docs has been missing it's top-most wrapping element.

Both of these are fixed by wrapping the rendered source component in a `div`.

@thompsongl for code review
@snide / @cchaos to double check the Demo HTML output

### Checklist

~- [ ] Check against **all themes** for compatability in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
- [x] Added **documentation** examples
~- [ ] Added or updated **jest tests**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
