### PR TITLE
Undo skipped date_format tests

### DIFF
--- a/src/components/search_bar/query/date_format.test.ts
+++ b/src/components/search_bar/query/date_format.test.ts
@@ -16,7 +16,7 @@ afterEach(() => {
 });
 
 describe('date format', () => {
-  test.skip('parse - explicit date', () => {
+  test('parse - explicit date', () => {
     const parsed = dateFormat.parse('2018-01-02T22:33:44.555Z');
     expect(parsed.utcOffset()).toBe(0);
     expect(parsed.year()).toBe(2018);
@@ -29,7 +29,7 @@ describe('date format', () => {
     expect(dateGranularity(parsed)).toBeUndefined();
   });
 
-  test.skip('parse - explicit date 2', () => {
+  test('parse - explicit date 2', () => {
     [
       '12 January 2018 22:33:44',
       '12 January 18 22:33:44',
@@ -48,7 +48,7 @@ describe('date format', () => {
     });
   });
 
-  test.skip('parse - explicit date 3', () => {
+  test('parse - explicit date 3', () => {
     [
       '12 January 2018 22:33',
       '12 January 18 22:33',
@@ -67,7 +67,7 @@ describe('date format', () => {
     });
   });
 
-  test.skip('parse - time', () => {
+  test('parse - time', () => {
     ['22:33', '10:33 PM', '10:33 pm'].forEach(time => {
       const parsed = dateFormat.parse(time);
       expect(parsed.utcOffset()).toBe(0);
@@ -93,7 +93,7 @@ describe('date format', () => {
     });
   });
 
-  test.skip('parse - day granularity', () => {
+  test('parse - day granularity', () => {
     [
       '2 Jan 18',
       '2nd Jan 18',
@@ -166,7 +166,7 @@ describe('date format', () => {
     expect(dateGranularity(parsed)).toBe(Granularity.DAY);
   });
 
-  test.skip('parse - week granularity', () => {
+  test('parse - week granularity', () => {
     const weekNumber = random.integer({ min: 0, max: 50 });
     const week = moment(now)
       .week(weekNumber)
@@ -219,7 +219,7 @@ describe('date format', () => {
     expect(dateGranularity(parsed)).toBe(Granularity.WEEK);
   });
 
-  test.skip('parse - month granularity', () => {
+  test('parse - month granularity', () => {
     ['Feb', 'February'].forEach(date => {
       const parsed = dateFormat.parse(date);
       expect(parsed.utcOffset()).toBe(0);
@@ -291,7 +291,7 @@ describe('date format', () => {
     expect(dateGranularity(parsed)).toBe(Granularity.MONTH);
   });
 
-  test.skip('parse - year granularity', () => {
+  test('parse - year granularity', () => {
     const year = random.integer({ min: 1970, max: new Date().getFullYear() });
     [
       year.toString(),

--- a/src/components/search_bar/query/date_format.ts
+++ b/src/components/search_bar/query/date_format.ts
@@ -149,7 +149,7 @@ const parseWeek = (value: string) => {
       parsed = utc().add(1, 'weeks');
       break;
     default:
-      const match = value.match(/week ([0-9][0-9]?)/i);
+      const match = value.match(/week (\d+)/i);
       if (match) {
         const weekNr = Number(match[1]);
         parsed = utc().weeks(weekNr);

--- a/src/components/search_bar/query/date_format.ts
+++ b/src/components/search_bar/query/date_format.ts
@@ -149,7 +149,7 @@ const parseWeek = (value: string) => {
       parsed = utc().add(1, 'weeks');
       break;
     default:
-      const match = value.match(/week ([1-9][1-9]?)/i);
+      const match = value.match(/week ([0-9][0-9]?)/i);
       if (match) {
         const weekNr = Number(match[1]);
         parsed = utc().weeks(weekNr);


### PR DESCRIPTION
### Summary

Fixes: #634

Fixed week check, earlier for `week 0, 10, etc`  it was failing

### Screenshot

![Screenshot 2020-03-26 at 1 50 07 AM](https://user-images.githubusercontent.com/43617894/77581667-2173a200-6f04-11ea-8144-98ddd9d644b1.png)


### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
