### PR TITLE
Fix pr multijob errors

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -28,6 +28,7 @@
           branches:
             - ${ghprbActualCommit}
           url: git@github.com:elastic/eui.git
+          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*
           basedir: ''
           wipe-workspace: 'True'
     parameters:

--- a/.ci/jobs/elastic+eui+deploy-docs.yml
+++ b/.ci/jobs/elastic+eui+deploy-docs.yml
@@ -5,15 +5,12 @@
     description: Build EUI documentation HTML and deploy to Elastic Bekitzur
     scm:
       - git:
-          clone: true
           branches:
             - $branch_specifier
-          url: git@github.com:elastic/eui.git
           # refspec appears to support space-delimited rules for applying
           # multiple sets of rules. this refspec is so that this job can be run
           # on PRs, but also ad-hoc for any tag or commit.
-          refspec: +refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*
-          reference-repo: /var/lib/jenkins/.git-references/eui.git
+          refspec: +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/* +refs/heads/*:refs/remotes/origin/*
     triggers: []
     vault:
       # auth/approle/role/kibana-issues/role-id

--- a/.ci/jobs/elastic+eui+deploy-docs.yml
+++ b/.ci/jobs/elastic+eui+deploy-docs.yml
@@ -21,7 +21,7 @@
           set -e
           set +x
           export GPROJECT=elastic-bekitzur
-          VAULT_ACCOUNT=secret/gce/$GPROJECT/service-account/jenkins
+          VAULT_ACCOUNT=secret/gce/$GPROJECT/service-account/kibana
           export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
           export GCE_ACCOUNT=$(vault read -field=value $VAULT_ACCOUNT)
           export GITHUB_TOKEN=$(vault read -field=github_token secret/kibana-issues/dev/kibanamachine)

--- a/.ci/jobs/elastic+eui+pull-request.yml
+++ b/.ci/jobs/elastic+eui+pull-request.yml
@@ -6,11 +6,6 @@
     project-type: multijob
     concurrent: true
     node: master
-    scm:
-      - git:
-          branches:
-            - ${ghprbActualCommit}
-          refspec: +refs/pull/*:refs/remotes/origin/pr/*
     triggers:
       - github-pull-request:
           org-list:

--- a/.ci/jobs/elastic-eui-pull-request.yml
+++ b/.ci/jobs/elastic-eui-pull-request.yml
@@ -11,7 +11,6 @@
           github-hooks: true
           status-context: eui-ci
           cancel-builds-on-update: true
-          refspec: +refs/pull/*:refs/remotes/origin/pr/*
     builders:
       - shell: |-
           #!/usr/local/bin/runbld


### PR DESCRIPTION
### Summary

Adjusts faulty `refspec` config, switches the docs build to use a new GCE service account's credentials.
