### PR TITLE
Silence expected console.warn messages

### DIFF
--- a/src/components/form/form_row/make_id.test.ts
+++ b/src/components/form/form_row/make_id.test.ts
@@ -4,14 +4,14 @@ describe('makeId', () => {
   const _consoleLog = console.log;
   beforeAll(() => {
     const _consoleLog = console.log;
-    console.log = (...args: any[]) => {
+    console.log = (...args: [any?, ...any[]]) => {
       // swallow the deprecation warning
       if (
         args[0] ===
         'WARNING: makeId is deprecated. Use htmlIdGenerator from @elastic/eui instead.'
       )
         return;
-      _consoleLog.call(console, args);
+      _consoleLog.apply(console, args);
     };
   });
 

--- a/src/components/table/table_footer_cell.test.tsx
+++ b/src/components/table/table_footer_cell.test.tsx
@@ -5,18 +5,14 @@ import { requiredProps } from '../../test/required_props';
 import { EuiTableFooterCell } from './table_footer_cell';
 
 import { RIGHT_ALIGNMENT, CENTER_ALIGNMENT } from '../../services';
+import { WARNING_MESSAGE } from './utils';
 
 describe('EuiTableFooterCell', () => {
   const _consoleWarn = console.warn;
   beforeAll(() => {
     console.warn = (...args: [any?, ...any[]]) => {
       // Suppress an expected warning
-      if (
-        args.length === 1 &&
-        args[0] ===
-          'Two `width` properties were provided. Provide only one of `style.width` or `width` to avoid conflicts.'
-      )
-        return;
+      if (args.length === 1 && args[0] === WARNING_MESSAGE) return;
       _consoleWarn.apply(console, args);
     };
   });

--- a/src/components/table/table_footer_cell.test.tsx
+++ b/src/components/table/table_footer_cell.test.tsx
@@ -10,7 +10,7 @@ describe('EuiTableFooterCell', () => {
   const _consoleWarn = console.warn;
   beforeAll(() => {
     console.warn = (...args: [any?, ...any[]]) => {
-      // Suppress an expencted warning
+      // Suppress an expected warning
       if (
         args.length === 1 &&
         args[0] ===

--- a/src/components/table/table_footer_cell.test.tsx
+++ b/src/components/table/table_footer_cell.test.tsx
@@ -7,6 +7,23 @@ import { EuiTableFooterCell } from './table_footer_cell';
 import { RIGHT_ALIGNMENT, CENTER_ALIGNMENT } from '../../services';
 
 describe('EuiTableFooterCell', () => {
+  const _consoleWarn = console.warn;
+  beforeAll(() => {
+    console.warn = (...args: [any?, ...any[]]) => {
+      // Suppress an expencted warning
+      if (
+        args.length === 1 &&
+        args[0] ===
+          'Two `width` properties were provided. Provide only one of `style.width` or `width` to avoid conflicts.'
+      )
+        return;
+      _consoleWarn.apply(console, args);
+    };
+  });
+  afterAll(() => {
+    console.warn = _consoleWarn;
+  });
+
   test('is rendered', () => {
     const component = render(
       <EuiTableFooterCell {...requiredProps}>children</EuiTableFooterCell>

--- a/src/components/table/table_header_cell.test.tsx
+++ b/src/components/table/table_header_cell.test.tsx
@@ -41,6 +41,23 @@ describe('align', () => {
 });
 
 describe('width and style', () => {
+  const _consoleWarn = console.warn;
+  beforeAll(() => {
+    console.warn = (...args: [any?, ...any[]]) => {
+      // Suppress an expencted warning
+      if (
+        args.length === 1 &&
+        args[0] ===
+          'Two `width` properties were provided. Provide only one of `style.width` or `width` to avoid conflicts.'
+      )
+        return;
+      _consoleWarn.apply(console, args);
+    };
+  });
+  afterAll(() => {
+    console.warn = _consoleWarn;
+  });
+
   test('accepts style attribute', () => {
     const component = (
       <EuiTableHeaderCell style={{ width: '20%' }}>Test</EuiTableHeaderCell>

--- a/src/components/table/table_header_cell.test.tsx
+++ b/src/components/table/table_header_cell.test.tsx
@@ -5,6 +5,7 @@ import { requiredProps } from '../../test/required_props';
 import { EuiTableHeaderCell } from './table_header_cell';
 
 import { RIGHT_ALIGNMENT, CENTER_ALIGNMENT } from '../../services';
+import { WARNING_MESSAGE } from './utils';
 
 test('renders EuiTableHeaderCell', () => {
   const component = (
@@ -45,12 +46,7 @@ describe('width and style', () => {
   beforeAll(() => {
     console.warn = (...args: [any?, ...any[]]) => {
       // Suppress an expected warning
-      if (
-        args.length === 1 &&
-        args[0] ===
-          'Two `width` properties were provided. Provide only one of `style.width` or `width` to avoid conflicts.'
-      )
-        return;
+      if (args.length === 1 && args[0] === WARNING_MESSAGE) return;
       _consoleWarn.apply(console, args);
     };
   });

--- a/src/components/table/table_header_cell.test.tsx
+++ b/src/components/table/table_header_cell.test.tsx
@@ -44,7 +44,7 @@ describe('width and style', () => {
   const _consoleWarn = console.warn;
   beforeAll(() => {
     console.warn = (...args: [any?, ...any[]]) => {
-      // Suppress an expencted warning
+      // Suppress an expected warning
       if (
         args.length === 1 &&
         args[0] ===

--- a/src/components/table/table_header_cell_checkbox.test.tsx
+++ b/src/components/table/table_header_cell_checkbox.test.tsx
@@ -3,18 +3,14 @@ import { render } from 'enzyme';
 import { requiredProps } from '../../test';
 
 import { EuiTableHeaderCellCheckbox } from './table_header_cell_checkbox';
+import { WARNING_MESSAGE } from './utils';
 
 describe('EuiTableHeaderCellCheckbox', () => {
   const _consoleWarn = console.warn;
   beforeAll(() => {
     console.warn = (...args: [any?, ...any[]]) => {
       // Suppress an expected warning
-      if (
-        args.length === 1 &&
-        args[0] ===
-          'Two `width` properties were provided. Provide only one of `style.width` or `width` to avoid conflicts.'
-      )
-        return;
+      if (args.length === 1 && args[0] === WARNING_MESSAGE) return;
       _consoleWarn.apply(console, args);
     };
   });

--- a/src/components/table/table_header_cell_checkbox.test.tsx
+++ b/src/components/table/table_header_cell_checkbox.test.tsx
@@ -5,6 +5,23 @@ import { requiredProps } from '../../test';
 import { EuiTableHeaderCellCheckbox } from './table_header_cell_checkbox';
 
 describe('EuiTableHeaderCellCheckbox', () => {
+  const _consoleWarn = console.warn;
+  beforeAll(() => {
+    console.warn = (...args: [any?, ...any[]]) => {
+      // Suppress an expencted warning
+      if (
+        args.length === 1 &&
+        args[0] ===
+          'Two `width` properties were provided. Provide only one of `style.width` or `width` to avoid conflicts.'
+      )
+        return;
+      _consoleWarn.apply(console, args);
+    };
+  });
+  afterAll(() => {
+    console.warn = _consoleWarn;
+  });
+
   test('is rendered', () => {
     const component = render(<EuiTableHeaderCellCheckbox {...requiredProps} />);
 

--- a/src/components/table/table_header_cell_checkbox.test.tsx
+++ b/src/components/table/table_header_cell_checkbox.test.tsx
@@ -8,7 +8,7 @@ describe('EuiTableHeaderCellCheckbox', () => {
   const _consoleWarn = console.warn;
   beforeAll(() => {
     console.warn = (...args: [any?, ...any[]]) => {
-      // Suppress an expencted warning
+      // Suppress an expected warning
       if (
         args.length === 1 &&
         args[0] ===

--- a/src/components/table/table_row_cell.test.tsx
+++ b/src/components/table/table_row_cell.test.tsx
@@ -75,6 +75,23 @@ describe("children's className", () => {
 });
 
 describe('width and style', () => {
+  const _consoleWarn = console.warn;
+  beforeAll(() => {
+    console.warn = (...args: [any?, ...any[]]) => {
+      // Suppress an expencted warning
+      if (
+        args.length === 1 &&
+        args[0] ===
+          'Two `width` properties were provided. Provide only one of `style.width` or `width` to avoid conflicts.'
+      )
+        return;
+      _consoleWarn.apply(console, args);
+    };
+  });
+  afterAll(() => {
+    console.warn = _consoleWarn;
+  });
+
   test('accepts style attribute', () => {
     const component = (
       <EuiTableRowCell style={{ width: '20%' }}>Test</EuiTableRowCell>

--- a/src/components/table/table_row_cell.test.tsx
+++ b/src/components/table/table_row_cell.test.tsx
@@ -5,6 +5,7 @@ import { requiredProps } from '../../test/required_props';
 import { EuiTableRowCell } from './table_row_cell';
 
 import { RIGHT_ALIGNMENT, CENTER_ALIGNMENT } from '../../services/alignment';
+import { WARNING_MESSAGE } from './utils';
 
 test('renders EuiTableRowCell', () => {
   const component = (
@@ -79,12 +80,7 @@ describe('width and style', () => {
   beforeAll(() => {
     console.warn = (...args: [any?, ...any[]]) => {
       // Suppress an expected warning
-      if (
-        args.length === 1 &&
-        args[0] ===
-          'Two `width` properties were provided. Provide only one of `style.width` or `width` to avoid conflicts.'
-      )
-        return;
+      if (args.length === 1 && args[0] === WARNING_MESSAGE) return;
       _consoleWarn.apply(console, args);
     };
   });

--- a/src/components/table/table_row_cell.test.tsx
+++ b/src/components/table/table_row_cell.test.tsx
@@ -78,7 +78,7 @@ describe('width and style', () => {
   const _consoleWarn = console.warn;
   beforeAll(() => {
     console.warn = (...args: [any?, ...any[]]) => {
-      // Suppress an expencted warning
+      // Suppress an expected warning
       if (
         args.length === 1 &&
         args[0] ===

--- a/src/components/table/utils.ts
+++ b/src/components/table/utils.ts
@@ -1,5 +1,8 @@
 import { CSSProperties } from 'react';
 
+export const WARNING_MESSAGE =
+  'Two `width` properties were provided. Provide only one of `style.width` or `width` to avoid conflicts.';
+
 export const resolveWidthAsStyle = (
   style: CSSProperties = {},
   width?: string | number
@@ -13,9 +16,7 @@ export const resolveWidthAsStyle = (
     attrWidth = `${attrWidth}px`;
   }
   if (styleWidth && attrWidth) {
-    console.warn(
-      'Two `width` properties were provided. Provide only one of `style.width` or `width` to avoid conflicts.'
-    );
+    console.warn(WARNING_MESSAGE);
   }
   return { ...styleRest, width: attrWidth || styleWidth };
 };


### PR DESCRIPTION
### Summary

This has bothered me for a while. There are four unit tests which purposefully trigger the warning

> Two `width` properties were provided. Provide only one of `style.width` or `width` to avoid conflicts.

which normalizes the idea of logs/warnings/errors in unit test output. This PR captures & verifies the messages, while continuing to emit any non-expected warnings. I also fixed a similar thing in the makeId test.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CONTRIBUTING.md#changelog) entry exists and is marked appropriately~
