### PR TITLE
Adding left-start placement of the popover to EuiDatePicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added exports for `EuiSteps` and related components types ([#3471](https://github.com/elastic/eui/pull/3471))
 - Added `displayName` to components using `React.forwardRef` ([#3451](https://github.com/elastic/eui/pull/3451))
 - Added event target checker for `EuiOverlayMask`'s `onClick` prop ([#3462](https://github.com/elastic/eui/pull/3462))
+- Added `left-start` popover placement to `EuiDatePicker` ([#3511](https://github.com/elastic/eui/pull/3511))
 
 **Bug Fixes**
 

--- a/src/components/date_picker/date_picker.tsx
+++ b/src/components/date_picker/date_picker.tsx
@@ -96,7 +96,7 @@ interface EuiExtendedDatePickerProps extends ReactDatePickerProps {
   iconType?: EuiFormControlLayoutIconsProps['icon'];
 
   /**
-   * Sets the placement of the popover. It accepts: `"bottom"`, `"bottom-end"`, `"bottom-start"`, `"left"`, `"left-end"`, `"right"`, `"right-end"`, `"right-start"`, `"top"`, `"top-end"`, `"top-start"`
+   * Sets the placement of the popover. It accepts: `"bottom"`, `"bottom-end"`, `"bottom-start"`, `"left"`, `"left-end"`, `"left-start"`, `"right"`, `"right-end"`, `"right-start"`, `"top"`, `"top-end"`, `"top-start"`
    */
   popoverPlacement?: ReactDatePickerProps['popperPlacement'];
 }

--- a/src/components/date_picker/react-datepicker.d.ts
+++ b/src/components/date_picker/react-datepicker.d.ts
@@ -39,6 +39,7 @@ type popperPlacement =
   | 'bottom-start'
   | 'left'
   | 'left-end'
+  | 'left-start'
   | 'right'
   | 'right-end'
   | 'right-start'


### PR DESCRIPTION
### Summary

According to https://github.com/elastic/eui/blob/master/packages/react-datepicker/src/popper_component.jsx, `left-start` popover placement is forgotten in current library.

### Checklist

<s>- [ ] Check against **all themes** for compatibility in both light and dark modes</s>
<s>- [ ] Checked in **mobile**</s>
<s>- [ ] Checked in **IE11** and **Firefox**</s>
- [x] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples

<s>- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**</s>
<s>- [ ] Checked for **breaking changes** and labeled appropriately</s>
<s>- [ ] Checked for **accessibility** including keyboard-only and screenreader modes</s>
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
