### PR TITLE
enables new ban-tslint-comment eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -97,6 +97,7 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/indent': 'off',
+    '@typescript-eslint/ban-tslint-comment': 'error',
     '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',

--- a/src-docs/src/views/expression/stringing.tsx
+++ b/src-docs/src/views/expression/stringing.tsx
@@ -4,12 +4,7 @@ import { EuiExpression } from '../../../../src/components/expression';
 
 export default () => (
   <div>
-    <EuiExpression
-      description="Select"
-      value="count(*)"
-      // tslint:disable no-empty
-      onClick={() => {}}
-    />
+    <EuiExpression description="Select" value="count(*)" onClick={() => {}} />
     <EuiExpression
       description="From"
       value="kibana_sample_data_ky_counties left"

--- a/src/components/accessibility/keyboard_accessible.test.tsx
+++ b/src/components/accessibility/keyboard_accessible.test.tsx
@@ -31,7 +31,6 @@ const noop = () => {
 
 describe('EuiKeyboardAccessible', () => {
   describe('throws an error', () => {
-    // tslint:disable-next-line:no-console
     const oldConsoleError = console.error;
     let consoleStub: jest.Mock<typeof console.error>;
 
@@ -40,12 +39,10 @@ describe('EuiKeyboardAccessible', () => {
       // console.error() override that throws an exception. For these
       // tests, we just want to know if console.error() was called.
 
-      // tslint:disable-next-line:no-console
       console.error = consoleStub = jest.fn();
     });
 
     afterEach(() => {
-      // tslint:disable-next-line:no-console
       console.error = oldConsoleError;
     });
 
@@ -126,14 +123,11 @@ describe('EuiKeyboardAccessible', () => {
     let consoleStub: jest.Mock<typeof console.error>;
 
     beforeEach(() => {
-      // tslint:disable-next-line:no-console
       oldConsoleError = console.error;
-      // tslint:disable-next-line:no-console
       console.error = consoleStub = jest.fn();
     });
 
     afterEach(() => {
-      // tslint:disable-next-line:no-console
       console.error = oldConsoleError;
     });
 

--- a/src/components/avatar/avatar.tsx
+++ b/src/components/avatar/avatar.tsx
@@ -143,7 +143,6 @@ function checkValidColor(color: EuiAvatarProps['color']) {
 function checkValidInitials(initials: EuiAvatarProps['initials']) {
   // Must be a string of 1 or 2 characters
   if (initials && initials.length > 2) {
-    // tslint:disable-next-line:no-console
     console.warn(
       'EuiAvatar only accepts a max of 2 characters for the initials as a string. It is displaying only the first 2 characters.'
     );

--- a/src/components/expression/expression.test.tsx
+++ b/src/components/expression/expression.test.tsx
@@ -30,7 +30,6 @@ describe('EuiExpression', () => {
         description="the answer is"
         value="42"
         isActive={false}
-        // tslint:disable no-empty
         onClick={() => {}}
         {...requiredProps}
       />

--- a/src/components/i18n/i18n_util.tsx
+++ b/src/components/i18n/i18n_util.tsx
@@ -89,7 +89,6 @@ export function processStringToChildren(
   // if we don't encounter a non-primitive
   // then `children` can be concatenated together at the end
   let encounteredNonPrimitive = false;
-  // tslint:disable-next-line:prefer-for-of
   for (let i = 0; i < input.length; i++) {
     const char = input[i];
 

--- a/src/components/selectable/selectable_list/selectable_list.test.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.test.tsx
@@ -52,7 +52,6 @@ const options: EuiSelectableOption[] = [
   },
 ];
 
-// tslint:disable:no-empty
 describe('EuiSelectableListItem', () => {
   test('is rendered', () => {
     const component = render(

--- a/src/components/tool_tip/tool_tip_popover.test.tsx
+++ b/src/components/tool_tip/tool_tip_popover.test.tsx
@@ -26,7 +26,6 @@ import { EuiToolTipPopover } from './tool_tip_popover';
 describe('EuiToolTipPopover', () => {
   test('is rendered', () => {
     const component = render(
-      // tslint:disable-next-line:no-empty
       <EuiToolTipPopover positionToolTip={() => {}} {...requiredProps} />
     );
     expect(component).toMatchSnapshot();

--- a/src/services/copy_to_clipboard.ts
+++ b/src/services/copy_to_clipboard.ts
@@ -52,7 +52,6 @@ export function copyToClipboard(text: string): boolean {
 
   if (!document.execCommand('copy')) {
     isCopied = false;
-    // tslint:disable-next-line:no-console
     console.warn('Unable to copy to clipboard.');
   }
 

--- a/src/services/predicate/lodash_predicates.ts
+++ b/src/services/predicate/lodash_predicates.ts
@@ -27,7 +27,6 @@ import _isNaN from 'lodash/isNaN';
 // wrap the lodash functions to avoid having lodash's TS type definition from being
 // exported, which can conflict with the lodash namespace if other versions are used
 
-// tslint:disable-next-line:ban-types
 export const isFunction = (value: any): value is (...args: any[]) => any =>
   _isFunction(value);
 export const isArray = (value: any): value is any[] => _isArray(value);

--- a/src/services/time/timer.test.ts
+++ b/src/services/time/timer.test.ts
@@ -23,7 +23,6 @@ describe('Timer', () => {
   describe('constructor', () => {
     test('counts down until time elapses and calls callback', done => {
       const callbackSpy = jest.fn();
-      // tslint:disable-next-line:no-unused-expression
       new Timer(callbackSpy, 5);
 
       setTimeout(() => {

--- a/src/test/react_warnings.ts
+++ b/src/test/react_warnings.ts
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-/* tslint:disable:no-console */
-
 /*
   Use this utility to throw errors whenever React complains via the console
   about things like invalid propTypes. This lets us assert that a propType


### PR DESCRIPTION
### Summary

This PR enables a [new eslint rule](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/ban-tslint-comment.md) that prevents accidental `tslint` directives (this project no longer uses tslint).

Since we just updated to @typescript-eslint:v3.2.0 anyway, this seemed fun enough to be worth doing.  I suspect it will be a default rule in the next major version anyway.

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

(didn't seem worthy of a changelog entry to me, but I'm happy to make one if not)
