### PR TITLE
[Feature] Added `EuiCollapsibleNav` component

### DIFF
--- a/src-docs/src/routes.js
+++ b/src-docs/src/routes.js
@@ -63,6 +63,8 @@ import { CodeEditorExample } from './views/code_editor/code_editor_example';
 
 import { CodeExample } from './views/code/code_example';
 
+import { CollapsibleNavExample } from './views/collapsible_nav/collapsible_nav_example';
+
 import { ColorPickerExample } from './views/color_picker/color_picker_example';
 
 import { ComboBoxExample } from './views/combo_box/combo_box_example';
@@ -323,6 +325,7 @@ const navigation = [
     items: [
       BreadcrumbsExample,
       ButtonExample,
+      CollapsibleNavExample,
       ContextMenuExample,
       ControlBarExample,
       FacetExample,

--- a/src-docs/src/views/collapsible_nav/collapsible_nav.tsx
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav.tsx
@@ -1,5 +1,24 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { EuiCollapsibleNav } from '../../../../src/components/collapsible_nav';
+import { EuiButton } from '../../../../src/components/button';
 
-export default () => <EuiCollapsibleNav />;
+export default () => {
+  const [navIsOpen, setNavIsOpen] = useState(false);
+  const [navIsDocked, setNavIsDocked] = useState(false);
+
+  return (
+    <>
+      <EuiButton onClick={() => setNavIsOpen(!navIsOpen)}>Toggle nav</EuiButton>
+      {navIsOpen && (
+        <EuiCollapsibleNav
+          docked={navIsDocked}
+          onClose={() => setNavIsOpen(false)}>
+          <EuiButton onClick={() => setNavIsDocked(!navIsDocked)}>
+            Toggle Docked
+          </EuiButton>
+        </EuiCollapsibleNav>
+      )}
+    </>
+  );
+};

--- a/src-docs/src/views/collapsible_nav/collapsible_nav.tsx
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+import { EuiCollapsibleNav } from '../../../../src/components/collapsible_nav';
+
+export default () => <EuiCollapsibleNav />;

--- a/src-docs/src/views/collapsible_nav/collapsible_nav.tsx
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
 
 import { EuiCollapsibleNav } from '../../../../src/components/collapsible_nav';
-import { EuiButton } from '../../../../src/components/button';
+import { EuiButton, EuiButtonToggle } from '../../../../src/components/button';
+import { EuiTitle } from '../../../../src/components/title';
+import { EuiSpacer } from '../../../../src/components/spacer';
 
 export default () => {
   const [navIsOpen, setNavIsOpen] = useState(false);
@@ -14,9 +16,19 @@ export default () => {
         <EuiCollapsibleNav
           docked={navIsDocked}
           onClose={() => setNavIsOpen(false)}>
-          <EuiButton onClick={() => setNavIsDocked(!navIsDocked)}>
-            Toggle Docked
-          </EuiButton>
+          <div style={{ padding: 16 }}>
+            <EuiTitle>
+              <h2>I am some nav</h2>
+            </EuiTitle>
+            <EuiSpacer />
+            <EuiButtonToggle
+              label={`Docked: ${navIsDocked ? 'on' : 'off'}`}
+              fill={navIsDocked}
+              onChange={() => {
+                setNavIsDocked(!navIsDocked);
+              }}
+            />
+          </div>
         </EuiCollapsibleNav>
       )}
     </>

--- a/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { renderToHtml } from '../../services';
+
+import { GuideSectionTypes } from '../../components';
+
+import { EuiCode, EuiCollapsibleNav } from '../../../../src/components';
+
+import CollapsibleNav from './collapsible_nav';
+const collapsibleNavSource = require('!!raw-loader!./collapsible_nav');
+const collapsibleNavHtml = renderToHtml(CollapsibleNav);
+
+export const CollapsibleNavExample = {
+  title: 'CollapsibleNav',
+  sections: [
+    {
+      title: 'CollapsibleNav',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: collapsibleNavSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: collapsibleNavHtml,
+        },
+      ],
+      text: (
+        <p>
+          Description needed: how to use the{' '}
+          <EuiCode>EuiCollapsibleNav</EuiCode> component.
+        </p>
+      ),
+      props: { EuiCollapsibleNav },
+      demo: <CollapsibleNav />,
+    },
+  ],
+};

--- a/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
@@ -1,20 +1,38 @@
 import React from 'react';
+import { Link } from 'react-router';
 
 import { renderToHtml } from '../../services';
 
 import { GuideSectionTypes } from '../../components';
 
-import { EuiCode, EuiCollapsibleNav } from '../../../../src/components';
+import {
+  EuiCode,
+  EuiCollapsibleNav,
+  EuiText,
+  EuiSpacer,
+} from '../../../../src/components';
 
 import CollapsibleNav from './collapsible_nav';
 const collapsibleNavSource = require('!!raw-loader!./collapsible_nav');
 const collapsibleNavHtml = renderToHtml(CollapsibleNav);
 
 export const CollapsibleNavExample = {
-  title: 'CollapsibleNav',
+  title: 'Collapsible nav',
+  intro: (
+    <EuiText>
+      <p>
+        This is a high level component that creates a flyout-style navigational
+        pane. It is the next evolution of{' '}
+        <Link to="/layout/nav-drawer">
+          <strong>EuiNavDrawer</strong>
+        </Link>{' '}
+        which will be deprecated in the coming months.
+      </p>
+      <EuiSpacer size="m" />
+    </EuiText>
+  ),
   sections: [
     {
-      title: 'CollapsibleNav',
       source: [
         {
           type: GuideSectionTypes.JS,
@@ -27,8 +45,14 @@ export const CollapsibleNavExample = {
       ],
       text: (
         <p>
-          Description needed: how to use the{' '}
-          <EuiCode>EuiCollapsibleNav</EuiCode> component.
+          <strong>EuiCollapsibleNav</strong> is simply a custom wrapper around{' '}
+          <Link to="/layout/flyout">
+            <strong>EuiFlyout</strong>
+          </Link>{' '}
+          the visibility of which must be maintained by the consuming
+          application. An extra feature that it provides is the ability to{' '}
+          <EuiCode>dock</EuiCode> the flyout. This affixes the flyout to the
+          window and pushes the body content by adding left side padding.
         </p>
       ),
       props: { EuiCollapsibleNav },

--- a/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
@@ -10,6 +10,7 @@ import {
   EuiCollapsibleNav,
   EuiText,
   EuiSpacer,
+  EuiCallOut,
 } from '../../../../src/components';
 
 import CollapsibleNav from './collapsible_nav';
@@ -44,16 +45,25 @@ export const CollapsibleNavExample = {
         },
       ],
       text: (
-        <p>
-          <strong>EuiCollapsibleNav</strong> is simply a custom wrapper around{' '}
-          <Link to="/layout/flyout">
-            <strong>EuiFlyout</strong>
-          </Link>{' '}
-          the visibility of which must be maintained by the consuming
-          application. An extra feature that it provides is the ability to{' '}
-          <EuiCode>dock</EuiCode> the flyout. This affixes the flyout to the
-          window and pushes the body content by adding left side padding.
-        </p>
+        <>
+          <p>
+            <strong>EuiCollapsibleNav</strong> is simply a custom wrapper around{' '}
+            <Link to="/layout/flyout">
+              <strong>EuiFlyout</strong>
+            </Link>{' '}
+            the visibility of which must be maintained by the consuming
+            application. An extra feature that it provides is the ability to{' '}
+            <EuiCode>dock</EuiCode> the flyout. This affixes the flyout to the
+            window and pushes the body content by adding left side padding.
+          </p>
+          <EuiCallOut title="Smaller screen sizes don't allow for docking">
+            <p>
+              There is not enough room to push the body content on smaller
+              screens, so <strong>EuiCollapsibleNav</strong> makes docking
+              conditional on window width.
+            </p>
+          </EuiCallOut>
+        </>
       ),
       props: { EuiCollapsibleNav },
       demo: <CollapsibleNav />,

--- a/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
@@ -47,22 +47,19 @@ export const CollapsibleNavExample = {
       text: (
         <>
           <p>
-            <strong>EuiCollapsibleNav</strong> is simply a custom wrapper around{' '}
+            <strong>EuiCollapsibleNav</strong> is a similar implementation to{' '}
             <Link to="/layout/flyout">
               <strong>EuiFlyout</strong>
-            </Link>{' '}
-            the visibility of which must be maintained by the consuming
+            </Link>
+            ; the visibility of which must be maintained by the consuming
             application. An extra feature that it provides is the ability to{' '}
             <EuiCode>dock</EuiCode> the flyout. This affixes the flyout to the
             window and pushes the body content by adding left side padding.
           </p>
-          <EuiCallOut title="Smaller screen sizes don't allow for docking">
-            <p>
-              There is not enough room to push the body content on smaller
-              screens, so <strong>EuiCollapsibleNav</strong> makes docking
-              conditional on window width.
-            </p>
-          </EuiCallOut>
+          <EuiCallOut
+            iconType="tableOfContents"
+            title="Docking is not possible on small screens because it would force less real estate for the page content."
+          />
         </>
       ),
       props: { EuiCollapsibleNav },

--- a/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiCollapsibleNav is rendered 1`] = `
+<div
+  aria-label="aria-label"
+  class="euiCollapsibleNav testClass1 testClass2"
+  data-test-subj="test subject string"
+/>
+`;

--- a/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiCollapsibleNav can be docked 1`] = `
+<div>
+  <div
+    data-focus-guard="true"
+    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+    tabindex="0"
+  />
+  <div
+    data-focus-guard="true"
+    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+    tabindex="1"
+  />
+  <div
+    data-focus-lock-disabled="false"
+  >
+    <div
+      class="euiFlyout euiFlyout--small euiCollapsibleNav euiCollapsibleNav--isDocked"
+      role="dialog"
+      tabindex="0"
+    />
+  </div>
+  <div
+    data-focus-guard="true"
+    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+    tabindex="0"
+  />
+</div>
+`;
+
 exports[`EuiCollapsibleNav is rendered 1`] = `
 <div
   aria-label="aria-label"

--- a/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
@@ -30,9 +30,35 @@ exports[`EuiCollapsibleNav can be docked 1`] = `
 `;
 
 exports[`EuiCollapsibleNav is rendered 1`] = `
-<div
-  aria-label="aria-label"
-  class="euiCollapsibleNav testClass1 testClass2"
-  data-test-subj="test subject string"
-/>
+Array [
+  <div />,
+  <div>
+    <div
+      data-focus-guard="true"
+      style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+      tabindex="0"
+    />
+    <div
+      data-focus-guard="true"
+      style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+      tabindex="1"
+    />
+    <div
+      data-focus-lock-disabled="false"
+    >
+      <div
+        aria-label="aria-label"
+        class="euiFlyout euiFlyout--small euiCollapsibleNav testClass1 testClass2"
+        data-test-subj="test subject string"
+        role="dialog"
+        tabindex="0"
+      />
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+      tabindex="0"
+    />
+  </div>,
+]
 `;

--- a/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
@@ -5,26 +5,44 @@ exports[`EuiCollapsibleNav can be docked 1`] = `
   <div
     data-focus-guard="true"
     style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
-    tabindex="0"
+    tabindex="-1"
   />
   <div
     data-focus-guard="true"
     style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
-    tabindex="1"
+    tabindex="-1"
   />
   <div
-    data-focus-lock-disabled="false"
+    data-focus-lock-disabled="disabled"
   >
-    <div
-      class="euiFlyout euiFlyout--small euiCollapsibleNav euiCollapsibleNav--isDocked"
-      role="dialog"
-      tabindex="0"
-    />
+    <nav
+      class="euiCollapsibleNav euiCollapsibleNav--isDocked"
+    >
+      <button
+        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiCollapsibleNav__closeButton"
+        type="button"
+      >
+        <span
+          class="euiButtonEmpty__content"
+        >
+          <div
+            aria-hidden="true"
+            class="euiButtonEmpty__icon"
+            data-euiicon-type="cross"
+          />
+          <span
+            class="euiButtonEmpty__text"
+          >
+            close
+          </span>
+        </span>
+      </button>
+    </nav>
   </div>
   <div
     data-focus-guard="true"
     style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
-    tabindex="0"
+    tabindex="-1"
   />
 </div>
 `;
@@ -46,13 +64,31 @@ Array [
     <div
       data-focus-lock-disabled="false"
     >
-      <div
+      <nav
         aria-label="aria-label"
-        class="euiFlyout euiFlyout--small euiCollapsibleNav testClass1 testClass2"
+        class="euiCollapsibleNav testClass1 testClass2"
         data-test-subj="test subject string"
-        role="dialog"
-        tabindex="0"
-      />
+      >
+        <button
+          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiCollapsibleNav__closeButton"
+          type="button"
+        >
+          <span
+            class="euiButtonEmpty__content"
+          >
+            <div
+              aria-hidden="true"
+              class="euiButtonEmpty__icon"
+              data-euiicon-type="cross"
+            />
+            <span
+              class="euiButtonEmpty__text"
+            >
+              close
+            </span>
+          </span>
+        </button>
+      </nav>
     </div>
     <div
       data-focus-guard="true"

--- a/src/components/collapsible_nav/_collapsible_nav.scss
+++ b/src/components/collapsible_nav/_collapsible_nav.scss
@@ -1,0 +1,3 @@
+.euiCollapsibleNav {
+  z-index: 1;
+}

--- a/src/components/collapsible_nav/_collapsible_nav.scss
+++ b/src/components/collapsible_nav/_collapsible_nav.scss
@@ -1,3 +1,33 @@
-.euiCollapsibleNav {
-  z-index: 1;
+// Is a EuiFlyout component but shifted to the left side
+// Using flyout class for specificity
+
+.euiFlyout.euiCollapsibleNav {
+  right: auto;
+  left: 0;
+  // Needs both to override vw units
+  min-width: $euiNavDrawerWidthExpanded;
+  max-width: $euiNavDrawerWidthExpanded;
+  animation: euiCollapsibleNav $euiAnimSpeedNormal $euiAnimSlightResistance;
+
+  &--isDocked {
+    @include euiBottomShadowMedium;
+  }
+}
+
+.euiBody--collapsibleNavIsDocked {
+  // Shrink the content from the left so it's no longer overlapped by the nav drawer (ALWAYS)
+  padding-left: $euiNavDrawerWidthExpanded !important; // sass-lint:disable-line no-important
+  transition: padding $euiAnimSpeedFast $euiAnimSlightResistance;
+}
+
+@keyframes euiCollapsibleNav {
+  0% {
+    opacity: 0;
+    transform: translateX(-100%);
+  }
+
+  75% {
+    opacity: 1;
+    transform: translateX(0%);
+  }
 }

--- a/src/components/collapsible_nav/_collapsible_nav.scss
+++ b/src/components/collapsible_nav/_collapsible_nav.scss
@@ -8,16 +8,20 @@
   min-width: $euiCollapsibleNavWidth;
   max-width: $euiCollapsibleNavWidth;
   animation: euiCollapsibleNavIn $euiAnimSpeedNormal $euiAnimSlightResistance;
-
-  &--isDocked {
-    @include euiBottomShadowMedium;
-  }
 }
 
-.euiBody--collapsibleNavIsDocked {
-  // Shrink the content from the left so it's no longer overlapped by the nav drawer (ALWAYS)
-  padding-left: $euiCollapsibleNavWidth !important; // sass-lint:disable-line no-important
-  transition: padding $euiAnimSpeedFast $euiAnimSlightResistance;
+@include euiBreakpoint('l', 'xl') {
+  // The addition of this class is handled through JS as well
+  // but adding under the breakpoint mixin is an additional fail-safe
+  .euiCollapsibleNav.euiCollapsibleNav--isDocked {
+    @include euiBottomShadowMedium;
+  }
+
+  .euiBody--collapsibleNavIsDocked {
+    // Shrink the content from the left so it's no longer overlapped by the nav drawer (ALWAYS)
+    padding-left: $euiCollapsibleNavWidth !important; // sass-lint:disable-line no-important
+    transition: padding $euiAnimSpeedFast $euiAnimSlightResistance;
+  }
 }
 
 // Specific keyframes so in comes in from the left

--- a/src/components/collapsible_nav/_collapsible_nav.scss
+++ b/src/components/collapsible_nav/_collapsible_nav.scss
@@ -1,13 +1,13 @@
-// Is a EuiFlyout component but shifted to the left side
-// Using flyout class for specificity
+// It's an EuiFlyout component but shifted to the left side
+// Needs flyout class for specificity
 
 .euiFlyout.euiCollapsibleNav {
   right: auto;
   left: 0;
   // Needs both to override vw units
-  min-width: $euiNavDrawerWidthExpanded;
-  max-width: $euiNavDrawerWidthExpanded;
-  animation: euiCollapsibleNav $euiAnimSpeedNormal $euiAnimSlightResistance;
+  min-width: $euiCollapsibleNavWidth;
+  max-width: $euiCollapsibleNavWidth;
+  animation: euiCollapsibleNavIn $euiAnimSpeedNormal $euiAnimSlightResistance;
 
   &--isDocked {
     @include euiBottomShadowMedium;
@@ -16,11 +16,12 @@
 
 .euiBody--collapsibleNavIsDocked {
   // Shrink the content from the left so it's no longer overlapped by the nav drawer (ALWAYS)
-  padding-left: $euiNavDrawerWidthExpanded !important; // sass-lint:disable-line no-important
+  padding-left: $euiCollapsibleNavWidth !important; // sass-lint:disable-line no-important
   transition: padding $euiAnimSpeedFast $euiAnimSlightResistance;
 }
 
-@keyframes euiCollapsibleNav {
+// Specific keyframes so in comes in from the left
+@keyframes euiCollapsibleNavIn {
   0% {
     opacity: 0;
     transform: translateX(-100%);

--- a/src/components/collapsible_nav/_collapsible_nav.scss
+++ b/src/components/collapsible_nav/_collapsible_nav.scss
@@ -1,13 +1,23 @@
-// It's an EuiFlyout component but shifted to the left side
-// Needs flyout class for specificity
+// Extends euiFlyout
+@use '../flyout/flyout';
 
-.euiFlyout.euiCollapsibleNav {
+.euiCollapsibleNav {
+  @extend %eui-flyout;
   right: auto;
   left: 0;
-  // Needs both to override vw units
-  min-width: $euiCollapsibleNavWidth;
-  max-width: $euiCollapsibleNavWidth;
-  animation: euiCollapsibleNavIn $euiAnimSpeedNormal $euiAnimSlightResistance;
+  width: $euiCollapsibleNavWidth;
+  max-width: 80vw;
+
+  &:not(.euiCollapsibleNav--isDocked) {
+    animation: euiCollapsibleNavIn $euiAnimSpeedNormal $euiAnimSlightResistance;
+  }
+}
+
+.euiCollapsibleNav__closeButton {
+  position: absolute;
+  right: 0;
+  top: $euiSize;
+  margin-right: -25%;
 }
 
 @include euiBreakpoint('l', 'xl') {
@@ -15,6 +25,10 @@
   // but adding under the breakpoint mixin is an additional fail-safe
   .euiCollapsibleNav.euiCollapsibleNav--isDocked {
     @include euiBottomShadowMedium;
+
+    .euiCollapsibleNav__closeButton {
+      display: none;
+    }
   }
 
   .euiBody--collapsibleNavIsDocked {

--- a/src/components/collapsible_nav/_index.scss
+++ b/src/components/collapsible_nav/_index.scss
@@ -1,0 +1,1 @@
+@import 'collapsible_nav';

--- a/src/components/collapsible_nav/_index.scss
+++ b/src/components/collapsible_nav/_index.scss
@@ -1,1 +1,2 @@
+@import 'variables';
 @import 'collapsible_nav';

--- a/src/components/collapsible_nav/_variables.scss
+++ b/src/components/collapsible_nav/_variables.scss
@@ -1,0 +1,7 @@
+@import '../header/variables';
+
+// Themable colors
+$euiNavDrawerBackgroundColor: $euiHeaderBackgroundColor;
+
+// Drawer variables
+$euiNavDrawerWidthExpanded: 315px;

--- a/src/components/collapsible_nav/_variables.scss
+++ b/src/components/collapsible_nav/_variables.scss
@@ -1,7 +1,2 @@
-@import '../header/variables';
-
-// Themable colors
-$euiNavDrawerBackgroundColor: $euiHeaderBackgroundColor;
-
-// Drawer variables
-$euiNavDrawerWidthExpanded: 315px;
+// Sizing
+$euiCollapsibleNavWidth: $euiSize * 20; // ~ 320px

--- a/src/components/collapsible_nav/collapsible_nav.test.tsx
+++ b/src/components/collapsible_nav/collapsible_nav.test.tsx
@@ -1,11 +1,11 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
 
 import { EuiCollapsibleNav } from './collapsible_nav';
 
-jest.mock('../portal', () => ({
-  EuiPortal: ({ children }: { children: ReactNode }) => children,
+jest.mock('../overlay_mask', () => ({
+  EuiOverlayMask: (props: any) => <div {...props} />,
 }));
 
 describe('EuiCollapsibleNav', () => {

--- a/src/components/collapsible_nav/collapsible_nav.test.tsx
+++ b/src/components/collapsible_nav/collapsible_nav.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render } from 'enzyme';
+import { requiredProps } from '../../test/required_props';
+
+import { EuiCollapsibleNav } from './collapsible_nav';
+
+describe('EuiCollapsibleNav', () => {
+  test('is rendered', () => {
+    const component = render(<EuiCollapsibleNav {...requiredProps} />);
+
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/components/collapsible_nav/collapsible_nav.test.tsx
+++ b/src/components/collapsible_nav/collapsible_nav.test.tsx
@@ -1,12 +1,26 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
 
 import { EuiCollapsibleNav } from './collapsible_nav';
 
+jest.mock('../portal', () => ({
+  EuiPortal: ({ children }: { children: ReactNode }) => children,
+}));
+
 describe('EuiCollapsibleNav', () => {
   test('is rendered', () => {
-    const component = render(<EuiCollapsibleNav {...requiredProps} />);
+    const component = render(
+      <EuiCollapsibleNav onClose={() => {}} {...requiredProps} />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
+  test('can be docked', () => {
+    const component = render(
+      <EuiCollapsibleNav docked={true} onClose={() => {}} />
+    );
 
     expect(component).toMatchSnapshot();
   });

--- a/src/components/collapsible_nav/collapsible_nav.tsx
+++ b/src/components/collapsible_nav/collapsible_nav.tsx
@@ -1,0 +1,20 @@
+import React, { HTMLAttributes, FunctionComponent } from 'react';
+import { CommonProps } from '../common';
+import classNames from 'classnames';
+
+export type EuiCollapsibleNavProps = HTMLAttributes<HTMLDivElement> &
+  CommonProps & {};
+
+export const EuiCollapsibleNav: FunctionComponent<EuiCollapsibleNavProps> = ({
+  children,
+  className,
+  ...rest
+}) => {
+  const classes = classNames('euiCollapsibleNav', className);
+
+  return (
+    <div className={classes} {...rest}>
+      {children}
+    </div>
+  );
+};

--- a/src/components/collapsible_nav/collapsible_nav.tsx
+++ b/src/components/collapsible_nav/collapsible_nav.tsx
@@ -13,7 +13,7 @@ export type EuiCollapsibleNavProps = EuiFlyoutProps & {
 export const EuiCollapsibleNav: FunctionComponent<EuiCollapsibleNavProps> = ({
   children,
   className,
-  docked,
+  docked = false,
   onClose,
   ...rest
 }) => {

--- a/src/components/collapsible_nav/collapsible_nav.tsx
+++ b/src/components/collapsible_nav/collapsible_nav.tsx
@@ -1,20 +1,53 @@
-import React, { HTMLAttributes, FunctionComponent } from 'react';
-import { CommonProps } from '../common';
+import React, { FunctionComponent, ReactNode, useEffect } from 'react';
 import classNames from 'classnames';
+import { EuiFlyout, EuiFlyoutProps } from '../flyout';
 
-export type EuiCollapsibleNavProps = HTMLAttributes<HTMLDivElement> &
-  CommonProps & {};
+export type EuiCollapsibleNavProps = EuiFlyoutProps & {
+  children?: ReactNode;
+  /**
+   * Keep navigation flyout visible and push `<body>` content via padding
+   */
+  docked?: boolean;
+};
 
 export const EuiCollapsibleNav: FunctionComponent<EuiCollapsibleNavProps> = ({
   children,
   className,
+  docked,
+  onClose,
   ...rest
 }) => {
-  const classes = classNames('euiCollapsibleNav', className);
+  useEffect(() => {
+    if (docked) {
+      document.body.classList.add('euiBody--collapsibleNavIsDocked');
+    }
+    return () => {
+      document.body.classList.remove('euiBody--collapsibleNavIsDocked');
+    };
+  }, [docked]);
+
+  const collapse = () => {
+    if (!docked) {
+      onClose();
+    }
+  };
+
+  const classes = classNames(
+    'euiCollapsibleNav',
+    { 'euiCollapsibleNav--isDocked': docked },
+    className
+  );
 
   return (
-    <div className={classes} {...rest}>
+    <EuiFlyout
+      ownFocus={!docked}
+      onClose={collapse}
+      size="s"
+      className={classes}
+      hideCloseButton={true}
+      {...rest}>
+      {/* TODO: Add a "skip navigation" keyboard only button */}
       {children}
-    </div>
+    </EuiFlyout>
   );
 };

--- a/src/components/collapsible_nav/index.ts
+++ b/src/components/collapsible_nav/index.ts
@@ -1,0 +1,1 @@
+export { EuiCollapsibleNav } from './collapsible_nav';

--- a/src/components/flyout/_flyout.scss
+++ b/src/components/flyout/_flyout.scss
@@ -1,4 +1,4 @@
-.euiFlyout {
+%eui-flyout {
   border-left: $euiBorderThin;
   // The mixin augments the above
   // sass-lint:disable mixins-before-declarations
@@ -10,10 +10,14 @@
   height: 100%;
   z-index: $euiZModal;
   background: $euiColorEmptyShade;
-  animation: euiFlyout $euiAnimSpeedNormal $euiAnimSlightResistance;
   display: flex;
   flex-direction: column;
   align-items: stretch;
+}
+
+.euiFlyout {
+  @extend %eui-flyout;
+  animation: euiFlyout $euiAnimSpeedNormal $euiAnimSlightResistance;
 }
 
 // The actual size of the X button in pixels is a bit fuzzy because of all the

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -28,6 +28,8 @@ export { EuiCode, EuiCodeBlock, EuiCodeBlockImpl } from './code';
 
 export { EuiCodeEditor } from './code_editor';
 
+export { EuiCollapsibleNav } from './collapsible_nav';
+
 export {
   EuiColorPicker,
   EuiColorPickerSwatch,

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -14,6 +14,7 @@
 @import 'card/index';
 @import 'code/index';
 @import 'code_editor/index';
+@import 'collapsible_nav/index';
 @import 'color_picker/index';
 @import 'combo_box/index';
 @import 'context_menu/index';


### PR DESCRIPTION
# Feature branch

This is the primary container for the new EuiCollapsibleNav component. It doesn't do much but 
- extend EuiFlyout, 
- push to the left side,
- add `docked` ability, and 
- setup some responsive behavior

## Basic flyout behavior

![Screen Recording 2020-03-03 at 06 40 PM](https://user-images.githubusercontent.com/549577/75830559-2454fa00-5d7f-11ea-86b9-74480cc79f1f.gif)


## Responsive behavior with docking

![Screen Recording 2020-03-03 at 06 40 PM](https://user-images.githubusercontent.com/549577/75830497-0091b400-5d7f-11ea-8d4c-69f0bca32973.gif)

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [x] Props have proper **autodocs**
- [x] Added **documentation** examples
- [x] Added or updated **jest tests**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- ~[ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~ Will be added via the Feature Branch
