### PR TITLE
Used default titleSize for EuiEmptyPrompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `BREAKPOINTS` and `getBreakpoint` utilities [#3578](https://github.com/elastic/eui/pull/3578))
 - Added `'any'` option to the `step` prop of the `EuiFieldNumber` ([#3562](https://github.com/elastic/eui/pull/3562))
 - Moved all `EuiHeader` SASS variables to `global_styles` ([#3592](https://github.com/elastic/eui/pull/3592))
+- Default `titleSize` get's implicitly set to 'm' for `EuiEmptyPrompt` ([#3598](https://github.com/elastic/eui/pull/3598))
 
 **Bug fixes**
 

--- a/src/components/empty_prompt/empty_prompt.tsx
+++ b/src/components/empty_prompt/empty_prompt.tsx
@@ -47,7 +47,7 @@ export const EuiEmptyPrompt: FunctionComponent<EuiEmptyPromptProps> = ({
   iconType,
   iconColor = 'subdued',
   title,
-  titleSize,
+  titleSize = 'm',
   body,
   actions,
   className,


### PR DESCRIPTION
### Summary

Used default titleSize _(m)_ for EuiEmptyPrompt , 
this is specifically docs side as it doesn't affect working of the component
when no `titleSize` is passed , `EuiTitle` applies a default size `'m'` to the title but no such identification is given inside the `docs`

![Screenshot 2020-06-12 at 1 24 14 AM](https://user-images.githubusercontent.com/43617894/84433228-9b860e00-ac4b-11ea-87e0-d96286d14b0a.png)
 This is just to shown that `titleSize` is implicitly set to  `'m'`  by default
 
### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
- [x] Improved **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
