### PR TITLE
[EuiRadio] Make `id` required if `label` is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 **Bug Fixes**
 
-- Added need of `id` if `lable` is passed to issue in `EuiRadio` ([#3376](https://github.com/elastic/eui/pull/3376))
+- Added need of `id` if `lable` is passed to issue in `EuiRadio` ([#3382](https://github.com/elastic/eui/pull/3382))
 - Fixed z-index issue in `EuiDatePicker` where it's popover would sit beneath other DOM siblings that had z-index applied ([#3376](https://github.com/elastic/eui/pull/3376))
 - Added `download` glyph to `EuiIcon` ([#3364](https://github.com/elastic/eui/pull/3364))
 - Applies `max-width: 100%` to `EuiPageBody` so inner flex-based items don't overflow their containers  ([#3375](https://github.com/elastic/eui/pull/3375))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **Bug Fixes**
 
+- Added need of `id` if `lable` is passed to issue in `EuiRadio` ([#3376](https://github.com/elastic/eui/pull/3376))
 - Fixed z-index issue in `EuiDatePicker` where it's popover would sit beneath other DOM siblings that had z-index applied ([#3376](https://github.com/elastic/eui/pull/3376))
 - Added `download` glyph to `EuiIcon` ([#3364](https://github.com/elastic/eui/pull/3364))
 - Applies `max-width: 100%` to `EuiPageBody` so inner flex-based items don't overflow their containers  ([#3375](https://github.com/elastic/eui/pull/3375))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 **Bug Fixes**
 
-- Added need of `id` if `label` is passed to issue in `EuiRadio` ([#3382](https://github.com/elastic/eui/pull/3382))
+- Added `id` requirement if `label` is used in `EuiRadio` ([#3382](https://github.com/elastic/eui/pull/3382))
 - Fixed z-index issue in `EuiDatePicker` where it's popover would sit beneath other DOM siblings that had z-index applied ([#3376](https://github.com/elastic/eui/pull/3376))
 - Added `download` glyph to `EuiIcon` ([#3364](https://github.com/elastic/eui/pull/3364))
 - Applies `max-width: 100%` to `EuiPageBody` so inner flex-based items don't overflow their containers  ([#3375](https://github.com/elastic/eui/pull/3375))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 **Bug Fixes**
 
-- Added need of `id` if `lable` is passed to issue in `EuiRadio` ([#3382](https://github.com/elastic/eui/pull/3382))
+- Added need of `id` if `label` is passed to issue in `EuiRadio` ([#3382](https://github.com/elastic/eui/pull/3382))
 - Fixed z-index issue in `EuiDatePicker` where it's popover would sit beneath other DOM siblings that had z-index applied ([#3376](https://github.com/elastic/eui/pull/3376))
 - Added `download` glyph to `EuiIcon` ([#3364](https://github.com/elastic/eui/pull/3364))
 - Applies `max-width: 100%` to `EuiPageBody` so inner flex-based items don't overflow their containers  ([#3375](https://github.com/elastic/eui/pull/3375))

--- a/src/components/form/radio/radio.tsx
+++ b/src/components/form/radio/radio.tsx
@@ -24,7 +24,7 @@ import React, {
   ReactNode,
 } from 'react';
 import classNames from 'classnames';
-import { CommonProps } from '../../common';
+import { CommonProps, ExclusiveUnion } from '../../common';
 
 export interface RadioProps {
   autoFocus?: boolean;
@@ -32,7 +32,6 @@ export interface RadioProps {
    * When `true` creates a shorter height radio row
    */
   compressed?: boolean;
-  label?: ReactNode;
   name?: string;
   value?: string;
   checked?: boolean;
@@ -40,10 +39,18 @@ export interface RadioProps {
   onChange: ChangeEventHandler<HTMLInputElement>;
 }
 
-export interface EuiRadioProps
-  extends CommonProps,
-    Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>,
-    RadioProps {}
+interface idWithLable extends RadioProps {
+  label: ReactNode;
+  id: string;
+}
+
+interface withId extends RadioProps {
+  id: string;
+}
+
+export type EuiRadioProps = CommonProps &
+  Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> &
+  ExclusiveUnion<ExclusiveUnion<RadioProps, idWithLable>, withId>;
 
 export const EuiRadio: FunctionComponent<EuiRadioProps> = ({
   className,

--- a/src/components/form/radio/radio.tsx
+++ b/src/components/form/radio/radio.tsx
@@ -39,7 +39,7 @@ export interface RadioProps {
   onChange: ChangeEventHandler<HTMLInputElement>;
 }
 
-interface idWithLable extends RadioProps {
+interface idWithLabel extends RadioProps {
   label: ReactNode;
   id: string;
 }
@@ -50,7 +50,7 @@ interface withId extends RadioProps {
 
 export type EuiRadioProps = CommonProps &
   Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> &
-  ExclusiveUnion<ExclusiveUnion<RadioProps, idWithLable>, withId>;
+  ExclusiveUnion<ExclusiveUnion<RadioProps, idWithLabel>, withId>;
 
 export const EuiRadio: FunctionComponent<EuiRadioProps> = ({
   className,

--- a/src/components/form/radio/radio_group.tsx
+++ b/src/components/form/radio/radio_group.tsx
@@ -75,6 +75,8 @@ export const EuiRadioGroup: FunctionComponent<EuiRadioGroupProps> = ({
     const {
       disabled: isOptionDisabled,
       className: optionClass,
+      id,
+      label,
       ...optionRest
     } = option;
     return (
@@ -82,11 +84,13 @@ export const EuiRadioGroup: FunctionComponent<EuiRadioGroupProps> = ({
         className={classNames('euiRadioGroup__item', optionClass)}
         key={index}
         name={name}
-        checked={option.id === idSelected}
+        checked={id === idSelected}
         disabled={disabled || isOptionDisabled}
-        onChange={onChange.bind(null, option.id, option.value)}
+        onChange={onChange.bind(null, id, option.value)}
         compressed={compressed}
-        {...optionRest as EuiRadioProps}
+        id={id}
+        label={label}
+        {...optionRest}
       />
     );
   });

--- a/src/components/form/radio/radio_group.tsx
+++ b/src/components/form/radio/radio_group.tsx
@@ -86,7 +86,7 @@ export const EuiRadioGroup: FunctionComponent<EuiRadioGroupProps> = ({
         disabled={disabled || isOptionDisabled}
         onChange={onChange.bind(null, option.id, option.value)}
         compressed={compressed}
-        {...optionRest}
+        {...optionRest as EuiRadioProps}
       />
     );
   });


### PR DESCRIPTION
### Summary

Fixes #3248  id is required if a label is passed to EuiRadio

Created new interface for checking if a label is passed or not and perform as required

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
