### PR TITLE
Dark EuiHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Added `displayName` to components using `React.forwardRef` ([#3451](https://github.com/elastic/eui/pull/3451))
 - Added event target checker for `EuiOverlayMask`'s `onClick` prop ([#3462](https://github.com/elastic/eui/pull/3462))
 - Added `left-start` popover placement to `EuiDatePicker` ([#3511](https://github.com/elastic/eui/pull/3511))
+- Added `theme` prop to `EuiHeader` ([#3524](https://github.com/elastic/eui/pull/3524))
+- Added `.euiHeaderLink-isActive` class to `EuiHeaderLink` when `isActive` ([#3524](https://github.com/elastic/eui/pull/3524))
 
 **Bug Fixes**
 
@@ -31,6 +33,7 @@
 - Improve `EuiOverlayMask` colors ([#3515](https://github.com/elastic/eui/pull/3515))
 - Updated shadow styles to improve smoothness, use black as the base color, and deprecated `opacity` value of shadow mixins ([#3428](https://github.com/elastic/eui/pull/3428))
 - Removed borders from `EuiFlyout` and `EuiPopover` ([#3477](https://github.com/elastic/eui/pull/3477))
+- Updated `EuiHeader` and components ([#3524](https://github.com/elastic/eui/pull/3524))
 
 ## [`24.0.0`](https://github.com/elastic/eui/tree/v24.0.0)
 

--- a/src-docs/src/views/header/header_alert.js
+++ b/src-docs/src/views/header/header_alert.js
@@ -1,20 +1,15 @@
-import React, { useState, useRef, Fragment } from 'react';
+import React from 'react';
+import { GuideFullScreen } from '../../services/full_screen/full_screen';
 
 import {
   EuiButton,
-  EuiFocusTrap,
-  EuiHorizontalRule,
   EuiHeader,
   EuiHeaderSection,
   EuiHeaderSectionItem,
-  EuiHeaderSectionItemButton,
   EuiHeaderLogo,
   EuiHeaderLink,
   EuiHeaderLinks,
   EuiIcon,
-  EuiImage,
-  EuiNavDrawerGroup,
-  EuiNavDrawer,
   EuiPage,
   EuiPageBody,
   EuiPageHeader,
@@ -23,251 +18,14 @@ import {
   EuiPageContentHeader,
   EuiPageContentHeaderSection,
   EuiPageContentBody,
-  EuiShowFor,
   EuiTitle,
 } from '../../../../src/components';
-
-import { keyCodes } from '../../../../src/services';
 
 import HeaderUserMenu from './header_user_menu';
 import HeaderSpacesMenu from './header_spaces_menu';
 import HeaderUpdates from './header_updates';
 
 export default () => {
-  const [isFullScreen, setIsFullScreen] = useState(false);
-
-  const faveExtraAction = {
-    color: 'subdued',
-    iconType: 'starEmpty',
-    iconSize: 's',
-    'aria-label': 'Add to favorites',
-  };
-
-  const pinExtraAction = {
-    color: 'subdued',
-    iconType: 'pin',
-    iconSize: 's',
-  };
-
-  const pinExtraActionFn = val => {
-    pinExtraAction['aria-label'] = `Pin ${val} to top`;
-    return pinExtraAction;
-  };
-
-  const topLinks = [
-    {
-      label: 'Recently viewed',
-      iconType: 'clock',
-      flyoutMenu: {
-        title: 'Recent items',
-        listItems: [
-          {
-            label: 'My dashboard',
-            href: '#/layout/nav-drawer',
-            iconType: 'dashboardApp',
-            extraAction: faveExtraAction,
-          },
-          {
-            label: 'Workpad with title that wraps',
-            href: '#/layout/nav-drawer',
-            iconType: 'canvasApp',
-            extraAction: faveExtraAction,
-          },
-          {
-            label: 'My logs',
-            href: '#/layout/nav-drawer',
-            iconType: 'logsApp',
-            'aria-label': 'This is an alternate aria-label',
-            extraAction: faveExtraAction,
-          },
-        ],
-      },
-    },
-    {
-      label: 'Favorites',
-      iconType: 'starEmpty',
-      flyoutMenu: {
-        title: 'Favorite items',
-        listItems: [
-          {
-            label: 'My workpad',
-            href: '#/layout/nav-drawer',
-            iconType: 'canvasApp',
-            extraAction: {
-              color: 'subdued',
-              iconType: 'starFilled',
-              iconSize: 's',
-              'aria-label': 'Remove from favorites',
-              alwaysShow: true,
-            },
-          },
-          {
-            label: 'My logs',
-            href: '#/layout/nav-drawer',
-            iconType: 'logsApp',
-            extraAction: {
-              color: 'subdued',
-              iconType: 'starFilled',
-              iconSize: 's',
-              'aria-label': 'Remove from favorites',
-              alwaysShow: true,
-            },
-          },
-        ],
-      },
-    },
-  ];
-
-  const exploreLinks = [
-    {
-      label: 'Canvas',
-      href: '#/layout/nav-drawer',
-      iconType: 'canvasApp',
-      isActive: true,
-      extraAction: {
-        ...pinExtraActionFn('Canvas'),
-        alwaysShow: true,
-      },
-    },
-    {
-      label: 'Discover',
-      href: '#/layout/nav-drawer',
-      iconType: 'discoverApp',
-      extraAction: { ...pinExtraActionFn('Discover') },
-    },
-    {
-      label: 'Visualize',
-      href: '#/layout/nav-drawer',
-      iconType: 'visualizeApp',
-      extraAction: { ...pinExtraActionFn('Visualize') },
-    },
-    {
-      label: 'Dashboard',
-      href: '#/layout/nav-drawer',
-      iconType: 'dashboardApp',
-      extraAction: { ...pinExtraActionFn('Dashboard') },
-    },
-    {
-      label: 'Machine learning',
-      href: '#/layout/nav-drawer',
-      iconType: 'machineLearningApp',
-      extraAction: { ...pinExtraActionFn('Machine learning') },
-    },
-    {
-      label: 'Custom Plugin (no icon)',
-      href: '#/layout/nav-drawer',
-      extraAction: { ...pinExtraActionFn('Custom Plugin') },
-    },
-    {
-      label: 'Nature Plugin (image as icon)',
-      href: '#/layout/nav-drawer',
-      extraAction: { ...pinExtraActionFn('Nature Plugin') },
-      icon: (
-        <EuiImage
-          size="s"
-          alt="Random nature image"
-          url="https://source.unsplash.com/300x300/?Nature"
-        />
-      ),
-    },
-  ];
-
-  const solutionsLinks = [
-    {
-      label: 'APM',
-      href: '#/layout/nav-drawer',
-      iconType: 'apmApp',
-      extraAction: { ...pinExtraActionFn('APM') },
-    },
-    {
-      label: 'Metrics',
-      href: '#/layout/nav-drawer',
-      iconType: 'metricsApp',
-      extraAction: { ...pinExtraActionFn('Infrastructure') },
-    },
-    {
-      label: 'Logs',
-      href: '#/layout/nav-drawer',
-      iconType: 'logsApp',
-      extraAction: { ...pinExtraActionFn('Log viewer') },
-    },
-    {
-      label: 'Uptime',
-      href: '#/layout/nav-drawer',
-      iconType: 'upgradeAssistantApp',
-      extraAction: { ...pinExtraActionFn('Uptime') },
-    },
-    {
-      label: 'Maps',
-      href: '#/layout/nav-drawer',
-      iconType: 'gisApp',
-      extraAction: { ...pinExtraActionFn('Maps') },
-    },
-    {
-      label: 'SIEM',
-      href: '#/layout/nav-drawer',
-      iconType: 'securityAnalyticsApp',
-      extraAction: { ...pinExtraActionFn('SIEM') },
-    },
-  ];
-
-  const adminLinks = [
-    {
-      label: 'Admin',
-      iconType: 'managementApp',
-      flyoutMenu: {
-        title: 'Tools and settings',
-        listItems: [
-          {
-            label: 'Dev tools',
-            href: '#/layout/nav-drawer',
-            iconType: 'devToolsApp',
-            extraAction: {
-              color: 'subdued',
-              iconType: 'starEmpty',
-              iconSize: 's',
-              'aria-label': 'Add to favorites',
-            },
-          },
-          {
-            label: 'Stack Monitoring',
-            href: '#/layout/nav-drawer',
-            iconType: 'monitoringApp',
-            extraAction: {
-              color: 'subdued',
-              iconType: 'starEmpty',
-              iconSize: 's',
-              'aria-label': 'Add to favorites',
-            },
-          },
-          {
-            label: 'Stack Management',
-            href: '#/layout/nav-drawer',
-            iconType: 'managementApp',
-            extraAction: {
-              color: 'subdued',
-              iconType: 'starEmpty',
-              iconSize: 's',
-              'aria-label': 'Add to favorites',
-            },
-          },
-        ],
-      },
-    },
-  ];
-
-  const onKeyDown = event => {
-    if (event.keyCode === keyCodes.ESCAPE) {
-      event.preventDefault();
-      event.stopPropagation();
-      closeFullScreen();
-    }
-  };
-
-  const toggleFullScreen = () => setIsFullScreen(isFullScreen => !isFullScreen);
-
-  const closeFullScreen = () => setIsFullScreen(false);
-
   const renderLogo = () => {
     return (
       <EuiHeaderLogo
@@ -278,39 +36,12 @@ export default () => {
     );
   };
 
-  const renderMenuTrigger = () => {
-    return (
-      <EuiHeaderSectionItemButton
-        aria-label="Open nav"
-        onClick={() => navDrawerRef.current.toggleOpen()}>
-        <EuiIcon type="apps" href="#" size="m" />
-      </EuiHeaderSectionItemButton>
-    );
-  };
-
-  const navDrawerRef = useRef(null);
-  let fullScreenDisplay;
-
-  if (isFullScreen) {
-    fullScreenDisplay = (
-      <EuiFocusTrap>
-        <div
-          style={{
-            position: 'fixed',
-            top: 0,
-            left: 0,
-            zIndex: 1000,
-            height: '100%',
-            width: '100%',
-          }}
-          onKeyDown={onKeyDown}>
+  return (
+    <GuideFullScreen>
+      {setIsFullScreen => (
+        <div className="guideFullScreenOverlay" style={{ zIndex: 9000 }}>
           <EuiHeader>
             <EuiHeaderSection grow={false}>
-              <EuiShowFor sizes={['xs', 's']}>
-                <EuiHeaderSectionItem border="right">
-                  {renderMenuTrigger()}
-                </EuiHeaderSectionItem>
-              </EuiShowFor>
               <EuiHeaderSectionItem border="right">
                 {renderLogo()}
               </EuiHeaderSectionItem>
@@ -331,17 +62,9 @@ export default () => {
               </EuiHeaderSectionItem>
             </EuiHeaderSection>
           </EuiHeader>
-          <EuiNavDrawer ref={navDrawerRef}>
-            <EuiNavDrawerGroup listItems={topLinks} />
-            <EuiHorizontalRule margin="none" />
-            <EuiNavDrawerGroup listItems={exploreLinks} />
-            <EuiHorizontalRule margin="none" />
-            <EuiNavDrawerGroup listItems={solutionsLinks} />
-            <EuiHorizontalRule margin="none" />
-            <EuiNavDrawerGroup listItems={adminLinks} />
-          </EuiNavDrawer>
-          <EuiPage className="euiNavDrawerPage">
-            <EuiPageBody className="euiNavDrawerPage__pageBody">
+
+          <EuiPage style={{ height: '100%' }}>
+            <EuiPageBody>
               <EuiPageHeader>
                 <EuiPageHeaderSection>
                   <EuiTitle size="m">
@@ -361,7 +84,7 @@ export default () => {
                 <EuiPageContentBody>
                   <EuiButton
                     fill
-                    onClick={toggleFullScreen}
+                    onClick={() => setIsFullScreen(false)}
                     iconType="exit"
                     aria-label="Exit fullscreen demo">
                     Exit fullscreen demo
@@ -371,25 +94,7 @@ export default () => {
             </EuiPageBody>
           </EuiPage>
         </div>
-      </EuiFocusTrap>
-    );
-  }
-
-  return (
-    <Fragment>
-      <EuiButton
-        onClick={toggleFullScreen}
-        iconType="fullScreen"
-        aria-label="Show fullscreen demo">
-        Show fullscreen demo
-      </EuiButton>
-
-      {/*
-            If the below fullScreen code renders, it actually attaches to the body because of
-            EuiOverlayMask's React portal usage.
-          */}
-
-      {fullScreenDisplay}
-    </Fragment>
+      )}
+    </GuideFullScreen>
   );
 };

--- a/src-docs/src/views/header/header_alert.js
+++ b/src-docs/src/views/header/header_alert.js
@@ -317,11 +317,10 @@ export default () => {
               <EuiHeaderSectionItem border="right">
                 <HeaderSpacesMenu />
               </EuiHeaderSectionItem>
+              <EuiHeaderLinks>
+                <EuiHeaderLink href="#">Home</EuiHeaderLink>
+              </EuiHeaderLinks>
             </EuiHeaderSection>
-
-            <EuiHeaderLinks>
-              <EuiHeaderLink href="#">Home</EuiHeaderLink>
-            </EuiHeaderLinks>
 
             <EuiHeaderSection side="right">
               <EuiHeaderSectionItem>

--- a/src-docs/src/views/header/header_alert.js
+++ b/src-docs/src/views/header/header_alert.js
@@ -76,7 +76,7 @@ export default () => {
                 <EuiPageContentHeader>
                   <EuiPageContentHeaderSection>
                     <p>
-                      Click the <EuiIcon type="email" size="m" /> button to see
+                      Click the <EuiIcon type="cheer" size="m" /> button to see
                       ‘What’s new?’
                     </p>
                   </EuiPageContentHeaderSection>

--- a/src-docs/src/views/header/header_dark.tsx
+++ b/src-docs/src/views/header/header_dark.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../../../src/components/header';
 import { EuiBadge } from '../../../../src/components/badge';
 import { EuiIcon } from '../../../../src/components/icon';
+import { EuiAvatar } from '../../../../src/components/avatar';
 
 export default ({ theme }: { theme: any }) => (
   <EuiHeader
@@ -49,8 +50,13 @@ export default ({ theme }: { theme: any }) => (
             iconSide="right">
             Production logs
           </EuiBadge>,
-          <EuiHeaderSectionItemButton aria-label="Alerts" notification={'•'}>
-            <EuiIcon type="email" size="m" />
+          <EuiHeaderSectionItemButton
+            aria-label="Notifications"
+            notification={'•'}>
+            <EuiIcon type="cheer" size="m" />
+          </EuiHeaderSectionItemButton>,
+          <EuiHeaderSectionItemButton aria-label="Account menu">
+            <EuiAvatar name="John Username" size="s" />
           </EuiHeaderSectionItemButton>,
         ],
         borders: 'none',

--- a/src-docs/src/views/header/header_dark.tsx
+++ b/src-docs/src/views/header/header_dark.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+/**
+ * Docs note: Consuming apps should import the theme via the export json file
+ * import theme from '@elastic/eui/dist/eui_theme_light.json';
+ */
+
+import {
+  EuiHeader,
+  EuiHeaderLogo,
+  EuiHeaderLinks,
+  EuiHeaderLink,
+  EuiHeaderSectionItemButton,
+} from '../../../../src/components/header';
+import { EuiBadge } from '../../../../src/components/badge';
+import { EuiIcon } from '../../../../src/components/icon';
+
+export default ({ theme }: { theme: any }) => (
+  <EuiHeader
+    theme="dark"
+    sections={[
+      {
+        items: [
+          <EuiHeaderLogo
+            iconType="logoElastic"
+            href="/"
+            aria-label="Goes to home">
+            Elastic
+          </EuiHeaderLogo>,
+          <EuiHeaderLinks>
+            <EuiHeaderLink href="#" isActive>
+              Docs
+            </EuiHeaderLink>
+
+            <EuiHeaderLink href="#">Code</EuiHeaderLink>
+
+            <EuiHeaderLink iconType="help" href="#">
+              Help
+            </EuiHeaderLink>
+          </EuiHeaderLinks>,
+        ],
+        borders: 'right',
+      },
+      {
+        items: [
+          <EuiBadge
+            color={theme.euiColorDarkestShade.rgba}
+            iconType="arrowDown"
+            iconSide="right">
+            Production logs
+          </EuiBadge>,
+          <EuiHeaderSectionItemButton aria-label="Alerts" notification={'•'}>
+            <EuiIcon type="email" size="m" />
+          </EuiHeaderSectionItemButton>,
+        ],
+        borders: 'none',
+      },
+    ]}
+  />
+);

--- a/src-docs/src/views/header/header_example.js
+++ b/src-docs/src/views/header/header_example.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router';
 import { renderToHtml } from '../../services';
 
 import { GuideSectionTypes } from '../../components';
+import lightColors from '!!sass-vars-to-js-loader!../../../../src/global_styling/variables/_colors.scss';
 
 import {
   EuiHeader,
@@ -39,6 +40,10 @@ const headerAlertHtml = renderToHtml(HeaderAlert);
 import HeaderLinks from './header_links';
 const headerLinksSource = require('!!raw-loader!./header_links');
 const headerLinksHtml = renderToHtml(HeaderLinks);
+
+import HeaderDark from './header_dark';
+const headerDarkSource = require('!!raw-loader!./header_dark');
+const headerDarkHtml = renderToHtml(HeaderDark);
 
 const headerSnippet = `<EuiHeader>
   <EuiHeaderSection grow={false}>
@@ -249,6 +254,33 @@ export const HeaderExample = {
       },
       snippet: headerLinksSnippet,
       demo: <HeaderAlert />,
+    },
+    {
+      title: 'Dark theme',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: headerDarkSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: headerDarkHtml,
+        },
+      ],
+      text: (
+        <p>
+          To make site-wide navigation more prominent,{' '}
+          <strong>EuiHeader</strong> supports reversing the colors to dark theme
+          with <EuiCode language="js">{'theme="dark"'}</EuiCode>.{' '}
+          <strong>However</strong>, it only supports a limited set of children
+          that will also shift their theme. These components include{' '}
+          <strong>EuiHeaderLogo, EuiHeaderLink(s),</strong> and{' '}
+          <strong>EuiHeaderSectionItemButton</strong>. Any other content may not
+          render correctly without custom configurations.
+        </p>
+      ),
+      snippet: '<EuiHeader theme="dark" />',
+      demo: <HeaderDark theme={lightColors} />,
     },
   ],
 };

--- a/src-docs/src/views/header/header_example.js
+++ b/src-docs/src/views/header/header_example.js
@@ -222,6 +222,33 @@ export const HeaderExample = {
       demo: <HeaderLinks />,
     },
     {
+      title: 'Dark theme',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: headerDarkSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: headerDarkHtml,
+        },
+      ],
+      text: (
+        <p>
+          To make site-wide navigation more prominent,{' '}
+          <strong>EuiHeader</strong> supports reversing the colors to dark theme
+          with <EuiCode language="js">{'theme="dark"'}</EuiCode>.{' '}
+          <strong>However</strong>, it only supports a limited set of children
+          that will also shift their theme. These components include{' '}
+          <strong>EuiHeaderLogo, EuiHeaderLink(s),</strong> and{' '}
+          <strong>EuiHeaderSectionItemButton</strong>. Any other content may not
+          render correctly without custom configurations.
+        </p>
+      ),
+      snippet: '<EuiHeader theme="dark" />',
+      demo: <HeaderDark theme={lightColors} />,
+    },
+    {
       title: 'Alerts in the header',
       source: [
         {
@@ -254,33 +281,6 @@ export const HeaderExample = {
       },
       snippet: headerLinksSnippet,
       demo: <HeaderAlert />,
-    },
-    {
-      title: 'Dark theme',
-      source: [
-        {
-          type: GuideSectionTypes.JS,
-          code: headerDarkSource,
-        },
-        {
-          type: GuideSectionTypes.HTML,
-          code: headerDarkHtml,
-        },
-      ],
-      text: (
-        <p>
-          To make site-wide navigation more prominent,{' '}
-          <strong>EuiHeader</strong> supports reversing the colors to dark theme
-          with <EuiCode language="js">{'theme="dark"'}</EuiCode>.{' '}
-          <strong>However</strong>, it only supports a limited set of children
-          that will also shift their theme. These components include{' '}
-          <strong>EuiHeaderLogo, EuiHeaderLink(s),</strong> and{' '}
-          <strong>EuiHeaderSectionItemButton</strong>. Any other content may not
-          render correctly without custom configurations.
-        </p>
-      ),
-      snippet: '<EuiHeader theme="dark" />',
-      demo: <HeaderDark theme={lightColors} />,
     },
   ],
 };

--- a/src-docs/src/views/header/header_links.js
+++ b/src-docs/src/views/header/header_links.js
@@ -15,17 +15,19 @@ export default () => {
         <EuiHeaderLogo href="#">Product</EuiHeaderLogo>
       </EuiHeaderSectionItem>
 
-      <EuiHeaderLinks>
-        <EuiHeaderLink href="#" isActive>
-          Docs
-        </EuiHeaderLink>
+      <EuiHeaderSectionItem>
+        <EuiHeaderLinks>
+          <EuiHeaderLink href="#" isActive>
+            Docs
+          </EuiHeaderLink>
 
-        <EuiHeaderLink href="#">Code</EuiHeaderLink>
+          <EuiHeaderLink href="#">Code</EuiHeaderLink>
 
-        <EuiHeaderLink iconType="help" href="#">
-          Help
-        </EuiHeaderLink>
-      </EuiHeaderLinks>
+          <EuiHeaderLink iconType="help" href="#">
+            Help
+          </EuiHeaderLink>
+        </EuiHeaderLinks>
+      </EuiHeaderSectionItem>
     </EuiHeader>
   );
 };

--- a/src-docs/src/views/header/header_position.js
+++ b/src-docs/src/views/header/header_position.js
@@ -22,7 +22,7 @@ export default () => {
     },
     {
       items: [
-        <div style={{ padding: 16 }}>
+        <div style={{ padding: 12 }}>
           <EuiSwitch
             label={`position: ${position}`}
             checked={position === 'fixed'}

--- a/src-docs/src/views/header/header_updates.js
+++ b/src-docs/src/views/header/header_updates.js
@@ -116,7 +116,7 @@ export default () => {
       }`}
       onClick={() => showFlyout()}
       notification={showBadge && '•'}>
-      <EuiIcon type="email" size="m" />
+      <EuiIcon type="cheer" size="m" />
     </EuiHeaderSectionItemButton>
   );
 

--- a/src-docs/src/views/header/header_updates.js
+++ b/src-docs/src/views/header/header_updates.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, Fragment } from 'react';
+import React, { useState, Fragment } from 'react';
 
 import {
   EuiIcon,
@@ -96,22 +96,14 @@ export default () => {
       badge: <EuiBadge color="hollow">6.5</EuiBadge>,
     },
   ];
-  function usePrevious(value) {
-    const ref = useRef();
-    useEffect(() => {
-      ref.current = value;
-    });
-    return ref.current;
-  }
 
   const closeFlyout = () => {
     setIsFlyoutVisible(false);
   };
 
-  const prevIsFlyoutVisible = usePrevious(isFlyoutVisible);
   const showFlyout = () => {
     setShowBadge(false);
-    setIsFlyoutVisible(!prevIsFlyoutVisible);
+    setIsFlyoutVisible(!isFlyoutVisible);
   };
 
   const button = (

--- a/src/components/header/__snapshots__/header.test.tsx.snap
+++ b/src/components/header/__snapshots__/header.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`EuiHeader is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="euiHeader euiHeader--static testClass1 testClass2"
+  class="euiHeader euiHeader--default euiHeader--static testClass1 testClass2"
   data-test-subj="test subject string"
 />
 `;
 
 exports[`EuiHeader renders children 1`] = `
 <div
-  class="euiHeader euiHeader--static"
+  class="euiHeader euiHeader--default euiHeader--static"
 >
   <span>
     Hello!
@@ -18,9 +18,15 @@ exports[`EuiHeader renders children 1`] = `
 </div>
 `;
 
+exports[`EuiHeader renders dark theme 1`] = `
+<div
+  class="euiHeader euiHeader--dark euiHeader--static"
+/>
+`;
+
 exports[`EuiHeader renders in fixed position 1`] = `
 <div
-  class="euiHeader euiHeader--fixed"
+  class="euiHeader euiHeader--default euiHeader--fixed"
 >
   <span>
     Hello!
@@ -30,7 +36,7 @@ exports[`EuiHeader renders in fixed position 1`] = `
 
 exports[`EuiHeader sections render breadcrumbs and props 1`] = `
 <div
-  class="euiHeader euiHeader--static"
+  class="euiHeader euiHeader--default euiHeader--static"
 >
   <nav
     aria-label="breadcrumb"
@@ -48,7 +54,7 @@ exports[`EuiHeader sections render breadcrumbs and props 1`] = `
 
 exports[`EuiHeader sections render simple items and borders 1`] = `
 <div
-  class="euiHeader euiHeader--static"
+  class="euiHeader euiHeader--default euiHeader--static"
 >
   <div
     class="euiHeaderSection euiHeaderSection--dontGrow euiHeaderSection--left"
@@ -83,7 +89,7 @@ exports[`EuiHeader sections render simple items and borders 1`] = `
 
 exports[`EuiHeader throws a warning if both children and sections were passed 1`] = `
 <div
-  class="euiHeader euiHeader--static"
+  class="euiHeader euiHeader--default euiHeader--static"
 >
   <div
     class="euiHeaderSection euiHeaderSection--dontGrow euiHeaderSection--left"

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -28,3 +28,10 @@
     z-index: $euiZModal + 1;
   }
 }
+
+.euiHeader--dark {
+  // Only force reverse theme if the theme is light
+  @if (lightness($euiTextColor) < 50) {
+    @include euiHeaderDarkTheme;
+  }
+}

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -3,6 +3,7 @@
 .euiHeader {
   @include euiBottomShadowSmall;
 
+  height: $euiHeaderHeight + 1; // Add one for the border
   position: relative;
   z-index: $euiZHeader; // ensure the shadow shows above content
   display: flex;

--- a/src/components/header/_header_logo.scss
+++ b/src/components/header/_header_logo.scss
@@ -8,7 +8,8 @@
   line-height: $euiHeaderChildSize;
   min-width: $euiHeaderChildSize + 1px;
   padding: 0 ($euiSizeM + 1px) 0 $euiSizeM;
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   vertical-align: middle;
   white-space: nowrap;
 

--- a/src/components/header/_header_logo.scss
+++ b/src/components/header/_header_logo.scss
@@ -23,12 +23,6 @@
   }
 }
 
-.euiHeaderLogo__icon {
-  opacity: 1;
-  position: relative;
-  top: -2px;
-}
-
 .euiHeaderLogo__text {
   @include euiTitle('s');
   padding-left: $euiSize;

--- a/src/components/header/_index.scss
+++ b/src/components/header/_index.scss
@@ -1,5 +1,7 @@
 // Components
 @import 'variables';
+@import 'mixins';
+
 @import 'header';
 @import 'header_profile';
 @import 'header_links/index';

--- a/src/components/header/_mixins.scss
+++ b/src/components/header/_mixins.scss
@@ -1,0 +1,37 @@
+@mixin euiHeaderDarkTheme {
+  $headerBackgroundColor: shade($euiColorDarkestShade, 28%);
+  background-color: $headerBackgroundColor;
+
+  .euiHeaderLogo__text,
+  .euiHeaderLink,
+  .euiHeaderSectionItem__button {
+    color: $euiColorGhost;
+  }
+
+  .euiHeaderLink-isActive {
+    color: makeHighContrastColor($euiColorPrimary, $headerBackgroundColor);
+  }
+
+  .euiHeaderSectionItem {
+    &:after {
+      background: $euiColorDarkShade;
+    }
+  }
+
+  .euiHeaderLogo,
+  .euiHeaderLink,
+  .euiHeaderSectionItem__button {
+    &:hover {
+      background: transparentize($euiColorDarkShade, .5);
+    }
+
+    &:focus {
+      background: shade($euiColorPrimary, 50%);
+    }
+  }
+
+  .euiHeaderNotification,
+  .euiHeaderSectionItemButton__notification {
+    box-shadow: 0 0 0 1px $headerBackgroundColor;
+  }
+}

--- a/src/components/header/_variables.scss
+++ b/src/components/header/_variables.scss
@@ -1,11 +1,11 @@
 // Note - these are also used by the EuiNavDrawer (/nav_drawer) component
 // Themable colors
-$euiHeaderBackgroundColor: $euiColorEmptyShade;
-$euiHeaderBreadcrumbColor: $euiColorDarkestShade;
+$euiHeaderBackgroundColor: $euiColorEmptyShade !default;
+$euiHeaderBreadcrumbColor: $euiColorDarkestShade !default;
 
 // Layout vars
-$euiHeaderHeight: $euiSizeXXL + $euiSizeS;
-$euiHeaderChildSize: $euiHeaderHeight;
+$euiHeaderHeight: $euiSizeXXL + $euiSizeS !default;
+$euiHeaderChildSize: $euiHeaderHeight !default;
 
 // Use the following variable in other components to afford for the fixed header
 $euiHeaderHeightCompensation: $euiHeaderHeight + 1px !default;

--- a/src/components/header/header.test.tsx
+++ b/src/components/header/header.test.tsx
@@ -50,6 +50,12 @@ describe('EuiHeader', () => {
     expect(component).toMatchSnapshot();
   });
 
+  test('renders dark theme', () => {
+    const component = render(<EuiHeader theme="dark" />);
+
+    expect(component).toMatchSnapshot();
+  });
+
   describe('sections', () => {
     test('render simple items and borders', () => {
       const component = render(

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -79,6 +79,11 @@ export type EuiHeaderProps = CommonProps &
      * adds the correct amount of top padding to the window when in `fixed` mode
      */
     position?: 'static' | 'fixed';
+    /**
+     * The `default` will inherit its coloring from the light or dark theme.
+     * Or, force the header into pseudo `dark` theme for all themes.
+     */
+    theme?: 'default' | 'dark';
   };
 
 export const EuiHeader: FunctionComponent<EuiHeaderProps> = ({
@@ -86,9 +91,15 @@ export const EuiHeader: FunctionComponent<EuiHeaderProps> = ({
   className,
   sections,
   position = 'static',
+  theme = 'default',
   ...rest
 }) => {
-  const classes = classNames('euiHeader', `euiHeader--${position}`, className);
+  const classes = classNames(
+    'euiHeader',
+    `euiHeader--${theme}`,
+    `euiHeader--${position}`,
+    className
+  );
 
   useEffect(() => {
     if (position === 'fixed') {

--- a/src/components/header/header_links/__snapshots__/header_link.test.tsx.snap
+++ b/src/components/header/header_links/__snapshots__/header_link.test.tsx.snap
@@ -16,3 +16,18 @@ exports[`EuiHeaderLink is rendered 1`] = `
   </span>
 </button>
 `;
+
+exports[`EuiHeaderLink is rendered as active 1`] = `
+<button
+  class="euiButtonEmpty euiButtonEmpty--primary euiHeaderLink euiHeaderLink-isActive"
+  type="button"
+>
+  <span
+    class="euiButtonEmpty__content"
+  >
+    <span
+      class="euiButtonEmpty__text"
+    />
+  </span>
+</button>
+`;

--- a/src/components/header/header_links/__snapshots__/header_links.test.tsx.snap
+++ b/src/components/header/header_links/__snapshots__/header_links.test.tsx.snap
@@ -16,19 +16,15 @@ exports[`EuiHeaderLinks is rendered 1`] = `
     <div
       class="euiPopover__anchor"
     >
-      <div
-        class="euiHeaderSectionItem euiHeaderSectionItem--borderLeft"
+      <button
+        aria-label="Open navigation menu"
+        class="euiHeaderSectionItem__button"
+        type="button"
       >
-        <button
-          aria-label="Open navigation menu"
-          class="euiHeaderSectionItem__button"
-          type="button"
-        >
-          <div
-            data-euiicon-type="apps"
-          />
-        </button>
-      </div>
+        <div
+          data-euiicon-type="apps"
+        />
+      </button>
     </div>
   </div>
 </nav>

--- a/src/components/header/header_links/_header_link.scss
+++ b/src/components/header/header_links/_header_link.scss
@@ -1,20 +1,15 @@
 .euiHeaderLink {
   @include euiLink;
-  display: inline-block;
-  height: $euiHeaderChildSize;
-  line-height: $euiHeaderChildSize;
-  padding: 0 $euiSizeS;
-  text-align: left;
+  margin: 0 $euiSizeS;
 }
 
 .euiHeaderLinks__mobileList {
   .euiHeaderLink {
     display: block;
-    height: auto;
-    line-height: $euiLineHeight;
     padding: $euiSizeS;
+    margin: 0;
 
-    // EuiButtons normally center, which macks sense. In mobile though we want
+    // EuiButtons normally center, which makes sense. In mobile though we want
     // them to align left. This is a safe hack given the specificity.
     > span {
       justify-content: flex-start;

--- a/src/components/header/header_links/_header_links.scss
+++ b/src/components/header/header_links/_header_links.scss
@@ -4,20 +4,18 @@
   display: flex;
   justify-content: space-between;
   position: relative;
-  flex-grow: 1;
 }
 
 .euiHeaderLinks__list {
   white-space: nowrap;
   overflow: hidden;
+  display: flex;
+  align-items: center;
 }
 
 .euiHeaderLinks__mobile {
   // sass-lint:disable-block no-important
   display: none !important; // override popover inline-block
-  position: absolute !important; // override popover relative
-  right: 0;
-
 }
 
 @include euiBreakpoint('m', 'l', 'xl') {

--- a/src/components/header/header_links/header_link.test.tsx
+++ b/src/components/header/header_links/header_link.test.tsx
@@ -29,4 +29,10 @@ describe('EuiHeaderLink', () => {
 
     expect(component).toMatchSnapshot();
   });
+
+  test('is rendered as active', () => {
+    const component = render(<EuiHeaderLink isActive />);
+
+    expect(component).toMatchSnapshot();
+  });
 });

--- a/src/components/header/header_links/header_link.tsx
+++ b/src/components/header/header_links/header_link.tsx
@@ -33,7 +33,13 @@ export const EuiHeaderLink: FunctionComponent<EuiHeaderLinkProps> = ({
   className,
   ...rest
 }) => {
-  const classes = classNames('euiHeaderLink', className);
+  const classes = classNames(
+    'euiHeaderLink',
+    {
+      'euiHeaderLink-isActive': isActive,
+    },
+    className
+  );
 
   const props = {
     ...rest,

--- a/src/components/header/header_links/header_links.tsx
+++ b/src/components/header/header_links/header_links.tsx
@@ -24,10 +24,7 @@ import { CommonProps } from '../../common';
 import { EuiIcon } from '../../icon';
 import { EuiPopover } from '../../popover';
 import { EuiI18n } from '../../i18n';
-import {
-  EuiHeaderSectionItemButton,
-  EuiHeaderSectionItem,
-} from '../header_section';
+import { EuiHeaderSectionItemButton } from '../header_section';
 
 interface State {
   isOpen: boolean;
@@ -64,19 +61,17 @@ export class EuiHeaderLinks extends Component<CommonProps, State> {
     const classes = classNames('euiHeaderLinks', className);
 
     const button = (
-      <EuiHeaderSectionItem border="left">
-        <EuiI18n
-          token="euiHeaderLinks.openNavigationMenu"
-          default="Open navigation menu">
-          {(openNavigationMenu: string) => (
-            <EuiHeaderSectionItemButton
-              aria-label={openNavigationMenu}
-              onClick={this.onMenuButtonClick}>
-              <EuiIcon type="apps" size="m" />
-            </EuiHeaderSectionItemButton>
-          )}
-        </EuiI18n>
-      </EuiHeaderSectionItem>
+      <EuiI18n
+        token="euiHeaderLinks.openNavigationMenu"
+        default="Open navigation menu">
+        {(openNavigationMenu: string) => (
+          <EuiHeaderSectionItemButton
+            aria-label={openNavigationMenu}
+            onClick={this.onMenuButtonClick}>
+            <EuiIcon type="apps" size="m" />
+          </EuiHeaderSectionItemButton>
+        )}
+      </EuiI18n>
     );
 
     return (

--- a/src/components/header/header_section/header_section_item.tsx
+++ b/src/components/header/header_section/header_section_item.tsx
@@ -31,6 +31,10 @@ const borderToClassNameMap: { [border in Border]: string | undefined } = {
 };
 
 export type EuiHeaderSectionItemProps = CommonProps & {
+  /**
+   * Side to display a short border on.
+   * Not supported in Amsterdam theme.
+   */
   border?: Border;
   children?: ReactNode;
 };

--- a/src/components/nav_drawer/_variables.scss
+++ b/src/components/nav_drawer/_variables.scss
@@ -3,11 +3,11 @@ $euiNavDrawerBackgroundColor: $euiHeaderBackgroundColor;
 
 // Drawer variables
 $euiNavDrawerWidthExpanded: 240px;
-$euiNavDrawerWidthCollapsed: $euiHeaderChildSize;
+$euiNavDrawerWidthCollapsed: $euiHeaderHeight;
 $euiNavDrawerSideShadow: 2px 0 2px -1px rgba($euiShadowColor, .3);
 
 // Layout variables
-$euiNavDrawerTopPosition: $euiHeaderChildSize + 1px;
+$euiNavDrawerTopPosition: $euiHeaderHeight + 1px;
 
 // Animation variables
 $euiNavDrawerExpandingDelay: $euiAnimSpeedNormal;

--- a/src/themes/eui-amsterdam/global_styling/variables/_header.scss
+++ b/src/themes/eui-amsterdam/global_styling/variables/_header.scss
@@ -1,0 +1,1 @@
+$euiHeaderChildSize: $euiSizeXXL;

--- a/src/themes/eui-amsterdam/global_styling/variables/_index.scss
+++ b/src/themes/eui-amsterdam/global_styling/variables/_index.scss
@@ -1,4 +1,5 @@
 @import 'buttons';
 @import 'borders';
+@import 'header';
 @import 'typography';
 @import 'shadows';

--- a/src/themes/eui-amsterdam/overrides/_header.scss
+++ b/src/themes/eui-amsterdam/overrides/_header.scss
@@ -5,6 +5,7 @@
   padding-right: $euiSizeS;
 }
 
+// Remove borders without deleting the prop just yet
 .euiHeaderSectionItem:after {
   display: none !important; // sass-lint:disable-line no-important
 }

--- a/src/themes/eui-amsterdam/overrides/_header.scss
+++ b/src/themes/eui-amsterdam/overrides/_header.scss
@@ -1,0 +1,24 @@
+.euiHeader {
+  height: $euiHeaderHeight;
+  border-bottom: none;
+  padding-left: $euiSizeS;
+  padding-right: $euiSizeS;
+}
+
+.euiHeaderSectionItem:after {
+  display: none !important; // sass-lint:disable-line no-important
+}
+
+.euiHeaderLogo {
+  padding-left: $euiSizeS;
+  padding-right: $euiSizeS;
+  min-width: $euiHeaderChildSize;
+}
+
+.euiHeaderLogo__text {
+  @include euiTitle('xxs');
+}
+
+.euiHeaderBreadcrumbs {
+  margin-left: $euiSizeS;
+}

--- a/src/themes/eui-amsterdam/overrides/_index.scss
+++ b/src/themes/eui-amsterdam/overrides/_index.scss
@@ -1,4 +1,5 @@
 @import 'button';
 @import 'button_empty';
 @import 'button_group';
+@import 'header';
 @import 'text';


### PR DESCRIPTION
### Part 1/3 for next iteration of K8 support

This PR tackles 3 main things:

## 1. Adds `theme` prop to **EuiHeader**

This adds support for providing `theme="dark"` and the header will display as if it's dark mode no matter the theme. For now it only supports a few child components.

![image](https://user-images.githubusercontent.com/549577/83202250-30015400-a115-11ea-934d-4c01ef48e500.png)
![image](https://user-images.githubusercontent.com/549577/83202267-3d1e4300-a115-11ea-99ad-8bc076c13536.png)


## 2. Adds Amsterdam updates to **EuiHeader**

Mainly fixes some usages of `$euiHeaderSize` vs `$euiHeaderChildSize` variables, and removes the borders. This does not yet tackle the breadcrumb updates.

![image](https://user-images.githubusercontent.com/549577/83202311-52936d00-a115-11ea-8c33-d30f1cbceb70.png)
![image](https://user-images.githubusercontent.com/549577/83202344-6212b600-a115-11ea-98bd-140fa605ad70.png)
![image](https://user-images.githubusercontent.com/549577/83202404-82db0b80-a115-11ea-9c58-70b526626bad.png)


## 3. Fixes a few minor things in some header sub-components

Like alignments and responsive displays.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [x] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
