### PR TITLE
Fixed EuiCode's fullscreen mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `26.0.0`.
+**Bug fixes**
+
+- Fixed fullscreen render issue in `EuiCode` ([#3633](https://github.com/elastic/eui/pull/3633))
 
 ## [`26.0.0`](https://github.com/elastic/eui/tree/v26.0.0)
 

--- a/src/components/code/_code_block.tsx
+++ b/src/components/code/_code_block.tsx
@@ -110,7 +110,9 @@ export const EuiCodeBlockImpl: FunctionComponent<Props> = ({
   const [isPortalTargetReady, setIsPortalTargetReady] = useState(false);
   const codeTarget = useRef<HTMLDivElement | null>(null);
   const code = useRef<HTMLElement | null>(null);
-  const codeFullScreen = useRef<HTMLElement | null>(null);
+  const [codeFullScreen, setCodeFullScreen] = useState<HTMLElement | null>(
+    null
+  );
 
   useEffect(() => {
     codeTarget.current = document.createElement('div');
@@ -130,20 +132,23 @@ export const EuiCodeBlockImpl: FunctionComponent<Props> = ({
     if (code.current) {
       code.current.innerHTML = html;
     }
-    if (codeFullScreen.current) {
-      codeFullScreen.current.innerHTML = html;
-    }
 
     if (language) {
       if (code.current) {
         hljs.highlightBlock(code.current);
       }
-
-      if (codeFullScreen.current) {
-        hljs.highlightBlock(codeFullScreen.current);
-      }
     }
   });
+
+  useEffect(() => {
+    if (codeFullScreen) {
+      const html = isPortalTargetReady ? codeTarget.current!.innerHTML : '';
+      codeFullScreen.innerHTML = html;
+      if (language) {
+        hljs.highlightBlock(codeFullScreen);
+      }
+    }
+  }, [isPortalTargetReady, codeFullScreen, language]);
 
   const onKeyDown = (event: KeyboardEvent<HTMLElement>) => {
     if (event.key === keys.ESCAPE) {
@@ -289,7 +294,7 @@ export const EuiCodeBlockImpl: FunctionComponent<Props> = ({
             <div className={fullScreenClasses}>
               <pre className={preClasses}>
                 <code
-                  ref={codeFullScreen}
+                  ref={setCodeFullScreen}
                   className={codeClasses}
                   tabIndex={0}
                   onKeyDown={onKeyDown}

--- a/src/components/code/code_block.test.tsx
+++ b/src/components/code/code_block.test.tsx
@@ -158,5 +158,20 @@ describe('EuiCodeBlock', () => {
 
       ReactDOM.render(<App />, appDiv);
     });
+
+    it('displays content in fullscreen mode', () => {
+      const component = mount(
+        <EuiCodeBlock language="javascript" overflowHeight={300}>
+          const value = &quot;hello&quot;
+        </EuiCodeBlock>
+      );
+
+      component.find('EuiButtonIcon[iconType="fullScreen"]').simulate('click');
+      component.update();
+
+      expect(component.find('.euiCodeBlock-isFullScreen').text()).toBe(
+        'const value = "hello"'
+      );
+    });
   });
 });


### PR DESCRIPTION
### Summary

Fixes #3627 

The fullscreen code container's ref wasn't being set in time the `useEffect` fired to set its content. This PR moves that ref into a state variable and creates a separate `useEffect` to fill it. I added a test and verified it fails without the accompanying changes to **EuiCodeBlockImpl**.

Not sure when/how this bug was introduced, I checked the published docs for the previous 2 PRs touching this file, and fullscreen mode works in both. Perhaps there's a difference in React's dev & production builds affecting this?

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-afaguidelines.md#changelog)** entry exists and is marked appropriately
