### PR TITLE
Set a max width to EuiPageBody

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `23.1.0`.
+- Applies `max-width: 100%` to `EuiPageBody` so inner flex-based items don't overflow their containers  ([#3375](https://github.com/elastic/eui/pull/3375))
 
 ## [`23.1.0`](https://github.com/elastic/eui/tree/v23.1.0)
 

--- a/src/components/page/page_body/_page_body.scss
+++ b/src/components/page/page_body/_page_body.scss
@@ -3,6 +3,8 @@
   flex-direction: column;
   align-items: stretch;
   flex: 1 1 100%;
+  // Make sure that inner flex layouts don't get larger than this container
+  max-width: 100%;
 
   &--restrictWidth-default,
   &--restrictWidth-custom {


### PR DESCRIPTION
### Summary

Fixes https://github.com/elastic/eui/issues/3373

See https://github.com/elastic/eui/issues/3373#issuecomment-617959532 for more discussion

By setting a max width of `EuiPageBody` we can likely force inner items to not break down in various smaller screen configs.

![image](https://user-images.githubusercontent.com/324519/80027214-41ad6700-8498-11ea-81ae-a814188f85ea.png)

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
- [ ] ~Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
