### PR TITLE
[EuiBasicTable] Always use Column Index for Footer key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed `EuiKeyPadMenu` and `EuiKeyPadMenuItem` aria roles ([#3502](https://github.com/elastic/eui/pull/3502))
 - Fixed `EuiFieldSearch` input clear button doesn't show when external input is passed([#3497](https://github.com/elastic/eui/pull/3497))
+- Fixed `EuiBasicTable` always uses a unique key for all columns ([#3559](https://github.com/elastic/eui/pull/3559))
 
 **Breaking changes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fixed `EuiKeyPadMenu` and `EuiKeyPadMenuItem` aria roles ([#3502](https://github.com/elastic/eui/pull/3502))
 - Fixed `EuiFieldSearch` input clear button doesn't show when external input is passed([#3497](https://github.com/elastic/eui/pull/3497))
-- Fixed `EuiBasicTable` always uses a unique key for all columns ([#3559](https://github.com/elastic/eui/pull/3559))
+- Fixed `EuiBasicTable` footers to always use a unique `key` ([#3559](https://github.com/elastic/eui/pull/3559))
 
 **Breaking changes**
 

--- a/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -958,19 +958,19 @@ exports[`EuiBasicTable footers render with pagination, selection, sorting, and f
           key="_selection_column_f"
         />
         <EuiTableFooterCell
-          key="footer_name"
+          key="footer_name_0"
         >
           <strong>
             Name
           </strong>
         </EuiTableFooterCell>
         <EuiTableFooterCell
-          key="footer_id"
+          key="footer_id_1"
         >
           ID
         </EuiTableFooterCell>
         <EuiTableFooterCell
-          key="footer_age"
+          key="footer_age_2"
         >
           <strong>
             sum:

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -864,7 +864,9 @@ export class EuiBasicTable<T = any> extends Component<
 
       if (footer) {
         footers.push(
-          <EuiTableFooterCell key={`footer_${field}`} align={align}>
+          <EuiTableFooterCell
+            key={`footer_${field}_${footers.length - 1}`}
+            align={align}>
             {footer}
           </EuiTableFooterCell>
         );


### PR DESCRIPTION
### Summary

This forces all keys to be unique regardless of field name collisions (rare) and computed columns (less rare).

Closes #3558 

### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **IE11** and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- [x] Checked **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)** examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
