### PR TITLE
Make EuiLink button text selectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 **Bug fixes**
 
 - Fixed `isExpanded` property of nodes from `EuiTreeView` ([#2700](https://github.com/elastic/eui/pull/#2700))
+- Added text selection to `EuiLink` button ([#2722](https://github.com/elastic/eui/pull/#2722))
 
 ## [`17.3.1`](https://github.com/elastic/eui/tree/v17.3.1)
 

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -38,4 +38,7 @@ $textColors: (
   }
 }
 
-
+// Make button EuiLink's text selectable
+button.euiLink { // sass-lint:disable-line no-qualifying-elements
+  user-select: text;
+}


### PR DESCRIPTION
### Summary

Make `EuiLink` button text selectable using CSS. Fixes #1259

Screen recording in Firefox: 

![select_text](https://user-images.githubusercontent.com/4016496/71600827-930aa280-2b05-11ea-8690-07a9eeba92c8.gif)


### Checklist

~- [ ] Check against **all themes** for compatability in both light and dark modes~
~- [ ] Checked in **mobile**~
- [x] Checked in **IE11** and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
