### PR TITLE
Don't change cell focus when user resizes a column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Bug fixes**
 
 - Fixed `isExpanded` property of nodes from `EuiTreeView` ([#2700](https://github.com/elastic/eui/pull/#2700))
+- Fixed bug in `EuiDataGrid` where resizing columns changed the active DOM element ([#2724](https://github.com/elastic/eui/pull/#2724))
 
 ## [`17.3.1`](https://github.com/elastic/eui/tree/v17.3.1)
 

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -67,7 +67,11 @@ function resizeColumn(
   const firstResizer = datagrid
     .find(`EuiDataGridColumnResizer[columnId="${columnId}"]`)
     .instance() as EuiDataGridColumnResizer;
-  firstResizer.onMouseDown({ pageX: originalWidth });
+  firstResizer.onMouseDown({
+    pageX: originalWidth,
+    stopPropagation: () => {},
+    preventDefault: () => {},
+  } as React.MouseEvent<HTMLDivElement>);
   firstResizer.onMouseMove({ pageX: columnWidth });
   act(() => firstResizer.onMouseUp());
 

--- a/src/components/datagrid/data_grid_column_resizer.tsx
+++ b/src/components/datagrid/data_grid_column_resizer.tsx
@@ -22,7 +22,7 @@ export class EuiDataGridColumnResizer extends Component<
     offset: 0,
   };
 
-  onMouseDown = (e: { pageX: number }) => {
+  onMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     this.setState({
       initialX: e.pageX,
     });
@@ -30,6 +30,10 @@ export class EuiDataGridColumnResizer extends Component<
     window.addEventListener('mouseup', this.onMouseUp);
     window.addEventListener('blur', this.onMouseUp);
     window.addEventListener('mousemove', this.onMouseMove);
+
+    // don't let this action steal focus
+    e.preventDefault();
+    e.stopPropagation();
   };
 
   onMouseUp = () => {

--- a/src/components/datagrid/data_grid_column_resizer.tsx
+++ b/src/components/datagrid/data_grid_column_resizer.tsx
@@ -33,7 +33,6 @@ export class EuiDataGridColumnResizer extends Component<
 
     // don't let this action steal focus
     e.preventDefault();
-    e.stopPropagation();
   };
 
   onMouseUp = () => {


### PR DESCRIPTION
### Summary

Fixes #2693 

When the data grid's header row has interactive elements, clicking on a column resize handle would steal focus and put it on the header cell. This change adds a `preventDefault` to the event handler to prevent the focus moving. Tested in Chrome, FF, Safari, and Edge.

### Checklist

~- [ ] Check against **all themes** for compatability in both light and dark modes~
~- [ ] Checked in **mobile**~
- [x] Checked in **IE11** and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
