### PR TITLE
[EuiContextMenu] Fix post-transition unclickable menu items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Added `gutterSize` prop to `EuiFacetGroup` ([#3639](https://github.com/elastic/eui/pull/3639))
 
+**Bug fixes**
+
+- Fixed `EuiContextMenu` panel `onAnimationEnd` transition bug in Chrome ([#3656](https://github.com/elastic/eui/pull/3656))
+
 ## [`26.1.0`](https://github.com/elastic/eui/tree/v26.1.0)
 
 - Optimized in-memory datagrid mount performance ([#3628](https://github.com/elastic/eui/pull/3628))

--- a/src-docs/src/views/context_menu/context_menu.js
+++ b/src-docs/src/views/context_menu/context_menu.js
@@ -94,7 +94,6 @@ export default () => {
             window.alert('Permalinks');
           },
         },
-        ,
       ],
     },
     {

--- a/src/components/context_menu/context_menu_panel.tsx
+++ b/src/components/context_menu/context_menu_panel.tsx
@@ -79,7 +79,6 @@ interface State {
     items: Props['items'];
   };
   menuItems: HTMLElement[];
-  isTransitioning: boolean;
   focusedItemIndex?: number;
   currentHeight?: number;
   height?: number;
@@ -104,7 +103,6 @@ export class EuiContextMenuPanel extends Component<Props, State> {
         items: this.props.items,
       },
       menuItems: [],
-      isTransitioning: Boolean(props.transitionType),
       focusedItemIndex: props.initialFocusedItemIndex,
       currentHeight: undefined,
     };
@@ -226,7 +224,7 @@ export class EuiContextMenuPanel extends Component<Props, State> {
 
       // Setting focus while transitioning causes the animation to glitch, so we have to wait
       // until it's finished before we focus anything.
-      if (this.state.isTransitioning) {
+      if (this.props.transitionType) {
         return;
       }
 
@@ -261,10 +259,6 @@ export class EuiContextMenuPanel extends Component<Props, State> {
   }
 
   onTransitionComplete = () => {
-    this.setState({
-      isTransitioning: false,
-    });
-
     if (this.props.onTransitionComplete) {
       this.props.onTransitionComplete();
     }
@@ -291,11 +285,6 @@ export class EuiContextMenuPanel extends Component<Props, State> {
       needsUpdate = true;
       nextState.menuItems = [];
       nextState.prevProps = { items: nextProps.items };
-    }
-
-    if (nextProps.transitionType) {
-      needsUpdate = true;
-      nextState.isTransitioning = true;
     }
 
     if (needsUpdate) {
@@ -349,7 +338,7 @@ export class EuiContextMenuPanel extends Component<Props, State> {
       return true;
     }
 
-    if (nextState.isTransitioning !== this.state.isTransitioning) {
+    if (nextProps.transitionType !== this.props.transitionType) {
       return true;
     }
 
@@ -470,8 +459,7 @@ export class EuiContextMenuPanel extends Component<Props, State> {
     const classes = classNames(
       'euiContextMenuPanel',
       className,
-      this.state.isTransitioning &&
-        transitionDirection &&
+      transitionDirection &&
         transitionType &&
         transitionDirectionAndTypeToClassNameMap[transitionDirection]
         ? transitionDirectionAndTypeToClassNameMap[transitionDirection][


### PR DESCRIPTION
### Summary

Fixes #3547, in which menu items in an **EuiContextMenuPanel** would become unclickable after animating in. The problem was caused by the applied animation class (e.g., `.euiContextMenuPanel-txOutRight`) that sets `pointer-events: none;` not being removed after the animation end.

This appeared only in Chromium browsers and was likely spurred on by a recent (unknown) change that resulted in a `setState` race condition.

The solution here is to bypass the offending state update by removing it entirely. The `isTransitioning` state flag was nothing more than an analog for the existence of the `transitionType` prop provided by the parent component and updated on the same events. Replacing `isTransitioning` and its `setState` methods with a truthy prop check simplifies logic without changing behavior.

Also fixed a bug in the docs that was causing prop type warnings in dev mode.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~

- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples

~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~

- [x] Checked for **breaking changes** and labeled appropriately

~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
