### PR TITLE
[EuiBadge] Fix the inline styles being wiped by consumer passed styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Fixed the inline styles being wiped by consumer passed inline styles in EuiBadge ([#3284](https://github.com/elastic/eui/pull/3284))
 - Added support for `href`, `onClick`, and related props in `EuiBasicTable` default actions ([#3115](https://github.com/elastic/eui/pull/3115))
 - Added support for `EuiCodeEditor` to set `readonly` and `id` on `<textarea />` ([#3212](https://github.com/elastic/eui/pull/3212))
 - Added `EuiComment` component ([#3179](https://github.com/elastic/eui/pull/3179))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Fixed the inline styles being wiped by consumer passed inline styles in EuiBadge ([#3284](https://github.com/elastic/eui/pull/3284))
+- Fixed the inline styles being overwritten by consumer-passed inline styles in EuiBadge ([#3284](https://github.com/elastic/eui/pull/3284))
 - Added support for `href`, `onClick`, and related props in `EuiBasicTable` default actions ([#3115](https://github.com/elastic/eui/pull/3115))
 - Added support for `EuiCodeEditor` to set `readonly` and `id` on `<textarea />` ([#3212](https://github.com/elastic/eui/pull/3212))
 - Added `EuiComment` component ([#3179](https://github.com/elastic/eui/pull/3179))

--- a/src/components/badge/__snapshots__/badge.test.tsx.snap
+++ b/src/components/badge/__snapshots__/badge.test.tsx.snap
@@ -299,3 +299,139 @@ exports[`EuiBadge props iconType is rendered 1`] = `
   </span>
 </span>
 `;
+
+exports[`EuiBadge props style is rendered 1`] = `
+<span
+  class="euiBadge euiBadge--iconLeft"
+  style="background-color:#d3dae6;color:#000;border:4px solid tomato"
+>
+  <span
+    class="euiBadge__content"
+  >
+    <span
+      class="euiBadge__text"
+    >
+      Content
+    </span>
+  </span>
+</span>
+`;
+
+exports[`EuiBadge props style is rendered with accent 1`] = `
+<span
+  class="euiBadge euiBadge--iconLeft"
+  style="background-color:#ee789d;color:#000;border:4px solid tomato"
+>
+  <span
+    class="euiBadge__content"
+  >
+    <span
+      class="euiBadge__text"
+    >
+      Content
+    </span>
+  </span>
+</span>
+`;
+
+exports[`EuiBadge props style is rendered with danger 1`] = `
+<span
+  class="euiBadge euiBadge--iconLeft"
+  style="background-color:#ff7e62;color:#000;border:4px solid tomato"
+>
+  <span
+    class="euiBadge__content"
+  >
+    <span
+      class="euiBadge__text"
+    >
+      Content
+    </span>
+  </span>
+</span>
+`;
+
+exports[`EuiBadge props style is rendered with default 1`] = `
+<span
+  class="euiBadge euiBadge--iconLeft"
+  style="background-color:#d3dae6;color:#000;border:4px solid tomato"
+>
+  <span
+    class="euiBadge__content"
+  >
+    <span
+      class="euiBadge__text"
+    >
+      Content
+    </span>
+  </span>
+</span>
+`;
+
+exports[`EuiBadge props style is rendered with hollow 1`] = `
+<span
+  class="euiBadge euiBadge--hollow euiBadge--iconLeft"
+  style="border:4px solid tomato"
+>
+  <span
+    class="euiBadge__content"
+  >
+    <span
+      class="euiBadge__text"
+    >
+      Content
+    </span>
+  </span>
+</span>
+`;
+
+exports[`EuiBadge props style is rendered with primary 1`] = `
+<span
+  class="euiBadge euiBadge--iconLeft"
+  style="background-color:#79aad9;color:#000;border:4px solid tomato"
+>
+  <span
+    class="euiBadge__content"
+  >
+    <span
+      class="euiBadge__text"
+    >
+      Content
+    </span>
+  </span>
+</span>
+`;
+
+exports[`EuiBadge props style is rendered with secondary 1`] = `
+<span
+  class="euiBadge euiBadge--iconLeft"
+  style="background-color:#6dccb1;color:#000;border:4px solid tomato"
+>
+  <span
+    class="euiBadge__content"
+  >
+    <span
+      class="euiBadge__text"
+    >
+      Content
+    </span>
+  </span>
+</span>
+`;
+
+exports[`EuiBadge props style is rendered with warning 1`] = `
+<span
+  class="euiBadge euiBadge--iconLeft"
+  style="background-color:#f1d86f;color:#000;border:4px solid tomato"
+>
+  <span
+    class="euiBadge__content"
+  >
+    <span
+      class="euiBadge__text"
+    >
+      Content
+    </span>
+  </span>
+</span>
+`;

--- a/src/components/badge/badge.test.tsx
+++ b/src/components/badge/badge.test.tsx
@@ -118,5 +118,37 @@ describe('EuiBadge', () => {
         });
       });
     });
+
+    describe('style', () => {
+      const style = { border: '4px solid tomato' };
+
+      it('is rendered', () => {
+        const component = render(<EuiBadge style={style}>Content</EuiBadge>);
+
+        expect(component).toMatchSnapshot();
+      });
+
+      COLORS.forEach(color => {
+        it(`is rendered with ${color}`, () => {
+          const component = render(
+            <EuiBadge style={style} color={color}>
+              Content
+            </EuiBadge>
+          );
+
+          expect(component).toMatchSnapshot();
+        });
+      });
+
+      it('is rendered with hollow', () => {
+        const component = render(
+          <EuiBadge style={style} color="hollow">
+            Content
+          </EuiBadge>
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -119,6 +119,7 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
   closeButtonProps,
   href,
   target,
+  style,
   ...rest
 }) => {
   checkValidColor(color);
@@ -141,6 +142,7 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
     optionalCustomStyles = {
       backgroundColor: colorHex,
       color: textColor,
+      ...style,
     };
   } else if (color !== 'hollow') {
     // This is a custom color that is neither from the base palette nor hollow
@@ -165,7 +167,11 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
       );
     }
 
-    optionalCustomStyles = { backgroundColor: color, color: textColor };
+    optionalCustomStyles = {
+      backgroundColor: color,
+      color: textColor,
+      ...style,
+    };
   }
 
   const classes = classNames(

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -124,7 +124,7 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
 }) => {
   checkValidColor(color);
 
-  let optionalCustomStyles: object | undefined = undefined;
+  let optionalCustomStyles: object | undefined = style;
   let textColor = null;
   // TODO - replace with variable once https://github.com/elastic/eui/issues/2731 is closed
   const wcagContrastBase = 4.5; // WCAG AA contrast level
@@ -142,7 +142,7 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
     optionalCustomStyles = {
       backgroundColor: colorHex,
       color: textColor,
-      ...style,
+      ...optionalCustomStyles,
     };
   } else if (color !== 'hollow') {
     // This is a custom color that is neither from the base palette nor hollow
@@ -170,7 +170,7 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
     optionalCustomStyles = {
       backgroundColor: color,
       color: textColor,
-      ...style,
+      ...optionalCustomStyles,
     };
   }
 


### PR DESCRIPTION
### Summary

Closes #3282 where the inline styles for EuiBadge are being wiped by consumer passed inline styles.

### Checklist

- [X] Check against **all themes** for compatibility in both light and dark modes
- ~~[ ] Checked in **mobile**~~
- [ ] Checked in **IE11** and **Firefox**
- ~~[ ] Props have proper **autodocs**~~
- ~~[ ] Added **documentation** examples~~
- [X] Added or updated **jest tests**
- ~~[ ] Checked for **breaking changes** and labeled appropriately~~
- ~~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [X] A [changelog](https://github.com/elastic/eui/blob/master/CONTRIBUTING.md#changelog) entry exists and is marked appropriately
