### PR TITLE
Fix EuiFieldSearch's onChange call so it is always called with the Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `18.2.0`.
+**Bug fixes**
+
+- Fixed `EuiFieldSearch`'s trigger of `onChange` when clearing the field value ([#2764](https://github.com/elastic/eui/pull/2764))
 
 ## [`18.2.0`](https://github.com/elastic/eui/tree/v18.2.0)
 

--- a/src-docs/src/views/form_controls/field_search.js
+++ b/src-docs/src/views/form_controls/field_search.js
@@ -15,7 +15,7 @@ export default class extends Component {
 
   onChange = e => {
     this.setState({
-      value: e === '' ? '' : e.target.value,
+      value: e.target.value,
     });
   };
 

--- a/src/components/form/field_search/field_search.js
+++ b/src/components/form/field_search/field_search.js
@@ -69,7 +69,19 @@ export class EuiFieldSearch extends Component {
   }
 
   onClear = () => {
-    this.props.onChange('');
+    // clear the field's value
+    this.inputElement.value = '';
+
+    // dispatch onChange event, with IE11 support/fallback
+    if ('createEvent' in document) {
+      const evt = document.createEvent('HTMLEvents');
+      evt.initEvent('change', true, false);
+      this.inputElement.dispatchEvent(evt);
+    } else {
+      this.inputElement.fireEvent('onchange');
+    }
+
+    // set focus on the search field
     this.inputElement.focus();
   };
 


### PR DESCRIPTION
### Summary

Fixes #2763 

When adding a clear button to `EuiSearchField`, the call signature for `onChange` was modified. This changes the call to always provide the change event to the handler.

This should make it into the Kibana 7.6 branch as a bug fix.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
