### PR TITLE
Fix typos in urls in datagrid docs

### DIFF
--- a/src-docs/src/views/datagrid/datagrid_example.js
+++ b/src-docs/src/views/datagrid/datagrid_example.js
@@ -316,18 +316,20 @@ export const DataGridExample = {
             <li>
               Unlike tables, the data grid <strong>forces truncation</strong>.
               To display more content your can customize{' '}
-              <Link to="/tabular-content/data-grid-schemas-and-popvers/">
+              <Link to="/tabular-content/data-grid-schemas-and-popovers/">
                 popovers
               </Link>{' '}
               to display more content and actions into popovers.
             </li>
             <li>
-              <Link to="/tabular-content/data-grid-styling/">Grid styling</Link>{' '}
+              <Link to="/tabular-content/data-grid-styling-and-toolbar/">
+                Grid styling
+              </Link>{' '}
               can be controlled by the engineer, but augmented by user
               preference depending upon the features you enable.
             </li>
             <li>
-              <Link to="/tabular-content/data-grid-control-collumns/">
+              <Link to="/tabular-content/data-grid-control-columns/">
                 Control columns
               </Link>{' '}
               allow you to add repeatable actions and controls like checkboxes


### PR DESCRIPTION
### Summary

Fixes 3 typos in URLs crosslinking between data grid docs

### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **IE11** and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **documentation** examples~
- ~[ ] Added or updated **jest tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
