### PR TITLE
Fix docs support for IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@babel/preset-env": "^7.8.3",
     "@babel/preset-react": "^7.8.3",
     "@babel/preset-typescript": "^7.8.3",
-    "@elastic/charts": "^17.0.2",
+    "@elastic/charts": "^17.0.3",
     "@elastic/datemath": "^5.0.2",
     "@elastic/eslint-config-kibana": "^0.15.0",
     "@svgr/core": "5.0.1",

--- a/src-docs/src/index.js
+++ b/src-docs/src/index.js
@@ -1,3 +1,6 @@
+// specifically polyfill Object.entries for IE11 support (used by @elastic/charts)
+import 'core-js/modules/es7.object.entries';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';

--- a/src-docs/src/views/elastic_charts/shared.js
+++ b/src-docs/src/views/elastic_charts/shared.js
@@ -11,6 +11,11 @@ import {
 } from '../../../../src/components';
 import { find } from 'lodash';
 import { BarSeries, LineSeries, AreaSeries } from '@elastic/charts';
+import { devDependencies } from '../../../../package';
+
+const chartsVersion = devDependencies['@elastic/charts'].match(
+  /\d+\.\d+\.\d+/
+)[0];
 
 export const CHART_COMPONENTS = {
   BarSeries: BarSeries,
@@ -25,9 +30,11 @@ export const ExternalBadge = () => {
       iconSide="right"
       onClickAriaLabel="Go to elastic-charts docs"
       onClick={() =>
-        window.open('https://github.com/elastic/elastic-charts/tree/v17.0.2')
+        window.open(
+          `https://github.com/elastic/elastic-charts/tree/v${chartsVersion}`
+        )
       }>
-      External library: elastic-charts v17.0.2
+      External library: elastic-charts v{chartsVersion}
     </EuiBadge>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -986,10 +986,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@elastic/charts@^17.0.2":
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-17.0.2.tgz#0bd2cb7b78bd60255eed2a9b0ce5049a62dc5d8a"
-  integrity sha512-hz31Yma/HSdu9tRS/05xNXY+YuaHOadD9Gd+eh7ankNlJJOFI4IRV6F8BMnloeWYedNXBSTp4susFLwJNQQ+0w==
+"@elastic/charts@^17.0.3":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-17.0.3.tgz#4117e18f572b751519a07d3ddfc0763e46f50e95"
+  integrity sha512-rrVSovjvEMh4hkg8pDgNRR493feokSInk0JfErDgCnf3kCZS7wpMh0xGvFYXmIECEiNxtayEkTmuaDBO8R114Q==
   dependencies:
     "@types/d3-shape" "^1.3.1"
     classnames "^2.2.6"
@@ -998,7 +998,6 @@
     d3-color "^1.4.0"
     d3-scale "^1.0.7"
     d3-shape "^1.3.4"
-    fast-deep-equal "^3.1.1"
     konva "^4.0.18"
     newtype-ts "^0.2.4"
     prop-types "^15.7.2"
@@ -5798,11 +5797,6 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
-
-fast-deep-equal@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
-  integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
 
 fast-diff@^1.1.2:
   version "1.2.0"


### PR DESCRIPTION
### Summary

Fixes for the docs + IE11:

* `@elastic/charts` fixed their IE11 support in v17.0.3
* `Object.keys` requires a polyfill for `@elastic/charts`
* Made the docs' mention of the `@elastic/charts` version dynamically read from _package.json_

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
- [x] Checked in **IE11** and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
