### PR TITLE
Adding an overflow to round card images.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Bug fixes**
 
-- Fixed an issue where card image corners (top left & top right) would peek out over their border radius ([#3556](https://github.com/elastic/eui/pull/3556))
+- Fixed `EuiCard` image corners to be contained within border radius ([#3556](https://github.com/elastic/eui/pull/3556))
 - Fixed `EuiKeyPadMenu` and `EuiKeyPadMenuItem` aria roles ([#3502](https://github.com/elastic/eui/pull/3502))
 
 **Breaking changes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Bug fixes**
 
+- Fixed an issue where card image corners (top left & top right) would peek out over their border radius ([#3556](https://github.com/elastic/eui/pull/3556))
 - Fixed `EuiKeyPadMenu` and `EuiKeyPadMenuItem` aria roles ([#3502](https://github.com/elastic/eui/pull/3502))
 
 **Breaking changes**

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -148,6 +148,7 @@
     // match border radius, minus 1px because it's inside a border
     border-top-left-radius: $euiBorderRadius - 1px;
     border-top-right-radius: $euiBorderRadius - 1px;
+    overflow: hidden;
 
     img {
       width: 100%;


### PR DESCRIPTION
### Summary

Fixes an issue that allowed card images to peek out of their containers at the top left/right corners.

#### Existing
![image](https://user-images.githubusercontent.com/739960/83799852-4ea6a400-a65b-11ea-9644-1c77e2e94be4.png)

![image](https://user-images.githubusercontent.com/739960/83799813-3afb3d80-a65b-11ea-8684-37c9afa5bea1.png)


#### Fixed
![image](https://user-images.githubusercontent.com/739960/83799866-55cdb200-a65b-11ea-9851-e167a49a1548.png)

![image](https://user-images.githubusercontent.com/739960/83799785-2d45b800-a65b-11ea-84e5-f670047f9028.png)


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples~
~- [ ] Added or updated **[jest tests]~(https://github.com/elastic/eui/blob/master/wiki/testing.md)**
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
