### PR TITLE
Add documentation around EuiInMemoryTable's usage of column names in sorting

### DIFF
--- a/src-docs/src/views/tables/in_memory/in_memory_custom_sorting_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_custom_sorting_section.js
@@ -31,10 +31,6 @@ export const customSortingSection = {
         <EuiCode>false</EuiCode>. The function is used to extract or calculate
         the intended sort value for each <EuiCode>item</EuiCode>.
       </p>
-      <p>
-        <strong>EuiMemoryTable</strong> relies on referential integrity of a
-        column&apos;s <EuiCode>name</EuiCode> field to sort on that column.
-      </p>
     </div>
   ),
   props: propsInfo,

--- a/src-docs/src/views/tables/in_memory/in_memory_custom_sorting_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_custom_sorting_section.js
@@ -31,6 +31,10 @@ export const customSortingSection = {
         <EuiCode>false</EuiCode>. The function is used to extract or calculate
         the intended sort value for each <EuiCode>item</EuiCode>.
       </p>
+      <p>
+        <strong>EuiMemoryTable</strong> relies on referential integrity of a
+        column&apos;s <EuiCode>name</EuiCode> field to sort on that column.
+      </p>
     </div>
   ),
   props: propsInfo,

--- a/src-docs/src/views/tables/in_memory/in_memory_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_section.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { GuideSectionTypes } from '../../../components';
 import { renderToHtml } from '../../../services';
 
+import { EuiCode, EuiCallOut } from '../../../../../src/components';
 import { Table } from './in_memory';
 import { propsInfo } from './props_info';
 
@@ -29,6 +30,19 @@ export const section = {
         it handling all configured functionality (pagination and sorting) for
         you.
       </p>
+      <EuiCallOut
+        title="EuiMemoryTable relies on referential integrity of a
+          column's name field to sort on that column."
+        color="warning">
+        <p>
+          <strong>EuiMemoryTable</strong> relies on referential integrity of a
+          column&apos;s <EuiCode>name</EuiCode> field when sorting by that
+          column. For example, if a JSX element is created for the name every
+          render it appears different to the table and prevents sorting.
+          Instead, that value needs to be lifted outside of the render method
+          and preserved between renders.
+        </p>
+      </EuiCallOut>
     </div>
   ),
   props: propsInfo,

--- a/src-docs/src/views/tables/in_memory/in_memory_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_section.js
@@ -31,11 +31,10 @@ export const section = {
         you.
       </p>
       <EuiCallOut
-        title="EuiMemoryTable relies on referential integrity of a
-          column's name field to sort on that column."
+        title="EuiMemoryTable relies on referential equality of a column's name"
         color="warning">
         <p>
-          <strong>EuiMemoryTable</strong> relies on referential integrity of a
+          <strong>EuiMemoryTable</strong> relies on referential equality of a
           column&apos;s <EuiCode>name</EuiCode> field when sorting by that
           column. For example, if a JSX element is created for the name every
           render it appears different to the table and prevents sorting.


### PR DESCRIPTION
### Summary

Fixes #3362 
Add documentation around EuiInMemoryTable's usage of column names in sorting

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples
~~- [ ] Added or updated **[jest tests]~~(https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
~~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~~
