### PR TITLE
Make isSortable optional on datagrid schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed `EuiFieldNumber` so values of type `number` are now allowed ([#3020](https://github.com/elastic/eui/pull/3020))
 - Fixed SASS `contrastRatio()` function in dark mode by fixing the `pow()` math function ([#3013], (https://github.com/elastic/eui/pull/3013))
 - Fixed bug preventing `EuiDataGrid` from re-evaluating the default column width on resize ([#2991](https://github.com/elastic/eui/pull/2991))
+- Made `EuiDataGrid`'s `schema.isSortable` value optional ([#2991](https://github.com/elastic/eui/pull/2991))
 
 ## [`21.0.0`](https://github.com/elastic/eui/tree/v21.0.0)
 

--- a/src/components/datagrid/column_sorting.tsx
+++ b/src/components/datagrid/column_sorting.tsx
@@ -107,7 +107,9 @@ export const useColumnSorting = (
       if (isSortable != null) {
         sortable = isSortable;
       } else if (schemaDetail != null) {
-        sortable = schemaDetail.isSortable;
+        sortable = schemaDetail.hasOwnProperty('isSortable')
+          ? schemaDetail.isSortable!
+          : true;
       }
       return sortable;
     }

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -916,7 +916,6 @@ Array [
                 color: 'primary',
                 sortTextAsc: 'a-z',
                 sortTextDesc: 'z-a',
-                isSortable: true,
               },
             ]}
             inMemory={{ level: 'pagination' }}

--- a/src/components/datagrid/data_grid_schema.tsx
+++ b/src/components/datagrid/data_grid_schema.tsx
@@ -40,9 +40,9 @@ export interface EuiDataGridSchemaDetector {
    */
   sortTextDesc: ReactNode;
   /**
-   * Whether this column is sortable
+   * Whether this column is sortable (defaults to true)
    */
-  isSortable: boolean;
+  isSortable?: boolean;
   /**
    * Default sort direction of the column
    */
@@ -91,7 +91,6 @@ export const schemaDetectors: EuiDataGridSchemaDetector[] = [
         default="False-True"
       />
     ),
-    isSortable: true,
   },
   {
     type: 'currency',
@@ -133,7 +132,6 @@ export const schemaDetectors: EuiDataGridSchemaDetector[] = [
         default="High-Low"
       />
     ),
-    isSortable: true,
   },
   {
     type: 'datetime',
@@ -166,7 +164,6 @@ export const schemaDetectors: EuiDataGridSchemaDetector[] = [
     sortTextDesc: (
       <EuiI18n token="euiDataGridSchema.dateSortTextDesc" default="Old-New" />
     ),
-    isSortable: true,
   },
   {
     type: 'numeric',
@@ -207,7 +204,6 @@ export const schemaDetectors: EuiDataGridSchemaDetector[] = [
         default="High-Low"
       />
     ),
-    isSortable: true,
   },
   {
     type: 'json',
@@ -242,7 +238,6 @@ export const schemaDetectors: EuiDataGridSchemaDetector[] = [
         default="Large-Small"
       />
     ),
-    isSortable: true,
   },
 ];
 


### PR DESCRIPTION
### Summary

The new `isSortable` prop added to data grid schemas was made required, an accidental breaking change. This PR makes it optional.

I'm planning on backporting this fix to eui@21 after merge

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
