### PR TITLE
[Docs] Add snippets to EuiEmptyPrompt

### DIFF
--- a/src-docs/src/views/empty_prompt/empty_prompt_example.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt_example.js
@@ -9,14 +9,44 @@ import { EuiCode, EuiEmptyPrompt } from '../../../../src/components';
 import EmptyPrompt from './empty_prompt';
 const emptyPromptSource = require('!!raw-loader!./empty_prompt');
 const emptyPromptHtml = renderToHtml(EmptyPrompt);
+const emptyPromptSnippet = `<EuiEmptyPrompt
+  iconType="editorStrike"
+  title={<h2>You have no spice</h2>}
+  body={bodyContent}
+  actions={
+    <EuiButton color="primary" fill>
+      Harvest spice
+    </EuiButton>
+  }
+/>`;
 
 import Custom from './custom';
 const customSource = require('!!raw-loader!./custom');
 const customHtml = renderToHtml(Custom);
+const customSnippet = `<EuiEmptyPrompt
+  iconType="editorStrike"
+  title={<h2>You have no spice</h2>}
+  titleSize="xs"
+  body={bodyContent}
+  actions={
+    <EuiButton  size="s" color="primary" fill>
+      Harvest spice
+    </EuiButton>
+  }
+/>`;
 
 import Simple from './simple';
 const simpleSource = require('!!raw-loader!./simple');
 const simpleHtml = renderToHtml(Simple);
+const simpleSnippet = `<EuiEmptyPrompt
+  title={<h2>You have no spice</h2>}
+  actions={[
+    <EuiButton color="primary" fill>
+      Harvest spice
+    </EuiButton>,
+    <EuiButtonEmpty color="danger">Sabotage all spice fields</EuiButtonEmpty>,
+  ]}
+/>`;
 
 export const EmptyPromptExample = {
   title: 'Empty prompt',
@@ -40,6 +70,7 @@ export const EmptyPromptExample = {
       ),
       props: { EuiEmptyPrompt },
       demo: <EmptyPrompt />,
+      snippet: emptyPromptSnippet,
     },
     {
       title: 'Custom sizes and colors',
@@ -61,6 +92,7 @@ export const EmptyPromptExample = {
       ),
       props: { EuiEmptyPrompt },
       demo: <Custom />,
+      snippet: customSnippet,
     },
     {
       title: 'Less content, more actions',
@@ -85,6 +117,7 @@ export const EmptyPromptExample = {
       ),
       props: { EuiEmptyPrompt },
       demo: <Simple />,
+      snippet: simpleSnippet,
     },
   ],
 };

--- a/src-docs/src/views/empty_prompt/empty_prompt_example.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt_example.js
@@ -13,11 +13,7 @@ const emptyPromptSnippet = `<EuiEmptyPrompt
   iconType="editorStrike"
   title={<h2>You have no spice</h2>}
   body={bodyContent}
-  actions={
-    <EuiButton color="primary" fill>
-      Harvest spice
-    </EuiButton>
-  }
+  actions={actions}
 />`;
 
 import Custom from './custom';

--- a/src-docs/src/views/empty_prompt/empty_prompt_example.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt_example.js
@@ -28,11 +28,7 @@ const customSnippet = `<EuiEmptyPrompt
   title={<h2>You have no spice</h2>}
   titleSize="xs"
   body={bodyContent}
-  actions={
-    <EuiButton size="s" color="primary" fill>
-      Harvest spice
-    </EuiButton>
-  }
+  actions={actions}
 />`;
 
 import Simple from './simple';

--- a/src-docs/src/views/empty_prompt/empty_prompt_example.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt_example.js
@@ -36,12 +36,7 @@ const simpleSource = require('!!raw-loader!./simple');
 const simpleHtml = renderToHtml(Simple);
 const simpleSnippet = `<EuiEmptyPrompt
   title={<h2>You have no spice</h2>}
-  actions={[
-    <EuiButton color="primary" fill>
-      Harvest spice
-    </EuiButton>,
-    <EuiButtonEmpty color="danger">Sabotage all spice fields</EuiButtonEmpty>,
-  ]}
+  actions={multipleActions}
 />`;
 
 export const EmptyPromptExample = {

--- a/src-docs/src/views/empty_prompt/empty_prompt_example.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt_example.js
@@ -29,7 +29,7 @@ const customSnippet = `<EuiEmptyPrompt
   titleSize="xs"
   body={bodyContent}
   actions={
-    <EuiButton  size="s" color="primary" fill>
+    <EuiButton size="s" color="primary" fill>
       Harvest spice
     </EuiButton>
   }


### PR DESCRIPTION
### Summary

This PR adds snippets to the **EuiEmptyPrompt** docs.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **IE11** and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- [x] Added **documentation** examples
- ~[ ] Added or updated **jest tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A [changelog](https://github.com/elastic/eui/blob/master/CONTRIBUTING.md#changelog) entry exists and is marked appropriately~
