### PR TITLE
made use of useState in custom code editor example

### DIFF
--- a/src-docs/src/views/code_editor/custom_mode.js
+++ b/src-docs/src/views/code_editor/custom_mode.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import 'brace/mode/text';
 
 import { EuiCodeEditor } from '../../../../src/components';
@@ -10,7 +10,11 @@ class MyCustomAceMode extends TextMode {
 }
 
 export default () => {
-  const value = '';
+  const [value, updateValue] = useState('');
+
+  const onChange = value => {
+    updateValue(value);
+  };
 
   return (
     <EuiCodeEditor
@@ -19,6 +23,7 @@ export default () => {
       theme="github"
       width="100%"
       value={value}
+      onChange={onChange}
       setOptions={{ fontSize: '14px' }}
     />
   );


### PR DESCRIPTION
### Summary

made use of useState in custom code editor example to preserve the text when user switches the tabs

# ScreenShot of issue

![Hnet com-image](https://user-images.githubusercontent.com/43617894/84076736-f1607900-a9f3-11ea-84d7-926e60f2c45e.gif)

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
- [x] Improved **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
