### PR TITLE
[Amsterdam] Added rounded corners to inline EuiCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 - Updated `EuiCallout` by removing left border, adding border radius and increasing font weight on titles ([#3557](https://github.com/elastic/eui/pull/3557/))
 - Updated `EuiHeaderBreadcrumbs` style to be more prominent ([#3578](https://github.com/elastic/eui/pull/3578/))
+- Updated `EuiCodeBlock` inline code style to use border radius ([#3599](https://github.com/elastic/eui/pull/3599))
 
 ## [`25.0.0`](https://github.com/elastic/eui/tree/v25.0.0)
 

--- a/src/themes/eui-amsterdam/global_styling/variables/_borders.scss
+++ b/src/themes/eui-amsterdam/global_styling/variables/_borders.scss
@@ -1,1 +1,2 @@
 $euiBorderRadius: $euiSizeS * .75;
+$euiBorderRadiusSmall: $euiSizeS * .5;

--- a/src/themes/eui-amsterdam/overrides/_code.scss
+++ b/src/themes/eui-amsterdam/overrides/_code.scss
@@ -1,5 +1,5 @@
 .euiCodeBlock {
   &.euiCodeBlock--inline {
-    border-radius: $euiSizeS * .5; //4px
+    border-radius: $euiSizeXS; //4px
   }
 }

--- a/src/themes/eui-amsterdam/overrides/_code.scss
+++ b/src/themes/eui-amsterdam/overrides/_code.scss
@@ -1,5 +1,5 @@
 .euiCodeBlock {
   &.euiCodeBlock--inline {
-    border-radius: $euiSizeXS; //4px
+    border-radius: $euiBorderRadiusSmall;
   }
 }

--- a/src/themes/eui-amsterdam/overrides/_code.scss
+++ b/src/themes/eui-amsterdam/overrides/_code.scss
@@ -1,0 +1,5 @@
+.euiCodeBlock {
+  &.euiCodeBlock--inline {
+    border-radius: $euiSizeS * .5; //4px
+  }
+}

--- a/src/themes/eui-amsterdam/overrides/_code.scss
+++ b/src/themes/eui-amsterdam/overrides/_code.scss
@@ -1,5 +1,3 @@
-.euiCodeBlock {
-  &.euiCodeBlock--inline {
-    border-radius: $euiBorderRadiusSmall;
-  }
+.euiCodeBlock--inline {
+  border-radius: $euiBorderRadiusSmall;
 }

--- a/src/themes/eui-amsterdam/overrides/_index.scss
+++ b/src/themes/eui-amsterdam/overrides/_index.scss
@@ -2,6 +2,7 @@
 @import 'button_empty';
 @import 'button_group';
 @import 'call_out';
+@import 'code';
 @import 'flyout';
 @import 'header';
 @import 'image';


### PR DESCRIPTION
### Summary

Small PR for EUI Amsterdam theme that adds rounded corners to inline versions of EuiCodeBlock. It is a very subtle change, but gives it a little more personality. I opted not to use `$euiBorderRadius` (6px) and instead used `$euiSizeXS` (4px) because the larger radius made the shape look too much like a pill. 

### Screenshot

![image](https://user-images.githubusercontent.com/847805/84433683-b2e9da80-abfc-11ea-97d5-b8ecbf5478f2.png)

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
