### PR TITLE
[Docs] Add snippets to EuiToolTip

### DIFF
--- a/src-docs/src/views/tool_tip/tool_tip_example.js
+++ b/src-docs/src/views/tool_tip/tool_tip_example.js
@@ -26,7 +26,7 @@ import IconTip from './icon_tip';
 const infoTipSource = require('!!raw-loader!./icon_tip');
 const infoTipHtml = renderToHtml(IconTip);
 const infoTipSnippet = `<EuiIconTip
-  content="Here is another tooltip text"
+  content="Tooltip text for the icon"
   position="top"
   type="iInCircle"
 />

--- a/src-docs/src/views/tool_tip/tool_tip_example.js
+++ b/src-docs/src/views/tool_tip/tool_tip_example.js
@@ -17,10 +17,20 @@ import {
 import ToolTip from './tool_tip';
 const toolTipSource = require('!!raw-loader!./tool_tip');
 const toolTipHtml = renderToHtml(ToolTip);
+const tooltipSnippet = `<EuiToolTip position="top" content="Here is some tooltip text">
+  <!-- An inline element to trigger the tooltip -->
+</EuiToolTip>
+`;
 
 import IconTip from './icon_tip';
 const infoTipSource = require('!!raw-loader!./icon_tip');
 const infoTipHtml = renderToHtml(IconTip);
+const infoTipSnippet = `<EuiIconTip
+  content="Here is another tooltip text"
+  position="top"
+  type="iInCircle"
+/>
+`;
 
 export const ToolTipExample = {
   title: 'Tooltip',
@@ -80,7 +90,9 @@ export const ToolTipExample = {
           code: toolTipHtml,
         },
       ],
+
       props: { EuiToolTip },
+      snippet: tooltipSnippet,
       demo: <ToolTip />,
     },
     {
@@ -112,6 +124,7 @@ export const ToolTipExample = {
         </Fragment>
       ),
       props: { EuiToolTip, EuiIconTip },
+      snippet: infoTipSnippet,
       demo: <IconTip />,
     },
   ],

--- a/src-docs/src/views/tool_tip/tool_tip_example.js
+++ b/src-docs/src/views/tool_tip/tool_tip_example.js
@@ -17,10 +17,20 @@ import {
 import ToolTip from './tool_tip';
 const toolTipSource = require('!!raw-loader!./tool_tip');
 const toolTipHtml = renderToHtml(ToolTip);
-const tooltipSnippet = `<EuiToolTip position="top" content="Here is some tooltip text">
+const tooltipSnippet = [
+  `<EuiToolTip position="top" content="Tooltip text">
   <!-- An inline element to trigger the tooltip -->
 </EuiToolTip>
-`;
+`,
+  `<EuiToolTip title="Tooltip title" content="Tooltip text">
+  <!-- An inline element to trigger the tooltip -->
+</EuiToolTip>
+`,
+  `<EuiToolTip content="A tooltip with a long delay" delay="long">
+  <!-- An inline element to trigger the tooltip -->
+</EuiToolTip>
+`,
+];
 
 import IconTip from './icon_tip';
 const infoTipSource = require('!!raw-loader!./icon_tip');


### PR DESCRIPTION
### Summary

This PR adds snippets to the **EuiToolTip** docs.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **IE11** and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- [x] Added **documentation** examples
- ~[ ] Added or updated **jest tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A [changelog](https://github.com/elastic/eui/blob/master/CONTRIBUTING.md#changelog) entry exists and is marked appropriately~