### PR TITLE
[DOCS] Added Snippets to EuiTitle.

### DIFF
--- a/src-docs/src/views/title/title_example.js
+++ b/src-docs/src/views/title/title_example.js
@@ -11,7 +11,7 @@ const titleSource = require('!!raw-loader!./title');
 const titleHtml = renderToHtml(Title);
 const titleSnippet = [
   `<EuiTitle>
-  <h2><!-- Default's to medium size. Change the heading level based on your context. --></h2>
+  <h2><!-- Defaults to medium size. Change the heading level based on your context. --></h2>
 </EuiTitle>`,
   `<EuiTitle size="s">
   <h2><!-- Small title but heading level can be anything based on your context. --></h2>

--- a/src-docs/src/views/title/title_example.js
+++ b/src-docs/src/views/title/title_example.js
@@ -9,12 +9,12 @@ import { EuiTitle } from '../../../../src/components';
 import Title from './title';
 const titleSource = require('!!raw-loader!./title');
 const titleHtml = renderToHtml(Title);
-const titleSnippet = `<EuiTitle size='l'><!---Content--></EuiTitle>
-<EuiTitle><!--Content--></EuiTitle>
-<EuiTitle size='s'><!---Content--></EuiTitle>
-<EuiTitle size='xs'><!---Content--></EuiTitle>
-<EuiTitle size='xxs'><!---Content--></EuiTitle>
-<EuiTitle size='xxxs'><!---Content--></EuiTitle>`;
+const titleSnippet = [
+  `<EuiTitle size="l" textTransform="uppercase"><!---Content--></EuiTitle>
+`,
+  `<EuiTitle><!--Content--></EuiTitle>
+`,
+];
 
 export const TitleExample = {
   title: 'Title',

--- a/src-docs/src/views/title/title_example.js
+++ b/src-docs/src/views/title/title_example.js
@@ -12,7 +12,7 @@ const titleHtml = renderToHtml(Title);
 const titleSnippet = [
   `<EuiTitle size="l" textTransform="uppercase"><!---Content--></EuiTitle>
 `,
-  `<EuiTitle><!--Content--></EuiTitle>
+  `<EuiTitle><!--Default--></EuiTitle>
 `,
 ];
 

--- a/src-docs/src/views/title/title_example.js
+++ b/src-docs/src/views/title/title_example.js
@@ -9,6 +9,12 @@ import { EuiTitle } from '../../../../src/components';
 import Title from './title';
 const titleSource = require('!!raw-loader!./title');
 const titleHtml = renderToHtml(Title);
+const titleSnippet = `<EuiTitle size='l'><!---Content--></EuiTitle>
+<EuiTitle><!--Content--></EuiTitle>
+<EuiTitle size='s'><!---Content--></EuiTitle>
+<EuiTitle size='xs'><!---Content--></EuiTitle>
+<EuiTitle size='xxs'><!---Content--></EuiTitle>
+<EuiTitle size='xxxs'><!---Content--></EuiTitle>`;
 
 export const TitleExample = {
   title: 'Title',
@@ -32,6 +38,7 @@ export const TitleExample = {
           they are margin neutral and more suitable for general layout design.
         </p>
       ),
+      snippet: titleSnippet,
       props: { EuiTitle },
       demo: <Title />,
     },

--- a/src-docs/src/views/title/title_example.js
+++ b/src-docs/src/views/title/title_example.js
@@ -10,10 +10,12 @@ import Title from './title';
 const titleSource = require('!!raw-loader!./title');
 const titleHtml = renderToHtml(Title);
 const titleSnippet = [
-  `<EuiTitle size="l" textTransform="uppercase"><!---Content--></EuiTitle>
-`,
-  `<EuiTitle><!--Default--></EuiTitle>
-`,
+  `<EuiTitle>
+  <h2><!-- Default's to medium size. Change the heading level based on your context. --></h2>
+</EuiTitle>`,
+  `<EuiTitle size="s">
+  <h2><!-- Small title but heading level can be anything based on your context. --></h2>
+</EuiTitle>`,
 ];
 
 export const TitleExample = {


### PR DESCRIPTION
### Summary

Added Snippets to EuiTitle.

![790](https://user-images.githubusercontent.com/52423075/78603331-92587980-7875-11ea-8c31-3a6d5db8fca6.png)

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [x] Added Snippets
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CONTRIBUTING.md#changelog) entry exists and is marked appropriately
