### PR TITLE
Extended types for ReactDatePicker's startDate and endDate to allow null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added `showCloseButton` and `dockedBreakpoint` flexibility to `EuiCollapsibleNav` ([#3330](https://github.com/elastic/eui/pull/3330))
 - Added `panelStyle` prop to `EuiPopover` to distinguish style object configuration ([#3329](https://github.com/elastic/eui/pull/3329))
+- Extended `EuiDatePicker`'s `startDate` and `endDate` types to accept `null` values for better interoperability ([#3343](https://github.com/elastic/eui/pull/3343))
 
 **Bug Fixes**
 

--- a/src/components/date_picker/react-datepicker.d.ts
+++ b/src/components/date_picker/react-datepicker.d.ts
@@ -69,7 +69,7 @@ export interface ReactDatePickerProps {
   disabled?: boolean;
   disabledKeyboardNavigation?: boolean;
   dropdownMode?: 'scroll' | 'select';
-  endDate?: moment.Moment;
+  endDate?: moment.Moment | null;
   excludeDates?: moment.Moment[];
   excludeTimes?: moment.Moment[];
   filterDate?(date: moment.Moment): boolean;
@@ -177,7 +177,7 @@ export interface ReactDatePickerProps {
   showTimeSelectOnly?: boolean;
   showWeekNumbers?: boolean;
   showYearDropdown?: boolean;
-  startDate?: moment.Moment;
+  startDate?: moment.Moment | null;
   startOpen?: boolean;
   tabIndex?: number;
   timeCaption?: string;


### PR DESCRIPTION
### Summary

Closes #3319 by allowing **ReactDatePicker**'s `startDate` and `endDate` values to be null. I tested passing `null` into these props to verify it works as expected, and also followed their usage in the code to check for possible breakages.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
