### PR TITLE
Fixed EuiNavDrawer not closing on outside click after being unlocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 **Bug Fixes**
 
 - Fixed `EuiBasicTable` item selection when `id` is `0` ([#3417](https://github.com/elastic/eui/pull/3417))
+- Fixed `EuiNavDrawer` not closing on outside click after being unlocked ([#3415](https://github.com/elastic/eui/pull/3415))
 - Fixed `EuiBadge` `iconOnClick` props makes badge text clickable ([#3392](https://github.com/elastic/eui/pull/3392))
 - Added `id` requirement if `label` is used in `EuiRadio` ([#3382](https://github.com/elastic/eui/pull/3382))
 - Fixed z-index issue in `EuiDatePicker` where it's popover would sit beneath other DOM siblings that had z-index applied ([#3376](https://github.com/elastic/eui/pull/3376))

--- a/src/components/nav_drawer/nav_drawer.tsx
+++ b/src/components/nav_drawer/nav_drawer.tsx
@@ -140,7 +140,7 @@ export class EuiNavDrawer extends Component<
     this.setState({
       isLocked: !isLocked,
       isCollapsed: false,
-      outsideClickDisabled: true,
+      outsideClickDisabled: !isLocked,
     });
   };
 


### PR DESCRIPTION
Fixes #3414

### Summary

If locked, the old behaviour disabled the outside click detector, even if it was then unlocked again. Even when locked, it seems like the outside click detector doesn't need to be disabled, because it calls closeBoth which also checks if the nav drawer is locked itself, and only closes the outer menu if locked.

This PR adjusts that behaviour so that when the lock button is pressed, the outside click detector is always kept enabled. 

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [ ] ~~Props have proper **autodocs**~~
- [ ] ~~Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~~
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [ ] ~~Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

Going to be honest, I'm not really sure how to approach testing this one - happy of course for you guys to just take this change and add tests how you see fit if that's okay?