### PR TITLE
[Docs] Converted i18n, link, list group and some other examples to functional components

### DIFF
--- a/src-docs/src/views/i18n/context.js
+++ b/src-docs/src/views/i18n/context.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { useState, Fragment } from 'react';
 
 import {
   EuiContext,
@@ -24,77 +24,70 @@ const mappings = {
   },
 };
 
-export default class extends Component {
-  state = {
-    language: 'en',
+export default () => {
+  const [language, setLanguage] = useState('en');
+
+  const i18n = {
+    mapping: mappings[language],
+    formatNumber: value => new Intl.NumberFormat(language).format(value),
   };
 
-  setLanguage = language => this.setState({ language });
+  return (
+    <EuiContext i18n={i18n}>
+      <div>
+        <EuiFlexGroup gutterSize="s" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              fill={language === 'en'}
+              onClick={() => setLanguage('en')}>
+              <EuiI18n token="euiContext.english" default="English" />
+            </EuiButton>
+          </EuiFlexItem>
 
-  render() {
-    const i18n = {
-      mapping: mappings[this.state.language],
-      formatNumber: value =>
-        new Intl.NumberFormat(this.state.language).format(value),
-    };
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              fill={language === 'fr'}
+              onClick={() => setLanguage('fr')}>
+              <EuiI18n token="euiContext.french" default="French" />
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
 
-    return (
-      <EuiContext i18n={i18n}>
-        <div>
-          <EuiFlexGroup gutterSize="s" alignItems="center">
-            <EuiFlexItem grow={false}>
-              <EuiButton
-                fill={this.state.language === 'en'}
-                onClick={() => this.setLanguage('en')}>
-                <EuiI18n token="euiContext.english" default="English" />
-              </EuiButton>
-            </EuiFlexItem>
+        <EuiSpacer size="m" />
 
-            <EuiFlexItem grow={false}>
-              <EuiButton
-                fill={this.state.language === 'fr'}
-                onClick={() => this.setLanguage('fr')}>
-                <EuiI18n token="euiContext.french" default="French" />
-              </EuiButton>
-            </EuiFlexItem>
-          </EuiFlexGroup>
+        <strong>
+          <EuiI18n token="euiContext.greeting" default="Welcome!" />
+        </strong>
 
-          <EuiSpacer size="m" />
+        <EuiSpacer size="s" />
 
-          <strong>
-            <EuiI18n token="euiContext.greeting" default="Welcome!" />
-          </strong>
+        <p>
+          <EuiI18n token="euiContext.guestNo" default="You are guest #" />
+          <EuiI18nNumber value={1582394} />
+        </p>
 
-          <EuiSpacer size="s" />
+        <EuiSpacer size="m" />
 
-          <p>
-            <EuiI18n token="euiContext.guestNo" default="You are guest #" />
-            <EuiI18nNumber value={1582394} />
-          </p>
+        <EuiI18n
+          tokens={[
+            'euiContext.question',
+            'euiContext.action',
+            'euiContext.placeholder',
+          ]}
+          defaults={['What is your name?', 'Submit', 'John Doe']}>
+          {([question, action, placeholder]) => (
+            <Fragment>
+              <EuiFormRow label={question}>
+                <EuiFieldText placeholder={placeholder} />
+              </EuiFormRow>
 
-          <EuiSpacer size="m" />
+              <EuiSpacer />
 
-          <EuiI18n
-            tokens={[
-              'euiContext.question',
-              'euiContext.action',
-              'euiContext.placeholder',
-            ]}
-            defaults={['What is your name?', 'Submit', 'John Doe']}>
-            {([question, action, placeholder]) => (
-              <Fragment>
-                <EuiFormRow label={question}>
-                  <EuiFieldText placeholder={placeholder} />
-                </EuiFormRow>
-
-                <EuiSpacer />
-
-                <EuiButton>{action}</EuiButton>
-              </Fragment>
-            )}
-          </EuiI18n>
-        </div>
-      </EuiContext>
-    );
-  }
-}
+              <EuiButton>{action}</EuiButton>
+            </Fragment>
+          )}
+        </EuiI18n>
+      </div>
+    </EuiContext>
+  );
+};

--- a/src-docs/src/views/link/link_disable.js
+++ b/src-docs/src/views/link/link_disable.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import {
   EuiLink,
   EuiSwitch,
@@ -6,56 +6,45 @@ import {
   EuiTextColor,
 } from '../../../../src/components';
 
-export class LinkDisable extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      disableLink: true,
-    };
-  }
+export const LinkDisable = () => {
+  const [disableLink, setDisableLink] = useState(true);
 
-  toggleLinkDisable = () => {
-    this.setState(prevState => ({ disableLink: !prevState.disableLink }));
-  };
-
-  render() {
-    return (
-      <div>
-        <EuiSwitch
-          label="Disable links"
-          checked={this.state.disableLink}
-          onChange={this.toggleLinkDisable}
-        />
-        <EuiSpacer size="m" />
-        <p>
-          This{' '}
-          <EuiLink
-            color="accent"
-            disabled={this.state.disableLink}
-            onClick={() => window.alert('Button clicked')}>
-            paragraph
-          </EuiLink>{' '}
-          has two{this.state.disableLink ? ' disabled ' : ' enabled '}
-          <EuiLink
-            color="warning"
-            disabled={this.state.disableLink}
-            onClick={() => window.alert('Button clicked')}>
-            links
-          </EuiLink>{' '}
-          in it.
-        </p>
-        <EuiSpacer size="m" />
-        <EuiTextColor color="accent">
-          When links are disabled, they inherit the{' '}
-          <EuiLink
-            color="secondary"
-            disabled={this.state.disableLink}
-            onClick={() => window.alert('Button clicked')}>
-            color
-          </EuiLink>{' '}
-          of surrounding text.
-        </EuiTextColor>
-      </div>
-    );
-  }
-}
+  return (
+    <div>
+      <EuiSwitch
+        label="Disable links"
+        checked={disableLink}
+        onChange={() => setDisableLink(!disableLink)}
+      />
+      <EuiSpacer size="m" />
+      <p>
+        This{' '}
+        <EuiLink
+          color="accent"
+          disabled={disableLink}
+          onClick={() => window.alert('Button clicked')}>
+          paragraph
+        </EuiLink>{' '}
+        has two{disableLink ? ' disabled ' : ' enabled '}
+        <EuiLink
+          color="warning"
+          disabled={disableLink}
+          onClick={() => window.alert('Button clicked')}>
+          links
+        </EuiLink>{' '}
+        in it.
+      </p>
+      <EuiSpacer size="m" />
+      <EuiTextColor color="accent">
+        When links are disabled, they inherit the{' '}
+        <EuiLink
+          color="secondary"
+          disabled={disableLink}
+          onClick={() => window.alert('Button clicked')}>
+          color
+        </EuiLink>{' '}
+        of surrounding text.
+      </EuiTextColor>
+    </div>
+  );
+};

--- a/src-docs/src/views/list_group/list_group.js
+++ b/src-docs/src/views/list_group/list_group.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { useState, Fragment } from 'react';
 
 import {
   EuiListGroup,
@@ -10,77 +10,58 @@ import {
   EuiFlexItem,
 } from '../../../../src/components';
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const [flushWidth, setFlushWidth] = useState(false);
+  const [showBorder, setShowBorder] = useState(false);
 
-    this.state = {
-      flushWidth: false,
-      showBorder: false,
-    };
-  }
-
-  toggleFlushWidth = () => {
-    this.setState(prevState => ({ flushWidth: !prevState.flushWidth }));
+  const handleOnClick = () => {
+    alert('Item was clicked');
   };
 
-  toggleBorder = () => {
-    this.setState(prevState => ({ showBorder: !prevState.showBorder }));
-  };
-
-  render() {
-    const { flushWidth, showBorder } = this.state;
-    const handleOnClick = () => {
-      alert('Item was clicked');
-    };
-
-    return (
-      <Fragment>
-        <EuiFlexGroup alignItems="center">
-          <EuiFlexItem grow={false}>
-            <EuiSwitch
-              label={
-                <span>
-                  Show as <EuiCode>flush</EuiCode>
-                </span>
-              }
-              checked={this.state.flushWidth}
-              onChange={this.toggleFlushWidth}
-            />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiSwitch
-              label={
-                <span>
-                  Show as <EuiCode>bordered</EuiCode>
-                </span>
-              }
-              checked={this.state.showBorder}
-              onChange={this.toggleBorder}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-
-        <EuiSpacer size="l" />
-
-        <EuiListGroup flush={flushWidth} bordered={showBorder}>
-          <EuiListGroupItem onClick={handleOnClick} label="First item" />
-
-          <EuiListGroupItem onClick={handleOnClick} label="Second item" />
-
-          <EuiListGroupItem
-            onClick={handleOnClick}
-            label="Third item"
-            isActive
+  return (
+    <Fragment>
+      <EuiFlexGroup alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiSwitch
+            label={
+              <span>
+                Show as <EuiCode>flush</EuiCode>
+              </span>
+            }
+            checked={flushWidth}
+            onChange={() => setFlushWidth(!flushWidth)}
           />
-
-          <EuiListGroupItem
-            onClick={handleOnClick}
-            label="Fourth item"
-            isDisabled
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiSwitch
+            label={
+              <span>
+                Show as <EuiCode>bordered</EuiCode>
+              </span>
+            }
+            checked={showBorder}
+            onChange={() => {
+              setShowBorder(!showBorder);
+            }}
           />
-        </EuiListGroup>
-      </Fragment>
-    );
-  }
-}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="l" />
+
+      <EuiListGroup flush={flushWidth} bordered={showBorder}>
+        <EuiListGroupItem onClick={handleOnClick} label="First item" />
+
+        <EuiListGroupItem onClick={handleOnClick} label="Second item" />
+
+        <EuiListGroupItem onClick={handleOnClick} label="Third item" isActive />
+
+        <EuiListGroupItem
+          onClick={handleOnClick}
+          label="Fourth item"
+          isDisabled
+        />
+      </EuiListGroup>
+    </Fragment>
+  );
+};

--- a/src-docs/src/views/list_group/list_group_link_actions.js
+++ b/src-docs/src/views/list_group/list_group_link_actions.js
@@ -1,125 +1,95 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import { EuiListGroup, EuiListGroupItem } from '../../../../src/components';
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const [favorite1, setFavorite1] = useState(undefined);
+  const [favorite2, setFavorite2] = useState('link2');
+  const [favorite3, setFavorite3] = useState(undefined);
 
-    this.state = {
-      favorite1: undefined,
-      favorite2: 'link2',
-      favorite3: undefined,
-    };
-  }
-
-  toggleFlushWidth = () => {
-    this.setState(prevState => ({ flushWidth: !prevState.flushWidth }));
-  };
-
-  toggleBorder = () => {
-    this.setState(prevState => ({ showBorder: !prevState.showBorder }));
-  };
-
-  link1Clicked = () => {
-    this.setState(prevState => {
-      return {
-        favorite1: prevState.favorite1 === 'link1' ? undefined : 'link1',
-      };
-    });
-    if (this.favorite1 === undefined) {
+  const link1Clicked = () => {
+    setFavorite1(favorite1 === 'link1' ? undefined : 'link1');
+    if (favorite1 === undefined) {
       document.activeElement.blur();
     }
   };
 
-  link2Clicked = () => {
-    this.setState(prevState => {
-      return {
-        favorite2: prevState.favorite2 === 'link2' ? undefined : 'link2',
-      };
-    });
-    if (this.favorite2 === undefined) {
+  const link2Clicked = () => {
+    setFavorite2(favorite2 === 'link2' ? undefined : 'link2');
+    if (favorite2 === undefined) {
       document.activeElement.blur();
     }
   };
 
-  link3Clicked = () => {
-    this.setState(prevState => {
-      return {
-        favorite3: prevState.favorite3 === 'link3' ? undefined : 'link3',
-      };
-    });
-    if (this.favorite3 === undefined) {
+  const link3Clicked = () => {
+    setFavorite3(favorite3 === 'link3' ? undefined : 'link3');
+    if (favorite3 === undefined) {
       document.activeElement.blur();
     }
   };
 
-  render() {
-    const { favorite1, favorite2, favorite3 } = this.state;
+  return (
+    <EuiListGroup maxWidth={288}>
+      <EuiListGroupItem
+        id="link1"
+        iconType="bullseye"
+        label="EUI button link"
+        onClick={() => window.alert('Button clicked')}
+        isActive
+        extraAction={{
+          color: 'subdued',
+          onClick: link1Clicked,
+          iconType: favorite1 === 'link1' ? 'starFilled' : 'starEmpty',
+          iconSize: 's',
+          'aria-label': 'Favorite link1',
+          alwaysShow: favorite1 === 'link1',
+        }}
+      />
 
-    return (
-      <EuiListGroup maxWidth={288}>
-        <EuiListGroupItem
-          id="link1"
-          iconType="bullseye"
-          label="EUI button link"
-          onClick={() => window.alert('Button clicked')}
-          isActive
-          extraAction={{
-            color: 'subdued',
-            onClick: this.link1Clicked,
-            iconType: favorite1 === 'link1' ? 'starFilled' : 'starEmpty',
-            iconSize: 's',
-            'aria-label': 'Favorite link1',
-            alwaysShow: favorite1 === 'link1',
-          }}
-        />
+      <EuiListGroupItem
+        id="link2"
+        iconType="beaker"
+        onClick={() => window.alert('Button clicked')}
+        label="EUI button link"
+        extraAction={{
+          color: 'subdued',
+          onClick: link2Clicked,
+          iconType: favorite2 === 'link2' ? 'starFilled' : 'starEmpty',
+          iconSize: 's',
+          'aria-label': 'Favorite link2',
+          alwaysShow: favorite2 === 'link2',
+        }}
+      />
 
-        <EuiListGroupItem
-          id="link2"
-          iconType="beaker"
-          onClick={() => window.alert('Button clicked')}
-          label="EUI button link"
-          extraAction={{
-            color: 'subdued',
-            onClick: this.link2Clicked,
-            iconType: favorite2 === 'link2' ? 'starFilled' : 'starEmpty',
-            iconSize: 's',
-            'aria-label': 'Favorite link2',
-            alwaysShow: favorite2 === 'link2',
-          }}
-        />
+      <EuiListGroupItem
+        id="link3"
+        onClick={() => window.alert('Button clicked')}
+        iconType="broom"
+        label="EUI button link"
+        extraAction={{
+          color: 'subdued',
+          onClick: link3Clicked,
+          iconType: favorite3 === 'link3' ? 'starFilled' : 'starEmpty',
+          iconSize: 's',
+          'aria-label': 'Favorite link3',
+          alwaysShow: favorite3 === 'link3',
+          isDisabled: true,
+        }}
+      />
 
-        <EuiListGroupItem
-          id="link3"
-          onClick={() => window.alert('Button clicked')}
-          iconType="broom"
-          label="EUI button link"
-          extraAction={{
-            color: 'subdued',
-            onClick: this.link3Clicked,
-            iconType: favorite3 === 'link3' ? 'starFilled' : 'starEmpty',
-            iconSize: 's',
-            'aria-label': 'Favorite link3',
-            alwaysShow: favorite3 === 'link3',
-            isDisabled: true,
-          }}
-        />
-
-        <EuiListGroupItem
-          id="link4"
-          iconType="brush"
-          isDisabled
-          label="EUI button link"
-          extraAction={{
-            color: 'subdued',
-            onClick: () => window.alert('Action clicked'),
-            iconType: 'starEmpty',
-            iconSize: 's',
-            'aria-label': 'Favorite link4',
-          }}
-        />
-      </EuiListGroup>
-    );
-  }
-}
+      <EuiListGroupItem
+        id="link4"
+        iconType="brush"
+        isDisabled
+        label="EUI button link"
+        extraAction={{
+          color: 'subdued',
+          onClick: () => window.alert('Action clicked'),
+          iconType: 'starEmpty',
+          iconSize: 's',
+          'aria-label': 'Favorite link4',
+        }}
+      />
+    </EuiListGroup>
+  );
+};

--- a/src-docs/src/views/mutation_observer/mutation_observer.js
+++ b/src-docs/src/views/mutation_observer/mutation_observer.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import {
   EuiButton,
@@ -10,78 +10,61 @@ import {
   EuiSpacer,
 } from '../../../../src/components';
 
-export class MutationObserver extends Component {
-  constructor(props) {
-    super(props);
+export const MutationObserver = () => {
+  const [lastMutation, setLastMutation] = useState('no changes detected');
+  const [buttonColor, setButtonColor] = useState('primary');
+  const [items, setItems] = useState(['Item 1', 'Item 2', 'Item 3']);
 
-    this.state = {
-      lastMutation: 'no changes detected',
-      buttonColor: 'primary',
-      items: ['Item 1', 'Item 2', 'Item 3'],
-    };
-  }
-
-  toggleButtonColor = () => {
-    this.setState(({ buttonColor }) => ({
-      buttonColor: buttonColor === 'primary' ? 'warning' : 'primary',
-    }));
+  const toggleButtonColor = () => {
+    setButtonColor(buttonColor === 'primary' ? 'warning' : 'primary');
   };
 
-  addItem = () => {
-    this.setState(({ items }) => ({
-      items: [...items, `Item ${items.length + 1}`],
-    }));
+  const addItem = () => {
+    setItems([...items, `Item ${items.length + 1}`]);
   };
 
-  onMutation = ([{ type }]) => {
-    this.setState({
-      lastMutation:
-        type === 'attributes'
-          ? 'button class name changed'
-          : 'DOM tree changed',
-    });
-  };
-
-  render() {
-    return (
-      <div>
-        <p>{this.state.lastMutation}</p>
-
-        <EuiSpacer />
-
-        <EuiMutationObserver
-          observerOptions={{ subtree: true, attributes: true, childList: true }}
-          onMutation={this.onMutation}>
-          {mutationRef => (
-            <div ref={mutationRef}>
-              <EuiButton
-                color={this.state.buttonColor}
-                fill={true}
-                onClick={this.toggleButtonColor}>
-                Toggle button color
-              </EuiButton>
-
-              <EuiSpacer />
-
-              <EuiFlexGroup>
-                <EuiFlexItem grow={false}>
-                  <EuiPanel grow={false}>
-                    <ul>
-                      {this.state.items.map(item => (
-                        <li key={item}>{item}</li>
-                      ))}
-                    </ul>
-                    <EuiSpacer size="s" />
-                    <EuiButtonEmpty onClick={this.addItem}>
-                      add item
-                    </EuiButtonEmpty>
-                  </EuiPanel>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </div>
-          )}
-        </EuiMutationObserver>
-      </div>
+  const onMutation = ([{ type }]) => {
+    setLastMutation(
+      type === 'attributes' ? 'button class name changed' : 'DOM tree changed'
     );
-  }
-}
+  };
+
+  return (
+    <div>
+      <p>{lastMutation}</p>
+
+      <EuiSpacer />
+
+      <EuiMutationObserver
+        observerOptions={{ subtree: true, attributes: true, childList: true }}
+        onMutation={onMutation}>
+        {mutationRef => (
+          <div ref={mutationRef}>
+            <EuiButton
+              color={buttonColor}
+              fill={true}
+              onClick={toggleButtonColor}>
+              Toggle button color
+            </EuiButton>
+
+            <EuiSpacer />
+
+            <EuiFlexGroup>
+              <EuiFlexItem grow={false}>
+                <EuiPanel grow={false}>
+                  <ul>
+                    {items.map(item => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                  <EuiSpacer size="s" />
+                  <EuiButtonEmpty onClick={addItem}>add item</EuiButtonEmpty>
+                </EuiPanel>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </div>
+        )}
+      </EuiMutationObserver>
+    </div>
+  );
+};

--- a/src-docs/src/views/outside_click_detector/outside_click_detector.js
+++ b/src-docs/src/views/outside_click_detector/outside_click_detector.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import {
   EuiButton,
@@ -6,44 +6,32 @@ import {
   EuiSpacer,
 } from '../../../../src/components';
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const [isDisabled, setIsDisabled] = useState(false);
 
-    this.state = {
-      isDisabled: false,
-    };
-  }
-
-  toggleDisabled = () => {
-    this.setState(prevState => ({
-      isDisabled: !prevState.isDisabled,
-    }));
+  const toggleDisabled = () => {
+    setIsDisabled(!isDisabled);
   };
 
-  render() {
-    const { isDisabled } = this.state;
+  return (
+    <div>
+      <EuiOutsideClickDetector
+        onOutsideClick={() => {
+          window.alert('Clicked outside');
+        }}
+        isDisabled={isDisabled}>
+        <p>
+          {isDisabled
+            ? 'This detector is disabled, so clicking outside will do nothing.'
+            : 'Clicking inside here will do nothing, but clicking outside will trigger an alert.'}
+        </p>
+      </EuiOutsideClickDetector>
 
-    return (
-      <div>
-        <EuiOutsideClickDetector
-          onOutsideClick={() => {
-            window.alert('Clicked outside');
-          }}
-          isDisabled={isDisabled}>
-          <p>
-            {isDisabled
-              ? 'This detector is disabled, so clicking outside will do nothing.'
-              : 'Clicking inside here will do nothing, but clicking outside will trigger an alert.'}
-          </p>
-        </EuiOutsideClickDetector>
+      <EuiSpacer size="l" />
 
-        <EuiSpacer size="l" />
-
-        <EuiButton onClick={this.toggleDisabled}>
-          {isDisabled ? 'Enable' : 'Disable'} the detector
-        </EuiButton>
-      </div>
-    );
-  }
-}
+      <EuiButton onClick={toggleDisabled}>
+        {isDisabled ? 'Enable' : 'Disable'} the detector
+      </EuiButton>
+    </div>
+  );
+};


### PR DESCRIPTION
### Summary

Makes progress on #3150 
Converted i18n, links, list group, mutation observer, outside click detector examples to functional components

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
- [x] Checked for **breaking changes** and labeled appropriately
~~- [] Checked for **accessibility** including keyboard-only and screenreader modes~~
~~- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CONTRIBUTING.md#changelog) entry exists and is marked appropriately~~
