### PR TITLE
Data grid header now fixed on scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@
 - Updated SASS mixin `makeHighContrastColor()` to default `$background: $euiPageBackgroundColor` and `$ratio: 4.5`. Created `makeGraphicContrastColor()` for graphic specific contrast levels of 3.0. ([#2873](https://github.com/elastic/eui/pull/2873))
 - Added `folderCheck`, `folderExclamation`, `push`, `quote`, `reporter` and `users` icons ([#2935](https://github.com/elastic/eui/pull/2935))
 - Updated `folderClosed` and `folderOpen` to match new additions and sit better on the pixel grid ([#2935](https://github.com/elastic/eui/pull/2935))
+- Adjusted the header on `EuiDataGrid` to fix within constrained containers and full screen mode  ([#2938](https://github.com/elastic/eui/pull/2938))
 
 **Bug fixes**
 
 - Fixed `EuiTitle` not rendering child classes ([#2926](https://github.com/elastic/eui/pull/2926))
+- Fixed z-index conflict with cell popovers in `EuiDataGrid` while in full screen mode ([#2938](https://github.com/elastic/eui/pull/2938))
 
 **Theme: Amsterdam**
 

--- a/src-docs/src/views/datagrid/datagrid.js
+++ b/src-docs/src/views/datagrid/datagrid.js
@@ -26,7 +26,7 @@ const columns = [
     id: 'email',
     display: (
       // This is an example of an icon next to a title that still respects text truncate
-      <EuiFlexGroup gutterSize="xs">
+      <EuiFlexGroup gutterSize="xs" responsive={false}>
         <EuiFlexItem className="eui-textTruncate">
           <div className="eui-textTruncate">email</div>
         </EuiFlexItem>

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -253,6 +253,36 @@ Array [
         </button>
       </div>
       <div
+        class="euiDataGridHeader"
+        data-test-subj="dataGridHeader"
+        role="row"
+      >
+        <div
+          class="euiDataGridHeaderCell"
+          data-test-subj="dataGridHeaderCell-A"
+          role="columnheader"
+          tabindex="-1"
+        >
+          <div
+            class="euiDataGridHeaderCell__content"
+          >
+            A
+          </div>
+        </div>
+        <div
+          class="euiDataGridHeaderCell"
+          data-test-subj="dataGridHeaderCell-B"
+          role="columnheader"
+          tabindex="-1"
+        >
+          <div
+            class="euiDataGridHeaderCell__content"
+          >
+            B
+          </div>
+        </div>
+      </div>
+      <div
         class="euiDataGrid__verticalScroll"
         data-test-subj="test subject string"
       >
@@ -264,36 +294,6 @@ Array [
             class="euiDataGrid__content"
             role="grid"
           >
-            <div
-              class="euiDataGridHeader"
-              data-test-subj="dataGridHeader"
-              role="row"
-            >
-              <div
-                class="euiDataGridHeaderCell"
-                data-test-subj="dataGridHeaderCell-A"
-                role="columnheader"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridHeaderCell__content"
-                >
-                  A
-                </div>
-              </div>
-              <div
-                class="euiDataGridHeaderCell"
-                data-test-subj="dataGridHeaderCell-B"
-                role="columnheader"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridHeaderCell__content"
-                >
-                  B
-                </div>
-              </div>
-            </div>
             <div
               class="euiDataGridRow"
               data-test-subj="dataGridRow"
@@ -775,6 +775,66 @@ Array [
         </button>
       </div>
       <div
+        class="euiDataGridHeader"
+        data-test-subj="dataGridHeader"
+        role="row"
+      >
+        <div
+          class="euiDataGridHeaderCell euiDataGridHeaderCell--controlColumn"
+          data-test-subj="dataGridHeaderCell-leading"
+          role="columnheader"
+          style="width:50px"
+          tabindex="-1"
+        >
+          <div
+            class="euiDataGridHeaderCell__content"
+          >
+            <span>
+              leading heading
+            </span>
+          </div>
+        </div>
+        <div
+          class="euiDataGridHeaderCell"
+          data-test-subj="dataGridHeaderCell-A"
+          role="columnheader"
+          tabindex="-1"
+        >
+          <div
+            class="euiDataGridHeaderCell__content"
+          >
+            A
+          </div>
+        </div>
+        <div
+          class="euiDataGridHeaderCell"
+          data-test-subj="dataGridHeaderCell-B"
+          role="columnheader"
+          tabindex="-1"
+        >
+          <div
+            class="euiDataGridHeaderCell__content"
+          >
+            B
+          </div>
+        </div>
+        <div
+          class="euiDataGridHeaderCell euiDataGridHeaderCell--controlColumn"
+          data-test-subj="dataGridHeaderCell-trailing"
+          role="columnheader"
+          style="width:50px"
+          tabindex="-1"
+        >
+          <div
+            class="euiDataGridHeaderCell__content"
+          >
+            <span>
+              trailing heading
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
         class="euiDataGrid__verticalScroll"
         data-test-subj="test subject string"
       >
@@ -786,66 +846,6 @@ Array [
             class="euiDataGrid__content"
             role="grid"
           >
-            <div
-              class="euiDataGridHeader"
-              data-test-subj="dataGridHeader"
-              role="row"
-            >
-              <div
-                class="euiDataGridHeaderCell euiDataGridHeaderCell--controlColumn"
-                data-test-subj="dataGridHeaderCell-leading"
-                role="columnheader"
-                style="width:50px"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridHeaderCell__content"
-                >
-                  <span>
-                    leading heading
-                  </span>
-                </div>
-              </div>
-              <div
-                class="euiDataGridHeaderCell"
-                data-test-subj="dataGridHeaderCell-A"
-                role="columnheader"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridHeaderCell__content"
-                >
-                  A
-                </div>
-              </div>
-              <div
-                class="euiDataGridHeaderCell"
-                data-test-subj="dataGridHeaderCell-B"
-                role="columnheader"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridHeaderCell__content"
-                >
-                  B
-                </div>
-              </div>
-              <div
-                class="euiDataGridHeaderCell euiDataGridHeaderCell--controlColumn"
-                data-test-subj="dataGridHeaderCell-trailing"
-                role="columnheader"
-                style="width:50px"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridHeaderCell__content"
-                >
-                  <span>
-                    trailing heading
-                  </span>
-                </div>
-              </div>
-            </div>
             <div
               class="euiDataGridRow"
               data-test-subj="dataGridRow"
@@ -1492,6 +1492,38 @@ Array [
         </button>
       </div>
       <div
+        class="euiDataGridHeader"
+        data-test-subj="dataGridHeader"
+        role="row"
+      >
+        <div
+          class="euiDataGridHeaderCell"
+          data-test-subj="dataGridHeaderCell-A"
+          role="columnheader"
+          tabindex="-1"
+        >
+          <div
+            class="euiDataGridHeaderCell__content"
+          >
+            Column A
+          </div>
+        </div>
+        <div
+          class="euiDataGridHeaderCell"
+          data-test-subj="dataGridHeaderCell-B"
+          role="columnheader"
+          tabindex="-1"
+        >
+          <div
+            class="euiDataGridHeaderCell__content"
+          >
+            <div>
+              More Elements
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
         class="euiDataGrid__verticalScroll"
         data-test-subj="test subject string"
       >
@@ -1503,38 +1535,6 @@ Array [
             class="euiDataGrid__content"
             role="grid"
           >
-            <div
-              class="euiDataGridHeader"
-              data-test-subj="dataGridHeader"
-              role="row"
-            >
-              <div
-                class="euiDataGridHeaderCell"
-                data-test-subj="dataGridHeaderCell-A"
-                role="columnheader"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridHeaderCell__content"
-                >
-                  Column A
-                </div>
-              </div>
-              <div
-                class="euiDataGridHeaderCell"
-                data-test-subj="dataGridHeaderCell-B"
-                role="columnheader"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridHeaderCell__content"
-                >
-                  <div>
-                    More Elements
-                  </div>
-                </div>
-              </div>
-            </div>
             <div
               class="euiDataGridRow"
               data-test-subj="dataGridRow"
@@ -2013,6 +2013,36 @@ Array [
         </button>
       </div>
       <div
+        class="euiDataGridHeader"
+        data-test-subj="dataGridHeader"
+        role="row"
+      >
+        <div
+          class="euiDataGridHeaderCell"
+          data-test-subj="dataGridHeaderCell-A"
+          role="columnheader"
+          tabindex="-1"
+        >
+          <div
+            class="euiDataGridHeaderCell__content"
+          >
+            A
+          </div>
+        </div>
+        <div
+          class="euiDataGridHeaderCell"
+          data-test-subj="dataGridHeaderCell-B"
+          role="columnheader"
+          tabindex="-1"
+        >
+          <div
+            class="euiDataGridHeaderCell__content"
+          >
+            B
+          </div>
+        </div>
+      </div>
+      <div
         class="euiDataGrid__verticalScroll"
         data-test-subj="test subject string"
       >
@@ -2024,36 +2054,6 @@ Array [
             class="euiDataGrid__content"
             role="grid"
           >
-            <div
-              class="euiDataGridHeader"
-              data-test-subj="dataGridHeader"
-              role="row"
-            >
-              <div
-                class="euiDataGridHeaderCell"
-                data-test-subj="dataGridHeaderCell-A"
-                role="columnheader"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridHeaderCell__content"
-                >
-                  A
-                </div>
-              </div>
-              <div
-                class="euiDataGridHeaderCell"
-                data-test-subj="dataGridHeaderCell-B"
-                role="columnheader"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridHeaderCell__content"
-                >
-                  B
-                </div>
-              </div>
-            </div>
             <div
               class="euiDataGridRow"
               data-test-subj="dataGridRow"

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -253,102 +253,162 @@ Array [
         </button>
       </div>
       <div
-        class="euiDataGridHeader"
-        data-test-subj="dataGridHeader"
-        role="row"
+        class="euiDataGrid__keyWrap"
       >
         <div
-          class="euiDataGridHeaderCell"
-          data-test-subj="dataGridHeaderCell-A"
-          role="columnheader"
-          tabindex="-1"
+          class="euiDataGridHeader"
+          data-test-subj="dataGridHeader"
+          role="row"
         >
           <div
-            class="euiDataGridHeaderCell__content"
+            class="euiDataGridHeaderCell"
+            data-test-subj="dataGridHeaderCell-A"
+            role="columnheader"
+            tabindex="-1"
           >
-            A
+            <div
+              class="euiDataGridHeaderCell__content"
+            >
+              A
+            </div>
+          </div>
+          <div
+            class="euiDataGridHeaderCell"
+            data-test-subj="dataGridHeaderCell-B"
+            role="columnheader"
+            tabindex="-1"
+          >
+            <div
+              class="euiDataGridHeaderCell__content"
+            >
+              B
+            </div>
           </div>
         </div>
         <div
-          class="euiDataGridHeaderCell"
-          data-test-subj="dataGridHeaderCell-B"
-          role="columnheader"
-          tabindex="-1"
+          class="euiDataGrid__verticalScroll"
+          data-test-subj="test subject string"
         >
           <div
-            class="euiDataGridHeaderCell__content"
-          >
-            B
-          </div>
-        </div>
-      </div>
-      <div
-        class="euiDataGrid__verticalScroll"
-        data-test-subj="test subject string"
-      >
-        <div
-          class="euiDataGrid__overflow"
-        >
-          <div
-            aria-label="aria-label"
-            class="euiDataGrid__content"
-            role="grid"
+            class="euiDataGrid__overflow"
           >
             <div
-              class="euiDataGridRow"
-              data-test-subj="dataGridRow"
-              role="row"
+              aria-label="aria-label"
+              class="euiDataGrid__content"
+              role="grid"
             >
               <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
+                class="euiDataGridRow"
+                data-test-subj="dataGridRow"
+                role="row"
               >
                 <div
-                  class="euiDataGridRowCell__content"
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    class="euiDataGridRowCell__content"
                   >
                     <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
                     >
                       <div
-                        class="euiDataGridRowCell__expandFlex"
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
                       >
                         <div
-                          class="euiDataGridRowCell__expandContent"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 1, Column: 1:
-                            </span>
-                          </p>
                           <div
-                            class="euiDataGridRowCell__truncate"
+                            class="euiDataGridRowCell__expandContent"
                           >
-                            0, A
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 1, Column: 1:
+                              </span>
+                            </p>
+                            <div
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              0, A
+                            </div>
+                          </div>
+                          <div
+                            class="euiDataGridRowCell__expandButton"
+                          >
+                            <button
+                              aria-hidden="true"
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
                           </div>
                         </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  <div
+                    class="euiDataGridRowCell__content"
+                  >
+                    <div
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    >
+                      <div
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
+                      >
                         <div
-                          class="euiDataGridRowCell__expandButton"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
+                          <div
+                            class="euiDataGridRowCell__expandContent"
                           >
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 1, Column: 2:
+                              </span>
+                            </p>
                             <div
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              0, B
+                            </div>
+                          </div>
+                          <div
+                            class="euiDataGridRowCell__expandButton"
+                          >
+                            <button
                               aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -356,235 +416,117 @@ Array [
                 </div>
               </div>
               <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
+                class="euiDataGridRow"
+                data-test-subj="dataGridRow"
+                role="row"
               >
                 <div
-                  class="euiDataGridRowCell__content"
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    class="euiDataGridRowCell__content"
                   >
                     <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
                     >
                       <div
-                        class="euiDataGridRowCell__expandFlex"
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
                       >
                         <div
-                          class="euiDataGridRowCell__expandContent"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 1, Column: 2:
-                            </span>
-                          </p>
                           <div
-                            class="euiDataGridRowCell__truncate"
+                            class="euiDataGridRowCell__expandContent"
                           >
-                            0, B
-                          </div>
-                        </div>
-                        <div
-                          class="euiDataGridRowCell__expandButton"
-                        >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
-                          >
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 2, Column: 1:
+                              </span>
+                            </p>
                             <div
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              1, A
+                            </div>
+                          </div>
+                          <div
+                            class="euiDataGridRowCell__expandButton"
+                          >
+                            <button
                               aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </div>
-            <div
-              class="euiDataGridRow"
-              data-test-subj="dataGridRow"
-              role="row"
-            >
-              <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
-              >
                 <div
-                  class="euiDataGridRowCell__content"
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    class="euiDataGridRowCell__content"
                   >
                     <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
                     >
                       <div
-                        class="euiDataGridRowCell__expandFlex"
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
                       >
                         <div
-                          class="euiDataGridRowCell__expandContent"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 2, Column: 1:
-                            </span>
-                          </p>
                           <div
-                            class="euiDataGridRowCell__truncate"
+                            class="euiDataGridRowCell__expandContent"
                           >
-                            1, A
-                          </div>
-                        </div>
-                        <div
-                          class="euiDataGridRowCell__expandButton"
-                        >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
-                          >
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 2, Column: 2:
+                              </span>
+                            </p>
                             <div
-                              aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridRowCell__content"
-                >
-                  <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
-                  >
-                    <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
-                    >
-                      <div
-                        class="euiDataGridRowCell__expandFlex"
-                      >
-                        <div
-                          class="euiDataGridRowCell__expandContent"
-                        >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 2, Column: 2:
-                            </span>
-                          </p>
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              1, B
+                            </div>
+                          </div>
                           <div
-                            class="euiDataGridRowCell__truncate"
+                            class="euiDataGridRowCell__expandButton"
                           >
-                            1, B
-                          </div>
-                        </div>
-                        <div
-                          class="euiDataGridRowCell__expandButton"
-                        >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
-                          >
-                            <div
+                            <button
                               aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="euiDataGridRow"
-              data-test-subj="dataGridRow"
-              role="row"
-            >
-              <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridRowCell__content"
-                >
-                  <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
-                  >
-                    <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
-                    >
-                      <div
-                        class="euiDataGridRowCell__expandFlex"
-                      >
-                        <div
-                          class="euiDataGridRowCell__expandContent"
-                        >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 3, Column: 1:
-                            </span>
-                          </p>
-                          <div
-                            class="euiDataGridRowCell__truncate"
-                          >
-                            2, A
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
                           </div>
-                        </div>
-                        <div
-                          class="euiDataGridRowCell__expandButton"
-                        >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
-                          >
-                            <div
-                              aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
                         </div>
                       </div>
                     </div>
@@ -592,55 +534,117 @@ Array [
                 </div>
               </div>
               <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
+                class="euiDataGridRow"
+                data-test-subj="dataGridRow"
+                role="row"
               >
                 <div
-                  class="euiDataGridRowCell__content"
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    class="euiDataGridRowCell__content"
                   >
                     <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
                     >
                       <div
-                        class="euiDataGridRowCell__expandFlex"
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
                       >
                         <div
-                          class="euiDataGridRowCell__expandContent"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 3, Column: 2:
-                            </span>
-                          </p>
                           <div
-                            class="euiDataGridRowCell__truncate"
+                            class="euiDataGridRowCell__expandContent"
                           >
-                            2, B
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 3, Column: 1:
+                              </span>
+                            </p>
+                            <div
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              2, A
+                            </div>
+                          </div>
+                          <div
+                            class="euiDataGridRowCell__expandButton"
+                          >
+                            <button
+                              aria-hidden="true"
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
                           </div>
                         </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  <div
+                    class="euiDataGridRowCell__content"
+                  >
+                    <div
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    >
+                      <div
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
+                      >
                         <div
-                          class="euiDataGridRowCell__expandButton"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
+                          <div
+                            class="euiDataGridRowCell__expandContent"
                           >
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 3, Column: 2:
+                              </span>
+                            </p>
                             <div
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              2, B
+                            </div>
+                          </div>
+                          <div
+                            class="euiDataGridRowCell__expandButton"
+                          >
+                            <button
                               aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -775,594 +779,598 @@ Array [
         </button>
       </div>
       <div
-        class="euiDataGridHeader"
-        data-test-subj="dataGridHeader"
-        role="row"
+        class="euiDataGrid__keyWrap"
       >
         <div
-          class="euiDataGridHeaderCell euiDataGridHeaderCell--controlColumn"
-          data-test-subj="dataGridHeaderCell-leading"
-          role="columnheader"
-          style="width:50px"
-          tabindex="-1"
+          class="euiDataGridHeader"
+          data-test-subj="dataGridHeader"
+          role="row"
         >
           <div
-            class="euiDataGridHeaderCell__content"
-          >
-            <span>
-              leading heading
-            </span>
-          </div>
-        </div>
-        <div
-          class="euiDataGridHeaderCell"
-          data-test-subj="dataGridHeaderCell-A"
-          role="columnheader"
-          tabindex="-1"
-        >
-          <div
-            class="euiDataGridHeaderCell__content"
-          >
-            A
-          </div>
-        </div>
-        <div
-          class="euiDataGridHeaderCell"
-          data-test-subj="dataGridHeaderCell-B"
-          role="columnheader"
-          tabindex="-1"
-        >
-          <div
-            class="euiDataGridHeaderCell__content"
-          >
-            B
-          </div>
-        </div>
-        <div
-          class="euiDataGridHeaderCell euiDataGridHeaderCell--controlColumn"
-          data-test-subj="dataGridHeaderCell-trailing"
-          role="columnheader"
-          style="width:50px"
-          tabindex="-1"
-        >
-          <div
-            class="euiDataGridHeaderCell__content"
-          >
-            <span>
-              trailing heading
-            </span>
-          </div>
-        </div>
-      </div>
-      <div
-        class="euiDataGrid__verticalScroll"
-        data-test-subj="test subject string"
-      >
-        <div
-          class="euiDataGrid__overflow"
-        >
-          <div
-            aria-label="aria-label"
-            class="euiDataGrid__content"
-            role="grid"
+            class="euiDataGridHeaderCell euiDataGridHeaderCell--controlColumn"
+            data-test-subj="dataGridHeaderCell-leading"
+            role="columnheader"
+            style="width:50px"
+            tabindex="-1"
           >
             <div
-              class="euiDataGridRow"
-              data-test-subj="dataGridRow"
-              role="row"
+              class="euiDataGridHeaderCell__content"
             >
-              <div
-                class="euiDataGridRowCell euiDataGridRowCell--controlColumn"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                style="width:50px"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridRowCell__expandFlex"
-                >
-                  <div
-                    class="euiDataGridRowCell__expandContent"
-                  >
-                    <p
-                      class="euiScreenReaderOnly"
-                    >
-                      <span>
-                        Row: 1, Column: 1:
-                      </span>
-                    </p>
-                    <div
-                      class="euiDataGridRowCell__truncate"
-                    >
-                      0
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridRowCell__content"
-                >
-                  <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
-                  >
-                    <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
-                    >
-                      <div
-                        class="euiDataGridRowCell__expandFlex"
-                      >
-                        <div
-                          class="euiDataGridRowCell__expandContent"
-                        >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 1, Column: 2:
-                            </span>
-                          </p>
-                          <div
-                            class="euiDataGridRowCell__truncate"
-                          >
-                            0, A
-                          </div>
-                        </div>
-                        <div
-                          class="euiDataGridRowCell__expandButton"
-                        >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
-                          >
-                            <div
-                              aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridRowCell__content"
-                >
-                  <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
-                  >
-                    <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
-                    >
-                      <div
-                        class="euiDataGridRowCell__expandFlex"
-                      >
-                        <div
-                          class="euiDataGridRowCell__expandContent"
-                        >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 1, Column: 3:
-                            </span>
-                          </p>
-                          <div
-                            class="euiDataGridRowCell__truncate"
-                          >
-                            0, B
-                          </div>
-                        </div>
-                        <div
-                          class="euiDataGridRowCell__expandButton"
-                        >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
-                          >
-                            <div
-                              aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="euiDataGridRowCell euiDataGridRowCell--controlColumn"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                style="width:50px"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridRowCell__expandFlex"
-                >
-                  <div
-                    class="euiDataGridRowCell__expandContent"
-                  >
-                    <p
-                      class="euiScreenReaderOnly"
-                    >
-                      <span>
-                        Row: 1, Column: 4:
-                      </span>
-                    </p>
-                    <div
-                      class="euiDataGridRowCell__truncate"
-                    >
-                      0
-                    </div>
-                  </div>
-                </div>
-              </div>
+              <span>
+                leading heading
+              </span>
             </div>
+          </div>
+          <div
+            class="euiDataGridHeaderCell"
+            data-test-subj="dataGridHeaderCell-A"
+            role="columnheader"
+            tabindex="-1"
+          >
             <div
-              class="euiDataGridRow"
-              data-test-subj="dataGridRow"
-              role="row"
+              class="euiDataGridHeaderCell__content"
             >
-              <div
-                class="euiDataGridRowCell euiDataGridRowCell--controlColumn"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                style="width:50px"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridRowCell__expandFlex"
-                >
-                  <div
-                    class="euiDataGridRowCell__expandContent"
-                  >
-                    <p
-                      class="euiScreenReaderOnly"
-                    >
-                      <span>
-                        Row: 2, Column: 1:
-                      </span>
-                    </p>
-                    <div
-                      class="euiDataGridRowCell__truncate"
-                    >
-                      1
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridRowCell__content"
-                >
-                  <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
-                  >
-                    <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
-                    >
-                      <div
-                        class="euiDataGridRowCell__expandFlex"
-                      >
-                        <div
-                          class="euiDataGridRowCell__expandContent"
-                        >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 2, Column: 2:
-                            </span>
-                          </p>
-                          <div
-                            class="euiDataGridRowCell__truncate"
-                          >
-                            1, A
-                          </div>
-                        </div>
-                        <div
-                          class="euiDataGridRowCell__expandButton"
-                        >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
-                          >
-                            <div
-                              aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridRowCell__content"
-                >
-                  <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
-                  >
-                    <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
-                    >
-                      <div
-                        class="euiDataGridRowCell__expandFlex"
-                      >
-                        <div
-                          class="euiDataGridRowCell__expandContent"
-                        >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 2, Column: 3:
-                            </span>
-                          </p>
-                          <div
-                            class="euiDataGridRowCell__truncate"
-                          >
-                            1, B
-                          </div>
-                        </div>
-                        <div
-                          class="euiDataGridRowCell__expandButton"
-                        >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
-                          >
-                            <div
-                              aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="euiDataGridRowCell euiDataGridRowCell--controlColumn"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                style="width:50px"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridRowCell__expandFlex"
-                >
-                  <div
-                    class="euiDataGridRowCell__expandContent"
-                  >
-                    <p
-                      class="euiScreenReaderOnly"
-                    >
-                      <span>
-                        Row: 2, Column: 4:
-                      </span>
-                    </p>
-                    <div
-                      class="euiDataGridRowCell__truncate"
-                    >
-                      1
-                    </div>
-                  </div>
-                </div>
-              </div>
+              A
             </div>
+          </div>
+          <div
+            class="euiDataGridHeaderCell"
+            data-test-subj="dataGridHeaderCell-B"
+            role="columnheader"
+            tabindex="-1"
+          >
             <div
-              class="euiDataGridRow"
-              data-test-subj="dataGridRow"
-              role="row"
+              class="euiDataGridHeaderCell__content"
+            >
+              B
+            </div>
+          </div>
+          <div
+            class="euiDataGridHeaderCell euiDataGridHeaderCell--controlColumn"
+            data-test-subj="dataGridHeaderCell-trailing"
+            role="columnheader"
+            style="width:50px"
+            tabindex="-1"
+          >
+            <div
+              class="euiDataGridHeaderCell__content"
+            >
+              <span>
+                trailing heading
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          class="euiDataGrid__verticalScroll"
+          data-test-subj="test subject string"
+        >
+          <div
+            class="euiDataGrid__overflow"
+          >
+            <div
+              aria-label="aria-label"
+              class="euiDataGrid__content"
+              role="grid"
             >
               <div
-                class="euiDataGridRowCell euiDataGridRowCell--controlColumn"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                style="width:50px"
-                tabindex="-1"
+                class="euiDataGridRow"
+                data-test-subj="dataGridRow"
+                role="row"
               >
                 <div
-                  class="euiDataGridRowCell__expandFlex"
+                  class="euiDataGridRowCell euiDataGridRowCell--controlColumn"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  style="width:50px"
+                  tabindex="-1"
                 >
                   <div
-                    class="euiDataGridRowCell__expandContent"
+                    class="euiDataGridRowCell__expandFlex"
                   >
-                    <p
-                      class="euiScreenReaderOnly"
-                    >
-                      <span>
-                        Row: 3, Column: 1:
-                      </span>
-                    </p>
                     <div
-                      class="euiDataGridRowCell__truncate"
+                      class="euiDataGridRowCell__expandContent"
                     >
-                      2
+                      <p
+                        class="euiScreenReaderOnly"
+                      >
+                        <span>
+                          Row: 1, Column: 1:
+                        </span>
+                      </p>
+                      <div
+                        class="euiDataGridRowCell__truncate"
+                      >
+                        0
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
-              >
                 <div
-                  class="euiDataGridRowCell__content"
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    class="euiDataGridRowCell__content"
                   >
                     <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
                     >
                       <div
-                        class="euiDataGridRowCell__expandFlex"
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
                       >
                         <div
-                          class="euiDataGridRowCell__expandContent"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 3, Column: 2:
-                            </span>
-                          </p>
                           <div
-                            class="euiDataGridRowCell__truncate"
+                            class="euiDataGridRowCell__expandContent"
                           >
-                            2, A
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 1, Column: 2:
+                              </span>
+                            </p>
+                            <div
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              0, A
+                            </div>
+                          </div>
+                          <div
+                            class="euiDataGridRowCell__expandButton"
+                          >
+                            <button
+                              aria-hidden="true"
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
                           </div>
                         </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  <div
+                    class="euiDataGridRowCell__content"
+                  >
+                    <div
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    >
+                      <div
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
+                      >
                         <div
-                          class="euiDataGridRowCell__expandButton"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
+                          <div
+                            class="euiDataGridRowCell__expandContent"
                           >
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 1, Column: 3:
+                              </span>
+                            </p>
                             <div
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              0, B
+                            </div>
+                          </div>
+                          <div
+                            class="euiDataGridRowCell__expandButton"
+                          >
+                            <button
                               aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
+                          </div>
                         </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiDataGridRowCell euiDataGridRowCell--controlColumn"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  style="width:50px"
+                  tabindex="-1"
+                >
+                  <div
+                    class="euiDataGridRowCell__expandFlex"
+                  >
+                    <div
+                      class="euiDataGridRowCell__expandContent"
+                    >
+                      <p
+                        class="euiScreenReaderOnly"
+                      >
+                        <span>
+                          Row: 1, Column: 4:
+                        </span>
+                      </p>
+                      <div
+                        class="euiDataGridRowCell__truncate"
+                      >
+                        0
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
               <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
+                class="euiDataGridRow"
+                data-test-subj="dataGridRow"
+                role="row"
               >
                 <div
-                  class="euiDataGridRowCell__content"
+                  class="euiDataGridRowCell euiDataGridRowCell--controlColumn"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  style="width:50px"
+                  tabindex="-1"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    class="euiDataGridRowCell__expandFlex"
                   >
                     <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
+                      class="euiDataGridRowCell__expandContent"
+                    >
+                      <p
+                        class="euiScreenReaderOnly"
+                      >
+                        <span>
+                          Row: 2, Column: 1:
+                        </span>
+                      </p>
+                      <div
+                        class="euiDataGridRowCell__truncate"
+                      >
+                        1
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  <div
+                    class="euiDataGridRowCell__content"
+                  >
+                    <div
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
                     >
                       <div
-                        class="euiDataGridRowCell__expandFlex"
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
                       >
                         <div
-                          class="euiDataGridRowCell__expandContent"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 3, Column: 3:
-                            </span>
-                          </p>
                           <div
-                            class="euiDataGridRowCell__truncate"
+                            class="euiDataGridRowCell__expandContent"
                           >
-                            2, B
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 2, Column: 2:
+                              </span>
+                            </p>
+                            <div
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              1, A
+                            </div>
+                          </div>
+                          <div
+                            class="euiDataGridRowCell__expandButton"
+                          >
+                            <button
+                              aria-hidden="true"
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
                           </div>
                         </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  <div
+                    class="euiDataGridRowCell__content"
+                  >
+                    <div
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    >
+                      <div
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
+                      >
                         <div
-                          class="euiDataGridRowCell__expandButton"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
+                          <div
+                            class="euiDataGridRowCell__expandContent"
                           >
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 2, Column: 3:
+                              </span>
+                            </p>
                             <div
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              1, B
+                            </div>
+                          </div>
+                          <div
+                            class="euiDataGridRowCell__expandButton"
+                          >
+                            <button
                               aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
+                          </div>
                         </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiDataGridRowCell euiDataGridRowCell--controlColumn"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  style="width:50px"
+                  tabindex="-1"
+                >
+                  <div
+                    class="euiDataGridRowCell__expandFlex"
+                  >
+                    <div
+                      class="euiDataGridRowCell__expandContent"
+                    >
+                      <p
+                        class="euiScreenReaderOnly"
+                      >
+                        <span>
+                          Row: 2, Column: 4:
+                        </span>
+                      </p>
+                      <div
+                        class="euiDataGridRowCell__truncate"
+                      >
+                        1
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
               <div
-                class="euiDataGridRowCell euiDataGridRowCell--controlColumn"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                style="width:50px"
-                tabindex="-1"
+                class="euiDataGridRow"
+                data-test-subj="dataGridRow"
+                role="row"
               >
                 <div
-                  class="euiDataGridRowCell__expandFlex"
+                  class="euiDataGridRowCell euiDataGridRowCell--controlColumn"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  style="width:50px"
+                  tabindex="-1"
                 >
                   <div
-                    class="euiDataGridRowCell__expandContent"
+                    class="euiDataGridRowCell__expandFlex"
                   >
-                    <p
-                      class="euiScreenReaderOnly"
-                    >
-                      <span>
-                        Row: 3, Column: 4:
-                      </span>
-                    </p>
                     <div
-                      class="euiDataGridRowCell__truncate"
+                      class="euiDataGridRowCell__expandContent"
                     >
-                      2
+                      <p
+                        class="euiScreenReaderOnly"
+                      >
+                        <span>
+                          Row: 3, Column: 1:
+                        </span>
+                      </p>
+                      <div
+                        class="euiDataGridRowCell__truncate"
+                      >
+                        2
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  <div
+                    class="euiDataGridRowCell__content"
+                  >
+                    <div
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    >
+                      <div
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
+                      >
+                        <div
+                          class="euiDataGridRowCell__expandFlex"
+                        >
+                          <div
+                            class="euiDataGridRowCell__expandContent"
+                          >
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 3, Column: 2:
+                              </span>
+                            </p>
+                            <div
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              2, A
+                            </div>
+                          </div>
+                          <div
+                            class="euiDataGridRowCell__expandButton"
+                          >
+                            <button
+                              aria-hidden="true"
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  <div
+                    class="euiDataGridRowCell__content"
+                  >
+                    <div
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    >
+                      <div
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
+                      >
+                        <div
+                          class="euiDataGridRowCell__expandFlex"
+                        >
+                          <div
+                            class="euiDataGridRowCell__expandContent"
+                          >
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 3, Column: 3:
+                              </span>
+                            </p>
+                            <div
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              2, B
+                            </div>
+                          </div>
+                          <div
+                            class="euiDataGridRowCell__expandButton"
+                          >
+                            <button
+                              aria-hidden="true"
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiDataGridRowCell euiDataGridRowCell--controlColumn"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  style="width:50px"
+                  tabindex="-1"
+                >
+                  <div
+                    class="euiDataGridRowCell__expandFlex"
+                  >
+                    <div
+                      class="euiDataGridRowCell__expandContent"
+                    >
+                      <p
+                        class="euiScreenReaderOnly"
+                      >
+                        <span>
+                          Row: 3, Column: 4:
+                        </span>
+                      </p>
+                      <div
+                        class="euiDataGridRowCell__truncate"
+                      >
+                        2
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1492,104 +1500,164 @@ Array [
         </button>
       </div>
       <div
-        class="euiDataGridHeader"
-        data-test-subj="dataGridHeader"
-        role="row"
+        class="euiDataGrid__keyWrap"
       >
         <div
-          class="euiDataGridHeaderCell"
-          data-test-subj="dataGridHeaderCell-A"
-          role="columnheader"
-          tabindex="-1"
+          class="euiDataGridHeader"
+          data-test-subj="dataGridHeader"
+          role="row"
         >
           <div
-            class="euiDataGridHeaderCell__content"
+            class="euiDataGridHeaderCell"
+            data-test-subj="dataGridHeaderCell-A"
+            role="columnheader"
+            tabindex="-1"
           >
-            Column A
+            <div
+              class="euiDataGridHeaderCell__content"
+            >
+              Column A
+            </div>
+          </div>
+          <div
+            class="euiDataGridHeaderCell"
+            data-test-subj="dataGridHeaderCell-B"
+            role="columnheader"
+            tabindex="-1"
+          >
+            <div
+              class="euiDataGridHeaderCell__content"
+            >
+              <div>
+                More Elements
+              </div>
+            </div>
           </div>
         </div>
         <div
-          class="euiDataGridHeaderCell"
-          data-test-subj="dataGridHeaderCell-B"
-          role="columnheader"
-          tabindex="-1"
+          class="euiDataGrid__verticalScroll"
+          data-test-subj="test subject string"
         >
           <div
-            class="euiDataGridHeaderCell__content"
-          >
-            <div>
-              More Elements
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="euiDataGrid__verticalScroll"
-        data-test-subj="test subject string"
-      >
-        <div
-          class="euiDataGrid__overflow"
-        >
-          <div
-            aria-label="aria-label"
-            class="euiDataGrid__content"
-            role="grid"
+            class="euiDataGrid__overflow"
           >
             <div
-              class="euiDataGridRow"
-              data-test-subj="dataGridRow"
-              role="row"
+              aria-label="aria-label"
+              class="euiDataGrid__content"
+              role="grid"
             >
               <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
+                class="euiDataGridRow"
+                data-test-subj="dataGridRow"
+                role="row"
               >
                 <div
-                  class="euiDataGridRowCell__content"
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    class="euiDataGridRowCell__content"
                   >
                     <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
                     >
                       <div
-                        class="euiDataGridRowCell__expandFlex"
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
                       >
                         <div
-                          class="euiDataGridRowCell__expandContent"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 1, Column: 1:
-                            </span>
-                          </p>
                           <div
-                            class="euiDataGridRowCell__truncate"
+                            class="euiDataGridRowCell__expandContent"
                           >
-                            0, A
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 1, Column: 1:
+                              </span>
+                            </p>
+                            <div
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              0, A
+                            </div>
+                          </div>
+                          <div
+                            class="euiDataGridRowCell__expandButton"
+                          >
+                            <button
+                              aria-hidden="true"
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
                           </div>
                         </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  <div
+                    class="euiDataGridRowCell__content"
+                  >
+                    <div
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    >
+                      <div
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
+                      >
                         <div
-                          class="euiDataGridRowCell__expandButton"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
+                          <div
+                            class="euiDataGridRowCell__expandContent"
                           >
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 1, Column: 2:
+                              </span>
+                            </p>
                             <div
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              0, B
+                            </div>
+                          </div>
+                          <div
+                            class="euiDataGridRowCell__expandButton"
+                          >
+                            <button
                               aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -1597,235 +1665,117 @@ Array [
                 </div>
               </div>
               <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
+                class="euiDataGridRow"
+                data-test-subj="dataGridRow"
+                role="row"
               >
                 <div
-                  class="euiDataGridRowCell__content"
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    class="euiDataGridRowCell__content"
                   >
                     <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
                     >
                       <div
-                        class="euiDataGridRowCell__expandFlex"
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
                       >
                         <div
-                          class="euiDataGridRowCell__expandContent"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 1, Column: 2:
-                            </span>
-                          </p>
                           <div
-                            class="euiDataGridRowCell__truncate"
+                            class="euiDataGridRowCell__expandContent"
                           >
-                            0, B
-                          </div>
-                        </div>
-                        <div
-                          class="euiDataGridRowCell__expandButton"
-                        >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
-                          >
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 2, Column: 1:
+                              </span>
+                            </p>
                             <div
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              1, A
+                            </div>
+                          </div>
+                          <div
+                            class="euiDataGridRowCell__expandButton"
+                          >
+                            <button
                               aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </div>
-            <div
-              class="euiDataGridRow"
-              data-test-subj="dataGridRow"
-              role="row"
-            >
-              <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
-              >
                 <div
-                  class="euiDataGridRowCell__content"
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    class="euiDataGridRowCell__content"
                   >
                     <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
                     >
                       <div
-                        class="euiDataGridRowCell__expandFlex"
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
                       >
                         <div
-                          class="euiDataGridRowCell__expandContent"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 2, Column: 1:
-                            </span>
-                          </p>
                           <div
-                            class="euiDataGridRowCell__truncate"
+                            class="euiDataGridRowCell__expandContent"
                           >
-                            1, A
-                          </div>
-                        </div>
-                        <div
-                          class="euiDataGridRowCell__expandButton"
-                        >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
-                          >
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 2, Column: 2:
+                              </span>
+                            </p>
                             <div
-                              aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridRowCell__content"
-                >
-                  <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
-                  >
-                    <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
-                    >
-                      <div
-                        class="euiDataGridRowCell__expandFlex"
-                      >
-                        <div
-                          class="euiDataGridRowCell__expandContent"
-                        >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 2, Column: 2:
-                            </span>
-                          </p>
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              1, B
+                            </div>
+                          </div>
                           <div
-                            class="euiDataGridRowCell__truncate"
+                            class="euiDataGridRowCell__expandButton"
                           >
-                            1, B
-                          </div>
-                        </div>
-                        <div
-                          class="euiDataGridRowCell__expandButton"
-                        >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
-                          >
-                            <div
+                            <button
                               aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="euiDataGridRow"
-              data-test-subj="dataGridRow"
-              role="row"
-            >
-              <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridRowCell__content"
-                >
-                  <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
-                  >
-                    <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
-                    >
-                      <div
-                        class="euiDataGridRowCell__expandFlex"
-                      >
-                        <div
-                          class="euiDataGridRowCell__expandContent"
-                        >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 3, Column: 1:
-                            </span>
-                          </p>
-                          <div
-                            class="euiDataGridRowCell__truncate"
-                          >
-                            2, A
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
                           </div>
-                        </div>
-                        <div
-                          class="euiDataGridRowCell__expandButton"
-                        >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
-                          >
-                            <div
-                              aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
                         </div>
                       </div>
                     </div>
@@ -1833,55 +1783,117 @@ Array [
                 </div>
               </div>
               <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
+                class="euiDataGridRow"
+                data-test-subj="dataGridRow"
+                role="row"
               >
                 <div
-                  class="euiDataGridRowCell__content"
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    class="euiDataGridRowCell__content"
                   >
                     <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
                     >
                       <div
-                        class="euiDataGridRowCell__expandFlex"
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
                       >
                         <div
-                          class="euiDataGridRowCell__expandContent"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 3, Column: 2:
-                            </span>
-                          </p>
                           <div
-                            class="euiDataGridRowCell__truncate"
+                            class="euiDataGridRowCell__expandContent"
                           >
-                            2, B
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 3, Column: 1:
+                              </span>
+                            </p>
+                            <div
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              2, A
+                            </div>
+                          </div>
+                          <div
+                            class="euiDataGridRowCell__expandButton"
+                          >
+                            <button
+                              aria-hidden="true"
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
                           </div>
                         </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  <div
+                    class="euiDataGridRowCell__content"
+                  >
+                    <div
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    >
+                      <div
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
+                      >
                         <div
-                          class="euiDataGridRowCell__expandButton"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
+                          <div
+                            class="euiDataGridRowCell__expandContent"
                           >
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 3, Column: 2:
+                              </span>
+                            </p>
                             <div
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              2, B
+                            </div>
+                          </div>
+                          <div
+                            class="euiDataGridRowCell__expandButton"
+                          >
+                            <button
                               aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -2013,102 +2025,162 @@ Array [
         </button>
       </div>
       <div
-        class="euiDataGridHeader"
-        data-test-subj="dataGridHeader"
-        role="row"
+        class="euiDataGrid__keyWrap"
       >
         <div
-          class="euiDataGridHeaderCell"
-          data-test-subj="dataGridHeaderCell-A"
-          role="columnheader"
-          tabindex="-1"
+          class="euiDataGridHeader"
+          data-test-subj="dataGridHeader"
+          role="row"
         >
           <div
-            class="euiDataGridHeaderCell__content"
+            class="euiDataGridHeaderCell"
+            data-test-subj="dataGridHeaderCell-A"
+            role="columnheader"
+            tabindex="-1"
           >
-            A
+            <div
+              class="euiDataGridHeaderCell__content"
+            >
+              A
+            </div>
+          </div>
+          <div
+            class="euiDataGridHeaderCell"
+            data-test-subj="dataGridHeaderCell-B"
+            role="columnheader"
+            tabindex="-1"
+          >
+            <div
+              class="euiDataGridHeaderCell__content"
+            >
+              B
+            </div>
           </div>
         </div>
         <div
-          class="euiDataGridHeaderCell"
-          data-test-subj="dataGridHeaderCell-B"
-          role="columnheader"
-          tabindex="-1"
+          class="euiDataGrid__verticalScroll"
+          data-test-subj="test subject string"
         >
           <div
-            class="euiDataGridHeaderCell__content"
-          >
-            B
-          </div>
-        </div>
-      </div>
-      <div
-        class="euiDataGrid__verticalScroll"
-        data-test-subj="test subject string"
-      >
-        <div
-          class="euiDataGrid__overflow"
-        >
-          <div
-            aria-label="aria-label"
-            class="euiDataGrid__content"
-            role="grid"
+            class="euiDataGrid__overflow"
           >
             <div
-              class="euiDataGridRow"
-              data-test-subj="dataGridRow"
-              role="row"
+              aria-label="aria-label"
+              class="euiDataGrid__content"
+              role="grid"
             >
               <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
+                class="euiDataGridRow"
+                data-test-subj="dataGridRow"
+                role="row"
               >
                 <div
-                  class="euiDataGridRowCell__content"
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    class="euiDataGridRowCell__content"
                   >
                     <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
                     >
                       <div
-                        class="euiDataGridRowCell__expandFlex"
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
                       >
                         <div
-                          class="euiDataGridRowCell__expandContent"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 1, Column: 1:
-                            </span>
-                          </p>
                           <div
-                            class="euiDataGridRowCell__truncate"
+                            class="euiDataGridRowCell__expandContent"
                           >
-                            0, A
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 1, Column: 1:
+                              </span>
+                            </p>
+                            <div
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              0, A
+                            </div>
+                          </div>
+                          <div
+                            class="euiDataGridRowCell__expandButton"
+                          >
+                            <button
+                              aria-hidden="true"
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
                           </div>
                         </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  <div
+                    class="euiDataGridRowCell__content"
+                  >
+                    <div
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    >
+                      <div
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
+                      >
                         <div
-                          class="euiDataGridRowCell__expandButton"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
+                          <div
+                            class="euiDataGridRowCell__expandContent"
                           >
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 1, Column: 2:
+                              </span>
+                            </p>
                             <div
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              0, B
+                            </div>
+                          </div>
+                          <div
+                            class="euiDataGridRowCell__expandButton"
+                          >
+                            <button
                               aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -2116,235 +2188,117 @@ Array [
                 </div>
               </div>
               <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
+                class="euiDataGridRow"
+                data-test-subj="dataGridRow"
+                role="row"
               >
                 <div
-                  class="euiDataGridRowCell__content"
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    class="euiDataGridRowCell__content"
                   >
                     <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
                     >
                       <div
-                        class="euiDataGridRowCell__expandFlex"
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
                       >
                         <div
-                          class="euiDataGridRowCell__expandContent"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 1, Column: 2:
-                            </span>
-                          </p>
                           <div
-                            class="euiDataGridRowCell__truncate"
+                            class="euiDataGridRowCell__expandContent"
                           >
-                            0, B
-                          </div>
-                        </div>
-                        <div
-                          class="euiDataGridRowCell__expandButton"
-                        >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
-                          >
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 2, Column: 1:
+                              </span>
+                            </p>
                             <div
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              1, A
+                            </div>
+                          </div>
+                          <div
+                            class="euiDataGridRowCell__expandButton"
+                          >
+                            <button
                               aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </div>
-            <div
-              class="euiDataGridRow"
-              data-test-subj="dataGridRow"
-              role="row"
-            >
-              <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
-              >
                 <div
-                  class="euiDataGridRowCell__content"
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    class="euiDataGridRowCell__content"
                   >
                     <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
                     >
                       <div
-                        class="euiDataGridRowCell__expandFlex"
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
                       >
                         <div
-                          class="euiDataGridRowCell__expandContent"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 2, Column: 1:
-                            </span>
-                          </p>
                           <div
-                            class="euiDataGridRowCell__truncate"
+                            class="euiDataGridRowCell__expandContent"
                           >
-                            1, A
-                          </div>
-                        </div>
-                        <div
-                          class="euiDataGridRowCell__expandButton"
-                        >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
-                          >
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 2, Column: 2:
+                              </span>
+                            </p>
                             <div
-                              aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridRowCell__content"
-                >
-                  <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
-                  >
-                    <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
-                    >
-                      <div
-                        class="euiDataGridRowCell__expandFlex"
-                      >
-                        <div
-                          class="euiDataGridRowCell__expandContent"
-                        >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 2, Column: 2:
-                            </span>
-                          </p>
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              1, B
+                            </div>
+                          </div>
                           <div
-                            class="euiDataGridRowCell__truncate"
+                            class="euiDataGridRowCell__expandButton"
                           >
-                            1, B
-                          </div>
-                        </div>
-                        <div
-                          class="euiDataGridRowCell__expandButton"
-                        >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
-                          >
-                            <div
+                            <button
                               aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="euiDataGridRow"
-              data-test-subj="dataGridRow"
-              role="row"
-            >
-              <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
-              >
-                <div
-                  class="euiDataGridRowCell__content"
-                >
-                  <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
-                  >
-                    <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
-                    >
-                      <div
-                        class="euiDataGridRowCell__expandFlex"
-                      >
-                        <div
-                          class="euiDataGridRowCell__expandContent"
-                        >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 3, Column: 1:
-                            </span>
-                          </p>
-                          <div
-                            class="euiDataGridRowCell__truncate"
-                          >
-                            2, A
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
                           </div>
-                        </div>
-                        <div
-                          class="euiDataGridRowCell__expandButton"
-                        >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
-                          >
-                            <div
-                              aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
                         </div>
                       </div>
                     </div>
@@ -2352,55 +2306,117 @@ Array [
                 </div>
               </div>
               <div
-                class="euiDataGridRowCell"
-                data-test-subj="dataGridRowCell"
-                role="gridcell"
-                tabindex="-1"
+                class="euiDataGridRow"
+                data-test-subj="dataGridRow"
+                role="row"
               >
                 <div
-                  class="euiDataGridRowCell__content"
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    class="euiDataGridRowCell__content"
                   >
                     <div
-                      class="euiPopover__anchor euiDataGridRowCell__expand"
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
                     >
                       <div
-                        class="euiDataGridRowCell__expandFlex"
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
                       >
                         <div
-                          class="euiDataGridRowCell__expandContent"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <p
-                            class="euiScreenReaderOnly"
-                          >
-                            <span>
-                              Row: 3, Column: 2:
-                            </span>
-                          </p>
                           <div
-                            class="euiDataGridRowCell__truncate"
+                            class="euiDataGridRowCell__expandContent"
                           >
-                            2, B
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 3, Column: 1:
+                              </span>
+                            </p>
+                            <div
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              2, A
+                            </div>
+                          </div>
+                          <div
+                            class="euiDataGridRowCell__expandButton"
+                          >
+                            <button
+                              aria-hidden="true"
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
                           </div>
                         </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiDataGridRowCell"
+                  data-test-subj="dataGridRowCell"
+                  role="gridcell"
+                  tabindex="-1"
+                >
+                  <div
+                    class="euiDataGridRowCell__content"
+                  >
+                    <div
+                      class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+                    >
+                      <div
+                        class="euiPopover__anchor euiDataGridRowCell__expand"
+                      >
                         <div
-                          class="euiDataGridRowCell__expandButton"
+                          class="euiDataGridRowCell__expandFlex"
                         >
-                          <button
-                            aria-hidden="true"
-                            class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
-                            tabindex="-1"
-                            title="Click or hit enter to interact with cell content"
-                            type="button"
+                          <div
+                            class="euiDataGridRowCell__expandContent"
                           >
+                            <p
+                              class="euiScreenReaderOnly"
+                            >
+                              <span>
+                                Row: 3, Column: 2:
+                              </span>
+                            </p>
                             <div
+                              class="euiDataGridRowCell__truncate"
+                            >
+                              2, B
+                            </div>
+                          </div>
+                          <div
+                            class="euiDataGridRowCell__expandButton"
+                          >
+                            <button
                               aria-hidden="true"
-                              class="euiButtonIcon__icon"
-                              data-euiicon-type="expandMini"
-                            />
-                          </button>
+                              class="euiButtonIcon euiButtonIcon--text euiDataGridRowCell__expandButtonIcon"
+                              tabindex="-1"
+                              title="Click or hit enter to interact with cell content"
+                              type="button"
+                            >
+                              <div
+                                aria-hidden="true"
+                                class="euiButtonIcon__icon"
+                                data-euiicon-type="expandMini"
+                              />
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>

--- a/src/components/datagrid/_data_grid.scss
+++ b/src/components/datagrid/_data_grid.scss
@@ -23,6 +23,13 @@
   }
 }
 
+.euiDataGrid__keyWrap {
+  display: flex;
+  flex-grow: 1;
+  overflow: hidden;
+  flex-direction: column;
+}
+
 .euiDataGrid__content {
   @include euiScrollBar;
   @include euiScrollBar;

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -811,85 +811,87 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
           ) : null}
           <EuiResizeObserver onResize={onResize}>
             {resizeRef => (
-              <div
-                onKeyDown={createKeyDownHandler(
-                  props,
-                  orderedVisibleColumns,
-                  leadingControlColumns,
-                  trailingControlColumns,
-                  focusedCell,
-                  headerIsInteractive,
-                  setFocusedCell,
-                  focusAfterRender
-                )}
-                className="euiDataGrid__verticalScroll"
-                ref={resizeRef}
-                {...rest}>
-                <div className="euiDataGrid__overflow">
-                  {inMemory ? (
-                    <EuiDataGridInMemoryRenderer
-                      inMemory={inMemory}
-                      renderCellValue={renderCellValue}
-                      columns={columns}
-                      rowCount={
-                        inMemory.level === 'enhancements'
-                          ? // if `inMemory.level === enhancements` then we can only be sure the pagination's pageSize is available in memory
-                            (pagination && pagination.pageSize) || rowCount
-                          : // otherwise, all of the data is present and usable
-                            rowCount
-                      }
-                      onCellRender={onCellRender}
-                    />
-                  ) : null}
-                  <div
-                    className="euiDataGrid__content"
-                    role="grid"
-                    {...gridAriaProps}>
-                    <EuiMutationObserver
-                      observerOptions={{
-                        subtree: true,
-                        childList: true,
-                      }}
-                      onMutation={handleHeaderChange}>
-                      {ref => (
-                        <EuiDataGridHeaderRow
-                          ref={ref}
-                          leadingControlColumns={leadingControlColumns}
-                          trailingControlColumns={trailingControlColumns}
-                          columns={orderedVisibleColumns}
-                          columnWidths={columnWidths}
-                          defaultColumnWidth={defaultColumnWidth}
-                          setColumnWidth={setColumnWidth}
-                          schema={mergedSchema}
-                          sorting={sorting}
-                          headerIsInteractive={headerIsInteractive}
-                          focusedCell={focusedCell}
-                          setFocusedCell={setFocusedCell}
-                        />
-                      )}
-                    </EuiMutationObserver>
-                    <EuiDataGridBody
-                      columnWidths={columnWidths}
-                      defaultColumnWidth={defaultColumnWidth}
-                      inMemoryValues={inMemoryValues}
-                      inMemory={inMemory}
+              <Fragment>
+                <EuiMutationObserver
+                  observerOptions={{
+                    subtree: true,
+                    childList: true,
+                  }}
+                  onMutation={handleHeaderChange}>
+                  {ref => (
+                    <EuiDataGridHeaderRow
+                      ref={ref}
                       leadingControlColumns={leadingControlColumns}
                       trailingControlColumns={trailingControlColumns}
                       columns={orderedVisibleColumns}
+                      columnWidths={columnWidths}
+                      defaultColumnWidth={defaultColumnWidth}
+                      setColumnWidth={setColumnWidth}
                       schema={mergedSchema}
-                      schemaDetectors={allSchemaDetectors}
-                      popoverContents={popoverContents}
-                      focusedCell={focusedCell}
-                      onCellFocus={setFocusedCell}
-                      pagination={pagination}
                       sorting={sorting}
-                      renderCellValue={renderCellValue}
-                      rowCount={rowCount}
-                      interactiveCellId={interactiveCellId}
+                      headerIsInteractive={headerIsInteractive}
+                      focusedCell={focusedCell}
+                      setFocusedCell={setFocusedCell}
                     />
+                  )}
+                </EuiMutationObserver>
+                <div
+                  onKeyDown={createKeyDownHandler(
+                    props,
+                    orderedVisibleColumns,
+                    leadingControlColumns,
+                    trailingControlColumns,
+                    focusedCell,
+                    headerIsInteractive,
+                    setFocusedCell,
+                    focusAfterRender
+                  )}
+                  className="euiDataGrid__verticalScroll"
+                  ref={resizeRef}
+                  {...rest}>
+                  <div className="euiDataGrid__overflow">
+                    {inMemory ? (
+                      <EuiDataGridInMemoryRenderer
+                        inMemory={inMemory}
+                        renderCellValue={renderCellValue}
+                        columns={columns}
+                        rowCount={
+                          inMemory.level === 'enhancements'
+                            ? // if `inMemory.level === enhancements` then we can only be sure the pagination's pageSize is available in memory
+                              (pagination && pagination.pageSize) || rowCount
+                            : // otherwise, all of the data is present and usable
+                              rowCount
+                        }
+                        onCellRender={onCellRender}
+                      />
+                    ) : null}
+                    <div
+                      className="euiDataGrid__content"
+                      role="grid"
+                      {...gridAriaProps}>
+                      <EuiDataGridBody
+                        columnWidths={columnWidths}
+                        defaultColumnWidth={defaultColumnWidth}
+                        inMemoryValues={inMemoryValues}
+                        inMemory={inMemory}
+                        leadingControlColumns={leadingControlColumns}
+                        trailingControlColumns={trailingControlColumns}
+                        columns={orderedVisibleColumns}
+                        schema={mergedSchema}
+                        schemaDetectors={allSchemaDetectors}
+                        popoverContents={popoverContents}
+                        focusedCell={focusedCell}
+                        onCellFocus={setFocusedCell}
+                        pagination={pagination}
+                        sorting={sorting}
+                        renderCellValue={renderCellValue}
+                        rowCount={rowCount}
+                        interactiveCellId={interactiveCellId}
+                      />
+                    </div>
                   </div>
                 </div>
-              </div>
+              </Fragment>
             )}
           </EuiResizeObserver>
 

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -811,7 +811,18 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
           ) : null}
           <EuiResizeObserver onResize={onResize}>
             {resizeRef => (
-              <Fragment>
+              <div
+                className="euiDataGrid__keyWrap"
+                onKeyDown={createKeyDownHandler(
+                  props,
+                  orderedVisibleColumns,
+                  leadingControlColumns,
+                  trailingControlColumns,
+                  focusedCell,
+                  headerIsInteractive,
+                  setFocusedCell,
+                  focusAfterRender
+                )}>
                 <EuiMutationObserver
                   observerOptions={{
                     subtree: true,
@@ -836,16 +847,6 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
                   )}
                 </EuiMutationObserver>
                 <div
-                  onKeyDown={createKeyDownHandler(
-                    props,
-                    orderedVisibleColumns,
-                    leadingControlColumns,
-                    trailingControlColumns,
-                    focusedCell,
-                    headerIsInteractive,
-                    setFocusedCell,
-                    focusAfterRender
-                  )}
                   className="euiDataGrid__verticalScroll"
                   ref={resizeRef}
                   {...rest}>
@@ -891,7 +892,7 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
                     </div>
                   </div>
                 </div>
-              </Fragment>
+              </div>
             )}
           </EuiResizeObserver>
 

--- a/src/components/datagrid/data_grid_cell.tsx
+++ b/src/components/datagrid/data_grid_cell.tsx
@@ -368,7 +368,7 @@ export class EuiDataGridCell extends Component<
             isOpen={this.state.popoverIsOpen}
             ownFocus
             panelClassName="euiDataGridRowCell__popover"
-            zIndex={2000}
+            zIndex={8001}
             display="block"
             closePopover={() => this.setState({ popoverIsOpen: false })}
             onTrapDeactivation={this.updateFocus}>


### PR DESCRIPTION
### Summary

Fixes https://github.com/elastic/eui/issues/2464

Moves the header above the scroll area so that it will be fixed to top on scroll. cc @AlonaNadler who will be happy. This should work fine in container views as well. While I was in there I noticed a minor documentation / mobile bug and a z-index bug for cell popovers being hidden when the grid is in full screen mode.

![](http://snid.es/0d8368bb322b/Screen%252520Recording%2525202020-02-26%252520at%25252008.48%252520PM.gif)

![](http://snid.es/b6dce8636389/Screen%252520Recording%2525202020-02-26%252520at%25252008.46%252520PM.gif)

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [ ] ~Props have proper **autodocs**~
- [x] Added **documentation** examples
- [x] Added or updated **jest tests**
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
