### PR TITLE
Fixes EuiComboBox Label not calculated correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Passed `getSelectedOptionForSearchValue` to `EuiComboBoxOptionsList` as prop ([#3501](https://github.com/elastic/eui/pull/3501))
 - Added `initialSelected` to `EuiTableSelectionType` properties to set initial selected checkboxes for `EuiBasicTable` ([#3418](https://github.com/elastic/eui/pull/3418))
 - Added exports for `EuiSteps` and related components types ([#3471](https://github.com/elastic/eui/pull/3471))
 - Added `displayName` to components using `React.forwardRef` ([#3451](https://github.com/elastic/eui/pull/3451))

--- a/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
+++ b/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
@@ -451,6 +451,7 @@ exports[`props singleSelection prepend and append is rendered 1`] = `
       areAllOptionsSelected={false}
       data-test-subj=""
       fullWidth={false}
+      getSelectedOptionForSearchValue={[Function]}
       listRef={[Function]}
       matchingOptions={
         Array [
@@ -584,6 +585,7 @@ exports[`props singleSelection selects existing option when opened 1`] = `
       areAllOptionsSelected={false}
       data-test-subj=""
       fullWidth={false}
+      getSelectedOptionForSearchValue={[Function]}
       listRef={[Function]}
       matchingOptions={
         Array [

--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -993,6 +993,7 @@ export class EuiComboBox<T> extends Component<
             updatePosition={this.updatePosition}
             width={width}
             delimiter={delimiter}
+            getSelectedOptionForSearchValue={getSelectedOptionForSearchValue}
           />
         </EuiPortal>
       );

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
@@ -67,7 +67,7 @@ export type EuiComboBoxOptionsListProps<T> = CommonProps &
     getSelectedOptionForSearchValue?: (
       searchValue: string,
       selectedOptions: any[]
-    ) => EuiComboBoxOptionOption<T>;
+    ) => EuiComboBoxOptionOption<T> | undefined;
     isLoading?: boolean;
     listRef: RefCallback<HTMLDivElement>;
     matchingOptions: Array<EuiComboBoxOptionOption<T>>;


### PR DESCRIPTION
### Summary

Fixes #3458 

- Pass `getSelectedOptionForSearchValue` to `EuiComboBoxOptionsList` options list as prop.

Before:

![Screen Cast 2020-05-19 at 12 00 17 AM](https://user-images.githubusercontent.com/10515204/82247311-cf7b5580-9963-11ea-90c6-2a24c36e22a3.gif)

After:

![Screen Cast 2020-05-19 at 12 01 17 AM](https://user-images.githubusercontent.com/10515204/82247377-eae66080-9963-11ea-8bd0-f87b55754d46.gif)


I think this was missed during the typescript conversion #2838

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
