### PR TITLE
Fix bug in EuiComboBox's inputRef callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed `EuiBasicTable` shows no items if all items of last page is deleted  ([#3422](https://github.com/elastic/eui/pull/3422))
 - Fixed TypeScript module name in generated `eui_charts_theme.d.ts` file  ([#3492](https://github.com/elastic/eui/pull/3492))
 - Fixed code highlight color contrast in `EuiCodeBlock` ([#3309](https://github.com/elastic/eui/pull/3309))
+- Fixed regression in `EuiComboBox` not triggering its `inputRef` callback ([#3532](https://github.com/elastic/eui/pull/3532))
 
 **Deprecations**
 

--- a/src/components/combo_box/combo_box.test.tsx
+++ b/src/components/combo_box/combo_box.test.tsx
@@ -372,4 +372,19 @@ describe('behavior', () => {
       expect(component.state('matchingOptions')[0].label).toBe('Enceladus');
     });
   });
+
+  it('calls the inputRef prop with the input element', () => {
+    const inputRefCallback = jest.fn();
+
+    const component = mount<
+      EuiComboBox<TitanOption>,
+      EuiComboBoxProps<TitanOption>,
+      { matchingOptions: TitanOption[] }
+    >(<EuiComboBox options={options} inputRef={inputRefCallback} />);
+
+    expect(inputRefCallback).toHaveBeenCalledTimes(1);
+    expect(component.find('input[role="textbox"]').getDOMNode()).toBe(
+      inputRefCallback.mock.calls[0][0]
+    );
+  });
 });

--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -257,6 +257,7 @@ export class EuiComboBox<T> extends Component<
   searchInputRefInstance: RefInstance<HTMLInputElement> = null;
   searchInputRefCallback: RefCallback<HTMLInputElement> = ref => {
     this.searchInputRefInstance = ref;
+    if (this.props.inputRef) this.props.inputRef(ref);
   };
 
   listRefInstance: RefInstance<HTMLDivElement> = null;


### PR DESCRIPTION
### Summary

Fixes #3528 , a regression from #2838 , where **EuiComboBox**'s `inputRef` callback was not fired.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
