### PR TITLE
Fix padding in EuiCallout when used as banner for EuiFlyout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fixed `EuiFieldNumber` so values of type `number` are now allowed ([#3020](https://github.com/elastic/eui/pull/3020))
 - Fixed SASS `contrastRatio()` function in dark mode by fixing the `pow()` math function ([#3013], (https://github.com/elastic/eui/pull/3013))
 - Fixed bug preventing `EuiDataGrid` from re-evaluating the default column width on resize ([#2991](https://github.com/elastic/eui/pull/2991))
+- Fixed padding in `EuiCallOut` when used as a `banner` for `EuiFlyout` ([#3098](https://github.com/elastic/eui/pull/3098))
 
 ## [`21.0.1`](https://github.com/elastic/eui/tree/v21.0.1)
 

--- a/src/components/flyout/_flyout_body.scss
+++ b/src/components/flyout/_flyout_body.scss
@@ -14,7 +14,8 @@
 
   .euiFlyoutBody__banner .euiCallOut {
     border: none; // Remove border from callout when it is a flyout banner
-    padding: $euiSize $euiSizeL; // Align callout's content with flyout's title
+    padding-left: $euiSizeL; // Align callout's content with flyout's title
+    padding-right: $euiSizeL; // Align callout's content with flyout's title
   }
 
   .euiFlyoutBody__overflowContent {

--- a/src/components/flyout/_flyout_body.scss
+++ b/src/components/flyout/_flyout_body.scss
@@ -14,6 +14,7 @@
 
   .euiFlyoutBody__banner .euiCallOut {
     border: none; // Remove border from callout when it is a flyout banner
+    padding: $euiSize $euiSizeL; // Align callout's content with flyout's title
   }
 
   .euiFlyoutBody__overflowContent {


### PR DESCRIPTION
### Summary

This PR aligns the content of a callout with the content of EuiFlyoutHeader 

Before

![76809805-384e2200-67a9-11ea-8d31-4ebe3829ad0e](https://user-images.githubusercontent.com/4016496/76810135-4486af00-67aa-11ea-8ce7-fa981b7c20b0.png)

After

![image](https://user-images.githubusercontent.com/4016496/76809834-51ef6980-67a9-11ea-9377-42576e54586f.png)


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
