### PR TITLE
Re-enable default markdown list parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "rehype-raw": "^4.0.1",
     "rehype-react": "^5.0.0",
     "rehype-stringify": "^6.0.1",
-    "remark-disable-tokenizers": "^1.0.24",
     "remark-emoji": "^2.1.0",
     "remark-highlight.js": "^5.2.0",
     "remark-parse": "^7.0.2",

--- a/src-docs/src/views/markdown_editor/plugins/markdown_checkbox.js
+++ b/src-docs/src/views/markdown_editor/plugins/markdown_checkbox.js
@@ -41,7 +41,7 @@ function CheckboxParser() {
   }
 
   tokenizers.checkbox = tokenizeCheckbox;
-  methods.splice(methods.indexOf('text'), 0, 'checkbox'); // Run it just before `text`.
+  methods.splice(methods.indexOf('list'), 0, 'checkbox'); // Run it just before default `list` plugin to inject our own idea of checkboxes.
 }
 
 const checkboxMarkdownHandler = (h, node) => {

--- a/src-docs/src/views/markdown_editor/plugins/markdown_checkbox.js
+++ b/src-docs/src/views/markdown_editor/plugins/markdown_checkbox.js
@@ -15,17 +15,15 @@ function CheckboxParser() {
      * optional whitespace
      * remainder of the line is consumed as the textbox label
      */
-    const checkboxMatch = value.match(/^(\s*-\s*)?\[([\sx]*)\]\s*([^\r\n]+)/);
+    const checkboxMatch = value.match(/^(\s*-\s*)?\[([\sx]*)\](.+)/);
     if (checkboxMatch == null) return false;
 
     if (silent) {
       return true;
     }
 
-    const [match, , checkboxStatus, text] = checkboxMatch;
+    const [match, lead = '', checkboxStatus, text] = checkboxMatch;
     const isChecked = checkboxStatus.indexOf('x') !== -1;
-
-    const position = eat.now();
 
     const now = eat.now();
     const offset = match.length - text.length;
@@ -35,7 +33,9 @@ function CheckboxParser() {
 
     return eat(match)({
       type: 'checkboxPlugin',
-      configuration: { isChecked, position },
+      lead,
+      label: text,
+      isChecked,
       children,
     });
   }
@@ -45,37 +45,23 @@ function CheckboxParser() {
 }
 
 const checkboxMarkdownHandler = (h, node) => {
-  return h(node.position, 'checkboxPlugin', node.configuration, all(h, node));
+  return h(node.position, 'checkboxPlugin', node, all(h, node));
 };
-const CheckboxMarkdownRenderer = ({ position, isChecked, children }) => {
-  const { markdown, setMarkdown } = useContext(EuiMarkdownContext);
+const CheckboxMarkdownRenderer = ({
+  position,
+  lead,
+  label,
+  isChecked,
+  children,
+}) => {
+  const { replaceNode } = useContext(EuiMarkdownContext);
   return (
     <EuiCheckbox
       id={htmlIdGenerator()()}
       checked={isChecked}
       label={children}
       onChange={() => {
-        const leadingMarkdown = markdown.substr(0, position.offset);
-
-        let index = position.offset;
-        let leadIn = '';
-        let hasSeenBracket = false;
-        for (; index < markdown.length; index++) {
-          const char = markdown[index];
-          if (hasSeenBracket === false) {
-            if (char === '[') hasSeenBracket = true;
-            else leadIn += char;
-          } else {
-            if (char === ']') break;
-          }
-        }
-        index++; // still need to skip over the closing bracket
-
-        const checkMarkdown = `[${isChecked ? ' ' : 'x'}]`;
-        const trailingMarkdown = markdown.substr(index);
-        const nextMarkdown = `${leadingMarkdown}${leadIn}${checkMarkdown}${trailingMarkdown}`;
-
-        setMarkdown(nextMarkdown);
+        replaceNode(position, `${lead}[${isChecked ? ' ' : 'x'}]${label}`);
       }}
     />
   );

--- a/src-docs/src/views/markdown_editor/plugins/markdown_tooltip.js
+++ b/src-docs/src/views/markdown_editor/plugins/markdown_tooltip.js
@@ -62,13 +62,13 @@ function TooltipParser() {
     }
 
     const now = eat.now();
-    now.column += 11 + tooltipText.length;
-    now.offset += 11 + tooltipText.length;
+    now.column += 10;
+    now.offset += 10;
     const children = this.tokenizeInline(tooltipAnchor, now);
 
     return eat(`!{tooltip[${tooltipAnchor}](${tooltipText})}`)({
       type: 'tooltipPlugin',
-      configuration: { content: tooltipText },
+      content: tooltipText,
       children,
     });
   }
@@ -83,7 +83,7 @@ function TooltipParser() {
 }
 
 const tooltipMarkdownHandler = (h, node) => {
-  return h(node.position, 'tooltipPlugin', node.configuration, all(h, node));
+  return h(node.position, 'tooltipPlugin', node, all(h, node));
 };
 const tooltipMarkdownRenderer = ({ content, children }) => {
   return (

--- a/src/components/markdown_editor/markdown_context.ts
+++ b/src/components/markdown_editor/markdown_context.ts
@@ -17,10 +17,20 @@
  * under the License.
  */
 
-export {
-  EuiMarkdownEditor,
-  EuiMarkdownEditorProps,
-  defaultParsingPlugins,
-  defaultProcessingPlugins,
-} from './markdown_editor';
-export { EuiMarkdownContext } from './markdown_context';
+import { createContext } from 'react';
+import { EuiMarkdownEditorUiPlugin } from './markdown_types';
+
+interface MarkdownPosition {
+  start: { line: number; column: number; offset: number };
+  end: { line: number; column: number; offset: number };
+}
+
+export interface ContextShape {
+  openPluginEditor: (plugin: EuiMarkdownEditorUiPlugin) => void;
+  replaceNode(position: MarkdownPosition, next: string): void;
+}
+
+export const EuiMarkdownContext = createContext<ContextShape>({
+  openPluginEditor: () => {},
+  replaceNode() {},
+});

--- a/src/components/markdown_editor/markdown_editor.tsx
+++ b/src/components/markdown_editor/markdown_editor.tsx
@@ -31,8 +31,6 @@ import classNames from 'classnames';
 import emoji from 'remark-emoji';
 import markdown from 'remark-parse';
 // @ts-ignore
-import disableTokenizers from 'remark-disable-tokenizers';
-// @ts-ignore
 import remark2rehype from 'remark-rehype';
 // @ts-ignore
 import highlight from 'remark-highlight.js';
@@ -56,13 +54,6 @@ import { ContextShape, EuiMarkdownContext } from './markdown_context';
 
 export const defaultParsingPlugins: PluggableList = [
   [markdown, {}],
-  [
-    disableTokenizers,
-    {
-      // disable the built-in task list / checkbox plugin in favour of a custom one
-      block: ['list'],
-    },
-  ],
   [highlight, {}],
   [emoji, { emoticon: true }],
 ];

--- a/src/components/markdown_editor/markdown_editor.tsx
+++ b/src/components/markdown_editor/markdown_editor.tsx
@@ -18,14 +18,14 @@
  */
 
 import React, {
-  createContext,
   createElement,
   FunctionComponent,
   HTMLAttributes,
+  useEffect,
   useMemo,
   useState,
 } from 'react';
-import unified, { PluggableList } from 'unified';
+import unified, { PluggableList, Processor } from 'unified';
 import classNames from 'classnames';
 // @ts-ignore
 import emoji from 'remark-emoji';
@@ -40,7 +40,7 @@ import highlight from 'remark-highlight.js';
 import rehype2react from 'rehype-react';
 
 import { CommonProps } from '../common';
-import MarkdownActions from './markdown_actions';
+import MarkdownActions, { insertText } from './markdown_actions';
 import { EuiMarkdownEditorToolbar } from './markdown_editor_toolbar';
 import { EuiMarkdownEditorTextArea } from './markdown_editor_text_area';
 import { EuiMarkdownFormat } from './markdown_format';
@@ -50,21 +50,9 @@ import { EuiLink } from '../link';
 import { EuiCodeBlock } from '../code';
 import { MARKDOWN_MODE, MODE_EDITING, MODE_VIEWING } from './markdown_modes';
 import { EuiMarkdownEditorUiPlugin } from './markdown_types';
-
-interface ContextShape {
-  markdown: string;
-  setMarkdown(next: string): void;
-}
-export const EuiMarkdownContext = createContext<ContextShape>({
-  markdown: '',
-  setMarkdown() {},
-});
-
-function storeMarkdownTree() {
-  return function(tree: any, file: any) {
-    file.data.markdownTree = JSON.parse(JSON.stringify(tree));
-  };
-}
+import { EuiOverlayMask } from '../overlay_mask';
+import { EuiModal } from '../modal';
+import { ContextShape, EuiMarkdownContext } from './markdown_context';
 
 export const defaultParsingPlugins: PluggableList = [
   [markdown, {}],
@@ -77,7 +65,6 @@ export const defaultParsingPlugins: PluggableList = [
   ],
   [highlight, {}],
   [emoji, { emoticon: true }],
-  [storeMarkdownTree, {}],
 ];
 
 export const defaultProcessingPlugins: PluggableList = [
@@ -144,15 +131,33 @@ export const EuiMarkdownEditor: FunctionComponent<EuiMarkdownEditorProps> = ({
   const [viewMode, setViewMode] = useState<MARKDOWN_MODE>(MODE_EDITING);
   const editorId = useMemo(() => _editorId || htmlIdGenerator()(), [_editorId]);
 
+  const [pluginEditorPlugin, setPluginEditorPlugin] = useState<
+    EuiMarkdownEditorUiPlugin | undefined
+  >(undefined);
+
   const markdownActions = useMemo(
     () => new MarkdownActions(editorId, uiPlugins),
-
     // uiPlugins _is_ accounted for
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [editorId, uiPlugins.map(({ name }) => name).join(',')]
   );
 
   const classes = classNames('euiMarkdownEditor', className);
+
+  const parser = useMemo(() => {
+    const Compiler = (tree: any) => {
+      return tree;
+    };
+
+    function identityCompiler(this: Processor) {
+      this.Compiler = Compiler;
+    }
+    return unified()
+      .use(parsingPluginList)
+      .use(identityCompiler);
+  }, [parsingPluginList]);
+
+  const parsed = useMemo(() => parser.processSync(value), [parser, value]);
 
   const processor = useMemo(
     () =>
@@ -162,51 +167,68 @@ export const EuiMarkdownEditor: FunctionComponent<EuiMarkdownEditorProps> = ({
     [parsingPluginList, processingPluginList]
   );
 
-  // const Compiler = (tree, file) => {
-  //   return JSON.stringify(tree, null, 2);
-  // }
-  //
-  // function stringify (options) {
-  //   this.Compiler = Compiler;
-  // }
-  //
-  // console.log(unified().use(parsingPluginList).use([remark2rehype, { allowDangerousHTML: true }]).use(rehypestringify).processSync(value));
-  // console.log(
-  //   JSON.parse(
-  //     unified()
-  //     .use(parsingPluginList)
-  //     .use(remark2rehype, {
-  //       allowDangerousHTML: true,
-  //       handlers: {
-  //         chart(h, node) {
-  //           console.log(h);
-  //           console.log(node);
-  //           return h(node.position, 'strong', {className: 'test'}, unistBuilder('test', 'HEY'));
-  //         }
-  //       },
-  //       unknownHandler(h, node) {
-  //         console.log(h);
-  //         console.log(node);
-  //         h(node.position, 'code', 'THIS IS A TEST');
-  //       }
-  //     })
-  //     .use(stringify)
-  //     .processSync(value)
-  //     .contents
-  //   )
-  // );
-
   const isPreviewing = viewMode === MODE_VIEWING;
 
   const contextValue = useMemo<ContextShape>(
-    () => ({ markdown: value, setMarkdown: onChange }),
+    () => ({
+      openPluginEditor: (plugin: EuiMarkdownEditorUiPlugin) =>
+        setPluginEditorPlugin(() => plugin),
+      replaceNode: (position, next) => {
+        const leading = value.substr(0, position.start.offset);
+        const trailing = value.substr(position.end.offset);
+        onChange(`${leading}${next}${trailing}`);
+      },
+    }),
     [value, onChange]
   );
+
+  const [selectedNode, setSelectedNode] = useState();
+
+  const [textareaRef, setTextareaRef] = useState<HTMLTextAreaElement | null>(
+    null
+  );
+  useEffect(() => {
+    if (textareaRef == null) return;
+
+    const getCursorNode = () => {
+      const { selectionStart } = textareaRef;
+
+      let node: any = parsed.contents;
+
+      outer: while (true) {
+        if (node.children) {
+          for (let i = 0; i < node.children.length; i++) {
+            const child = node.children[i];
+            if (
+              child.position.start.offset < selectionStart &&
+              selectionStart < child.position.end.offset
+            ) {
+              if (child.type === 'text') break outer; // don't dive into `text` nodes
+              node = child;
+              continue outer;
+            }
+          }
+        }
+        break;
+      }
+
+      setSelectedNode(node);
+    };
+
+    textareaRef.addEventListener('keyup', getCursorNode);
+    textareaRef.addEventListener('mouseup', getCursorNode);
+
+    return () => {
+      textareaRef.removeEventListener('keyup', getCursorNode);
+      textareaRef.removeEventListener('mouseup', getCursorNode);
+    };
+  }, [textareaRef, parsed]);
 
   return (
     <EuiMarkdownContext.Provider value={contextValue}>
       <div className={classes} {...rest}>
         <EuiMarkdownEditorToolbar
+          selectedNode={selectedNode}
           markdownActions={markdownActions}
           onClickPreview={() =>
             setViewMode(isPreviewing ? MODE_EDITING : MODE_VIEWING)
@@ -222,14 +244,48 @@ export const EuiMarkdownEditor: FunctionComponent<EuiMarkdownEditorProps> = ({
             <EuiMarkdownFormat processor={processor}>{value}</EuiMarkdownFormat>
           </div>
         ) : (
-          <EuiMarkdownEditorDropZone>
-            <EuiMarkdownEditorTextArea
-              height={height}
-              id={editorId}
-              onChange={e => onChange(e.target.value)}
-              value={value}
-            />
-          </EuiMarkdownEditorDropZone>
+          <>
+            <EuiMarkdownEditorDropZone>
+              <EuiMarkdownEditorTextArea
+                ref={setTextareaRef}
+                height={height}
+                id={editorId}
+                onChange={e => onChange(e.target.value)}
+                value={value}
+              />
+            </EuiMarkdownEditorDropZone>
+            {textareaRef && pluginEditorPlugin && (
+              <EuiOverlayMask>
+                <EuiModal onClose={() => setPluginEditorPlugin(undefined)}>
+                  {createElement(pluginEditorPlugin.editor!, {
+                    node:
+                      selectedNode &&
+                      selectedNode.type === pluginEditorPlugin.name
+                        ? selectedNode
+                        : null,
+                    onCancel: () => setPluginEditorPlugin(undefined),
+                    onSave: markdown => {
+                      if (
+                        selectedNode &&
+                        selectedNode.type === pluginEditorPlugin.name
+                      ) {
+                        textareaRef.setSelectionRange(
+                          selectedNode.position.start.offset,
+                          selectedNode.position.end.offset
+                        );
+                      }
+                      insertText(textareaRef, {
+                        text: markdown,
+                        selectionStart: undefined,
+                        selectionEnd: undefined,
+                      });
+                      setPluginEditorPlugin(undefined);
+                    },
+                  })}
+                </EuiModal>
+              </EuiOverlayMask>
+            )}
+          </>
         )}
       </div>
     </EuiMarkdownContext.Provider>

--- a/src/components/markdown_editor/markdown_editor_text_area.tsx
+++ b/src/components/markdown_editor/markdown_editor_text_area.tsx
@@ -81,3 +81,5 @@ export const EuiMarkdownEditorTextArea = forwardRef<
     );
   }
 );
+
+EuiMarkdownEditorTextArea.displayName = 'EuiMarkdownEditorTextArea';

--- a/src/components/markdown_editor/markdown_editor_text_area.tsx
+++ b/src/components/markdown_editor/markdown_editor_text_area.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { TextareaHTMLAttributes, Ref, FunctionComponent } from 'react';
+import React, { TextareaHTMLAttributes, forwardRef } from 'react';
 import { CommonProps } from '../common';
 
 export type EuiMarkdownEditorTextAreaProps = TextareaHTMLAttributes<
@@ -33,8 +33,6 @@ export type EuiMarkdownEditorTextAreaProps = TextareaHTMLAttributes<
      */
     resize?: keyof typeof resizeToClassNameMap;
 
-    inputRef?: Ref<HTMLTextAreaElement>;
-
     height: number;
   };
 
@@ -47,34 +45,39 @@ const resizeToClassNameMap = {
 
 export const RESIZE = Object.keys(resizeToClassNameMap);
 
-export const EuiMarkdownEditorTextArea: FunctionComponent<
+export const EuiMarkdownEditorTextArea = forwardRef<
+  HTMLTextAreaElement,
   EuiMarkdownEditorTextAreaProps
-> = ({
-  children,
-  className,
-  compressed,
-  id,
-  inputRef,
-  isInvalid,
-  name,
-  placeholder,
-  rows,
-  height,
-  ...rest
-}) => {
-  const dropZoneButtonHeight = 32;
+>(
+  (
+    {
+      children,
+      className,
+      compressed,
+      id,
+      isInvalid,
+      name,
+      placeholder,
+      rows,
+      height,
+      ...rest
+    },
+    ref
+  ) => {
+    const dropZoneButtonHeight = 32;
 
-  return (
-    <textarea
-      style={{ height: `calc(${height - dropZoneButtonHeight}px` }}
-      className="euiMarkdownEditor__textArea"
-      {...rest}
-      rows={6}
-      name={name}
-      id={id}
-      ref={inputRef}
-      placeholder={placeholder}>
-      {children}
-    </textarea>
-  );
-};
+    return (
+      <textarea
+        ref={ref}
+        style={{ height: `calc(${height - dropZoneButtonHeight}px` }}
+        className="euiMarkdownEditor__textArea"
+        {...rest}
+        rows={6}
+        name={name}
+        id={id}
+        placeholder={placeholder}>
+        {children}
+      </textarea>
+    );
+  }
+);

--- a/src/components/markdown_editor/markdown_editor_toolbar.tsx
+++ b/src/components/markdown_editor/markdown_editor_toolbar.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { Component, HTMLAttributes } from 'react';
+import React, { FunctionComponent, HTMLAttributes, useContext } from 'react';
 import { CommonProps } from '../common';
 import { EuiButtonEmpty, EuiButtonIcon } from '../button';
 import { EuiFlexItem, EuiFlexGroup } from '../flex';
@@ -25,168 +25,185 @@ import { EuiI18n } from '../i18n';
 import { EuiToolTip } from '../tool_tip';
 import { MARKDOWN_MODE, MODE_VIEWING } from './markdown_modes';
 import { EuiMarkdownEditorUiPlugin } from './markdown_types';
+import { EuiMarkdownContext } from './markdown_context';
+import MarkdownActions from './markdown_actions';
 
 export type EuiMarkdownEditorToolbarProps = HTMLAttributes<HTMLDivElement> &
   CommonProps & {
-    markdownActions?: any;
-    viewMode?: MARKDOWN_MODE;
-    onClickPreview?: any;
+    selectedNode?: null | any;
+    markdownActions: MarkdownActions;
+    viewMode: MARKDOWN_MODE;
+    onClickPreview: any;
     uiPlugins: EuiMarkdownEditorUiPlugin[];
   };
 
-export class EuiMarkdownEditorToolbar extends Component<
+const boldItalicButtons = [
+  {
+    id: 'mdBold',
+    label: 'Bold',
+    name: 'bold',
+    iconType: 'editorBold',
+  },
+  {
+    id: 'mdItalic',
+    label: 'Italic',
+    name: 'italic',
+    iconType: 'editorItalic',
+  },
+];
+
+const listButtons = [
+  {
+    id: 'mdUl',
+    label: 'Unordered list',
+    name: 'ul',
+    iconType: 'editorUnorderedList',
+  },
+  {
+    id: 'mdOl',
+    label: 'Ordered list',
+    name: 'ol',
+    iconType: 'editorOrderedList',
+  },
+];
+
+const quoteCodeLinkButtons = [
+  {
+    id: 'mdQuote',
+    label: 'Quote',
+    name: 'quote',
+    iconType: 'editorComment',
+  },
+  {
+    id: 'mdCode',
+    label: 'Code',
+    name: 'code',
+    iconType: 'editorCodeBlock',
+  },
+  {
+    id: 'mdLink',
+    label: 'Link',
+    name: 'link',
+    iconType: 'editorLink',
+  },
+];
+
+export const EuiMarkdownEditorToolbar: FunctionComponent<
   EuiMarkdownEditorToolbarProps
-> {
-  boldItalicButtons = [
-    {
-      id: 'mdBold',
-      label: 'Bold',
-      name: 'bold',
-      iconType: 'editorBold',
-    },
-    {
-      id: 'mdItalic',
-      label: 'Italic',
-      name: 'italic',
-      iconType: 'editorItalic',
-    },
-  ];
+> = ({
+  markdownActions,
+  viewMode,
+  onClickPreview,
+  uiPlugins,
+  selectedNode,
+}) => {
+  const { openPluginEditor } = useContext(EuiMarkdownContext);
 
-  listButtons = [
-    {
-      id: 'mdUl',
-      label: 'Unordered list',
-      name: 'ul',
-      iconType: 'editorUnorderedList',
-    },
-    {
-      id: 'mdOl',
-      label: 'Ordered list',
-      name: 'ol',
-      iconType: 'editorOrderedList',
-    },
-  ];
-
-  quoteCodeLinkButtons = [
-    {
-      id: 'mdQuote',
-      label: 'Quote',
-      name: 'quote',
-      iconType: 'editorComment',
-    },
-    {
-      id: 'mdCode',
-      label: 'Code',
-      name: 'code',
-      iconType: 'editorCodeBlock',
-    },
-    {
-      id: 'mdLink',
-      label: 'Link',
-      name: 'link',
-      iconType: 'editorLink',
-    },
-  ];
-
-  handleMdButtonClick = (mdButtonId: string) => {
-    this.props.markdownActions.do(mdButtonId);
+  const handleMdButtonClick = (mdButtonId: string) => {
+    const actionResult = markdownActions.do(mdButtonId);
+    if (actionResult !== true) openPluginEditor(actionResult);
   };
 
-  render() {
-    const { viewMode, onClickPreview, uiPlugins } = this.props;
+  const isPreviewing = viewMode === MODE_VIEWING;
 
-    const isPreviewing = viewMode === MODE_VIEWING;
-
-    return (
-      <div className="euiMarkdownEditor__toolbar">
-        <EuiFlexGroup
-          justifyContent="spaceBetween"
-          alignItems="center"
-          responsive={false}>
-          <EuiFlexItem
-            grow={false}
-            className="euiMarkdownEditor__toolbar__buttons">
-            {this.boldItalicButtons.map(item => (
-              <EuiToolTip key={item.id} content={item.label} delay="long">
-                <EuiButtonIcon
-                  color="text"
-                  onClick={() => this.handleMdButtonClick(item.id)}
-                  iconType={item.iconType}
-                  aria-label={item.label}
-                  isDisabled={isPreviewing}
-                />
-              </EuiToolTip>
-            ))}
-            <span className="euiMarkdownEditor__toolbar__divider" />
-            {this.listButtons.map(item => (
-              <EuiToolTip key={item.id} content={item.label} delay="long">
-                <EuiButtonIcon
-                  color="text"
-                  onClick={() => this.handleMdButtonClick(item.id)}
-                  iconType={item.iconType}
-                  aria-label={item.label}
-                  isDisabled={isPreviewing}
-                />
-              </EuiToolTip>
-            ))}
-            <span className="euiMarkdownEditor__toolbar__divider" />
-            {this.quoteCodeLinkButtons.map(item => (
-              <EuiToolTip key={item.id} content={item.label} delay="long">
-                <EuiButtonIcon
-                  color="text"
-                  onClick={() => this.handleMdButtonClick(item.id)}
-                  iconType={item.iconType}
-                  aria-label={item.label}
-                  isDisabled={isPreviewing}
-                />
-              </EuiToolTip>
-            ))}
-            {uiPlugins.length > 0 ? (
-              <>
-                <span className="euiMarkdownEditor__toolbar__divider" />
-                {uiPlugins.map(({ name, button }) => (
+  return (
+    <div className="euiMarkdownEditor__toolbar">
+      <EuiFlexGroup
+        justifyContent="spaceBetween"
+        alignItems="center"
+        responsive={false}>
+        <EuiFlexItem
+          grow={false}
+          className="euiMarkdownEditor__toolbar__buttons">
+          {boldItalicButtons.map(item => (
+            <EuiToolTip key={item.id} content={item.label} delay="long">
+              <EuiButtonIcon
+                color="text"
+                onClick={() => handleMdButtonClick(item.id)}
+                iconType={item.iconType}
+                aria-label={item.label}
+                isDisabled={isPreviewing}
+              />
+            </EuiToolTip>
+          ))}
+          <span className="euiMarkdownEditor__toolbar__divider" />
+          {listButtons.map(item => (
+            <EuiToolTip key={item.id} content={item.label} delay="long">
+              <EuiButtonIcon
+                color="text"
+                onClick={() => handleMdButtonClick(item.id)}
+                iconType={item.iconType}
+                aria-label={item.label}
+                isDisabled={isPreviewing}
+              />
+            </EuiToolTip>
+          ))}
+          <span className="euiMarkdownEditor__toolbar__divider" />
+          {quoteCodeLinkButtons.map(item => (
+            <EuiToolTip key={item.id} content={item.label} delay="long">
+              <EuiButtonIcon
+                color="text"
+                onClick={() => handleMdButtonClick(item.id)}
+                iconType={item.iconType}
+                aria-label={item.label}
+                isDisabled={isPreviewing}
+              />
+            </EuiToolTip>
+          ))}
+          {uiPlugins.length > 0 ? (
+            <>
+              <span className="euiMarkdownEditor__toolbar__divider" />
+              {uiPlugins.map(({ name, button }) => {
+                const isSelectedNodeType =
+                  selectedNode && selectedNode.type === name;
+                return (
                   <EuiToolTip key={name} content={button.label} delay="long">
                     <EuiButtonIcon
                       color="text"
-                      onClick={() => this.handleMdButtonClick(name)}
+                      {...(isSelectedNodeType
+                        ? {
+                            style: { background: 'rgba(0, 0, 0, 0.15)' },
+                          }
+                        : null)}
+                      onClick={() => handleMdButtonClick(name)}
                       iconType={button.iconType}
                       aria-label={button.label}
                       isDisabled={isPreviewing}
                     />
                   </EuiToolTip>
-                ))}
-              </>
-            ) : null}
-          </EuiFlexItem>
+                );
+              })}
+            </>
+          ) : null}
+        </EuiFlexItem>
 
-          <EuiFlexItem grow={false}>
-            {/* The idea was to use the EuiButtonToggle but it doesn't work when pressing the enter key */}
-            {isPreviewing ? (
-              <EuiButtonEmpty
-                iconType="editorCodeBlock"
-                color="text"
-                size="s"
-                onClick={onClickPreview}>
-                <EuiI18n
-                  token="euiMarkdownEditorToolbar.editor"
-                  default="Editor"
-                />
-              </EuiButtonEmpty>
-            ) : (
-              <EuiButtonEmpty
-                iconType="eye"
-                color="text"
-                size="s"
-                onClick={onClickPreview}>
-                <EuiI18n
-                  token="euiMarkdownEditorToolbar.previewMarkdown"
-                  default="Preview"
-                />
-              </EuiButtonEmpty>
-            )}
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </div>
-    );
-  }
-}
+        <EuiFlexItem grow={false}>
+          {/* The idea was to use the EuiButtonToggle but it doesn't work when pressing the enter key */}
+          {isPreviewing ? (
+            <EuiButtonEmpty
+              iconType="editorCodeBlock"
+              color="text"
+              size="s"
+              onClick={onClickPreview}>
+              <EuiI18n
+                token="euiMarkdownEditorToolbar.editor"
+                default="Editor"
+              />
+            </EuiButtonEmpty>
+          ) : (
+            <EuiButtonEmpty
+              iconType="eye"
+              color="text"
+              size="s"
+              onClick={onClickPreview}>
+              <EuiI18n
+                token="euiMarkdownEditorToolbar.previewMarkdown"
+                default="Preview"
+              />
+            </EuiButtonEmpty>
+          )}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </div>
+  );
+};

--- a/src/components/markdown_editor/markdown_types.ts
+++ b/src/components/markdown_editor/markdown_types.ts
@@ -18,15 +18,37 @@
  */
 
 import { IconType } from '../icon';
+import { ComponentType } from 'react';
 
-export interface EuiMarkdownEditorUiPlugin {
+export interface EuiMarkdownEditorUiPluginEditorProps {
+  node?: object | null;
+  onCancel: () => void;
+  onSave: (markdown: string) => void;
+}
+
+export const isPluginWithImmediateFormatting = (
+  x: PluginWithImmediateFormatting | PluginWithDelayedFormatting
+): x is PluginWithImmediateFormatting => {
+  return x.hasOwnProperty('formatting');
+};
+
+export interface PluginWithImmediateFormatting {
+  formatting: EuiMarkdownFormatting;
+  editor?: never;
+}
+
+export interface PluginWithDelayedFormatting {
+  formatting?: never;
+  editor: ComponentType<EuiMarkdownEditorUiPluginEditorProps>;
+}
+
+export type EuiMarkdownEditorUiPlugin = {
   name: string;
   button: {
     label: string;
     iconType: IconType;
   };
-  formatting: EuiMarkdownFormatting;
-}
+} & (PluginWithImmediateFormatting | PluginWithDelayedFormatting);
 
 export interface EuiMarkdownFormatting {
   prefix?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3517,11 +3517,6 @@ clone@^2.1.1:
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.1.tgz#d217d1e961118e3ac9a4b8bba3285553bf647cdb"
   integrity sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=
 
-clone@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
-  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
-
 cloneable-readable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cloneable-readable/-/cloneable-readable-1.0.0.tgz#a6290d413f217a61232f95e458ff38418cfb0117"
@@ -13832,13 +13827,6 @@ relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
-
-remark-disable-tokenizers@^1.0.24:
-  version "1.0.24"
-  resolved "https://registry.yarnpkg.com/remark-disable-tokenizers/-/remark-disable-tokenizers-1.0.24.tgz#98efd5ade2da46e8e6167cc3318c7cd93d15449d"
-  integrity sha512-HsAmBY5cNliHYAzba4zuskZzkDdp6sG+tRelDb4AoPo2YHNGHnxYsatShzTIsnRNLgCbsxycW5Ge6KigHn701A==
-  dependencies:
-    clone "^2.1.2"
 
 remark-emoji@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
### Summary

Fixes #3526 

Un-disables remark's default list parsing/processing, and injects EUI's checkbox plugin above that default `list` parser so we can execute first.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
