### PR TITLE
Fix ApplyClassComponentDefaults's typing of a defaultProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `23.2.0`.
+**Bug Fixes**
+
+- Fixed `ApplyClassComponentDefaults` typescript utility to correctly determine defaulted properties' types ([#3425](https://github.com/elastic/eui/pull/3425))
 
 ## [`23.2.0`](https://github.com/elastic/eui/tree/v23.2.0)
 

--- a/src/components/common.ts
+++ b/src/components/common.ts
@@ -73,7 +73,11 @@ export type ApplyClassComponentDefaults<
   C extends new (...args: any) => any,
   D = ExtractDefaultProps<C>,
   P = ExtractProps<C>
-> = Omit<P, keyof D> & Partial<D>;
+> =
+  // definition of Props that are not defaulted
+  Omit<P, keyof D> &
+    // definition of Props, made optional, that are have keys in defaultProps
+    { [K in keyof D]?: K extends keyof P ? P[K] : never };
 
 /*
 https://github.com/Microsoft/TypeScript/issues/28339

--- a/src/components/date_picker/date_picker.tsx
+++ b/src/components/date_picker/date_picker.tsx
@@ -119,7 +119,7 @@ export class EuiDatePicker extends Component<_EuiDatePickerProps> {
     showIcon: true,
     showTimeSelect: false,
     timeFormat: euiDatePickerDefaultTimeFormat,
-    popoverPlacement: 'bottom-start' as _EuiDatePickerProps['popoverPlacement'],
+    popoverPlacement: 'bottom-start',
   };
 
   render() {


### PR DESCRIPTION
### Summary

`ApplyClassComponentDefaults` errantly applied TS's interpretation of `defaultProps` to the extracted definition, instead of using `defaultProps`'s keys to index/lookup the types already defined by the component's props.

I tested this change by mimicking a wrapping of the datepicker Kibana does, and using both that wrapper and EuiDatePicker directly in various configurations of required, defaulted, and omitted values.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
- [x] Props have proper **autodocs**
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
