### PR TITLE
Improve contrast for EuiCollapsibleNav close link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Added `sortBy` and `sortShift` props to `euiPaletteColorBlind()` for sorting along the color wheel ([#3387](https://github.com/elastic/eui/pull/3387))
 - Added `partition` key to `EuiChartThemeType` for Partition chart support ([#3387](https://github.com/elastic/eui/pull/3387))
 - Updated `EuiImage`'s `caption` prop type from `string` to `ReactNode` ([#3387](https://github.com/elastic/eui/pull/3387))
-- Improved contrast for `EuiCollapsibleNav` close button ([#3387](https://github.com/elastic/eui/pull/3387))
+- Improved contrast for `EuiCollapsibleNav` close button ([#3465](https://github.com/elastic/eui/pull/3465))
 
 **Breaking changes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added `sortBy` and `sortShift` props to `euiPaletteColorBlind()` for sorting along the color wheel ([#3387](https://github.com/elastic/eui/pull/3387))
 - Added `partition` key to `EuiChartThemeType` for Partition chart support ([#3387](https://github.com/elastic/eui/pull/3387))
 - Updated `EuiImage`'s `caption` prop type from `string` to `ReactNode` ([#3387](https://github.com/elastic/eui/pull/3387))
+- Improved contrast for `EuiCollapsibleNav` close button ([#3387](https://github.com/elastic/eui/pull/3387))
 
 **Breaking changes**
 

--- a/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
@@ -69,7 +69,7 @@ Array [
               class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
             >
               <span
-                class="euiCollapsibleNav__closeButtonLabel"
+                class="eui-hideFor--xs"
               >
                 close
               </span>
@@ -128,7 +128,7 @@ Array [
               class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
             >
               <span
-                class="euiCollapsibleNav__closeButtonLabel"
+                class="eui-hideFor--xs"
               >
                 close
               </span>
@@ -189,7 +189,7 @@ Array [
               class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
             >
               <span
-                class="euiCollapsibleNav__closeButtonLabel"
+                class="eui-hideFor--xs"
               >
                 close
               </span>
@@ -244,7 +244,7 @@ Array [
               class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
             >
               <span
-                class="euiCollapsibleNav__closeButtonLabel"
+                class="eui-hideFor--xs"
               >
                 close
               </span>
@@ -297,7 +297,7 @@ exports[`EuiCollapsibleNav props isDocked 1`] = `
             class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
           >
             <span
-              class="euiCollapsibleNav__closeButtonLabel"
+              class="eui-hideFor--xs"
             >
               close
             </span>
@@ -351,7 +351,7 @@ Array [
               class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
             >
               <span
-                class="euiCollapsibleNav__closeButtonLabel"
+                class="eui-hideFor--xs"
               >
                 close
               </span>
@@ -411,7 +411,7 @@ Array [
               class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
             >
               <span
-                class="euiCollapsibleNav__closeButtonLabel"
+                class="eui-hideFor--xs"
               >
                 close
               </span>

--- a/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
@@ -53,7 +53,7 @@ Array [
         id="id"
       >
         <button
-          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiCollapsibleNav__closeButton class"
+          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton class"
           data-test-subj="test"
           type="button"
         >
@@ -113,7 +113,7 @@ Array [
         id="id"
       >
         <button
-          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiCollapsibleNav__closeButton"
+          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
           type="button"
         >
           <span
@@ -174,7 +174,7 @@ Array [
         id="id"
       >
         <button
-          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiCollapsibleNav__closeButton"
+          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
           type="button"
         >
           <span
@@ -229,7 +229,7 @@ Array [
         id="id"
       >
         <button
-          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiCollapsibleNav__closeButton"
+          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
           type="button"
         >
           <span
@@ -282,7 +282,7 @@ exports[`EuiCollapsibleNav props isDocked 1`] = `
       id="id"
     >
       <button
-        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiCollapsibleNav__closeButton"
+        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
         type="button"
       >
         <span
@@ -336,7 +336,7 @@ Array [
         id="id"
       >
         <button
-          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiCollapsibleNav__closeButton"
+          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
           type="button"
         >
           <span
@@ -396,7 +396,7 @@ Array [
         id="id"
       >
         <button
-          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiCollapsibleNav__closeButton"
+          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiScreenReaderOnly--showOnFocus euiCollapsibleNav__closeButton"
           type="button"
         >
           <span

--- a/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
@@ -68,11 +68,7 @@ Array [
             <span
               class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
             >
-              <span
-                class="eui-hideFor--xs"
-              >
-                close
-              </span>
+              close
             </span>
           </span>
         </button>
@@ -127,11 +123,7 @@ Array [
             <span
               class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
             >
-              <span
-                class="eui-hideFor--xs"
-              >
-                close
-              </span>
+              close
             </span>
           </span>
         </button>
@@ -188,11 +180,7 @@ Array [
             <span
               class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
             >
-              <span
-                class="eui-hideFor--xs"
-              >
-                close
-              </span>
+              close
             </span>
           </span>
         </button>
@@ -243,11 +231,7 @@ Array [
             <span
               class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
             >
-              <span
-                class="eui-hideFor--xs"
-              >
-                close
-              </span>
+              close
             </span>
           </span>
         </button>
@@ -296,11 +280,7 @@ exports[`EuiCollapsibleNav props isDocked 1`] = `
           <span
             class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
           >
-            <span
-              class="eui-hideFor--xs"
-            >
-              close
-            </span>
+            close
           </span>
         </span>
       </button>
@@ -350,11 +330,7 @@ Array [
             <span
               class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
             >
-              <span
-                class="eui-hideFor--xs"
-              >
-                close
-              </span>
+              close
             </span>
           </span>
         </button>
@@ -410,11 +386,7 @@ Array [
             <span
               class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
             >
-              <span
-                class="eui-hideFor--xs"
-              >
-                close
-              </span>
+              close
             </span>
           </span>
         </button>

--- a/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
@@ -66,7 +66,7 @@ Array [
               data-euiicon-type="cross"
             />
             <span
-              class="euiButtonEmpty__text"
+              class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
             >
               <span
                 class="euiCollapsibleNav__closeButtonLabel"
@@ -125,7 +125,7 @@ Array [
               data-euiicon-type="cross"
             />
             <span
-              class="euiButtonEmpty__text"
+              class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
             >
               <span
                 class="euiCollapsibleNav__closeButtonLabel"
@@ -186,7 +186,7 @@ Array [
               data-euiicon-type="cross"
             />
             <span
-              class="euiButtonEmpty__text"
+              class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
             >
               <span
                 class="euiCollapsibleNav__closeButtonLabel"
@@ -241,7 +241,7 @@ Array [
               data-euiicon-type="cross"
             />
             <span
-              class="euiButtonEmpty__text"
+              class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
             >
               <span
                 class="euiCollapsibleNav__closeButtonLabel"
@@ -294,7 +294,7 @@ exports[`EuiCollapsibleNav props isDocked 1`] = `
             data-euiicon-type="cross"
           />
           <span
-            class="euiButtonEmpty__text"
+            class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
           >
             <span
               class="euiCollapsibleNav__closeButtonLabel"
@@ -348,7 +348,7 @@ Array [
               data-euiicon-type="cross"
             />
             <span
-              class="euiButtonEmpty__text"
+              class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
             >
               <span
                 class="euiCollapsibleNav__closeButtonLabel"
@@ -408,7 +408,7 @@ Array [
               data-euiicon-type="cross"
             />
             <span
-              class="euiButtonEmpty__text"
+              class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
             >
               <span
                 class="euiCollapsibleNav__closeButtonLabel"

--- a/src/components/collapsible_nav/_collapsible_nav.scss
+++ b/src/components/collapsible_nav/_collapsible_nav.scss
@@ -50,6 +50,10 @@
   // At tiny screens, reduce the close button to a simple `x`
   .euiCollapsibleNav__closeButton {
     margin-right: -15%;
+
+    .euiButtonEmpty__text {
+      margin-left: 0;
+    }
   }
 
   .euiCollapsibleNav__closeButtonLabel {

--- a/src/components/collapsible_nav/_collapsible_nav.scss
+++ b/src/components/collapsible_nav/_collapsible_nav.scss
@@ -51,15 +51,10 @@
   // At tiny screens, reduce the close button to a simple `x`
   .euiCollapsibleNav__closeButton {
     margin-right: -15%;
-  }
 
-  .euiCollapsibleNav__closeButtonText {
-    margin-left: 0;
-  }
-
-  .euiCollapsibleNav__closeButtonLabel {
-    // But be sure the text can still be read by a screenreader
-    @include euiScreenReaderOnly;
+    .euiCollapsibleNav__closeButtonText {
+      margin-left: 0;
+    }
   }
 }
 

--- a/src/components/collapsible_nav/_collapsible_nav.scss
+++ b/src/components/collapsible_nav/_collapsible_nav.scss
@@ -54,7 +54,7 @@
 
     .euiCollapsibleNav__closeButtonText {
       // But be sure the text can still be read by a screenreader
-      @include euiScreenReaderOnly
+      @include euiScreenReaderOnly;
     }
   }
 }

--- a/src/components/collapsible_nav/_collapsible_nav.scss
+++ b/src/components/collapsible_nav/_collapsible_nav.scss
@@ -53,6 +53,7 @@
     margin-right: -15%;
 
     .euiCollapsibleNav__closeButtonText {
+      @include euiScreenReaderOnly
       margin-left: 0;
     }
   }
@@ -70,4 +71,3 @@
     transform: translateX(0%);
   }
 }
-

--- a/src/components/collapsible_nav/_collapsible_nav.scss
+++ b/src/components/collapsible_nav/_collapsible_nav.scss
@@ -14,7 +14,19 @@
   position: absolute;
   right: 0;
   top: $euiSize;
-  margin-right: -25%;
+  margin-right: -27%;
+  padding: $euiSizeM 0;
+  line-height: 1;
+  border-radius: $euiBorderRadius;
+
+  &:focus {
+    @include euiFocusRing;
+  }
+
+  &,
+  &:focus {
+    background: $euiColorEmptyShade;
+  }
 }
 
 // The addition of this class is handled through JS

--- a/src/components/collapsible_nav/_collapsible_nav.scss
+++ b/src/components/collapsible_nav/_collapsible_nav.scss
@@ -53,8 +53,8 @@
     margin-right: -15%;
 
     .euiCollapsibleNav__closeButtonText {
+      // But be sure the text can still be read by a screenreader
       @include euiScreenReaderOnly
-      margin-left: 0;
     }
   }
 }

--- a/src/components/collapsible_nav/_collapsible_nav.scss
+++ b/src/components/collapsible_nav/_collapsible_nav.scss
@@ -25,6 +25,7 @@
 
   &,
   &:focus {
+    // Override default `EuiButtonEmpty` :focus background to ensure better contrast 
     background: $euiColorEmptyShade;
   }
 }
@@ -50,10 +51,10 @@
   // At tiny screens, reduce the close button to a simple `x`
   .euiCollapsibleNav__closeButton {
     margin-right: -15%;
+  }
 
-    .euiButtonEmpty__text {
-      margin-left: 0;
-    }
+  .euiCollapsibleNav__closeButtonText {
+    margin-left: 0;
   }
 
   .euiCollapsibleNav__closeButtonLabel {

--- a/src/components/collapsible_nav/collapsible_nav.tsx
+++ b/src/components/collapsible_nav/collapsible_nav.tsx
@@ -35,6 +35,7 @@ import { CommonProps } from '../common';
 import { EuiButtonEmpty, EuiButtonEmptyProps } from '../button';
 import { EuiI18n } from '../i18n';
 import { EuiScreenReaderOnly } from '../accessibility';
+import { EuiHideFor } from '../responsive/hide_for';
 
 export type EuiCollapsibleNavProps = CommonProps &
   HTMLAttributes<HTMLElement> & {
@@ -172,9 +173,14 @@ export const EuiCollapsibleNav: FunctionComponent<EuiCollapsibleNavProps> = ({
           'euiCollapsibleNav__closeButton',
           closeButtonProps && closeButtonProps.className
         )}>
-        <span className="euiCollapsibleNav__closeButtonLabel">
-          <EuiI18n token="euiCollapsibleNav.closeButtonLabel" default="close" />
-        </span>
+        <EuiHideFor sizes={['xs']}>
+          <span>
+            <EuiI18n
+              token="euiCollapsibleNav.closeButtonLabel"
+              default="close"
+            />
+          </span>
+        </EuiHideFor>
       </EuiButtonEmpty>
     </EuiScreenReaderOnly>
   );

--- a/src/components/collapsible_nav/collapsible_nav.tsx
+++ b/src/components/collapsible_nav/collapsible_nav.tsx
@@ -34,6 +34,7 @@ import { EuiOverlayMask } from '../overlay_mask';
 import { CommonProps } from '../common';
 import { EuiButtonEmpty, EuiButtonEmptyProps } from '../button';
 import { EuiI18n } from '../i18n';
+import { EuiScreenReaderOnly } from '../accessibility';
 
 export type EuiCollapsibleNavProps = CommonProps &
   HTMLAttributes<HTMLElement> & {
@@ -160,19 +161,21 @@ export const EuiCollapsibleNav: FunctionComponent<EuiCollapsibleNavProps> = ({
         });
 
   const closeButton = showCloseButton && (
-    <EuiButtonEmpty
-      onClick={collapse}
-      size="xs"
-      iconType="cross"
-      {...closeButtonProps}
-      className={classNames(
-        'euiCollapsibleNav__closeButton',
-        closeButtonProps && closeButtonProps.className
-      )}>
-      <span className="euiCollapsibleNav__closeButtonLabel">
-        <EuiI18n token="euiCollapsibleNav.closeButtonLabel" default="close" />
-      </span>
-    </EuiButtonEmpty>
+    <EuiScreenReaderOnly showOnFocus>
+      <EuiButtonEmpty
+        onClick={collapse}
+        size="xs"
+        iconType="cross"
+        {...closeButtonProps}
+        className={classNames(
+          'euiCollapsibleNav__closeButton',
+          closeButtonProps && closeButtonProps.className
+        )}>
+        <span className="euiCollapsibleNav__closeButtonLabel">
+          <EuiI18n token="euiCollapsibleNav.closeButtonLabel" default="close" />
+        </span>
+      </EuiButtonEmpty>
+    </EuiScreenReaderOnly>
   );
 
   const flyout = (

--- a/src/components/collapsible_nav/collapsible_nav.tsx
+++ b/src/components/collapsible_nav/collapsible_nav.tsx
@@ -165,6 +165,7 @@ export const EuiCollapsibleNav: FunctionComponent<EuiCollapsibleNavProps> = ({
       <EuiButtonEmpty
         onClick={collapse}
         size="xs"
+        textProps={{ className: 'euiCollapsibleNav__closeButtonText' }}
         iconType="cross"
         {...closeButtonProps}
         className={classNames(

--- a/src/components/collapsible_nav/collapsible_nav.tsx
+++ b/src/components/collapsible_nav/collapsible_nav.tsx
@@ -173,14 +173,10 @@ export const EuiCollapsibleNav: FunctionComponent<EuiCollapsibleNavProps> = ({
           'euiCollapsibleNav__closeButton',
           closeButtonProps && closeButtonProps.className
         )}>
-        <EuiHideFor sizes={['xs']}>
-          <span>
             <EuiI18n
               token="euiCollapsibleNav.closeButtonLabel"
               default="close"
             />
-          </span>
-        </EuiHideFor>
       </EuiButtonEmpty>
     </EuiScreenReaderOnly>
   );

--- a/src/components/collapsible_nav/collapsible_nav.tsx
+++ b/src/components/collapsible_nav/collapsible_nav.tsx
@@ -35,7 +35,6 @@ import { CommonProps } from '../common';
 import { EuiButtonEmpty, EuiButtonEmptyProps } from '../button';
 import { EuiI18n } from '../i18n';
 import { EuiScreenReaderOnly } from '../accessibility';
-import { EuiHideFor } from '../responsive/hide_for';
 
 export type EuiCollapsibleNavProps = CommonProps &
   HTMLAttributes<HTMLElement> & {
@@ -173,10 +172,7 @@ export const EuiCollapsibleNav: FunctionComponent<EuiCollapsibleNavProps> = ({
           'euiCollapsibleNav__closeButton',
           closeButtonProps && closeButtonProps.className
         )}>
-            <EuiI18n
-              token="euiCollapsibleNav.closeButtonLabel"
-              default="close"
-            />
+        <EuiI18n token="euiCollapsibleNav.closeButtonLabel" default="close" />
       </EuiButtonEmpty>
     </EuiScreenReaderOnly>
   );


### PR DESCRIPTION
### Summary

This PR closes #3402 

With this PR I'm improving the contrast for the **EuiCollapsibleNav** close link.

<img width="1194" alt="Implementation@2x" src="https://user-images.githubusercontent.com/2750668/81680452-f8bf5180-944a-11ea-8452-bda87779db82.png">


A few decisions:
- During the implementation, I decided to keep the **EuiButtonEmpty** because it was the most similar button to what I wanted to achieve.
- Since this button was only implemented to keyboard users I used the `<EuiScreenReaderOnly showOnFocus>` component and added a visible focus ring as suggested by @chaos. 



### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
