### PR TITLE
Fixed EuiSuperDatePicker "End date" popover shows wrong relative time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 **Bug Fixes**
 
+- Fixed bug in `EuiSuperDatePicker` not showing correct values in relative tab of end date ([#3132](https://github.com/elastic/eui/pull/3132))
 - Fixed bug in `EuiSuperDatePicker` to show correct values of commonly used values in relative tab ([#3106](https://github.com/elastic/eui/pull/3106))
 - Fixed race condition in `EuiIcon` when switching from dynamically fetched components ([#3118](https://github.com/elastic/eui/pull/3118))
 

--- a/src/components/date_picker/super_date_picker/date_popover/date_popover_content.js
+++ b/src/components/date_picker/super_date_picker/date_popover/date_popover_content.js
@@ -63,7 +63,7 @@ export function EuiDatePopoverContent({
           <EuiRelativeTab
             dateFormat={dateFormat}
             locale={locale}
-            value={value}
+            value={toAbsoluteString(value, roundUp)}
             onChange={onChange}
             roundUp={roundUp}
             position={position}


### PR DESCRIPTION
### Summary

Possible Fix for: #3131 

The "End date" popover shows the same relative time as the "Start date" popover. This can be solved by converting the value on relative tab to absolute string using toAbsoluteString function

Before:

![before5](https://user-images.githubusercontent.com/10515204/77143050-076f3500-6aa8-11ea-9931-adb47d39a164.gif)

After:

![after5](https://user-images.githubusercontent.com/10515204/77143066-15bd5100-6aa8-11ea-9a76-64a3b4ba5b45.gif)


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
