### PR TITLE
Adding `react-axe`

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "puppeteer": "^2.0.0",
     "raw-loader": "^0.5.1",
     "react": "^16.12.0",
+    "react-axe": "^3.4.1",
     "react-dom": "^16.12.0",
     "react-redux": "^5.1.2",
     "react-router": "^3.2.5",

--- a/src-docs/src/index.js
+++ b/src-docs/src/index.js
@@ -22,6 +22,11 @@ import themeDark from './theme_dark.scss';
 import themeAmsterdamLight from './theme_amsterdam_light.scss';
 import themeAmsterdamDark from './theme_amsterdam_dark.scss';
 
+if (process.env.NODE_ENV === 'development') {
+  const axe = require('react-axe');
+  axe(React, ReactDOM, 1000);
+}
+
 registerTheme('light', [themeLight]);
 registerTheme('dark', [themeDark]);
 registerTheme('amsterdam-light', [themeAmsterdamLight]);

--- a/src/components/key_pad_menu/__snapshots__/key_pad_menu.test.tsx.snap
+++ b/src/components/key_pad_menu/__snapshots__/key_pad_menu.test.tsx.snap
@@ -5,6 +5,5 @@ exports[`EuiKeyPadMenu is rendered 1`] = `
   aria-label="aria-label"
   class="euiKeyPadMenu testClass1 testClass2"
   data-test-subj="test subject string"
-  role="menu"
 />
 `;

--- a/src/components/key_pad_menu/key_pad_menu.tsx
+++ b/src/components/key_pad_menu/key_pad_menu.tsx
@@ -32,7 +32,7 @@ export const EuiKeyPadMenu: FunctionComponent<EuiKeyPadMenuProps> = ({
   const classes = classNames('euiKeyPadMenu', className);
 
   return (
-    <div className={classes} role="menu" {...rest}>
+    <div className={classes} {...rest}>
       {children}
     </div>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2192,6 +2192,11 @@ axe-core@^3.1.2, axe-core@^3.3.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.4.0.tgz#a57ee620c182d5389aff229586aaae06bc541abe"
   integrity sha512-5C0OdgxPv/DrQguO6Taj5F1dY5OlkWg4SVmZIVABFYKWlnAc5WTLPzG+xJSgIwf2fmY+NiNGiZXhXx2qT0u/9Q==
 
+axe-core@^3.5.0:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.3.tgz#5b7c0ee7c5197d546bd3a07c3ef701896f5773e9"
+  integrity sha512-HZpLE7xu05+8AbpqXITGdxp1Xwk8ysAXrg7MiKRY27py3DAyEJpoJQo1727pWF3F+O79V3r+cTWhOzfB49P89w==
+
 axe-puppeteer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/axe-puppeteer/-/axe-puppeteer-1.0.0.tgz#cebbeec2c65a2e0cb7d5fd1e7aef26c5f71895a4"
@@ -12407,6 +12412,14 @@ react-ace@^7.0.5:
     lodash.isequal "^4.5.0"
     prop-types "^15.7.2"
 
+react-axe@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/react-axe/-/react-axe-3.4.1.tgz#8874ca48b5af71452d97c2991d37cdcbba6c3a48"
+  integrity sha512-1UDeqesgb5gCj2XPE5WXqKv2xcwGGeWIock3uBVtZSVGbZGVzjmgYf4eRyNJ8BNnHpPQKUs4Ro5jW2+V037deg==
+  dependencies:
+    axe-core "^3.5.0"
+    requestidlecallback "^0.3.0"
+
 react-beautiful-dnd@^13.0.0:
   version "13.0.0"
   resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.0.0.tgz#f70cc8ff82b84bc718f8af157c9f95757a6c3b40"
@@ -13127,6 +13140,11 @@ request@2.88.0, request@^2.65.0, request@^2.74.0, request@^2.78.0, request@^2.83
     tough-cookie "~2.4.3"
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
+
+requestidlecallback@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/requestidlecallback/-/requestidlecallback-0.3.0.tgz#6fb74e0733f90df3faa4838f9f6a2a5f9b742ac5"
+  integrity sha1-b7dOBzP5DfP6pIOPn2oqX5t0KsU=
 
 require-directory@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
### Summary

`react-axe` adds axe errors to the dev console only in dev mode.

It's the same errors that our axe testing can provide already and is the same errors as the axe plugin but I think this compliments the other two nicely for a few reasons:
- We've disabled color contrast for our axe testing because we have more known errors there than makes sense to individually disable. However, we also have unknown errors so showing all errors in the console can expose the unknown errors without causing failures.
- We haven't turned on testing for all pages yet and the effort is somewhat stalled in rollout because fixing errors takes time. These console messages don't need to be resolved immediately so they do a good job of highlighting the problems without making them blockers.
- It's easy to forget to run the axe plugin all the time so it seems sensible to do it for you. It also works on every component render so it will catch more component states easily.
- It's easier to run the axe plugin for everyone instead of educating everyone on installing the axe plugin at all.

Just clicking around our docs page, it helped me spot a really low-hanging issue we had on our **KeyPadMenu** component so it's had payoff really quickly.