### PR TITLE
Added side property to 'EuiGlobalToastList' 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `BREAKPOINTS` and `getBreakpoint` utilities [#3578](https://github.com/elastic/eui/pull/3578))
 - Added `'any'` option to the `step` prop of the `EuiFieldNumber` ([#3562](https://github.com/elastic/eui/pull/3562))
 - Moved all `EuiHeader` SASS variables to `global_styles` ([#3592](https://github.com/elastic/eui/pull/3592))
+- Added `side` prop to  `EuiGlobalToastList` to allow the user to determine the side(left or right) of the toasts ([#3600](https://github.com/elastic/eui/pull/3600))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,8 @@
 - Added `BREAKPOINTS` and `getBreakpoint` utilities [#3578](https://github.com/elastic/eui/pull/3578))
 - Added `'any'` option to the `step` prop of the `EuiFieldNumber` ([#3562](https://github.com/elastic/eui/pull/3562))
 - Moved all `EuiHeader` SASS variables to `global_styles` ([#3592](https://github.com/elastic/eui/pull/3592))
-- Added `side` prop to  `EuiGlobalToastList` to allow the user to determine the side(left or right) of the toasts ([#3600](https://github.com/elastic/eui/pull/3600))
+- Added `side` prop to `EuiGlobalToastList` for choosing which window side to display toasts ([#3600](https://github.com/elastic/eui/pull/3600))
 - Default `titleSize` get's implicitly set to 'm' for `EuiEmptyPrompt` ([#3598](https://github.com/elastic/eui/pull/3598))
-
 
 **Bug fixes**
 

--- a/src/components/toast/__snapshots__/global_toast_list.test.tsx.snap
+++ b/src/components/toast/__snapshots__/global_toast_list.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`EuiGlobalToastList is rendered 1`] = `
 <div
   aria-label="aria-label"
   aria-live="polite"
-  class="euiGlobalToastList testClass1 testClass2 euiGlobalToastList-right"
+  class="euiGlobalToastList euiGlobalToastList--right testClass1 testClass2"
   data-test-subj="test subject string"
   role="region"
 />
@@ -13,7 +13,102 @@ exports[`EuiGlobalToastList is rendered 1`] = `
 exports[`EuiGlobalToastList props toasts is rendered 1`] = `
 <div
   aria-live="polite"
-  class="euiGlobalToastList euiGlobalToastList-left"
+  class="euiGlobalToastList euiGlobalToastList--right"
+  role="region"
+>
+  <div
+    class="euiToast euiToast--success euiGlobalToastListItem"
+    data-test-subj="a"
+    id="a"
+  >
+    <p
+      class="euiScreenReaderOnly"
+    >
+      A new notification appears
+    </p>
+    <div
+      aria-label="Notification"
+      class="euiToastHeader euiToastHeader--withBody"
+      data-test-subj="euiToastHeader"
+    >
+      <div
+        aria-hidden="true"
+        class="euiToastHeader__icon"
+        data-euiicon-type="check"
+      />
+      <span
+        class="euiToastHeader__title"
+      >
+        A
+      </span>
+    </div>
+    <button
+      aria-label="Dismiss toast"
+      class="euiToast__closeButton"
+      data-test-subj="toastCloseButton"
+      type="button"
+    >
+      <div
+        aria-hidden="true"
+        data-euiicon-type="cross"
+      />
+    </button>
+    <div
+      class="euiText euiText--small euiToastBody"
+    >
+      a
+    </div>
+  </div>
+  <div
+    class="euiToast euiToast--danger euiGlobalToastListItem"
+    data-test-subj="b"
+    id="b"
+  >
+    <p
+      class="euiScreenReaderOnly"
+    >
+      A new notification appears
+    </p>
+    <div
+      aria-label="Notification"
+      class="euiToastHeader euiToastHeader--withBody"
+      data-test-subj="euiToastHeader"
+    >
+      <div
+        aria-hidden="true"
+        class="euiToastHeader__icon"
+        data-euiicon-type="alert"
+      />
+      <span
+        class="euiToastHeader__title"
+      >
+        B
+      </span>
+    </div>
+    <button
+      aria-label="Dismiss toast"
+      class="euiToast__closeButton"
+      data-test-subj="toastCloseButton"
+      type="button"
+    >
+      <div
+        aria-hidden="true"
+        data-euiicon-type="cross"
+      />
+    </button>
+    <div
+      class="euiText euiText--small euiToastBody"
+    >
+      b
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiGlobalToastList props toasts is side prop consistent 1`] = `
+<div
+  aria-live="polite"
+  class="euiGlobalToastList euiGlobalToastList--left"
   role="region"
 >
   <div

--- a/src/components/toast/__snapshots__/global_toast_list.test.tsx.snap
+++ b/src/components/toast/__snapshots__/global_toast_list.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`EuiGlobalToastList is rendered 1`] = `
 <div
   aria-label="aria-label"
   aria-live="polite"
-  class="euiGlobalToastList testClass1 testClass2"
+  class="euiGlobalToastList testClass1 testClass2 euiGlobalToastList-right"
   data-test-subj="test subject string"
   role="region"
 />
@@ -13,7 +13,7 @@ exports[`EuiGlobalToastList is rendered 1`] = `
 exports[`EuiGlobalToastList props toasts is rendered 1`] = `
 <div
   aria-live="polite"
-  class="euiGlobalToastList"
+  class="euiGlobalToastList euiGlobalToastList-right"
   role="region"
 >
   <div

--- a/src/components/toast/__snapshots__/global_toast_list.test.tsx.snap
+++ b/src/components/toast/__snapshots__/global_toast_list.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`EuiGlobalToastList is rendered 1`] = `
 exports[`EuiGlobalToastList props toasts is rendered 1`] = `
 <div
   aria-live="polite"
-  class="euiGlobalToastList euiGlobalToastList-right"
+  class="euiGlobalToastList euiGlobalToastList-left"
   role="region"
 >
   <div

--- a/src/components/toast/__snapshots__/global_toast_list.test.tsx.snap
+++ b/src/components/toast/__snapshots__/global_toast_list.test.tsx.snap
@@ -10,10 +10,10 @@ exports[`EuiGlobalToastList is rendered 1`] = `
 />
 `;
 
-exports[`EuiGlobalToastList props toasts is rendered 1`] = `
+exports[`EuiGlobalToastList props side side can be changed to left 1`] = `
 <div
   aria-live="polite"
-  class="euiGlobalToastList euiGlobalToastList--right"
+  class="euiGlobalToastList euiGlobalToastList--left"
   role="region"
 >
   <div
@@ -105,10 +105,10 @@ exports[`EuiGlobalToastList props toasts is rendered 1`] = `
 </div>
 `;
 
-exports[`EuiGlobalToastList props toasts is side prop consistent 1`] = `
+exports[`EuiGlobalToastList props toasts is rendered 1`] = `
 <div
   aria-live="polite"
-  class="euiGlobalToastList euiGlobalToastList--left"
+  class="euiGlobalToastList euiGlobalToastList--right"
   role="region"
 >
   <div

--- a/src/components/toast/__snapshots__/global_toast_list.test.tsx.snap
+++ b/src/components/toast/__snapshots__/global_toast_list.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`EuiGlobalToastList is rendered 1`] = `
 />
 `;
 
-exports[`EuiGlobalToastList props side side can be changed to left 1`] = `
+exports[`EuiGlobalToastList props side can be changed to left 1`] = `
 <div
   aria-live="polite"
   class="euiGlobalToastList euiGlobalToastList--left"

--- a/src/components/toast/_global_toast_list.scss
+++ b/src/components/toast/_global_toast_list.scss
@@ -22,11 +22,11 @@
   }
 }
 
-.euiGlobalToastList-right {
+.euiGlobalToastList--right {
   right: 0;
 }
 
-.euiGlobalToastList-left {
+.euiGlobalToastList--left {
   left: 0;
 }
 

--- a/src/components/toast/_global_toast_list.scss
+++ b/src/components/toast/_global_toast_list.scss
@@ -12,7 +12,6 @@
   position: fixed;
   z-index: $euiZToastList;
   bottom: 0;
-  right: 0;
   width: $euiToastWidth + $euiSize + $euiSizeXL; /* 3 */
   padding-right: $euiSize;
   padding-left: $euiSizeXL;
@@ -21,6 +20,14 @@
   &:hover {
     overflow-y: auto; /* 2 */
   }
+}
+
+.euiGlobalToastList-right {
+  right: 0;
+}
+
+.euiGlobalToastList-left {
+  left: 0;
 }
 
 .euiGlobalToastListItem {

--- a/src/components/toast/_global_toast_list.scss
+++ b/src/components/toast/_global_toast_list.scss
@@ -1,38 +1,49 @@
 /**
  * 1. Allow list to expand as items are added, but cap it at the screen height.
- * 2. Only show the scroll on hover. Generally, scrolling is bad for toasts.
- * 3. Allow some padding if a scroll shows up.
+ * 2. Allow some padding for shadow
  */
 .euiGlobalToastList {
   @include euiScrollBar;
-
   display: flex;
   flex-direction: column;
   align-items: stretch;
   position: fixed;
   z-index: $euiZToastList;
   bottom: 0;
-  width: $euiToastWidth + $euiSize + $euiSizeXL; /* 3 */
-  padding-right: $euiSize;
-  padding-left: $euiSizeXL;
+  width: $euiToastWidth + ($euiSize * 5); /* 2 */
   max-height: 100vh; /* 1 */
+  overflow-y: auto;
 
-  &:hover {
-    overflow-y: auto; /* 2 */
+  // Hide the scrollbar entirely
+  // sass-lint:disable-block no-misspelled-properties
+  scrollbar-width: none;
+
+  // sass-lint:disable-block no-vendor-prefixes
+  &::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
+
+  // The top and bottom padding give heighto to the list creating a dead-zone effect
+  // when there's no toasts in the list, meaning you can't click anything beneath it.
+  // Only add the padding if there's content.
+  &:not(:empty) {
+    padding: $euiSize;
   }
 }
 
-.euiGlobalToastList--right {
+.euiGlobalToastList--right:not(:empty) {
   right: 0;
+  padding-left: $euiSize * 4; /* 2 */
 }
 
-.euiGlobalToastList--left {
+.euiGlobalToastList--left:not(:empty) {
   left: 0;
+  padding-right: $euiSize * 4; /* 2 */
 }
 
 .euiGlobalToastListItem {
   margin-bottom: $euiSize;
-  margin-right: $euiSize;
   animation: $euiAnimSpeedNormal euiShowToast $euiAnimSlightResistance;
   opacity: 1;
 
@@ -42,6 +53,10 @@
    */
   &:first-child {
     margin-top: auto; /* 1 */
+  }
+
+  &:last-child {
+    margin-bottom: 0;
   }
 
   &.euiGlobalToastListItem-isDismissed {
@@ -66,9 +81,10 @@
   /**
    * 1. Mobile we make these 100%. Matching change happens on the item as well.
    */
-  .euiGlobalToastList {
+  .euiGlobalToastList:not(:empty) {
     left: 0;
     padding-left: $euiSize;
+    padding-right: $euiSize;
     width: 100%; /* 1 */
   }
 }

--- a/src/components/toast/global_toast_list.test.tsx
+++ b/src/components/toast/global_toast_list.test.tsx
@@ -77,7 +77,7 @@ describe('EuiGlobalToastList', () => {
     });
 
     describe('side', () => {
-      test('side can be changed to left', () => {
+      test('can be changed to left', () => {
         const toasts: Toast[] = [
           {
             title: 'A',

--- a/src/components/toast/global_toast_list.test.tsx
+++ b/src/components/toast/global_toast_list.test.tsx
@@ -69,6 +69,7 @@ describe('EuiGlobalToastList', () => {
             toasts={toasts}
             dismissToast={() => {}}
             toastLifeTimeMs={5}
+            side="left"
           />
         );
 

--- a/src/components/toast/global_toast_list.test.tsx
+++ b/src/components/toast/global_toast_list.test.tsx
@@ -69,10 +69,39 @@ describe('EuiGlobalToastList', () => {
             toasts={toasts}
             dismissToast={() => {}}
             toastLifeTimeMs={5}
-            side="left"
           />
         );
 
+        expect(component).toMatchSnapshot();
+      });
+      test('is side prop consistent', () => {
+        const toasts: Toast[] = [
+          {
+            title: 'A',
+            text: 'a',
+            color: 'success',
+            iconType: 'check',
+            'data-test-subj': 'a',
+            id: 'a',
+          },
+          {
+            title: 'B',
+            text: 'b',
+            color: 'danger',
+            iconType: 'alert',
+            'data-test-subj': 'b',
+            id: 'b',
+          },
+        ];
+
+        const component = render(
+          <EuiGlobalToastList
+            toasts={toasts}
+            dismissToast={() => {}}
+            toastLifeTimeMs={5}
+            side="left"
+          />
+        );
         expect(component).toMatchSnapshot();
       });
     });

--- a/src/components/toast/global_toast_list.test.tsx
+++ b/src/components/toast/global_toast_list.test.tsx
@@ -74,7 +74,10 @@ describe('EuiGlobalToastList', () => {
 
         expect(component).toMatchSnapshot();
       });
-      test('is side prop consistent', () => {
+    });
+
+    describe('side', () => {
+      test('side can be changed to left', () => {
         const toasts: Toast[] = [
           {
             title: 'A',

--- a/src/components/toast/global_toast_list.tsx
+++ b/src/components/toast/global_toast_list.tsx
@@ -37,6 +37,7 @@ export interface EuiGlobalToastListProps extends CommonProps {
   toasts: Toast[];
   dismissToast: (this: EuiGlobalToastList, toast: Toast) => void;
   toastLifeTimeMs: number;
+  side?: 'right' | 'left';
 }
 
 interface State {
@@ -69,6 +70,7 @@ export class EuiGlobalToastList extends Component<
 
   static defaultProps = {
     toasts: [],
+    side: 'right',
   };
 
   startScrollingToBottom() {
@@ -247,6 +249,7 @@ export class EuiGlobalToastList extends Component<
       toasts,
       dismissToast,
       toastLifeTimeMs,
+      side,
       ...rest
     } = this.props;
 
@@ -267,8 +270,13 @@ export class EuiGlobalToastList extends Component<
         </EuiGlobalToastListItem>
       );
     });
-
-    const classes = classNames('euiGlobalToastList', className);
+    const additionalClass =
+      side === 'left' ? 'euiGlobalToastList-left' : 'euiGlobalToastList-right';
+    const classes = classNames(
+      'euiGlobalToastList',
+      className,
+      additionalClass
+    );
 
     return (
       <div

--- a/src/components/toast/global_toast_list.tsx
+++ b/src/components/toast/global_toast_list.tsx
@@ -46,7 +46,9 @@ export interface EuiGlobalToastListProps extends CommonProps {
   toasts: Toast[];
   dismissToast: (this: EuiGlobalToastList, toast: Toast) => void;
   toastLifeTimeMs: number;
-  //side prop determines which side(right or left) will the toast appear
+  /**
+   * Determines which side of the browser window the toasts should appear
+   */
   side?: ToastSide;
 }
 

--- a/src/components/toast/global_toast_list.tsx
+++ b/src/components/toast/global_toast_list.tsx
@@ -20,10 +20,19 @@
 import React, { Component, ReactChild } from 'react';
 import classNames from 'classnames';
 
-import { CommonProps } from '../common';
+import { CommonProps, keysOf } from '../common';
 import { Timer } from '../../services/time';
 import { EuiGlobalToastListItem } from './global_toast_list_item';
 import { EuiToast, EuiToastProps } from './toast';
+
+type ToastSide = 'right' | 'left';
+
+const sideToClassNameMap: { [side in ToastSide]: string } = {
+  left: 'euiGlobalToastList--left',
+  right: 'euiGlobalToastList--right',
+};
+
+export const SIDES = keysOf(sideToClassNameMap);
 
 export const TOAST_FADE_OUT_MS = 250;
 
@@ -37,7 +46,8 @@ export interface EuiGlobalToastListProps extends CommonProps {
   toasts: Toast[];
   dismissToast: (this: EuiGlobalToastList, toast: Toast) => void;
   toastLifeTimeMs: number;
-  side?: 'right' | 'left';
+  //side prop determines which side(right or left) will the toast appear
+  side?: ToastSide;
 }
 
 interface State {
@@ -270,12 +280,10 @@ export class EuiGlobalToastList extends Component<
         </EuiGlobalToastListItem>
       );
     });
-    const additionalClass =
-      side === 'left' ? 'euiGlobalToastList-left' : 'euiGlobalToastList-right';
     const classes = classNames(
       'euiGlobalToastList',
-      className,
-      additionalClass
+      side ? sideToClassNameMap[side] : null,
+      className
     );
 
     return (


### PR DESCRIPTION
### Summary

Added the `side` property to `EuiGlobalToastList` to allow the user to place the toasts left or right instead of just the default right

### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- ~[ ] Checked in **mobile**~
- [x] Checked in **IE11** and **Firefox**
- [x] Props have proper **autodocs**
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

fixes #3435 
@cchaos @chandlerprall 