### PR TITLE
[Wiki] Re-organizing documentation guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ### Summary
 
-Summarize your PR. If it includes design elements include a screenshot or gif.
+Provide a detailed summary of your PR. Explain how you arrived at your solution. If it includes changes to UI elements include a screenshot or gif.
 
 ### Checklist
 
@@ -8,8 +8,8 @@ Summarize your PR. If it includes design elements include a screenshot or gif.
 - [ ] Checked in **mobile**
 - [ ] Checked in **IE11** and **Firefox**
 - [ ] Props have proper **autodocs**
-- [ ] Added **documentation** examples
-- [ ] Added or updated **jest tests**
+- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples
+- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
 - [ ] Checked for **breaking changes** and labeled appropriately
 - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
-- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CONTRIBUTING.md#changelog) entry exists and is marked appropriately
+- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,35 +30,27 @@ EUI has strict quality and testing standards due to its large downstream footpri
 
 If you have a preference, let us know when you make your PR, but never feel guilty about just handing it off. We're here to help.
 
-## Adding icons
+## Helpful documents
 
-EUI provides an ever-growing set of [icons][icons], but our set can be incomplete. If you find you need an icon that does not exist, create a new issue and tag it with the *icons* label. A designer from the EUI team will respond to discuss your needs.
-
-If you are willing and able to design the icon yourself, then please refer to the [Creating icons][creating-icons] section of the wiki for design guidelines and instructions on creating your pull request.
-
-
-## Documentation
-
-### 👉Refer to the [Documentation Guidelines][documentation-guidelines] for more instruction on writing docs.
-
-## Changelog
-
-Any updates to the `src/` folder require an entry in the `CHANGELOG.md` file. Documentation-only changes do not. Here are our guidelines for updating the file:
-
-* Append your changes to the `master` sub-heading of [`CHANGELOG.md`](CHANGELOG.md).
-* Add a list item for each significant change in the PR: bugs that were fixed, new features, new components, or changes to the public API
-* In the list item, always link to any relevant pull requests
-* Add a summary of what has changed, making sure it's informative to consumers who might be unaware of implementation details
-* Avoid documenting internal implementation changes that don't affect the public interface
-* Write your entry in the past tense, starting with a verb (e.g. Added... , Fixed...)
+* [Component design][component-design]
+* [Component development][component-development]
+  * [Creating components manually][creating-components-manually]
+  * [Creating components with Yeoman][creating-components-yeoman]
+* [Creating icons][icons]
+* [Theming][theming]
+* [Testing][testing]
+  * [Accessibility Testing][a11y-testing]
+* [Documentation][docs-guidelines]
+* [Releasing versions][releasing-versions]
 
 
-## Releases
-
-When we are ready to create a new release, we follow the [Release Process][docs-releases] documentation.
-
-[creating-icons]: wiki/creating-icons.md
-[docs-components]: wiki/component-development.md
-[docs-releases]: wiki/releasing-versions.md
-[icons]: https://elastic.github.io/eui/#/display/icons
-[documentation-guidelines]: wiki/documentation-guidelines.md
+[component-design]: wiki/component-design.md
+[component-development]: wiki/component-development.md
+[creating-components-manually]: wiki/creating-components-manually.md
+[creating-components-yeoman]: wiki/creating-components-yeoman.md
+[icons]: wiki/creating-icons.md
+[testing]: wiki/testing.md
+[a11y-testing]: wiki/automated-accessibility-testing.md
+[docs-guidelines]: wiki/documentation-guidelines.md
+[theming]: wiki/theming.md
+[releasing-versions]: wiki/releasing-versions.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,24 +30,16 @@ EUI has strict quality and testing standards due to its large downstream footpri
 
 If you have a preference, let us know when you make your PR, but never feel guilty about just handing it off. We're here to help.
 
-### Adding icons
+## Adding icons
 
 EUI provides an ever-growing set of [icons][icons], but our set can be incomplete. If you find you need an icon that does not exist, create a new issue and tag it with the *icons* label. A designer from the EUI team will respond to discuss your needs.
 
 If you are willing and able to design the icon yourself, then please refer to the [Creating icons][creating-icons] section of the wiki for design guidelines and instructions on creating your pull request.
 
+
 ## Documentation
 
-Always remember to update [documentation site][docs] via the `src-docs` folder and the [`CHANGELOG.md`](CHANGELOG.md) in the same PR that contains functional changes. We do this in tandem to prevent our examples from going out of sync with the actual components. In this sense, treat documentation no differently than how you would treat tests.
-
-Here are our formatting guidelines for writing documentation:
-
-- Use sentence case, always, for page and section titles. Example: `This component does something`
-- When referencing the component name, wrap it in `<strong>` tags. Example: `<strong>EuiComponent</strong>`
-- When referencing the component name, always include the `Eui` prefix unless you are referencing the generic term. Example: `EuiFlyout` vs `flyout`
-- Wrap references to prop names and elements in `<EuiCode>` blocks. Example: `<EuiCode>propName</EuiCode>`
-- If the code reference is more than a single prop name or value, add the language type. Example: `<EuiCode language="js">propName=true</EuiCode>`
-- When referencing another EUI component, wrap the reference in a link to the component. Example: `<Link to="/component/url><strong>EuiComponent</strong><Link>`
+### 👉Refer to the [Documentation Guidelines][documentation-guidelines] for more instruction on writing docs.
 
 ## Changelog
 
@@ -60,12 +52,13 @@ Any updates to the `src/` folder require an entry in the `CHANGELOG.md` file. Do
 * Avoid documenting internal implementation changes that don't affect the public interface
 * Write your entry in the past tense, starting with a verb (e.g. Added... , Fixed...)
 
+
 ## Releases
 
 When we are ready to create a new release, we follow the [Release Process][docs-releases] documentation.
 
 [creating-icons]: wiki/creating-icons.md
-[docs]: https://elastic.github.io/eui/
 [docs-components]: wiki/component-development.md
 [docs-releases]: wiki/releasing-versions.md
 [icons]: https://elastic.github.io/eui/#/display/icons
+[documentation-guidelines]: wiki/documentation-guidelines.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,25 +32,13 @@ If you have a preference, let us know when you make your PR, but never feel guil
 
 ## Helpful documents
 
-* [Component design][component-design]
-* [Component development][component-development]
-  * [Creating components manually][creating-components-manually]
-  * [Creating components with Yeoman][creating-components-yeoman]
-* [Creating icons][icons]
-* [Theming][theming]
-* [Testing][testing]
-  * [Accessibility Testing][a11y-testing]
-* [Documentation][docs-guidelines]
-* [Releasing versions][releasing-versions]
-
-
-[component-design]: wiki/component-design.md
-[component-development]: wiki/component-development.md
-[creating-components-manually]: wiki/creating-components-manually.md
-[creating-components-yeoman]: wiki/creating-components-yeoman.md
-[icons]: wiki/creating-icons.md
-[testing]: wiki/testing.md
-[a11y-testing]: wiki/automated-accessibility-testing.md
-[docs-guidelines]: wiki/documentation-guidelines.md
-[theming]: wiki/theming.md
-[releasing-versions]: wiki/releasing-versions.md
+* [Component design](wiki/component-design.md)
+* [Component development](wiki/component-development.md)
+  * [Creating components manually](wiki/creating-components-manually.md)
+  * [Creating components with Yeoman](wiki/creating-components-yeoman.md)
+* [Creating icons](wiki/creating-icons.md)
+* [Theming](wiki/theming.md)
+* [Testing](wiki/testing.md)
+  * [Accessibility Testing](wiki/automated-accessibility-testing.md)
+* [Documentation](wiki/documentation-guidelines.md)
+* [Releasing versions](wiki/releasing-versions.md)

--- a/FAQ.md
+++ b/FAQ.md
@@ -24,7 +24,7 @@ For styling we use Sass and generate a final CSS blob for the entire library, wi
 
 ## Can I contribute to EUI
 
-Yes! We accept PRs regularly similar to our other Elastic repos.
+Yes! We accept PRs regularly similar to our other Elastic repos. You can find documentation around creating and submitting new components in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Why is EUI open source?
 

--- a/README.md
+++ b/README.md
@@ -63,22 +63,22 @@ directly in the code. And unit test coverage for the UI components allows us to 
 ### Consumption
 
 * [Consuming EUI][consuming]
-* [Using EUI with react-router][react-router]
+* [Using EUI with react-router](wiki/react-router.md)
 
 ### Maintenance / Contributing
 
 [CONTRIBUTING.md](CONTRIBUTING.md)
 
-* [Component design][component-design]
-* [Component development][component-development]
-  * [Creating components manually][creating-components-manually]
-  * [Creating components with Yeoman][creating-components-yeoman]
-* [Creating icons][icons]
-* [Theming][theming]
-* [Testing][testing]
-  * [Accessibility Testing][a11y-testing]
-* [Documentation][docs-guidelines]
-* [Releasing versions][releasing-versions]
+* [Component design](wiki/component-design.md)
+* [Component development](wiki/component-development.md)
+  * [Creating components manually](wiki/creating-components-manually.md)
+  * [Creating components with Yeoman](wiki/creating-components-yeoman.md)
+* [Creating icons](wiki/creating-icons.md)
+* [Theming](wiki/theming.md)
+* [Testing](wiki/testing.md)
+  * [Accessibility Testing](wiki/automated-accessibility-testing.md)
+* [Documentation](wiki/documentation-guidelines.md)
+* [Releasing versions](wiki/releasing-versions.md)
 
 ## License
 
@@ -87,15 +87,4 @@ directly in the code. And unit test coverage for the UI components allows us to 
 [license]: LICENSE
 [faq]: FAQ.md
 [consuming]: wiki/consuming.md
-[component-design]: wiki/component-design.md
-[component-development]: wiki/component-development.md
-[creating-components-manually]: wiki/creating-components-manually.md
-[creating-components-yeoman]: wiki/creating-components-yeoman.md
-[icons]: wiki/creating-icons.md
-[testing]: wiki/testing.md
-[a11y-testing]: wiki/automated-accessibility-testing.md
-[docs-guidelines]: wiki/documentation-guidelines.md
-[theming]: wiki/theming.md
-[react-router]: wiki/react-router.md
-[releasing-versions]: wiki/releasing-versions.md
 [docs]: https://elastic.github.io/eui/

--- a/README.md
+++ b/README.md
@@ -57,9 +57,6 @@ As a single source of truth, the framework allows our designers to make changes 
 directly in the code. And unit test coverage for the UI components allows us to deliver a stable
 "API for user interfaces".
 
-## Contributing
-
-You can find documentation around creating and submitting new components in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Wiki
 
@@ -68,14 +65,19 @@ You can find documentation around creating and submitting new components in [CON
 * [Consuming EUI][consuming]
 * [Using EUI with react-router][react-router]
 
-### Maintenance
+### Maintenance / Contributing
+
+[CONTRIBUTING.md](CONTRIBUTING.md)
 
 * [Component design][component-design]
 * [Component development][component-development]
   * [Creating components manually][creating-components-manually]
   * [Creating components with Yeoman][creating-components-yeoman]
-  * [Testing][testing]
+* [Creating icons][icons]
 * [Theming][theming]
+* [Testing][testing]
+  * [Accessibility Testing][a11y-testing]
+* [Documentation][docs-guidelines]
 * [Releasing versions][releasing-versions]
 
 ## License
@@ -89,8 +91,11 @@ You can find documentation around creating and submitting new components in [CON
 [component-development]: wiki/component-development.md
 [creating-components-manually]: wiki/creating-components-manually.md
 [creating-components-yeoman]: wiki/creating-components-yeoman.md
-[releasing-versions]: wiki/releasing-versions.md
+[icons]: wiki/creating-icons.md
 [testing]: wiki/testing.md
+[a11y-testing]: wiki/automated-accessibility-testing.md
+[docs-guidelines]: wiki/documentation-guidelines.md
 [theming]: wiki/theming.md
 [react-router]: wiki/react-router.md
+[releasing-versions]: wiki/releasing-versions.md
 [docs]: https://elastic.github.io/eui/

--- a/src-docs/src/views/button/button_icon.js
+++ b/src-docs/src/views/button/button_icon.js
@@ -24,7 +24,7 @@ export default () => (
           color={color}
           onClick={() => window.alert('Button clicked')}
           iconType="arrowRight"
-          // aria-label="Next"
+          aria-label="Next"
           disabled={color === 'disabled' ? true : false}
         />
       </EuiFlexItem>

--- a/src-docs/src/views/button/button_icon.js
+++ b/src-docs/src/views/button/button_icon.js
@@ -24,7 +24,7 @@ export default () => (
           color={color}
           onClick={() => window.alert('Button clicked')}
           iconType="arrowRight"
-          aria-label="Next"
+          // aria-label="Next"
           disabled={color === 'disabled' ? true : false}
         />
       </EuiFlexItem>

--- a/wiki/component-design.md
+++ b/wiki/component-design.md
@@ -126,7 +126,7 @@ All event handlers should take the form `onEvent` and accurately describe when i
 Try to leverage the `children` prop wherever possible. This will create a simpler more uniform
 API throughout our components.
 
-We also [require some props](../src/test/required_props.js) to be supported by all components, as
+We also [require some props](../src/test/required_props.ts) to be supported by all components, as
 reflected in our tests; for example, `className`. These are easily added via the `CommonProps` mentioned above.
 
 [component-development]: component-development.md

--- a/wiki/component-design.md
+++ b/wiki/component-design.md
@@ -126,7 +126,7 @@ All event handlers should take the form `onEvent` and accurately describe when i
 Try to leverage the `children` prop wherever possible. This will create a simpler more uniform
 API throughout our components.
 
-We also [require some props](../src/test/reqiured_props.js) to be supported by all components, as
+We also [require some props](../src/test/required_props.js) to be supported by all components, as
 reflected in our tests; for example, `className`. These are easily added via the `CommonProps` mentioned above.
 
 [component-development]: component-development.md

--- a/wiki/component-development.md
+++ b/wiki/component-development.md
@@ -84,7 +84,7 @@ Many of our components use `rest parameters` and the `spread` operator to pass p
 
 A `Foo` component that passes `...rest` through to a `button` element would have the props interface
 
-```
+```ts
 // passes extra props to a button
 interface FooProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   title: string
@@ -93,7 +93,7 @@ interface FooProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 
 Some DOM elements (e.g. `div`, `span`) do not have attributes beyond the basic ones provided by all HTML elements. In these cases there isn't a specific `*HTMLAttributes<T>` interface, and you should use `HTMLAttributes<HTMLDivElement>`.
 
-```
+```ts
 // passes extra props to a div
 interface FooProps extends HTMLAttributes<HTMLDivElement> {
   title: string
@@ -102,7 +102,7 @@ interface FooProps extends HTMLAttributes<HTMLDivElement> {
 
 If your component forwards the `ref` through to an underlying element, the interface is further extended with `DetailedHTMLProps`
 
-```
+```ts
 // passes extra props and forwards the ref to a button
 interface FooProps extends DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {
   title: string

--- a/wiki/consuming.md
+++ b/wiki/consuming.md
@@ -118,4 +118,4 @@ This eliminates the need to polyfill or transform the EUI build for an environme
 
 ### Mocked component files
 
-Besides babel transforms, the test environment build consumes mocked component files of the type `src/**/[name].testenv.*`. During the build, files of the type `src/**/[name].*` will be replaced by those with the `testenv` namespace. The purpose of this mocking is to further mitigate the impacts of time- and import-dependent rendering, and simplify environment output such as test snapshots. Information on creating mock component files can be found with [testing documentation](testing).
+Besides babel transforms, the test environment build consumes mocked component files of the type `src/**/[name].testenv.*`. During the build, files of the type `src/**/[name].*` will be replaced by those with the `testenv` namespace. The purpose of this mocking is to further mitigate the impacts of time- and import-dependent rendering, and simplify environment output such as test snapshots. Information on creating mock component files can be found with [testing documentation](testing.md).

--- a/wiki/creating-components-manually.md
+++ b/wiki/creating-components-manually.md
@@ -25,14 +25,8 @@ This makes your React component available for import into your project.
 3. Add the route to this file in `src-docs/src/services/routes/routes.js`.
 4. In the `{component name}_example.js` file you created, define examples which demonstrate the component and describe its role from a UI perspective.
 
-The complexity of the component should determine how many examples you need to create, and how complex they should be. In general, your examples should demonstrate:
-
-* The most common use-cases for the component.
-* How the component handles edge cases, e.g. overflowing content, text-based vs. element-based content.
-* The various states of the component, e.g. disabled, selected, empty of content, error state.
-
-### 👉Refer to the [Documentation Guidelines][documentation-guidelines] for more instruction on writing docs.
+### 👉 Refer to the [Documentation Guidelines][documentation-guidelines] for more instruction on writing docs.
 
 [docs]: https://elastic.github.io/eui/
 [docs-logical-group]: creating-components.md#logically-grouped-components
-[documentation-guidelines]: documentation-guidelines
+[documentation-guidelines]: documentation-guidelines.md

--- a/wiki/creating-components-manually.md
+++ b/wiki/creating-components-manually.md
@@ -28,5 +28,5 @@ This makes your React component available for import into your project.
 ### 👉 Refer to the [Documentation Guidelines][documentation-guidelines] for more instruction on writing docs.
 
 [docs]: https://elastic.github.io/eui/
-[docs-logical-group]: creating-components.md#logically-grouped-components
+[docs-logical-group]: component-development.md#logically-grouped-components
 [documentation-guidelines]: documentation-guidelines.md

--- a/wiki/creating-components-manually.md
+++ b/wiki/creating-components-manually.md
@@ -25,8 +25,7 @@ This makes your React component available for import into your project.
 3. Add the route to this file in `src-docs/src/services/routes/routes.js`.
 4. In the `{component name}_example.js` file you created, define examples which demonstrate the component and describe its role from a UI perspective.
 
-### 👉 Refer to the [Documentation Guidelines][documentation-guidelines] for more instruction on writing docs.
+### 👉 Refer to the [Documentation Guidelines](documentation-guidelines.md) for more instruction on writing docs.
 
 [docs]: https://elastic.github.io/eui/
 [docs-logical-group]: component-development.md#logically-grouped-components
-[documentation-guidelines]: documentation-guidelines.md

--- a/wiki/creating-components-manually.md
+++ b/wiki/creating-components-manually.md
@@ -31,78 +31,8 @@ The complexity of the component should determine how many examples you need to c
 * How the component handles edge cases, e.g. overflowing content, text-based vs. element-based content.
 * The various states of the component, e.g. disabled, selected, empty of content, error state.
 
-### Adding snippets
-There are a couple themes to keep in mind when adding snippets:
-
-#### Ask yourself
-- Does this snippet provide the consumer with everything it needs for the component to work?
-- Does this snippet provide the details of a specific object the component needs to work?
-- If it doesn't provide either and the whole demo JS is needed for the component to work, then it's probably best to not add a snippet.
-
-#### Stay consistent
-- Don't use `this.`, but write the snippet like a **Function Component**.
-- Use descriptive JS variables in place of **consumer generated** strings, functions, states and node prop types.
-- All other props, like enums, should be written with proper value types.
-
-``` js
-<EuiPopover
-  id={popoverId}
-  button={button}
-  isOpen={isPopoverOpen}
-  closePopover={closePopover}
-  anchorPosition="downLeft"
->
-  <!-- Popover content -->
-</EuiPopover>
-```
-
-- If the demo code provides lots of examples, this is probably mostly for us maintainers to manage all the different states. However, **the consumer really just needs a single basic snippet**. In some cases, you can add a second one with the **most commonly used props**. The basic example should always come first.
-
-```js
-<EuiLink href="#"><!-- Link text --></EuiLink>
-```
-
-```js
-<EuiLink href="#" color="secondary">
-  <!-- Colored link text -->
-</EuiLink>
-```
-
-
-- Use HTML comments to suggest what the `children` might be.
-
-``` js
-<EuiText color="danger"><!-- Raw HTML content --></EuiText>
-```
-
-- The snippet should illustrate when a component requires its children to be wrapped with a specific tag.
-
-``` js
-<EuiCallOut>
-  <p><!-- Content --></p>
-</EuiCallOut>
-```
-
-- When a component contains a single element child the snippet should illustrate it. Enforce best practices by providing a description.
-
-``` js
-<EuiTitle>
-  <h2><!-- Defaults to medium size. Change the heading level based on your context. --></h2> 
-</EuiTitle>
-```
-
-- When a prop receives an array of objects, display only one object and show all the required keys.
-
-``` js
-<EuiSteps
-  steps={[
-    {
-      title: 'Step 1',
-      children: <p>Do this first</p>,
-    },
-  ]}
-/>
-```
+### 👉Refer to the [Documentation Guidelines][documentation-guidelines] for more instruction on writing docs.
 
 [docs]: https://elastic.github.io/eui/
 [docs-logical-group]: creating-components.md#logically-grouped-components
+[documentation-guidelines]: documentation-guidelines

--- a/wiki/creating-components-yeoman.md
+++ b/wiki/creating-components-yeoman.md
@@ -57,14 +57,6 @@ Follow the prompts and your documentation files will be created. You can use the
 
 The script will ask you for the name of the component you'd like to document, then create some files in `src-docs/src/views/`. If the name you provide isn't the exact name of a component, you might need to adjust the `import` in the generated files. Otherwise simply add the document to the `src-docs/src/services/routes/routes.js` file to make it available in the browser.
 
-### Adding snippets
-There are a couple themes to keep in mind when adding snippets:
+### 👉Refer to the [Documentation Guidelines][documentation-guidelines] for more instruction on writing docs.
 
-1. **Ask yourself**
-   a. Does this snippet provide the consumer with everything it needs for the component to work?
-   b. Does this snippet provide the details of a specific object the component needs to work?
-   c. If it doesn't provide either and the whole demo JS is needed for the component to work, then it's probably best to not add a snippet.
-2. **Stay consistent**
-   a. When using text should it display actual strings or comments?
-   b. Don't use `this.` for variables, only for `this.state` or functions
-3. If the demo code provides lots of examples, this is probably mostly for us maintainers to manage all the different states. However, **the consumer really just needs a single basic snippet** with maybe a few self-explanatory props added that can be removed by the consumer. When there are more than 2 or 3 snippets it's hard to know what the differences are among them.
+[documentation-guidelines]: documentation-guidelines

--- a/wiki/creating-components-yeoman.md
+++ b/wiki/creating-components-yeoman.md
@@ -57,6 +57,6 @@ Follow the prompts and your documentation files will be created. You can use the
 
 The script will ask you for the name of the component you'd like to document, then create some files in `src-docs/src/views/`. If the name you provide isn't the exact name of a component, you might need to adjust the `import` in the generated files. Otherwise simply add the document to the `src-docs/src/services/routes/routes.js` file to make it available in the browser.
 
-### 👉Refer to the [Documentation Guidelines][documentation-guidelines] for more instruction on writing docs.
+### 👉 Refer to the [Documentation Guidelines][documentation-guidelines] for more instruction on writing docs.
 
-[documentation-guidelines]: documentation-guidelines
+[documentation-guidelines]: documentation-guidelines.md

--- a/wiki/creating-components-yeoman.md
+++ b/wiki/creating-components-yeoman.md
@@ -57,6 +57,4 @@ Follow the prompts and your documentation files will be created. You can use the
 
 The script will ask you for the name of the component you'd like to document, then create some files in `src-docs/src/views/`. If the name you provide isn't the exact name of a component, you might need to adjust the `import` in the generated files. Otherwise simply add the document to the `src-docs/src/services/routes/routes.js` file to make it available in the browser.
 
-### 👉 Refer to the [Documentation Guidelines][documentation-guidelines] for more instruction on writing docs.
-
-[documentation-guidelines]: documentation-guidelines.md
+### 👉 Refer to the [Documentation Guidelines](documentation-guidelines.md) for more instruction on writing docs.

--- a/wiki/creating-icons.md
+++ b/wiki/creating-icons.md
@@ -1,10 +1,12 @@
 # Creating icons
 
-Below you will find guidelines for designing a new icon, cleaning up the SVG, and getting it added to EUI. While designers on the EUI team are available to assist, we greatly appreciate your contributions and pull requests.
+EUI provides an ever-growing set of [icons][icons], but our set can be incomplete. If you find you need an icon that does not exist, create a new issue and tag it with the *icons* label. A designer from the EUI team will respond to discuss your needs.
+
+If you are willing and able to design the icon yourself, this document descibes the guidelines for designing a new icon, cleaning up the SVG, and getting it added to EUI. While designers on the EUI team are available to assist, we greatly appreciate your contributions and pull requests.
 
 If you read through these guidelines or begin designing your icon and realize you're in too deep, then create an issue in this repo and request assistance. An EUI team member will reply and discuss options.
 
-_**Note**: The `EuiIcon` component accepts external references to icon files, so techincally speaking you do not have to add them to the EUI repo. In other words, you can store and reference your icon files within your application code._
+_**Note**: The `EuiIcon` component accepts external references to icon files, so you have the option to maintain the icon in your consuming applicaiton._
 
 ## Design the icon
 

--- a/wiki/creating-icons.md
+++ b/wiki/creating-icons.md
@@ -88,6 +88,7 @@ _\* The Icons page actually contains several sections. In most cases, you will b
 _\** Run `yarn && yarn start` to view the EUI docs site locally._
 
 
+[icons]: https://elastic.github.io/eui/#/display/icons
 [docs]: https://elastic.github.io/eui/
 [sketch-SVGO-plugin]: [https://www.sketch.com/extensions/plugins/svgo-compressor/]
 [sketch-symbol-organizer-plugin]: [https://github.com/sonburn/symbol-organizer]

--- a/wiki/documentation-guidelines.md
+++ b/wiki/documentation-guidelines.md
@@ -2,6 +2,14 @@
 
 Always remember to update [documentation site][docs] via the `src-docs` folder and the `CHANGELOG.md` in the same PR that contains functional changes. We do this in tandem to prevent our examples from going out of sync with the actual components. In this sense, treat documentation no differently than how you would treat tests.
 
+The complexity of the component should determine how many examples you need to create, and how complex they should be. In general, your examples should demonstrate:
+
+* The most common use-cases for the component.
+* How the component handles edge cases, e.g. overflowing content, text-based vs. element-based content.
+* The various states of the component, e.g. disabled, selected, empty of content, error state.
+
+## Writing docs
+
 Here are our formatting guidelines for writing documentation:
 
 - Use sentence case, always, for page and section titles. Example: `This component does something`
@@ -11,15 +19,13 @@ Here are our formatting guidelines for writing documentation:
 - If the code reference is more than a single prop name or value, add the language type. Example: `<EuiCode language="js">propName=true</EuiCode>`
 - When referencing another EUI component, wrap the reference in a link to the component. Example: `<Link to="/component/url><strong>EuiComponent</strong><Link>`
 
-## Links
-
-### Linking between EUI doc pages/components
+## Linking between EUI doc pages/components
 
 In instances where you would like to provide a link to another EUI component
 referenced in a given component description or example, take advantage of `react-router`,
 which is used for routing in EUI docs. Aside from the benefit of shorter path names, `react-router` will take the environment into account and provide the correct URL for both development and production locations.
 
-#### Basic example:
+### Basic example:
 
 ```js
 import {
@@ -121,5 +127,16 @@ There are a couple themes to keep in mind when adding snippets:
   ]}
 />
 ```
+
+## Changelog
+
+Any updates to the `src/` folder require an entry in the [CHANGELOG.md](../CHANGELOG.md) file. Documentation-only changes do not. Here are our guidelines for updating the file:
+
+* Append your changes to the `master` sub-heading of `CHANGELOG.md`.
+* Add a list item for each significant change in the PR: bugs that were fixed, new features, new components, or changes to the public API
+* In the list item, always link to any relevant pull requests
+* Add a summary of what has changed, making sure it's informative to consumers who might be unaware of implementation details
+* Avoid documenting internal implementation changes that don't affect the public interface
+* Write your entry in the **past tense**, starting with a verb (e.g. Added... , Fixed...)
 
 [docs]: https://elastic.github.io/eui/

--- a/wiki/documentation-guidelines.md
+++ b/wiki/documentation-guidelines.md
@@ -1,5 +1,16 @@
 # Documentation guidelines
 
+Always remember to update [documentation site][docs] via the `src-docs` folder and the `CHANGELOG.md` in the same PR that contains functional changes. We do this in tandem to prevent our examples from going out of sync with the actual components. In this sense, treat documentation no differently than how you would treat tests.
+
+Here are our formatting guidelines for writing documentation:
+
+- Use sentence case, always, for page and section titles. Example: `This component does something`
+- When referencing the component name, wrap it in `<strong>` tags. Example: `<strong>EuiComponent</strong>`
+- When referencing the component name, always include the `Eui` prefix unless you are referencing the generic term. Example: `EuiFlyout` vs `flyout`
+- Wrap references to prop names and elements in `<EuiCode>` blocks. Example: `<EuiCode>propName</EuiCode>`
+- If the code reference is more than a single prop name or value, add the language type. Example: `<EuiCode language="js">propName=true</EuiCode>`
+- When referencing another EUI component, wrap the reference in a link to the component. Example: `<Link to="/component/url><strong>EuiComponent</strong><Link>`
+
 ## Links
 
 ### Linking between EUI doc pages/components
@@ -36,3 +47,79 @@ import {
 
 <EuiLink href="https://github.com/elastic/eui/blob/master/src/global_styling/mixins/_shadow.scss">View the Sass code for shadow mixins</EuiLink>.
 ```
+
+## Adding snippets
+
+There are a couple themes to keep in mind when adding snippets:
+
+### Ask yourself
+- Does this snippet provide the consumer with everything it needs for the component to work?
+- Does this snippet provide the details of a specific object the component needs to work?
+- If it doesn't provide either and the whole demo JS is needed for the component to work, then it's probably best to not add a snippet.
+
+### Stay consistent
+- Don't use `this.`, but write the snippet like a **Function Component**.
+- Use descriptive JS variables in place of **consumer generated** strings, functions, states and node prop types.
+- All other props, like enums, should be written with proper value types.
+
+``` js
+<EuiPopover
+  id={popoverId}
+  button={button}
+  isOpen={isPopoverOpen}
+  closePopover={closePopover}
+  anchorPosition="downLeft"
+>
+  <!-- Popover content -->
+</EuiPopover>
+```
+
+- If the demo code provides lots of examples, this is probably mostly for us maintainers to manage all the different states. However, **the consumer really just needs a single basic snippet**. In some cases, you can add a second one with the **most commonly used props**. The basic example should always come first.
+
+```js
+<EuiLink href="#"><!-- Link text --></EuiLink>
+```
+
+```js
+<EuiLink href="#" color="secondary">
+  <!-- Colored link text -->
+</EuiLink>
+```
+
+
+- Use HTML comments to suggest what the `children` might be.
+
+``` js
+<EuiText color="danger"><!-- Raw HTML content --></EuiText>
+```
+
+- The snippet should illustrate when a component requires its children to be wrapped with a specific tag.
+
+``` js
+<EuiCallOut>
+  <p><!-- Content --></p>
+</EuiCallOut>
+```
+
+- When a component contains a single element child the snippet should illustrate it. Enforce best practices by providing a description.
+
+``` js
+<EuiTitle>
+  <h2><!-- Defaults to medium size. Change the heading level based on your context. --></h2>
+</EuiTitle>
+```
+
+- When a prop receives an array of objects, display only one object and show all the required keys.
+
+``` js
+<EuiSteps
+  steps={[
+    {
+      title: 'Step 1',
+      children: <p>Do this first</p>,
+    },
+  ]}
+/>
+```
+
+[docs]: https://elastic.github.io/eui/

--- a/wiki/theming.md
+++ b/wiki/theming.md
@@ -22,7 +22,7 @@ needs of that theme.
 4. Import your variables into the top of this file, making sure the global_variables and
 components load after it.
 
-```sass
+```scss
 // These are variable overwrites used only for this theme.
 @import 'themes/my_theme_name/my_theme_name_sizes';
 @import 'themes/my_theme_name/my_theme_name_colors';

--- a/wiki/theming.md
+++ b/wiki/theming.md
@@ -36,7 +36,7 @@ components load after it.
 
 #### Make your theme available in the docs
 
-Lastly, make sure to include your theme in the /src-docs/index.js file so that it's available
+Lastly, make sure to include your theme in the `/src-docs/index.js` file so that it's available
 through the theme selector.
 
 ## Theming tips


### PR DESCRIPTION
Simply moving any documentation specific guidelines to the actual documentation-guidelines.md.
