### PR TITLE
removed ghost "Show component code" button

### DIFF
--- a/src-docs/src/components/guide_page/guide_page.js
+++ b/src-docs/src/components/guide_page/guide_page.js
@@ -1,8 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 
-import { Link } from 'react-router';
-
 import {
   EuiTitle,
   EuiSpacer,
@@ -41,8 +39,8 @@ export const GuidePage = ({
           </EuiFlexItem>
           {componentLinkTo && (
             <EuiFlexItem grow={false}>
-              <EuiButton>
-                <Link to={componentLinkTo}>View component code</Link>
+              <EuiButton href={`#${componentLinkTo}`}>
+                View component code
               </EuiButton>
             </EuiFlexItem>
           )}

--- a/src-docs/src/components/guide_page/guide_page.js
+++ b/src-docs/src/components/guide_page/guide_page.js
@@ -41,9 +41,9 @@ export const GuidePage = ({
           </EuiFlexItem>
           {componentLinkTo && (
             <EuiFlexItem grow={false}>
-              <Link to={componentLinkTo}>
-                <EuiButton>View component code</EuiButton>
-              </Link>
+              <EuiButton>
+                <Link to={componentLinkTo}>View component code</Link>
+              </EuiButton>
             </EuiFlexItem>
           )}
         </EuiFlexGroup>


### PR DESCRIPTION
### Summary

Fixes: #696

"ghost" Show Component Code button is removed, on first tab "Show component code" but is active

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
