### PR TITLE
Refactor renderToHtml to use client-side React for rendering

### DIFF
--- a/src-docs/src/services/string/render_to_html.js
+++ b/src-docs/src/services/string/render_to_html.js
@@ -1,31 +1,30 @@
 import React from 'react';
-
-import { render, configure } from 'enzyme';
-
-import EnzymeAdapter from 'enzyme-adapter-react-16';
+import ReactDOM from 'react-dom';
 
 import html from 'html';
 
-configure({ adapter: new EnzymeAdapter() });
-
+const renderTarget = document.createElement('div');
 export function renderToHtml(ComponentReference, props = {}) {
   // If there's a failure, just return an empty string. The actual component itself should
   // trip an error boundary in the UI when it fails.
   try {
     // Create the React element, render it and get its HTML, then format it prettily.
     // the .html() call below renders the contents of the first node, so wrap everything in a div
-    const element = (
-      <div>
-        <ComponentReference {...props} />
-      </div>
-    );
-    const renderedNodes = render(element);
+    const element = <ComponentReference {...props} />;
 
-    const htmlString = renderedNodes.html();
-    return html.prettyPrint(htmlString, {
-      indent_size: 2,
-      unformatted: [], // Expand all tags, including spans
-    });
+    return {
+      render() {
+        ReactDOM.render(element, renderTarget);
+        const htmlString = renderTarget.innerHTML;
+        const result = htmlString;
+        ReactDOM.unmountComponentAtNode(renderTarget);
+
+        return html.prettyPrint(result, {
+          indent_size: 2,
+          unformatted: [], // Expand all tags, including spans
+        });
+      },
+    };
   } catch (e) {
     return '';
   }


### PR DESCRIPTION
### Summary

Fixes #2859 

While we should still seek a build-time solution for the HTML tab, this PR modifies `renderToHtml` to return a render method which is called when switching the tabs. The modified flow means:

* the docs now load ~2 seconds faster (in dev)
* small delay when opening an _Demo HTML_ tab, not noticeable for small components
* more _Demo HTML_ tabs work (e.g. data grid)

My first pass used this new render workflow at docs startup, as the old approach did. However, that added 3-4 seconds to startup time so I opted for this complete refactor.

/cc @markov00 

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
- [x] Checked in **IE11** and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
