### PR TITLE
always render a progress element for EuiProgress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Bug Fixes**
 
--`EuiProgress` always render a progress element ([#2979](https://github.com/elastic/eui/pull/2979))
+-`EuiProgress` always render a progress element ([#2985](https://github.com/elastic/eui/pull/2985))
 - Fixed `EuiDataGrid`'s sort popover to behave properly on mobile screens ([#2979](https://github.com/elastic/eui/pull/2979))
 - Fixed `EuiButton` and other textual components' disabled contrast ([#2874](https://github.com/elastic/eui/pull/2874))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Bug Fixes**
 
--`EuiProgress` always render a progress element ([#2985](https://github.com/elastic/eui/pull/2985))
+- Fixed `EuiProgress` to always render a progress element ([#2985](https://github.com/elastic/eui/pull/2985))
 - Fixed `EuiDataGrid`'s sort popover to behave properly on mobile screens ([#2979](https://github.com/elastic/eui/pull/2979))
 - Fixed `EuiButton` and other textual components' disabled contrast ([#2874](https://github.com/elastic/eui/pull/2874))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Bug Fixes**
 
+-`EuiProgress` always render a progress element ([#2979](https://github.com/elastic/eui/pull/2979))
 - Fixed `EuiDataGrid`'s sort popover to behave properly on mobile screens ([#2979](https://github.com/elastic/eui/pull/2979))
 - Fixed `EuiButton` and other textual components' disabled contrast ([#2874](https://github.com/elastic/eui/pull/2874))
 

--- a/src/components/progress/__snapshots__/progress.test.tsx.snap
+++ b/src/components/progress/__snapshots__/progress.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiProgress is rendered 1`] = `
-<div
+<progress
   aria-label="aria-label"
   class="euiProgress euiProgress--indeterminate euiProgress--m euiProgress--secondary testClass1 testClass2"
   data-test-subj="test subject string"

--- a/src/components/progress/_progress.scss
+++ b/src/components/progress/_progress.scss
@@ -49,6 +49,12 @@ $euiProgressSizes: (
  * See https://css-tricks.com/html5-progress-element/ for more info.
  */
 .euiProgress--indeterminate {
+  width: 100%;
+
+  &::-webkit-progress-bar {
+    background-color: $euiColorLightShade;
+  }
+
   &:before {
     position: absolute;
     content: '';

--- a/src/components/progress/progress.tsx
+++ b/src/components/progress/progress.tsx
@@ -77,20 +77,23 @@ export const EuiProgress: FunctionComponent<
     className
   );
 
+  const rel: {
+    max?: number;
+    value?: string | number | string[];
+  } = {};
+
   // Because of a Firefox animation issue, indeterminate progress needs to not use <progress />.
   // See https://css-tricks.com/html5-progress-element/
   if (determinate) {
-    return (
-      <progress
-        className={classes}
-        max={max}
-        value={value}
-        {...rest as ProgressHTMLAttributes<HTMLProgressElement>}
-      />
-    );
-  } else {
-    return (
-      <div className={classes} {...rest as HTMLAttributes<HTMLDivElement>} />
-    );
+    rel.max = max;
+    rel.value = value;
   }
+
+  return (
+    <progress
+      className={classes}
+      {...rel}
+      {...rest as ProgressHTMLAttributes<HTMLProgressElement>}
+    />
+  );
 };


### PR DESCRIPTION
### Summary

Fixes: #2984

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
