### PR TITLE
extend the onChange Event to CheckableCard__control

### DIFF
--- a/src-docs/src/views/card/card_checkable.js
+++ b/src-docs/src/views/card/card_checkable.js
@@ -88,7 +88,7 @@ export default () => {
         checkableType="checkbox"
         value="checkbox1"
         checked={checkbox}
-        onChange={() => setCheckbox(!checkbox)}
+        onChange={() => setCheckbox(prevCb => !prevCb)}
       />
     </Fragment>
   );

--- a/src/components/card/checkable_card/_checkable_card.scss
+++ b/src/components/card/checkable_card/_checkable_card.scss
@@ -29,7 +29,7 @@
   align-items: center;
   background-color: map-get($euiCardSelectButtonBackgrounds, 'text');
   transition: background-color $euiAnimSpeedNormal ease-in;
-
+  cursor: pointer;
   .euiCheckableCard-isChecked & {
     background-color: map-get($euiCardSelectButtonBackgrounds, 'primary');
   }

--- a/src/components/card/checkable_card/_checkable_card.scss
+++ b/src/components/card/checkable_card/_checkable_card.scss
@@ -23,13 +23,14 @@
 }
 
 .euiCheckableCard__control {
+  cursor: pointer;
   display: flex;
   flex: 0 0 $euiSizeXXL;
   justify-content: center;
   align-items: center;
   background-color: map-get($euiCardSelectButtonBackgrounds, 'text');
   transition: background-color $euiAnimSpeedNormal ease-in;
-  cursor: pointer;
+
   .euiCheckableCard-isChecked & {
     background-color: map-get($euiCardSelectButtonBackgrounds, 'primary');
   }

--- a/src/components/card/checkable_card/_checkable_card.scss
+++ b/src/components/card/checkable_card/_checkable_card.scss
@@ -1,6 +1,7 @@
 @include euiPanel($selector: '.euiCheckableCard');
 
 .euiCheckableCard {
+  cursor: pointer;
   transition: border-color $euiAnimSpeedNormal ease-in;
   overflow: hidden; // Hides background color inside panel rounded corners
 

--- a/src/components/card/checkable_card/_checkable_card.scss
+++ b/src/components/card/checkable_card/_checkable_card.scss
@@ -16,8 +16,6 @@
   border-color: $euiColorPrimary;
 }
 
-
-
 .euiCheckableCard__row {
   display: flex;
   align-items: stretch;

--- a/src/components/card/checkable_card/checkable_card.tsx
+++ b/src/components/card/checkable_card/checkable_card.tsx
@@ -89,9 +89,8 @@ export const EuiCheckableCard: FunctionComponent<EuiCheckableCardProps> = ({
     'euiCheckableCard__label-isDisabled': disabled,
   });
 
-  const handleCLick = () => {
+  const handleCLick = () =>
     typeof clickRef.current !== 'undefined' && clickRef.current.click();
-  };
 
   const labelRef = (clickRef as unknown) as Ref<HTMLLabelElement>;
 

--- a/src/components/card/checkable_card/checkable_card.tsx
+++ b/src/components/card/checkable_card/checkable_card.tsx
@@ -89,17 +89,15 @@ export const EuiCheckableCard: FunctionComponent<EuiCheckableCardProps> = ({
   });
 
   return (
-    <div className={classes}>
+    <div
+      className={classes}
+      onClick={
+        (rest.onChange as unknown) as (
+          event: React.MouseEvent<HTMLDivElement, MouseEvent>
+        ) => void
+      }>
       <div className="euiCheckableCard__row">
-        <div
-          className="euiCheckableCard__control"
-          onClick={
-            (rest.onChange as unknown) as (
-              event: React.MouseEvent<HTMLDivElement, MouseEvent>
-            ) => void
-          }>
-          {checkableElement}
-        </div>
+        <div className="euiCheckableCard__control">{checkableElement}</div>
         <label
           className={labelClasses}
           htmlFor={id}

--- a/src/components/card/checkable_card/checkable_card.tsx
+++ b/src/components/card/checkable_card/checkable_card.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { FunctionComponent, ReactNode } from 'react';
+import React, { FunctionComponent, ReactNode, LegacyRef } from 'react';
 import classNames from 'classnames';
 
 import {
@@ -60,6 +60,7 @@ export const EuiCheckableCard: FunctionComponent<EuiCheckableCardProps> = ({
   ...rest
 }) => {
   const { id } = rest;
+  const clickRef = React.useRef<HTMLInputElement>();
   const classes = classNames(
     'euiCheckableCard',
     {
@@ -88,17 +89,20 @@ export const EuiCheckableCard: FunctionComponent<EuiCheckableCardProps> = ({
     'euiCheckableCard__label-isDisabled': disabled,
   });
 
+  const handleCLick = () =>
+    typeof clickRef.current !== 'undefined' && clickRef.current.click();
+
+  const labelRef =
+    checkableType === 'radio'
+      ? ((clickRef as unknown) as LegacyRef<HTMLLabelElement>)
+      : null;
+
   return (
-    <div
-      className={classes}
-      onClick={
-        (rest.onChange as unknown) as (
-          event: React.MouseEvent<HTMLDivElement, MouseEvent>
-        ) => void
-      }>
+    <div className={classes} onClick={handleCLick}>
       <div className="euiCheckableCard__row">
         <div className="euiCheckableCard__control">{checkableElement}</div>
         <label
+          ref={labelRef}
           className={labelClasses}
           htmlFor={id}
           aria-describedby={children ? `${id}-details` : undefined}>

--- a/src/components/card/checkable_card/checkable_card.tsx
+++ b/src/components/card/checkable_card/checkable_card.tsx
@@ -91,7 +91,15 @@ export const EuiCheckableCard: FunctionComponent<EuiCheckableCardProps> = ({
   return (
     <div className={classes}>
       <div className="euiCheckableCard__row">
-        <div className="euiCheckableCard__control">{checkableElement}</div>
+        <div
+          className="euiCheckableCard__control"
+          onClick={
+            (rest.onChange as unknown) as (
+              event: React.MouseEvent<HTMLDivElement, MouseEvent>
+            ) => void
+          }>
+          {checkableElement}
+        </div>
         <label
           className={labelClasses}
           htmlFor={id}

--- a/src/components/card/checkable_card/checkable_card.tsx
+++ b/src/components/card/checkable_card/checkable_card.tsx
@@ -89,18 +89,18 @@ export const EuiCheckableCard: FunctionComponent<EuiCheckableCardProps> = ({
     'euiCheckableCard__label-isDisabled': disabled,
   });
 
-  const handleCLick = () =>
+  const handleCLick = () => {
     typeof clickRef.current !== 'undefined' && clickRef.current.click();
+  };
 
-  const labelRef =
-    checkableType === 'radio'
-      ? ((clickRef as unknown) as Ref<HTMLLabelElement>)
-      : null;
+  const labelRef = (clickRef as unknown) as Ref<HTMLLabelElement>;
 
   return (
-    <div className={classes} onClick={handleCLick}>
+    <div className={classes}>
       <div className="euiCheckableCard__row">
-        <div className="euiCheckableCard__control">{checkableElement}</div>
+        <div className="euiCheckableCard__control" onClick={handleCLick}>
+          {checkableElement}
+        </div>
         <label
           ref={labelRef}
           className={labelClasses}
@@ -111,7 +111,6 @@ export const EuiCheckableCard: FunctionComponent<EuiCheckableCardProps> = ({
       </div>
       {children && (
         <div className="euiCheckableCard__row">
-          {/* Empty div for left side background color only */}
           <div className="euiCheckableCard__control" />
           <div id={`${id}-details`} className="euiCheckableCard__children">
             {children}

--- a/src/components/card/checkable_card/checkable_card.tsx
+++ b/src/components/card/checkable_card/checkable_card.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { FunctionComponent, ReactNode, LegacyRef } from 'react';
+import React, { FunctionComponent, ReactNode, Ref } from 'react';
 import classNames from 'classnames';
 
 import {
@@ -94,7 +94,7 @@ export const EuiCheckableCard: FunctionComponent<EuiCheckableCardProps> = ({
 
   const labelRef =
     checkableType === 'radio'
-      ? ((clickRef as unknown) as LegacyRef<HTMLLabelElement>)
+      ? ((clickRef as unknown) as Ref<HTMLLabelElement>)
       : null;
 
   return (


### PR DESCRIPTION

### Summary
The Aim of this Pull Request is to fix the following issue:
 [EuiCheckableCard grey portion around the radio button is not clickable #3629](https://github.com/elastic/eui/issues/3629)

> With this pull request, the label text, the button itself, and even the grey container are clickable!

### Checklist

- [X] Check against **all themes** for compatibility in both light and dark modes
- [X] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [X] Checked for **breaking changes** and labeled appropriately
- [X] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
