### PR TITLE
Exported `EuiCard` TypeScript types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ No public interface changes since `26.0.1`.
 
 ## [`26.0.1`](https://github.com/elastic/eui/tree/v26.0.1)
 
-- Exported `EuiCardProps` in the `EuiCard` component and `EuiCheckableCardProps` in `EuiCheckableCard` component([#3640](https://github.com/elastic/eui/pull/3640))
+- Exported `EuiCardProps` in the `EuiCard` Typesrcipt types and `EuiCheckableCardProps` in `EuiCheckableCard` Typescript types([#3640](https://github.com/elastic/eui/pull/3640))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ No public interface changes since `26.0.1`.
 
 ## [`26.0.1`](https://github.com/elastic/eui/tree/v26.0.1)
 
+- Returned `EuiCardProps` in the `EuiCard` component ([#3640](https://github.com/elastic/eui/pull/3640))
+
 **Bug fixes**
 
 - Fixed fullscreen render issue in `EuiCode` ([#3633](https://github.com/elastic/eui/pull/3633))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `26.0.1`.
+- Exported `EuiCardProps` and `EuiCheckableCardProps` types ([#3640](https://github.com/elastic/eui/pull/3640))
 
 ## [`26.0.1`](https://github.com/elastic/eui/tree/v26.0.1)
-
-- Exported `EuiCardProps` and `EuiCheckableCardProps` types ([#3640](https://github.com/elastic/eui/pull/3640))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ No public interface changes since `26.0.1`.
 
 ## [`26.0.1`](https://github.com/elastic/eui/tree/v26.0.1)
 
-- Exported `EuiCardProps` in the `EuiCard` Typesrcipt types and `EuiCheckableCardProps` in `EuiCheckableCard` Typescript types([#3640](https://github.com/elastic/eui/pull/3640))
+- Exported `EuiCardProps` and `EuiCheckableCardProps` types ([#3640](https://github.com/elastic/eui/pull/3640))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ No public interface changes since `26.0.1`.
 
 ## [`26.0.1`](https://github.com/elastic/eui/tree/v26.0.1)
 
-- Returned `EuiCardProps` in the `EuiCard` component ([#3640](https://github.com/elastic/eui/pull/3640))
+- Exported `EuiCardProps` in the `EuiCard` component and `EuiCheckableCardProps` in `EuiCheckableCard` component([#3640](https://github.com/elastic/eui/pull/3640))
 
 **Bug fixes**
 

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -66,7 +66,7 @@ const displayToClassNameMap: { [display in CardDisplay]: string } = {
 
 export const DISPLAYS = keysOf(displayToClassNameMap);
 
-type EuiCardProps = Omit<CommonProps, 'aria-label'> & {
+export type EuiCardProps = Omit<CommonProps, 'aria-label'> & {
   /**
    * Card's are required to have at least a title and description
    */

--- a/src/components/card/index.ts
+++ b/src/components/card/index.ts
@@ -17,5 +17,5 @@
  * under the License.
  */
 
-export { EuiCard } from './card';
+export { EuiCard, EuiCardProps } from './card';
 export { EuiCheckableCard } from './checkable_card';

--- a/src/components/card/index.ts
+++ b/src/components/card/index.ts
@@ -18,4 +18,4 @@
  */
 
 export { EuiCard, EuiCardProps } from './card';
-export { EuiCheckableCard } from './checkable_card';
+export { EuiCheckableCard, EuiCheckableCardProps } from './checkable_card';


### PR DESCRIPTION
### Summary

The `EuiCardProps` weren't being returned in the `EuiCard` component

### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **IE11** and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
Closes #3634 
@chandlerprall @thompsongl 