### PR TITLE
[Docs] Update EuiComment snippet

### DIFF
--- a/src-docs/src/views/comment/comment_example.js
+++ b/src-docs/src/views/comment/comment_example.js
@@ -56,12 +56,7 @@ const commentTimelineIconsSnippet = [
 `,
   `<EuiComment timelineIcon="tag" username="janed" />
 `,
-  `<EuiComment timelineIcon={
-    <EuiAvatar
-      name="Jane D"
-      size="l"
-    />
-  } username="janed">
+  `<EuiComment timelineIcon={avatar} username="janed">
   {body}
 </EuiComment>
 `,


### PR DESCRIPTION
### Summary

Continuing the snippets work! 🎉 

This PR updates one of the EuiComment snippets. A very small fix.

<img width="959" alt="euiComment@2x" src="https://user-images.githubusercontent.com/2750668/80411178-a5ce9180-88c3-11ea-8193-689287806359.png">


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **IE11** and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- [x] Added **documentation** examples
- ~[ ] Added or updated **jest tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A [changelog](https://github.com/elastic/eui/blob/master/CONTRIBUTING.md#changelog) entry exists and is marked appropriately~
