### PR TITLE
[EuiDatePicker] `defaultProps` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fixed `EuiDatePickerRange` start date popover to sit left under the icon ([#3383](https://github.com/elastic/eui/pull/3383))
 - Fixed `EuiHeader` `z-index` issues with popovers and added body classes for the presence of `EuiFlyout` and `EuiCollapsibleNav.isOpen` ([#3398](https://github.com/elastic/eui/pull/3398))
 - Fixed `EuiInMemoryTable` data reset when filter is set and item is selected ([#3419](https://github.com/elastic/eui/pull/3419))
+- Fixed `popoverPlacement` default value for `EuiDatePicker` ([#3427](https://github.com/elastic/eui/pull/3427))
 
 ## [`23.1.0`](https://github.com/elastic/eui/tree/v23.1.0)
 

--- a/src/components/date_picker/date_picker.tsx
+++ b/src/components/date_picker/date_picker.tsx
@@ -108,7 +108,7 @@ export type EuiDatePickerProps = ApplyClassComponentDefaults<
 >;
 
 export class EuiDatePicker extends Component<_EuiDatePickerProps> {
-  static defaultProps = {
+  static defaultProps: Partial<_EuiDatePickerProps> = {
     adjustDateOnChange: true,
     dateFormat: euiDatePickerDefaultDateFormat,
     fullWidth: false,

--- a/src/components/date_picker/date_picker.tsx
+++ b/src/components/date_picker/date_picker.tsx
@@ -119,7 +119,7 @@ export class EuiDatePicker extends Component<_EuiDatePickerProps> {
     showIcon: true,
     showTimeSelect: false,
     timeFormat: euiDatePickerDefaultTimeFormat,
-    popoverPlacement: 'bottom-start' as const,
+    popoverPlacement: 'bottom-start' as _EuiDatePickerProps['popoverPlacement'],
   };
 
   render() {

--- a/src/components/date_picker/date_picker.tsx
+++ b/src/components/date_picker/date_picker.tsx
@@ -108,7 +108,7 @@ export type EuiDatePickerProps = ApplyClassComponentDefaults<
 >;
 
 export class EuiDatePicker extends Component<_EuiDatePickerProps> {
-  static defaultProps: Partial<_EuiDatePickerProps> = {
+  static defaultProps = {
     adjustDateOnChange: true,
     dateFormat: euiDatePickerDefaultDateFormat,
     fullWidth: false,
@@ -119,7 +119,7 @@ export class EuiDatePicker extends Component<_EuiDatePickerProps> {
     showIcon: true,
     showTimeSelect: false,
     timeFormat: euiDatePickerDefaultTimeFormat,
-    popoverPlacement: 'bottom-start',
+    popoverPlacement: 'bottom-start' as const,
   };
 
   render() {

--- a/src/components/date_picker/date_picker_range.tsx
+++ b/src/components/date_picker/date_picker_range.tsx
@@ -100,7 +100,7 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
         showIcon: false,
         fullWidth: fullWidth,
         readOnly: readOnly,
-        popoverPlacement: 'bottom-end',
+        popoverPlacement: 'bottom-end' as EuiDatePickerProps['popoverPlacement'],
       }
     );
   }

--- a/src/components/date_picker/date_picker_range.tsx
+++ b/src/components/date_picker/date_picker_range.tsx
@@ -100,7 +100,7 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
         showIcon: false,
         fullWidth: fullWidth,
         readOnly: readOnly,
-        popoverPlacement: 'bottom-end' as EuiDatePickerProps['popoverPlacement'],
+        popoverPlacement: 'bottom-end',
       }
     );
   }


### PR DESCRIPTION
### Summary

Resolves a type mismatch problem between the exported component interface (`EuiDatePickerProps`) and `defaultProps` interface in <b>EuiDatePicker</b>.

The component makes use of `ApplyClassComponentDefaults`, which in this case applies the inferred default type of `popoverPlacement` (`string | undefined`) over the explicit type defined in `_EuiDatePickerProps` (union type).

Resolved by using `as const` with the `popoverPlacement` default value.

(Kibana extends this component and the `...rest` interface errors as a mistype)

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~

- [x] Checked for **breaking changes** and labeled appropriately

~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
