### PR TITLE
[Docs] Improved EuiHealth example and added description for `color` prop

### DIFF
--- a/src-docs/src/views/health/health.js
+++ b/src-docs/src/views/health/health.js
@@ -17,5 +17,9 @@ export default () => (
     <EuiSpacer />
 
     <EuiHealth color="danger">Failure</EuiHealth>
+
+    <EuiSpacer />
+
+    <EuiHealth color="#000000">Dominance</EuiHealth>
   </div>
 );

--- a/src-docs/src/views/health/health.js
+++ b/src-docs/src/views/health/health.js
@@ -20,6 +20,6 @@ export default () => (
 
     <EuiSpacer />
 
-    <EuiHealth color="#000000">Dominance</EuiHealth>
+    <EuiHealth color="#000000">Custom color as hex</EuiHealth>
   </div>
 );

--- a/src-docs/src/views/health/health_example.js
+++ b/src-docs/src/views/health/health_example.js
@@ -29,8 +29,8 @@ export const HealthExample = {
           The <strong>EuiHealth</strong> component should be used when showing
           comparitive health of listed objects (like servers, HTTP response
           status codes(as per convenience), nodes, indexes..etc). Because icons
-          are vague and bulky and color alone does not work, color plus
-          text provides a recognizable, lightweight combo that works in most
+          are vague and bulky and color alone does not work, color plus text
+          provides a recognizable, lightweight combo that works in most
           situations.
         </p>
       ),

--- a/src-docs/src/views/health/health_example.js
+++ b/src-docs/src/views/health/health_example.js
@@ -27,10 +27,11 @@ export const HealthExample = {
       text: (
         <p>
           The <strong>EuiHealth</strong> component should be used when showing
-          comparitive health of listed objects (like servers, nodes,
-          indexes..etc). Because icons are vague and bulky and color alone does
-          not work, we think color plus text provides a recognizable,
-          lightweight combo that works in most situations.
+          comparitive health of listed objects (like servers, HTTP response
+          status codes(as per convenience), nodes, indexes..etc). Because icons
+          are vague and bulky and color alone does not work, we think color plus
+          text provides a recognizable, lightweight combo that works in most
+          situations.
         </p>
       ),
       props: { EuiHealth },

--- a/src-docs/src/views/health/health_example.js
+++ b/src-docs/src/views/health/health_example.js
@@ -29,7 +29,7 @@ export const HealthExample = {
           The <strong>EuiHealth</strong> component should be used when showing
           comparitive health of listed objects (like servers, HTTP response
           status codes(as per convenience), nodes, indexes..etc). Because icons
-          are vague and bulky and color alone does not work, we think color plus
+          are vague and bulky and color alone does not work, color plus
           text provides a recognizable, lightweight combo that works in most
           situations.
         </p>

--- a/src/components/health/health.tsx
+++ b/src/components/health/health.tsx
@@ -8,6 +8,11 @@ import { EuiFlexGroup, EuiFlexItem } from '../flex';
 
 type EuiHealthProps = CommonProps &
   Omit<HTMLAttributes<HTMLDivElement>, 'color'> & {
+    /**
+     * sets the color of the health component.
+     * It can either accept `enum` values like `default`, `primary`,  `secondary`,  `success`, `accent`, `warning`, `danger`, `text`,
+     * `subdued` and `ghost` or any `custom color` wrapped in `string` which can be any `valid CSS color data-type` like custom hex string present in the example
+     */
     color?: IconColor;
   };
 

--- a/src/components/health/health.tsx
+++ b/src/components/health/health.tsx
@@ -9,9 +9,9 @@ import { EuiFlexGroup, EuiFlexItem } from '../flex';
 type EuiHealthProps = CommonProps &
   Omit<HTMLAttributes<HTMLDivElement>, 'color'> & {
     /**
-     * sets the color of the health component.
-     * It can either accept `enum` values like `default`, `primary`,  `secondary`,  `success`, `accent`, `warning`, `danger`, `text`,
-     * `subdued` and `ghost` or any `custom color` wrapped in `string` which can be any `valid CSS color data-type` like custom hex string present in the example
+     * Sets the color of the dot icon.
+     * It accepts any `IconColor`: `default`, `primary`, `secondary`, `success`, `accent`, `warning`, `danger`, `text`,
+     * `subdued` or `ghost`; or any valid CSS color value as a `string`
      */
     color?: IconColor;
   };


### PR DESCRIPTION
### Summary

Closes #3163 

<strong>Added custom Hex String Example</strong>

![741](https://user-images.githubusercontent.com/52423075/78699599-c38e8380-7921-11ea-8b14-4e5e5c3b7f77.png)

<strong>Added Description for color prop</strong>

![742](https://user-images.githubusercontent.com/52423075/78699612-ca1cfb00-7921-11ea-9dc3-b2a22901a675.png)

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [x] Added **documentation** examples
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CONTRIBUTING.md#changelog) entry exists and is marked appropriately
