### PR TITLE
Update wiki doc - React Router 5.1 code snippet

### DIFF
--- a/wiki/react-router.md
+++ b/wiki/react-router.md
@@ -304,7 +304,6 @@ import React from 'react';
 import { EuiLink } from '@elastic/eui';
 import { useHistory } from 'react-router';
 
-// Most of the content of this files are from https://github.com/elastic/eui/pull/1976.
 const isModifiedEvent = (event) =>
   !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
 

--- a/wiki/react-router.md
+++ b/wiki/react-router.md
@@ -310,6 +310,11 @@ const isModifiedEvent = (event) =>
 
 const isLeftClickEvent = (event) => event.button === 0;
 
+const isTargetBlank = (event) => {
+  const target = event.target.getAttribute('target');
+  return target && target !== '_self';
+};
+
 export default function EuiCustomLink({ to, ...rest }) {
   // This is the key!
   const history = useHistory();
@@ -319,12 +324,8 @@ export default function EuiCustomLink({ to, ...rest }) {
       return;
     }
 
-    // If target prop is set (e.g. to "_blank"), let browser handle link.
-    if (event.target.getAttribute('target')) {
-      return;
-    }
-
-    if (isModifiedEvent(event) || !isLeftClickEvent(event)) {
+    // Let the browser handle links that open new tabs/windows
+    if (isModifiedEvent(event) || !isLeftClickEvent(event) || isTargetBlank(event)) {
       return;
     }
 

--- a/wiki/react-router.md
+++ b/wiki/react-router.md
@@ -335,7 +335,10 @@ export default function EuiCustomLink({ to, ...props }) {
     history.push(to);
   }
 
-  return <EuiLink {...props} href={to} onClick={onClick} />;
+  // Generate the correct link href (with basename accounted for)
+  const href = history.createHref({ pathname: to });
+
+  return <EuiLink {...props} href={href} onClick={onClick} />;
 }
 ```
 

--- a/wiki/react-router.md
+++ b/wiki/react-router.md
@@ -310,7 +310,7 @@ const isModifiedEvent = (event) =>
 
 const isLeftClickEvent = (event) => event.button === 0;
 
-export default function EuiCustomLink({ to, ...props }) {
+export default function EuiCustomLink({ to, ...rest }) {
   // This is the key!
   const history = useHistory();
 
@@ -338,7 +338,8 @@ export default function EuiCustomLink({ to, ...props }) {
   // Generate the correct link href (with basename accounted for)
   const href = history.createHref({ pathname: to });
 
-  return <EuiLink {...props} href={href} onClick={onClick} />;
+  const props = { ...rest, href, onClick };
+  return <EuiLink {...props} />;
 }
 ```
 


### PR DESCRIPTION
### Summary

I chatted about this with @chandlerprall and @thompsongl yesterday when asking for assistance in merging React Router's `<Link>` component behavior with `<EuiButton>`, and was super helpfully pointed towards the [React Router wiki](https://github.com/elastic/eui/blob/constance/react-router-links-update/wiki/react-router.md#react-router-51) doc.

After wrangling the 5.1 snippet/code example to work in Kibana, I realized it was missing a few details to get it working 100% the same as `<Link>` does:

- 6b35491 was the major functionality I noticed missing. In Kibana plugins, URL routes look something like `localhost:5063/xyz/app/your_plugin_name` and get added to the `<Router basename="...">` prop.
The snippet wasn't accounting for basename, and as such clicking would work, but `href` links/new tabs would open in `localhost:5603/foo` (a non-existent route) instead of `localhost:5063/xyz/app/your_plugin_name/foo`.

- a0575b1 was a very minor thing I noticed when reviewing [React Router's Link component](https://github.com/ReactTraining/react-router/blob/ea44618e68f6a112e48404b2ea0da3e207daf4f0/packages/react-router-dom/modules/Link.js#L43-L48). Their logic is very similar, but they harden the `target="_blank"` check by making sure the target isn't `_self` (which opens the link in the same tab/window).

- 8070963 and f63cdd5 are optional cleanup commits: if you'd rather me leave them out of this PR, just let me know and I'll happily do so 😄 

### Checklist

N/A - documentation only