### PR TITLE
Add snippets to avatar docs

### DIFF
--- a/src-docs/src/views/avatar/avatar_example.js
+++ b/src-docs/src/views/avatar/avatar_example.js
@@ -9,10 +9,24 @@ import { EuiAvatar, EuiCode } from '../../../../src/components';
 import Avatar from './avatar';
 const avatarSource = require('!!raw-loader!./avatar');
 const avatarHtml = renderToHtml(Avatar);
+const avatarSnippet = [
+  `<EuiAvatar size="s" name="Raphael" />
+`,
+  `<EuiAvatar size="s" name="Cat" imageUrl="https://source.unsplash.com/64x64/?cat" />
+`,
+];
 
 import AvatarInitials from './avatar_initials';
 const avatarInitialsSource = require('!!raw-loader!./avatar_initials');
 const avatarInitialsHtml = renderToHtml(AvatarInitials);
+const avatarInitialsSnippet = [
+  `<EuiAvatar size="m" type="user" name="Two Words" />
+`,
+  `<EuiAvatar size="m" type="space" name="Kibana" initialsLength={2}/>
+`,
+  `<EuiAvatar size="m" type="space"  name="Engineering Space" initials="En" initialsLength={2} />
+`,
+];
 
 export const AvatarExample = {
   title: 'Avatar',
@@ -41,6 +55,7 @@ export const AvatarExample = {
         </div>
       ),
       props: { EuiAvatar },
+      snippet: avatarSnippet,
       demo: <Avatar />,
     },
     {
@@ -76,6 +91,7 @@ export const AvatarExample = {
           </p>
         </div>
       ),
+      snippet: avatarInitialsSnippet,
       demo: <AvatarInitials />,
     },
   ],


### PR DESCRIPTION
### Summary

This PR adds some snippets to the **EuiAvatar** docs.

### Checklist

- [X] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **IE11** and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- [x] Added **documentation** examples
- ~[ ] Added or updated **jest tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately~
