### PR TITLE
Add minSizeForControls to euiDataGrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Added `minSizeForControls` to `euiDataGrid` as prop to control the min size for grid controls ([#3527](https://github.com/elastic/eui/pull/3527))
+- Added `minSizeForControls` prop to `EuiDataGrid` to control the minimum width for showing grid controls ([#3527](https://github.com/elastic/eui/pull/3527))
 - Passed `getSelectedOptionForSearchValue` to `EuiComboBoxOptionsList` as prop ([#3501](https://github.com/elastic/eui/pull/3501))
 - Added `appendIconComponentCache` function to allow manual pre-emptive loading of source elements into the `EuiIcon` cache ([#3481](https://github.com/elastic/eui/pull/3481))
 - Added `initialSelected` to `EuiTableSelectionType` properties to set initial selected checkboxes for `EuiBasicTable` ([#3418](https://github.com/elastic/eui/pull/3418))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Added `minSizeForControls` to `euiDataGrid` as prop to control the min size for grid controls ([#](https://github.com/elastic/eui/pull/))
+- Added `minSizeForControls` to `euiDataGrid` as prop to control the min size for grid controls ([#3527](https://github.com/elastic/eui/pull/3527))
 - Passed `getSelectedOptionForSearchValue` to `EuiComboBoxOptionsList` as prop ([#3501](https://github.com/elastic/eui/pull/3501))
 - Added `appendIconComponentCache` function to allow manual pre-emptive loading of source elements into the `EuiIcon` cache ([#3481](https://github.com/elastic/eui/pull/3481))
 - Added `initialSelected` to `EuiTableSelectionType` properties to set initial selected checkboxes for `EuiBasicTable` ([#3418](https://github.com/elastic/eui/pull/3418))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Added `minSizeForControls` to `euiDataGrid` as prop to control the min size for grid controls ([#](https://github.com/elastic/eui/pull/))
 - Passed `getSelectedOptionForSearchValue` to `EuiComboBoxOptionsList` as prop ([#3501](https://github.com/elastic/eui/pull/3501))
 - Added `appendIconComponentCache` function to allow manual pre-emptive loading of source elements into the `EuiIcon` cache ([#3481](https://github.com/elastic/eui/pull/3481))
 - Added `initialSelected` to `EuiTableSelectionType` properties to set initial selected checkboxes for `EuiBasicTable` ([#3418](https://github.com/elastic/eui/pull/3418))

--- a/src-docs/src/views/datagrid/datagrid_styling_example.js
+++ b/src-docs/src/views/datagrid/datagrid_styling_example.js
@@ -183,7 +183,9 @@ export const DataGridStylingExample = {
       text: (
         <p>
           When wrapped inside a container, like a dashboard panel, the grid will
-          start hiding controls and adopt a more strict flex layout
+          start hiding controls and adopt a more strict flex layout.
+          Use the `minSizeForControls` prop to control the min width to
+          enables/disables grid controls based on available width.
         </p>
       ),
       components: { DataGridContainer },

--- a/src-docs/src/views/datagrid/datagrid_styling_example.js
+++ b/src-docs/src/views/datagrid/datagrid_styling_example.js
@@ -184,7 +184,7 @@ export const DataGridStylingExample = {
         <p>
           When wrapped inside a container, like a dashboard panel, the grid will
           start hiding controls and adopt a more strict flex layout.
-          Use the `minSizeForControls` prop to control the min width to
+          Use the <EuiCode>minSizeForControls</EuiCode> prop to control the min width to
           enables/disables grid controls based on available width.
         </p>
       ),

--- a/src-docs/src/views/datagrid/datagrid_styling_example.js
+++ b/src-docs/src/views/datagrid/datagrid_styling_example.js
@@ -183,8 +183,8 @@ export const DataGridStylingExample = {
       text: (
         <p>
           When wrapped inside a container, like a dashboard panel, the grid will
-          start hiding controls and adopt a more strict flex layout.
-          Use the <EuiCode>minSizeForControls</EuiCode> prop to control the min width to
+          start hiding controls and adopt a more strict flex layout. Use the
+          <EuiCode>minSizeForControls</EuiCode> prop to control the min width to
           enables/disables grid controls based on available width.
         </p>
       ),

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -140,6 +140,11 @@ type CommonGridProps = CommonProps &
      * A callback for when a column's size changes. Callback receives `{ columnId: string, width: number }`.
      */
     onColumnResize?: EuiDataGridOnColumnResizeHandler;
+    /**
+     * Defines a control for the min size when the grid only shows the full screen button.
+     * Default to `MINIMUM_WIDTH_FOR_GRID_CONTROLS`.
+     */
+    minSizeForControls?: number;
   };
 
 // This structure forces either aria-label or aria-labelledby to be defined
@@ -326,12 +331,13 @@ function useColumnWidths(
 
 function useOnResize(
   setHasRoomForGridControls: (hasRoomForGridControls: boolean) => void,
-  isFullScreen: boolean
+  isFullScreen: boolean,
+  minSizeForControls: number
 ) {
   return useCallback(
     ({ width }: { width: number }) => {
       setHasRoomForGridControls(
-        width > MINIMUM_WIDTH_FOR_GRID_CONTROLS || isFullScreen
+        width > minSizeForControls || isFullScreen
       );
     },
     [setHasRoomForGridControls, isFullScreen]
@@ -593,11 +599,14 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
   );
 
   // enables/disables grid controls based on available width
+  const minSizeForControls = typeof props.minSizeForControls === 'undefined' ?
+    MINIMUM_WIDTH_FOR_GRID_CONTROLS :
+    props.minSizeForControls;
   const onResize = useOnResize(nextHasRoomForGridControls => {
     if (nextHasRoomForGridControls !== hasRoomForGridControls) {
       setHasRoomForGridControls(nextHasRoomForGridControls);
     }
-  }, isFullScreen);
+  }, isFullScreen, minSizeForControls);
 
   const handleGridKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
     switch (e.keyCode) {

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -141,8 +141,7 @@ type CommonGridProps = CommonProps &
      */
     onColumnResize?: EuiDataGridOnColumnResizeHandler;
     /**
-     * Defines a control for the min size when the grid only shows the full screen button.
-     * Default to `MINIMUM_WIDTH_FOR_GRID_CONTROLS`.
+     * Defines a minimum width for the grid to show all controls in its header.
      */
     minSizeForControls?: number;
   };
@@ -625,9 +624,7 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
     inMemory,
     popoverContents,
     onColumnResize,
-    minSizeForControls = typeof props.minSizeForControls === 'undefined' ?
-      MINIMUM_WIDTH_FOR_GRID_CONTROLS :
-      props.minSizeForControls,
+    minSizeForControls = MINIMUM_WIDTH_FOR_GRID_CONTROLS,
     ...rest
   } = props;
 

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -598,16 +598,6 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
     [headerIsInteractive, setHeaderIsInteractive, focusedCell, setFocusedCell]
   );
 
-  // enables/disables grid controls based on available width
-  const minSizeForControls = typeof props.minSizeForControls === 'undefined' ?
-    MINIMUM_WIDTH_FOR_GRID_CONTROLS :
-    props.minSizeForControls;
-  const onResize = useOnResize(nextHasRoomForGridControls => {
-    if (nextHasRoomForGridControls !== hasRoomForGridControls) {
-      setHasRoomForGridControls(nextHasRoomForGridControls);
-    }
-  }, isFullScreen, minSizeForControls);
-
   const handleGridKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
     switch (e.keyCode) {
       case keyCodes.ESCAPE:
@@ -635,8 +625,18 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
     inMemory,
     popoverContents,
     onColumnResize,
+    minSizeForControls = typeof props.minSizeForControls === 'undefined' ?
+      MINIMUM_WIDTH_FOR_GRID_CONTROLS :
+      props.minSizeForControls,
     ...rest
   } = props;
+
+  // enables/disables grid controls based on available width
+  const onResize = useOnResize(nextHasRoomForGridControls => {
+    if (nextHasRoomForGridControls !== hasRoomForGridControls) {
+      setHasRoomForGridControls(nextHasRoomForGridControls);
+    }
+  }, isFullScreen, minSizeForControls);
 
   const [columnWidths, setColumnWidth] = useColumnWidths(
     columns,

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -335,11 +335,9 @@ function useOnResize(
 ) {
   return useCallback(
     ({ width }: { width: number }) => {
-      setHasRoomForGridControls(
-        width > minSizeForControls || isFullScreen
-      );
+      setHasRoomForGridControls(width > minSizeForControls || isFullScreen);
     },
-    [setHasRoomForGridControls, isFullScreen]
+    [setHasRoomForGridControls, isFullScreen, minSizeForControls]
   );
 }
 
@@ -629,11 +627,15 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
   } = props;
 
   // enables/disables grid controls based on available width
-  const onResize = useOnResize(nextHasRoomForGridControls => {
-    if (nextHasRoomForGridControls !== hasRoomForGridControls) {
-      setHasRoomForGridControls(nextHasRoomForGridControls);
-    }
-  }, isFullScreen, minSizeForControls);
+  const onResize = useOnResize(
+    nextHasRoomForGridControls => {
+      if (nextHasRoomForGridControls !== hasRoomForGridControls) {
+        setHasRoomForGridControls(nextHasRoomForGridControls);
+      }
+    },
+    isFullScreen,
+    minSizeForControls
+  );
 
   const [columnWidths, setColumnWidth] = useColumnWidths(
     columns,


### PR DESCRIPTION
### Summary

Fixes #3505

Added `minSizeForControls` to `euiDataGrid` as prop to control the min size for grid controls.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
~~[ ] Checked in **IE11** and **Firefox**~~
- [x] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples
~~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
- [x] Checked for **breaking changes** and labeled appropriately
~~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
