### PR TITLE
Fixed EuiI8n hasPropName utility errors on null values 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ No public interface changes since `22.5.0`.
 
 **Bug Fixes**
 
+- Fixed EuiI8n hasPropName utility errors on null values ([#3303](https://github.com/elastic/eui/pull/3303))
 - Fixed the inline styles being overwritten by consumer-passed inline styles in EuiBadge ([#3284](https://github.com/elastic/eui/pull/3284))
 
 ## [`22.4.0`](https://github.com/elastic/eui/tree/v22.4.0)

--- a/src/components/i18n/__snapshots__/i18n.test.tsx.snap
+++ b/src/components/i18n/__snapshots__/i18n.test.tsx.snap
@@ -135,6 +135,22 @@ exports[`EuiI18n default rendering rendering to dom renders a string with placeh
 </EuiI18n>
 `;
 
+exports[`EuiI18n default rendering rendering to dom renders when value is null 1`] = `
+<EuiI18n
+  default="{arg}"
+  token="test"
+  values={
+    Object {
+      "arg": null,
+    }
+  }
+>
+  <Component
+    arg={null}
+  />
+</EuiI18n>
+`;
+
 exports[`EuiI18n reading values from context mappingFunc calls the mapping function with the source string 1`] = `
 <EuiContext
   i18n={

--- a/src/components/i18n/i18n.test.tsx
+++ b/src/components/i18n/i18n.test.tsx
@@ -38,6 +38,13 @@ describe('EuiI18n', () => {
 
         expect(renderCallback).toHaveBeenCalledWith(values);
       });
+
+      it('renders when value is null', () => {
+        const component = mount(
+          <EuiI18n token="test" default="{arg}" values={{ arg: null }} />
+        );
+        expect(component).toMatchSnapshot();
+      });
     });
 
     describe('render prop with single token', () => {

--- a/src/components/i18n/i18n_util.tsx
+++ b/src/components/i18n/i18n_util.tsx
@@ -14,7 +14,9 @@ function isPrimitive(value: ReactChild) {
 type Child = string | { propName: string } | ReactChild | undefined;
 
 function hasPropName(child: Child): child is { propName: string } {
-  return typeof child === 'object' && child.hasOwnProperty('propName');
+  return child
+    ? typeof child === 'object' && child.hasOwnProperty('propName')
+    : false;
 }
 
 /**


### PR DESCRIPTION
### Summary

Fixes #3301 
- Added test to render component if the value is null
- Fixed issue by checking if the child is null then return false

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~~
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
- [x] Checked for **breaking changes** and labeled appropriately
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
