### PR TITLE
Fix popover's container constraint example

### DIFF
--- a/src-docs/src/views/popover/popover_container.js
+++ b/src-docs/src/views/popover/popover_container.js
@@ -10,15 +10,11 @@ import {
 
 export default () => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [panelRef, setPanelRef] = useState(null);
 
   const onButtonClick = () =>
     setIsPopoverOpen(isPopoverOpen1 => !isPopoverOpen1);
   const closePopover = () => setIsPopoverOpen(false);
-
-  let panel;
-  const setPanelRef = node => {
-    panel = node;
-  };
 
   const button = (
     <EuiButton
@@ -36,7 +32,7 @@ export default () => {
         button={button}
         isOpen={isPopoverOpen}
         closePopover={closePopover}
-        container={panel}>
+        container={panelRef}>
         <div>
           Popover is positioned <EuiCode>downCenter</EuiCode> but constrained to
           fit within the panel.


### PR DESCRIPTION
### Summary

Fixes #3608

The constrained popover example broke during its class->function component conversion. The container's ref was not tracked properly, leading to an `undefined` value passed as the container.

### ~Checklist~
