### PR TITLE
Disable legacy PR test job

### DIFF
--- a/.ci/jobs/elastic-eui-pull-request.yml
+++ b/.ci/jobs/elastic-eui-pull-request.yml
@@ -3,6 +3,7 @@
     name: elastic-eui-pull-request
     display-name: 'elastic / eui # pull-request'
     description: Testing of eui pull requests.
+    disabled: true
     triggers:
       - github-pull-request:
           org-list:


### PR DESCRIPTION
### Summary

Disables the old PR test job now that the new one is running.
