### PR TITLE
Fix EUI docs in IE11 & Safari < 13

### DIFF
--- a/src-docs/src/services/string/clean_imports.js
+++ b/src-docs/src/services/string/clean_imports.js
@@ -12,13 +12,12 @@ export const cleanEuiImports = code => {
 };
 
 export const listExtraDeps = code => {
-  return [
-    ...code.matchAll(
+  return code
+    .match(
       // Match anything not directly calling eui (like lib dirs)
-      /(import)(?!.*(elastic\/eui|\.))\s.*?'(?<import>(@[^.]+?\/)?[^.]+?)['\/]/g
-    ),
-  ]
-    .map(x => x.groups.import)
+      /import(?!.*(elastic\/eui|\.))\s.*?'(@[^.]+?\/)?[^.]+?['\/]/g
+    )
+    .map(match => match.match(/'(.+)['\/]/)[1])
     .reduce((deps, dep) => {
       // Make sure that we are using the latest version of a dep
       deps[dep] = 'latest';


### PR DESCRIPTION
### Summary

Replaced the `.matchAll` call with `.match` and updated how those matched values are extracted. Tested that the docs load in those two browsers, and that the code sandbox links still function as expected

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
- [x] Checked in **IE11** and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
