### PR TITLE
Use `<button>` in `EuiToggleButton`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 **Breaking changes**
 
+- Switched `EuiToggleButton` to button ([#2929](https://github.com/elastic/eui/pull/2929))
 - Updated `@types/react` and `@types/react-dom` to utilize React.RefCallback type instead of custom implementation ([#2929](https://github.com/elastic/eui/pull/2929))
 
 **Theme: Amsterdam**

--- a/src-docs/src/views/button/button_toggle.js
+++ b/src-docs/src/views/button/button_toggle.js
@@ -19,16 +19,16 @@ export default class extends Component {
     };
   }
 
-  onToggle0Change = e => {
-    this.setState({ toggle0On: e.target.checked });
+  onToggle0Change = () => {
+    this.setState({ toggle0On: !this.state.toggle0On });
   };
 
-  onToggle1Change = e => {
-    this.setState({ toggle1On: e.target.checked });
+  onToggle1Change = () => {
+    this.setState({ toggle1On: !this.state.toggle1On });
   };
 
-  onToggle4Change = e => {
-    this.setState({ toggle4On: e.target.checked });
+  onToggle4Change = () => {
+    this.setState({ toggle4On: !this.state.toggle4On });
   };
 
   render() {
@@ -37,7 +37,7 @@ export default class extends Component {
         <EuiButtonToggle
           label="Toggle Me"
           iconType={this.state.toggle0On ? 'starPlusEmpty' : 'starFilledSpace'}
-          onChange={this.onToggle0Change}
+          onChange={() => this.onToggle0Change()}
           isSelected={this.state.toggle0On}
         />
         &emsp;
@@ -48,14 +48,14 @@ export default class extends Component {
               : "I'm a primary toggle"
           }
           fill={this.state.toggle1On}
-          onChange={this.onToggle1Change}
+          onChange={() => this.onToggle1Change()}
           isSelected={this.state.toggle1On}
         />
         &emsp;
         <EuiButtonToggle
           label="Toggle Me"
           iconType={this.state.toggle4On ? 'eye' : 'eyeClosed'}
-          onChange={this.onToggle4Change}
+          onChange={() => this.onToggle4Change()}
           isSelected={this.state.toggle4On}
           isEmpty
           isIconOnly

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -80,6 +80,7 @@ export interface EuiButtonProps extends CommonProps {
    * Object of props passed to the <span/> wrapping the component's {children}
    */
   textProps?: HTMLAttributes<HTMLSpanElement>;
+  onClick?: (prop?: any) => void;
 }
 
 type EuiButtonPropsForAnchor = PropsForAnchor<
@@ -119,6 +120,7 @@ export const EuiButton: FunctionComponent<Props> = ({
   contentProps,
   textProps,
   fullWidth,
+  onClick,
   ...rest
 }) => {
   // If in the loading state, force disabled to true
@@ -180,6 +182,7 @@ export const EuiButton: FunctionComponent<Props> = ({
     href?: string;
     type?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
     target?: string;
+    onClick?: () => void;
   } = {};
 
   if (href && !isDisabled) {
@@ -187,6 +190,7 @@ export const EuiButton: FunctionComponent<Props> = ({
     relObj.rel = getSecureRelForTarget({ href, target, rel });
     relObj.target = target;
   } else {
+    relObj.onClick = onClick;
     relObj.type = type as ButtonHTMLAttributes<HTMLButtonElement>['type'];
   }
 

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -3,6 +3,7 @@ import React, {
   HTMLAttributes,
   Ref,
   ButtonHTMLAttributes,
+  MouseEventHandler,
 } from 'react';
 import classNames from 'classnames';
 
@@ -80,7 +81,11 @@ export interface EuiButtonProps extends CommonProps {
    * Object of props passed to the <span/> wrapping the component's {children}
    */
   textProps?: HTMLAttributes<HTMLSpanElement>;
-  onClick?: (prop?: any) => void;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+  // | ((event: React.MouseEvent<HTMLElement>) => void)
+  // | ((event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void)
+  // | ((event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void)
+  // | undefined;
 }
 
 type EuiButtonPropsForAnchor = PropsForAnchor<
@@ -182,7 +187,11 @@ export const EuiButton: FunctionComponent<Props> = ({
     href?: string;
     type?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
     target?: string;
-    onClick?: () => void;
+    onClick?: MouseEventHandler<HTMLButtonElement>;
+    // | ((event: React.MouseEvent<HTMLElement, MouseEvent>) => void)
+    // | ((event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void)
+    // | ((event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void)
+    // | undefined;
   } = {};
 
   if (href && !isDisabled) {

--- a/src/components/button/button_toggle/button_toggle.tsx
+++ b/src/components/button/button_toggle/button_toggle.tsx
@@ -1,7 +1,6 @@
 import React, {
   AnchorHTMLAttributes,
   ButtonHTMLAttributes,
-  ChangeEventHandler,
   FunctionComponent,
   MouseEventHandler,
   ReactNode,
@@ -9,9 +8,8 @@ import React, {
 import classNames from 'classnames';
 import { CommonProps, ExclusiveUnion } from '../../common';
 
-import { EuiToggle, ToggleType } from '../../toggle';
+import { ToggleType } from '../../toggle';
 import { EuiButton, EuiButtonProps } from '../button';
-import { useRenderToText } from '../../inner_text/render_to_text';
 
 export interface EuiButtonToggleProps extends EuiButtonProps, CommonProps {
   /**
@@ -45,7 +43,9 @@ export interface EuiButtonToggleProps extends EuiButtonProps, CommonProps {
    */
   type?: ToggleType;
 
-  onChange?: ChangeEventHandler<HTMLInputElement>;
+  onChange?: () => void;
+  ariaOn?: string;
+  ariaOff?: string;
 }
 
 type EuiButtonTogglePropsForAnchor = EuiButtonToggleProps &
@@ -76,11 +76,13 @@ export const EuiButtonToggle: FunctionComponent<Props> = ({
   isSelected,
   label,
   name,
-  onChange,
+  onChange = () => {},
   toggleClassName,
   type,
   value,
   'data-test-subj': dataTestSubj,
+  ariaOff,
+  ariaOn,
   ...rest
 }) => {
   const classes = classNames(
@@ -92,45 +94,21 @@ export const EuiButtonToggle: FunctionComponent<Props> = ({
     className
   );
 
-  const wrapperClasses = classNames(
-    'euiButtonToggle__wrapper',
-    {
-      'euiButtonToggle--isDisabled': isDisabled,
-    },
-    toggleClassName
-  );
-
   const buttonContent = isIconOnly ? '' : label;
-  const labelText = useRenderToText(
-    label,
-    typeof label === 'string' ? label : ''
-  );
 
   return (
-    <EuiToggle
-      className={wrapperClasses}
-      inputClassName="euiButtonToggle__input"
-      checked={isSelected}
-      isDisabled={isDisabled}
-      label={labelText}
-      name={name}
-      onChange={onChange}
-      type={type}
-      title={labelText}
-      value={value}
-      data-test-subj={dataTestSubj}>
-      <EuiButton
-        tabIndex={-1} // prevents double focus from input to button
-        className={classes}
-        color={color}
-        disabled={isDisabled}
-        size={isIconOnly ? 's' : undefined} // only force small if it's the icon only version
-        {...rest as Extract<
-          EuiButtonTogglePropsForAnchor,
-          EuiButtonTogglePropsForButtonToggle
-        >}>
-        {buttonContent}
-      </EuiButton>
-    </EuiToggle>
+    <EuiButton
+      tabIndex={-1} // prevents double focus from input to button
+      className={classes}
+      color={color}
+      onClick={onChange}
+      disabled={isDisabled}
+      size={isIconOnly ? 's' : undefined} // only force small if it's the icon only version
+      {...rest as Extract<
+        EuiButtonTogglePropsForAnchor,
+        EuiButtonTogglePropsForButtonToggle
+      >}>
+      {buttonContent}
+    </EuiButton>
   );
 };

--- a/src/components/button/button_toggle/button_toggle.tsx
+++ b/src/components/button/button_toggle/button_toggle.tsx
@@ -11,7 +11,9 @@ import { CommonProps, ExclusiveUnion } from '../../common';
 import { ToggleType } from '../../toggle';
 import { EuiButton, EuiButtonProps } from '../button';
 
-export interface EuiButtonToggleProps extends EuiButtonProps, CommonProps {
+export interface EuiButtonToggleProps
+  extends EuiButtonProps,
+    Omit<CommonProps, 'label' | ('labelOn' & 'lableOff')> {
   /**
    * Simulates a `EuiButtonEmpty`
    */
@@ -26,12 +28,10 @@ export interface EuiButtonToggleProps extends EuiButtonProps, CommonProps {
    * Initial state of the toggle
    */
   isSelected?: boolean;
-
   /**
    * Button label, which is also passed to `EuiToggle` as the input's label
    */
-  label: ReactNode;
-
+  label?: ReactNode;
   /**
    * Classnames to add to `EuiToggle` instead of the `EuiButton`
    */
@@ -43,9 +43,12 @@ export interface EuiButtonToggleProps extends EuiButtonProps, CommonProps {
    */
   type?: ToggleType;
 
-  onChange?: () => void;
-  ariaOn?: string;
-  ariaOff?: string;
+  onChange?: MouseEventHandler<HTMLButtonElement>;
+  // | ((event: React.MouseEvent<HTMLElement>) => void)
+  // | ((event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void)
+  // | undefined;
+  labelOn?: string;
+  labelOff?: string;
 }
 
 type EuiButtonTogglePropsForAnchor = EuiButtonToggleProps &
@@ -76,13 +79,13 @@ export const EuiButtonToggle: FunctionComponent<Props> = ({
   isSelected,
   label,
   name,
-  onChange = () => {},
+  onChange,
   toggleClassName,
   type,
   value,
   'data-test-subj': dataTestSubj,
-  ariaOff,
-  ariaOn,
+  labelOn,
+  labelOff,
   ...rest
 }) => {
   const classes = classNames(
@@ -95,14 +98,23 @@ export const EuiButtonToggle: FunctionComponent<Props> = ({
   );
 
   const buttonContent = isIconOnly ? '' : label;
+  const relObj: {
+    'aria-pressed'?: string | ReactNode;
+  } = {};
 
+  if (label) {
+    relObj['aria-pressed'] = label;
+  }
+  if (labelOn && labelOff) {
+    relObj['aria-pressed'] = undefined;
+  }
   return (
     <EuiButton
-      tabIndex={-1} // prevents double focus from input to button
       className={classes}
       color={color}
       onClick={onChange}
       disabled={isDisabled}
+      {...relObj}
       size={isIconOnly ? 's' : undefined} // only force small if it's the icon only version
       {...rest as Extract<
         EuiButtonTogglePropsForAnchor,


### PR DESCRIPTION
### Summary

Fixes #2982  
Used button instead of input element

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
