### PR TITLE
Unmount enzyme components after test execution

### DIFF
--- a/scripts/jest/config.json
+++ b/scripts/jest/config.json
@@ -23,6 +23,9 @@
     "<rootDir>/scripts/jest/setup/enzyme.js",
     "<rootDir>/scripts/jest/setup/throw_on_console_error.js"
   ],
+  "setupFilesAfterEnv": [
+    "<rootDir>/scripts/jest/setup/unmount_enzyme.js"
+  ],
   "coverageDirectory": "<rootDir>/reports/jest-coverage",
   "coverageReporters": [
     "html"

--- a/scripts/jest/polyfills/mutation_observer.js
+++ b/scripts/jest/polyfills/mutation_observer.js
@@ -524,7 +524,7 @@ var MutationNotifier = /** @class */ (function (_super) {
   __extends(MutationNotifier, _super);
   function MutationNotifier() {
     var _this = _super.call(this) || this;
-    _this.setMaxListeners(294); // bump this as needed - some tests do not perform the unmounting lifecycle
+    _this.setMaxListeners(30); // bump this as needed, it's mostly dependant on test parallelization
     return _this;
   }
   MutationNotifier.getInstance = function () {

--- a/scripts/jest/setup/unmount_enzyme.js
+++ b/scripts/jest/setup/unmount_enzyme.js
@@ -1,0 +1,21 @@
+const mockMountedComponents = [];
+jest.mock('enzyme', () => {
+  const enzyme = jest.requireActual('enzyme');
+  return {
+    ...enzyme,
+    mount: component => {
+      const mountedComponent = enzyme.mount(component);
+      mockMountedComponents.push(mountedComponent);
+      return mountedComponent;
+    },
+  };
+});
+
+afterEach(() => {
+  while (mockMountedComponents.length) {
+    const component = mockMountedComponents.pop();
+    if (component.length === 1) {
+      component.unmount();
+    }
+  }
+});

--- a/src/components/drag_and_drop/__snapshots__/droppable.test.tsx.snap
+++ b/src/components/drag_and_drop/__snapshots__/droppable.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiDroppable can be given ReactElement children 1`] = `
 <div
   class="euiDroppable euiDroppable--noGrow"
-  data-rbd-droppable-context-id="2"
+  data-rbd-droppable-context-id="0"
   data-rbd-droppable-id="testDroppable"
   data-test-subj="droppable"
 >
@@ -17,7 +17,7 @@ exports[`EuiDroppable can be given ReactElement children 1`] = `
 exports[`EuiDroppable can be given multiple ReactElement children 1`] = `
 <div
   class="euiDroppable euiDroppable--noGrow"
-  data-rbd-droppable-context-id="3"
+  data-rbd-droppable-context-id="0"
   data-rbd-droppable-id="testDroppable"
   data-test-subj="droppable"
 >
@@ -33,7 +33,7 @@ exports[`EuiDroppable can be given multiple ReactElement children 1`] = `
 exports[`EuiDroppable is rendered 1`] = `
 <div
   class="euiDroppable euiDroppable--noGrow"
-  data-rbd-droppable-context-id="1"
+  data-rbd-droppable-context-id="0"
   data-rbd-droppable-id="testDroppable"
   data-test-subj="droppable"
 >

--- a/src/components/drag_and_drop/droppable.test.tsx
+++ b/src/components/drag_and_drop/droppable.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
+import { resetServerContext } from 'react-beautiful-dnd';
 
 import { findTestSubject } from '../../test';
 import { requiredProps } from '../../test/required_props';
@@ -16,6 +17,10 @@ function snapshotDragDropContext(component: ReactWrapper) {
 }
 
 describe('EuiDroppable', () => {
+  afterEach(() => {
+    resetServerContext();
+  });
+
   test('is rendered', () => {
     const handler = jest.fn();
     jest.mock('react', () => {
@@ -86,26 +91,42 @@ describe('EuiDroppable', () => {
           useLayoutEffect: react.useEffect,
         };
       });
-      const handler = jest.fn();
-      const component = mount(
-        <EuiDragDropContext onDragEnd={handler} {...requiredProps}>
-          <EuiDroppable droppableId="testDroppable" cloneDraggables={true}>
-            <EuiDroppableContext.Consumer>
-              {({ cloneItems }) => (
-                <div data-test-subj="child">
-                  {cloneItems ? 'true' : 'false'}
-                </div>
-              )}
-            </EuiDroppableContext.Consumer>
-          </EuiDroppable>
-        </EuiDragDropContext>
-      );
 
       test('sets `cloneItems` on proprietary context', () => {
+        const handler = jest.fn();
+        const component = mount(
+          <EuiDragDropContext onDragEnd={handler} {...requiredProps}>
+            <EuiDroppable droppableId="testDroppable" cloneDraggables={true}>
+              <EuiDroppableContext.Consumer>
+                {({ cloneItems }) => (
+                  <div data-test-subj="child">
+                    {cloneItems ? 'true' : 'false'}
+                  </div>
+                )}
+              </EuiDroppableContext.Consumer>
+            </EuiDroppable>
+          </EuiDragDropContext>
+        );
+
         expect(findTestSubject(component, 'child').text()).toBe('true');
       });
 
       test('sets `isDropDisabled`', () => {
+        const handler = jest.fn();
+        const component = mount(
+          <EuiDragDropContext onDragEnd={handler} {...requiredProps}>
+            <EuiDroppable droppableId="testDroppable" cloneDraggables={true}>
+              <EuiDroppableContext.Consumer>
+                {({ cloneItems }) => (
+                  <div data-test-subj="child">
+                    {cloneItems ? 'true' : 'false'}
+                  </div>
+                )}
+              </EuiDroppableContext.Consumer>
+            </EuiDroppable>
+          </EuiDragDropContext>
+        );
+
         expect(component.find('.euiDroppable--isDisabled').length).toBe(1);
       });
     });


### PR DESCRIPTION
### Summary

Turns out enzyme [does not attempt to unmount or cleanup components](https://github.com/enzymejs/enzyme/issues/911) after executing. It makes sense, but is unfortunate. The impact to us has mostly been through the MutationObserver polyfill singleton yelling about too many listeners and possible memory leak. Turns out there was a memory leak.

* intercepts calls to `mount` and stores a reference to the returned component
* added a global `afterEach` to unmount any still-mounted components
* ~bumped~ ~un-bumped?~ **cratered** the MutationObserver polyfill's setMaxListeners back to a reasonable number
* modified **EuiDroppable**'s test to reset the react-beautiful-dnd context counter
  * the snapshots were already affected by the global unmounting
  * its individual snapshots are no longer reliant on order or existence of execution

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **documentation** examples~
- [x] Added or updated **jest tests**
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CONTRIBUTING.md#changelog) entry exists and is marked appropriately~
