### PR TITLE
Run sub-jobs in parallel as they're mostly unrelated

### DIFF
--- a/.ci/jobs/elastic+eui+pull-request.yml
+++ b/.ci/jobs/elastic+eui+pull-request.yml
@@ -18,7 +18,6 @@
     builders:
       - multijob:
           name: run child jobs
-          execution-type: SEQUENTIALLY
           projects:
             - name: elastic+eui+pull-request-test
               predefined-parameters: branch_specifier=${ghprbActualCommit}


### PR DESCRIPTION
### Summary

Originally @nyurik [suggested that we run these jobs sequentially](https://github.com/elastic/eui/pull/2852#pullrequestreview-357929984), but in practice the test job is pretty slow (15+ minutes). Parallelizing the jobs will make sure the PR gets a passing or failing build report more quickly. There are many cases where tests could fail but the docs would still build, and it might actually be useful to have a copy of the docs built even if tests fail so the bad code can be tested in a PR-specific sandbox.

So, let's parallelize it.