### PR TITLE
[Docs] Fix typo with EuiSuperSelect examples

### DIFF
--- a/src-docs/src/views/flyout/flyout_complicated.js
+++ b/src-docs/src/views/flyout/flyout_complicated.js
@@ -27,7 +27,7 @@ export default () => {
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
   const [selectedTabId, setSelectedTabId] = useState('1');
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-  const [superSelectvalue, setSuperSeelctValue] = useState('option_one');
+  const [superSelectvalue, setSuperSelectValue] = useState('option_one');
   const [isExpressionOpen, setIsExpressionOpen] = useState(false);
 
   const tabs = [
@@ -106,7 +106,7 @@ export default () => {
   ];
 
   const onSuperSelectChange = value => {
-    setSuperSeelctValue(value);
+    setSuperSelectValue(value);
   };
 
   const flyoutContent = (

--- a/src-docs/src/views/modal/modal.js
+++ b/src-docs/src/views/modal/modal.js
@@ -25,7 +25,7 @@ import { htmlIdGenerator } from '../../../../src/services';
 export default () => {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [isSwitchChecked, setIsSwitchChecked] = useState(true);
-  const [superSelectvalue, setSuperSeelctValue] = useState('option_one');
+  const [superSelectvalue, setSuperSelectValue] = useState('option_one');
 
   const onSwitchChange = () =>
     setIsSwitchChecked(isSwitchChecked => !isSwitchChecked);
@@ -118,7 +118,7 @@ export default () => {
   );
 
   const onSuperSelectChange = value => {
-    setSuperSeelctValue(value);
+    setSuperSelectValue(value);
   };
 
   let modal;


### PR DESCRIPTION
### Summary

There are some typos in src-docs. I think ```setSuperSeelctValue``` should be changed to ```setSuperSelectValue```.

### Checklist

~~- [ ] Check against **all themes** for compatibility in both light and dark modes~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **IE11** and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
~~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~~
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
~~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~~
