### PR TITLE
[DOCS] Fixed import statements for EuiResizableContainer

### DIFF
--- a/src-docs/src/views/resizable_container/resizable_container_basic.js
+++ b/src-docs/src/views/resizable_container/resizable_container_basic.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { EuiText, EuiResizableContainer } from '../../../../src';
+import { EuiText, EuiResizableContainer } from '../../../../src/components';
 
 const text = require('!!raw-loader!./lorem.txt');
 

--- a/src-docs/src/views/resizable_container/resizable_container_reset_values.js
+++ b/src-docs/src/views/resizable_container/resizable_container_reset_values.js
@@ -7,7 +7,7 @@ import {
   EuiResizableContainer,
   EuiButton,
   EuiSpacer,
-} from '../../../../src';
+} from '../../../../src/components';
 
 const text = require('!!raw-loader!./lorem.txt');
 

--- a/src-docs/src/views/resizable_container/resizable_container_three_panels.js
+++ b/src-docs/src/views/resizable_container/resizable_container_three_panels.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { EuiText, EuiResizableContainer } from '../../../../src';
+import { EuiText, EuiResizableContainer } from '../../../../src/components';
 
 const text = require('!!raw-loader!./lorem.txt');
 

--- a/src-docs/src/views/resizable_container/resizable_container_vertical.js
+++ b/src-docs/src/views/resizable_container/resizable_container_vertical.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { EuiText, EuiResizableContainer } from '../../../../src';
+import { EuiText, EuiResizableContainer } from '../../../../src/components';
 
 const text = require('!!raw-loader!./lorem.txt');
 

--- a/src-docs/src/views/resizable_container/resizable_resizer_size.js
+++ b/src-docs/src/views/resizable_container/resizable_resizer_size.js
@@ -1,6 +1,10 @@
 import React from 'react';
 
-import { EuiText, EuiCode, EuiResizableContainer } from '../../../../src';
+import {
+  EuiText,
+  EuiCode,
+  EuiResizableContainer,
+} from '../../../../src/components';
 
 export default () => (
   <EuiResizableContainer style={{ height: '200px' }}>


### PR DESCRIPTION
### Summary

Fixes: #3444

used `'../../../../src/components';` instead of `'../../../../src';` as per the function requirements to classify services , utils , components

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs*~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
