### PR TITLE
Simplify docs instructions for basic `EuiContextMenu` example

### DIFF
--- a/src-docs/src/views/context_menu/context_menu.js
+++ b/src-docs/src/views/context_menu/context_menu.js
@@ -10,21 +10,6 @@ import {
   EuiSpacer,
 } from '../../../../src/components';
 
-function flattenPanelTree(tree, array = []) {
-  array.push(tree);
-
-  if (tree.items) {
-    tree.items.forEach(item => {
-      if (item.panel) {
-        flattenPanelTree(item.panel, array);
-        item.panel = item.panel.id;
-      }
-    });
-  }
-
-  return array;
-}
-
 export default () => {
   const [isPopoverOpen, setPopover] = useState(false);
 
@@ -36,112 +21,113 @@ export default () => {
     setPopover(false);
   };
 
-  const panelTree = {
-    id: 0,
-    title: 'This is a context menu',
-    items: [
-      {
-        name: 'Handle an onClick',
-        icon: <EuiIcon type="search" size="m" />,
-        onClick: () => {
-          closePopover();
-          window.alert('Show fullscreen');
+  const panels = [
+    {
+      id: 0,
+      title: 'This is a context menu',
+      items: [
+        {
+          name: 'Handle an onClick',
+          icon: <EuiIcon type="search" size="m" />,
+          onClick: () => {
+            closePopover();
+            window.alert('Show fullscreen');
+          },
         },
-      },
-      {
-        name: 'Go to a link',
-        icon: 'user',
-        href: 'http://elastic.co',
-        target: '_blank',
-      },
-      {
-        name: 'Nest panels',
-        icon: 'user',
-        panel: {
-          id: 1,
-          title: 'Nest panels',
-          items: [
-            {
-              name: 'PDF reports',
-              icon: 'user',
-              onClick: () => {
-                closePopover();
-                window.alert('PDF reports');
-              },
-            },
-            {
-              name: 'Embed code',
-              icon: 'user',
-              panel: {
-                id: 2,
-                title: 'Embed code',
-                content: (
-                  <div style={{ padding: 16 }}>
-                    <EuiFormRow
-                      label="Generate a public snapshot?"
-                      hasChildLabel={false}>
-                      <EuiSwitch
-                        name="switch"
-                        id="asdf"
-                        label="Snapshot data"
-                        checked={true}
-                        onChange={() => {}}
-                      />
-                    </EuiFormRow>
-                    <EuiFormRow
-                      label="Include the following in the embed"
-                      hasChildLabel={false}>
-                      <EuiSwitch
-                        name="switch"
-                        id="asdf2"
-                        label="Current time range"
-                        checked={true}
-                        onChange={() => {}}
-                      />
-                    </EuiFormRow>
-                    <EuiSpacer />
-                    <EuiButton fill>Copy iFrame code</EuiButton>
-                  </div>
-                ),
-              },
-            },
-            {
-              name: 'Permalinks',
-              icon: 'user',
-              onClick: () => {
-                closePopover();
-                window.alert('Permalinks');
-              },
-            },
-          ],
+        {
+          name: 'Go to a link',
+          icon: 'user',
+          href: 'http://elastic.co',
+          target: '_blank',
         },
-      },
-      {
-        name: 'You can add a tooltip',
-        icon: 'user',
-        toolTipTitle: 'Optional tooltip',
-        toolTipContent: 'Optional content for a tooltip',
-        toolTipPosition: 'right',
-        onClick: () => {
-          closePopover();
-          window.alert('Display options');
+        {
+          name: 'Nest panels',
+          icon: 'user',
+          panel: 1,
         },
-      },
-      {
-        name: 'Disabled option',
-        icon: 'user',
-        toolTipContent: 'For reasons, this item is disabled',
-        toolTipPosition: 'right',
-        disabled: true,
-        onClick: () => {
-          closePopover();
-          window.alert('Disabled option');
+        {
+          name: 'You can add a tooltip',
+          icon: 'user',
+          toolTipTitle: 'Optional tooltip',
+          toolTipContent: 'Optional content for a tooltip',
+          toolTipPosition: 'right',
+          onClick: () => {
+            closePopover();
+            window.alert('Display options');
+          },
         },
-      },
-    ],
-  };
-
-  const panels = flattenPanelTree(panelTree);
+        {
+          name: 'Disabled option',
+          icon: 'user',
+          toolTipContent: 'For reasons, this item is disabled',
+          toolTipPosition: 'right',
+          disabled: true,
+          onClick: () => {
+            closePopover();
+            window.alert('Disabled option');
+          },
+        },
+      ],
+    },
+    {
+      id: 1,
+      title: 'Nest panels',
+      items: [
+        {
+          name: 'PDF reports',
+          icon: 'user',
+          onClick: () => {
+            closePopover();
+            window.alert('PDF reports');
+          },
+        },
+        {
+          name: 'Embed code',
+          icon: 'user',
+          panel: 2,
+        },
+        {
+          name: 'Permalinks',
+          icon: 'user',
+          onClick: () => {
+            closePopover();
+            window.alert('Permalinks');
+          },
+        },
+        ,
+      ],
+    },
+    {
+      id: 2,
+      title: 'Embed code',
+      content: (
+        <div style={{ padding: 16 }}>
+          <EuiFormRow label="Generate a public snapshot?" hasChildLabel={false}>
+            <EuiSwitch
+              name="switch"
+              id="asdf"
+              label="Snapshot data"
+              checked={true}
+              onChange={() => {}}
+            />
+          </EuiFormRow>
+          <EuiFormRow
+            label="Include the following in the embed"
+            hasChildLabel={false}>
+            <EuiSwitch
+              name="switch"
+              id="asdf2"
+              label="Current time range"
+              checked={true}
+              onChange={() => {}}
+            />
+          </EuiFormRow>
+          <EuiSpacer />
+          <EuiButton fill>Copy iFrame code</EuiButton>
+        </div>
+      ),
+    },
+  ];
 
   const button = (
     <EuiButton iconType="arrowDown" iconSide="right" onClick={onButtonClick}>


### PR DESCRIPTION
### Summary

I recently experienced some difficulty comprehending the docs' example code explaining how to create a nested context menu. There was some clever code demonstrating the configuration, but it obscured for me the basic requirements the component needs to function.

There are other examples using the same type of code further down the page, so I wanted to create a "barebones" example with POJOs to show how to use this feature.

To check the changes, compare the docs outputted by this patch against https://elastic.github.io/eui/#/navigation/context-menu and ensure that the interaction you see looks the same as the example below:

![Apr-30-2020 17-18-41](https://user-images.githubusercontent.com/18429259/80760296-ac008000-8b06-11ea-925e-6db2fd96cfb0.gif)

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
