### PR TITLE
[DOCS] Removed unnecessary `EuiToolTip`

### DIFF
--- a/src-docs/src/views/tool_tip/tool_tip_example.js
+++ b/src-docs/src/views/tool_tip/tool_tip_example.js
@@ -133,7 +133,7 @@ export const ToolTipExample = {
           </p>
         </Fragment>
       ),
-      props: { EuiToolTip, EuiIconTip },
+      props: { EuiIconTip },
       snippet: infoTipSnippet,
       demo: <IconTip />,
     },


### PR DESCRIPTION
### Summary

Removed unnecessary `EuiToolTip` from `EuiIconTip`

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
