### PR TITLE
Created a `euiPaletteColorBlindBehindText` variant of the color blind palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Converted `EuiRangeInput` to TypeScript ([#2732](https://github.com/elastic/eui/pull/2732))
 - Added `bellSlash` glyph to `EuiIcon` ([#2714](https://github.com/elastic/eui/pull/2714))
 - Added `legend` prop to `EuiCheckboxGroup` and `EuiRadioGroup` to add `EuiFieldset` wrappers for title the groups ([#2739](https://github.com/elastic/eui/pull/2739))
+- Created a `euiPaletteColorBlindBehindText` variant of the color blind palette ([#2750](https://github.com/elastic/eui/pull/2750))
 
 **Bug fixes**
 

--- a/src-docs/src/views/color_palette/color_palette.js
+++ b/src-docs/src/views/color_palette/color_palette.js
@@ -10,7 +10,7 @@ import {
 
 import {
   euiPaletteColorBlind,
-  euiPaletteColorBlindWithText,
+  euiPaletteColorBlindBehindText,
 } from '../../../../src/services';
 import { ColorPaletteFlexItem, ColorPaletteCopyCode } from './shared';
 
@@ -69,7 +69,7 @@ export default () => (
         <EuiSpacer size="xl" />
       </Fragment>
     ))}
-    {euiPaletteColorBlindWithText().map((color, i) => (
+    {euiPaletteColorBlindBehindText().map((color, i) => (
       <EuiBadge key={i} color={color}>
         Text
       </EuiBadge>

--- a/src-docs/src/views/color_palette/color_palette.js
+++ b/src-docs/src/views/color_palette/color_palette.js
@@ -5,9 +5,13 @@ import {
   EuiFlexItem,
   EuiTitle,
   EuiSpacer,
+  EuiBadge,
 } from '../../../../src/components';
 
-import { euiPaletteColorBlind } from '../../../../src/services';
+import {
+  euiPaletteColorBlind,
+  euiPaletteColorBlindWithText,
+} from '../../../../src/services';
 import { ColorPaletteFlexItem, ColorPaletteCopyCode } from './shared';
 
 const customPalettes = [
@@ -64,6 +68,11 @@ export default () => (
         </EuiFlexGroup>
         <EuiSpacer size="xl" />
       </Fragment>
+    ))}
+    {euiPaletteColorBlindWithText().map((color, i) => (
+      <EuiBadge key={i} color={color}>
+        Text
+      </EuiBadge>
     ))}
   </Fragment>
 );

--- a/src-docs/src/views/color_palette/color_palette.js
+++ b/src-docs/src/views/color_palette/color_palette.js
@@ -78,7 +78,7 @@ export default () => (
       <EuiFlexItem grow={false} style={{ maxWidth: 240 }}>
         <EuiFlexGrid columns={4} gutterSize="s">
           {euiPaletteColorBlindBehindText().map((color, i) => (
-            <EuiFlexItem key={i}>
+            <EuiFlexItem key={i} grow={false}>
               <span>
                 <EuiBadge color={color}>Text</EuiBadge>
               </span>

--- a/src-docs/src/views/color_palette/color_palette.js
+++ b/src-docs/src/views/color_palette/color_palette.js
@@ -6,6 +6,7 @@ import {
   EuiTitle,
   EuiSpacer,
   EuiBadge,
+  EuiFlexGrid,
 } from '../../../../src/components';
 
 import {
@@ -69,10 +70,28 @@ export default () => (
         <EuiSpacer size="xl" />
       </Fragment>
     ))}
-    {euiPaletteColorBlindBehindText().map((color, i) => (
-      <EuiBadge key={i} color={color}>
-        Text
-      </EuiBadge>
-    ))}
+    <EuiTitle size="xxs">
+      <h3>Behind text variant</h3>
+    </EuiTitle>
+    <EuiSpacer size="s" />
+    <EuiFlexGroup alignItems="center">
+      <EuiFlexItem grow={false} style={{ maxWidth: 240 }}>
+        <EuiFlexGrid columns={4} gutterSize="s">
+          {euiPaletteColorBlindBehindText().map((color, i) => (
+            <EuiFlexItem key={i}>
+              <span>
+                <EuiBadge color={color}>Text</EuiBadge>
+              </span>
+            </EuiFlexItem>
+          ))}
+        </EuiFlexGrid>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <ColorPaletteCopyCode
+          textToCopy={'euiPaletteColorBlindBehindText()'}
+          code={'euiPaletteColorBlindBehindText()'}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
   </Fragment>
 );

--- a/src-docs/src/views/color_palette/color_palette_example.js
+++ b/src-docs/src/views/color_palette/color_palette_example.js
@@ -5,7 +5,12 @@ import { renderToHtml } from '../../services';
 
 import { GuideSectionTypes } from '../../components';
 
-import { EuiCode, EuiText, EuiSpacer } from '../../../../src/components';
+import {
+  EuiCode,
+  EuiText,
+  EuiSpacer,
+  EuiCallOut,
+} from '../../../../src/components';
 
 import ColorPalette from './color_palette';
 const colorPaletteSource = require('!!raw-loader!./color_palette');
@@ -96,6 +101,11 @@ export const ColorPaletteExample = {
             in the number of steps needed and the function will interpolate
             between the colors.
           </p>
+          <EuiCallOut
+            color="warning"
+            iconType="accessibility"
+            title="The palette for status is the only palette that has proper contrast ratios. When using the other palettes, consider adding another form of the data for screen readers."
+          />
         </div>
       ),
       demo: <ColorPaletteQuant />,

--- a/src-docs/src/views/color_palette/color_palette_example.js
+++ b/src-docs/src/views/color_palette/color_palette_example.js
@@ -58,6 +58,14 @@ export const ColorPaletteExample = {
             more groups of 10 which are alternates of the original. This is
             better than allowing the initial set to loop.
           </p>
+          <p>
+            These colors are meant to be used as graphics and contrasted against
+            the value of <EuiCode>euiColorEmptyShade</EuiCode> for the current
+            theme. When placing text on top of these colors, use the{' '}
+            <EuiCode>euiPaletteColorBlindBehindText()</EuiCode> variant. It is a
+            brightened version of the base palette to create better contrast
+            with text.
+          </p>
         </div>
       ),
       demo: <ColorPalette />,

--- a/src-docs/src/views/combo_box/colors.js
+++ b/src-docs/src/views/combo_box/colors.js
@@ -1,58 +1,65 @@
 import React, { Component } from 'react';
 
 import { EuiComboBox } from '../../../../src/components';
+import {
+  euiPaletteColorBlind,
+  euiPaletteColorBlindBehindText,
+} from '../../../../src/services';
 
 export default class extends Component {
   constructor(props) {
     super(props);
 
+    this.visColors = euiPaletteColorBlind();
+    this.visColorsBehindText = euiPaletteColorBlindBehindText();
+
     this.options = [
       {
         label: 'Titan',
         'data-test-subj': 'titanOption',
-        color: 'primary',
+        color: this.visColorsBehindText[0],
       },
       {
         label: 'Enceladus',
-        color: 'secondary',
+        color: this.visColorsBehindText[1],
       },
       {
         label: 'Mimas',
-        color: '#D36086',
+        color: this.visColorsBehindText[2],
       },
       {
         label: 'Dione',
-        color: 'accent',
+        color: this.visColorsBehindText[3],
       },
       {
         label: 'Iapetus',
-        color: 'warning',
+        color: this.visColorsBehindText[4],
       },
       {
         label: 'Phoebe',
-        color: 'danger',
+        color: this.visColorsBehindText[5],
       },
       {
         label: 'Rhea',
-        color: 'default',
+        color: this.visColorsBehindText[6],
       },
       {
         label:
           "Pandora is one of Saturn's moons, named for a Titaness of Greek mythology",
-        color: '#DA8B45',
+        color: this.visColorsBehindText[7],
       },
       {
         label: 'Tethys',
-        color: '#CA8EAE',
+        color: this.visColorsBehindText[8],
       },
       {
         label: 'Hyperion',
-        color: '#B9A888',
+        color: this.visColorsBehindText[9],
       },
     ];
 
     this.state = {
-      selectedOptions: [this.options[2], this.options[4]],
+      selectedOptions: [this.options[2], this.options[5]],
     };
   }
 

--- a/src-docs/src/views/combo_box/colors.js
+++ b/src-docs/src/views/combo_box/colors.js
@@ -1,16 +1,12 @@
 import React, { Component } from 'react';
 
 import { EuiComboBox } from '../../../../src/components';
-import {
-  euiPaletteColorBlind,
-  euiPaletteColorBlindBehindText,
-} from '../../../../src/services';
+import { euiPaletteColorBlindBehindText } from '../../../../src/services';
 
 export default class extends Component {
   constructor(props) {
     super(props);
 
-    this.visColors = euiPaletteColorBlind();
     this.visColorsBehindText = euiPaletteColorBlindBehindText();
 
     this.options = [

--- a/src-docs/src/views/combo_box/render_option.js
+++ b/src-docs/src/views/combo_box/render_option.js
@@ -5,10 +5,17 @@ import {
   EuiHighlight,
   EuiHealth,
 } from '../../../../src/components';
+import {
+  euiPaletteColorBlind,
+  euiPaletteColorBlindBehindText,
+} from '../../../../src/services';
 
 export default class extends Component {
   constructor(props) {
     super(props);
+
+    this.visColors = euiPaletteColorBlind();
+    this.visColorsBehindText = euiPaletteColorBlindBehindText();
 
     this.options = [
       {
@@ -17,49 +24,49 @@ export default class extends Component {
         },
         label: 'Titan',
         'data-test-subj': 'titanOption',
-        color: 'primary',
+        color: this.visColorsBehindText[0],
       },
       {
         value: {
           size: 2,
         },
         label: 'Enceladus',
-        color: 'secondary',
+        color: this.visColorsBehindText[1],
       },
       {
         value: {
           size: 15,
         },
         label: 'Mimas',
-        color: '#D36086',
+        color: this.visColorsBehindText[2],
       },
       {
         value: {
           size: 1,
         },
         label: 'Dione',
-        color: 'accent',
+        color: this.visColorsBehindText[3],
       },
       {
         value: {
           size: 8,
         },
         label: 'Iapetus',
-        color: 'warning',
+        color: this.visColorsBehindText[4],
       },
       {
         value: {
           size: 2,
         },
         label: 'Phoebe',
-        color: 'danger',
+        color: this.visColorsBehindText[5],
       },
       {
         value: {
           size: 33,
         },
         label: 'Rhea',
-        color: 'default',
+        color: this.visColorsBehindText[6],
       },
       {
         value: {
@@ -67,26 +74,26 @@ export default class extends Component {
         },
         label:
           "Pandora is one of Saturn's moons, named for a Titaness of Greek mythology",
-        color: '#DA8B45',
+        color: this.visColorsBehindText[7],
       },
       {
         value: {
           size: 9,
         },
         label: 'Tethys',
-        color: '#CA8EAE',
+        color: this.visColorsBehindText[8],
       },
       {
         value: {
           size: 4,
         },
         label: 'Hyperion',
-        color: '#B9A888',
+        color: this.visColorsBehindText[9],
       },
     ];
 
     this.state = {
-      selectedOptions: [this.options[2], this.options[4]],
+      selectedOptions: [this.options[2], this.options[5]],
     };
   }
 
@@ -129,8 +136,9 @@ export default class extends Component {
 
   renderOption = (option, searchValue, contentClassName) => {
     const { color, label, value } = option;
+    const dotColor = this.visColors[this.visColorsBehindText.indexOf(color)];
     return (
-      <EuiHealth color={color}>
+      <EuiHealth color={dotColor}>
         <span className={contentClassName}>
           <EuiHighlight search={searchValue}>{label}</EuiHighlight>
           &nbsp;

--- a/src-docs/src/views/guidelines/colors.js
+++ b/src-docs/src/views/guidelines/colors.js
@@ -410,7 +410,7 @@ color: $${color2};`;
 }
 
 function visPaletteContrast(foreground, background, index, name) {
-  const initialContrast = chroma.contrast(foreground, background);
+  // const initialContrast = chroma.contrast(foreground, background);
   // const textColor = isColorDark(foreground) ? '#FFFFFF' : '#000000';
 
   // const betterForeground = createNonTextContrast(background, foreground);
@@ -432,9 +432,9 @@ function visPaletteContrast(foreground, background, index, name) {
           {betterContrast.toFixed(1)} &ensp; {'better'}
         </span>
       )} */}
-      <EuiBadge color={foreground}>
+      {/* <EuiBadge color={foreground}>
         {initialContrast.toFixed(1)}: {name}
-      </EuiBadge>
+      </EuiBadge> */}
       <EuiBadge
         color={chroma(foreground)
           .brighten(0.5)

--- a/src-docs/src/views/guidelines/colors.js
+++ b/src-docs/src/views/guidelines/colors.js
@@ -1,9 +1,5 @@
 import React, { Component } from 'react';
-import chroma from 'chroma-js';
-
 import { Link } from 'react-router';
-
-import lightColorsJSON from '../../../../dist/eui_theme_light.json';
 
 import lightColors from '!!sass-vars-to-js-loader!../../../../src/global_styling/variables/_colors.scss';
 import darkColors from '!!sass-vars-to-js-loader!../../../../src/themes/eui/eui_colors_dark.scss';
@@ -388,65 +384,7 @@ color: $${color2};`;
             );
           })}
         </EuiFlexGroup>
-
-        <EuiSpacer />
-
-        <EuiFlexGrid columns={1}>
-          {visColorKeys.map(function(color, index) {
-            const foreground = visColors[color].graphic.rgba;
-            const background = palette[allowedColors[0]].rgba;
-            return (
-              <EuiFlexItem key={index}>
-                <span>
-                  {visPaletteContrast(foreground, background, index, color)}
-                </span>
-              </EuiFlexItem>
-            );
-          })}
-        </EuiFlexGrid>
       </GuidePage>
     );
   }
-}
-
-function visPaletteContrast(foreground, background, index, name) {
-  // const initialContrast = chroma.contrast(foreground, background);
-  // const textColor = isColorDark(foreground) ? '#FFFFFF' : '#000000';
-
-  // const betterForeground = createNonTextContrast(background, foreground);
-  // const betterContrast = chroma.contrast(betterForeground, background);
-  // const betterTextColor = isColorDark(betterForeground) ? '#FFFFFF' : '#000000';
-
-  return (
-    <>
-      {/* {initialContrast < 3 && (
-        <span
-          className="eui-fullWidth eui-textLeft"
-          style={{
-            backgroundColor: chroma(betterForeground).hex(),
-            color: betterTextColor,
-            padding: 6,
-            marginBottom: 2,
-            borderRadius: 4,
-          }}>
-          {betterContrast.toFixed(1)} &ensp; {'better'}
-        </span>
-      )} */}
-      {/* <EuiBadge color={foreground}>
-        {initialContrast.toFixed(1)}: {name}
-      </EuiBadge> */}
-      <EuiBadge
-        color={chroma(foreground)
-          .brighten(0.5)
-          .hex()}>
-        JS:{' '}
-        {chroma(foreground)
-          .brighten(0.5)
-          .hex()}
-      </EuiBadge>
-      <EuiBadge color={lightColorsJSON.euiColorVisColorsBehindText[name]}>
-        CSS: {lightColorsJSON.euiColorVisColorsBehindText[name]}
-      </EuiBadge>
-    </>
-  );
 }

--- a/src-docs/src/views/guidelines/colors.js
+++ b/src-docs/src/views/guidelines/colors.js
@@ -52,7 +52,7 @@ function renderPaletteColor(palette, color, index, key) {
   const name = key && key !== 'graphic' ? `${color}_${key}` : color;
 
   return (
-    <EuiFlexItem key={index}>
+    <EuiFlexItem key={index} grow={false}>
       <EuiFlexGroup responsive={false} alignItems="center">
         <EuiFlexItem grow={false}>
           <EuiCopy beforeMessage="Click to copy color name" textToCopy={name}>

--- a/src-docs/src/views/guidelines/colors.js
+++ b/src-docs/src/views/guidelines/colors.js
@@ -3,6 +3,8 @@ import chroma from 'chroma-js';
 
 import { Link } from 'react-router';
 
+import lightColorsJSON from '../../../../dist/eui_theme_light.json';
+
 import lightColors from '!!sass-vars-to-js-loader!../../../../src/global_styling/variables/_colors.scss';
 import darkColors from '!!sass-vars-to-js-loader!../../../../src/themes/eui/eui_colors_dark.scss';
 import lightAmsterdamColors from '!!sass-vars-to-js-loader!../../../../src/themes/eui-amsterdam/eui_amsterdam_colors_light.scss';
@@ -44,19 +46,6 @@ const allowedColors = [
   'euiColorWarning',
   'euiColorDanger',
   'euiColorAccent',
-];
-
-const visColors = [
-  'euiColorVis0',
-  'euiColorVis1',
-  'euiColorVis2',
-  'euiColorVis3',
-  'euiColorVis4',
-  'euiColorVis5',
-  'euiColorVis6',
-  'euiColorVis7',
-  'euiColorVis8',
-  'euiColorVis9',
 ];
 
 const ratingAAA = <EuiBadge color="#000">AAA</EuiBadge>;
@@ -173,6 +162,10 @@ export default class extends Component {
     } else {
       palette = lightColors;
     }
+
+    // Vis colors are the same for all palettes
+    const visColors = lightColors.euiColorVisColors;
+    const visColorKeys = Object.keys(lightColors.euiColorVisColors);
 
     function getContrastRatings(color1, color2) {
       if (color1.indexOf('Shade') === -1 && color2.indexOf('Shade') === -1) {
@@ -359,25 +352,24 @@ color: $${color2};`;
         <EuiSpacer />
 
         <EuiFlexGroup direction="column" gutterSize="s">
-          {visColors.map(function(color, index) {
-            return renderPaletteColor(palette, color, index);
+          {visColorKeys.map(function(color, index) {
+            return renderPaletteColor(visColors, color, index);
           })}
         </EuiFlexGroup>
 
         <EuiSpacer />
 
         <EuiFlexGrid columns={3}>
-          {visColors.map(function(color, index) {
+          {visColorKeys.map(function(color, index) {
+            const foreground = visColors[color].rgba;
+            const background = palette[allowedColors[0]].rgba;
             return (
               <EuiFlexItem key={index}>
                 <EuiText size="xs">
-                  <h3>{color}</h3>
-                  {visPaletteContrast(
-                    palette[color].rgba,
-                    palette[allowedColors[0]].rgba,
-                    index,
-                    color
-                  )}
+                  <h3>
+                    {chroma.contrast(foreground, background).toFixed(1)} {color}
+                  </h3>
+                  {visPaletteContrast(foreground, background, index, color)}
                 </EuiText>
               </EuiFlexItem>
             );
@@ -407,8 +399,7 @@ function visPaletteContrast(foreground, background, index, name) {
           marginBottom: 2,
           borderRadius: 4,
         }}>
-        {initialContrast.toFixed(1)} &ensp;{' '}
-        {(index > 0 && index < 4) || index === 9 ? 'original' : 'new'}
+        {/* {initialContrast.toFixed(1)} &ensp; Base: {chroma(foreground).hex()} */}
       </span>
       {initialContrast < 3 && (
         <span
@@ -428,7 +419,13 @@ function visPaletteContrast(foreground, background, index, name) {
         color={chroma(foreground)
           .brighten(0.5)
           .hex()}>
-        {'lightened by 0.5'}
+        JS:{' '}
+        {chroma(foreground)
+          .brighten(0.5)
+          .hex()}
+      </EuiBadge>
+      <EuiBadge color={lightColorsJSON.euiColorVisColorsBehindText[name]}>
+        CSS: {lightColorsJSON.euiColorVisColorsBehindText[name]}
       </EuiBadge>
     </>
   );

--- a/src/components/avatar/__snapshots__/avatar.test.tsx.snap
+++ b/src/components/avatar/__snapshots__/avatar.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`EuiAvatar allows a name composed entirely of whitespace 1`] = `
   aria-label="aria-label"
   class="euiAvatar euiAvatar--m euiAvatar--user testClass1 testClass2"
   data-test-subj="test subject string"
-  style="background-image:none;background-color:#D36086;color:#000000"
+  style="background-image:none;background-color:#ee789d;color:#000000"
   title="  "
 >
   <span
@@ -21,7 +21,7 @@ exports[`EuiAvatar is rendered 1`] = `
   aria-label="aria-label"
   class="euiAvatar euiAvatar--m euiAvatar--user testClass1 testClass2"
   data-test-subj="test subject string"
-  style="background-image:none;background-color:#CA8EAE;color:#000000"
+  style="background-image:none;background-color:#e4a6c7;color:#000000"
   title="name"
 >
   <span
@@ -51,7 +51,7 @@ exports[`EuiAvatar props imageUrl is rendered 1`] = `
 <div
   aria-label="name"
   class="euiAvatar euiAvatar--m euiAvatar--user"
-  style="background-image:url(image url);background-color:#CA8EAE;color:#000000"
+  style="background-image:url(image url);background-color:#e4a6c7;color:#000000"
   title="name"
 />
 `;
@@ -60,7 +60,7 @@ exports[`EuiAvatar props initials is rendered 1`] = `
 <div
   aria-label="name"
   class="euiAvatar euiAvatar--m euiAvatar--user"
-  style="background-image:none;background-color:#CA8EAE;color:#000000"
+  style="background-image:none;background-color:#e4a6c7;color:#000000"
   title="name"
 >
   <span
@@ -75,7 +75,7 @@ exports[`EuiAvatar props initialsLength is rendered 1`] = `
 <div
   aria-label="name"
   class="euiAvatar euiAvatar--m euiAvatar--user"
-  style="background-image:none;background-color:#CA8EAE;color:#000000"
+  style="background-image:none;background-color:#e4a6c7;color:#000000"
   title="name"
 >
   <span
@@ -90,7 +90,7 @@ exports[`EuiAvatar props size l is rendered 1`] = `
 <div
   aria-label="name"
   class="euiAvatar euiAvatar--l euiAvatar--user"
-  style="background-image:none;background-color:#CA8EAE;color:#000000"
+  style="background-image:none;background-color:#e4a6c7;color:#000000"
   title="name"
 >
   <span
@@ -105,7 +105,7 @@ exports[`EuiAvatar props size m is rendered 1`] = `
 <div
   aria-label="name"
   class="euiAvatar euiAvatar--m euiAvatar--user"
-  style="background-image:none;background-color:#CA8EAE;color:#000000"
+  style="background-image:none;background-color:#e4a6c7;color:#000000"
   title="name"
 >
   <span
@@ -120,7 +120,7 @@ exports[`EuiAvatar props size none is rendered 1`] = `
 <div
   aria-label="name"
   class="euiAvatar euiAvatar--user"
-  style="background-image:none;background-color:#CA8EAE;color:#000000"
+  style="background-image:none;background-color:#e4a6c7;color:#000000"
   title="name"
 >
   <span
@@ -135,7 +135,7 @@ exports[`EuiAvatar props size s is rendered 1`] = `
 <div
   aria-label="name"
   class="euiAvatar euiAvatar--s euiAvatar--user"
-  style="background-image:none;background-color:#CA8EAE;color:#000000"
+  style="background-image:none;background-color:#e4a6c7;color:#000000"
   title="name"
 >
   <span
@@ -150,7 +150,7 @@ exports[`EuiAvatar props size xl is rendered 1`] = `
 <div
   aria-label="name"
   class="euiAvatar euiAvatar--xl euiAvatar--user"
-  style="background-image:none;background-color:#CA8EAE;color:#000000"
+  style="background-image:none;background-color:#e4a6c7;color:#000000"
   title="name"
 >
   <span
@@ -165,7 +165,7 @@ exports[`EuiAvatar props type is rendered 1`] = `
 <div
   aria-label="name"
   class="euiAvatar euiAvatar--m euiAvatar--space"
-  style="background-image:none;background-color:#CA8EAE;color:#000000"
+  style="background-image:none;background-color:#e4a6c7;color:#000000"
   title="name"
 >
   <span

--- a/src/components/avatar/avatar.tsx
+++ b/src/components/avatar/avatar.tsx
@@ -2,8 +2,8 @@ import React, { HTMLAttributes, FunctionComponent } from 'react';
 import { CommonProps, keysOf } from '../common';
 import classNames from 'classnames';
 
-import { isColorDark, hexToRgb } from '../../services/color';
-import { VISUALIZATION_COLORS, toInitials } from '../../services';
+import { isColorDark, hexToRgb, isValidHex } from '../../services/color';
+import { euiPaletteColorBlindBehindText, toInitials } from '../../services';
 
 const sizeToClassNameMap = {
   none: null,
@@ -67,6 +67,8 @@ export const EuiAvatar: FunctionComponent<EuiAvatarProps> = ({
   type = 'user',
   ...rest
 }) => {
+  const visColors = euiPaletteColorBlindBehindText();
+
   const classes = classNames(
     'euiAvatar',
     sizeToClassNameMap[size],
@@ -85,8 +87,7 @@ export const EuiAvatar: FunctionComponent<EuiAvatarProps> = ({
   }
 
   const assignedColor =
-    color ||
-    VISUALIZATION_COLORS[Math.floor(name.length % VISUALIZATION_COLORS.length)];
+    color || visColors[Math.floor(name.length % visColors.length)];
   const textColor = isColorDark(...hexToRgb(assignedColor))
     ? '#FFFFFF'
     : '#000000';
@@ -111,7 +112,7 @@ export const EuiAvatar: FunctionComponent<EuiAvatarProps> = ({
 
 // TODO: Migrate to a service
 function checkValidColor(color: EuiAvatarProps['color']) {
-  const validHex = color && /(^#[0-9A-F]{6}$)|(^#[0-9A-F]{3}$)/i.test(color);
+  const validHex = color && isValidHex(color);
   if (color && !validHex) {
     throw new Error(
       'EuiAvatar needs to pass a valid color. This can either be a three ' +

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -7,7 +7,7 @@ import React, {
 import classNames from 'classnames';
 import { CommonProps, ExclusiveUnion, keysOf, PropsOf } from '../common';
 import chroma from 'chroma-js';
-import { euiPaletteColorBlind, isValidHex } from '../../services';
+import { euiPaletteColorBlindBehindText, isValidHex } from '../../services';
 import { EuiInnerText } from '../inner_text';
 import { EuiIcon, IconColor, IconType } from '../icon';
 
@@ -72,28 +72,18 @@ const colorInk = '#000';
 const colorGhost = '#fff';
 
 // The color blind palette has some stricter accessibility needs with regards to
-// charts and contrast. We can ease (brighten) that requirement here since our
+// charts and contrast. We use the euiPaletteColorBlindBehindText variant here since our
 // accessibility concerns pertain to foreground (text) and background contrast
-const brightenValue = 0.5;
+const visColors = euiPaletteColorBlindBehindText();
 
 const colorToHexMap: { [color in IconColor]: string } = {
   // TODO - replace with variable once https://github.com/elastic/eui/issues/2731 is closed
   default: '#d3dae6',
-  primary: chroma(euiPaletteColorBlind()[1])
-    .brighten(brightenValue)
-    .hex(),
-  secondary: chroma(euiPaletteColorBlind()[0])
-    .brighten(brightenValue)
-    .hex(),
-  accent: chroma(euiPaletteColorBlind()[2])
-    .brighten(brightenValue)
-    .hex(),
-  warning: chroma(euiPaletteColorBlind()[5])
-    .brighten(brightenValue)
-    .hex(),
-  danger: chroma(euiPaletteColorBlind()[9])
-    .brighten(brightenValue)
-    .hex(),
+  primary: visColors[1],
+  secondary: visColors[0],
+  accent: visColors[2],
+  warning: visColors[5],
+  danger: visColors[9],
 };
 
 export const COLORS = keysOf(colorToHexMap);

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -7,7 +7,7 @@ import React, {
 import classNames from 'classnames';
 import { CommonProps, ExclusiveUnion, keysOf, PropsOf } from '../common';
 import chroma from 'chroma-js';
-import { euiPaletteColorBlind } from '../../services/color/eui_palettes';
+import { euiPaletteColorBlind, isValidHex } from '../../services';
 import { EuiInnerText } from '../inner_text';
 import { EuiIcon, IconColor, IconType } from '../icon';
 
@@ -297,11 +297,9 @@ function setTextColor(bgColor: string) {
 }
 
 function checkValidColor(color: null | IconColor | string) {
-  const validHex = /(^#[0-9A-F]{6}$)|(^#[0-9A-F]{3}$)/i;
-
   if (
     color != null &&
-    !validHex.test(color) &&
+    !isValidHex(color) &&
     !COLORS.includes(color) &&
     color !== 'hollow'
   ) {

--- a/src/components/loading/_loading_chart.scss
+++ b/src/components/loading/_loading_chart.scss
@@ -14,21 +14,21 @@
   animation: euiLoadingChart 1s infinite;
 
   &:nth-child(1) {
-    background-color: $euiColorPrimary;
+    background-color: $euiColorVis0;
   }
 
   &:nth-child(2) {
-    background-color: $euiColorSecondary;
+    background-color: $euiColorVis1;
     animation-delay: .1s;
   }
 
   &:nth-child(3) {
-    background-color: $euiColorAccent;
+    background-color: $euiColorVis2;
     animation-delay: .2s;
   }
 
   &:nth-child(4) {
-    background-color: $euiColorDarkestShade;
+    background-color: $euiColorVis3;
     animation-delay: .3s;
   }
 }

--- a/src/global_styling/functions/_colors.scss
+++ b/src/global_styling/functions/_colors.scss
@@ -1,3 +1,8 @@
+// Converting a normal hex color to RBG
+@function hexToRGB($color) {
+  @return 'rgb%28#{round(red($color))}, #{round(green($color))}, #{round(blue($color))}%29';
+}
+
 // Mixes a provided color with white.
 @function tint($color, $percent) {
   @return mix($euiColorGhost, $color, $percent);
@@ -115,7 +120,13 @@
   @return $highContrastTextColor;
 }
 
-// Converting a normal hex color to RBG
-@function hexToRGB($color) {
-  @return 'rgb%28#{round(red($color))}, #{round(green($color))}, #{round(blue($color))}%29';
+// The visualization palette is meant to be used as a graphic and contrated with the page background.
+// However, if using text on top of the visualization color, the background color can be lightened to increase the contrast with the text.
+@function convertVisColorForBehindText($color) {
+  // Chroma adjusts brightness on an 18 pt scale
+  // Therefore 1 chroma brightness = ~18% sass lightness
+
+  // adjust-color properties:
+  // $color, $red: null, $green: null, $blue: null, $hue: null, $saturation: null, $lightness: null, $alpha: null
+  @return adjust-color($color, null, null, null, null, 9.7%, 9.7%, null);
 }

--- a/src/global_styling/functions/_colors.scss
+++ b/src/global_styling/functions/_colors.scss
@@ -119,14 +119,3 @@
 
   @return $highContrastTextColor;
 }
-
-// The visualization palette is meant to be used as a graphic and contrated with the page background.
-// However, if using text on top of the visualization color, the background color can be lightened to increase the contrast with the text.
-@function convertVisColorForBehindText($color) {
-  // Chroma adjusts brightness on an 18 pt scale
-  // Therefore 1 chroma brightness = ~18% sass lightness
-
-  // adjust-color properties:
-  // $color, $red: null, $green: null, $blue: null, $hue: null, $saturation: null, $lightness: null, $alpha: null
-  @return adjust-color($color, null, null, null, null, 9.7%, 9.7%, null);
-}

--- a/src/global_styling/variables/_colors.scss
+++ b/src/global_styling/variables/_colors.scss
@@ -34,6 +34,7 @@ $euiPageBackgroundColor: tintOrShade($euiColorLightestShade, 50%, 30%) !default;
 
 // Maps allow for easier JSON usage
 // Use map_merge($euiColorVisColors, $yourMap) to change individual colors after importing ths file
+// The `behindText` variant is a direct copy of the hex output by the JS euiPaletteColorBlindBehindText() function
 $euiPaletteColorBlind: (
   euiColorVis0: (
     graphic: #54B399,

--- a/src/global_styling/variables/_colors.scss
+++ b/src/global_styling/variables/_colors.scss
@@ -32,20 +32,47 @@ $euiPageBackgroundColor: tintOrShade($euiColorLightestShade, 50%, 30%) !default;
 
 // Visualization colors
 
-$euiColorVis0: #54B399 !default;
-$euiColorVis1: #6092C0 !default;
-$euiColorVis2: #D36086 !default;
-$euiColorVis3: #9170B8 !default;
-$euiColorVis4: #CA8EAE !default;
-$euiColorVis5: #D6BF57 !default;
-$euiColorVis6: #B9A888 !default;
-$euiColorVis7: #DA8B45 !default;
-$euiColorVis8: #AA6556 !default;
-$euiColorVis9: #E7664C !default;
+// Maps allow for easier JSON usage
+// Use map_merge($euiColorVisColors, $yourMap) to change individual colors after importing ths file
+$euiColorVisColors: (
+  euiColorVis0: #54B399,
+  euiColorVis1: #6092C0,
+  euiColorVis2: #D36086,
+  euiColorVis3: #9170B8,
+  euiColorVis4: #CA8EAE,
+  euiColorVis5: #D6BF57,
+  euiColorVis6: #B9A888,
+  euiColorVis7: #DA8B45,
+  euiColorVis8: #AA6556,
+  euiColorVis9: #E7664C
+) !default;
+
+$euiColorVis0: map-get($euiColorVisColors, 'euiColorVis0') !default;
+$euiColorVis1: map-get($euiColorVisColors, 'euiColorVis1') !default;
+$euiColorVis2: map-get($euiColorVisColors, 'euiColorVis2') !default;
+$euiColorVis3: map-get($euiColorVisColors, 'euiColorVis3') !default;
+$euiColorVis4: map-get($euiColorVisColors, 'euiColorVis4') !default;
+$euiColorVis5: map-get($euiColorVisColors, 'euiColorVis5') !default;
+$euiColorVis6: map-get($euiColorVisColors, 'euiColorVis6') !default;
+$euiColorVis7: map-get($euiColorVisColors, 'euiColorVis7') !default;
+$euiColorVis8: map-get($euiColorVisColors, 'euiColorVis8') !default;
+$euiColorVis9: map-get($euiColorVisColors, 'euiColorVis9') !default;
+
+$euiColorVisColorsBehindText: (
+  euiColorVis0: convertVisColorForBehindText($euiColorVis0),
+  euiColorVis1: convertVisColorForBehindText($euiColorVis1),
+  euiColorVis2: convertVisColorForBehindText($euiColorVis2),
+  euiColorVis3: convertVisColorForBehindText($euiColorVis3),
+  euiColorVis4: convertVisColorForBehindText($euiColorVis4),
+  euiColorVis5: convertVisColorForBehindText($euiColorVis5),
+  euiColorVis6: convertVisColorForBehindText($euiColorVis6),
+  euiColorVis7: convertVisColorForBehindText($euiColorVis7),
+  euiColorVis8: convertVisColorForBehindText($euiColorVis8),
+  euiColorVis9: convertVisColorForBehindText($euiColorVis9)
+) !default;
 
 $euiColorChartLines: #EFF1F4 !default;
 $euiColorChartBand: #F5F7FA !default;
-
 
 // Code
 

--- a/src/global_styling/variables/_colors.scss
+++ b/src/global_styling/variables/_colors.scss
@@ -34,42 +34,71 @@ $euiPageBackgroundColor: tintOrShade($euiColorLightestShade, 50%, 30%) !default;
 
 // Maps allow for easier JSON usage
 // Use map_merge($euiColorVisColors, $yourMap) to change individual colors after importing ths file
-$euiColorVisColors: (
-  euiColorVis0: #54B399,
-  euiColorVis1: #6092C0,
-  euiColorVis2: #D36086,
-  euiColorVis3: #9170B8,
-  euiColorVis4: #CA8EAE,
-  euiColorVis5: #D6BF57,
-  euiColorVis6: #B9A888,
-  euiColorVis7: #DA8B45,
-  euiColorVis8: #AA6556,
-  euiColorVis9: #E7664C
+$euiPaletteColorBlind: (
+  euiColorVis0: (
+    graphic: #54B399,
+    behindText: #6DCCB1,
+  ),
+  euiColorVis1: (
+    graphic: #6092C0,
+    behindText: #79AAD9,
+  ),
+  euiColorVis2: (
+    graphic: #D36086,
+    behindText: #EE789D,
+  ),
+  euiColorVis3: (
+    graphic: #9170B8,
+    behindText: #A987D1,
+  ),
+  euiColorVis4: (
+    graphic: #CA8EAE,
+    behindText: #E4A6C7,
+  ),
+  euiColorVis5: (
+    graphic: #D6BF57,
+    behindText: #F1D86F,
+  ),
+  euiColorVis6: (
+    graphic: #B9A888,
+    behindText: #D2C0A0,
+  ),
+  euiColorVis7: (
+    graphic: #DA8B45,
+    behindText: #F5A35C,
+  ),
+  euiColorVis8: (
+    graphic: #AA6556,
+    behindText: #C47C6C,
+  ),
+  euiColorVis9: (
+    graphic: #E7664C,
+    behindText: #FF7E62,
+  )
 ) !default;
 
-$euiColorVis0: map-get($euiColorVisColors, 'euiColorVis0') !default;
-$euiColorVis1: map-get($euiColorVisColors, 'euiColorVis1') !default;
-$euiColorVis2: map-get($euiColorVisColors, 'euiColorVis2') !default;
-$euiColorVis3: map-get($euiColorVisColors, 'euiColorVis3') !default;
-$euiColorVis4: map-get($euiColorVisColors, 'euiColorVis4') !default;
-$euiColorVis5: map-get($euiColorVisColors, 'euiColorVis5') !default;
-$euiColorVis6: map-get($euiColorVisColors, 'euiColorVis6') !default;
-$euiColorVis7: map-get($euiColorVisColors, 'euiColorVis7') !default;
-$euiColorVis8: map-get($euiColorVisColors, 'euiColorVis8') !default;
-$euiColorVis9: map-get($euiColorVisColors, 'euiColorVis9') !default;
+$euiColorVis0: map-get(map-get($euiPaletteColorBlind, 'euiColorVis0'), 'graphic') !default;
+$euiColorVis1: map-get(map-get($euiPaletteColorBlind, 'euiColorVis1'), 'graphic') !default;
+$euiColorVis2: map-get(map-get($euiPaletteColorBlind, 'euiColorVis2'), 'graphic') !default;
+$euiColorVis3: map-get(map-get($euiPaletteColorBlind, 'euiColorVis3'), 'graphic') !default;
+$euiColorVis4: map-get(map-get($euiPaletteColorBlind, 'euiColorVis4'), 'graphic') !default;
+$euiColorVis5: map-get(map-get($euiPaletteColorBlind, 'euiColorVis5'), 'graphic') !default;
+$euiColorVis6: map-get(map-get($euiPaletteColorBlind, 'euiColorVis6'), 'graphic') !default;
+$euiColorVis7: map-get(map-get($euiPaletteColorBlind, 'euiColorVis7'), 'graphic') !default;
+$euiColorVis8: map-get(map-get($euiPaletteColorBlind, 'euiColorVis8'), 'graphic') !default;
+$euiColorVis9: map-get(map-get($euiPaletteColorBlind, 'euiColorVis9'), 'graphic') !default;
 
-$euiColorVisColorsBehindText: (
-  euiColorVis0: convertVisColorForBehindText($euiColorVis0),
-  euiColorVis1: convertVisColorForBehindText($euiColorVis1),
-  euiColorVis2: convertVisColorForBehindText($euiColorVis2),
-  euiColorVis3: convertVisColorForBehindText($euiColorVis3),
-  euiColorVis4: convertVisColorForBehindText($euiColorVis4),
-  euiColorVis5: convertVisColorForBehindText($euiColorVis5),
-  euiColorVis6: convertVisColorForBehindText($euiColorVis6),
-  euiColorVis7: convertVisColorForBehindText($euiColorVis7),
-  euiColorVis8: convertVisColorForBehindText($euiColorVis8),
-  euiColorVis9: convertVisColorForBehindText($euiColorVis9)
-) !default;
+// sass-lint:disable-block variable-name-format
+$euiColorVis0_behindText: map-get(map-get($euiPaletteColorBlind, 'euiColorVis0'), 'behindText') !default;
+$euiColorVis1_behindText: map-get(map-get($euiPaletteColorBlind, 'euiColorVis1'), 'behindText') !default;
+$euiColorVis2_behindText: map-get(map-get($euiPaletteColorBlind, 'euiColorVis2'), 'behindText') !default;
+$euiColorVis3_behindText: map-get(map-get($euiPaletteColorBlind, 'euiColorVis3'), 'behindText') !default;
+$euiColorVis4_behindText: map-get(map-get($euiPaletteColorBlind, 'euiColorVis4'), 'behindText') !default;
+$euiColorVis5_behindText: map-get(map-get($euiPaletteColorBlind, 'euiColorVis5'), 'behindText') !default;
+$euiColorVis6_behindText: map-get(map-get($euiPaletteColorBlind, 'euiColorVis6'), 'behindText') !default;
+$euiColorVis7_behindText: map-get(map-get($euiPaletteColorBlind, 'euiColorVis7'), 'behindText') !default;
+$euiColorVis8_behindText: map-get(map-get($euiPaletteColorBlind, 'euiColorVis8'), 'behindText') !default;
+$euiColorVis9_behindText: map-get(map-get($euiPaletteColorBlind, 'euiColorVis9'), 'behindText') !default;
 
 $euiColorChartLines: #EFF1F4 !default;
 $euiColorChartBand: #F5F7FA !default;

--- a/src/services/color/eui_palettes.ts
+++ b/src/services/color/eui_palettes.ts
@@ -1,6 +1,7 @@
+import { flatten } from 'lodash';
+import chroma from 'chroma-js';
 import { HEX } from './color_types';
 import { colorPalette } from './color_palette';
-import { flatten } from 'lodash';
 
 export type EuiPalette = string[];
 
@@ -62,6 +63,20 @@ export const euiPaletteColorBlind = function(
   }
 
   return colors;
+};
+
+/**
+ * Color blind palette with text is meant for use when text is applied on top of the color.
+ * It increases the brightness of the color to give the text more contrast.
+ */
+export const euiPaletteColorBlindWithText = function(): EuiPalette {
+  const originalPalette = euiPaletteColorBlind();
+  const newPalette = originalPalette.map(color =>
+    chroma(color)
+      .brighten(0.5)
+      .hex()
+  );
+  return newPalette;
 };
 
 export const euiPaletteForLightBackground = function(): EuiPalette {

--- a/src/services/color/eui_palettes.ts
+++ b/src/services/color/eui_palettes.ts
@@ -69,7 +69,7 @@ export const euiPaletteColorBlind = function(
  * Color blind palette with text is meant for use when text is applied on top of the color.
  * It increases the brightness of the color to give the text more contrast.
  */
-export const euiPaletteColorBlindWithText = function(): EuiPalette {
+export const euiPaletteColorBlindBehindText = function(): EuiPalette {
   const originalPalette = euiPaletteColorBlind();
   const newPalette = originalPalette.map(color =>
     chroma(color)

--- a/src/services/color/index.ts
+++ b/src/services/color/index.ts
@@ -19,6 +19,7 @@ export {
   euiPaletteForLightBackground,
   euiPaletteForDarkBackground,
   euiPaletteColorBlind,
+  euiPaletteColorBlindBehindText,
   euiPaletteForStatus,
   euiPaletteForTemperature,
   euiPaletteComplimentary,

--- a/src/services/color/luminance_and_contrast.ts
+++ b/src/services/color/luminance_and_contrast.ts
@@ -1,3 +1,4 @@
+import chroma from 'chroma-js';
 import { rgbDef } from './color_types';
 
 export function calculateLuminance(r: number, g: number, b: number): number {
@@ -17,4 +18,39 @@ export function calculateContrast(rgb1: rgbDef, rgb2: rgbDef): number {
     contrast = 1 / contrast;
   }
   return contrast;
+}
+
+export function createNonTextContrast(background: string, foreground: string) {
+  let contrast = chroma.contrast(foreground, background);
+
+  // Determine the lightness factor of the background color first to
+  // determine whether to shade or tint the foreground.
+  const brightness = chroma(background).lab()[0]; // get LAB Lightness value
+  let highContrastTextColor = chroma(foreground).hex();
+
+  while (contrast < 3) {
+    if (brightness > 50) {
+      highContrastTextColor = chroma(highContrastTextColor)
+        .darken(0.1)
+        .hex();
+    } else {
+      highContrastTextColor = chroma(highContrastTextColor)
+        .brighten(0.1)
+        .hex();
+    }
+
+    contrast = chroma.contrast(highContrastTextColor, background);
+
+    // @if (lightness($highContrastTextColor) < 5) {
+    //   @warn 'High enough contrast could not be determined. Most likely your background color does not adjust for light mode.';
+    //   @return $highContrastTextColor;
+    // }
+
+    // @if (lightness($highContrastTextColor) > 95) {
+    //   @warn 'High enough contrast could not be determined. Most likely your background color does not adjust for dark mode.';
+    //   @return $highContrastTextColor;
+    // }
+  }
+
+  return highContrastTextColor;
 }

--- a/src/services/color/luminance_and_contrast.ts
+++ b/src/services/color/luminance_and_contrast.ts
@@ -1,4 +1,3 @@
-import chroma from 'chroma-js';
 import { rgbDef } from './color_types';
 
 export function calculateLuminance(r: number, g: number, b: number): number {
@@ -18,39 +17,4 @@ export function calculateContrast(rgb1: rgbDef, rgb2: rgbDef): number {
     contrast = 1 / contrast;
   }
   return contrast;
-}
-
-export function createNonTextContrast(background: string, foreground: string) {
-  let contrast = chroma.contrast(foreground, background);
-
-  // Determine the lightness factor of the background color first to
-  // determine whether to shade or tint the foreground.
-  const brightness = chroma(background).lab()[0]; // get LAB Lightness value
-  let highContrastTextColor = chroma(foreground).hex();
-
-  while (contrast < 3) {
-    if (brightness > 50) {
-      highContrastTextColor = chroma(highContrastTextColor)
-        .darken(0.1)
-        .hex();
-    } else {
-      highContrastTextColor = chroma(highContrastTextColor)
-        .brighten(0.1)
-        .hex();
-    }
-
-    contrast = chroma.contrast(highContrastTextColor, background);
-
-    // @if (lightness($highContrastTextColor) < 5) {
-    //   @warn 'High enough contrast could not be determined. Most likely your background color does not adjust for light mode.';
-    //   @return $highContrastTextColor;
-    // }
-
-    // @if (lightness($highContrastTextColor) > 95) {
-    //   @warn 'High enough contrast could not be determined. Most likely your background color does not adjust for dark mode.';
-    //   @return $highContrastTextColor;
-    // }
-  }
-
-  return highContrastTextColor;
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -33,6 +33,7 @@ export {
   euiPaletteForLightBackground,
   euiPaletteForDarkBackground,
   euiPaletteColorBlind,
+  euiPaletteColorBlindBehindText,
   euiPaletteForStatus,
   euiPaletteForTemperature,
   euiPaletteComplimentary,

--- a/src/themes/eui-amsterdam/eui_amsterdam_colors_dark.scss
+++ b/src/themes/eui-amsterdam/eui_amsterdam_colors_dark.scss
@@ -29,19 +29,6 @@ $euiFocusBackgroundColor: #232635;
 $euiShadowColor: #000;
 $euiShadowColorLarge: #000;
 
-// Visualization colors
-// Currently this is the same as light. It is required to list them for our docs to work
-$euiColorVis0: #54B399;
-$euiColorVis1: #6092C0;
-$euiColorVis2: #D36086;
-$euiColorVis3: #9170B8;
-$euiColorVis4: #CA8EAE;
-$euiColorVis5: #D6BF57;
-$euiColorVis6: #B9A888;
-$euiColorVis7: #DA8B45;
-$euiColorVis8: #AA6556;
-$euiColorVis9: #E7664C;
-
 $euiColorChartLines: #343741;
 $euiColorChartBand: #2A2C35;
 

--- a/src/themes/eui/eui_colors_dark.scss
+++ b/src/themes/eui/eui_colors_dark.scss
@@ -29,19 +29,6 @@ $euiFocusBackgroundColor: #232635;
 $euiShadowColor: #000;
 $euiShadowColorLarge: #000;
 
-// Visualization colors
-// Currently this is the same as light. It is required to list them for our docs to work
-$euiColorVis0: #54B399;
-$euiColorVis1: #6092C0;
-$euiColorVis2: #D36086;
-$euiColorVis3: #9170B8;
-$euiColorVis4: #CA8EAE;
-$euiColorVis5: #D6BF57;
-$euiColorVis6: #B9A888;
-$euiColorVis7: #DA8B45;
-$euiColorVis8: #AA6556;
-$euiColorVis9: #E7664C;
-
 $euiColorChartLines: #343741;
 $euiColorChartBand: #2A2C35;
 


### PR DESCRIPTION
### This PR adds another palette called `euiPaletteColorBlindBehindText()` for use in places like EuiBadge

As mentioned in #2455, we can increase the brightness of the color blind palette when using it with text. This creates an automatic palette for this use case.

<img width="590" alt="Screen Shot 2020-01-09 at 16 57 29 PM" src="https://user-images.githubusercontent.com/549577/72111705-9245ed80-3309-11ea-8f56-18a84d1463ad.png">

It also updates the SASS by creating a new SASS map with both `graphic` and `behindText` variants.

In the color guidelines page, the example has been updated to import the palette from JS and allowing the user to toggle between variants.

![Screen Recording 2020-01-09 at 04 58 PM](https://user-images.githubusercontent.com/549577/72111809-d638f280-3309-11ea-8aad-e546d2bea4f2.gif)

This palette is now being used directly by EuiBadge, EuiAvatar, EuiLoadingChart, and EuiComboBox's examples.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [ ] Checked in **IE11** and **Firefox**
- ~[ ] Props have proper **autodocs**~
- [x] Added **documentation** examples
- [x] Added or updated **jest tests**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
