### PR TITLE
Fix InMemory table selection demo by keeping 'users' defined

### DIFF
--- a/src-docs/src/views/tables/in_memory/in_memory_selection.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_selection.js
@@ -64,7 +64,7 @@ export class Table extends Component {
     this.setState({
       message: 'Loading users...',
       loading: true,
-      users: undefined,
+      users: [],
       error: undefined,
     });
     setTimeout(() => {
@@ -81,14 +81,14 @@ export class Table extends Component {
     this.setState({
       message: 'Loading users...',
       loading: true,
-      users: undefined,
+      users: [],
       error: undefined,
     });
     setTimeout(() => {
       this.setState({
         loading: false,
         error: 'ouch!... again... ',
-        users: undefined,
+        users: [],
         message: noItemsFoundMsg,
       });
     }, random.number({ min: 0, max: 3000 }));


### PR DESCRIPTION
### Summary

Fixes the _In-Memory Table - Selection_ demo. `items` is a required field but the demo would set to `undefined` while generating a new list.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
