### PR TITLE
[SASS] Change output style comments to non-rendered comments in invisibles files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added `tableCaption` prop to `EuiBasicTable` and improved the default one ([#2782](https://github.com/elastic/eui/pull/2782))
+- Changed SASS comments to non-compiled comments in invisibles files ([#2807](https://github.com/elastic/eui/pull/2807))
 
 ## [`18.3.0`](https://github.com/elastic/eui/tree/v18.3.0)
 

--- a/src-docs/src/views/icon/icon_types.js
+++ b/src-docs/src/views/icon/icon_types.js
@@ -12,7 +12,8 @@ import {
   EuiButton,
 } from '../../../../src/components';
 
-import reactSvg from '../../images/custom.svg';
+// import reactSvg from '../../images/custom.svg';
+import reactSvg from '../../../../src/components/icon/assets/alert.svg';
 
 export default () => (
   <div>

--- a/src-docs/src/views/icon/icon_types.js
+++ b/src-docs/src/views/icon/icon_types.js
@@ -12,8 +12,7 @@ import {
   EuiButton,
 } from '../../../../src/components';
 
-// import reactSvg from '../../images/custom.svg';
-import reactSvg from '../../../../src/components/icon/assets/alert.svg';
+import reactSvg from '../../images/custom.svg';
 
 export default () => (
   <div>

--- a/src/global_styling/mixins/_beta_badge.scss
+++ b/src/global_styling/mixins/_beta_badge.scss
@@ -1,13 +1,11 @@
 
-/**
- * 1. Extend beta badges to at least 40% of the container's width
- * 2. Fix for IE to ensure badges are visible outside of a <button> tag
- */
+// 1. Extend beta badges to at least 40% of the container's width
+// 2. Fix for IE to ensure badges are visible outside of a <button> tag
 
 @mixin euiHasBetaBadge($selector, $spacing: $euiSize) {
   #{$selector}--hasBetaBadge {
     position: relative;
-    overflow: visible; /* 2 */
+    overflow: visible; // 2
 
     #{$selector}__betaBadgeWrapper {
       position: absolute;
@@ -15,12 +13,12 @@
       left: 50%;
       transform: translateX(-50%);
       z-index: 3; // get above abs positioned image
-      min-width: 40%; /* 1 */
+      min-width: 40%; // 1
       max-width: calc(100% - #{($spacing * 2)});
 
       .euiToolTipAnchor,
       #{$selector}__betaBadge {
-        width: 100%; /* 1 */
+        width: 100%; // 1
       }
 
       #{$selector}__betaBadge {

--- a/src/global_styling/mixins/_button.scss
+++ b/src/global_styling/mixins/_button.scss
@@ -33,10 +33,9 @@
   }
 }
 
-/**
- * 1. Apply margin to all but last item in the flex.
- * 2. Margin gets flipped because of the row-reverse.
- */
+// 1. Apply margin to all but last item in the flex.
+// 2. Margin gets flipped because of the row-reverse.
+
 @mixin euiButtonContent($isReverse: false) {
   height: 100%;
   width: 100%;
@@ -51,8 +50,8 @@
     flex-direction: row-reverse;
 
     > * + * {
-      margin-left: 0; /* 1 */
-      margin-right: $euiSizeS; /* 1 */
+      margin-left: 0; // 1, 2
+      margin-right: $euiSizeS; // 1, 2
     }
   } @else {
     display: flex;
@@ -60,7 +59,7 @@
     align-items: center;
 
     > * + * {
-      margin-left: $euiSizeS; /* 1 */
+      margin-left: $euiSizeS; // 1
     }
   }
 }

--- a/src/global_styling/mixins/_form.scss
+++ b/src/global_styling/mixins/_form.scss
@@ -209,11 +209,11 @@
   padding: $euiFormControlPadding;
 
   @if ($includeStates) {
-    &:invalid { /* 4 */
+    &:invalid { // 2
       @include euiFormControlInvalidStyle;
     }
 
-    &:focus { /* 4 */
+    &:focus { // 2
       @include euiFormControlFocusStyle;
     }
 

--- a/src/global_styling/mixins/_form.scss
+++ b/src/global_styling/mixins/_form.scss
@@ -65,10 +65,6 @@
   );
 }
 
-/**
- * 3. Must supply both values to background-size or some browsers apply the single value to both directions
- */
-
 @mixin euiFormControlText {
   @include euiFont;
   font-size: $euiFontSizeS;
@@ -129,11 +125,13 @@
   }
 }
 
+// 1. Must supply both values to background-size or some browsers apply the single value to both directions
+
 @mixin euiFormControlDefaultShadow($borderOnly: false) {
   // sass-lint:disable-block indentation
   background-color: $euiFormBackgroundColor;
   background-repeat: no-repeat;
-  background-size: 0% 100%; /* 3 */
+  background-size: 0% 100%; // 1
 
   @if ($borderOnly) {
     box-shadow: inset 0 0 0 1px $euiFormBorderColor;
@@ -161,7 +159,7 @@
   // sass-lint:disable-block indentation, empty-args
   background-color: tintOrShade($euiColorEmptyShade, 0%, 40%);
   background-image: euiFormControlGradient();
-  background-size: 100% 100%; /* 3 */
+  background-size: 100% 100%; // 1
 
   @if ($borderOnly) {
     box-shadow: inset 0 0 0 1px $euiFormBorderColor;
@@ -198,9 +196,8 @@
   box-shadow: inset 0 0 0 1px $euiFormBorderDisabledColor;
 }
 
-/**
- * 4. Override invalid state with focus state.
- */
+
+// 2. Override invalid state with focus state.
 
 @mixin euiFormControlStyle($borderOnly: false, $includeStates: true, $includeSizes: true) {
   @include euiFormControlSize($includeAlternates: $includeSizes);
@@ -248,11 +245,11 @@
   border-radius: $euiFormControlCompressedBorderRadius;
 
   @if ($includeStates) {
-    &:invalid { /* 4 */
+    &:invalid { // 2
       @include euiFormControlInvalidStyle;
     }
 
-    &:focus { /* 4 */
+    &:focus { // 2
       @include euiFormControlFocusStyle($borderOnly: true);
     }
 

--- a/src/global_styling/mixins/_panel.scss
+++ b/src/global_styling/mixins/_panel.scss
@@ -1,8 +1,3 @@
-/**
- *  Mixin for use in:
- *  - EuiCard
- *  - EuiPageContent
-*/
 @mixin euiPanel($selector) {
   @if variable-exists(selector) == false {
     @error 'A $selector must be provided to @mixin euiPanel().';

--- a/src/global_styling/mixins/_typography.scss
+++ b/src/global_styling/mixins/_typography.scss
@@ -116,11 +116,11 @@
 
 @mixin euiTextTruncate {
   // sass-lint:disable-block no-important
-  max-width: 100%; /* 1 */
+  max-width: 100%; // 1
   overflow: hidden !important;
   text-overflow: ellipsis !important;
   white-space: nowrap !important;
-  word-wrap: normal !important; /* 2 */
+  word-wrap: normal !important; // 2
 }
 
 @mixin euiNumberFormat {

--- a/src/global_styling/variables/_form.scss
+++ b/src/global_styling/variables/_form.scss
@@ -39,8 +39,8 @@ $euiFormInputGroupBorder: 1px solid shadeOrTint($euiFormInputGroupLabelBackgroun
 $euiSwitchOffColor: lightOrDarkTheme(transparentize($euiColorMediumShade, .8), transparentize($euiColorMediumShade, .3)) !default;
 
 // Control Layout
-$euiFormControlLayoutGroupInputHeight: $euiFormControlHeight - 2px !default; /* 1 */
-$euiFormControlLayoutGroupInputCompressedHeight: $euiFormControlCompressedHeight - 2px !default; /* 1 */
+$euiFormControlLayoutGroupInputHeight: $euiFormControlHeight - 2px !default;
+$euiFormControlLayoutGroupInputCompressedHeight: $euiFormControlCompressedHeight - 2px !default;
 $euiFormControlLayoutGroupInputCompressedBorderRadius: $euiFormControlCompressedBorderRadius / 2 !default;
 
 // Range


### PR DESCRIPTION
### Summary

There are two kinds of SASS comments.

1. `// This style doesn't get output in the compiled CSS file`
2. `/* This style does */`

When importing the invisibles files (variables, mixins, functions), if those files contain the second comment style, then the comments will be output in the consumer's CSS. This is unnecessary and can cause confusion.

**Kibana example:**

<img width="1913" alt="Screen Shot 2020-01-30 at 15 05 10 PM" src="https://user-images.githubusercontent.com/549577/73487686-7c11d700-4375-11ea-818d-9516a76a830d.png">

This PR, just changes the comments from the invisibles files to be the non-compiled style.

### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **IE11** and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **documentation** examples~
- ~[ ] Added or updated **jest tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
