### PR TITLE
[EuiCodeEditor] Console error when using the editor without import the default theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added `utcOffset` prop to `EuiSuperDatePicker` ([#3436](https://github.com/elastic/eui/pull/3436))
 - Added `partition` key to `EuiChartThemeType` for Partition chart support ([#3387](https://github.com/elastic/eui/pull/3387))
 - Updated `EuiImage`'s `caption` prop type from `string` to `ReactNode` ([#3387](https://github.com/elastic/eui/pull/3387))
+- Fixed `EuiCodeEditor` console error when using the editor without import the default theme ([#3454](https://github.com/elastic/eui/pull/3454))
 
 **Bug Fixes**
 

--- a/src/components/code_editor/__snapshots__/code_editor.test.tsx.snap
+++ b/src/components/code_editor/__snapshots__/code_editor.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`EuiCodeEditor is rendered 1`] = `
     </p>
   </div>
   <div
-    class=" ace_editor ace-github testClass1 testClass2"
+    class=" ace_editor ace-tm testClass1 testClass2"
     id="htmlId"
     style="width: 500px; height: 500px;"
   >
@@ -203,7 +203,7 @@ exports[`EuiCodeEditor props aria attributes allows setting aria-describedby on 
     </p>
   </div>
   <div
-    class=" ace_editor ace-github"
+    class=" ace_editor ace-tm"
     id="htmlId"
     style="width: 500px; height: 500px;"
   >
@@ -319,7 +319,7 @@ exports[`EuiCodeEditor props aria attributes allows setting aria-labelledby on t
     </p>
   </div>
   <div
-    class=" ace_editor ace-github"
+    class=" ace_editor ace-tm"
     id="htmlId"
     style="width: 500px; height: 500px;"
   >
@@ -435,7 +435,7 @@ exports[`EuiCodeEditor props isReadOnly renders alternate hint text 1`] = `
     </p>
   </div>
   <div
-    class=" ace_editor ace-github"
+    class=" ace_editor ace-tm"
     id="htmlId"
     style="width: 500px; height: 500px;"
   >

--- a/src/components/code_editor/__snapshots__/code_editor.test.tsx.snap
+++ b/src/components/code_editor/__snapshots__/code_editor.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`EuiCodeEditor is rendered 1`] = `
     </p>
   </div>
   <div
-    class=" ace_editor ace-tm testClass1 testClass2"
+    class=" ace_editor ace-github testClass1 testClass2"
     id="htmlId"
     style="width: 500px; height: 500px;"
   >
@@ -203,7 +203,7 @@ exports[`EuiCodeEditor props aria attributes allows setting aria-describedby on 
     </p>
   </div>
   <div
-    class=" ace_editor ace-tm"
+    class=" ace_editor ace-github"
     id="htmlId"
     style="width: 500px; height: 500px;"
   >
@@ -319,7 +319,7 @@ exports[`EuiCodeEditor props aria attributes allows setting aria-labelledby on t
     </p>
   </div>
   <div
-    class=" ace_editor ace-tm"
+    class=" ace_editor ace-github"
     id="htmlId"
     style="width: 500px; height: 500px;"
   >
@@ -435,7 +435,7 @@ exports[`EuiCodeEditor props isReadOnly renders alternate hint text 1`] = `
     </p>
   </div>
   <div
-    class=" ace_editor ace-tm"
+    class=" ace_editor ace-github"
     id="htmlId"
     style="width: 500px; height: 500px;"
   >

--- a/src/components/code_editor/code_editor.tsx
+++ b/src/components/code_editor/code_editor.tsx
@@ -25,10 +25,8 @@ import { keysOf } from '../common';
 import { htmlIdGenerator, keyCodes } from '../../services';
 import { EuiI18n } from '../i18n';
 
-import 'brace/theme/github';
-
 const DEFAULT_MODE = 'text';
-const DEFAULT_THEME = 'github';
+const DEFAULT_THEME = 'textmate';
 
 function setOrRemoveAttribute(
   element: HTMLTextAreaElement,

--- a/src/components/code_editor/code_editor.tsx
+++ b/src/components/code_editor/code_editor.tsx
@@ -25,7 +25,10 @@ import { keysOf } from '../common';
 import { htmlIdGenerator, keyCodes } from '../../services';
 import { EuiI18n } from '../i18n';
 
+import 'brace/theme/github';
+
 const DEFAULT_MODE = 'text';
+const DEFAULT_THEME = 'github';
 
 function setOrRemoveAttribute(
   element: HTMLTextAreaElement,
@@ -215,7 +218,7 @@ export class EuiCodeEditor extends Component<
       cursorStart,
       mode = DEFAULT_MODE,
       'data-test-subj': dataTestSubj = 'codeEditorContainer',
-      theme = 'github',
+      theme = DEFAULT_THEME,
       ...rest
     } = this.props;
 


### PR DESCRIPTION
### Summary

In #2970 the default value for the theme was set to `github`. As a result, now we have many places in `Kibana` where we need to import this theme even if we don't want to specify theme (remind you it's optional property). 

Related issue in Kibana repo: 
https://github.com/elastic/kibana/issues/56424

I think if we decided to set `github` as a default theme, it should be loaded here

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
