### PR TITLE
[DOCS] Converts multiple examples from class to functional components

### DIFF
--- a/src-docs/src/views/context_menu/content_panel.js
+++ b/src-docs/src/views/context_menu/content_panel.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import {
   EuiButton,
@@ -6,52 +6,38 @@ import {
   EuiPopover,
 } from '../../../../src/components';
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const [isPopoverOpen, setPopover] = useState(false);
 
-    this.interval = undefined;
-
-    this.state = {
-      isPopoverOpen: false,
-    };
-  }
-
-  onButtonClick = () => {
-    this.setState(prevState => ({
-      isPopoverOpen: !prevState.isPopoverOpen,
-    }));
+  const onButtonClick = () => {
+    setPopover(!isPopoverOpen);
   };
 
-  closePopover = () => {
-    this.setState({
-      isPopoverOpen: false,
-    });
+  const closePopover = () => {
+    setPopover(false);
   };
 
-  render() {
-    const button = (
-      <EuiButton
-        size="s"
-        iconType="arrowDown"
-        iconSide="right"
-        onClick={this.onButtonClick}>
-        Click to show some content
-      </EuiButton>
-    );
+  const button = (
+    <EuiButton
+      size="s"
+      iconType="arrowDown"
+      iconSide="right"
+      onClick={onButtonClick}>
+      Click to show some content
+    </EuiButton>
+  );
 
-    return (
-      <EuiPopover
-        id="contentPanel"
-        button={button}
-        isOpen={this.state.isPopoverOpen}
-        closePopover={this.closePopover}
-        panelPaddingSize="s"
-        anchorPosition="downLeft">
-        <EuiContextMenuPanel>
-          This context menu doesn&#39;t render items, it passes a child instead.
-        </EuiContextMenuPanel>
-      </EuiPopover>
-    );
-  }
-}
+  return (
+    <EuiPopover
+      id="contentPanel"
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      panelPaddingSize="s"
+      anchorPosition="downLeft">
+      <EuiContextMenuPanel>
+        This context menu doesn&#39;t render items, it passes a child instead.
+      </EuiContextMenuPanel>
+    </EuiPopover>
+  );
+};

--- a/src-docs/src/views/context_menu/context_menu.js
+++ b/src-docs/src/views/context_menu/context_menu.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import {
   EuiButton,
@@ -25,155 +25,140 @@ function flattenPanelTree(tree, array = []) {
   return array;
 }
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const [isPopoverOpen, setPopover] = useState(false);
 
-    this.state = {
-      isPopoverOpen: false,
-    };
-
-    const panelTree = {
-      id: 0,
-      title: 'This is a context menu',
-      items: [
-        {
-          name: 'Handle an onClick',
-          icon: <EuiIcon type="search" size="m" />,
-          onClick: () => {
-            this.closePopover();
-            window.alert('Show fullscreen');
-          },
-        },
-        {
-          name: 'Go to a link',
-          icon: 'user',
-          href: 'http://elastic.co',
-          target: '_blank',
-        },
-        {
-          name: 'Nest panels',
-          icon: 'user',
-          panel: {
-            id: 1,
-            title: 'Nest panels',
-            items: [
-              {
-                name: 'PDF reports',
-                icon: 'user',
-                onClick: () => {
-                  this.closePopover();
-                  window.alert('PDF reports');
-                },
-              },
-              {
-                name: 'Embed code',
-                icon: 'user',
-                panel: {
-                  id: 2,
-                  title: 'Embed code',
-                  content: (
-                    <div style={{ padding: 16 }}>
-                      <EuiFormRow
-                        label="Generate a public snapshot?"
-                        hasChildLabel={false}>
-                        <EuiSwitch
-                          name="switch"
-                          id="asdf"
-                          label="Snapshot data"
-                          checked={true}
-                          onChange={() => {}}
-                        />
-                      </EuiFormRow>
-                      <EuiFormRow
-                        label="Include the following in the embed"
-                        hasChildLabel={false}>
-                        <EuiSwitch
-                          name="switch"
-                          id="asdf2"
-                          label="Current time range"
-                          checked={true}
-                          onChange={() => {}}
-                        />
-                      </EuiFormRow>
-                      <EuiSpacer />
-                      <EuiButton fill>Copy iFrame code</EuiButton>
-                    </div>
-                  ),
-                },
-              },
-              {
-                name: 'Permalinks',
-                icon: 'user',
-                onClick: () => {
-                  this.closePopover();
-                  window.alert('Permalinks');
-                },
-              },
-            ],
-          },
-        },
-        {
-          name: 'You can add a tooltip',
-          icon: 'user',
-          toolTipTitle: 'Optional tooltip',
-          toolTipContent: 'Optional content for a tooltip',
-          toolTipPosition: 'right',
-          onClick: () => {
-            this.closePopover();
-            window.alert('Display options');
-          },
-        },
-        {
-          name: 'Disabled option',
-          icon: 'user',
-          toolTipContent: 'For reasons, this item is disabled',
-          toolTipPosition: 'right',
-          disabled: true,
-          onClick: () => {
-            this.closePopover();
-            window.alert('Disabled option');
-          },
-        },
-      ],
-    };
-
-    this.panels = flattenPanelTree(panelTree);
-  }
-
-  onButtonClick = () => {
-    this.setState(prevState => ({
-      isPopoverOpen: !prevState.isPopoverOpen,
-    }));
+  const onButtonClick = () => {
+    setPopover(!isPopoverOpen);
   };
 
-  closePopover = () => {
-    this.setState({
-      isPopoverOpen: false,
-    });
+  const closePopover = () => {
+    setPopover(false);
   };
 
-  render() {
-    const button = (
-      <EuiButton
-        iconType="arrowDown"
-        iconSide="right"
-        onClick={this.onButtonClick}>
-        Click me to load a context menu
-      </EuiButton>
-    );
+  const panelTree = {
+    id: 0,
+    title: 'This is a context menu',
+    items: [
+      {
+        name: 'Handle an onClick',
+        icon: <EuiIcon type="search" size="m" />,
+        onClick: () => {
+          closePopover();
+          window.alert('Show fullscreen');
+        },
+      },
+      {
+        name: 'Go to a link',
+        icon: 'user',
+        href: 'http://elastic.co',
+        target: '_blank',
+      },
+      {
+        name: 'Nest panels',
+        icon: 'user',
+        panel: {
+          id: 1,
+          title: 'Nest panels',
+          items: [
+            {
+              name: 'PDF reports',
+              icon: 'user',
+              onClick: () => {
+                closePopover();
+                window.alert('PDF reports');
+              },
+            },
+            {
+              name: 'Embed code',
+              icon: 'user',
+              panel: {
+                id: 2,
+                title: 'Embed code',
+                content: (
+                  <div style={{ padding: 16 }}>
+                    <EuiFormRow
+                      label="Generate a public snapshot?"
+                      hasChildLabel={false}>
+                      <EuiSwitch
+                        name="switch"
+                        id="asdf"
+                        label="Snapshot data"
+                        checked={true}
+                        onChange={() => {}}
+                      />
+                    </EuiFormRow>
+                    <EuiFormRow
+                      label="Include the following in the embed"
+                      hasChildLabel={false}>
+                      <EuiSwitch
+                        name="switch"
+                        id="asdf2"
+                        label="Current time range"
+                        checked={true}
+                        onChange={() => {}}
+                      />
+                    </EuiFormRow>
+                    <EuiSpacer />
+                    <EuiButton fill>Copy iFrame code</EuiButton>
+                  </div>
+                ),
+              },
+            },
+            {
+              name: 'Permalinks',
+              icon: 'user',
+              onClick: () => {
+                closePopover();
+                window.alert('Permalinks');
+              },
+            },
+          ],
+        },
+      },
+      {
+        name: 'You can add a tooltip',
+        icon: 'user',
+        toolTipTitle: 'Optional tooltip',
+        toolTipContent: 'Optional content for a tooltip',
+        toolTipPosition: 'right',
+        onClick: () => {
+          closePopover();
+          window.alert('Display options');
+        },
+      },
+      {
+        name: 'Disabled option',
+        icon: 'user',
+        toolTipContent: 'For reasons, this item is disabled',
+        toolTipPosition: 'right',
+        disabled: true,
+        onClick: () => {
+          closePopover();
+          window.alert('Disabled option');
+        },
+      },
+    ],
+  };
 
-    return (
-      <EuiPopover
-        id="contextMenuExample"
-        button={button}
-        isOpen={this.state.isPopoverOpen}
-        closePopover={this.closePopover}
-        panelPaddingSize="none"
-        withTitle
-        anchorPosition="downLeft">
-        <EuiContextMenu initialPanelId={0} panels={this.panels} />
-      </EuiPopover>
-    );
-  }
-}
+  const panels = flattenPanelTree(panelTree);
+
+  const button = (
+    <EuiButton iconType="arrowDown" iconSide="right" onClick={onButtonClick}>
+      Click me to load a context menu
+    </EuiButton>
+  );
+
+  return (
+    <EuiPopover
+      id="contextMenuExample"
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      panelPaddingSize="none"
+      withTitle
+      anchorPosition="downLeft">
+      <EuiContextMenu initialPanelId={0} panels={panels} />
+    </EuiPopover>
+  );
+};

--- a/src-docs/src/views/context_menu/context_menu_with_content.js
+++ b/src-docs/src/views/context_menu/context_menu_with_content.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import {
   EuiButton,
@@ -26,128 +26,110 @@ function flattenPanelTree(tree, array = []) {
   return array;
 }
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const [isPopoverOpen, setPopover] = useState(false);
+  const [isDynamicPopoverOpen, setDynamicPopover] = useState(false);
 
-    this.state = {
-      isPopoverOpen: false,
-    };
-
-    this.createPanelTree = Content => {
-      return flattenPanelTree({
-        id: 0,
-        title: 'View options',
-        items: [
-          {
-            name: 'Show fullscreen',
-            icon: <EuiIcon type="search" size="m" />,
-            onClick: () => {
-              this.closePopover();
-              window.alert('Show fullscreen');
-            },
-          },
-          {
-            name: 'See more',
-            icon: 'plusInCircle',
-            panel: {
-              id: 1,
-              width: 400,
-              title: 'See more',
-              content: <Content />,
-            },
-          },
-        ],
-      });
-    };
-
-    this.panels = this.createPanelTree(() => (
-      <EuiText style={{ padding: 24 }} textAlign="center">
-        <p>
-          <EuiIcon type="faceHappy" size="xxl" />
-        </p>
-
-        <h3>Context panels can contain anything</h3>
-        <p>
-          You can stuff just about anything into these panels. Be mindful of
-          size though. This panel is set to 400px and the height will grow as
-          space allows.
-        </p>
-      </EuiText>
-    ));
-
-    this.dynamicPanels = this.createPanelTree(EuiTabsExample);
-  }
-
-  onButtonClick = () => {
-    this.setState(prevState => ({
-      isPopoverOpen: !prevState.isPopoverOpen,
-    }));
+  const onButtonClick = () => {
+    setPopover(!isPopoverOpen);
   };
 
-  onDynamicButtonClick = () => {
-    this.setState(prevState => ({
-      isDynamicPopoverOpen: !prevState.isDynamicPopoverOpen,
-    }));
+  const closePopover = () => {
+    setPopover(false);
   };
 
-  closePopover = () => {
-    this.setState({
-      isPopoverOpen: false,
+  const onDynamicButtonClick = () => {
+    setDynamicPopover(!isDynamicPopoverOpen);
+  };
+
+  const closeDynamicPopover = () => {
+    setDynamicPopover(false);
+  };
+
+  const createPanelTree = Content => {
+    return flattenPanelTree({
+      id: 0,
+      title: 'View options',
+      items: [
+        {
+          name: 'Show fullscreen',
+          icon: <EuiIcon type="search" size="m" />,
+          onClick: () => {
+            closePopover();
+            window.alert('Show fullscreen');
+          },
+        },
+        {
+          name: 'See more',
+          icon: 'plusInCircle',
+          panel: {
+            id: 1,
+            width: 400,
+            title: 'See more',
+            content: <Content />,
+          },
+        },
+      ],
     });
   };
 
-  closeDynamicPopover = () => {
-    this.setState({
-      isDynamicPopoverOpen: false,
-    });
-  };
+  const panels = createPanelTree(() => (
+    <EuiText style={{ padding: 24 }} textAlign="center">
+      <p>
+        <EuiIcon type="faceHappy" size="xxl" />
+      </p>
 
-  render() {
-    const button = (
-      <EuiButton
-        iconType="arrowDown"
-        iconSide="right"
-        onClick={this.onButtonClick}>
-        Click me to load mixed content menu
-      </EuiButton>
-    );
+      <h3>Context panels can contain anything</h3>
+      <p>
+        You can stuff just about anything into these panels. Be mindful of size
+        though. This panel is set to 400px and the height will grow as space
+        allows.
+      </p>
+    </EuiText>
+  ));
 
-    const dynamicButton = (
-      <EuiButton
-        iconType="arrowDown"
-        iconSide="right"
-        onClick={this.onDynamicButtonClick}>
-        Click me to load dynamic mixed content menu
-      </EuiButton>
-    );
+  const dynamicPanels = createPanelTree(EuiTabsExample);
 
-    return (
-      <React.Fragment>
-        <EuiPopover
-          id="contextMenuNormal"
-          button={button}
-          isOpen={this.state.isPopoverOpen}
-          closePopover={this.closePopover}
-          panelPaddingSize="none"
-          withTitle
-          anchorPosition="upLeft">
-          <EuiContextMenu initialPanelId={0} panels={this.panels} />
-        </EuiPopover>
+  const button = (
+    <EuiButton iconType="arrowDown" iconSide="right" onClick={onButtonClick}>
+      Click me to load mixed content menu
+    </EuiButton>
+  );
 
-        <EuiSpacer size="l" />
+  const dynamicButton = (
+    <EuiButton
+      iconType="arrowDown"
+      iconSide="right"
+      onClick={onDynamicButtonClick}>
+      Click me to load dynamic mixed content menu
+    </EuiButton>
+  );
 
-        <EuiPopover
-          id="contextMenuDynamic"
-          button={dynamicButton}
-          isOpen={this.state.isDynamicPopoverOpen}
-          closePopover={this.closeDynamicPopover}
-          panelPaddingSize="none"
-          withTitle
-          anchorPosition="upLeft">
-          <EuiContextMenu initialPanelId={0} panels={this.dynamicPanels} />
-        </EuiPopover>
-      </React.Fragment>
-    );
-  }
-}
+  return (
+    <React.Fragment>
+      <EuiPopover
+        id="contextMenuNormal"
+        button={button}
+        isOpen={isPopoverOpen}
+        closePopover={closePopover}
+        panelPaddingSize="none"
+        withTitle
+        anchorPosition="upLeft">
+        <EuiContextMenu initialPanelId={0} panels={panels} />
+      </EuiPopover>
+
+      <EuiSpacer size="l" />
+
+      <EuiPopover
+        id="contextMenuDynamic"
+        button={dynamicButton}
+        isOpen={isDynamicPopoverOpen}
+        closePopover={closeDynamicPopover}
+        panelPaddingSize="none"
+        withTitle
+        anchorPosition="upLeft">
+        <EuiContextMenu initialPanelId={0} panels={dynamicPanels} />
+      </EuiPopover>
+    </React.Fragment>
+  );
+};

--- a/src-docs/src/views/context_menu/single_panel.js
+++ b/src-docs/src/views/context_menu/single_panel.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import {
   EuiButtonEmpty,
@@ -7,87 +7,75 @@ import {
   EuiPopover,
 } from '../../../../src/components';
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const [isPopoverOpen, setPopover] = useState(false);
 
-    this.state = {
-      isPopoverOpen: false,
-    };
-  }
-
-  onButtonClick = () => {
-    this.setState(prevState => ({
-      isPopoverOpen: !prevState.isPopoverOpen,
-    }));
+  const onButtonClick = () => {
+    setPopover(!isPopoverOpen);
   };
 
-  closePopover = () => {
-    this.setState({
-      isPopoverOpen: false,
-    });
+  const closePopover = () => {
+    setPopover(false);
   };
 
-  render() {
-    const button = (
-      <EuiButtonEmpty
-        size="s"
-        iconType="arrowDown"
-        iconSide="right"
-        onClick={this.onButtonClick}>
-        Rows per page: 50
-      </EuiButtonEmpty>
-    );
+  const button = (
+    <EuiButtonEmpty
+      size="s"
+      iconType="arrowDown"
+      iconSide="right"
+      onClick={onButtonClick}>
+      Rows per page: 50
+    </EuiButtonEmpty>
+  );
 
-    const items = [
-      <EuiContextMenuItem
-        key="10 rows"
-        icon="empty"
-        onClick={() => {
-          this.closePopover();
-          window.alert('10 rows');
-        }}>
-        10 rows
-      </EuiContextMenuItem>,
-      <EuiContextMenuItem
-        key="20 rows"
-        icon="empty"
-        onClick={() => {
-          this.closePopover();
-          window.alert('20 rows');
-        }}>
-        20 rows
-      </EuiContextMenuItem>,
-      <EuiContextMenuItem
-        key="50 rows"
-        icon="check"
-        onClick={() => {
-          this.closePopover();
-          window.alert('50 rows');
-        }}>
-        50 rows
-      </EuiContextMenuItem>,
-      <EuiContextMenuItem
-        key="100 rows"
-        icon="empty"
-        onClick={() => {
-          this.closePopover();
-          window.alert('100 rows');
-        }}>
-        100 rows
-      </EuiContextMenuItem>,
-    ];
+  const items = [
+    <EuiContextMenuItem
+      key="10 rows"
+      icon="empty"
+      onClick={() => {
+        closePopover();
+        window.alert('10 rows');
+      }}>
+      10 rows
+    </EuiContextMenuItem>,
+    <EuiContextMenuItem
+      key="20 rows"
+      icon="empty"
+      onClick={() => {
+        closePopover();
+        window.alert('20 rows');
+      }}>
+      20 rows
+    </EuiContextMenuItem>,
+    <EuiContextMenuItem
+      key="50 rows"
+      icon="check"
+      onClick={() => {
+        closePopover();
+        window.alert('50 rows');
+      }}>
+      50 rows
+    </EuiContextMenuItem>,
+    <EuiContextMenuItem
+      key="100 rows"
+      icon="empty"
+      onClick={() => {
+        closePopover();
+        window.alert('100 rows');
+      }}>
+      100 rows
+    </EuiContextMenuItem>,
+  ];
 
-    return (
-      <EuiPopover
-        id="singlePanel"
-        button={button}
-        isOpen={this.state.isPopoverOpen}
-        closePopover={this.closePopover}
-        panelPaddingSize="none"
-        anchorPosition="downLeft">
-        <EuiContextMenuPanel items={items} />
-      </EuiPopover>
-    );
-  }
-}
+  return (
+    <EuiPopover
+      id="singlePanel"
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      panelPaddingSize="none"
+      anchorPosition="downLeft">
+      <EuiContextMenuPanel items={items} />
+    </EuiPopover>
+  );
+};

--- a/src-docs/src/views/control_bar/control_bar.js
+++ b/src-docs/src/views/control_bar/control_bar.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import {
   EuiButton,
@@ -8,173 +8,156 @@ import {
 } from '../../../../src/components';
 import { keyCodes } from '../../../../src/services';
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      contentIsVisible: false,
-      isDisplaying: false,
-    };
-  }
+export default () => {
+  const [contentIsVisible, setVisibility] = useState(false);
+  const [isDisplaying, setDisplay] = useState(false);
 
-  toggleContent = () => {
-    this.setState(prevState => ({
-      contentIsVisible: !prevState.contentIsVisible,
-    }));
+  const toggleContent = () => {
+    setVisibility(!contentIsVisible);
   };
 
-  toggleDisplay = () => {
-    this.setState(prevState => ({
-      isDisplaying: !prevState.isDisplaying,
-      contentIsVisible: false,
-    }));
+  const toggleDisplay = () => {
+    setDisplay(!isDisplaying);
+    setVisibility(false);
   };
 
-  onKeyDown = event => {
+  const onKeyDown = event => {
     if (event.keyCode === keyCodes.ESCAPE) {
       event.preventDefault();
       event.stopPropagation();
-      this.setState({
-        isDisplaying: false,
-        contentIsVisible: false,
-      });
+      setDisplay(false);
+      setVisibility(false);
     }
   };
 
-  render() {
-    const codeControls = [
-      {
-        controlType: 'icon',
-        id: 'root_icon',
-        iconType: 'submodule',
-        'aria-label': 'Project Root',
-      },
-      {
-        controlType: 'breadcrumbs',
-        id: 'current_file_path',
-        responsive: true,
-        breadcrumbs: [
-          {
-            text: 'src',
-          },
-          {
-            text: 'components',
-          },
-        ],
-      },
-      {
-        controlType: 'spacer',
-      },
-      {
-        controlType: 'icon',
-        id: 'status_icon',
-        iconType: 'alert',
-        color: 'warning',
-        'aria-label': 'Repo Status',
-      },
-      {
-        controlType: 'divider',
-      },
-      {
-        controlType: 'icon',
-        id: 'branch_icon',
-        iconType: 'branch',
-        'aria-label': 'Branch Icon',
-      },
-      {
-        controlType: 'text',
-        id: 'branch_name',
-        text: 'some_long_branch',
-      },
-      {
-        controlType: 'divider',
-      },
-      {
-        controlType: 'icon',
-        id: 'github_icon',
-        iconType: 'logoGithub',
-        onClick: () => {},
-        title: 'Open in Github',
-        'aria-label': 'Open in Github',
-      },
-      {
-        controlType: 'divider',
-      },
-      {
-        controlType: 'button',
-        id: 'open_history_view',
-        label: this.state.contentIsVisible ? 'Hide history' : 'Show history',
-        color: 'primary',
-        onClick: this.toggleContent,
-      },
-    ];
+  const codeControls = [
+    {
+      controlType: 'icon',
+      id: 'root_icon',
+      iconType: 'submodule',
+      'aria-label': 'Project Root',
+    },
+    {
+      controlType: 'breadcrumbs',
+      id: 'current_file_path',
+      responsive: true,
+      breadcrumbs: [
+        {
+          text: 'src',
+        },
+        {
+          text: 'components',
+        },
+      ],
+    },
+    {
+      controlType: 'spacer',
+    },
+    {
+      controlType: 'icon',
+      id: 'status_icon',
+      iconType: 'alert',
+      color: 'warning',
+      'aria-label': 'Repo Status',
+    },
+    {
+      controlType: 'divider',
+    },
+    {
+      controlType: 'icon',
+      id: 'branch_icon',
+      iconType: 'branch',
+      'aria-label': 'Branch Icon',
+    },
+    {
+      controlType: 'text',
+      id: 'branch_name',
+      text: 'some_long_branch',
+    },
+    {
+      controlType: 'divider',
+    },
+    {
+      controlType: 'icon',
+      id: 'github_icon',
+      iconType: 'logoGithub',
+      onClick: () => {},
+      title: 'Open in Github',
+      'aria-label': 'Open in Github',
+    },
+    {
+      controlType: 'divider',
+    },
+    {
+      controlType: 'button',
+      id: 'open_history_view',
+      label: contentIsVisible ? 'Hide history' : 'Show history',
+      color: 'primary',
+      onClick: toggleContent,
+    },
+  ];
 
-    let display;
+  let display;
 
-    if (this.state.isDisplaying) {
-      display = (
-        <EuiControlBar
-          controls={codeControls}
-          showContent={this.state.contentIsVisible}>
-          <div style={{ padding: '2rem', maxWidth: '60rem', margin: '0 auto' }}>
-            <EuiPanel>
-              <EuiText>
-                <h1>1984</h1>
-                <h3>By: George Orwell</h3>
-                <p>
-                  It was a bright cold day in April, and the clocks were
-                  striking thirteen. Winston Smith, his chin nuzzled into his
-                  breast in an effort to escape the vile wind, slipped quickly
-                  through the glass doors of Victory Mansions, though not
-                  quickly enough to prevent a swirl of gritty dust from entering
-                  along with him.
-                </p>
-                <p>
-                  The hallway smelt of boiled cabbage and old rag mats. At one
-                  end of it a coloured poster, too large for indoor display, had
-                  been tacked to the wall. It depicted simply an enormous face,
-                  more than a metre wide: the face of a man of about forty-five,
-                  with a heavy black moustache and ruggedly handsome features.
-                  Winston made for the stairs. It was no use trying the lift.
-                  Even at the best of times it was seldom working, and at
-                  present the electric current was cut off during daylight
-                  hours. It was part of the economy drive in preparation for
-                  Hate Week. The flat was seven flights up, and Winston, who was
-                  thirty-nine and had a varicose ulcer above his right ankle,
-                  went slowly, resting several times on the way. On each
-                  landing, opposite the lift-shaft, the poster with the enormous
-                  face gazed from the wall. It was one of those pictures which
-                  are so contrived that the eyes follow you about when you move.
-                  BIG BROTHER IS WATCHING YOU, the caption beneath it ran.
-                </p>
-                <p>
-                  Inside the flat a fruity voice was reading out a list of
-                  figures which had something to do with the production of
-                  pig-iron. The voice came from an oblong metal plaque like a
-                  dulled mirror which formed part of the surface of the
-                  right-hand wall. Winston turned a switch and the voice sank
-                  somewhat, though the words were still distinguishable. The
-                  instrument (the telescreen, it was called) could be dimmed,
-                  but there was no way of shutting it off completely. He moved
-                  over to the window: a smallish, frail figure, the meagreness
-                  of his body merely emphasized by the blue overalls which were
-                  the uniform of the party. His hair was very fair, his face
-                  naturally sanguine, his skin roughened by coarse soap and
-                  blunt razor blades and the cold of the winter that had just
-                  ended.
-                </p>
-              </EuiText>
-            </EuiPanel>
-          </div>
-        </EuiControlBar>
-      );
-    }
-
-    return (
-      <div>
-        <EuiButton onClick={this.toggleDisplay}>Toggle example</EuiButton>
-        {display}
-      </div>
+  if (isDisplaying) {
+    display = (
+      <EuiControlBar controls={codeControls} showContent={contentIsVisible}>
+        <div style={{ padding: '2rem', maxWidth: '60rem', margin: '0 auto' }}>
+          <EuiPanel>
+            <EuiText>
+              <h1>1984</h1>
+              <h3>By: George Orwell</h3>
+              <p>
+                It was a bright cold day in April, and the clocks were striking
+                thirteen. Winston Smith, his chin nuzzled into his breast in an
+                effort to escape the vile wind, slipped quickly through the
+                glass doors of Victory Mansions, though not quickly enough to
+                prevent a swirl of gritty dust from entering along with him.
+              </p>
+              <p>
+                The hallway smelt of boiled cabbage and old rag mats. At one end
+                of it a coloured poster, too large for indoor display, had been
+                tacked to the wall. It depicted simply an enormous face, more
+                than a metre wide: the face of a man of about forty-five, with a
+                heavy black moustache and ruggedly handsome features. Winston
+                made for the stairs. It was no use trying the lift. Even at the
+                best of times it was seldom working, and at present the electric
+                current was cut off during daylight hours. It was part of the
+                economy drive in preparation for Hate Week. The flat was seven
+                flights up, and Winston, who was thirty-nine and had a varicose
+                ulcer above his right ankle, went slowly, resting several times
+                on the way. On each landing, opposite the lift-shaft, the poster
+                with the enormous face gazed from the wall. It was one of those
+                pictures which are so contrived that the eyes follow you about
+                when you move. BIG BROTHER IS WATCHING YOU, the caption beneath
+                it ran.
+              </p>
+              <p>
+                Inside the flat a fruity voice was reading out a list of figures
+                which had something to do with the production of pig-iron. The
+                voice came from an oblong metal plaque like a dulled mirror
+                which formed part of the surface of the right-hand wall. Winston
+                turned a switch and the voice sank somewhat, though the words
+                were still distinguishable. The instrument (the telescreen, it
+                was called) could be dimmed, but there was no way of shutting it
+                off completely. He moved over to the window: a smallish, frail
+                figure, the meagreness of his body merely emphasized by the blue
+                overalls which were the uniform of the party. His hair was very
+                fair, his face naturally sanguine, his skin roughened by coarse
+                soap and blunt razor blades and the cold of the winter that had
+                just ended.
+              </p>
+            </EuiText>
+          </EuiPanel>
+        </div>
+      </EuiControlBar>
     );
   }
-}
+
+  return (
+    <div>
+      <EuiButton onClick={toggleDisplay}>Toggle example</EuiButton>
+      {display}
+    </div>
+  );
+};

--- a/src-docs/src/views/control_bar/control_bar.js
+++ b/src-docs/src/views/control_bar/control_bar.js
@@ -6,7 +6,6 @@ import {
   EuiPanel,
   EuiText,
 } from '../../../../src/components';
-import { keyCodes } from '../../../../src/services';
 
 export default () => {
   const [contentIsVisible, setVisibility] = useState(false);
@@ -19,15 +18,6 @@ export default () => {
   const toggleDisplay = () => {
     setDisplay(!isDisplaying);
     setVisibility(false);
-  };
-
-  const onKeyDown = event => {
-    if (event.keyCode === keyCodes.ESCAPE) {
-      event.preventDefault();
-      event.stopPropagation();
-      setDisplay(false);
-      setVisibility(false);
-    }
   };
 
   const codeControls = [

--- a/src-docs/src/views/control_bar/control_bar_example.js
+++ b/src-docs/src/views/control_bar/control_bar_example.js
@@ -19,9 +19,9 @@ import { renderToHtml } from '../../services';
 import { GuideSectionTypes } from '../../components';
 
 import ControlBar from './control_bar';
-import { Controls } from './controls';
-import { ControlBarWithTabs } from './tabs';
-import { ControlBarMobile } from './mobile';
+import Controls from './controls';
+import ControlBarWithTabs from './tabs';
+import ControlBarMobile from './mobile';
 
 const controlsSource = require('!!raw-loader!./controls');
 const controlsHtml = renderToHtml(Controls);

--- a/src-docs/src/views/control_bar/controls.js
+++ b/src-docs/src/views/control_bar/controls.js
@@ -1,86 +1,79 @@
 import React from 'react';
 
 import { EuiControlBar, EuiLink } from '../../../../src/components';
-export class Controls extends React.Component {
-  constructor(props) {
-    super(props);
-  }
 
-  soundTheAlarms = () => {
+export default () => {
+  const soundTheAlarms = () => {
     alert('You clicked a button!');
   };
 
-  render() {
-    const controls = [
-      {
-        controlType: 'button',
-        id: 'controls_button',
-        label: 'Button',
-        onClick: this.soundTheAlarms,
-      },
-      {
-        controlType: 'spacer',
-      },
-      {
-        controlType: 'icon',
-        id: 'controls_icon',
-        iconType: 'flag',
-      },
-      {
-        controlType: 'divider',
-      },
-      {
-        controlType: 'icon',
-        id: 'controls_icon_button',
-        iconType: 'bell',
-        onClick: this.soundTheAlarms,
-        color: 'primary',
-        'aria-label': 'Bell',
-      },
-      {
-        controlType: 'divider',
-      },
-      {
-        controlType: 'text',
-        id: 'controls_text',
-        text: 'Some text',
-      },
-      {
-        controlType: 'divider',
-      },
-      {
-        controlType: 'tab',
-        id: 'controls_tab',
-        label: 'Tab',
-        onClick: () => {},
-      },
-      {
-        controlType: 'divider',
-      },
-      {
-        controlType: 'text',
-        id: 'some_text',
-        text: <EuiLink>A sample link</EuiLink>,
-      },
-      {
-        controlType: 'spacer',
-      },
-      {
-        controlType: 'breadcrumbs',
-        id: 'controls_breadcrumbs',
-        breadcrumbs: [
-          {
-            text: 'Breadcrumbs',
-          },
-          {
-            text: 'Item',
-          },
-        ],
-      },
-    ];
+  const controls = [
+    {
+      controlType: 'button',
+      id: 'controls_button',
+      label: 'Button',
+      onClick: soundTheAlarms,
+    },
+    {
+      controlType: 'spacer',
+    },
+    {
+      controlType: 'icon',
+      id: 'controls_icon',
+      iconType: 'flag',
+    },
+    {
+      controlType: 'divider',
+    },
+    {
+      controlType: 'icon',
+      id: 'controls_icon_button',
+      iconType: 'bell',
+      onClick: soundTheAlarms,
+      color: 'primary',
+      'aria-label': 'Bell',
+    },
+    {
+      controlType: 'divider',
+    },
+    {
+      controlType: 'text',
+      id: 'controls_text',
+      text: 'Some text',
+    },
+    {
+      controlType: 'divider',
+    },
+    {
+      controlType: 'tab',
+      id: 'controls_tab',
+      label: 'Tab',
+      onClick: () => {},
+    },
+    {
+      controlType: 'divider',
+    },
+    {
+      controlType: 'text',
+      id: 'some_text',
+      text: <EuiLink>A sample link</EuiLink>,
+    },
+    {
+      controlType: 'spacer',
+    },
+    {
+      controlType: 'breadcrumbs',
+      id: 'controls_breadcrumbs',
+      breadcrumbs: [
+        {
+          text: 'Breadcrumbs',
+        },
+        {
+          text: 'Item',
+        },
+      ],
+    },
+  ];
 
-    return (
-      <EuiControlBar controls={controls} position="relative" showOnMobile />
-    );
-  }
-}
+  return <EuiControlBar controls={controls} position="relative" showOnMobile />;
+};

--- a/src-docs/src/views/control_bar/mobile.js
+++ b/src-docs/src/views/control_bar/mobile.js
@@ -1,74 +1,62 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { EuiButton, EuiControlBar } from '../../../../src/components';
 
-export class ControlBarMobile extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isDisplaying: false,
-      tabContent: '',
-    };
-  }
+export default () => {
+  const [isDisplaying, setDisplay] = useState(false);
 
-  toggleDisplay = () => {
-    this.setState(prevState => ({
-      isDisplaying: !prevState.isDisplaying,
-    }));
+  const toggleDisplay = () => {
+    setDisplay(!isDisplaying);
   };
 
-  render() {
-    const controls = [
-      {
-        controlType: 'icon',
-        id: 'icon',
-        iconType: 'folderClosed',
-        'aria-label': 'folder',
-        className: 'eui-hideFor--m eui-hideFor--l eui-hideFor--xl',
-      },
-      {
-        controlType: 'breadcrumbs',
-        id: 'current_file_path',
-        responsive: true,
-        className: 'eui-hideFor--s eui-hideFor--xs',
-        breadcrumbs: [
-          {
-            text: 'src',
-          },
-          {
-            text: 'components',
-          },
-        ],
-      },
-      {
-        controlType: 'spacer',
-      },
-      {
-        controlType: 'icon',
-        id: 'github_icon',
-        iconType: 'logoGithub',
-        'aria-label': 'Github',
-      },
-      {
-        controlType: 'text',
-        id: 'github_text',
-        text: 'Open in Github',
-      },
-    ];
+  const controls = [
+    {
+      controlType: 'icon',
+      id: 'icon',
+      iconType: 'folderClosed',
+      'aria-label': 'folder',
+      className: 'eui-hideFor--m eui-hideFor--l eui-hideFor--xl',
+    },
+    {
+      controlType: 'breadcrumbs',
+      id: 'current_file_path',
+      responsive: true,
+      className: 'eui-hideFor--s eui-hideFor--xs',
+      breadcrumbs: [
+        {
+          text: 'src',
+        },
+        {
+          text: 'components',
+        },
+      ],
+    },
+    {
+      controlType: 'spacer',
+    },
+    {
+      controlType: 'icon',
+      id: 'github_icon',
+      iconType: 'logoGithub',
+      'aria-label': 'Github',
+    },
+    {
+      controlType: 'text',
+      id: 'github_text',
+      text: 'Open in Github',
+    },
+  ];
 
-    let display;
+  let display;
 
-    if (this.state.isDisplaying) {
-      display = <EuiControlBar controls={controls} showOnMobile />;
-    }
-
-    return (
-      <div>
-        <EuiButton onClick={this.toggleDisplay}>
-          Toggle mobile example
-        </EuiButton>
-        {display}
-      </div>
-    );
+  if (isDisplaying) {
+    display = <EuiControlBar controls={controls} showOnMobile />;
   }
-}
+
+  return (
+    <div>
+      <EuiButton onClick={toggleDisplay}>Toggle mobile example</EuiButton>
+      {display}
+    </div>
+  );
+};

--- a/src-docs/src/views/control_bar/tabs.js
+++ b/src-docs/src/views/control_bar/tabs.js
@@ -1,117 +1,107 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { EuiButton, EuiControlBar, EuiText } from '../../../../src/components';
 
-export class ControlBarWithTabs extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      contentIsVisible: false,
-      isDisplaying: false,
-      tabContent: '',
-    };
-  }
+export default () => {
+  const [tabContent, setTabContent] = useState('');
+  const [isDisplaying, setDisplay] = useState(false);
+  const [contentIsVisible, setVisibility] = useState(false);
 
-  soundTheAlarms = () => {
+  const soundTheAlarms = () => {
     alert('You clicked a button!');
   };
 
-  closeTheHatch = () => {
-    this.setState({
-      contentIsVisible: false,
-    });
+  const closeTheHatch = () => {
+    setVisibility(false);
   };
 
-  tabOne = () => {
-    this.setState({
-      contentIsVisible: true,
-      tabContent:
-        "Oceanic Airlines Flight 815 was a scheduled flight from Sydney, Australia to Los Angeles, California, United States, on a Boeing 777-200ER. On September 22, 2004 at 4:16 P.M., the airliner, carrying 324 passengers, deviated from its original course and disappeared over the Pacific Ocean. This is the central moment in the series that kicked off its plotline, and marked the chronological beginning of the main characters' adventures on the Island.",
-    });
+  const tabOne = () => {
+    setVisibility(true);
+
+    setTabContent(
+      "Oceanic Airlines Flight 815 was a scheduled flight from Sydney, Australia to Los Angeles, California, United States, on a Boeing 777-200ER. On September 22, 2004 at 4:16 P.M., the airliner, carrying 324 passengers, deviated from its original course and disappeared over the Pacific Ocean. This is the central moment in the series that kicked off its plotline, and marked the chronological beginning of the main characters' adventures on the Island."
+    );
   };
 
-  tabTwo = () => {
-    this.setState({
-      contentIsVisible: true,
-      tabContent:
-        'The Others, referred to by the DHARMA Initiative as the Hostiles or the Natives, and also by the tail section survivors of Oceanic Flight 815 as Them, are a group of people living on the Island who were followers of Jacob, intermediated by Richard Alpert. Jacob never showed himself to his people, and they took orders from a succession of leaders including Eloise Hawking, Charles Widmore, Benjamin Linus, and briefly, John Locke.',
-    });
+  const tabTwo = () => {
+    setVisibility(true);
+
+    setTabContent(
+      'The Others, referred to by the DHARMA Initiative as the Hostiles or the Natives, and also by the tail section survivors of Oceanic Flight 815 as Them, are a group of people living on the Island who were followers of Jacob, intermediated by Richard Alpert. Jacob never showed himself to his people, and they took orders from a succession of leaders including Eloise Hawking, Charles Widmore, Benjamin Linus, and briefly, John Locke.'
+    );
   };
 
-  toggleDisplay = () => {
-    this.setState(prevState => ({
-      isDisplaying: !prevState.isDisplaying,
-      contentIsVisible: false,
-    }));
+  const toggleDisplay = () => {
+    setVisibility(false);
+
+    setDisplay(!isDisplaying);
   };
 
-  render() {
-    const controls = [
-      {
-        controlType: 'tab',
-        id: 'flight_815',
-        label: 'Flight 815',
-        onClick: this.tabOne,
-      },
-      {
-        controlType: 'tab',
-        id: 'the_others',
-        label: 'The Others',
-        onClick: this.tabTwo,
-      },
-      {
-        controlType: 'button',
-        id: 'sound_the_alarm',
-        label: 'Sound the Alarm',
-        onClick: this.soundTheAlarms,
-        color: 'danger',
-        iconType: 'bell',
-        'data-test-subj': 'look',
-      },
-      {
-        controlType: 'button',
-        id: 'close_the_hatch',
-        label: 'Close the Hatch',
-        fill: true,
-        onClick: this.closeTheHatch,
-        className: 'customClassName',
-        color: 'primary',
-      },
-      {
-        controlType: 'spacer',
-      },
-      {
-        controlType: 'icon',
-        id: 'set_the_timer',
-        iconType: 'clock',
-        onClick: this.closeTheHatch,
-        'aria-label': 'Set the Timer',
-      },
-    ];
+  const controls = [
+    {
+      controlType: 'tab',
+      id: 'flight_815',
+      label: 'Flight 815',
+      onClick: tabOne,
+    },
+    {
+      controlType: 'tab',
+      id: 'the_others',
+      label: 'The Others',
+      onClick: tabTwo,
+    },
+    {
+      controlType: 'button',
+      id: 'sound_the_alarm',
+      label: 'Sound the Alarm',
+      onClick: soundTheAlarms,
+      color: 'danger',
+      iconType: 'bell',
+      'data-test-subj': 'look',
+    },
+    {
+      controlType: 'button',
+      id: 'close_the_hatch',
+      label: 'Close the Hatch',
+      fill: true,
+      onClick: closeTheHatch,
+      className: 'customClassName',
+      color: 'primary',
+    },
+    {
+      controlType: 'spacer',
+    },
+    {
+      controlType: 'icon',
+      id: 'set_the_timer',
+      iconType: 'clock',
+      onClick: closeTheHatch,
+      'aria-label': 'Set the Timer',
+    },
+  ];
 
-    let display;
+  let display;
 
-    if (this.state.isDisplaying) {
-      display = (
-        <EuiControlBar
-          controls={controls}
-          size="m"
-          showContent={this.state.contentIsVisible}
-          showOnMobile>
-          {this.state.tabContent !== '' && (
-            <div style={{ padding: '1rem' }}>
-              <EuiText>{this.state.tabContent}</EuiText>
-            </div>
-          )}
-        </EuiControlBar>
-      );
-    }
-
-    return (
-      <div>
-        <EuiButton onClick={this.toggleDisplay}>Toggle tabs example</EuiButton>
-        {display}
-      </div>
+  if (isDisplaying) {
+    display = (
+      <EuiControlBar
+        controls={controls}
+        size="m"
+        showContent={contentIsVisible}
+        showOnMobile>
+        {tabContent !== '' && (
+          <div style={{ padding: '1rem' }}>
+            <EuiText>{tabContent}</EuiText>
+          </div>
+        )}
+      </EuiControlBar>
     );
   }
-}
+
+  return (
+    <div>
+      <EuiButton onClick={toggleDisplay}>Toggle tabs example</EuiButton>
+      {display}
+    </div>
+  );
+};

--- a/src-docs/src/views/copy/copy.js
+++ b/src-docs/src/views/copy/copy.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import {
   EuiCopy,
@@ -8,32 +8,24 @@ import {
   EuiFormRow,
 } from '../../../../src/components/';
 
-export default class extends Component {
-  state = {
-    copyText: 'I am the text that will be copied',
+export default () => {
+  const [copyText, setCopyText] = useState('I am the text that will be copied');
+
+  const onChange = e => {
+    setCopyText(e.target.value);
   };
 
-  onChange = e => {
-    this.setState({
-      copyText: e.target.value,
-    });
-  };
+  return (
+    <div>
+      <EuiFormRow label="Enter text that will be copied to clipboard">
+        <EuiFieldText value={copyText} onChange={onChange} />
+      </EuiFormRow>
 
-  render() {
-    return (
-      <div>
-        <EuiFormRow label="Enter text that will be copied to clipboard">
-          <EuiFieldText value={this.state.copyText} onChange={this.onChange} />
-        </EuiFormRow>
+      <EuiSpacer size="m" />
 
-        <EuiSpacer size="m" />
-
-        <EuiCopy textToCopy={this.state.copyText}>
-          {copy => (
-            <EuiButton onClick={copy}>Click to copy input text</EuiButton>
-          )}
-        </EuiCopy>
-      </div>
-    );
-  }
-}
+      <EuiCopy textToCopy={copyText}>
+        {copy => <EuiButton onClick={copy}>Click to copy input text</EuiButton>}
+      </EuiCopy>
+    </div>
+  );
+};

--- a/src-docs/src/views/datagrid/additional_controls.js
+++ b/src-docs/src/views/datagrid/additional_controls.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { useState, useCallback, Fragment } from 'react';
 import { fake } from 'faker';
 
 import {
@@ -39,77 +39,64 @@ for (let i = 1; i < 20; i++) {
   });
 }
 
-export default class DataGridContainer extends Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
 
-    this.state = {
-      pagination: {
-        pageIndex: 0,
-        pageSize: 10,
-      },
-      visibleColumns: columns.map(({ id }) => id),
-    };
-  }
+  const [visibleColumns, setVisibleColumns] = useState(() =>
+    columns.map(({ id }) => id)
+  );
 
-  setPageIndex = pageIndex =>
-    this.setState(({ pagination }) => ({
-      pagination: { ...pagination, pageIndex },
-    }));
+  const setPageIndex = useCallback(
+    pageIndex => setPagination({ ...pagination, pageIndex }),
+    [pagination, setPagination]
+  );
+  const setPageSize = useCallback(
+    pageSize => setPagination({ ...pagination, pageSize, pageIndex: 0 }),
+    [pagination, setPagination]
+  );
 
-  setPageSize = pageSize =>
-    this.setState(({ pagination }) => ({
-      pagination: { ...pagination, pageSize, pageIndex: 0 },
-    }));
-
-  setVisibleColumns = visibleColumns => this.setState({ visibleColumns });
-
-  render() {
-    const { pagination } = this.state;
-
-    return (
-      <EuiDataGrid
-        aria-label="Top EUI contributors"
-        columns={columns}
-        columnVisibility={{
-          visibleColumns: this.state.visibleColumns,
-          setVisibleColumns: this.setVisibleColumns,
-        }}
-        rowCount={data.length}
-        gridStyle={{
-          border: 'horizontal',
-          header: 'underline',
-        }}
-        renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
-        pagination={{
-          ...pagination,
-          pageSizeOptions: [5, 10, 25],
-          onChangeItemsPerPage: this.setPageSize,
-          onChangePage: this.setPageIndex,
-        }}
-        toolbarVisibility={{
-          additionalControls: (
-            <Fragment>
-              <EuiButtonEmpty
-                size="xs"
-                iconType="bell"
-                color="primary"
-                className="euiDataGrid__controlBtn"
-                onClick={() => alert('You clicked me! Hugs.')}>
-                New button
-              </EuiButtonEmpty>
-              <EuiButtonEmpty
-                size="xs"
-                iconType="branch"
-                color="danger"
-                className="euiDataGrid__controlBtn"
-                onClick={() => alert('You clicked me! Hugs.')}>
-                Another button
-              </EuiButtonEmpty>
-            </Fragment>
-          ),
-        }}
-      />
-    );
-  }
-}
+  return (
+    <EuiDataGrid
+      aria-label="Top EUI contributors"
+      columns={columns}
+      columnVisibility={{
+        visibleColumns: visibleColumns,
+        setVisibleColumns: setVisibleColumns,
+      }}
+      rowCount={data.length}
+      gridStyle={{
+        border: 'horizontal',
+        header: 'underline',
+      }}
+      renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
+      pagination={{
+        ...pagination,
+        pageSizeOptions: [5, 10, 25],
+        onChangeItemsPerPage: setPageSize,
+        onChangePage: setPageIndex,
+      }}
+      toolbarVisibility={{
+        additionalControls: (
+          <Fragment>
+            <EuiButtonEmpty
+              size="xs"
+              iconType="bell"
+              color="primary"
+              className="euiDataGrid__controlBtn"
+              onClick={() => alert('You clicked me! Hugs.')}>
+              New button
+            </EuiButtonEmpty>
+            <EuiButtonEmpty
+              size="xs"
+              iconType="branch"
+              color="danger"
+              className="euiDataGrid__controlBtn"
+              onClick={() => alert('You clicked me! Hugs.')}>
+              Another button
+            </EuiButtonEmpty>
+          </Fragment>
+        ),
+      }}
+    />
+  );
+};

--- a/src-docs/src/views/datagrid/column_widths.js
+++ b/src-docs/src/views/datagrid/column_widths.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState, useCallback } from 'react';
 import { fake } from 'faker';
 
 import { EuiDataGrid, EuiAvatar } from '../../../../src/components/';
@@ -46,51 +46,38 @@ for (let i = 1; i < 5; i++) {
   });
 }
 
-export default class DataGrid extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      pagination: {
-        pageIndex: 0,
-        pageSize: 50,
-      },
+export default () => {
+  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
 
-      visibleColumns: columns.map(({ id }) => id),
-    };
-  }
+  const [visibleColumns, setVisibleColumns] = useState(() =>
+    columns.map(({ id }) => id)
+  );
 
-  setPageIndex = pageIndex =>
-    this.setState(({ pagination }) => ({
-      pagination: { ...pagination, pageIndex },
-    }));
+  const setPageIndex = useCallback(
+    pageIndex => setPagination({ ...pagination, pageIndex }),
+    [pagination, setPagination]
+  );
+  const setPageSize = useCallback(
+    pageSize => setPagination({ ...pagination, pageSize, pageIndex: 0 }),
+    [pagination, setPagination]
+  );
 
-  setPageSize = pageSize =>
-    this.setState(({ pagination }) => ({
-      pagination: { ...pagination, pageSize, pageIndex: 0 },
-    }));
-
-  setVisibleColumns = visibleColumns => this.setState({ visibleColumns });
-
-  render() {
-    const { pagination } = this.state;
-
-    return (
-      <EuiDataGrid
-        aria-label="DataGrid demonstrating column sizing constraints"
-        columns={columns}
-        columnVisibility={{
-          visibleColumns: this.state.visibleColumns,
-          setVisibleColumns: this.setVisibleColumns,
-        }}
-        rowCount={data.length}
-        renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
-        pagination={{
-          ...pagination,
-          pageSizeOptions: [5, 10, 25],
-          onChangeItemsPerPage: this.setPageSize,
-          onChangePage: this.setPageIndex,
-        }}
-      />
-    );
-  }
-}
+  return (
+    <EuiDataGrid
+      aria-label="DataGrid demonstrating column sizing constraints"
+      columns={columns}
+      columnVisibility={{
+        visibleColumns: visibleColumns,
+        setVisibleColumns: setVisibleColumns,
+      }}
+      rowCount={data.length}
+      renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
+      pagination={{
+        ...pagination,
+        pageSizeOptions: [5, 10, 25],
+        onChangeItemsPerPage: setPageSize,
+        onChangePage: setPageIndex,
+      }}
+    />
+  );
+};

--- a/src-docs/src/views/datagrid/container.js
+++ b/src-docs/src/views/datagrid/container.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState, useCallback } from 'react';
 import { fake } from 'faker';
 
 import { EuiDataGrid, EuiPanel, EuiLink } from '../../../../src/components/';
@@ -35,61 +35,46 @@ for (let i = 1; i < 20; i++) {
   });
 }
 
-export default class DataGridContainer extends Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
 
-    this.state = {
-      pagination: {
-        pageIndex: 0,
-        pageSize: 10,
-      },
-      visibleColumns: columns.map(({ id }) => id),
-    };
-  }
+  const [visibleColumns, setVisibleColumns] = useState(() =>
+    columns.map(({ id }) => id)
+  );
 
-  setPageIndex = pageIndex =>
-    this.setState(({ pagination }) => ({
-      pagination: { ...pagination, pageIndex },
-    }));
+  const setPageIndex = useCallback(
+    pageIndex => setPagination({ ...pagination, pageIndex }),
+    [pagination, setPagination]
+  );
+  const setPageSize = useCallback(
+    pageSize => setPagination({ ...pagination, pageSize, pageIndex: 0 }),
+    [pagination, setPagination]
+  );
 
-  setPageSize = pageSize =>
-    this.setState(({ pagination }) => ({
-      pagination: { ...pagination, pageSize, pageIndex: 0 },
-    }));
-
-  setVisibleColumns = visibleColumns => this.setState({ visibleColumns });
-
-  render() {
-    const { pagination } = this.state;
-
-    return (
-      <EuiPanel style={{ width: 400, paddingBottom: 4 }} paddingSize="none">
-        <div style={{ height: 300 }}>
-          <EuiDataGrid
-            aria-label="Top EUI contributors"
-            columns={columns}
-            columnVisibility={{
-              visibleColumns: this.state.visibleColumns,
-              setVisibleColumns: this.setVisibleColumns,
-            }}
-            rowCount={data.length}
-            gridStyle={{
-              border: 'horizontal',
-              header: 'underline',
-            }}
-            renderCellValue={({ rowIndex, columnId }) =>
-              data[rowIndex][columnId]
-            }
-            pagination={{
-              ...pagination,
-              pageSizeOptions: [5, 10, 25],
-              onChangeItemsPerPage: this.setPageSize,
-              onChangePage: this.setPageIndex,
-            }}
-          />
-        </div>
-      </EuiPanel>
-    );
-  }
-}
+  return (
+    <EuiPanel style={{ width: 400, paddingBottom: 4 }} paddingSize="none">
+      <div style={{ height: 300 }}>
+        <EuiDataGrid
+          aria-label="Top EUI contributors"
+          columns={columns}
+          columnVisibility={{
+            visibleColumns: visibleColumns,
+            setVisibleColumns: setVisibleColumns,
+          }}
+          rowCount={data.length}
+          gridStyle={{
+            border: 'horizontal',
+            header: 'underline',
+          }}
+          renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
+          pagination={{
+            ...pagination,
+            pageSizeOptions: [5, 10, 25],
+            onChangeItemsPerPage: setPageSize,
+            onChangePage: setPageIndex,
+          }}
+        />
+      </div>
+    </EuiPanel>
+  );
+};

--- a/src-docs/src/views/date_picker/classes.js
+++ b/src-docs/src/views/date_picker/classes.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import moment from 'moment';
 
@@ -8,70 +8,58 @@ import {
   EuiSpacer,
 } from '../../../../src/components';
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const [startDate, setStartDate] = useState(moment());
 
-    this.state = {
-      startDate: moment(),
-    };
+  const handleChange = date => {
+    setStartDate(date);
+  };
 
-    this.handleChange = this.handleChange.bind(this);
-  }
+  return (
+    <div>
+      <EuiFormRow label="className example">
+        <EuiDatePicker
+          selected={startDate}
+          showTimeSelect
+          onChange={handleChange}
+          className="dpTest__purpleInput"
+        />
+      </EuiFormRow>
 
-  handleChange(date) {
-    this.setState({
-      startDate: date,
-    });
-  }
+      <EuiSpacer size="m" />
 
-  render() {
-    return (
-      <div>
-        <EuiFormRow label="className example">
-          <EuiDatePicker
-            selected={this.state.startDate}
-            showTimeSelect
-            onChange={this.handleChange}
-            className="dpTest__purpleInput"
-          />
-        </EuiFormRow>
+      <EuiFormRow label="calendarClassName example">
+        <EuiDatePicker
+          selected={startDate}
+          showTimeSelect
+          onChange={handleChange}
+          calendarClassName="dpTest__purpleCal"
+        />
+      </EuiFormRow>
 
-        <EuiSpacer size="m" />
+      <EuiSpacer size="m" />
 
-        <EuiFormRow label="calendarClassName example">
-          <EuiDatePicker
-            selected={this.state.startDate}
-            showTimeSelect
-            onChange={this.handleChange}
-            calendarClassName="dpTest__purpleCal"
-          />
-        </EuiFormRow>
+      <EuiFormRow label="dayClassName example">
+        <EuiDatePicker
+          selected={startDate}
+          showTimeSelect
+          onChange={handleChange}
+          dayClassName={date =>
+            date.date() < Math.random() * 31 ? 'dpTest__purpleDay' : undefined
+          }
+        />
+      </EuiFormRow>
 
-        <EuiSpacer size="m" />
+      <EuiSpacer size="m" />
 
-        <EuiFormRow label="dayClassName example">
-          <EuiDatePicker
-            selected={this.state.startDate}
-            showTimeSelect
-            onChange={this.handleChange}
-            dayClassName={date =>
-              date.date() < Math.random() * 31 ? 'dpTest__purpleDay' : undefined
-            }
-          />
-        </EuiFormRow>
-
-        <EuiSpacer size="m" />
-
-        <EuiFormRow label="popperClassName example">
-          <EuiDatePicker
-            selected={this.state.startDate}
-            showTimeSelect
-            onChange={this.handleChange}
-            popperClassName="dpTest__purplePopper"
-          />
-        </EuiFormRow>
-      </div>
-    );
-  }
-}
+      <EuiFormRow label="popperClassName example">
+        <EuiDatePicker
+          selected={startDate}
+          showTimeSelect
+          onChange={handleChange}
+          popperClassName="dpTest__purplePopper"
+        />
+      </EuiFormRow>
+    </div>
+  );
+};

--- a/src-docs/src/views/date_picker/date_picker.js
+++ b/src-docs/src/views/date_picker/date_picker.js
@@ -1,34 +1,19 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import moment from 'moment';
 
 import { EuiDatePicker, EuiFormRow } from '../../../../src/components';
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const [startDate, setStartDate] = useState(moment());
 
-    this.state = {
-      startDate: moment(),
-    };
+  const handleChange = date => {
+    setStartDate(date);
+  };
 
-    this.handleChange = this.handleChange.bind(this);
-  }
-
-  handleChange(date) {
-    this.setState({
-      startDate: date,
-    });
-  }
-
-  render() {
-    return (
-      <EuiFormRow label="Select a date">
-        <EuiDatePicker
-          selected={this.state.startDate}
-          onChange={this.handleChange}
-        />
-      </EuiFormRow>
-    );
-  }
-}
+  return (
+    <EuiFormRow label="Select a date">
+      <EuiDatePicker selected={startDate} onChange={handleChange} />
+    </EuiFormRow>
+  );
+};

--- a/src-docs/src/views/date_picker/inline.js
+++ b/src-docs/src/views/date_picker/inline.js
@@ -1,43 +1,31 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import moment from 'moment';
 
 import { EuiDatePicker } from '../../../../src/components';
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const [startDate, setStartDate] = useState(moment());
 
-    this.state = {
-      startDate: moment(),
-    };
+  const handleChange = date => {
+    setStartDate(date);
+  };
 
-    this.handleChange = this.handleChange.bind(this);
-  }
-
-  handleChange(date) {
-    this.setState({
-      startDate: date,
-    });
-  }
-
-  render() {
-    return (
-      <div>
-        <EuiDatePicker
-          selected={this.state.startDate}
-          onChange={this.handleChange}
-          inline
-          showTimeSelect
-        />
-        <EuiDatePicker
-          selected={this.state.startDate}
-          onChange={this.handleChange}
-          inline
-          showTimeSelect
-          shadow={false}
-        />
-      </div>
-    );
-  }
-}
+  return (
+    <div>
+      <EuiDatePicker
+        selected={startDate}
+        onChange={handleChange}
+        inline
+        showTimeSelect
+      />
+      <EuiDatePicker
+        selected={startDate}
+        onChange={handleChange}
+        inline
+        showTimeSelect
+        shadow={false}
+      />
+    </div>
+  );
+};

--- a/src-docs/src/views/date_picker/locale.js
+++ b/src-docs/src/views/date_picker/locale.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import moment from 'moment';
 
@@ -8,72 +8,60 @@ import {
   EuiSpacer,
 } from '../../../../src/components';
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const [startDate, setStartDate] = useState(moment());
 
-    this.state = {
-      startDate: moment(),
-    };
+  const handleChange = date => {
+    setStartDate(date);
+  };
 
-    this.handleChange = this.handleChange.bind(this);
-  }
+  return (
+    <div>
+      <EuiFormRow label="US with fractional seconds">
+        <EuiDatePicker
+          selected={startDate}
+          showTimeSelect
+          onChange={handleChange}
+          dateFormat="YYYY-MM-DD hh:mm:ss:SSS A"
+        />
+      </EuiFormRow>
 
-  handleChange(date) {
-    this.setState({
-      startDate: date,
-    });
-  }
+      <EuiSpacer size="m" />
 
-  render() {
-    return (
-      <div>
-        <EuiFormRow label="US with fractional seconds">
-          <EuiDatePicker
-            selected={this.state.startDate}
-            showTimeSelect
-            onChange={this.handleChange}
-            dateFormat="YYYY-MM-DD hh:mm:ss:SSS A"
-          />
-        </EuiFormRow>
+      <EuiFormRow label="China">
+        <EuiDatePicker
+          selected={startDate}
+          showTimeSelect
+          onChange={handleChange}
+          dateFormat="YYYY-MM-DD hh:mm A"
+          locale="zh-cn"
+        />
+      </EuiFormRow>
 
-        <EuiSpacer size="m" />
+      <EuiSpacer size="m" />
 
-        <EuiFormRow label="China">
-          <EuiDatePicker
-            selected={this.state.startDate}
-            showTimeSelect
-            onChange={this.handleChange}
-            dateFormat="YYYY-MM-DD hh:mm A"
-            locale="zh-cn"
-          />
-        </EuiFormRow>
+      <EuiFormRow label="Korea">
+        <EuiDatePicker
+          selected={startDate}
+          showTimeSelect
+          onChange={handleChange}
+          locale="ko"
+          dateFormat="YYYY-MM-DD hh:mm A"
+        />
+      </EuiFormRow>
 
-        <EuiSpacer size="m" />
+      <EuiSpacer size="m" />
 
-        <EuiFormRow label="Korea">
-          <EuiDatePicker
-            selected={this.state.startDate}
-            showTimeSelect
-            onChange={this.handleChange}
-            locale="ko"
-            dateFormat="YYYY-MM-DD hh:mm A"
-          />
-        </EuiFormRow>
-
-        <EuiSpacer size="m" />
-
-        <EuiFormRow label="Germany on 24 hour clock">
-          <EuiDatePicker
-            selected={this.state.startDate}
-            showTimeSelect
-            onChange={this.handleChange}
-            dateFormat="DD-MM-YYYY HH:mm"
-            timeFormat="HH:mm"
-            locale="de-de"
-          />
-        </EuiFormRow>
-      </div>
-    );
-  }
-}
+      <EuiFormRow label="Germany on 24 hour clock">
+        <EuiDatePicker
+          selected={startDate}
+          showTimeSelect
+          onChange={handleChange}
+          dateFormat="DD-MM-YYYY HH:mm"
+          timeFormat="HH:mm"
+          locale="de-de"
+        />
+      </EuiFormRow>
+    </div>
+  );
+};

--- a/src-docs/src/views/date_picker/open_to_date.js
+++ b/src-docs/src/views/date_picker/open_to_date.js
@@ -1,36 +1,24 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import moment from 'moment';
 
 import { EuiDatePicker, EuiFormRow } from '../../../../src/components';
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const [startDate, setStartDate] = useState(null);
 
-    this.state = {
-      startDate: null,
-    };
+  const handleChange = date => {
+    setStartDate(date);
+  };
 
-    this.handleChange = this.handleChange.bind(this);
-  }
-
-  handleChange(date) {
-    this.setState({
-      startDate: date,
-    });
-  }
-
-  render() {
-    return (
-      <EuiFormRow label="Select a date">
-        <EuiDatePicker
-          selected={this.state.startDate}
-          onChange={this.handleChange}
-          openToDate={moment('1993-09-28')}
-          placeholder="Back to 1993"
-        />
-      </EuiFormRow>
-    );
-  }
-}
+  return (
+    <EuiFormRow label="Select a date">
+      <EuiDatePicker
+        selected={startDate}
+        onChange={handleChange}
+        openToDate={moment('1993-09-28')}
+        placeholder="Back to 1993"
+      />
+    </EuiFormRow>
+  );
+};

--- a/src-docs/src/views/date_picker/states.js
+++ b/src-docs/src/views/date_picker/states.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import {
   EuiDatePicker,
@@ -7,63 +7,51 @@ import {
 } from '../../../../src/components';
 import { DisplayToggles } from '../form_controls/display_toggles';
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const [startDate, setStartDate] = useState(null);
 
-    this.state = {
-      startDate: null,
-    };
+  const handleChange = date => {
+    setStartDate(date);
+  };
 
-    this.handleChange = this.handleChange.bind(this);
-  }
+  const errors = [
+    "Here's an example of an error",
+    'You might have more than one error, so pass an array.',
+  ];
 
-  handleChange(date) {
-    this.setState({
-      startDate: date,
-    });
-  }
-
-  render() {
-    const errors = [
-      "Here's an example of an error",
-      'You might have more than one error, so pass an array.',
-    ];
-
-    return (
-      /* DisplayToggles wrapper for Docs only */
-      <div>
-        <DisplayToggles canCompressed={false}>
-          <EuiDatePicker
-            showTimeSelect
-            selected={this.state.startDate}
-            onChange={this.handleChange}
-            placeholder="Placeholder text"
-          />
-        </DisplayToggles>
-
-        <EuiSpacer size="l" />
-
+  return (
+    /* DisplayToggles wrapper for Docs only */
+    <div>
+      <DisplayToggles canCompressed={false}>
         <EuiDatePicker
           showTimeSelect
-          selected={this.state.startDate}
-          onChange={this.handleChange}
-          onClear={() => this.handleChange(null)}
-          placeholder="Clearable"
+          selected={startDate}
+          onChange={handleChange}
+          placeholder="Placeholder text"
         />
+      </DisplayToggles>
 
-        <EuiSpacer size="m" />
+      <EuiSpacer size="l" />
 
-        <EuiFormRow label="Form row validation" isInvalid error={errors}>
-          <EuiDatePicker
-            showTimeSelect
-            isInvalid
-            selected={this.state.startDate}
-            onChange={this.handleChange}
-            placeholder="Example of an error"
-          />
-        </EuiFormRow>
-      </div>
-    );
-  }
-}
+      <EuiDatePicker
+        showTimeSelect
+        selected={startDate}
+        onChange={handleChange}
+        onClear={() => handleChange(null)}
+        placeholder="Clearable"
+      />
+
+      <EuiSpacer size="m" />
+
+      <EuiFormRow label="Form row validation" isInvalid error={errors}>
+        <EuiDatePicker
+          showTimeSelect
+          isInvalid
+          selected={startDate}
+          onChange={handleChange}
+          placeholder="Example of an error"
+        />
+      </EuiFormRow>
+    </div>
+  );
+};

--- a/src-docs/src/views/date_picker/time_select.js
+++ b/src-docs/src/views/date_picker/time_select.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import moment from 'moment';
 
@@ -8,71 +8,59 @@ import {
   EuiSpacer,
 } from '../../../../src/components';
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const [startDate, setStartDate] = useState(moment());
 
-    this.state = {
-      startDate: moment(),
-    };
+  const handleChange = date => {
+    setStartDate(date);
+  };
 
-    this.handleChange = this.handleChange.bind(this);
-  }
+  return (
+    <div>
+      <EuiFormRow label="Time select on">
+        <EuiDatePicker
+          showTimeSelect
+          selected={startDate}
+          onChange={handleChange}
+        />
+      </EuiFormRow>
 
-  handleChange(date) {
-    this.setState({
-      startDate: date,
-    });
-  }
+      <EuiSpacer />
 
-  render() {
-    return (
-      <div>
-        <EuiFormRow label="Time select on">
-          <EuiDatePicker
-            showTimeSelect
-            selected={this.state.startDate}
-            onChange={this.handleChange}
-          />
-        </EuiFormRow>
+      <EuiFormRow label="Only time select, 24 hour clock">
+        <EuiDatePicker
+          showTimeSelect
+          showTimeSelectOnly
+          selected={startDate}
+          onChange={handleChange}
+          dateFormat="HH:mm"
+          timeFormat="HH:mm"
+        />
+      </EuiFormRow>
 
-        <EuiSpacer />
+      <EuiSpacer />
 
-        <EuiFormRow label="Only time select, 24 hour clock">
-          <EuiDatePicker
-            showTimeSelect
-            showTimeSelectOnly
-            selected={this.state.startDate}
-            onChange={this.handleChange}
-            dateFormat="HH:mm"
-            timeFormat="HH:mm"
-          />
-        </EuiFormRow>
-
-        <EuiSpacer />
-
-        <EuiFormRow label="Inject additional times into the list">
-          <EuiDatePicker
-            showTimeSelect
-            showTimeSelectOnly
-            selected={this.state.startDate}
-            onChange={this.handleChange}
-            dateFormat="hh:mm a"
-            timeFormat="hh:mm a"
-            injectTimes={[
-              moment()
-                .hours(0)
-                .minutes(1),
-              moment()
-                .hours(0)
-                .minutes(5),
-              moment()
-                .hours(23)
-                .minutes(59),
-            ]}
-          />
-        </EuiFormRow>
-      </div>
-    );
-  }
-}
+      <EuiFormRow label="Inject additional times into the list">
+        <EuiDatePicker
+          showTimeSelect
+          showTimeSelectOnly
+          selected={startDate}
+          onChange={handleChange}
+          dateFormat="hh:mm a"
+          timeFormat="hh:mm a"
+          injectTimes={[
+            moment()
+              .hours(0)
+              .minutes(1),
+            moment()
+              .hours(0)
+              .minutes(5),
+            moment()
+              .hours(23)
+              .minutes(59),
+          ]}
+        />
+      </EuiFormRow>
+    </div>
+  );
+};

--- a/src-docs/src/views/delay_render/delay_hide.js
+++ b/src-docs/src/views/delay_render/delay_hide.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { useState, Fragment } from 'react';
 import {
   EuiDelayHide,
   EuiFlexItem,
@@ -8,48 +8,44 @@ import {
   EuiLoadingSpinner,
 } from '../../../../src/components';
 
-export default class extends Component {
-  state = {
-    minimumDuration: 3000,
-    hide: false,
+export default () => {
+  const [minimumDuration, setDuration] = useState(3000);
+  const [hide, setHide] = useState(false);
+
+  const onChangeMinimumDuration = event => {
+    setDuration(parseInt(event.target.value, 10));
   };
 
-  onChangeMinimumDuration = event => {
-    this.setState({ minimumDuration: parseInt(event.target.value, 10) });
+  const onChangeHide = event => {
+    setHide(event.target.checked);
   };
 
-  onChangeHide = event => {
-    this.setState({ hide: event.target.checked });
-  };
+  return (
+    <Fragment>
+      <EuiFlexItem>
+        <EuiFormRow>
+          <EuiCheckbox
+            id="dummy-id"
+            checked={hide}
+            onChange={onChangeHide}
+            label="Hide child"
+          />
+        </EuiFormRow>
+        <EuiFormRow label="Minimum duration">
+          <EuiFieldNumber
+            value={minimumDuration}
+            onChange={onChangeMinimumDuration}
+          />
+        </EuiFormRow>
 
-  render() {
-    return (
-      <Fragment>
-        <EuiFlexItem>
-          <EuiFormRow>
-            <EuiCheckbox
-              id="dummy-id"
-              checked={this.state.hide}
-              onChange={this.onChangeHide}
-              label="Hide child"
-            />
-          </EuiFormRow>
-          <EuiFormRow label="Minimum duration">
-            <EuiFieldNumber
-              value={this.state.minimumDuration}
-              onChange={this.onChangeMinimumDuration}
-            />
-          </EuiFormRow>
-
-          <EuiFormRow label="Child to render">
-            <EuiDelayHide
-              hide={this.state.hide}
-              minimumDuration={this.state.minimumDuration}
-              render={() => <EuiLoadingSpinner size="m" />}
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
-      </Fragment>
-    );
-  }
-}
+        <EuiFormRow label="Child to render">
+          <EuiDelayHide
+            hide={hide}
+            minimumDuration={minimumDuration}
+            render={() => <EuiLoadingSpinner size="m" />}
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+    </Fragment>
+  );
+};

--- a/src-docs/src/views/delay_render/delay_render.js
+++ b/src-docs/src/views/delay_render/delay_render.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { useState, Fragment } from 'react';
 import {
   EuiDelayRender,
   EuiFlexItem,
@@ -8,52 +8,48 @@ import {
   EuiLoadingSpinner,
 } from '../../../../src/components';
 
-export default class extends Component {
-  state = {
-    minimumDelay: 3000,
-    render: false,
+export default () => {
+  const [minimumDelay, setDelay] = useState(3000);
+  const [render, setRender] = useState(false);
+
+  const onChangeMinimumDelay = event => {
+    setDelay(parseInt(event.target.value, 10));
   };
 
-  onChangeMinimumDelay = event => {
-    this.setState({ minimumDelay: parseInt(event.target.value, 10) });
+  const onChangeHide = event => {
+    setRender(event.target.checked);
   };
 
-  onChangeHide = event => {
-    this.setState({ render: event.target.checked });
-  };
+  const status = render ? 'showing' : 'hidden';
+  const label = `Child (${status})`;
+  return (
+    <Fragment>
+      <EuiFlexItem>
+        <EuiFormRow>
+          <EuiCheckbox
+            id="dummy-id"
+            checked={render}
+            onChange={onChangeHide}
+            label="Show child"
+          />
+        </EuiFormRow>
+        <EuiFormRow label="Minimum delay">
+          <EuiFieldNumber
+            value={minimumDelay}
+            onChange={onChangeMinimumDelay}
+          />
+        </EuiFormRow>
 
-  render() {
-    const status = this.state.render ? 'showing' : 'hidden';
-    const label = `Child (${status})`;
-    return (
-      <Fragment>
-        <EuiFlexItem>
-          <EuiFormRow>
-            <EuiCheckbox
-              id="dummy-id"
-              checked={this.state.render}
-              onChange={this.onChangeHide}
-              label="Show child"
-            />
-          </EuiFormRow>
-          <EuiFormRow label="Minimum delay">
-            <EuiFieldNumber
-              value={this.state.minimumDelay}
-              onChange={this.onChangeMinimumDelay}
-            />
-          </EuiFormRow>
-
-          <EuiFormRow label={label}>
-            {this.state.render ? (
-              <EuiDelayRender delay={this.state.minimumDelay}>
-                <EuiLoadingSpinner size="m" />
-              </EuiDelayRender>
-            ) : (
-              <Fragment />
-            )}
-          </EuiFormRow>
-        </EuiFlexItem>
-      </Fragment>
-    );
-  }
-}
+        <EuiFormRow label={label}>
+          {render ? (
+            <EuiDelayRender delay={minimumDelay}>
+              <EuiLoadingSpinner size="m" />
+            </EuiDelayRender>
+          ) : (
+            <Fragment />
+          )}
+        </EuiFormRow>
+      </EuiFlexItem>
+    </Fragment>
+  );
+};


### PR DESCRIPTION
### Summary

Makes progress on #3150

Converted multiple docs examples from class to functional components:

- EuiContextMenu
- EuiControlBar
- EuiCopy
- EuiDataGrid 
- EuiDatePicker
- EuiDelayRender
- EuiDelayHide 

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
- [x] Turned **documentation** examples into functional
~- [ ] Added or updated **jest tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
