### PR TITLE
Fix euiFormControlIsLoading mixin to prevent the loading icon overlapping when compressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Added `ReactElement` to `EuiCard` `image` prop type to allow custom component ([#3370](https://github.com/elastic/eui/pull/3370))
 - Fixed `EuiCollapsibleNavGroup` `titleSize` prop type to properly exclude `l` and `m` sizes ([#3365](https://github.com/elastic/eui/pull/3365))
 - Fixed `EuiDatePickerRange` start date popover to sit left under the icon ([#3383](https://github.com/elastic/eui/pull/3383))
-- Fixed `euiFormControlIsLoading` SASS mixin to prevent the loading icon from overlapping with the text when the form control is `compressed` ([#3365](https://github.com/elastic/eui/pull/3365)
+- Fixed `euiFormControlIsLoading` SASS mixin to prevent the loading icon from overlapping with the text when the form control is `compressed` and has an icon on the right side ([#3401](https://github.com/elastic/eui/pull/3401)
 
 ## [`23.1.0`](https://github.com/elastic/eui/tree/v23.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added `ReactElement` to `EuiCard` `image` prop type to allow custom component ([#3370](https://github.com/elastic/eui/pull/3370))
 - Fixed `EuiCollapsibleNavGroup` `titleSize` prop type to properly exclude `l` and `m` sizes ([#3365](https://github.com/elastic/eui/pull/3365))
 - Fixed `EuiDatePickerRange` start date popover to sit left under the icon ([#3383](https://github.com/elastic/eui/pull/3383))
+- Fixed `euiFormControlIsLoading` SASS mixin to prevent the loading icon from overlapping with the text when the form control is `compressed` ([#3365](https://github.com/elastic/eui/pull/3365)
 
 ## [`23.1.0`](https://github.com/elastic/eui/tree/v23.1.0)
 

--- a/src/global_styling/mixins/_form.scss
+++ b/src/global_styling/mixins/_form.scss
@@ -10,7 +10,6 @@
   $iconPadding: $euiFormControlPadding;
   $marginBetweenIcons: $euiFormControlPadding / 2;
 
-
   @if ($compressed) {
     $iconPadding: $euiFormControlCompressedPadding;
   }
@@ -21,6 +20,8 @@
     padding-#{$side}: $iconPadding + $iconSize + $iconPadding;
   } @else if $numOfIcons == 2 {
     padding-#{$side}: $iconPadding + $iconSize + $marginBetweenIcons + $iconSize + $iconPadding;
+  } @else if $numOfIcons == 3 {
+    padding-#{$side}: $iconPadding + $iconSize + $marginBetweenIcons + $iconSize + $marginBetweenIcons + $iconSize + $iconPadding;
   }
 }
 
@@ -114,7 +115,7 @@
 
 @mixin euiFormControlIsLoading($isNextToIcon: false) {
   @at-root {
-    #{&}-isLoading:not(#{&}--compressed) {
+    #{&}-isLoading {
       @if ($isNextToIcon) {
         @include euiFormControlLayoutPadding(2);
       } @else {

--- a/src/global_styling/mixins/_form.scss
+++ b/src/global_styling/mixins/_form.scss
@@ -115,7 +115,8 @@
 
 @mixin euiFormControlIsLoading($isNextToIcon: false) {
   @at-root {
-    #{&}-isLoading {
+    #{&}-isLoading,
+    #{&}-isLoading#{&}--compressed {
       @if ($isNextToIcon) {
         @include euiFormControlLayoutPadding(2);
       } @else {

--- a/src/global_styling/mixins/_form.scss
+++ b/src/global_styling/mixins/_form.scss
@@ -6,22 +6,21 @@
 }
 
 @mixin euiFormControlLayoutPadding($numOfIcons, $side: 'right', $compressed: false) {
-  $firstIconSize: $euiFormControlPadding + $euiSize + $euiFormControlPadding;
-  $secondIconSize: $euiFormControlPadding + $euiSize;
+  $iconSize: $euiSize;
+  $iconPadding: $euiFormControlPadding;
+  $marginBetweenIcons: $euiFormControlPadding / 2;
+
 
   @if ($compressed) {
-    $firstIconSize: $euiFormControlCompressedPadding + $euiSize + $euiFormControlCompressedPadding;
-    $secondIconSize: $euiFormControlCompressedPadding + $euiSize;
+    $iconPadding: $euiFormControlCompressedPadding;
   }
 
   @if variable-exists(numOfIcons) == false {
     @error '$numOfIcons:integer (1-3) must be provided to @mixin euiFormControlLayoutPadding().';
   } @else if $numOfIcons == 1 {
-    padding-#{$side}: $firstIconSize;
+    padding-#{$side}: $iconPadding + $iconSize + $iconPadding;
   } @else if $numOfIcons == 2 {
-    padding-#{$side}: $firstIconSize + $secondIconSize;
-  } @else if $numOfIcons == 3 {
-    padding-#{$side}: $firstIconSize + ($secondIconSize * 2);
+    padding-#{$side}: $iconPadding + $iconSize + $marginBetweenIcons + $iconSize + $iconPadding;
   }
 }
 
@@ -115,12 +114,19 @@
 
 @mixin euiFormControlIsLoading($isNextToIcon: false) {
   @at-root {
-    #{&}-isLoading,
-    #{&}-isLoading#{&}--compressed {
+    #{&}-isLoading:not(#{&}--compressed) {
       @if ($isNextToIcon) {
         @include euiFormControlLayoutPadding(2);
       } @else {
         @include euiFormControlLayoutPadding(1);
+      }
+    }
+
+    #{&}-isLoading#{&}--compressed {
+      @if ($isNextToIcon) {
+        @include euiFormControlLayoutPadding(2, $compressed: true);
+      } @else {
+        @include euiFormControlLayoutPadding(1, $compressed: true);
       }
     }
   }


### PR DESCRIPTION
### Summary

This PR fixed the `euiFormControlIsLoading` SASS mixin to prevent the loading icon from overlapping with the text when the form control is `compressed` and has an icon on the right side.

I noticed this issue when I was working on the **EuiColorPalettePicker**.

<img width="488" alt="form-control@2x" src="https://user-images.githubusercontent.com/2750668/81099894-82c76180-8f03-11ea-8a32-f7dc8505f5e2.png">


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [ ] Checked in **IE11** and **Firefox**
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
