### PR TITLE
fixing Issue #2998 on Data Grid Overlap

### DIFF
--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -51,6 +51,7 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   border-left: $euiBorderThin;
   max-width: 1000px;
   margin-left: 240px;
+  z-index:1;
 }
 
 .guideDemo__highlightLayout {
@@ -228,6 +229,7 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   .guidePageContent {
     margin-left: 0;
     width: 100%;
+    z-index:auto;
   }
 }
 


### PR DESCRIPTION
this issue is because of the positions of components of guideSideNav and guidePageContent, I have to change the z-index value of guidePageContent so that these components don't overlap and I set z-index: auto to xs,s  Breakpoint. Now, the whole guidePageContent component act as a Slider.

### Summary
Fixes #2998
![euiissue1](https://user-images.githubusercontent.com/22548047/77068802-35ec0200-6a0d-11ea-935a-2bb77ab11aea.jpg)

