### PR TITLE
[EuiInMemoryTable] Fixed data reset on selection change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 **Bug Fixes**
 
-- Fixed `EuiInMemoryTable` data reset on selection and filter is set ([#3419](https://github.com/elastic/eui/pull/3419))
+- Fixed `EuiInMemoryTable` data reset when filter is set and item is selected ([#3419](https://github.com/elastic/eui/pull/3419))
 - Fixed `EuiBadge` `iconOnClick` props makes badge text clickable ([#3392](https://github.com/elastic/eui/pull/3392))
 - Added `id` requirement if `label` is used in `EuiRadio` ([#3382](https://github.com/elastic/eui/pull/3382))
 - Fixed z-index issue in `EuiDatePicker` where it's popover would sit beneath other DOM siblings that had z-index applied ([#3376](https://github.com/elastic/eui/pull/3376))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 **Bug Fixes**
 
+- Fixed `EuiInMemoryTable` data reset on selection and filter is set ([#3419](https://github.com/elastic/eui/pull/3419))
 - Fixed `EuiBadge` `iconOnClick` props makes badge text clickable ([#3392](https://github.com/elastic/eui/pull/3392))
 - Added `id` requirement if `label` is used in `EuiRadio` ([#3382](https://github.com/elastic/eui/pull/3382))
 - Fixed z-index issue in `EuiDatePicker` where it's popover would sit beneath other DOM siblings that had z-index applied ([#3376](https://github.com/elastic/eui/pull/3376))

--- a/src/components/basic_table/in_memory_table.tsx
+++ b/src/components/basic_table/in_memory_table.tsx
@@ -270,16 +270,21 @@ export class EuiInMemoryTable<T> extends Component<
     }
 
     if (
-      (nextProps.search as EuiSearchBarProps) !==
+      (nextProps.search as EuiSearchBarProps) &&
       (prevState.prevProps.search as EuiSearchBarProps)
     ) {
-      return {
-        prevProps: {
-          ...prevState.prevProps,
-          search: nextProps.search,
-        },
-        query: getQueryFromSearch(nextProps.search, false),
-      };
+      const nextQuery = (nextProps.search as EuiSearchBarProps).query;
+      const prevQuery = (prevState.prevProps.search as EuiSearchBarProps).query;
+
+      if (nextQuery !== prevQuery) {
+        return {
+          prevProps: {
+            ...prevState.prevProps,
+            search: nextProps.search,
+          },
+          query: getQueryFromSearch(nextProps.search, false),
+        };
+      }
     }
     return null;
   }

--- a/src/components/basic_table/in_memory_table.tsx
+++ b/src/components/basic_table/in_memory_table.tsx
@@ -269,23 +269,23 @@ export class EuiInMemoryTable<T> extends Component<
       };
     }
 
-    if (
-      (nextProps.search as EuiSearchBarProps) &&
-      (prevState.prevProps.search as EuiSearchBarProps)
-    ) {
-      const nextQuery = (nextProps.search as EuiSearchBarProps).query;
-      const prevQuery = (prevState.prevProps.search as EuiSearchBarProps).query;
+    const nextQuery = nextProps.search
+      ? (nextProps.search as EuiSearchBarProps).query
+      : '';
+    const prevQuery = prevState.prevProps.search
+      ? (prevState.prevProps.search as EuiSearchBarProps).query
+      : '';
 
-      if (nextQuery !== prevQuery) {
-        return {
-          prevProps: {
-            ...prevState.prevProps,
-            search: nextProps.search,
-          },
-          query: getQueryFromSearch(nextProps.search, false),
-        };
-      }
+    if (nextQuery !== prevQuery) {
+      return {
+        prevProps: {
+          ...prevState.prevProps,
+          search: nextProps.search,
+        },
+        query: getQueryFromSearch(nextProps.search, false),
+      };
     }
+
     return null;
   }
 


### PR DESCRIPTION
### Summary

PR #3371 introduces a new issue when a filter is set and when we try to select a row the data is reset as shown in the screenshot. This issue can be found at [https://eui.elastic.co/pr_3371/](https://eui.elastic.co/pr_3371/).

Before

![Screen Cast 2020-05-03 at 9 48 25 PM](https://user-images.githubusercontent.com/10515204/80919598-7f5b9b00-8d88-11ea-817f-4b0cff5de660.gif)

After

![Screen Cast 2020-05-03 at 9 58 07 PM](https://user-images.githubusercontent.com/10515204/80919747-61426a80-8d89-11ea-9b81-cfe5ba989bf5.gif)
 

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~~
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
- [x] Checked for **breaking changes** and labeled appropriately
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

