### PR TITLE
[DOCS] Added info onColumnResize props and updated link to types in EuiDataGrid

### DIFF
--- a/src-docs/src/views/datagrid/datagrid_example.js
+++ b/src-docs/src/views/datagrid/datagrid_example.js
@@ -268,6 +268,15 @@ const gridConcepts = [
       </span>
     ),
   },
+  {
+    title: 'onColumnResize',
+    description: (
+      <span>
+        A callback for when a column&apos; size changes. Callback receives
+        `&#123; columnId: string, width: number &#125;`
+      </span>
+    ),
+  },
 ];
 
 export const DataGridExample = {
@@ -383,9 +392,9 @@ export const DataGridExample = {
               explanation on the lower level object types. The majority of the
               types are defined in the{' '}
               <a
-                href="https://github.com/elastic/eui/tree/master/src/components/data_grid/data_grid_types.ts"
+                href="https://github.com/elastic/eui/tree/master/src/components/datagrid/data_grid_types.ts"
                 target="_blank">
-                /data_grid/data_grid_types.ts
+                /datagrid/data_grid_types.ts
               </a>{' '}
               file.
             </p>

--- a/src-docs/src/views/datagrid/datagrid_example.js
+++ b/src-docs/src/views/datagrid/datagrid_example.js
@@ -272,8 +272,8 @@ const gridConcepts = [
     title: 'onColumnResize',
     description: (
       <span>
-        A callback for when a column&apos; size changes. Callback receives
-        `&#123; columnId: string, width: number &#125;`
+        A callback for when a column&apos;s size changes. Callback receives
+        <EuiCode>&#123; columnId: string, width: number &#125;</EuiCode>
       </span>
     ),
   },

--- a/src-docs/src/views/datagrid/datagrid_example.js
+++ b/src-docs/src/views/datagrid/datagrid_example.js
@@ -272,7 +272,7 @@ const gridConcepts = [
     title: 'onColumnResize',
     description: (
       <span>
-        A callback for when a column&apos;s size changes. Callback receives
+        A callback for when a column&apos;s size changes. Callback receives{' '}
         <EuiCode>&#123; columnId: string, width: number &#125;</EuiCode>
       </span>
     ),


### PR DESCRIPTION
### Summary

Fixes #3607

- Updated link to `data_grid_types`
- Added info about `onColumnResize`

Provide a detailed summary of your PR. Explain how you arrived at your solution. If it includes changes to UI elements include a screenshot or gif.

### Checklist

~~- [ ] Check against **all themes** for compatibility in both light and dark modes~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
~~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~~
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
~~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~~
