### PR TITLE
[New Nav Feature] Added `ghost` colored EuiListGroupItem

### DIFF
--- a/src-docs/src/views/list_group/list_group_example.js
+++ b/src-docs/src/views/list_group/list_group_example.js
@@ -191,7 +191,8 @@ export const ListGroupExample = {
             <EuiCode>anchor</EuiCode>, or <EuiCode>span</EuiCode>. You can
             enforce a different color of <EuiCode>primary</EuiCode>,{' '}
             <EuiCode>text</EuiCode>, or <EuiCode>subdued</EuiCode> with the{' '}
-            <EuiCode>color</EuiCode> prop.
+            <EuiCode>color</EuiCode> prop. Or provide the prop directly to{' '}
+            <strong>EuiListGroup</strong>.
           </p>
           <p>
             They also accept options for text size;{' '}

--- a/src-docs/src/views/list_group/list_group_item_color.tsx
+++ b/src-docs/src/views/list_group/list_group_item_color.tsx
@@ -18,6 +18,13 @@ export default () => (
 
     <EuiListGroupItem href="#" label="Text (m)" color="text" />
 
-    <EuiListGroupItem href="#" label="Subdued (l)" color="ghost" size="l" />
+    <EuiListGroupItem href="#" label="Subdued (l)" color="subdued" size="l" />
+
+    <EuiListGroupItem
+      href="#"
+      label="Ghost"
+      color="ghost"
+      style={{ background: 'black' }}
+    />
   </EuiListGroup>
 );

--- a/src-docs/src/views/list_group/list_group_item_color.tsx
+++ b/src-docs/src/views/list_group/list_group_item_color.tsx
@@ -18,6 +18,6 @@ export default () => (
 
     <EuiListGroupItem href="#" label="Text (m)" color="text" />
 
-    <EuiListGroupItem href="#" label="Subdued (l)" color="subdued" size="l" />
+    <EuiListGroupItem href="#" label="Subdued (l)" color="ghost" size="l" />
   </EuiListGroup>
 );

--- a/src-docs/src/views/list_group/list_group_item_color.tsx
+++ b/src-docs/src/views/list_group/list_group_item_color.tsx
@@ -4,27 +4,29 @@ import {
   EuiListGroupItem,
   EuiListGroup,
 } from '../../../../src/components/list_group';
+import { EuiSpacer } from '../../../../src/components/spacer';
 
 export default () => (
-  <EuiListGroup>
-    <EuiListGroupItem href="#" label="Inherit by default (xs)" size="xs" />
+  <>
+    <EuiListGroup>
+      <EuiListGroupItem href="#" label="Inherit by default (xs)" size="xs" />
 
-    <EuiListGroupItem
-      onClick={() => {}}
-      label="Primary (s)"
-      color="primary"
-      size="s"
-    />
+      <EuiListGroupItem
+        onClick={() => {}}
+        label="Primary (s)"
+        color="primary"
+        size="s"
+      />
 
-    <EuiListGroupItem href="#" label="Text (m)" color="text" />
+      <EuiListGroupItem href="#" label="Text (m)" color="text" />
 
-    <EuiListGroupItem href="#" label="Subdued (l)" color="subdued" size="l" />
+      <EuiListGroupItem href="#" label="Subdued (l)" color="subdued" size="l" />
+    </EuiListGroup>
 
-    <EuiListGroupItem
-      href="#"
-      label="Ghost"
-      color="ghost"
-      style={{ background: 'black' }}
-    />
-  </EuiListGroup>
+    <EuiSpacer size="s" />
+
+    <EuiListGroup style={{ background: 'black' }}>
+      <EuiListGroupItem href="#" label="Ghost" color="ghost" />
+    </EuiListGroup>
+  </>
 );

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -28,12 +28,18 @@
   // Puts the arrow on the right
   flex-direction: row-reverse;
   justify-content: space-between;
+
+  .euiAccordion__iconWrapper {
+    margin-left: $euiSizeS;
+    margin-right: $euiSizeXS;
+  }
 }
 
 .euiAccordion__iconWrapper {
   @include size($euiSize);
   border-radius: $euiBorderRadius;
   margin-right: $euiSizeS;
+  margin-left: $euiSizeXS;
   flex-shrink: 0;
 
   // Nested to override EuiIcon

--- a/src/components/list_group/__snapshots__/list_group.test.tsx.snap
+++ b/src/components/list_group/__snapshots__/list_group.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`EuiListGroup is rendered 1`] = `
 <ul
   aria-label="aria-label"
-  class="euiListGroup euiListGroup--gutterS euiListGroup-maxWidthDefault testClass1 testClass2"
+  class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault testClass1 testClass2"
   data-test-subj="test subject string"
 />
 `;
 
 exports[`EuiListGroup is rendered with listItems 1`] = `
 <ul
-  class="euiListGroup euiListGroup--gutterS euiListGroup-maxWidthDefault"
+  class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault"
 >
   <li
     class="euiListGroupItem euiListGroupItem--medium"
@@ -89,19 +89,19 @@ exports[`EuiListGroup is rendered with listItems 1`] = `
 
 exports[`EuiListGroup props bordered is rendered 1`] = `
 <ul
-  class="euiListGroup euiListGroup-bordered euiListGroup--gutterS euiListGroup-maxWidthDefault"
+  class="euiListGroup euiListGroup-bordered euiListGroup--gutterSmall euiListGroup-maxWidthDefault"
 />
 `;
 
 exports[`EuiListGroup props flush is rendered 1`] = `
 <ul
-  class="euiListGroup euiListGroup-flush euiListGroup--gutterS euiListGroup-maxWidthDefault"
+  class="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault"
 />
 `;
 
 exports[`EuiListGroup props gutter size m is rendered 1`] = `
 <ul
-  class="euiListGroup euiListGroup--gutterM euiListGroup-maxWidthDefault"
+  class="euiListGroup euiListGroup--gutterMedium euiListGroup-maxWidthDefault"
 />
 `;
 
@@ -113,38 +113,38 @@ exports[`EuiListGroup props gutter size none is rendered 1`] = `
 
 exports[`EuiListGroup props gutter size s is rendered 1`] = `
 <ul
-  class="euiListGroup euiListGroup--gutterS euiListGroup-maxWidthDefault"
+  class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault"
 />
 `;
 
 exports[`EuiListGroup props maxWidth as a number is rendered 1`] = `
 <ul
-  class="euiListGroup euiListGroup--gutterS"
+  class="euiListGroup euiListGroup--gutterSmall"
   style="max-width:300px"
 />
 `;
 
 exports[`EuiListGroup props maxWidth as a string is rendered 1`] = `
 <ul
-  class="euiListGroup euiListGroup--gutterS"
+  class="euiListGroup euiListGroup--gutterSmall"
   style="max-width:20em"
 />
 `;
 
 exports[`EuiListGroup props maxWidth as true is rendered 1`] = `
 <ul
-  class="euiListGroup euiListGroup--gutterS euiListGroup-maxWidthDefault"
+  class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault"
 />
 `;
 
 exports[`EuiListGroup props showToolTips is rendered 1`] = `
 <ul
-  class="euiListGroup euiListGroup--gutterS euiListGroup-maxWidthDefault"
+  class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault"
 />
 `;
 
 exports[`EuiListGroup props wrapText is rendered 1`] = `
 <ul
-  class="euiListGroup euiListGroup--gutterS euiListGroup-maxWidthDefault"
+  class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault"
 />
 `;

--- a/src/components/list_group/__snapshots__/list_group.test.tsx.snap
+++ b/src/components/list_group/__snapshots__/list_group.test.tsx.snap
@@ -87,6 +87,85 @@ exports[`EuiListGroup is rendered with listItems 1`] = `
 </ul>
 `;
 
+exports[`EuiListGroup is rendered with listItems and color 1`] = `
+<ul
+  class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault"
+>
+  <li
+    class="euiListGroupItem euiListGroupItem--medium euiListGroupItem--primary"
+  >
+    <span
+      class="euiListGroupItem__text"
+    >
+      <div
+        class="euiListGroupItem__icon"
+        data-euiicon-type="stop"
+      />
+      <span
+        class="euiListGroupItem__label"
+        title="Label with iconType"
+      >
+        Label with iconType
+      </span>
+    </span>
+  </li>
+  <li
+    class="euiListGroupItem euiListGroupItem--medium euiListGroupItem--primary euiListGroupItem-hasExtraAction"
+  >
+    <span
+      class="euiListGroupItem__text"
+    >
+      <span
+        class="euiListGroupItem__label"
+        title="Custom extra action"
+      >
+        Custom extra action
+      </span>
+    </span>
+    <button
+      class="euiButtonIcon euiButtonIcon--primary euiListGroupItem__extraAction euiListGroupItem__extraAction-alwaysShow"
+      type="button"
+    >
+      <div
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        data-euiicon-type="bell"
+      />
+    </button>
+  </li>
+  <li
+    class="euiListGroupItem euiListGroupItem--medium euiListGroupItem--primary euiListGroupItem-isClickable"
+  >
+    <button
+      class="euiListGroupItem__button"
+      type="button"
+    >
+      <span
+        class="euiListGroupItem__label"
+        title="Button with onClick"
+      >
+        Button with onClick
+      </span>
+    </button>
+  </li>
+  <li
+    class="euiListGroupItem euiListGroupItem--medium euiListGroupItem--primary euiListGroupItem-isClickable"
+  >
+    <a
+      class="euiListGroupItem__button"
+      href="#"
+    >
+      <span
+        class="euiListGroupItem__label"
+        title="Link with href"
+      >
+        Link with href
+      </span>
+    </a>
+  </li>
+</ul>
+`;
+
 exports[`EuiListGroup props bordered is rendered 1`] = `
 <ul
   class="euiListGroup euiListGroup-bordered euiListGroup--gutterSmall euiListGroup-maxWidthDefault"

--- a/src/components/list_group/__snapshots__/list_group_item.test.tsx.snap
+++ b/src/components/list_group/__snapshots__/list_group_item.test.tsx.snap
@@ -17,6 +17,23 @@ exports[`EuiListGroupItem is rendered 1`] = `
 </li>
 `;
 
+exports[`EuiListGroupItem props color ghost is rendered 1`] = `
+<li
+  class="euiListGroupItem euiListGroupItem--medium euiListGroupItem--ghost"
+>
+  <span
+    class="euiListGroupItem__text"
+  >
+    <span
+      class="euiListGroupItem__label"
+      title="Label"
+    >
+      Label
+    </span>
+  </span>
+</li>
+`;
+
 exports[`EuiListGroupItem props color inherit is rendered 1`] = `
 <li
   class="euiListGroupItem euiListGroupItem--medium"

--- a/src/components/list_group/_list_group_item.scss
+++ b/src/components/list_group/_list_group_item.scss
@@ -10,12 +10,20 @@
 
   &.euiListGroupItem-isActive,
   &.euiListGroupItem-isClickable:hover {
-    background-color: tintOrShade($euiColorLightestShade, 0%, 30%);
+    background-color: $euiListGroupItemHoverBackground;
   }
 
   &.euiListGroupItem-isClickable .euiListGroupItem__button:focus {
-    background-color: tintOrShade($euiColorLightestShade, 0%, 30%);
+    background-color: $euiListGroupItemHoverBackground;
     text-decoration: underline;
+  }
+
+  &.euiListGroupItem--ghost {
+    &.euiListGroupItem-isActive,
+    &.euiListGroupItem-isClickable:hover,
+    &.euiListGroupItem-isClickable .euiListGroupItem__button:focus {
+      background-color: $euiListGroupItemHoverBackgroundGhost;
+    }
   }
 
   // Style all disabled list items whether or not they are links or buttons
@@ -49,6 +57,10 @@
     .euiListGroupItem--#{$colorName} &:not(:disabled) {
       color: $color;
     }
+  }
+
+  .euiListGroupItem-isActive:not(.euiListGroupItem--ghost) & {
+    color: $euiTextColor;
   }
 }
 

--- a/src/components/list_group/_list_group_item.scss
+++ b/src/components/list_group/_list_group_item.scss
@@ -106,6 +106,10 @@
   line-height: $euiSizeM;
 }
 
+.euiListGroupItem--large {
+  line-height: $euiSizeL;
+}
+
 .euiListGroupItem--wrapText {
   .euiListGroupItem__button,
   .euiListGroupItem__text {

--- a/src/components/list_group/_list_group_item.scss
+++ b/src/components/list_group/_list_group_item.scss
@@ -46,7 +46,7 @@
   }
 
   @each $colorName, $color in $euiListGroupItemColorTypes {
-    .euiListGroupItem--#{$colorName} & {
+    .euiListGroupItem--#{$colorName} &:not(:disabled) {
       color: $color;
     }
   }

--- a/src/components/list_group/_variables.scss
+++ b/src/components/list_group/_variables.scss
@@ -1,10 +1,13 @@
+$euiListGroupItemHoverBackground: transparentize($euiColorLightShade, .75);
+$euiListGroupItemHoverBackgroundGhost: transparentize($euiColorGhost, .9);
+
 $euiListGroupGutterTypes: (
   gutterSmall: $euiSizeS,
   gutterMedium: $euiSize,
 );
 
 $euiListGroupItemColorTypes: (
-  primary: $euiColorPrimary,
+  primary: $euiColorPrimaryText,
   text: $euiTextColor,
   subdued: $euiColorDarkShade,
   ghost: $euiColorGhost,

--- a/src/components/list_group/_variables.scss
+++ b/src/components/list_group/_variables.scss
@@ -1,12 +1,13 @@
 $euiListGroupGutterTypes: (
-  gutterS: $euiSizeS,
-  gutterM: $euiSize,
+  gutterSmall: $euiSizeS,
+  gutterMedium: $euiSize,
 );
 
 $euiListGroupItemColorTypes: (
   primary: $euiColorPrimary,
   text: $euiTextColor,
   subdued: $euiColorDarkShade,
+  ghost: $euiColorGhost,
 );
 
 $euiListGroupItemSizeTypes: (

--- a/src/components/list_group/list_group.test.tsx
+++ b/src/components/list_group/list_group.test.tsx
@@ -42,6 +42,14 @@ describe('EuiListGroup', () => {
     expect(component).toMatchSnapshot();
   });
 
+  test('is rendered with listItems and color', () => {
+    const component = render(
+      <EuiListGroup color="primary" listItems={someListItems} />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
   describe('props', () => {
     test('bordered is rendered', () => {
       const component = render(<EuiListGroup bordered />);

--- a/src/components/list_group/list_group.tsx
+++ b/src/components/list_group/list_group.tsx
@@ -37,6 +37,11 @@ export type EuiListGroupProps = CommonProps &
     listItems?: EuiListGroupItemProps[];
 
     /**
+     * Change the colors of all `listItems` at once
+     */
+    color?: EuiListGroupItemProps['color'];
+
+    /**
      * Sets the max-width of the page,
      * set to `true` to use the default size,
      * set to `false` to not restrict the width,
@@ -68,6 +73,7 @@ export const EuiListGroup: FunctionComponent<EuiListGroupProps> = ({
   wrapText = false,
   maxWidth = true,
   showToolTips = false,
+  color,
   ariaLabelledby,
   ...rest
 }) => {
@@ -105,6 +111,7 @@ export const EuiListGroup: FunctionComponent<EuiListGroupProps> = ({
           key={`title-${index}`}
           showToolTip={showToolTips}
           wrapText={wrapText}
+          color={color}
           {...item}
         />,
       ];

--- a/src/components/list_group/list_group.tsx
+++ b/src/components/list_group/list_group.tsx
@@ -7,8 +7,8 @@ import { CommonProps } from '../common';
 type GutterSize = 'none' | 's' | 'm';
 const gutterSizeToClassNameMap: { [size in GutterSize]: string } = {
   none: '',
-  s: 'euiListGroup--gutterS',
-  m: 'euiListGroup--gutterM',
+  s: 'euiListGroup--gutterSmall',
+  m: 'euiListGroup--gutterMedium',
 };
 export const GUTTER_SIZES = Object.keys(
   gutterSizeToClassNameMap

--- a/src/components/list_group/list_group_item.tsx
+++ b/src/components/list_group/list_group_item.tsx
@@ -25,12 +25,13 @@ const sizeToClassNameMap: { [size in ItemSize]: string } = {
 };
 export const SIZES = Object.keys(sizeToClassNameMap) as ItemSize[];
 
-type Color = 'inherit' | 'primary' | 'text' | 'subdued';
+type Color = 'inherit' | 'primary' | 'text' | 'subdued' | 'ghost';
 const colorToClassNameMap: { [color in Color]: string } = {
   inherit: '',
   primary: 'euiListGroupItem--primary',
   text: 'euiListGroupItem--text',
   subdued: 'euiListGroupItem--subdued',
+  ghost: 'euiListGroupItem--ghost',
 };
 export const COLORS = Object.keys(colorToClassNameMap) as Color[];
 
@@ -48,7 +49,7 @@ export type EuiListGroupItemProps = CommonProps &
     size?: ItemSize;
     /**
      * By default the item will inherit the color of its wrapper (button/link/span),
-     * otherwise pass on of the acceptable options
+     * otherwise pass one of the acceptable options
      */
     color?: Color;
 

--- a/src/components/nav_drawer/__snapshots__/nav_drawer.test.js.snap
+++ b/src/components/nav_drawer/__snapshots__/nav_drawer.test.js.snap
@@ -15,7 +15,7 @@ exports[`EuiNavDrawer is rendered 1`] = `
         id="navDrawerMenu"
       >
         <ul
-          class="euiListGroup euiListGroup-flush euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawer__expandButton"
+          class="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawer__expandButton"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isClickable euiListGroupItem-hasExtraAction navDrawerExpandButton-isCollapsed"
@@ -42,7 +42,7 @@ exports[`EuiNavDrawer is rendered 1`] = `
           </li>
         </ul>
         <ul
-          class="euiListGroup euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawerGroup"
+          class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawerGroup"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isClickable euiNavDrawerGroup__item"
@@ -96,7 +96,7 @@ exports[`EuiNavDrawer is rendered 1`] = `
           </li>
         </ul>
         <ul
-          class="euiListGroup euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawerGroup"
+          class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawerGroup"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isActive euiListGroupItem-isClickable euiListGroupItem-hasExtraAction euiNavDrawerGroup__item"
@@ -276,7 +276,7 @@ exports[`EuiNavDrawer renders with falsy children 1`] = `
         id="navDrawerMenu"
       >
         <ul
-          class="euiListGroup euiListGroup-flush euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawer__expandButton"
+          class="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawer__expandButton"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isClickable euiListGroupItem-hasExtraAction navDrawerExpandButton-isCollapsed"
@@ -303,7 +303,7 @@ exports[`EuiNavDrawer renders with falsy children 1`] = `
           </li>
         </ul>
         <ul
-          class="euiListGroup euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawerGroup"
+          class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawerGroup"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isActive euiListGroupItem-isClickable euiListGroupItem-hasExtraAction euiNavDrawerGroup__item"
@@ -483,7 +483,7 @@ exports[`EuiNavDrawer renders with fragments 1`] = `
         id="navDrawerMenu"
       >
         <ul
-          class="euiListGroup euiListGroup-flush euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawer__expandButton"
+          class="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawer__expandButton"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isClickable euiListGroupItem-hasExtraAction navDrawerExpandButton-isCollapsed"
@@ -510,7 +510,7 @@ exports[`EuiNavDrawer renders with fragments 1`] = `
           </li>
         </ul>
         <ul
-          class="euiListGroup euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawerGroup"
+          class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawerGroup"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isClickable euiNavDrawerGroup__item"
@@ -564,7 +564,7 @@ exports[`EuiNavDrawer renders with fragments 1`] = `
           </li>
         </ul>
         <ul
-          class="euiListGroup euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawerGroup"
+          class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawerGroup"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isActive euiListGroupItem-isClickable euiListGroupItem-hasExtraAction euiNavDrawerGroup__item"


### PR DESCRIPTION
### Adds one more option to EuiListGroupItem for color

which is `ghost`, for use when the list is on a dark background as will be needed like in this screenshot:

<img width="314" alt="Screen Shot 2020-03-09 at 16 11 36 PM" src="https://user-images.githubusercontent.com/549577/76253224-ac744d00-6220-11ea-8a0b-58e6a2f528df.png">

### Also, adds the option for EuiListGroup to pass the `color` option to every list item

Typically you'd only be able to color each list item, but now you color all of them if you're passing items via the `listItems` prop object.


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [x] Checked in **IE11** and **Firefox**
- [x] Props have proper **autodocs**
- [x] Added **documentation** examples
- [x] Added or updated **jest tests**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~ Will get added via feature branch
