### PR TITLE
Fix Props tab & PropTypes for components with PropsForAnchor, PropsForButton

### DIFF
--- a/scripts/babel/proptypes-from-ts-props/index.js
+++ b/scripts/babel/proptypes-from-ts-props/index.js
@@ -220,6 +220,20 @@ function resolveIdentifierToPropTypes(node, state) {
     return buildPropTypePrimitiveExpression(types, 'func');
   if (identifier.name === 'Function')
     return buildPropTypePrimitiveExpression(types, 'func');
+  if (
+    (identifier.name === 'PropsForAnchor' ||
+      identifier.name === 'PropsForButton') &&
+    node.typeParameters != null
+  ) {
+    return getPropTypesForNode(
+      {
+        type: 'TSIntersectionType',
+        types: node.typeParameters.params,
+      },
+      true,
+      state
+    );
+  }
   if (identifier.name === 'ExclusiveUnion') {
     // We use ExclusiveUnion at the top level to exclusively discriminate between types
     // propTypes itself must be an object so merge the union sets together as an intersection

--- a/scripts/babel/proptypes-from-ts-props/index.test.js
+++ b/scripts/babel/proptypes-from-ts-props/index.test.js
@@ -1153,6 +1153,36 @@ FooComponent.propTypes = {
 };`);
       });
 
+      it('parses PropsForAnchor and PropsForButton arguments', () => {
+        const result = transform(
+          `
+import React from 'react';
+interface PropsA { a: boolean }
+interface PropsB { b?: number }
+interface PropsC { c: string }
+interface PropsD { d?: null }
+type Props = PropsForAnchor<PropsA, PropsB> & PropsForButton<PropsC, PropsD>
+const FooComponent: React.SFC<Props> = () => {
+  return (<div>Hello World</div>);
+}`,
+          babelOptions
+        );
+
+        expect(result.code).toBe(`import React from 'react';
+import PropTypes from "prop-types";
+
+const FooComponent = () => {
+  return <div>Hello World</div>;
+};
+
+FooComponent.propTypes = {
+  a: PropTypes.bool.isRequired,
+  b: PropTypes.number,
+  c: PropTypes.string.isRequired,
+  d: PropTypes.oneOf([null])
+};`);
+      });
+
       it('intersects overlapping string enums in ExclusiveUnion', () => {
         const result = transform(
           `

--- a/scripts/babel/proptypes-from-ts-props/index.test.js
+++ b/scripts/babel/proptypes-from-ts-props/index.test.js
@@ -1176,6 +1176,8 @@ const FooComponent = () => {
 };
 
 FooComponent.propTypes = {
+  href: PropTypes.string,
+  onClick: PropTypes.func,
   a: PropTypes.bool.isRequired,
   b: PropTypes.number,
   c: PropTypes.string.isRequired,

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -66,7 +66,13 @@ export interface EuiButtonProps extends CommonProps {
   isLoading?: boolean;
   isDisabled?: boolean;
   fullWidth?: boolean;
+  /**
+   * Object of props passed to the <span/> wrapping the button's content
+   */
   contentProps?: HTMLAttributes<HTMLSpanElement>;
+  /**
+   * Object of props passed to the <span/> wrapping the component's {children}
+   */
   textProps?: HTMLAttributes<HTMLSpanElement>;
 }
 


### PR DESCRIPTION
## Summary

Supersedes #2715 

Added support for `PropsForAnchor` and `PropsForButton` to the typescript->proptype generator. Previously, any component props defined with these utility types were dropped.

Testing this PR: you'll need to delete the `.cache-loader` directory before starting the dev server

## EuiButton
### Previously
![EuiButton props, previously](https://d.pr/i/OnkXRQ.png)
### Now
![EuiButton props, now](https://d.pr/i/EUdX0v.png)

## EuiButtonEmpty
### Previously
![EuiButtonEmpty props, previously](https://d.pr/i/f3MfgZ.png)
### Now
![EuiButtonEmpty props, now](https://d.pr/i/oUyXr2.png)

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
- [x] Props have proper **autodocs**
~- [ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
