### PR TITLE
Convert `find_test_subject.test` to TypeScript

### DIFF
--- a/src/test/find_test_subject.test.tsx
+++ b/src/test/find_test_subject.test.tsx
@@ -50,6 +50,7 @@ describe('findTestSubject', () => {
     test('throws an error if unsupported matcher is provided', () => {
       const TestComponent = () => <div data-test-subj="test" />;
       const component = mount(<TestComponent />);
+      // @ts-ignore intentional error
       expect(() => findTestSubject(component, 'test', '===')).toThrow();
     });
   });


### PR DESCRIPTION
### Summary

Converts the last remaining `src` JS file to TS (excluding open PRs and index files).

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
