### PR TITLE
Adding conditional rendering in EuiCallOut component based on title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - A fixed `EuiHeader` no longer automatically padding directly to the `<body>` element ([#3538](https://github.com/elastic/eui/pull/3538))
 - Improved `EuiPagination`, `EuiDataGrid`, `EuiBasicTable` and `EuiInMemoryTable` accessibility, causing `EuiPaginationButton` to require a new prop `pageIndex` ([#3294](https://github.com/elastic/eui/pull/3294))
+- Added conditional rendering of the title element in `EuiCallOut` to avoid usage of additional space caused by the rendered `<div>` element ([#3549](https://github.com/elastic/eui/pull/3549))
 
 
 ## [`24.1.0`](https://github.com/elastic/eui/tree/v24.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Added conditional rendering of the title element in `EuiCallOut` to avoid usage of additional space caused by the rendered `<div>` element ([#3549](https://github.com/elastic/eui/pull/3549))
+
 **Bug fixes**
 
 - Fixed `EuiKeyPadMenu` and `EuiKeyPadMenuItem` aria roles ([#3502](https://github.com/elastic/eui/pull/3502))
-- Added conditional rendering of the title element in `EuiCallOut` to avoid usage of additional space caused by the rendered `<div>` element ([#3549](https://github.com/elastic/eui/pull/3549))
 
 **Breaking changes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 **Bug fixes**
 
 - Fixed `EuiKeyPadMenu` and `EuiKeyPadMenuItem` aria roles ([#3502](https://github.com/elastic/eui/pull/3502))
+- Added conditional rendering of the title element in `EuiCallOut` to avoid usage of additional space caused by the rendered `<div>` element ([#3549](https://github.com/elastic/eui/pull/3549))
 
 **Breaking changes**
 
 - A fixed `EuiHeader` no longer automatically padding directly to the `<body>` element ([#3538](https://github.com/elastic/eui/pull/3538))
 - Improved `EuiPagination`, `EuiDataGrid`, `EuiBasicTable` and `EuiInMemoryTable` accessibility, causing `EuiPaginationButton` to require a new prop `pageIndex` ([#3294](https://github.com/elastic/eui/pull/3294))
-- Added conditional rendering of the title element in `EuiCallOut` to avoid usage of additional space caused by the rendered `<div>` element ([#3549](https://github.com/elastic/eui/pull/3549))
 
 
 ## [`24.1.0`](https://github.com/elastic/eui/tree/v24.1.0)

--- a/src/components/call_out/__snapshots__/call_out.test.tsx.snap
+++ b/src/components/call_out/__snapshots__/call_out.test.tsx.snap
@@ -7,13 +7,6 @@ exports[`EuiCallOut is rendered 1`] = `
   data-test-subj="test subject string"
 >
   <div
-    class="euiCallOutHeader"
-  >
-    <span
-      class="euiCallOutHeader__title"
-    />
-  </div>
-  <div
     class="euiText euiText--small"
   >
     Content
@@ -24,174 +17,73 @@ exports[`EuiCallOut is rendered 1`] = `
 exports[`EuiCallOut props color danger is rendered 1`] = `
 <div
   class="euiCallOut euiCallOut--danger"
->
-  <div
-    class="euiCallOutHeader"
-  >
-    <span
-      class="euiCallOutHeader__title"
-    />
-  </div>
-</div>
+/>
 `;
 
 exports[`EuiCallOut props color primary is rendered 1`] = `
 <div
   class="euiCallOut euiCallOut--primary"
->
-  <div
-    class="euiCallOutHeader"
-  >
-    <span
-      class="euiCallOutHeader__title"
-    />
-  </div>
-</div>
+/>
 `;
 
 exports[`EuiCallOut props color success is rendered 1`] = `
 <div
   class="euiCallOut euiCallOut--success"
->
-  <div
-    class="euiCallOutHeader"
-  >
-    <span
-      class="euiCallOutHeader__title"
-    />
-  </div>
-</div>
+/>
 `;
 
 exports[`EuiCallOut props color warning is rendered 1`] = `
 <div
   class="euiCallOut euiCallOut--warning"
->
-  <div
-    class="euiCallOutHeader"
-  >
-    <span
-      class="euiCallOutHeader__title"
-    />
-  </div>
-</div>
+/>
 `;
 
 exports[`EuiCallOut props heading h1 is rendered 1`] = `
 <div
   class="euiCallOut euiCallOut--primary"
->
-  <div
-    class="euiCallOutHeader"
-  >
-    <h1
-      class="euiCallOutHeader__title"
-    />
-  </div>
-</div>
+/>
 `;
 
 exports[`EuiCallOut props heading h2 is rendered 1`] = `
 <div
   class="euiCallOut euiCallOut--primary"
->
-  <div
-    class="euiCallOutHeader"
-  >
-    <h2
-      class="euiCallOutHeader__title"
-    />
-  </div>
-</div>
+/>
 `;
 
 exports[`EuiCallOut props heading h3 is rendered 1`] = `
 <div
   class="euiCallOut euiCallOut--primary"
->
-  <div
-    class="euiCallOutHeader"
-  >
-    <h3
-      class="euiCallOutHeader__title"
-    />
-  </div>
-</div>
+/>
 `;
 
 exports[`EuiCallOut props heading h4 is rendered 1`] = `
 <div
   class="euiCallOut euiCallOut--primary"
->
-  <div
-    class="euiCallOutHeader"
-  >
-    <h4
-      class="euiCallOutHeader__title"
-    />
-  </div>
-</div>
+/>
 `;
 
 exports[`EuiCallOut props heading h5 is rendered 1`] = `
 <div
   class="euiCallOut euiCallOut--primary"
->
-  <div
-    class="euiCallOutHeader"
-  >
-    <h5
-      class="euiCallOutHeader__title"
-    />
-  </div>
-</div>
+/>
 `;
 
 exports[`EuiCallOut props heading h6 is rendered 1`] = `
 <div
   class="euiCallOut euiCallOut--primary"
->
-  <div
-    class="euiCallOutHeader"
-  >
-    <h6
-      class="euiCallOutHeader__title"
-    />
-  </div>
-</div>
+/>
 `;
 
 exports[`EuiCallOut props heading p is rendered 1`] = `
 <div
   class="euiCallOut euiCallOut--primary"
->
-  <div
-    class="euiCallOutHeader"
-  >
-    <p
-      class="euiCallOutHeader__title"
-    />
-  </div>
-</div>
+/>
 `;
 
 exports[`EuiCallOut props iconType is rendered 1`] = `
 <div
   class="euiCallOut euiCallOut--primary"
->
-  <div
-    class="euiCallOutHeader"
-  >
-    <div
-      aria-hidden="true"
-      class="euiCallOutHeader__icon"
-      data-euiicon-type="user"
-    />
-    <span
-      class="euiCallOutHeader__title"
-    />
-  </div>
-</div>
+/>
 `;
 
 exports[`EuiCallOut props title is rendered 1`] = `

--- a/src/components/call_out/call_out.tsx
+++ b/src/components/call_out/call_out.tsx
@@ -95,11 +95,19 @@ export const EuiCallOut: FunctionComponent<EuiCallOutProps> = ({
 
   return (
     <div className={classes} {...rest}>
-      <div className="euiCallOutHeader">
-        {headerIcon}
+      {
+        title ?
+        (
+          <div className="euiCallOutHeader">
+            {headerIcon}
+            <H className="euiCallOutHeader__title">{title}</H>
+          </div>
+        ):
+        (
+          null
+        )
+      }
 
-        <H className="euiCallOutHeader__title">{title}</H>
-      </div>
 
       {optionalChildren}
     </div>

--- a/src/components/call_out/call_out.tsx
+++ b/src/components/call_out/call_out.tsx
@@ -92,22 +92,15 @@ export const EuiCallOut: FunctionComponent<EuiCallOutProps> = ({
   }
 
   const H: any = heading ? `${heading}` : 'span';
-  const isTitlePresent = title ? (true) : (false);
+  const isTitlePresent = title ? true : false;
   return (
     <div className={classes} {...rest}>
-      {
-        isTitlePresent ?
-        (
-          <div className="euiCallOutHeader">
-            {headerIcon}
-            <H className="euiCallOutHeader__title">{title}</H>
-          </div>
-        ):
-        (
-          null
-        )
-      }
-
+      {isTitlePresent ? (
+        <div className="euiCallOutHeader">
+          {headerIcon}
+          <H className="euiCallOutHeader__title">{title}</H>
+        </div>
+      ) : null}
 
       {optionalChildren}
     </div>

--- a/src/components/call_out/call_out.tsx
+++ b/src/components/call_out/call_out.tsx
@@ -92,15 +92,19 @@ export const EuiCallOut: FunctionComponent<EuiCallOutProps> = ({
   }
 
   const H: any = heading ? `${heading}` : 'span';
-  const isTitlePresent = title ? true : false;
+  let header;
+
+  if (title) {
+    header = (
+      <div className="euiCallOutHeader">
+        {headerIcon}
+        <H className="euiCallOutHeader__title">{title}</H>
+      </div>
+    );
+  }
   return (
     <div className={classes} {...rest}>
-      {isTitlePresent ? (
-        <div className="euiCallOutHeader">
-          {headerIcon}
-          <H className="euiCallOutHeader__title">{title}</H>
-        </div>
-      ) : null}
+      {header}
 
       {optionalChildren}
     </div>

--- a/src/components/call_out/call_out.tsx
+++ b/src/components/call_out/call_out.tsx
@@ -92,11 +92,11 @@ export const EuiCallOut: FunctionComponent<EuiCallOutProps> = ({
   }
 
   const H: any = heading ? `${heading}` : 'span';
-
+  const isTitlePresent = title ? (true) : (false);
   return (
     <div className={classes} {...rest}>
       {
-        title ?
+        isTitlePresent ?
         (
           <div className="euiCallOutHeader">
             {headerIcon}


### PR DESCRIPTION
### Summary

I added conditional rendering to the title in the callout function. As extra space was being taken up, when there was a missing title.

Relating to Issue : fixes #3473


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [x] Checked in **IE11** and **Firefox**
- [x] Props have proper **autodocs**
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

@cchaos 