### PR TITLE
[Docs] Add EuiExpression snippets

### DIFF
--- a/src-docs/src/views/expression/expression_example.js
+++ b/src-docs/src/views/expression/expression_example.js
@@ -11,14 +11,37 @@ import { EuiExpression } from '../../../../src/components/expression';
 import Expression from './expression';
 const expressionSource = require('!!raw-loader!./expression');
 const expressionHtml = renderToHtml(Expression);
+const expressionSnippet = `<EuiExpression
+  description="description"
+  value={value}
+  isActive={isActive}
+  onClick={handleClick}
+/>`;
 
 import Colors from './colors';
 const colorSource = require('!!raw-loader!./colors');
 const colorHtml = renderToHtml(Colors);
+const colorSnippet = `<EuiExpression 
+  description="description" 
+  value={value}
+  color="primary" 
+/>`;
 
 import Stringing from './stringing';
 const stringingSource = require('!!raw-loader!./stringing');
 const stringingHtml = renderToHtml(Stringing);
+const stringingSnippet = `<div>
+  <EuiExpression
+    description="description1"
+    value={value1}
+    onClick={handleClick1}
+  />
+  <EuiExpression
+    description="description2"
+    value={value2}
+    onClick={handleClick2}
+  />
+</div>`;
 
 export const ExpressionExample = {
   title: 'Expression',
@@ -45,6 +68,7 @@ export const ExpressionExample = {
         </p>
       ),
       props: { EuiExpression },
+      snippet: expressionSnippet,
       demo: <Expression />,
     },
     {
@@ -65,6 +89,7 @@ export const ExpressionExample = {
           the <EuiCode>description</EuiCode>.
         </p>
       ),
+      snippet: colorSnippet,
       demo: <Colors />,
     },
     {
@@ -86,6 +111,7 @@ export const ExpressionExample = {
           and wrap at logical points.
         </p>
       ),
+      snippet: stringingSnippet,
       demo: <Stringing />,
     },
   ],


### PR DESCRIPTION
### Summary

This PR adds  snippets to`EuiExpression` following our "Adding snippets" documentation.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
