### PR TITLE
Extend EuiCodeEditor's props with those from react-ace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 **Bug fixes**
 
 - Fixed `EuiTitle` not rendering child classes ([#2926](https://github.com/elastic/eui/pull/2926))
+- Added TypeScript definition for `EuiCodeEditor`'s accepting `react-ace` props ([#2926](https://github.com/elastic/eui/pull/2926))
 
 **Theme: Amsterdam**
 

--- a/src/components/code_editor/code_editor.tsx
+++ b/src/components/code_editor/code_editor.tsx
@@ -25,7 +25,9 @@ type SupportedAriaAttribute =
   | 'aria-describedby';
 type SupportedAriaAttributes = Pick<AriaAttributes, SupportedAriaAttribute>;
 
-export interface EuiCodeEditorProps extends SupportedAriaAttributes {
+export interface EuiCodeEditorProps
+  extends SupportedAriaAttributes,
+    Omit<IAceEditorProps, 'mode'> {
   width?: string;
   height?: string;
   onBlur?: IAceEditorProps['onBlur'];


### PR DESCRIPTION
### Summary

Allow `EuiCodeEditor` to accept additional props intended for the `react-ace` editor.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
