### PR TITLE
Fixed focus on EuiTabbedContent when initialFocus is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 **Bug Fixes**
 
-- Fixed `EuiTabbedContent` doesn't focus on the correct tab when using the mouse and initialFocus is selected ([#3285](https://github.com/elastic/eui/pull/3285))
+- Fixed `EuiTabbedContent` focus discrepancy between selected and initialFocus tabs ([#3285](https://github.com/elastic/eui/pull/3285))
 - Fixed the `initialSelectedTab` prop of `EuiTabbedContent` to not steal focus from content. Which fixed the bug in `EuiSuperDatePicker` that required two clicks to focus input in relative tab  ([#3154](https://github.com/elastic/eui/pull/3154))
 - Fixed the `img` element in `EuiIcon` using custom SVGs to have an `alt` attribute with an empty string, rather than no `alt` attribute at all ([#3245](https://github.com/elastic/eui/pull/3245))
 - Added overflows to EuiDataGrid toolbar dropdowns when there are many columns ([#3238](https://github.com/elastic/eui/pull/3238))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 **Bug Fixes**
 
+- Fixed `EuiTabbedContent` doesn't focus on the correct tab when using the mouse and initialFocus is selected ([#3285](https://github.com/elastic/eui/pull/3285))
 - Fixed the `initialSelectedTab` prop of `EuiTabbedContent` to not steal focus from content. Which fixed the bug in `EuiSuperDatePicker` that required two clicks to focus input in relative tab  ([#3154](https://github.com/elastic/eui/pull/3154))
 - Fixed the `img` element in `EuiIcon` using custom SVGs to have an `alt` attribute with an empty string, rather than no `alt` attribute at all ([#3245](https://github.com/elastic/eui/pull/3245))
 - Added overflows to EuiDataGrid toolbar dropdowns when there are many columns ([#3238](https://github.com/elastic/eui/pull/3238))

--- a/src/components/tabs/tabbed_content/tabbed_content.tsx
+++ b/src/components/tabs/tabbed_content/tabbed_content.tsx
@@ -108,15 +108,19 @@ export class EuiTabbedContent extends Component<
     }
   }
 
+  focusTab = () => {
+    const targetTab: HTMLDivElement | null = this.tabsRef.current!.querySelector(
+      `#${this.state.selectedTabId}`
+    );
+    targetTab!.focus();
+  };
+
   initializeFocus = () => {
     if (!this.state.inFocus && this.props.autoFocus === 'selected') {
       // Must wait for setState to finish before calling `.focus()`
       // as the focus call triggers a blur on the first tab
       this.setState({ inFocus: true }, () => {
-        const targetTab: HTMLDivElement | null = this.tabsRef.current!.querySelector(
-          `#${this.state.selectedTabId}`
-        );
-        targetTab!.focus();
+        this.focusTab();
       });
     }
   };
@@ -142,7 +146,9 @@ export class EuiTabbedContent extends Component<
 
     // Only track selection state if it's not controlled externally.
     if (!externalSelectedTab) {
-      this.setState({ selectedTabId: selectedTab.id });
+      this.setState({ selectedTabId: selectedTab.id }, () => {
+        this.focusTab();
+      });
     }
   };
 


### PR DESCRIPTION
### Summary

Fixes #3261 

Fixed EuiTabbedContent doesn't focus on the correct tab when using the mouse and `initialFocus` is `selected`

This issue was fixed by calling focus after `setState` so the correct tab is focused.

Before:
![before](https://user-images.githubusercontent.com/10515204/78865926-22f0ae80-7a5c-11ea-8c5e-4b8526ce91cb.gif)

After :
![after](https://user-images.githubusercontent.com/10515204/78865658-9e059500-7a5b-11ea-9d39-e6565ea6456d.gif)


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **documentation** examples~~
~~- [ ] Added or updated **jest tests**~~
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/master/CONTRIBUTING.md#changelog) entry exists and is marked appropriately
