### PR TITLE
Add branch parameter to docs publish job

### DIFF
--- a/.ci/jobs/elastic+eui+deploy-docs.yml
+++ b/.ci/jobs/elastic+eui+deploy-docs.yml
@@ -3,6 +3,13 @@
     name: elastic+eui+deploy-docs
     display-name: elastic / eui - deploy-docs
     description: Build EUI documentation HTML and deploy to Elastic Bekitzur
+    parameters:
+      - string:
+          name: branch_specifier
+          default: refs/heads/master
+          description: >-
+            the Git branch specifier to build
+            (&lt;branchName&gt;, &lt;tagName&gt;, &lt;commitId&gt;, etc.)
     triggers: []
     builders:
     - shell: |-


### PR DESCRIPTION
### Summary

Adds a missing Git branch parameter to the docs build/deploy Jenkins job definition. A small oversight. 😄 