### PR TITLE
Match button text alignment to card textAlign prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Fixed bug in `EuiCard` where button text was not properly aligned ([#2741](https://github.com/elastic/eui/pull/2741))
 - Converted `EuiRange` to TypeScript ([#2732](https://github.com/elastic/eui/pull/2732))
 - Converted `EuiDualRange` to TypeScript ([#2732](https://github.com/elastic/eui/pull/2732))
 - Converted `EuiRangeInput` to TypeScript ([#2732](https://github.com/elastic/eui/pull/2732))

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -79,6 +79,10 @@
   &.euiCard--leftAligned {
     text-align: left;
     align-items: flex-start;
+
+    .euiCard__titleButton {
+      text-align: left;
+    }
   }
 
   &.euiCard--centerAligned {
@@ -89,6 +93,10 @@
   &.euiCard--rightAligned {
     text-align: right;
     align-items: flex-end;
+
+    .euiCard__titleButton {
+      text-align: right;
+    }
   }
 
   &.euiCard--isSelectable {


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/2740

### Summary

While working in Canvas, I noticed that the title text for clickable cards was being centered. Seems like a regression, but regardless it's an easy fix.

#### Before

<img width="977" alt="Screenshot 2020-01-07 14 16 19" src="https://user-images.githubusercontent.com/446285/71927866-1490af00-315c-11ea-977d-c6eaa5fc0929.png">

#### After

`textAlign: left`
<img width="961" alt="Screenshot 2020-01-07 14 37 34" src="https://user-images.githubusercontent.com/446285/71927890-1b1f2680-315c-11ea-829b-132cdb46005b.png">

`textAlign: right`
<img width="974" alt="Screenshot 2020-01-07 14 45 23" src="https://user-images.githubusercontent.com/446285/71928032-5d486800-315c-11ea-8a86-0d53640378e9.png">


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [ ] ~Props have proper **autodocs**~
- [ ] ~Added **documentation** examples~
- [ ] ~Added or updated **jest tests**~
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
