### PR TITLE
[Docs] Adds a *NEW* badge to side nav items that are new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added overflows to EuiDataGrid toolbar dropdowns when there are many columns ([#3238](https://github.com/elastic/eui/pull/3238))
 - Fixed `EuiIcon`'s icon `type` definition to allow custom React components ([#3252](https://github.com/elastic/eui/pull/3252))
 - Fixed `initialSelectedTab` properties used in `EuiDatePopoverContent` ([#3254](https://github.com/elastic/eui/pull/3254))
+- Fixed `EuiSideNavItem` overriding custom `className` of item and icon ([#3283](https://github.com/elastic/eui/pull/3283))
 
 ## [`22.3.0`](https://github.com/elastic/eui/tree/v22.3.0)
 

--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -48,6 +48,7 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   // By using the `icon` display of EuiSideNavItem, it will continue to:
   // a) truncate properly
   // b) not underline the badge when selected
+  // But it shows to the left of the label instead of right, so we have to shift the order of the label
   order: -1;
 }
 

--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -43,18 +43,25 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   }
 }
 
-// Hate to do this, but it's the only way to get the badge to display correctly
-.guideSideNav__item .euiSideNavItemButton__label {
-  // By using the `icon` display of EuiSideNavItem, it will continue to:
-  // a) truncate properly
-  // b) not underline the badge when selected
-  // But it shows to the left of the label instead of right, so we have to shift the order of the label
-  order: -1;
-}
+.guideSideNav__item {
+  // Hate to do this, but it's the only way to get the badge to display correctly
+  .euiSideNavItemButton__label {
+    // By using the `icon` display of EuiSideNavItem, it will continue to:
+    // a) truncate properly
+    // b) not underline the badge when selected
+    // But it shows to the left of the label instead of right, so we have to shift the order of the label
+    order: -1;
+  }
 
-.guideSideNav__newBadge {
-  margin-left: $euiSizeXS;
-  margin-right: $euiSizeXS;
+  .guideSideNav__newBadge {
+    margin-left: $euiSizeXS;
+    margin-right: $euiSizeXS;
+  }
+
+  // Shift the margin on the badge when selected and the dropdown arrow no longer shows
+  .euiSideNavItemButton-isSelected .guideSideNav__newBadge {
+    margin-right: 0;
+  }
 }
 
 .guideSideNav__item--inSearch {

--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -43,6 +43,19 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   }
 }
 
+// Hate to do this, but it's the only way to get the badge to display correctly
+.guideSideNav__item .euiSideNavItemButton__label {
+  // By using the `icon` display of EuiSideNavItem, it will continue to:
+  // a) truncate properly
+  // b) not underline the badge when selected
+  order: -1;
+}
+
+.guideSideNav__newBadge {
+  margin-left: $euiSizeXS;
+  margin-right: $euiSizeXS;
+}
+
 .guideSideNav__item--inSearch {
   color: $euiColorDarkShade;
 }

--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -20,6 +20,7 @@ import {
 import { GuideLocaleSelector } from '../guide_locale_selector';
 import { GuideThemeSelector } from '../guide_theme_selector';
 import { EuiHighlight } from '../../../../src/components/highlight';
+import { EuiBadge } from '../../../../src/components/badge';
 
 const scrollTo = position => {
   $('html, body').animate(
@@ -243,17 +244,28 @@ export class GuidePageChrome extends Component {
       });
 
       const items = matchingItems.map(item => {
-        const { name, path, sections } = item;
+        const { name, path, sections, isNew } = item;
         const href = `#/${path}`;
+
+        let newBadge;
+        if (isNew) {
+          newBadge = (
+            <EuiBadge color="accent" className="guideSideNav__newBadge">
+              NEW
+            </EuiBadge>
+          );
+        }
 
         let visibleName = name;
         if (searchTerm) {
           visibleName = (
-            <EuiHighlight
-              className="guideSideNav__item--inSearch"
-              search={searchTerm}>
-              {name}
-            </EuiHighlight>
+            <>
+              <EuiHighlight
+                className="guideSideNav__item--inSearch"
+                search={searchTerm}>
+                {name}
+              </EuiHighlight>
+            </>
           );
         }
 
@@ -265,6 +277,8 @@ export class GuidePageChrome extends Component {
           items: this.renderSubSections(href, sections, searchTerm),
           isSelected: item === this.props.currentRoute,
           forceOpen: !!(searchTerm && hasMatchingSubItem),
+          className: 'guideSideNav__item',
+          icon: newBadge,
         };
       });
 

--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -259,13 +259,11 @@ export class GuidePageChrome extends Component {
         let visibleName = name;
         if (searchTerm) {
           visibleName = (
-            <>
-              <EuiHighlight
-                className="guideSideNav__item--inSearch"
-                search={searchTerm}>
-                {name}
-              </EuiHighlight>
-            </>
+            <EuiHighlight
+              className="guideSideNav__item--inSearch"
+              search={searchTerm}>
+              {name}
+            </EuiHighlight>
           );
         }
 

--- a/src-docs/src/routes.js
+++ b/src-docs/src/routes.js
@@ -243,7 +243,7 @@ const createExample = (example, customTitle) => {
     );
   }
 
-  const { title, intro, sections, beta } = example;
+  const { title, intro, sections, beta, isNew } = example;
   sections.forEach(section => {
     section.id = slugify(section.title || title);
   });
@@ -267,6 +267,7 @@ const createExample = (example, customTitle) => {
     name: customTitle || title,
     component,
     sections,
+    isNew,
   };
 };
 

--- a/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
@@ -32,6 +32,7 @@ const collapsibleNavAllHtml = renderToHtml(CollapsibleNavAll);
 
 export const CollapsibleNavExample = {
   title: 'Collapsible nav',
+  isNew: true,
   intro: (
     <EuiText>
       <p>

--- a/src-docs/src/views/comment/comment_example.js
+++ b/src-docs/src/views/comment/comment_example.js
@@ -65,6 +65,7 @@ const commentActionsSnippet = `<EuiComment username="janed" actions={customActio
 
 export const CommentExample = {
   title: 'Comment',
+  isNew: true,
   sections: [
     {
       source: [

--- a/src-docs/src/views/comment/comment_example.js
+++ b/src-docs/src/views/comment/comment_example.js
@@ -64,7 +64,7 @@ const commentActionsSnippet = `<EuiComment username="janed" actions={customActio
 </EuiComment>`;
 
 export const CommentExample = {
-  title: 'Comment just to check truncation',
+  title: 'Comment',
   isNew: true,
   sections: [
     {

--- a/src-docs/src/views/comment/comment_example.js
+++ b/src-docs/src/views/comment/comment_example.js
@@ -64,7 +64,7 @@ const commentActionsSnippet = `<EuiComment username="janed" actions={customActio
 </EuiComment>`;
 
 export const CommentExample = {
-  title: 'Comment',
+  title: 'Comment just to check truncation',
   isNew: true,
   sections: [
     {

--- a/src-docs/src/views/html_id_generator/html_id_generator_example.js
+++ b/src-docs/src/views/html_id_generator/html_id_generator_example.js
@@ -28,6 +28,7 @@ const prefixSuffixSnippet = " htmlIdGenerator('prefix')('suffix')";
 
 export const HtmlIdGeneratorExample = {
   title: 'HTML ID Generator',
+  isNew: true,
   sections: [
     {
       source: [

--- a/src-docs/src/views/html_id_generator/html_id_generator_example.js
+++ b/src-docs/src/views/html_id_generator/html_id_generator_example.js
@@ -28,7 +28,6 @@ const prefixSuffixSnippet = " htmlIdGenerator('prefix')('suffix')";
 
 export const HtmlIdGeneratorExample = {
   title: 'HTML ID Generator',
-  isNew: true,
   sections: [
     {
       source: [

--- a/src/components/side_nav/side_nav_item.tsx
+++ b/src/components/side_nav/side_nav_item.tsx
@@ -92,6 +92,7 @@ export function EuiSideNavItem<
   children,
   renderItem: RenderItem = DefaultRenderItem,
   depth = 0,
+  className,
   ...rest
 }: EuiSideNavItemProps<T>) {
   let childItems;
@@ -104,17 +105,21 @@ export function EuiSideNavItem<
 
   if (icon) {
     buttonIcon = cloneElement(icon, {
-      className: 'euiSideNavItemButton__icon',
+      className: classNames('euiSideNavItemButton__icon', icon.props.className),
     });
   }
 
-  const classes = classNames('euiSideNavItem', {
-    'euiSideNavItem--root': depth === 0,
-    'euiSideNavItem--rootIcon': depth === 0 && icon,
-    'euiSideNavItem--trunk': depth === 1,
-    'euiSideNavItem--branch': depth > 1,
-    'euiSideNavItem--hasChildItems': !!childItems,
-  });
+  const classes = classNames(
+    'euiSideNavItem',
+    {
+      'euiSideNavItem--root': depth === 0,
+      'euiSideNavItem--rootIcon': depth === 0 && icon,
+      'euiSideNavItem--trunk': depth === 1,
+      'euiSideNavItem--branch': depth > 1,
+      'euiSideNavItem--hasChildItems': !!childItems,
+    },
+    className
+  );
 
   const buttonClasses = classNames('euiSideNavItemButton', {
     'euiSideNavItemButton--isClickable': onClick || href,


### PR DESCRIPTION
### This is still a very manual process (it's not automatic with releases) but...

When there is a new component added to the docs, you can now add the key `isNew: true` to the sections object (just below the `title` in the `_example.js` files). This will add the pink **NEW** badge in the side nav.

Here are examples of the different states including truncation.

<img width="232" alt="Screen Shot 2020-04-08 at 17 44 09 PM" src="https://user-images.githubusercontent.com/549577/78837632-80382180-79c2-11ea-8023-e8ce154c5cfb.png">
<img width="240" alt="Screen Shot 2020-04-08 at 17 44 04 PM" src="https://user-images.githubusercontent.com/549577/78837643-83331200-79c2-11ea-91c3-3a5e90e5d5b8.png">
<img width="240" alt="Screen Shot 2020-04-08 at 17 43 50 PM" src="https://user-images.githubusercontent.com/549577/78837651-862e0280-79c2-11ea-8be1-eefe78397b2b.png">
<img width="269" alt="Screen Shot 2020-04-08 at 17 43 37 PM" src="https://user-images.githubusercontent.com/549577/78837655-88905c80-79c2-11ea-9573-12e135711eb4.png">

---

## Also

I had to fix EuiSideNavItem's to pass down `className` on both itself and the icon otherwise custom classNames were getting overridden/ignored. Fixes part of #2380

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **documentation** examples~
- ~[ ] Added or updated **jest tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CONTRIBUTING.md#changelog) entry exists and is marked appropriately
