### PR TITLE
Removed moz border on focus from EuiSelect.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Bug Fixes**
 
+- Fixed `outline of select box` appearing `in moz on focus` in EuiSelect
 - Fixed EuiBasicTable proptypes of itemId ([#3133](https://github.com/elastic/eui/pull/3133))
 - Updated `EuiSuperDatePicker` to inherit the selected value in quick select ([#3105](https://github.com/elastic/eui/pull/3105))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 **Bug Fixes**
 
-- Fixed `outline of select box` appearing `in moz on focus` in EuiSelect ([#3197] (https://github.com/elastic/eui/pull/3197))
+- Removed outline of `EuiSelect` in Firefox ([#3197] (https://github.com/elastic/eui/pull/3197))
 - Fixed EuiBasicTable proptypes of itemId ([#3133](https://github.com/elastic/eui/pull/3133))
 - Updated `EuiSuperDatePicker` to inherit the selected value in quick select ([#3105](https://github.com/elastic/eui/pull/3105))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 **Bug Fixes**
 
-- Fixed `outline of select box` appearing `in moz on focus` in EuiSelect
+- Fixed `outline of select box` appearing `in moz on focus` in EuiSelect ([#3197] (https://github.com/elastic/eui/pull/3197))
 - Fixed EuiBasicTable proptypes of itemId ([#3133](https://github.com/elastic/eui/pull/3133))
 - Updated `EuiSuperDatePicker` to inherit the selected value in quick select ([#3105](https://github.com/elastic/eui/pull/3105))
 

--- a/src/components/form/select/_select.scss
+++ b/src/components/form/select/_select.scss
@@ -40,8 +40,7 @@
   }
 
   &:-moz-focusring {
-        color: transparent;
-        text-shadow: 0 0 0 $euiTextColor;
-      }
-
+    color: transparent;
+    text-shadow: 0 0 0 $euiTextColor;
+  }
 }

--- a/src/components/form/select/_select.scss
+++ b/src/components/form/select/_select.scss
@@ -41,7 +41,7 @@
 
   &:-moz-focusring {
         color: transparent;
-        text-shadow: 0 0 0 $euiColorFullShade;
+        text-shadow: 0 0 0 $euiTextColor;
       }
 
 }

--- a/src/components/form/select/_select.scss
+++ b/src/components/form/select/_select.scss
@@ -38,4 +38,10 @@
     color: $euiTextColor;
     background: transparent;
   }
+
+  &:-moz-focusring {
+        color: transparent;
+        text-shadow: 0 0 0 $euiColorFullShade;
+      }
+
 }


### PR DESCRIPTION
<h1>Description</h1>

Old - #3178

Fixes #3171 

GIF


![2-2](https://user-images.githubusercontent.com/52423075/77933320-47b28c80-72cc-11ea-9e2b-0b72176ba3a7.gif)




### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
