### PR TITLE
Add exports for EuiColorPalettePicker types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added `theme` prop to `EuiHeader` ([#3524](https://github.com/elastic/eui/pull/3524))
 - Added `.euiHeaderLink-isActive` class to `EuiHeaderLink` when `isActive` ([#3524](https://github.com/elastic/eui/pull/3524))
 - Added `display`, `descriptionWidth`, `textWrap` and `isInvalid` props to `EuiExpression` ([#3467](https://github.com/elastic/eui/pull/3467))
+- Added more exports for `EuiColorPalettePicker` types ([#3542](https://github.com/elastic/eui/pull/3542))
 
 **Bug Fixes**
 

--- a/src-docs/src/views/color_picker/color_picker_example.js
+++ b/src-docs/src/views/color_picker/color_picker_example.js
@@ -12,7 +12,11 @@ import {
   EuiSpacer,
   EuiText,
 } from '../../../../src/components';
-import { EuiColorPalettePickerPalette } from './props';
+import {
+  EuiColorPalettePickerPaletteText,
+  EuiColorPalettePickerPaletteFixed,
+  EuiColorPalettePickerPaletteGradient,
+} from './props';
 
 import { ColorPicker } from './color_picker';
 const colorPickerSource = require('!!raw-loader!./color_picker');
@@ -341,7 +345,12 @@ export const ColorPickerExample = {
           code: colorPalettePickerHtml,
         },
       ],
-      props: { EuiColorPalettePicker, EuiColorPalettePickerPalette },
+      props: {
+        EuiColorPalettePicker,
+        EuiColorPalettePickerPaletteText,
+        EuiColorPalettePickerPaletteFixed,
+        EuiColorPalettePickerPaletteGradient,
+      },
       snippet: colorPalettePickerSnippet,
       demo: <ColorPalettePicker />,
     },

--- a/src-docs/src/views/color_picker/props.tsx
+++ b/src-docs/src/views/color_picker/props.tsx
@@ -1,7 +1,19 @@
 import React, { FunctionComponent } from 'react';
 
-import { EuiColorPalettePickerPaletteProps } from '../../../../src/components/color_picker/color_palette_picker';
+import {
+  EuiColorPalettePickerPaletteTextProps,
+  EuiColorPalettePickerPaletteFixedProps,
+  EuiColorPalettePickerPaletteGradientProps,
+} from '../../../../src/components/color_picker/color_palette_picker';
 
-export const EuiColorPalettePickerPalette: FunctionComponent<
-  EuiColorPalettePickerPaletteProps
+export const EuiColorPalettePickerPaletteText: FunctionComponent<
+  EuiColorPalettePickerPaletteTextProps
+> = () => <div />;
+
+export const EuiColorPalettePickerPaletteFixed: FunctionComponent<
+  EuiColorPalettePickerPaletteFixedProps
+> = () => <div />;
+
+export const EuiColorPalettePickerPaletteGradient: FunctionComponent<
+  EuiColorPalettePickerPaletteGradientProps
 > = () => <div />;

--- a/src/components/color_picker/color_palette_picker/color_palette_picker.tsx
+++ b/src/components/color_picker/color_palette_picker/color_palette_picker.tsx
@@ -28,7 +28,7 @@ import { ColorStop } from '../color_stops';
 
 import { EuiSuperSelectProps } from '../../form/super_select';
 
-interface EuiColorPalettePickerPaletteText {
+export interface EuiColorPalettePickerPaletteTextProps {
   /**
    *  For storing unique value of item
    */
@@ -48,7 +48,7 @@ interface EuiColorPalettePickerPaletteText {
   palette?: string[] | ColorStop[];
 }
 
-interface EuiColorPalettePickerPaletteFixed {
+export interface EuiColorPalettePickerPaletteFixedProps {
   /**
    *  For storing unique value of item
    */
@@ -67,7 +67,7 @@ interface EuiColorPalettePickerPaletteFixed {
   palette: string[];
 }
 
-interface EuiColorPalettePickerPaletteGradient {
+export interface EuiColorPalettePickerPaletteGradientProps {
   /**
    *  For storing unique value of item
    */
@@ -88,9 +88,9 @@ interface EuiColorPalettePickerPaletteGradient {
 }
 
 export type EuiColorPalettePickerPaletteProps =
-  | EuiColorPalettePickerPaletteText
-  | EuiColorPalettePickerPaletteFixed
-  | EuiColorPalettePickerPaletteGradient;
+  | EuiColorPalettePickerPaletteTextProps
+  | EuiColorPalettePickerPaletteFixedProps
+  | EuiColorPalettePickerPaletteGradientProps;
 
 export type EuiColorPalettePickerProps<T extends string> = CommonProps &
   Omit<
@@ -103,7 +103,7 @@ export type EuiColorPalettePickerProps<T extends string> = CommonProps &
     selectionDisplay?: 'palette' | 'title';
 
     /**
-     * An array of #EuiColorPalettePickerPalette objects
+     * An array of one of the following objects: #EuiColorPalettePickerPaletteText, #EuiColorPalettePickerPaletteFixed, #EuiColorPalettePickerPaletteGradient
      */
     palettes: EuiColorPalettePickerPaletteProps[];
   };
@@ -127,8 +127,8 @@ export const EuiColorPalettePicker: FunctionComponent<
 }) => {
   const getPalette = (
     item:
-      | EuiColorPalettePickerPaletteFixed
-      | EuiColorPalettePickerPaletteGradient
+      | EuiColorPalettePickerPaletteFixedProps
+      | EuiColorPalettePickerPaletteGradientProps
   ) => {
     const background =
       item.type === 'fixed'

--- a/src/components/color_picker/color_palette_picker/index.ts
+++ b/src/components/color_picker/color_palette_picker/index.ts
@@ -20,5 +20,8 @@
 export {
   EuiColorPalettePicker,
   EuiColorPalettePickerProps,
+  EuiColorPalettePickerPaletteTextProps,
+  EuiColorPalettePickerPaletteFixedProps,
+  EuiColorPalettePickerPaletteGradientProps,
   EuiColorPalettePickerPaletteProps,
 } from './color_palette_picker';


### PR DESCRIPTION
### Summary

I noticed that after some TS changes for the **EuiColorPalettePicker** that the docs props tab wasn't showing properly all the props. 

This PR adds exports for the missing types so that they can be visible in our docs.
 
<img width="1957" alt="ColorPalettePickerPropsTab@2x" src="https://user-images.githubusercontent.com/2750668/83633387-c8c22480-a598-11ea-97fc-e3591383d1b9.png">


### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **IE11** and **Firefox**~
- [x] Props have proper **autodocs**
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
