### PR TITLE
Ensure `string` return from `prettyDuration` util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - Fixed `EuiCode` and `EuiCodeBlock` from erroring in environments without a DOM implementation ([#3405](https://github.com/elastic/eui/pull/3405))
 - Fixed `ApplyClassComponentDefaults` typescript utility to correctly determine defaulted properties' types ([#3430](https://github.com/elastic/eui/pull/3430))
+- Fixed `prettyDuration` return type to be `string`, use fallback value  ([#3438](https://github.com/elastic/eui/pull/3438))
 
 ## [`23.2.0`](https://github.com/elastic/eui/tree/v23.2.0)
 

--- a/src/components/date_picker/super_date_picker/pretty_duration.ts
+++ b/src/components/date_picker/super_date_picker/pretty_duration.ts
@@ -87,7 +87,7 @@ export function prettyDuration(
       return timeFrom === quickFrom && timeTo === quickTo;
     }
   );
-  if (matchingQuickRange) {
+  if (matchingQuickRange && matchingQuickRange.label) {
     return matchingQuickRange.label;
   }
 


### PR DESCRIPTION
### Summary

The `prettyDuration` util function has an implicit `string | undefined` return type because of `matchingQuickRange.label`.
`matchingQuickRange.label` should allow `undefined`, but `prettyDuration` has a fallback value (`cantLookup(...)`) that should be used in place of an empty label.

Kibana indirectly uses `prettyDuration` and correctly expects a `string` for output.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~

- [x] Checked for **breaking changes** and labeled appropriately

~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
