### PR TITLE
Fixes: #2851 : unnecessary pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Improved `EuiPagination` so that it does not appear unnecessarily ([#2905](https://github.com/elastic/eui/pull/2905/files))
 - Converted `EuiCodeEditor` to Typescript ([#2836](https://github.com/elastic/eui/pull/2836))
 - Converted `EuiCode` and `EuiCodeBlock` and to Typescript ([#2835](https://github.com/elastic/eui/pull/2835))
 - Converted `EuiFilePicker` to TypeScript ([#2832](https://github.com/elastic/eui/issues/2832))
@@ -2819,4 +2820,3 @@ instead of just string ([#516](https://github.com/elastic/eui/pull/516))
 ## [`0.0.1`](https://github.com/elastic/eui/tree/v0.0.1) Initial Release
 
 - Initial public release
-- Improved `EuiPagination` so that it does not appear unnecessarily ([pr](link))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2819,3 +2819,4 @@ instead of just string ([#516](https://github.com/elastic/eui/pull/516))
 ## [`0.0.1`](https://github.com/elastic/eui/tree/v0.0.1) Initial Release
 
 - Initial public release
+- Improved `EuiPagination` so that it does not appear unnecessarily ([pr](link))

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -223,13 +223,23 @@ export const EuiPagination: FunctionComponent<Props> = ({
     );
   }
 
+  if (pages.length > 1) {
+    return (
+      <div className={classes} role="group" {...rest}>
+        {previousButton}
+        {firstPageButtons}
+        {selectablePages}
+        {lastPageButtons}
+        {nextButton}
+      </div>
+    );
+  }
+
   return (
     <div className={classes} role="group" {...rest}>
-      {previousButton}
       {firstPageButtons}
       {selectablePages}
       {lastPageButtons}
-      {nextButton}
     </div>
   );
 };


### PR DESCRIPTION
### Summary

Improved `EuiPagination` so that it does not appear unnecessarily 
Fixes: #2851

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
