### PR TITLE
Add caching layer to EuiIcon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added `titleSize` prop to `EuiStep` and `EuiSteps` ([#3340](https://github.com/elastic/eui/pull/3340))
 - Handled `ref` passed to `EuiHeaderSectionItemButton` ([#3378](https://github.com/elastic/eui/pull/3378))
 - Added `iconProps` prop to `EuiCollapsibleNavGroup` to extend the props passed to the rendered `EuiIcon` ([#3365](https://github.com/elastic/eui/pull/3365))
+- Added caching layer on `EuiIcon` to prevent delays and flickering when rendering an already fetched icon ([#3404](https://github.com/elastic/eui/pull/3404))
 
 **Bug Fixes**
 

--- a/src/components/icon/__snapshots__/icon.test.tsx.snap
+++ b/src/components/icon/__snapshots__/icon.test.tsx.snap
@@ -9078,7 +9078,7 @@ exports[`EuiIcon renders custom components 1`] = `
 <span
   aria-hidden="true"
   aria-label="heart"
-  class="euiIcon euiIcon--medium euiIcon-isLoaded"
+  class="euiIcon euiIcon--medium"
   focusable="false"
   role="img"
 >

--- a/src/components/icon/icon.test.tsx
+++ b/src/components/icon/icon.test.tsx
@@ -22,12 +22,14 @@ import { mount } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
 import cheerio from 'cheerio';
 
-import { EuiIcon, SIZES, TYPES, COLORS } from './icon';
+import { EuiIcon, SIZES, TYPES, COLORS, clearIconComponentCache } from './icon';
 import { PropsOf } from '../common';
 
 jest.mock('./icon', () => {
   return require.requireActual('./icon');
 });
+
+beforeEach(() => clearIconComponentCache());
 
 const prettyHtml = cheerio.load('');
 

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -511,6 +511,7 @@ interface State {
   icon: undefined | ComponentType | string;
   iconTitle: undefined | string;
   isLoading: boolean;
+  neededLoading: boolean; // controls the fade-in animation, cached icons are immediately rendered
 }
 
 function isEuiIconType(x: EuiIconProps['type']): x is EuiIconType {
@@ -522,6 +523,9 @@ function getInitialIcon(icon: EuiIconProps['type']) {
     return undefined;
   }
   if (isEuiIconType(icon)) {
+    if (iconComponentCache.hasOwnProperty(icon)) {
+      return iconComponentCache[icon];
+    }
     return undefined;
   }
 
@@ -529,6 +533,15 @@ function getInitialIcon(icon: EuiIconProps['type']) {
 }
 
 const generateId = htmlIdGenerator();
+
+let iconComponentCache: { [key: string]: ComponentType } = {};
+export const clearIconComponentCache = (icon?: EuiIconType) => {
+  if (icon != null) {
+    delete iconComponentCache[icon];
+  } else {
+    iconComponentCache = {};
+  }
+};
 
 export class EuiIcon extends PureComponent<EuiIconProps, State> {
   isMounted = true;
@@ -539,15 +552,18 @@ export class EuiIcon extends PureComponent<EuiIconProps, State> {
     const initialIcon = getInitialIcon(type);
     let isLoading = false;
 
-    if (isEuiIconType(type)) {
+    if (isEuiIconType(type) && initialIcon == null) {
       isLoading = true;
       this.loadIconComponent(type);
+    } else {
+      this.onIconLoad();
     }
 
     this.state = {
       icon: initialIcon,
       iconTitle: undefined,
       isLoading,
+      neededLoading: isLoading,
     };
   }
 
@@ -557,6 +573,7 @@ export class EuiIcon extends PureComponent<EuiIconProps, State> {
       if (isEuiIconType(type)) {
         // eslint-disable-next-line react/no-did-update-set-state
         this.setState({
+          neededLoading: iconComponentCache.hasOwnProperty(type),
           isLoading: true,
         });
         this.loadIconComponent(type);
@@ -564,6 +581,7 @@ export class EuiIcon extends PureComponent<EuiIconProps, State> {
         // eslint-disable-next-line react/no-did-update-set-state
         this.setState({
           icon: type,
+          neededLoading: true,
           isLoading: false,
         });
       }
@@ -575,6 +593,17 @@ export class EuiIcon extends PureComponent<EuiIconProps, State> {
   }
 
   loadIconComponent = (iconType: EuiIconType) => {
+    if (iconComponentCache.hasOwnProperty(iconType)) {
+      // exists in cache
+      this.setState({
+        isLoading: false,
+        neededLoading: false,
+        icon: iconComponentCache[iconType],
+      });
+      this.onIconLoad();
+      return;
+    }
+
     import(
       /* webpackChunkName: "icon.[request]" */
       // It's important that we don't use a template string here, it
@@ -582,6 +611,7 @@ export class EuiIcon extends PureComponent<EuiIconProps, State> {
       // eslint-disable-next-line prefer-template
       './assets/' + typeToPathMap[iconType] + '.js'
     ).then(({ icon }) => {
+      iconComponentCache[iconType] = icon;
       enqueueStateChange(() => {
         if (this.isMounted && this.props.type === iconType) {
           this.setState(
@@ -590,16 +620,18 @@ export class EuiIcon extends PureComponent<EuiIconProps, State> {
               iconTitle: iconType,
               isLoading: false,
             },
-            () => {
-              const { onIconLoad } = this.props;
-              if (onIconLoad) {
-                onIconLoad();
-              }
-            }
+            this.onIconLoad
           );
         }
       });
     });
+  };
+
+  onIconLoad = () => {
+    const { onIconLoad } = this.props;
+    if (onIconLoad) {
+      onIconLoad();
+    }
   };
 
   render() {
@@ -614,7 +646,7 @@ export class EuiIcon extends PureComponent<EuiIconProps, State> {
       ...rest
     } = this.props;
 
-    const { isLoading } = this.state;
+    const { isLoading, neededLoading } = this.state;
 
     let optionalColorClass = null;
     let optionalCustomStyles: any = null;
@@ -640,7 +672,7 @@ export class EuiIcon extends PureComponent<EuiIconProps, State> {
       {
         'euiIcon--app': isAppIcon,
         'euiIcon-isLoading': isLoading,
-        'euiIcon-isLoaded': !isLoading,
+        'euiIcon-isLoaded': !isLoading && neededLoading,
       },
       className
     );


### PR DESCRIPTION
### Summary

Fixes #3393 

Added a caching layer and some other logic to avoid fading in icons when they are immediately renderable.

* Added a caching layer to EuiIcon and an exported function to clear one-or-all of the cache entries
* Removed the `euiIcon-isLoaded` class when an icon is immediately renderable, removing the fade-in animation on cached icons or when a custom component is provided
* Single snapshot touched, proving the non-fade-in for custom components

The various update paths for the icon's state is definitely a mess. Everything's working, rendering, and snapshotting as expected but the next time the maze is touched it should be documented & refactored.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
