### PR TITLE
[EuiBasicTable] Custom actions in a collapsed actions menu should close popover on click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed `euiHeaderAffordForFixed` mixin's use of header SASS variable ([#3592](https://github.com/elastic/eui/pull/3592))
 - Included `onClick` as a valid prop for `EuiControlBar` **icon** controls ([#3581](https://github.com/elastic/eui/pull/3581))
 - Fixed poor performance of `EuiToolTip` during frequent mouesover/mouseout events ([#3596](https://github.com/elastic/eui/pull/3596))
+- Fixed `EuiBasicTable` custom actions popover from remaining open after click ([#3619](https://github.com/elastic/eui/pull/3619))
 
 **Breaking changes**
 

--- a/src/components/basic_table/collapsed_item_actions.tsx
+++ b/src/components/basic_table/collapsed_item_actions.tsx
@@ -128,10 +128,12 @@ export class CollapsedItemActions<T> extends Component<
           controls.push(
             <EuiContextMenuItem
               key={key}
-              onClick={
-                actionControlOnClick
-                  ? actionControlOnClick.bind(null, item)
-                  : () => {}
+              onClick={() =>
+                this.onClickItem(
+                  actionControlOnClick
+                    ? () => actionControlOnClick(item)
+                    : undefined
+                )
               }>
               {actionControl}
             </EuiContextMenuItem>
@@ -159,10 +161,9 @@ export class CollapsedItemActions<T> extends Component<
               target={target}
               icon={icon}
               data-test-subj={dataTestSubj}
-              onClick={this.onClickItem.bind(
-                null,
-                onClick ? onClick.bind(null, item) : undefined
-              )}>
+              onClick={() =>
+                this.onClickItem(onClick ? () => onClick(item) : undefined)
+              }>
               {name}
             </EuiContextMenuItem>
           );


### PR DESCRIPTION
### Summary

**EuiBasicTable** actions:
Custom actions (i.e., those with their own `render` function) in a collapsed actions menu (i.e., a per-row context menu) should close the context menu popover on click. This was already the default behavior of default actions.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~

- [x] Checked for **breaking changes** and labeled appropriately

~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
