### PR TITLE
[Docs] Converted EuiSideNav EuiSelectable and some other examples to functional components 

### DIFF
--- a/src-docs/src/views/form_layouts/described_form_group.js
+++ b/src-docs/src/views/form_layouts/described_form_group.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 
 import {
   EuiCode,
@@ -13,161 +13,96 @@ import {
   EuiLink,
 } from '../../../../src/components';
 
-import { htmlIdGenerator } from '../../../../src/services';
+export default () => {
+  const [isSwitchChecked, setIsSwitchChecked] = useState(false);
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
-
-    const idPrefix = htmlIdGenerator()();
-
-    this.state = {
-      isSwitchChecked: false,
-      checkboxes: [
-        {
-          id: `${idPrefix}0`,
-          label: 'Option one',
-        },
-        {
-          id: `${idPrefix}1`,
-          label: 'Option two is checked by default',
-        },
-        {
-          id: `${idPrefix}2`,
-          label: 'Option three',
-        },
-      ],
-      checkboxIdToSelectedMap: {
-        [`${idPrefix}1`]: true,
-      },
-      radios: [
-        {
-          id: `${idPrefix}4`,
-          label: 'Option one',
-        },
-        {
-          id: `${idPrefix}5`,
-          label: 'Option two is selected by default',
-        },
-        {
-          id: `${idPrefix}6`,
-          label: 'Option three',
-        },
-      ],
-      radioIdSelected: `${idPrefix}5`,
-    };
-  }
-
-  onSwitchChange = () => {
-    this.setState({
-      isSwitchChecked: !this.state.isSwitchChecked,
-    });
+  const onSwitchChange = () => {
+    setIsSwitchChecked(!isSwitchChecked);
   };
 
-  onCheckboxChange = optionId => {
-    const newCheckboxIdToSelectedMap = {
-      ...this.state.checkboxIdToSelectedMap,
-      ...{
-        [optionId]: !this.state.checkboxIdToSelectedMap[optionId],
-      },
-    };
+  return (
+    <EuiForm>
+      <EuiDescribedFormGroup
+        title={<h3>Single text field</h3>}
+        description={
+          <Fragment>
+            A single text field that can be used to display additional text. It
+            can have{' '}
+            <EuiLink href="http://www.elastic.co" target="_blank">
+              links
+            </EuiLink>{' '}
+            or any other type of content.
+          </Fragment>
+        }>
+        <EuiFormRow label="Text field">
+          <EuiFieldText name="first" aria-label="Example" />
+        </EuiFormRow>
+      </EuiDescribedFormGroup>
 
-    this.setState({
-      checkboxIdToSelectedMap: newCheckboxIdToSelectedMap,
-    });
-  };
+      <EuiDescribedFormGroup title={<h3>No description</h3>}>
+        <EuiFormRow label="Text field">
+          <EuiFieldText name="first" />
+        </EuiFormRow>
+      </EuiDescribedFormGroup>
 
-  onRadioChange = optionId => {
-    this.setState({
-      radioIdSelected: optionId,
-    });
-  };
+      <EuiDescribedFormGroup
+        title={<h3>Multiple fields</h3>}
+        description="Here are three form rows. The first form row does not have a title.">
+        <EuiFormRow
+          hasEmptyLabelSpace
+          helpText={<span>This is a help text</span>}>
+          <EuiSelect
+            hasNoInitialSelection
+            options={[
+              { value: 'option_one', text: 'Option one' },
+              { value: 'option_two', text: 'Option two' },
+              { value: 'option_three', text: 'Option three' },
+            ]}
+            aria-label="An example of a form element without a visible label"
+          />
+        </EuiFormRow>
 
-  render() {
-    return (
-      <EuiForm>
-        <EuiDescribedFormGroup
-          title={<h3>Single text field</h3>}
-          description={
-            <Fragment>
-              A single text field that can be used to display additional text.
-              It can have{' '}
-              <EuiLink href="http://www.elastic.co" target="_blank">
-                links
-              </EuiLink>{' '}
-              or any other type of content.
-            </Fragment>
-          }>
-          <EuiFormRow label="Text field">
-            <EuiFieldText name="first" aria-label="Example" />
-          </EuiFormRow>
-        </EuiDescribedFormGroup>
+        <EuiFormRow label="File picker">
+          <EuiFilePicker />
+        </EuiFormRow>
 
-        <EuiDescribedFormGroup title={<h3>No description</h3>}>
-          <EuiFormRow label="Text field">
-            <EuiFieldText name="first" />
-          </EuiFormRow>
-        </EuiDescribedFormGroup>
+        <EuiFormRow label="Range">
+          <EuiRange min={0} max={100} name="range" id="range" />
+        </EuiFormRow>
+      </EuiDescribedFormGroup>
 
-        <EuiDescribedFormGroup
-          title={<h3>Multiple fields</h3>}
-          description="Here are three form rows. The first form row does not have a title.">
-          <EuiFormRow
-            hasEmptyLabelSpace
-            helpText={<span>This is a help text</span>}>
-            <EuiSelect
-              hasNoInitialSelection
-              options={[
-                { value: 'option_one', text: 'Option one' },
-                { value: 'option_two', text: 'Option two' },
-                { value: 'option_three', text: 'Option three' },
-              ]}
-              aria-label="An example of a form element without a visible label"
-            />
-          </EuiFormRow>
-
-          <EuiFormRow label="File picker">
-            <EuiFilePicker />
-          </EuiFormRow>
-
-          <EuiFormRow label="Range">
-            <EuiRange min={0} max={100} name="range" id="range" />
-          </EuiFormRow>
-        </EuiDescribedFormGroup>
-
-        <EuiDescribedFormGroup
-          title={<h2>Full width</h2>}
-          titleSize="xxxs"
-          description={
-            <Fragment>
-              By default, <strong>EuiDescribedFormGroup</strong> will be double
-              the default width of form elements. However, you can pass{' '}
-              <EuiCode>fullWidth</EuiCode> prop to this, the individual field
-              and row components to expand to their container.
-            </Fragment>
-          }
+      <EuiDescribedFormGroup
+        title={<h2>Full width</h2>}
+        titleSize="xxxs"
+        description={
+          <Fragment>
+            By default, <strong>EuiDescribedFormGroup</strong> will be double
+            the default width of form elements. However, you can pass{' '}
+            <EuiCode>fullWidth</EuiCode> prop to this, the individual field and
+            row components to expand to their container.
+          </Fragment>
+        }
+        fullWidth>
+        <EuiFormRow
+          label="Use a switch instead of a single checkbox"
+          hasChildLabel={false}
           fullWidth>
-          <EuiFormRow
-            label="Use a switch instead of a single checkbox"
-            hasChildLabel={false}
-            fullWidth>
-            <EuiSwitch
-              name="switch"
-              label="Should we do this?"
-              checked={this.state.isSwitchChecked}
-              onChange={this.onSwitchChange}
-            />
-          </EuiFormRow>
+          <EuiSwitch
+            name="switch"
+            label="Should we do this?"
+            checked={isSwitchChecked}
+            onChange={onSwitchChange}
+          />
+        </EuiFormRow>
 
-          <EuiFormRow fullWidth>
-            <EuiFieldText
-              name="second"
-              fullWidth
-              aria-label="An example of EuiTextField with fullWidth"
-            />
-          </EuiFormRow>
-        </EuiDescribedFormGroup>
-      </EuiForm>
-    );
-  }
-}
+        <EuiFormRow fullWidth>
+          <EuiFieldText
+            name="second"
+            fullWidth
+            aria-label="An example of EuiTextField with fullWidth"
+          />
+        </EuiFormRow>
+      </EuiDescribedFormGroup>
+    </EuiForm>
+  );
+};

--- a/src-docs/src/views/form_layouts/form_rows.js
+++ b/src-docs/src/views/form_layouts/form_rows.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import {
   EuiButton,
@@ -17,135 +17,120 @@ import {
 
 import { htmlIdGenerator } from '../../../../src/services/accessibility';
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const idPrefix = htmlIdGenerator()();
+  const [isSwitchChecked, setIsSwitchChecked] = useState(false);
+  const [checkboxes] = useState([
+    {
+      id: `${idPrefix}0`,
+      label: 'Option one',
+    },
+    {
+      id: `${idPrefix}1`,
+      label: 'Option two is checked by default',
+    },
+    {
+      id: `${idPrefix}2`,
+      label: 'Option three',
+    },
+  ]);
+  const [checkboxIdToSelectedMap, setCheckboxIdToSelectedMap] = useState({
+    [`${idPrefix}1`]: true,
+  });
+  // const [radios, setRadios] = useState([
+  //   {
+  //     id: `${idPrefix}4`,
+  //     label: 'Option one',
+  //   },
+  //   {
+  //     id: `${idPrefix}5`,
+  //     label: 'Option two is selected by default',
+  //   },
+  //   {
+  //     id: `${idPrefix}6`,
+  //     label: 'Option three',
+  //   },
+  // ]);
+  // const [radioIdSelected, setRadioIdSelected] = useState(`${idPrefix}5`);
 
-    const idPrefix = htmlIdGenerator()();
-
-    this.state = {
-      isSwitchChecked: false,
-      checkboxes: [
-        {
-          id: `${idPrefix}0`,
-          label: 'Option one',
-        },
-        {
-          id: `${idPrefix}1`,
-          label: 'Option two is checked by default',
-        },
-        {
-          id: `${idPrefix}2`,
-          label: 'Option three',
-        },
-      ],
-      checkboxIdToSelectedMap: {
-        [`${idPrefix}1`]: true,
-      },
-      radios: [
-        {
-          id: `${idPrefix}4`,
-          label: 'Option one',
-        },
-        {
-          id: `${idPrefix}5`,
-          label: 'Option two is selected by default',
-        },
-        {
-          id: `${idPrefix}6`,
-          label: 'Option three',
-        },
-      ],
-      radioIdSelected: `${idPrefix}5`,
-    };
-  }
-
-  onSwitchChange = () => {
-    this.setState({
-      isSwitchChecked: !this.state.isSwitchChecked,
-    });
+  const onSwitchChange = () => {
+    setIsSwitchChecked(!isSwitchChecked);
   };
 
-  onCheckboxChange = optionId => {
+  const onCheckboxChange = optionId => {
     const newCheckboxIdToSelectedMap = {
-      ...this.state.checkboxIdToSelectedMap,
+      ...checkboxIdToSelectedMap,
       ...{
-        [optionId]: !this.state.checkboxIdToSelectedMap[optionId],
+        [optionId]: !checkboxIdToSelectedMap[optionId],
       },
     };
 
-    this.setState({
-      checkboxIdToSelectedMap: newCheckboxIdToSelectedMap,
-    });
+    setCheckboxIdToSelectedMap(newCheckboxIdToSelectedMap);
   };
 
-  onRadioChange = optionId => {
-    this.setState({
-      radioIdSelected: optionId,
-    });
-  };
+  // const onRadioChange = optionId => {
+  //   setRadioIdSelected(optionId);
+  // };
 
-  render() {
-    return (
-      <EuiForm component="form">
-        <EuiFormRow label="Text field" helpText="I am some friendly help text.">
-          <EuiFieldText name="first" />
-        </EuiFormRow>
+  return (
+    <EuiForm component="form">
+      <EuiFormRow label="Text field" helpText="I am some friendly help text.">
+        <EuiFieldText name="first" />
+      </EuiFormRow>
 
-        <EuiFormRow
-          label="Select (with no initial selection)"
-          labelAppend={
-            <EuiText size="xs">
-              <EuiLink>Link to some help</EuiLink>
-            </EuiText>
-          }>
-          <EuiSelect
-            hasNoInitialSelection
-            options={[
-              { value: 'option_one', text: 'Option one' },
-              { value: 'option_two', text: 'Option two' },
-              { value: 'option_three', text: 'Option three' },
-            ]}
-          />
-        </EuiFormRow>
-
-        <EuiFormRow label="File picker">
-          <EuiFilePicker />
-        </EuiFormRow>
-
-        <EuiFormRow label="Range">
-          <EuiRange min={0} max={100} name="range" id="range" />
-        </EuiFormRow>
-
-        <EuiFormRow
-          label="Use a switch instead of a single checkbox and set 'hasChildLabel' to false"
-          hasChildLabel={false}>
-          <EuiSwitch
-            name="switch"
-            label="Should we do this?"
-            checked={this.state.isSwitchChecked}
-            onChange={this.onSwitchChange}
-          />
-        </EuiFormRow>
-
-        <EuiSpacer />
-
-        <EuiCheckboxGroup
-          options={this.state.checkboxes}
-          idToSelectedMap={this.state.checkboxIdToSelectedMap}
-          onChange={this.onCheckboxChange}
-          legend={{
-            children:
-              'Checkbox groups should use the `legend` prop instead of form row',
-          }}
+      <EuiFormRow
+        label="Select (with no initial selection)"
+        labelAppend={
+          <EuiText size="xs">
+            <EuiLink>Link to some help</EuiLink>
+          </EuiText>
+        }>
+        <EuiSelect
+          hasNoInitialSelection
+          options={[
+            { value: 'option_one', text: 'Option one' },
+            { value: 'option_two', text: 'Option two' },
+            { value: 'option_three', text: 'Option three' },
+          ]}
         />
+      </EuiFormRow>
 
-        <EuiSpacer />
+      <EuiFormRow label="File picker">
+        <EuiFilePicker />
+      </EuiFormRow>
 
-        <EuiButton type="submit" fill>
-          Save form
-        </EuiButton>
-      </EuiForm>
-    );
-  }
-}
+      <EuiFormRow label="Range">
+        <EuiRange min={0} max={100} name="range" id="range" />
+      </EuiFormRow>
+
+      <EuiFormRow
+        label="Use a switch instead of a single checkbox and set 'hasChildLabel' to false"
+        hasChildLabel={false}>
+        <EuiSwitch
+          name="switch"
+          label="Should we do this?"
+          checked={isSwitchChecked}
+          onChange={onSwitchChange}
+        />
+      </EuiFormRow>
+
+      <EuiSpacer />
+
+      <EuiCheckboxGroup
+        options={checkboxes}
+        idToSelectedMap={checkboxIdToSelectedMap}
+        onChange={onCheckboxChange}
+        legend={{
+          children:
+            'Checkbox groups should use the `legend` prop instead of form row',
+        }}
+      />
+
+      <EuiSpacer />
+
+      <EuiButton type="submit" fill>
+        Save form
+      </EuiButton>
+    </EuiForm>
+  );
+};

--- a/src-docs/src/views/form_layouts/form_rows.js
+++ b/src-docs/src/views/form_layouts/form_rows.js
@@ -37,21 +37,6 @@ export default () => {
   const [checkboxIdToSelectedMap, setCheckboxIdToSelectedMap] = useState({
     [`${idPrefix}1`]: true,
   });
-  // const [radios, setRadios] = useState([
-  //   {
-  //     id: `${idPrefix}4`,
-  //     label: 'Option one',
-  //   },
-  //   {
-  //     id: `${idPrefix}5`,
-  //     label: 'Option two is selected by default',
-  //   },
-  //   {
-  //     id: `${idPrefix}6`,
-  //     label: 'Option three',
-  //   },
-  // ]);
-  // const [radioIdSelected, setRadioIdSelected] = useState(`${idPrefix}5`);
 
   const onSwitchChange = () => {
     setIsSwitchChecked(!isSwitchChecked);
@@ -67,10 +52,6 @@ export default () => {
 
     setCheckboxIdToSelectedMap(newCheckboxIdToSelectedMap);
   };
-
-  // const onRadioChange = optionId => {
-  //   setRadioIdSelected(optionId);
-  // };
 
   return (
     <EuiForm component="form">

--- a/src-docs/src/views/form_layouts/inline_popover.js
+++ b/src-docs/src/views/form_layouts/inline_popover.js
@@ -115,7 +115,7 @@ export default () => {
         ownFocus
         button={button}
         isOpen={isPopoverOpen}
-        closePopover={closePopover.bind(this)}>
+        closePopover={closePopover}>
         <div style={{ width: 500 }}>{formSample}</div>
       </EuiPopover>
       &emsp;

--- a/src-docs/src/views/form_layouts/inline_popover.js
+++ b/src-docs/src/views/form_layouts/inline_popover.js
@@ -124,7 +124,7 @@ export default () => {
         ownFocus
         button={button2}
         isOpen={isPopover2Open}
-        closePopover={closePopover2.bind(this)}>
+        closePopover={closePopover2}>
         <div style={{ width: '300px' }}>{formSample2}</div>
       </EuiPopover>
     </div>

--- a/src-docs/src/views/form_layouts/inline_popover.js
+++ b/src-docs/src/views/form_layouts/inline_popover.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import {
   EuiButton,
@@ -16,142 +16,117 @@ import {
 
 import { htmlIdGenerator } from '../../../../src/services';
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [isPopover2Open, setIsPopover2Open] = useState(false);
+  const [isSwitchChecked, setIsSwitchChecked] = useState(true);
 
-    this.state = {
-      isPopoverOpen: false,
-      isSwitchChecked: true,
-      isPopover2Open: false,
-      isSwitch2Checked: true,
-    };
-  }
-
-  onSwitchChange = () => {
-    this.setState({
-      isSwitchChecked: !this.state.isSwitchChecked,
-    });
+  const onButtonClick = () => {
+    setIsPopoverOpen(!isPopoverOpen);
   };
 
-  onButtonClick = () => {
-    this.setState({
-      isPopoverOpen: !this.state.isPopoverOpen,
-    });
+  const closePopover = () => {
+    setIsPopoverOpen(false);
   };
 
-  closePopover = () => {
-    this.setState({
-      isPopoverOpen: false,
-    });
+  const onSwitchChange = () => {
+    setIsSwitchChecked(!isSwitchChecked);
   };
 
-  onSwitch2Change = () => {
-    this.setState({
-      isSwitch2Checked: !this.state.isSwitch2Checked,
-    });
+  const onButton2Click = () => {
+    setIsPopover2Open(!isPopover2Open);
   };
 
-  onButton2Click = () => {
-    this.setState({
-      isPopover2Open: !this.state.isPopover2Open,
-    });
+  const closePopover2 = () => {
+    setIsPopover2Open(false);
   };
 
-  closePopover2 = () => {
-    this.setState({
-      isPopover2Open: false,
-    });
-  };
+  const button = (
+    <EuiButton
+      iconSide="right"
+      fill
+      iconType="arrowDown"
+      onClick={onButtonClick}>
+      Inline form in a popover
+    </EuiButton>
+  );
 
-  render() {
-    const button = (
-      <EuiButton
-        iconSide="right"
-        fill
-        iconType="arrowDown"
-        onClick={this.onButtonClick}>
-        Inline form in a popover
-      </EuiButton>
-    );
+  const formSample = (
+    <EuiForm>
+      <EuiFlexGroup>
+        <EuiFlexItem grow={false} style={{ width: 100 }}>
+          <EuiFormRow label="Age">
+            <EuiFieldNumber max={10} placeholder={42} />
+          </EuiFormRow>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiFormRow label="Full name">
+            <EuiFieldText icon="user" placeholder="John Doe" />
+          </EuiFormRow>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiFormRow hasEmptyLabelSpace>
+            <EuiButton>Save</EuiButton>
+          </EuiFormRow>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiForm>
+  );
 
-    const formSample = (
-      <EuiForm>
-        <EuiFlexGroup>
-          <EuiFlexItem grow={false} style={{ width: 100 }}>
-            <EuiFormRow label="Age">
-              <EuiFieldNumber max={10} placeholder={42} />
-            </EuiFormRow>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiFormRow label="Full name">
-              <EuiFieldText icon="user" placeholder="John Doe" />
-            </EuiFormRow>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiFormRow hasEmptyLabelSpace>
-              <EuiButton>Save</EuiButton>
-            </EuiFormRow>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiForm>
-    );
+  const button2 = (
+    <EuiButton
+      iconSide="right"
+      fill
+      iconType="arrowDown"
+      onClick={onButton2Click}>
+      Vertical form in a popover
+    </EuiButton>
+  );
 
-    const button2 = (
-      <EuiButton
-        iconSide="right"
-        fill
-        iconType="arrowDown"
-        onClick={this.onButton2Click}>
-        Vertical form in a popover
-      </EuiButton>
-    );
+  const formSample2 = (
+    <EuiForm>
+      <EuiFormRow>
+        <EuiSwitch
+          id={htmlIdGenerator()()}
+          name="popswitch"
+          label="Isn't this popover form cool?"
+          checked={isSwitchChecked}
+          onChange={onSwitchChange}
+        />
+      </EuiFormRow>
 
-    const formSample2 = (
-      <EuiForm>
-        <EuiFormRow>
-          <EuiSwitch
-            id={htmlIdGenerator()()}
-            name="popswitch"
-            label="Isn't this popover form cool?"
-            checked={this.state.isSwitch2Checked}
-            onChange={this.onSwitch2Change}
-          />
-        </EuiFormRow>
+      <EuiFormRow label="A text field">
+        <EuiFieldText name="popfirst" />
+      </EuiFormRow>
 
-        <EuiFormRow label="A text field">
-          <EuiFieldText name="popfirst" />
-        </EuiFormRow>
+      <EuiFormRow label="Range" helpText="Some help text for the range">
+        <EuiRange min={0} max={100} name="poprange" />
+      </EuiFormRow>
 
-        <EuiFormRow label="Range" helpText="Some help text for the range">
-          <EuiRange min={0} max={100} name="poprange" />
-        </EuiFormRow>
+      <EuiSpacer />
+      <EuiButton fullWidth>Save</EuiButton>
+    </EuiForm>
+  );
 
-        <EuiSpacer />
-        <EuiButton fullWidth>Save</EuiButton>
-      </EuiForm>
-    );
-
-    return (
-      <div>
-        <EuiPopover
-          id="inlineFormPopover"
-          ownFocus
-          button={button}
-          isOpen={this.state.isPopoverOpen}
-          closePopover={this.closePopover.bind(this)}>
-          <div style={{ width: 500 }}>{formSample}</div>
-        </EuiPopover>
-        &emsp;
-        <EuiPopover
-          id="formPopover"
-          ownFocus
-          button={button2}
-          isOpen={this.state.isPopover2Open}
-          closePopover={this.closePopover2.bind(this)}>
-          <div style={{ width: '300px' }}>{formSample2}</div>
-        </EuiPopover>
-      </div>
-    );
-  }
-}
+  return (
+    <div>
+      <EuiPopover
+        id="inlineFormPopover"
+        ownFocus
+        button={button}
+        isOpen={isPopoverOpen}
+        closePopover={closePopover.bind(this)}>
+        <div style={{ width: 500 }}>{formSample}</div>
+      </EuiPopover>
+      &emsp;
+      <EuiPopover
+        id="formPopover"
+        ownFocus
+        button={button2}
+        isOpen={isPopover2Open}
+        closePopover={closePopover2.bind(this)}>
+        <div style={{ width: '300px' }}>{formSample2}</div>
+      </EuiPopover>
+    </div>
+  );
+};

--- a/src-docs/src/views/guidelines/toasts.js
+++ b/src-docs/src/views/guidelines/toasts.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import {
   GuidePage,
@@ -24,514 +24,501 @@ import {
   EuiCodeBlock,
 } from '../../../../src/components';
 
-export class ToastGuidelines extends Component {
-  constructor(props) {
-    super(props);
+export const ToastGuidelines = () => {
+  const [isModalVisible, setIsModalVisible] = useState(false);
 
-    this.state = {
-      isModalVisible: false,
-    };
+  const closeModal = () => {
+    setIsModalVisible(false);
+  };
 
-    this.closeModal = this.closeModal.bind(this);
-    this.showModal = this.showModal.bind(this);
-  }
+  const showModal = () => {
+    setIsModalVisible(true);
+  };
 
-  closeModal() {
-    this.setState({ isModalVisible: false });
-  }
+  let modal;
 
-  showModal() {
-    this.setState({ isModalVisible: true });
-  }
+  if (isModalVisible) {
+    modal = (
+      <EuiOverlayMask>
+        <EuiModal onClose={closeModal}>
+          <EuiModalHeader>
+            <EuiModalHeaderTitle>
+              Your visualization has an error
+            </EuiModalHeaderTitle>
+          </EuiModalHeader>
 
-  render() {
-    let modal;
-
-    if (this.state.isModalVisible) {
-      modal = (
-        <EuiOverlayMask>
-          <EuiModal onClose={this.closeModal}>
-            <EuiModalHeader>
-              <EuiModalHeaderTitle>
-                Your visualization has an error
-              </EuiModalHeaderTitle>
-            </EuiModalHeader>
-
-            <EuiModalBody>
-              <EuiCallOut
-                title="The maximum bucket size of 200 was exceeded"
-                color="danger"
-                size="s"
-                iconType="alert"
-              />
-              <EuiSpacer size="s" />
-              <EuiCodeBlock>
-                {`--- FAKE ERROR ---
+          <EuiModalBody>
+            <EuiCallOut
+              title="The maximum bucket size of 200 was exceeded"
+              color="danger"
+              size="s"
+              iconType="alert"
+            />
+            <EuiSpacer size="s" />
+            <EuiCodeBlock>
+              {`--- FAKE ERROR ---
 An extremely long error trace can exist in a modal so you have time
 and space to read it properly. Alternatively just link to a full page.
 ---
                 `}
-              </EuiCodeBlock>
-            </EuiModalBody>
+            </EuiCodeBlock>
+          </EuiModalBody>
 
-            <EuiModalFooter>
-              <EuiButton onClick={this.closeModal} fill>
-                Close
-              </EuiButton>
-            </EuiModalFooter>
-          </EuiModal>
-        </EuiOverlayMask>
-      );
-    }
-    return (
-      <GuidePage title="Toast guidelines" componentLinkTo="/display/toast">
-        <EuiText grow={false} className="guideSection__text">
-          <p>
-            This page documents patterns for using toasts, short messages that
-            appears on the lower right corner and time out after a few seconds.
-            They are a popular design choice because they don&apos;t need to fit
-            in a layout and don&apos;t disrupt the user.
-          </p>
-        </EuiText>
+          <EuiModalFooter>
+            <EuiButton onClick={closeModal} fill>
+              Close
+            </EuiButton>
+          </EuiModalFooter>
+        </EuiModal>
+      </EuiOverlayMask>
+    );
+  }
+  return (
+    <GuidePage title="Toast guidelines" componentLinkTo="/display/toast">
+      <EuiText grow={false} className="guideSection__text">
+        <p>
+          This page documents patterns for using toasts, short messages that
+          appears on the lower right corner and time out after a few seconds.
+          They are a popular design choice because they don&apos;t need to fit
+          in a layout and don&apos;t disrupt the user.
+        </p>
+      </EuiText>
 
-        <GuideRuleTitle>Toast types</GuideRuleTitle>
+      <GuideRuleTitle>Toast types</GuideRuleTitle>
 
-        <EuiSpacer size="xl" />
+      <EuiSpacer size="xl" />
 
-        <EuiFlexGroup alignItems="center">
-          <EuiFlexItem grow={false} style={{ minWidth: 120 }}>
+      <EuiFlexGroup alignItems="center">
+        <EuiFlexItem grow={false} style={{ minWidth: 120 }}>
+          <EuiToast
+            style={{ width: 300 }}
+            title="Your report is complete"
+            color="success"
+          />
+        </EuiFlexItem>
+
+        <EuiFlexItem>
+          <EuiText className="guideSection__text">
+            <h3>Success toasts indicate that everything worked out</h3>
+            <p>They are the most-commonly used toasts.</p>
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer />
+
+      <EuiFlexGroup alignItems="center">
+        <EuiFlexItem grow={false} style={{ minWidth: 120 }}>
+          <EuiToast
+            style={{ width: 300 }}
+            title="Node 726 is having trouble"
+            color="warning"
+          />
+        </EuiFlexItem>
+
+        <EuiFlexItem>
+          <EuiText className="guideSection__text">
+            <h3>Warning toasts direct user attention to a potential problem</h3>
+            <p>
+              These toasts work well in monitoring apps when something
+              significant requires action.
+            </p>
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer />
+
+      <EuiFlexGroup alignItems="center">
+        <EuiFlexItem grow={false} style={{ minWidth: 120 }}>
+          <EuiToast
+            style={{ width: 300 }}
+            title="Search failed.  Check your Elasticsearch connection."
+            color="danger"
+          />
+        </EuiFlexItem>
+
+        <EuiFlexItem>
+          <EuiText className="guideSection__text">
+            <h3>Error toasts report a problem</h3>
+            <p>
+              An error toast might let users know an action didn&apos;t complete
+              or that a form has errors.
+            </p>
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer />
+
+      <EuiFlexGroup alignItems="center">
+        <EuiFlexItem grow={false} style={{ minWidth: 120 }}>
+          <div>
             <EuiToast
               style={{ width: 300 }}
-              title="Your report is complete"
-              color="success"
+              title="Please wait while your report is created"
+              color="primary"
             />
-          </EuiFlexItem>
+          </div>
+        </EuiFlexItem>
 
-          <EuiFlexItem>
-            <EuiText className="guideSection__text">
-              <h3>Success toasts indicate that everything worked out</h3>
-              <p>They are the most-commonly used toasts.</p>
-            </EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
+        <EuiFlexItem>
+          <EuiText className="guideSection__text">
+            <h3>Info toasts relay neutral information</h3>
+            <p>
+              The default toast, an info toast might notify users about an
+              ongoing action.
+            </p>
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
 
-        <EuiSpacer />
+      <EuiSpacer />
 
-        <EuiFlexGroup alignItems="center">
-          <EuiFlexItem grow={false} style={{ minWidth: 120 }}>
-            <EuiToast
-              style={{ width: 300 }}
-              title="Node 726 is having trouble"
-              color="warning"
-            />
-          </EuiFlexItem>
+      <GuideRuleTitle>Use a toast for a timely message</GuideRuleTitle>
 
-          <EuiFlexItem>
-            <EuiText className="guideSection__text">
-              <h3>
-                Warning toasts direct user attention to a potential problem
-              </h3>
-              <p>
-                These toasts work well in monitoring apps when something
-                significant requires action.
-              </p>
-            </EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-
-        <EuiSpacer />
-
-        <EuiFlexGroup alignItems="center">
-          <EuiFlexItem grow={false} style={{ minWidth: 120 }}>
-            <EuiToast
-              style={{ width: 300 }}
-              title="Search failed.  Check your Elasticsearch connection."
-              color="danger"
-            />
-          </EuiFlexItem>
-
-          <EuiFlexItem>
-            <EuiText className="guideSection__text">
-              <h3>Error toasts report a problem</h3>
-              <p>
-                An error toast might let users know an action didn&apos;t
-                complete or that a form has errors.
-              </p>
-            </EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-
-        <EuiSpacer />
-
-        <EuiFlexGroup alignItems="center">
-          <EuiFlexItem grow={false} style={{ minWidth: 120 }}>
-            <div>
-              <EuiToast
-                style={{ width: 300 }}
-                title="Please wait while your report is created"
-                color="primary"
-              />
-            </div>
-          </EuiFlexItem>
-
-          <EuiFlexItem>
-            <EuiText className="guideSection__text">
-              <h3>Info toasts relay neutral information</h3>
-              <p>
-                The default toast, an info toast might notify users about an
-                ongoing action.
-              </p>
-            </EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-
-        <EuiSpacer />
-
-        <GuideRuleTitle>Use a toast for a timely message</GuideRuleTitle>
-
-        <GuideRule
-          description="Toasts are appropriate for short feedback related to a user action.
+      <GuideRule
+        description="Toasts are appropriate for short feedback related to a user action.
           A toast should contain a message about a current action, not a historical action.">
-          <GuideRuleExample
-            type="do"
-            panel={false}
-            frame
-            text="Do. Use a toast for a brief message about the current action.">
+        <GuideRuleExample
+          type="do"
+          panel={false}
+          frame
+          text="Do. Use a toast for a brief message about the current action.">
+          <EuiToast
+            style={{ maxWidth: 300 }}
+            title="Your folder was moved"
+            color="success"
+          />
+        </GuideRuleExample>
+
+        <GuideRuleExample
+          panel={false}
+          type="dont"
+          frame
+          text="Don't greet users with a toast when they open a page.">
+          <div style={{ textAlign: 'center' }}>
             <EuiToast
               style={{ maxWidth: 300 }}
-              title="Your folder was moved"
-              color="success"
+              title="Haven't seen you in a while"
+              color="primary"
             />
-          </GuideRuleExample>
+          </div>
+        </GuideRuleExample>
+      </GuideRule>
 
-          <GuideRuleExample
-            panel={false}
-            type="dont"
-            frame
-            text="Don't greet users with a toast when they open a page.">
-            <div style={{ textAlign: 'center' }}>
-              <EuiToast
-                style={{ maxWidth: 300 }}
-                title="Haven't seen you in a while"
-                color="primary"
-              />
-            </div>
-          </GuideRuleExample>
-        </GuideRule>
+      <GuideRuleTitle>
+        Most often, it&apos;s a single line of text
+      </GuideRuleTitle>
 
-        <GuideRuleTitle>
-          Most often, it&apos;s a single line of text
-        </GuideRuleTitle>
-
-        <GuideRule
-          description="By default, a toast stays on the screen 10 seconds.
+      <GuideRule
+        description="By default, a toast stays on the screen 10 seconds.
           Users should be able read the message in 6 to 7 seconds.
           The message should get straight to the point and rarely include more than one line.
 
           ">
-          <GuideRuleExample
-            panel={false}
-            frame
-            type="do"
-            text="Do. A single line of text is readable at a glance.">
-            <div style={{ textAlign: 'center' }}>
-              <EuiToast
-                style={{ maxWidth: 300 }}
-                title="Check your form for errors"
-                color="danger"
-              />
-            </div>
-          </GuideRuleExample>
+        <GuideRuleExample
+          panel={false}
+          frame
+          type="do"
+          text="Do. A single line of text is readable at a glance.">
+          <div style={{ textAlign: 'center' }}>
+            <EuiToast
+              style={{ maxWidth: 300 }}
+              title="Check your form for errors"
+              color="danger"
+            />
+          </div>
+        </GuideRuleExample>
 
-          <GuideRuleExample
-            type="dont"
-            panel={false}
-            frame
-            text="Don't cram a lot of detail into a toast.
+        <GuideRuleExample
+          type="dont"
+          panel={false}
+          frame
+          text="Don't cram a lot of detail into a toast.
             These errors should persist in callouts and validations on the form.
             They don't need to be spelled out in the toast.">
-            <div>
-              <EuiToast
-                style={{ maxWidth: 300 }}
-                title="Your form has errors"
-                color="danger">
-                <EuiText className="guideSection__text">
-                  <ul>
-                    <li>Username is a required field.</li>
-                    <li>Password must be at least 6 characters long.</li>
-                    <li>Email is a required field.</li>
-                  </ul>
-                </EuiText>
-              </EuiToast>
-            </div>
-          </GuideRuleExample>
-        </GuideRule>
+          <div>
+            <EuiToast
+              style={{ maxWidth: 300 }}
+              title="Your form has errors"
+              color="danger">
+              <EuiText className="guideSection__text">
+                <ul>
+                  <li>Username is a required field.</li>
+                  <li>Password must be at least 6 characters long.</li>
+                  <li>Email is a required field.</li>
+                </ul>
+              </EuiText>
+            </EuiToast>
+          </div>
+        </GuideRuleExample>
+      </GuideRule>
 
-        <GuideRuleTitle>
-          Toasts should only contain a single action
-        </GuideRuleTitle>
+      <GuideRuleTitle>
+        Toasts should only contain a single action
+      </GuideRuleTitle>
 
-        <GuideRule
-          description="A toast can have a single action, styled as a standard button.
+      <GuideRule
+        description="A toast can have a single action, styled as a standard button.
           If more actions are needed, or if the action is important enough to
           interrupt the user, use a modal instead.">
-          <GuideRuleExample
-            panel={false}
-            type="do"
-            frame
-            text="Do. Use only one action per toast and favor a one-word label.
+        <GuideRuleExample
+          panel={false}
+          type="do"
+          frame
+          text="Do. Use only one action per toast and favor a one-word label.
               Align actions to the right, which follows our button guidelines for
               usage within restricted width containers.">
+          <EuiToast
+            style={{ maxWidth: 300 }}
+            color="success"
+            title="Your report is complete">
+            <div style={{ textAlign: 'right' }}>
+              <EuiButton size="s">Download</EuiButton>
+            </div>
+          </EuiToast>
+        </GuideRuleExample>
+
+        <GuideRuleExample
+          type="dont"
+          panel={false}
+          frame
+          text="Don't use multiple actions. Don't align buttons in toasts to the left.
+              This message is better in a confirmation modal.">
+          <EuiToast
+            style={{ maxWidth: 300 }}
+            title="All messages will be deleted"
+            color="danger">
+            <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
+              <EuiFlexItem grow={false}>
+                <EuiButton size="s">Cancel</EuiButton>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButton size="s" color="danger">
+                  Delete
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiToast>
+        </GuideRuleExample>
+      </GuideRule>
+
+      <EuiSpacer size="l" />
+
+      <GuideRuleTitle>Icons should emphasize actions</GuideRuleTitle>
+
+      <GuideRule description="An icon on the left of the message can help define the message type.">
+        <GuideRuleExample
+          panel={false}
+          type="do"
+          frame
+          text="Do. The check icon reinforces that the action succeeded.
+                The alert icon helps users understand the message is an error.">
+          <div>
             <EuiToast
               style={{ maxWidth: 300 }}
+              title="Your dashboard was updated"
+              iconType="check"
               color="success"
-              title="Your report is complete">
+            />
+
+            <EuiSpacer />
+
+            <EuiToast
+              style={{ maxWidth: 300 }}
+              title="A dashboard named 'MyDashboard' already exists"
+              iconType="alert"
+              color="danger"
+            />
+          </div>
+        </GuideRuleExample>
+
+        <GuideRuleExample
+          type="dont"
+          panel={false}
+          frame
+          text="Don't use icons that are hard to understand. They distract from the message.">
+          <EuiToast
+            color="primary"
+            style={{ maxWidth: 300 }}
+            title="Message sent"
+            iconType="help"
+          />
+        </GuideRuleExample>
+      </GuideRule>
+
+      <GuideRuleTitle>Display one toast at a time</GuideRuleTitle>
+
+      <GuideRule
+        description="Users should be able to take
+          in all the details from one toast before the next one arrives.">
+        <GuideRuleExample
+          panel={false}
+          type="do"
+          frame
+          text="Do. Display one toast at a time.">
+          <EuiToast
+            style={{ maxWidth: 300 }}
+            color="primary"
+            title="3 new messages"
+          />
+        </GuideRuleExample>
+
+        <GuideRuleExample
+          type="dont"
+          panel={false}
+          frame
+          text="Don't stack toasts.">
+          <div>
+            <EuiToast
+              style={{ maxWidth: 300 }}
+              color="danger"
+              title="There was a problem with your node">
               <div style={{ textAlign: 'right' }}>
-                <EuiButton size="s">Download</EuiButton>
+                <EuiButton size="s">Learn more</EuiButton>
               </div>
             </EuiToast>
-          </GuideRuleExample>
+            <EuiSpacer />
 
-          <GuideRuleExample
-            type="dont"
-            panel={false}
-            frame
-            text="Don't use multiple actions. Don't align buttons in toasts to the left.
-              This message is better in a confirmation modal.">
-            <EuiToast
-              style={{ maxWidth: 300 }}
-              title="All messages will be deleted"
-              color="danger">
-              <EuiFlexGroup justifyContent="flexEnd" gutterSize="s">
-                <EuiFlexItem grow={false}>
-                  <EuiButton size="s">Cancel</EuiButton>
-                </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiButton size="s" color="danger">
-                    Delete
-                  </EuiButton>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiToast>
-          </GuideRuleExample>
-        </GuideRule>
-
-        <EuiSpacer size="l" />
-
-        <GuideRuleTitle>Icons should emphasize actions</GuideRuleTitle>
-
-        <GuideRule description="An icon on the left of the message can help define the message type.">
-          <GuideRuleExample
-            panel={false}
-            type="do"
-            frame
-            text="Do. The check icon reinforces that the action succeeded.
-                The alert icon helps users understand the message is an error.">
-            <div>
-              <EuiToast
-                style={{ maxWidth: 300 }}
-                title="Your dashboard was updated"
-                iconType="check"
-                color="success"
-              />
-
-              <EuiSpacer />
-
-              <EuiToast
-                style={{ maxWidth: 300 }}
-                title="A dashboard named 'MyDashboard' already exists"
-                iconType="alert"
-                color="danger"
-              />
-            </div>
-          </GuideRuleExample>
-
-          <GuideRuleExample
-            type="dont"
-            panel={false}
-            frame
-            text="Don't use icons that are hard to understand. They distract from the message.">
             <EuiToast
               color="primary"
               style={{ maxWidth: 300 }}
-              title="Message sent"
-              iconType="help"
-            />
-          </GuideRuleExample>
-        </GuideRule>
-
-        <GuideRuleTitle>Display one toast at a time</GuideRuleTitle>
-
-        <GuideRule
-          description="Users should be able to take
-          in all the details from one toast before the next one arrives.">
-          <GuideRuleExample
-            panel={false}
-            type="do"
-            frame
-            text="Do. Display one toast at a time.">
-            <EuiToast
-              style={{ maxWidth: 300 }}
-              color="primary"
               title="3 new messages"
             />
-          </GuideRuleExample>
+          </div>
+        </GuideRuleExample>
+      </GuideRule>
 
-          <GuideRuleExample
-            type="dont"
-            panel={false}
-            frame
-            text="Don't stack toasts.">
-            <div>
-              <EuiToast
-                style={{ maxWidth: 300 }}
-                color="danger"
-                title="There was a problem with your node">
-                <div style={{ textAlign: 'right' }}>
-                  <EuiButton size="s">Learn more</EuiButton>
-                </div>
-              </EuiToast>
-              <EuiSpacer />
+      <GuideRuleTitle>Keep messages as short as possible</GuideRuleTitle>
 
-              <EuiToast
-                color="primary"
-                style={{ maxWidth: 300 }}
-                title="3 new messages"
-              />
-            </div>
-          </GuideRuleExample>
-        </GuideRule>
-
-        <GuideRuleTitle>Keep messages as short as possible</GuideRuleTitle>
-
-        <GuideRule
-          description="For common actions such as create, add, delete, remove, and save,
+      <GuideRule
+        description="For common actions such as create, add, delete, remove, and save,
           include the object type, the object name if available, and the past tense of the action.
           ">
-          <GuideRuleExample
-            panel={false}
-            type="do"
-            frame
-            text="Do. Include the object name if it's not too long.
+        <GuideRuleExample
+          panel={false}
+          type="do"
+          frame
+          text="Do. Include the object name if it's not too long.
             Use single quotation marks around the object name if it helps clarify meaning.">
-            <div>
-              <EuiToast
-                color="success"
-                style={{ maxWidth: 300 }}
-                title="User 'Casey Smith' was added"
-              />
-            </div>
-          </GuideRuleExample>
-
-          <GuideRuleExample
-            type="dont"
-            panel={false}
-            frame
-            text='Don&apos;t use the generic "Your object."'>
+          <div>
             <EuiToast
               color="success"
               style={{ maxWidth: 300 }}
-              title="Your object has been saved"
+              title="User 'Casey Smith' was added"
             />
-          </GuideRuleExample>
-        </GuideRule>
+          </div>
+        </GuideRuleExample>
 
-        <GuideRule description="Don't include the word &quot;successfully.&quot; It's implied.">
-          <GuideRuleExample
-            panel={false}
-            frame
-            type="do"
-            text="Do. Use this format for a success message.">
-            <EuiToast
-              color="success"
-              style={{ maxWidth: 300 }}
-              title="Dashboard 'My_dashboard_with_a_very_long_name' was saved"
-            />
-          </GuideRuleExample>
+        <GuideRuleExample
+          type="dont"
+          panel={false}
+          frame
+          text='Don&apos;t use the generic "Your object."'>
+          <EuiToast
+            color="success"
+            style={{ maxWidth: 300 }}
+            title="Your object has been saved"
+          />
+        </GuideRuleExample>
+      </GuideRule>
 
-          <GuideRuleExample
-            type="dont"
-            panel={false}
-            frame
-            text='Don&apos;t include "successfully."'>
-            <EuiToast
-              color="success"
-              style={{ maxWidth: 300 }}
-              title="Dashboard 'My_dashboard' was successfully saved"
-            />
-          </GuideRuleExample>
-        </GuideRule>
+      <GuideRule description="Don't include the word &quot;successfully.&quot; It's implied.">
+        <GuideRuleExample
+          panel={false}
+          frame
+          type="do"
+          text="Do. Use this format for a success message.">
+          <EuiToast
+            color="success"
+            style={{ maxWidth: 300 }}
+            title="Dashboard 'My_dashboard_with_a_very_long_name' was saved"
+          />
+        </GuideRuleExample>
 
-        <GuideRule description="For a message about multiple objects, include the object count, but not the names of the objects.">
-          <GuideRuleExample
-            panel={false}
-            type="do"
-            frame
-            text="Do. Include the object count.">
-            <EuiToast
-              color="success"
-              style={{ maxWidth: 300 }}
-              title="4 visualizations were deleted"
-            />
-          </GuideRuleExample>
-          <GuideRuleExample
-            panel={false}
-            type="dont"
-            frame
-            text="Don't overwhelm the user by listing the names of all the objects.">
-            <EuiToast
-              color="success"
-              style={{ maxWidth: 300 }}
-              title="Visualization 1, Visualization 2, Visualization 3, and Visualization 4 were deleted"
-            />
-          </GuideRuleExample>
-        </GuideRule>
+        <GuideRuleExample
+          type="dont"
+          panel={false}
+          frame
+          text='Don&apos;t include "successfully."'>
+          <EuiToast
+            color="success"
+            style={{ maxWidth: 300 }}
+            title="Dashboard 'My_dashboard' was successfully saved"
+          />
+        </GuideRuleExample>
+      </GuideRule>
 
-        <GuideRuleTitle>
-          Use call-to-action buttons when the content needs more room
-        </GuideRuleTitle>
+      <GuideRule description="For a message about multiple objects, include the object count, but not the names of the objects.">
+        <GuideRuleExample
+          panel={false}
+          type="do"
+          frame
+          text="Do. Include the object count.">
+          <EuiToast
+            color="success"
+            style={{ maxWidth: 300 }}
+            title="4 visualizations were deleted"
+          />
+        </GuideRuleExample>
+        <GuideRuleExample
+          panel={false}
+          type="dont"
+          frame
+          text="Don't overwhelm the user by listing the names of all the objects.">
+          <EuiToast
+            color="success"
+            style={{ maxWidth: 300 }}
+            title="Visualization 1, Visualization 2, Visualization 3, and Visualization 4 were deleted"
+          />
+        </GuideRuleExample>
+      </GuideRule>
 
-        <GuideRule
-          description="Occassionally the content of a toast is too involved to fit into the constrained space of a toast.
+      <GuideRuleTitle>
+        Use call-to-action buttons when the content needs more room
+      </GuideRuleTitle>
+
+      <GuideRule
+        description="Occassionally the content of a toast is too involved to fit into the constrained space of a toast.
           This is common in long error messages. In these cases use the toast to deliver the summary of the
           information and use a button to provide a call-to-action for the full message.">
-          <GuideRuleExample
-            panel={false}
-            type="do"
-            frame
-            text="Use the toast message to provide a summary and a button to link to the full content">
-            <EuiToast
-              style={{ maxWidth: 300 }}
-              color="danger"
-              title="Your visualization has an error">
-              <p>The maximum bucket size of 200 was exceeded.</p>
-              <div style={{ textAlign: 'right' }}>
-                <EuiButton size="s" color="danger" onClick={this.showModal}>
-                  See the full error
-                </EuiButton>
-                {modal}
-              </div>
-            </EuiToast>
-          </GuideRuleExample>
+        <GuideRuleExample
+          panel={false}
+          type="do"
+          frame
+          text="Use the toast message to provide a summary and a button to link to the full content">
+          <EuiToast
+            style={{ maxWidth: 300 }}
+            color="danger"
+            title="Your visualization has an error">
+            <p>The maximum bucket size of 200 was exceeded.</p>
+            <div style={{ textAlign: 'right' }}>
+              <EuiButton size="s" color="danger" onClick={showModal}>
+                See the full error
+              </EuiButton>
+              {modal}
+            </div>
+          </EuiToast>
+        </GuideRuleExample>
 
-          <GuideRuleExample
-            type="dont"
-            panel={false}
-            frame
-            text="Don't cram a lot of content into the small space of a toast.">
-            <EuiToast
-              style={{ maxWidth: 300 }}
-              color="danger"
-              title="Your visualization has an error">
-              <EuiCallOut
-                title="The maximum bucket size of 200 was exceeded"
-                color="danger">
-                <p>An extremely long error trace.</p>
-              </EuiCallOut>
-            </EuiToast>
-          </GuideRuleExample>
-        </GuideRule>
-      </GuidePage>
-    );
-  }
-}
+        <GuideRuleExample
+          type="dont"
+          panel={false}
+          frame
+          text="Don't cram a lot of content into the small space of a toast.">
+          <EuiToast
+            style={{ maxWidth: 300 }}
+            color="danger"
+            title="Your visualization has an error">
+            <EuiCallOut
+              title="The maximum bucket size of 200 was exceeded"
+              color="danger">
+              <p>An extremely long error trace.</p>
+            </EuiCallOut>
+          </EuiToast>
+        </GuideRuleExample>
+      </GuideRule>
+    </GuidePage>
+  );
+};

--- a/src-docs/src/views/header/header_spaces_menu.js
+++ b/src-docs/src/views/header/header_spaces_menu.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import {
   EuiHeaderSectionItemButton,
@@ -11,139 +11,124 @@ import {
 } from '../../../../src/components';
 import { Fragment } from 'react-is';
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const spacesValues = [
+    {
+      label: 'Sales team',
+      prepend: <EuiAvatar type="space" name="Sales Team" size="s" />,
+      checked: 'on',
+    },
+    {
+      label: 'Engineering',
+      prepend: <EuiAvatar type="space" name="Engineering" size="s" />,
+    },
+    {
+      label: 'Security',
+      prepend: <EuiAvatar type="space" name="Security" size="s" />,
+    },
+    {
+      label: 'Default',
+      prepend: <EuiAvatar type="space" name="Default" size="s" />,
+    },
+  ];
 
-    this.spaces = [
-      {
-        label: 'Sales team',
-        prepend: <EuiAvatar type="space" name="Sales Team" size="s" />,
-        checked: 'on',
-      },
-      {
-        label: 'Engineering',
-        prepend: <EuiAvatar type="space" name="Engineering" size="s" />,
-      },
-      {
-        label: 'Security',
-        prepend: <EuiAvatar type="space" name="Security" size="s" />,
-      },
-      {
-        label: 'Default',
-        prepend: <EuiAvatar type="space" name="Default" size="s" />,
-      },
-    ];
+  const additionalSpaces = [
+    {
+      label: 'Sales team 2',
+      prepend: <EuiAvatar type="space" name="Sales Team 2" size="s" />,
+    },
+    {
+      label: 'Engineering 2',
+      prepend: <EuiAvatar type="space" name="Engineering 2" size="s" />,
+    },
+    {
+      label: 'Security 2',
+      prepend: <EuiAvatar type="space" name="Security 2" size="s" />,
+    },
+    {
+      label: 'Default 2',
+      prepend: <EuiAvatar type="space" name="Default 2" size="s" />,
+    },
+  ];
 
-    this.additionalSpaces = [
-      {
-        label: 'Sales team 2',
-        prepend: <EuiAvatar type="space" name="Sales Team 2" size="s" />,
-      },
-      {
-        label: 'Engineering 2',
-        prepend: <EuiAvatar type="space" name="Engineering 2" size="s" />,
-      },
-      {
-        label: 'Security 2',
-        prepend: <EuiAvatar type="space" name="Security 2" size="s" />,
-      },
-      {
-        label: 'Default 2',
-        prepend: <EuiAvatar type="space" name="Default 2" size="s" />,
-      },
-    ];
+  const [spaces, setSpaces] = useState(spacesValues);
+  const [selectedSpace, setSelectedSpace] = useState(
+    spaces.filter(option => option.checked)[0]
+  );
+  const [isOpen, setIsOpen] = useState(false);
 
-    this.state = {
-      spaces: this.spaces,
-      selectedSpace: this.spaces.filter(option => option.checked)[0],
-      isOpen: false,
-    };
-  }
-
-  isListExtended = () => {
-    return this.state.spaces.length > 4 ? true : false;
+  const isListExtended = () => {
+    return spaces.length > 4 ? true : false;
   };
 
-  onMenuButtonClick = () => {
-    this.setState({
-      isOpen: !this.state.isOpen,
-    });
+  const onMenuButtonClick = () => {
+    setIsOpen(!isOpen);
   };
 
-  closePopover = () => {
-    this.setState({
-      isOpen: false,
-    });
+  const closePopover = () => {
+    setIsOpen(false);
   };
 
-  onChange = options => {
-    this.setState({
-      spaces: options,
-      selectedSpace: options.filter(option => option.checked)[0],
-      isOpen: false,
-    });
+  const onChange = options => {
+    setSpaces(options);
+    setSelectedSpace(options.filter(option => option.checked)[0]);
+    setIsOpen(false);
   };
 
-  addMoreSpaces = () => {
-    this.setState({
-      spaces: this.spaces.concat(this.additionalSpaces),
-    });
+  const addMoreSpaces = () => {
+    setSpaces(spaces.concat(additionalSpaces));
   };
 
-  render() {
-    const { selectedSpace, isOpen, spaces } = this.state;
-    const button = (
-      <EuiHeaderSectionItemButton
-        aria-controls="headerSpacesMenuList"
-        aria-expanded={isOpen}
-        aria-haspopup="true"
-        aria-label="Apps menu"
-        onClick={this.onMenuButtonClick}>
-        {selectedSpace.prepend}
-      </EuiHeaderSectionItemButton>
-    );
+  const button = (
+    <EuiHeaderSectionItemButton
+      aria-controls="headerSpacesMenuList"
+      aria-expanded={isOpen}
+      aria-haspopup="true"
+      aria-label="Apps menu"
+      onClick={onMenuButtonClick}>
+      {selectedSpace.prepend}
+    </EuiHeaderSectionItemButton>
+  );
 
-    return (
-      <EuiPopover
-        id="headerSpacesMenu"
-        ownFocus
-        button={button}
-        isOpen={isOpen}
-        anchorPosition="downLeft"
-        closePopover={this.closePopover}
-        panelPaddingSize="none">
-        <EuiSelectable
-          searchable={this.isListExtended()}
-          searchProps={{
-            placeholder: 'Find a space',
-            compressed: true,
-          }}
-          options={spaces}
-          singleSelection="always"
-          style={{ width: 300 }}
-          onChange={this.onChange}
-          listProps={{
-            rowHeight: 40,
-            showIcons: false,
-          }}>
-          {(list, search) => (
-            <Fragment>
-              <EuiPopoverTitle>{search || 'Your spaces'}</EuiPopoverTitle>
-              {list}
-              <EuiPopoverFooter>
-                <EuiButton
-                  size="s"
-                  fullWidth
-                  onClick={this.addMoreSpaces}
-                  disabled={this.isListExtended()}>
-                  Add more spaces
-                </EuiButton>
-              </EuiPopoverFooter>
-            </Fragment>
-          )}
-        </EuiSelectable>
-      </EuiPopover>
-    );
-  }
-}
+  return (
+    <EuiPopover
+      id="headerSpacesMenu"
+      ownFocus
+      button={button}
+      isOpen={isOpen}
+      anchorPosition="downLeft"
+      closePopover={closePopover}
+      panelPaddingSize="none">
+      <EuiSelectable
+        searchable={isListExtended()}
+        searchProps={{
+          placeholder: 'Find a space',
+          compressed: true,
+        }}
+        options={spaces}
+        singleSelection="always"
+        style={{ width: 300 }}
+        onChange={onChange}
+        listProps={{
+          rowHeight: 40,
+          showIcons: false,
+        }}>
+        {(list, search) => (
+          <Fragment>
+            <EuiPopoverTitle>{search || 'Your spaces'}</EuiPopoverTitle>
+            {list}
+            <EuiPopoverFooter>
+              <EuiButton
+                size="s"
+                fullWidth
+                onClick={addMoreSpaces}
+                disabled={isListExtended()}>
+                Add more spaces
+              </EuiButton>
+            </EuiPopoverFooter>
+          </Fragment>
+        )}
+      </EuiSelectable>
+    </EuiPopover>
+  );
+};

--- a/src-docs/src/views/portal/portal.js
+++ b/src-docs/src/views/portal/portal.js
@@ -1,44 +1,30 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import { EuiPortal, EuiButton, EuiBottomBar } from '../../../../src/components';
 
-export class Portal extends Component {
-  constructor(props) {
-    super(props);
+export const Portal = () => {
+  const [isPortalVisible, setIsPortalVisible] = useState(false);
 
-    this.state = {
-      isPortalVisible: false,
-    };
+  const togglePortal = () => {
+    setIsPortalVisible(!isPortalVisible);
+  };
 
-    this.togglePortal = this.togglePortal.bind(this);
-  }
+  let portal;
 
-  togglePortal() {
-    this.setState(prevState => ({
-      isPortalVisible: !prevState.isPortalVisible,
-    }));
-  }
-
-  render() {
-    let portal;
-
-    if (this.state.isPortalVisible) {
-      portal = (
-        <EuiPortal>
-          <EuiBottomBar>
-            <p>
-              This element is appended to the body in the DOM if you inspect
-            </p>
-          </EuiBottomBar>
-        </EuiPortal>
-      );
-    }
-    return (
-      <div>
-        <EuiButton onClick={this.togglePortal}>Toggle portal</EuiButton>
-
-        {portal}
-      </div>
+  if (isPortalVisible) {
+    portal = (
+      <EuiPortal>
+        <EuiBottomBar>
+          <p>This element is appended to the body in the DOM if you inspect</p>
+        </EuiBottomBar>
+      </EuiPortal>
     );
   }
-}
+  return (
+    <div>
+      <EuiButton onClick={togglePortal}>Toggle portal</EuiButton>
+
+      {portal}
+    </div>
+  );
+};

--- a/src-docs/src/views/portal/portal_insert.js
+++ b/src-docs/src/views/portal/portal_insert.js
@@ -1,45 +1,35 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import { EuiPortal, EuiButton } from '../../../../src/components';
 import { EuiSpacer } from '../../../../src/components/spacer/spacer';
 
-export class PortalInsert extends Component {
-  constructor(props) {
-    super(props);
+let buttonRef = null;
 
-    this.buttonRef = null;
+export const PortalInsert = () => {
+  const [isPortalVisible, setIsPortalVisible] = useState(false);
 
-    this.state = {
-      isPortalVisible: false,
-    };
-  }
+  const setButtonRef = node => (buttonRef = node);
 
-  setButtonRef = node => (this.buttonRef = node);
-
-  togglePortal = () => {
-    this.setState(prevState => ({
-      isPortalVisible: !prevState.isPortalVisible,
-    }));
+  const togglePortal = () => {
+    setIsPortalVisible(!isPortalVisible);
   };
 
-  render() {
-    let portal;
+  let portal;
 
-    if (this.state.isPortalVisible) {
-      portal = (
-        <EuiPortal insert={{ sibling: this.buttonRef, position: 'after' }}>
-          <EuiSpacer />
-          <p>This element is appended immediately after the button.</p>
-        </EuiPortal>
-      );
-    }
-    return (
-      <div>
-        <EuiButton onClick={this.togglePortal} buttonRef={this.setButtonRef}>
-          Toggle portal
-        </EuiButton>
-        {portal}
-      </div>
+  if (isPortalVisible) {
+    portal = (
+      <EuiPortal insert={{ sibling: buttonRef, position: 'after' }}>
+        <EuiSpacer />
+        <p>This element is appended immediately after the button.</p>
+      </EuiPortal>
     );
   }
-}
+  return (
+    <div>
+      <EuiButton onClick={togglePortal} buttonRef={setButtonRef}>
+        Toggle portal
+      </EuiButton>
+      {portal}
+    </div>
+  );
+};

--- a/src-docs/src/views/selectable/selectable_custom_render.js
+++ b/src-docs/src/views/selectable/selectable_custom_render.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { useState, Fragment } from 'react';
 
 import {
   EuiBadge,
@@ -10,43 +10,33 @@ import {
 import { EuiSelectable } from '../../../../src/components/selectable';
 import { createDataStore } from '../tables/data_store';
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
-
-    this.countries = createDataStore().countries.map(country => {
-      return {
-        id: country.code,
-        label: `${country.name}`,
-        prepend: country.flag,
-        append: <EuiBadge>{country.code}</EuiBadge>,
-      };
-    });
-
-    this.countries.unshift({
-      label: 'Country options',
-      isGroupLabel: true,
-    });
-
-    this.state = {
-      options: this.countries,
-      useCustomContent: false,
+export default () => {
+  const countries = createDataStore().countries.map(country => {
+    return {
+      id: country.code,
+      label: `${country.name}`,
+      prepend: country.flag,
+      append: <EuiBadge>{country.code}</EuiBadge>,
     };
-  }
+  });
 
-  onChange = options => {
-    this.setState({
-      options,
-    });
+  countries.unshift({
+    label: 'Country options',
+    isGroupLabel: true,
+  });
+
+  const [options, setOptions] = useState(countries);
+  const [useCustomContent, setUseCustomContent] = useState(countries);
+
+  const onChange = options => {
+    setOptions(options);
   };
 
-  onCustom = e => {
-    this.setState({
-      useCustomContent: e.currentTarget.checked,
-    });
+  const onCustom = e => {
+    setUseCustomContent(e.currentTarget.checked);
   };
 
-  renderCountryOption = (option, searchValue) => {
+  const renderCountryOption = (option, searchValue) => {
     return (
       <Fragment>
         <EuiHighlight search={searchValue}>{option.label}</EuiHighlight>
@@ -58,44 +48,40 @@ export default class extends Component {
     );
   };
 
-  render() {
-    const { options, useCustomContent } = this.state;
-
-    let customProps;
-    if (useCustomContent) {
-      customProps = {
-        height: 240,
-        renderOption: this.renderCountryOption,
-        listProps: {
-          rowHeight: 50,
-          showIcons: false,
-        },
-      };
-    }
-
-    return (
-      <Fragment>
-        <EuiSwitch
-          label="Custom content with no icons"
-          checked={useCustomContent}
-          onChange={this.onCustom}
-        />
-
-        <EuiSpacer />
-
-        <EuiSelectable
-          searchable
-          options={options}
-          onChange={this.onChange}
-          {...customProps}>
-          {(list, search) => (
-            <Fragment>
-              {search}
-              {list}
-            </Fragment>
-          )}
-        </EuiSelectable>
-      </Fragment>
-    );
+  let customProps;
+  if (useCustomContent) {
+    customProps = {
+      height: 240,
+      renderOption: renderCountryOption,
+      listProps: {
+        rowHeight: 50,
+        showIcons: false,
+      },
+    };
   }
-}
+
+  return (
+    <Fragment>
+      <EuiSwitch
+        label="Custom content with no icons"
+        checked={useCustomContent}
+        onChange={onCustom}
+      />
+
+      <EuiSpacer />
+
+      <EuiSelectable
+        searchable
+        options={options}
+        onChange={onChange}
+        {...customProps}>
+        {(list, search) => (
+          <Fragment>
+            {search}
+            {list}
+          </Fragment>
+        )}
+      </EuiSelectable>
+    </Fragment>
+  );
+};

--- a/src-docs/src/views/selectable/selectable_popover.js
+++ b/src-docs/src/views/selectable/selectable_popover.js
@@ -57,10 +57,7 @@ export default () => {
   };
 
   const button = (
-    <EuiButton
-      iconType="arrowDown"
-      iconSide="right"
-      onClick={onButtonClick}>
+    <EuiButton iconType="arrowDown" iconSide="right" onClick={onButtonClick}>
       Show popover
     </EuiButton>
   );

--- a/src-docs/src/views/selectable/selectable_popover.js
+++ b/src-docs/src/views/selectable/selectable_popover.js
@@ -60,7 +60,7 @@ export default () => {
     <EuiButton
       iconType="arrowDown"
       iconSide="right"
-      onClick={onButtonClick.bind(this)}>
+      onClick={onButtonClick}>
       Show popover
     </EuiButton>
   );

--- a/src-docs/src/views/selectable/selectable_popover.js
+++ b/src-docs/src/views/selectable/selectable_popover.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 import {
   EuiButton,
   EuiCode,
@@ -17,154 +17,133 @@ import { Comparators } from '../../../../src/services/sort';
 import { Options } from './data';
 import { createDataStore } from '../tables/data_store';
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
-
-    this.countries = createDataStore().countries.map(country => {
-      return {
-        id: country.code,
-        label: `${country.name}`,
-        append: country.flag,
-      };
-    });
-
-    this.state = {
-      options: Options,
-      countries: this.countries,
-      isPopoverOpen: false,
-      isFlyoutVisible: false,
+export default () => {
+  const countriesStore = createDataStore().countries.map(country => {
+    return {
+      id: country.code,
+      label: `${country.name}`,
+      append: country.flag,
     };
-  }
+  });
 
-  onButtonClick = () => {
-    this.setState(prevState => ({
-      options: prevState.options.slice().sort(Comparators.property('checked')),
-      isPopoverOpen: !prevState.isPopoverOpen,
-    }));
+  const [options, setOptions] = useState(Options);
+  const [countries, setCountries] = useState(countriesStore);
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
+
+  const onButtonClick = () => {
+    setOptions(options.slice().sort(Comparators.property('checked')));
+    setIsPopoverOpen(!isPopoverOpen);
   };
 
-  closePopover = () => {
-    this.setState({
-      isPopoverOpen: false,
-    });
+  const closePopover = () => {
+    setIsPopoverOpen(false);
   };
 
-  onChange = options => {
-    this.setState({
-      options,
-    });
+  const onChange = options => {
+    setOptions(options);
   };
 
-  onFlyoutChange = options => {
-    this.setState({
-      countries: options,
-    });
+  const onFlyoutChange = options => {
+    setCountries(options);
   };
 
-  closeFlyout = () => {
-    this.setState({ isFlyoutVisible: false });
+  const closeFlyout = () => {
+    setIsFlyoutVisible(false);
   };
 
-  showFlyout = () => {
-    this.setState({ isFlyoutVisible: true });
+  const showFlyout = () => {
+    setIsFlyoutVisible(true);
   };
 
-  render() {
-    const { isPopoverOpen, options, countries } = this.state;
+  const button = (
+    <EuiButton
+      iconType="arrowDown"
+      iconSide="right"
+      onClick={onButtonClick.bind(this)}>
+      Show popover
+    </EuiButton>
+  );
 
-    const button = (
-      <EuiButton
-        iconType="arrowDown"
-        iconSide="right"
-        onClick={this.onButtonClick.bind(this)}>
-        Show popover
-      </EuiButton>
-    );
+  return (
+    <Fragment>
+      <EuiPopover
+        id="popover"
+        panelPaddingSize="none"
+        button={button}
+        isOpen={isPopoverOpen}
+        closePopover={closePopover}>
+        <EuiSelectable
+          searchable
+          searchProps={{
+            placeholder: 'Filter list',
+            compressed: true,
+          }}
+          options={options}
+          onChange={onChange}>
+          {(list, search) => (
+            <div style={{ width: 240 }}>
+              <EuiPopoverTitle>{search}</EuiPopoverTitle>
+              {list}
+              <EuiPopoverFooter>
+                <EuiButton size="s" fullWidth>
+                  Manage this list
+                </EuiButton>
+              </EuiPopoverFooter>
+            </div>
+          )}
+        </EuiSelectable>
+      </EuiPopover>
 
-    return (
-      <Fragment>
-        <EuiPopover
-          id="popover"
-          panelPaddingSize="none"
-          button={button}
-          isOpen={isPopoverOpen}
-          closePopover={this.closePopover}>
+      <EuiSpacer />
+
+      <EuiButton onClick={showFlyout}>Show flyout</EuiButton>
+
+      {isFlyoutVisible && (
+        <EuiFlyout ownFocus onClose={closeFlyout} aria-labelledby="flyoutTitle">
           <EuiSelectable
             searchable
-            searchProps={{
-              placeholder: 'Filter list',
-              compressed: true,
-            }}
-            options={options}
-            onChange={this.onChange}>
+            options={countries}
+            onChange={onFlyoutChange}
+            height="full">
             {(list, search) => (
-              <div style={{ width: 240 }}>
-                <EuiPopoverTitle>{search}</EuiPopoverTitle>
+              <Fragment>
+                <EuiFlyoutHeader hasBorder>
+                  <EuiTitle size="m">
+                    <h2 id="flyoutTitle">Be mindful of the flexbox</h2>
+                  </EuiTitle>
+                  <EuiSpacer />
+                  {search}
+                </EuiFlyoutHeader>
+                <EuiSpacer size="xs" />
                 {list}
-                <EuiPopoverFooter>
-                  <EuiButton size="s" fullWidth>
-                    Manage this list
-                  </EuiButton>
-                </EuiPopoverFooter>
-              </div>
+              </Fragment>
             )}
           </EuiSelectable>
-        </EuiPopover>
+          <EuiSpacer size="xs" />
+          <EuiFlyoutFooter>
+            <EuiButton fill>Some extra action</EuiButton>
+          </EuiFlyoutFooter>
+        </EuiFlyout>
+      )}
 
-        <EuiSpacer />
+      <EuiSpacer />
 
-        <EuiButton onClick={this.showFlyout}>Show flyout</EuiButton>
+      <EuiTitle size="xxs">
+        <h4>
+          Using <EuiCode language="js">listProps.bordered=true</EuiCode>
+        </h4>
+      </EuiTitle>
 
-        {this.state.isFlyoutVisible && (
-          <EuiFlyout
-            ownFocus
-            onClose={this.closeFlyout}
-            aria-labelledby="flyoutTitle">
-            <EuiSelectable
-              searchable
-              options={countries}
-              onChange={this.onFlyoutChange}
-              height="full">
-              {(list, search) => (
-                <Fragment>
-                  <EuiFlyoutHeader hasBorder>
-                    <EuiTitle size="m">
-                      <h2 id="flyoutTitle">Be mindful of the flexbox</h2>
-                    </EuiTitle>
-                    <EuiSpacer />
-                    {search}
-                  </EuiFlyoutHeader>
-                  <EuiSpacer size="xs" />
-                  {list}
-                </Fragment>
-              )}
-            </EuiSelectable>
-            <EuiSpacer size="xs" />
-            <EuiFlyoutFooter>
-              <EuiButton fill>Some extra action</EuiButton>
-            </EuiFlyoutFooter>
-          </EuiFlyout>
-        )}
+      <EuiSpacer />
 
-        <EuiSpacer />
-
-        <EuiTitle size="xxs">
-          <h4>
-            Using <EuiCode language="js">listProps.bordered=true</EuiCode>
-          </h4>
-        </EuiTitle>
-
-        <EuiSpacer />
-
-        <EuiSelectable
-          options={options}
-          onChange={() => {}}
-          style={{ width: 300 }}
-          listProps={{ bordered: true }}>
-          {list => list}
-        </EuiSelectable>
-      </Fragment>
-    );
-  }
-}
+      <EuiSelectable
+        options={options}
+        onChange={() => {}}
+        style={{ width: 300 }}
+        listProps={{ bordered: true }}>
+        {list => list}
+      </EuiSelectable>
+    </Fragment>
+  );
+};

--- a/src-docs/src/views/side_nav/side_nav.js
+++ b/src-docs/src/views/side_nav/side_nav.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import { EuiSideNav } from '../../../../src/components';
 
-export default function() {
+export default () => {
   const [isSideNavOpenOnMobile, setisSideNavOpenOnMobile] = useState(false);
 
   const toggleOpenOnMobile = () => {
@@ -54,4 +54,4 @@ export default function() {
       items={sideNav}
     />
   );
-}
+};

--- a/src-docs/src/views/side_nav/side_nav_complex.js
+++ b/src-docs/src/views/side_nav/side_nav_complex.js
@@ -1,92 +1,80 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import { EuiIcon, EuiSideNav } from '../../../../src/components';
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const [isSideNavOpenOnMobile, setIsSideNavOpenOnMobile] = useState(false);
+  const [selectedItemName, setSelectedItem] = useState('Lion stuff');
 
-    this.state = {
-      isSideNavOpenOnMobile: false,
-      selectedItemName: 'Lion stuff',
-    };
-  }
-
-  toggleOpenOnMobile = () => {
-    this.setState({
-      isSideNavOpenOnMobile: !this.state.isSideNavOpenOnMobile,
-    });
+  const toggleOpenOnMobile = () => {
+    setIsSideNavOpenOnMobile(!isSideNavOpenOnMobile);
   };
 
-  selectItem = name => {
-    this.setState({
-      selectedItemName: name,
-    });
+  const selectItem = name => {
+    setSelectedItem(name);
   };
 
-  createItem = (name, data = {}) => {
+  const createItem = (name, data = {}) => {
     // NOTE: Duplicate `name` values will cause `id` collisions.
     return {
       ...data,
       id: name,
       name,
-      isSelected: this.state.selectedItemName === name,
-      onClick: () => this.selectItem(name),
+      isSelected: selectedItemName === name,
+      onClick: () => selectItem(name),
     };
   };
 
-  render() {
-    const sideNav = [
-      this.createItem('Elasticsearch', {
-        icon: <EuiIcon type="logoElasticsearch" />,
-        items: [
-          this.createItem('Data sources'),
-          this.createItem('Users'),
-          this.createItem('Roles'),
-          this.createItem('Watches'),
-          this.createItem(
-            'Extremely long title will become truncated when the browser is narrow enough'
-          ),
-        ],
-      }),
-      this.createItem('Kibana', {
-        icon: <EuiIcon type="logoKibana" />,
-        items: [
-          this.createItem('Advanced settings', {
-            items: [
-              this.createItem('General'),
-              this.createItem('Timelion', {
-                items: [
-                  this.createItem('Time stuff', {
-                    icon: <EuiIcon type="clock" />,
-                  }),
-                  this.createItem('Lion stuff', {
-                    icon: <EuiIcon type="stats" />,
-                  }),
-                ],
-              }),
-              this.createItem('Visualizations'),
-            ],
-          }),
-          this.createItem('Index Patterns'),
-          this.createItem('Saved Objects'),
-          this.createItem('Reporting'),
-        ],
-      }),
-      this.createItem('Logstash', {
-        icon: <EuiIcon type="logoLogstash" />,
-        items: [this.createItem('Pipeline viewer')],
-      }),
-    ];
+  const sideNav = [
+    createItem('Elasticsearch', {
+      icon: <EuiIcon type="logoElasticsearch" />,
+      items: [
+        createItem('Data sources'),
+        createItem('Users'),
+        createItem('Roles'),
+        createItem('Watches'),
+        createItem(
+          'Extremely long title will become truncated when the browser is narrow enough'
+        ),
+      ],
+    }),
+    createItem('Kibana', {
+      icon: <EuiIcon type="logoKibana" />,
+      items: [
+        createItem('Advanced settings', {
+          items: [
+            createItem('General'),
+            createItem('Timelion', {
+              items: [
+                createItem('Time stuff', {
+                  icon: <EuiIcon type="clock" />,
+                }),
+                createItem('Lion stuff', {
+                  icon: <EuiIcon type="stats" />,
+                }),
+              ],
+            }),
+            createItem('Visualizations'),
+          ],
+        }),
+        createItem('Index Patterns'),
+        createItem('Saved Objects'),
+        createItem('Reporting'),
+      ],
+    }),
+    createItem('Logstash', {
+      icon: <EuiIcon type="logoLogstash" />,
+      items: [createItem('Pipeline viewer')],
+    }),
+  ];
 
-    return (
-      <EuiSideNav
-        mobileTitle="Navigate within $APP_NAME"
-        toggleOpenOnMobile={this.toggleOpenOnMobile}
-        isOpenOnMobile={this.state.isSideNavOpenOnMobile}
-        items={sideNav}
-        style={{ width: 192 }}
-      />
-    );
-  }
-}
+  return (
+    <EuiSideNav
+      mobileTitle="Navigate within $APP_NAME"
+      toggleOpenOnMobile={toggleOpenOnMobile}
+      isOpenOnMobile={isSideNavOpenOnMobile}
+      items={sideNav}
+      style={{ width: 192 }}
+    />
+  );
+};

--- a/src-docs/src/views/side_nav/side_nav_force_open.js
+++ b/src-docs/src/views/side_nav/side_nav_force_open.js
@@ -1,80 +1,68 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 
 import { EuiIcon, EuiSideNav } from '../../../../src/components';
 
-export default class extends Component {
-  constructor(props) {
-    super(props);
+export default () => {
+  const [isSideNavOpenOnMobile, setIsSideNavOpenOnMobile] = useState(false);
+  const [selectedItemName, setSelectedItem] = useState(null);
 
-    this.state = {
-      isSideNavOpenOnMobile: false,
-      selectedItemName: null,
-    };
-  }
-
-  toggleOpenOnMobile = () => {
-    this.setState({
-      isSideNavOpenOnMobile: !this.state.isSideNavOpenOnMobile,
-    });
+  const toggleOpenOnMobile = () => {
+    setIsSideNavOpenOnMobile(!isSideNavOpenOnMobile);
   };
 
-  selectItem = name => {
-    this.setState({
-      selectedItemName: name,
-    });
+  const selectItem = name => {
+    setSelectedItem(name);
   };
 
-  createItem = (name, data = {}) => {
+  const createItem = (name, data = {}) => {
     // NOTE: Duplicate `name` values will cause `id` collisions.
     return {
       ...data,
       id: name,
       name,
-      isSelected: this.state.selectedItemName === name,
-      onClick: () => this.selectItem(name),
+      isSelected: selectedItemName === name,
+      onClick: () => selectItem(name),
     };
   };
 
-  render() {
-    const sideNav = [
-      this.createItem('Kibana', {
-        icon: <EuiIcon type="logoKibana" />,
-        items: [
-          this.createItem('Has normal children', {
-            items: [
-              this.createItem('Without forceOpen', {
-                items: [this.createItem('Child 1'), this.createItem('Child 2')],
-              }),
-            ],
-          }),
-          this.createItem('Normally not open', {
-            items: [
-              this.createItem('Has forceOpen:true', {
-                forceOpen: true,
-                items: [this.createItem('Child 3'), this.createItem('Child 4')],
-              }),
-            ],
-          }),
-          this.createItem('With forceOpen:true', {
-            forceOpen: true,
-            items: [
-              this.createItem('Normal child', {
-                items: [this.createItem('Child 5'), this.createItem('Child 6')],
-              }),
-            ],
-          }),
-        ],
-      }),
-    ];
+  const sideNav = [
+    createItem('Kibana', {
+      icon: <EuiIcon type="logoKibana" />,
+      items: [
+        createItem('Has normal children', {
+          items: [
+            createItem('Without forceOpen', {
+              items: [createItem('Child 1'), createItem('Child 2')],
+            }),
+          ],
+        }),
+        createItem('Normally not open', {
+          items: [
+            createItem('Has forceOpen:true', {
+              forceOpen: true,
+              items: [createItem('Child 3'), createItem('Child 4')],
+            }),
+          ],
+        }),
+        createItem('With forceOpen:true', {
+          forceOpen: true,
+          items: [
+            createItem('Normal child', {
+              items: [createItem('Child 5'), createItem('Child 6')],
+            }),
+          ],
+        }),
+      ],
+    }),
+  ];
 
-    return (
-      <EuiSideNav
-        mobileTitle="Navigate within $APP_NAME"
-        toggleOpenOnMobile={this.toggleOpenOnMobile}
-        isOpenOnMobile={this.state.isSideNavOpenOnMobile}
-        items={sideNav}
-        style={{ width: 192 }}
-      />
-    );
-  }
-}
+  return (
+    <EuiSideNav
+      mobileTitle="Navigate within $APP_NAME"
+      toggleOpenOnMobile={toggleOpenOnMobile}
+      isOpenOnMobile={isSideNavOpenOnMobile}
+      items={sideNav}
+      style={{ width: 192 }}
+    />
+  );
+};


### PR DESCRIPTION
### Summary

Makes progress on #3150 

Converted 
 - EuiSideNav 
 - EuiSelectable
 - EuiPortal
 - EuiHeaderSpacesMenu
 - Toast Guidelines
 - EuiFormGroup

examples to functional components


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~~
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
- [x] Checked for **breaking changes** and labeled appropriately
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
~~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~~
