### PR TITLE
Retain className for EuiFormControlLayout.prepend nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Increased column width on `EuiTableHeaderCellCheckbox` to prevent `EuiCheckbox`'s focus ring from getting clipped in `EuiBasicTable` ([#2770](https://github.com/elastic/eui/pull/2770))
 - Fixed the display of `EuiButton` within `EuiControlBar` when `fill={true}` to be more consistent with other buttons ([#2781](https://github.com/elastic/eui/pull/2781))
+- Fixed `EuiFormControlLayout` from overwriting className for `prepend` nodes.  ([#2796](https://github.com/elastic/eui/pull/2796))
 
 **Deprecations**
 

--- a/src/components/form/form_control_layout/__snapshots__/form_control_layout.test.tsx.snap
+++ b/src/components/form/form_control_layout/__snapshots__/form_control_layout.test.tsx.snap
@@ -276,6 +276,21 @@ exports[`EuiFormControlLayout props one prepend node is rendered 1`] = `
 </div>
 `;
 
+exports[`EuiFormControlLayout props one prepend node is rendered with className 1`] = `
+<div
+  class="euiFormControlLayout euiFormControlLayout--group"
+>
+  <span
+    class="euiFormControlLayout__prepend myClass"
+  >
+    1
+  </span>
+  <div
+    class="euiFormControlLayout__childrenWrapper"
+  />
+</div>
+`;
+
 exports[`EuiFormControlLayout props one prepend string is rendered 1`] = `
 <div
   class="euiFormControlLayout euiFormControlLayout--group"

--- a/src/components/form/form_control_layout/form_control_layout.test.tsx
+++ b/src/components/form/form_control_layout/form_control_layout.test.tsx
@@ -130,6 +130,14 @@ describe('EuiFormControlLayout', () => {
       expect(component).toMatchSnapshot();
     });
 
+    test('one prepend node is rendered with className', () => {
+      const component = render(
+        <EuiFormControlLayout prepend={<span className="myClass">1</span>} />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
     test('one prepend string is rendered', () => {
       const component = render(<EuiFormControlLayout prepend="1" />);
 

--- a/src/components/form/form_control_layout/form_control_layout.tsx
+++ b/src/components/form/form_control_layout/form_control_layout.tsx
@@ -136,8 +136,15 @@ export class EuiFormControlLayout extends Component<EuiFormControlLayoutProps> {
     key: React.Key
   ) {
     return cloneElement(node, {
-      className: `euiFormControlLayout__${side}`,
+      className: classNames(
+        `euiFormControlLayout__${side}`,
+        node.props.className
+      ),
       key: key,
     });
+    /*return cloneElement(node, {
+      className: `euiFormControlLayout__${side}`,
+      key: key,
+    });*/
   }
 }

--- a/src/components/form/form_control_layout/form_control_layout.tsx
+++ b/src/components/form/form_control_layout/form_control_layout.tsx
@@ -142,9 +142,5 @@ export class EuiFormControlLayout extends Component<EuiFormControlLayoutProps> {
       ),
       key: key,
     });
-    /*return cloneElement(node, {
-      className: `euiFormControlLayout__${side}`,
-      key: key,
-    });*/
   }
 }


### PR DESCRIPTION
Kibana maps application is using EuiFieldText to show the selected icon. This uses the `prepend` property like this. The problem is that the `className` property is not getting passed to the rendered prepend prop because `EuiFormControlLayout` over rights that prop to a static value. This PR just updates the logic to preserve the original className when provided.

```
        <EuiFieldText
          onClick={this._togglePopover}
          onKeyDown={this._handleKeyboardActivity}
          value={value}
          compressed
          readOnly
          fullWidth
          prepend={
            <SymbolIcon
              className="mapIconSelectSymbol__inputButton"
              symbolId={value}
              fill={isDarkMode ? 'rgb(223, 229, 239)' : 'rgb(52, 55, 65)'}
              stroke={isDarkMode ? 'rgb(255, 255, 255)' : 'rgb(0, 0, 0)'}
              strokeWidth={'1px'}
            />
          }
        />
```

<img width="150" alt="Screen Shot 2020-01-27 at 11 58 04 AM" src="https://user-images.githubusercontent.com/373691/73195989-d3f1d900-40fc-11ea-9518-9a4f31b19a2b.png">
