### PR TITLE
Fixed double search issue with [EuiFieldSearch]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 **Bug Fixes**
 
+- Fixed `EuiFieldSearch` to trigger `onSearch` single time instead of two times ([#3425](https://github.com/elastic/eui/pull/3425))
 - Fixed `EuiBasicTable` item selection when `id` is `0` ([#3417](https://github.com/elastic/eui/pull/3417))
 - Fixed `EuiNavDrawer` not closing on outside click after being unlocked ([#3415](https://github.com/elastic/eui/pull/3415))
 - Fixed `EuiBadge` `iconOnClick` props makes badge text clickable ([#3392](https://github.com/elastic/eui/pull/3392))

--- a/src/components/form/field_search/field_search.tsx
+++ b/src/components/form/field_search/field_search.tsx
@@ -21,6 +21,7 @@ import React, { Component, InputHTMLAttributes, KeyboardEvent } from 'react';
 import classNames from 'classnames';
 import { Browser } from '../../../services/browser';
 import { CommonProps } from '../../common';
+import { ENTER } from '../../../services/key_codes';
 
 import {
   EuiFormControlLayout,
@@ -75,6 +76,8 @@ interface EuiFieldSearchState {
   value: string;
 }
 
+let isSearchSupported: boolean = false;
+
 export class EuiFieldSearch extends Component<
   EuiFieldSearchProps,
   EuiFieldSearchState
@@ -96,7 +99,8 @@ export class EuiFieldSearch extends Component<
 
   componentDidMount() {
     if (!this.inputElement) return;
-    if (Browser.isEventSupported('search', this.inputElement)) {
+    isSearchSupported = Browser.isEventSupported('search', this.inputElement);
+    if (isSearchSupported) {
       const onSearch = (event?: Event) => {
         if (this.props.onSearch) {
           if (!event || !event.target || event.defaultPrevented) return;
@@ -186,7 +190,10 @@ export class EuiFieldSearch extends Component<
         return;
       }
     }
-    if (onSearch && incremental) {
+    if (
+      onSearch &&
+      (incremental || (event.keyCode === ENTER && !isSearchSupported))
+    ) {
       onSearch((event.target as HTMLInputElement).value);
     }
   };

--- a/src/components/form/field_search/field_search.tsx
+++ b/src/components/form/field_search/field_search.tsx
@@ -190,9 +190,11 @@ export class EuiFieldSearch extends Component<
         return;
       }
     }
+
     if (
       onSearch &&
-      (incremental || (event.keyCode === ENTER && !isSearchSupported))
+      ((event.keyCode !== ENTER && incremental) ||
+        (event.keyCode === ENTER && !isSearchSupported))
     ) {
       onSearch((event.target as HTMLInputElement).value);
     }

--- a/src/components/form/field_search/field_search.tsx
+++ b/src/components/form/field_search/field_search.tsx
@@ -20,7 +20,6 @@
 import React, { Component, InputHTMLAttributes, KeyboardEvent } from 'react';
 import classNames from 'classnames';
 import { Browser } from '../../../services/browser';
-import { ENTER } from '../../../services/key_codes';
 import { CommonProps } from '../../common';
 
 import {
@@ -100,7 +99,7 @@ export class EuiFieldSearch extends Component<
     if (Browser.isEventSupported('search', this.inputElement)) {
       const onSearch = (event?: Event) => {
         if (this.props.onSearch) {
-          if (!event || !event.target) return;
+          if (!event || !event.target || event.defaultPrevented) return;
           this.props.onSearch((event.target as HTMLInputElement).value);
         }
       };
@@ -187,7 +186,7 @@ export class EuiFieldSearch extends Component<
         return;
       }
     }
-    if (onSearch && (incremental || event.keyCode === ENTER)) {
+    if (onSearch && incremental) {
       onSearch((event.target as HTMLInputElement).value);
     }
   };


### PR DESCRIPTION
### Summary

Fixes: #3420

I noticed that `onSearch` was called twice because of its binding with the input element during `componentDidMount` function as well as `onKeyUp` function. 

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [X] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
