### PR TITLE
[DOCS] Added Snippets to EuiCodeEditor.

### DIFF
--- a/src-docs/src/views/code_editor/code_editor_example.js
+++ b/src-docs/src/views/code_editor/code_editor_example.js
@@ -9,14 +9,52 @@ import { EuiCode, EuiCodeEditor } from '../../../../src/components';
 import CodeEditor from './code_editor';
 const codeEditorSource = require('!!raw-loader!./code_editor');
 const codeEditorHtml = renderToHtml(CodeEditor);
+const codeEditorSnippet = `<EuiCodeEditor
+    mode="typescript"
+    theme="github"
+    width="100%"
+    height="500px"
+    value={value}
+    onChange={onChange}
+    isReadOnly={false}
+    aria-label="Code Editor"
+    setOptions={{
+      fontSize: '25px',
+      enableBasicAutocompletion: true,
+      enableSnippets: true,
+      enableLiveAutocompletion: true,
+    }}
+    onBlur={() => {
+      console.log('blur');
+    }}
+  />`;
 
 import ReadOnly from './read_only';
 const readOnlySource = require('!!raw-loader!./read_only');
 const readOnlyrHtml = renderToHtml(ReadOnly);
+const readOnlySnippet = `<EuiCodeEditor
+      mode="less"
+      theme="github"
+      width="100%"
+      height="500px"
+      value={value}
+      setOptions={{ fontSize: '23px' }}
+      isReadOnly={true}
+      aria-label="Read only code editor"
+  />`;
 
 import CustomMode from './custom_mode';
 const customModeSource = require('!!raw-loader!./custom_mode');
 const customModeHtml = renderToHtml(CustomMode);
+const customModeSnippet = `<EuiCodeEditor
+      mode={new MyCustomAceMode()}
+      aria-label="Custom mode code editor"
+      theme="github"
+      width="100%"
+      height="500px"
+      value={value}
+      setOptions={{ fontSize: '20px' }}
+  />`;
 
 export const CodeEditorExample = {
   title: 'Code editor',
@@ -46,6 +84,7 @@ export const CodeEditorExample = {
           </p>
         </div>
       ),
+      snippet: codeEditorSnippet,
       props: { EuiCodeEditor },
       demo: <CodeEditor />,
     },
@@ -61,6 +100,7 @@ export const CodeEditorExample = {
           code: readOnlyrHtml,
         },
       ],
+      snippet: readOnlySnippet,
       demo: <ReadOnly />,
     },
     {
@@ -75,6 +115,7 @@ export const CodeEditorExample = {
           code: customModeHtml,
         },
       ],
+      snippet: customModeSnippet,
       demo: <CustomMode />,
     },
   ],


### PR DESCRIPTION
### Summary

Added Snippets to EuiCodeEditor.
![752](https://user-images.githubusercontent.com/52423075/78707689-94324380-792e-11ea-8ba0-71a4f6f12b30.png)
![753](https://user-images.githubusercontent.com/52423075/78707726-9d231500-792e-11ea-857f-40d4e2555570.png)
![754](https://user-images.githubusercontent.com/52423075/78707741-a3b18c80-792e-11ea-9b35-bc80d00f9388.png)

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [x] Added Snippets
- [ ] Added or updated **jest tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CONTRIBUTING.md#changelog) entry exists and is marked appropriately
