### PR TITLE
Add headerRow to EuiBasicTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `18.3.0`.
+- Added `tableCaption` prop to `EuiBasicTable` and improved the default one ([#2782](https://github.com/elastic/eui/pull/2782))
 
 ## [`18.3.0`](https://github.com/elastic/eui/tree/v18.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added `tableCaption` prop to `EuiBasicTable` and improved the default one ([#2782](https://github.com/elastic/eui/pull/2782))
+- Added `rowHeader` prop to `EuiBasicTable` to allow consumers to set the identifying cell in a row ([#2802](https://github.com/elastic/eui/pull/2802))
 
 ## [`18.3.0`](https://github.com/elastic/eui/tree/v18.3.0)
 

--- a/src-docs/src/views/tables/basic/basic.js
+++ b/src-docs/src/views/tables/basic/basic.js
@@ -121,6 +121,7 @@ export const Table = () => {
   return (
     <EuiBasicTable
       items={items}
+      rowHeader="firstName"
       columns={columns}
       rowProps={getRowProps}
       cellProps={getCellProps}

--- a/src-docs/src/views/tables/basic/props_info.js
+++ b/src-docs/src/views/tables/basic/props_info.js
@@ -95,6 +95,12 @@ export const propsInfo = {
           required: false,
           type: { name: '(criteria: #Criteria) => void' },
         },
+        rowHeader: {
+          description:
+            'Indicates which column should be used as the identifying cell in each row. Should match a "field" prop in FieldDataColumn',
+          required: false,
+          type: { name: 'string' },
+        },
         tableCaption: {
           description:
             'Describes the content of the table. If not specified, the caption will be "This table contains {itemCount} rows."',

--- a/src-docs/src/views/tables/basic/props_info.js
+++ b/src-docs/src/views/tables/basic/props_info.js
@@ -95,6 +95,12 @@ export const propsInfo = {
           required: false,
           type: { name: '(criteria: #Criteria) => void' },
         },
+        tableCaption: {
+          description:
+            'Describes the content of the table. If not specified, the caption will be "This table contains {itemCount} rows."',
+          required: false,
+          type: { name: 'string' },
+        },
         tableLayout: {
           description:
             'Sets the table-layout CSS property. Note that auto tableLayout prevents truncateText from working properly.',

--- a/src-docs/src/views/tables/selection/selection.js
+++ b/src-docs/src/views/tables/selection/selection.js
@@ -215,6 +215,7 @@ export class Table extends Component {
           isSelectable={true}
           selection={selection}
           onChange={this.onTableChange}
+          rowHeader="firstName"
         />
       </Fragment>
     );

--- a/src-docs/src/views/tables/selection/selection.js
+++ b/src-docs/src/views/tables/selection/selection.js
@@ -215,7 +215,6 @@ export class Table extends Component {
           isSelectable={true}
           selection={selection}
           onChange={this.onTableChange}
-          rowHeader="firstName"
         />
       </Fragment>
     );

--- a/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -69,6 +69,7 @@ exports[`EuiBasicTable cellProps renders cells with custom props from a callback
               }
             }
             onClick={[Function]}
+            setScopeRow={false}
             textOnly={true}
           >
             name1
@@ -89,6 +90,7 @@ exports[`EuiBasicTable cellProps renders cells with custom props from a callback
               }
             }
             onClick={[Function]}
+            setScopeRow={false}
             textOnly={true}
           >
             name2
@@ -109,6 +111,7 @@ exports[`EuiBasicTable cellProps renders cells with custom props from a callback
               }
             }
             onClick={[Function]}
+            setScopeRow={false}
             textOnly={true}
           >
             name3
@@ -189,6 +192,7 @@ exports[`EuiBasicTable cellProps renders rows with custom props from an object 1
               }
             }
             onClick={[Function]}
+            setScopeRow={false}
             textOnly={true}
           >
             name1
@@ -209,6 +213,7 @@ exports[`EuiBasicTable cellProps renders rows with custom props from an object 1
               }
             }
             onClick={[Function]}
+            setScopeRow={false}
             textOnly={true}
           >
             name2
@@ -229,6 +234,7 @@ exports[`EuiBasicTable cellProps renders rows with custom props from an object 1
               }
             }
             onClick={[Function]}
+            setScopeRow={false}
             textOnly={true}
           >
             name3
@@ -531,6 +537,7 @@ exports[`EuiBasicTable footers do not render without a column footer definition 
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name1
@@ -544,6 +551,7 @@ exports[`EuiBasicTable footers do not render without a column footer definition 
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             1
@@ -557,6 +565,7 @@ exports[`EuiBasicTable footers do not render without a column footer definition 
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             20
@@ -574,6 +583,7 @@ exports[`EuiBasicTable footers do not render without a column footer definition 
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name2
@@ -587,6 +597,7 @@ exports[`EuiBasicTable footers do not render without a column footer definition 
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             2
@@ -600,6 +611,7 @@ exports[`EuiBasicTable footers do not render without a column footer definition 
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             21
@@ -617,6 +629,7 @@ exports[`EuiBasicTable footers do not render without a column footer definition 
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name3
@@ -630,6 +643,7 @@ exports[`EuiBasicTable footers do not render without a column footer definition 
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             3
@@ -643,6 +657,7 @@ exports[`EuiBasicTable footers do not render without a column footer definition 
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             22
@@ -780,6 +795,7 @@ exports[`EuiBasicTable footers render with pagination, selection, sorting, and f
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name1
@@ -793,6 +809,7 @@ exports[`EuiBasicTable footers render with pagination, selection, sorting, and f
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             1
@@ -806,6 +823,7 @@ exports[`EuiBasicTable footers render with pagination, selection, sorting, and f
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             20
@@ -834,6 +852,7 @@ exports[`EuiBasicTable footers render with pagination, selection, sorting, and f
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name2
@@ -847,6 +866,7 @@ exports[`EuiBasicTable footers render with pagination, selection, sorting, and f
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             2
@@ -860,6 +880,7 @@ exports[`EuiBasicTable footers render with pagination, selection, sorting, and f
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             21
@@ -888,6 +909,7 @@ exports[`EuiBasicTable footers render with pagination, selection, sorting, and f
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name3
@@ -901,6 +923,7 @@ exports[`EuiBasicTable footers render with pagination, selection, sorting, and f
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             3
@@ -914,6 +937,7 @@ exports[`EuiBasicTable footers render with pagination, selection, sorting, and f
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             22
@@ -1031,6 +1055,7 @@ exports[`EuiBasicTable itemIdToExpandedRowMap renders an expanded row 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name1
@@ -1061,6 +1086,7 @@ exports[`EuiBasicTable itemIdToExpandedRowMap renders an expanded row 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name2
@@ -1078,6 +1104,7 @@ exports[`EuiBasicTable itemIdToExpandedRowMap renders an expanded row 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name3
@@ -1159,6 +1186,7 @@ exports[`EuiBasicTable rowProps renders rows with custom props from a callback 1
                   "render": undefined,
                 }
               }
+              setScopeRow={false}
               textOnly={true}
             >
               name1
@@ -1181,6 +1209,7 @@ exports[`EuiBasicTable rowProps renders rows with custom props from a callback 1
                   "render": undefined,
                 }
               }
+              setScopeRow={false}
               textOnly={true}
             >
               name2
@@ -1203,6 +1232,7 @@ exports[`EuiBasicTable rowProps renders rows with custom props from a callback 1
                   "render": undefined,
                 }
               }
+              setScopeRow={false}
               textOnly={true}
             >
               name3
@@ -1285,6 +1315,7 @@ exports[`EuiBasicTable rowProps renders rows with custom props from an object 1`
                   "render": undefined,
                 }
               }
+              setScopeRow={false}
               textOnly={true}
             >
               name1
@@ -1307,6 +1338,7 @@ exports[`EuiBasicTable rowProps renders rows with custom props from an object 1`
                   "render": undefined,
                 }
               }
+              setScopeRow={false}
               textOnly={true}
             >
               name2
@@ -1329,6 +1361,7 @@ exports[`EuiBasicTable rowProps renders rows with custom props from an object 1`
                   "render": undefined,
                 }
               }
+              setScopeRow={false}
               textOnly={true}
             >
               name3
@@ -1408,6 +1441,7 @@ exports[`EuiBasicTable with pagination - 2nd page 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name1
@@ -1425,6 +1459,7 @@ exports[`EuiBasicTable with pagination - 2nd page 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name2
@@ -1514,6 +1549,7 @@ exports[`EuiBasicTable with pagination 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name1
@@ -1531,6 +1567,7 @@ exports[`EuiBasicTable with pagination 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name2
@@ -1548,6 +1585,7 @@ exports[`EuiBasicTable with pagination 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name3
@@ -1738,6 +1776,7 @@ exports[`EuiBasicTable with pagination and selection 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name1
@@ -1766,6 +1805,7 @@ exports[`EuiBasicTable with pagination and selection 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name2
@@ -1794,6 +1834,7 @@ exports[`EuiBasicTable with pagination and selection 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name3
@@ -1883,6 +1924,7 @@ exports[`EuiBasicTable with pagination, hiding the per page options 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name1
@@ -1900,6 +1942,7 @@ exports[`EuiBasicTable with pagination, hiding the per page options 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name2
@@ -1917,6 +1960,7 @@ exports[`EuiBasicTable with pagination, hiding the per page options 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name3
@@ -2052,6 +2096,7 @@ exports[`EuiBasicTable with pagination, selection and sorting 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name1
@@ -2080,6 +2125,7 @@ exports[`EuiBasicTable with pagination, selection and sorting 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name2
@@ -2108,6 +2154,7 @@ exports[`EuiBasicTable with pagination, selection and sorting 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name3
@@ -2249,6 +2296,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name1
@@ -2306,6 +2354,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name2
@@ -2363,6 +2412,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name3
@@ -2525,6 +2575,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and column dataType 1
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             1
@@ -2553,6 +2604,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and column dataType 1
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             2
@@ -2581,6 +2633,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and column dataType 1
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             3
@@ -2715,6 +2768,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and column renderer 1
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={false}
           >
             NAME1
@@ -2743,6 +2797,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and column renderer 1
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={false}
           >
             NAME2
@@ -2771,6 +2826,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and column renderer 1
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={false}
           >
             NAME3
@@ -2912,6 +2968,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name1
@@ -2975,6 +3032,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name2
@@ -3038,6 +3096,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name3
@@ -3206,6 +3265,7 @@ exports[`EuiBasicTable with pagination, selection, sorting, column renderer and 
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={false}
           >
             x
@@ -3234,6 +3294,7 @@ exports[`EuiBasicTable with pagination, selection, sorting, column renderer and 
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={false}
           >
             xx
@@ -3262,6 +3323,7 @@ exports[`EuiBasicTable with pagination, selection, sorting, column renderer and 
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={false}
           >
             xxx
@@ -3350,6 +3412,7 @@ exports[`EuiBasicTable with sortable columns and sorting disabled 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name1
@@ -3367,6 +3430,7 @@ exports[`EuiBasicTable with sortable columns and sorting disabled 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name2
@@ -3384,6 +3448,7 @@ exports[`EuiBasicTable with sortable columns and sorting disabled 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name3
@@ -3478,6 +3543,7 @@ exports[`EuiBasicTable with sorting 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name1
@@ -3495,6 +3561,7 @@ exports[`EuiBasicTable with sorting 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name2
@@ -3512,6 +3579,7 @@ exports[`EuiBasicTable with sorting 1`] = `
                 "render": undefined,
               }
             }
+            setScopeRow={false}
             textOnly={true}
           >
             name3

--- a/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -25,17 +25,14 @@ exports[`EuiBasicTable cellProps renders cells with custom props from a callback
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows."
+              token="euiBasicTable.tableDescriptionWithoutPagination"
               values={
                 Object {
                   "itemCount": 3,
@@ -148,17 +145,14 @@ exports[`EuiBasicTable cellProps renders rows with custom props from an object 1
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows."
+              token="euiBasicTable.tableDescriptionWithoutPagination"
               values={
                 Object {
                   "itemCount": 3,
@@ -273,17 +267,14 @@ exports[`EuiBasicTable empty is rendered 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows."
+              token="euiBasicTable.tableDescriptionWithoutPagination"
               values={
                 Object {
                   "itemCount": 0,
@@ -343,17 +334,14 @@ exports[`EuiBasicTable empty renders a node as a custom message 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows."
+              token="euiBasicTable.tableDescriptionWithoutPagination"
               values={
                 Object {
                   "itemCount": 0,
@@ -421,17 +409,14 @@ exports[`EuiBasicTable empty renders a string as a custom message 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows."
+              token="euiBasicTable.tableDescriptionWithoutPagination"
               values={
                 Object {
                   "itemCount": 0,
@@ -491,17 +476,14 @@ exports[`EuiBasicTable footers do not render without a column footer definition 
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows."
+              token="euiBasicTable.tableDescriptionWithoutPagination"
               values={
                 Object {
                   "itemCount": 3,
@@ -718,20 +700,18 @@ exports[`EuiBasicTable footers render with pagination, selection, sorting, and f
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows out of {totalItemCount} rows."
+              token="euiBasicTable.tableDescriptionWithPagination"
               values={
                 Object {
                   "itemCount": 3,
+                  "totalItemCount": 5,
                 }
               }
             />
@@ -1009,17 +989,14 @@ exports[`EuiBasicTable itemIdToExpandedRowMap renders an expanded row 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows."
+              token="euiBasicTable.tableDescriptionWithoutPagination"
               values={
                 Object {
                   "itemCount": 3,
@@ -1137,17 +1114,14 @@ exports[`EuiBasicTable rowProps renders rows with custom props from a callback 1
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows."
+              token="euiBasicTable.tableDescriptionWithoutPagination"
               values={
                 Object {
                   "itemCount": 3,
@@ -1266,17 +1240,14 @@ exports[`EuiBasicTable rowProps renders rows with custom props from an object 1`
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows."
+              token="euiBasicTable.tableDescriptionWithoutPagination"
               values={
                 Object {
                   "itemCount": 3,
@@ -1395,20 +1366,18 @@ exports[`EuiBasicTable with pagination - 2nd page 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows out of {totalItemCount} rows."
+              token="euiBasicTable.tableDescriptionWithPagination"
               values={
                 Object {
                   "itemCount": 2,
+                  "totalItemCount": 5,
                 }
               }
             />
@@ -1503,20 +1472,18 @@ exports[`EuiBasicTable with pagination 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows out of {totalItemCount} rows."
+              token="euiBasicTable.tableDescriptionWithPagination"
               values={
                 Object {
                   "itemCount": 3,
+                  "totalItemCount": 5,
                 }
               }
             />
@@ -1628,20 +1595,18 @@ exports[`EuiBasicTable with pagination and error 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows out of {totalItemCount} rows."
+              token="euiBasicTable.tableDescriptionWithPagination"
               values={
                 Object {
                   "itemCount": 3,
+                  "totalItemCount": 5,
                 }
               }
             />
@@ -1710,20 +1675,18 @@ exports[`EuiBasicTable with pagination and selection 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows out of {totalItemCount} rows."
+              token="euiBasicTable.tableDescriptionWithPagination"
               values={
                 Object {
                   "itemCount": 3,
+                  "totalItemCount": 5,
                 }
               }
             />
@@ -1878,20 +1841,18 @@ exports[`EuiBasicTable with pagination, hiding the per page options 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows out of {totalItemCount} rows."
+              token="euiBasicTable.tableDescriptionWithPagination"
               values={
                 Object {
                   "itemCount": 3,
+                  "totalItemCount": 5,
                 }
               }
             />
@@ -2025,20 +1986,18 @@ exports[`EuiBasicTable with pagination, selection and sorting 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows out of {totalItemCount} rows."
+              token="euiBasicTable.tableDescriptionWithPagination"
               values={
                 Object {
                   "itemCount": 3,
+                  "totalItemCount": 5,
                 }
               }
             />
@@ -2217,20 +2176,18 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows out of {totalItemCount} rows."
+              token="euiBasicTable.tableDescriptionWithPagination"
               values={
                 Object {
                   "itemCount": 3,
+                  "totalItemCount": 5,
                 }
               }
             />
@@ -2502,20 +2459,18 @@ exports[`EuiBasicTable with pagination, selection, sorting and column dataType 1
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows out of {totalItemCount} rows."
+              token="euiBasicTable.tableDescriptionWithPagination"
               values={
                 Object {
                   "itemCount": 3,
+                  "totalItemCount": 5,
                 }
               }
             />
@@ -2694,20 +2649,18 @@ exports[`EuiBasicTable with pagination, selection, sorting and column renderer 1
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows out of {totalItemCount} rows."
+              token="euiBasicTable.tableDescriptionWithPagination"
               values={
                 Object {
                   "itemCount": 3,
+                  "totalItemCount": 5,
                 }
               }
             />
@@ -2886,20 +2839,18 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows out of {totalItemCount} rows."
+              token="euiBasicTable.tableDescriptionWithPagination"
               values={
                 Object {
                   "itemCount": 3,
+                  "totalItemCount": 5,
                 }
               }
             />
@@ -3189,20 +3140,18 @@ exports[`EuiBasicTable with pagination, selection, sorting, column renderer and 
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows out of {totalItemCount} rows."
+              token="euiBasicTable.tableDescriptionWithPagination"
               values={
                 Object {
                   "itemCount": 3,
+                  "totalItemCount": 5,
                 }
               }
             />
@@ -3360,17 +3309,14 @@ exports[`EuiBasicTable with sortable columns and sorting disabled 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows."
+              token="euiBasicTable.tableDescriptionWithoutPagination"
               values={
                 Object {
                   "itemCount": 3,
@@ -3488,17 +3434,14 @@ exports[`EuiBasicTable with sorting 1`] = `
     >
       <EuiScreenReaderOnly>
         <caption
-          aria-live="polite"
-          aria-relevant="text"
           className="euiTableCaption"
-          role="status"
         >
           <EuiDelayRender
             delay={500}
           >
             <EuiI18n
-              default="Below is a table of {itemCount} items."
-              token="euiBasicTable.tableDescription"
+              default="This table contains {itemCount} rows."
+              token="euiBasicTable.tableDescriptionWithoutPagination"
               values={
                 Object {
                   "itemCount": 3,

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -134,10 +134,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
           >
             <EuiScreenReaderOnly>
               <caption
-                aria-live="polite"
-                aria-relevant="text"
                 className="euiScreenReaderOnly euiTableCaption"
-                role="status"
               >
                 <EuiDelayRender
                   delay={500}

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -193,6 +193,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                           "render": undefined,
                         }
                       }
+                      setScopeRow={false}
                       textOnly={true}
                     >
                       <td
@@ -236,6 +237,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                           "render": undefined,
                         }
                       }
+                      setScopeRow={false}
                       textOnly={true}
                     >
                       <td

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -177,6 +177,7 @@ interface BasicTableProps<T> extends Omit<EuiTableProps, 'onChange'> {
   cellProps?: object | CellPropsCallback<T>;
   columns: Array<EuiBasicTableColumn<T>>;
   error?: string;
+  tableCaption?: string;
   hasActions?: boolean;
   isExpandable?: boolean;
   isSelectable?: boolean;
@@ -439,6 +440,7 @@ export class EuiBasicTable<T = any> extends Component<
       hasActions,
       rowProps,
       cellProps,
+      tableCaption,
       tableLayout,
       ...rest
     } = this.props;
@@ -533,22 +535,38 @@ export class EuiBasicTable<T = any> extends Component<
   }
 
   renderTableCaption() {
-    const { items } = this.props;
-
+    const { items, pagination, tableCaption } = this.props;
+    let captionElement;
+    if (tableCaption) {
+      captionElement = tableCaption;
+    } else {
+      if (pagination && pagination.totalItemCount > 0) {
+        captionElement = (
+          <EuiI18n
+            token="euiBasicTable.tableDescriptionWithPagination"
+            default="This table contains {itemCount} rows out of {totalItemCount} rows."
+            values={{
+              totalItemCount: pagination.totalItemCount,
+              itemCount: items.length,
+            }}
+          />
+        );
+      } else {
+        captionElement = (
+          <EuiI18n
+            token="euiBasicTable.tableDescriptionWithoutPagination"
+            default="This table contains {itemCount} rows."
+            values={{
+              itemCount: items.length,
+            }}
+          />
+        );
+      }
+    }
     return (
       <EuiScreenReaderOnly>
-        <caption
-          className="euiTableCaption"
-          role="status"
-          aria-relevant="text"
-          aria-live="polite">
-          <EuiDelayRender>
-            <EuiI18n
-              token="euiBasicTable.tableDescription"
-              default="Below is a table of {itemCount} items."
-              values={{ itemCount: items.length }}
-            />
-          </EuiDelayRender>
+        <caption className="euiTableCaption">
+          <EuiDelayRender>{captionElement}</EuiDelayRender>
         </caption>
       </EuiScreenReaderOnly>
     );

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -178,6 +178,7 @@ interface BasicTableProps<T> extends Omit<EuiTableProps, 'onChange'> {
   columns: Array<EuiBasicTableColumn<T>>;
   error?: string;
   tableCaption?: string;
+  rowHeader?: string;
   hasActions?: boolean;
   isExpandable?: boolean;
   isSelectable?: boolean;
@@ -441,6 +442,7 @@ export class EuiBasicTable<T = any> extends Component<
       rowProps,
       cellProps,
       tableCaption,
+      rowHeader,
       tableLayout,
       ...rest
     } = this.props;
@@ -826,6 +828,7 @@ export class EuiBasicTable<T = any> extends Component<
       selection,
       isSelectable,
       hasActions,
+      rowHeader,
       itemIdToExpandedRowMap = {},
       isExpandable,
     } = this.props;
@@ -861,14 +864,27 @@ export class EuiBasicTable<T = any> extends Component<
         );
         calculatedHasActions = true;
       } else if ((column as EuiTableFieldDataColumnType<T>).field) {
-        cells.push(
-          this.renderItemFieldDataCell(
-            itemId,
-            item,
-            column as EuiTableFieldDataColumnType<T>,
-            columnIndex
-          )
-        );
+        if ((column as EuiTableFieldDataColumnType<T>).field === rowHeader) {
+          cells.push(
+            this.renderItemFieldDataCell(
+              itemId,
+              item,
+              column as EuiTableFieldDataColumnType<T>,
+              columnIndex,
+              true
+            )
+          );
+        } else {
+          cells.push(
+            this.renderItemFieldDataCell(
+              itemId,
+              item,
+              column as EuiTableFieldDataColumnType<T>,
+              columnIndex,
+              false
+            )
+          );
+        }
       } else {
         cells.push(
           this.renderItemComputedCell(
@@ -1051,7 +1067,8 @@ export class EuiBasicTable<T = any> extends Component<
     itemId: ItemId<T>,
     item: T,
     column: EuiTableFieldDataColumnType<T>,
-    columnIndex: number
+    columnIndex: number,
+    setScopeRow: boolean
   ) {
     const { field, render, dataType } = column;
 
@@ -1060,7 +1077,7 @@ export class EuiBasicTable<T = any> extends Component<
     const value = get(item, field as string);
     const content = contentRenderer(value, item);
 
-    return this.renderItemCell(item, column, key, content);
+    return this.renderItemCell(item, column, key, content, setScopeRow);
   }
 
   renderItemComputedCell(
@@ -1075,14 +1092,15 @@ export class EuiBasicTable<T = any> extends Component<
     const contentRenderer = render || this.getRendererForDataType();
     const content = contentRenderer(item);
 
-    return this.renderItemCell(item, column, key, content);
+    return this.renderItemCell(item, column, key, content, false);
   }
 
   renderItemCell(
     item: T,
     column: EuiBasicTableColumn<T>,
     key: string | number,
-    content: ReactNode
+    content: ReactNode,
+    setScopeRow: boolean
   ) {
     const {
       align,
@@ -1112,6 +1130,7 @@ export class EuiBasicTable<T = any> extends Component<
         align={columnAlign}
         isExpander={isExpander}
         textOnly={textOnly || !render}
+        setScopeRow={setScopeRow}
         mobileOptions={{
           ...mobileOptions,
           render:

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -864,27 +864,16 @@ export class EuiBasicTable<T = any> extends Component<
         );
         calculatedHasActions = true;
       } else if ((column as EuiTableFieldDataColumnType<T>).field) {
-        if ((column as EuiTableFieldDataColumnType<T>).field === rowHeader) {
-          cells.push(
-            this.renderItemFieldDataCell(
-              itemId,
-              item,
-              column as EuiTableFieldDataColumnType<T>,
-              columnIndex,
-              true
-            )
-          );
-        } else {
-          cells.push(
-            this.renderItemFieldDataCell(
-              itemId,
-              item,
-              column as EuiTableFieldDataColumnType<T>,
-              columnIndex,
-              false
-            )
-          );
-        }
+        const fieldDataColumn = column as EuiTableFieldDataColumnType<T>;
+        cells.push(
+          this.renderItemFieldDataCell(
+            itemId,
+            item,
+            column as EuiTableFieldDataColumnType<T>,
+            columnIndex,
+            fieldDataColumn.field === rowHeader
+          )
+        );
       } else {
         cells.push(
           this.renderItemComputedCell(

--- a/src/components/table/_mixins.scss
+++ b/src/components/table/_mixins.scss
@@ -2,6 +2,8 @@
   vertical-align: middle;
   border-top: $euiBorderThin;
   border-bottom: $euiBorderThin;
+  font-weight: inherit;
+  text-align: inherit;
 }
 
 @mixin euiTableCellCheckbox {

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -109,6 +109,9 @@ interface EuiTableRowCellProps {
    */
   mobileOptions?: EuiTableRowCellMobileOptionsShape &
     EuiTableRowCellSharedPropsShape;
+  /**
+   * Indicates whether the cell should be marked as the heading for its row
+   */
   setScopeRow?: boolean;
 }
 

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -109,6 +109,7 @@ interface EuiTableRowCellProps {
    */
   mobileOptions?: EuiTableRowCellMobileOptionsShape &
     EuiTableRowCellSharedPropsShape;
+  setScopeRow?: boolean;
 }
 
 type Props = CommonProps &
@@ -121,6 +122,7 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
   children,
   className,
   truncateText,
+  setScopeRow,
   showOnHover,
   textOnly = true,
   hasActions,
@@ -205,40 +207,82 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
   let cellRender;
 
   if (mobileOptions.show === false || hideForMobile) {
-    cellRender = (
-      <td
-        className={`${cellClasses} ${hideForMobileClasses}`}
-        style={styleObj}
-        {...rest}>
-        <div className={contentClasses}>{childrenNode}</div>
-      </td>
-    );
-  } else {
-    cellRender = (
-      <td className={cellClasses} style={styleObj} {...rest}>
-        {/* Mobile-only header */}
-        {(mobileOptions.header || header) && !isMobileHeader && (
-          <div
-            className={`euiTableRowCell__mobileHeader ${showForMobileClasses}`}>
-            {mobileOptions.header || header}
-          </div>
-        )}
-
-        {/* Content depending on mobile render existing */}
-        {mobileOptions.render ? (
-          <Fragment>
-            <div className={`${mobileContentClasses} ${showForMobileClasses}`}>
-              {modifyChildren(mobileOptions.render)}
-            </div>
-            <div className={`${contentClasses} ${hideForMobileClasses}`}>
-              {childrenNode}
-            </div>
-          </Fragment>
-        ) : (
+    if (setScopeRow) {
+      cellRender = (
+        <th
+          scope="row"
+          className={`${cellClasses} ${hideForMobileClasses}`}
+          style={styleObj}
+          {...rest}>
           <div className={contentClasses}>{childrenNode}</div>
-        )}
-      </td>
-    );
+        </th>
+      );
+    } else {
+      cellRender = (
+        <td
+          className={`${cellClasses} ${hideForMobileClasses}`}
+          style={styleObj}
+          {...rest}>
+          <div className={contentClasses}>{childrenNode}</div>
+        </td>
+      );
+    }
+  } else {
+    if (setScopeRow) {
+      cellRender = (
+        <th scope="row" className={cellClasses} style={styleObj} {...rest}>
+          {/* Mobile-only header */}
+          {(mobileOptions.header || header) && !isMobileHeader && (
+            <div
+              className={`euiTableRowCell__mobileHeader ${showForMobileClasses}`}>
+              {mobileOptions.header || header}
+            </div>
+          )}
+
+          {/* Content depending on mobile render existing */}
+          {mobileOptions.render ? (
+            <Fragment>
+              <div
+                className={`${mobileContentClasses} ${showForMobileClasses}`}>
+                {modifyChildren(mobileOptions.render)}
+              </div>
+              <div className={`${contentClasses} ${hideForMobileClasses}`}>
+                {childrenNode}
+              </div>
+            </Fragment>
+          ) : (
+            <div className={contentClasses}>{childrenNode}</div>
+          )}
+        </th>
+      );
+    } else {
+      cellRender = (
+        <td className={cellClasses} style={styleObj} {...rest}>
+          {/* Mobile-only header */}
+          {(mobileOptions.header || header) && !isMobileHeader && (
+            <div
+              className={`euiTableRowCell__mobileHeader ${showForMobileClasses}`}>
+              {mobileOptions.header || header}
+            </div>
+          )}
+
+          {/* Content depending on mobile render existing */}
+          {mobileOptions.render ? (
+            <Fragment>
+              <div
+                className={`${mobileContentClasses} ${showForMobileClasses}`}>
+                {modifyChildren(mobileOptions.render)}
+              </div>
+              <div className={`${contentClasses} ${hideForMobileClasses}`}>
+                {childrenNode}
+              </div>
+            </Fragment>
+          ) : (
+            <div className={contentClasses}>{childrenNode}</div>
+          )}
+        </td>
+      );
+    }
   }
 
   return cellRender;


### PR DESCRIPTION
### Summary

This PR adds a new prop called `headerRow` to `BasicTable` that lets consumers specify what column is the row header (and thus should have `<th scope=“row”>`).

Doing something like
```
    <EuiBasicTable
      items={items}
      rowHeader="firstName"
      columns={columns}
      rowProps={getRowProps}
      cellProps={getCellProps}
    />

```
results in this markup

<img width="259" alt="Pasted Graphic 7 copy" src="https://user-images.githubusercontent.com/4016496/73415443-c5efb400-42c6-11ea-9d66-b7c8cab2de49.png">
 

Limitations:

This only works with `FieldDataColumn` as it has `field` as a required prop which is what I’m using for doing

`(column as EuiTableFieldDataColumnType<T>).field === headerRow
`

Fixes #2335 #2337

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
- [x] Props have proper **autodocs**
- [x] Added **documentation** examples
- [x] Added or updated **jest tests**
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
