### PR TITLE
[EuiHeader] Fix SASS globals & docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@
 - Converted `EuiOverlayMask` to be a React functional component ([#3555](https://github.com/elastic/eui/pull/3555))
 - Changed `responsive` and `max` behavior of `EuiBreadcrumbs` to always display collapsed items in popover [#3578](https://github.com/elastic/eui/pull/3578))
 - Added `BREAKPOINTS` and `getBreakpoint` utilities [#3578](https://github.com/elastic/eui/pull/3578))
+- Moved all `EuiHeader` SASS variables to `global_styles` ([#3592](https://github.com/elastic/eui/pull/3592))
 
 **Bug fixes**
 
 - Added `display` prop to `EuiDataGridColumnSortingDraggable` to pass` displayAsText` prop correctly to the column sorting popover.([#3574](https://github.com/elastic/eui/pull/3574))
 - Fixed `EuiCodeBlockImpl` testenv mock pass-through of `data-test-subj` attribute ([#3560](https://github.com/elastic/eui/pull/3560))
 - Fixed DOM element creation issues in `EuiOverlayMask` by using lifecycle methods ([#3555](https://github.com/elastic/eui/pull/3555))
+- Fixed `euiHeaderAffordForFixed` mixin's use of header SASS variable ([#3592](https://github.com/elastic/eui/pull/3592))
 
 **Breaking changes**
 

--- a/src-docs/src/views/header/header_example.js
+++ b/src-docs/src/views/header/header_example.js
@@ -199,14 +199,14 @@ export const HeaderExample = {
             afford for the header height. EUI supplies a helper mixin that also
             accounts for this height in flyouts and the collapsible nav. Simply
             add{' '}
-            <EuiCode language="sass">@mixin euiHeaderAffordForFixed;</EuiCode>{' '}
+            <EuiCode language="scss">@include euiHeaderAffordForFixed;</EuiCode>{' '}
             anywhere in your SASS.
           </p>
         </>
       ),
       snippet: [
         '<EuiHeader position="fixed" />',
-        '@mixin euiHeaderAffordForFixed;',
+        '@include euiHeaderAffordForFixed;',
       ],
       demo: <HeaderPosition />,
     },
@@ -320,8 +320,8 @@ export const HeaderExample = {
         </p>
       ),
       snippet: [
-        `<EuiHeader theme="dark" />
-<EuiHeader />`,
+        `<EuiHeader theme="dark" position="fixed" />
+<EuiHeader position="fixed" />`,
         '@include euiHeaderAffordForFixed($euiHeaderHeightCompensation * 2);',
       ],
       demo: <HeaderStacked />,

--- a/src/components/control_bar/_index.scss
+++ b/src/components/control_bar/_index.scss
@@ -1,4 +1,3 @@
-@import '../header/variables';
 @import '../nav_drawer/variables';
 @import 'variables';
 @import 'control_bar';

--- a/src/components/flyout/_mixins.scss
+++ b/src/components/flyout/_mixins.scss
@@ -1,4 +1,3 @@
-@import '../header/variables';
 
 @mixin euiFlyout {
   border-left: $euiFlyoutBorder;

--- a/src/components/header/_index.scss
+++ b/src/components/header/_index.scss
@@ -1,5 +1,4 @@
 // Components
-@import 'variables';
 @import 'mixins';
 
 @import 'header';

--- a/src/components/nav_drawer/_index.scss
+++ b/src/components/nav_drawer/_index.scss
@@ -1,4 +1,3 @@
-@import '../header/variables';
 @import 'variables';
 
 // Components

--- a/src/global_styling/mixins/_header.scss
+++ b/src/global_styling/mixins/_header.scss
@@ -1,3 +1,5 @@
+@import '../variables/header';
+
 @mixin euiHeaderAffordForFixed($headerHeight: $euiHeaderHeightCompensation) {
   // The `&` allows for grouping inside another specific body class.
   // When not applied inside of another selector, it simply renders with the single class

--- a/src/global_styling/variables/_header.scss
+++ b/src/global_styling/variables/_header.scss
@@ -1,4 +1,3 @@
-// Note - these are also used by the EuiNavDrawer (/nav_drawer) component
 // Themable colors
 $euiHeaderBackgroundColor: $euiColorEmptyShade !default;
 $euiHeaderBorderColor: $euiBorderColor !default;

--- a/src/global_styling/variables/_index.scss
+++ b/src/global_styling/variables/_index.scss
@@ -18,5 +18,6 @@
 
 @import 'buttons';
 @import 'form';
+@import 'header';
 @import 'panel';
 @import 'tool_tip';


### PR DESCRIPTION
### Fixes #3589

It was pointed out that the mixin provided for fixed headers wasn't properly importing the necessary variables so consumers got hit with a missing variable error when trying to use it. This was because the header variable that was being used in the mixin wasn't in the global_styles but in the component styles. 

I've moved all the header variables to `global_variables` since these seem to be affecting more than itself anyway.

I have tested that this fixes the missing variable issue by linking locally in the K8 POC. Errors are gone 👍 !

This also fixes the docs that accidentally said to use `@mixin ...` instead of `@include ...`.



### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **IE11** and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- [x] Updated **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
