### PR TITLE
Fix DOM implementation in lifecycle hook.

### DIFF
--- a/src/components/code/__snapshots__/code_block.test.tsx.snap
+++ b/src/components/code/__snapshots__/code_block.test.tsx.snap
@@ -1,17 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiCodeBlock dynamic content updates DOM when input changes 1`] = `
-"<div>
-  <div class=\\"euiCodeBlock euiCodeBlock--fontSmall euiCodeBlock--paddingLarge\\">
-    <pre class=\\"euiCodeBlock__pre euiCodeBlock__pre--whiteSpacePreWrap\\">
-      <code class=\\"euiCodeBlock__code javascript hljs\\">
-        <span class=\\"hljs-keyword\\">const</span>value =
-        <span class=\\"hljs-string\\">'State 1'</span>
-      </code>
-    </pre>
-  </div>
-</div>"
-`;
+exports[`EuiCodeBlock dynamic content updates DOM when input changes 1`] = `"<div></div>"`;
 
 exports[`EuiCodeBlock dynamic content updates DOM when input changes 2`] = `
 "<div>

--- a/src/components/code/_code_block.tsx
+++ b/src/components/code/_code_block.tsx
@@ -84,6 +84,7 @@ interface Props {
 
 interface State {
   isFullScreen: boolean;
+  mounted: boolean;
 }
 
 /**
@@ -104,10 +105,11 @@ export class EuiCodeBlockImpl extends Component<Props, State> {
 
     this.state = {
       isFullScreen: false,
+      mounted: false,
     };
   }
 
-  codeTarget = document.createElement('div');
+  codeTarget!: HTMLDivElement; //Definite Assignment Assertions used, we need to set this in the componentDidMount() where we have the native DOM available.
   code: HTMLElement | null = null;
   codeFullScreen: HTMLElement | null = null;
 
@@ -119,6 +121,7 @@ export class EuiCodeBlockImpl extends Component<Props, State> {
      * copy from that fragment into the target elements
      * (https://github.com/elastic/eui/issues/2322)
      */
+
     const html = this.codeTarget.innerHTML;
 
     if (this.code) {
@@ -159,15 +162,24 @@ export class EuiCodeBlockImpl extends Component<Props, State> {
     });
   };
 
+  /* eslint-disable react/no-did-mount-set-state */
   componentDidMount() {
-    this.highlight();
+    this.codeTarget = document.createElement('div');
+    this.setState({
+      mounted: true,
+    });
   }
+  /* eslint-enable react/no-did-mount-set-state */
 
   componentDidUpdate() {
     this.highlight();
   }
 
   render() {
+    if (this.state.mounted === false) {
+      return null;
+    }
+
     const {
       inline,
       children,

--- a/src/components/code/code_block.test.tsx
+++ b/src/components/code/code_block.test.tsx
@@ -128,7 +128,7 @@ describe('EuiCodeBlock', () => {
 
       function App() {
         const [value, setValue] = useState('State 1');
-
+        // console.log([value, setValue], "value and setValue");
         useEffect(() => {
           takeSnapshot();
           setValue('State 2');


### PR DESCRIPTION
### Summary

This PR resolves #3156

It removes the need for the calling of `document.createElement` when the class instance is constructed. We cannot use `document.createElement` in the class because this code is also run serverside where this function is not available. 

This PR provides an alternative to the calling of DOM instances from the class by moving the logic of DOM manipulation in the proper lifecycle hook i.e. componentDidMount() so that the code is not run on the server. 

To solve this issue, I used the following example:
https://github.com/zeit/next.js/blob/b3459055ebef38c29f932ce6f9a7c4a5b2140db6/examples/with-portals/components/ClientOnlyPortal.js

The componentDidMount lifecycle doesn’t run on the serverside and makes it ideal for this problem. This solution also introduces a new state variable called `this.state.mount` and when it first runs, nothing is rendered because `this.state.mount` is set to false by default. 

When the state is set to false nothing is rendered and the guard clause runs. The second time, it runs, `this.state.mount` is set to true in the componentDidMount lifecycle hook and the componentIDidUpdate hook runs. When run on the server anything that needs the browser environment (DOM) goes in the componentDidMount. This may cause a visible render flash but we are rendering nothing the first time, as a result, there will not be a rendering flash issue. 

It was necessary to disable the linting rule Disable eslint, to allow setState in the componentDidMount where we have the native DOM available. This solution depends completely on it. The only way to move the DOM manipulation outside of the class instance, to move it out of the class and move the logic in the lifecycle hooks and this is exactly what this PR does. 


### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
