### PR TITLE
[EuiCard] Allow custom component for image prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Applies `max-width: 100%` to `EuiPageBody` so inner flex-based items don't overflow their containers  ([#3375](https://github.com/elastic/eui/pull/3375))
-- Added `ReactElement` to `EuiCard` `image` property to allow custom component
+- Added `ReactElement` to `EuiCard` `image` prop type to allow custom component ([#3370](https://github.com/elastic/eui/pull/3370))
 
 
 ## [`23.1.0`](https://github.com/elastic/eui/tree/v23.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `23.0.0`.
+- Added `ReactElement` to `EuiCard` `image` property to allow custom component
 
 ## [`23.0.0`](https://github.com/elastic/eui/tree/v23.0.0)
 

--- a/src-docs/src/views/card/card_example.js
+++ b/src-docs/src/views/card/card_example.js
@@ -154,8 +154,8 @@ export const CardExample = {
                 Make sure that all images are the{' '}
                 <strong>same proportions</strong> when used in a singular row.
                 <br />
-                If custom component is passed to <EuiCode>image</EuiCode> prop
-                and it consists solely of inline elements and no{' '}
+                If an element is passed as the <EuiCode>image</EuiCode> prop and
+                it consists solely of inline elements and no{' '}
                 <EuiCode>{'<img />'}</EuiCode> elements, please make sure to
                 provide <EuiCode>{'{ width: 100%; }'}</EuiCode> styling.
               </span>

--- a/src-docs/src/views/card/card_example.js
+++ b/src-docs/src/views/card/card_example.js
@@ -153,14 +153,16 @@ export const CardExample = {
               <span>
                 Make sure that all images are the{' '}
                 <strong>same proportions</strong> when used in a singular row.
-                <br />
-                If an element is passed as the <EuiCode>image</EuiCode> prop and
-                it consists solely of inline elements and no{' '}
-                <EuiCode>{'<img />'}</EuiCode> elements, please make sure to
-                provide <EuiCode>{'{ width: 100%; }'}</EuiCode> styling.
               </span>
-            }
-          />
+            }>
+            <p>
+              Also, when passing an <strong>element</strong> to the{' '}
+              <EuiCode>image</EuiCode> prop that consists solely of inline
+              elements or does not contain an
+              <EuiCode>{'<img />'}</EuiCode> element, each element will require
+              a style of <EuiCode>width: 100%</EuiCode>.
+            </p>
+          </EuiCallOut>
         </div>
       ),
       props: { EuiCard },

--- a/src-docs/src/views/card/card_example.js
+++ b/src-docs/src/views/card/card_example.js
@@ -153,6 +153,11 @@ export const CardExample = {
               <span>
                 Make sure that all images are the{' '}
                 <strong>same proportions</strong> when used in a singular row.
+                <br />
+                If custom component is passed to <EuiCode>image</EuiCode> prop
+                and it consists solely of inline elements and no{' '}
+                <EuiCode>{'<img />'}</EuiCode> elements, please make sure to
+                provide <EuiCode>{'{ width: 100%; }'}</EuiCode> styling.
               </span>
             }
           />

--- a/src-docs/src/views/card/card_image.js
+++ b/src-docs/src/views/card/card_image.js
@@ -21,7 +21,14 @@ export default () => (
     <EuiFlexItem>
       <EuiCard
         textAlign="left"
-        image="https://source.unsplash.com/400x200/?Nature"
+        image={
+          <div>
+            <img
+              src="https://source.unsplash.com/400x200/?Nature"
+              alt="Nature"
+            />
+          </div>
+        }
         title="Elastic in Nature"
         description="Example of a card's description. Stick to one or two sentences."
         footer={cardFooterContent}

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -120,6 +120,10 @@
   .euiCard__image {
     // Without a border, the image should stand on it's own so it needs to have all corners rounded
     border-radius: $euiBorderRadius;
+
+    & img {
+      width: 100%;
+    }
   }
 }
 
@@ -148,6 +152,10 @@
     // match border radius, minus 1px because it's inside a border
     border-top-left-radius: $euiBorderRadius - 1px;
     border-top-right-radius: $euiBorderRadius - 1px;
+
+    & img {
+      width: 100%;
+    }
 
     // IF both exist, position the icon centered on top of image
     + .euiCard__icon {

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -120,10 +120,6 @@
   .euiCard__image {
     // Without a border, the image should stand on it's own so it needs to have all corners rounded
     border-radius: $euiBorderRadius;
-
-    & img {
-      width: 100%;
-    }
   }
 }
 
@@ -153,7 +149,7 @@
     border-top-left-radius: $euiBorderRadius - 1px;
     border-top-right-radius: $euiBorderRadius - 1px;
 
-    & img {
+    img {
       width: 100%;
     }
 

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -17,7 +17,12 @@
  * under the License.
  */
 
-import React, { FunctionComponent, ReactElement, ReactNode } from 'react';
+import React, {
+  FunctionComponent,
+  ReactElement,
+  ReactNode,
+  isValidElement,
+} from 'react';
 import classNames from 'classnames';
 
 import { CommonProps, keysOf } from '../common';
@@ -89,9 +94,9 @@ type EuiCardProps = Omit<CommonProps, 'aria-label'> & {
   icon?: ReactElement<EuiIconProps>;
 
   /**
-   * Accepts a url in string form
+   * Accepts a url in string form or ReactElement for custom image component
    */
-  image?: string;
+  image?: string | ReactElement;
 
   /**
    * Content to be rendered between the description and the footer
@@ -229,7 +234,15 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
 
   let imageNode;
   if (image && layout === 'vertical') {
-    imageNode = <img className="euiCard__image" src={image} alt="" />;
+    if (isValidElement(image) || typeof image === 'string') {
+      imageNode = (
+        <div className="euiCard__image">
+          {isValidElement(image) ? image : <img src={image} alt="" />}
+        </div>
+      );
+    } else {
+      imageNode = null;
+    }
   }
 
   let iconNode;

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -94,7 +94,7 @@ type EuiCardProps = Omit<CommonProps, 'aria-label'> & {
   icon?: ReactElement<EuiIconProps>;
 
   /**
-   * Accepts a url in string form or ReactElement for custom image component
+   * Accepts a url in string form or ReactElement for a custom image component
    */
   image?: string | ReactElement;
 


### PR DESCRIPTION
### Summary

Issue: #3341
Added `ReactElement` to the `EuiCard` `image` prop to allow passing custom component.

### Checklist

~~- [ ] Check against **all themes** for compatibility in both light and dark modes~~
- [x] Checked in **mobile**
~~- [ ] Checked in **IE11** and **Firefox**~~
- [x] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
