### PR TITLE
Fixed data grid break on invalid schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 **Bug fixes**
 
+- Fixed `EuiDataGrid` breaking if invalid schema passed ([#2955](https://github.com/elastic/eui/pull/2955))
 - Fixed `EuiTitle` not rendering child classes ([#2925](https://github.com/elastic/eui/pull/2925))
 - Extended `div` element in `EuiFlyout` type ([#2914](https://github.com/elastic/eui/pull/2914))
 - Fixed popover positioning service to be more lenient when positioning 0-width or 0-height content ([#2948](https://github.com/elastic/eui/pull/2948))

--- a/src/components/datagrid/column_sorting.tsx
+++ b/src/components/datagrid/column_sorting.tsx
@@ -96,10 +96,18 @@ export const useColumnSorting = (
 
   const numberOfSortedFields = sorting.columns.length;
 
-  const inactiveSortableColumns = inactiveColumns.filter(({ id, isSortable }) =>
+  const schemaDetails = (id: string | number) =>
     schema.hasOwnProperty(id) && schema[id].columnType != null
-      ? getDetailsForSchema(schemaDetectors, schema[id].columnType).isSortable
-      : isSortable !== false
+      ? getDetailsForSchema(schemaDetectors, schema[id].columnType)
+      : null;
+
+  const inactiveSortableColumns = inactiveColumns.filter(
+    ({ id, isSortable }) => {
+      const schemaDetail = schemaDetails(id);
+      const sortable =
+        schemaDetail != null ? schemaDetail.isSortable : isSortable !== false;
+      return sortable;
+    }
   );
 
   const columnSorting = (
@@ -221,8 +229,7 @@ export const useColumnSorting = (
                               <EuiFlexItem grow={false}>
                                 <EuiToken
                                   iconType={
-                                    schema.hasOwnProperty(id) &&
-                                    schema[id].columnType != null
+                                    schemaDetails(id) != null
                                       ? getDetailsForSchema(
                                           schemaDetectors,
                                           schema[id].columnType
@@ -230,8 +237,7 @@ export const useColumnSorting = (
                                       : 'tokenString'
                                   }
                                   color={
-                                    schema.hasOwnProperty(id) &&
-                                    schema[id].columnType != null
+                                    schemaDetails(id) != null
                                       ? getDetailsForSchema(
                                           schemaDetectors,
                                           schema[id].columnType

--- a/src/components/datagrid/column_sorting.tsx
+++ b/src/components/datagrid/column_sorting.tsx
@@ -104,8 +104,12 @@ export const useColumnSorting = (
   const inactiveSortableColumns = inactiveColumns.filter(
     ({ id, isSortable }) => {
       const schemaDetail = schemaDetails(id);
-      const sortable =
-        schemaDetail != null ? schemaDetail.isSortable : isSortable !== false;
+      let sortable = true;
+      if (isSortable != null) {
+        sortable = isSortable;
+      } else if (schemaDetail != null) {
+        sortable = schemaDetail.isSortable;
+      }
       return sortable;
     }
   );

--- a/src/components/datagrid/column_sorting_draggable.tsx
+++ b/src/components/datagrid/column_sorting_draggable.tsx
@@ -26,16 +26,21 @@ export interface EuiDataGridColumnSortingDraggableProps {
 export const EuiDataGridColumnSortingDraggable: FunctionComponent<
   EuiDataGridColumnSortingDraggableProps
 > = ({ id, direction, index, sorting, schema, schemaDetectors, ...rest }) => {
+  const schemaDetails =
+    schema.hasOwnProperty(id) && schema[id].columnType != null
+      ? getDetailsForSchema(schemaDetectors, schema[id].columnType)
+      : null;
+
   const textSortAsc =
-    schema.hasOwnProperty(id) && schema[id].columnType != null ? (
-      getDetailsForSchema(schemaDetectors, schema[id].columnType).sortTextAsc
+    schemaDetails != null ? (
+      schemaDetails.sortTextAsc
     ) : (
       <EuiI18n token="euiColumnSortingDraggable.defaultSortAsc" default="A-Z" />
     );
 
   const textSortDesc =
-    schema.hasOwnProperty(id) && schema[id].columnType != null ? (
-      getDetailsForSchema(schemaDetectors, schema[id].columnType).sortTextDesc
+    schemaDetails != null ? (
+      schemaDetails.sortTextDesc
     ) : (
       <EuiI18n
         token="euiColumnSortingDraggable.defaultSortDesc"
@@ -108,21 +113,9 @@ export const EuiDataGridColumnSortingDraggable: FunctionComponent<
 
             <EuiFlexItem grow={false}>
               <EuiToken
-                color={
-                  schema.hasOwnProperty(id) && schema[id].columnType != null
-                    ? getDetailsForSchema(
-                        schemaDetectors,
-                        schema[id].columnType
-                      ).color
-                    : undefined
-                }
+                color={schemaDetails != null ? schemaDetails.color : undefined}
                 iconType={
-                  schema.hasOwnProperty(id) && schema[id].columnType != null
-                    ? getDetailsForSchema(
-                        schemaDetectors,
-                        schema[id].columnType
-                      ).icon
-                    : 'tokenString'
+                  schemaDetails != null ? schemaDetails.icon : 'tokenString'
                 }
               />
             </EuiFlexItem>


### PR DESCRIPTION
### Summary

Fixes #2949 
Fixed Data grid break on invalid schema

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
