### PR TITLE
[Docs] Add spacerSize prop to DisplayToggles

### DIFF
--- a/src-docs/src/views/form_controls/display_toggles.js
+++ b/src-docs/src/views/form_controls/display_toggles.js
@@ -13,6 +13,8 @@ import {
   EuiSpacer,
 } from '../../../../src/components';
 
+import { SIZES } from '../../../../src/components/spacer/spacer';
+
 export class DisplayToggles extends Component {
   constructor(props) {
     super(props);
@@ -222,7 +224,7 @@ DisplayToggles.propTypes = {
   canAppend: PropTypes.bool,
   canInvalid: PropTypes.bool,
   extras: PropTypes.arrayOf(PropTypes.node),
-  spacerSize: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl', 'xxl']),
+  spacerSize: PropTypes.oneOf(SIZES),
 };
 
 DisplayToggles.defaultProps = {

--- a/src-docs/src/views/form_controls/display_toggles.js
+++ b/src-docs/src/views/form_controls/display_toggles.js
@@ -50,6 +50,7 @@ export class DisplayToggles extends Component {
       canInvalid,
       children,
       extras,
+      spacerSize,
     } = this.props;
 
     const canProps = {};
@@ -66,7 +67,7 @@ export class DisplayToggles extends Component {
     return (
       <Fragment>
         {cloneElement(children, canProps)}
-        <EuiSpacer />
+        <EuiSpacer size={spacerSize} />
         <EuiPopover
           panelPaddingSize="s"
           isOpen={this.state.isPopoverOpen}
@@ -221,6 +222,7 @@ DisplayToggles.propTypes = {
   canAppend: PropTypes.bool,
   canInvalid: PropTypes.bool,
   extras: PropTypes.arrayOf(PropTypes.node),
+  spacerSize: PropTypes.oneOf(['xs', 's', 'm', 'l', 'xl', 'xxl']),
 };
 
 DisplayToggles.defaultProps = {
@@ -233,4 +235,5 @@ DisplayToggles.defaultProps = {
   canInvalid: true,
   canPrepend: false,
   canAppend: false,
+  spacerSize: 'l',
 };


### PR DESCRIPTION
### Summary

While working on a different issue I found the size of the **EuiSpacer** inside of the **DisplayToggles** component too large.  

To solve this, I'm allowing consumers to pass a prop called `spacerSize` to control this size.

<img width="989" alt="DisplayToggles@2x" src="https://user-images.githubusercontent.com/2750668/81954338-a4f66900-9600-11ea-8aa0-bc47d39e6ec6.png">

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- ~ ] Checked in **IE11** and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
