### PR TITLE
Used EuiCode instead of strong tag

### DIFF
--- a/src-docs/src/views/icon/icon_example.js
+++ b/src-docs/src/views/icon/icon_example.js
@@ -74,7 +74,7 @@ export const IconExample = {
     <div>
       <EuiText>
         <p>
-          <strong>EuiIcon</strong> is a handy component for using our custom
+          <EuiCode>EuiIcon</EuiCode> is a handy component for using our custom
           glyphs and logos. The <EuiCode>type</EuiCode> prop accepts either an
           enumerated name from one of the sets below, a location to a custom SVG
           asset, or a React Element.


### PR DESCRIPTION
### Summary

Used `<EuiCode>` instead of `<strong>` tag as it seems more appropriate.

**Before:**

<img width="962" alt="Screenshot 2020-04-01 at 6 31 53 PM" src="https://user-images.githubusercontent.com/31135861/78140917-5de55780-7448-11ea-909f-2f47c4d91910.png">

**After:**

<img width="958" alt="Screenshot 2020-04-01 at 6 31 30 PM" src="https://user-images.githubusercontent.com/31135861/78140928-6178de80-7448-11ea-87b9-5b0f352ba2b3.png">

### Checklist

~~- [ ] Check against **all themes** for compatibility in both light and dark modes~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
~~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~~
