### PR TITLE
Added null as acceptable `icon` for EuiCard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Allow `null` as acceptable children for `EuiCard` ([#3470](https://github.com/elastic/eui/pull/3470))
 - Added `sortBy` and `sortShift` props to `euiPaletteColorBlind()` for sorting along the color wheel ([#3387](https://github.com/elastic/eui/pull/3387))
 - Added `utcOffset` prop to `EuiSuperDatePicker` ([#3436](https://github.com/elastic/eui/pull/3436))
 - Added `partition` key to `EuiChartThemeType` for Partition chart support ([#3387](https://github.com/elastic/eui/pull/3387))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Allow `null` as acceptable children for `EuiCard` ([#3470](https://github.com/elastic/eui/pull/3470))
+- Allow `null` as acceptable `icon` for `EuiCard` ([#3470](https://github.com/elastic/eui/pull/3470))
 - Added `sortBy` and `sortShift` props to `euiPaletteColorBlind()` for sorting along the color wheel ([#3387](https://github.com/elastic/eui/pull/3387))
 - Added `utcOffset` prop to `EuiSuperDatePicker` ([#3436](https://github.com/elastic/eui/pull/3436))
 - Added `partition` key to `EuiChartThemeType` for Partition chart support ([#3387](https://github.com/elastic/eui/pull/3387))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Allow `null` as acceptable `icon` for `EuiCard` ([#3470](https://github.com/elastic/eui/pull/3470))
+- Added `null` as acceptable `icon` prop for `EuiCard` ([#3470](https://github.com/elastic/eui/pull/3470))
 - Added `sortBy` and `sortShift` props to `euiPaletteColorBlind()` for sorting along the color wheel ([#3387](https://github.com/elastic/eui/pull/3387))
 - Added `utcOffset` prop to `EuiSuperDatePicker` ([#3436](https://github.com/elastic/eui/pull/3436))
 - Added `partition` key to `EuiChartThemeType` for Partition chart support ([#3387](https://github.com/elastic/eui/pull/3387))

--- a/src/components/card/__snapshots__/card.test.tsx.snap
+++ b/src/components/card/__snapshots__/card.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`EuiCard is rendered 1`] = `
 </div>
 `;
 
-exports[`EuiCard props a null children 1`] = `
+exports[`EuiCard props a null icon 1`] = `
 <div
   class="euiCard euiCard--centerAligned"
 >

--- a/src/components/card/__snapshots__/card.test.tsx.snap
+++ b/src/components/card/__snapshots__/card.test.tsx.snap
@@ -27,6 +27,31 @@ exports[`EuiCard is rendered 1`] = `
 </div>
 `;
 
+exports[`EuiCard props a null children 1`] = `
+<div
+  class="euiCard euiCard--centerAligned"
+>
+  <div
+    class="euiCard__content"
+  >
+    <span
+      class="euiTitle euiTitle--small euiCard__title"
+      id="generated-idTitle"
+    >
+      Card title
+    </span>
+    <div
+      class="euiText euiText--small euiCard__description"
+      id="generated-idDescription"
+    >
+      <p>
+        Card description
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EuiCard props children 1`] = `
 <div
   class="euiCard euiCard--centerAligned euiCard--hasChildren"

--- a/src/components/card/card.test.tsx
+++ b/src/components/card/card.test.tsx
@@ -55,6 +55,18 @@ describe('EuiCard', () => {
       expect(component).toMatchSnapshot();
     });
 
+    test('a null icon', () => {
+      const component = render(
+        <EuiCard
+          title="Card title"
+          description="Card description"
+          icon={null}
+        />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
     test('horizontal', () => {
       const component = render(
         <EuiCard
@@ -137,16 +149,6 @@ describe('EuiCard', () => {
       const component = render(
         <EuiCard title="Card title" description="Card description">
           Child
-        </EuiCard>
-      );
-
-      expect(component).toMatchSnapshot();
-    });
-
-    test('a null children', () => {
-      const component = render(
-        <EuiCard title="Card title" description="Card description">
-          {null}
         </EuiCard>
       );
 

--- a/src/components/card/card.test.tsx
+++ b/src/components/card/card.test.tsx
@@ -143,6 +143,16 @@ describe('EuiCard', () => {
       expect(component).toMatchSnapshot();
     });
 
+    test('a null children', () => {
+      const component = render(
+        <EuiCard title="Card title" description="Card description">
+          {null}
+        </EuiCard>
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
     test('textAlign', () => {
       const component = render(
         <EuiCard

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -101,7 +101,7 @@ type EuiCardProps = Omit<CommonProps, 'aria-label'> & {
   /**
    * Content to be rendered between the description and the footer
    */
-  children?: ReactNode;
+  children?: ReactNode | null;
 
   /**
    * Accepts any combination of elements

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -89,7 +89,7 @@ type EuiCardProps = Omit<CommonProps, 'aria-label'> & {
   description: NonNullable<ReactNode>;
 
   /**
-   * If provided, should be an `<EuiIcon>` node
+   * Accepts an `<EuiIcon>` node or `null`
    */
   icon?: ReactElement<EuiIconProps> | null;
 

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -89,7 +89,7 @@ type EuiCardProps = Omit<CommonProps, 'aria-label'> & {
   description: NonNullable<ReactNode>;
 
   /**
-   * Requires a <EuiIcon> node
+   * If provided, should be an `<EuiIcon>` node
    */
   icon?: ReactElement<EuiIconProps> | null;
 

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -91,7 +91,7 @@ type EuiCardProps = Omit<CommonProps, 'aria-label'> & {
   /**
    * Requires a <EuiIcon> node
    */
-  icon?: ReactElement<EuiIconProps>;
+  icon?: ReactElement<EuiIconProps> | null;
 
   /**
    * Accepts a url in string form or ReactElement for a custom image component
@@ -101,7 +101,7 @@ type EuiCardProps = Omit<CommonProps, 'aria-label'> & {
   /**
    * Content to be rendered between the description and the footer
    */
-  children?: ReactNode | null;
+  children?: ReactNode;
 
   /**
    * Accepts any combination of elements


### PR DESCRIPTION
### Summary

Fixes : #3459

Added `null` as acceptable type to `icon` for `EuiCardProps`

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
