### PR TITLE
Docs routing service for react-router `Link` behavior

### DIFF
--- a/src-docs/src/components/guide_page/guide_page.js
+++ b/src-docs/src/components/guide_page/guide_page.js
@@ -10,6 +10,8 @@ import {
   EuiBetaBadge,
 } from '../../../../src/components';
 
+import { getRouterLinkProps } from '../../services';
+
 export const GuidePage = ({
   children,
   title,
@@ -39,7 +41,7 @@ export const GuidePage = ({
           </EuiFlexItem>
           {componentLinkTo && (
             <EuiFlexItem grow={false}>
-              <EuiButton href={`#${componentLinkTo}`}>
+              <EuiButton href={getRouterLinkProps(componentLinkTo).href}>
                 View component code
               </EuiButton>
             </EuiFlexItem>

--- a/src-docs/src/services/index.js
+++ b/src-docs/src/services/index.js
@@ -3,3 +3,5 @@ export { renderToHtml } from './string/render_to_html';
 export { translateUsingPseudoLocale } from './string/pseudo_locale_translator';
 
 export { registerTheme, applyTheme } from './theme/theme';
+
+export { getRouterLinkProps, registerRouter } from './routing/routing';

--- a/src-docs/src/services/routing/routing.js
+++ b/src-docs/src/services/routing/routing.js
@@ -1,0 +1,42 @@
+// See `/wiki/react-router.md`
+const isModifiedEvent = event =>
+  !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
+
+const isLeftClickEvent = event => event.button === 0;
+
+const resolveToLocation = (to, router) =>
+  typeof to === 'function' ? to(router.location) : to;
+
+let router;
+export const registerRouter = reactRouter => {
+  router = reactRouter;
+};
+
+/**
+ * The logic for generating hrefs and onClick handlers from the `to` prop is largely borrowed from
+ * https://github.com/ReactTraining/react-router/blob/v3/modules/Link.js.
+ */
+export const getRouterLinkProps = to => {
+  const location = resolveToLocation(to, router);
+  const href = router.createHref(location);
+  const onClick = event => {
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    // If target prop is set (e.g. to "_blank"), let browser handle link.
+    if (event.target.getAttribute('target')) {
+      return;
+    }
+
+    if (isModifiedEvent(event) || !isLeftClickEvent(event)) {
+      return;
+    }
+
+    // Prevent regular link behavior, which causes a browser refresh.
+    event.preventDefault();
+    router.push(location);
+  };
+
+  return { href, onClick };
+};

--- a/src-docs/src/views/app_view.js
+++ b/src-docs/src/views/app_view.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 import { GuidePageChrome, ThemeProvider, ThemeContext } from '../components';
-import { translateUsingPseudoLocale } from '../services';
+import { registerRouter, translateUsingPseudoLocale } from '../services';
 
 import {
   EuiErrorBoundary,
@@ -14,6 +14,13 @@ import {
 import { keyCodes } from '../../../src/services';
 
 export class AppView extends Component {
+  constructor(...args) {
+    super(...args);
+
+    // Share the router with the app without requiring React or context.
+    // See `/wiki/react-router.md`
+    registerRouter(this.context.router);
+  }
   componentDidUpdate(prevProps) {
     if (prevProps.currentRoute.path !== this.props.currentRoute.path) {
       window.scrollTo(0, 0);
@@ -117,4 +124,11 @@ AppView.propTypes = {
 
 AppView.defaultProps = {
   currentRoute: {},
+};
+
+AppView.contextTypes = {
+  router: PropTypes.shape({
+    createHref: PropTypes.func.isRequired,
+    push: PropTypes.func.isRequired,
+  }).isRequired,
 };

--- a/wiki/react-router.md
+++ b/wiki/react-router.md
@@ -104,7 +104,7 @@ Note that if using HMR, you'll need to re-register the router after a hot reload
 ### `routing.js` service
 
 You can create a `routing.js` service to surface the `registerRouter` method as well as your
-conversion function (called `getRouterLinkProps` here).
+conversion function (called `getRouterLinkProps` here). The EUI documentation site [uses this approach](../src-docs/src/services/routing/routing.js)
 
 ```js
 // routing.js
@@ -227,7 +227,7 @@ export const getRouterLinkProps = to => {
     if (event.defaultPrevented) {
       return;
     }
-    
+
     // If target prop is set (e.g. to "_blank"), let browser handle link.
     if (event.target.getAttribute('target')) {
       return;

--- a/wiki/react-router.md
+++ b/wiki/react-router.md
@@ -104,7 +104,7 @@ Note that if using HMR, you'll need to re-register the router after a hot reload
 ### `routing.js` service
 
 You can create a `routing.js` service to surface the `registerRouter` method as well as your
-conversion function (called `getRouterLinkProps` here). The EUI documentation site [uses this approach](../src-docs/src/services/routing/routing.js)
+conversion function (called `getRouterLinkProps` here). The EUI documentation site [uses this approach](../src-docs/src/services/routing/routing.js).
 
 ```js
 // routing.js


### PR DESCRIPTION
### Summary

Follow up to #3078, where it was discovered that we have some good ideas in our wiki that we weren't taking advantage of.

Following the thread from https://github.com/elastic/eui/blob/master/wiki/react-router.md#1-conversion-function-recommended and shamelessly copy-pasting from the 3.x section, we can use react-router `Link` behavior without the a11y concerns of nested `a` and `button`.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
