### PR TITLE
Add EuiCodeBlock showLineNumbers

### DIFF
--- a/src-docs/src/views/code/code_block.js
+++ b/src-docs/src/views/code/code_block.js
@@ -22,6 +22,7 @@ export default () => (
       paddingSize="m"
       color="dark"
       overflowHeight={300}
+      showLineNumbers
       isCopyable>
       {jsCode}
     </EuiCodeBlock>

--- a/src-docs/src/views/code/code_example.js
+++ b/src-docs/src/views/code/code_example.js
@@ -62,7 +62,8 @@ export const CodeExample = {
       text: (
         <p>
           <EuiCode>EuiCodeBlock</EuiCode> can be used to create multi-line code
-          blocks. <EuiCode>showLineNumbers</EuiCode> can be used to show the line numbers. Copy and fullscreen buttons can be enabled via the
+          blocks. <EuiCode>showLineNumbers</EuiCode> can be used to show the
+          line numbers. Copy and fullscreen buttons can be enabled via the
           <EuiCode>isCopyable</EuiCode> and <EuiCode>overflowHeight</EuiCode>
           props, respectively.
         </p>

--- a/src-docs/src/views/code/code_example.js
+++ b/src-docs/src/views/code/code_example.js
@@ -62,7 +62,7 @@ export const CodeExample = {
       text: (
         <p>
           <EuiCode>EuiCodeBlock</EuiCode> can be used to create multi-line code
-          blocks. Copy and fullscreen buttons can be enabled via the
+          blocks. <EuiCode>showLineNumbers</EuiCode> can be used to show the line numbers. Copy and fullscreen buttons can be enabled via the
           <EuiCode>isCopyable</EuiCode> and <EuiCode>overflowHeight</EuiCode>
           props, respectively.
         </p>

--- a/src/components/code/_code_block.scss
+++ b/src/components/code/_code_block.scss
@@ -51,6 +51,7 @@
     }
 
     .euiCodeBlock__lineNumbers {
+      // sass-lint:disable-block no-important
       margin: -$euiSizeXL !important;
       margin-right: $euiSizeXL !important;
     }
@@ -81,6 +82,7 @@
     .euiCodeBlock__pre {
       padding: $euiSizeS;
     }
+
     .euiCodeBlock__lineNumbers {
       margin: -$euiSizeS;
       margin-right: $euiSizeS;
@@ -101,6 +103,7 @@
     .euiCodeBlock__pre {
       padding: $euiSize;
     }
+
     .euiCodeBlock__lineNumbers {
       margin: -$euiSize;
       margin-right: $euiSize;
@@ -122,6 +125,7 @@
     .euiCodeBlock__pre {
       padding: $euiSizeL;
     }
+
     .euiCodeBlock__lineNumbers {
       margin: -$euiSizeL;
       margin-right: $euiSizeL;
@@ -285,23 +289,20 @@
 
 
 
-  .euiCodeBlock__lineNumbers{
+  .euiCodeBlock__lineNumbers {
     @include euiCodeFont;
     width: auto;
     padding: inherit;
     height: inherit;
-
     color: $euiTextColor;
-
     padding-left: 10px;
     padding-right: 6px;
-    
     line-height: $euiLineHeight;
     font-weight: $euiFontWeightRegular;
     user-select: none;
     text-align: right;
     font-size: inherit;
-    border-right:solid 1px $euiColorLightShade;
+    border-right: solid 1px $euiColorLightShade;
     opacity: .7;
   }
 

--- a/src/components/code/_code_block.scss
+++ b/src/components/code/_code_block.scss
@@ -8,7 +8,8 @@
     @include euiScrollBar;
     height: 100%;
     overflow: auto;
-    display: block;
+    display: flex;
+    position: relative;
   }
 
   .euiCodeBlock__pre--whiteSpacePre {
@@ -49,6 +50,11 @@
       padding: $euiSizeXL !important;
     }
 
+    .euiCodeBlock__lineNumbers {
+      margin: -$euiSizeXL !important;
+      margin-right: $euiSizeXL !important;
+    }
+
     .euiCodeBlock__controls {
       top: $euiSizeXS;
       right: $euiSizeXS;
@@ -75,6 +81,10 @@
     .euiCodeBlock__pre {
       padding: $euiSizeS;
     }
+    .euiCodeBlock__lineNumbers {
+      margin: -$euiSizeS;
+      margin-right: $euiSizeS;
+    }
 
     .euiCodeBlock__controls {
       top: $euiSizeS;
@@ -91,6 +101,11 @@
     .euiCodeBlock__pre {
       padding: $euiSize;
     }
+    .euiCodeBlock__lineNumbers {
+      margin: -$euiSize;
+      margin-right: $euiSize;
+    }
+
 
     .euiCodeBlock__controls {
       top: $euiSize;
@@ -107,6 +122,11 @@
     .euiCodeBlock__pre {
       padding: $euiSizeL;
     }
+    .euiCodeBlock__lineNumbers {
+      margin: -$euiSizeL;
+      margin-right: $euiSizeL;
+    }
+
 
     .euiCodeBlock__controls {
       top: $euiSizeL;
@@ -260,4 +280,29 @@
   .hljs-link {
     text-decoration: underline;
   }
+
+
+
+
+
+  .euiCodeBlock__lineNumbers{
+    @include euiCodeFont;
+    width: auto;
+    padding: inherit;
+    height: inherit;
+
+    color: $euiTextColor;
+
+    padding-left: 10px;
+    padding-right: 6px;
+    
+    line-height: $euiLineHeight;
+    font-weight: $euiFontWeightRegular;
+    user-select: none;
+    text-align: right;
+    font-size: inherit;
+    border-right:solid 1px $euiColorLightShade;
+    opacity: .7;
+  }
+
 }

--- a/src/components/code/_code_block.tsx
+++ b/src/components/code/_code_block.tsx
@@ -61,6 +61,11 @@ interface Props {
    * `pre-wrap` respects line breaks/white space but does force them to wrap the line when necessary.
    */
   whiteSpace?: 'pre' | 'pre-wrap';
+
+  /**
+   * Specifies whether to show line numbers or not.
+   */ 
+  showLineNumbers?: boolean;
 }
 
 interface State {
@@ -77,7 +82,7 @@ export class EuiCodeBlockImpl extends Component<Props, State> {
     paddingSize: 'l',
     fontSize: 's',
     isCopyable: false,
-    whiteSpace: 'pre-wrap',
+    whiteSpace: 'pre-wrap'
   };
 
   constructor(props: Props) {
@@ -160,8 +165,10 @@ export class EuiCodeBlockImpl extends Component<Props, State> {
       transparentBackground,
       isCopyable,
       whiteSpace,
+      showLineNumbers,
       ...otherProps
     } = this.props;
+
 
     const classes = classNames(
       'euiCodeBlock',
@@ -171,6 +178,7 @@ export class EuiCodeBlockImpl extends Component<Props, State> {
         'euiCodeBlock--transparentBackground': transparentBackground,
         'euiCodeBlock--inline': inline,
         'euiCodeBlock--hasControls': isCopyable || overflowHeight,
+        'euiCodeBlock--lineNumbers': showLineNumbers
       },
       className
     );
@@ -197,6 +205,7 @@ export class EuiCodeBlockImpl extends Component<Props, State> {
         {...otherProps}
       />
     );
+
 
     const wrapperProps = {
       className: classes,
@@ -320,20 +329,46 @@ export class EuiCodeBlockImpl extends Component<Props, State> {
       return fullScreenDisplay;
     };
 
+    const getLineNumbers = () => {
+      const numLines = this.code ? this.code.innerHTML.trim().split(/\r\n|\r|\n/).length : 0;
+      const lines = [];
+
+      for(let i=1; i<=numLines; i++){
+        lines.push(
+          <li key={i} ><span>{i}</span></li>
+        )
+      }
+
+      return (
+        <div className="euiCodeBlock__lineNumbers">
+          <ul>
+            {lines}
+          </ul>
+        </div>
+      )
+    }
+
+
     return (
       <>
         {createPortal(children, this.codeTarget)}
         <EuiInnerText fallback="">
           {(innerTextRef, innerText) => {
             const codeBlockControls = getCodeBlockControls(innerText);
+            const lineNumbers = showLineNumbers ? getLineNumbers() : "";
+            
             return (
               <div {...wrapperProps}>
+                
+
                 <pre
                   ref={innerTextRef}
                   style={optionalStyles}
                   className={preClasses}>
+                  {lineNumbers}
                   {codeSnippet}
                 </pre>
+                  
 
                 {/*
                 If the below fullScreen code renders, it actually attaches to the body because of

--- a/src/components/code/_code_block.tsx
+++ b/src/components/code/_code_block.tsx
@@ -64,7 +64,7 @@ interface Props {
 
   /**
    * Specifies whether to show line numbers or not.
-   */ 
+   */
   showLineNumbers?: boolean;
 }
 
@@ -82,7 +82,7 @@ export class EuiCodeBlockImpl extends Component<Props, State> {
     paddingSize: 'l',
     fontSize: 's',
     isCopyable: false,
-    whiteSpace: 'pre-wrap'
+    whiteSpace: 'pre-wrap',
   };
 
   constructor(props: Props) {
@@ -169,7 +169,6 @@ export class EuiCodeBlockImpl extends Component<Props, State> {
       ...otherProps
     } = this.props;
 
-
     const classes = classNames(
       'euiCodeBlock',
       fontSizeToClassNameMap[fontSize],
@@ -178,7 +177,7 @@ export class EuiCodeBlockImpl extends Component<Props, State> {
         'euiCodeBlock--transparentBackground': transparentBackground,
         'euiCodeBlock--inline': inline,
         'euiCodeBlock--hasControls': isCopyable || overflowHeight,
-        'euiCodeBlock--lineNumbers': showLineNumbers
+        'euiCodeBlock--lineNumbers': showLineNumbers,
       },
       className
     );
@@ -205,7 +204,6 @@ export class EuiCodeBlockImpl extends Component<Props, State> {
         {...otherProps}
       />
     );
-
 
     const wrapperProps = {
       className: classes,
@@ -330,24 +328,25 @@ export class EuiCodeBlockImpl extends Component<Props, State> {
     };
 
     const getLineNumbers = () => {
-      const numLines = this.code ? this.code.innerHTML.trim().split(/\r\n|\r|\n/).length : 0;
+      const numLines = this.code
+        ? this.code.innerHTML.trim().split(/\r\n|\r|\n/).length
+        : 0;
       const lines = [];
 
-      for(let i=1; i<=numLines; i++){
+      for (let i = 1; i <= numLines; i++) {
         lines.push(
-          <li key={i} ><span>{i}</span></li>
-        )
+          <li key={i}>
+            <span>{i}</span>
+          </li>
+        );
       }
 
       return (
         <div className="euiCodeBlock__lineNumbers">
-          <ul>
-            {lines}
-          </ul>
+          <ul>{lines}</ul>
         </div>
-      )
-    }
-
+      );
+    };
 
     return (
       <>
@@ -355,12 +354,10 @@ export class EuiCodeBlockImpl extends Component<Props, State> {
         <EuiInnerText fallback="">
           {(innerTextRef, innerText) => {
             const codeBlockControls = getCodeBlockControls(innerText);
-            const lineNumbers = showLineNumbers ? getLineNumbers() : "";
-            
+            const lineNumbers = showLineNumbers ? getLineNumbers() : '';
+
             return (
               <div {...wrapperProps}>
-                
-
                 <pre
                   ref={innerTextRef}
                   style={optionalStyles}
@@ -368,7 +365,6 @@ export class EuiCodeBlockImpl extends Component<Props, State> {
                   {lineNumbers}
                   {codeSnippet}
                 </pre>
-                  
 
                 {/*
                 If the below fullScreen code renders, it actually attaches to the body because of

--- a/src/components/code/code_block.tsx
+++ b/src/components/code/code_block.tsx
@@ -18,5 +18,11 @@ export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
   showLineNumbers,
   ...rest
 }) => {
-  return <EuiCodeBlockImpl inline={false} showLineNumbers={showLineNumbers} {...rest} />;
+  return (
+    <EuiCodeBlockImpl
+      inline={false}
+      showLineNumbers={showLineNumbers}
+      {...rest}
+    />
+  );
 };

--- a/src/components/code/code_block.tsx
+++ b/src/components/code/code_block.tsx
@@ -6,6 +6,7 @@ import { EuiCodeSharedProps } from './code';
 
 interface OwnProps extends EuiCodeSharedProps {
   inline?: false;
+  showLineNumbers?: false;
 }
 
 export type EuiCodeBlockProps = CommonProps &
@@ -14,7 +15,8 @@ export type EuiCodeBlockProps = CommonProps &
 
 export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
   inline,
+  showLineNumbers,
   ...rest
 }) => {
-  return <EuiCodeBlockImpl inline={false} {...rest} />;
+  return <EuiCodeBlockImpl inline={false} showLineNumbers={showLineNumbers} {...rest} />;
 };


### PR DESCRIPTION
### Summary

Issue #3140 

EuiCodeBlock does not show line numbers, neither it has an option to enable it.
I added showLineNumbers prop to show/hide line numbers.

There is just one little bug in there right now (not working well with code block having wrapping enabled), no need to approve it.

Had to create a pull request for GSoC, so this is just now as a reference. Will be working soon solve the issue.
 
