### PR TITLE
[Docs] Update design goals on home page

### DIFF
--- a/src-docs/src/views/home/home_view.js
+++ b/src-docs/src/views/home/home_view.js
@@ -195,7 +195,7 @@ export const HomeView = () => (
           Theming involves changing fewer than a dozen lines of code. This means
           strict variable usage.
         </dd>
-        <dt>EUI is flexible.</dt>
+        <dt>EUI is flexible and composable.</dt>
         <dd>
           Configurable enough to meet the needs of a wide array of contexts
           while maintaining brand and low-level consistency.

--- a/src-docs/src/views/home/home_view.js
+++ b/src-docs/src/views/home/home_view.js
@@ -184,26 +184,28 @@ export const HomeView = () => (
     <EuiSpacer />
     <EuiText grow={false}>
       <h2>Design goals</h2>
-      <p>EUI has the following primary goals...</p>
       <dl>
         <dt>EUI is accessible to everyone.</dt>
         <dd>
-          Use high contrast, color-blind safe palettes and proper aria labels.
+          Uses high contrast, color-blind safe palettes and tested with most
+          assistive technology.
         </dd>
         <dt>EUI is themable.</dt>
         <dd>
-          Theming should involve changing fewer than a dozen lines of code. This
-          means strict variable usage.
+          Theming involves changing fewer than a dozen lines of code. This means
+          strict variable usage.
+        </dd>
+        <dt>EUI is flexible.</dt>
+        <dd>
+          Configurable enough to meet the needs of a wide array of contexts
+          while maintaining brand and low-level consistency.
         </dd>
         <dt>EUI is responsive.</dt>
-        <dd>
-          Currently we target mobile, laptop, desktop, and wide desktop
-          breakpoints.
-        </dd>
+        <dd>Supports multiple window sizes from large desktop to mobile.</dd>
+        <dt>EUI is well documented and tested.</dt>
+        <dd>Code is friendly to the novice and expert alike.</dd>
         <dt>EUI is playful.</dt>
-        <dd>Consistent use of animation can bring life to our design.</dd>
-        <dt>EUI is documented and has tests.</dt>
-        <dd>Make sure the code is friendly to the novice and expert alike.</dd>
+        <dd>Simple and consistent use of animation brings life.</dd>
       </dl>
     </EuiText>
   </div>


### PR DESCRIPTION
### Caroline's been doing some thinking

I adjusted some of the wording, but the main change is the addition of this:

<img width="578" alt="Screen Shot 2020-04-16 at 09 37 41 AM" src="https://user-images.githubusercontent.com/549577/79462777-f7267900-7fc5-11ea-8e8a-8e6a6d7eb08e.png">

EUI's original role was to support engineers building UI in Kibana. Especially those who didn't have designer to help with layouts, UX, etc. And so EUI was/is very opinionated in terms of the UI it renders and the configurable options.

However, I now see EUI's role evolving as we grow and Elastic gains more designers to work alongside the engineers. I think the system needs to start being much more flexible and customizable so it can **support the designer’s needs while also supporting the engineers with minimal overrides.**

We should still be able to "maintain brand" through our judicious use of tokens for color, spacing, and typography. And since these are the building blocks of any component, they may also be customized so long as the consuming application sticks to the available tokens.

It's no longer up to EUI to **force** full cohesion and harmony at the layout or page level but to **support** it.