### PR TITLE
Fixed `EuiInMemoryTable` `isClearable` property to initiate reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+**Bug Fixes**
+
+- Fixed `EuiInMemoryTable` `isClearable` property to initiate reset ([#3198](https://github.com/elastic/eui/pull/3198))
+
 **Breaking changes**
 
 - Upgraded `TypeScript` to 3.7.2 ([#3295](https://github.com/elastic/eui/pull/3295))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Bug Fixes**
 
-- Fixed `EuiInMemoryTable` `isClearable` property to initiate reset ([#3198](https://github.com/elastic/eui/pull/3198))
+- Fixed `EuiInMemoryTable` `isClearable` property to initiate reset ([#3328](https://github.com/elastic/eui/pull/3328))
 
 **Breaking changes**
 

--- a/src/components/form/field_search/field_search.tsx
+++ b/src/components/form/field_search/field_search.tsx
@@ -136,6 +136,12 @@ export class EuiFieldSearch extends Component<
       this.inputElement.focus();
     }
     this.setState({ value: '' });
+
+    const { incremental, onSearch } = this.props;
+
+    if (onSearch && incremental) {
+      onSearch('');
+    }
   };
 
   componentWillUnmount() {


### PR DESCRIPTION
### Summary

Closes: #3323

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
