### PR TITLE
converted time_units to typescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Converted `time_units` to TypeScript ([#2838](https://github.com/elastic/eui/pull/2838))
+- Converted `time_units` to TypeScript ([#2920](https://github.com/elastic/eui/pull/2920))
 - Converted `EuiComboBox`, `EuiComboBoxInput`, `EuiComboBoxPill`, `EuiComboBoxOptionsList`, `EuiComboBoxOption`, and `EuiComboBoxTitle` to TypeScript ([#2838](https://github.com/elastic/eui/pull/2838))
 - Converted `EuiCodeEditor` to TypeScript ([#2836](https://github.com/elastic/eui/pull/2836))
 - Converted `EuiCode` and `EuiCodeBlock` and to TypeScript ([#2835](https://github.com/elastic/eui/pull/2835))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Converted `time_units` to TypeScript ([#2838](https://github.com/elastic/eui/pull/2838))
 - Converted `EuiComboBox`, `EuiComboBoxInput`, `EuiComboBoxPill`, `EuiComboBoxOptionsList`, `EuiComboBoxOption`, and `EuiComboBoxTitle` to TypeScript ([#2838](https://github.com/elastic/eui/pull/2838))
 - Converted `EuiCodeEditor` to TypeScript ([#2836](https://github.com/elastic/eui/pull/2836))
 - Converted `EuiCode` and `EuiCodeBlock` and to TypeScript ([#2835](https://github.com/elastic/eui/pull/2835))

--- a/src/components/date_picker/super_date_picker/time_units.ts
+++ b/src/components/date_picker/super_date_picker/time_units.ts
@@ -1,4 +1,14 @@
-export const timeUnits = {
+interface TimeUnits {
+  s: string;
+  m: string;
+  h: string;
+  d: string;
+  w: string;
+  M: string;
+  y: string;
+}
+
+export const timeUnits: TimeUnits = {
   s: 'second',
   m: 'minute',
   h: 'hour',
@@ -8,7 +18,7 @@ export const timeUnits = {
   y: 'year',
 };
 
-export const timeUnitsPlural = {
+export const timeUnitsPlural: TimeUnits = {
   s: 'seconds',
   m: 'minutes',
   h: 'hours',


### PR DESCRIPTION
### Summary

converted time_units to typescript , added interface for TimeUnits

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
