### PR TITLE
Remove duplicate `@types/react-input-autosize` dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "@types/jest": "^24.0.6",
     "@types/react": "^16.9.23",
     "@types/react-dom": "^16.9.5",
-    "@types/react-input-autosize": "^2.0.1",
     "@types/react-is": "^16.7.1",
     "@types/resize-observer-browser": "^0.1.1",
     "@types/tabbable": "^3.1.0",


### PR DESCRIPTION
### Summary

Fixing a console warning from a package that recently moved from `devDependencies` to `dependencies`, but I think got accidentally reinserted in a later merge conflict resolution:

> warning package.json: "dependencies" has dependency "@types/react-input-autosize" with range "^2.0.2" that collides with a dependency in "devDependencies" of the same name with version "^2.0.1"

### Checklist

~~- [ ] Check against **all themes** for compatibility in both light and dark modes~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
~~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~~
