### PR TITLE
Ensure alt attribute in custom icon img elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `22.3.0`.
+- Fixed the `img` element in `EuiIcon` using custom SVGs to have an `alt` attribute with an empty string, rather than no `alt` attribute at all ([#3245](https://github.com/elastic/eui/pull/3245))
 
 ## [`22.3.0`](https://github.com/elastic/eui/tree/v22.3.0)
 

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -638,7 +638,7 @@ export class EuiIcon extends PureComponent<EuiIconProps, State> {
     if (typeof icon === 'string') {
       return (
         <img
-          alt={title}
+          alt={title ? title : ''}
           src={icon}
           className={classes}
           tabIndex={tabIndex}


### PR DESCRIPTION
### Summary

This PR fixes the `img` element in `EuiIcon` components using custom SVGs to have an `alt` attribute with an empty string, rather than no `alt` attribute at all. This ensures validation while also indicating to screen readers to not read icons that are for decoration purposes only.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
~- [ ] Added or updated **jest tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CONTRIBUTING.md#changelog) entry exists and is marked appropriately
