### PR TITLE
Allowed variable gutterSize in EuiFacetGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `26.1.0`.
+- Added `gutterSize` prop to `EuiFacetGroup` ([#3639](https://github.com/elastic/eui/pull/3639))
 
 ## [`26.1.0`](https://github.com/elastic/eui/tree/v26.1.0)
 

--- a/src-docs/src/views/facet/facet_example.js
+++ b/src-docs/src/views/facet/facet_example.js
@@ -40,15 +40,18 @@ export const FacetExample = {
         },
       ],
       text: (
-        <p>
-          <strong>EuiFacetButtons</strong> are to be used when allowing lists
-          with multiple search params to be filtered down by these particular
-          params. They allow for an <EuiCode>icon</EuiCode> node and/or{' '}
-          <EuiCode>quantity</EuiCode> to be passed. You can also indicate the
-          current selection with <EuiCode>isSelected</EuiCode>. Other props
-          include <EuiCode>isDisabled</EuiCode> and <EuiCode>isLoading</EuiCode>{' '}
-          (which will swap the quantity indicator with a loading icon).
-        </p>
+        <>
+          <p>
+            <strong>EuiFacetButtons</strong> are to be used when allowing lists
+            with multiple search params to be filtered down by these particular
+            params. They allow for an <EuiCode>icon</EuiCode> node and/or{' '}
+            <EuiCode>quantity</EuiCode> to be passed. You can also indicate the
+            current selection with <EuiCode>isSelected</EuiCode>. Other props
+            include <EuiCode>isDisabled</EuiCode> and{' '}
+            <EuiCode>isLoading</EuiCode> (which will swap the quantity indicator
+            with a loading icon).
+          </p>
+        </>
       ),
       props: { EuiFacetButton },
       snippet: facetSnippet,
@@ -67,30 +70,32 @@ export const FacetExample = {
         },
       ],
       text: (
-        <div>
-          <p>
-            Typically, each facet grouping should display similarly. For
-            example, they should all have icons or be similar icon nodes (like
-            avatars). It is up to you whether each group should be single or
-            multi-selection.
-          </p>
+        <>
           <p>
             Utilize the <strong>EuiFacetGroup</strong> wrapper to correctly
             layout multiple facets. You can supply a <EuiCode>layout</EuiCode>{' '}
             of either <EuiCode>horizontal</EuiCode> or{' '}
             <EuiCode>vertical</EuiCode> with the default being{' '}
             <EuiCode>vertical</EuiCode>. Be sure to contain vertical layouts in
-            a skinny component or give it a max-width.
+            a skinny component or give it a max-width. You can also adjust the
+            spacing between items with the <EuiCode>gutterSize</EuiCode> prop.
           </p>
-        </div>
+          <p>
+            Typically, each facet grouping should display similarly. For
+            example, they should all have icons or be similar icon nodes (like
+            avatars). It is up to you whether each group should be single or
+            multi-selection.
+          </p>
+        </>
       ),
       props: { EuiFacetGroup },
       demo: <FacetLayout />,
-      snippet: `// Restrict the width of default (vertical) if not restricted by parent
-<EuiFacetGroup style={{ maxWidth: 200 }}>{facets}</EuiFacetGroup>
-
-// Horizontal
-<EuiFacetGroup layout="horizontal">{facets}</EuiFacetGroup>`,
+      snippet: [
+        `// Restrict the width of default (vertical) if not restricted by parent
+<EuiFacetGroup style={{ maxWidth: 200 }}>{facets}</EuiFacetGroup>`,
+        `// Horizontal
+<EuiFacetGroup layout="horizontal" gutterSize="l">{facets}</EuiFacetGroup>`,
+      ],
     },
   ],
 };

--- a/src-docs/src/views/facet/facet_layout.js
+++ b/src-docs/src/views/facet/facet_layout.js
@@ -67,42 +67,42 @@ export default () => {
       id: 'facet0',
       label: 'Simple, no icon',
       quantity: 6,
-      iconColor: euiPaletteColorBlind[0],
+      iconColor: euiPaletteColorBlind()[0],
       onClick: facet0Clicked,
     },
     {
       id: 'facet1',
       label: 'Label or color indicator',
       quantity: 60,
-      iconColor: euiPaletteColorBlind[1],
+      iconColor: euiPaletteColorBlind()[1],
       onClick: facet1Clicked,
     },
     {
       id: 'facet2',
       label: 'Disable all others',
       quantity: 600,
-      iconColor: euiPaletteColorBlind[2],
+      iconColor: euiPaletteColorBlind()[2],
       onClick: facet2Clicked,
     },
     {
       id: 'facet3',
       label: 'Avatars instead of icons',
       quantity: 60,
-      iconColor: euiPaletteColorBlind[3],
+      iconColor: euiPaletteColorBlind()[3],
       onClick: facet3Clicked,
     },
     {
       id: 'facet4',
       label: 'Show all as loading',
       quantity: 6,
-      iconColor: euiPaletteColorBlind[4],
+      iconColor: euiPaletteColorBlind()[4],
       onClick: facet4Clicked,
     },
     {
       id: 'facet5',
       label: 'Just here to show truncation of really long labels',
       quantity: 0,
-      iconColor: euiPaletteColorBlind[5],
+      iconColor: euiPaletteColorBlind()[5],
     },
   ];
 
@@ -156,9 +156,11 @@ export default () => {
       <EuiSpacer />
 
       <EuiTitle size="s">
-        <h3>Horizontal</h3>
+        <h3>Horizontal and large gutter</h3>
       </EuiTitle>
-      <EuiFacetGroup layout="horizontal">{facets('Horizontal')}</EuiFacetGroup>
+      <EuiFacetGroup layout="horizontal" gutterSize="l">
+        {facets('Horizontal')}
+      </EuiFacetGroup>
     </div>
   );
 };

--- a/src/components/facet/__snapshots__/facet_button.test.tsx.snap
+++ b/src/components/facet/__snapshots__/facet_button.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`EuiFacetButton is rendered 1`] = `
   aria-label="aria-label"
   class="euiFacetButton euiFacetButton--unSelected testClass1 testClass2"
   data-test-subj="test subject string"
+  title="aria-label"
   type="button"
 >
   <span
@@ -12,7 +13,6 @@ exports[`EuiFacetButton is rendered 1`] = `
   >
     <span
       class="euiFacetButton__text"
-      data-text="Content"
     >
       Content
     </span>
@@ -34,7 +34,6 @@ exports[`EuiFacetButton props icon is rendered 1`] = `
     />
     <span
       class="euiFacetButton__text"
-      data-text="Content"
     >
       Content
     </span>
@@ -53,7 +52,6 @@ exports[`EuiFacetButton props isDisabled is rendered 1`] = `
   >
     <span
       class="euiFacetButton__text"
-      data-text="Content"
     >
       Content
     </span>
@@ -72,7 +70,6 @@ exports[`EuiFacetButton props isLoading is rendered 1`] = `
   >
     <span
       class="euiFacetButton__text"
-      data-text="Content"
     >
       Content
     </span>
@@ -93,7 +90,6 @@ exports[`EuiFacetButton props isSelected is rendered 1`] = `
   >
     <span
       class="euiFacetButton__text"
-      data-text="Content"
     >
       Content
     </span>
@@ -111,7 +107,6 @@ exports[`EuiFacetButton props quantity is rendered 1`] = `
   >
     <span
       class="euiFacetButton__text"
-      data-text="Content"
     >
       Content
     </span>

--- a/src/components/facet/__snapshots__/facet_group.test.tsx.snap
+++ b/src/components/facet/__snapshots__/facet_group.test.tsx.snap
@@ -8,14 +8,38 @@ exports[`EuiFacetGroup is rendered 1`] = `
 />
 `;
 
-exports[`EuiFacetGroup props gutterSize is rendered 1`] = `
+exports[`EuiFacetGroup props gutterSize l is rendered 1`] = `
 <div
   class="euiFlexGroup euiFlexGroup--directionColumn euiFlexGroup--responsive euiFacetGroup euiFacetGroup--vertical euiFacetGroup--gutterLarge"
 />
 `;
 
-exports[`EuiFacetGroup props layout is rendered 1`] = `
+exports[`EuiFacetGroup props gutterSize m is rendered 1`] = `
+<div
+  class="euiFlexGroup euiFlexGroup--directionColumn euiFlexGroup--responsive euiFacetGroup euiFacetGroup--vertical euiFacetGroup--gutterMedium"
+/>
+`;
+
+exports[`EuiFacetGroup props gutterSize none is rendered 1`] = `
+<div
+  class="euiFlexGroup euiFlexGroup--directionColumn euiFlexGroup--responsive euiFacetGroup euiFacetGroup--vertical euiFacetGroup--gutterNone"
+/>
+`;
+
+exports[`EuiFacetGroup props gutterSize s is rendered 1`] = `
+<div
+  class="euiFlexGroup euiFlexGroup--directionColumn euiFlexGroup--responsive euiFacetGroup euiFacetGroup--vertical euiFacetGroup--gutterSmall"
+/>
+`;
+
+exports[`EuiFacetGroup props layout horizontal is rendered 1`] = `
 <div
   class="euiFlexGroup euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap euiFacetGroup euiFacetGroup--horizontal euiFacetGroup--gutterMedium"
+/>
+`;
+
+exports[`EuiFacetGroup props layout vertical is rendered 1`] = `
+<div
+  class="euiFlexGroup euiFlexGroup--directionColumn euiFlexGroup--responsive euiFacetGroup euiFacetGroup--vertical euiFacetGroup--gutterMedium"
 />
 `;

--- a/src/components/facet/__snapshots__/facet_group.test.tsx.snap
+++ b/src/components/facet/__snapshots__/facet_group.test.tsx.snap
@@ -3,13 +3,19 @@
 exports[`EuiFacetGroup is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="euiFlexGroup euiFlexGroup--directionColumn euiFlexGroup--responsive euiFacetGroup euiFacetGroup--vertical testClass1 testClass2"
+  class="euiFlexGroup euiFlexGroup--directionColumn euiFlexGroup--responsive euiFacetGroup euiFacetGroup--vertical euiFacetGroup--gutterMedium testClass1 testClass2"
   data-test-subj="test subject string"
+/>
+`;
+
+exports[`EuiFacetGroup props gutterSize is proper 1`] = `
+<div
+  class="euiFlexGroup euiFlexGroup--directionColumn euiFlexGroup--responsive euiFacetGroup euiFacetGroup--vertical euiFacetGroup--gutterLarge"
 />
 `;
 
 exports[`EuiFacetGroup props layout is rendered 1`] = `
 <div
-  class="euiFlexGroup euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap euiFacetGroup euiFacetGroup--horizontal"
+  class="euiFlexGroup euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap euiFacetGroup euiFacetGroup--horizontal euiFacetGroup--gutterMedium"
 />
 `;

--- a/src/components/facet/__snapshots__/facet_group.test.tsx.snap
+++ b/src/components/facet/__snapshots__/facet_group.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`EuiFacetGroup is rendered 1`] = `
 />
 `;
 
-exports[`EuiFacetGroup props gutterSize is proper 1`] = `
+exports[`EuiFacetGroup props gutterSize is rendered 1`] = `
 <div
   class="euiFlexGroup euiFlexGroup--directionColumn euiFlexGroup--responsive euiFacetGroup euiFacetGroup--vertical euiFacetGroup--gutterLarge"
 />

--- a/src/components/facet/_facet_button.scss
+++ b/src/components/facet/_facet_button.scss
@@ -1,26 +1,20 @@
 /**
- * 1. We don't want any of the animations that come inherited from the mixin.
- *    These should act like normal links instead.
- * 2. Change the easing, quickness to not bounce so lighter backgrounds don't flash
- * 3. Make sure the quantity doesn't get an underline on hover
+ * 1. Make sure the quantity doesn't get an underline on hover
  */
 .euiFacetButton {
-  // sass-lint:disable-block no-important
-  @include euiButton;
+  @include euiButtonBase;
+  @include euiFont;
   @include euiFontSizeS;
+
+  height: $euiButtonHeightSmall;
   text-align: left;
-  border: none;
-  transform: none !important; /* 1 */
-  animation: none !important; /* 1 */
-  transition: all $euiAnimSpeedFast ease-in; /* 2 */
+  text-decoration: none;
+  transition: all $euiAnimSpeedFast ease-in;
 
   &:hover,
   &:focus {
-    // sass-lint:disable-block no-important
-    text-decoration: none !important; /* 3 */
-
     &:not(:disabled) .euiFacetButton__text {
-      text-decoration: underline; /* 3 */
+      text-decoration: underline; /* 1 */
     }
   }
 

--- a/src/components/facet/_facet_group.scss
+++ b/src/components/facet/_facet_group.scss
@@ -1,9 +1,23 @@
+$gutterTypes: (
+  gutterExtraSmall: $euiSizeXS,
+  gutterSmall: $euiSizeS,
+  gutterMedium: $euiSize,
+  gutterLarge: $euiSizeL,
+  gutterExtraLarge: $euiSizeXXL,
+);
 .euiFacetGroup--horizontal {
   .euiFacetButton {
     height: $euiButtonHeightSmall;
 
-    &:not(:last-of-type) {
-      margin-right: $euiSizeL;
+  }
+}
+@each $gutterName, $gutterSize in $gutterTypes {
+  .euiFacetGroup--#{$gutterName} {
+    .euiFacetButton {
+      &:not(:last-of-type) {
+        margin-right: $gutterSize;
+      }
+      margin-bottom: $gutterSize;
     }
   }
 }

--- a/src/components/facet/_facet_group.scss
+++ b/src/components/facet/_facet_group.scss
@@ -5,6 +5,7 @@ $gutterTypes: (
   gutterLarge: $euiSizeL,
   gutterExtraLarge: $euiSizeXXL,
 );
+
 .euiFacetGroup--horizontal {
   .euiFacetButton {
     height: $euiButtonHeightSmall;
@@ -14,10 +15,11 @@ $gutterTypes: (
 @each $gutterName, $gutterSize in $gutterTypes {
   .euiFacetGroup--#{$gutterName} {
     .euiFacetButton {
+      margin-bottom: $gutterSize;
+
       &:not(:last-of-type) {
         margin-right: $gutterSize;
       }
-      margin-bottom: $gutterSize;
     }
   }
 }

--- a/src/components/facet/_facet_group.scss
+++ b/src/components/facet/_facet_group.scss
@@ -1,24 +1,23 @@
-$gutterTypes: (
-  gutterExtraSmall: $euiSizeXS,
-  gutterSmall: $euiSizeS,
-  gutterMedium: $euiSize,
-  gutterLarge: $euiSizeL,
-  gutterExtraLarge: $euiSizeXXL,
-);
-
-.euiFacetGroup--horizontal {
-  .euiFacetButton {
-    height: $euiButtonHeightSmall;
-
-  }
-}
-@each $gutterName, $gutterSize in $gutterTypes {
+@each $gutterName, $gutterSize in $euiFacetGutterSizes {
   .euiFacetGroup--#{$gutterName} {
     .euiFacetButton {
-      margin-bottom: $gutterSize;
+      // Split the margin between top and bottom
+      margin-top: $gutterSize / 2;
+      margin-bottom: $gutterSize / 2;
+    }
 
-      &:not(:last-of-type) {
-        margin-right: $gutterSize;
+    &.euiFacetGroup--horizontal {
+      // There needs to be an additional distance between horizontal buttons to ensure
+      // the number notification is closer in proximity to the text it belongs to rather than the button
+      $gutterAdjustment: $euiSizeM + $gutterSize;
+
+      // Collapse margin on the right side of the group to allow it to extend the full width
+      margin-right: -#{$gutterAdjustment};
+
+      .euiFacetButton {
+        margin-right: $gutterAdjustment;
+        // Adjust the max-width so it fits within the alloted margin
+        max-width: calc(100% - #{$gutterAdjustment});
       }
     }
   }

--- a/src/components/facet/_index.scss
+++ b/src/components/facet/_index.scss
@@ -1,2 +1,4 @@
+@import 'variables';
+
 @import 'facet_button';
 @import 'facet_group';

--- a/src/components/facet/_variables.scss
+++ b/src/components/facet/_variables.scss
@@ -1,0 +1,6 @@
+$euiFacetGutterSizes: (
+  gutterNone: 0,
+  gutterSmall: $euiSizeXS,
+  gutterMedium: $euiSizeS,
+  gutterLarge: $euiSizeM,
+);

--- a/src/components/facet/facet_button.tsx
+++ b/src/components/facet/facet_button.tsx
@@ -23,6 +23,7 @@ import React, {
   MouseEventHandler,
   ReactNode,
   RefCallback,
+  ReactElement,
 } from 'react';
 import classNames from 'classnames';
 
@@ -31,6 +32,7 @@ import { CommonProps } from '../common';
 import { EuiNotificationBadge } from '../badge';
 
 import { EuiLoadingSpinner } from '../loading';
+import { EuiInnerText } from '../inner_text';
 
 export interface EuiFacetButtonProps {
   buttonRef?: RefCallback<HTMLButtonElement>;
@@ -81,7 +83,7 @@ export const EuiFacetButton: FunctionComponent<
   );
 
   // Add quanity number if provided or loading indicator
-  let buttonQuantity;
+  let buttonQuantity: ReactElement;
 
   if (isLoading) {
     buttonQuantity = (
@@ -99,7 +101,7 @@ export const EuiFacetButton: FunctionComponent<
   }
 
   // Add an icon to the button if one exists.
-  let buttonIcon;
+  let buttonIcon: ReactElement;
 
   if (React.isValidElement<{ className?: string }>(icon)) {
     buttonIcon = React.cloneElement(icon, {
@@ -107,25 +109,28 @@ export const EuiFacetButton: FunctionComponent<
     });
   }
 
-  let dataText;
-  if (typeof children === 'string') {
-    dataText = children;
-  }
-
   return (
-    <button
-      className={classes}
-      disabled={isDisabled}
-      type="button"
-      ref={buttonRef}
-      {...rest}>
-      <span className="euiFacetButton__content">
-        {buttonIcon}
-        <span data-text={dataText} className="euiFacetButton__text">
-          {children}
-        </span>
-        {buttonQuantity}
-      </span>
-    </button>
+    <EuiInnerText>
+      {(ref, innerText) => (
+        <button
+          className={classes}
+          disabled={isDisabled}
+          type="button"
+          ref={buttonRef}
+          title={rest['aria-label'] || innerText}
+          {...rest}>
+          <span className="euiFacetButton__content">
+            {buttonIcon}
+            <span
+              className="euiFacetButton__text"
+              data-text={innerText}
+              ref={ref}>
+              {children}
+            </span>
+            {buttonQuantity}
+          </span>
+        </button>
+      )}
+    </EuiInnerText>
   );
 };

--- a/src/components/facet/facet_group.test.tsx
+++ b/src/components/facet/facet_group.test.tsx
@@ -43,7 +43,7 @@ describe('EuiFacetGroup', () => {
         const component = render(<EuiFacetGroup gutterSize="l" />);
 
         expect(component).toMatchSnapshot();
-      })
-    })
+      });
+    });
   });
 });

--- a/src/components/facet/facet_group.test.tsx
+++ b/src/components/facet/facet_group.test.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../test';
 
-import { EuiFacetGroup } from './facet_group';
+import { EuiFacetGroup, LAYOUTS, GUTTER_SIZES } from './facet_group';
 
 describe('EuiFacetGroup', () => {
   test('is rendered', () => {
@@ -32,17 +32,22 @@ describe('EuiFacetGroup', () => {
 
   describe('props', () => {
     describe('layout', () => {
-      it('is rendered', () => {
-        const component = render(<EuiFacetGroup layout="horizontal" />);
+      LAYOUTS.forEach(layout => {
+        test(`${layout} is rendered`, () => {
+          const component = render(<EuiFacetGroup layout={layout} />);
 
-        expect(component).toMatchSnapshot();
+          expect(component).toMatchSnapshot();
+        });
       });
     });
-    describe('gutterSize', () => {
-      it('is rendered', () => {
-        const component = render(<EuiFacetGroup gutterSize="l" />);
 
-        expect(component).toMatchSnapshot();
+    describe('gutterSize', () => {
+      GUTTER_SIZES.forEach(size => {
+        test(`${size} is rendered`, () => {
+          const component = render(<EuiFacetGroup gutterSize={size} />);
+
+          expect(component).toMatchSnapshot();
+        });
       });
     });
   });

--- a/src/components/facet/facet_group.test.tsx
+++ b/src/components/facet/facet_group.test.tsx
@@ -38,5 +38,12 @@ describe('EuiFacetGroup', () => {
         expect(component).toMatchSnapshot();
       });
     });
+    describe('gutterSize', () => {
+      it('is rendered', () => {
+        const component = render(<EuiFacetGroup gutterSize="l" />);
+
+        expect(component).toMatchSnapshot();
+      })
+    })
   });
 });

--- a/src/components/facet/facet_group.tsx
+++ b/src/components/facet/facet_group.tsx
@@ -20,30 +20,42 @@
 import React, { FunctionComponent, HTMLAttributes } from 'react';
 import classNames from 'classnames';
 
-import { CommonProps } from '../common';
+import { CommonProps, keysOf } from '../common';
 import { EuiFlexGroup } from '../flex';
 
 type FacetGroupLayout = 'vertical' | 'horizontal';
-
-const gutterSizeToClassNameMap = {
-  xs: 'euiFacetGroup--gutterExtraSmall',
-  s: 'euiFacetGroup--gutterSmall',
-  m: 'euiFacetGroup--gutterMedium',
-  l: 'euiFacetGroup--gutterLarge',
-  xl: 'euiFacetGroup--gutterExtraLarge',
-};
-
-export type EuiFacetGroupGutterSize = keyof typeof gutterSizeToClassNameMap;
 
 const layoutToClassNameMap: { [layout in FacetGroupLayout]: string } = {
   vertical: 'euiFacetGroup--vertical',
   horizontal: 'euiFacetGroup--horizontal',
 };
 
+export const LAYOUTS = keysOf(layoutToClassNameMap);
+
+type FacetGroupGutterSize = 'none' | 's' | 'm' | 'l';
+
+const gutterSizeToClassNameMap: {
+  [gutterSize in FacetGroupGutterSize]: string
+} = {
+  none: 'euiFacetGroup--gutterNone',
+  s: 'euiFacetGroup--gutterSmall',
+  m: 'euiFacetGroup--gutterMedium',
+  l: 'euiFacetGroup--gutterLarge',
+};
+
+export const GUTTER_SIZES = keysOf(gutterSizeToClassNameMap);
+
 export type EuiFacetGroupProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {
+    /**
+     * Vertically in a column, or horizontally in one wrapping line
+     */
     layout?: FacetGroupLayout;
-    gutterSize?: EuiFacetGroupGutterSize;
+    /**
+     * Distance between facet buttons.
+     * Horizontal layout always adds more distance horizontally between buttons.
+     */
+    gutterSize?: FacetGroupGutterSize;
   };
 
 export const EuiFacetGroup: FunctionComponent<EuiFacetGroupProps> = ({

--- a/src/components/facet/facet_group.tsx
+++ b/src/components/facet/facet_group.tsx
@@ -25,6 +25,16 @@ import { EuiFlexGroup } from '../flex';
 
 type FacetGroupLayout = 'vertical' | 'horizontal';
 
+const gutterSizeToClassNameMap = {
+  xs: 'euiFacetGroup--gutterExtraSmall',
+  s: 'euiFacetGroup--gutterSmall',
+  m: 'euiFacetGroup--gutterMedium',
+  l: 'euiFacetGroup--gutterLarge',
+  xl: 'euiFacetGroup--gutterExtraLarge',
+};
+
+export type EuiFacetGroupGutterSize = keyof typeof gutterSizeToClassNameMap;
+
 const layoutToClassNameMap: { [layout in FacetGroupLayout]: string } = {
   vertical: 'euiFacetGroup--vertical',
   horizontal: 'euiFacetGroup--horizontal',
@@ -33,17 +43,20 @@ const layoutToClassNameMap: { [layout in FacetGroupLayout]: string } = {
 export type EuiFacetGroupProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {
     layout?: FacetGroupLayout;
+    gutterSize?: EuiFacetGroupGutterSize;
   };
 
 export const EuiFacetGroup: FunctionComponent<EuiFacetGroupProps> = ({
   children,
   className,
   layout = 'vertical',
+  gutterSize = 'm',
   ...rest
 }) => {
   const classes = classNames(
     'euiFacetGroup',
     layoutToClassNameMap[layout],
+    gutterSizeToClassNameMap[gutterSize],
     className
   );
   const direction = layout === 'vertical' ? 'column' : 'row';


### PR DESCRIPTION
### Summary
Allowing user to choose the size of gutter in EuiFacetGroup, by adding gutterSize 
Closes #3621 
### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [x] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-

@snide We can put different margin for horizontal and vertical, although that might not be of much use and make the sass code redundant, if you like these changes, I'll add the tests :)