### PR TITLE
Fix multijob

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -28,7 +28,6 @@
           branches:
             - ${ghprbActualCommit}
           url: git@github.com:elastic/eui.git
-          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
           basedir: ''
           wipe-workspace: 'True'
     parameters:

--- a/.ci/jobs/elastic+eui+deploy-docs.yml
+++ b/.ci/jobs/elastic+eui+deploy-docs.yml
@@ -9,6 +9,10 @@
           branches:
             - $branch_specifier
           url: git@github.com:elastic/eui.git
+          # refspec appears to support space-delimited rules for applying
+          # multiple sets of rules. this refspec is so that this job can be run
+          # on PRs, but also ad-hoc for any tag or commit.
+          refspec: +refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*
           reference-repo: /var/lib/jenkins/.git-references/eui.git
     triggers: []
     vault:

--- a/.ci/jobs/elastic+eui+pull-request-test.yml
+++ b/.ci/jobs/elastic+eui+pull-request-test.yml
@@ -3,6 +3,9 @@
     name: elastic+eui+pull-request-test
     display-name: 'elastic / eui # pull request test'
     description: Testing of eui pull requests.
+    scm:
+      - git:
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
     builders:
       - shell: |-
           #!/usr/local/bin/runbld

--- a/.ci/jobs/elastic+eui+pull-request.yml
+++ b/.ci/jobs/elastic+eui+pull-request.yml
@@ -3,7 +3,6 @@
     name: elastic+eui+pull-request
     display-name: "elastic / eui # pull-request"
     description: Jobs to run on EUI pull requests
-    disabled: true
     project-type: multijob
     concurrent: true
     node: master

--- a/.ci/jobs/elastic-eui-pull-request.yml
+++ b/.ci/jobs/elastic-eui-pull-request.yml
@@ -11,6 +11,7 @@
           github-hooks: true
           status-context: eui-ci
           cancel-builds-on-update: true
+          refspec: +refs/pull/*:refs/remotes/origin/pr/*
     builders:
       - shell: |-
           #!/usr/local/bin/runbld


### PR DESCRIPTION
### Summary

Adds refspec rules to ensure PR jobs can pick up commits in unmerged PR branches. Also reenables the multijob that caused some issues earlier.