### PR TITLE
Allow `EuiProgress` to render meter component 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Bug Fixes**
 
-- Allow `EuiProgress` to render meter component ([#2986](https://github.com/elastic/eui/pull/2986))
+- Added `element` prop to `EuiProgress` to render meter or progress component ([#2986](https://github.com/elastic/eui/pull/2986))
 - Fixed `EuiDataGrid`'s sort popover to behave properly on mobile screens ([#2979](https://github.com/elastic/eui/pull/2979))
 - Fixed `EuiButton` and other textual components' disabled contrast ([#2874](https://github.com/elastic/eui/pull/2874))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Bug Fixes**
 
-- Allow `EuiProgress` to render meter component ([#2979](https://github.com/elastic/eui/pull/2979))
+- Allow `EuiProgress` to render meter component ([#2986](https://github.com/elastic/eui/pull/2986))
 - Fixed `EuiDataGrid`'s sort popover to behave properly on mobile screens ([#2979](https://github.com/elastic/eui/pull/2979))
 - Fixed `EuiButton` and other textual components' disabled contrast ([#2874](https://github.com/elastic/eui/pull/2874))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Bug Fixes**
 
+- Allow `EuiProgress` to render meter component ([#2979](https://github.com/elastic/eui/pull/2979))
 - Fixed `EuiDataGrid`'s sort popover to behave properly on mobile screens ([#2979](https://github.com/elastic/eui/pull/2979))
 - Fixed `EuiButton` and other textual components' disabled contrast ([#2874](https://github.com/elastic/eui/pull/2874))
 

--- a/src/components/progress/__snapshots__/progress.test.tsx.snap
+++ b/src/components/progress/__snapshots__/progress.test.tsx.snap
@@ -7,3 +7,13 @@ exports[`EuiProgress is rendered 1`] = `
   data-test-subj="test subject string"
 />
 `;
+
+exports[`EuiProgress renderes meter element 1`] = `
+<meter
+  aria-label="aria-label"
+  class="euiProgress euiProgress--native euiProgress--m euiProgress--secondary testClass1 testClass2"
+  data-test-subj="test subject string"
+  max="100"
+  value="0"
+/>
+`;

--- a/src/components/progress/progress.test.tsx
+++ b/src/components/progress/progress.test.tsx
@@ -10,4 +10,12 @@ describe('EuiProgress', () => {
 
     expect(component).toMatchSnapshot();
   });
+
+  test('is rendered meter element', () => {
+    const component = render(
+      <EuiProgress {...requiredProps} Element="meter" />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
 });

--- a/src/components/progress/progress.test.tsx
+++ b/src/components/progress/progress.test.tsx
@@ -11,9 +11,9 @@ describe('EuiProgress', () => {
     expect(component).toMatchSnapshot();
   });
 
-  test('is rendered meter element', () => {
+  test('renderes meter element', () => {
     const component = render(
-      <EuiProgress {...requiredProps} Element="meter" />
+      <EuiProgress {...requiredProps} Element="meter" max={100} value={0} />
     );
 
     expect(component).toMatchSnapshot();

--- a/src/components/progress/progress.tsx
+++ b/src/components/progress/progress.tsx
@@ -45,8 +45,8 @@ export type EuiProgressProps = CommonProps & {
   size?: EuiProgressSize;
   color?: EuiProgressColor;
   position?: EuiProgressPosition;
-  /** Describe the type of element to render */
-  Element?: 'progress' | 'meter';
+  /** Which HTML element to render */
+  element?: 'progress' | 'meter';
 };
 
 type Indeterminate = EuiProgressProps & HTMLAttributes<HTMLDivElement>;

--- a/src/components/progress/progress.tsx
+++ b/src/components/progress/progress.tsx
@@ -2,6 +2,7 @@ import React, {
   FunctionComponent,
   HTMLAttributes,
   ProgressHTMLAttributes,
+  MeterHTMLAttributes,
 } from 'react';
 import classNames from 'classnames';
 import { CommonProps, ExclusiveUnion } from '../common';
@@ -44,11 +45,14 @@ export type EuiProgressProps = CommonProps & {
   size?: EuiProgressSize;
   color?: EuiProgressColor;
   position?: EuiProgressPosition;
+  /** Describe the type of element to render */
+  Element?: 'progress' | 'meter';
 };
 
 type Indeterminate = EuiProgressProps & HTMLAttributes<HTMLDivElement>;
 
 type Determinate = EuiProgressProps &
+  MeterHTMLAttributes<HTMLProgressElement> &
   ProgressHTMLAttributes<HTMLProgressElement> & {
     max: number;
   };
@@ -61,6 +65,7 @@ export const EuiProgress: FunctionComponent<
   size = 'm',
   position = 'static',
   max,
+  Element = 'progress',
   value,
   ...rest
 }) => {
@@ -81,11 +86,13 @@ export const EuiProgress: FunctionComponent<
   // See https://css-tricks.com/html5-progress-element/
   if (determinate) {
     return (
-      <progress
+      <Element
         className={classes}
         max={max}
         value={value}
-        {...rest as ProgressHTMLAttributes<HTMLProgressElement>}
+        {...rest as
+          | ProgressHTMLAttributes<HTMLProgressElement>
+          | MeterHTMLAttributes<HTMLProgressElement>}
       />
     );
   } else {


### PR DESCRIPTION
### Summary

Fixes : #2983
used a prop Element in EuiProgress to render meter or progress(default progress) component 


### Screenshot of change

![Screenshot 2020-03-05 at 12 17 07 PM](https://user-images.githubusercontent.com/43617894/75955123-3cda2700-5edb-11ea-8654-dbfed77ab140.png)


### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
