### PR TITLE
Publish docs to eui.elastic.co

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -39,6 +39,9 @@
         github-hooks: true
         status-context: eui-ci
         cancel-builds-on-update: true
+    vault:
+      # auth/approle/role/bekitzur-ci/role-id
+      role_id: 3a72c576-4f45-3b41-b698-d371dc717227
     wrappers:
     - ansicolor
     - timeout:

--- a/.ci/jobs/elastic+eui+deploy-docs.yml
+++ b/.ci/jobs/elastic+eui+deploy-docs.yml
@@ -1,0 +1,22 @@
+---
+- job:
+    name: elastic+eui+deploy-docs
+    display-name: elastic / eui - deploy-docs
+    description: Build EUI documentation HTML and deploy to Elastic Bekitzur
+    triggers: []
+    builders:
+    - shell: |-
+        #!/usr/local/bin/runbld
+        set -e
+        set +x
+        export GPROJECT=elastic-bekitzur
+        VAULT_ACCOUNT=secret/gce/$GPROJECT/service-account/jenkins
+        VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+        export VAULT_TOKEN
+        GCE_ACCOUNT=$(vault read -field=value $VAULT_ACCOUNT)
+        export GCE_ACCOUNT
+        unset VAULT_ROLE_ID VAULT_SECRET_ID VAULT_ADDR VAULT_TOKEN VAULT_ACCOUNT
+
+        # Run EUI build/deploy script, set in the template parameter
+        # Expects env: GPROJECT, GCE_ACCOUNT, GIT_BRANCH
+        ./scripts/deploy/deploy_docs

--- a/scripts/deploy/build_docs
+++ b/scripts/deploy/build_docs
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
 
 #
-# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-# or more contributor license agreements. Licensed under the Elastic License;
-# you may not use this file except in compliance with the Elastic License.
+# Licensed to Elasticsearch B.V. under one or more contributor license
+# agreements. See the NOTICE file distributed with this work for additional
+# information regarding copyright ownership. Elasticsearch B.V. licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
 #
 
 set -e

--- a/scripts/deploy/build_docs
+++ b/scripts/deploy/build_docs
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+set -e
+
+NODE_IMG="node:10"
+
+# Compile using node image
+echo "Building docs using ${NODE_IMG} Docker image"
+docker pull $NODE_IMG
+docker run \
+    --rm -i \
+    --env HOME=/tmp \
+    --user=$(id -u):$(id -g) \
+    --volume $PWD:/app \
+    --workdir /app \
+    $NODE_IMG \
+    bash -c 'yarn && npm run build && npm run build-docs'

--- a/scripts/deploy/deploy_docs
+++ b/scripts/deploy/deploy_docs
@@ -79,7 +79,12 @@ else
   # The trailing slash is critical with the branch.
   # Otherwise, files from subdirs will go to the same destination dir.
   echo "Copying $PWD/docs/* to gs://$BUCKET/$BRANCH/"
-  gsutil -m cp -r -a public-read -z js,css,html "$PWD/docs/*" "gs://$BUCKET/$BRANCH/"
+  gsutil -m cp \
+    -r \
+    -a public-read \
+    -z js,css,html \
+    -h "Cache-Control:public, max-age=604800" \
+    "$PWD/docs/*" "gs://$BUCKET/$BRANCH/"
 
   # if this is the highest release number to date, set redirect from root to
   # this version's directory
@@ -89,6 +94,10 @@ else
     sed -e \
       "s/___URL___/https:\/\/eui.elastic.co\/$GIT_BRANCH\//g" \
       scripts/deploy/redirect_template.html > $OUT_FILE
-    gsutil cp -a public-read -z html "$OUT_FILE" "gs://$BUCKET/index.html"
+    gsutil cp \
+      -a public-read \
+      -z html \
+      -h "Cache-Control:public, max-age=3600" \
+      "$OUT_FILE" "gs://$BUCKET/index.html"
   fi
 fi

--- a/scripts/deploy/deploy_docs
+++ b/scripts/deploy/deploy_docs
@@ -97,7 +97,7 @@ else
     gsutil cp \
       -a public-read \
       -z html \
-      -h "Cache-Control:public, max-age=3600" \
+      -h "Cache-Control:public, max-age=300" \
       "$OUT_FILE" "gs://$BUCKET/index.html"
   fi
 fi

--- a/scripts/deploy/deploy_docs
+++ b/scripts/deploy/deploy_docs
@@ -79,25 +79,24 @@ else
   # The trailing slash is critical with the branch.
   # Otherwise, files from subdirs will go to the same destination dir.
   echo "Copying $PWD/docs/* to gs://$BUCKET/$BRANCH/"
-  gsutil -m cp \
+  gsutil -m \
+    -h "Cache-Control:public, max-age=604800" \
+    cp \
     -r \
     -a public-read \
     -z js,css,html \
-    -h "Cache-Control:public, max-age=604800" \
     "$PWD/docs/*" "gs://$BUCKET/$BRANCH/"
 
-  # if this is the highest release number to date, set redirect from root to
-  # this version's directory
+  # if this is the highest release number to date, also publish the docs to the
+  # root directory
   if [[ "v$CURRENT_RELEASE" == "$GIT_BRANCH" ]]; then
-    echo "This is the current release. Redirecting https://eui.elastic.co/ to path https://eui.elastic.co/$GIT_BRANCH/"
-    OUT_FILE=scripts/deploy/redirect_$GIT_BRANCH.html
-    sed -e \
-      "s/___URL___/https:\/\/eui.elastic.co\/$GIT_BRANCH\//g" \
-      scripts/deploy/redirect_template.html > $OUT_FILE
-    gsutil cp \
+    echo "This is the current release. Copying $PWD/docs/* to the root gs://$BUCKET/ directory."
+    gsutil -m \
+      -h "Cache-Control:public, max-age=1800" \
+      cp \
+      -r \
       -a public-read \
-      -z html \
-      -h "Cache-Control:public, max-age=300" \
-      "$OUT_FILE" "gs://$BUCKET/index.html"
+      -z js,css,html \
+      "$PWD/docs/*" "gs://$BUCKET/"
   fi
 fi

--- a/scripts/deploy/deploy_docs
+++ b/scripts/deploy/deploy_docs
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
 
 #
-# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-# or more contributor license agreements. Licensed under the Elastic License;
-# you may not use this file except in compliance with the Elastic License.
+# Licensed to Elasticsearch B.V. under one or more contributor license
+# agreements. See the NOTICE file distributed with this work for additional
+# information regarding copyright ownership. Elasticsearch B.V. licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
 #
 
 set -e

--- a/scripts/deploy/deploy_docs
+++ b/scripts/deploy/deploy_docs
@@ -67,6 +67,23 @@ else
 
   # The trailing slash is critical with the branch.
   # Otherwise, files from subdirs will go to the same destination dir.
-  echo "Copying $PWD/release/* to gs://$BUCKET/$BRANCH/"
+  echo "Copying $PWD/docs/* to gs://$BUCKET/$BRANCH/"
   gsutil -m cp -r -a public-read -z js,css,html "$PWD/docs/*" "gs://$BUCKET/$BRANCH/"
+
+  # if this is the highest release number to date, set redirect from root to
+  # this version's directory
+  LATEST_RELEASE=$(docker run \
+    --rm -i \
+    --volume $PWD:/app \
+    --workdir /app \
+    node:10 \
+    bash -c 'git tag | xargs npx semver' | tail -n 1)
+  if [[ "v$LATEST_RELEASE" == "$GIT_BRANCH" ]]; then
+    echo "This is the latest release. Redirecting https://eui.elastic.co/ to path https://eui.elastic.co/$GIT_BRANCH/"
+    OUT_FILE=scripts/deploy/redirect_$GIT_BRANCH.html
+    sed -e \
+      "s/___URL___/https:\/\/eui.elastic.co\/v$GIT_BRANCH\//g" \
+      scripts/deploy/redirect_template.html > $OUT_FILE
+    gsutil cp -a public-read -z html "$OUT_FILE" "gs://$BUCKET/index.html"
+  fi
 fi

--- a/scripts/deploy/deploy_docs
+++ b/scripts/deploy/deploy_docs
@@ -37,6 +37,16 @@ fi
 if [[ "$1" != "nodocker" ]]; then
   ./scripts/deploy/build_docs
 
+  # we look this up to inject into the next docker run so it can decide whether
+  # we need to overwrite the root /index.html file with a new one.
+  echo "Looking up most-current release info"
+  CURRENT_RELEASE=$(docker run \
+    --rm -i \
+    --volume $PWD:/app \
+    --workdir /app \
+    node:10 \
+    bash -c 'git tag | xargs npx semver' | tail -n 1)
+
   # Run this script from inside the docker container, using google/cloud-sdk
   # image echo "Deploying to bucket"
   docker run \
@@ -44,6 +54,7 @@ if [[ "$1" != "nodocker" ]]; then
     --env GCE_ACCOUNT \
     --env GIT_BRANCH \
     --env GPROJECT \
+    --env CURRENT_RELEASE="$CURRENT_RELEASE" \
     --env HOME=/tmp \
     --volume $PWD:/app \
     --user=$(id -u):$(id -g) \
@@ -72,17 +83,11 @@ else
 
   # if this is the highest release number to date, set redirect from root to
   # this version's directory
-  LATEST_RELEASE=$(docker run \
-    --rm -i \
-    --volume $PWD:/app \
-    --workdir /app \
-    node:10 \
-    bash -c 'git tag | xargs npx semver' | tail -n 1)
-  if [[ "v$LATEST_RELEASE" == "$GIT_BRANCH" ]]; then
-    echo "This is the latest release. Redirecting https://eui.elastic.co/ to path https://eui.elastic.co/$GIT_BRANCH/"
+  if [[ "v$CURRENT_RELEASE" == "$GIT_BRANCH" ]]; then
+    echo "This is the current release. Redirecting https://eui.elastic.co/ to path https://eui.elastic.co/$GIT_BRANCH/"
     OUT_FILE=scripts/deploy/redirect_$GIT_BRANCH.html
     sed -e \
-      "s/___URL___/https:\/\/eui.elastic.co\/v$GIT_BRANCH\//g" \
+      "s/___URL___/https:\/\/eui.elastic.co\/$GIT_BRANCH\//g" \
       scripts/deploy/redirect_template.html > $OUT_FILE
     gsutil cp -a public-read -z html "$OUT_FILE" "gs://$BUCKET/index.html"
   fi

--- a/scripts/deploy/deploy_docs
+++ b/scripts/deploy/deploy_docs
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+set -e
+set +x
+
+# Two stage script: first it compiles using Node Docker container, then it runs
+# itself from within another docker container to deploy to GCP.
+
+# Usage:
+# * Compile and deploy:          ./scripts/deploy/deploy_docs
+# * Deploy only without docker:  ./scripts/deploy/deploy_docs nodocker
+
+# Expected env variables:
+# * GPROJECT - GCE project name, e.g. elastic-bekitzur
+# * GCE_ACCOUNT - credentials for the google service account (JSON blob)
+# * GIT_BRANCH - current Git branch or tag (e.g. "refs/heads/master", "v18.2.1")
+
+if [[ -z "${GPROJECT}" ]]; then
+    echo "GPROJECT is not set, e.g. 'GPROJECT=elastic-bekitzur'"
+    exit 1
+fi
+if [[ -z "${GCE_ACCOUNT}" ]]; then
+  echo "GCE_ACCOUNT is not set. Expected Google service account JSON blob."
+  exit 1
+fi
+if [[ -z "${GIT_BRANCH}" ]]; then
+  echo "GIT_BRANCH is not set, e.g. 'GIT_BRANCH=refs/heads/master'"
+  exit 1
+fi
+
+if [[ "$1" != "nodocker" ]]; then
+  ./scripts/deploy/build_docs
+
+  # Run this script from inside the docker container, using google/cloud-sdk
+  # image echo "Deploying to bucket"
+  docker run \
+    --rm -i \
+    --env GCE_ACCOUNT \
+    --env GIT_BRANCH \
+    --env GPROJECT \
+    --env HOME=/tmp \
+    --volume $PWD:/app \
+    --user=$(id -u):$(id -g) \
+    --workdir /app \
+    'google/cloud-sdk:slim' \
+    /app/scripts/deploy/deploy_docs nodocker "$@"
+  unset GCE_ACCOUNT
+else
+  # Copying files to the bucket
+  # Login to the cloud with the service account
+  gcloud auth activate-service-account --key-file <(echo "$GCE_ACCOUNT")
+  unset GCE_ACCOUNT
+
+  # All branches go into correspondingly named dirs.
+  # remove remote "origin/", leaving just the branch name
+  BRANCH="${GIT_BRANCH#*/}"
+
+  # Copy files
+  EUI_DOCS_PROJECT=eui-docs-live
+  BUCKET=${GPROJECT}-${EUI_DOCS_PROJECT}
+
+  # The trailing slash is critical with the branch.
+  # Otherwise, files from subdirs will go to the same destination dir.
+  echo "Copying $PWD/release/* to gs://$BUCKET/$BRANCH/"
+  gsutil -m cp -r -a public-read -z js,css,html "$PWD/docs/*" "gs://$BUCKET/$BRANCH/"
+fi

--- a/scripts/deploy/redirect_template.html
+++ b/scripts/deploy/redirect_template.html
@@ -1,8 +1,0 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>EUI | Redirecting...</title>
-    <meta http-equiv="refresh" content="2;___URL___" />
-  </head>
-  <body onload="window.location = '___URL___'">Redirecting to the current version's documentation: <a href="___URL___">___URL___</a>.</body>
-</html>

--- a/scripts/deploy/redirect_template.html
+++ b/scripts/deploy/redirect_template.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting...</title>
+    <meta http-equiv="refresh" content="2;___URL___" />
+  </head>
+  <body />
+</html>

--- a/scripts/deploy/redirect_template.html
+++ b/scripts/deploy/redirect_template.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Redirecting...</title>
+    <title>EUI | Redirecting...</title>
     <meta http-equiv="refresh" content="2;___URL___" />
   </head>
-  <body />
+  <body onload="window.location = '___URL___'">Redirecting to the current version's documentation: <a href="___URL___">___URL___</a>.</body>
 </html>


### PR DESCRIPTION
### Summary

Adds scripts and a Jenkins job definition that build and deploy EUI docs to an internal, Bekitzur-managed GCS bucket, soon to replace the work of publishing docs to Github Pages.

See https://eui.elastic.co for an example of the docs published for the most current version of EUI.

### Checklist

N/A; I didn't change any EUI code to do this. 😎 

- [ ] ~Check against **all themes** for compatibility in both light and dark modes~
- [ ] ~Checked in **mobile**~
- [ ] ~Checked in **IE11** and **Firefox**~
- [ ] ~Props have proper **autodocs**~
- [ ] ~Added **documentation** examples~
- [ ] ~Added or updated **jest tests**~
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] ~A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
