### PR TITLE
[EuiHeader] Stacked example

### DIFF
--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -11,6 +11,22 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   }
 }
 
+@include euiHeaderAffordForFixed;
+
+.euiBody--headerIsFixed {
+  .guideSideNav {
+    top: $euiHeaderHeightCompensation;
+  }
+}
+
+.euiBody--headerIsFixed--double {
+  @include euiHeaderAffordForFixed($euiHeaderHeightCompensation * 2);
+
+  .guideSideNav {
+    top: $euiHeaderHeightCompensation * 2;
+  }
+}
+
 .guidePage {
   padding: 0;
 }
@@ -215,6 +231,19 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   top: 0;
 }
 
+.euiDataGridRowCell--favoriteFranchise {
+  background: transparentize($color: #800080, $amount: .95) !important;
+}
+
+.euiDataGridHeaderCell--favoriteFranchise {
+  background: transparentize($color: #800080, $amount: .9) !important;
+}
+
+.euiTreeView__nodeInnerExample {
+  color: $euiColorDanger;
+  font-weight: $euiFontWeightBold;
+}
+
 @import '../views/guidelines/index';
 @import 'guide_section/index';
 @import 'guide_rule/index';
@@ -229,7 +258,7 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   }
 
   .guideSideNav {
-    position: relative;
+    position: static;
     width: auto;
 
     // This is a temporary hack till we fix how classes pass into form controls
@@ -262,17 +291,4 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
     margin-left: 0;
     width: 100%;
   }
-}
-
-.euiDataGridRowCell--favoriteFranchise {
-  background: transparentize($color: #800080, $amount: .95) !important;
-}
-
-.euiDataGridHeaderCell--favoriteFranchise {
-  background: transparentize($color: #800080, $amount: .9) !important;
-}
-
-.euiTreeView__nodeInnerExample {
-  color: $euiColorDanger;
-  font-weight: $euiFontWeightBold;
 }

--- a/src-docs/src/views/header/header_example.js
+++ b/src-docs/src/views/header/header_example.js
@@ -45,6 +45,10 @@ import HeaderDark from './header_dark';
 const headerDarkSource = require('!!raw-loader!./header_dark');
 const headerDarkHtml = renderToHtml(HeaderDark);
 
+import HeaderStacked from './header_stacked';
+const headerStackedSource = require('!!raw-loader!./header_stacked');
+const headerStackedHtml = renderToHtml(HeaderStacked);
+
 const headerSnippet = `<EuiHeader>
   <EuiHeaderSection grow={false}>
     <EuiHeaderSectionItem border="right">
@@ -184,15 +188,26 @@ export const HeaderExample = {
       text: (
         <>
           <p>
-            Most consumer need a header that does not scroll way with the page
-            contents. You can apply this display by changing{' '}
-            <EuiCode>position</EuiCode> to <EuiCode>fixed</EuiCode>. It will
-            also add the appropriate padding to the window body by applying a
-            class.
+            Most consumers need a header that does not scroll away with the page
+            contents. You can apply this display by applying{' '}
+            <EuiCode language="ts">{'position="fixed"'}</EuiCode>. It will also
+            add a class of <EuiCode>.euiBody--headerIsFixed</EuiCode> to the
+            window body.
+          </p>
+          <p>
+            You will then need to apply your own padding to this class to afford
+            for the header height. EUI supplies a helper mixin that also
+            accounts for this height in flyouts and the collapsible nav. Simply
+            add{' '}
+            <EuiCode language="sass">@mixin euiHeaderAffordForFixed;</EuiCode>{' '}
+            anywhere in your SASS.
           </p>
         </>
       ),
-      snippet: '<EuiHeader position="fixed" />',
+      snippet: [
+        '<EuiHeader position="fixed" />',
+        '@mixin euiHeaderAffordForFixed;',
+      ],
       demo: <HeaderPosition />,
     },
     {
@@ -281,6 +296,35 @@ export const HeaderExample = {
       },
       snippet: headerLinksSnippet,
       demo: <HeaderAlert />,
+    },
+    {
+      title: 'Stacked headers',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: headerStackedSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: headerStackedHtml,
+        },
+      ],
+      text: (
+        <p>
+          Stacking multiple headers provide a great way to separate global
+          navigation concerns. However, the{' '}
+          <EuiCode language="ts">{'position="fixed"'}</EuiCode> option will not
+          be aware of the number of headers. Therefore, if you do need fixed and
+          stacked headers, you will need to apply the helper mixin and pass in
+          the correct height to afford for.
+        </p>
+      ),
+      snippet: [
+        `<EuiHeader theme="dark" />
+<EuiHeader />`,
+        '@include euiHeaderAffordForFixed($euiHeaderHeightCompensation * 2);',
+      ],
+      demo: <HeaderStacked />,
     },
   ],
 };

--- a/src-docs/src/views/header/header_stacked.tsx
+++ b/src-docs/src/views/header/header_stacked.tsx
@@ -8,6 +8,8 @@ import {
 import { EuiSwitch } from '../../../../src/components/form';
 import { EuiSpacer } from '../../../../src/components/spacer';
 import { EuiAvatar } from '../../../../src/components/avatar';
+// @ts-ignore
+import HeaderUpdates from './header_updates';
 
 export default () => {
   const [isFixed, setIsFixed] = useState(false);
@@ -65,6 +67,9 @@ export default () => {
             ],
             breadcrumbs: breadcrumbs,
             borders: 'none',
+          },
+          {
+            items: isFixed ? [<HeaderUpdates />] : undefined,
           },
         ]}
       />

--- a/src-docs/src/views/header/header_stacked.tsx
+++ b/src-docs/src/views/header/header_stacked.tsx
@@ -1,0 +1,85 @@
+import React, { useState, useEffect } from 'react';
+
+import {
+  EuiHeader,
+  EuiHeaderLogo,
+  EuiHeaderSectionItemButton,
+} from '../../../../src/components/header';
+import { EuiSwitch } from '../../../../src/components/form';
+import { EuiSpacer } from '../../../../src/components/spacer';
+import { EuiAvatar } from '../../../../src/components/avatar';
+
+export default () => {
+  const [isFixed, setIsFixed] = useState(false);
+
+  const breadcrumbs = [
+    {
+      text: 'Management',
+      href: '#',
+    },
+    {
+      text: 'Users',
+    },
+  ];
+
+  /**
+   * Docs Note: This additional class is needed only for docs to override the usualy single header
+   */
+  useEffect(() => {
+    if (isFixed) document.body.classList.add('euiBody--headerIsFixed--double');
+
+    return () => {
+      document.body.classList.remove('euiBody--headerIsFixed--double');
+    };
+  }, [isFixed]);
+
+  const headers = (
+    <>
+      <EuiHeader
+        theme="dark"
+        position={isFixed ? 'fixed' : 'static'}
+        sections={[
+          {
+            items: [
+              <EuiHeaderLogo iconType="logoElastic">Elastic</EuiHeaderLogo>,
+            ],
+            borders: 'right',
+          },
+          {
+            items: [
+              <EuiHeaderSectionItemButton aria-label="Account menu">
+                <EuiAvatar name="John Username" size="s" />
+              </EuiHeaderSectionItemButton>,
+            ],
+          },
+        ]}
+      />
+      <EuiHeader
+        position={isFixed ? 'fixed' : 'static'}
+        sections={[
+          {
+            items: [
+              <EuiHeaderSectionItemButton aria-label="Account menu">
+                <EuiAvatar type="space" name="Default Space" size="s" />
+              </EuiHeaderSectionItemButton>,
+            ],
+            breadcrumbs: breadcrumbs,
+            borders: 'none',
+          },
+        ]}
+      />
+    </>
+  );
+
+  return (
+    <>
+      <EuiSwitch
+        label={'Make header fixed position'}
+        checked={isFixed}
+        onChange={e => setIsFixed(e.target.checked)}
+      />
+      <EuiSpacer />
+      {headers}
+    </>
+  );
+};

--- a/src-docs/src/views/header/header_updates.js
+++ b/src-docs/src/views/header/header_updates.js
@@ -121,18 +121,13 @@ export default () => {
   );
 
   let flyout;
-  const flyoutStyle = {
-    top: '49px',
-    height: 'calc(100vh - 49px)',
-  };
   if (isFlyoutVisible) {
     flyout = (
       <EuiFlyout
         onClose={() => closeFlyout()}
         size="s"
         id="headerNewsFeed"
-        aria-labelledby="flyoutSmallTitle"
-        style={flyoutStyle}>
+        aria-labelledby="flyoutSmallTitle">
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="s">
             <h2 id="flyoutSmallTitle">What&apos;s new</h2>

--- a/src/components/flyout/_mixins.scss
+++ b/src/components/flyout/_mixins.scss
@@ -15,10 +15,4 @@
   display: flex;
   flex-direction: column;
   align-items: stretch;
-
-  // When the EuiHeader is fixed, we need to account for it in the position of the flyout
-  .euiBody--headerIsFixed & {
-    top: $euiHeaderHeightCompensation;
-    height: calc(100% - #{$euiHeaderHeightCompensation});
-  }
 }

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -31,8 +31,10 @@
 }
 
 .euiHeader--dark {
-  // Only force reverse theme if the theme is light
   @if (lightness($euiTextColor) < 50) {
-    @include euiHeaderDarkTheme;
+    @include euiHeaderDarkTheme($backgroundColor: shade($euiColorDarkestShade, 28%));
+  } @else {
+    // Makes forced "dark" theme darker than the typical dark them to separate them visually
+    @include euiHeaderDarkTheme($backgroundColor: shade($euiColorLightestShade, 50%));
   }
 }

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -19,15 +19,15 @@
   }
 }
 
-.euiBody--headerIsFixed {
-  padding-top: $euiHeaderHeightCompensation;
-}
-
 .euiBody--collapsibleNavIsOpen,
 .euiBody--hasFlyout {
   .euiHeader--fixed {
     z-index: $euiZModal + 1;
   }
+}
+
+.euiHeader--fixed + .euiHeader--fixed {
+  top: $euiHeaderHeightCompensation;
 }
 
 .euiHeader--dark {

--- a/src/components/header/_mixins.scss
+++ b/src/components/header/_mixins.scss
@@ -1,6 +1,6 @@
-@mixin euiHeaderDarkTheme {
-  $headerBackgroundColor: shade($euiColorDarkestShade, 28%);
-  background-color: $headerBackgroundColor;
+@mixin euiHeaderDarkTheme($backgroundColor) {
+  background-color: $backgroundColor;
+  border-bottom-color: lightOrDarkTheme($backgroundColor, $euiBorderColor);
 
   .euiHeaderLogo__text,
   .euiHeaderLink,
@@ -9,12 +9,12 @@
   }
 
   .euiHeaderLink-isActive {
-    color: makeHighContrastColor($euiColorPrimary, $headerBackgroundColor);
+    color: makeHighContrastColor($euiColorPrimary, $backgroundColor);
   }
 
   .euiHeaderSectionItem {
     &:after {
-      background: $euiColorDarkShade;
+      background: lightOrDarkTheme($euiColorDarkShade, $euiColorLightestShade);
     }
   }
 
@@ -22,7 +22,7 @@
   .euiHeaderLink,
   .euiHeaderSectionItem__button {
     &:hover {
-      background: transparentize($euiColorDarkShade, .5);
+      background: transparentize(lightOrDarkTheme($euiColorDarkShade, $euiColorLightestShade), .5);
     }
 
     &:focus {
@@ -32,6 +32,6 @@
 
   .euiHeaderNotification,
   .euiHeaderSectionItemButton__notification {
-    box-shadow: 0 0 0 1px $headerBackgroundColor;
+    box-shadow: 0 0 0 1px $backgroundColor;
   }
 }

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -86,6 +86,9 @@ export type EuiHeaderProps = CommonProps &
     theme?: 'default' | 'dark';
   };
 
+// Start a counter to manage the total number of fixed headers that need the body class
+let euiHeaderFixedCounter = 0;
+
 export const EuiHeader: FunctionComponent<EuiHeaderProps> = ({
   children,
   className,
@@ -103,11 +106,18 @@ export const EuiHeader: FunctionComponent<EuiHeaderProps> = ({
 
   useEffect(() => {
     if (position === 'fixed') {
+      // Increment fixed header counter for each fixed header
+      euiHeaderFixedCounter++;
       document.body.classList.add('euiBody--headerIsFixed');
+
+      return () => {
+        // Both decrement the fixed counter AND then check if there are none
+        if (--euiHeaderFixedCounter === 0) {
+          // If there are none, THEN remove class
+          document.body.classList.remove('euiBody--headerIsFixed');
+        }
+      };
     }
-    return () => {
-      document.body.classList.remove('euiBody--headerIsFixed');
-    };
   }, [position]);
 
   let contents;

--- a/src/components/header/header_breadcrumbs/_header_breadcrumbs.scss
+++ b/src/components/header/header_breadcrumbs/_header_breadcrumbs.scss
@@ -1,18 +1,9 @@
 // Breadcrumb navigation included in the header.
 
-@import '../../link/mixins';
-
 .euiHeaderBreadcrumbs {
-  margin-left: $euiSize;
-  margin-right: $euiSize;
+  margin-left: $euiSizeS;
+  margin-right: $euiSizeS;
   display: flex;
   align-items: center;
   flex-grow: 1;
-}
-
-@include euiBreakpoint('xs') {
-  .euiHeaderBreadcrumbs {
-    margin-left: $euiSizeS;
-    margin-right: $euiSizeS;
-  }
 }

--- a/src/global_styling/mixins/_header.scss
+++ b/src/global_styling/mixins/_header.scss
@@ -1,0 +1,14 @@
+@mixin euiHeaderAffordForFixed($headerHeight: $euiHeaderHeightCompensation) {
+  // The `&` allows for grouping inside another specific body class.
+  // When not applied inside of another selector, it simply renders with the single class
+  &.euiBody--headerIsFixed {
+    padding-top: $headerHeight;
+
+    // When the EuiHeader is fixed, we need to account for it in the position of the flyout
+    .euiFlyout,
+    .euiCollapsibleNav {
+      top: $headerHeight;
+      height: calc(100% - #{$headerHeight});
+    }
+  }
+}

--- a/src/global_styling/mixins/_index.scss
+++ b/src/global_styling/mixins/_index.scss
@@ -9,6 +9,7 @@
 @import 'beta_badge';
 @import 'button';
 @import 'form';
+@import 'header';
 @import 'loading';
 @import 'panel';
 @import 'popover';

--- a/src/global_styling/variables/_index.scss
+++ b/src/global_styling/variables/_index.scss
@@ -6,7 +6,7 @@
 // coming from when looking inside the individual component files. Any component local
 // variables should be declared at the top of those documents prefixed with $componentName.
 
-// Import order is important. Size and color..etc are used in other variables.
+// Import order is important. Size, color, ...etc are used in other variables.
 @import 'size';
 @import 'colors';
 @import 'animations';

--- a/src/themes/eui-amsterdam/global_styling/variables/_header.scss
+++ b/src/themes/eui-amsterdam/global_styling/variables/_header.scss
@@ -1,1 +1,4 @@
+$euiHeaderHeight: $euiSizeXXL + $euiSizeS;
+
 $euiHeaderChildSize: $euiSizeXXL;
+$euiHeaderHeightCompensation: $euiHeaderHeight;

--- a/src/themes/eui-amsterdam/overrides/_header.scss
+++ b/src/themes/eui-amsterdam/overrides/_header.scss
@@ -11,6 +11,10 @@
 }
 
 .euiHeaderLogo {
+  @include euiBreakpoint('xs') {
+    padding: 0 $euiSizeXS;
+  }
+
   padding-left: $euiSizeS;
   padding-right: $euiSizeS;
   min-width: $euiHeaderChildSize;
@@ -22,4 +26,8 @@
 
 .euiHeaderBreadcrumbs {
   margin-left: $euiSizeS;
+}
+
+.euiHeader--default + .euiHeader--default {
+  border-top: $euiBorderThin;
 }


### PR DESCRIPTION
### Part 2/3 for next iteration of K8 support

This PR is mostly a docs example as it does not add any new props. However it does contain a **breaking change** to the way the `position="fixed"` version handles adding body padding. Spoiler, it no longer does.

## Rendered example:

<img width="977" alt="Screen Shot 2020-06-02 at 14 23 15 PM" src="https://user-images.githubusercontent.com/549577/83556696-5db41780-a4de-11ea-8c87-0e89917ef149.png">

**Dark mode `theme="dark"` now renders slightly darker** to create visual separation when they're stacked.

<img width="813" alt="Screen Shot 2020-06-02 at 14 37 09 PM" src="https://user-images.githubusercontent.com/549577/83556851-99e77800-a4de-11ea-99bf-e03d83f2656d.png">


## Breaking change

Before, when a consumer added `position="fixed"` it would add the `euiBody--headerIsFixed` body class **and** apply top padding styles. However, some consumers may want this and some may not, but there's no configuration option. And with the allowed stacked headers, EUI cannot know how many headers they are stacking. 

So now it's on the now consumer to apply the appropriate padding and EUI provides both variables and mixins to help. The fixed header example was updated to describe this in description and snippet.

<img width="818" alt="Screen Shot 2020-06-02 at 14 43 25 PM" src="https://user-images.githubusercontent.com/549577/83557378-8a1c6380-a4df-11ea-8a0c-9f0bc0e01b9e.png">


The stacked example provides a SASS snippet as well.

<img width="817" alt="Screen Shot 2020-06-02 at 14 43 33 PM" src="https://user-images.githubusercontent.com/549577/83557391-8ee11780-a4df-11ea-8174-ddf10de32b10.png">


### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- ~[ ] Props have proper **autodocs**~
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [ ] Checked for **breaking changes** and labeled appropriately
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
