### PR TITLE
Disable new Jenkins multijob

### DIFF
--- a/.ci/jobs/elastic+eui+pull-request.yml
+++ b/.ci/jobs/elastic+eui+pull-request.yml
@@ -3,6 +3,7 @@
     name: elastic+eui+pull-request
     display-name: "elastic / eui # pull-request"
     description: Jobs to run on EUI pull requests
+    disabled: true
     project-type: multijob
     concurrent: true
     node: master


### PR DESCRIPTION
### Summary

Temporarily disabling the new CI multijob that runs tests and builds a docs preview.