### PR TITLE
[Docs] Add EuiColorPalettePicker to charts theming docs

### DIFF
--- a/src-docs/src/views/elastic_charts/theming.js
+++ b/src-docs/src/views/elastic_charts/theming.js
@@ -32,6 +32,7 @@ import {
   euiPalettePositive,
   euiPaletteGray,
 } from '../../../../src/services';
+
 const paletteData = {
   euiPaletteColorBlind,
   euiPaletteForStatus,

--- a/src-docs/src/views/elastic_charts/theming.js
+++ b/src-docs/src/views/elastic_charts/theming.js
@@ -59,14 +59,14 @@ export const Theming = () => {
           };
 
     return {
-      value: String(index),
+      value: paletteName,
       title: paletteName,
       palette: paletteData[paletteNames[index]](options),
       type: 'fixed',
     };
   });
 
-  const [barPalette, setBarPalette] = useState('0');
+  const [barPalette, setBarPalette] = useState('euiPaletteColorBlind');
 
   /**
    * Create data
@@ -83,12 +83,14 @@ export const Theming = () => {
     ? EUI_CHARTS_THEME_DARK.theme
     : EUI_CHARTS_THEME_LIGHT.theme;
 
+  const barPaletteIndex = paletteNames.findIndex(item => item === barPalette);
+
   const customTheme =
-    Number(barPalette) > 0
+    barPaletteIndex > 0
       ? [
           {
             colors: {
-              vizColors: paletteData[paletteNames[Number(barPalette)]](5),
+              vizColors: paletteData[paletteNames[barPaletteIndex]](5),
             },
           },
           theme,
@@ -126,7 +128,6 @@ export const Theming = () => {
             palettes={palettes}
             onChange={setBarPalette}
             valueOfSelected={barPalette}
-            compressed
           />
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/src-docs/src/views/elastic_charts/theming.js
+++ b/src-docs/src/views/elastic_charts/theming.js
@@ -13,7 +13,7 @@ import {
   EuiSpacer,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiSuperSelect,
+  EuiColorPalettePicker,
 } from '../../../../src/components';
 
 import {
@@ -43,22 +43,29 @@ const paletteData = {
   euiPaletteWarm,
   euiPaletteGray,
 };
+
 const paletteNames = Object.keys(paletteData);
 
 export const Theming = () => {
   const themeContext = useContext(ThemeContext);
 
-  /**
-   * Create palette select
-   */
-  const paletteOptions = paletteNames.map((paletteName, index) =>
-    createPaletteOption(paletteName, index)
-  );
+  const palettes = paletteNames.map((paletteName, index) => {
+    const options =
+      index > 0
+        ? 10
+        : {
+            sortBy: 'natural',
+          };
+
+    return {
+      value: String(index),
+      title: paletteName,
+      palette: paletteData[paletteNames[index]](options),
+      type: 'fixed',
+    };
+  });
 
   const [barPalette, setBarPalette] = useState('0');
-  const onBarPaletteChange = value => {
-    setBarPalette(value);
-  };
 
   /**
    * Create data
@@ -113,55 +120,15 @@ export const Theming = () => {
       </Chart>
       <EuiSpacer size="xxl" />
       <EuiFlexGroup justifyContent="center">
-        <EuiFlexItem grow={false}>
-          <EuiSuperSelect
-            id="setChartBarColor"
-            options={paletteOptions}
+        <EuiFlexItem grow={false} style={{ width: 300 }}>
+          <EuiColorPalettePicker
+            palettes={palettes}
+            onChange={setBarPalette}
             valueOfSelected={barPalette}
-            onChange={onBarPaletteChange}
-            aria-label="Bars color palette"
-            style={{ width: 300 }}
+            compressed
           />
         </EuiFlexItem>
       </EuiFlexGroup>
     </Fragment>
-  );
-};
-
-const createPaletteOption = function(paletteName, index) {
-  const options =
-    index > 0
-      ? 10
-      : {
-          sortBy: 'natural',
-        };
-
-  return {
-    value: String(index),
-    inputDisplay: createPalette(paletteData[paletteNames[index]](options)),
-    dropdownDisplay: (
-      <Fragment>
-        <strong>{paletteName}</strong>
-        <EuiSpacer size="xs" />
-        {createPalette(paletteData[paletteNames[index]](options))}
-      </Fragment>
-    ),
-  };
-};
-
-const createPalette = function(palette) {
-  return (
-    <EuiFlexGroup
-      className="guideColorPalette__swatchHolder"
-      gutterSize="none"
-      responsive={false}>
-      {palette.map(hexCode => (
-        <EuiFlexItem
-          key={hexCode}
-          className={'guideColorPalette__swatch--small'}>
-          <span title={hexCode} style={{ backgroundColor: hexCode }} />
-        </EuiFlexItem>
-      ))}
-    </EuiFlexGroup>
   );
 };


### PR DESCRIPTION
### Summary

This PR adds the **EuiColorPalettePicker** to the charts theming docs.

<img width="2038" alt="color_palette_picker_example@2x" src="https://user-images.githubusercontent.com/2750668/85416802-cdaa4080-b566-11ea-9dfa-722db5cce378.png">


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [x] Checked in **IE11** and **Firefox**
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
