### PR TITLE
[Feature / Selectable A11y] Improve basic use case a11y

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "@types/react-beautiful-dnd": "^10.1.0",
     "@types/react-input-autosize": "^2.0.2",
     "@types/react-virtualized": "^9.18.7",
+    "@types/react-virtualized-auto-sizer": "^1.0.0",
+    "@types/react-window": "^1.8.1",
     "chroma-js": "^2.0.4",
     "classnames": "^2.2.5",
     "highlight.js": "^9.12.0",
@@ -67,6 +69,8 @@
     "react-input-autosize": "^2.2.2",
     "react-is": "~16.3.0",
     "react-virtualized": "^9.21.2",
+    "react-virtualized-auto-sizer": "^1.0.2",
+    "react-window": "^1.8.5",
     "resize-observer-polyfill": "^1.5.0",
     "tabbable": "^3.0.0",
     "uuid": "^3.1.0"

--- a/src/components/selectable/selectable_list/__snapshots__/selectable_list.test.tsx.snap
+++ b/src/components/selectable/selectable_list/__snapshots__/selectable_list.test.tsx.snap
@@ -8,17 +8,7 @@ exports[`EuiSelectableListItem is rendered 1`] = `
 >
   <div
     style="overflow:visible;width:0"
-  >
-    <div
-      aria-label="grid"
-      aria-readonly="true"
-      class="ReactVirtualized__Grid ReactVirtualized__List euiSelectableList__list"
-      id="htmlId"
-      role="listbox"
-      style="box-sizing:border-box;direction:ltr;height:192px;position:relative;width:0;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden"
-      tabindex="0"
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -28,17 +18,7 @@ exports[`EuiSelectableListItem props activeOptionIndex 1`] = `
 >
   <div
     style="overflow:visible;width:0"
-  >
-    <div
-      aria-label="grid"
-      aria-readonly="true"
-      class="ReactVirtualized__Grid ReactVirtualized__List euiSelectableList__list"
-      id="htmlId"
-      role="listbox"
-      style="box-sizing:border-box;direction:ltr;height:192px;position:relative;width:0;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden"
-      tabindex="0"
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -48,17 +28,7 @@ exports[`EuiSelectableListItem props allowExclusions 1`] = `
 >
   <div
     style="overflow:visible;width:0"
-  >
-    <div
-      aria-label="grid"
-      aria-readonly="true"
-      class="ReactVirtualized__Grid ReactVirtualized__List euiSelectableList__list"
-      id="htmlId"
-      role="listbox"
-      style="box-sizing:border-box;direction:ltr;height:192px;position:relative;width:0;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden"
-      tabindex="0"
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -68,17 +38,7 @@ exports[`EuiSelectableListItem props bordered 1`] = `
 >
   <div
     style="overflow:visible;width:0"
-  >
-    <div
-      aria-label="grid"
-      aria-readonly="true"
-      class="ReactVirtualized__Grid ReactVirtualized__List euiSelectableList__list"
-      id="htmlId"
-      role="listbox"
-      style="box-sizing:border-box;direction:ltr;height:192px;position:relative;width:0;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden"
-      tabindex="0"
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -88,17 +48,7 @@ exports[`EuiSelectableListItem props height is forced 1`] = `
 >
   <div
     style="overflow:visible;width:0"
-  >
-    <div
-      aria-label="grid"
-      aria-readonly="true"
-      class="ReactVirtualized__Grid ReactVirtualized__List euiSelectableList__list"
-      id="htmlId"
-      role="listbox"
-      style="box-sizing:border-box;direction:ltr;height:200px;position:relative;width:0;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden"
-      tabindex="0"
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -108,17 +58,7 @@ exports[`EuiSelectableListItem props height is full 1`] = `
 >
   <div
     style="overflow:visible;height:0;width:0"
-  >
-    <div
-      aria-label="grid"
-      aria-readonly="true"
-      class="ReactVirtualized__Grid ReactVirtualized__List euiSelectableList__list"
-      id="htmlId"
-      role="listbox"
-      style="box-sizing:border-box;direction:ltr;height:0;position:relative;width:0;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:auto"
-      tabindex="0"
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -128,17 +68,7 @@ exports[`EuiSelectableListItem props renderOption 1`] = `
 >
   <div
     style="overflow:visible;width:0"
-  >
-    <div
-      aria-label="grid"
-      aria-readonly="true"
-      class="ReactVirtualized__Grid ReactVirtualized__List euiSelectableList__list"
-      id="htmlId"
-      role="listbox"
-      style="box-sizing:border-box;direction:ltr;height:192px;position:relative;width:0;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden"
-      tabindex="0"
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -148,17 +78,7 @@ exports[`EuiSelectableListItem props rowHeight 1`] = `
 >
   <div
     style="overflow:visible;width:0"
-  >
-    <div
-      aria-label="grid"
-      aria-readonly="true"
-      class="ReactVirtualized__Grid ReactVirtualized__List euiSelectableList__list"
-      id="htmlId"
-      role="listbox"
-      style="box-sizing:border-box;direction:ltr;height:120px;position:relative;width:0;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden"
-      tabindex="0"
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -168,17 +88,7 @@ exports[`EuiSelectableListItem props searchValue 1`] = `
 >
   <div
     style="overflow:visible;width:0"
-  >
-    <div
-      aria-label="grid"
-      aria-readonly="true"
-      class="ReactVirtualized__Grid ReactVirtualized__List euiSelectableList__list"
-      id="htmlId"
-      role="listbox"
-      style="box-sizing:border-box;direction:ltr;height:192px;position:relative;width:0;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden"
-      tabindex="0"
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -188,17 +98,7 @@ exports[`EuiSelectableListItem props searchValue 2`] = `
 >
   <div
     style="overflow:visible;width:0"
-  >
-    <div
-      aria-label="grid"
-      aria-readonly="true"
-      class="ReactVirtualized__Grid ReactVirtualized__List euiSelectableList__list"
-      id="htmlId"
-      role="listbox"
-      style="box-sizing:border-box;direction:ltr;height:192px;position:relative;width:0;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden"
-      tabindex="0"
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -208,17 +108,7 @@ exports[`EuiSelectableListItem props showIcons can be turned off 1`] = `
 >
   <div
     style="overflow:visible;width:0"
-  >
-    <div
-      aria-label="grid"
-      aria-readonly="true"
-      class="ReactVirtualized__Grid ReactVirtualized__List euiSelectableList__list"
-      id="htmlId"
-      role="listbox"
-      style="box-sizing:border-box;direction:ltr;height:192px;position:relative;width:0;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden"
-      tabindex="0"
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -228,17 +118,7 @@ exports[`EuiSelectableListItem props singleSelection can be forced so that at le
 >
   <div
     style="overflow:visible;width:0"
-  >
-    <div
-      aria-label="grid"
-      aria-readonly="true"
-      class="ReactVirtualized__Grid ReactVirtualized__List euiSelectableList__list"
-      id="htmlId"
-      role="listbox"
-      style="box-sizing:border-box;direction:ltr;height:192px;position:relative;width:0;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden"
-      tabindex="0"
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -248,17 +128,7 @@ exports[`EuiSelectableListItem props singleSelection can be turned on 1`] = `
 >
   <div
     style="overflow:visible;width:0"
-  >
-    <div
-      aria-label="grid"
-      aria-readonly="true"
-      class="ReactVirtualized__Grid ReactVirtualized__List euiSelectableList__list"
-      id="htmlId"
-      role="listbox"
-      style="box-sizing:border-box;direction:ltr;height:192px;position:relative;width:0;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden"
-      tabindex="0"
-    />
-  </div>
+  />
 </div>
 `;
 
@@ -268,16 +138,6 @@ exports[`EuiSelectableListItem props visibleOptions 1`] = `
 >
   <div
     style="overflow:visible;width:0"
-  >
-    <div
-      aria-label="grid"
-      aria-readonly="true"
-      class="ReactVirtualized__Grid ReactVirtualized__List euiSelectableList__list"
-      id="htmlId"
-      role="listbox"
-      style="box-sizing:border-box;direction:ltr;height:128px;position:relative;width:0;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden"
-      tabindex="0"
-    />
-  </div>
+  />
 </div>
 `;

--- a/src/components/selectable/selectable_list/__snapshots__/selectable_list_item.test.tsx.snap
+++ b/src/components/selectable/selectable_list/__snapshots__/selectable_list_item.test.tsx.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiSelectableListItem is rendered 1`] = `
-<button
+<li
   aria-label="aria-label"
+  aria-selected="false"
   class="euiSelectableListItem testClass1 testClass2"
   data-test-subj="test subject string"
   role="option"
-  type="button"
 >
   <span
     class="euiSelectableListItem__content"
@@ -19,14 +19,14 @@ exports[`EuiSelectableListItem is rendered 1`] = `
       class="euiSelectableListItem__text"
     />
   </span>
-</button>
+</li>
 `;
 
 exports[`EuiSelectableListItem props append 1`] = `
-<button
+<li
+  aria-selected="false"
   class="euiSelectableListItem"
   role="option"
-  type="button"
 >
   <span
     class="euiSelectableListItem__content"
@@ -44,14 +44,14 @@ exports[`EuiSelectableListItem props append 1`] = `
       <span />
     </span>
   </span>
-</button>
+</li>
 `;
 
 exports[`EuiSelectableListItem props checked is off 1`] = `
-<button
+<li
+  aria-selected="false"
   class="euiSelectableListItem"
   role="option"
-  type="button"
 >
   <span
     class="euiSelectableListItem__content"
@@ -65,14 +65,14 @@ exports[`EuiSelectableListItem props checked is off 1`] = `
       class="euiSelectableListItem__text"
     />
   </span>
-</button>
+</li>
 `;
 
 exports[`EuiSelectableListItem props checked is on 1`] = `
-<button
+<li
+  aria-selected="true"
   class="euiSelectableListItem"
   role="option"
-  type="button"
 >
   <span
     class="euiSelectableListItem__content"
@@ -86,16 +86,15 @@ exports[`EuiSelectableListItem props checked is on 1`] = `
       class="euiSelectableListItem__text"
     />
   </span>
-</button>
+</li>
 `;
 
 exports[`EuiSelectableListItem props disabled 1`] = `
-<button
+<li
   aria-disabled="true"
+  aria-selected="false"
   class="euiSelectableListItem"
-  disabled=""
   role="option"
-  type="button"
 >
   <span
     class="euiSelectableListItem__content"
@@ -108,15 +107,14 @@ exports[`EuiSelectableListItem props disabled 1`] = `
       class="euiSelectableListItem__text"
     />
   </span>
-</button>
+</li>
 `;
 
 exports[`EuiSelectableListItem props isFocused 1`] = `
-<button
-  aria-selected="true"
+<li
+  aria-selected="false"
   class="euiSelectableListItem euiSelectableListItem-isFocused"
   role="option"
-  type="button"
 >
   <span
     class="euiSelectableListItem__content"
@@ -129,14 +127,14 @@ exports[`EuiSelectableListItem props isFocused 1`] = `
       class="euiSelectableListItem__text"
     />
   </span>
-</button>
+</li>
 `;
 
 exports[`EuiSelectableListItem props prepend 1`] = `
-<button
+<li
+  aria-selected="false"
   class="euiSelectableListItem"
   role="option"
-  type="button"
 >
   <span
     class="euiSelectableListItem__content"
@@ -154,14 +152,14 @@ exports[`EuiSelectableListItem props prepend 1`] = `
       class="euiSelectableListItem__text"
     />
   </span>
-</button>
+</li>
 `;
 
 exports[`EuiSelectableListItem props showIcons can be turned off 1`] = `
-<button
+<li
+  aria-selected="false"
   class="euiSelectableListItem"
   role="option"
-  type="button"
 >
   <span
     class="euiSelectableListItem__content"
@@ -170,5 +168,5 @@ exports[`EuiSelectableListItem props showIcons can be turned off 1`] = `
       class="euiSelectableListItem__text"
     />
   </span>
-</button>
+</li>
 `;

--- a/src/components/selectable/selectable_list/_selectable_list.scss
+++ b/src/components/selectable/selectable_list/_selectable_list.scss
@@ -12,6 +12,10 @@
 .euiSelectableList__list {
   @include euiOverflowShadow;
   @include euiScrollBar;
+
+  &:focus-within {
+    @include euiFocusRing; // TODO @myasonik why don't this work?
+  }
 }
 
 .euiSelectableList__groupLabel {

--- a/src/components/selectable/selectable_list/_selectable_list_item.scss
+++ b/src/components/selectable/selectable_list/_selectable_list_item.scss
@@ -5,32 +5,25 @@
   width: 100%;
   text-align: left;
   color: $euiTextColor;
+  cursor: pointer;
 
   &:not(:last-of-type) {
     border-bottom: $euiSelectableListItemBorder;
   }
 
-  &:hover,
-  &:focus {
+  &-isFocused:not([aria-disabled='true']),
+  &:hover:not([aria-disabled='true']) {
+    color: $euiColorPrimary;
+    background-color: $euiFocusBackgroundColor;
+
     .euiSelectableListItem__text {
       text-decoration: underline;
     }
   }
 
-  &:focus,
-  &-isFocused {
-    cursor: pointer;
-    color: $euiColorPrimary;
-    background-color: $euiFocusBackgroundColor;
-  }
-
-  &[disabled] {
+  &[aria-disabled='true'] {
     color: $euiColorMediumShade;
     cursor: not-allowed;
-
-    &:hover {
-      text-decoration: none;
-    }
   }
 }
 

--- a/src/components/selectable/selectable_list/selectable_list.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.tsx
@@ -35,9 +35,9 @@ export type EuiSelectableOptionsListProps = CommonProps &
     showIcons?: boolean;
     singleSelection?: 'always' | boolean;
     /**
-     * Any props to send specifically to the react-virtualized `List`
+     * Any props to send specifically to the react-window `FixedSizeList`
      */
-    virtualizedProps?: ListProps;
+    windowProps?: ListProps;
     /**
      * Adds a border around the list to indicate the bounds;
      * Useful when the list scrolls, otherwise use your own container
@@ -210,7 +210,7 @@ export class EuiSelectableList extends Component<EuiSelectableListProps> {
       onOptionClick,
       renderOption,
       height: forcedHeight,
-      virtualizedProps,
+      windowProps,
       rowHeight,
       activeOptionIndex,
       rootId,
@@ -269,7 +269,7 @@ export class EuiSelectableList extends Component<EuiSelectableListProps> {
               itemSize={rowHeight}
               innerElementType="ul"
               innerRef={this.setListBoxRef}
-              {...virtualizedProps}>
+              {...windowProps}>
               {this.ListRow}
             </FixedSizeList>
           )}

--- a/src/components/selectable/selectable_list/selectable_list.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.tsx
@@ -1,8 +1,6 @@
-import React, { Component, HTMLAttributes, ReactNode } from 'react';
+import React, { Component, HTMLAttributes, ReactNode, memo } from 'react';
 import classNames from 'classnames';
 import { CommonProps } from '../../common';
-// eslint-disable-next-line import/named
-import { List, AutoSizer, ListProps } from 'react-virtualized';
 import { htmlIdGenerator } from '../../../services';
 import {
   EuiSelectableListItem,
@@ -10,8 +8,13 @@ import {
 } from './selectable_list_item';
 import { EuiHighlight } from '../../highlight';
 import { EuiSelectableOption } from '../selectable_option';
-
-export type EuiSelectableSingleOptionProps = 'always' | boolean;
+import AutoSizer from 'react-virtualized-auto-sizer';
+import {
+  FixedSizeList,
+  ListProps,
+  ListChildComponentProps,
+  areEqual,
+} from 'react-window';
 
 // Consumer Configurable Props via `EuiSelectable.listProps`
 export type EuiSelectableOptionsListProps = CommonProps &
@@ -30,7 +33,7 @@ export type EuiSelectableOptionsListProps = CommonProps &
      * Show the check/cross selection indicator icons
      */
     showIcons?: boolean;
-    singleSelection?: EuiSelectableSingleOptionProps;
+    singleSelection?: 'always' | boolean;
     /**
      * Any props to send specifically to the react-virtualized `List`
      */
@@ -79,6 +82,7 @@ export type EuiSelectableListProps = EuiSelectableOptionsListProps & {
    */
   allowExclusions?: boolean;
   rootId?: (appendix?: string) => string;
+  searchable?: boolean;
 };
 
 export class EuiSelectableList extends Component<EuiSelectableListProps> {
@@ -88,10 +92,115 @@ export class EuiSelectableList extends Component<EuiSelectableListProps> {
   };
 
   rootId = this.props.rootId || htmlIdGenerator();
+  listRef: FixedSizeList | null = null;
+  listBoxRef: HTMLUListElement | null = null;
+
+  makeOptionId(index: number | undefined) {
+    if (typeof index === 'undefined') {
+      return '';
+    }
+
+    return this.rootId(`_option-${index}`);
+  }
+
+  setListRef = (ref: FixedSizeList | null) => {
+    this.listRef = ref;
+
+    if (ref && this.props.activeOptionIndex) {
+      ref.scrollToItem(this.props.activeOptionIndex, 'auto');
+    }
+  };
+
+  setListBoxRef = (ref: HTMLUListElement | null) => {
+    this.listBoxRef = ref;
+
+    if (ref) {
+      ref.setAttribute('id', this.rootId('listbox'));
+      ref.setAttribute('role', 'listBox');
+
+      if (this.props.searchable !== true) {
+        ref.setAttribute('tabindex', '0');
+      }
+
+      if (
+        this.props.singleSelection !== 'always' &&
+        this.props.singleSelection !== true
+      ) {
+        ref.setAttribute('aria-multiselectable', 'true');
+      }
+    }
+  };
+
+  componentDidUpdate() {
+    const { activeOptionIndex } = this.props;
+
+    if (this.listBoxRef) {
+      this.listBoxRef.setAttribute(
+        'aria-activedescendant',
+        `${this.makeOptionId(activeOptionIndex)}`
+      );
+    }
+
+    if (this.listRef && typeof this.props.activeOptionIndex !== 'undefined') {
+      this.listRef.scrollToItem(this.props.activeOptionIndex, 'auto');
+    }
+  }
 
   constructor(props: EuiSelectableListProps) {
     super(props);
   }
+
+  ListRow = memo(({ data, index, style }: ListChildComponentProps) => {
+    const option = data[index];
+    const {
+      label,
+      isGroupLabel,
+      checked,
+      disabled,
+      prepend,
+      append,
+      ref,
+      key,
+      ...optionRest
+    } = option;
+
+    if (isGroupLabel) {
+      return (
+        <li
+          role="presentation"
+          className="euiSelectableList__groupLabel"
+          style={style}
+          {...optionRest as HTMLAttributes<HTMLLIElement>}>
+          {prepend}
+          {label}
+          {append}
+        </li>
+      );
+    }
+
+    return (
+      <EuiSelectableListItem
+        id={this.makeOptionId(index)}
+        style={style}
+        key={key || label.toLowerCase()}
+        onClick={() => this.onAddOrRemoveOption(option)}
+        ref={ref ? ref.bind(null, index) : undefined}
+        isFocused={this.props.activeOptionIndex === index}
+        title={label}
+        showIcons={this.props.showIcons}
+        checked={checked}
+        disabled={disabled}
+        prepend={prepend}
+        append={append}
+        {...optionRest as EuiSelectableListItemProps}>
+        {this.props.renderOption ? (
+          this.props.renderOption(option, this.props.searchValue)
+        ) : (
+          <EuiHighlight search={this.props.searchValue}>{label}</EuiHighlight>
+        )}
+      </EuiSelectableListItem>
+    );
+  }, areEqual);
 
   render() {
     const {
@@ -110,6 +219,7 @@ export class EuiSelectableList extends Component<EuiSelectableListProps> {
       visibleOptions,
       allowExclusions,
       bordered,
+      searchable,
       ...rest
     } = this.props;
 
@@ -149,66 +259,19 @@ export class EuiSelectableList extends Component<EuiSelectableListProps> {
       <div className={classes} {...rest}>
         <AutoSizer disableHeight={!heightIsFull}>
           {({ width, height }) => (
-            <List
-              id={this.rootId('listbox')}
+            <FixedSizeList
+              ref={this.setListRef}
               className="euiSelectableList__list"
-              role="listbox"
               width={width}
               height={calculatedHeight || height}
-              rowCount={optionArray.length}
-              rowHeight={rowHeight}
-              scrollToIndex={activeOptionIndex}
-              {...virtualizedProps}
-              rowRenderer={({ key: rowKey, index, style }) => {
-                const option = optionArray[index];
-                const {
-                  label,
-                  isGroupLabel,
-                  checked,
-                  disabled,
-                  prepend,
-                  append,
-                  ref,
-                  key,
-                  ...optionRest
-                } = option;
-                if (isGroupLabel) {
-                  return (
-                    <div
-                      className="euiSelectableList__groupLabel"
-                      key={rowKey}
-                      style={style}
-                      {...optionRest as HTMLAttributes<HTMLDivElement>}>
-                      {prepend}
-                      {label}
-                      {append}
-                    </div>
-                  );
-                }
-                return (
-                  <EuiSelectableListItem
-                    id={this.rootId(`_option-${index}`)}
-                    style={style}
-                    key={key || option.label.toLowerCase()}
-                    onClick={() => this.onAddOrRemoveOption(option)}
-                    ref={ref ? ref.bind(null, index) : undefined}
-                    isFocused={activeOptionIndex === index}
-                    title={label}
-                    showIcons={showIcons}
-                    checked={checked}
-                    disabled={disabled}
-                    prepend={prepend}
-                    append={append}
-                    {...optionRest as EuiSelectableListItemProps}>
-                    {renderOption ? (
-                      renderOption(option, searchValue)
-                    ) : (
-                      <EuiHighlight search={searchValue}>{label}</EuiHighlight>
-                    )}
-                  </EuiSelectableListItem>
-                );
-              }}
-            />
+              itemCount={optionArray.length}
+              itemData={optionArray}
+              itemSize={rowHeight}
+              innerElementType="ul"
+              innerRef={this.setListBoxRef}
+              {...virtualizedProps}>
+              {this.ListRow}
+            </FixedSizeList>
           )}
         </AutoSizer>
       </div>

--- a/src/components/selectable/selectable_list/selectable_list_item.tsx
+++ b/src/components/selectable/selectable_list/selectable_list_item.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ButtonHTMLAttributes } from 'react';
+import React, { Component, LiHTMLAttributes } from 'react';
 import classNames from 'classnames';
 import { CommonProps } from '../../common';
 import { EuiIcon, IconType, IconColor } from '../../icon';
@@ -15,9 +15,7 @@ function resolveIconAndColor(
     : { icon: 'cross', color: 'text' };
 }
 
-export type EuiSelectableListItemProps = ButtonHTMLAttributes<
-  HTMLButtonElement
-> &
+export type EuiSelectableListItemProps = LiHTMLAttributes<HTMLLIElement> &
   CommonProps & {
     children?: React.ReactNode;
     /**
@@ -70,10 +68,10 @@ export class EuiSelectableListItem extends Component<
       className
     );
 
-    let buttonIcon: React.ReactNode;
+    let optionIcon: React.ReactNode;
     if (showIcons) {
       const { icon, color } = resolveIconAndColor(checked);
-      buttonIcon = (
+      optionIcon = (
         <EuiIcon
           className="euiSelectableListItem__icon"
           color={color}
@@ -97,21 +95,20 @@ export class EuiSelectableListItem extends Component<
     }
 
     return (
-      <button
+      <li
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
         role="option"
-        type="button"
-        aria-selected={isFocused}
+        aria-selected={checked === 'on'}
         className={classes}
-        disabled={disabled}
         aria-disabled={disabled}
         {...rest}>
         <span className="euiSelectableListItem__content">
-          {buttonIcon}
+          {optionIcon}
           {prependNode}
           <span className="euiSelectableListItem__text">{children}</span>
           {appendNode}
         </span>
-      </button>
+      </li>
     );
   }
 }

--- a/src/components/selectable/selectable_search/selectable_search.tsx
+++ b/src/components/selectable/selectable_search/selectable_search.tsx
@@ -4,6 +4,7 @@ import { CommonProps } from '../../common';
 import { EuiFieldSearch, EuiFieldSearchProps } from '../../form';
 import { getMatchingOptions } from '../matching_options';
 import { EuiSelectableOption } from '../selectable_option';
+import { EuiI18n } from '../../i18n';
 
 export type EuiSelectableSearchProps = Omit<
   InputHTMLAttributes<HTMLInputElement> & EuiFieldSearchProps,
@@ -67,15 +68,21 @@ export class EuiSelectableSearch extends Component<
     const classes = classNames('euiSelectableSearch', className);
 
     return (
-      <EuiFieldSearch
-        className={classes}
-        placeholder="Filter options"
-        onSearch={this.onSearchChange}
-        incremental
-        defaultValue={defaultValue}
-        fullWidth
-        {...rest}
-      />
+      <EuiI18n
+        token="euiSelectableSearch.placeholderName"
+        default="Filter options">
+        {(placeholderName: string) => (
+          <EuiFieldSearch
+            className={classes}
+            placeholder={placeholderName}
+            onSearch={this.onSearchChange}
+            incremental
+            defaultValue={defaultValue}
+            fullWidth
+            {...rest}
+          />
+        )}
+      </EuiI18n>
     );
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1304,12 +1304,26 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-virtualized-auto-sizer@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.0.tgz#fc32f30a8dab527b5816f3a757e1e1d040c8f272"
+  integrity sha512-NMErdIdSnm2j/7IqMteRiRvRulpjoELnXWUwdbucYCz84xG9PHcoOrr7QfXwB/ku7wd6egiKFrzt/+QK4Imeeg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-virtualized@^9.18.7":
-  version "9.21.5"
-  resolved "https://registry.yarnpkg.com/@types/react-virtualized/-/react-virtualized-9.21.5.tgz#8b849c7c3c92c7b28b29bc75602c067a912310c6"
-  integrity sha512-oCoGJzkW90YQkvXwvtkCBDN0TTYvaQs217TJDOh+VipzJ9iiHD/NpD0ILvB844+ewf3/4xYOI5Oj5kj5m6J/4w==
+  version "9.21.8"
+  resolved "https://registry.yarnpkg.com/@types/react-virtualized/-/react-virtualized-9.21.8.tgz#dc0150a75fd6e42f33729886463ece04d03367ea"
+  integrity sha512-7fZoA0Azd2jLIE9XC37fMZgMqaJe3o3pfzGjvrzphoKjBCdT4oNl6wikvo4dDMESDnpkZ8DvVTc7aSe4DW86Ew==
   dependencies:
     "@types/prop-types" "*"
+    "@types/react" "*"
+
+"@types/react-window@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@types/react-window/-/react-window-1.8.1.tgz#6e1ceab2e6f2f78dbf1f774ee0e00f1bb0364bb3"
+  integrity sha512-V3k1O5cbfZIRa0VVbQ81Ekq/7w42CK1SuiB9U1oPMTxv270D9qUn7rHb3sZoqMkIJFfB1NZxaH7NRDlk+ToDsg==
+  dependencies:
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.9.23":
@@ -3358,9 +3372,9 @@ cloneable-readable@^1.0.0:
     through2 "^2.0.1"
 
 clsx@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.0.4.tgz#0c0171f6d5cb2fe83848463c15fcc26b4df8c2ec"
-  integrity sha512-1mQ557MIZTrL/140j+JVdRM6e31/OA4vTYxXgqIIZlndyfjHpyawKZia1Im05Vp9BWmImkcNrNtFYQMyFcgJDg==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.0.tgz#62937c6adfea771247c34b54d320fb99624f5702"
+  integrity sha512-3avwM37fSK5oP6M5rQ9CNe99lwxhXDOeSWVPAOYF6OazUTgZCMb0yWlJpmdD74REy1gkEaFiub2ULv4fq9GUhA==
 
 co@^4.6.0:
   version "4.6.0"
@@ -4214,15 +4228,10 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   dependencies:
     cssom "0.3.x"
 
-csstype@^2.2.0:
+csstype@^2.2.0, csstype@^2.6.7:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.9.tgz#05141d0cd557a56b8891394c1911c40c8a98d098"
   integrity sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==
-
-csstype@^2.6.7:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.7.tgz#20b0024c20b6718f4eda3853a1f5a1cce7f5e4a5"
-  integrity sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -9145,14 +9154,14 @@ loglevel@^1.4.1:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
   integrity sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=
 
-loose-envify@^1.0.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.3.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.0:
+loose-envify@^1.1.0, loose-envify@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   integrity sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=
@@ -9371,6 +9380,11 @@ mem@^4.0.0:
     map-age-cleaner "^0.1.1"
     mimic-fn "^1.0.0"
     p-is-promise "^1.1.0"
+
+"memoize-one@>=3.1.1 <6":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
+  integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
 
 memoize-one@^5.0.0:
   version "5.0.0"
@@ -12303,6 +12317,11 @@ react-test-renderer@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-virtualized-auto-sizer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.2.tgz#a61dd4f756458bbf63bd895a92379f9b70f803bd"
+  integrity sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg==
+
 react-virtualized@^9.21.2:
   version "9.21.2"
   resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.21.2.tgz#02e6df65c1e020c8dbf574ec4ce971652afca84e"
@@ -12314,6 +12333,14 @@ react-virtualized@^9.21.2:
     loose-envify "^1.3.0"
     prop-types "^15.6.0"
     react-lifecycles-compat "^3.0.4"
+
+react-window@^1.8.5:
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.5.tgz#a56b39307e79979721021f5d06a67742ecca52d1"
+  integrity sha512-HeTwlNa37AFa8MDZFZOKcNEkuF2YflA0hpGPiTT9vR7OawEt+GZbfM6wqkBahD3D3pUjIabQYzsnY/BSJbgq6Q==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    memoize-one ">=3.1.1 <6"
 
 react@^16.12.0:
   version "16.12.0"


### PR DESCRIPTION
Sorry for conflating two things in this PR - I thought all the changes were going to be smaller but as they started to pile on, I thought it'd be better to cut this PR and open a feature branch for future work.

## Summary
This PR accomplishes two things:
1. Swaps [`react-virtualized`](https://github.com/bvaughn/react-virtualized) for [`react-window`](https://github.com/bvaughn/react-window)+[`react-virtualized-auto-sizer`](https://github.com/bvaughn/react-virtualized-auto-sizer)
	- `virtualized` makes some bad a11y assumptions that `react-window` doesn't make. They're both made by the same person actually and `react-window` is his slimmer replacement for `virtualized`.
	- I used `react-virtualized-auto-sizer` because after this effort, only one other component uses `react-virtualized` which would probably be good to swap for `react-window` as well, completetly removing `react-virtualized` as a dependency 
2. Fixes the a11y for a "basic" selectable 
	- multiselect is done
	- searchable selectable is not
	- including vs excluding options is not

## Breaking changes
-  `virtualizedProps` off of `EuiSelectableOptionsList` is now passed into `react-window` instead of `react-virtualized` which accept different hings

## Future work
Mostly a11y work ahead:
- For `searchable` selectables, we need to move a lot of the `aria` attributes to the `<input />` instead of the `<ul>` where they are now
- For excluding options, we need to figure out a better way to communicate if something is included/excluded and how that corresponds to the `aria-selected` state
- Some a11y work on wiring up the loading/messaging states for `searchable`
- Improved keyboard shortcuts 
- Improve mobile focus support (everything works but there are multiple focus states depending on how/where you tap/long-press). Will address after the rest of the DOM stuff settles in the future PRs.

## Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [x] Props have proper **autodocs**
~- [ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~