### PR TITLE
Pass title and aria attributes to `EuiToken`'s icon element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Improved `htmlIdGenerator` when supplying both `prefix` and `suffix` ([#3076](https://github.com/elastic/eui/pull/3076))
 - Updated pagination prop descriptions for `EuiInMemoryTable` ([#3142](https://github.com/elastic/eui/pull/3142))
-- Added title and aria attributes to `EuiToken`'s icon element ([#3195](https://github.com/elastic/eui/pull/3195))
+- Added `title` and `aria` attributes to `EuiToken`'s icon element ([#3195](https://github.com/elastic/eui/pull/3195))
 
 ## [`22.2.0`](https://github.com/elastic/eui/tree/v22.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Improved `htmlIdGenerator` when supplying both `prefix` and `suffix` ([#3076](https://github.com/elastic/eui/pull/3076))
+- Added title and aria attributes to `EuiToken`'s icon element ([#3195](https://github.com/elastic/eui/pull/3195)) 
 
 ## [`22.2.0`](https://github.com/elastic/eui/tree/v22.2.0)
 
@@ -10,7 +11,6 @@
 
 - Fixed EuiBasicTable proptypes of itemId ([#3133](https://github.com/elastic/eui/pull/3133))
 - Updated `EuiSuperDatePicker` to inherit the selected value in quick select ([#3105](https://github.com/elastic/eui/pull/3105))
-- Pass title and aria attributes to `EuiToken`'s icon element ([#3195](https://github.com/elastic/eui/pull/3195)) 
 
 ### Feature: EuiCollapsibleNav ([#3019](https://github.com/elastic/eui/pull/3019))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed EuiBasicTable proptypes of itemId ([#3133](https://github.com/elastic/eui/pull/3133))
 - Updated `EuiSuperDatePicker` to inherit the selected value in quick select ([#3105](https://github.com/elastic/eui/pull/3105))
+- Pass title and aria attributes to `EuiToken`'s icon element ([#3195](https://github.com/elastic/eui/pull/3195)) 
 
 ### Feature: EuiCollapsibleNav ([#3019](https://github.com/elastic/eui/pull/3019))
 

--- a/src/components/token/__snapshots__/token.test.tsx.snap
+++ b/src/components/token/__snapshots__/token.test.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`EuiToken is rendered 1`] = `
 <span
-  aria-label="aria-label"
   class="euiToken euiToken--gray euiToken--circle euiToken--light euiToken--small testClass1 testClass2"
   data-test-subj="test subject string"
 >
   <div
+    aria-label="aria-label"
     data-euiicon-type="dot"
   />
 </span>

--- a/src/components/token/token.tsx
+++ b/src/components/token/token.tsx
@@ -90,7 +90,7 @@ export interface TokenProps {
    */
   size?: TokenSize;
   /**
-   * What would typically be the icon's title. Required for accessibility.
+   * The icon's title. Required for accessibility
    */
   title?: string;
   'aria-label'?: string;

--- a/src/components/token/token.tsx
+++ b/src/components/token/token.tsx
@@ -89,6 +89,13 @@ export interface TokenProps {
    * Size of the token
    */
   size?: TokenSize;
+  /**
+   * What would typically be the icon's title. Required for accessibility.
+   */
+  title?: string;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+  'aria-describedby'?: string;
 }
 
 export type EuiTokenProps = CommonProps &
@@ -103,6 +110,10 @@ export const EuiToken: FunctionComponent<EuiTokenProps> = ({
   size = 's',
   style = {},
   className,
+  title,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledby,
+  'aria-describedby': ariaDescribedby,
   ...rest
 }) => {
   // Set the icon size to the same as the passed size
@@ -171,7 +182,14 @@ export const EuiToken: FunctionComponent<EuiTokenProps> = ({
 
   return (
     <span className={classes} style={style} {...rest}>
-      <EuiIcon type={iconType} size={finalSize} />
+      <EuiIcon
+        type={iconType}
+        size={finalSize}
+        title={title}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledby}
+        aria-describedby={ariaDescribedby}
+      />
     </span>
   );
 };


### PR DESCRIPTION
### Summary

#3182
aria-label, aria-labelledby, aria-describedby, title is now added to EuiToken

### Checklist

~~Check against **all themes** for compatibility in both light and dark modes
~~Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [x] Props have proper **autodocs**
~~Added **documentation** examples~~
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
