### PR TITLE
Remove extra div wrapping around EuiCode contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 **Bug fixes**
 
 - Exported missing `EuiSelectProps` type ([#2815](https://github.com/elastic/eui/pull/2815))
-- Fixed `EuiCode`'s & `EuiCodeBlock`'s ability to accept non-string children ([#2792](https://github.com/elastic/eui/pull/2792))
+- Fixed `EuiCode`'s & `EuiCodeBlock`'s ability to accept non-string children ([#2792](https://github.com/elastic/eui/pull/2792)) ([#2820](https://github.com/elastic/eui/pull/2820))
 - Fixed `EuiSearchBar`, `Query`, and `AST`'s ability to accept literal parenthesis characters ([#2791](https://github.com/elastic/eui/pull/2791))
 
 **Breaking changes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 
 - Exported missing `EuiSelectProps` type ([#2815](https://github.com/elastic/eui/pull/2815))
 - Fixed `EuiCode`'s & `EuiCodeBlock`'s ability to accept non-string children ([#2792](https://github.com/elastic/eui/pull/2792))
-- Reverted a bug in `EuiCode`'s & `EuiCodeBlock` layout positioning on Firefox ([#2820](https://github.com/elastic/eui/pull/2820))
 - Fixed `EuiSearchBar`, `Query`, and `AST`'s ability to accept literal parenthesis characters ([#2791](https://github.com/elastic/eui/pull/2791))
 
 **Breaking changes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Exported missing `EuiSelectProps` type ([#2815](https://github.com/elastic/eui/pull/2815))
 - Fixed `EuiCode`'s & `EuiCodeBlock`'s ability to accept non-string children ([#2792](https://github.com/elastic/eui/pull/2792))
+- Reverted a bug in `EuiCode`'s & `EuiCodeBlock` layout positioning on Firefox ([#2820](https://github.com/elastic/eui/pull/2820))
 - Fixed `EuiSearchBar`, `Query`, and `AST`'s ability to accept literal parenthesis characters ([#2791](https://github.com/elastic/eui/pull/2791))
 
 **Breaking changes**

--- a/src/components/code/__snapshots__/_code_block.test.js.snap
+++ b/src/components/code/__snapshots__/_code_block.test.js.snap
@@ -9,9 +9,7 @@ exports[`EuiCodeBlockImpl block highlights javascript code, adding "js" class 1`
   >
     <code
       class="euiCodeBlock__code js hljs javascript"
-    >
-      <div />
-    </code>
+    />
   </pre>
 </div>
 `;
@@ -28,10 +26,8 @@ exports[`EuiCodeBlockImpl block renders a pre block tag 1`] = `
       class="euiCodeBlock__code"
       data-test-subj="test subject string"
     >
-      <div>
-        var some = 'code';
+      var some = 'code';
 console.log(some);
-      </div>
     </code>
   </pre>
 </div>
@@ -46,9 +42,7 @@ exports[`EuiCodeBlockImpl block renders with transparent background 1`] = `
   >
     <code
       class="euiCodeBlock__code"
-    >
-      <div />
-    </code>
+    />
   </pre>
 </div>
 `;
@@ -59,9 +53,7 @@ exports[`EuiCodeBlockImpl inline highlights javascript code, adding "js" class 1
 >
   <code
     class="euiCodeBlock__code js hljs javascript"
-  >
-    <div />
-  </code>
+  />
 </span>
 `;
 
@@ -74,10 +66,8 @@ exports[`EuiCodeBlockImpl inline renders an inline code tag 1`] = `
     class="euiCodeBlock__code"
     data-test-subj="test subject string"
   >
-    <div>
-      var some = 'code';
+    var some = 'code';
 console.log(some);
-    </div>
   </code>
 </span>
 `;
@@ -88,8 +78,6 @@ exports[`EuiCodeBlockImpl inline renders with transparent background 1`] = `
 >
   <code
     class="euiCodeBlock__code"
-  >
-    <div />
-  </code>
+  />
 </span>
 `;

--- a/src/components/code/__snapshots__/code.test.js.snap
+++ b/src/components/code/__snapshots__/code.test.js.snap
@@ -9,10 +9,8 @@ exports[`EuiCode renders a code snippet 1`] = `
     class="euiCodeBlock__code"
     data-test-subj="test subject string"
   >
-    <div>
-      var some = 'code';
+    var some = 'code';
 console.log(some);
-    </div>
   </code>
 </span>
 `;

--- a/src/components/code/__snapshots__/code_block.test.js.snap
+++ b/src/components/code/__snapshots__/code_block.test.js.snap
@@ -5,10 +5,8 @@ exports[`EuiCodeBlock dynamic content updates DOM when input changes 1`] = `
   <div class=\\"euiCodeBlock euiCodeBlock--fontSmall euiCodeBlock--paddingLarge\\">
     <pre class=\\"euiCodeBlock__pre\\">
       <code class=\\"euiCodeBlock__code javascript hljs\\">
-        <div>
-          <span class=\\"hljs-keyword\\">const</span>value =
-          <span class=\\"hljs-string\\">'State 1'</span>
-        </div>
+        <span class=\\"hljs-keyword\\">const</span>value =
+        <span class=\\"hljs-string\\">'State 1'</span>
       </code>
     </pre>
   </div>
@@ -20,10 +18,8 @@ exports[`EuiCodeBlock dynamic content updates DOM when input changes 2`] = `
   <div class=\\"euiCodeBlock euiCodeBlock--fontSmall euiCodeBlock--paddingLarge\\">
     <pre class=\\"euiCodeBlock__pre\\">
       <code class=\\"euiCodeBlock__code javascript hljs\\">
-        <div>
-          <span class=\\"hljs-keyword\\">const</span>value =
-          <span class=\\"hljs-string\\">'State 2'</span>
-        </div>
+        <span class=\\"hljs-keyword\\">const</span>value =
+        <span class=\\"hljs-string\\">'State 2'</span>
       </code>
     </pre>
   </div>
@@ -40,10 +36,8 @@ exports[`EuiCodeBlock props fontSize l is rendered 1`] = `
     <code
       class="euiCodeBlock__code"
     >
-      <div>
-        var some = 'code';
+      var some = 'code';
 console.log(some);
-      </div>
     </code>
   </pre>
 </div>
@@ -59,10 +53,8 @@ exports[`EuiCodeBlock props fontSize m is rendered 1`] = `
     <code
       class="euiCodeBlock__code"
     >
-      <div>
-        var some = 'code';
+      var some = 'code';
 console.log(some);
-      </div>
     </code>
   </pre>
 </div>
@@ -78,10 +70,8 @@ exports[`EuiCodeBlock props fontSize s is rendered 1`] = `
     <code
       class="euiCodeBlock__code"
     >
-      <div>
-        var some = 'code';
+      var some = 'code';
 console.log(some);
-      </div>
     </code>
   </pre>
 </div>
@@ -97,10 +87,8 @@ exports[`EuiCodeBlock props isCopyable is rendered 1`] = `
     <code
       class="euiCodeBlock__code"
     >
-      <div>
-        var some = 'code';
+      var some = 'code';
 console.log(some);
-      </div>
     </code>
   </pre>
   <div
@@ -144,10 +132,8 @@ exports[`EuiCodeBlock props language is rendered 1`] = `
     <code
       class="euiCodeBlock__code html hljs xml"
     >
-      <div>
-        var some = 'code';
+      var some = 'code';
 console.log(some);
-      </div>
     </code>
   </pre>
 </div>
@@ -165,10 +151,8 @@ exports[`EuiCodeBlock props overflowHeight is rendered 1`] = `
     <code
       class="euiCodeBlock__code"
     >
-      <div>
-        var some = 'code';
+      var some = 'code';
 console.log(some);
-      </div>
     </code>
   </pre>
   <div
@@ -204,10 +188,8 @@ exports[`EuiCodeBlock props paddingSize l is rendered 1`] = `
     <code
       class="euiCodeBlock__code"
     >
-      <div>
-        var some = 'code';
+      var some = 'code';
 console.log(some);
-      </div>
     </code>
   </pre>
 </div>
@@ -223,10 +205,8 @@ exports[`EuiCodeBlock props paddingSize m is rendered 1`] = `
     <code
       class="euiCodeBlock__code"
     >
-      <div>
-        var some = 'code';
+      var some = 'code';
 console.log(some);
-      </div>
     </code>
   </pre>
 </div>
@@ -242,10 +222,8 @@ exports[`EuiCodeBlock props paddingSize none is rendered 1`] = `
     <code
       class="euiCodeBlock__code"
     >
-      <div>
-        var some = 'code';
+      var some = 'code';
 console.log(some);
-      </div>
     </code>
   </pre>
 </div>
@@ -261,10 +239,8 @@ exports[`EuiCodeBlock props paddingSize s is rendered 1`] = `
     <code
       class="euiCodeBlock__code"
     >
-      <div>
-        var some = 'code';
+      var some = 'code';
 console.log(some);
-      </div>
     </code>
   </pre>
 </div>
@@ -280,10 +256,8 @@ exports[`EuiCodeBlock props transparentBackground is rendered 1`] = `
     <code
       class="euiCodeBlock__code"
     >
-      <div>
-        var some = 'code';
+      var some = 'code';
 console.log(some);
-      </div>
     </code>
   </pre>
 </div>
@@ -301,10 +275,8 @@ exports[`EuiCodeBlock renders a code block 1`] = `
       class="euiCodeBlock__code"
       data-test-subj="test subject string"
     >
-      <div>
-        var some = 'code';
+      var some = 'code';
 console.log(some);
-      </div>
     </code>
   </pre>
 </div>

--- a/src/components/code/_code_block.js
+++ b/src/components/code/_code_block.js
@@ -152,7 +152,7 @@ export class EuiCodeBlockImpl extends Component {
     if (inline) {
       return (
         <>
-          {createPortal(<div>{children}</div>, this.codeTarget)}
+          {createPortal(children, this.codeTarget)}
           <span {...wrapperProps}>{codeSnippet}</span>
         </>
       );
@@ -272,7 +272,7 @@ export class EuiCodeBlockImpl extends Component {
 
     return (
       <>
-        {createPortal(<div>{children}</div>, this.codeTarget)}
+        {createPortal(children, this.codeTarget)}
         <EuiInnerText fallback="">
           {(innerTextRef, innerText) => {
             const codeBlockControls = getCodeBlockControls(innerText);


### PR DESCRIPTION
### Summary

Fixes a bug introduced by #2792 which screws up the contents' vertical alignment in at least Firefox. PR removes a wrapping `div` from the rendering output. Tested changes in Chrome, FF, Safari, Edge, IE11, and Chrome for Android

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
