### PR TITLE
Added display prop to EuiDataGridColumnSortingDraggable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Added `display` prop to `EuiDataGridColumnSortingDraggable` ([#3574](https://github.com/elastic/eui/pull/3574))
 - Added `useEuiTextDiff` react hook utility ([#3288](https://github.com/elastic/eui/pull/3288))
 - Converted `EuiOverlayMask` to be a React functional component ([#3555](https://github.com/elastic/eui/pull/3555))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Added `display` prop to `EuiDataGridColumnSortingDraggable` ([#3574](https://github.com/elastic/eui/pull/3574))
 - Added `useEuiTextDiff` react hook utility ([#3288](https://github.com/elastic/eui/pull/3288))
 - Converted `EuiOverlayMask` to be a React functional component ([#3555](https://github.com/elastic/eui/pull/3555))
 
 **Bug fixes**
 
+- Added `display` prop to `EuiDataGridColumnSortingDraggable` to pass` displayAsText` prop correctly to the column sorting popover.([#3574](https://github.com/elastic/eui/pull/3574))
 - Fixed `EuiCodeBlockImpl` testenv mock pass-through of `data-test-subj` attribute ([#3560](https://github.com/elastic/eui/pull/3560))
 - Fixed DOM element creation issues in `EuiOverlayMask` by using lifecycle methods ([#3555](https://github.com/elastic/eui/pull/3555))
 

--- a/src/components/datagrid/column_sorting.tsx
+++ b/src/components/datagrid/column_sorting.tsx
@@ -176,6 +176,7 @@ export const useColumnSorting = (
                     <EuiDataGridColumnSortingDraggable
                       key={id}
                       id={id}
+                      display={displayValues[id]}
                       direction={direction}
                       index={index}
                       sorting={sorting}

--- a/src/components/datagrid/column_sorting_draggable.tsx
+++ b/src/components/datagrid/column_sorting_draggable.tsx
@@ -40,11 +40,24 @@ export interface EuiDataGridColumnSortingDraggableProps {
   sorting: EuiDataGridSorting;
   schema: EuiDataGridSchema;
   schemaDetectors: EuiDataGridSchemaDetector[];
+  /**
+   * Value to be shown in column sorting popover.
+   */
+  display: string;
 }
 
 export const EuiDataGridColumnSortingDraggable: FunctionComponent<
   EuiDataGridColumnSortingDraggableProps
-> = ({ id, direction, index, sorting, schema, schemaDetectors, ...rest }) => {
+> = ({
+  id,
+  display,
+  direction,
+  index,
+  sorting,
+  schema,
+  schemaDetectors,
+  ...rest
+}) => {
   const schemaDetails =
     schema.hasOwnProperty(id) && schema[id].columnType != null
       ? getDetailsForSchema(schemaDetectors, schema[id].columnType)
@@ -95,7 +108,7 @@ export const EuiDataGridColumnSortingDraggable: FunctionComponent<
                 default="is sorting this data grid">
                 {(activeSortLabel: ReactChild) => (
                   <span>
-                    {id} {activeSortLabel}
+                    {display} {activeSortLabel}
                   </span>
                 )}
               </EuiI18n>
@@ -140,7 +153,7 @@ export const EuiDataGridColumnSortingDraggable: FunctionComponent<
             </EuiFlexItem>
             <EuiFlexItem aria-hidden>
               <EuiText size="xs">
-                <p>{id}</p>
+                <p>{display}</p>
               </EuiText>
             </EuiFlexItem>
             <EuiFlexItem className="euiDataGridColumnSorting__orderButtons">


### PR DESCRIPTION
### Summary

From: https://github.com/elastic/eui/pull/3520#issuecomment-640285036

Added display prop to `EuiDataGridColumnSortingDraggable` to set the value to the column sorting popover popover

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [x] Props have proper **autodocs**
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
~~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~~
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
