### PR TITLE
EuiBottomBar: allow customization of whether the component makes room for itself

### DIFF
--- a/src-docs/src/views/bottom_bar/bottom_bar.js
+++ b/src-docs/src/views/bottom_bar/bottom_bar.js
@@ -2,63 +2,119 @@ import React, { useState } from 'react';
 
 import {
   EuiBottomBar,
-  EuiFlexGroup,
-  EuiFlexItem,
+  EuiButtonGroup,
   EuiButton,
   EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
 } from '../../../../src/components';
 
 export default () => {
-  const [showBar, setShowBar] = useState(false);
+  const [toggleIdSelected, setToggleIdSelected] = useState(null);
 
-  const button = (
-    <EuiButton color="primary" onClick={() => setShowBar(!showBar)}>
-      Toggle appearance of the bottom bar
-    </EuiButton>
-  );
+  const toggleButtons = [
+    {
+      id: 'bottomBarStandard',
+      label: 'Show bottom bar',
+    },
+    {
+      id: 'bottomBarWithoutAffordForDisplacement',
+      label: 'Show bottom bar (without affordForDisplacement behavior)',
+    },
+  ];
 
-  let bottomBar;
-  if (showBar) {
-    bottomBar = (
-      <EuiBottomBar>
-        <EuiFlexGroup justifyContent="spaceBetween">
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup gutterSize="s">
-              <EuiFlexItem grow={false}>
-                <EuiButton color="ghost" size="s" iconType="help">
-                  Help
-                </EuiButton>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiButton color="ghost" size="s" iconType="user">
-                  Add user
-                </EuiButton>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup gutterSize="s">
-              <EuiFlexItem grow={false}>
-                <EuiButtonEmpty color="ghost" size="s" iconType="cross">
-                  Discard
-                </EuiButtonEmpty>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiButton color="primary" fill size="s" iconType="check">
-                  Save
-                </EuiButton>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiBottomBar>
-    );
-  }
+  const onChange = optionId => {
+    setToggleIdSelected(optionId);
+  };
 
   return (
     <div>
-      {button}
-      {bottomBar}
+      <EuiButtonGroup
+        legend="Bottom Bar demo toggle buttons group"
+        type="single"
+        buttonSize="m"
+        options={toggleButtons}
+        idSelected={toggleIdSelected}
+        onChange={id => onChange(id)}
+      />
+
+      {toggleIdSelected === 'bottomBarStandard' && (
+        <EuiBottomBar>
+          <EuiFlexGroup justifyContent="spaceBetween">
+            <EuiFlexItem grow={false}>
+              <EuiFlexGroup gutterSize="s">
+                <EuiFlexItem grow={false}>
+                  <EuiButton color="ghost" size="s" iconType="help">
+                    Help
+                  </EuiButton>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiButton color="ghost" size="s" iconType="user">
+                    Add user
+                  </EuiButton>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiFlexGroup gutterSize="s">
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty
+                    onClick={() => setToggleIdSelected(null)}
+                    color="ghost"
+                    size="s"
+                    iconType="cross">
+                    Discard
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiButton color="primary" size="s" iconType="check" fill>
+                    Save
+                  </EuiButton>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiBottomBar>
+      )}
+
+      {toggleIdSelected === 'bottomBarWithoutAffordForDisplacement' && (
+        <EuiBottomBar affordForDisplacement={false}>
+          <EuiFlexGroup justifyContent="spaceBetween">
+            <EuiFlexItem grow={false}>
+              <EuiFlexGroup gutterSize="s">
+                <EuiFlexItem grow={false}>
+                  <EuiButton color="ghost" size="s" iconType="help">
+                    Help
+                  </EuiButton>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiButton color="ghost" size="s" iconType="user">
+                    Add user
+                  </EuiButton>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiFlexGroup gutterSize="s">
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty
+                    onClick={() => setToggleIdSelected(null)}
+                    color="ghost"
+                    size="s"
+                    iconType="cross">
+                    Discard
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiButton color="primary" size="s" iconType="check" fill>
+                    Save
+                  </EuiButton>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiBottomBar>
+      )}
     </div>
   );
 };

--- a/src-docs/src/views/bottom_bar/bottom_bar_example.js
+++ b/src-docs/src/views/bottom_bar/bottom_bar_example.js
@@ -38,13 +38,12 @@ export const BottomBarExample = {
             if a form is in a savable state.
           </p>
           <p>
-            There is a <EuiCode>affordForDisplacement</EuiCode> prop (defaulting
+            There is an <EuiCode>affordForDisplacement</EuiCode> prop (defaulting
             to <EuiCode>true</EuiCode>), which determines whether the component
-            makes room for itself by adding vertical padding equivalent to its
-            own height on the document body element - setting this to{' '}
-            <EuiCode>false</EuiCode> can be useful in cases such as a web app
-            where it is desired that the appearance of vertical scrollbars is
-            minimized.
+            makes room for itself by adding bottom padding equivalent to its
+            own height on the document body element. Setting this to{' '}
+            <EuiCode>false</EuiCode> can be useful to minimize scrollbars visibility
+            but will overlap body content.
           </p>
           <p>
             Like many of our other wrapper components,{' '}

--- a/src-docs/src/views/bottom_bar/bottom_bar_example.js
+++ b/src-docs/src/views/bottom_bar/bottom_bar_example.js
@@ -38,10 +38,20 @@ export const BottomBarExample = {
             if a form is in a savable state.
           </p>
           <p>
+            There is a <EuiCode>affordForDisplacement</EuiCode> prop (defaulting
+            to <EuiCode>true</EuiCode>), which determines whether the component
+            makes room for itself by adding vertical padding equivalent to its
+            own height on the document body element - setting this to{' '}
+            <EuiCode>false</EuiCode> can be useful in cases such as a web app
+            where it is desired that the appearance of vertical scrollbars is
+            minimized.
+          </p>
+          <p>
             Like many of our other wrapper components,{' '}
             <strong>EuiBottomBar</strong> accepts a{' '}
             <EuiCode>paddingSize</EuiCode> prop, which can be set to{' '}
-            <EuiCode>s / m / l / none</EuiCode>.
+            <EuiCode>s / m / l / none</EuiCode> - by default, it is set to{' '}
+            <EuiCode>m</EuiCode>.
           </p>
         </div>
       ),

--- a/src-docs/src/views/bottom_bar/bottom_bar_example.js
+++ b/src-docs/src/views/bottom_bar/bottom_bar_example.js
@@ -49,8 +49,7 @@ export const BottomBarExample = {
             Like many of our other wrapper components,{' '}
             <strong>EuiBottomBar</strong> accepts a{' '}
             <EuiCode>paddingSize</EuiCode> prop, which can be set to{' '}
-            <EuiCode>s / m / l / none</EuiCode> - by default, it is set to{' '}
-            <EuiCode>m</EuiCode>.
+            <EuiCode>s / m (default) / l / none</EuiCode>.
           </p>
         </div>
       ),

--- a/src/components/bottom_bar/bottom_bar.tsx
+++ b/src/components/bottom_bar/bottom_bar.tsx
@@ -38,34 +38,51 @@ export const paddingSizeToClassNameMap: {
 
 interface Props extends CommonProps {
   /**
+   * Padding applied to the bar. Default is 'm'.
+   */
+  paddingSize: BottomBarPaddingSize;
+
+  /**
+   * Whether the component should apply padding on the document body element to afford for its own displacement height.
+   * Default is true.
+   */
+  affordForDisplacement: boolean;
+
+  /**
    * Optional class applied to the body class
    */
   bodyClassName?: string;
 
   /**
-   * Padding applied to the bar
-   */
-  paddingSize?: BottomBarPaddingSize;
-
-  /**
-   * Customize the screen reader heading that helps users find this control. Default is "Page level controls".
+   * Customize the screen reader heading that helps users find this control. Default is 'Page level controls'.
    */
   landmarkHeading?: string;
 }
 
 export class EuiBottomBar extends Component<Props> {
+  static defaultProps = {
+    paddingSize: 'm',
+    affordForDisplacement: true,
+  };
+
   private bar: HTMLElement | null = null;
 
   componentDidMount() {
-    const height = this.bar ? this.bar.clientHeight : -1;
-    document.body.style.paddingBottom = `${height}px`;
+    if (this.props.affordForDisplacement) {
+      const height = this.bar ? this.bar.clientHeight : -1;
+      document.body.style.paddingBottom = `${height}px`;
+    }
+
     if (this.props.bodyClassName) {
       document.body.classList.add(this.props.bodyClassName);
     }
   }
 
   componentWillUnmount() {
-    document.body.style.paddingBottom = '';
+    if (this.props.affordForDisplacement) {
+      document.body.style.paddingBottom = '';
+    }
+
     if (this.props.bodyClassName) {
       document.body.classList.remove(this.props.bodyClassName);
     }
@@ -75,9 +92,10 @@ export class EuiBottomBar extends Component<Props> {
     const {
       children,
       className,
-      paddingSize = 'm',
+      paddingSize,
       bodyClassName,
       landmarkHeading,
+      affordForDisplacement, // eslint-disable-line no-unused-vars
       ...rest
     } = this.props;
 

--- a/src/components/bottom_bar/bottom_bar.tsx
+++ b/src/components/bottom_bar/bottom_bar.tsx
@@ -49,7 +49,7 @@ interface Props extends CommonProps {
   affordForDisplacement: boolean;
 
   /**
-   * Optional class applied to the body class
+   * Optional class applied to the body element on mount
    */
   bodyClassName?: string;
 


### PR DESCRIPTION
* Add new `affordForDisplacement` prop (default: true) to allow customization of whether the component makes room for itself by adding padding equivalent to its own height on the document body element.

Use case is a web app which ordinarily doesn't require vertical scrollbars (with a large enough browser viewport) - the existing unconfigurable behavior was forcing a vertical scrollbar to appear in this scenario, as can be seen in the updated component doc page.

* Make clear that the `paddingSize` prop default is "m".

### Summary

The most relevant previous code change this builds off is https://github.com/elastic/eui/pull/680 by @snide 

I understand that there is the facility to specify a custom `className` to effect this, but my rationale here is two-fold - it feels inelegant to have to set a custom CSS class with an `!important` rule in order to override the existing behavior (as it is achieved with inline styles), and IMO it is worthwhile having an explicit ability to opt-out of this behavior (whilst keeping the existing behavior as the default).

I've seen (quite late into making this change) that there is a similar [EuiControlBar](https://elastic.github.io/eui/#/navigation/control-bar) component which seems to be favored for future development effort - the same mechanism for automatically adding a height displacement occurs there too. If you are satisfied with my changes here, I will make the same component prop addition in that component, and then update the `CHANGELOG`.


### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
