### PR TITLE
Start date popover for date picker range starts at the calendar icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Added `optionalIcon` prop to `EuiDatePicker` ([#3383](https://github.com/elastic/eui/pull/3383))
+- Added `iconType` prop to `EuiDatePicker` ([#3383](https://github.com/elastic/eui/pull/3383))
 - Applied `max-width: 100%` to `EuiPageBody` so inner flex-based items don't overflow their containers  ([#3375](https://github.com/elastic/eui/pull/3375))
 - Added `titleSize` prop to `EuiStep` and `EuiSteps` ([#3340](https://github.com/elastic/eui/pull/3340))
 - Handled `ref` passed to `EuiHeaderSectionItemButton` ([#3378](https://github.com/elastic/eui/pull/3378))
@@ -15,7 +15,7 @@
 - Applies `max-width: 100%` to `EuiPageBody` so inner flex-based items don't overflow their containers  ([#3375](https://github.com/elastic/eui/pull/3375))
 - Added `ReactElement` to `EuiCard` `image` prop type to allow custom component ([#3370](https://github.com/elastic/eui/pull/3370))
 - Fixed `EuiCollapsibleNavGroup` `titleSize` prop type to properly exclude `l` and `m` sizes ([#3365](https://github.com/elastic/eui/pull/3365))
-- Fixed `EuiDatePicker` `startDateControl` where the popover now sits on the left under the icon ([#3383](https://github.com/elastic/eui/pull/3383)) 
+- Fixed `EuiDatePickerRange` start date popover to sit left under the icon ([#3383](https://github.com/elastic/eui/pull/3383))
 
 ## [`23.1.0`](https://github.com/elastic/eui/tree/v23.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Added `optionalIcon` prop to `EuiDatePicker` ([#3383](https://github.com/elastic/eui/pull/3383))
 - Applied `max-width: 100%` to `EuiPageBody` so inner flex-based items don't overflow their containers  ([#3375](https://github.com/elastic/eui/pull/3375))
 - Added `titleSize` prop to `EuiStep` and `EuiSteps` ([#3340](https://github.com/elastic/eui/pull/3340))
 - Handled `ref` passed to `EuiHeaderSectionItemButton` ([#3378](https://github.com/elastic/eui/pull/3378))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 **Bug Fixes**
 
+- Fixed `EuiDatePicker` `startDateControl` where the popover now sits on the left under the icon ([#3383](https://github.com/elastic/eui/pull/3383)) 
 - Fixed z-index issue in `EuiDatePicker` where it's popover would sit beneath other DOM siblings that had z-index applied ([#3376](https://github.com/elastic/eui/pull/3376))
 - Added `download` glyph to `EuiIcon` ([#3364](https://github.com/elastic/eui/pull/3364))
 - Applies `max-width: 100%` to `EuiPageBody` so inner flex-based items don't overflow their containers  ([#3375](https://github.com/elastic/eui/pull/3375))

--- a/src/components/date_picker/__snapshots__/date_picker_range.test.tsx.snap
+++ b/src/components/date_picker/__snapshots__/date_picker_range.test.tsx.snap
@@ -6,13 +6,6 @@ exports[`EuiDatePickerRange is rendered 1`] = `
   class="euiDatePickerRange testClass1 testClass2"
   data-test-subj="test subject string"
 >
-  <span
-    class="euiDatePickerRange__icon"
-  >
-    <div
-      data-euiicon-type="calendar"
-    />
-  </span>
   <span>
     <span
       class="euiDatePicker euiDatePicker--shadow"
@@ -31,11 +24,24 @@ exports[`EuiDatePickerRange is rendered 1`] = `
             >
               <input
                 aria-label=""
-                class="euiDatePicker euiFieldText"
+                class="euiDatePicker euiFieldText euiFieldText--withIcon"
                 type="text"
                 value=""
               />
             </div>
+          </div>
+          <div
+            class="euiFormControlLayoutIcons"
+          >
+            <span
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <div
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="calendar"
+              />
+            </span>
           </div>
         </div>
       </div>

--- a/src/components/date_picker/_date_picker_range.scss
+++ b/src/components/date_picker/_date_picker_range.scss
@@ -37,12 +37,6 @@
 
   // Direct descendent selectors to override `> span`
 
-  > .euiDatePickerRange__icon {
-    flex: 0 0 auto;
-    padding-left: $euiFormControlPadding;
-    padding-right: $euiFormControlPadding;
-  }
-
   > .euiDatePickerRange__delimeter {
     background-color: transparent !important; // override .euiFormControlLayout--group .euiText
     line-height: 1 !important;

--- a/src/components/date_picker/date_picker.tsx
+++ b/src/components/date_picker/date_picker.tsx
@@ -71,6 +71,10 @@ interface EuiExtendedDatePickerProps extends ReactDatePickerProps {
   onClear?: MouseEventHandler<HTMLButtonElement>;
 
   /**
+   * Which icon in input
+   */
+  optionalIcon?: EuiFormControlLayoutIconsProps['icon'];
+  /**
    * Opens to this date (in moment format) on first press, regardless of selection
    */
   openToDate?: Moment;
@@ -156,6 +160,8 @@ export class EuiDatePicker extends Component<_EuiDatePickerProps> {
       ...rest
     } = this.props;
 
+    let { optionalIcon } = this.props;
+
     const classes = classNames('euiDatePicker', {
       'euiDatePicker--shadow': shadow,
       'euiDatePicker--inline': inline,
@@ -173,13 +179,14 @@ export class EuiDatePicker extends Component<_EuiDatePickerProps> {
       className
     );
 
-    let optionalIcon: EuiFormControlLayoutIconsProps['icon'];
-    if (inline || customInput || !showIcon) {
-      optionalIcon = undefined;
-    } else if (showTimeSelectOnly) {
-      optionalIcon = 'clock';
-    } else {
-      optionalIcon = 'calendar';
+    if (!optionalIcon) {
+      if (inline || customInput || !showIcon) {
+        optionalIcon = undefined;
+      } else if (showTimeSelectOnly) {
+        optionalIcon = 'clock';
+      } else {
+        optionalIcon = 'calendar';
+      }
     }
 
     // In case the consumer did not alter the default date format but wants

--- a/src/components/date_picker/date_picker.tsx
+++ b/src/components/date_picker/date_picker.tsx
@@ -71,10 +71,6 @@ interface EuiExtendedDatePickerProps extends ReactDatePickerProps {
   onClear?: MouseEventHandler<HTMLButtonElement>;
 
   /**
-   * Which icon in input
-   */
-  optionalIcon?: EuiFormControlLayoutIconsProps['icon'];
-  /**
    * Opens to this date (in moment format) on first press, regardless of selection
    */
   openToDate?: Moment;
@@ -93,6 +89,11 @@ interface EuiExtendedDatePickerProps extends ReactDatePickerProps {
    * Show the icon in input
    */
   showIcon?: boolean;
+
+  /**
+   * Pass an icon type to change the default `calendar` or `clock` icon
+   */
+  iconType?: EuiFormControlLayoutIconsProps['icon'];
 
   /**
    * Sets the placement of the popover. It accepts: `"bottom"`, `"bottom-end"`, `"bottom-start"`, `"left"`, `"left-end"`, `"right"`, `"right-end"`, `"right-start"`, `"top"`, `"top-end"`, `"top-start"`
@@ -133,6 +134,7 @@ export class EuiDatePicker extends Component<_EuiDatePickerProps> {
       excludeDates,
       filterDate,
       fullWidth,
+      iconType,
       injectTimes,
       inline,
       inputRef,
@@ -160,8 +162,6 @@ export class EuiDatePicker extends Component<_EuiDatePickerProps> {
       ...rest
     } = this.props;
 
-    let { optionalIcon } = this.props;
-
     const classes = classNames('euiDatePicker', {
       'euiDatePicker--shadow': shadow,
       'euiDatePicker--inline': inline,
@@ -179,14 +179,15 @@ export class EuiDatePicker extends Component<_EuiDatePickerProps> {
       className
     );
 
-    if (!optionalIcon) {
-      if (inline || customInput || !showIcon) {
-        optionalIcon = undefined;
-      } else if (showTimeSelectOnly) {
-        optionalIcon = 'clock';
-      } else {
-        optionalIcon = 'calendar';
-      }
+    let optionalIcon: EuiFormControlLayoutIconsProps['icon'];
+    if (inline || customInput || !showIcon) {
+      optionalIcon = undefined;
+    } else if (iconType) {
+      optionalIcon = iconType;
+    } else if (showTimeSelectOnly) {
+      optionalIcon = 'clock';
+    } else {
+      optionalIcon = 'calendar';
     }
 
     // In case the consumer did not alter the default date format but wants

--- a/src/components/date_picker/date_picker_range.tsx
+++ b/src/components/date_picker/date_picker_range.tsx
@@ -27,7 +27,7 @@ import React, {
 import classNames from 'classnames';
 
 import { EuiText } from '../text';
-import { EuiIcon, IconType } from '../icon';
+import { IconType } from '../icon';
 import { CommonProps } from '../common';
 import { EuiDatePickerProps } from './date_picker';
 
@@ -65,7 +65,7 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
   className,
   startDateControl,
   endDateControl,
-  iconType = false,
+  iconType = true,
   fullWidth,
   isCustom,
   readOnly,
@@ -82,15 +82,12 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
 
   // Set the icon for the entire group instead of per control
   let optionalIcon;
+  let showIcon = false;
   if (iconType) {
-    const icon = typeof iconType === 'string' ? iconType : 'calendar';
-    optionalIcon = (
-      <span className="euiDatePickerRange__icon">
-        <EuiIcon type={icon} />
-      </span>
-    );
+    optionalIcon = typeof iconType === 'string' ? iconType : 'calendar';
+    showIcon = true;
   } else {
-    optionalIcon = null;
+    optionalIcon = undefined;
   }
 
   let startControl = startDateControl;
@@ -100,7 +97,8 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
     startControl = cloneElement(
       startDateControl as ReactElement<EuiDatePickerProps>,
       {
-        showIcon: true,
+        optionalIcon: optionalIcon,
+        showIcon: showIcon,
         fullWidth: fullWidth,
         readOnly: readOnly,
       }
@@ -123,7 +121,6 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
         children
       ) : (
         <Fragment>
-          {optionalIcon}
           {startControl}
           <EuiText
             className="euiDatePickerRange__delimeter"

--- a/src/components/date_picker/date_picker_range.tsx
+++ b/src/components/date_picker/date_picker_range.tsx
@@ -80,16 +80,6 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
     className
   );
 
-  // Set the icon for the entire group instead of per control
-  let optionalIcon;
-  let showIcon = false;
-  if (iconType) {
-    optionalIcon = typeof iconType === 'string' ? iconType : 'calendar';
-    showIcon = true;
-  } else {
-    optionalIcon = undefined;
-  }
-
   let startControl = startDateControl;
   let endControl = endDateControl;
 
@@ -97,10 +87,10 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
     startControl = cloneElement(
       startDateControl as ReactElement<EuiDatePickerProps>,
       {
-        optionalIcon: optionalIcon,
-        showIcon: showIcon,
         fullWidth: fullWidth,
         readOnly: readOnly,
+        iconType: typeof iconType === 'boolean' ? undefined : iconType,
+        showIcon: !!iconType,
       }
     );
 

--- a/src/components/date_picker/date_picker_range.tsx
+++ b/src/components/date_picker/date_picker_range.tsx
@@ -65,7 +65,7 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
   className,
   startDateControl,
   endDateControl,
-  iconType = true,
+  iconType = false,
   fullWidth,
   isCustom,
   readOnly,
@@ -100,7 +100,7 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
     startControl = cloneElement(
       startDateControl as ReactElement<EuiDatePickerProps>,
       {
-        showIcon: false,
+        showIcon: true,
         fullWidth: fullWidth,
         readOnly: readOnly,
       }


### PR DESCRIPTION
### Summary

Fixes #3374 
Icon has been changed to be a part of the start date, so the picker aligns with the front,
![datePickerRange](https://user-images.githubusercontent.com/36285522/80172638-8382fe00-85bb-11ea-89b5-8021a33f93a8.PNG)


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [x] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
<s> - [ ] Checked for **accessibility** including keyboard-only and screenreader modes </s>
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
