### PR TITLE
Allow any character to be used in Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added `gutterSize` prop to `EuiFacetGroup` ([#3639](https://github.com/elastic/eui/pull/3639))
 - Updated props of `EuiCode` and `EuiCodeBlock` to reflect only functional props ([#3647](https://github.com/elastic/eui/pull/3647))
+- Extended `Query` / `EuiSearchBar` to allow any character inside double-quoted phrases ([#3432](https://github.com/elastic/eui/pull/3432))
 
 **Bug fixes**
 

--- a/src/components/search_bar/query/__snapshots__/ast_to_es_query_dsl.test.ts.snap
+++ b/src/components/search_bar/query/__snapshots__/ast_to_es_query_dsl.test.ts.snap
@@ -391,6 +391,20 @@ Object {
 }
 `;
 
+exports[`astToEsQueryDsl ast - name:"First \\"Nickname\\" Last" 1`] = `
+Object {
+  "bool": Object {
+    "must": Array [
+      Object {
+        "match_phrase": Object {
+          "name": "First \\"Nickname\\" Last",
+        },
+      },
+    ],
+  },
+}
+`;
+
 exports[`astToEsQueryDsl ast - name:john (is:enrolled OR Teacher) 1`] = `
 Object {
   "bool": Object {

--- a/src/components/search_bar/query/ast_to_es_query_dsl.test.ts
+++ b/src/components/search_bar/query/ast_to_es_query_dsl.test.ts
@@ -185,4 +185,11 @@ describe('astToEsQueryDsl', () => {
     );
     expect(query).toMatchSnapshot();
   });
+
+  test('ast - name:"First \\"Nickname\\" Last"', () => {
+    const query = astToEsQueryDsl(
+      AST.create([AST.Field.must.eq('name', 'First "Nickname" Last')])
+    );
+    expect(query).toMatchSnapshot();
+  });
 });

--- a/src/components/search_bar/query/ast_to_es_query_string.test.ts
+++ b/src/components/search_bar/query/ast_to_es_query_string.test.ts
@@ -180,4 +180,11 @@ describe('astToEsQueryString', () => {
     );
     expect(query).toBe('+name:john +(enrolled:true Teacher)');
   });
+
+  test('ast - name:"First \\"Nickname\\" Last"', () => {
+    const query = astToEsQueryString(
+      AST.create([AST.Field.must.eq('name', 'First "Nickname" Last')])
+    );
+    expect(query).toBe('+name:"First \\"Nickname\\" Last"');
+  });
 });

--- a/src/components/search_bar/query/ast_to_es_query_string.ts
+++ b/src/components/search_bar/query/ast_to_es_query_string.ts
@@ -48,6 +48,13 @@ const emitMatch = (match: MatchType | undefined) => {
   return AST.Match.isMust(match) ? '+' : '-';
 };
 
+const escapeValue = (value: Value) => {
+  if (typeof value === 'string') {
+    return value.replace(/([\\"])/g, '\\$1');
+  }
+  return value;
+};
+
 const emitFieldDateLikeClause = (
   field: string,
   value: moment.Moment | Date,
@@ -139,9 +146,9 @@ const emitFieldStringClause = (
 ) => {
   const matchOp = emitMatch(match);
   if (value.match(/\s/)) {
-    return `${matchOp}${field}:"${value}"`;
+    return `${matchOp}${field}:"${escapeValue(value)}"`;
   }
-  return `${matchOp}${field}:${value}`;
+  return `${matchOp}${field}:${escapeValue(value)}`;
 };
 
 const emitFieldBooleanClause = (
@@ -205,7 +212,7 @@ const emitTermClause = (clause: TermClause, isGroupMember: boolean): string => {
   }
 
   const matchOp = emitMatch(match);
-  return `${matchOp}${value}`;
+  return `${matchOp}${escapeValue(value)}`;
 };
 
 const emitIsClause = (clause: IsClause, isGroupMember: boolean): string => {

--- a/src/components/search_bar/query/default_syntax.test.ts
+++ b/src/components/search_bar/query/default_syntax.test.ts
@@ -468,7 +468,7 @@ describe('defaultSyntax', () => {
     expect(clause.value).toBe('foo (bar)');
 
     const printedQuery = defaultSyntax.print(ast);
-    expect(printedQuery).toBe('"foo \\(bar\\)"');
+    expect(printedQuery).toBe('"foo (bar)"');
   });
 
   test('field phrases', () => {
@@ -589,6 +589,25 @@ describe('defaultSyntax', () => {
 
     const printedQuery = defaultSyntax.print(ast);
     expect(printedQuery).toBe('f:"this is a relaxed phrase"');
+  });
+
+  test('phrases with extra characters', () => {
+    const term = '& _ - \\\\ \\" \' or OR < > ? : @';
+    const term_unescaped = term.replace(/\\(.)/g, '$1');
+    const query = `"${term}"`;
+    const ast = defaultSyntax.parse(query);
+
+    expect(ast).toBeDefined();
+    expect(ast.clauses).toHaveLength(1);
+
+    const clause: Clause = ast.getTermClause(term_unescaped)!;
+    expect(clause).toBeDefined();
+    expect(AST.Term.isInstance(clause)).toBe(true);
+    expect(AST.Match.isMustClause(clause)).toBe(true);
+    expect(clause.value).toBe(term_unescaped);
+
+    const printedQuery = defaultSyntax.print(ast);
+    expect(printedQuery).toBe(query);
   });
 
   test('single term or expression', () => {

--- a/src/components/search_bar/query/default_syntax.ts
+++ b/src/components/search_bar/query/default_syntax.ts
@@ -26,7 +26,7 @@ import peg from 'pegjs-inline-precompile'; // eslint-disable-line import/no-unre
 
 const parser = peg`
 {
-  const { AST, Exp, unescapeValue, resolveFieldValue } = options;
+  const { AST, Exp, unescapeValue, unescapePhraseValue, resolveFieldValue } = options;
   const ctx = Object.assign({ error }, options );
 }
 
@@ -158,15 +158,14 @@ containsValue
 
 phrase
   = '"' space? phrase:(
-  	(phraseWord+)? (space phraseWord+)* { return unescapeValue(text()); }
+  	(phraseWord+)? (space phraseWord+)* { return unescapePhraseValue(text()); }
   ) space? '"' { return Exp.string(phrase, location()); }
 
 phraseWord
+  // not a backslash, quote, or space
   = [^\\\\" ]+
-  / '\\\\"'
-//  = orWord
-//  / word
-//  / [()] // adding parens directly to "wordChar" makes it too aggresive as it consumes the closing paren
+  // escaped character
+  / '\\\\' (.)
 
 word
   = wordChar+ {
@@ -278,6 +277,14 @@ const unescapeValue = (value: string) => {
 
 const escapeValue = (value: string) => {
   return value.replace(/([:\-\\()])/g, '\\$1');
+};
+
+const unescapePhraseValue = (value: string) => {
+  return value.replace(/\\(.)/g, '$1');
+};
+
+const escapePhraseValue = (value: string) => {
+  return value.replace(/([\\"])/g, '\\$1');
 };
 
 const escapeFieldValue = (value: string) => {
@@ -456,10 +463,11 @@ const printValue = (value: Value, options: ParseOptions) => {
     return value.toString();
   }
 
-  const escapeFn = options.escapeValue || escapeValue;
   if (value.length === 0 || value.match(/\s/) || value.toLowerCase() === 'or') {
-    return `"${escapeFn(value)}"`;
+    return `"${escapePhraseValue(value)}"`;
   }
+
+  const escapeFn = options.escapeValue || escapeValue;
   return escapeFn(value);
 };
 
@@ -497,6 +505,7 @@ export const defaultSyntax: Syntax = Object.freeze({
       AST,
       Exp,
       unescapeValue,
+      unescapePhraseValue,
       parseDate,
       resolveFieldValue,
       validateFlag,

--- a/src/components/search_bar/query/default_syntax.ts
+++ b/src/components/search_bar/query/default_syntax.ts
@@ -162,9 +162,11 @@ phrase
   ) space? '"' { return Exp.string(phrase, location()); }
 
 phraseWord
-  = orWord
-  / word
-  / [()] // adding parens directly to "wordChar" makes it too aggresive as it consumes the closing paren
+  = [^\\\\" ]+
+  / '\\\\"'
+//  = orWord
+//  / word
+//  / [()] // adding parens directly to "wordChar" makes it too aggresive as it consumes the closing paren
 
 word
   = wordChar+ {


### PR DESCRIPTION
### Summary

Closes #2325 and closes #3426

* Updated query syntax to allow any character inside double-quoted phrases; `"` and `\` characters must be escaped with a backslash
* Added unit test covering AST->ES DSL generation when a `"` or `\` is present
* Updated AST -> ES querystring conversion and added a unit test to escape `"` and `\` characters

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
