### PR TITLE
#3026 [Docs] TypeError in In-Memory Table - Selection

### DIFF
--- a/src-docs/src/views/tables/in_memory/in_memory_selection.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_selection.js
@@ -95,9 +95,9 @@ export class Table extends Component {
   }
 
   renderToolsLeft() {
-    const selection = this.state.control_columns;
+    const selection = this.state.selection;
 
-    if (!selection || selection.length === 0) {
+    if (selection.length === 0) {
       return;
     }
 


### PR DESCRIPTION
Fixes  #3026
### Summary
So, it all started from [this commit](https://github.com/elastic/eui/commit/22c983bb5ce868e944a78fa21eb66764162bbcdd#diff-032471f91c9a03ca48b34d7f1a79dae1R98). Later, the TypeError got patched in [this commit](https://github.com/elastic/eui/commit/63739a6f4562b2a5a57ef8a112dcaddc67681326#diff-032471f91c9a03ca48b34d7f1a79dae1R100) but despite an error no longer being thrown, this was not the desired behaviour. @pugnascotia could you please have a look?
The control columns were added to `EuiDataGrid`, this doc page demos `EuiInMemoryTable`.

#### Current Behaviour (Incorrect):
![image](https://user-images.githubusercontent.com/18154526/76312643-62947100-62cb-11ea-9da9-46ba71ee6888.png)

#### Expected Behaviour (Patched in this PR):
![image](https://user-images.githubusercontent.com/18154526/76312665-6f18c980-62cb-11ea-94a7-7d74bd42d47d.png)


### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
