### PR TITLE
Fix closing of relative time dropdown in super timepicker for Firefox Browser

### DIFF
--- a/src/components/tool_tip/tool_tip_popover.tsx
+++ b/src/components/tool_tip/tool_tip_popover.tsx
@@ -30,14 +30,11 @@ export class EuiToolTipPopover extends Component<Props> {
   };
 
   componentDidMount() {
-    document.body.classList.add('euiBody-hasPortalContent');
-
     this.updateDimensions();
     window.addEventListener('resize', this.updateDimensions);
   }
 
   componentWillUnmount() {
-    document.body.classList.remove('euiBody-hasPortalContent');
     window.removeEventListener('resize', this.updateDimensions);
   }
 


### PR DESCRIPTION
Fixes: #1708

### Summary

On Firefox browser, the relative timepicker dropdown closes as soon as tooltip disappears making it difficult for a user to select an option from dropdown.

This PR fixes the issue by removing the class `euiBody-hasPortalContent` from the `tool_tip_popover.tsx` which adds a `position: relative` to the component.

![eui](https://user-images.githubusercontent.com/21174572/75088462-682e4f00-5588-11ea-85ee-3dbb2a063798.gif)

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
