### PR TITLE
[DOCS] Improved Demos for EuiPrettyDuration.

### DIFF
--- a/src-docs/src/views/pretty_duration/pretty_duration.js
+++ b/src-docs/src/views/pretty_duration/pretty_duration.js
@@ -57,7 +57,7 @@ export default function prettyDurationExample() {
     <Fragment>
       {examples.map(({ start, end, quickRanges, dateFormat }, idx) => (
         <div key={idx}>
-          <EuiCodeBlock paddingSize="s">
+          <EuiCodeBlock paddingSize="s" isCopyable language="js">
             prettyDuration(&apos;{start}&apos;, &apos;{end}&apos;,{' '}
             {JSON.stringify(quickRanges)}, &apos;
             {dateFormat}&apos;)

--- a/src-docs/src/views/pretty_duration/pretty_duration_example.js
+++ b/src-docs/src/views/pretty_duration/pretty_duration_example.js
@@ -15,26 +15,6 @@ import {
 import PrettyDuration from './pretty_duration';
 const prettyDurationSource = require('!!raw-loader!./pretty_duration');
 const prettyDurationHtml = renderToHtml(PrettyDuration);
-const prettyDurationSnippet = [
-  `let example = {
-    start: '2018-01-17T18:57:57.149Z',
-    end: '2018-01-17T20:00:00.000Z',
-    quickRanges: [],
-    dateFormat: 'MMMM Do YYYY, HH:mm:ss.SSS',
-}
-<EuiText>
-   <p>{prettyDuration(example.start, example.end, example.quickRanges, example.dateFormat)}</p>
-</EuiText>`,
-  `let example = {
-    start: '2018-01-17T18:57:57.149Z',
-    end: 'now-2h',
-    quickRanges: [],
-    dateFormat: 'MMMM Do YYYY @ HH:mm:ss.SSS',
-}
-<EuiText>
-   <p>{prettyDuration(example.start, example.end, example.quickRanges, example.dateFormat)}</p>
-</EuiText>`,
-];
 
 export const PrettyDurationExample = {
   title: 'Pretty duration',
@@ -85,7 +65,6 @@ export const PrettyDurationExample = {
           </p>
         </Fragment>
       ),
-      snippet: prettyDurationSnippet,
       demo: <PrettyDuration />,
     },
   ],

--- a/src-docs/src/views/pretty_duration/pretty_duration_example.js
+++ b/src-docs/src/views/pretty_duration/pretty_duration_example.js
@@ -34,30 +34,6 @@ const prettyDurationSnippet = [
 <EuiText>
    <p>{prettyDuration(example.start, example.end, example.quickRanges, example.dateFormat)}</p>
 </EuiText>`,
-  `let example = {
-    start: 'now-17m',
-    end: 'now-1m',
-    quickRanges: [],
-    dateFormat: 'MMMM Do YYYY @ HH:mm:ss.SSS',
-}
-<EuiText>
-   <p>{prettyDuration(example.start, example.end, example.quickRanges, example.dateFormat)}</p>
-</EuiText>`,
-  `let example = {
-    start: 'now-15m',
-    end: 'now',
-    quickRanges: [
-      {
-        start: 'now-15m',
-        end: 'now',
-        label: 'quick range 15 minutes custom display',
-      },
-    ],
-    dateFormat: 'MMMM Do YYYY, HH:mm:ss.SSS',
-  }
-<EuiText>
-   <p>{prettyDuration(example.start, example.end, example.quickRanges, example.dateFormat)}</p>
-</EuiText>`,
 ];
 
 export const PrettyDurationExample = {

--- a/src-docs/src/views/pretty_duration/pretty_duration_example.js
+++ b/src-docs/src/views/pretty_duration/pretty_duration_example.js
@@ -33,8 +33,7 @@ const prettyDurationSnippet = [
 }
 <EuiText>
    <p>{prettyDuration(example.start, example.end, example.quickRanges, example.dateFormat)}</p>
-</EuiText>
-`,
+</EuiText>`,
   `let example = {
     start: 'now-17m',
     end: 'now-1m',
@@ -43,8 +42,7 @@ const prettyDurationSnippet = [
 }
 <EuiText>
    <p>{prettyDuration(example.start, example.end, example.quickRanges, example.dateFormat)}</p>
-</EuiText>
-`,
+</EuiText>`,
   `let example = {
     start: 'now-15m',
     end: 'now',
@@ -59,8 +57,7 @@ const prettyDurationSnippet = [
   }
 <EuiText>
    <p>{prettyDuration(example.start, example.end, example.quickRanges, example.dateFormat)}</p>
-</EuiText>
-`,
+</EuiText>`,
 ];
 
 export const PrettyDurationExample = {

--- a/src-docs/src/views/pretty_duration/pretty_duration_example.js
+++ b/src-docs/src/views/pretty_duration/pretty_duration_example.js
@@ -15,6 +15,53 @@ import {
 import PrettyDuration from './pretty_duration';
 const prettyDurationSource = require('!!raw-loader!./pretty_duration');
 const prettyDurationHtml = renderToHtml(PrettyDuration);
+const prettyDurationSnippet = [
+  `let example = {
+    start: '2018-01-17T18:57:57.149Z',
+    end: '2018-01-17T20:00:00.000Z',
+    quickRanges: [],
+    dateFormat: 'MMMM Do YYYY, HH:mm:ss.SSS',
+}
+<EuiText>
+   <p>{prettyDuration(example.start, example.end, example.quickRanges, example.dateFormat)}</p>
+</EuiText>`,
+  `let example = {
+    start: '2018-01-17T18:57:57.149Z',
+    end: 'now-2h',
+    quickRanges: [],
+    dateFormat: 'MMMM Do YYYY @ HH:mm:ss.SSS',
+}
+<EuiText>
+   <p>{prettyDuration(example.start, example.end, example.quickRanges, example.dateFormat)}</p>
+</EuiText>
+`,
+  `let example = {
+    start: 'now-17m',
+    end: 'now-1m',
+    quickRanges: [],
+    dateFormat: 'MMMM Do YYYY @ HH:mm:ss.SSS',
+}
+<EuiText>
+   <p>{prettyDuration(example.start, example.end, example.quickRanges, example.dateFormat)}</p>
+</EuiText>
+`,
+  `let example = {
+    start: 'now-15m',
+    end: 'now',
+    quickRanges: [
+      {
+        start: 'now-15m',
+        end: 'now',
+        label: 'quick range 15 minutes custom display',
+      },
+    ],
+    dateFormat: 'MMMM Do YYYY, HH:mm:ss.SSS',
+  }
+<EuiText>
+   <p>{prettyDuration(example.start, example.end, example.quickRanges, example.dateFormat)}</p>
+</EuiText>
+`,
+];
 
 export const PrettyDurationExample = {
   title: 'Pretty duration',
@@ -65,6 +112,7 @@ export const PrettyDurationExample = {
           </p>
         </Fragment>
       ),
+      snippet: prettyDurationSnippet,
       demo: <PrettyDuration />,
     },
   ],


### PR DESCRIPTION
### Summary

This PR started by adding Snippets to EuiPrettyDuration. But after some discussion, it was decided to:
-  Enable the copy button for the demos **EuiCodeBlock**s
- Not adding snippets

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
