### PR TITLE
Fixed EuiBasicTable selection doesn't work as expected when id is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 **Bug Fixes**
 
+- Fixed `EuiBasicTable` select doesn't work as expected when id in data is 0 ([#3417](https://github.com/elastic/eui/pull/3417))
 - Fixed `EuiBadge` `iconOnClick` props makes badge text clickable ([#3392](https://github.com/elastic/eui/pull/3392))
 - Added `id` requirement if `label` is used in `EuiRadio` ([#3382](https://github.com/elastic/eui/pull/3382))
 - Fixed z-index issue in `EuiDatePicker` where it's popover would sit beneath other DOM siblings that had z-index applied ([#3376](https://github.com/elastic/eui/pull/3376))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 **Bug Fixes**
 
-- Fixed `EuiBasicTable` select doesn't work as expected when id in data is 0 ([#3417](https://github.com/elastic/eui/pull/3417))
+- Fixed `EuiBasicTable` item selection when `id` is `0` ([#3417](https://github.com/elastic/eui/pull/3417))
 - Fixed `EuiBadge` `iconOnClick` props makes badge text clickable ([#3392](https://github.com/elastic/eui/pull/3392))
 - Added `id` requirement if `label` is used in `EuiRadio` ([#3382](https://github.com/elastic/eui/pull/3382))
 - Fixed z-index issue in `EuiDatePicker` where it's popover would sit beneath other DOM siblings that had z-index applied ([#3376](https://github.com/elastic/eui/pull/3376))

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -885,8 +885,7 @@ export class EuiBasicTable<T = any> extends Component<
 
     const { itemId: itemIdCallback } = this.props;
     const itemId: ItemIdResolved =
-      getItemId(item, itemIdCallback) !== null &&
-      typeof getItemId(item, itemIdCallback) !== 'undefined'
+      getItemId(item, itemIdCallback) != null
         ? getItemId(item, itemIdCallback)
         : rowIndex;
     const selected = !selection

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -884,7 +884,11 @@ export class EuiBasicTable<T = any> extends Component<
     const cells = [];
 
     const { itemId: itemIdCallback } = this.props;
-    const itemId: ItemIdResolved = getItemId(item, itemIdCallback) || rowIndex;
+    const itemId: ItemIdResolved =
+      getItemId(item, itemIdCallback) !== null &&
+      typeof getItemId(item, itemIdCallback) !== 'undefined'
+        ? getItemId(item, itemIdCallback)
+        : rowIndex;
     const selected = !selection
       ? false
       : this.state.selection &&


### PR DESCRIPTION
### Summary

Fixes #3416 

When `id` of the data is `0` EuiBasicTable selection doesn't work as expected because `0` is falsy. This issue is solved by checking if the `id` is `null` or `undefined`.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~~
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
- [x] Checked for **breaking changes** and labeled appropriately
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
