### PR TITLE
Added textOnly prop info in the table-docs.

### DIFF
--- a/src-docs/src/views/tables/basic/props_info.js
+++ b/src-docs/src/views/tables/basic/props_info.js
@@ -109,7 +109,7 @@ export const propsInfo = {
         },
         textOnly: {
           description:
-            'Applied to table cells => Any cell using render function will have the value of this prop bydefault to be false, leading to unnecessary word breaks. Do not forget to apply "textOnly: true" in order to ensure it breaks properly',
+            'Applied to table cells => Any cell using render function will set this to be `false`, leading to unnecessary word breaks. Apply `textOnly: true` in order to ensure it breaks properly',
           required: false,
           type: { name: 'bool' },
           defaultValue: { value: 'false' },

--- a/src-docs/src/views/tables/basic/props_info.js
+++ b/src-docs/src/views/tables/basic/props_info.js
@@ -107,6 +107,13 @@ export const propsInfo = {
           required: false,
           type: { name: 'string' },
         },
+        textOnly: {
+          description:
+            'Applied to table cells => Any cell using render function will have the value of this prop bydefault to be false, leading to unnecessary word breaks. Do not forget to apply "textOnly: true" in order to ensure it breaks properly',
+          required: false,
+          type: { name: 'bool' },
+          defaultValue: { value: 'false' },
+        },
         tableLayout: {
           description:
             'Sets the table-layout CSS property. Note that auto tableLayout prevents truncateText from working properly.',


### PR DESCRIPTION
<h1>Description</h1>

Fixes #62 
### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
