### PR TITLE
Context menu allow jsx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Changed SASS comments to non-compiled comments in invisibles files ([#2807](https://github.com/elastic/eui/pull/2807))
 - Added `rowHeader` prop to `EuiBasicTable` to allow consumers to set the identifying cell in a row ([#2802](https://github.com/elastic/eui/pull/2802))
 - Improved `EuiDescribedFormGroup` accessibility by avoiding duplicated output in screen readers ([#2783](https://github.com/elastic/eui/pull/2783))
-- Added optional `key` attribute to `EuiContextMenu` items and relaxed `node` attribute to allow any React node ([#2817](https://github.com/elastic/eui/pull/2817))
+- Added optional `key` attribute to `EuiContextMenu` items and relaxed `name` attribute to allow any React node ([#2817](https://github.com/elastic/eui/pull/2817))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Changed SASS comments to non-compiled comments in invisibles files ([#2807](https://github.com/elastic/eui/pull/2807))
 - Added `rowHeader` prop to `EuiBasicTable` to allow consumers to set the identifying cell in a row ([#2802](https://github.com/elastic/eui/pull/2802))
 - Improved `EuiDescribedFormGroup` accessibility by avoiding duplicated output in screen readers ([#2783](https://github.com/elastic/eui/pull/2783))
+- Added optional `key` attribute to `EuiContextMenu` items and relaxed `node` attribute to allow any React node ([#2817](https://github.com/elastic/eui/pull/2817))
 
 **Bug fixes**
 

--- a/src/components/context_menu/__snapshots__/context_menu.test.tsx.snap
+++ b/src/components/context_menu/__snapshots__/context_menu.test.tsx.snap
@@ -8,6 +8,49 @@ exports[`EuiContextMenu is rendered 1`] = `
 />
 `;
 
+exports[`EuiContextMenu panel item can contain JSX 1`] = `
+<div
+  class="euiContextMenu"
+>
+  <div
+    class="euiContextMenuPanel euiContextMenu__panel"
+    tabindex="0"
+  >
+    <div
+      class="euiPopoverTitle"
+    >
+      <span
+        class="euiContextMenu__itemLayout"
+      >
+        3
+      </span>
+    </div>
+    <div>
+      <div>
+        <button
+          class="euiContextMenuItem"
+          type="button"
+        >
+          <span
+            class="euiContextMenu__itemLayout"
+          >
+            <span
+              class="euiContextMenuItem__text"
+            >
+              <span
+                style="color:tomato"
+              >
+                foo
+              </span>
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EuiContextMenu props panels and initialPanelId allows you to click the title button to go back to the previous panel 1`] = `
 <div
   class="euiContextMenu"

--- a/src/components/context_menu/__snapshots__/context_menu_panel.test.tsx.snap
+++ b/src/components/context_menu/__snapshots__/context_menu_panel.test.tsx.snap
@@ -8,6 +8,49 @@ exports[`EuiContextMenu is rendered 1`] = `
 />
 `;
 
+exports[`EuiContextMenu panel item can contain JSX 1`] = `
+<div
+  class="euiContextMenu"
+>
+  <div
+    class="euiContextMenuPanel euiContextMenu__panel"
+    tabindex="0"
+  >
+    <div
+      class="euiPopoverTitle"
+    >
+      <span
+        class="euiContextMenu__itemLayout"
+      >
+        3
+      </span>
+    </div>
+    <div>
+      <div>
+        <button
+          class="euiContextMenuItem"
+          type="button"
+        >
+          <span
+            class="euiContextMenu__itemLayout"
+          >
+            <span
+              class="euiContextMenuItem__text"
+            >
+              <span
+                style="color:tomato"
+              >
+                foo
+              </span>
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EuiContextMenu props panels and initialPanelId allows you to click the title button to go back to the previous panel 1`] = `
 <div
   class="euiContextMenu"

--- a/src/components/context_menu/context_menu.test.tsx
+++ b/src/components/context_menu/context_menu.test.tsx
@@ -5,6 +5,17 @@ import { requiredProps, takeMountedSnapshot } from '../../test';
 import { EuiContextMenu } from './context_menu';
 import { setTimeout } from 'timers';
 
+const panel3 = {
+  id: 3,
+  title: '3',
+  items: [
+    {
+      name: <span style={{ color: 'tomato' }}>foo</span>,
+      key: 'foo',
+    },
+  ],
+};
+
 const panel2 = {
   id: 2,
   title: '2',
@@ -42,7 +53,7 @@ const panel0 = {
   ],
 };
 
-const panels = [panel0, panel1, panel2];
+const panels = [panel0, panel1, panel2, panel3];
 
 export const tick = (ms = 0) =>
   new Promise(resolve => {
@@ -52,6 +63,14 @@ export const tick = (ms = 0) =>
 describe('EuiContextMenu', () => {
   test('is rendered', () => {
     const component = render(<EuiContextMenu {...requiredProps} />);
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it('panel item can contain JSX', () => {
+    const component = render(
+      <EuiContextMenu panels={panels} initialPanelId={3} />
+    );
 
     expect(component).toMatchSnapshot();
   });

--- a/src/components/context_menu/context_menu.tsx
+++ b/src/components/context_menu/context_menu.tsx
@@ -23,7 +23,8 @@ export type EuiContextMenuPanelItemDescriptor = Omit<
   EuiContextMenuItemProps,
   'hasPanel'
 > & {
-  name: string;
+  name: React.ReactNode;
+  key?: string;
   panel?: EuiContextMenuPanelId;
 };
 
@@ -260,6 +261,7 @@ export class EuiContextMenu extends Component<EuiContextMenuProps, State> {
       const {
         panel,
         name,
+        key,
         icon,
         onClick,
         toolTipTitle,
@@ -285,7 +287,7 @@ export class EuiContextMenu extends Component<EuiContextMenuProps, State> {
 
       return (
         <EuiContextMenuItem
-          key={name}
+          key={key || (typeof name === 'string' ? name : undefined) || index}
           icon={icon}
           onClick={onClickHandler}
           hasPanel={Boolean(panel)}


### PR DESCRIPTION
### Summary

This change will allow us to render more complex context menu items on Dashboard in Kibana, like `Edit` link below:

![image](https://user-images.githubusercontent.com/9773803/73575544-c92aa180-4478-11ea-9815-30a98079331f.png)

### Checklist

- ~~Check against **all themes** for compatibility in both light and dark modes~~
- ~~Checked in **mobile**~~
- ~~Checked in **IE11** and **Firefox**~~
- ~~Props have proper **autodocs**~~
- ~~Added **documentation** examples~~
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
- ~~Checked for **accessibility** including keyboard-only and screenreader modes~~
- ~~A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~~
