### PR TITLE
Focus trap requires two clicks when focus is on EuiSelect

### DIFF
--- a/src/components/form/select/select.tsx
+++ b/src/components/form/select/select.tsx
@@ -71,7 +71,7 @@ export const EuiSelect: FunctionComponent<EuiSelectProps> = ({
     // notably for use in conjunction with EuiOutsideClickDetector.
     // See https://github.com/elastic/eui/pull/1926 for full discussion on
     // rationale and alternatives should this intervention become problematic.
-    e.nativeEvent.stopImmediatePropagation();
+    e.nativeEvent.stopPropagation();
     if (onMouseUp) onMouseUp(e);
   };
 


### PR DESCRIPTION
### Summary

Possible Fix for #3172 

This issue was due to `stopImmediatePropagation` that prevents any parent handlers and also any other handlers from executing. So the closePopover was not executed. The possible fix was to use `stopPropogation` instead of `stopImmediatePropagation` so that only the parent handlers are prevented.
This fixes the issue in firefox and chrome but doesn't fix the issue in safari. This behavior is better than the current behavior.

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
- [ ] Checked for **breaking changes** and labeled appropriately
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
