### PR TITLE
[Docs] Add snippets to EuiDescriptionList

### DIFF
--- a/src-docs/src/views/description_list/description_list_example.js
+++ b/src-docs/src/views/description_list/description_list_example.js
@@ -14,26 +14,98 @@ import {
 import DescriptionList from './description_list';
 const descriptionListSource = require('!!raw-loader!./description_list');
 const descriptionListHtml = renderToHtml(DescriptionList);
+const descriptionListSnippet = [
+  `<EuiDescriptionList
+  listItems={[
+    {
+      title: 'The Elder Scrolls: Morrowind',
+      description: 'The opening music alone evokes such strong memories.',
+    },
+    {
+      title: 'TIE Fighter',
+      description: 'The sequel to XWING, join the dark side and fly for the Emporer.',
+    },
+  ]}
+/>`,
+  `<EuiDescriptionList>
+  <EuiDescriptionListTitle>Dota 2</EuiDescriptionListTitle>
+  <EuiDescriptionListDescription>
+    A videogame that I have spent way too much time on over the years.
+  </EuiDescriptionListDescription>
+  <EuiDescriptionListTitle>Kings Quest VI</EuiDescriptionListTitle>
+  <EuiDescriptionListDescription>
+    The game that forced me to learn DOS.
+  </EuiDescriptionListDescription>
+</EuiDescriptionList>`,
+];
 
 import DescriptionListColumn from './description_list_column';
 const descriptionListColumnSource = require('!!raw-loader!./description_list_column');
 const descriptionListColumnHtml = renderToHtml(DescriptionListColumn);
+const descriptionListColumnSnippet = [
+  `<EuiDescriptionList
+  type="column"
+  listItems={favoriteVideoGames}
+/>`,
+  `<EuiDescriptionList
+  type="responsiveColumn"
+  listItems={favoriteVideoGames}
+/>`,
+];
 
 import DescriptionListStyling from './description_list_styling';
 const descriptionListStylingSource = require('!!raw-loader!./description_list_styling');
 const descriptionListStylingHtml = renderToHtml(DescriptionListStyling);
+const descriptionListStylingSnippet = [
+  `<EuiDescriptionList
+  listItems={favoriteVideoGames}
+  align="center"
+  compressed
+/>`,
+  `<EuiDescriptionList
+  listItems={favoriteVideoGames}
+  type="column"
+  align="center"
+  compressed
+/>`,
+  `<EuiDescriptionList
+  listItems={favoriteVideoGames}
+  type="inline"
+  align="center"
+  compressed
+/>`,
+];
 
 import DescriptionListInline from './description_list_inline';
 const descriptionListInlineSource = require('!!raw-loader!./description_list_inline');
 const descriptionListInlineHtml = renderToHtml(DescriptionListInline);
+const descriptionListInlineSnippet = [
+  `<EuiDescriptionList
+  type="inline"
+  listItems={favoriteVideoGames}
+/>`,
+];
 
 import DescriptionListReverse from './description_list_reverse';
 const descriptionListReverseSource = require('!!raw-loader!./description_list_reverse');
 const descriptionListReverseHtml = renderToHtml(DescriptionListReverse);
+const descriptionListReverseSnippet = [
+  `<EuiDescriptionList
+  textStyle="reverse"
+  listItems={favoriteVideoGames}
+/>`,
+];
 
 import DescriptionListClasses from './description_list_classes';
 const descriptionListClassesSource = require('!!raw-loader!./description_list_classes');
 const descriptionListClassesHtml = renderToHtml(DescriptionListClasses);
+const descriptionListClassesSnippet = [
+  `<EuiDescriptionList
+  titleProps={{ className: 'eui-textTruncate' }}
+  descriptionProps={{ className: 'eui-textTruncate' }}
+  listItems={favoriteVideoGames}
+/>`,
+];
 
 export const DescriptionListExample = {
   title: 'Description list',
@@ -64,6 +136,7 @@ export const DescriptionListExample = {
         EuiDescriptionListTitle,
         EuiDescriptionListDescription,
       },
+      snippet: descriptionListSnippet,
       demo: <DescriptionList />,
     },
     {
@@ -93,6 +166,7 @@ export const DescriptionListExample = {
           </p>
         </div>
       ),
+      snippet: descriptionListReverseSnippet,
       demo: <DescriptionListReverse />,
     },
     {
@@ -120,6 +194,7 @@ export const DescriptionListExample = {
           </p>
         </Fragment>
       ),
+      snippet: descriptionListColumnSnippet,
       demo: <DescriptionListColumn />,
     },
     {
@@ -142,6 +217,7 @@ export const DescriptionListExample = {
           smaller than normal lists due to their compact nature.
         </p>
       ),
+      snippet: descriptionListInlineSnippet,
       demo: <DescriptionListInline />,
     },
     {
@@ -163,6 +239,7 @@ export const DescriptionListExample = {
           works with column and inline types.
         </p>
       ),
+      snippet: descriptionListStylingSnippet,
       demo: <DescriptionListStyling />,
     },
     {
@@ -186,6 +263,7 @@ export const DescriptionListExample = {
           to do so.
         </p>
       ),
+      snippet: descriptionListClassesSnippet,
       demo: <DescriptionListClasses />,
     },
   ],

--- a/src-docs/src/views/description_list/description_list_example.js
+++ b/src-docs/src/views/description_list/description_list_example.js
@@ -23,8 +23,7 @@ const descriptionListSnippet = [
     },
   ]}
 />`,
-  `<EuiDescriptionList
->
+  `<EuiDescriptionList>
   <EuiDescriptionListTitle>Dota 2</EuiDescriptionListTitle>
   <EuiDescriptionListDescription>
     A videogame that I have spent way too much time on over the years.

--- a/src-docs/src/views/description_list/description_list_example.js
+++ b/src-docs/src/views/description_list/description_list_example.js
@@ -16,6 +16,9 @@ const descriptionListSource = require('!!raw-loader!./description_list');
 const descriptionListHtml = renderToHtml(DescriptionList);
 const descriptionListSnippet = [
   `<EuiDescriptionList
+  type="row"
+  textStyle="normal"
+  compressed={false}
   listItems={[
     {
       title: 'The Elder Scrolls: Morrowind',
@@ -27,7 +30,11 @@ const descriptionListSnippet = [
     },
   ]}
 />`,
-  `<EuiDescriptionList>
+  `<EuiDescriptionList
+  type="row"
+  textStyle="normal"
+  compressed={false}  
+>
   <EuiDescriptionListTitle>Dota 2</EuiDescriptionListTitle>
   <EuiDescriptionListDescription>
     A videogame that I have spent way too much time on over the years.

--- a/src-docs/src/views/description_list/description_list_example.js
+++ b/src-docs/src/views/description_list/description_list_example.js
@@ -24,9 +24,6 @@ const descriptionListSnippet = [
   ]}
 />`,
   `<EuiDescriptionList
-  type="row"
-  textStyle="normal"
-  compressed={false}  
 >
   <EuiDescriptionListTitle>Dota 2</EuiDescriptionListTitle>
   <EuiDescriptionListDescription>

--- a/src-docs/src/views/description_list/description_list_example.js
+++ b/src-docs/src/views/description_list/description_list_example.js
@@ -16,17 +16,10 @@ const descriptionListSource = require('!!raw-loader!./description_list');
 const descriptionListHtml = renderToHtml(DescriptionList);
 const descriptionListSnippet = [
   `<EuiDescriptionList
-  type="row"
-  textStyle="normal"
-  compressed={false}
   listItems={[
     {
       title: 'The Elder Scrolls: Morrowind',
       description: 'The opening music alone evokes such strong memories.',
-    },
-    {
-      title: 'TIE Fighter',
-      description: 'The sequel to XWING, join the dark side and fly for the Emporer.',
     },
   ]}
 />`,
@@ -38,10 +31,6 @@ const descriptionListSnippet = [
   <EuiDescriptionListTitle>Dota 2</EuiDescriptionListTitle>
   <EuiDescriptionListDescription>
     A videogame that I have spent way too much time on over the years.
-  </EuiDescriptionListDescription>
-  <EuiDescriptionListTitle>Kings Quest VI</EuiDescriptionListTitle>
-  <EuiDescriptionListDescription>
-    The game that forced me to learn DOS.
   </EuiDescriptionListDescription>
 </EuiDescriptionList>`,
 ];
@@ -66,18 +55,6 @@ const descriptionListStylingHtml = renderToHtml(DescriptionListStyling);
 const descriptionListStylingSnippet = [
   `<EuiDescriptionList
   listItems={favoriteVideoGames}
-  align="center"
-  compressed
-/>`,
-  `<EuiDescriptionList
-  listItems={favoriteVideoGames}
-  type="column"
-  align="center"
-  compressed
-/>`,
-  `<EuiDescriptionList
-  listItems={favoriteVideoGames}
-  type="inline"
   align="center"
   compressed
 />`,


### PR DESCRIPTION
### Summary

This PR adds snippets to the **EuiDescriptionList** docs.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **IE11** and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- [x] Added **documentation** examples
- ~[ ] Added or updated **jest tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A [changelog](https://github.com/elastic/eui/blob/master/CONTRIBUTING.md#changelog) entry exists and is marked appropriately~