### PR TITLE
More aria attributes for Selectable

### DIFF
--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -347,7 +347,7 @@ export class EuiSelectable extends Component<
       ...cleanedListProps
     } = listProps || unknownAccessibleName;
 
-    let messageContent;
+    let messageContent: JSX.Element | undefined;
 
     if (isLoading) {
       messageContent = (
@@ -391,6 +391,7 @@ export class EuiSelectable extends Component<
       className
     );
 
+    const messageContentId = messageContent && this.rootId('messageContent');
     const listId = this.rootId('listbox');
     const makeOptionId = (index: number | undefined) => {
       if (typeof index === 'undefined') {
@@ -414,15 +415,22 @@ export class EuiSelectable extends Component<
       props:
         | Partial<EuiSelectableSearchProps>
         | EuiSelectableOptionsListPropsWithDefaults
-        | undefined
+        | undefined,
+      messageContentId?: string
     ) => {
       if (props && props['aria-label']) {
         return { 'aria-label': props['aria-label'] };
       }
 
+      const messageContentIdString = messageContentId
+        ? ` ${messageContentId}`
+        : '';
+
       if (props && props['aria-describedby']) {
         return {
-          'aria-describedby': props['aria-describedby'],
+          'aria-describedby': `${
+            props['aria-describedby']
+          }${messageContentIdString}`,
         };
       }
 
@@ -431,13 +439,18 @@ export class EuiSelectable extends Component<
       }
 
       if (ariaDescribedby) {
-        return { 'aria-describedby': ariaDescribedby };
+        return {
+          'aria-describedby': `${ariaDescribedby}${messageContentIdString}`,
+        };
       }
 
       return {};
     };
 
-    const searchAccessibleName = getAccessibleName(searchProps);
+    const searchAccessibleName = getAccessibleName(
+      searchProps,
+      messageContentId
+    );
     const searchHasAccessibleName = Boolean(
       Object.keys(searchAccessibleName).length
     );
@@ -467,7 +480,7 @@ export class EuiSelectable extends Component<
       Object.keys(listAccessibleName).length
     );
     const list = messageContent ? (
-      <EuiSelectableMessage key="listMessage">
+      <EuiSelectableMessage key="listMessage" id={messageContentId}>
         {messageContent}
       </EuiSelectableMessage>
     ) : (

--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -492,6 +492,9 @@ export class EuiSelectable extends Component<
             visibleOptions={visibleOptions}
             searchValue={searchValue}
             activeOptionIndex={activeOptionIndex}
+            setActiveOptionIndex={index =>
+              this.setState({ activeOptionIndex: index })
+            }
             onOptionClick={this.onOptionClick}
             singleSelection={singleSelection}
             ref={this.optionsListRef}

--- a/src/components/selectable/selectable_list/selectable_list.test.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.test.tsx
@@ -56,6 +56,7 @@ const selectableListRequiredProps = {
   makeOptionId: (index: number | undefined) => `option_${index}`,
   listId: 'list',
   onOptionClick: () => {},
+  setActiveOptionIndex: () => undefined,
   ...requiredProps,
 };
 

--- a/src/components/selectable/selectable_list/selectable_list.test.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.test.tsx
@@ -56,7 +56,7 @@ const selectableListRequiredProps = {
   makeOptionId: (index: number | undefined) => `option_${index}`,
   listId: 'list',
   onOptionClick: () => {},
-  setActiveOptionIndex: () => undefined,
+  setActiveOptionIndex: () => {},
   ...requiredProps,
 };
 

--- a/src/components/selectable/selectable_list/selectable_list.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.tsx
@@ -30,9 +30,13 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import {
   FixedSizeList,
   ListProps,
-  ListChildComponentProps,
+  ListChildComponentProps as ReactWindowListChildComponentProps,
   areEqual,
 } from 'react-window';
+
+interface ListChildComponentProps extends ReactWindowListChildComponentProps {
+  data: EuiSelectableOption[];
+}
 
 // Consumer Configurable Props via `EuiSelectable.listProps`
 export type EuiSelectableOptionsListProps = CommonProps &
@@ -211,6 +215,8 @@ export class EuiSelectableList extends Component<EuiSelectableListProps> {
       );
     }
 
+    const labelCount = data.filter(option => option.isGroupLabel).length;
+
     return (
       <EuiSelectableListItem
         id={this.props.makeOptionId(index)}
@@ -225,6 +231,8 @@ export class EuiSelectableList extends Component<EuiSelectableListProps> {
         disabled={disabled}
         prepend={prepend}
         append={append}
+        aria-posinset={index + 1 - labelCount}
+        aria-setsize={data.length - labelCount}
         {...optionRest as EuiSelectableListItemProps}>
         {this.props.renderOption ? (
           this.props.renderOption(option, this.props.searchValue)

--- a/src/components/selectable/selectable_list/selectable_list.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.tsx
@@ -106,6 +106,7 @@ export type EuiSelectableListProps = EuiSelectableOptionsListProps & {
   searchable?: boolean;
   makeOptionId: (index: number | undefined) => string;
   listId: string;
+  setActiveOptionIndex: (index: number) => void;
 };
 
 export class EuiSelectableList extends Component<EuiSelectableListProps> {
@@ -262,6 +263,7 @@ export class EuiSelectableList extends Component<EuiSelectableListProps> {
       bordered,
       searchable,
       listId,
+      setActiveOptionIndex,
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledby,
       'aria-describedby': ariaDescribedby,
@@ -331,6 +333,10 @@ export class EuiSelectableList extends Component<EuiSelectableListProps> {
     }
 
     const { allowExclusions } = this.props;
+
+    this.props.setActiveOptionIndex(
+      this.props.options.findIndex(({ label }) => label === option.label)
+    );
 
     if (option.checked === 'on' && allowExclusions) {
       this.onExcludeOption(option);


### PR DESCRIPTION
### Summary (3 things)

1. Adds `aria-setsize` and `aria-posinset` attributes to the options (gives accurate sizes and positions to screen readers in virtualized lists)
2. Adds the messages (e.g., "no results found") as an `aria-describedby` to the search field
3. When clicking on an option, it would set focus on the first focusable option. Now, instead, it sets it on the option you clicked which prevents a weird jump and seems to just work better. (**Breaking change:** needed to pass around another function for this)

Reviewer note: Each of these is a single commit if you want to review that way.

### Checklist

- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~