### PR TITLE
Lighten hollow badge border in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Changed `EuiBadge` hollow border color in dark mode ([#2746](https://github.com/elastic/eui/pull/2746))
 - Changed `EuiBadge` to use EUI palette colors ([#2455](https://github.com/elastic/eui/pull/2455))
 - Darkened a few `euiPaletteColorBlind` colors ([#2455](https://github.com/elastic/eui/pull/2455))
 - Fixed bug in `EuiCard` where button text was not properly aligned ([#2741](https://github.com/elastic/eui/pull/2741))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Changed `EuiBadge` hollow border color in dark mode ([#2746](https://github.com/elastic/eui/pull/2746))
+- Lightened `EuiBadge` hollow border color in dark mode ([#2746](https://github.com/elastic/eui/pull/2746))
 - Changed `EuiBadge` to use EUI palette colors ([#2455](https://github.com/elastic/eui/pull/2455))
 - Darkened a few `euiPaletteColorBlind` colors ([#2455](https://github.com/elastic/eui/pull/2455))
 - Fixed bug in `EuiCard` where button text was not properly aligned ([#2741](https://github.com/elastic/eui/pull/2741))

--- a/src/components/badge/_badge.scss
+++ b/src/components/badge/_badge.scss
@@ -126,6 +126,6 @@
 // Hollow has a border and is mostly used for autocompleters.
 .euiBadge--hollow {
   background-color: $euiColorEmptyShade;
-  border-color: $euiBorderColor;
+  border-color: lightOrDarkTheme($euiBorderColor, tint($euiBorderColor, 15%));
   color: $euiTextColor;
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/2744

### Summary

After the recent badge color update, the hollow badge border became hard to see in dark mode. This PR adds some tint to lighten the border when in dark mode. Similar to the light version, the border remains more subtle than the text.

#### Before

<img width="274" alt="Screenshot 2020-01-08 17 21 34" src="https://user-images.githubusercontent.com/446285/72024737-b1764980-323b-11ea-8172-28e0ecf4511b.png">

#### After

<img width="276" alt="Screenshot 2020-01-09 08 11 14" src="https://user-images.githubusercontent.com/446285/72074520-b1b42a80-32b7-11ea-9c5b-314b5b8711c9.png">


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
