### PR TITLE
Ensure correct display name for `forwardRef` components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added `aria-hidden = true` to `EuiRangeSlider` and `EuiRangeTrack` if `showInput = true` ([#3423](https://github.com/elastic/eui/pull/3423))
 - Added `testenv` mock for `EuiCode` and `EuiCodeBlock` ([#3405](https://github.com/elastic/eui/pull/3405))
+- Added `displayName` to components using `React.forwardRef` ([#3440](https://github.com/elastic/eui/pull/3440))
 
 **Bug Fixes**
 

--- a/src/components/badge/badge_group/badge_group.tsx
+++ b/src/components/badge/badge_group/badge_group.tsx
@@ -42,7 +42,7 @@ export interface EuiBadgeGroupProps {
   children?: ReactNode;
 }
 
-export const EuiBadgeGroup = React.forwardRef<
+const EuiBadgeGroup = React.forwardRef<
   HTMLDivElement,
   CommonProps & HTMLAttributes<HTMLDivElement> & EuiBadgeGroupProps
 >(
@@ -65,3 +65,6 @@ export const EuiBadgeGroup = React.forwardRef<
     );
   }
 );
+
+EuiBadgeGroup.displayName = 'EuiBadgeGroup';
+export { EuiBadgeGroup };

--- a/src/components/badge/badge_group/badge_group.tsx
+++ b/src/components/badge/badge_group/badge_group.tsx
@@ -42,7 +42,7 @@ export interface EuiBadgeGroupProps {
   children?: ReactNode;
 }
 
-const EuiBadgeGroup = React.forwardRef<
+export const EuiBadgeGroup = React.forwardRef<
   HTMLDivElement,
   CommonProps & HTMLAttributes<HTMLDivElement> & EuiBadgeGroupProps
 >(
@@ -67,4 +67,3 @@ const EuiBadgeGroup = React.forwardRef<
 );
 
 EuiBadgeGroup.displayName = 'EuiBadgeGroup';
-export { EuiBadgeGroup };

--- a/src/components/header/header_section/header_section_item_button.tsx
+++ b/src/components/header/header_section/header_section_item_button.tsx
@@ -40,7 +40,7 @@ type Props = CommonProps &
 
 export type EuiHeaderSectionItemButtonRef = HTMLButtonElement;
 
-const EuiHeaderSectionItemButton = React.forwardRef<
+export const EuiHeaderSectionItemButton = React.forwardRef<
   EuiHeaderSectionItemButtonRef,
   PropsWithChildren<Props>
 >(
@@ -76,4 +76,3 @@ const EuiHeaderSectionItemButton = React.forwardRef<
 );
 
 EuiHeaderSectionItemButton.displayName = 'EuiHeaderSectionItemButton';
-export { EuiHeaderSectionItemButton };

--- a/src/components/header/header_section/header_section_item_button.tsx
+++ b/src/components/header/header_section/header_section_item_button.tsx
@@ -40,7 +40,7 @@ type Props = CommonProps &
 
 export type EuiHeaderSectionItemButtonRef = HTMLButtonElement;
 
-export const EuiHeaderSectionItemButton = React.forwardRef<
+const EuiHeaderSectionItemButton = React.forwardRef<
   EuiHeaderSectionItemButtonRef,
   PropsWithChildren<Props>
 >(
@@ -74,3 +74,6 @@ export const EuiHeaderSectionItemButton = React.forwardRef<
     );
   }
 );
+
+EuiHeaderSectionItemButton.displayName = 'EuiHeaderSectionItemButton';
+export { EuiHeaderSectionItemButton };

--- a/src/components/tabs/tabbed_content/__snapshots__/tabbed_content.test.tsx.snap
+++ b/src/components/tabs/tabbed_content/__snapshots__/tabbed_content.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`EuiTabbedContent behavior when uncontrolled, the selected tab should up
   }
 >
   <div>
-    <ForwardRef
+    <EuiTabs
       onFocus={[Function]}
     >
       <div
@@ -135,7 +135,7 @@ exports[`EuiTabbedContent behavior when uncontrolled, the selected tab should up
           </button>
         </EuiTab>
       </div>
-    </ForwardRef>
+    </EuiTabs>
     <div
       aria-labelledby="kibana"
       id="42"

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -55,10 +55,7 @@ export type EuiTabsProps = CommonProps &
 
 export type EuiTabRef = HTMLDivElement;
 
-export const EuiTabs = React.forwardRef<
-  EuiTabRef,
-  PropsWithChildren<EuiTabsProps>
->(
+const EuiTabs = React.forwardRef<EuiTabRef, PropsWithChildren<EuiTabsProps>>(
   (
     {
       children,
@@ -87,3 +84,6 @@ export const EuiTabs = React.forwardRef<
     );
   }
 );
+
+EuiTabs.displayName = 'EuiTabs';
+export { EuiTabs };

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -55,7 +55,10 @@ export type EuiTabsProps = CommonProps &
 
 export type EuiTabRef = HTMLDivElement;
 
-const EuiTabs = React.forwardRef<EuiTabRef, PropsWithChildren<EuiTabsProps>>(
+export const EuiTabs = React.forwardRef<
+  EuiTabRef,
+  PropsWithChildren<EuiTabsProps>
+>(
   (
     {
       children,
@@ -86,4 +89,3 @@ const EuiTabs = React.forwardRef<EuiTabRef, PropsWithChildren<EuiTabsProps>>(
 );
 
 EuiTabs.displayName = 'EuiTabs';
-export { EuiTabs };


### PR DESCRIPTION
### Summary

Set `displayName` value for top-level components using `React.forwardRef`. Otherwise, each component renders as `<ForwardRef>` in shapshots and React dev tools.

Eliminates snapshot churn Kibana.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~

- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately

~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
