### PR TITLE
EuiTablePagination: Adds data-test-subj to the EuiContextMenuItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Converted `EuiFilterButton` to TypeScript ([#2761](https://github.com/elastic/eui/pull/2761))
 - Converted `EuiFilterSelectItem` to TypeScript ([#2761](https://github.com/elastic/eui/pull/2761))
 - Converted `EuiFieldSearch` to TypeScript ([#2775](https://github.com/elastic/eui/pull/2775))
+- Added `data-test-subj` to the `EuiContextMenuItem` in `EuiTablePagination` ([#2778](https://github.com/elastic/eui/pull/2778))
 
 **Bug fixes**
 

--- a/src/components/table/table_pagination/table_pagination.tsx
+++ b/src/components/table/table_pagination/table_pagination.tsx
@@ -6,12 +6,11 @@ import { EuiFlexGroup, EuiFlexItem } from '../../flex';
 import { EuiPagination } from '../../pagination';
 import { EuiPopover } from '../../popover';
 import { EuiI18n } from '../../i18n';
-import { CommonProps } from '../../common';
 
 export type PageChangeHandler = (pageIndex: number) => void;
 export type ItemsPerPageChangeHandler = (pageSize: number) => void;
 
-export interface Props extends CommonProps {
+export interface Props {
   activePage?: number;
   hidePerPageOptions?: boolean;
   itemsPerPage?: number;
@@ -51,7 +50,6 @@ export class EuiTablePagination extends Component<Props, State> {
       onChangeItemsPerPage = () => {},
       onChangePage,
       pageCount,
-      'data-test-subj': dataTestSubj,
     } = this.props;
 
     const button = (
@@ -78,7 +76,7 @@ export class EuiTablePagination extends Component<Props, State> {
           this.closePopover();
           onChangeItemsPerPage(itemsPerPageOption);
         }}
-        data-test-subj={dataTestSubj}>
+        data-test-subj={`tablePagination-${itemsPerPageOption}-rows`}>
         <EuiI18n
           token="euiTablePagination.rowsPerPageOption"
           values={{ rowsPerPage: itemsPerPageOption }}

--- a/src/components/table/table_pagination/table_pagination.tsx
+++ b/src/components/table/table_pagination/table_pagination.tsx
@@ -6,11 +6,12 @@ import { EuiFlexGroup, EuiFlexItem } from '../../flex';
 import { EuiPagination } from '../../pagination';
 import { EuiPopover } from '../../popover';
 import { EuiI18n } from '../../i18n';
+import { CommonProps } from '../../common';
 
 export type PageChangeHandler = (pageIndex: number) => void;
 export type ItemsPerPageChangeHandler = (pageSize: number) => void;
 
-export interface Props {
+export interface Props extends CommonProps {
   activePage?: number;
   hidePerPageOptions?: boolean;
   itemsPerPage?: number;
@@ -50,6 +51,7 @@ export class EuiTablePagination extends Component<Props, State> {
       onChangeItemsPerPage = () => {},
       onChangePage,
       pageCount,
+      'data-test-subj': dataTestSubj,
     } = this.props;
 
     const button = (
@@ -75,7 +77,8 @@ export class EuiTablePagination extends Component<Props, State> {
         onClick={() => {
           this.closePopover();
           onChangeItemsPerPage(itemsPerPageOption);
-        }}>
+        }}
+        data-test-subj={dataTestSubj}>
         <EuiI18n
           token="euiTablePagination.rowsPerPageOption"
           values={{ rowsPerPage: itemsPerPageOption }}


### PR DESCRIPTION
### Summary

Closes https://github.com/elastic/eui/issues/2762

Added `data-test-subj` to the `EuiContextMenuItem` in `EuiTablePagination`

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
