### PR TITLE
Removed moz border on focus from EuiSelect

### DIFF
--- a/src/components/form/select/_select.scss
+++ b/src/components/form/select/_select.scss
@@ -38,4 +38,8 @@
     color: $euiTextColor;
     background: transparent;
   }
+  &:-moz-focusring {
+    color: transparent;
+    text-shadow: 0 0 0 #000;
+  }
 }


### PR DESCRIPTION
### Summary

Fixes #3171

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
