### PR TITLE
eui button now has a single return statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- `EuiButton` now has a single return statement ([#2896](https://github.com/elastic/eui/pull/2896))
+- `EuiButton` now has a single return statement ([#2954](https://github.com/elastic/eui/pull/2954))
 - Converted `EuiForm` to TypeScript, added many missing `/form` Prop types ([#2896](https://github.com/elastic/eui/pull/2896))
 - Empty table th elements replaced with td in `EuiTable`. ([#2934](https://github.com/elastic/eui/pull/2934))
 - Added default prompt text to `aria-describedby` for `EuiFilePicker` ([#2919](https://github.com/elastic/eui/pull/2919))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- `EuiButton` now has a single return statement ([#2896](https://github.com/elastic/eui/pull/2896))
 - Converted `EuiForm` to TypeScript, added many missing `/form` Prop types ([#2896](https://github.com/elastic/eui/pull/2896))
 - Empty table th elements replaced with td in `EuiTable`. ([#2934](https://github.com/elastic/eui/pull/2934))
 - Added default prompt text to `aria-describedby` for `EuiFilePicker` ([#2919](https://github.com/elastic/eui/pull/2919))

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,9 +1,8 @@
 import React, {
-  AnchorHTMLAttributes,
-  ButtonHTMLAttributes,
   FunctionComponent,
   HTMLAttributes,
   Ref,
+  ButtonHTMLAttributes,
 } from 'react';
 import classNames from 'classnames';
 
@@ -165,33 +164,24 @@ export const EuiButton: FunctionComponent<Props> = ({
     </span>
   );
 
-  // <a> elements don't respect the `disabled` attribute. So if we're disabled, we'll just pretend
+  // <Element> elements don't respect the `disabled` attribute. So if we're disabled, we'll just pretend
   // this is a button and piggyback off its disabled styles.
-  if (href && !isDisabled) {
-    const secureRel = getSecureRelForTarget({ href, target, rel });
+  const Element = href && !isDisabled ? 'a' : 'button';
 
-    return (
-      <a
-        className={classes}
-        href={href}
-        target={target}
-        rel={secureRel}
-        ref={buttonRef as Ref<HTMLAnchorElement>}
-        {...rest as AnchorHTMLAttributes<HTMLAnchorElement>}>
-        {innerNode}
-      </a>
-    );
-  }
-
+  const secureRel = getSecureRelForTarget({ href, target, rel });
   let buttonType: ButtonHTMLAttributes<HTMLButtonElement>['type'];
+
   return (
-    <button
-      disabled={isDisabled}
+    <Element
       className={classes}
+      disabled={isDisabled}
+      href={href}
+      target={target}
+      rel={secureRel}
+      ref={buttonRef as Ref<HTMLButtonElement & HTMLAnchorElement>}
       type={type as typeof buttonType}
-      ref={buttonRef as Ref<HTMLButtonElement>}
-      {...rest as ButtonHTMLAttributes<HTMLButtonElement>}>
+      {...rest as HTMLAttributes<HTMLAnchorElement | HTMLButtonElement>}>
       {innerNode}
-    </button>
+    </Element>
   );
 };

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -167,21 +167,28 @@ export const EuiButton: FunctionComponent<Props> = ({
   // <Element> elements don't respect the `disabled` attribute. So if we're disabled, we'll just pretend
   // this is a button and piggyback off its disabled styles.
   const Element = href && !isDisabled ? 'a' : 'button';
-  const relObj: { rel?: string } = {};
-  if (href && !isDisabled)
-    relObj.rel = getSecureRelForTarget({ href, target, rel });
 
-  let buttonType: ButtonHTMLAttributes<HTMLButtonElement>['type'];
+  const relObj: {
+    rel?: string;
+    href?: string;
+    type?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
+    target?: string;
+  } = {};
+
+  if (href && !isDisabled) {
+    relObj.href = href;
+    relObj.rel = getSecureRelForTarget({ href, target, rel });
+    relObj.target = target;
+  } else {
+    relObj.type = type as ButtonHTMLAttributes<HTMLButtonElement>['type'];
+  }
 
   return (
     <Element
       className={classes}
       disabled={isDisabled}
-      href={href}
-      target={target}
       {...relObj}
       ref={buttonRef as Ref<HTMLButtonElement & HTMLAnchorElement>}
-      type={type as typeof buttonType}
       {...rest as HTMLAttributes<HTMLAnchorElement | HTMLButtonElement>}>
       {innerNode}
     </Element>

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -167,8 +167,10 @@ export const EuiButton: FunctionComponent<Props> = ({
   // <Element> elements don't respect the `disabled` attribute. So if we're disabled, we'll just pretend
   // this is a button and piggyback off its disabled styles.
   const Element = href && !isDisabled ? 'a' : 'button';
+  const relObj: { rel?: string } = {};
+  if (href && !isDisabled)
+    relObj.rel = getSecureRelForTarget({ href, target, rel });
 
-  const secureRel = getSecureRelForTarget({ href, target, rel });
   let buttonType: ButtonHTMLAttributes<HTMLButtonElement>['type'];
 
   return (
@@ -177,7 +179,7 @@ export const EuiButton: FunctionComponent<Props> = ({
       disabled={isDisabled}
       href={href}
       target={target}
-      rel={secureRel}
+      {...relObj}
       ref={buttonRef as Ref<HTMLButtonElement & HTMLAnchorElement>}
       type={type as typeof buttonType}
       {...rest as HTMLAttributes<HTMLAnchorElement | HTMLButtonElement>}>


### PR DESCRIPTION
### Summary

Fixes : #2831

eui button now has a single return statement to rerturn button or anchor tag

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
