### PR TITLE
[Docs] 'Demo JS' tab error fix

### DIFF
--- a/src-docs/src/components/guide_section/guide_section.js
+++ b/src-docs/src/components/guide_section/guide_section.js
@@ -208,7 +208,15 @@ export class GuideSection extends Component {
       }
     }
 
-    this.setState({ selectedTab, renderedCode });
+    this.setState({ selectedTab, renderedCode }, () => {
+      if (name === 'javascript') {
+        requestAnimationFrame(() => {
+          const pre = this.refs.javascript.querySelector('.euiCodeBlock__pre');
+          if (!pre) return;
+          pre.scrollTop = this.memoScroll;
+        });
+      }
+    });
   };
 
   renderTabs() {
@@ -433,13 +441,6 @@ export class GuideSection extends Component {
         )}
       </div>
     );
-  }
-
-  componentDidUpdate() {
-    if (this.state.selectedTab.name === 'javascript') {
-      const pre = this.refs.javascript.querySelector('.euiCodeBlock__pre');
-      pre.scrollTop = this.memoScroll;
-    }
   }
 
   renderCode(name) {


### PR DESCRIPTION
### Summary

Fixes a race condition where _sometimes_ the content of the Demo JS is not available when the `scrollTop` check is done on an internal element.

This fix does a few things:
1) Moves the check closer to where the tab switch happens and calls it fewer times
2) Adds some wait time via `requestAnimationFrame`
3) Checks for existence of the element, just in case.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
