### PR TITLE
Support different sizes for EuiHealth text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ No public interface changes since `26.0.1`.
 - Allowed user to enter hexcode for colors in `EuiStat` ([#3617](https://github.com/elastic/eui/pull/3617))
 - Extended `CommonProps` in `EuiColorPalettePickerPaletteTextProps`, `EuiColorPalettePickerPaletteFixedProps` and `EuiColorPalettePickerPaletteGradientProps` types ([#3616](https://github.com/elastic/eui/pull/3616))
 - Updated `onToggle` callback in `EuiAccordion` to  allow for external state control ([#3614](https://github.com/elastic/eui/pull/3614))
+- Added `size` prop to `EuiHealth` to allow different font sizes ([#3645](https://github.com/elastic/eui/pull/3645))
 
 **Bug fixes**
 

--- a/src-docs/src/views/health/health_example.js
+++ b/src-docs/src/views/health/health_example.js
@@ -46,7 +46,7 @@ export const HealthExample = {
   ),
   sections: [
     {
-      title: 'Colors',
+      title: 'Color',
       source: [
         {
           type: GuideSectionTypes.JS,
@@ -62,7 +62,7 @@ export const HealthExample = {
       demo: <Health />,
     },
     {
-      title: 'Sizes',
+      title: 'Size',
       source: [
         {
           type: GuideSectionTypes.JS,

--- a/src-docs/src/views/health/health_example.js
+++ b/src-docs/src/views/health/health_example.js
@@ -1,10 +1,15 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 
 import { renderToHtml } from '../../services';
 
 import { GuideSectionTypes } from '../../components';
 
-import { EuiHealth } from '../../../../src/components';
+import {
+  EuiCode,
+  EuiHealth,
+  EuiText,
+  EuiSpacer,
+} from '../../../../src/components';
 
 import Health from './health';
 const healthSource = require('!!raw-loader!./health');
@@ -14,10 +19,34 @@ const healthSnippet = [
   '<EuiHealth color="#33CC33">Custom color as hex</EuiHealth>',
 ];
 
+import HealthSize from './health_size';
+const healthSizeSource = require('!!raw-loader!./health_size');
+const healthSizeHtml = renderToHtml(HealthSize);
+const healthSizeSnippet = [
+  '<EuiHealth color="success">Healthy</EuiHealth>',
+  '<EuiHealth size="xs" color="success">Healthy</EuiHealth>',
+];
+
 export const HealthExample = {
   title: 'Health',
+  intro: (
+    <Fragment>
+      <EuiText>
+        <p>
+          The <strong>EuiHealth</strong> component should be used when showing
+          comparitive health of listed objects (like servers, HTTP response
+          status codes(as per convenience), nodes, indexes..etc). Because icons
+          are vague and bulky and color alone does not work, color plus text
+          provides a recognizable, lightweight combo that works in most
+          situations.
+        </p>
+      </EuiText>
+      <EuiSpacer size="l" />
+    </Fragment>
+  ),
   sections: [
     {
+      title: 'Colors',
       source: [
         {
           type: GuideSectionTypes.JS,
@@ -28,19 +57,31 @@ export const HealthExample = {
           code: healthHtml,
         },
       ],
-      text: (
-        <p>
-          The <strong>EuiHealth</strong> component should be used when showing
-          comparitive health of listed objects (like servers, HTTP response
-          status codes(as per convenience), nodes, indexes..etc). Because icons
-          are vague and bulky and color alone does not work, color plus text
-          provides a recognizable, lightweight combo that works in most
-          situations.
-        </p>
-      ),
       snippet: healthSnippet,
       props: { EuiHealth },
       demo: <Health />,
+    },
+    {
+      title: 'Sizes',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: healthSizeSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: healthSizeHtml,
+        },
+      ],
+      text: (
+        <p>
+          <strong>EuiHealth</strong> can be used at different sizes. If a size
+          is not specified, it will use the default size, <EuiCode>S</EuiCode>.
+        </p>
+      ),
+      snippet: healthSizeSnippet,
+      props: { EuiHealth },
+      demo: <HealthSize />,
     },
   ],
 };

--- a/src-docs/src/views/health/health_size.js
+++ b/src-docs/src/views/health/health_size.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { EuiHealth, EuiSpacer } from '../../../../src/components';
+
+export default () => (
+  <div>
+    <EuiHealth size="xs" color="success">
+      Extra small
+    </EuiHealth>
+
+    <EuiSpacer />
+
+    <EuiHealth color="success">Small (default)</EuiHealth>
+
+    <EuiSpacer />
+
+    <EuiHealth size="m" color="success">
+      Medium
+    </EuiHealth>
+  </div>
+);

--- a/src/components/health/__snapshots__/health.test.tsx.snap
+++ b/src/components/health/__snapshots__/health.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiHealth is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="euiHealth testClass1 testClass2"
+  class="euiHealth euiHealth--small testClass1 testClass2"
   data-test-subj="test subject string"
 >
   <div

--- a/src/components/health/_health.scss
+++ b/src/components/health/_health.scss
@@ -1,4 +1,15 @@
 .euiHealth {
-  @include euiFontSizeS;
   display: inline-block;
+}
+
+.euiHealth--medium {
+  @include euiFontSize;
+}
+
+.euiHealth--small {
+  @include euiFontSizeS;
+}
+
+.euiHealth--extraSmall {
+  @include euiFontSizeXS;
 }

--- a/src/components/health/health.tsx
+++ b/src/components/health/health.tsx
@@ -25,6 +25,14 @@ import { EuiIcon, IconColor } from '../icon';
 
 import { EuiFlexGroup, EuiFlexItem } from '../flex';
 
+export type HealthSize = 'xs' | 's' | 'm';
+
+const sizeToClassNameMap: { [size in HealthSize]: string | null } = {
+  xs: 'euiHealth--extraSmall',
+  s: 'euiHealth--small',
+  m: 'euiHealth--medium',
+};
+
 type EuiHealthProps = CommonProps &
   Omit<HTMLAttributes<HTMLDivElement>, 'color'> & {
     /**
@@ -33,15 +41,21 @@ type EuiHealthProps = CommonProps &
      * `subdued` or `ghost`; or any valid CSS color value as a `string`
      */
     color?: IconColor;
+    size?: HealthSize;
   };
 
 export const EuiHealth: FunctionComponent<EuiHealthProps> = ({
   children,
   className,
   color,
+  size = 's',
   ...rest
 }) => {
-  const classes = classNames('euiHealth', className);
+  const classes = classNames(
+    'euiHealth',
+    size ? sizeToClassNameMap[size] : null,
+    className
+  );
 
   return (
     <div className={classes} {...rest}>


### PR DESCRIPTION
### Summary

There have been places in our designs, such as compressed tables, where custom css was required to match the EuiHealth font size to the text in other cells. This PR adds a `size` prop to **EuiHealth** to change the font size. It can be `xs` (12px), `s` (14px), or `m` (16px). Defaults to `s`, which is the current font size for this component. 

![image](https://user-images.githubusercontent.com/847805/85434973-ced27200-b554-11ea-83d1-5197f9acf87d.png)

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [x] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
