### PR TITLE
Overhaul EuiDataGrid's cell focus states

### DIFF
--- a/src-docs/src/routes.js
+++ b/src-docs/src/routes.js
@@ -76,6 +76,7 @@ import { CopyExample } from './views/copy/copy_example';
 import { DataGridExample } from './views/datagrid/datagrid_example';
 import { DataGridMemoryExample } from './views/datagrid/datagrid_memory_example';
 import { DataGridSchemaExample } from './views/datagrid/datagrid_schema_example';
+import { DataGridFocusExample } from './views/datagrid/datagrid_focus_example';
 import { DataGridStylingExample } from './views/datagrid/datagrid_styling_example';
 import { DataGridControlColumnsExample } from './views/datagrid/datagrid_controlcolumns_example';
 
@@ -339,6 +340,7 @@ const navigation = [
       DataGridExample,
       DataGridMemoryExample,
       DataGridSchemaExample,
+      DataGridFocusExample,
       DataGridStylingExample,
       DataGridControlColumnsExample,
       TableExample,

--- a/src-docs/src/views/datagrid/datagrid_focus_example.js
+++ b/src-docs/src/views/datagrid/datagrid_focus_example.js
@@ -1,0 +1,49 @@
+import React, { Fragment } from 'react';
+
+import { renderToHtml } from '../../services';
+
+import { GuideSectionTypes } from '../../components';
+import { EuiCode } from '../../../../src/components';
+
+import DataGridFocus from './focus';
+const dataGridFocusSource = require('!!raw-loader!./focus');
+const dataGridFocusHtml = renderToHtml(DataGridFocus);
+
+export const DataGridFocusExample = {
+  title: 'Data grid focus',
+  sections: [
+    {
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: dataGridFocusSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: dataGridFocusHtml,
+        },
+      ],
+      text: (
+        <Fragment>
+          <p>
+            Focus focus focus, focus <EuiCode>focus</EuiCode>, focus focus focus. Focus focus. Focus!
+          </p>
+          <p>
+            ✅ No focusable elements (+ is not expandable): focus cell, no interaction
+          </p>
+          <p>
+            ✅ Only one focusable element (not expandable): shift focus to the element
+          </p>
+          <p>
+            ✅ Only one focusable element (the expansion button): outline cell, focus on expansion button
+          </p>
+          <p>
+            ✅ 2+ focusable elements (not expandable): focus cell, enter/f2 enters focus trap
+          </p>
+        </Fragment>
+      ),
+      components: { DataGridFocus },
+      demo: <DataGridFocus />,
+    },
+  ],
+};

--- a/src-docs/src/views/datagrid/datagrid_focus_example.js
+++ b/src-docs/src/views/datagrid/datagrid_focus_example.js
@@ -38,7 +38,10 @@ export const DataGridFocusExample = {
             ✅ Only one focusable element (the expansion button): outline cell, focus on expansion button
           </p>
           <p>
-            ✅ 2+ focusable elements (not expandable): focus cell, enter/f2 enters focus trap
+            ⛔ 2+ focusable elements (not expandable): focus cell, enter/f2 enters focus trap
+          </p>
+          <p>
+            ✅️ 1+ focusable elements (element + expandable): focus cell, enter/f2 opens popover
           </p>
         </Fragment>
       ),

--- a/src-docs/src/views/datagrid/datagrid_focus_example.js
+++ b/src-docs/src/views/datagrid/datagrid_focus_example.js
@@ -3,7 +3,7 @@ import React, { Fragment } from 'react';
 import { renderToHtml } from '../../services';
 
 import { GuideSectionTypes } from '../../components';
-import { EuiTitle } from '../../../../src/components';
+import { EuiCallOut, EuiCode } from '../../../../src/components';
 
 import DataGridFocus from './focus';
 const dataGridFocusSource = require('!!raw-loader!./focus');
@@ -25,85 +25,87 @@ export const DataGridFocusExample = {
       ],
       text: (
         <Fragment>
-          <EuiTitle>
-            <h3>Initial focus</h3>
-          </EuiTitle>
           <p>
-            <span role="img" aria-label="working">
-              ✅
-            </span>{' '}
-            Datagrid does not auto-focus on mount / page load
+            Data Grid tracks and manages complicated focus state management
+            based upon the content of the individual inner cells. The following
+            scenarios are supported and tested:
           </p>
+          <h3>Initial focus</h3>
+          <ul>
+            <li>
+              When tabbing to the grid before it has received focus, the first
+              cell of either the header (if it is interaction) or first content
+              cell is focused.
+            </li>
+            <li> Datagrid does not auto-focus on mount / page load</li>
+            <li>
+              When removing focus from the grid and then returning, the last
+              focused cell remains focused.
+            </li>
+          </ul>
+          <h3>Click and key events</h3>
+          <ul>
+            <li>
+              Clicking on an interactive cell (not its content) should focus on
+              the cell, or if it has only one interactive element the focus
+              should shift to the element.
+            </li>
+            <li>
+              Clicking on an interactive element within a cell the focus should
+              always remain on that element, not shift to the cell or another
+              element unless a subsequent user action changes it.
+            </li>
+            <li>
+              Enter or F2 can be used interchangibly to enter inner cell focus
+              if the logic below allows it.
+            </li>
+          </ul>
+          <h3>
+            The content and expandability of the cells dicate the focus target
+            of the cell
+          </h3>
           <p>
-            <span role="img" aria-label="working">
-              ✅
-            </span>{' '}
-            When tabbing to the grid before it has received focus, the first
-            cell of [either header or first content row] is focused
+            The following combinations of focus are maintained to provide for a
+            good balance between accessibility and ease of use while navigating
+            a grid with your keyboard.
           </p>
-          <p>
-            <span role="img" aria-label="working">
-              ✅
-            </span>{' '}
-            When tabbing to the grid after it has received focus, the last
-            focused cell remains focused
-          </p>
-
-          <EuiTitle>
-            <h3>Clicking</h3>
-          </EuiTitle>
-          <p>
-            <span role="img" aria-label="working">
-              ✅
-            </span>{' '}
-            Clicking on any interactive cell appropriately focuses that cell
-            and/or its content
-          </p>
-          <p>
-            <span role="img" aria-label="working">
-              ✅
-            </span>{' '}
-            Clicking on an interactive element, focus remains on that element
-          </p>
-
-          <EuiTitle>
-            <h3>Cell focus states</h3>
-          </EuiTitle>
-          <p>
-            <span role="img" aria-label="working">
-              ✅
-            </span>{' '}
-            No focusable elements (+ is not expandable): focus cell, no
-            interaction
-          </p>
-          <p>
-            <span role="img" aria-label="working">
-              ✅
-            </span>{' '}
-            Only one focusable element (not expandable): shift focus to the
-            element
-          </p>
-          <p>
-            <span role="img" aria-label="working">
-              ✅
-            </span>{' '}
-            Only one focusable element (the expansion button): outline cell,
-            focus on expansion button
-          </p>
-          <p>
-            <span role="img" aria-label="working">
-              ✅
-            </span>{' '}
-            2+ focusable elements (not expandable): focus cell, enter/f2 enters
-            focus trap
-          </p>
-          <p>
-            <span role="img" aria-label="working">
-              ✅
-            </span>{' '}
-            1+ focusable elements (element + expandable): focus cell, enter/f2
-            opens popover
-          </p>
+          <h5>
+            Cell alone recieves the focus, with no possible inner focus action
+            when:
+          </h5>
+          <ul>
+            <li>The cell is not expandable.</li>
+            <li>The cell has no interactive elements</li>
+          </ul>
+          <h5>A single inner element within the cell recieves focus when:</h5>
+          <ul>
+            <li>The cell is not expandable.</li>
+            <li>The cell has a single interaction element.</li>
+          </ul>
+          <h5>A cell will focus on the expansion action when:</h5>
+          <ul>
+            <li>The expansion ability is allowed on the cell.</li>
+            <li>
+              Any combination of interactive / non-interactive is contained in
+              the cell contents.
+            </li>
+          </ul>
+          <h5>A cell will allow a non-expanding focus trap on keyDown when</h5>
+          <ul>
+            <li>The cell is not expandable.</li>
+            <li>The cell contains multiple interactive elements.</li>
+          </ul>
+          <EuiCallOut
+            size="s"
+            color="warning"
+            title="A caution about turning off cell expansion when the width of the column is unknown">
+            In general, you should turn <EuiCode>isExpandible</EuiCode> to false
+            only when you know the exact width and number of items that a cell
+            will include. Control columns that contain row actions are a good
+            example of when to use them. In certain scenarios, allowing multiple
+            interactive elements in cells when you can not control the width can
+            lead to hidden focus because the content is truncated.
+          </EuiCallOut>
         </Fragment>
       ),
       components: { DataGridFocus },

--- a/src-docs/src/views/datagrid/datagrid_focus_example.js
+++ b/src-docs/src/views/datagrid/datagrid_focus_example.js
@@ -3,7 +3,7 @@ import React, { Fragment } from 'react';
 import { renderToHtml } from '../../services';
 
 import { GuideSectionTypes } from '../../components';
-import { EuiCode } from '../../../../src/components';
+import { EuiTitle } from '../../../../src/components';
 
 import DataGridFocus from './focus';
 const dataGridFocusSource = require('!!raw-loader!./focus');
@@ -25,9 +25,36 @@ export const DataGridFocusExample = {
       ],
       text: (
         <Fragment>
+          <EuiTitle>
+            <h3>Initial focus</h3>
+          </EuiTitle>
           <p>
-            Focus focus focus, focus <EuiCode>focus</EuiCode>, focus focus focus. Focus focus. Focus!
+            ✅ Datagrid does not auto-focus on mount / page load
           </p>
+          <p>
+            ✅ When tabbing to the grid before it has received focus, the first
+            cell of [either header or first content row] is focused
+          </p>
+          <p>
+            ✅ When tabbing to the grid after it has received focus, the last
+            focused cell remains focused
+          </p>
+
+          <EuiTitle>
+            <h3>Clicking</h3>
+          </EuiTitle>
+          <p>
+            ✅ Clicking on any interactive cell appropriately focuses that cell
+            and/or its content
+          </p>
+          <p>
+            ✅️ Clicking on an interactive element, focus remains on that
+            element
+          </p>
+
+          <EuiTitle>
+            <h3>Cell focus states</h3>
+          </EuiTitle>
           <p>
             ✅ No focusable elements (+ is not expandable): focus cell, no interaction
           </p>
@@ -38,7 +65,7 @@ export const DataGridFocusExample = {
             ✅ Only one focusable element (the expansion button): outline cell, focus on expansion button
           </p>
           <p>
-            ⛔ 2+ focusable elements (not expandable): focus cell, enter/f2 enters focus trap
+            ✅ 2+ focusable elements (not expandable): focus cell, enter/f2 enters focus trap
           </p>
           <p>
             ✅️ 1+ focusable elements (element + expandable): focus cell, enter/f2 opens popover

--- a/src-docs/src/views/datagrid/datagrid_focus_example.js
+++ b/src-docs/src/views/datagrid/datagrid_focus_example.js
@@ -29,14 +29,23 @@ export const DataGridFocusExample = {
             <h3>Initial focus</h3>
           </EuiTitle>
           <p>
-            ✅ Datagrid does not auto-focus on mount / page load
+            <span role="img" aria-label="working">
+              ✅
+            </span>{' '}
+            Datagrid does not auto-focus on mount / page load
           </p>
           <p>
-            ✅ When tabbing to the grid before it has received focus, the first
+            <span role="img" aria-label="working">
+              ✅
+            </span>{' '}
+            When tabbing to the grid before it has received focus, the first
             cell of [either header or first content row] is focused
           </p>
           <p>
-            ✅ When tabbing to the grid after it has received focus, the last
+            <span role="img" aria-label="working">
+              ✅
+            </span>{' '}
+            When tabbing to the grid after it has received focus, the last
             focused cell remains focused
           </p>
 
@@ -44,31 +53,56 @@ export const DataGridFocusExample = {
             <h3>Clicking</h3>
           </EuiTitle>
           <p>
-            ✅ Clicking on any interactive cell appropriately focuses that cell
+            <span role="img" aria-label="working">
+              ✅
+            </span>{' '}
+            Clicking on any interactive cell appropriately focuses that cell
             and/or its content
           </p>
           <p>
-            ✅️ Clicking on an interactive element, focus remains on that
-            element
+            <span role="img" aria-label="working">
+              ✅
+            </span>{' '}
+            Clicking on an interactive element, focus remains on that element
           </p>
 
           <EuiTitle>
             <h3>Cell focus states</h3>
           </EuiTitle>
           <p>
-            ✅ No focusable elements (+ is not expandable): focus cell, no interaction
+            <span role="img" aria-label="working">
+              ✅
+            </span>{' '}
+            No focusable elements (+ is not expandable): focus cell, no
+            interaction
           </p>
           <p>
-            ✅ Only one focusable element (not expandable): shift focus to the element
+            <span role="img" aria-label="working">
+              ✅
+            </span>{' '}
+            Only one focusable element (not expandable): shift focus to the
+            element
           </p>
           <p>
-            ✅ Only one focusable element (the expansion button): outline cell, focus on expansion button
+            <span role="img" aria-label="working">
+              ✅
+            </span>{' '}
+            Only one focusable element (the expansion button): outline cell,
+            focus on expansion button
           </p>
           <p>
-            ✅ 2+ focusable elements (not expandable): focus cell, enter/f2 enters focus trap
+            <span role="img" aria-label="working">
+              ✅
+            </span>{' '}
+            2+ focusable elements (not expandable): focus cell, enter/f2 enters
+            focus trap
           </p>
           <p>
-            ✅️ 1+ focusable elements (element + expandable): focus cell, enter/f2 opens popover
+            <span role="img" aria-label="working">
+              ✅
+            </span>{' '}
+            1+ focusable elements (element + expandable): focus cell, enter/f2
+            opens popover
           </p>
         </Fragment>
       ),

--- a/src-docs/src/views/datagrid/focus.js
+++ b/src-docs/src/views/datagrid/focus.js
@@ -78,21 +78,11 @@ export default () => {
       },
       {
         id: 'no-interactives is expandable',
-        display: (
-          <>
-            {renderHeaderIcon(areHeadersInteractive)}⓪ interactives, ✅
-            expandable
-          </>
-        ),
+        display: '⓪ interactives, ✅ expandable',
       },
       {
         id: 'one-interactive not expandable',
-        display: (
-          <>
-            {renderHeaderIcon(areHeadersInteractive)}① interactive, ⛔️
-            expandable
-          </>
-        ),
+        display: '① interactive, ⛔️ expandable',
         isExpandable: false,
       },
       {
@@ -106,22 +96,12 @@ export default () => {
       },
       {
         id: 'two-interactives not expandable',
-        display: (
-          <>
-            {renderHeaderIcon(areHeadersInteractive)}⓶ interactives, ⛔️
-            expandable
-          </>
-        ),
+        display: '⓶ interactives, ⛔️ expandable',
         isExpandable: false,
       },
       {
         id: 'two-interactives is expandable',
-        display: (
-          <>
-            {renderHeaderIcon(areHeadersInteractive)}⓶ interactives, ✅
-            expandable
-          </>
-        ),
+        display: '⓶ interactives, ✅ expandable',
       },
     ],
     [areHeadersInteractive]

--- a/src-docs/src/views/datagrid/focus.js
+++ b/src-docs/src/views/datagrid/focus.js
@@ -43,19 +43,19 @@ for (let i = 1; i < 5; i++) {
     <span>{fake('{{name.firstName}}')}</span>,
 
     <span>
-      <EuiLink href="#">{fake('{{internet.email}}')}</EuiLink>
+      <EuiLink href="#/tabular-content/data-grid-focus">{fake('{{internet.email}}')}</EuiLink>
     </span>,
     <span>
-      <EuiLink href="#">{fake('{{internet.email}}')}</EuiLink>
+      <EuiLink href="#/tabular-content/data-grid-focus">{fake('{{internet.email}}')}</EuiLink>
     </span>,
 
     <span>
-      <EuiButtonEmpty size="s">Yes</EuiButtonEmpty>
-      <EuiButtonEmpty size="s">No</EuiButtonEmpty>
+      <EuiButtonEmpty size="s" onClick={() => console.log('clickerooed')}>Yes</EuiButtonEmpty>
+      <EuiButtonEmpty size="s" onClick={() => console.log('clickerooed')}>No</EuiButtonEmpty>
     </span>,
     <span>
-      <EuiButtonEmpty size="s">Yes</EuiButtonEmpty>
-      <EuiButtonEmpty size="s">No</EuiButtonEmpty>
+      <EuiButtonEmpty size="s" onClick={() => console.log('clickerooed')}>Yes</EuiButtonEmpty>
+      <EuiButtonEmpty size="s" onClick={() => console.log('clickerooed')}>No</EuiButtonEmpty>
     </span>,
   ]);
 }

--- a/src-docs/src/views/datagrid/focus.js
+++ b/src-docs/src/views/datagrid/focus.js
@@ -9,6 +9,11 @@ import {
   EuiLink,
   EuiSwitch,
   EuiSpacer,
+  EuiBadge,
+  EuiIcon,
+  EuiToken,
+  EuiFlexGroup,
+  EuiFlexItem,
 } from '../../../../src/components/';
 
 const data = [];
@@ -30,18 +35,24 @@ for (let i = 0; i < 10; i++) {
     </span>,
 
     <span>
-      <EuiButtonEmpty size="s" onClick={() => console.log('clicked Yes')}>
+      <EuiButtonEmpty size="xs" onClick={() => console.log('clicked Yes')}>
         Yes
       </EuiButtonEmpty>
-      <EuiButtonEmpty size="s" onClick={() => console.log('clicked No')}>
+      <EuiButtonEmpty
+        size="xs"
+        color="danger"
+        onClick={() => console.log('clicked No')}>
         No
       </EuiButtonEmpty>
     </span>,
     <span>
-      <EuiButtonEmpty size="s" onClick={() => console.log('clicked Yes')}>
+      <EuiButtonEmpty size="xs" onClick={() => console.log('clicked Yes')}>
         Yes
       </EuiButtonEmpty>
-      <EuiButtonEmpty size="s" onClick={() => console.log('clicked No')}>
+      <EuiButtonEmpty
+        size="xs"
+        color="danger"
+        onClick={() => console.log('clicked No')}>
         No
       </EuiButtonEmpty>
     </span>,
@@ -50,11 +61,13 @@ for (let i = 0; i < 10; i++) {
 
 const renderHeaderIcon = areHeadersInteractive =>
   areHeadersInteractive ? (
-    <EuiButtonIcon
-      aria-label="column settings"
-      iconType="gear"
-      onClick={() => console.log('gear icon clicked')}
-    />
+    <EuiFlexItem grow={false}>
+      <EuiButtonIcon
+        aria-label="column settings"
+        iconType="gear"
+        onClick={() => console.log('gear icon clicked')}
+      />
+    </EuiFlexItem>
   ) : null;
 
 export default () => {
@@ -69,39 +82,117 @@ export default () => {
       {
         id: 'no-interactives not expandable',
         display: (
-          <>
-            {renderHeaderIcon(areHeadersInteractive)}⓪ interactives, ⛔️
-            expandable
-          </>
+          <EuiFlexGroup alignItems="center" gutterSize="xs">
+            {renderHeaderIcon(areHeadersInteractive)}
+            <EuiFlexItem grow={false}>
+              <EuiToken
+                iconType="expandMini"
+                color="euiColorVis2"
+                shape="square"
+                fill="dark"
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge>0 interactive</EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
         ),
         isExpandable: false,
       },
       {
         id: 'no-interactives is expandable',
-        display: '⓪ interactives, ✅ expandable',
+        display: (
+          <EuiFlexGroup alignItems="center" gutterSize="xs">
+            <EuiFlexItem grow={false}>
+              <EuiToken
+                iconType="expandMini"
+                color="euiColorVis0"
+                shape="square"
+                fill="dark"
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge>0 interactive</EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        ),
       },
       {
         id: 'one-interactive not expandable',
-        display: '① interactive, ⛔️ expandable',
+        display: (
+          <EuiFlexGroup alignItems="center" gutterSize="xs">
+            <EuiFlexItem grow={false}>
+              <EuiToken
+                iconType="expandMini"
+                color="euiColorVis2"
+                shape="square"
+                fill="dark"
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge>1 interactive</EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        ),
         isExpandable: false,
       },
       {
         id: 'one-interactives is expandable',
         display: (
-          <>
-            {renderHeaderIcon(areHeadersInteractive)}①️ interactive, ✅
-            expandable
-          </>
+          <EuiFlexGroup alignItems="center" gutterSize="xs">
+            {renderHeaderIcon(areHeadersInteractive)}
+            <EuiFlexItem grow={false}>
+              <EuiToken
+                iconType="expandMini"
+                color="euiColorVis0"
+                shape="square"
+                fill="dark"
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge>1 interactive</EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
         ),
       },
       {
         id: 'two-interactives not expandable',
-        display: '⓶ interactives, ⛔️ expandable',
+
+        display: (
+          <EuiFlexGroup alignItems="center" gutterSize="xs">
+            <EuiFlexItem grow={false}>
+              <EuiToken
+                iconType="expandMini"
+                color="euiColorVis2"
+                shape="square"
+                fill="dark"
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge>2 interactive</EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        ),
         isExpandable: false,
       },
       {
         id: 'two-interactives is expandable',
-        display: '⓶ interactives, ✅ expandable',
+
+        display: (
+          <EuiFlexGroup alignItems="center" gutterSize="xs">
+            <EuiFlexItem grow={false}>
+              <EuiToken
+                iconType="expandMini"
+                color="euiColorVis0"
+                shape="square"
+                fill="dark"
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge>2 interactive</EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        ),
       },
     ],
     [areHeadersInteractive]

--- a/src-docs/src/views/datagrid/focus.js
+++ b/src-docs/src/views/datagrid/focus.js
@@ -10,7 +10,6 @@ import {
   EuiSwitch,
   EuiSpacer,
   EuiBadge,
-  EuiIcon,
   EuiToken,
   EuiFlexGroup,
   EuiFlexItem,
@@ -82,7 +81,7 @@ export default () => {
       {
         id: 'no-interactives not expandable',
         display: (
-          <EuiFlexGroup alignItems="center" gutterSize="xs">
+          <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false}>
             {renderHeaderIcon(areHeadersInteractive)}
             <EuiFlexItem grow={false}>
               <EuiToken
@@ -102,7 +101,7 @@ export default () => {
       {
         id: 'no-interactives is expandable',
         display: (
-          <EuiFlexGroup alignItems="center" gutterSize="xs">
+          <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false}>
             <EuiFlexItem grow={false}>
               <EuiToken
                 iconType="expandMini"
@@ -120,7 +119,7 @@ export default () => {
       {
         id: 'one-interactive not expandable',
         display: (
-          <EuiFlexGroup alignItems="center" gutterSize="xs">
+          <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false}>
             <EuiFlexItem grow={false}>
               <EuiToken
                 iconType="expandMini"
@@ -139,7 +138,7 @@ export default () => {
       {
         id: 'one-interactives is expandable',
         display: (
-          <EuiFlexGroup alignItems="center" gutterSize="xs">
+          <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false}>
             {renderHeaderIcon(areHeadersInteractive)}
             <EuiFlexItem grow={false}>
               <EuiToken
@@ -159,7 +158,7 @@ export default () => {
         id: 'two-interactives not expandable',
 
         display: (
-          <EuiFlexGroup alignItems="center" gutterSize="xs">
+          <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false}>
             <EuiFlexItem grow={false}>
               <EuiToken
                 iconType="expandMini"
@@ -179,7 +178,7 @@ export default () => {
         id: 'two-interactives is expandable',
 
         display: (
-          <EuiFlexGroup alignItems="center" gutterSize="xs">
+          <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false}>
             <EuiFlexItem grow={false}>
               <EuiToken
                 iconType="expandMini"

--- a/src-docs/src/views/datagrid/focus.js
+++ b/src-docs/src/views/datagrid/focus.js
@@ -1,40 +1,16 @@
-import React, { Component } from 'react';
+/* eslint-disable jsx-a11y/accessible-emoji */
+import React, { useState, useCallback, useMemo } from 'react';
 import { fake } from 'faker';
 
 import {
   EuiDataGrid,
   EuiButtonEmpty,
+  EuiButtonIcon,
   EuiLink,
+  EuiSwitch,
+  EuiSpacer,
 } from '../../../../src/components/';
 
-const columns = [
-  {
-    id: '⓪ interactives, ⛔️ expandable',
-    isExpandable: false,
-  },
-  {
-    id: '⓪ interactives, ✅ expandable',
-  },
-  {
-    id: '① interactive, ⛔️ expandable',
-    isExpandable: false,
-  },
-  {
-    id: '①️ interactive, ✅ expandable',
-  },
-  {
-    id: '⓶ interactives, ⛔️ expandable',
-    isExpandable: false,
-  },
-  {
-    id: '⓶ interactives, ✅ expandable',
-  },
-];
-
-const columnIdToIndex = columns.reduce((acc, { id }, index) => {
-  acc[id] = index;
-  return acc;
-}, {});
 const data = [];
 
 for (let i = 1; i < 5; i++) {
@@ -54,129 +30,137 @@ for (let i = 1; i < 5; i++) {
     </span>,
 
     <span>
-      <EuiButtonEmpty size="s" onClick={() => console.log('clickerooed')}>
+      <EuiButtonEmpty size="s" onClick={() => console.log('clicked Yes')}>
         Yes
       </EuiButtonEmpty>
-      <EuiButtonEmpty size="s" onClick={() => console.log('clickerooed')}>
+      <EuiButtonEmpty size="s" onClick={() => console.log('clicked No')}>
         No
       </EuiButtonEmpty>
     </span>,
     <span>
-      <EuiButtonEmpty size="s" onClick={() => console.log('clickerooed')}>
+      <EuiButtonEmpty size="s" onClick={() => console.log('clicked Yes')}>
         Yes
       </EuiButtonEmpty>
-      <EuiButtonEmpty size="s" onClick={() => console.log('clickerooed')}>
+      <EuiButtonEmpty size="s" onClick={() => console.log('clicked No')}>
         No
       </EuiButtonEmpty>
     </span>,
   ]);
 }
 
-export default class DataGridSchema extends Component {
-  constructor(props) {
-    super(props);
+const renderHeaderIcon = areHeadersInteractive =>
+  areHeadersInteractive ? (
+    <EuiButtonIcon
+      aria-label="column settings"
+      iconType="gear"
+      onClick={() => console.log('gear icon clicked')}
+    />
+  ) : null;
 
-    this.state = {
-      data,
-      sortingColumns: [{ id: 'contributions', direction: 'asc' }],
+export default () => {
+  const [areHeadersInteractive, setAreHeadersInteractive] = useState(false);
+  const switchInteractiveHeaders = useCallback(
+    e => setAreHeadersInteractive(e.target.checked),
+    [setAreHeadersInteractive]
+  );
 
-      pagination: {
-        pageIndex: 0,
-        pageSize: 10,
+  const columns = useMemo(
+    () => [
+      {
+        id: 'no-interactives not expandable',
+        display: (
+          <>
+            {renderHeaderIcon(areHeadersInteractive)}⓪ interactives, ⛔️
+            expandable
+          </>
+        ),
+        isExpandable: false,
       },
+      {
+        id: 'no-interactives is expandable',
+        display: (
+          <>
+            {renderHeaderIcon(areHeadersInteractive)}⓪ interactives, ✅
+            expandable
+          </>
+        ),
+      },
+      {
+        id: 'one-interactive not expandable',
+        display: (
+          <>
+            {renderHeaderIcon(areHeadersInteractive)}① interactive, ⛔️
+            expandable
+          </>
+        ),
+        isExpandable: false,
+      },
+      {
+        id: 'one-interactives is expandable',
+        display: (
+          <>
+            {renderHeaderIcon(areHeadersInteractive)}①️ interactive, ✅
+            expandable
+          </>
+        ),
+      },
+      {
+        id: 'two-interactives not expandable',
+        display: (
+          <>
+            {renderHeaderIcon(areHeadersInteractive)}⓶ interactives, ⛔️
+            expandable
+          </>
+        ),
+        isExpandable: false,
+      },
+      {
+        id: 'two-interactives is expandable',
+        display: (
+          <>
+            {renderHeaderIcon(areHeadersInteractive)}⓶ interactives, ✅
+            expandable
+          </>
+        ),
+      },
+    ],
+    [areHeadersInteractive]
+  );
+  const columnIdToIndex = columns.reduce((acc, { id }, index) => {
+    acc[id] = index;
+    return acc;
+  }, {});
 
-      visibleColumns: columns.map(({ id }) => id),
-    };
-  }
+  const renderCellValue = useCallback(
+    ({ rowIndex, columnId }) => {
+      const columnIndex = columnIdToIndex[columnId];
+      return data[rowIndex][columnIndex];
+    },
+    [columnIdToIndex]
+  );
 
-  setSorting = sortingColumns => {
-    const data = [...this.state.data].sort((a, b) => {
-      for (let i = 0; i < sortingColumns.length; i++) {
-        const column = sortingColumns[i];
-        const aValue = a[column.id];
-        const bValue = b[column.id];
+  const [visibleColumns, setVisibleColumns] = useState(
+    columns.map(({ id }) => id)
+  );
 
-        if (aValue < bValue) return column.direction === 'asc' ? -1 : 1;
-        if (aValue > bValue) return column.direction === 'asc' ? 1 : -1;
-      }
+  return (
+    <>
+      <EuiSwitch
+        label="Use interactive headers - toggling will reset the datagrid and any internal states"
+        checked={areHeadersInteractive}
+        onChange={switchInteractiveHeaders}
+      />
 
-      return 0;
-    });
+      <EuiSpacer />
 
-    this.setState({ data, sortingColumns });
-  };
-
-  setPageIndex = pageIndex =>
-    this.setState(({ pagination }) => ({
-      pagination: { ...pagination, pageIndex },
-    }));
-
-  setPageSize = pageSize =>
-    this.setState(({ pagination }) => ({
-      pagination: { ...pagination, pageSize, pageIndex: 0 },
-    }));
-
-  setVisibleColumns = visibleColumns => this.setState({ visibleColumns });
-
-  render() {
-    const { data, pagination, sortingColumns } = this.state;
-
-    return (
       <EuiDataGrid
+        key={areHeadersInteractive ? 'interactive-headers' : 'static-headers'}
         aria-label="Top EUI contributors"
         columns={columns}
-        columnVisibility={{
-          visibleColumns: this.state.visibleColumns,
-          setVisibleColumns: this.setVisibleColumns,
-        }}
+        columnVisibility={{ visibleColumns, setVisibleColumns }}
         rowCount={data.length}
-        inMemory={{ level: 'sorting' }}
-        renderCellValue={({ rowIndex, columnId }) => {
-          const columnIndex = columnIdToIndex[columnId];
-          return data[rowIndex][columnIndex];
-        }}
-        sorting={{ columns: sortingColumns, onSort: this.setSorting }}
-        pagination={{
-          ...pagination,
-          pageSizeOptions: [5, 10, 25],
-          onChangeItemsPerPage: this.setPageSize,
-          onChangePage: this.setPageIndex,
-        }}
-        schemaDetectors={[
-          {
-            type: 'favoriteFranchise',
-            detector(value) {
-              return value.toLowerCase() === 'star wars' ||
-                value.toLowerCase() === 'star trek'
-                ? 1
-                : 0;
-            },
-            comparator(a, b, direction) {
-              const aValue = a.toLowerCase() === 'star wars';
-              const bValue = b.toLowerCase() === 'star wars';
-              if (aValue < bValue) return direction === 'asc' ? 1 : -1;
-              if (aValue > bValue) return direction === 'asc' ? -1 : 1;
-              return 0;
-            },
-            sortTextAsc: 'Star wars-Star trek',
-            sortTextDesc: 'Star trek-Star wars',
-            icon: 'starFilled',
-            color: '#800080',
-          },
-        ]}
-        popoverContents={{
-          numeric: ({ cellContentsElement }) => {
-            // want to process the already-rendered cell value
-            const stringContents = cellContentsElement.textContent;
-
-            // extract the groups-of-three digits that are right-aligned
-            return stringContents.replace(/((\d{3})+)$/, match =>
-              // then replace each group of xyz digits with ,xyz
-              match.replace(/(\d{3})/g, ',$1')
-            );
-          },
-        }}
+        renderCellValue={renderCellValue}
       />
-    );
-  }
-}
+    </>
+  );
+};

--- a/src-docs/src/views/datagrid/focus.js
+++ b/src-docs/src/views/datagrid/focus.js
@@ -13,7 +13,7 @@ import {
 
 const data = [];
 
-for (let i = 1; i < 5; i++) {
+for (let i = 0; i < 10; i++) {
   data.push([
     <span>{fake('{{name.firstName}}')}</span>,
     <span>{fake('{{name.firstName}}')}</span>,
@@ -123,6 +123,20 @@ export default () => {
     columns.map(({ id }) => id)
   );
 
+  const [pagination, setPagination] = useState({
+    pageSize: 4,
+    pageIndex: 0,
+    pageSizeOptions: [4],
+  });
+  const onChangeItemsPerPage = useCallback(
+    pageSize => setPagination(pagination => ({ ...pagination, pageSize })),
+    [setPagination]
+  );
+  const onChangePage = useCallback(
+    pageIndex => setPagination(pagination => ({ ...pagination, pageIndex })),
+    [setPagination]
+  );
+
   return (
     <>
       <EuiSwitch
@@ -140,6 +154,11 @@ export default () => {
         columnVisibility={{ visibleColumns, setVisibleColumns }}
         rowCount={data.length}
         renderCellValue={renderCellValue}
+        pagination={{
+          ...pagination,
+          onChangeItemsPerPage,
+          onChangePage,
+        }}
       />
     </>
   );

--- a/src-docs/src/views/datagrid/focus.js
+++ b/src-docs/src/views/datagrid/focus.js
@@ -1,0 +1,170 @@
+import React, { Component } from 'react';
+import { fake } from 'faker';
+
+import {
+  EuiDataGrid,
+  EuiButtonEmpty,
+  EuiLink,
+} from '../../../../src/components/';
+
+const columns = [
+  {
+    id: '⓪ interactives, ⛔️ expandable',
+    isExpandable: false,
+  },
+  {
+    id: '⓪ interactives, ✅ expandable',
+  },
+  {
+    id: '① interactive, ⛔️ expandable',
+    isExpandable: false,
+  },
+  {
+    id: '①️ interactive, ✅ expandable',
+  },
+  {
+    id: '⓶ interactives, ⛔️ expandable',
+    isExpandable: false,
+  },
+  {
+    id: '⓶ interactives, ✅ expandable',
+  },
+];
+
+const columnIdToIndex = columns.reduce((acc, { id }, index) => {
+  acc[id] = index;
+  return acc;
+}, {});
+const data = [];
+
+for (let i = 1; i < 5; i++) {
+  data.push([
+    <span>{fake('{{name.firstName}}')}</span>,
+    <span>{fake('{{name.firstName}}')}</span>,
+
+    <span>
+      <EuiLink href="#">{fake('{{internet.email}}')}</EuiLink>
+    </span>,
+    <span>
+      <EuiLink href="#">{fake('{{internet.email}}')}</EuiLink>
+    </span>,
+
+    <span>
+      <EuiButtonEmpty size="s">Yes</EuiButtonEmpty>
+      <EuiButtonEmpty size="s">No</EuiButtonEmpty>
+    </span>,
+    <span>
+      <EuiButtonEmpty size="s">Yes</EuiButtonEmpty>
+      <EuiButtonEmpty size="s">No</EuiButtonEmpty>
+    </span>,
+  ]);
+}
+
+export default class DataGridSchema extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      data,
+      sortingColumns: [{ id: 'contributions', direction: 'asc' }],
+
+      pagination: {
+        pageIndex: 0,
+        pageSize: 10,
+      },
+
+      visibleColumns: columns.map(({ id }) => id),
+    };
+  }
+
+  setSorting = sortingColumns => {
+    const data = [...this.state.data].sort((a, b) => {
+      for (let i = 0; i < sortingColumns.length; i++) {
+        const column = sortingColumns[i];
+        const aValue = a[column.id];
+        const bValue = b[column.id];
+
+        if (aValue < bValue) return column.direction === 'asc' ? -1 : 1;
+        if (aValue > bValue) return column.direction === 'asc' ? 1 : -1;
+      }
+
+      return 0;
+    });
+
+    this.setState({ data, sortingColumns });
+  };
+
+  setPageIndex = pageIndex =>
+    this.setState(({ pagination }) => ({
+      pagination: { ...pagination, pageIndex },
+    }));
+
+  setPageSize = pageSize =>
+    this.setState(({ pagination }) => ({
+      pagination: { ...pagination, pageSize, pageIndex: 0 },
+    }));
+
+  setVisibleColumns = visibleColumns => this.setState({ visibleColumns });
+
+  render() {
+    const { data, pagination, sortingColumns } = this.state;
+
+    return (
+      <EuiDataGrid
+        aria-label="Top EUI contributors"
+        columns={columns}
+        columnVisibility={{
+          visibleColumns: this.state.visibleColumns,
+          setVisibleColumns: this.setVisibleColumns,
+        }}
+        rowCount={data.length}
+        inMemory={{ level: 'sorting' }}
+        renderCellValue={({ rowIndex, columnId }) => {
+          const columnIndex = columnIdToIndex[columnId];
+          return data[rowIndex][columnIndex];
+        }}
+        sorting={{ columns: sortingColumns, onSort: this.setSorting }}
+        pagination={{
+          ...pagination,
+          pageSizeOptions: [5, 10, 25],
+          onChangeItemsPerPage: this.setPageSize,
+          onChangePage: this.setPageIndex,
+        }}
+        schemaDetectors={[
+          {
+            type: 'favoriteFranchise',
+            detector(value) {
+              return value.toLowerCase() === 'star wars' ||
+                value.toLowerCase() === 'star trek'
+                ? 1
+                : 0;
+            },
+            comparator(a, b, direction) {
+              const aValue = a.toLowerCase() === 'star wars';
+              const bValue = b.toLowerCase() === 'star wars';
+              if (aValue < bValue) return direction === 'asc' ? 1 : -1;
+              if (aValue > bValue) return direction === 'asc' ? -1 : 1;
+              return 0;
+            },
+            sortTextAsc: 'Star wars-Star trek',
+            sortTextDesc: 'Star trek-Star wars',
+            icon: 'starFilled',
+            color: '#800080',
+          },
+        ]}
+        popoverContents={{
+          numeric: ({ cellContentsElement }) => {
+            // want to process the already-rendered cell value
+            const stringContents = cellContentsElement.textContent;
+
+            // extract the groups-of-three digits that are right-aligned
+            return stringContents.replace(/((\d{3})+)$/, match =>
+              // then replace each group of xyz digits with ,xyz
+              match.replace(/(\d{3})/g, ',$1')
+            );
+          },
+        }}
+      />
+    );
+  }
+}

--- a/src-docs/src/views/datagrid/focus.js
+++ b/src-docs/src/views/datagrid/focus.js
@@ -43,19 +43,31 @@ for (let i = 1; i < 5; i++) {
     <span>{fake('{{name.firstName}}')}</span>,
 
     <span>
-      <EuiLink href="#/tabular-content/data-grid-focus">{fake('{{internet.email}}')}</EuiLink>
+      <EuiLink href="#/tabular-content/data-grid-focus">
+        {fake('{{internet.email}}')}
+      </EuiLink>
     </span>,
     <span>
-      <EuiLink href="#/tabular-content/data-grid-focus">{fake('{{internet.email}}')}</EuiLink>
+      <EuiLink href="#/tabular-content/data-grid-focus">
+        {fake('{{internet.email}}')}
+      </EuiLink>
     </span>,
 
     <span>
-      <EuiButtonEmpty size="s" onClick={() => console.log('clickerooed')}>Yes</EuiButtonEmpty>
-      <EuiButtonEmpty size="s" onClick={() => console.log('clickerooed')}>No</EuiButtonEmpty>
+      <EuiButtonEmpty size="s" onClick={() => console.log('clickerooed')}>
+        Yes
+      </EuiButtonEmpty>
+      <EuiButtonEmpty size="s" onClick={() => console.log('clickerooed')}>
+        No
+      </EuiButtonEmpty>
     </span>,
     <span>
-      <EuiButtonEmpty size="s" onClick={() => console.log('clickerooed')}>Yes</EuiButtonEmpty>
-      <EuiButtonEmpty size="s" onClick={() => console.log('clickerooed')}>No</EuiButtonEmpty>
+      <EuiButtonEmpty size="s" onClick={() => console.log('clickerooed')}>
+        Yes
+      </EuiButtonEmpty>
+      <EuiButtonEmpty size="s" onClick={() => console.log('clickerooed')}>
+        No
+      </EuiButtonEmpty>
     </span>,
   ]);
 }

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -163,8 +163,6 @@ Array [
   >
     <div
       class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--rowHoverHighlight testClass1 testClass2"
-      data-test-subj="dataGridWrapper"
-      tabindex="0"
     >
       <div
         class="euiDataGrid__controls"
@@ -262,7 +260,9 @@ Array [
           <div
             aria-label="aria-label"
             class="euiDataGrid__content"
+            data-test-subj="dataGridWrapper"
             role="grid"
+            tabindex="0"
           >
             <div
               class="euiDataGridHeader"
@@ -685,8 +685,6 @@ Array [
   >
     <div
       class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--rowHoverHighlight testClass1 testClass2"
-      data-test-subj="dataGridWrapper"
-      tabindex="0"
     >
       <div
         class="euiDataGrid__controls"
@@ -784,7 +782,9 @@ Array [
           <div
             aria-label="aria-label"
             class="euiDataGrid__content"
+            data-test-subj="dataGridWrapper"
             role="grid"
+            tabindex="0"
           >
             <div
               class="euiDataGridHeader"
@@ -858,25 +858,46 @@ Array [
                 style="width:50px"
                 tabindex="-1"
               >
-                <div
-                  class="euiDataGridRowCell__expandFlex"
-                >
+                <div>
                   <div
-                    class="euiDataGridRowCell__expandContent"
+                    data-focus-guard="true"
+                    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+                    tabindex="-1"
+                  />
+                  <div
+                    data-focus-guard="true"
+                    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+                    tabindex="-1"
+                  />
+                  <div
+                    data-focus-lock-disabled="disabled"
                   >
-                    <p
-                      class="euiScreenReaderOnly"
-                    >
-                      <span>
-                        Row: 1, Column: 1:
-                      </span>
-                    </p>
                     <div
-                      class="euiDataGridRowCell__truncate"
+                      class="euiDataGridRowCell__expandFlex"
                     >
-                      0
+                      <div
+                        class="euiDataGridRowCell__expandContent"
+                      >
+                        <p
+                          class="euiScreenReaderOnly"
+                        >
+                          <span>
+                            Row: 1, Column: 1:
+                          </span>
+                        </p>
+                        <div
+                          class="euiDataGridRowCell__truncate"
+                        >
+                          0
+                        </div>
+                      </div>
                     </div>
                   </div>
+                  <div
+                    data-focus-guard="true"
+                    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+                    tabindex="-1"
+                  />
                 </div>
               </div>
               <div
@@ -998,25 +1019,46 @@ Array [
                 style="width:50px"
                 tabindex="-1"
               >
-                <div
-                  class="euiDataGridRowCell__expandFlex"
-                >
+                <div>
                   <div
-                    class="euiDataGridRowCell__expandContent"
+                    data-focus-guard="true"
+                    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+                    tabindex="-1"
+                  />
+                  <div
+                    data-focus-guard="true"
+                    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+                    tabindex="-1"
+                  />
+                  <div
+                    data-focus-lock-disabled="disabled"
                   >
-                    <p
-                      class="euiScreenReaderOnly"
-                    >
-                      <span>
-                        Row: 1, Column: 4:
-                      </span>
-                    </p>
                     <div
-                      class="euiDataGridRowCell__truncate"
+                      class="euiDataGridRowCell__expandFlex"
                     >
-                      0
+                      <div
+                        class="euiDataGridRowCell__expandContent"
+                      >
+                        <p
+                          class="euiScreenReaderOnly"
+                        >
+                          <span>
+                            Row: 1, Column: 4:
+                          </span>
+                        </p>
+                        <div
+                          class="euiDataGridRowCell__truncate"
+                        >
+                          0
+                        </div>
+                      </div>
                     </div>
                   </div>
+                  <div
+                    data-focus-guard="true"
+                    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+                    tabindex="-1"
+                  />
                 </div>
               </div>
             </div>
@@ -1032,25 +1074,46 @@ Array [
                 style="width:50px"
                 tabindex="-1"
               >
-                <div
-                  class="euiDataGridRowCell__expandFlex"
-                >
+                <div>
                   <div
-                    class="euiDataGridRowCell__expandContent"
+                    data-focus-guard="true"
+                    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+                    tabindex="-1"
+                  />
+                  <div
+                    data-focus-guard="true"
+                    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+                    tabindex="-1"
+                  />
+                  <div
+                    data-focus-lock-disabled="disabled"
                   >
-                    <p
-                      class="euiScreenReaderOnly"
-                    >
-                      <span>
-                        Row: 2, Column: 1:
-                      </span>
-                    </p>
                     <div
-                      class="euiDataGridRowCell__truncate"
+                      class="euiDataGridRowCell__expandFlex"
                     >
-                      1
+                      <div
+                        class="euiDataGridRowCell__expandContent"
+                      >
+                        <p
+                          class="euiScreenReaderOnly"
+                        >
+                          <span>
+                            Row: 2, Column: 1:
+                          </span>
+                        </p>
+                        <div
+                          class="euiDataGridRowCell__truncate"
+                        >
+                          1
+                        </div>
+                      </div>
                     </div>
                   </div>
+                  <div
+                    data-focus-guard="true"
+                    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+                    tabindex="-1"
+                  />
                 </div>
               </div>
               <div
@@ -1172,25 +1235,46 @@ Array [
                 style="width:50px"
                 tabindex="-1"
               >
-                <div
-                  class="euiDataGridRowCell__expandFlex"
-                >
+                <div>
                   <div
-                    class="euiDataGridRowCell__expandContent"
+                    data-focus-guard="true"
+                    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+                    tabindex="-1"
+                  />
+                  <div
+                    data-focus-guard="true"
+                    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+                    tabindex="-1"
+                  />
+                  <div
+                    data-focus-lock-disabled="disabled"
                   >
-                    <p
-                      class="euiScreenReaderOnly"
-                    >
-                      <span>
-                        Row: 2, Column: 4:
-                      </span>
-                    </p>
                     <div
-                      class="euiDataGridRowCell__truncate"
+                      class="euiDataGridRowCell__expandFlex"
                     >
-                      1
+                      <div
+                        class="euiDataGridRowCell__expandContent"
+                      >
+                        <p
+                          class="euiScreenReaderOnly"
+                        >
+                          <span>
+                            Row: 2, Column: 4:
+                          </span>
+                        </p>
+                        <div
+                          class="euiDataGridRowCell__truncate"
+                        >
+                          1
+                        </div>
+                      </div>
                     </div>
                   </div>
+                  <div
+                    data-focus-guard="true"
+                    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+                    tabindex="-1"
+                  />
                 </div>
               </div>
             </div>
@@ -1206,25 +1290,46 @@ Array [
                 style="width:50px"
                 tabindex="-1"
               >
-                <div
-                  class="euiDataGridRowCell__expandFlex"
-                >
+                <div>
                   <div
-                    class="euiDataGridRowCell__expandContent"
+                    data-focus-guard="true"
+                    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+                    tabindex="-1"
+                  />
+                  <div
+                    data-focus-guard="true"
+                    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+                    tabindex="-1"
+                  />
+                  <div
+                    data-focus-lock-disabled="disabled"
                   >
-                    <p
-                      class="euiScreenReaderOnly"
-                    >
-                      <span>
-                        Row: 3, Column: 1:
-                      </span>
-                    </p>
                     <div
-                      class="euiDataGridRowCell__truncate"
+                      class="euiDataGridRowCell__expandFlex"
                     >
-                      2
+                      <div
+                        class="euiDataGridRowCell__expandContent"
+                      >
+                        <p
+                          class="euiScreenReaderOnly"
+                        >
+                          <span>
+                            Row: 3, Column: 1:
+                          </span>
+                        </p>
+                        <div
+                          class="euiDataGridRowCell__truncate"
+                        >
+                          2
+                        </div>
+                      </div>
                     </div>
                   </div>
+                  <div
+                    data-focus-guard="true"
+                    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+                    tabindex="-1"
+                  />
                 </div>
               </div>
               <div
@@ -1346,25 +1451,46 @@ Array [
                 style="width:50px"
                 tabindex="-1"
               >
-                <div
-                  class="euiDataGridRowCell__expandFlex"
-                >
+                <div>
                   <div
-                    class="euiDataGridRowCell__expandContent"
+                    data-focus-guard="true"
+                    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+                    tabindex="-1"
+                  />
+                  <div
+                    data-focus-guard="true"
+                    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+                    tabindex="-1"
+                  />
+                  <div
+                    data-focus-lock-disabled="disabled"
                   >
-                    <p
-                      class="euiScreenReaderOnly"
-                    >
-                      <span>
-                        Row: 3, Column: 4:
-                      </span>
-                    </p>
                     <div
-                      class="euiDataGridRowCell__truncate"
+                      class="euiDataGridRowCell__expandFlex"
                     >
-                      2
+                      <div
+                        class="euiDataGridRowCell__expandContent"
+                      >
+                        <p
+                          class="euiScreenReaderOnly"
+                        >
+                          <span>
+                            Row: 3, Column: 4:
+                          </span>
+                        </p>
+                        <div
+                          class="euiDataGridRowCell__truncate"
+                        >
+                          2
+                        </div>
+                      </div>
                     </div>
                   </div>
+                  <div
+                    data-focus-guard="true"
+                    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+                    tabindex="-1"
+                  />
                 </div>
               </div>
             </div>
@@ -1405,8 +1531,6 @@ Array [
   >
     <div
       class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--rowHoverHighlight testClass1 testClass2"
-      data-test-subj="dataGridWrapper"
-      tabindex="0"
     >
       <div
         class="euiDataGrid__controls"
@@ -1501,7 +1625,9 @@ Array [
           <div
             aria-label="aria-label"
             class="euiDataGrid__content"
+            data-test-subj="dataGridWrapper"
             role="grid"
+            tabindex="0"
           >
             <div
               class="euiDataGridHeader"
@@ -1926,8 +2052,6 @@ Array [
   >
     <div
       class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--rowHoverHighlight testClass1 testClass2"
-      data-test-subj="dataGridWrapper"
-      tabindex="0"
     >
       <div
         class="euiDataGrid__controls"
@@ -2022,7 +2146,9 @@ Array [
           <div
             aria-label="aria-label"
             class="euiDataGrid__content"
+            data-test-subj="dataGridWrapper"
             role="grid"
+            tabindex="0"
           >
             <div
               class="euiDataGridHeader"

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -537,6 +537,7 @@ Array [
   Object {
     "className": "euiDataGridRowCell customClass",
     "data-test-subj": "dataGridRowCell",
+    "onBlur": [Function],
     "onFocus": [Function],
     "onKeyDown": [Function],
     "role": "gridcell",
@@ -549,6 +550,7 @@ Array [
   Object {
     "className": "euiDataGridRowCell customClass",
     "data-test-subj": "dataGridRowCell",
+    "onBlur": [Function],
     "onFocus": [Function],
     "onKeyDown": [Function],
     "role": "gridcell",
@@ -561,6 +563,7 @@ Array [
   Object {
     "className": "euiDataGridRowCell customClass",
     "data-test-subj": "dataGridRowCell",
+    "onBlur": [Function],
     "onFocus": [Function],
     "onKeyDown": [Function],
     "role": "gridcell",
@@ -573,6 +576,7 @@ Array [
   Object {
     "className": "euiDataGridRowCell customClass",
     "data-test-subj": "dataGridRowCell",
+    "onBlur": [Function],
     "onFocus": [Function],
     "onKeyDown": [Function],
     "role": "gridcell",

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -1968,11 +1968,11 @@ Array [
         .simulate('keydown', { keyCode: keyCodes.LEFT }) // 6, A
         .simulate('keydown', {
           keyCode: keyCodes.PAGE_UP,
-        }); // 3, A
+        }); // 5, A
       focusableCell = getFocusableCell(component);
       expect(
         focusableCell.find('[data-test-subj="cell-content"]').text()
-      ).toEqual('3, A');
+      ).toEqual('5, A');
 
       // return to the previous (first) page
       focusableCell.simulate('keydown', {
@@ -1981,7 +1981,7 @@ Array [
       focusableCell = getFocusableCell(component);
       expect(
         focusableCell.find('[data-test-subj="cell-content"]').text()
-      ).toEqual('0, A');
+      ).toEqual('2, A');
 
       // move to the last cell of the page then advance one page
       focusableCell
@@ -1991,20 +1991,20 @@ Array [
         }) // 2, C (last cell of the first page)
         .simulate('keydown', {
           keyCode: keyCodes.PAGE_DOWN,
-        }); // 5, C (last cell of the second page, same cell position as previous page)
+        }); // 3, C (first cell of the second page, same cell position as previous page)
       focusableCell = getFocusableCell(component);
       expect(
         focusableCell.find('[data-test-subj="cell-content"]').text()
-      ).toEqual('5, C');
+      ).toEqual('3, C');
 
-      // advance to the final page, but there is 1 row less on page 3 so focus should retreat a row but retain the column
+      // advance to the final page
       focusableCell.simulate('keydown', {
         keyCode: keyCodes.PAGE_DOWN,
-      }); // 7, C
+      }); // 6, C
       focusableCell = getFocusableCell(component);
       expect(
         focusableCell.find('[data-test-subj="cell-content"]').text()
-      ).toEqual('7, C');
+      ).toEqual('6, C');
     });
 
     it('does not break arrow key focus control behavior when also using a mouse', () => {

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -1926,13 +1926,14 @@ Array [
       ).toEqual('0, A');
 
       // page should not change when moving before the first entry
+      // but the last row should remain focused
       focusableCell.simulate('keydown', {
         keyCode: keyCodes.PAGE_UP,
       });
       focusableCell = getFocusableCell(component);
       expect(
         focusableCell.find('[data-test-subj="cell-content"]').text()
-      ).toEqual('0, A');
+      ).toEqual('2, A');
 
       // advance to the next page
       focusableCell.simulate('keydown', {

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -481,19 +481,27 @@ const useFocus = (
     EuiDataGridFocusedCell | undefined
   >(undefined);
 
-  const canCellsBeFocused = useMemo(() => focusedCell != null, [focusedCell]);
+  const hasHadFocus = useMemo(() => focusedCell != null, [focusedCell]);
 
   const focusProps = useMemo<FocusProps>(
     () =>
-      canCellsBeFocused
+      hasHadFocus
         ? {}
         : {
             tabIndex: 0,
-            onFocus: () =>
-              setFocusedCell(headerIsInteractive ? [0, -1] : [0, 0]),
+            onFocus: e => {
+              // if e.target (the source element of the `focus event`
+              // matches e.currentTarget (always the div with this onFocus listener)
+              // then the user has focused directly on the data grid wrapper (almost definitely by tabbing)
+              // so shift focus to the first interactive cell within the grid
+              if (e.target === e.currentTarget) {
+                setFocusedCell(headerIsInteractive ? [0, -1] : [0, 0]);
+              }
+            },
           },
-    [canCellsBeFocused, setFocusedCell, headerIsInteractive]
+    [hasHadFocus, setFocusedCell, headerIsInteractive]
   );
+  // const focusProps = useMemo(() => ({}), []);
 
   return [focusProps, focusedCell, setFocusedCell];
 };

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -403,9 +403,9 @@ function createKeyDownHandler(
         const pageCount = Math.ceil(rowCount / pageSize);
         if (pageIndex < pageCount - 1) {
           props.pagination.onChangePage(pageIndex + 1);
-          setFocusedCell([focusedCell[0], 0]);
-          updateFocus();
         }
+        setFocusedCell([focusedCell[0], 0]);
+        updateFocus();
       }
     } else if (keyCode === keyCodes.PAGE_UP) {
       if (props.pagination) {
@@ -413,9 +413,9 @@ function createKeyDownHandler(
         const pageIndex = props.pagination.pageIndex;
         if (pageIndex > 0) {
           props.pagination.onChangePage(pageIndex - 1);
-          setFocusedCell([focusedCell[0], props.pagination.pageSize - 1]);
-          updateFocus();
         }
+        setFocusedCell([focusedCell[0], props.pagination.pageSize - 1]);
+        updateFocus();
       }
     } else if (keyCode === (ctrlKey && keyCodes.END)) {
       event.preventDefault();

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -494,7 +494,6 @@ const useFocus = (
           },
     [hasHadFocus, setFocusedCell, headerIsInteractive]
   );
-  // const focusProps = useMemo(() => ({}), []);
 
   return [focusProps, focusedCell, setFocusedCell];
 };

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -403,18 +403,7 @@ function createKeyDownHandler(
         const pageCount = Math.ceil(rowCount / pageSize);
         if (pageIndex < pageCount - 1) {
           props.pagination.onChangePage(pageIndex + 1);
-          const newPageRowCount = computeVisibleRows({
-            rowCount,
-            pagination: {
-              ...props.pagination,
-              pageIndex: pageIndex + 1,
-            },
-          });
-          const rowIndex =
-            focusedCell[1] < newPageRowCount
-              ? focusedCell[1]
-              : newPageRowCount - 1;
-          setFocusedCell([focusedCell[0], rowIndex]);
+          setFocusedCell([focusedCell[0], 0]);
           updateFocus();
         }
       }
@@ -424,6 +413,7 @@ function createKeyDownHandler(
         const pageIndex = props.pagination.pageIndex;
         if (pageIndex > 0) {
           props.pagination.onChangePage(pageIndex - 1);
+          setFocusedCell([focusedCell[0], props.pagination.pageSize - 1]);
           updateFocus();
         }
       }

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -486,7 +486,10 @@ const useFocus = (
   const focusProps = useMemo<FocusProps>(
     () =>
       hasHadFocus
-        ? {}
+        ? {
+            // FireFox allows tabbing to a div that is scrollable, while Chrome does not
+            tabIndex: -1,
+          }
         : {
             tabIndex: 0,
             onFocus: e => {
@@ -829,8 +832,6 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
     <DataGridContext.Provider value={datagridContext}>
       <EuiFocusTrap disabled={!isFullScreen} style={{ height: '100%' }}>
         <div
-          data-test-subj="dataGridWrapper"
-          {...wrappingDivFocusProps}
           className={classes}
           onKeyDown={handleGridKeyDown}
           ref={setContainerRef}>
@@ -881,8 +882,10 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
                   ) : null}
                   <div
                     ref={contentRef}
+                    data-test-subj="dataGridWrapper"
                     className="euiDataGrid__content"
                     role="grid"
+                    {...wrappingDivFocusProps}
                     {...gridAriaProps}>
                     <EuiMutationObserver
                       observerOptions={{

--- a/src/components/datagrid/data_grid_cell.tsx
+++ b/src/components/datagrid/data_grid_cell.tsx
@@ -114,10 +114,19 @@ export class EuiDataGridCell extends Component<
 
   updateFocus = () => {
     const cell = this.cellRef.current;
+    const tabbingRef = this.tabbingRef;
     const { isFocused } = this.props;
 
-    if (cell && isFocused) {
-      cell.focus();
+    if (cell && tabbingRef && isFocused) {
+      const interactables = tabbingRef.querySelectorAll<HTMLElement>(
+        '[data-datagrid-interactable=true]'
+      );
+      if (this.props.isExpandable === false && interactables.length === 1) {
+        // Only one element can be interacted with
+        interactables[0].focus();
+      } else {
+        cell.focus();
+      }
     }
   };
 
@@ -178,7 +187,9 @@ export class EuiDataGridCell extends Component<
     if (this.tabbingRef) {
       const tabbables = tabbable(this.tabbingRef);
       for (let i = 0; i < tabbables.length; i++) {
-        tabbables[i].setAttribute('tabIndex', '-1');
+        const element = tabbables[i];
+        element.setAttribute('tabIndex', '-1');
+        element.setAttribute('data-datagrid-interactable', 'true');
       }
     }
   };

--- a/src/components/datagrid/data_grid_cell.tsx
+++ b/src/components/datagrid/data_grid_cell.tsx
@@ -8,6 +8,7 @@ import React, {
   HTMLAttributes,
   KeyboardEvent,
   ReactChild,
+  MutableRefObject,
 } from 'react';
 import classNames from 'classnames';
 import tabbable from 'tabbable';
@@ -104,8 +105,7 @@ export class EuiDataGridCell extends Component<
   EuiDataGridCellState
 > {
   cellRef = createRef<HTMLDivElement>();
-  // cellContentsRef = createRef<HTMLDivElement>();
-  // tabbingRef: HTMLDivElement | null = null;
+  popoverPanelRef: MutableRefObject<HTMLElement | null> = createRef();
   cellContentsRef: HTMLDivElement | null = null;
   state: EuiDataGridCellState = {
     cellProps: {},
@@ -466,11 +466,19 @@ export class EuiDataGridCell extends Component<
             anchorClassName="euiDataGridRowCell__expand"
             button={anchorContent}
             isOpen={this.state.popoverIsOpen}
+            panelRef={ref => (this.popoverPanelRef.current = ref)}
             ownFocus
             panelClassName="euiDataGridRowCell__popover"
             zIndex={8001}
             display="block"
             closePopover={() => this.setState({ popoverIsOpen: false })}
+            onKeyDown={e => {
+              if (e.key === 'F2' || e.key === 'Escape') {
+                e.preventDefault();
+                e.stopPropagation();
+                this.setState({ popoverIsOpen: false });
+              }
+            }}
             onTrapDeactivation={this.updateFocus}>
             {popoverContent}
           </EuiPopover>

--- a/src/components/datagrid/data_grid_header_cell.tsx
+++ b/src/components/datagrid/data_grid_header_cell.tsx
@@ -2,6 +2,7 @@ import React, {
   AriaAttributes,
   FunctionComponent,
   HTMLAttributes,
+  useCallback,
   useEffect,
   useRef,
   useState,
@@ -91,33 +92,37 @@ export const EuiDataGridHeaderCell: FunctionComponent<
     focusedCell != null && focusedCell[0] === index && focusedCell[1] === -1;
   const [isCellEntered, setIsCellEntered] = useState(false);
 
+  const enableInteractives = useCallback(() => {
+    if (headerRef.current) {
+      const interactiveElements = headerRef.current.querySelectorAll(
+        '[data-euigrid-tab-managed]'
+      );
+      for (let i = 0; i < interactiveElements.length; i++) {
+        interactiveElements[i].setAttribute('tabIndex', '0');
+      }
+    }
+  }, []);
+
+  const disableInteractives = useCallback(() => {
+    if (headerRef.current) {
+      const tababbles = tabbable(headerRef.current);
+      if (tababbles.length > 1) {
+        console.warn(
+          `EuiDataGridHeaderCell expects at most 1 tabbable element, ${
+            tababbles.length
+          } found instead`
+        );
+      }
+      for (let i = 0; i < tababbles.length; i++) {
+        const element = tababbles[i];
+        element.setAttribute('data-euigrid-tab-managed', 'true');
+        element.setAttribute('tabIndex', '-1');
+      }
+    }
+  }, []);
+
   useEffect(() => {
     if (headerRef.current) {
-      function enableInteractives() {
-        const interactiveElements = headerRef.current!.querySelectorAll(
-          '[data-euigrid-tab-managed]'
-        );
-        for (let i = 0; i < interactiveElements.length; i++) {
-          interactiveElements[i].setAttribute('tabIndex', '0');
-        }
-      }
-
-      function disableInteractives() {
-        const tababbles = tabbable(headerRef.current!);
-        if (tababbles.length > 1) {
-          console.warn(
-            `EuiDataGridHeaderCell expects at most 1 tabbable element, ${
-              tababbles.length
-            } found instead`
-          );
-        }
-        for (let i = 0; i < tababbles.length; i++) {
-          const element = tababbles[i];
-          element.setAttribute('data-euigrid-tab-managed', 'true');
-          element.setAttribute('tabIndex', '-1');
-        }
-      }
-
       if (isCellEntered) {
         enableInteractives();
         const tabbables = tabbable(headerRef.current!);
@@ -128,7 +133,7 @@ export const EuiDataGridHeaderCell: FunctionComponent<
         disableInteractives();
       }
     }
-  }, [isCellEntered]);
+  }, [disableInteractives, enableInteractives, isCellEntered]);
 
   useEffect(() => {
     if (headerRef.current) {
@@ -154,7 +159,23 @@ export const EuiDataGridHeaderCell: FunctionComponent<
           return false;
         } else {
           // take the focus
-          setFocusedCell([index, -1]);
+          if (
+            focusedCell == null ||
+            focusedCell[0] !== index ||
+            focusedCell[1] !== -1
+          ) {
+            setFocusedCell([index, -1]);
+          } else if (headerRef.current) {
+            // this cell already had the grid's focus, so re-enable interactives
+            enableInteractives();
+            setIsCellEntered(true);
+
+            // if there is only one interactive element shift focus to the interactive element
+            const tabbables = tabbable(headerRef.current);
+            if (tabbables.length === 1) {
+              tabbables[0].focus();
+            }
+          }
         }
       }
 
@@ -211,14 +232,22 @@ export const EuiDataGridHeaderCell: FunctionComponent<
         headerNode.removeEventListener('keyup', onKeyUp);
       };
     }
-  }, [headerIsInteractive, isFocused, setIsCellEntered, setFocusedCell, index]);
+  }, [
+    enableInteractives,
+    headerIsInteractive,
+    isFocused,
+    setIsCellEntered,
+    focusedCell,
+    setFocusedCell,
+    index,
+  ]);
 
   return (
     <div
       role="columnheader"
       {...ariaProps}
       ref={headerRef}
-      tabIndex={isFocused ? 0 : -1}
+      tabIndex={isFocused && !isCellEntered ? 0 : -1}
       className={classes}
       data-test-subj={`dataGridHeaderCell-${id}`}
       style={width != null ? { width: `${width}px` } : {}}>

--- a/src/components/focus_trap/focus_trap.tsx
+++ b/src/components/focus_trap/focus_trap.tsx
@@ -57,6 +57,13 @@ export class EuiFocusTrap extends Component<Props, State> {
     this.setInitialFocus(this.props.initialFocus);
   }
 
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.disabled === true && this.props.disabled === false) {
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({ hasBeenDisabledByClick: false });
+    }
+  }
+
   // Programmatically sets focus on a nested DOM node; optional
   setInitialFocus = (initialFocus?: FocusTarget) => {
     let node = initialFocus instanceof HTMLElement ? initialFocus : null;


### PR DESCRIPTION
### Summary

Fixes #2626 

This is ready to review **functionality**, not yet the code side.

Added a new docs page for data grid, **Data grid focus**, to track requirements and provide a datagrid for testing these states. This also touched `EuiFocusTrap`'s outside-click-disabling, so we'll want to double check that (added ability to re-enable a trap which was previously-disabled-by-click).

I also want to diagram/record the focus logic and refactor it, but that has to wait until the logic is solidified and should be in another PR.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
- [ ] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
