### PR TITLE
Fixed console error in EuiDatePopoverContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed the `img` element in `EuiIcon` using custom SVGs to have an `alt` attribute with an empty string, rather than no `alt` attribute at all ([#3245](https://github.com/elastic/eui/pull/3245))
 - Added overflows to EuiDataGrid toolbar dropdowns when there are many columns ([#3238](https://github.com/elastic/eui/pull/3238))
 - Fixed `EuiIcon`'s icon `type` definition to allow custom React components ([#3252](https://github.com/elastic/eui/pull/3252))
+- Fixed `initialSelectedTab` properties used in `EuiDatePopoverContent` ([#3254](https://github.com/elastic/eui/pull/3254))
 
 ## [`22.3.0`](https://github.com/elastic/eui/tree/v22.3.0)
 

--- a/src/components/date_picker/super_date_picker/date_popover/date_popover_content.js
+++ b/src/components/date_picker/super_date_picker/date_popover/date_popover_content.js
@@ -100,12 +100,18 @@ export function EuiDatePopoverContent({
     ];
   };
 
+  const initialSelectedTab = {
+    name: getDateMode(value),
+    id: getDateMode(value),
+    content: getDateMode(value),
+  };
+
   return (
     <EuiTabbedContent
       className="euiDatePopoverContent"
       tabs={renderTabs()}
       autoFocus="selected"
-      initialSelectedTab={{ id: getDateMode(value) }}
+      initialSelectedTab={initialSelectedTab}
       onTabClick={onTabClick}
       size="s"
       expand

--- a/src/components/date_picker/super_date_picker/date_popover/date_popover_content.js
+++ b/src/components/date_picker/super_date_picker/date_popover/date_popover_content.js
@@ -37,81 +37,76 @@ export function EuiDatePopoverContent({
 
   const ariaLabel = `${position === 'start' ? 'Start' : 'End'} date:`;
 
-  const renderTabs = () => {
-    return [
-      {
-        id: DATE_MODES.ABSOLUTE,
-        name: 'Absolute',
-        content: (
-          <EuiAbsoluteTab
-            dateFormat={dateFormat}
-            timeFormat={timeFormat}
-            locale={locale}
-            value={value}
-            onChange={onChange}
-            roundUp={roundUp}
-            position={position}
-          />
-        ),
-        'data-test-subj': 'superDatePickerAbsoluteTab',
-        'aria-label': `${ariaLabel} Absolute`,
-      },
-      {
-        id: DATE_MODES.RELATIVE,
-        name: 'Relative',
-        content: (
-          <EuiRelativeTab
-            dateFormat={dateFormat}
-            locale={locale}
-            value={toAbsoluteString(value, roundUp)}
-            onChange={onChange}
-            roundUp={roundUp}
-            position={position}
-          />
-        ),
-        'data-test-subj': 'superDatePickerRelativeTab',
-        'aria-label': `${ariaLabel} Relative`,
-      },
-      {
-        id: DATE_MODES.NOW,
-        name: 'Now',
-        content: (
-          <EuiText
+  const renderTabs = [
+    {
+      id: DATE_MODES.ABSOLUTE,
+      name: 'Absolute',
+      content: (
+        <EuiAbsoluteTab
+          dateFormat={dateFormat}
+          timeFormat={timeFormat}
+          locale={locale}
+          value={value}
+          onChange={onChange}
+          roundUp={roundUp}
+          position={position}
+        />
+      ),
+      'data-test-subj': 'superDatePickerAbsoluteTab',
+      'aria-label': `${ariaLabel} Absolute`,
+    },
+    {
+      id: DATE_MODES.RELATIVE,
+      name: 'Relative',
+      content: (
+        <EuiRelativeTab
+          dateFormat={dateFormat}
+          locale={locale}
+          value={toAbsoluteString(value, roundUp)}
+          onChange={onChange}
+          roundUp={roundUp}
+          position={position}
+        />
+      ),
+      'data-test-subj': 'superDatePickerRelativeTab',
+      'aria-label': `${ariaLabel} Relative`,
+    },
+    {
+      id: DATE_MODES.NOW,
+      name: 'Now',
+      content: (
+        <EuiText
+          size="s"
+          color="subdued"
+          className="euiDatePopoverContent__padded--large">
+          <p>
+            Setting the time to &quot;now&quot; means that on every refresh this
+            time will be set to the time of the refresh.
+          </p>
+          <EuiButton
+            data-test-subj="superDatePickerNowButton"
+            onClick={() => onChange('now')}
+            fullWidth
             size="s"
-            color="subdued"
-            className="euiDatePopoverContent__padded--large">
-            <p>
-              Setting the time to &quot;now&quot; means that on every refresh
-              this time will be set to the time of the refresh.
-            </p>
-            <EuiButton
-              data-test-subj="superDatePickerNowButton"
-              onClick={() => onChange('now')}
-              fullWidth
-              size="s"
-              fill>
-              Set {position} date and time to now
-            </EuiButton>
-          </EuiText>
-        ),
-        'data-test-subj': 'superDatePickerNowTab',
-        'aria-label': `${ariaLabel} Now`,
-      },
-    ];
-  };
+            fill>
+            Set {position} date and time to now
+          </EuiButton>
+        </EuiText>
+      ),
+      'data-test-subj': 'superDatePickerNowTab',
+      'aria-label': `${ariaLabel} Now`,
+    },
+  ];
 
-  const initialSelectedTab = {
-    name: getDateMode(value),
-    id: getDateMode(value),
-    content: getDateMode(value),
-  };
+  const initialSelectedTab = () =>
+    renderTabs.filter(tabs => tabs.id === getDateMode(value))[0];
 
   return (
     <EuiTabbedContent
       className="euiDatePopoverContent"
-      tabs={renderTabs()}
+      tabs={renderTabs}
       autoFocus="selected"
-      initialSelectedTab={initialSelectedTab}
+      initialSelectedTab={initialSelectedTab()}
       onTabClick={onTabClick}
       size="s"
       expand


### PR DESCRIPTION
### Summary

Fixes #3250 

This error due to `name` and `content` not passed to EuiTabbedContent.
### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
- [x] Checked for **breaking changes** and labeled appropriately
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
~~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CONTRIBUTING.md#changelog) entry exists and is marked appropriately~~
