### PR TITLE
Added PropsAXorB utility type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 -  Added `prepend` and `append` ability to `EuiComboBox` single selection only ([#3003](https://github.com/elastic/eui/pull/3003))
+- Added `PropsAXorB` utility type for creating exclusive subclass combinations ([#3045](https://github.com/elastic/eui/pull/3045))
 
 **Bug Fixes**
 

--- a/scripts/babel/proptypes-from-ts-props/index.js
+++ b/scripts/babel/proptypes-from-ts-props/index.js
@@ -156,6 +156,7 @@ function resolveArrayTypeToPropTypes(node, state) {
  *    - Arrays
  *    - MouseEventHandler is interpretted as functions
  *    - ExclusiveUnion custom type
+ *    - PropsAXorB custom type
  *    - defined types/interfaces (found during initial program body parsing)
  * Returns `null` for unresolvable types
  * @param node
@@ -334,6 +335,20 @@ function resolveIdentifierToPropTypes(node, state) {
     }
 
     return propTypes;
+  }
+
+  if (identifier.name === 'PropsAXorB') {
+    // PropTypes for PropsAXorB remove from Base the keys in A and B
+    // then keys in A and B are made optional and unioned together
+    // Which is how TSIntersectionType is processed
+    return getPropTypesForNode(
+      {
+        type: 'TSIntersectionType',
+        types: node.typeParameters.params,
+      },
+      true,
+      state
+    );
   }
 
   // Lookup this identifier from types/interfaces defined in code

--- a/scripts/babel/proptypes-from-ts-props/index.test.js
+++ b/scripts/babel/proptypes-from-ts-props/index.test.js
@@ -1153,6 +1153,63 @@ FooComponent.propTypes = {
 };`);
       });
 
+      it('parses PropsAXorB arguments', () => {
+        const result = transform(
+          `
+import React from 'react';
+interface BaseProps {
+  /**
+   * Toggle something on or off
+   */
+  isOn: boolean;
+  'aria-label'?: string;
+}
+type Props = PropsAXorB<
+  BaseProps,
+  {
+    /**
+     * aria-label or aria-labelledby must be provided
+     */
+    'aria-label': string
+  },
+  {
+    /**
+     * aria-label or aria-labelledby must be provided
+     */
+    'aria-labelledby': string
+  }
+>;
+const FooComponent: React.SFC<Props> = () => {
+  return (<div>Hello World</div>);
+}`,
+          babelOptions
+        );
+
+        expect(result.code).toBe(`import React from 'react';
+import PropTypes from "prop-types";
+
+const FooComponent = () => {
+  return <div>Hello World</div>;
+};
+
+FooComponent.propTypes = {
+  /**
+     * Toggle something on or off
+     */
+  isOn: PropTypes.bool.isRequired,
+
+  /**
+       * aria-label or aria-labelledby must be provided
+       */
+  "aria-label": PropTypes.oneOfType([PropTypes.string, PropTypes.string.isRequired]),
+
+  /**
+       * aria-label or aria-labelledby must be provided
+       */
+  "aria-labelledby": PropTypes.string.isRequired
+};`);
+      });
+
       it('parses PropsForAnchor and PropsForButton arguments', () => {
         const result = transform(
           `

--- a/src/components/common.ts
+++ b/src/components/common.ts
@@ -134,3 +134,17 @@ export type PropsForButton<T, P = {}> = T &
   ButtonHTMLAttributes<HTMLButtonElement> & {
     onClick?: MouseEventHandler<HTMLButtonElement>;
   } & P;
+
+/**
+ * We have a common pattern of requiring `aria-label` XOR `aria-labelledby`
+ * where one is required, but the other cannot be present
+ * This utility extracts that functionality into a call like
+ *
+ * type AccessibleDivProps = PropsAXorB<HTMLAttributes<HTMLDivElement>, { 'aria-label': string }, { 'aria-labelledby': string }>
+ *
+ * This can also be used to make multiple properties required when unioned together:
+ *
+ * PropsAXorB<ButtonLink, { 'aria-label': string; role: string }, { 'aria-labelledby': string }>
+ */
+export type PropsAXorB<Base, A, B> = Omit<Base, keyof A | keyof B> &
+  ((A & { [key in keyof B]?: never }) | (B & { [key in keyof A]?: never }));

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -16,7 +16,7 @@ import classNames from 'classnames';
 import tabbable from 'tabbable';
 import { EuiI18n } from '../i18n';
 import { EuiDataGridHeaderRow } from './data_grid_header_row';
-import { CommonProps } from '../common';
+import { CommonProps, PropsAXorB } from '../common';
 import {
   EuiDataGridColumn,
   EuiDataGridColumnWidths,
@@ -59,8 +59,10 @@ import { DataGridContext } from './data_grid_context';
 // When below this number the grid only shows the full screen button
 const MINIMUM_WIDTH_FOR_GRID_CONTROLS = 479;
 
-type CommonGridProps = CommonProps &
-  HTMLAttributes<HTMLDivElement> & {
+type CommonGridProps = CommonProps & {
+  // redundant because of HTMLAttributes<HTMLDivElement>, but including this improves the docs
+  'aria-labelledby'?: string;
+} & HTMLAttributes<HTMLDivElement> & {
     /**
      * An array of #EuiDataGridControlColumn objects. Used to define ancillary columns on the left side of the data grid.
      */
@@ -119,23 +121,21 @@ type CommonGridProps = CommonProps &
 
 // This structure forces either aria-label or aria-labelledby to be defined
 // making some type of label a requirement
-export type EuiDataGridProps = Omit<
+export type EuiDataGridProps = PropsAXorB<
   CommonGridProps,
-  'aria-label' | 'aria-labelledby'
-> &
-  (
-    | {
-        /**
-         * must provide either aria-label OR aria-labelledby as a title for the grid
-         */
-        'aria-label': string;
-      }
-    | {
-        /**
-         * must provide either aria-label OR aria-labelledby as a title for the grid
-         */
-        'aria-labelledby': string;
-      });
+  {
+    /**
+     * must provide either aria-label OR aria-labelledby as a title for the grid
+     */
+    'aria-label': string;
+  },
+  {
+    /**
+     * must provide either aria-label OR aria-labelledby as a title for the grid
+     */
+    'aria-labelledby': string;
+  }
+>;
 
 // Each gridStyle object above sets a specific CSS select to .euiGrid
 const fontSizesToClassMap: { [size in EuiDataGridStyleFontSizes]: string } = {


### PR DESCRIPTION
### Summary

@myasonik asked for this to be an exported utility type

Description & usage:
```
/**
 * We have a common pattern of requiring `aria-label` XOR `aria-labelledby`
 * where one is required, but the other cannot be present
 * This utility extracts that functionality into a call like
 *
 * type AccessibleDivProps = PropsAXorB<HTMLAttributes<HTMLDivElement>, { 'aria-label': string }, { 'aria-labelledby': string }>
 *
 * This can also be used to make multiple properties required when unioned together:
 *
 * PropsAXorB<ButtonLink, { 'aria-label': string; role: string }, { 'aria-labelledby': string }>
 */
```

This started as providing keys to the utility type: `PropsAXorB<Base, 'aria-label', 'aria-labelledby'>` but that didn't allow providing doc comments, and prevented other use cases of adding properties not existent on the base type.

I updated `EuiDataGrid` to use this utility, which fixed a bug where data grid allowed both `aria-label` and `aria-labelledby` to be passed. I tested this utility & data grid change with:

```
// first and second usages are valid
// third is invalid by providing both props, this used to pass
// fourth is invalid as one of the aria- props is required
export const Foo = () => {
  return (
    <>
      <EuiDataGrid
        rowCount={0}
        renderCellValue={() => null}
        columns={[]}
        columnVisibility={{} as any}
        aria-label="test"
      />
      <EuiDataGrid
        rowCount={0}
        renderCellValue={() => null}
        columns={[]}
        columnVisibility={{} as any}
        aria-labelledby="test"
      />
      <EuiDataGrid
        rowCount={0}
        renderCellValue={() => null}
        columns={[]}
        columnVisibility={{} as any}
        aria-label="test"
        aria-labelledby="test"
      />
      <EuiDataGrid
        rowCount={0}
        renderCellValue={() => null}
        columns={[]}
        columnVisibility={{} as any}
      />
    </>
  );
};
```

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
- [x] Props have proper **autodocs**
~- [ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
