### PR TITLE
Change lint-es task in package.json to use escaped double-quotes (to fix Windows console issue)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "extract-i18n-strings": "node ./scripts/babel/fetch-i18n-strings",
     "lint": "yarn tsc --noEmit && yarn lint-es && yarn lint-sass",
     "lint-fix": "yarn lint-es-fix",
-    "lint-es": "eslint --cache '{src,src-docs,src-framer}/**/*.{ts,tsx,js}' --max-warnings 0",
+    "lint-es": "eslint --cache \"{src,src-docs,src-framer}/**/*.{ts,tsx,js}\" --max-warnings 0",
     "lint-es-fix": "yarn lint-es --fix",
     "lint-sass": "sass-lint -v --max-warnings 0",
     "lint-sass-fix": "sass-lint-auto-fix -c ./.sass-lint-fix.yml",

--- a/src-docs/.eslintrc.js
+++ b/src-docs/.eslintrc.js
@@ -3,5 +3,5 @@ module.exports = {
   rules: {
     '@typescript-eslint/no-var-requires': 'off',
     'local/require-license-header': 'off',
-  }
-}
+  },
+};

--- a/src-framer/.eslintrc.js
+++ b/src-framer/.eslintrc.js
@@ -1,12 +1,13 @@
 module.exports = {
   extends: '../.eslintrc.js',
   rules: {
-    'import/no-unresolved': ['error', { ignore: [
-      '^framer$',
-      '^@elastic/eui/lib/',
-      '^!!raw-loader!',
-    ]}],
+    'import/no-unresolved': [
+      'error',
+      {
+        ignore: ['^framer$', '^@elastic/eui/lib/', '^!!raw-loader!'],
+      },
+    ],
     '@typescript-eslint/no-var-requires': 'off',
     'local/require-license-header': 'off',
-  }
-}
+  },
+};


### PR DESCRIPTION
* Change lint-es task in package.json to use escaped double-quotes.

When running `yarn lint-es` on Windows, the following error is thrown in the console:

No files matching the pattern "'{src,src-docs,src-framer}/**/*.{ts,tsx,js}'" were found.
Please check for typing mistakes in the pattern.

This is due to https://eslint.org/docs/user-guide/command-line-interface:

"If you want to use node glob syntax, you have to quote your parameter (using double quotes if you need it to run in Windows)"

With this fix, it works as expected on all platforms.

Fixes #3484

--------------------

* Reformat .eslintrc.js files matching the guidance output from `yarn lint-es` (prettier/prettier rules).

All files in the project lint pattern now pass linting.
