### PR TITLE
Fix dev&docs build issues on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - Exported `EuiSelectOptionProps` type ([#2830](https://github.com/elastic/eui/pull/2830))
 - Added `paperClip` glyph to `EuiIcon` ([#2845](https://github.com/elastic/eui/pull/2845))
 
+**Bug fixes**
+
+- Fixed building dev & docs on Windows ([#2847](https://github.com/elastic/eui/pull/2847))
+
 ## [`19.0.0`](https://github.com/elastic/eui/tree/v19.0.0)
 
 - Added `cheer` glyph to `EuiIcon` ([#2814](https://github.com/elastic/eui/pull/2814))

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   "docker_image": "node:10",
   "sideEffects": false,
   "scripts": {
-    "start": "BABEL_MODULES=false webpack-dev-server --port 8030 --inline --hot --config=src-docs/webpack.config.js",
+    "start": "cross-env BABEL_MODULES=false webpack-dev-server --port 8030 --inline --hot --config=src-docs/webpack.config.js",
     "test-docker": "docker pull $npm_package_docker_image && docker run --rm -i -e GIT_COMMITTER_NAME=test -e GIT_COMMITTER_EMAIL=test --user=$(id -u):$(id -g) -e HOME=/tmp -v $(pwd):/app -w /app $npm_package_docker_image bash -c 'npm config set spin false && /opt/yarn*/bin/yarn && npm run test && npm run build'",
     "sync-docs": "node ./scripts/docs-sync.js",
-    "build-docs": "BABEL_MODULES=false cross-env NODE_ENV=production NODE_OPTIONS=--max-old-space-size=4096 webpack --config=src-docs/webpack.config.js",
+    "build-docs": "cross-env BABEL_MODULES=false cross-env NODE_ENV=production NODE_OPTIONS=--max-old-space-size=4096 webpack --config=src-docs/webpack.config.js",
     "build": "yarn extract-i18n-strings && node ./scripts/compile-clean.js && node ./scripts/compile-eui.js && node ./scripts/compile-scss.js $npm_package_name",
     "compile-icons": "node ./scripts/compile-icons.js && prettier --write --loglevel=warn \"./src/components/icon/assets/**/*.js\"",
     "extract-i18n-strings": "node ./scripts/babel/fetch-i18n-strings",

--- a/src-docs/webpack.config.js
+++ b/src-docs/webpack.config.js
@@ -41,7 +41,7 @@ const webpackConfig = {
       {
         test: /\.(js|tsx?)$/,
         loaders: useCache(['babel-loader']), // eslint-disable-line react-hooks/rules-of-hooks
-        exclude: [/node_modules/, /packages\/react-datepicker/],
+        exclude: [/node_modules/, /packages(\/|\\)react-datepicker/],
       },
       {
         test: /\.scss$/,


### PR DESCRIPTION
### Summary

Fixes two issues with building EUI on Windows:

* two `scripts` in _package.json_ were setting environment keys without `cross-env` (side note: yarn2 polyfills this behaviour, if we go that route)
* regex for excluding `react-datepicker` package from babel processing was only configured for *nix environment

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
- [x] Checked in **IE11** and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
