### PR TITLE
fixed data grid sort popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Made `DataGrid` sort popover non-responsive ([#2979](https://github.com/elastic/eui/pull/2979))
+**Bug Fixes**
+
+- Fixed `EuiDataGrid`'s sort popover to behave properly on mobile screens ([#2979](https://github.com/elastic/eui/pull/2979))
 
 ## [`20.1.0`](https://github.com/elastic/eui/tree/v20.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Made `DataGrid` sort popover non-responsive ([#2970](https://github.com/elastic/eui/pull/2970))
+- Made `DataGrid` sort popover non-responsive ([#2979](https://github.com/elastic/eui/pull/2979))
 
 ## [`20.1.0`](https://github.com/elastic/eui/tree/v20.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `20.1.0`.
+- Made `DataGrid` sort popover non-responsive ([#2970](https://github.com/elastic/eui/pull/2970))
 
 ## [`20.1.0`](https://github.com/elastic/eui/tree/v20.1.0)
 

--- a/src/components/datagrid/column_sorting.tsx
+++ b/src/components/datagrid/column_sorting.tsx
@@ -230,9 +230,7 @@ export const useColumnSorting = (
                               alignItems="center"
                               gutterSize="s"
                               component="span"
-                              direction="row"
-                              responsive={false}
-                              wrap={false}>
+                              responsive={false}>
                               <EuiFlexItem grow={false}>
                                 <EuiToken
                                   iconType={

--- a/src/components/datagrid/column_sorting.tsx
+++ b/src/components/datagrid/column_sorting.tsx
@@ -229,7 +229,10 @@ export const useColumnSorting = (
                             <EuiFlexGroup
                               alignItems="center"
                               gutterSize="s"
-                              component="span">
+                              component="span"
+                              direction="row"
+                              responsive={false}
+                              wrap={false}>
                               <EuiFlexItem grow={false}>
                                 <EuiToken
                                   iconType={
@@ -251,9 +254,7 @@ export const useColumnSorting = (
                                 />
                               </EuiFlexItem>
                               <EuiFlexItem grow={false}>
-                                <EuiText size="xs">
-                                  <span>{id}</span>
-                                </EuiText>
+                                <EuiText size="xs">{id}</EuiText>
                               </EuiFlexItem>
                             </EuiFlexGroup>
                           </button>


### PR DESCRIPTION
### Summary

Fixes: #2975  fixed data grid sort popover

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
