### PR TITLE
[EuiMarkdownEditor] Improve markdown editor font

### DIFF
--- a/src/components/markdown_editor/_index.scss
+++ b/src/components/markdown_editor/_index.scss
@@ -1,4 +1,3 @@
-@import 'variables';
 @import 'markdown_editor';
 @import 'markdown_editor_drop_zone';
 @import 'markdown_format';

--- a/src/components/markdown_editor/_index.scss
+++ b/src/components/markdown_editor/_index.scss
@@ -1,3 +1,4 @@
+@import 'variables';
 @import 'markdown_editor';
 @import 'markdown_editor_drop_zone';
 @import 'markdown_format';

--- a/src/components/markdown_editor/_index.scss
+++ b/src/components/markdown_editor/_index.scss
@@ -1,5 +1,6 @@
 @import 'markdown_editor';
 @import 'markdown_editor_drop_zone';
 @import 'markdown_format';
+@import 'markdown_editor_preview';
 @import 'markdown_editor_text_area';
 @import 'markdown_editor_toolbar';

--- a/src/components/markdown_editor/_markdown_editor.scss
+++ b/src/components/markdown_editor/_markdown_editor.scss
@@ -5,7 +5,6 @@
 
   &__textArea,
   &__previewContainer {
-    color: $euiTextColor;
     padding: $euiSizeM;
     background: $euiColorEmptyShade;
   }

--- a/src/components/markdown_editor/_markdown_editor.scss
+++ b/src/components/markdown_editor/_markdown_editor.scss
@@ -2,17 +2,4 @@
   &:focus-within {
     @include euiSlightShadowHover;
   }
-
-  &__textArea,
-  &__previewContainer {
-    padding: $euiSizeM;
-    background: $euiColorEmptyShade;
-  }
-}
-
-.euiMarkdownEditor__previewContainer {
-  @include euiScrollBar;
-  height: 150px;
-  overflow-y: auto;
-  border: $euiBorderThin;
 }

--- a/src/components/markdown_editor/_markdown_editor.scss
+++ b/src/components/markdown_editor/_markdown_editor.scss
@@ -3,20 +3,17 @@
     @include euiSlightShadowHover;
   }
 
-  .euiMarkdownEditor__textArea,
-  .euiMarkdownEditor__previewContainer {
+  &__textArea,
+  &__previewContainer {
+    color: $euiTextColor;
     padding: $euiSizeM;
+    background: $euiColorEmptyShade;
   }
 }
 
 .euiMarkdownEditor__previewContainer {
   @include euiScrollBar;
-  background: $euiColorEmptyShade;
   height: 150px;
   overflow-y: auto;
   border: $euiBorderThin;
-}
-
-.euiMarkdownEditor__textArea {
-  background: $euiColorEmptyShade;
 }

--- a/src/components/markdown_editor/_markdown_editor_preview.scss
+++ b/src/components/markdown_editor/_markdown_editor_preview.scss
@@ -1,0 +1,7 @@
+.euiMarkdownEditor__preview {
+  @include euiScrollBar;
+  height: 150px;
+  overflow-y: auto;
+  border: $euiBorderThin;
+  padding: $euiSizeM;
+}

--- a/src/components/markdown_editor/_markdown_editor_text_area.scss
+++ b/src/components/markdown_editor/_markdown_editor_text_area.scss
@@ -3,6 +3,7 @@
   width: 100%;
   height: 100%;
   min-height: 150px;
+  padding: $euiSizeM;
   background-color: $euiFormBackgroundColor;
   border: $euiBorderThin;
   border-bottom: 1px dashed $euiColorLightShade;

--- a/src/components/markdown_editor/_markdown_editor_text_area.scss
+++ b/src/components/markdown_editor/_markdown_editor_text_area.scss
@@ -1,4 +1,6 @@
 .euiMarkdownEditor__textArea {
+  @include euiFont;
+  @include euiFontSizeS;
   width: 100%;
   height: 100%;
   min-height: 150px;
@@ -6,9 +8,6 @@
   border: $euiBorderThin;
   border-bottom: 1px dashed $euiColorLightShade;
   border-color: $euiColorLightShade;
-  font-family: $euiMarkdownEditorFontFamily;
-  font-size: $euiFontSizeS;
-  line-height: 1.5;
   resize: vertical;
 
   &:focus {

--- a/src/components/markdown_editor/_markdown_editor_text_area.scss
+++ b/src/components/markdown_editor/_markdown_editor_text_area.scss
@@ -1,6 +1,4 @@
 .euiMarkdownEditor__textArea {
-  @include euiFormControlText;
-  font-family: $euiCodeFontFamily;
   width: 100%;
   height: 100%;
   min-height: 150px;
@@ -8,6 +6,10 @@
   border: $euiBorderThin;
   border-bottom: 1px dashed $euiColorLightShade;
   border-color: $euiColorLightShade;
+  font-family: $euiMarkdownEditorFontFamily;
+  font-size: $euiFontSizeS;
+  color: $euiTextColor;
+  line-height: 1.5;
   resize: vertical;
 
   &:focus {

--- a/src/components/markdown_editor/_markdown_editor_text_area.scss
+++ b/src/components/markdown_editor/_markdown_editor_text_area.scss
@@ -1,5 +1,5 @@
 .euiMarkdownEditor__textArea {
-  @include  euiFormControlText;
+  @include euiFormControlText;
   width: 100%;
   height: 100%;
   min-height: 150px;
@@ -7,7 +7,7 @@
   border: $euiBorderThin;
   border-bottom: 1px dashed $euiColorLightShade;
   border-color: $euiColorLightShade;
-  // Overrides default euiFormControlText line-height that is very small
+  // Overrides the euiFormControlText line-height that is very small
   line-height: $euiLineHeight;
   resize: vertical;
 

--- a/src/components/markdown_editor/_markdown_editor_text_area.scss
+++ b/src/components/markdown_editor/_markdown_editor_text_area.scss
@@ -8,7 +8,6 @@
   border-color: $euiColorLightShade;
   font-family: $euiMarkdownEditorFontFamily;
   font-size: $euiFontSizeS;
-  color: $euiTextColor;
   line-height: 1.5;
   resize: vertical;
 

--- a/src/components/markdown_editor/_markdown_editor_text_area.scss
+++ b/src/components/markdown_editor/_markdown_editor_text_area.scss
@@ -1,6 +1,5 @@
 .euiMarkdownEditor__textArea {
-  @include euiFont;
-  @include euiFontSizeS;
+  @include  euiFormControlText;
   width: 100%;
   height: 100%;
   min-height: 150px;
@@ -8,6 +7,8 @@
   border: $euiBorderThin;
   border-bottom: 1px dashed $euiColorLightShade;
   border-color: $euiColorLightShade;
+  // Overrides default euiFormControlText line-height that is very small
+  line-height: $euiLineHeight;
   resize: vertical;
 
   &:focus {

--- a/src/components/markdown_editor/_markdown_format.scss
+++ b/src/components/markdown_editor/_markdown_format.scss
@@ -18,7 +18,7 @@ $euiDefaultFontSize: 14px;
 }
 
 .euiMarkdownFormat {
-  font-family: $euiMarkdownEditorFontFamily;
+  @include euiFont;
 
   // Font size variables
   $euiMarkdownFontSizeS: canvasToEm(12px);

--- a/src/components/markdown_editor/_markdown_format.scss
+++ b/src/components/markdown_editor/_markdown_format.scss
@@ -20,6 +20,7 @@ $euiDefaultFontSize: 14px;
 .euiMarkdownFormat {
   @include euiFont;
   @include euiText;
+  padding: $euiSizeM;
 
   // Font size variables
   $euiMarkdownFontSizeS: canvasToEm(12px);

--- a/src/components/markdown_editor/_markdown_format.scss
+++ b/src/components/markdown_editor/_markdown_format.scss
@@ -20,7 +20,6 @@ $euiDefaultFontSize: 14px;
 .euiMarkdownFormat {
   @include euiFont;
   @include euiText;
-  padding: $euiSizeM;
 
   // Font size variables
   $euiMarkdownFontSizeS: canvasToEm(12px);

--- a/src/components/markdown_editor/_markdown_format.scss
+++ b/src/components/markdown_editor/_markdown_format.scss
@@ -18,9 +18,7 @@ $euiDefaultFontSize: 14px;
 }
 
 .euiMarkdownFormat {
-  // sass-lint:disable-block indentation
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial,
-    sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  font-family: $euiMarkdownEditorFontFamily;
 
   // Font size variables
   $euiMarkdownFontSizeS: canvasToEm(12px);
@@ -45,10 +43,6 @@ $euiDefaultFontSize: 14px;
   $euiMarkdownAlphaLightestShadeReversed: rgba($euiColorEmptyShade, .05);
   $euiMarkdownAlphaLightShadeReversed: rgba($euiColorEmptyShade, .15);
   $euiMarkdownAlphaDarkShadeReversed: rgba($euiColorEmptyShade, .65);
-
-  &--reversed {
-    color: $euiColorLightestShade;
-  }
 
   > *:first-child {
     // sass-lint:disable-block no-important

--- a/src/components/markdown_editor/_markdown_format.scss
+++ b/src/components/markdown_editor/_markdown_format.scss
@@ -19,6 +19,7 @@ $euiDefaultFontSize: 14px;
 
 .euiMarkdownFormat {
   @include euiFont;
+  @include euiText;
 
   // Font size variables
   $euiMarkdownFontSizeS: canvasToEm(12px);

--- a/src/components/markdown_editor/_variables.scss
+++ b/src/components/markdown_editor/_variables.scss
@@ -1,0 +1,2 @@
+$euiMarkdownEditorFontFamily: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial,
+sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';

--- a/src/components/markdown_editor/_variables.scss
+++ b/src/components/markdown_editor/_variables.scss
@@ -1,2 +1,0 @@
-$euiMarkdownEditorFontFamily: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial,
-sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';

--- a/src/components/markdown_editor/markdown_editor.tsx
+++ b/src/components/markdown_editor/markdown_editor.tsx
@@ -217,7 +217,7 @@ export const EuiMarkdownEditor: FunctionComponent<EuiMarkdownEditorProps> = ({
 
         {isPreviewing ? (
           <div
-            className="euiMarkdownEditor__previewContainer"
+            className="euiMarkdownEditor__preview"
             style={{ height: `${height}px` }}>
             <EuiMarkdownFormat processor={processor}>{value}</EuiMarkdownFormat>
           </div>


### PR DESCRIPTION
### Summary

This PR improves the fonts for the `EuiMarkdownEditor` text and preview areas:

- I'm removing the code font family from the text area that created some visual issues
- The text and preview areas are now both using the `Inter UI` font.
- I'm also making sure the text color and background changes according to the theme.

<img width="1990" alt="MD Font@2x" src="https://user-images.githubusercontent.com/2750668/83253613-26bfc800-a1a5-11ea-87a9-386c4ee4306f.png">


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [x] Checked in **IE11** and **Firefox**
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
