### PR TITLE
Optimized in-memory datagrid mount performance

### DIFF
--- a/src/components/datagrid/data_grid_inmemory_renderer.tsx
+++ b/src/components/datagrid/data_grid_inmemory_renderer.tsx
@@ -18,10 +18,10 @@
  */
 
 import React, {
-  Fragment,
   FunctionComponent,
   JSXElementConstructor,
   useEffect,
+  useCallback,
   useMemo,
   useState,
 } from 'react';
@@ -32,17 +32,14 @@ import {
 } from './data_grid_cell';
 import { EuiDataGridColumn, EuiDataGridInMemory } from './data_grid_types';
 import { enqueueStateChange } from '../../services/react';
+import { EuiMutationObserver } from '../observer/mutation_observer';
 
 export interface EuiDataGridInMemoryRendererProps {
   inMemory: EuiDataGridInMemory;
   columns: EuiDataGridColumn[];
   rowCount: number;
   renderCellValue: EuiDataGridCellProps['renderCellValue'];
-  onCellRender: (
-    rowIndex: number,
-    column: EuiDataGridColumn,
-    value: string
-  ) => void;
+  onCellRender: (rowIndex: number, columnId: string, value: string) => void;
 }
 
 function noop() {}
@@ -55,101 +52,108 @@ function getElementText(element: HTMLElement) {
       element.textContent || undefined;
 }
 
-const ObservedCell: FunctionComponent<{
-  renderCellValue: EuiDataGridInMemoryRendererProps['renderCellValue'];
-  onCellRender: EuiDataGridInMemoryRendererProps['onCellRender'];
-  i: number;
-  column: EuiDataGridColumn;
-  isExpandable: boolean;
-}> = ({ renderCellValue, i, column, onCellRender, isExpandable }) => {
-  const [ref, setRef] = useState<HTMLDivElement | null>();
-
-  useEffect(() => {
-    if (ref) {
-      // this is part of React's component lifecycle, onCellRender->setState are automatically batched
-      onCellRender(i, column, getElementText(ref));
-      const observer = new MutationObserver(() => {
-        // onMutation callbacks aren't in the component lifecycle, intentionally batch any effects
-        enqueueStateChange(
-          onCellRender.bind(null, i, column, getElementText(ref))
-        );
-      });
-      observer.observe(ref, {
-        characterData: true,
-        subtree: true,
-        attributes: true,
-        childList: true,
-      });
-
-      return () => {
-        observer.disconnect();
-      };
-    }
-  }, [column, i, onCellRender, ref]);
-
-  const CellElement = renderCellValue as JSXElementConstructor<
-    EuiDataGridCellValueElementProps
-  >;
-
-  return (
-    <div ref={setRef}>
-      <CellElement
-        rowIndex={i}
-        columnId={column.id}
-        setCellProps={noop}
-        isExpandable={isExpandable}
-        isExpanded={false}
-        isDetails={false}
-      />
-    </div>
-  );
-};
-
 export const EuiDataGridInMemoryRenderer: FunctionComponent<
   EuiDataGridInMemoryRendererProps
 > = ({ inMemory, columns, rowCount, renderCellValue, onCellRender }) => {
   const [documentFragment] = useState(() => document.createDocumentFragment());
 
-  const rows = useMemo(() => {
-    const rows = [];
+  const cells = useMemo(() => {
+    const CellElement = renderCellValue as JSXElementConstructor<
+      EuiDataGridCellValueElementProps
+    >;
+
+    const cells = [];
 
     for (let i = 0; i < rowCount; i++) {
-      rows.push(
-        <Fragment key={i}>
-          {columns
-            .map(column => {
-              const skipThisColumn =
-                inMemory.skipColumns &&
-                inMemory.skipColumns.indexOf(column.id) !== -1;
+      cells.push(
+        columns
+          .map(column => {
+            const skipThisColumn =
+              inMemory.skipColumns &&
+              inMemory.skipColumns.indexOf(column.id) !== -1;
 
-              if (skipThisColumn) {
-                return null;
-              }
+            if (skipThisColumn) {
+              return null;
+            }
 
-              const isExpandable =
-                column.isExpandable !== undefined ? column.isExpandable : true;
+            const isExpandable =
+              column.isExpandable !== undefined ? column.isExpandable : true;
 
-              return (
-                <ObservedCell
-                  key={column.id}
-                  i={i}
-                  renderCellValue={renderCellValue}
-                  column={column}
-                  onCellRender={onCellRender}
+            return (
+              <div
+                key={`${i}-${column.id}`}
+                data-dg-row={i}
+                data-dg-column={column.id}>
+                <CellElement
+                  rowIndex={i}
+                  columnId={column.id}
+                  setCellProps={noop}
                   isExpandable={isExpandable}
+                  isExpanded={false}
+                  isDetails={false}
                 />
-              );
-            })
-            .filter(cell => cell != null)}
-        </Fragment>
+              </div>
+            );
+          })
+          .filter(cell => cell != null)
       );
     }
 
-    return rows;
-  }, [rowCount, columns, inMemory.skipColumns, renderCellValue, onCellRender]);
+    return cells;
+  }, [rowCount, columns, inMemory.skipColumns, renderCellValue]);
+
+  const onMutation = useCallback<MutationCallback>(
+    records => {
+      recordLoop: for (let i = 0; i < records.length; i++) {
+        const record = records[i];
+        let target: Node | null = record.target;
+
+        while (true) {
+          if (target == null) continue recordLoop; // somehow hit the document fragment
+          if (
+            target.nodeType === Node.ELEMENT_NODE &&
+            (target as Element).hasAttribute('data-dg-row')
+          ) {
+            // target is the cell wrapping div
+            break;
+          }
+          target = target.parentElement;
+        }
+
+        const cellDiv = target as HTMLDivElement;
+        const rowIndex = parseInt(cellDiv.getAttribute('data-dg-row')!, 10);
+        const column = cellDiv.getAttribute('data-dg-column')!;
+        enqueueStateChange(() =>
+          onCellRender(rowIndex, column, getElementText(cellDiv))
+        );
+      }
+    },
+    [onCellRender]
+  );
+
+  useEffect(() => {
+    const cellDivs = documentFragment.children[0].children;
+    for (let i = 0; i < cellDivs.length; i++) {
+      const cellDiv = cellDivs[i] as HTMLDivElement;
+      const rowIndex = parseInt(cellDiv.getAttribute('data-dg-row')!, 10);
+      const column = cellDiv.getAttribute('data-dg-column')!;
+      onCellRender(rowIndex, column, getElementText(cellDiv));
+    }
+    // changes to documentFragment.children is reflected by `cells`
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onCellRender, cells]);
 
   return createPortal(
-    <Fragment>{rows}</Fragment>,
+    <EuiMutationObserver
+      onMutation={onMutation}
+      observerOptions={{
+        characterData: true,
+        subtree: true,
+        attributes: true,
+        childList: true,
+      }}>
+      {ref => <div ref={ref}>{cells}</div>}
+    </EuiMutationObserver>,
     (documentFragment as unknown) as Element
   );
 };

--- a/src/components/datagrid/data_grid_inmemory_renderer.tsx
+++ b/src/components/datagrid/data_grid_inmemory_renderer.tsx
@@ -132,7 +132,7 @@ export const EuiDataGridInMemoryRenderer: FunctionComponent<
   );
 
   useEffect(() => {
-    const cellDivs = documentFragment.children[0].children;
+    const cellDivs = documentFragment.childNodes[0].childNodes;
     for (let i = 0; i < cellDivs.length; i++) {
       const cellDiv = cellDivs[i] as HTMLDivElement;
       const rowIndex = parseInt(cellDiv.getAttribute('data-dg-row')!, 10);


### PR DESCRIPTION
### Summary

* Mutation observer previously wrapped each individual in-memory cell, this has been moved to a single observer wrapping the entire in-memory table
* Less components are rendered in the Virtual DOM hierarchy 
* `onCellRender` callback updated to mutate the values object instead of cloning every time a cell reports a new value

#### Performance

I modified the *in_memory_sorting.js* example and took the timings from the first 3 togglings-on

<details>
<summary>see modified example file</summary>

```
import React, { Fragment, useCallback, useMemo, useState } from 'react';
import { fake } from 'faker';

import { EuiDataGrid, EuiLink, EuiButton } from '../../../../src/components/';

const columns = [
  {
    id: 'name',
  },
  {
    id: 'email',
  },
  {
    id: 'location',
  },
  {
    id: 'account',
  },
  {
    id: 'date',
  },
  {
    id: 'amount',
  },
  {
    id: 'phone',
  },
  {
    id: 'version',
  },
];

const raw_data = [];

for (let i = 1; i < 1000; i++) {
  raw_data.push({
    name: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
    email: <EuiLink href="">{fake('{{internet.email}}')}</EuiLink>,
    location: (
      <Fragment>
        {`${fake('{{address.city}}')}, `}
        <EuiLink href="https://google.com">
          {fake('{{address.country}}')}
        </EuiLink>
      </Fragment>
    ),
    date: fake('{{date.past}}'),
    account: fake('{{finance.account}}'),
    amount: fake('${{commerce.price}}'),
    phone: fake('{{phone.phoneNumber}}'),
    version: fake('{{system.semver}}'),
  });
}

export default () => {
  // ** Pagination config
  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 1 });
  const onChangeItemsPerPage = useCallback(
    pageSize =>
      setPagination(pagination => ({ ...pagination, pageSize, pageIndex: 0 })),
    [setPagination]
  );
  const onChangePage = useCallback(
    pageIndex => setPagination(pagination => ({ ...pagination, pageIndex })),
    [setPagination]
  );

  // ** Sorting config
  const [sortingColumns, setSortingColumns] = useState([]);
  const onSort = useCallback(
    sortingColumns => {
      setSortingColumns(sortingColumns);
    },
    [setSortingColumns]
  );

  // Column visibility
  const [visibleColumns, setVisibleColumns] = useState(() =>
    columns.map(({ id }) => id)
  ); // initialize to the full set of columns

  const renderCellValue = useMemo(() => {
    return ({ rowIndex, columnId }) => {
      return raw_data.hasOwnProperty(rowIndex)
        ? raw_data[rowIndex][columnId]
        : null;
    };
  }, []);

  const [isOpen, setIsOpen] = useState(false);

  return (
    <>
      <EuiButton onClick={() => setIsOpen(!isOpen)}>toggle</EuiButton>
      {isOpen && (
        <EuiDataGrid
          aria-label="inMemory level set to sorting data grid demo"
          columns={columns}
          columnVisibility={{ visibleColumns, setVisibleColumns }}
          rowCount={raw_data.length}
          renderCellValue={renderCellValue}
          inMemory={{ level: 'sorting' }}
          sorting={{ columns: sortingColumns, onSort }}
          pagination={{
            ...pagination,
            pageSizeOptions: [10, 50, 100],
            onChangeItemsPerPage: onChangeItemsPerPage,
            onChangePage: onChangePage,
          }}
        />
      )}
    </>
  );
};

```
</details>

Previous
Mount - 2760ms, 2520ms, 2400ms
Set inMemory values - 349ms, 384ms, 326ms

Optimized
Mount - 1160ms, 1040ms, 946ms
Set inMemory values - 119ms, 92ms, 95ms

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
