### PR TITLE
Pass markdown parse results to application

### DIFF
--- a/src-docs/src/views/markdown_editor/markdown_editor.js
+++ b/src-docs/src/views/markdown_editor/markdown_editor.js
@@ -1,7 +1,13 @@
-/* eslint-disable prettier/prettier */
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
-import { defaultParsingPlugins, defaultProcessingPlugins, EuiMarkdownEditor } from '../../../../src';
+import {
+  defaultParsingPlugins,
+  defaultProcessingPlugins,
+  EuiMarkdownEditor,
+  EuiSpacer,
+  EuiText,
+  EuiCodeBlock,
+} from '../../../../src';
 import * as MarkdownChart from './plugins/markdown_chart';
 import * as MarkdownTooltip from './plugins/markdown_tooltip';
 import * as MarkdownCheckbox from './plugins/markdown_checkbox';
@@ -23,9 +29,33 @@ exampleProcessingList[0][1].handlers.tooltipPlugin = MarkdownTooltip.handler;
 exampleProcessingList[1][1].components.tooltipPlugin = MarkdownTooltip.renderer;
 
 exampleProcessingList[0][1].handlers.checkboxPlugin = MarkdownCheckbox.handler;
-exampleProcessingList[1][1].components.checkboxPlugin = MarkdownCheckbox.renderer;
+exampleProcessingList[1][1].components.checkboxPlugin =
+  MarkdownCheckbox.renderer;
 
 export default () => {
   const [value, setValue] = useState(markdownExample);
-  return <EuiMarkdownEditor value={value} onChange={setValue} height={400} uiPlugins={[MarkdownChart.plugin, MarkdownTooltip.plugin]} parsingPluginList={exampleParsingList} processingPluginList={exampleProcessingList} />;
+  const [messages, setMessages] = useState([]);
+  const [ast, setAst] = useState(null);
+  const onParse = useCallback((err, { messages, ast }) => {
+    setMessages(err ? [err] : messages);
+    setAst(JSON.stringify(ast, null, 2));
+  }, []);
+  return (
+    <>
+      <EuiMarkdownEditor
+        value={value}
+        onChange={setValue}
+        height={400}
+        uiPlugins={[MarkdownChart.plugin, MarkdownTooltip.plugin]}
+        parsingPluginList={exampleParsingList}
+        processingPluginList={exampleProcessingList}
+        onParse={onParse}
+      />
+      <EuiSpacer />
+      {messages.map((message, idx) => (
+        <EuiText key={idx}>{message.toString()}</EuiText>
+      ))}
+      <EuiCodeBlock language="json">{ast}</EuiCodeBlock>
+    </>
+  );
 };

--- a/src-docs/src/views/markdown_editor/plugins/markdown_chart.js
+++ b/src-docs/src/views/markdown_editor/plugins/markdown_chart.js
@@ -155,8 +155,13 @@ function ChartParser() {
       match += configurationString;
       try {
         configuration = JSON.parse(configurationString);
-        // eslint-disable-next-line no-empty
-      } catch (e) {}
+      } catch (e) {
+        const now = eat.now();
+        this.file.fail(`Unable to parse chart JSON configuration: ${e}`, {
+          line: now.line,
+          column: now.column + 7,
+        });
+      }
     }
 
     match += '}';

--- a/src-docs/src/views/markdown_editor/plugins/markdown_tooltip.js
+++ b/src-docs/src/views/markdown_editor/plugins/markdown_tooltip.js
@@ -55,13 +55,27 @@ function TooltipParser() {
     const tooltipAnchor = readArg('[', ']');
     const tooltipText = readArg('(', ')');
 
+    const now = eat.now();
+
+    if (!tooltipAnchor) {
+      this.file.info('No tooltip anchor found', {
+        line: now.line,
+        column: now.column + 10,
+      });
+    }
+    if (!tooltipText) {
+      this.file.info('No tooltip text found', {
+        line: now.line,
+        column: now.column + 12 + tooltipAnchor.length,
+      });
+    }
+
     if (!tooltipText || !tooltipAnchor) return false;
 
     if (silent) {
       return true;
     }
 
-    const now = eat.now();
     now.column += 10;
     now.offset += 10;
     const children = this.tokenizeInline(tooltipAnchor, now);

--- a/src/components/markdown_editor/markdown_format.tsx
+++ b/src/components/markdown_editor/markdown_format.tsx
@@ -29,9 +29,12 @@ export const EuiMarkdownFormat: FunctionComponent<EuiMarkdownFormatProps> = ({
   children,
   processor,
 }) => {
-  const result = useMemo(() => processor.processSync(children), [
-    processor,
-    children,
-  ]);
-  return <div className="euiMarkdownFormat">{result.contents}</div>;
+  const result = useMemo(() => {
+    try {
+      return processor.processSync(children).contents;
+    } catch (e) {
+      return children;
+    }
+  }, [processor, children]);
+  return <div className="euiMarkdownFormat">{result}</div>;
 };


### PR DESCRIPTION
### Summary

Added `onParse` callback to provide stop-the-world error, info messages, and parse results to the consuming application. I've updated the sole markdown example to display this information until we split it up into multiple examples.

#### Stop-the-world-error

Unified immediately stops all parsing and halts, no parsing result is generated. I've added this to the chart plugin, if you have a malformed JSON configuration object e.g. `!{chart{"palette": ,"height":300}}`. As another example, I encountered a parsing failure from one of the 3rd party modules, if you use the malformed tag `!{tooltip[])}`.

If it does fail to parse, the markdown formatter component now renders the markdown string with no processing.

#### Info messages

Plugins can also generate info messages which do not prevent further parsing. I've given the checkbox plugin 2, one for each of the anchor and tooltip text if no text is provided.

![info messages](https://d.pr/i/XbsEDk.png)

### Future

#### Decisions

We should establish a pattern for what qualifies for info vs failure messages. Traditionally, markdown does not fail - but unified supports the behaviour and we should handle it at least a little gracefully.

#### Design

If there is a catastrophic stop-the-world error, we probably want to message it in the editor itself.