### PR TITLE
[Docs] Update EuiPopover snippets

### DIFF
--- a/src-docs/src/views/popover/popover_example.js
+++ b/src-docs/src/views/popover/popover_example.js
@@ -58,31 +58,31 @@ const inputPopoverHtml = renderToHtml(PopoverBlock);
 
 const popOverSnippet = `<EuiPopover
   button={button}
-  isOpen={this.state.isPopoverOpen}
-  closePopover={this.closePopover}>
+  isOpen={isPopoverOpen}
+  closePopover={closePopover}>
   <!-- Popover content -->
 </EuiPopover>`;
 
 const trapFocusSnippet = `<EuiPopover
   button={button}
   ownFocus
-  isOpen={this.state.isPopoverOpen}
-  closePopover={this.closePopover}>
+  isOpen={isPopoverOpen}
+  closePopover={closePopover}>
   <!-- Popover content -->
 </EuiPopover>`;
 
 const popoverAnchorSnippet = `<EuiPopover
   button={button}
-  isOpen={this.state.isPopoverOpen}
-  closePopover={this.closePopover}
+  isOpen={isPopoverOpen}
+  closePopover={closePopover}
   anchorPosition="downLeft">
   <!-- Popover content -->
 </EuiPopover>`;
 
 const popoverWithTitleSnippet = `<EuiPopover
   button={button}
-  isOpen={this.state.isPopoverOpen}
-  closePopover={this.closePopover}>
+  isOpen={isPopoverOpen}
+  closePopover={closePopover}>
   <EuiPopoverTitle><!-- Popover title --></EuiPopoverTitle>
   <div><!-- Popover body --></div>
   <EuiPopoverFooter><!-- Popover footer --></EuiPopoverFooter>
@@ -91,17 +91,17 @@ const popoverWithTitleSnippet = `<EuiPopover
 const popoverPanelClassNameSnippet = `<EuiPopover
   ownFocus
   button={button}
-  isOpen={this.state.isPopoverOpen}
-  closePopover={this.closePopover}
+  isOpen={isPopoverOpen}
+  closePopover={closePopover}
   panelClassName="yourClassNameHere"
   panelPaddingSize="none">
-  <!-- Popover with custom class name and custom padding -->
+  <!-- Content for popover with custom class name and custom padding -->
 </EuiPopover>`;
 
 const popoverWithTitlePaddingSnippet = `<EuiPopover
   button={button}
-  isOpen={this.state.isPopoverOpen}
-  closePopover={this.closePopover}
+  isOpen={isPopoverOpen}
+  closePopover={closePopover}
   panelPaddingSize="s">
   <EuiPopoverTitle><!-- Popover title --></EuiPopoverTitle>
   <!-- Content for popover with small padding -->
@@ -109,32 +109,32 @@ const popoverWithTitlePaddingSnippet = `<EuiPopover
 
 const popoverContainerSnippet = `<EuiPopover
   button={button}
-  isOpen={this.state.isPopoverOpen}
-  closePopover={this.closePopover}
-  container={this.panel}>
-  <!-- Popover content -->
+  isOpen={isPopoverOpen}
+  closePopover={closePopover}
+  container={panel}>
+  <!-- Content for popover inside a container -->
 </EuiPopover>`;
 
 const popoverFixedSnippet = `<EuiPopover
   button={button}
-  isOpen={this.state.isPopoverOpen}
-  closePopover={this.closePopover}
+  isOpen={isPopoverOpen}
+  closePopover={closePopover}
   repositionOnScroll={true}>
-  <!-- Popover on a fixed element -->
+  <!-- Content for popover on a fixed element -->
 </EuiPopover>`;
 
 const popoverBlockSnippet = `<EuiPopover
   button={button}
-  isOpen={this.state.isPopoverOpen}
-  closePopover={this.closePopover}
+  isOpen={isPopoverOpen}
+  closePopover={closePopover}
   display="block">
-  <!-- Popover anchor is display block -->
+  <!-- Content for popover displaying in block -->
 </EuiPopover>`;
 
 const inputPopoverSnippet = `<EuiInputPopover
   input={input}
-  isOpen={this.state.isPopoverOpen}
-  closePopover={this.closePopover}>
+  isOpen={isPopoverOpen}
+  closePopover={closePopover}>
   <!-- Popover content attached to input -->
 </EuiInputPopover>`;
 

--- a/src-docs/src/views/popover/popover_example.js
+++ b/src-docs/src/views/popover/popover_example.js
@@ -128,7 +128,7 @@ const popoverBlockSnippet = `<EuiPopover
   isOpen={isPopoverOpen}
   closePopover={closePopover}
   display="block">
-  <!-- Content for popover displaying in block -->
+  <!-- Content for popover with display block anchor -->
 </EuiPopover>`;
 
 const inputPopoverSnippet = `<EuiInputPopover


### PR DESCRIPTION
### Summary

This PR updates the **EuiPopover** snippets so they can match our **Adding snippets** documentation.

Also, the **Demo JS** tabs were recently updated and are now written like a **Function Component** so it makes sense to have the snippets with the same format.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **IE11** and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- [x] Added **documentation** examples
- ~[ ] Added or updated **jest tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A [changelog](https://github.com/elastic/eui/blob/master/CONTRIBUTING.md#changelog) entry exists and is marked appropriately~
