### PR TITLE
Allow toggling of EuiForm top level error and changed its default title 

### DIFF
--- a/src-docs/src/views/form_validation/validation.js
+++ b/src-docs/src/views/form_validation/validation.js
@@ -43,7 +43,10 @@ export default class extends Component {
 
     return (
       <Fragment>
-        <EuiForm isInvalid={this.state.showErrors} error={errors}>
+        <EuiForm
+          isInvalid={this.state.showErrors}
+          error={errors}
+          showCallout={true}>
           <EuiFormRow label="Validation only" isInvalid={this.state.showErrors}>
             <EuiFieldText name="first" isInvalid={this.state.showErrors} />
           </EuiFormRow>

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -53,7 +53,7 @@ export const EuiForm: FunctionComponent<EuiFormProps> = ({
     optionalErrorAlert = (
       <EuiI18n
         token="euiForm.addressFormErrors"
-        default="Please address the errors in your form.">
+        default="Please address the highlighted errors.">
         {(addressFormErrors: string) => (
           <EuiCallOut
             className="euiForm__errors"

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -20,6 +20,9 @@ export type EuiFormProps = CommonProps &
      */
     component?: 'form' | 'div';
     error?: ReactNode | ReactNode[];
+    /**
+     * Whether to show form top level error or not
+     */
     showCallout?: boolean;
   };
 

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -20,6 +20,7 @@ export type EuiFormProps = CommonProps &
      */
     component?: 'form' | 'div';
     error?: ReactNode | ReactNode[];
+    showCallout?: boolean;
   };
 
 export const EuiForm: FunctionComponent<EuiFormProps> = ({
@@ -27,6 +28,7 @@ export const EuiForm: FunctionComponent<EuiFormProps> = ({
   className,
   isInvalid,
   error,
+  showCallout = true,
   component = 'div',
   ...rest
 }) => {
@@ -49,7 +51,7 @@ export const EuiForm: FunctionComponent<EuiFormProps> = ({
 
   let optionalErrorAlert;
 
-  if (isInvalid) {
+  if (isInvalid && showCallout) {
     optionalErrorAlert = (
       <EuiI18n
         token="euiForm.addressFormErrors"


### PR DESCRIPTION
### Summary

Changed EuiForm's top level error and added option to enable/disable the callout.
Added a prop 'showCallout ' to the form, which can be set to False in order t o disable the top level alert.

Related to #478 

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
