### PR TITLE
[New Nav Feature] Created `EuiCollapsibleGroup`

### DIFF
--- a/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
@@ -11,11 +11,16 @@ import {
   EuiText,
   EuiSpacer,
   EuiCallOut,
+  EuiCollapsibleNavGroup,
 } from '../../../../src/components';
 
 import CollapsibleNav from './collapsible_nav';
 const collapsibleNavSource = require('!!raw-loader!./collapsible_nav');
 const collapsibleNavHtml = renderToHtml(CollapsibleNav);
+
+import CollapsibleNavGroup from './collapsible_nav_group';
+const collapsibleNavGroupSource = require('!!raw-loader!./collapsible_nav_group');
+const collapsibleNavGroupHtml = renderToHtml(CollapsibleNavGroup);
 
 export const CollapsibleNavExample = {
   title: 'Collapsible nav',
@@ -64,6 +69,42 @@ export const CollapsibleNavExample = {
       ),
       props: { EuiCollapsibleNav },
       demo: <CollapsibleNav />,
+    },
+    {
+      title: 'Collapsible nav group',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: collapsibleNavGroupSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: collapsibleNavGroupHtml,
+        },
+      ],
+      text: (
+        <>
+          <p>
+            An <strong>EuiCollapsibleNavGroup</strong> adds some basic borders
+            and <EuiCode>background</EuiCode> color of <EuiCode>none</EuiCode>,{' '}
+            <EuiCode>light</EuiCode>, or <EuiCode>dark</EuiCode>. You can
+            provide an optional <EuiCode>title</EuiCode> and{' '}
+            <EuiCode>iconType</EuiCode> to give each seaction a heading. Make
+            the section collapsible (
+            <Link to="/layout/accordion">accordion style</Link>) with{' '}
+            <EuiCode>collapsible=true</EuiCode>.
+          </p>
+          <p>
+            When in <EuiCode>collapsible</EuiCode> mode, a{' '}
+            <EuiCode>title</EuiCode> and{' '}
+            <EuiCode>initialIsOpen: boolean</EuiCode> is required.
+          </p>
+        </>
+      ),
+      props: {
+        EuiCollapsibleNavGroup,
+      },
+      demo: <CollapsibleNavGroup />,
     },
   ],
 };

--- a/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
@@ -69,6 +69,13 @@ export const CollapsibleNavExample = {
       ),
       props: { EuiCollapsibleNav },
       demo: <CollapsibleNav />,
+      snippet: `<EuiButton onClick={() => setNavIsOpen(!navIsOpen)}>Toggle nav</EuiButton>
+{navIsOpen && (
+  <EuiCollapsibleNav
+    docked={navIsDocked}
+    onClose={() => setNavIsOpen(false)}
+  />
+)}`,
     },
     {
       title: 'Collapsible nav group',
@@ -92,12 +99,12 @@ export const CollapsibleNavExample = {
             <EuiCode>iconType</EuiCode> to give each seaction a heading. Make
             the section collapsible (
             <Link to="/layout/accordion">accordion style</Link>) with{' '}
-            <EuiCode>collapsible=true</EuiCode>.
+            <EuiCode language="js">collapsible=true</EuiCode>.
           </p>
           <p>
             When in <EuiCode>collapsible</EuiCode> mode, a{' '}
             <EuiCode>title</EuiCode> and{' '}
-            <EuiCode>initialIsOpen: boolean</EuiCode> is required.
+            <EuiCode language="ts">initialIsOpen:boolean</EuiCode> is required.
           </p>
         </>
       ),
@@ -105,6 +112,13 @@ export const CollapsibleNavExample = {
         EuiCollapsibleNavGroup,
       },
       demo: <CollapsibleNavGroup />,
+      snippet: `<EuiCollapsibleNavGroup
+  title="Nav group"
+  iconType="logo"
+  collapsible={true}
+  initialIsOpen={true}
+  background="none"
+/>`,
     },
   ],
 };

--- a/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
@@ -98,10 +98,10 @@ export const CollapsibleNavExample = {
             seaction a heading by providing an optional <EuiCode>title</EuiCode>{' '}
             and <EuiCode>iconType</EuiCode>. Make the section collapsible (
             <Link to="/layout/accordion">accordion style</Link>) with{' '}
-            <EuiCode language="js">collapsible=true</EuiCode>.
+            <EuiCode language="js">isCollapsible=true</EuiCode>.
           </p>
           <p>
-            When in <EuiCode>collapsible</EuiCode> mode, a{' '}
+            When in <EuiCode>isCollapsible</EuiCode> mode, a{' '}
             <EuiCode>title</EuiCode> and{' '}
             <EuiCode language="ts">initialIsOpen:boolean</EuiCode> is required.
           </p>
@@ -114,7 +114,7 @@ export const CollapsibleNavExample = {
       snippet: `<EuiCollapsibleNavGroup
   title="Nav group"
   iconType="logo"
-  collapsible={true}
+  isCollapsible={true}
   initialIsOpen={true}
   background="none"
 />`,

--- a/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
@@ -94,10 +94,9 @@ export const CollapsibleNavExample = {
           <p>
             An <strong>EuiCollapsibleNavGroup</strong> adds some basic borders
             and <EuiCode>background</EuiCode> color of <EuiCode>none</EuiCode>,{' '}
-            <EuiCode>light</EuiCode>, or <EuiCode>dark</EuiCode>. You can
-            provide an optional <EuiCode>title</EuiCode> and{' '}
-            <EuiCode>iconType</EuiCode> to give each seaction a heading. Make
-            the section collapsible (
+            <EuiCode>light</EuiCode>, or <EuiCode>dark</EuiCode>. Give each
+            seaction a heading by providing an optional <EuiCode>title</EuiCode>{' '}
+            and <EuiCode>iconType</EuiCode>. Make the section collapsible (
             <Link to="/layout/accordion">accordion style</Link>) with{' '}
             <EuiCode language="js">collapsible=true</EuiCode>.
           </p>

--- a/src-docs/src/views/collapsible_nav/collapsible_nav_group.tsx
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav_group.tsx
@@ -22,7 +22,7 @@ export default () => (
     <EuiCollapsibleNavGroup
       background="light"
       title="Nav group"
-      collapsible={true}
+      isCollapsible={true}
       iconType="logoElastic"
       initialIsOpen={true}>
       <EuiText size="s" color="subdued">
@@ -39,7 +39,7 @@ export default () => (
       iconType="logoGCPMono"
       iconSize="xxl"
       titleSize="s"
-      collapsible={true}
+      isCollapsible={true}
       initialIsOpen={false}
       background="dark">
       <EuiText size="s">

--- a/src-docs/src/views/collapsible_nav/collapsible_nav_group.tsx
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav_group.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+import { EuiCollapsibleNavGroup } from '../../../../src/components/collapsible_nav';
+import { EuiText } from '../../../../src/components/text';
+import { EuiCode } from '../../../../src/components/code';
+
+export default () => (
+  <>
+    <EuiCollapsibleNavGroup>
+      <EuiText size="s" color="subdued">
+        <p>This is a basic group without any modifications</p>
+      </EuiText>
+    </EuiCollapsibleNavGroup>
+    <EuiCollapsibleNavGroup title="Nav group" iconType="logoElastic">
+      <EuiText size="s" color="subdued">
+        <p>
+          This is a nice group with a heading supplied via{' '}
+          <EuiCode>title</EuiCode> and <EuiCode>iconType</EuiCode>.
+        </p>
+      </EuiText>
+    </EuiCollapsibleNavGroup>
+    <EuiCollapsibleNavGroup
+      background="light"
+      title="Nav group"
+      collapsible={true}
+      iconType="logoElastic"
+      initialIsOpen={true}>
+      <EuiText size="s" color="subdued">
+        <p>
+          This group is <EuiCode>collapsible</EuiCode> and set with{' '}
+          <EuiCode>initialIsOpen</EuiCode>. It has a heading that is the
+          collapsing button via <EuiCode>title</EuiCode> and{' '}
+          <EuiCode>iconType</EuiCode>.
+        </p>
+      </EuiText>
+    </EuiCollapsibleNavGroup>
+    <EuiCollapsibleNavGroup
+      title="Nav group"
+      iconType="logoGCPMono"
+      iconSize="xxl"
+      titleSize="large"
+      collapsible={true}
+      initialIsOpen={false}
+      background="dark">
+      <EuiText size="s">
+        <p>
+          This is a <EuiCode>dark</EuiCode> <EuiCode>collapsible</EuiCode> group
+          that is initally set to closed,{' '}
+          <EuiCode>iconSize=&quot;xxl&quot;</EuiCode> and{' '}
+          <EuiCode>titleSize=&quot;large&quot;</EuiCode>.
+        </p>
+      </EuiText>
+    </EuiCollapsibleNavGroup>
+  </>
+);

--- a/src-docs/src/views/collapsible_nav/collapsible_nav_group.tsx
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav_group.tsx
@@ -38,7 +38,7 @@ export default () => (
       title="Nav group"
       iconType="logoGCPMono"
       iconSize="xxl"
-      titleSize="large"
+      titleSize="s"
       collapsible={true}
       initialIsOpen={false}
       background="dark">
@@ -47,7 +47,7 @@ export default () => (
           This is a <EuiCode>dark</EuiCode> <EuiCode>collapsible</EuiCode> group
           that is initally set to closed,{' '}
           <EuiCode>iconSize=&quot;xxl&quot;</EuiCode> and{' '}
-          <EuiCode>titleSize=&quot;large&quot;</EuiCode>.
+          <EuiCode>titleSize=&quot;s&quot;</EuiCode>.
         </p>
       </EuiText>
     </EuiCollapsibleNavGroup>

--- a/src/components/collapsible_nav/_index.scss
+++ b/src/components/collapsible_nav/_index.scss
@@ -1,2 +1,4 @@
 @import 'variables';
+
+@import 'collapsible_nav_group/index';
 @import 'collapsible_nav';

--- a/src/components/collapsible_nav/_variables.scss
+++ b/src/components/collapsible_nav/_variables.scss
@@ -1,2 +1,8 @@
 // Sizing
 $euiCollapsibleNavWidth: $euiSize * 20; // ~ 320px
+
+$euiCollapsibleNavGroupTitleSizes: (
+  small: $euiFontSizeS,
+  medium: $euiFontSizeM,
+  large: $euiFontSizeL,
+)

--- a/src/components/collapsible_nav/_variables.scss
+++ b/src/components/collapsible_nav/_variables.scss
@@ -1,12 +1,6 @@
 // Sizing
 $euiCollapsibleNavWidth: $euiSize * 20; // ~ 320px
 
-$euiCollapsibleNavGroupTitleSizes: (
-  small: $euiFontSizeS,
-  medium: $euiFontSizeM,
-  large: $euiFontSizeL,
-);
-
 $euiCollapsibleNavGroupLightBackgroundColor: $euiPageBackgroundColor;
 
 $euiCollapsibleNavGroupDarkBackgroundColor: lightOrDarkTheme(

--- a/src/components/collapsible_nav/_variables.scss
+++ b/src/components/collapsible_nav/_variables.scss
@@ -5,4 +5,16 @@ $euiCollapsibleNavGroupTitleSizes: (
   small: $euiFontSizeS,
   medium: $euiFontSizeM,
   large: $euiFontSizeL,
-)
+);
+
+$euiCollapsibleNavGroupLightBackgroundColor: $euiPageBackgroundColor;
+
+$euiCollapsibleNavGroupDarkBackgroundColor: lightOrDarkTheme(
+  shade($euiColorDarkestShade, 20%),
+  shade($euiColorLightestShade, 50%),
+);
+
+$euiCollapsibleNavGroupDarkHighContrastColor: makeGraphicContrastColor(
+  $euiColorPrimary,
+  $euiCollapsibleNavGroupDarkBackgroundColor
+);

--- a/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
+++ b/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
@@ -146,7 +146,7 @@ exports[`EuiCollapsibleNavGroup props title is rendered 1`] = `
 </div>
 `;
 
-exports[`EuiCollapsibleNavGroup props titleElement can change the rendere element to h2 1`] = `
+exports[`EuiCollapsibleNavGroup props titleElement can change the rendered element to h2 1`] = `
 <div
   class="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
   id="id"

--- a/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
+++ b/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`EuiCollapsibleNavGroup props iconSize is rendered 1`] = `
   id="id"
 >
   <div
-    class="euiCollapsibleNavGroup__button"
+    class="euiCollapsibleNavGroup__title"
   >
     <div
       class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
@@ -86,7 +86,7 @@ exports[`EuiCollapsibleNavGroup props iconType is rendered 1`] = `
   id="id"
 >
   <div
-    class="euiCollapsibleNavGroup__button"
+    class="euiCollapsibleNavGroup__title"
   >
     <div
       class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
@@ -120,7 +120,7 @@ exports[`EuiCollapsibleNavGroup props title is rendered 1`] = `
   id="id"
 >
   <div
-    class="euiCollapsibleNavGroup__button"
+    class="euiCollapsibleNavGroup__title"
   >
     <div
       class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
@@ -161,7 +161,7 @@ exports[`EuiCollapsibleNavGroup when collapsible is true will render an accordio
     <button
       aria-controls="id"
       aria-expanded="false"
-      class="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__button"
+      class="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__title"
       type="button"
     >
       <span

--- a/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
+++ b/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
@@ -48,14 +48,14 @@ exports[`EuiCollapsibleNavGroup props background none is rendered 1`] = `
 
 exports[`EuiCollapsibleNavGroup props iconSize is rendered 1`] = `
 <div
-  class="euiCollapsibleNavGroup euiCollapsibleNavGroup--withTitle"
+  class="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
   id="id"
 >
   <div
-    class="euiCollapsibleNavGroup__title euiCollapsibleNavGroup__title--small"
+    class="euiCollapsibleNavGroup__heading"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
     >
       <div
         class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -68,7 +68,9 @@ exports[`EuiCollapsibleNavGroup props iconSize is rendered 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3>
+        <h3
+          class="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+        >
           Title
         </h3>
       </div>
@@ -82,14 +84,14 @@ exports[`EuiCollapsibleNavGroup props iconSize is rendered 1`] = `
 
 exports[`EuiCollapsibleNavGroup props iconType is rendered 1`] = `
 <div
-  class="euiCollapsibleNavGroup euiCollapsibleNavGroup--withTitle"
+  class="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
   id="id"
 >
   <div
-    class="euiCollapsibleNavGroup__title euiCollapsibleNavGroup__title--small"
+    class="euiCollapsibleNavGroup__heading"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
     >
       <div
         class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -102,7 +104,9 @@ exports[`EuiCollapsibleNavGroup props iconType is rendered 1`] = `
       <div
         class="euiFlexItem"
       >
-        <h3>
+        <h3
+          class="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+        >
           Title
         </h3>
       </div>
@@ -116,19 +120,21 @@ exports[`EuiCollapsibleNavGroup props iconType is rendered 1`] = `
 
 exports[`EuiCollapsibleNavGroup props title is rendered 1`] = `
 <div
-  class="euiCollapsibleNavGroup euiCollapsibleNavGroup--withTitle"
+  class="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
   id="id"
 >
   <div
-    class="euiCollapsibleNavGroup__title euiCollapsibleNavGroup__title--small"
+    class="euiCollapsibleNavGroup__heading"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
     >
       <div
         class="euiFlexItem"
       >
-        <h3>
+        <h3
+          class="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+        >
           Title
         </h3>
       </div>
@@ -142,19 +148,21 @@ exports[`EuiCollapsibleNavGroup props title is rendered 1`] = `
 
 exports[`EuiCollapsibleNavGroup props titleElement can change the rendere element to h2 1`] = `
 <div
-  class="euiCollapsibleNavGroup euiCollapsibleNavGroup--withTitle"
+  class="euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
   id="id"
 >
   <div
-    class="euiCollapsibleNavGroup__title euiCollapsibleNavGroup__title--small"
+    class="euiCollapsibleNavGroup__heading"
   >
     <div
-      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
     >
       <div
         class="euiFlexItem"
       >
-        <h2>
+        <h2
+          class="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+        >
           Title
         </h2>
       </div>
@@ -166,40 +174,7 @@ exports[`EuiCollapsibleNavGroup props titleElement can change the rendere elemen
 </div>
 `;
 
-exports[`EuiCollapsibleNavGroup props titleSize inherit is rendered 1`] = `
-<div
-  class="euiCollapsibleNavGroup"
-  id="id"
->
-  <div
-    class="euiCollapsibleNavGroup__children"
-  />
-</div>
-`;
-
-exports[`EuiCollapsibleNavGroup props titleSize large is rendered 1`] = `
-<div
-  class="euiCollapsibleNavGroup"
-  id="id"
->
-  <div
-    class="euiCollapsibleNavGroup__children"
-  />
-</div>
-`;
-
-exports[`EuiCollapsibleNavGroup props titleSize medium is rendered 1`] = `
-<div
-  class="euiCollapsibleNavGroup"
-  id="id"
->
-  <div
-    class="euiCollapsibleNavGroup__children"
-  />
-</div>
-`;
-
-exports[`EuiCollapsibleNavGroup props titleSize small is rendered 1`] = `
+exports[`EuiCollapsibleNavGroup props titleSize can be larger 1`] = `
 <div
   class="euiCollapsibleNavGroup"
   id="id"
@@ -223,7 +198,7 @@ exports[`EuiCollapsibleNavGroup throws a warning if iconType is passed without a
 
 exports[`EuiCollapsibleNavGroup when collapsible is true will render an accordion 1`] = `
 <div
-  class="euiAccordion euiCollapsibleNavGroup euiCollapsibleNavGroup--withTitle"
+  class="euiAccordion euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
 >
   <div
     class="euiAccordion__triggerWrapper"
@@ -231,7 +206,7 @@ exports[`EuiCollapsibleNavGroup when collapsible is true will render an accordio
     <button
       aria-controls="id"
       aria-expanded="false"
-      class="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__title euiCollapsibleNavGroup__title--small"
+      class="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__heading"
       type="button"
     >
       <span
@@ -244,12 +219,14 @@ exports[`EuiCollapsibleNavGroup when collapsible is true will render an accordio
       </span>
       <span>
         <div
-          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+          class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
         >
           <div
             class="euiFlexItem"
           >
-            <h3>
+            <h3
+              class="euiTitle euiTitle--xxsmall euiCollapsibleNavGroup__title"
+            >
               Title
             </h3>
           </div>

--- a/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
+++ b/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
@@ -30,7 +30,168 @@ exports[`EuiCollapsibleNavGroup is rendered 1`] = `
           <div
             class="euiFlexItem"
           >
-            Title
+            <h3>
+              Title
+            </h3>
+          </div>
+        </div>
+      </span>
+    </button>
+  </div>
+  <div
+    class="euiAccordion__childWrapper"
+    id="id"
+  >
+    <div>
+      <div
+        class=""
+      >
+        <div
+          class="euiCollapsibleNavGroup__children"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiCollapsibleNavGroup props background dark is rendered 1`] = `
+<div
+  class="euiAccordion euiCollapsibleNavGroup euiCollapsibleNavGroup--dark"
+>
+  <div
+    class="euiAccordion__triggerWrapper"
+  >
+    <button
+      aria-controls="id"
+      aria-expanded="false"
+      class="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__button"
+      type="button"
+    >
+      <span
+        class="euiAccordion__iconWrapper"
+      >
+        <div
+          class="euiAccordion__icon"
+          data-euiicon-type="arrowRight"
+        />
+      </span>
+      <span>
+        <div
+          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+        >
+          <div
+            class="euiFlexItem"
+          >
+            <h3>
+              Title
+            </h3>
+          </div>
+        </div>
+      </span>
+    </button>
+  </div>
+  <div
+    class="euiAccordion__childWrapper"
+    id="id"
+  >
+    <div>
+      <div
+        class=""
+      >
+        <div
+          class="euiCollapsibleNavGroup__children"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiCollapsibleNavGroup props background light is rendered 1`] = `
+<div
+  class="euiAccordion euiCollapsibleNavGroup euiCollapsibleNavGroup--light"
+>
+  <div
+    class="euiAccordion__triggerWrapper"
+  >
+    <button
+      aria-controls="id"
+      aria-expanded="false"
+      class="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__button"
+      type="button"
+    >
+      <span
+        class="euiAccordion__iconWrapper"
+      >
+        <div
+          class="euiAccordion__icon"
+          data-euiicon-type="arrowRight"
+        />
+      </span>
+      <span>
+        <div
+          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+        >
+          <div
+            class="euiFlexItem"
+          >
+            <h3>
+              Title
+            </h3>
+          </div>
+        </div>
+      </span>
+    </button>
+  </div>
+  <div
+    class="euiAccordion__childWrapper"
+    id="id"
+  >
+    <div>
+      <div
+        class=""
+      >
+        <div
+          class="euiCollapsibleNavGroup__children"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiCollapsibleNavGroup props background none is rendered 1`] = `
+<div
+  class="euiAccordion euiCollapsibleNavGroup"
+>
+  <div
+    class="euiAccordion__triggerWrapper"
+  >
+    <button
+      aria-controls="id"
+      aria-expanded="false"
+      class="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__button"
+      type="button"
+    >
+      <span
+        class="euiAccordion__iconWrapper"
+      >
+        <div
+          class="euiAccordion__icon"
+          data-euiicon-type="arrowRight"
+        />
+      </span>
+      <span>
+        <div
+          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+        >
+          <div
+            class="euiFlexItem"
+          >
+            <h3>
+              Title
+            </h3>
           </div>
         </div>
       </span>
@@ -82,13 +243,16 @@ exports[`EuiCollapsibleNavGroup props iconType is rendered 1`] = `
             class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <div
+              aria-hidden="true"
               data-euiicon-type="bolt"
             />
           </div>
           <div
             class="euiFlexItem"
           >
-            Title
+            <h3>
+              Title
+            </h3>
           </div>
         </div>
       </span>

--- a/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
+++ b/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
@@ -3,220 +3,157 @@
 exports[`EuiCollapsibleNavGroup is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="euiAccordion euiCollapsibleNavGroup testClass1 testClass2"
+  class="euiCollapsibleNavGroup testClass1 testClass2"
   data-test-subj="test subject string"
+  id="id"
 >
   <div
-    class="euiAccordion__triggerWrapper"
-  >
-    <button
-      aria-controls="id"
-      aria-expanded="false"
-      class="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__button"
-      type="button"
-    >
-      <span
-        class="euiAccordion__iconWrapper"
-      >
-        <div
-          class="euiAccordion__icon"
-          data-euiicon-type="arrowRight"
-        />
-      </span>
-      <span>
-        <div
-          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-        >
-          <div
-            class="euiFlexItem"
-          >
-            <h3>
-              Title
-            </h3>
-          </div>
-        </div>
-      </span>
-    </button>
-  </div>
-  <div
-    class="euiAccordion__childWrapper"
-    id="id"
-  >
-    <div>
-      <div
-        class=""
-      >
-        <div
-          class="euiCollapsibleNavGroup__children"
-        />
-      </div>
-    </div>
-  </div>
+    class="euiCollapsibleNavGroup__children"
+  />
 </div>
 `;
 
 exports[`EuiCollapsibleNavGroup props background dark is rendered 1`] = `
 <div
-  class="euiAccordion euiCollapsibleNavGroup euiCollapsibleNavGroup--dark"
+  class="euiCollapsibleNavGroup euiCollapsibleNavGroup--dark"
+  id="id"
 >
   <div
-    class="euiAccordion__triggerWrapper"
-  >
-    <button
-      aria-controls="id"
-      aria-expanded="false"
-      class="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__button"
-      type="button"
-    >
-      <span
-        class="euiAccordion__iconWrapper"
-      >
-        <div
-          class="euiAccordion__icon"
-          data-euiicon-type="arrowRight"
-        />
-      </span>
-      <span>
-        <div
-          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-        >
-          <div
-            class="euiFlexItem"
-          >
-            <h3>
-              Title
-            </h3>
-          </div>
-        </div>
-      </span>
-    </button>
-  </div>
-  <div
-    class="euiAccordion__childWrapper"
-    id="id"
-  >
-    <div>
-      <div
-        class=""
-      >
-        <div
-          class="euiCollapsibleNavGroup__children"
-        />
-      </div>
-    </div>
-  </div>
+    class="euiCollapsibleNavGroup__children"
+  />
 </div>
 `;
 
 exports[`EuiCollapsibleNavGroup props background light is rendered 1`] = `
 <div
-  class="euiAccordion euiCollapsibleNavGroup euiCollapsibleNavGroup--light"
+  class="euiCollapsibleNavGroup euiCollapsibleNavGroup--light"
+  id="id"
 >
   <div
-    class="euiAccordion__triggerWrapper"
-  >
-    <button
-      aria-controls="id"
-      aria-expanded="false"
-      class="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__button"
-      type="button"
-    >
-      <span
-        class="euiAccordion__iconWrapper"
-      >
-        <div
-          class="euiAccordion__icon"
-          data-euiicon-type="arrowRight"
-        />
-      </span>
-      <span>
-        <div
-          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-        >
-          <div
-            class="euiFlexItem"
-          >
-            <h3>
-              Title
-            </h3>
-          </div>
-        </div>
-      </span>
-    </button>
-  </div>
-  <div
-    class="euiAccordion__childWrapper"
-    id="id"
-  >
-    <div>
-      <div
-        class=""
-      >
-        <div
-          class="euiCollapsibleNavGroup__children"
-        />
-      </div>
-    </div>
-  </div>
+    class="euiCollapsibleNavGroup__children"
+  />
 </div>
 `;
 
 exports[`EuiCollapsibleNavGroup props background none is rendered 1`] = `
 <div
-  class="euiAccordion euiCollapsibleNavGroup"
+  class="euiCollapsibleNavGroup"
+  id="id"
 >
   <div
-    class="euiAccordion__triggerWrapper"
-  >
-    <button
-      aria-controls="id"
-      aria-expanded="false"
-      class="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__button"
-      type="button"
-    >
-      <span
-        class="euiAccordion__iconWrapper"
-      >
-        <div
-          class="euiAccordion__icon"
-          data-euiicon-type="arrowRight"
-        />
-      </span>
-      <span>
-        <div
-          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-        >
-          <div
-            class="euiFlexItem"
-          >
-            <h3>
-              Title
-            </h3>
-          </div>
-        </div>
-      </span>
-    </button>
-  </div>
+    class="euiCollapsibleNavGroup__children"
+  />
+</div>
+`;
+
+exports[`EuiCollapsibleNavGroup props iconSize is rendered 1`] = `
+<div
+  class="euiCollapsibleNavGroup euiCollapsibleNavGroup--withTitle"
+  id="id"
+>
   <div
-    class="euiAccordion__childWrapper"
-    id="id"
+    class="euiCollapsibleNavGroup__button"
   >
-    <div>
+    <div
+      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+    >
       <div
-        class=""
+        class="euiFlexItem euiFlexItem--flexGrowZero"
       >
         <div
-          class="euiCollapsibleNavGroup__children"
+          aria-hidden="true"
+          data-euiicon-type="bolt"
         />
+      </div>
+      <div
+        class="euiFlexItem"
+      >
+        <h3>
+          Title
+        </h3>
       </div>
     </div>
   </div>
+  <div
+    class="euiCollapsibleNavGroup__children"
+  />
 </div>
 `;
 
 exports[`EuiCollapsibleNavGroup props iconType is rendered 1`] = `
 <div
-  class="euiAccordion euiCollapsibleNavGroup"
+  class="euiCollapsibleNavGroup euiCollapsibleNavGroup--withTitle"
+  id="id"
+>
+  <div
+    class="euiCollapsibleNavGroup__button"
+  >
+    <div
+      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+    >
+      <div
+        class="euiFlexItem euiFlexItem--flexGrowZero"
+      >
+        <div
+          aria-hidden="true"
+          data-euiicon-type="bolt"
+        />
+      </div>
+      <div
+        class="euiFlexItem"
+      >
+        <h3>
+          Title
+        </h3>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiCollapsibleNavGroup__children"
+  />
+</div>
+`;
+
+exports[`EuiCollapsibleNavGroup props title is rendered 1`] = `
+<div
+  class="euiCollapsibleNavGroup euiCollapsibleNavGroup--withTitle"
+  id="id"
+>
+  <div
+    class="euiCollapsibleNavGroup__button"
+  >
+    <div
+      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+    >
+      <div
+        class="euiFlexItem"
+      >
+        <h3>
+          Title
+        </h3>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiCollapsibleNavGroup__children"
+  />
+</div>
+`;
+
+exports[`EuiCollapsibleNavGroup throws a warning if iconType is passed without a title 1`] = `
+<div
+  class="euiCollapsibleNavGroup"
+  id="id"
+>
+  <div
+    class="euiCollapsibleNavGroup__children"
+  />
+</div>
+`;
+
+exports[`EuiCollapsibleNavGroup when collapsible is true will render an accordion 1`] = `
+<div
+  class="euiAccordion euiCollapsibleNavGroup euiCollapsibleNavGroup--withTitle"
 >
   <div
     class="euiAccordion__triggerWrapper"
@@ -239,14 +176,6 @@ exports[`EuiCollapsibleNavGroup props iconType is rendered 1`] = `
         <div
           class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
         >
-          <div
-            class="euiFlexItem euiFlexItem--flexGrowZero"
-          >
-            <div
-              aria-hidden="true"
-              data-euiicon-type="bolt"
-            />
-          </div>
           <div
             class="euiFlexItem"
           >

--- a/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
+++ b/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiCollapsibleNavGroup is rendered 1`] = `
+<div
+  aria-label="aria-label"
+  class="euiCollapsibleNavGroup testClass1 testClass2"
+  data-test-subj="test subject string"
+/>
+`;

--- a/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
+++ b/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`EuiCollapsibleNavGroup props iconSize is rendered 1`] = `
   id="id"
 >
   <div
-    class="euiCollapsibleNavGroup__title"
+    class="euiCollapsibleNavGroup__title euiCollapsibleNavGroup__title--small"
   >
     <div
       class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
@@ -86,7 +86,7 @@ exports[`EuiCollapsibleNavGroup props iconType is rendered 1`] = `
   id="id"
 >
   <div
-    class="euiCollapsibleNavGroup__title"
+    class="euiCollapsibleNavGroup__title euiCollapsibleNavGroup__title--small"
   >
     <div
       class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
@@ -120,7 +120,7 @@ exports[`EuiCollapsibleNavGroup props title is rendered 1`] = `
   id="id"
 >
   <div
-    class="euiCollapsibleNavGroup__title"
+    class="euiCollapsibleNavGroup__title euiCollapsibleNavGroup__title--small"
   >
     <div
       class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
@@ -134,6 +134,76 @@ exports[`EuiCollapsibleNavGroup props title is rendered 1`] = `
       </div>
     </div>
   </div>
+  <div
+    class="euiCollapsibleNavGroup__children"
+  />
+</div>
+`;
+
+exports[`EuiCollapsibleNavGroup props titleElement can change the rendere element to h2 1`] = `
+<div
+  class="euiCollapsibleNavGroup euiCollapsibleNavGroup--withTitle"
+  id="id"
+>
+  <div
+    class="euiCollapsibleNavGroup__title euiCollapsibleNavGroup__title--small"
+  >
+    <div
+      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+    >
+      <div
+        class="euiFlexItem"
+      >
+        <h2>
+          Title
+        </h2>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiCollapsibleNavGroup__children"
+  />
+</div>
+`;
+
+exports[`EuiCollapsibleNavGroup props titleSize inherit is rendered 1`] = `
+<div
+  class="euiCollapsibleNavGroup"
+  id="id"
+>
+  <div
+    class="euiCollapsibleNavGroup__children"
+  />
+</div>
+`;
+
+exports[`EuiCollapsibleNavGroup props titleSize large is rendered 1`] = `
+<div
+  class="euiCollapsibleNavGroup"
+  id="id"
+>
+  <div
+    class="euiCollapsibleNavGroup__children"
+  />
+</div>
+`;
+
+exports[`EuiCollapsibleNavGroup props titleSize medium is rendered 1`] = `
+<div
+  class="euiCollapsibleNavGroup"
+  id="id"
+>
+  <div
+    class="euiCollapsibleNavGroup__children"
+  />
+</div>
+`;
+
+exports[`EuiCollapsibleNavGroup props titleSize small is rendered 1`] = `
+<div
+  class="euiCollapsibleNavGroup"
+  id="id"
+>
   <div
     class="euiCollapsibleNavGroup__children"
   />
@@ -161,7 +231,7 @@ exports[`EuiCollapsibleNavGroup when collapsible is true will render an accordio
     <button
       aria-controls="id"
       aria-expanded="false"
-      class="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__title"
+      class="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__title euiCollapsibleNavGroup__title--small"
       type="button"
     >
       <span

--- a/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
+++ b/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
@@ -3,7 +3,110 @@
 exports[`EuiCollapsibleNavGroup is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="euiCollapsibleNavGroup testClass1 testClass2"
+  class="euiAccordion euiCollapsibleNavGroup testClass1 testClass2"
   data-test-subj="test subject string"
-/>
+>
+  <div
+    class="euiAccordion__triggerWrapper"
+  >
+    <button
+      aria-controls="id"
+      aria-expanded="false"
+      class="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__button"
+      type="button"
+    >
+      <span
+        class="euiAccordion__iconWrapper"
+      >
+        <div
+          class="euiAccordion__icon"
+          data-euiicon-type="arrowRight"
+        />
+      </span>
+      <span>
+        <div
+          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+        >
+          <div
+            class="euiFlexItem"
+          >
+            Title
+          </div>
+        </div>
+      </span>
+    </button>
+  </div>
+  <div
+    class="euiAccordion__childWrapper"
+    id="id"
+  >
+    <div>
+      <div
+        class=""
+      >
+        <div
+          class="euiCollapsibleNavGroup__children"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiCollapsibleNavGroup props iconType is rendered 1`] = `
+<div
+  class="euiAccordion euiCollapsibleNavGroup"
+>
+  <div
+    class="euiAccordion__triggerWrapper"
+  >
+    <button
+      aria-controls="id"
+      aria-expanded="false"
+      class="euiAccordion__button euiAccordion__buttonReverse euiCollapsibleNavGroup__button"
+      type="button"
+    >
+      <span
+        class="euiAccordion__iconWrapper"
+      >
+        <div
+          class="euiAccordion__icon"
+          data-euiicon-type="arrowRight"
+        />
+      </span>
+      <span>
+        <div
+          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+        >
+          <div
+            class="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <div
+              data-euiicon-type="bolt"
+            />
+          </div>
+          <div
+            class="euiFlexItem"
+          >
+            Title
+          </div>
+        </div>
+      </span>
+    </button>
+  </div>
+  <div
+    class="euiAccordion__childWrapper"
+    id="id"
+  >
+    <div>
+      <div
+        class=""
+      >
+        <div
+          class="euiCollapsibleNavGroup__children"
+        />
+      </div>
+    </div>
+  </div>
+</div>
 `;

--- a/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
+++ b/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
@@ -196,7 +196,7 @@ exports[`EuiCollapsibleNavGroup throws a warning if iconType is passed without a
 </div>
 `;
 
-exports[`EuiCollapsibleNavGroup when collapsible is true will render an accordion 1`] = `
+exports[`EuiCollapsibleNavGroup when isCollapsible is true will render an accordion 1`] = `
 <div
   class="euiAccordion euiCollapsibleNavGroup euiCollapsibleNavGroup--withHeading"
 >

--- a/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
+++ b/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
@@ -1,3 +1,8 @@
+$euiCollapsibleNavGroupDarkBackgroundColor: lightOrDarkTheme(
+  $euiColorDarkestShade,
+  $euiColorLightestShade
+);
+
 .euiCollapsibleNavGroup {
   &:not(:first-child) {
     border-top: $euiBorderThin;
@@ -7,6 +12,15 @@
     padding: $euiSize;
     font-size: $euiFontSizeS;
     font-weight: $euiFontWeightSemiBold;
+  }
+
+  &--light {
+    background-color: $euiPageBackgroundColor;
+  }
+
+  &--dark {
+    background-color: shade($euiCollapsibleNavGroupDarkBackgroundColor, 20%);
+    color: $euiColorGhost;
   }
 }
 

--- a/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
+++ b/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
@@ -13,28 +13,26 @@
   color: $euiColorGhost;
 
   // Forcing better contrast of focus state on EuiAccordion toggle icon
-  .euiCollapsibleNavGroup__title:focus .euiAccordion__iconWrapper {
+  .euiCollapsibleNavGroup__heading:focus .euiAccordion__iconWrapper {
     color: $euiCollapsibleNavGroupDarkHighContrastColor;
     animation-name: euiCollapsibleNavGroupDarkFocusRingAnimate !important; // sass-lint:disable-line no-important
   }
+
+  .euiCollapsibleNavGroup__title {
+    color: inherit;
+  }
 }
 
-.euiCollapsibleNavGroup__title {
+.euiCollapsibleNavGroup__heading {
   padding: $euiSize;
   font-weight: $euiFontWeightSemiBold;
-}
-
-@each $sizeName, $fontSize in $euiCollapsibleNavGroupTitleSizes {
-  .euiCollapsibleNavGroup__title--#{$sizeName} {
-    font-size: $fontSize;
-  }
 }
 
 .euiCollapsibleNavGroup__children {
   padding: $euiSizeS;
 }
 
-.euiCollapsibleNavGroup--withTitle .euiCollapsibleNavGroup__children {
+.euiCollapsibleNavGroup--withHeading .euiCollapsibleNavGroup__children {
   padding-top: 0;
 }
 

--- a/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
+++ b/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
@@ -9,12 +9,6 @@ $euiCollapsibleNavGroupDarkBackgroundColor: lightOrDarkTheme(
     border-top: $euiBorderThin;
   }
 
-  &__button {
-    padding: $euiSize;
-    font-size: $euiFontSizeS;
-    font-weight: $euiFontWeightSemiBold;
-  }
-
   &--light {
     background-color: $euiCollapsibleNavGroupLightBackgroundColor;
   }
@@ -23,6 +17,12 @@ $euiCollapsibleNavGroupDarkBackgroundColor: lightOrDarkTheme(
     background-color: $euiCollapsibleNavGroupDarkBackgroundColor;
     color: $euiColorGhost;
   }
+}
+
+.euiCollapsibleNavGroup__title {
+  padding: $euiSize;
+  font-size: $euiFontSizeS;
+  font-weight: $euiFontWeightSemiBold;
 }
 
 .euiCollapsibleNavGroup__children {

--- a/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
+++ b/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
@@ -1,3 +1,15 @@
 .euiCollapsibleNavGroup {
-  color: $euiTextColor;
+  &:not(:first-child) {
+    border-top: $euiBorderThin;
+  }
+
+  &__button {
+    padding: $euiSize;
+    font-size: $euiFontSizeS;
+    font-weight: $euiFontWeightSemiBold;
+  }
+}
+
+.euiCollapsibleNavGroup__children {
+  padding: 0 $euiSizeS $euiSizeS;
 }

--- a/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
+++ b/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
@@ -8,21 +8,26 @@ $euiCollapsibleNavGroupDarkBackgroundColor: lightOrDarkTheme(
   &:not(:first-child) {
     border-top: $euiBorderThin;
   }
+}
 
-  &--light {
-    background-color: $euiCollapsibleNavGroupLightBackgroundColor;
-  }
+.euiCollapsibleNavGroup--light {
+  background-color: $euiCollapsibleNavGroupLightBackgroundColor;
+}
 
-  &--dark {
-    background-color: $euiCollapsibleNavGroupDarkBackgroundColor;
-    color: $euiColorGhost;
-  }
+.euiCollapsibleNavGroup--dark {
+  background-color: $euiCollapsibleNavGroupDarkBackgroundColor;
+  color: $euiColorGhost;
 }
 
 .euiCollapsibleNavGroup__title {
   padding: $euiSize;
-  font-size: $euiFontSizeS;
   font-weight: $euiFontWeightSemiBold;
+}
+
+@each $sizeName, $fontSize in $euiCollapsibleNavGroupTitleSizes {
+  .euiCollapsibleNavGroup__title--#{$sizeName} {
+    font-size: $fontSize;
+  }
 }
 
 .euiCollapsibleNavGroup__children {

--- a/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
+++ b/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
@@ -1,6 +1,6 @@
 $euiCollapsibleNavGroupDarkBackgroundColor: lightOrDarkTheme(
   $euiColorDarkestShade,
-  $euiColorLightestShade
+  shade($euiColorLightestShade, 30%),
 );
 
 .euiCollapsibleNavGroup {

--- a/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
+++ b/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
@@ -1,0 +1,3 @@
+.euiCollapsibleNavGroup {
+  color: $euiTextColor;
+}

--- a/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
+++ b/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
@@ -1,9 +1,3 @@
-$euiCollapsibleNavGroupLightBackgroundColor: $euiPageBackgroundColor;
-$euiCollapsibleNavGroupDarkBackgroundColor: lightOrDarkTheme(
-  shade($euiColorDarkestShade, 20%),
-  shade($euiColorLightestShade, 50%),
-);
-
 .euiCollapsibleNavGroup {
   &:not(:first-child) {
     border-top: $euiBorderThin;
@@ -17,6 +11,12 @@ $euiCollapsibleNavGroupDarkBackgroundColor: lightOrDarkTheme(
 .euiCollapsibleNavGroup--dark {
   background-color: $euiCollapsibleNavGroupDarkBackgroundColor;
   color: $euiColorGhost;
+
+  // Forcing better contrast of focus state on EuiAccordion toggle icon
+  .euiAccordion__button:focus .euiAccordion__iconWrapper {
+    color: $euiCollapsibleNavGroupDarkHighContrastColor;
+    animation-name: euiCollapsibleNavGroupDarkFocusRingAnimate !important; // sass-lint:disable-line no-important
+  }
 }
 
 .euiCollapsibleNavGroup__title {
@@ -36,4 +36,14 @@ $euiCollapsibleNavGroupDarkBackgroundColor: lightOrDarkTheme(
 
 .euiCollapsibleNavGroup--withTitle .euiCollapsibleNavGroup__children {
   padding-top: 0;
+}
+
+@keyframes euiCollapsibleNavGroupDarkFocusRingAnimate {
+  0% {
+    box-shadow: 0 0 0 $euiFocusRingAnimStartSize $euiFocusRingAnimStartColor;
+  }
+
+  100% {
+    box-shadow: 0 0 0 $euiFocusRingSize $euiCollapsibleNavGroupDarkHighContrastColor;
+  }
 }

--- a/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
+++ b/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
@@ -1,6 +1,7 @@
+$euiCollapsibleNavGroupLightBackgroundColor: $euiPageBackgroundColor;
 $euiCollapsibleNavGroupDarkBackgroundColor: lightOrDarkTheme(
-  $euiColorDarkestShade,
-  shade($euiColorLightestShade, 30%),
+  shade($euiColorDarkestShade, 20%),
+  shade($euiColorLightestShade, 50%),
 );
 
 .euiCollapsibleNavGroup {
@@ -15,15 +16,19 @@ $euiCollapsibleNavGroupDarkBackgroundColor: lightOrDarkTheme(
   }
 
   &--light {
-    background-color: $euiPageBackgroundColor;
+    background-color: $euiCollapsibleNavGroupLightBackgroundColor;
   }
 
   &--dark {
-    background-color: shade($euiCollapsibleNavGroupDarkBackgroundColor, 20%);
+    background-color: $euiCollapsibleNavGroupDarkBackgroundColor;
     color: $euiColorGhost;
   }
 }
 
 .euiCollapsibleNavGroup__children {
-  padding: 0 $euiSizeS $euiSizeS;
+  padding: $euiSizeS;
+}
+
+.euiCollapsibleNavGroup--withTitle .euiCollapsibleNavGroup__children {
+  padding-top: 0;
 }

--- a/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
+++ b/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
@@ -13,7 +13,7 @@
   color: $euiColorGhost;
 
   // Forcing better contrast of focus state on EuiAccordion toggle icon
-  .euiAccordion__button:focus .euiAccordion__iconWrapper {
+  .euiCollapsibleNavGroup__title:focus .euiAccordion__iconWrapper {
     color: $euiCollapsibleNavGroupDarkHighContrastColor;
     animation-name: euiCollapsibleNavGroupDarkFocusRingAnimate !important; // sass-lint:disable-line no-important
   }

--- a/src/components/collapsible_nav/collapsible_nav_group/_index.scss
+++ b/src/components/collapsible_nav/collapsible_nav_group/_index.scss
@@ -1,0 +1,1 @@
+@import 'collapsible_nav_group';

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
@@ -93,7 +93,7 @@ describe('EuiCollapsibleNavGroup', () => {
 
       expect(consoleStub).toBeCalled();
       expect(consoleStub.mock.calls[0][0]).toMatch(
-        'icon without also passing a `title`'
+        'not render an icon without `title`'
       );
       expect(component).toMatchSnapshot();
     });

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render } from 'enzyme';
+import { requiredProps } from '../../../test/required_props';
+
+import { EuiCollapsibleNavGroup } from './collapsible_nav_group';
+
+describe('EuiCollapsibleNavGroup', () => {
+  test('is rendered', () => {
+    const component = render(<EuiCollapsibleNavGroup {...requiredProps} />);
+
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
 
-import { EuiCollapsibleNavGroup } from './collapsible_nav_group';
+import { EuiCollapsibleNavGroup, BACKGROUNDS } from './collapsible_nav_group';
 
 describe('EuiCollapsibleNavGroup', () => {
   test('is rendered', () => {
@@ -30,6 +30,23 @@ describe('EuiCollapsibleNavGroup', () => {
       );
 
       expect(component).toMatchSnapshot();
+    });
+
+    describe('background', () => {
+      BACKGROUNDS.forEach(color => {
+        test(`${color} is rendered`, () => {
+          const component = render(
+            <EuiCollapsibleNavGroup
+              title="Title"
+              initialIsOpen={false}
+              id="id"
+              background={color}
+            />
+          );
+
+          expect(component).toMatchSnapshot();
+        });
+      });
     });
   });
 });

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
@@ -7,23 +7,34 @@ import { EuiCollapsibleNavGroup, BACKGROUNDS } from './collapsible_nav_group';
 describe('EuiCollapsibleNavGroup', () => {
   test('is rendered', () => {
     const component = render(
-      <EuiCollapsibleNavGroup
-        title="Title"
-        initialIsOpen={false}
-        id="id"
-        {...requiredProps}
-      />
+      <EuiCollapsibleNavGroup id="id" {...requiredProps} />
     );
 
     expect(component).toMatchSnapshot();
   });
 
   describe('props', () => {
+    test('title is rendered', () => {
+      const component = render(
+        <EuiCollapsibleNavGroup title="Title" id="id" />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
     test('iconType is rendered', () => {
+      const component = render(
+        <EuiCollapsibleNavGroup title="Title" iconType="bolt" id="id" />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
+    test('iconSize is rendered', () => {
       const component = render(
         <EuiCollapsibleNavGroup
           title="Title"
-          initialIsOpen={false}
+          iconSize="s"
           iconType="bolt"
           id="id"
         />
@@ -36,17 +47,55 @@ describe('EuiCollapsibleNavGroup', () => {
       BACKGROUNDS.forEach(color => {
         test(`${color} is rendered`, () => {
           const component = render(
-            <EuiCollapsibleNavGroup
-              title="Title"
-              initialIsOpen={false}
-              id="id"
-              background={color}
-            />
+            <EuiCollapsibleNavGroup id="id" background={color} />
           );
 
           expect(component).toMatchSnapshot();
         });
       });
+    });
+  });
+
+  describe('when collapsible is true', () => {
+    test('will render an accordion', () => {
+      const component = render(
+        <EuiCollapsibleNavGroup
+          collapsible={true}
+          initialIsOpen={false}
+          title="Title"
+          id="id"
+        />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+  });
+
+  describe('throws a warning', () => {
+    const oldConsoleError = console.warn;
+    let consoleStub: jest.Mock;
+
+    beforeEach(() => {
+      // We don't use jest.spyOn() here, because EUI's tests apply a global
+      // console.error() override that throws an exception. For these
+      // tests, we just want to know if console.error() was called.
+      console.warn = consoleStub = jest.fn();
+    });
+
+    afterEach(() => {
+      console.warn = oldConsoleError;
+    });
+
+    test('if iconType is passed without a title', () => {
+      const component = render(
+        <EuiCollapsibleNavGroup iconType="bolt" id="id" />
+      );
+
+      expect(consoleStub).toBeCalled();
+      expect(consoleStub.mock.calls[0][0]).toMatch(
+        'icon without also passing a `title`'
+      );
+      expect(component).toMatchSnapshot();
     });
   });
 });

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
@@ -55,7 +55,7 @@ describe('EuiCollapsibleNavGroup', () => {
       });
     });
 
-    test('titleElement can change the rendere element to h2', () => {
+    test('titleElement can change the rendered element to h2', () => {
       const component = render(
         <EuiCollapsibleNavGroup title="Title" titleElement="h2" id="id" />
       );

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
 
-import { EuiCollapsibleNavGroup, BACKGROUNDS } from './collapsible_nav_group';
+import {
+  EuiCollapsibleNavGroup,
+  BACKGROUNDS,
+  TITLE_SIZES,
+} from './collapsible_nav_group';
 
 describe('EuiCollapsibleNavGroup', () => {
   test('is rendered', () => {
@@ -48,6 +52,26 @@ describe('EuiCollapsibleNavGroup', () => {
         test(`${color} is rendered`, () => {
           const component = render(
             <EuiCollapsibleNavGroup id="id" background={color} />
+          );
+
+          expect(component).toMatchSnapshot();
+        });
+      });
+    });
+
+    test('titleElement can change the rendere element to h2', () => {
+      const component = render(
+        <EuiCollapsibleNavGroup title="Title" titleElement="h2" id="id" />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
+    describe('titleSize', () => {
+      TITLE_SIZES.forEach(size => {
+        test(`${size} is rendered`, () => {
+          const component = render(
+            <EuiCollapsibleNavGroup id="id" titleSize={size} />
           );
 
           expect(component).toMatchSnapshot();

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
@@ -72,11 +72,11 @@ describe('EuiCollapsibleNavGroup', () => {
     });
   });
 
-  describe('when collapsible is true', () => {
+  describe('when isCollapsible is true', () => {
     test('will render an accordion', () => {
       const component = render(
         <EuiCollapsibleNavGroup
-          collapsible={true}
+          isCollapsible={true}
           initialIsOpen={false}
           title="Title"
           id="id"

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
@@ -2,11 +2,7 @@ import React from 'react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
 
-import {
-  EuiCollapsibleNavGroup,
-  BACKGROUNDS,
-  TITLE_SIZES,
-} from './collapsible_nav_group';
+import { EuiCollapsibleNavGroup, BACKGROUNDS } from './collapsible_nav_group';
 
 describe('EuiCollapsibleNavGroup', () => {
   test('is rendered', () => {
@@ -67,16 +63,12 @@ describe('EuiCollapsibleNavGroup', () => {
       expect(component).toMatchSnapshot();
     });
 
-    describe('titleSize', () => {
-      TITLE_SIZES.forEach(size => {
-        test(`${size} is rendered`, () => {
-          const component = render(
-            <EuiCollapsibleNavGroup id="id" titleSize={size} />
-          );
+    test('titleSize can be larger', () => {
+      const component = render(
+        <EuiCollapsibleNavGroup id="id" titleSize="s" />
+      );
 
-          expect(component).toMatchSnapshot();
-        });
-      });
+      expect(component).toMatchSnapshot();
     });
   });
 

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
@@ -6,8 +6,30 @@ import { EuiCollapsibleNavGroup } from './collapsible_nav_group';
 
 describe('EuiCollapsibleNavGroup', () => {
   test('is rendered', () => {
-    const component = render(<EuiCollapsibleNavGroup {...requiredProps} />);
+    const component = render(
+      <EuiCollapsibleNavGroup
+        title="Title"
+        initialIsOpen={false}
+        id="id"
+        {...requiredProps}
+      />
+    );
 
     expect(component).toMatchSnapshot();
+  });
+
+  describe('props', () => {
+    test('iconType is rendered', () => {
+      const component = render(
+        <EuiCollapsibleNavGroup
+          title="Title"
+          initialIsOpen={false}
+          iconType="bolt"
+          id="id"
+        />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
   });
 });

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactNode } from 'react';
+import React, { FunctionComponent, ReactNode, useState } from 'react';
 import classNames from 'classnames';
 import { CommonProps, ExclusiveUnion } from '../../common';
 import { htmlIdGenerator } from '../../../services';
@@ -18,7 +18,7 @@ export const BACKGROUNDS = Object.keys(
   backgroundToClassNameMap
 ) as Background[];
 
-export interface EuiCollapsibleNavGroupProps extends CommonProps {
+export interface EuiCollapsibleNavGroupInterface extends CommonProps {
   children?: ReactNode;
   /**
    * Sits left of the `title` and only when `title` is present
@@ -47,7 +47,7 @@ export interface EuiCollapsibleNavGroupProps extends CommonProps {
   titleSize?: Omit<EuiTitleProps['size'], 'l' | 'm'>;
 }
 
-type GroupAsAccordion = EuiCollapsibleNavGroupProps &
+type GroupAsAccordion = EuiCollapsibleNavGroupInterface &
   Omit<EuiAccordionProps, 'id'> & {
     /**
      * If `true`, wraps children in the body of an accordion,
@@ -61,7 +61,7 @@ type GroupAsAccordion = EuiCollapsibleNavGroupProps &
     title: ReactNode;
   };
 
-type GroupAsDiv = EuiCollapsibleNavGroupProps & {
+type GroupAsDiv = EuiCollapsibleNavGroupInterface & {
   /**
    * When `false`, simply renders a div without any accordion functionality
    */
@@ -73,8 +73,13 @@ type GroupAsDiv = EuiCollapsibleNavGroupProps & {
   title?: ReactNode;
 };
 
+export type EuiCollapsibleNavGroupProps = ExclusiveUnion<
+  GroupAsAccordion,
+  GroupAsDiv
+>;
+
 export const EuiCollapsibleNavGroup: FunctionComponent<
-  ExclusiveUnion<GroupAsAccordion, GroupAsDiv>
+  EuiCollapsibleNavGroupProps
 > = ({
   className,
   children,
@@ -88,6 +93,7 @@ export const EuiCollapsibleNavGroup: FunctionComponent<
   titleSize = 'xxs',
   ...rest
 }) => {
+  const [groupID] = useState(id || htmlIdGenerator()());
   const classes = classNames(
     'euiCollapsibleNavGroup',
     backgroundToClassNameMap[background],
@@ -132,11 +138,9 @@ export const EuiCollapsibleNavGroup: FunctionComponent<
   );
 
   if (isCollapsible && title) {
-    const generateID = htmlIdGenerator();
-
     return (
       <EuiAccordion
-        id={id || generateID()}
+        id={groupID}
         className={classes}
         buttonClassName={headingClasses}
         buttonContent={titleContent}
@@ -148,7 +152,7 @@ export const EuiCollapsibleNavGroup: FunctionComponent<
     );
   } else {
     return (
-      <div id={id} className={classes} {...rest}>
+      <div id={groupID} className={classes} {...rest}>
         {titleContent && <div className={headingClasses}>{titleContent}</div>}
         {content}
       </div>

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
@@ -51,9 +51,9 @@ type GroupAsAccordion = EuiCollapsibleNavGroupProps &
   Omit<EuiAccordionProps, 'id'> & {
     /**
      * If `true`, wraps children in the body of an accordion,
-     * using the `title` (required for use with `collapsible`) as the button
+     * requiring the prop `title` to be used as the button
      */
-    collapsible: true;
+    isCollapsible: true;
     /**
      * The title gets wrapped in the appropriate heading level
      * with the option to add an iconType
@@ -65,7 +65,7 @@ type GroupAsDiv = EuiCollapsibleNavGroupProps & {
   /**
    * When `false`, simply renders a div without any accordion functionality
    */
-  collapsible?: false;
+  isCollapsible?: false;
   /**
    * The title gets wrapped in the appropriate heading level
    * with the option to add an iconType
@@ -83,7 +83,7 @@ export const EuiCollapsibleNavGroup: FunctionComponent<
   iconType,
   iconSize = 'l',
   background = 'none',
-  collapsible = false,
+  isCollapsible = false,
   titleElement = 'h3',
   titleSize = 'xxs',
   ...rest
@@ -131,7 +131,7 @@ export const EuiCollapsibleNavGroup: FunctionComponent<
     undefined
   );
 
-  if (collapsible && title) {
+  if (isCollapsible && title) {
     const generateID = htmlIdGenerator();
 
     return (

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
@@ -1,40 +1,79 @@
 import React, { FunctionComponent, ReactNode } from 'react';
 import classNames from 'classnames';
 import { CommonProps } from '../../common';
-import { htmlIdGenerator } from '../../../services';
+import { htmlIdGenerator, slugify } from '../../../services';
 
 import { EuiAccordion, EuiAccordionProps } from '../../accordion';
 import { EuiIcon, IconType } from '../../icon';
 import { EuiFlexGroup, EuiFlexItem } from '../../flex';
 
+type Background = 'none' | 'light' | 'dark';
+const backgroundToClassNameMap: { [color in Background]: string } = {
+  none: '',
+  light: 'euiCollapsibleNavGroup--light',
+  dark: 'euiCollapsibleNavGroup--dark',
+};
+export const BACKGROUNDS = Object.keys(
+  backgroundToClassNameMap
+) as Background[];
+
 export interface EuiCollapsibleNavGroupProps  // TODO: paddingSize should be optional on EuiAccordion
   extends CommonProps,
     Omit<EuiAccordionProps, 'id'> {
   children?: ReactNode;
+  /**
+   * The title gets wrapped in the appropriate heading level
+   * with the option to add an iconType
+   */
   title: string;
+  /**
+   * Sits left of the `title` and only when `title` is present
+   */
   iconType?: IconType;
+  /**
+   * Optionally provide an id, othewise one will be created
+   */
   id?: string;
+  /**
+   * Adds a background color to the entire group,
+   * applying the correct text color to the title only
+   */
+  background?: Background;
 }
 
 export const EuiCollapsibleNavGroup: FunctionComponent<
   EuiCollapsibleNavGroupProps
-> = ({ className, children, title, iconType, id, ...rest }) => {
-  const classes = classNames('euiCollapsibleNavGroup', className);
+> = ({
+  className,
+  children,
+  title,
+  iconType,
+  id,
+  background = 'none',
+  ...rest
+}) => {
+  const classes = classNames(
+    'euiCollapsibleNavGroup',
+    backgroundToClassNameMap[background],
+    className
+  );
   const buttonClasses = classNames('euiCollapsibleNavGroup__button');
 
   const buttonContent = (
     <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
       {iconType && (
         <EuiFlexItem grow={false}>
-          <EuiIcon type={iconType} size="l" />
+          <EuiIcon type={iconType} size="l" aria-hidden="true" />
         </EuiFlexItem>
       )}
 
-      <EuiFlexItem>{title}</EuiFlexItem>
+      <EuiFlexItem>
+        <h3>{title}</h3>
+      </EuiFlexItem>
     </EuiFlexGroup>
   );
 
-  const generateID = htmlIdGenerator(title);
+  const generateID = htmlIdGenerator(slugify(title));
 
   return (
     <EuiAccordion

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
@@ -87,10 +87,10 @@ export const EuiCollapsibleNavGroup: FunctionComponent<
 > = ({
   className,
   children,
+  id,
   title,
   iconType,
   iconSize = 'l',
-  id,
   background = 'none',
   collapsible = false,
   titleElement = 'h3',

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
@@ -1,0 +1,18 @@
+import React, { HTMLAttributes, FunctionComponent } from 'react';
+import { CommonProps } from '../../common';
+import classNames from 'classnames';
+
+export type EuiCollapsibleNavGroupProps = HTMLAttributes<HTMLDivElement> &
+  CommonProps & {};
+
+export const EuiCollapsibleNavGroup: FunctionComponent<
+  EuiCollapsibleNavGroupProps
+> = ({ children, className, ...rest }) => {
+  const classes = classNames('euiCollapsibleNavGroup', className);
+
+  return (
+    <div className={classes} {...rest}>
+      {children}
+    </div>
+  );
+};

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
@@ -90,7 +90,7 @@ export const EuiCollapsibleNavGroup: FunctionComponent<
   // Warn if consumer passes an iconType without a title
   if (iconType && !title) {
     console.warn(
-      'EuiCollapsibleNavGroup will not render an icon without also passing a `title`.'
+      'EuiCollapsibleNavGroup will not render an icon without `title`.'
     );
   }
 
@@ -98,7 +98,7 @@ export const EuiCollapsibleNavGroup: FunctionComponent<
     <div className="euiCollapsibleNavGroup__children">{children}</div>
   );
 
-  const titleClasses = classNames('euiCollapsibleNavGroup__button');
+  const titleClasses = 'euiCollapsibleNavGroup__title';
 
   const titleContent = title ? (
     <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
@@ -1,18 +1,51 @@
-import React, { HTMLAttributes, FunctionComponent } from 'react';
-import { CommonProps } from '../../common';
+import React, { FunctionComponent, ReactNode } from 'react';
 import classNames from 'classnames';
+import { CommonProps } from '../../common';
+import { htmlIdGenerator } from '../../../services';
 
-export type EuiCollapsibleNavGroupProps = HTMLAttributes<HTMLDivElement> &
-  CommonProps & {};
+import { EuiAccordion, EuiAccordionProps } from '../../accordion';
+import { EuiIcon, IconType } from '../../icon';
+import { EuiFlexGroup, EuiFlexItem } from '../../flex';
+
+export interface EuiCollapsibleNavGroupProps  // TODO: paddingSize should be optional on EuiAccordion
+  extends CommonProps,
+    Omit<EuiAccordionProps, 'id'> {
+  children?: ReactNode;
+  title: string;
+  iconType?: IconType;
+  id?: string;
+}
 
 export const EuiCollapsibleNavGroup: FunctionComponent<
   EuiCollapsibleNavGroupProps
-> = ({ children, className, ...rest }) => {
+> = ({ className, children, title, iconType, id, ...rest }) => {
   const classes = classNames('euiCollapsibleNavGroup', className);
+  const buttonClasses = classNames('euiCollapsibleNavGroup__button');
+
+  const buttonContent = (
+    <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+      {iconType && (
+        <EuiFlexItem grow={false}>
+          <EuiIcon type={iconType} size="l" />
+        </EuiFlexItem>
+      )}
+
+      <EuiFlexItem>{title}</EuiFlexItem>
+    </EuiFlexGroup>
+  );
+
+  const generateID = htmlIdGenerator(title);
 
   return (
-    <div className={classes} {...rest}>
-      {children}
-    </div>
+    <EuiAccordion
+      id={id || generateID()}
+      className={classes}
+      buttonClassName={buttonClasses}
+      buttonContent={buttonContent}
+      initialIsOpen={true}
+      arrowDisplay="right"
+      {...rest}>
+      <div className="euiCollapsibleNavGroup__children">{children}</div>
+    </EuiAccordion>
   );
 };

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
@@ -17,6 +17,15 @@ export const BACKGROUNDS = Object.keys(
   backgroundToClassNameMap
 ) as Background[];
 
+type TitleSize = 'small' | 'medium' | 'inherit' | 'large';
+const titleSizeToClassNameMap: { [size in TitleSize]: string } = {
+  small: 'euiCollapsibleNavGroup__title--small',
+  medium: 'euiCollapsibleNavGroup__title--medium',
+  inherit: '',
+  large: 'euiCollapsibleNavGroup__title--large',
+};
+export const TITLE_SIZES = Object.keys(titleSizeToClassNameMap) as TitleSize[];
+
 export interface EuiCollapsibleNavGroupProps extends CommonProps {
   // TODO: paddingSize should be optional on EuiAccordion
   children?: ReactNode;
@@ -37,6 +46,14 @@ export interface EuiCollapsibleNavGroupProps extends CommonProps {
    * applying the correct text color to the title only
    */
   background?: Background;
+  /**
+   * Determines the title's heading element
+   */
+  titleElement?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span';
+  /**
+   * Title sizing based on the SASS variable equivelant
+   */
+  titleSize?: TitleSize;
 }
 
 type GroupAsAccordion = EuiCollapsibleNavGroupProps &
@@ -76,6 +93,8 @@ export const EuiCollapsibleNavGroup: FunctionComponent<
   id,
   background = 'none',
   collapsible = false,
+  titleElement = 'h3',
+  titleSize = 'small',
   ...rest
 }) => {
   const classes = classNames(
@@ -98,7 +117,11 @@ export const EuiCollapsibleNavGroup: FunctionComponent<
     <div className="euiCollapsibleNavGroup__children">{children}</div>
   );
 
-  const titleClasses = 'euiCollapsibleNavGroup__title';
+  const titleClasses = classNames(
+    'euiCollapsibleNavGroup__title',
+    titleSizeToClassNameMap[titleSize]
+  );
+  const TitleElement = titleElement;
 
   const titleContent = title ? (
     <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
@@ -109,7 +132,7 @@ export const EuiCollapsibleNavGroup: FunctionComponent<
       )}
 
       <EuiFlexItem>
-        <h3>{title}</h3>
+        <TitleElement>{title}</TitleElement>
       </EuiFlexItem>
     </EuiFlexGroup>
   ) : (

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
@@ -1,10 +1,10 @@
 import React, { FunctionComponent, ReactNode } from 'react';
 import classNames from 'classnames';
-import { CommonProps } from '../../common';
+import { CommonProps, ExclusiveUnion } from '../../common';
 import { htmlIdGenerator, slugify } from '../../../services';
 
 import { EuiAccordion, EuiAccordionProps } from '../../accordion';
-import { EuiIcon, IconType } from '../../icon';
+import { EuiIcon, IconType, IconSize } from '../../icon';
 import { EuiFlexGroup, EuiFlexItem } from '../../flex';
 
 type Background = 'none' | 'light' | 'dark';
@@ -17,19 +17,17 @@ export const BACKGROUNDS = Object.keys(
   backgroundToClassNameMap
 ) as Background[];
 
-export interface EuiCollapsibleNavGroupProps  // TODO: paddingSize should be optional on EuiAccordion
-  extends CommonProps,
-    Omit<EuiAccordionProps, 'id'> {
+export interface EuiCollapsibleNavGroupProps extends CommonProps {
+  // TODO: paddingSize should be optional on EuiAccordion
   children?: ReactNode;
-  /**
-   * The title gets wrapped in the appropriate heading level
-   * with the option to add an iconType
-   */
-  title: string;
   /**
    * Sits left of the `title` and only when `title` is present
    */
   iconType?: IconType;
+  /**
+   * Change the size of the icon in the `title`
+   */
+  iconSize?: IconSize;
   /**
    * Optionally provide an id, othewise one will be created
    */
@@ -41,29 +39,72 @@ export interface EuiCollapsibleNavGroupProps  // TODO: paddingSize should be opt
   background?: Background;
 }
 
+type GroupAsAccordion = EuiCollapsibleNavGroupProps &
+  Omit<EuiAccordionProps, 'id'> & {
+    /**
+     * If `true`, wraps children in the body of an accordion,
+     * using the `title` (required for use with `collapsible`) as the button
+     */
+    collapsible: true;
+    /**
+     * The title gets wrapped in the appropriate heading level
+     * with the option to add an iconType
+     */
+    title: ReactNode;
+  };
+
+type GroupAsDiv = EuiCollapsibleNavGroupProps & {
+  /**
+   * When `false`, simply renders a div without any accordion functionality
+   */
+  collapsible?: false;
+  /**
+   * The title gets wrapped in the appropriate heading level
+   * with the option to add an iconType
+   */
+  title?: ReactNode;
+};
+
 export const EuiCollapsibleNavGroup: FunctionComponent<
-  EuiCollapsibleNavGroupProps
+  ExclusiveUnion<GroupAsAccordion, GroupAsDiv>
 > = ({
   className,
   children,
   title,
   iconType,
+  iconSize = 'l',
   id,
   background = 'none',
+  collapsible = false,
   ...rest
 }) => {
   const classes = classNames(
     'euiCollapsibleNavGroup',
     backgroundToClassNameMap[background],
+    {
+      'euiCollapsibleNavGroup--withTitle': title,
+    },
     className
   );
-  const buttonClasses = classNames('euiCollapsibleNavGroup__button');
 
-  const buttonContent = (
+  // Warn if consumer passes an iconType without a title
+  if (iconType && !title) {
+    console.warn(
+      'EuiCollapsibleNavGroup will not render an icon without also passing a `title`.'
+    );
+  }
+
+  const content = (
+    <div className="euiCollapsibleNavGroup__children">{children}</div>
+  );
+
+  const titleClasses = classNames('euiCollapsibleNavGroup__button');
+
+  const titleContent = title ? (
     <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
       {iconType && (
         <EuiFlexItem grow={false}>
-          <EuiIcon type={iconType} size="l" aria-hidden="true" />
+          <EuiIcon type={iconType} size={iconSize} aria-hidden="true" />
         </EuiFlexItem>
       )}
 
@@ -71,20 +112,33 @@ export const EuiCollapsibleNavGroup: FunctionComponent<
         <h3>{title}</h3>
       </EuiFlexItem>
     </EuiFlexGroup>
+  ) : (
+    undefined
   );
 
-  const generateID = htmlIdGenerator(slugify(title));
+  if (collapsible && title) {
+    const generateID = htmlIdGenerator(
+      title && typeof title === 'string' ? slugify(title) : ''
+    );
 
-  return (
-    <EuiAccordion
-      id={id || generateID()}
-      className={classes}
-      buttonClassName={buttonClasses}
-      buttonContent={buttonContent}
-      initialIsOpen={true}
-      arrowDisplay="right"
-      {...rest}>
-      <div className="euiCollapsibleNavGroup__children">{children}</div>
-    </EuiAccordion>
-  );
+    return (
+      <EuiAccordion
+        id={id || generateID()}
+        className={classes}
+        buttonClassName={titleClasses}
+        buttonContent={titleContent}
+        initialIsOpen={true}
+        arrowDisplay="right"
+        {...rest}>
+        {content}
+      </EuiAccordion>
+    );
+  } else {
+    return (
+      <div id={id} className={classes} {...rest}>
+        {titleContent && <div className={titleClasses}>{titleContent}</div>}
+        {content}
+      </div>
+    );
+  }
 };

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, ReactNode } from 'react';
 import classNames from 'classnames';
 import { CommonProps, ExclusiveUnion } from '../../common';
-import { htmlIdGenerator, slugify } from '../../../services';
+import { htmlIdGenerator } from '../../../services';
 
 import { EuiAccordion, EuiAccordionProps } from '../../accordion';
 import { EuiIcon, IconType, IconSize } from '../../icon';
@@ -117,9 +117,7 @@ export const EuiCollapsibleNavGroup: FunctionComponent<
   );
 
   if (collapsible && title) {
-    const generateID = htmlIdGenerator(
-      title && typeof title === 'string' ? slugify(title) : ''
-    );
+    const generateID = htmlIdGenerator();
 
     return (
       <EuiAccordion

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
@@ -6,6 +6,7 @@ import { htmlIdGenerator } from '../../../services';
 import { EuiAccordion, EuiAccordionProps } from '../../accordion';
 import { EuiIcon, IconType, IconSize } from '../../icon';
 import { EuiFlexGroup, EuiFlexItem } from '../../flex';
+import { EuiTitle, EuiTitleProps, EuiTitleSize } from '../../title';
 
 type Background = 'none' | 'light' | 'dark';
 const backgroundToClassNameMap: { [color in Background]: string } = {
@@ -17,17 +18,7 @@ export const BACKGROUNDS = Object.keys(
   backgroundToClassNameMap
 ) as Background[];
 
-type TitleSize = 'small' | 'medium' | 'inherit' | 'large';
-const titleSizeToClassNameMap: { [size in TitleSize]: string } = {
-  small: 'euiCollapsibleNavGroup__title--small',
-  medium: 'euiCollapsibleNavGroup__title--medium',
-  inherit: '',
-  large: 'euiCollapsibleNavGroup__title--large',
-};
-export const TITLE_SIZES = Object.keys(titleSizeToClassNameMap) as TitleSize[];
-
 export interface EuiCollapsibleNavGroupProps extends CommonProps {
-  // TODO: paddingSize should be optional on EuiAccordion
   children?: ReactNode;
   /**
    * Sits left of the `title` and only when `title` is present
@@ -38,12 +29,12 @@ export interface EuiCollapsibleNavGroupProps extends CommonProps {
    */
   iconSize?: IconSize;
   /**
-   * Optionally provide an id, othewise one will be created
+   * Optionally provide an id, otherwise one will be created
    */
   id?: string;
   /**
    * Adds a background color to the entire group,
-   * applying the correct text color to the title only
+   * applying the correct text color to the `title` only
    */
   background?: Background;
   /**
@@ -51,9 +42,9 @@ export interface EuiCollapsibleNavGroupProps extends CommonProps {
    */
   titleElement?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span';
   /**
-   * Title sizing based on the SASS variable equivelant
+   * Title sizing equivelant to EuiTitle, but only `s` and smaller
    */
-  titleSize?: TitleSize;
+  titleSize?: Omit<EuiTitleProps['size'], 'l' | 'm'>;
 }
 
 type GroupAsAccordion = EuiCollapsibleNavGroupProps &
@@ -94,14 +85,14 @@ export const EuiCollapsibleNavGroup: FunctionComponent<
   background = 'none',
   collapsible = false,
   titleElement = 'h3',
-  titleSize = 'small',
+  titleSize = 'xxs',
   ...rest
 }) => {
   const classes = classNames(
     'euiCollapsibleNavGroup',
     backgroundToClassNameMap[background],
     {
-      'euiCollapsibleNavGroup--withTitle': title,
+      'euiCollapsibleNavGroup--withHeading': title,
     },
     className
   );
@@ -117,14 +108,11 @@ export const EuiCollapsibleNavGroup: FunctionComponent<
     <div className="euiCollapsibleNavGroup__children">{children}</div>
   );
 
-  const titleClasses = classNames(
-    'euiCollapsibleNavGroup__title',
-    titleSizeToClassNameMap[titleSize]
-  );
-  const TitleElement = titleElement;
+  const headingClasses = 'euiCollapsibleNavGroup__heading';
 
+  const TitleElement = titleElement;
   const titleContent = title ? (
-    <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+    <EuiFlexGroup gutterSize="m" alignItems="center" responsive={false}>
       {iconType && (
         <EuiFlexItem grow={false}>
           <EuiIcon type={iconType} size={iconSize} aria-hidden="true" />
@@ -132,7 +120,11 @@ export const EuiCollapsibleNavGroup: FunctionComponent<
       )}
 
       <EuiFlexItem>
-        <TitleElement>{title}</TitleElement>
+        <EuiTitle size={titleSize as EuiTitleSize}>
+          <TitleElement className="euiCollapsibleNavGroup__title">
+            {title}
+          </TitleElement>
+        </EuiTitle>
       </EuiFlexItem>
     </EuiFlexGroup>
   ) : (
@@ -146,7 +138,7 @@ export const EuiCollapsibleNavGroup: FunctionComponent<
       <EuiAccordion
         id={id || generateID()}
         className={classes}
-        buttonClassName={titleClasses}
+        buttonClassName={headingClasses}
         buttonContent={titleContent}
         initialIsOpen={true}
         arrowDisplay="right"
@@ -157,7 +149,7 @@ export const EuiCollapsibleNavGroup: FunctionComponent<
   } else {
     return (
       <div id={id} className={classes} {...rest}>
-        {titleContent && <div className={titleClasses}>{titleContent}</div>}
+        {titleContent && <div className={headingClasses}>{titleContent}</div>}
         {content}
       </div>
     );

--- a/src/components/collapsible_nav/collapsible_nav_group/index.ts
+++ b/src/components/collapsible_nav/collapsible_nav_group/index.ts
@@ -1,3 +1,1 @@
 export { EuiCollapsibleNavGroup } from './collapsible_nav_group';
-
-export { EuiCollapsibleNav } from './collapsible_nav';

--- a/src/components/collapsible_nav/collapsible_nav_group/index.ts
+++ b/src/components/collapsible_nav/collapsible_nav_group/index.ts
@@ -1,1 +1,4 @@
-export { EuiCollapsibleNavGroup } from './collapsible_nav_group';
+export {
+  EuiCollapsibleNavGroup,
+  EuiCollapsibleNavGroupProps,
+} from './collapsible_nav_group';

--- a/src/components/collapsible_nav/index.ts
+++ b/src/components/collapsible_nav/index.ts
@@ -1,3 +1,6 @@
-export { EuiCollapsibleNavGroup } from './collapsible_nav_group';
+export {
+  EuiCollapsibleNavGroup,
+  EuiCollapsibleNavGroupProps,
+} from './collapsible_nav_group';
 
-export { EuiCollapsibleNav } from './collapsible_nav';
+export { EuiCollapsibleNav, EuiCollapsibleNavProps } from './collapsible_nav';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -37,7 +37,7 @@ export { EuiCode, EuiCodeBlock, EuiCodeBlockImpl } from './code';
 
 export { EuiCodeEditor } from './code_editor';
 
-export { EuiCollapsibleNav } from './collapsible_nav';
+export { EuiCollapsibleNavGroup, EuiCollapsibleNav } from './collapsible_nav';
 
 export {
   EuiColorPicker,

--- a/src/components/nav_drawer/__snapshots__/nav_drawer.test.js.snap
+++ b/src/components/nav_drawer/__snapshots__/nav_drawer.test.js.snap
@@ -15,7 +15,7 @@ exports[`EuiNavDrawer is rendered 1`] = `
         id="navDrawerMenu"
       >
         <ul
-          class="euiListGroup euiListGroup-flush euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawer__expandButton"
+          class="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawer__expandButton"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isClickable euiListGroupItem-hasExtraAction navDrawerExpandButton-isCollapsed"
@@ -42,7 +42,7 @@ exports[`EuiNavDrawer is rendered 1`] = `
           </li>
         </ul>
         <ul
-          class="euiListGroup euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawerGroup"
+          class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawerGroup"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isClickable euiNavDrawerGroup__item"
@@ -96,7 +96,7 @@ exports[`EuiNavDrawer is rendered 1`] = `
           </li>
         </ul>
         <ul
-          class="euiListGroup euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawerGroup"
+          class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawerGroup"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isActive euiListGroupItem-isClickable euiListGroupItem-hasExtraAction euiNavDrawerGroup__item"
@@ -276,7 +276,7 @@ exports[`EuiNavDrawer renders with falsy children 1`] = `
         id="navDrawerMenu"
       >
         <ul
-          class="euiListGroup euiListGroup-flush euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawer__expandButton"
+          class="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawer__expandButton"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isClickable euiListGroupItem-hasExtraAction navDrawerExpandButton-isCollapsed"
@@ -303,7 +303,7 @@ exports[`EuiNavDrawer renders with falsy children 1`] = `
           </li>
         </ul>
         <ul
-          class="euiListGroup euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawerGroup"
+          class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawerGroup"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isActive euiListGroupItem-isClickable euiListGroupItem-hasExtraAction euiNavDrawerGroup__item"
@@ -483,7 +483,7 @@ exports[`EuiNavDrawer renders with fragments 1`] = `
         id="navDrawerMenu"
       >
         <ul
-          class="euiListGroup euiListGroup-flush euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawer__expandButton"
+          class="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawer__expandButton"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isClickable euiListGroupItem-hasExtraAction navDrawerExpandButton-isCollapsed"
@@ -510,7 +510,7 @@ exports[`EuiNavDrawer renders with fragments 1`] = `
           </li>
         </ul>
         <ul
-          class="euiListGroup euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawerGroup"
+          class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawerGroup"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isClickable euiNavDrawerGroup__item"
@@ -564,7 +564,7 @@ exports[`EuiNavDrawer renders with fragments 1`] = `
           </li>
         </ul>
         <ul
-          class="euiListGroup euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawerGroup"
+          class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawerGroup"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isActive euiListGroupItem-isClickable euiListGroupItem-hasExtraAction euiNavDrawerGroup__item"

--- a/src/components/nav_drawer/__snapshots__/nav_drawer.test.js.snap
+++ b/src/components/nav_drawer/__snapshots__/nav_drawer.test.js.snap
@@ -15,7 +15,7 @@ exports[`EuiNavDrawer is rendered 1`] = `
         id="navDrawerMenu"
       >
         <ul
-          class="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawer__expandButton"
+          class="euiListGroup euiListGroup-flush euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawer__expandButton"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isClickable euiListGroupItem-hasExtraAction navDrawerExpandButton-isCollapsed"
@@ -42,7 +42,7 @@ exports[`EuiNavDrawer is rendered 1`] = `
           </li>
         </ul>
         <ul
-          class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawerGroup"
+          class="euiListGroup euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawerGroup"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isClickable euiNavDrawerGroup__item"
@@ -96,7 +96,7 @@ exports[`EuiNavDrawer is rendered 1`] = `
           </li>
         </ul>
         <ul
-          class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawerGroup"
+          class="euiListGroup euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawerGroup"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isActive euiListGroupItem-isClickable euiListGroupItem-hasExtraAction euiNavDrawerGroup__item"
@@ -276,7 +276,7 @@ exports[`EuiNavDrawer renders with falsy children 1`] = `
         id="navDrawerMenu"
       >
         <ul
-          class="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawer__expandButton"
+          class="euiListGroup euiListGroup-flush euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawer__expandButton"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isClickable euiListGroupItem-hasExtraAction navDrawerExpandButton-isCollapsed"
@@ -303,7 +303,7 @@ exports[`EuiNavDrawer renders with falsy children 1`] = `
           </li>
         </ul>
         <ul
-          class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawerGroup"
+          class="euiListGroup euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawerGroup"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isActive euiListGroupItem-isClickable euiListGroupItem-hasExtraAction euiNavDrawerGroup__item"
@@ -483,7 +483,7 @@ exports[`EuiNavDrawer renders with fragments 1`] = `
         id="navDrawerMenu"
       >
         <ul
-          class="euiListGroup euiListGroup-flush euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawer__expandButton"
+          class="euiListGroup euiListGroup-flush euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawer__expandButton"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isClickable euiListGroupItem-hasExtraAction navDrawerExpandButton-isCollapsed"
@@ -510,7 +510,7 @@ exports[`EuiNavDrawer renders with fragments 1`] = `
           </li>
         </ul>
         <ul
-          class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawerGroup"
+          class="euiListGroup euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawerGroup"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isClickable euiNavDrawerGroup__item"
@@ -564,7 +564,7 @@ exports[`EuiNavDrawer renders with fragments 1`] = `
           </li>
         </ul>
         <ul
-          class="euiListGroup euiListGroup--gutterSmall euiListGroup-maxWidthDefault euiNavDrawerGroup"
+          class="euiListGroup euiListGroup--gutterS euiListGroup-maxWidthDefault euiNavDrawerGroup"
         >
           <li
             class="euiListGroupItem euiListGroupItem--small euiListGroupItem-isActive euiListGroupItem-isClickable euiListGroupItem-hasExtraAction euiNavDrawerGroup__item"

--- a/src/global_styling/utility/_animations.scss
+++ b/src/global_styling/utility/_animations.scss
@@ -28,7 +28,7 @@
 
 @keyframes focusRingAnimate {
   0% {
-    box-shadow: 0 0 0 6px $euiFocusRingAnimStartColor;
+    box-shadow: 0 0 0 $euiFocusRingAnimStartSize $euiFocusRingAnimStartColor;
   }
 
   100% {
@@ -38,7 +38,7 @@
 
 @keyframes focusRingAnimateLarge {
   0% {
-    box-shadow: 0 0 0 10px $euiFocusRingAnimStartColor;
+    box-shadow: 0 0 0 $euiFocusRingAnimStartSizeLarge $euiFocusRingAnimStartColor;
   }
 
   100% {

--- a/src/global_styling/variables/_states.scss
+++ b/src/global_styling/variables/_states.scss
@@ -1,6 +1,8 @@
 // Colors
 $euiFocusRingColor: rgba($euiColorPrimary, .3) !default;
 $euiFocusRingAnimStartColor: rgba($euiColorPrimary, 0) !default;
+$euiFocusRingAnimStartSize: 6px !default;
+$euiFocusRingAnimStartSizeLarge: 10px !default;
 
 // Sizing
 $euiFocusRingSizeLarge: $euiSizeXS !default;


### PR DESCRIPTION
### EuiCollapsibleGroup

This is the **accordion** style grouping that will make up these three portions:

<img width="439" alt="Screen Shot 2020-03-10 at 13 16 39 PM" src="https://user-images.githubusercontent.com/549577/76340163-7f33a780-62d1-11ea-8822-42e489202a72.png">

_The contents of the group doesn't matter, hence the scribbles_

Instead of trying to create 3 components, I made one that is child-agnostic and can be an accordion via `collapsible=true` or not. Consumers can also add a header with `title` and `iconType`. They can also choose the background color.

<img width="981" alt="Screen Shot 2020-03-10 at 13 19 31 PM" src="https://user-images.githubusercontent.com/549577/76340332-c9b52400-62d1-11ea-9dc4-a76ebc3770d1.png">

### Accessibility

Since it does wrap the EuiAccordion when `collapsible=true`, if there's any a11y needs for that specifically, we should do it **in EuiAccordion** and make an issue for that.

The one thing I had to deal with is the focus states of the `dark` background accordion toggle arrow were hard to see. So I **forced** a different focus ring color with overrides.

<img width="122" alt="Screen Shot 2020-03-10 at 15 59 29 PM" src="https://user-images.githubusercontent.com/549577/76354263-84e8b780-62e8-11ea-9c95-152ac68c4081.png">


### Dark mode

In dark mode, they all just get different shades of dark that aren't that noticeable from each other. 🤷‍♀ 

<img width="963" alt="Screen Shot 2020-03-10 at 13 21 51 PM" src="https://user-images.githubusercontent.com/549577/76340587-34665f80-62d2-11ea-9b30-a84ab97fb698.png">


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [x] Props have proper **autodocs**
- [x] Added **documentation** examples
- [x] Added or updated **jest tests**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- ~[ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~ Will be added to feature PR
