### PR TITLE
[EuiSelectableListItem]: Add an additional `euiSelectableListItem-checked` CSS state class when the item prop `checked` is set to `on`

### DIFF
--- a/src/components/selectable/selectable_list/__snapshots__/selectable_list_item.test.tsx.snap
+++ b/src/components/selectable/selectable_list/__snapshots__/selectable_list_item.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`EuiSelectableListItem props checked is off 1`] = `
 
 exports[`EuiSelectableListItem props checked is on 1`] = `
 <button
-  class="euiSelectableListItem"
+  class="euiSelectableListItem euiSelectableListItem-checked"
   role="option"
   type="button"
 >

--- a/src/components/selectable/selectable_list/selectable_list_item.tsx
+++ b/src/components/selectable/selectable_list/selectable_list_item.tsx
@@ -84,6 +84,7 @@ export class EuiSelectableListItem extends Component<
     const classes = classNames(
       'euiSelectableListItem',
       {
+        'euiSelectableListItem-checked': checked === 'on',
         'euiSelectableListItem-isFocused': isFocused,
       },
       className


### PR DESCRIPTION
* Add an additional `euiSelectableListItem-checked` CSS state class when the item prop `checked` is set to `on`. This complements the existing `euiSelectableListItem-isFocused` state class.

This will allow consumers of this component to set custom styling rules for the checked state.

### Checklist

- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**

