### PR TITLE
Add an imperative ref to EuiMarkdownEditor

### DIFF
--- a/src/components/markdown_editor/markdown_editor.tsx
+++ b/src/components/markdown_editor/markdown_editor.tsx
@@ -253,7 +253,7 @@ export const EuiMarkdownEditor: FunctionComponent<
         textarea.removeEventListener('keyup', getCursorNode);
         textarea.removeEventListener('mouseup', getCursorNode);
       };
-    }, [textareaRef, parsed]);
+    }, [parsed]);
 
     useEffect(() => {
       if (onParse) {
@@ -302,7 +302,7 @@ export const EuiMarkdownEditor: FunctionComponent<
                 value={value}
               />
             </EuiMarkdownEditorDropZone>
-            {textareaRef && pluginEditorPlugin && (
+            {pluginEditorPlugin && (
               <EuiOverlayMask>
                 <EuiModal onClose={() => setPluginEditorPlugin(undefined)}>
                   {createElement(pluginEditorPlugin.editor!, {

--- a/src/components/markdown_editor/markdown_editor.tsx
+++ b/src/components/markdown_editor/markdown_editor.tsx
@@ -22,8 +22,12 @@ import React, {
   FunctionComponent,
   HTMLAttributes,
   useEffect,
+  useImperativeHandle,
   useMemo,
   useState,
+  forwardRef,
+  useCallback,
+  useRef,
 } from 'react';
 import unified, { PluggableList, Processor } from 'unified';
 import { VFileMessage } from 'vfile-message';
@@ -119,196 +123,220 @@ export type EuiMarkdownEditorProps = HTMLAttributes<HTMLDivElement> &
     ) => void;
   };
 
-export const EuiMarkdownEditor: FunctionComponent<EuiMarkdownEditorProps> = ({
-  className,
-  editorId: _editorId,
-  value,
-  onChange,
-  height = 150,
-  parsingPluginList = defaultParsingPlugins,
-  processingPluginList = defaultProcessingPlugins,
-  uiPlugins = [],
-  onParse,
-  ...rest
-}) => {
-  const [viewMode, setViewMode] = useState<MARKDOWN_MODE>(MODE_EDITING);
-  const editorId = useMemo(() => _editorId || htmlIdGenerator()(), [_editorId]);
+export const EuiMarkdownEditor: FunctionComponent<
+  EuiMarkdownEditorProps
+> = forwardRef(
+  (
+    {
+      className,
+      editorId: _editorId,
+      value,
+      onChange,
+      height = 150,
+      parsingPluginList = defaultParsingPlugins,
+      processingPluginList = defaultProcessingPlugins,
+      uiPlugins = [],
+      onParse,
+      ...rest
+    },
+    ref
+  ) => {
+    const [viewMode, setViewMode] = useState<MARKDOWN_MODE>(MODE_EDITING);
+    const editorId = useMemo(() => _editorId || htmlIdGenerator()(), [
+      _editorId,
+    ]);
 
-  const [pluginEditorPlugin, setPluginEditorPlugin] = useState<
-    EuiMarkdownEditorUiPlugin | undefined
-  >(undefined);
+    const [pluginEditorPlugin, setPluginEditorPlugin] = useState<
+      EuiMarkdownEditorUiPlugin | undefined
+    >(undefined);
 
-  const markdownActions = useMemo(
-    () => new MarkdownActions(editorId, uiPlugins),
-    // uiPlugins _is_ accounted for
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [editorId, uiPlugins.map(({ name }) => name).join(',')]
-  );
+    const markdownActions = useMemo(
+      () => new MarkdownActions(editorId, uiPlugins),
+      // uiPlugins _is_ accounted for
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [editorId, uiPlugins.map(({ name }) => name).join(',')]
+    );
 
-  const classes = classNames('euiMarkdownEditor', className);
+    const classes = classNames('euiMarkdownEditor', className);
 
-  const parser = useMemo(() => {
-    const Compiler = (tree: any) => {
-      return tree;
-    };
+    const parser = useMemo(() => {
+      const Compiler = (tree: any) => {
+        return tree;
+      };
 
-    function identityCompiler(this: Processor) {
-      this.Compiler = Compiler;
-    }
-    return unified()
-      .use(parsingPluginList)
-      .use(identityCompiler);
-  }, [parsingPluginList]);
-
-  const [parsed, parseError] = useMemo<
-    [any | null, VFileMessage | null]
-  >(() => {
-    try {
-      const parsed = parser.processSync(value);
-      return [parsed, null];
-    } catch (e) {
-      return [null, e];
-    }
-  }, [parser, value]);
-
-  const processor = useMemo(
-    () =>
-      unified()
+      function identityCompiler(this: Processor) {
+        this.Compiler = Compiler;
+      }
+      return unified()
         .use(parsingPluginList)
-        .use(processingPluginList),
-    [parsingPluginList, processingPluginList]
-  );
+        .use(identityCompiler);
+    }, [parsingPluginList]);
 
-  const isPreviewing = viewMode === MODE_VIEWING;
+    const [parsed, parseError] = useMemo<
+      [any | null, VFileMessage | null]
+    >(() => {
+      try {
+        const parsed = parser.processSync(value);
+        return [parsed, null];
+      } catch (e) {
+        return [null, e];
+      }
+    }, [parser, value]);
 
-  const contextValue = useMemo<ContextShape>(
-    () => ({
-      openPluginEditor: (plugin: EuiMarkdownEditorUiPlugin) =>
-        setPluginEditorPlugin(() => plugin),
-      replaceNode: (position, next) => {
+    const processor = useMemo(
+      () =>
+        unified()
+          .use(parsingPluginList)
+          .use(processingPluginList),
+      [parsingPluginList, processingPluginList]
+    );
+
+    const isPreviewing = viewMode === MODE_VIEWING;
+
+    const replaceNode = useCallback(
+      (position, next) => {
         const leading = value.substr(0, position.start.offset);
         const trailing = value.substr(position.end.offset);
         onChange(`${leading}${next}${trailing}`);
       },
-    }),
-    [value, onChange]
-  );
+      [value, onChange]
+    );
 
-  const [selectedNode, setSelectedNode] = useState();
+    const contextValue = useMemo<ContextShape>(
+      () => ({
+        openPluginEditor: (plugin: EuiMarkdownEditorUiPlugin) =>
+          setPluginEditorPlugin(() => plugin),
+        replaceNode,
+      }),
+      [replaceNode]
+    );
 
-  const [textareaRef, setTextareaRef] = useState<HTMLTextAreaElement | null>(
-    null
-  );
-  useEffect(() => {
-    if (textareaRef == null) return;
-    if (parsed == null) return;
+    const [selectedNode, setSelectedNode] = useState();
 
-    const getCursorNode = () => {
-      const { selectionStart } = textareaRef;
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-      let node: any = parsed.contents;
+    useEffect(() => {
+      if (textareaRef == null) return;
+      if (parsed == null) return;
 
-      outer: while (true) {
-        if (node.children) {
-          for (let i = 0; i < node.children.length; i++) {
-            const child = node.children[i];
-            if (
-              child.position.start.offset < selectionStart &&
-              selectionStart < child.position.end.offset
-            ) {
-              if (child.type === 'text') break outer; // don't dive into `text` nodes
-              node = child;
-              continue outer;
+      const getCursorNode = () => {
+        const { selectionStart } = textareaRef.current!;
+
+        let node: any = parsed.contents;
+
+        outer: while (true) {
+          if (node.children) {
+            for (let i = 0; i < node.children.length; i++) {
+              const child = node.children[i];
+              if (
+                child.position.start.offset < selectionStart &&
+                selectionStart < child.position.end.offset
+              ) {
+                if (child.type === 'text') break outer; // don't dive into `text` nodes
+                node = child;
+                continue outer;
+              }
             }
           }
+          break;
         }
-        break;
+
+        setSelectedNode(node);
+      };
+
+      const textarea = textareaRef.current!;
+
+      textarea.addEventListener('keyup', getCursorNode);
+      textarea.addEventListener('mouseup', getCursorNode);
+
+      return () => {
+        textarea.removeEventListener('keyup', getCursorNode);
+        textarea.removeEventListener('mouseup', getCursorNode);
+      };
+    }, [textareaRef, parsed]);
+
+    useEffect(() => {
+      if (onParse) {
+        const messages = parsed ? parsed.messages : [];
+        const ast = parsed ? parsed.contents : null;
+        onParse(parseError, { messages, ast });
       }
+    }, [onParse, parsed, parseError]);
 
-      setSelectedNode(node);
-    };
+    useImperativeHandle(
+      ref,
+      () => ({ textarea: textareaRef.current, replaceNode }),
+      [replaceNode]
+    );
 
-    textareaRef.addEventListener('keyup', getCursorNode);
-    textareaRef.addEventListener('mouseup', getCursorNode);
+    return (
+      <EuiMarkdownContext.Provider value={contextValue}>
+        <div className={classes} {...rest}>
+          <EuiMarkdownEditorToolbar
+            selectedNode={selectedNode}
+            markdownActions={markdownActions}
+            onClickPreview={() =>
+              setViewMode(isPreviewing ? MODE_EDITING : MODE_VIEWING)
+            }
+            viewMode={viewMode}
+            uiPlugins={uiPlugins}
+          />
 
-    return () => {
-      textareaRef.removeEventListener('keyup', getCursorNode);
-      textareaRef.removeEventListener('mouseup', getCursorNode);
-    };
-  }, [textareaRef, parsed]);
-
-  useEffect(() => {
-    if (onParse) {
-      const messages = parsed ? parsed.messages : [];
-      const ast = parsed ? parsed.contents : null;
-      onParse(parseError, { messages, ast });
-    }
-  }, [onParse, parsed, parseError]);
-
-  return (
-    <EuiMarkdownContext.Provider value={contextValue}>
-      <div className={classes} {...rest}>
-        <EuiMarkdownEditorToolbar
-          selectedNode={selectedNode}
-          markdownActions={markdownActions}
-          onClickPreview={() =>
-            setViewMode(isPreviewing ? MODE_EDITING : MODE_VIEWING)
-          }
-          viewMode={viewMode}
-          uiPlugins={uiPlugins}
-        />
-
-        {isPreviewing && (
-          <div
-            className="euiMarkdownEditor__preview"
-            style={{ height: `${height}px` }}>
-            <EuiMarkdownFormat processor={processor}>{value}</EuiMarkdownFormat>
-          </div>
-        )}
-        {/* Toggle the editor's display instead of unmounting to retain its undo/redo history */}
-        <div style={{ display: isPreviewing ? 'none' : 'block' }}>
-          <EuiMarkdownEditorDropZone>
-            <EuiMarkdownEditorTextArea
-              ref={setTextareaRef}
-              height={height}
-              id={editorId}
-              onChange={e => onChange(e.target.value)}
-              value={value}
-            />
-          </EuiMarkdownEditorDropZone>
-          {textareaRef && pluginEditorPlugin && (
-            <EuiOverlayMask>
-              <EuiModal onClose={() => setPluginEditorPlugin(undefined)}>
-                {createElement(pluginEditorPlugin.editor!, {
-                  node:
-                    selectedNode &&
-                    selectedNode.type === pluginEditorPlugin.name
-                      ? selectedNode
-                      : null,
-                  onCancel: () => setPluginEditorPlugin(undefined),
-                  onSave: markdown => {
-                    if (
+          {isPreviewing && (
+            <div
+              className="euiMarkdownEditor__preview"
+              style={{ height: `${height}px` }}>
+              <EuiMarkdownFormat processor={processor}>
+                {value}
+              </EuiMarkdownFormat>
+            </div>
+          )}
+          {/* Toggle the editor's display instead of unmounting to retain its undo/redo history */}
+          <div style={{ display: isPreviewing ? 'none' : 'block' }}>
+            <EuiMarkdownEditorDropZone>
+              <EuiMarkdownEditorTextArea
+                ref={textareaRef}
+                height={height}
+                id={editorId}
+                onChange={e => onChange(e.target.value)}
+                value={value}
+              />
+            </EuiMarkdownEditorDropZone>
+            {textareaRef && pluginEditorPlugin && (
+              <EuiOverlayMask>
+                <EuiModal onClose={() => setPluginEditorPlugin(undefined)}>
+                  {createElement(pluginEditorPlugin.editor!, {
+                    node:
                       selectedNode &&
                       selectedNode.type === pluginEditorPlugin.name
-                    ) {
-                      textareaRef.setSelectionRange(
-                        selectedNode.position.start.offset,
-                        selectedNode.position.end.offset
-                      );
-                    }
-                    insertText(textareaRef, {
-                      text: markdown,
-                      selectionStart: undefined,
-                      selectionEnd: undefined,
-                    });
-                    setPluginEditorPlugin(undefined);
-                  },
-                })}
-              </EuiModal>
-            </EuiOverlayMask>
-          )}
+                        ? selectedNode
+                        : null,
+                    onCancel: () => setPluginEditorPlugin(undefined),
+                    onSave: markdown => {
+                      if (
+                        selectedNode &&
+                        selectedNode.type === pluginEditorPlugin.name
+                      ) {
+                        textareaRef.current!.setSelectionRange(
+                          selectedNode.position.start.offset,
+                          selectedNode.position.end.offset
+                        );
+                      }
+                      insertText(textareaRef.current!, {
+                        text: markdown,
+                        selectionStart: undefined,
+                        selectionEnd: undefined,
+                      });
+                      setPluginEditorPlugin(undefined);
+                    },
+                  })}
+                </EuiModal>
+              </EuiOverlayMask>
+            )}
+          </div>
         </div>
-      </div>
-    </EuiMarkdownContext.Provider>
-  );
-};
+      </EuiMarkdownContext.Provider>
+    );
+  }
+);
+EuiMarkdownEditor.displayName = 'EuiMarkdownEditor';


### PR DESCRIPTION
### Summary

Allows the consuming application to pass a `ref` to **EuiMarkdownEditor**, the ref receives an object with the shape `{ textarea, replaceNode }` allowing the app to interact directly with the editor's textarea and also programmatically alter the markdown AST.

I tested both items on the ref by manually altering the existing example, but did not leave any of that test code in place.

~### Checklist~
