### PR TITLE
#3029 EuiBasicTable: Accounting for action availability while computing row actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Updated pagination prop descriptions for `EuiInMemoryTable` ([#3142](https://github.com/elastic/eui/pull/3142))
 - Added `title` and `aria` attributes to `EuiToken`'s icon element ([#3195](https://github.com/elastic/eui/pull/3195))
 - Added new Elasticsearch token types ([58036](https://github.com/elastic/kibana/issues/58036))
+- Accounting for action availability while computing row actions in EuiBasicTable ([3030](https://github.com/elastic/kibana/issues/3030))
 
 **Bug Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - Fixed bug in `EuiAccordion` to adjust to the correct height when content height changes ([#3160](https://github.com/elastic/eui/pull/3160))
 - Fixed bug in `EuiBasicTable` to handle dynamic icon value properly in collapsed actions ([#3145](https://github.com/elastic/eui/pull/3145))
-- Fixed `availability` check for actions `EuiBasicTable` ([3030](https://github.com/elastic/kibana/issues/3030))
+- Fixed `availability` check for actions in `EuiBasicTable` ([3030](https://github.com/elastic/kibana/issues/3030))
 
 ## [`22.2.0`](https://github.com/elastic/eui/tree/v22.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@
 - Updated pagination prop descriptions for `EuiInMemoryTable` ([#3142](https://github.com/elastic/eui/pull/3142))
 - Added `title` and `aria` attributes to `EuiToken`'s icon element ([#3195](https://github.com/elastic/eui/pull/3195))
 - Added new Elasticsearch token types ([58036](https://github.com/elastic/kibana/issues/58036))
-- Accounting for action availability while computing row actions in EuiBasicTable ([3030](https://github.com/elastic/kibana/issues/3030))
 
 **Bug Fixes**
 
 - Fixed bug in `EuiAccordion` to adjust to the correct height when content height changes ([#3160](https://github.com/elastic/eui/pull/3160))
 - Fixed bug in `EuiBasicTable` to handle dynamic icon value properly in collapsed actions ([#3145](https://github.com/elastic/eui/pull/3145))
+- Fixed `availability` check for actions `EuiBasicTable` ([3030](https://github.com/elastic/kibana/issues/3030))
 
 ## [`22.2.0`](https://github.com/elastic/eui/tree/v22.2.0)
 

--- a/src-docs/src/views/tables/actions/actions.js
+++ b/src-docs/src/views/tables/actions/actions.js
@@ -178,6 +178,7 @@ export class Table extends Component {
             {
               name: 'Edit',
               isPrimary: true,
+              available: ({ online }) => !online,
               description: 'Edit this user',
               icon: 'pencil',
               type: 'icon',

--- a/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -1374,6 +1374,314 @@ exports[`EuiBasicTable rowProps renders rows with custom props from an object 1`
 </div>
 `;
 
+exports[`EuiBasicTable with multiple record actions with custom availability 1`] = `
+<div
+  className="euiBasicTable"
+>
+  <div>
+    <EuiTableHeaderMobile>
+      <EuiFlexGroup
+        alignItems="baseline"
+        justifyContent="spaceBetween"
+        responsive={false}
+      >
+        <EuiFlexItem
+          grow={false}
+        />
+        <EuiFlexItem
+          grow={false}
+        />
+      </EuiFlexGroup>
+    </EuiTableHeaderMobile>
+    <EuiTable
+      responsive={true}
+      tableLayout="fixed"
+    >
+      <EuiScreenReaderOnly>
+        <caption
+          className="euiTableCaption"
+        >
+          <EuiDelayRender
+            delay={500}
+          >
+            <EuiI18n
+              default="This table contains {itemCount} rows."
+              token="euiBasicTable.tableDescriptionWithoutPagination"
+              values={
+                Object {
+                  "itemCount": 4,
+                }
+              }
+            />
+          </EuiDelayRender>
+        </caption>
+      </EuiScreenReaderOnly>
+      <EuiTableHeader>
+        <EuiTableHeaderCell
+          align="left"
+          data-test-subj="tableHeaderCell_name_0"
+          key="_data_h_name_0"
+        >
+          Name
+        </EuiTableHeaderCell>
+        <EuiTableHeaderCell
+          align="right"
+          key="_actions_h_1"
+        >
+          Actions
+        </EuiTableHeaderCell>
+      </EuiTableHeader>
+      <EuiTableBody
+        bodyRef={[Function]}
+      >
+        <EuiTableRow
+          hasActions={true}
+          isSelected={false}
+        >
+          <EuiTableRowCell
+            align="left"
+            key="_data_column_name_1_0"
+            mobileOptions={
+              Object {
+                "header": "Name",
+                "render": undefined,
+              }
+            }
+            setScopeRow={false}
+            textOnly={true}
+          >
+            name1
+          </EuiTableRowCell>
+          <EuiTableRowCell
+            align="right"
+            hasActions={true}
+            key="record_actions_1_1"
+            showOnHover={true}
+            textOnly={false}
+          >
+            <ExpandedItemActions
+              actionEnabled={[Function]}
+              actions={
+                Array [
+                  Object {
+                    "description": "copy",
+                    "icon": "copy",
+                    "isPrimary": true,
+                    "name": "Copy",
+                    "onClick": [Function],
+                    "type": "icon",
+                  },
+                  Object {
+                    "description": "delete",
+                    "icon": "trash",
+                    "isPrimary": true,
+                    "name": "Delete",
+                    "onClick": [Function],
+                    "type": "icon",
+                  },
+                  Object {
+                    "name": "All actions",
+                    "render": [Function],
+                  },
+                ]
+              }
+              item={
+                Object {
+                  "id": "1",
+                  "name": "name1",
+                }
+              }
+              itemId="1"
+            />
+          </EuiTableRowCell>
+        </EuiTableRow>
+        <EuiTableRow
+          hasActions={true}
+          isSelected={false}
+        >
+          <EuiTableRowCell
+            align="left"
+            key="_data_column_name_2_0"
+            mobileOptions={
+              Object {
+                "header": "Name",
+                "render": undefined,
+              }
+            }
+            setScopeRow={false}
+            textOnly={true}
+          >
+            name2
+          </EuiTableRowCell>
+          <EuiTableRowCell
+            align="right"
+            hasActions={true}
+            key="record_actions_2_1"
+            showOnHover={true}
+            textOnly={false}
+          >
+            <ExpandedItemActions
+              actionEnabled={[Function]}
+              actions={
+                Array [
+                  Object {
+                    "available": [Function],
+                    "description": "edit",
+                    "icon": "pencil",
+                    "isPrimary": true,
+                    "name": "Edit",
+                    "onClick": [Function],
+                    "type": "icon",
+                  },
+                  Object {
+                    "description": "copy",
+                    "icon": "copy",
+                    "isPrimary": true,
+                    "name": "Copy",
+                    "onClick": [Function],
+                    "type": "icon",
+                  },
+                  Object {
+                    "name": "All actions",
+                    "render": [Function],
+                  },
+                ]
+              }
+              item={
+                Object {
+                  "id": "2",
+                  "name": "name2",
+                }
+              }
+              itemId="2"
+            />
+          </EuiTableRowCell>
+        </EuiTableRow>
+        <EuiTableRow
+          hasActions={true}
+          isSelected={false}
+        >
+          <EuiTableRowCell
+            align="left"
+            key="_data_column_name_3_0"
+            mobileOptions={
+              Object {
+                "header": "Name",
+                "render": undefined,
+              }
+            }
+            setScopeRow={false}
+            textOnly={true}
+          >
+            name3
+          </EuiTableRowCell>
+          <EuiTableRowCell
+            align="right"
+            hasActions={true}
+            key="record_actions_3_1"
+            showOnHover={true}
+            textOnly={false}
+          >
+            <ExpandedItemActions
+              actionEnabled={[Function]}
+              actions={
+                Array [
+                  Object {
+                    "description": "copy",
+                    "icon": "copy",
+                    "isPrimary": true,
+                    "name": "Copy",
+                    "onClick": [Function],
+                    "type": "icon",
+                  },
+                  Object {
+                    "description": "delete",
+                    "icon": "trash",
+                    "isPrimary": true,
+                    "name": "Delete",
+                    "onClick": [Function],
+                    "type": "icon",
+                  },
+                ]
+              }
+              item={
+                Object {
+                  "id": "3",
+                  "name": "name3",
+                }
+              }
+              itemId="3"
+            />
+          </EuiTableRowCell>
+        </EuiTableRow>
+        <EuiTableRow
+          hasActions={true}
+          isSelected={false}
+        >
+          <EuiTableRowCell
+            align="left"
+            key="_data_column_name_4_0"
+            mobileOptions={
+              Object {
+                "header": "Name",
+                "render": undefined,
+              }
+            }
+            setScopeRow={false}
+            textOnly={true}
+          >
+            name3
+          </EuiTableRowCell>
+          <EuiTableRowCell
+            align="right"
+            hasActions={true}
+            key="record_actions_4_1"
+            showOnHover={true}
+            textOnly={false}
+          >
+            <ExpandedItemActions
+              actionEnabled={[Function]}
+              actions={
+                Array [
+                  Object {
+                    "available": [Function],
+                    "description": "edit",
+                    "icon": "pencil",
+                    "isPrimary": true,
+                    "name": "Edit",
+                    "onClick": [Function],
+                    "type": "icon",
+                  },
+                  Object {
+                    "description": "copy",
+                    "icon": "copy",
+                    "isPrimary": true,
+                    "name": "Copy",
+                    "onClick": [Function],
+                    "type": "icon",
+                  },
+                  Object {
+                    "name": "All actions",
+                    "render": [Function],
+                  },
+                ]
+              }
+              item={
+                Object {
+                  "id": "4",
+                  "name": "name3",
+                }
+              }
+              itemId="4"
+            />
+          </EuiTableRowCell>
+        </EuiTableRow>
+      </EuiTableBody>
+    </EuiTable>
+  </div>
+</div>
+`;
+
 exports[`EuiBasicTable with pagination - 2nd page 1`] = `
 <div
   className="euiBasicTable"

--- a/src/components/basic_table/basic_table.test.tsx
+++ b/src/components/basic_table/basic_table.test.tsx
@@ -777,4 +777,65 @@ describe('EuiBasicTable', () => {
 
     expect(component).toMatchSnapshot();
   });
+
+  test('with multiple record actions with custom availability', () => {
+    const props: EuiBasicTableProps<BasicItem> = {
+      items: [
+        { id: '1', name: 'name1' },
+        { id: '2', name: 'name2' },
+        { id: '3', name: 'name3' },
+        { id: '4', name: 'name3' },
+      ],
+      itemId: 'id',
+      columns: [
+        {
+          field: 'name',
+          name: 'Name',
+          description: 'description',
+        },
+        {
+          name: 'Actions',
+          actions: [
+            {
+              type: 'icon',
+              name: 'Edit',
+              isPrimary: true,
+              icon: 'pencil',
+              available: ({ id }) => !(Number(id) % 2),
+              description: 'edit',
+              onClick: () => undefined,
+            },
+            {
+              type: 'icon',
+              name: 'Copy',
+              isPrimary: true,
+              icon: 'copy',
+              description: 'copy',
+              onClick: () => undefined,
+            },
+            {
+              type: 'icon',
+              name: 'Delete',
+              isPrimary: true,
+              icon: 'trash',
+              description: 'delete',
+              onClick: () => undefined,
+            },
+            {
+              type: 'icon',
+              name: 'Share',
+              icon: 'trash',
+              available: ({ id }) => id !== '3',
+              description: 'share',
+              onClick: () => undefined,
+            },
+          ],
+        },
+      ],
+      onChange: () => {},
+    };
+    const component = shallow(<EuiBasicTable {...props} />);
+
+    expect(component).toMatchSnapshot();
+  });
 });

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -1031,10 +1031,12 @@ export class EuiBasicTable<T = any> extends Component<
       this.state.selection.length === 0 &&
       (!action.enabled || action.enabled(item));
 
-    let actualActions = column.actions;
-    if (column.actions.length > 2) {
+    let actualActions = column.actions.filter(
+      (action: Action<T>) => !action.available || action.available(item)
+    );
+    if (actualActions.length > 2) {
       // if any of the actions `isPrimary`, add them inline as well, but only the first 2
-      const primaryActions = column.actions.filter(o => o.isPrimary);
+      const primaryActions = actualActions.filter(o => o.isPrimary);
       actualActions = primaryActions.slice(0, 2);
 
       // if we have more than 1 action, we don't show them all in the cell, instead we


### PR DESCRIPTION
Fixes #3029 UI/UX: Accounting for action availability while computing row actions

### Summary
As stated in the docs ([Adding actions to BasicTable](https://elastic.github.io/eui/#/tabular-content/tables)): 

> There can only be up to 2 actions visible per row. When more than two actions are defined, the first 2 isPrimary actions will stay visible, an ellipses icon button will hold all actions in a single popover.

Currently, the availability of an action is not being taken into account while computing for popover and primary actions.

Let's say you have:
- Total Actions: 4.
- Active Action on a particular row: 1.

#### In a Table with 4 actions, the current behaviour seems to be:
##### Row with 1 active action:
![image](https://user-images.githubusercontent.com/18154526/76332864-c711f900-62e8-11ea-8eb0-7fe6d8369cf7.png)

![image](https://user-images.githubusercontent.com/18154526/76334090-7c917c00-62ea-11ea-8aeb-7b309d7e9014.png)


##### Row with 4 active actions:
![image](https://user-images.githubusercontent.com/18154526/76332285-14da3180-62e8-11ea-9aed-6fed966e3dba.png)
![image](https://user-images.githubusercontent.com/18154526/76332311-1efc3000-62e8-11ea-9a76-3547796505be.png)

#### Expected behaviour (As per EUI UI/UX Guidelines) (fixed in this PR):
![image](https://user-images.githubusercontent.com/18154526/76332163-f116eb80-62e7-11ea-96fe-df5ca7ff62cd.png)

Similarly, if the first 2 primary actions in  your action list happen to be unavailable, none of your available primary action will not even be shown on hover as primary actions are being [selected from the universal list of actions](https://github.com/elastic/eui/blob/fa2ec106c69ead133b4541ed936ef0b262039840/src/components/basic_table/basic_table.tsx#L1036), not just the available actions.

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [x] Added **documentation** examples
- [x] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
