### PR TITLE
[EuiNavDrawer] Fix scrolling in mobile view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Added `delimiter` prop to `EuiComboBox` ([#3104](https://github.com/elastic/eui/pull/3104))
 
+**Bug Fixes**
+
+- Fixed `EuiNavDrawer` scrolling issue on mobile ([#3174](https://github.com/elastic/eui/pull/3174))
+
 ## [`22.0.0`](https://github.com/elastic/eui/tree/v22.0.0)
 
 - Replaced various `lodash` functions with native functions ([#3053](https://github.com/elastic/eui/pull/3053))
@@ -20,7 +24,6 @@
 
 **Bug Fixes**
 
-- Fixed `EuiNavDrawer` not scrolling on mobile issue ([#3174](https://github.com/elastic/eui/pull/3174))
 - Fixed bug in `EuiSuperDatePicker` not showing correct values in relative tab of end date ([#3132](https://github.com/elastic/eui/pull/3132))
 - Fixed bug in `EuiSuperDatePicker` to show correct values of commonly used values in relative tab ([#3106](https://github.com/elastic/eui/pull/3106))
 - Fixed race condition in `EuiIcon` when switching from dynamically fetched components ([#3118](https://github.com/elastic/eui/pull/3118))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 **Bug Fixes**
 
+- Fixed `EuiNavDrawer` not scrolling on mobile issue ([#3174](https://github.com/elastic/eui/pull/3174))
 - Fixed bug in `EuiSuperDatePicker` not showing correct values in relative tab of end date ([#3132](https://github.com/elastic/eui/pull/3132))
 - Fixed bug in `EuiSuperDatePicker` to show correct values of commonly used values in relative tab ([#3106](https://github.com/elastic/eui/pull/3106))
 - Fixed race condition in `EuiIcon` when switching from dynamically fetched components ([#3118](https://github.com/elastic/eui/pull/3118))

--- a/src/components/nav_drawer/__snapshots__/nav_drawer.test.js.snap
+++ b/src/components/nav_drawer/__snapshots__/nav_drawer.test.js.snap
@@ -5,7 +5,7 @@ exports[`EuiNavDrawer is rendered 1`] = `
   class="euiNavDrawer euiNavDrawer-isCollapsed euiNavDrawer-flyoutIsCollapsed"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiFlexGroup euiFlexGroup--directionRow"
   >
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -266,7 +266,7 @@ exports[`EuiNavDrawer renders with falsy children 1`] = `
   class="euiNavDrawer euiNavDrawer-isCollapsed euiNavDrawer-flyoutIsCollapsed"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiFlexGroup euiFlexGroup--directionRow"
   >
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -473,7 +473,7 @@ exports[`EuiNavDrawer renders with fragments 1`] = `
   class="euiNavDrawer euiNavDrawer-isCollapsed euiNavDrawer-flyoutIsCollapsed"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiFlexGroup euiFlexGroup--directionRow"
   >
     <div
       class="euiFlexItem euiFlexItem--flexGrowZero"

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -94,6 +94,11 @@
 }
 
 @include euiBreakpoint('xs', 's') {
+  .euiNavDrawer > .euiFlexGroup--responsive {
+    flex-wrap: nowrap;
+    overflow-x: hidden;
+  }
+
   .euiNavDrawer {
     width: 0;
 

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -94,11 +94,6 @@
 }
 
 @include euiBreakpoint('xs', 's') {
-  .euiNavDrawer > .euiFlexGroup--responsive {
-    flex-wrap: nowrap;
-    overflow-x: hidden;
-  }
-
   .euiNavDrawer {
     width: 0;
 

--- a/src/components/nav_drawer/nav_drawer.js
+++ b/src/components/nav_drawer/nav_drawer.js
@@ -347,7 +347,7 @@ export class EuiNavDrawer extends Component {
         onOutsideClick={() => this.closeBoth()}
         isDisabled={this.state.outsideClickDisabled}>
         <nav className={classes} {...rest}>
-          <EuiFlexGroup gutterSize="none">
+          <EuiFlexGroup gutterSize="none" responsive={false}>
             <EuiFlexItem grow={false}>
               <div
                 id={MENU_ELEMENT_ID}


### PR DESCRIPTION
### Summary
#3143
NavDrawer didn't scroll in mobile view. Problem solved using respective css selectors to modify flex-wrap property.
![ezgif-4-261b86f08eb8](https://user-images.githubusercontent.com/26645152/77644420-30ffe480-6f1e-11ea-8466-49d4e5261aee.gif)


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately