### PR TITLE
[EuiAccordion] Allow external control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `side` prop to `EuiGlobalToastList` for choosing which window side to display toasts ([#3600](https://github.com/elastic/eui/pull/3600))
 - Default `titleSize` get's implicitly set to 'm' for `EuiEmptyPrompt` ([#3598](https://github.com/elastic/eui/pull/3598))
 - Updated `logoElastic` to meet brand guidelines ([#3613](https://github.com/elastic/eui/pull/3613))
+- Updated `onToggle` callback in `EuiAccordion` to  allow for external state control ([#3614](https://github.com/elastic/eui/pull/3614))
 
 **Bug fixes**
 

--- a/src-docs/src/views/accordion/accordion_example.js
+++ b/src-docs/src/views/accordion/accordion_example.js
@@ -332,7 +332,7 @@ export const AccordionExample = {
       demo: <AccordionForm />,
     },
     {
-      title: 'Force accordion state',
+      title: 'External state control',
       source: [
         {
           type: GuideSectionTypes.JS,
@@ -346,7 +346,8 @@ export const AccordionExample = {
       text: (
         <p>
           Use the <EuiCode>forceState</EuiCode> prop to control open and close
-          state.
+          state. The <EuiCode>onToggle</EuiCode> callback prop can still be used
+          to update external state or perform side effects.
         </p>
       ),
       snippet: accordionForceStateSnippet,

--- a/src-docs/src/views/accordion/accordion_forceState.js
+++ b/src-docs/src/views/accordion/accordion_forceState.js
@@ -29,6 +29,12 @@ export default () => {
     setID(id);
   };
 
+  const onToggle = isOpen => {
+    const newState = isOpen ? 'closed' : 'open';
+    setTrigger(newState);
+    setID(`${idPrefix}--${newState}`);
+  };
+
   return (
     <div>
       <EuiButtonGroup
@@ -41,6 +47,7 @@ export default () => {
       <EuiAccordion
         id="accordion--forceState"
         forceState={trigger}
+        onToggle={onToggle}
         buttonContent="I am controlled via prop">
         <EuiText>
           <p>

--- a/src-docs/src/views/accordion/accordion_forceState.js
+++ b/src-docs/src/views/accordion/accordion_forceState.js
@@ -30,7 +30,7 @@ export default () => {
   };
 
   const onToggle = isOpen => {
-    const newState = isOpen ? 'closed' : 'open';
+    const newState = isOpen ? 'open' : 'closed';
     setTrigger(newState);
     setID(`${idPrefix}--${newState}`);
   };

--- a/src/components/accordion/__snapshots__/accordion.test.tsx.snap
+++ b/src/components/accordion/__snapshots__/accordion.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiAccordion behavior closes when clicked twice 1`] = `
 <EuiAccordion
   arrowDisplay="left"
-  id="9"
+  id="10"
   initialIsOpen={false}
   paddingSize="none"
 >
@@ -14,7 +14,7 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
       className="euiAccordion__triggerWrapper"
     >
       <button
-        aria-controls="9"
+        aria-controls="10"
         aria-expanded={false}
         className="euiAccordion__button"
         onClick={[Function]}
@@ -42,7 +42,7 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
     </div>
     <div
       className="euiAccordion__childWrapper"
-      id="9"
+      id="10"
     >
       <EuiResizeObserver
         onResize={[Function]}
@@ -61,7 +61,7 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
 exports[`EuiAccordion behavior opens when clicked once 1`] = `
 <EuiAccordion
   arrowDisplay="left"
-  id="8"
+  id="9"
   initialIsOpen={false}
   paddingSize="none"
 >
@@ -72,7 +72,7 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
       className="euiAccordion__triggerWrapper"
     >
       <button
-        aria-controls="8"
+        aria-controls="9"
         aria-expanded={true}
         className="euiAccordion__button"
         onClick={[Function]}
@@ -100,7 +100,7 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
     </div>
     <div
       className="euiAccordion__childWrapper"
-      id="8"
+      id="9"
     >
       <EuiResizeObserver
         onResize={[Function]}

--- a/src/components/accordion/accordion.test.tsx
+++ b/src/components/accordion/accordion.test.tsx
@@ -130,7 +130,7 @@ describe('EuiAccordion', () => {
 
         component.find('button').simulate('click');
         expect(onToggleHandler).toBeCalled();
-        expect(onToggleHandler).toBeCalledWith(false);
+        expect(onToggleHandler).toBeCalledWith(true);
       });
     });
   });

--- a/src/components/accordion/accordion.test.tsx
+++ b/src/components/accordion/accordion.test.tsx
@@ -117,6 +117,21 @@ describe('EuiAccordion', () => {
 
         expect(component).toMatchSnapshot();
       });
+
+      it('accepts and calls an optional callback on click', () => {
+        const onToggleHandler = jest.fn();
+        const component = mount(
+          <EuiAccordion
+            id={getId()}
+            onToggle={onToggleHandler}
+            forceState="closed"
+          />
+        );
+
+        component.find('button').simulate('click');
+        expect(onToggleHandler).toBeCalled();
+        expect(onToggleHandler).toBeCalledWith(false);
+      });
     });
   });
 

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -121,15 +121,18 @@ export class EuiAccordion extends Component<
 
   onToggle = () => {
     const { forceState } = this.props;
-    if (forceState) return this.setState({ isOpen: forceState === 'open' });
-    this.setState(
-      prevState => ({
-        isOpen: !prevState.isOpen,
-      }),
-      () => {
-        this.props.onToggle && this.props.onToggle(this.state.isOpen);
-      }
-    );
+    if (forceState) {
+      this.props.onToggle && this.props.onToggle(forceState === 'open');
+    } else {
+      this.setState(
+        prevState => ({
+          isOpen: !prevState.isOpen,
+        }),
+        () => {
+          this.props.onToggle && this.props.onToggle(this.state.isOpen);
+        }
+      );
+    }
   };
 
   setChildContentRef = (node: HTMLDivElement | null) => {

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -122,7 +122,8 @@ export class EuiAccordion extends Component<
   onToggle = () => {
     const { forceState } = this.props;
     if (forceState) {
-      this.props.onToggle && this.props.onToggle(forceState === 'open');
+      this.props.onToggle &&
+        this.props.onToggle(forceState === 'open' ? false : true);
     } else {
       this.setState(
         prevState => ({


### PR DESCRIPTION
### Summary

Resolves #3594 by allowing `forceState` and `onToggle` to work together as an external state value and update function pair.

When `forceState` is in use `onToggle` will be called with a boolean reflecting the _current_ open/closed state. This might be slightly confusing as standard `onToggle` is called with a boolean reflecting the _new_ open/closed state after click.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~

- [x] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately

~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
