### PR TITLE
removes errant `console.log`s from EuiTour

### DIFF
--- a/src-docs/src/views/tour/fullscreen.js
+++ b/src-docs/src/views/tour/fullscreen.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useState } from 'react';
+import React, { Fragment, useState } from 'react';
 
 import { GuideFullScreen } from '../../services';
 
@@ -66,10 +66,6 @@ export default () => {
     actions,
     reducerState,
   ] = useEuiTour(demoTourSteps, tourConfig);
-
-  useEffect(() => {
-    console.log('Update', reducerState);
-  }, [reducerState]);
 
   const onSelectColor = color => {
     setColor(color);

--- a/src-docs/src/views/tour/managed.js
+++ b/src-docs/src/views/tour/managed.js
@@ -59,7 +59,6 @@ export default () => {
     <EuiTour steps={demoTourSteps} initialState={state}>
       {([euiTourStepOne, euiTourStepTwo], actions, reducerState) => {
         useEffect(() => {
-          console.log('Updating localStorage', STORAGE_KEY, reducerState);
           localStorage.setItem(STORAGE_KEY, JSON.stringify(reducerState));
         }, [reducerState]);
 

--- a/src-docs/src/views/tour/managed_hook.js
+++ b/src-docs/src/views/tour/managed_hook.js
@@ -60,7 +60,6 @@ export default () => {
   );
 
   useEffect(() => {
-    console.log('Updating localStorage', STORAGE_KEY, reducerState);
     localStorage.setItem(STORAGE_KEY, JSON.stringify(reducerState));
   }, [reducerState]);
 


### PR DESCRIPTION
see: https://github.com/elastic/eui/pull/2766#discussion_r430417591

I noticed over the weekend whilst exploring EuiTour that there are `console.log` statements that are firing when you step through.  I checked with @thompsongl and it appears that these were added during development with the intention of removal prior to merge.  This PR removes them.

 Check against all themes for compatibility in both light and dark modes
- ~[ ] Checked in mobile~
- ~[ ] Checked in IE11 and Firefox~
- ~[ ] Props have proper autodocs~
- ~[ ] Added documentation examples~
 ~Added or updated jest tests~
 ~Checked for breaking changes and labeled appropriately~
- ~[ ] Checked for accessibility including keyboard-only and screenreader modes~
~A changelog entry exists and is marked appropriately~ (it seemed to me that a changelog for such a thing is not necessary but I'm happy to add one if anyone feels it adds value)