### PR TITLE
Fixes : #2925  Now euiTitle renders classes of children too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 **Bug fixes**
 
-- Fixed `euiTitle` not rendering child classes ([#2926](https://github.com/elastic/eui/pull/2926))
+- Fixed `EuiTitle` not rendering child classes ([#2926](https://github.com/elastic/eui/pull/2926))
 - Fixed building dev & docs on Windows ([#2847](https://github.com/elastic/eui/pull/2847))
 - Fixed screen reader discovery issues with `EuiBottomBar` and `EuiControlBar` ([#2861](https://github.com/elastic/eui/pull/2861))
 - Fixed a bug in `EuiDataGrid` causing the first cell to autofocus if interactive ([#2872](https://github.com/elastic/eui/pull/2872))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 **Bug fixes**
 
+- Fixed `euiTitle` not rendering child classes ([#2926](https://github.com/elastic/eui/pull/2926))
 - Fixed building dev & docs on Windows ([#2847](https://github.com/elastic/eui/pull/2847))
 - Fixed screen reader discovery issues with `EuiBottomBar` and `EuiControlBar` ([#2861](https://github.com/elastic/eui/pull/2861))
 - Fixed a bug in `EuiDataGrid` causing the first cell to autofocus if interactive ([#2872](https://github.com/elastic/eui/pull/2872))

--- a/src/components/title/__snapshots__/title.test.tsx.snap
+++ b/src/components/title/__snapshots__/title.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`EuiTitle is rendered 1`] = `
 </h1>
 `;
 
-exports[`EuiTitle rendereds class of child too 1`] = `
+exports[`EuiTitle renders children element className 1`] = `
 <h1
   aria-label="aria-label"
   class="euiTitle euiTitle--medium testClass1 testClass2 test"

--- a/src/components/title/__snapshots__/title.test.tsx.snap
+++ b/src/components/title/__snapshots__/title.test.tsx.snap
@@ -9,3 +9,13 @@ exports[`EuiTitle is rendered 1`] = `
   Title
 </h1>
 `;
+
+exports[`EuiTitle rendereds class of child too 1`] = `
+<h1
+  aria-label="aria-label"
+  class="euiTitle euiTitle--medium testClass1 testClass2 test"
+  data-test-subj="test subject string"
+>
+  Title
+</h1>
+`;

--- a/src/components/title/title.test.tsx
+++ b/src/components/title/title.test.tsx
@@ -14,4 +14,14 @@ describe('EuiTitle', () => {
 
     expect(component).toMatchSnapshot();
   });
+
+  test('rendereds class of child too', () => {
+    const component = render(
+      <EuiTitle {...requiredProps}>
+        <h1 className="test">Title</h1>
+      </EuiTitle>
+    );
+
+    expect(component).toMatchSnapshot();
+  });
 });

--- a/src/components/title/title.test.tsx
+++ b/src/components/title/title.test.tsx
@@ -15,7 +15,7 @@ describe('EuiTitle', () => {
     expect(component).toMatchSnapshot();
   });
 
-  test('rendereds class of child too', () => {
+  test('renders children element className', () => {
     const component = render(
       <EuiTitle {...requiredProps}>
         <h1 className="test">Title</h1>

--- a/src/components/title/title.tsx
+++ b/src/components/title/title.tsx
@@ -39,7 +39,8 @@ export const EuiTitle: FunctionComponent<EuiTitleProps> = ({
     'euiTitle',
     titleSizeToClassNameMap[size],
     textTransform ? textTransformToClassNameMap[textTransform] : undefined,
-    className
+    className,
+    children.props.className
   );
 
   const props = {


### PR DESCRIPTION
### Summary

Fixes : #2925 
Now euiTitle renders classNames of children too

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
