### PR TITLE
EuiComboBox type fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed `EuiTitle` not rendering child classes ([#2925](https://github.com/elastic/eui/pull/2925))
 - Extended `div` element in `EuiFlyout` type ([#2914](https://github.com/elastic/eui/pull/2914))
 - Fixed popover positioning service to be more lenient when positioning 0-width or 0-height content ([#2948](https://github.com/elastic/eui/pull/2948))
+- Fixed type definitions for `EuiComboBox` ([#2971](https://github.com/elastic/eui/pull/2971))
 
 **Theme: Amsterdam**
 

--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -49,7 +49,7 @@ type DrillProps<T> = Pick<
   'onCreateOption' | 'options' | 'renderOption' | 'selectedOptions'
 >;
 
-export interface EuiComboBoxProps<T>
+interface _EuiComboBoxProps<T>
   extends CommonProps,
     Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>,
     DrillProps<T> {
@@ -75,6 +75,27 @@ export interface EuiComboBoxProps<T>
   singleSelection: boolean | EuiComboBoxSingleSelectionShape;
 }
 
+/**
+ * Because of how TypeScript's LibraryManagedAttributes is designed to handle defaultProps (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-0.html#support-for-defaultprops-in-jsx)
+ * we can't directly export the above Props definitions, as the defaulted values are not made optional
+ * as it isn't processed by LibraryManagedAttributes. To get around this, we:
+ * - remove the props which have default values applied
+ *   - additionally re-define `options` and `selectedOptions` defaults, necessary as static members can't access generics and become never[]
+ * - export (Props - Defaults) & Partial<Defaults>
+ */
+type DefaultProps<T> = Omit<
+  typeof EuiComboBox['defaultProps'],
+  'options' | 'selectedOptions'
+> & {
+  options: Array<EuiComboBoxOptionOption<T>>;
+  selectedOptions: Array<EuiComboBoxOptionOption<T>>;
+};
+export type EuiComboBoxProps<T> = Omit<
+  _EuiComboBoxProps<T>,
+  keyof DefaultProps<T>
+> &
+  Partial<DefaultProps<T>>;
+
 interface EuiComboBoxState<T> {
   activeOptionIndex: number;
   hasFocus: boolean;
@@ -89,7 +110,7 @@ interface EuiComboBoxState<T> {
 const initialSearchValue = '';
 
 export class EuiComboBox<T> extends Component<
-  EuiComboBoxProps<T>,
+  _EuiComboBoxProps<T>,
   EuiComboBoxState<T>
 > {
   static defaultProps = {
@@ -654,7 +675,7 @@ export class EuiComboBox<T> extends Component<
   }
 
   static getDerivedStateFromProps<T>(
-    nextProps: EuiComboBoxProps<T>,
+    nextProps: _EuiComboBoxProps<T>,
     prevState: EuiComboBoxState<T>
   ) {
     const { options, selectedOptions, singleSelection } = nextProps;

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
@@ -52,7 +52,7 @@ export type EuiComboBoxOptionsListProps<T> = CommonProps &
     onCreateOption?: (
       searchValue: string,
       options: Array<EuiComboBoxOptionOption<T>>
-    ) => boolean;
+    ) => boolean | void;
     onOptionClick?: OptionHandler<T>;
     onOptionEnterKey?: OptionHandler<T>;
     onScroll?: ListProps['onScroll'];


### PR DESCRIPTION
### Summary

Another bugfix for `v20.0` types. The first was a regression in *combo_box_options_list.tsx*'s `onCreateOption`, which primarily returns `void`. The second is an interaction between TypeScript's management of class components' `defaultProps` and our pattern of exporting a component's props - the prop interface is not the end result.

I have verified that Kibana builds and passes type checks & jest tests, with these changes.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
