### PR TITLE
Compute EuiComboBox's listbox zIndex

### DIFF
--- a/src-docs/src/views/flyout/flyout_complicated.js
+++ b/src-docs/src/views/flyout/flyout_complicated.js
@@ -4,6 +4,8 @@ import {
   EuiButton,
   EuiButtonEmpty,
   EuiCodeBlock,
+  EuiComboBox,
+  EuiExpression,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFlyout,
@@ -26,6 +28,7 @@ export default () => {
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
   const [selectedTabId, setSelectedTabId] = useState('1');
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [isExpressionOpen, setIsExpressionOpen] = useState(false);
 
   const tabs = [
     {
@@ -162,6 +165,26 @@ export default () => {
               <SuperSelectComplexExample />
             </EuiFormRow>
           </EuiForm>
+          <EuiSpacer />
+          <EuiPopover
+            isOpen={isExpressionOpen}
+            closePopover={() => setIsExpressionOpen(false)}
+            button={
+              <EuiExpression
+                description="expression"
+                value="configurations"
+                onClick={() => setIsExpressionOpen(!isExpressionOpen)}
+              />
+            }>
+            <EuiComboBox
+              selectedOptions={[{ label: 'Option one' }]}
+              options={[
+                { label: 'Option one' },
+                { label: 'Option two' },
+                { label: 'Option three' },
+              ]}
+            />
+          </EuiPopover>
           <EuiSpacer />
           {flyoutContent}
           <EuiCodeBlock language="html">{htmlCode}</EuiCodeBlock>

--- a/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
+++ b/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
@@ -311,6 +311,7 @@ exports[`props options list is rendered 1`] = `
   <div
     class="euiPanel euiComboBoxOptionsList euiComboBoxOptionsList--bottom"
     data-test-subj="comboBoxOptionsList alsoGetsAppliedToOptionsList-optionsList"
+    style="z-index: 0;"
   >
     <div
       class="euiComboBoxOptionsList__rowWrap"

--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -63,6 +63,7 @@ import { EuiFilterSelectItem } from '../filter_group';
 import AutosizeInput from 'react-input-autosize';
 import { CommonProps } from '../common';
 import { EuiFormControlLayoutProps } from '../form';
+import { getElementZIndex } from '../../services/popover';
 
 type DrillProps<T> = Pick<
   EuiComboBoxOptionsListProps<T>,
@@ -178,6 +179,7 @@ interface EuiComboBoxState<T> {
   isListOpen: boolean;
   listElement?: RefInstance<HTMLDivElement>;
   listPosition: EuiComboBoxOptionsListPosition;
+  listZIndex: number | undefined;
   matchingOptions: Array<EuiComboBoxOptionOption<T>>;
   searchValue: string;
   width: number;
@@ -208,6 +210,7 @@ export class EuiComboBox<T> extends Component<
     isListOpen: false,
     listElement: null,
     listPosition: 'bottom',
+    listZIndex: undefined,
     matchingOptions: getMatchingOptions<T>(
       this.props.options,
       this.props.selectedOptions,
@@ -262,6 +265,15 @@ export class EuiComboBox<T> extends Component<
 
   listRefInstance: RefInstance<HTMLDivElement> = null;
   listRefCallback: RefCallback<HTMLDivElement> = ref => {
+    if (this.comboBoxRefInstance) {
+      // find the zIndex of the combobox relative to the page body
+      // and use that to depth-position the list box
+      const listZIndex = getElementZIndex(
+        this.comboBoxRefInstance,
+        document.body
+      );
+      this.setState({ listZIndex });
+    }
     this.listRefInstance = ref;
   };
 
@@ -291,6 +303,7 @@ export class EuiComboBox<T> extends Component<
   closeList = () => {
     this.clearActiveOption();
     this.setState({
+      listZIndex: undefined,
       isListOpen: false,
     });
   };
@@ -969,6 +982,7 @@ export class EuiComboBox<T> extends Component<
       optionsList = (
         <EuiPortal>
           <EuiComboBoxOptionsList
+            zIndex={this.state.listZIndex}
             activeOptionIndex={this.state.activeOptionIndex}
             areAllOptionsSelected={this.areAllOptionsSelected()}
             data-test-subj={optionsListDataTestSubj}

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
@@ -96,6 +96,7 @@ export type EuiComboBoxOptionsListProps<T> = CommonProps &
     width: number;
     singleSelection?: boolean | EuiComboBoxSingleSelectionShape;
     delimiter?: string;
+    zIndex?: number;
   };
 
 export class EuiComboBoxOptionsList<T> extends Component<
@@ -200,6 +201,8 @@ export class EuiComboBoxOptionsList<T> extends Component<
       updatePosition,
       width,
       delimiter,
+      zIndex,
+      style,
       ...rest
     } = this.props;
 
@@ -383,6 +386,7 @@ export class EuiComboBoxOptionsList<T> extends Component<
         className={classes}
         panelRef={this.listRefCallback}
         data-test-subj={`comboBoxOptionsList ${dataTestSubj}`}
+        style={{ ...style, zIndex: zIndex }}
         {...rest}>
         <div className="euiComboBoxOptionsList__rowWrap">
           {emptyState || optionsList}


### PR DESCRIPTION
### Summary

Fixes an issue reported by @Kerry350 where a flyout>expression>popover>combobox's options list is rendered under the popover.

* call `getElementZIndex` from _popover_positioning_ service to find the target zIndex when opening the listbox
* added example to the _More complicated flyout_ section

### Before
![broken zindex stacking](https://d.pr/i/qN0M1Q.png)

### After
![proper zindex stacking](https://d.pr/i/VAe2pE.png)

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
- [x] Checked in **mobile**
- [x] Checked in ~**IE11**~ and **Firefox**
~- [ ] Props have proper **autodocs**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
