### PR TITLE
Fixed EuiPagination vertical alignment of text when is compressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Improved `EuiButtonEmpty` focus state when the `color` type is `text` ([#3135](https://github.com/elastic/eui/pull/3135))
 - Added `EuiLoadingElastic` component ([#3017](https://github.com/elastic/eui/pull/3017))
 - Upgraded `react-beautiful-dnd` to v13 ([#3064](https://github.com/elastic/eui/pull/3064))
+- Fixed `EuiPagination` vertical alignment of the text when used as `compressed` ([#3152](https://github.com/elastic/eui/pull/3152))
 
 **Bug Fixes**
 

--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -2,8 +2,16 @@
   display: flex;
   align-items: center;
 
-  &__text {
+  &__compressedText {
     display: inline-flex;
     align-items: center;
+
+    > *:first-child {
+      margin-right: $euiSizeXS;
+    }
+
+    > *:last-child {
+      margin-left: $euiSizeXS;
+    }
   }
 }

--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -1,4 +1,9 @@
 .euiPagination {
   display: flex;
   align-items: center;
+
+  &__text {
+    display: inline-flex;
+    align-items: center;
+  }
 }

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -208,7 +208,7 @@ export const EuiPagination: FunctionComponent<Props> = ({
     return (
       <div className={classes} {...rest}>
         {previousButton}
-        <EuiText size="s" className="euiPagination__text">
+        <EuiText size="s" className="euiPagination__compressedText">
           <EuiI18n
             token="euiPagination.pageOfTotalCompressed"
             default="{page} of {total}"

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -208,7 +208,7 @@ export const EuiPagination: FunctionComponent<Props> = ({
     return (
       <div className={classes} {...rest}>
         {previousButton}
-        <EuiText size="s">
+        <EuiText size="s" className="euiPagination__text">
           <EuiI18n
             token="euiPagination.pageOfTotalCompressed"
             default="{page} of {total}"


### PR DESCRIPTION
### Summary

Closes #3148

This PR fixes the vertical alignment of the `of` word when the `EuiPagination` is `compressed`.  

<img width="401" alt="Frame 5@2x" src="https://user-images.githubusercontent.com/2750668/77355102-c42cf480-6d3b-11ea-9750-00a96f782468.png">

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~~[ ] Checked in **mobile**~~
- [x] Checked in **IE11** and **Firefox**
- ~~[ ] Props have proper **autodocs**~~
- ~~[ ] Added **documentation** examples~~
- ~~[ ] Added or updated **jest tests**~~
- ~~[ ] Checked for **breaking changes** and labeled appropriately~~
- ~~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
