### PR TITLE
Fix race condition in EuiIcon's internal setState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Added `Enter` key press functionality to `EuiSuperDatePicker` ([#3048](https://github.com/elastic/eui/pull/3048))
 
+**Bug Fixes**
+
+- Fixed race condition in `EuiIcon` when switching from dynamically fetched components ([#3118](https://github.com/elastic/eui/pull/3118))
+
 ## [`21.1.0`](https://github.com/elastic/eui/tree/v21.1.0)
 
 - Updated `EuiFilterSelect` to retain the order of its filters ([#3063](https://github.com/elastic/eui/pull/3063))

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -548,7 +548,7 @@ export class EuiIcon extends PureComponent<EuiIconProps, State> {
       './assets/' + typeToPathMap[iconType] + '.js'
     ).then(({ icon }) => {
       enqueueStateChange(() => {
-        if (this.isMounted) {
+        if (this.isMounted && this.props.type === iconType) {
           this.setState(
             {
               icon,


### PR DESCRIPTION
### Summary

Fixes #3113 

Reproduced the issue in the Kibana branch as described. Copied code to EUI's docs to boil it down to a basic use case, and found:

* start with `empty` , which triggers a dynamic fetch for the empty icon
* get the url for the correct icon & set the icon's type
* `img` element created, network request made
* dynamic fetch returns, setting empty back to the icon's internal state
* icon re-renders with empty icon 😱

After making this change in EUI & confirming it fixed my simplified test case, I built EUI with the change and dropped it into the above Kibana branch, confirming it resolves the issue there too.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
