### PR TITLE
[Docs] Add snippets to EuiSideNav

### DIFF
--- a/src-docs/src/views/side_nav/side_nav_example.js
+++ b/src-docs/src/views/side_nav/side_nav_example.js
@@ -9,14 +9,156 @@ import { EuiCode, EuiSideNav } from '../../../../src/components';
 import SideNav from './side_nav';
 const sideNavSource = require('!!raw-loader!./side_nav');
 const sideNavHtml = renderToHtml(SideNav);
+const sideNavSnippet = `<EuiSideNav
+  mobileTitle="Navbar Items"
+  toggleOpenOnMobile={toggleOpenOnMobile}
+  isOpenOnMobile={isSideNavOpenOnMobile}
+  items={[
+    {
+      name: 'Kibana',
+      id: 0,
+      items: [
+        {
+          name: 'Advanced settings',
+          id: 1,
+          onClick: () => selectItem('Advanced settings'),
+        },
+        {
+          name: 'Index Patterns (link)',
+          id: 2,
+          href: '#',
+        },
+      ]
+    }
+  ]}
+/>
+`;
 
 import SideNavComplex from './side_nav_complex';
 const sideNavComplexSource = require('!!raw-loader!./side_nav_complex');
 const sideNavComplexHtml = renderToHtml(SideNavComplex);
+const sideNavComplexSnippet = `<EuiSideNav
+  mobileTitle="Navbar Items"
+  toggleOpenOnMobile={toggleOpenOnMobile}
+  isOpenOnMobile={isSideNavOpenOnMobile}
+  items={[
+    {
+      name: 'Elasticsearch',
+      icon: <EuiIcon type="logoElasticsearch" />,
+      id: '0',
+      items: [
+        {
+          name: 'Data source',
+          id: '0.1',
+          onClick: () => selectItem('Data source'),
+        },
+        {
+          name: 'Users',
+          id: '0.2',
+          href: '#',
+        },
+      ],
+    },
+    {
+      name: 'Kibana',
+      icon: <EuiIcon type="logoKibana" />,
+      id: '1',
+      items: [
+        {
+          name: 'Advanced settings',
+          id: '1.1',
+          onClick: () => selectItem('Advanced settings'),
+          items: [
+            {
+              name: 'General',
+              id: '1.1.1',
+              onClick: () => selectItem('General'),
+            },
+            {
+              name: 'Timelion',
+              id: '1.1.2',
+              onClick: () => selectItem('Timelion'),
+              items: [
+                {
+                  name: 'Time Stuff',
+                  id: '1.1.2.1',
+                  onClick: () => selectItem('Time Stuff'),
+                },
+                {
+                  name: 'Lion Stuff',
+                  id: '1.1.2.2',
+                  onClick: () => selectItem('Lion Stuff'),
+                  isSelected: true,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ]}
+/>
+`;
 
 import SideNavForceOpen from './side_nav_force_open';
 const sideNavForceOpenSource = require('!!raw-loader!./side_nav_force_open');
 const sideNavForceOpenHtml = renderToHtml(SideNavForceOpen);
+const sideNavForceSnippet = `<EuiSideNav
+  mobileTitle="Navbar Items"
+  toggleOpenOnMobile={toggleOpenOnMobile}
+  isOpenOnMobile={isSideNavOpenOnMobile}
+  items={[
+    {
+      name: 'Kibana',
+      id: '1',
+      items: [
+        {
+          name: 'Kibana',
+          id: '1',
+          items: [
+            {
+              name: 'Forced open items',
+              id: '0.1',
+              onClick: () => selectItem('Forced open items'),
+              forceOpen: true,
+              items: [
+                {
+                  name: 'General',
+                  id: '0.1.1',
+                  onClick: () => selectItem('General'),
+                },
+                {
+                  name: 'Timelion',
+                  id: '0.1.2',
+                  onClick: () => selectItem('Timelion'),
+                },
+              ],
+            },
+            {
+              name: 'Closed items',
+              id: '1.1',
+              onClick: () => selectItem('Closed items'),
+              forceOpen: false,
+              items: [
+                {
+                  name: 'General',
+                  id: '1.1.1',
+                  onClick: () => this.selectItem('General'),
+                },
+                {
+                  name: 'Timelion',
+                  id: '1.1.2',
+                  onClick: () => selectItem('Timelion'),
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ]}
+/>
+`;
 
 import { SideNavItem } from './props';
 
@@ -51,6 +193,7 @@ export const SideNavExample = {
         </div>
       ),
       props: { EuiSideNav, EuiSideNavItem: SideNavItem },
+      snippet: sideNavSnippet,
       demo: <SideNav />,
     },
     {
@@ -71,6 +214,7 @@ export const SideNavExample = {
           data.
         </p>
       ),
+      snippet: sideNavComplexSnippet,
       demo: <SideNavComplex />,
     },
     {
@@ -91,6 +235,7 @@ export const SideNavExample = {
           <EuiCode>items[n].forceOpen = true</EuiCode>
         </p>
       ),
+      snippet: sideNavForceSnippet,
       demo: <SideNavForceOpen />,
     },
   ],


### PR DESCRIPTION
### Summary

This PR adds snippets to the **EuiSideNav** docs.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **IE11** and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- [x] Added **documentation** examples
- ~[ ] Added or updated **jest tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A [changelog](https://github.com/elastic/eui/blob/master/CONTRIBUTING.md#changelog) entry exists and is marked appropriately~
