### PR TITLE
[DOCS] EuiBadgeGroup props are passed to correct example

### DIFF
--- a/src-docs/src/views/badge/badge_example.js
+++ b/src-docs/src/views/badge/badge_example.js
@@ -237,6 +237,7 @@ export const BadgeExample = {
           </p>
         </Fragment>
       ),
+      props: { EuiBadgeGroup },
       demo: <BadgeTruncate />,
       snippet: badgeTruncateSnippet,
     },
@@ -281,7 +282,7 @@ export const BadgeExample = {
           </p>
         </div>
       ),
-      props: { EuiBetaBadge, EuiBadgeGroup },
+      props: { EuiBetaBadge },
       snippet: betaBadgeSnippet,
       demo: <BetaBadge />,
     },


### PR DESCRIPTION
# Summary

## Before : 
`EuiBadgeGroup` props section was displayed underneath the `EuiBetaBadge` prop's section.
![Screenshot 2020-06-12 at 12 47 52 AM](https://user-images.githubusercontent.com/43617894/84429781-5a3f2f80-ac46-11ea-9cc6-7f09943e9928.png)

## Now : 

![Screenshot 2020-06-12 at 12 48 15 AM](https://user-images.githubusercontent.com/43617894/84429805-67f4b500-ac46-11ea-93cb-58166a4af0bd.png)
<hr/>
![Screenshot 2020-06-12 at 12 48 26 AM](https://user-images.githubusercontent.com/43617894/84429846-6fb45980-ac46-11ea-9608-ba7e0c7e43db.png)


### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
- [x] Improved **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
