### PR TITLE
Fix EuiPopover arrow position in Android and Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Improved edge case for EuiPopover arrow subpixel rendering bug ([#3188](https://github.com/elastic/eui/pull/3188))
 - Improved `htmlIdGenerator` when supplying both `prefix` and `suffix` ([#3076](https://github.com/elastic/eui/pull/3076))
 
 ## [`22.2.0`](https://github.com/elastic/eui/tree/v22.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Improved edge case for `EuiPopover` arrow subpixel rendering bug ([#3188](https://github.com/elastic/eui/pull/3188))
+- Fixed `EuiPopover` arrow position in Android and Linux ([#3188](https://github.com/elastic/eui/pull/3188))
 - Improved `htmlIdGenerator` when supplying both `prefix` and `suffix` ([#3076](https://github.com/elastic/eui/pull/3076))
 
 ## [`22.2.0`](https://github.com/elastic/eui/tree/v22.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Improved edge case for EuiPopover arrow subpixel rendering bug ([#3188](https://github.com/elastic/eui/pull/3188))
+- Improved edge case for `EuiPopover` arrow subpixel rendering bug ([#3188](https://github.com/elastic/eui/pull/3188))
 - Improved `htmlIdGenerator` when supplying both `prefix` and `suffix` ([#3076](https://github.com/elastic/eui/pull/3076))
 
 ## [`22.2.0`](https://github.com/elastic/eui/tree/v22.2.0)

--- a/src/components/popover/_popover.scss
+++ b/src/components/popover/_popover.scss
@@ -74,14 +74,14 @@
 
     &.euiPopover__panelArrow--top {
       &:before {
-        bottom: -$euiPopoverArrowSize + 1;
+        bottom: -$euiPopoverArrowSize + 2;
         border-left: $euiPopoverArrowSize solid transparent;
         border-right: $euiPopoverArrowSize solid transparent;
         border-top: $euiPopoverArrowSize solid $euiBorderColor;
       }
 
       &:after {
-        bottom: -$euiPopoverArrowSize + 2;
+        bottom: -$euiPopoverArrowSize + 3;
         border-left: $euiPopoverArrowSize solid transparent;
         border-right: $euiPopoverArrowSize solid transparent;
         border-top: $euiPopoverArrowSize solid $euiColorEmptyShade;


### PR DESCRIPTION
## TLDR;

### Before
![Screenshot_20200329_105112](https://user-images.githubusercontent.com/15232461/77852188-40479200-71ab-11ea-9f4a-053d5560b2cb.png)

### After
![Screenshot_20200329_105107](https://user-images.githubusercontent.com/15232461/77852192-4473af80-71ab-11ea-8022-2f4684e747ba.png)

This is a one-pixel offset change.

### Summary

So I noticed that some of the chevrons (i.e. arrows) on the popovers on the [BasicTables](https://elastic.github.io/eui/#/tabular-content/tables) component had a dark line between the arrow and the box:

without dark line:
<img src="https://user-images.githubusercontent.com/15232461/77852026-628ce000-71aa-11ea-81f8-2a116803f680.png" height="300" />

with dark line:
<img src="https://user-images.githubusercontent.com/15232461/77852034-6a4c8480-71aa-11ea-98fc-cc323a5a7a12.png" height="300" />

I noticed that this happens repeatably for the same components on the same page (at the same zoom level), as well as that which popovers on the page do it changes if I adjust my browser zoom.  This suggests it's just a subpixel thingy, as I like to call them.

To help illustrate: we can move the arrow down to exaggerate the effect:
![Screenshot_20200327_155107](https://user-images.githubusercontent.com/15232461/77852128-e050eb80-71aa-11ea-8596-294c64e025c6.png)

Or we can move it up _too far_:
![Screenshot_20200327_155059](https://user-images.githubusercontent.com/15232461/77852134-e646cc80-71aa-11ea-9d0f-f0bfeae33095.png)

It seemed like, in this case, all that was needed was _one more pixel_.  And it's in better shape now.

I checked all of the positions in 3 different zoom levels and (on my machine, running chrome) they all seemed to work now.  Just to be sure there wasn't anything I missed with the background of the popover and the background of the page both being white I made sure to color the background for the tests.  I know the border is grey, but I can imagine why the bottom one might stand out more because of the bottom shadow, and also I found out that if you star at enough of these you start to imagine the line being there when it isn't thanks to the [hermann grid illusion](https://www.illusionsindex.org/i/hermann-grid), haha.

<img src="https://user-images.githubusercontent.com/15232461/77852220-63724180-71ab-11ea-9e67-b7db77f659a1.png" height="100" />


### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
