### PR TITLE
Fix incorrect TypeScript type for custom components passed to EuiIcon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug Fixes**
 
 - Fixed the `img` element in `EuiIcon` using custom SVGs to have an `alt` attribute with an empty string, rather than no `alt` attribute at all ([#3245](https://github.com/elastic/eui/pull/3245))
+- Fixed `EuiIcon`'s icon `type` definition to allow custom React components ([#3252](https://github.com/elastic/eui/pull/3252))
 
 ## [`22.3.0`](https://github.com/elastic/eui/tree/v22.3.0)
 

--- a/scripts/babel/proptypes-from-ts-props/index.js
+++ b/scripts/babel/proptypes-from-ts-props/index.js
@@ -225,6 +225,12 @@ function resolveIdentifierToPropTypes(node, state) {
         types.identifier('node')
       );
 
+    case 'ComponentType':
+      return types.memberExpression(
+        types.identifier('PropTypes'),
+        types.identifier('elementType')
+      );
+
     case 'JSXElementConstructor':
       return types.memberExpression(
         types.identifier('PropTypes'),

--- a/scripts/babel/proptypes-from-ts-props/index.test.js
+++ b/scripts/babel/proptypes-from-ts-props/index.test.js
@@ -1001,6 +1001,58 @@ FooComponent.propTypes = {
 
       });
 
+      describe('elementType propType', () => {
+
+        it('understands React.ComponentType', () => {
+          const result = transform(
+            `
+import React from 'react';
+interface IFooProps {foo: React.ComponentType, bar: React.ComponentType<{ prop: any }>}
+const FooComponent: React.SFC<IFooProps> = () => {
+  return (<div>Hello World</div>);
+}`,
+            babelOptions
+          );
+
+          expect(result.code).toBe(`import React from 'react';
+import PropTypes from "prop-types";
+
+const FooComponent = () => {
+  return <div>Hello World</div>;
+};
+
+FooComponent.propTypes = {
+  foo: PropTypes.elementType.isRequired,
+  bar: PropTypes.elementType.isRequired
+};`);
+        });
+
+        it('understands ComponentType', () => {
+          const result = transform(
+            `
+import React from 'react';
+interface IFooProps {foo: ComponentType, bar: ComponentType<{ prop: any }>}
+const FooComponent: React.SFC<IFooProps> = () => {
+  return (<div>Hello World</div>);
+}`,
+            babelOptions
+          );
+
+          expect(result.code).toBe(`import React from 'react';
+import PropTypes from "prop-types";
+
+const FooComponent = () => {
+  return <div>Hello World</div>;
+};
+
+FooComponent.propTypes = {
+  foo: PropTypes.elementType.isRequired,
+  bar: PropTypes.elementType.isRequired
+};`);
+        });
+
+      });
+
     });
 
     describe('intersection types', () => {

--- a/src/components/icon/__snapshots__/icon.test.tsx.snap
+++ b/src/components/icon/__snapshots__/icon.test.tsx.snap
@@ -9053,3 +9053,15 @@ exports[`EuiIcon props type wrench is rendered 1`] = `
   />
 </svg>
 `;
+
+exports[`EuiIcon renders custom components 1`] = `
+<span
+  aria-hidden="true"
+  aria-label="heart"
+  class="euiIcon euiIcon--medium euiIcon-isLoaded"
+  focusable="false"
+  role="img"
+>
+  ❤️
+</span>
+`;

--- a/src/components/icon/icon.test.tsx
+++ b/src/components/icon/icon.test.tsx
@@ -93,4 +93,16 @@ describe('EuiIcon', () => {
       );
     });
   });
+
+  it('renders custom components', () => {
+    const CustomIcon = ({ ...props }) => {
+      return (
+        <span role="img" aria-label="heart" {...props}>
+          ❤️
+        </span>
+      );
+    };
+    const component = mount(<EuiIcon type={CustomIcon} />);
+    expect(prettyHtml(component.html())).toMatchSnapshot();
+  });
 });

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -1,7 +1,7 @@
 import React, {
   PureComponent,
   HTMLAttributes,
-  ReactElement,
+  ComponentType,
   SVGAttributes,
 } from 'react';
 import classNames from 'classnames';
@@ -415,7 +415,7 @@ export const TYPES = keysOf(typeToPathMap);
 
 export type EuiIconType = keyof typeof typeToPathMap;
 
-export type IconType = EuiIconType | string | ReactElement;
+export type IconType = EuiIconType | string | ComponentType;
 
 const colorToClassMap = {
   default: null,
@@ -488,7 +488,7 @@ export type EuiIconProps = CommonProps &
   };
 
 interface State {
-  icon: undefined | ReactElement | string;
+  icon: undefined | ComponentType | string;
   iconTitle: undefined | string;
   isLoading: boolean;
 }
@@ -625,7 +625,7 @@ export class EuiIcon extends PureComponent<EuiIconProps, State> {
       className
     );
 
-    const icon = this.state.icon || empty;
+    const icon = this.state.icon || (empty as ComponentType);
 
     // This is a fix for IE and Edge, which ignores tabindex="-1" on an SVG, but respects
     // focusable="false".

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -457,7 +457,7 @@ export type IconSize = keyof typeof sizeToClassNameMap;
 export type EuiIconProps = CommonProps &
   Omit<SVGAttributes<SVGElement>, 'type' | 'color' | 'size'> & {
     /**
-     * `Enum` is any of the named icons listed in the docs, `Element` is any React SVG element, and `string` is usually a URL to an SVG file
+     * `Enum` is any of the named icons listed in the docs, `string` is usually a URL to an SVG file, and `elementType` is any React SVG component
      */
     type: IconType;
     /**


### PR DESCRIPTION
### Summary

Fixes #3175 

**EuiIcon** incorrectly specified `ReactElement` instead of `ComponentType`, this passed through TS because the svg imports are typed as `any`, mixing in that type at `const icon = this.state.icon || empty;` and losing any subsequent type checking.

* fixed the type
* added proper type casting on `empty` to avoid mixing in `any`
* added unit test

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
- [x] Props have proper **autodocs**
~- [ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CONTRIBUTING.md#changelog) entry exists and is marked appropriately
