### PR TITLE
Fixes for EuiHeader z-index, EuiPopover buffer, and EuiCollapsibleNav close button props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Added `titleSize` prop to `EuiStep` and `EuiSteps` ([#3340](https://github.com/elastic/eui/pull/3340))
 - Handled `ref` passed to `EuiHeaderSectionItemButton` ([#3378](https://github.com/elastic/eui/pull/3378))
 - Added `iconProps` prop to `EuiCollapsibleNavGroup` to extend the props passed to the rendered `EuiIcon` ([#3365](https://github.com/elastic/eui/pull/3365))
+- Added `closeButtonProps` to `EuiCollapsibleNav` ([#3398](https://github.com/elastic/eui/pull/3398))
+- Added `buffer` prop to `EuiPopover` for altering minimum distance to container edges ([#3398](https://github.com/elastic/eui/pull/3398))
 
 **Bug Fixes**
 
@@ -14,6 +16,7 @@
 - Applies `max-width: 100%` to `EuiPageBody` so inner flex-based items don't overflow their containers  ([#3375](https://github.com/elastic/eui/pull/3375))
 - Added `ReactElement` to `EuiCard` `image` prop type to allow custom component ([#3370](https://github.com/elastic/eui/pull/3370))
 - Fixed `EuiCollapsibleNavGroup` `titleSize` prop type to properly exclude `l` and `m` sizes ([#3365](https://github.com/elastic/eui/pull/3365))
+- Fixed `EuiHeader` `z-index` issues with popovers and added body classes for the presence of `EuiFlyout` and `EuiCollapsibleNav.isOpen` ([#3398](https://github.com/elastic/eui/pull/3398))
 
 ## [`23.1.0`](https://github.com/elastic/eui/tree/v23.1.0)
 

--- a/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
@@ -1,5 +1,92 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiCollapsibleNav close button can be hidden 1`] = `
+Array [
+  <div />,
+  <div>
+    <div
+      data-focus-guard="true"
+      style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+      tabindex="0"
+    />
+    <div
+      data-focus-guard="true"
+      style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+      tabindex="1"
+    />
+    <div
+      data-focus-lock-disabled="false"
+    >
+      <nav
+        class="euiCollapsibleNav"
+        id="id"
+      />
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+      tabindex="0"
+    />
+  </div>,
+]
+`;
+
+exports[`EuiCollapsibleNav close button extends EuiButtonEmpty 1`] = `
+Array [
+  <div />,
+  <div>
+    <div
+      data-focus-guard="true"
+      style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+      tabindex="0"
+    />
+    <div
+      data-focus-guard="true"
+      style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+      tabindex="1"
+    />
+    <div
+      data-focus-lock-disabled="false"
+    >
+      <nav
+        class="euiCollapsibleNav"
+        id="id"
+      >
+        <button
+          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiCollapsibleNav__closeButton class"
+          data-test-subj="test"
+          type="button"
+        >
+          <span
+            class="euiButtonEmpty__content"
+          >
+            <div
+              aria-hidden="true"
+              class="euiButtonEmpty__icon"
+              data-euiicon-type="cross"
+            />
+            <span
+              class="euiButtonEmpty__text"
+            >
+              <span
+                class="euiCollapsibleNav__closeButtonLabel"
+              >
+                close
+              </span>
+            </span>
+          </span>
+        </button>
+      </nav>
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+      tabindex="0"
+    />
+  </div>,
+]
+`;
+
 exports[`EuiCollapsibleNav does not render if isOpen is false 1`] = `null`;
 
 exports[`EuiCollapsibleNav is rendered 1`] = `
@@ -337,37 +424,6 @@ Array [
       data-focus-guard="true"
       style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
       tabindex="-1"
-    />
-  </div>,
-]
-`;
-
-exports[`EuiCollapsibleNav props showCloseButton can be false 1`] = `
-Array [
-  <div />,
-  <div>
-    <div
-      data-focus-guard="true"
-      style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
-      tabindex="0"
-    />
-    <div
-      data-focus-guard="true"
-      style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
-      tabindex="1"
-    />
-    <div
-      data-focus-lock-disabled="false"
-    >
-      <nav
-        class="euiCollapsibleNav"
-        id="id"
-      />
-    </div>
-    <div
-      data-focus-guard="true"
-      style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
-      tabindex="0"
     />
   </div>,
 ]

--- a/src/components/collapsible_nav/_collapsible_nav.scss
+++ b/src/components/collapsible_nav/_collapsible_nav.scss
@@ -21,6 +21,7 @@
 // via the `dockingBreakpoint` and `isDocked` combination
 .euiCollapsibleNav.euiCollapsibleNav--isDocked {
   @include euiBottomShadowMedium;
+  z-index: $euiZHeader; // When docked, make it the same level as the header
 
   .euiCollapsibleNav__closeButton {
     display: none;

--- a/src/components/collapsible_nav/collapsible_nav.test.tsx
+++ b/src/components/collapsible_nav/collapsible_nav.test.tsx
@@ -71,14 +71,6 @@ describe('EuiCollapsibleNav', () => {
       expect(component).toMatchSnapshot();
     });
 
-    test('showCloseButton can be false', () => {
-      const component = render(
-        <EuiCollapsibleNav {...propsNeededToRender} showCloseButton={false} />
-      );
-
-      expect(component).toMatchSnapshot();
-    });
-
     test('showButtonIfDocked', () => {
       const component = render(
         <EuiCollapsibleNav
@@ -86,6 +78,27 @@ describe('EuiCollapsibleNav', () => {
           button={<button />}
           isDocked={true}
           showButtonIfDocked={true}
+        />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+  });
+
+  describe('close button', () => {
+    test('can be hidden', () => {
+      const component = render(
+        <EuiCollapsibleNav {...propsNeededToRender} showCloseButton={false} />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
+    test('extends EuiButtonEmpty', () => {
+      const component = render(
+        <EuiCollapsibleNav
+          {...propsNeededToRender}
+          closeButtonProps={{ className: 'class', 'data-test-subj': 'test' }}
         />
       );
 

--- a/src/components/collapsible_nav/collapsible_nav.tsx
+++ b/src/components/collapsible_nav/collapsible_nav.tsx
@@ -32,7 +32,7 @@ import { EuiWindowEvent, keyCodes, htmlIdGenerator } from '../../services';
 import { EuiFocusTrap } from '../focus_trap';
 import { EuiOverlayMask } from '../overlay_mask';
 import { CommonProps } from '../common';
-import { EuiButtonEmpty } from '../button';
+import { EuiButtonEmpty, EuiButtonEmptyProps } from '../button';
 import { EuiI18n } from '../i18n';
 
 export type EuiCollapsibleNavProps = CommonProps &
@@ -63,6 +63,10 @@ export type EuiCollapsibleNavProps = CommonProps &
      * If `false`, you must then keep the `button` displayed at all breakpoints.
      */
     showCloseButton?: boolean;
+    /**
+     * Extend the props of the close button, an EuiButtonEmpty
+     */
+    closeButtonProps?: EuiButtonEmptyProps;
     onClose?: () => void;
   };
 
@@ -75,6 +79,7 @@ export const EuiCollapsibleNav: FunctionComponent<EuiCollapsibleNavProps> = ({
   showButtonIfDocked = false,
   dockedBreakpoint = 992,
   showCloseButton = true,
+  closeButtonProps,
   onClose,
   id,
   ...rest
@@ -159,7 +164,11 @@ export const EuiCollapsibleNav: FunctionComponent<EuiCollapsibleNavProps> = ({
       onClick={collapse}
       size="xs"
       iconType="cross"
-      className="euiCollapsibleNav__closeButton">
+      {...closeButtonProps}
+      className={classNames(
+        'euiCollapsibleNav__closeButton',
+        closeButtonProps && closeButtonProps.className
+      )}>
       <span className="euiCollapsibleNav__closeButtonLabel">
         <EuiI18n token="euiCollapsibleNav.closeButtonLabel" default="close" />
       </span>

--- a/src/components/collapsible_nav/collapsible_nav.tsx
+++ b/src/components/collapsible_nav/collapsible_nav.tsx
@@ -100,13 +100,16 @@ export const EuiCollapsibleNav: FunctionComponent<EuiCollapsibleNavProps> = ({
 
     if (navIsDocked) {
       document.body.classList.add('euiBody--collapsibleNavIsDocked');
+    } else if (isOpen) {
+      document.body.classList.add('euiBody--collapsibleNavIsOpen');
     }
 
     return () => {
       document.body.classList.remove('euiBody--collapsibleNavIsDocked');
+      document.body.classList.remove('euiBody--collapsibleNavIsOpen');
       window.removeEventListener('resize', functionToCallOnWindowResize);
     };
-  }, [navIsDocked, functionToCallOnWindowResize]);
+  }, [navIsDocked, functionToCallOnWindowResize, isOpen]);
 
   const onKeyDown = (event: KeyboardEvent) => {
     if (event.keyCode === keyCodes.ESCAPE) {

--- a/src/components/flyout/__snapshots__/flyout.test.tsx.snap
+++ b/src/components/flyout/__snapshots__/flyout.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`EuiFlyout is rendered 1`] = `
       tabindex="0"
     >
       <button
-        aria-label="Closes this dialog"
+        aria-label="Close this dialog"
         class="euiButtonIcon euiButtonIcon--text euiFlyout__closeButton"
         data-test-subj="euiFlyoutCloseButton"
         type="button"
@@ -66,7 +66,7 @@ exports[`EuiFlyout max width can be set to a custom number 1`] = `
       tabindex="0"
     >
       <button
-        aria-label="Closes this dialog"
+        aria-label="Close this dialog"
         class="euiButtonIcon euiButtonIcon--text euiFlyout__closeButton"
         data-test-subj="euiFlyoutCloseButton"
         type="button"
@@ -109,7 +109,7 @@ exports[`EuiFlyout max width can be set to a custom value and measurement 1`] = 
       tabindex="0"
     >
       <button
-        aria-label="Closes this dialog"
+        aria-label="Close this dialog"
         class="euiButtonIcon euiButtonIcon--text euiFlyout__closeButton"
         data-test-subj="euiFlyoutCloseButton"
         type="button"
@@ -151,7 +151,7 @@ exports[`EuiFlyout max width can be set to a default 1`] = `
       tabindex="0"
     >
       <button
-        aria-label="Closes this dialog"
+        aria-label="Close this dialog"
         class="euiButtonIcon euiButtonIcon--text euiFlyout__closeButton"
         data-test-subj="euiFlyoutCloseButton"
         type="button"
@@ -194,7 +194,7 @@ exports[`EuiFlyout props accepts div props 1`] = `
       tabindex="0"
     >
       <button
-        aria-label="Closes this dialog"
+        aria-label="Close this dialog"
         class="euiButtonIcon euiButtonIcon--text euiFlyout__closeButton"
         data-test-subj="euiFlyoutCloseButton"
         type="button"
@@ -265,7 +265,7 @@ exports[`EuiFlyout size l is rendered 1`] = `
       tabindex="0"
     >
       <button
-        aria-label="Closes this dialog"
+        aria-label="Close this dialog"
         class="euiButtonIcon euiButtonIcon--text euiFlyout__closeButton"
         data-test-subj="euiFlyoutCloseButton"
         type="button"
@@ -307,7 +307,7 @@ exports[`EuiFlyout size m is rendered 1`] = `
       tabindex="0"
     >
       <button
-        aria-label="Closes this dialog"
+        aria-label="Close this dialog"
         class="euiButtonIcon euiButtonIcon--text euiFlyout__closeButton"
         data-test-subj="euiFlyoutCloseButton"
         type="button"
@@ -349,7 +349,7 @@ exports[`EuiFlyout size s is rendered 1`] = `
       tabindex="0"
     >
       <button
-        aria-label="Closes this dialog"
+        aria-label="Close this dialog"
         class="euiButtonIcon euiButtonIcon--text euiFlyout__closeButton"
         data-test-subj="euiFlyoutCloseButton"
         type="button"

--- a/src/components/flyout/flyout.test.tsx
+++ b/src/components/flyout/flyout.test.tsx
@@ -49,7 +49,7 @@ describe('EuiFlyout', () => {
         const label = component
           .find('[data-test-subj="euiFlyoutCloseButton"]')
           .prop('aria-label');
-        expect(label).toBe('Closes this dialog');
+        expect(label).toBe('Close this dialog');
       });
 
       test('sets a custom label for the close button', () => {

--- a/src/components/flyout/flyout.tsx
+++ b/src/components/flyout/flyout.tsx
@@ -32,6 +32,7 @@ import { CommonProps } from '../common';
 import { EuiFocusTrap } from '../focus_trap';
 import { EuiOverlayMask } from '../overlay_mask';
 import { EuiButtonIcon } from '../button';
+import { EuiI18n } from '../i18n';
 
 export type EuiFlyoutSize = 's' | 'm' | 'l';
 
@@ -59,6 +60,7 @@ export interface EuiFlyoutProps
   ownFocus?: boolean;
   /**
    * Specify an aria-label for the close button of the flyout.
+   * Default is `'Close this dialog'`.
    */
   closeButtonAriaLabel?: string;
   /**
@@ -80,7 +82,7 @@ export const EuiFlyout: FunctionComponent<EuiFlyoutProps> = ({
   onClose,
   ownFocus = false,
   size = 'm',
-  closeButtonAriaLabel = 'Closes this dialog',
+  closeButtonAriaLabel,
   maxWidth = false,
   style,
   ...rest
@@ -119,14 +121,18 @@ export const EuiFlyout: FunctionComponent<EuiFlyoutProps> = ({
   let closeButton;
   if (onClose && !hideCloseButton) {
     closeButton = (
-      <EuiButtonIcon
-        className="euiFlyout__closeButton"
-        iconType="cross"
-        color="text"
-        aria-label={closeButtonAriaLabel}
-        onClick={onClose}
-        data-test-subj="euiFlyoutCloseButton"
-      />
+      <EuiI18n token="euiFlyout.closeAriaLabel" default="Close this dialog">
+        {(closeAriaLabel: string) => (
+          <EuiButtonIcon
+            className="euiFlyout__closeButton"
+            iconType="cross"
+            color="text"
+            aria-label={closeButtonAriaLabel || closeAriaLabel}
+            onClick={onClose}
+            data-test-subj="euiFlyoutCloseButton"
+          />
+        )}
+      </EuiI18n>
     );
   }
 

--- a/src/components/flyout/flyout.tsx
+++ b/src/components/flyout/flyout.tsx
@@ -18,10 +18,11 @@
  */
 
 import React, {
-  Component,
+  FunctionComponent,
   CSSProperties,
   Fragment,
   HTMLAttributes,
+  useEffect,
 } from 'react';
 import classnames from 'classnames';
 
@@ -72,93 +73,89 @@ export interface EuiFlyoutProps
   style?: CSSProperties;
 }
 
-export class EuiFlyout extends Component<EuiFlyoutProps> {
-  static defaultProps: Partial<EuiFlyoutProps> = {
-    size: 'm',
-    hideCloseButton: false,
-    ownFocus: false,
-    closeButtonAriaLabel: 'Closes this dialog',
-    maxWidth: false,
-  };
-
-  onKeyDown = (event: KeyboardEvent) => {
+export const EuiFlyout: FunctionComponent<EuiFlyoutProps> = ({
+  className,
+  children,
+  hideCloseButton = false,
+  onClose,
+  ownFocus = false,
+  size = 'm',
+  closeButtonAriaLabel = 'Closes this dialog',
+  maxWidth = false,
+  style,
+  ...rest
+}) => {
+  const onKeyDown = (event: KeyboardEvent) => {
     if (event.keyCode === keyCodes.ESCAPE) {
       event.preventDefault();
-      this.props.onClose();
+      onClose();
     }
   };
 
-  render() {
-    const {
-      className,
-      children,
-      hideCloseButton,
-      onClose,
-      ownFocus,
-      size,
-      closeButtonAriaLabel,
-      maxWidth,
-      style,
-      ...rest
-    } = this.props;
+  useEffect(() => {
+    document.body.classList.add('euiBody--hasFlyout');
 
-    let newStyle;
-    let widthClassName;
-    if (maxWidth === true) {
-      widthClassName = 'euiFlyout--maxWidth-default';
-    } else if (maxWidth !== false) {
-      const value = typeof maxWidth === 'number' ? `${maxWidth}px` : maxWidth;
-      newStyle = { ...style, maxWidth: value };
-    }
+    return () => {
+      document.body.classList.remove('euiBody--hasFlyout');
+    };
+  });
 
-    const classes = classnames(
-      'euiFlyout',
-      sizeToClassNameMap[size!],
-      widthClassName,
-      className
-    );
+  let newStyle;
+  let widthClassName;
+  if (maxWidth === true) {
+    widthClassName = 'euiFlyout--maxWidth-default';
+  } else if (maxWidth !== false) {
+    const value = typeof maxWidth === 'number' ? `${maxWidth}px` : maxWidth;
+    newStyle = { ...style, maxWidth: value };
+  }
 
-    let closeButton;
-    if (onClose && !hideCloseButton) {
-      closeButton = (
-        <EuiButtonIcon
-          className="euiFlyout__closeButton"
-          iconType="cross"
-          color="text"
-          aria-label={closeButtonAriaLabel}
-          onClick={onClose}
-          data-test-subj="euiFlyoutCloseButton"
-        />
-      );
-    }
+  const classes = classnames(
+    'euiFlyout',
+    sizeToClassNameMap[size!],
+    widthClassName,
+    className
+  );
 
-    const flyoutContent = (
-      <div
-        role="dialog"
-        className={classes}
-        tabIndex={0}
-        style={newStyle || style}
-        {...rest}>
-        {closeButton}
-        {children}
-      </div>
-    );
-
-    // If ownFocus is set, show an overlay behind the flyout and allow the user
-    // to click it to close it.
-    let optionalOverlay;
-    if (ownFocus) {
-      optionalOverlay = <EuiOverlayMask onClick={onClose} />;
-    }
-
-    return (
-      <Fragment>
-        <EuiWindowEvent event="keydown" handler={this.onKeyDown} />
-        {optionalOverlay}
-        {/* Trap focus even when ownFocus={false}, otherwise closing the flyout won't return focus
-        to the originating button */}
-        <EuiFocusTrap clickOutsideDisables={true}>{flyoutContent}</EuiFocusTrap>
-      </Fragment>
+  let closeButton;
+  if (onClose && !hideCloseButton) {
+    closeButton = (
+      <EuiButtonIcon
+        className="euiFlyout__closeButton"
+        iconType="cross"
+        color="text"
+        aria-label={closeButtonAriaLabel}
+        onClick={onClose}
+        data-test-subj="euiFlyoutCloseButton"
+      />
     );
   }
-}
+
+  const flyoutContent = (
+    <div
+      role="dialog"
+      className={classes}
+      tabIndex={0}
+      style={newStyle || style}
+      {...rest}>
+      {closeButton}
+      {children}
+    </div>
+  );
+
+  // If ownFocus is set, show an overlay behind the flyout and allow the user
+  // to click it to close it.
+  let optionalOverlay;
+  if (ownFocus) {
+    optionalOverlay = <EuiOverlayMask onClick={onClose} />;
+  }
+
+  return (
+    <Fragment>
+      <EuiWindowEvent event="keydown" handler={onKeyDown} />
+      {optionalOverlay}
+      {/* Trap focus even when ownFocus={false}, otherwise closing the flyout won't return focus
+        to the originating button */}
+      <EuiFocusTrap clickOutsideDisables={true}>{flyoutContent}</EuiFocusTrap>
+    </Fragment>
+  );
+};

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -25,6 +25,6 @@
 .euiBody--collapsibleNavIsOpen,
 .euiBody--hasFlyout {
   .euiHeader--fixed {
-    z-index: $euiZMask + 1;
+    z-index: $euiZModal + 1;
   }
 }

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -15,10 +15,16 @@
     top: 0;
     left: 0;
     right: 0;
-    z-index: $euiZLevel7;
   }
 }
 
 .euiBody--headerIsFixed {
   padding-top: $euiHeaderHeightCompensation;
+}
+
+.euiBody--collapsibleNavIsOpen,
+.euiBody--hasFlyout {
+  .euiHeader--fixed {
+    z-index: $euiZMask + 1;
+  }
 }

--- a/src/components/popover/__snapshots__/popover.test.tsx.snap
+++ b/src/components/popover/__snapshots__/popover.test.tsx.snap
@@ -132,6 +132,56 @@ exports[`EuiPopover props arrowChildren is rendered 1`] = `
 </div>
 `;
 
+exports[`EuiPopover props buffer 1`] = `
+<div>
+  <div
+    class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
+    id="18"
+  >
+    <div
+      class="euiPopover__anchor"
+    >
+      <button />
+    </div>
+    <div>
+      <div
+        data-focus-guard="true"
+        style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+        tabindex="-1"
+      />
+      <div
+        data-focus-guard="true"
+        style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+        tabindex="-1"
+      />
+      <div
+        data-focus-lock-disabled="disabled"
+      >
+        <div
+          aria-describedby="htmlId"
+          aria-live="assertive"
+          aria-modal="true"
+          class="euiPanel euiPanel--paddingMedium euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
+          role="dialog"
+          style="top: 16px; left: -22px; z-index: 2000;"
+        >
+          <div
+            class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
+            style="left: 10px; top: 0px;"
+          />
+          <div />
+        </div>
+      </div>
+      <div
+        data-focus-guard="true"
+        style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+        tabindex="-1"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EuiPopover props display block is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"

--- a/src/components/popover/popover.test.tsx
+++ b/src/components/popover/popover.test.tsx
@@ -325,6 +325,22 @@ describe('EuiPopover', () => {
         expect(component.render()).toMatchSnapshot();
       });
     });
+
+    test('buffer', () => {
+      const component = mount(
+        <div>
+          <EuiPopover
+            id={getId()}
+            button={<button />}
+            closePopover={() => {}}
+            buffer={0}
+            isOpen
+          />
+        </div>
+      );
+
+      expect(component.render()).toMatchSnapshot();
+    });
   });
 
   describe('listener cleanup', () => {

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -148,6 +148,12 @@ export interface EuiPopoverProps {
   offset?: number;
 
   /**
+   * Minimum distance between the popover and the bounding container.
+   * Default is 16
+   */
+  buffer?: number;
+
+  /**
    * Element to pass as the child element of the arrow. Use case is typically limited to an accompanying `EuiBeacon`
    */
   arrowChildren?: ReactNode;
@@ -520,6 +526,7 @@ export class EuiPopover extends Component<Props, State> {
         arrowBuffer: 10,
       },
       returnBoundingBox: this.props.attachToAnchor,
+      buffer: this.props.buffer,
     });
 
     // the popover's z-index must inherit from the button
@@ -613,6 +620,7 @@ export class EuiPopover extends Component<Props, State> {
       attachToAnchor,
       display,
       onTrapDeactivation,
+      buffer,
       ...rest
     } = this.props;
 


### PR DESCRIPTION
### Continued support for Kibana K8

## 1. EuiHeader z-index

It was found that the fixed EuiHeader's z-index was too high, causing popovers to slip underneath. While the primary fix would be to contain the popover's within Kibana's main app area, this isn't possible at the moment.

<img width="548" alt="Screen Shot 2020-04-28 at 21 07 00 PM" src="https://user-images.githubusercontent.com/549577/80552325-4ee4bd00-8994-11ea-802e-0c80e59af137.png">


The quick fix is to lower the header's z-index from `7000` to `1000` (keeping the same z-index for static and fixed position). This allows the popovers to overlap the header (for now).

<img width="513" alt="Screen Shot 2020-04-28 at 21 08 50 PM" src="https://user-images.githubusercontent.com/549577/80552409-83f10f80-8994-11ea-94f5-a7601483e097.png">


**However**, this caused issues when flyouts or the nav (with EuiOverlayMask) were open, where the nav would then be hidden underneath (including the collapsible nav).

<img width="716" alt="Screen Shot 2020-04-28 at 21 10 21 PM" src="https://user-images.githubusercontent.com/549577/80552460-b13dbd80-8994-11ea-9c0d-c56e7b9477cd.png">

**The fix** was to add to the body's class list a class indicating when a flyout is open `.euiBody--hasFlyout` or when the nav is open `.euiBody--collapsibleNavIsOpen` and use that to increase the header's z-index up to  `8001` (1 more than `$euiZModal` used by `.euiFlyout`).

<img width="918" alt="Screen Shot 2020-04-28 at 21 24 55 PM" src="https://user-images.githubusercontent.com/549577/80553139-c0be0600-8996-11ea-8cf4-defee818b776.png">


This does mean that both the nav and a flyout can be at the same plane (visible), but that's hardly a showstopper at the moment.


## EuiPopover buffer

The first screenshot also shows how EuiPopover's default `buffer` (minimum distance between popover and container/browser window) is too small for some places. Dashboard's app padding is a mere `8px` while the default buffer is `16px`. This PR adds the ability to change the overall `buffer` via a new prop.

<img width="793" alt="Image 2020-04-28 at 9 17 08 PM" src="https://user-images.githubusercontent.com/549577/80552794-be0ee100-8995-11ea-805b-4dd1eb4de85a.png">


_I didn't add a docs example for this prop as it should rarely be used._

## EuiCollapsibleNav close button props

It was also asked that we provide more options to pass to the close button, like `data-test-subj`. So now there is a `closeButtonProps` prop that extends EuiButtonEmpty. cc @myasonik 

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [x] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
