### PR TITLE
Fix EuiCodeBlock padding for scrollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Fixed `isExpanded` property of nodes from `EuiTreeView` ([#2700](https://github.com/elastic/eui/pull/#2700))
 - Added text selection to `EuiLink` button ([#2722](https://github.com/elastic/eui/pull/#2722))
+- Fixed position of scrollbar in `EuiCodeBlock` ([#2727](https://github.com/elastic/eui/pull/#2727))
 
 ## [`17.3.1`](https://github.com/elastic/eui/tree/v17.3.1)
 

--- a/src/components/code/_code_block.scss
+++ b/src/components/code/_code_block.scss
@@ -20,10 +20,6 @@
     font-size: inherit;
   }
 
-  &.euiCodeBlock--hasControls {
-    padding-right: $euiSizeL + $euiSizeXS;
-  }
-
   .euiCodeBlock__controls {
     position: absolute;
     top: 0;
@@ -64,6 +60,8 @@
     font-size: $euiFontSize;
   }
 
+  $controlsPadding: $euiSizeL + $euiSizeXS;
+
   // Small padding
   &.euiCodeBlock--paddingSmall {
     .euiCodeBlock__pre {
@@ -73,6 +71,10 @@
     .euiCodeBlock__controls {
       top: $euiSizeS;
       right: $euiSizeS;
+    }
+
+    &.euiCodeBlock--hasControls .euiCodeBlock__pre {
+      padding-right: $euiSizeS + $controlsPadding;
     }
   }
 
@@ -86,6 +88,10 @@
       top: $euiSize;
       right: $euiSize;
     }
+
+    &.euiCodeBlock--hasControls .euiCodeBlock__pre {
+      padding-right: $euiSize + $controlsPadding;
+    }
   }
 
   // Large padding
@@ -97,6 +103,10 @@
     .euiCodeBlock__controls {
       top: $euiSizeL;
       right: $euiSizeL;
+    }
+
+    &.euiCodeBlock--hasControls .euiCodeBlock__pre {
+      padding-right: $euiSizeL + $controlsPadding;
     }
   }
 

--- a/src/components/code/_code_block.scss
+++ b/src/components/code/_code_block.scss
@@ -60,6 +60,7 @@
     font-size: $euiFontSize;
   }
 
+  // Storing for re-use the sizing of controls plus extra padding
   $controlsPadding: $euiSizeL + $euiSizeXS;
 
   // Small padding
@@ -110,14 +111,14 @@
     }
   }
 
-  /**
-  ** 1. Size the code against the text its embedded within.
-  **/
+  /*
+   * 1. Size the code against the text its embedded within.
+   */
   &.euiCodeBlock--inline {
     display: inline-block;
     white-space: pre;
     color: $euiTextColor;
-    font-size: 90%; // 1
+    font-size: 90%; /* 1 */
     padding: 0 $euiSizeS;
     background: $euiCodeBlockBackgroundColor;
 


### PR DESCRIPTION
### Fixes a regression that was introduced when adjusting the position of the EuiCodeBlock control buttons

**Before**
<img width="965" alt="Screen Shot 2020-01-02 at 15 09 50 PM" src="https://user-images.githubusercontent.com/549577/71690211-0ca6c880-2d72-11ea-94ac-8f8a9a81c926.png">


**After**
<img width="966" alt="Screen Shot 2020-01-02 at 15 12 12 PM" src="https://user-images.githubusercontent.com/549577/71690314-4c6db000-2d72-11ea-894e-745075640fcf.png">


### Checklist

- ~[ ] Check against **all themes** for compatability in both light and dark modes~
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **documentation** examples~
- ~[ ] Added or updated **jest tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
