### PR TITLE
Improving EuiButtonEmpty focus state for color type text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `title` to headers of `EuiTable` in case of truncation ([#3094](https://github.com/elastic/eui/pull/3094))
 - Added i18n to `EuiTableHeaderCell` ([#3094](https://github.com/elastic/eui/pull/3094))
 - Added `number` and `string` to `size` type of `EuiImage` for setting custom sizes ([#3012](https://github.com/elastic/eui/pull/3012))
+- Improved `EuiButtonEmpty` focus state when the color type is text ([#3135](https://github.com/elastic/eui/pull/3135))
 
 **Bug Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Added `title` to headers of `EuiTable` in case of truncation ([#3094](https://github.com/elastic/eui/pull/3094))
 - Added i18n to `EuiTableHeaderCell` ([#3094](https://github.com/elastic/eui/pull/3094))
 - Added `number` and `string` to `size` type of `EuiImage` for setting custom sizes ([#3012](https://github.com/elastic/eui/pull/3012))
-- Improved `EuiButtonEmpty` focus state when the color type is text ([#3135](https://github.com/elastic/eui/pull/3135))
+- Improved `EuiButtonEmpty` focus state when the `color` type is `text` ([#3135](https://github.com/elastic/eui/pull/3135))
 
 **Bug Fixes**
 

--- a/src/components/button/button_empty/_button_empty.scss
+++ b/src/components/button/button_empty/_button_empty.scss
@@ -89,7 +89,7 @@ $euiButtonEmptyTypes: (
 
     &:focus {
       @if ($name == 'text') {
-        background-color: $euiColorLightestShade;
+        background-color: transparentize($euiTextColor, .9);
       } @else {
         background-color: transparentize($color, .9);
       }

--- a/src/components/button/button_empty/_button_empty.scss
+++ b/src/components/button/button_empty/_button_empty.scss
@@ -88,11 +88,7 @@ $euiButtonEmptyTypes: (
     }
 
     &:focus {
-      @if ($name == 'text') {
-        background-color: transparentize($euiTextColor, .9);
-      } @else {
-        background-color: transparentize($color, .9);
-      }
+      background-color: transparentize($color, .9);
     }
 
     &:hover {


### PR DESCRIPTION
## Summary

This PR adds a darker background on **focus state** for `EuiButtonEmpty` when the `color` type is `text`. 

The same background color is used in other components like:

-  `EuiButtonIcon`

- `EuiButtonToggle`

I think it makes sense that all the buttons that allow the color type text to have the same background color on focus state.

## The issue
As we can see, the previous focus state background color wouldn't work in situations like this:

<img width="1086" alt="Frame 4@2x" src="https://user-images.githubusercontent.com/2750668/77181259-fd0e6480-6ac2-11ea-84dd-111c244d1319.png">


## Color contrast a11y

With this new color the contrast decreases a little bit but it still ok.
<img width="750" alt="Frame 2@2x" src="https://user-images.githubusercontent.com/2750668/77179146-faf6d680-6abf-11ea-8085-868511c219ad.png">



### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~~[ ] Checked in **mobile**~~
- [ ] Checked in **IE11** and **Firefox**
- ~~[ ] Props have proper **autodocs**~~
- ~~[ ] Added **documentation** examples~~
- ~~[ ] Added or updated **jest tests**~~
- ~~[ ] Checked for **breaking changes** and labeled appropriately~~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately