### PR TITLE
Fix jest memory leak

### DIFF
--- a/scripts/jest/config.json
+++ b/scripts/jest/config.json
@@ -19,11 +19,11 @@
     "/icon$": "<rootDir>/scripts/jest/mocks/icon_mock.js"
   },
   "setupFiles": [
-    "<rootDir>/scripts/jest/setup/polyfills.js",
     "<rootDir>/scripts/jest/setup/enzyme.js",
     "<rootDir>/scripts/jest/setup/throw_on_console_error.js"
   ],
   "setupFilesAfterEnv": [
+    "<rootDir>/scripts/jest/setup/polyfills.js",
     "<rootDir>/scripts/jest/setup/unmount_enzyme.js"
   ],
   "coverageDirectory": "<rootDir>/reports/jest-coverage",

--- a/scripts/jest/setup/polyfills.js
+++ b/scripts/jest/setup/polyfills.js
@@ -3,56 +3,79 @@ import { MutationObserver, MutationNotifier } from '../polyfills/mutation_observ
 // polyfill window.MutationObserver and intersect jsdom's relevant methods
 // from https://github.com/aurelia/pal-nodejs
 // https://github.com/aurelia/pal-nodejs/blob/56396ff7c7693669dbafc8e9e49ee6bc29472f12/src/nodejs-pal-builder.ts#L63
-Object.defineProperty(window, 'MutationObserver', { value: MutationObserver });
-patchNotifyChange(window);
 
-function patchNotifyChange(window) {
-  const notifyInstance = MutationNotifier.getInstance();
-  const notify = function (node) {
-    notifyInstance.notifyChanged(node);
-  };
+const undos = [];
+afterAll(() => {
+  while (undos.length) {
+    undos.pop()();
+  }
+});
 
-  const nodeProto = window.Node.prototype;
+beforeAll(() => {
+  Object.defineProperty(window, 'MutationObserver', { value: MutationObserver });
+  patchNotifyChange(window);
 
-  intersectMethod(nodeProto, 'appendChild', notify);
-  intersectMethod(nodeProto, 'insertBefore', notify);
-  intersectMethod(nodeProto, 'removeChild', notify);
-  intersectMethod(nodeProto, 'replaceChild', notify);
-  intersectSetter(nodeProto, 'nodeValue', notify);
-  intersectSetter(nodeProto, 'textContent', notify);
+  function patchNotifyChange(window) {
+    const notifyInstance = MutationNotifier.getInstance();
+    const notify = function(node) {
+      notifyInstance.notifyChanged(node);
+    };
 
-  const charProto = window.CharacterData.prototype;
+    const nodeProto = window.Node.prototype;
 
-  intersectSetter(charProto, 'data', notify);
+    intersectMethod(nodeProto, 'appendChild', notify);
+    intersectMethod(nodeProto, 'insertBefore', notify);
+    intersectMethod(nodeProto, 'removeChild', notify);
+    intersectMethod(nodeProto, 'replaceChild', notify);
+    intersectSetter(nodeProto, 'nodeValue', notify);
+    intersectSetter(nodeProto, 'textContent', notify);
 
-  const elementProto = window.Element.prototype;
+    const charProto = window.CharacterData.prototype;
 
-  intersectMethod(elementProto, 'setAttribute', notify);
-  intersectMethod(elementProto, 'removeAttribute', notify);
-  intersectMethod(elementProto, 'removeAttributeNode', notify);
-  intersectMethod(elementProto, 'removeAttributeNS', notify);
-}
+    intersectSetter(charProto, 'data', notify);
 
-function intersectMethod(proto, methodName, intersect) {
-  const orig = proto[methodName];
-  proto[methodName] = function (...args) {
-    const ret = orig.apply(this, args);
-    intersect(this);
-    return ret;
-  };
-}
+    const elementProto = window.Element.prototype;
 
-function intersectSetter(proto, propertyName, intersect) {
-  const old = Object.getOwnPropertyDescriptor(proto, propertyName);
-  const oldSet = old.set;
-  const newSet = function set(V) {
-    oldSet.call(this, V);
-    intersect(this);
-  };
-  Object.defineProperty(proto, propertyName, {
-    set: newSet,
-    get: old.get,
-    configurable: old.configurable,
-    enumerable: old.enumerable
-  });
-}
+    intersectMethod(elementProto, 'setAttribute', notify);
+    intersectMethod(elementProto, 'removeAttribute', notify);
+    intersectMethod(elementProto, 'removeAttributeNode', notify);
+    intersectMethod(elementProto, 'removeAttributeNS', notify);
+  }
+
+  function intersectMethod(proto, methodName, intersect) {
+    const orig = proto[methodName];
+    proto[methodName] = function(...args) {
+      const ret = orig.apply(this, args);
+      intersect(this);
+      return ret;
+    };
+
+    undos.push(() => {
+      proto[methodName] = orig;
+    });
+  }
+
+  function intersectSetter(proto, propertyName, intersect) {
+    const old = Object.getOwnPropertyDescriptor(proto, propertyName);
+    const oldSet = old.set;
+    const newSet = function set(V) {
+      oldSet.call(this, V);
+      intersect(this);
+    };
+    Object.defineProperty(proto, propertyName, {
+      set: newSet,
+      get: old.get,
+      configurable: old.configurable,
+      enumerable: old.enumerable,
+    });
+
+    undos.push(() => {
+      Object.defineProperty(proto, propertyName, {
+        set: oldSet,
+        get: old.get,
+        configurable: old.configurable,
+        enumerable: old.enumerable,
+      });
+    });
+  }
+});


### PR DESCRIPTION
### Summary

Memory leaks, grr.

Quick google search led to an excellent article https://chanind.github.io/javascript/2019/10/12/jest-tests-memory-leak.html wherein I learned about combining node's `--expose-gc` and jest's `--logHeapUsage` (in addition to `--runInBand)`:

```
node --expose-gc node_modules/.bin/jest --logHeapUsage --runInBand --config ./scripts/jest/config.json
```

Running that showed every test suite slowly but surely increased the heap size, leaking memory. Threw in an `--inspect-brk` and looked around the heap snapshots, and it appeared that nothing was being cleaned up. No smoking guns, just **everything** stuck around. Yay.

Commented out the contents of our setup files:
```
    "<rootDir>/scripts/jest/setup/polyfills.js",
    "<rootDir>/scripts/jest/setup/enzyme.js",
    "<rootDir>/scripts/jest/setup/throw_on_console_error.js"
    "<rootDir>/scripts/jest/setup/unmount_enzyme.js"
```
and no memory issues. Yay?. Quickly isolated this to the mutation polyfill code, specifically `patchNotifyChange` which we use to integrate the polyfill with jest's jsdom environment.

wtf! module cache is reset between executions, jsdom environments are re-created between suites, etc. Well, there's definitely a leak, so digging a little further showed `window.Node.prototype` is in fact shared between all the tests, and can be demonstrated with

```
JSDOM = require('jsdom').JSDOM
a = new JSDOM()
b = new JSDOM()
a.window === b.window // false
a.window.Node === b.window.Node // true
```

Aha! Okay, so definitely have the culprit. Every test suite adds its own patch onto the previous suite's patching, stacking 280 patches on top of each other and preventing tons of garbage collection.

The fix is to unpatch methods & setters after the suite executes, which brings us down to almost no memory leaking. Yay!

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
