### PR TITLE
[EuiSkipLink] Fix TS types and Safari click issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 **Bug fixes**
 
 - Fixed `EuiContextMenu` panel `onAnimationEnd` transition bug in Chrome ([#3656](https://github.com/elastic/eui/pull/3656))
+- Fixed `EuiSkipLink` interactive props and Safari click issue ([#3665](https://github.com/elastic/eui/pull/3665))
 
 ## [`26.1.0`](https://github.com/elastic/eui/tree/v26.1.0)
 

--- a/src-docs/src/views/accessibility/skip_link.js
+++ b/src-docs/src/views/accessibility/skip_link.js
@@ -1,16 +1,18 @@
-import React, { Fragment, useState } from 'react';
+import React, { useState } from 'react';
 
-import { EuiSkipLink } from '../../../../src/components/accessibility/skip_link';
-import { EuiCallOut } from '../../../../src/components/call_out';
-import { EuiText } from '../../../../src/components/text';
-import { EuiSpacer } from '../../../../src/components/spacer';
-import { EuiSwitch } from '../../../../src/components/form/switch';
+import {
+  EuiSkipLink,
+  EuiCallOut,
+  EuiText,
+  EuiSpacer,
+  EuiSwitch,
+} from '../../../../src/components';
 
 export default () => {
   const [isFixed, setFixed] = useState(false);
 
   return (
-    <Fragment>
+    <>
       <EuiText>
         {isFixed ? (
           <p>
@@ -36,26 +38,21 @@ export default () => {
         onChange={e => setFixed(e.target.checked)}
       />
       <EuiSpacer />
-      {isFixed ? (
-        <Fragment>
-          <EuiSkipLink
-            destinationId="/utilities/accessibility"
-            position="fixed">
-            Skip to main content
-          </EuiSkipLink>
+      <EuiSkipLink
+        destinationId="/utilities/accessibility"
+        position={isFixed ? 'fixed' : 'static'}
+        data-test-subj="skip-link-demo-subj">
+        Skip to {isFixed && 'main '}content
+      </EuiSkipLink>
+      {isFixed && (
+        <>
           <EuiCallOut
             size="s"
             title="A functional &lsquo;Skip to main content&rsquo; link will be added to the EUI docs site once our URL format is updated."
             iconType="iInCircle"
           />
-        </Fragment>
-      ) : (
-        <EuiSkipLink
-          destinationId="/utilities/accessibility"
-          data-test-subj="skip-link-demo-subj">
-          Skip to content
-        </EuiSkipLink>
+        </>
       )}
-    </Fragment>
+    </>
   );
 };

--- a/src/components/accessibility/__snapshots__/skip_link.test.tsx.snap
+++ b/src/components/accessibility/__snapshots__/skip_link.test.tsx.snap
@@ -1,57 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiSkipLink is rendered 1`] = `
-<a
+<button
   aria-label="aria-label"
   class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--static testClass1 testClass2 euiButton--fill"
   data-test-subj="test subject string"
-  href="#somewhere"
-  rel="noreferrer"
+  type="button"
 >
   <span
     class="euiButton__content"
   >
     <span
       class="euiButton__text"
-    />
+    >
+      Skip
+    </span>
   </span>
-</a>
+</button>
 `;
 
-exports[`EuiSkipLink position absolute is rendered 1`] = `
-<a
-  class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--absolute euiButton--fill"
-  href="#somewhere"
-  rel="noreferrer"
->
-  <span
-    class="euiButton__content"
-  >
-    <span
-      class="euiButton__text"
-    />
-  </span>
-</a>
-`;
-
-exports[`EuiSkipLink position fixed is rendered 1`] = `
-<a
-  class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--fixed euiButton--fill"
-  href="#somewhere"
-  rel="noreferrer"
-  tabindex="0"
->
-  <span
-    class="euiButton__content"
-  >
-    <span
-      class="euiButton__text"
-    />
-  </span>
-</a>
-`;
-
-exports[`EuiSkipLink position static is rendered 1`] = `
+exports[`EuiSkipLink props destinationId is rendered 1`] = `
 <a
   class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--static euiButton--fill"
   href="#somewhere"
@@ -65,4 +33,97 @@ exports[`EuiSkipLink position static is rendered 1`] = `
     />
   </span>
 </a>
+`;
+
+exports[`EuiSkipLink props onClick and destinationId is rendered 1`] = `
+<a
+  class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--static euiButton--fill"
+  href="#somewhere"
+  rel="noreferrer"
+>
+  <span
+    class="euiButton__content"
+  >
+    <span
+      class="euiButton__text"
+    />
+  </span>
+</a>
+`;
+
+exports[`EuiSkipLink props onClick is rendered 1`] = `
+<button
+  class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--static euiButton--fill"
+  type="button"
+>
+  <span
+    class="euiButton__content"
+  >
+    <span
+      class="euiButton__text"
+    />
+  </span>
+</button>
+`;
+
+exports[`EuiSkipLink props position absolute is rendered 1`] = `
+<button
+  class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--absolute euiButton--fill"
+  type="button"
+>
+  <span
+    class="euiButton__content"
+  >
+    <span
+      class="euiButton__text"
+    />
+  </span>
+</button>
+`;
+
+exports[`EuiSkipLink props position fixed is rendered 1`] = `
+<button
+  class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--fixed euiButton--fill"
+  tabindex="0"
+  type="button"
+>
+  <span
+    class="euiButton__content"
+  >
+    <span
+      class="euiButton__text"
+    />
+  </span>
+</button>
+`;
+
+exports[`EuiSkipLink props position static is rendered 1`] = `
+<button
+  class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--static euiButton--fill"
+  type="button"
+>
+  <span
+    class="euiButton__content"
+  >
+    <span
+      class="euiButton__text"
+    />
+  </span>
+</button>
+`;
+
+exports[`EuiSkipLink props tabIndex is rendered 1`] = `
+<button
+  class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--static euiButton--fill"
+  tabindex="-1"
+  type="button"
+>
+  <span
+    class="euiButton__content"
+  >
+    <span
+      class="euiButton__text"
+    />
+  </span>
+</button>
 `;

--- a/src/components/accessibility/__snapshots__/skip_link.test.tsx.snap
+++ b/src/components/accessibility/__snapshots__/skip_link.test.tsx.snap
@@ -1,11 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiSkipLink is rendered 1`] = `
-<button
+<a
   aria-label="aria-label"
   class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--static testClass1 testClass2 euiButton--fill"
   data-test-subj="test subject string"
-  type="button"
+  href="#somewhere"
+  rel="noreferrer"
 >
   <span
     class="euiButton__content"
@@ -16,45 +17,14 @@ exports[`EuiSkipLink is rendered 1`] = `
       Skip
     </span>
   </span>
-</button>
-`;
-
-exports[`EuiSkipLink props destinationId is rendered 1`] = `
-<a
-  class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--static euiButton--fill"
-  href="#somewhere"
-  rel="noreferrer"
->
-  <span
-    class="euiButton__content"
-  >
-    <span
-      class="euiButton__text"
-    />
-  </span>
-</a>
-`;
-
-exports[`EuiSkipLink props onClick and destinationId is rendered 1`] = `
-<a
-  class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--static euiButton--fill"
-  href="#somewhere"
-  rel="noreferrer"
->
-  <span
-    class="euiButton__content"
-  >
-    <span
-      class="euiButton__text"
-    />
-  </span>
 </a>
 `;
 
 exports[`EuiSkipLink props onClick is rendered 1`] = `
-<button
+<a
   class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--static euiButton--fill"
-  type="button"
+  href="#somewhere"
+  rel="noreferrer"
 >
   <span
     class="euiButton__content"
@@ -63,13 +33,14 @@ exports[`EuiSkipLink props onClick is rendered 1`] = `
       class="euiButton__text"
     />
   </span>
-</button>
+</a>
 `;
 
 exports[`EuiSkipLink props position absolute is rendered 1`] = `
-<button
+<a
   class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--absolute euiButton--fill"
-  type="button"
+  href="#somewhere"
+  rel="noreferrer"
 >
   <span
     class="euiButton__content"
@@ -78,14 +49,15 @@ exports[`EuiSkipLink props position absolute is rendered 1`] = `
       class="euiButton__text"
     />
   </span>
-</button>
+</a>
 `;
 
 exports[`EuiSkipLink props position fixed is rendered 1`] = `
-<button
+<a
   class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--fixed euiButton--fill"
+  href="#somewhere"
+  rel="noreferrer"
   tabindex="0"
-  type="button"
 >
   <span
     class="euiButton__content"
@@ -94,13 +66,14 @@ exports[`EuiSkipLink props position fixed is rendered 1`] = `
       class="euiButton__text"
     />
   </span>
-</button>
+</a>
 `;
 
 exports[`EuiSkipLink props position static is rendered 1`] = `
-<button
+<a
   class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--static euiButton--fill"
-  type="button"
+  href="#somewhere"
+  rel="noreferrer"
 >
   <span
     class="euiButton__content"
@@ -109,14 +82,15 @@ exports[`EuiSkipLink props position static is rendered 1`] = `
       class="euiButton__text"
     />
   </span>
-</button>
+</a>
 `;
 
 exports[`EuiSkipLink props tabIndex is rendered 1`] = `
-<button
+<a
   class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--static euiButton--fill"
+  href="#somewhere"
+  rel="noreferrer"
   tabindex="-1"
-  type="button"
 >
   <span
     class="euiButton__content"
@@ -125,5 +99,5 @@ exports[`EuiSkipLink props tabIndex is rendered 1`] = `
       class="euiButton__text"
     />
   </span>
-</button>
+</a>
 `;

--- a/src/components/accessibility/_screen_reader.scss
+++ b/src/components/accessibility/_screen_reader.scss
@@ -1,4 +1,5 @@
+// The `:active` selector is necessary for Safari which removes `:focus` when a button is pressed
 .euiScreenReaderOnly,
-.euiScreenReaderOnly--showOnFocus:not(:focus) {
+.euiScreenReaderOnly--showOnFocus:not(:focus):not(:active) {
   @include euiScreenReaderOnly;
 }

--- a/src/components/accessibility/index.ts
+++ b/src/components/accessibility/index.ts
@@ -19,4 +19,4 @@
 
 export { EuiKeyboardAccessible } from './keyboard_accessible';
 export { EuiScreenReaderOnly } from './screen_reader';
-export { EuiSkipLink } from './skip_link';
+export { EuiSkipLink, EuiSkipLinkProps } from './skip_link';

--- a/src/components/accessibility/skip_link.test.tsx
+++ b/src/components/accessibility/skip_link.test.tsx
@@ -26,20 +26,46 @@ import { EuiSkipLink, POSITIONS } from './skip_link';
 describe('EuiSkipLink', () => {
   test('is rendered', () => {
     const component = render(
-      <EuiSkipLink destinationId="somewhere" {...requiredProps} />
+      <EuiSkipLink {...requiredProps}>Skip</EuiSkipLink>
     );
 
     expect(component).toMatchSnapshot();
   });
 
-  describe('position', () => {
-    POSITIONS.forEach(position => {
-      test(`${position} is rendered`, () => {
-        const component = render(
-          <EuiSkipLink position={position} destinationId="somewhere" />
-        );
+  describe('props', () => {
+    test('destinationId is rendered', () => {
+      const component = render(<EuiSkipLink destinationId="somewhere" />);
 
-        expect(component).toMatchSnapshot();
+      expect(component).toMatchSnapshot();
+    });
+
+    test('tabIndex is rendered', () => {
+      const component = render(<EuiSkipLink tabIndex={-1} />);
+
+      expect(component).toMatchSnapshot();
+    });
+
+    test('onClick is rendered', () => {
+      const component = render(<EuiSkipLink onClick={() => {}} />);
+
+      expect(component).toMatchSnapshot();
+    });
+
+    test('onClick and destinationId is rendered', () => {
+      const component = render(
+        <EuiSkipLink onClick={() => {}} destinationId="somewhere" />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
+    describe('position', () => {
+      POSITIONS.forEach(position => {
+        test(`${position} is rendered`, () => {
+          const component = render(<EuiSkipLink position={position} />);
+
+          expect(component).toMatchSnapshot();
+        });
       });
     });
   });

--- a/src/components/accessibility/skip_link.test.tsx
+++ b/src/components/accessibility/skip_link.test.tsx
@@ -26,34 +26,26 @@ import { EuiSkipLink, POSITIONS } from './skip_link';
 describe('EuiSkipLink', () => {
   test('is rendered', () => {
     const component = render(
-      <EuiSkipLink {...requiredProps}>Skip</EuiSkipLink>
+      <EuiSkipLink destinationId="somewhere" {...requiredProps}>
+        Skip
+      </EuiSkipLink>
     );
 
     expect(component).toMatchSnapshot();
   });
 
   describe('props', () => {
-    test('destinationId is rendered', () => {
-      const component = render(<EuiSkipLink destinationId="somewhere" />);
-
-      expect(component).toMatchSnapshot();
-    });
-
     test('tabIndex is rendered', () => {
-      const component = render(<EuiSkipLink tabIndex={-1} />);
+      const component = render(
+        <EuiSkipLink destinationId="somewhere" tabIndex={-1} />
+      );
 
       expect(component).toMatchSnapshot();
     });
 
     test('onClick is rendered', () => {
-      const component = render(<EuiSkipLink onClick={() => {}} />);
-
-      expect(component).toMatchSnapshot();
-    });
-
-    test('onClick and destinationId is rendered', () => {
       const component = render(
-        <EuiSkipLink onClick={() => {}} destinationId="somewhere" />
+        <EuiSkipLink destinationId="somewhere" onClick={() => {}} />
       );
 
       expect(component).toMatchSnapshot();
@@ -62,7 +54,9 @@ describe('EuiSkipLink', () => {
     describe('position', () => {
       POSITIONS.forEach(position => {
         test(`${position} is rendered`, () => {
-          const component = render(<EuiSkipLink position={position} />);
+          const component = render(
+            <EuiSkipLink destinationId="somewhere" position={position} />
+          );
 
           expect(component).toMatchSnapshot();
         });

--- a/src/components/accessibility/skip_link.tsx
+++ b/src/components/accessibility/skip_link.tsx
@@ -28,16 +28,18 @@ export const POSITIONS = ['static', 'fixed', 'absolute'] as Positions[];
 
 export interface EuiSkipLinkProps extends EuiButtonProps {
   /**
-   * If true, the link will be fixed to the top left of the viewport
+   * Change the display position of the element when focused.
+   * If 'fixed', the link will be fixed to the top left of the viewport
    */
   position?: Positions;
-
   /**
    * Typically an anchor id (e.g. `a11yMainContent`), the value provided
    * will be prepended with a hash `#` and used as the link `href`
    */
-  destinationId: string;
-
+  destinationId?: string;
+  /**
+   * When position is fixed, this is forced to `0`
+   */
   tabIndex?: number;
 }
 
@@ -55,9 +57,9 @@ type propsForButton = PropsForButton<
   }
 >;
 
-export type Props = ExclusiveUnion<propsForAnchor, propsForButton>;
+type Props = ExclusiveUnion<propsForAnchor, propsForButton>;
 
-export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
+export const EuiSkipLink: FunctionComponent<Props> = ({
   destinationId,
   tabIndex,
   position = 'static',
@@ -71,14 +73,22 @@ export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
     className
   );
 
+  // Create the `href` from `destinationId` IF provided
+  let optionalProps = {};
+  if (destinationId) {
+    optionalProps = {
+      href: `#${destinationId}`,
+    };
+  }
+
   return (
     <EuiScreenReaderOnly showOnFocus>
       <EuiButton
         className={classes}
-        href={`#${destinationId}`}
         tabIndex={position === 'fixed' ? 0 : tabIndex}
         size="s"
         fill
+        {...optionalProps}
         {...rest}>
         {children}
       </EuiButton>

--- a/src/components/accessibility/skip_link.tsx
+++ b/src/components/accessibility/skip_link.tsx
@@ -36,7 +36,7 @@ interface EuiSkipLinkInterface extends EuiButtonProps {
    * Typically an anchor id (e.g. `a11yMainContent`), the value provided
    * will be prepended with a hash `#` and used as the link `href`
    */
-  destinationId?: string;
+  destinationId: string;
   /**
    * When position is fixed, this is forced to `0`
    */
@@ -73,7 +73,7 @@ export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
     className
   );
 
-  // Create the `href` from `destinationId` IF provided
+  // Create the `href` from `destinationId`
   let optionalProps = {};
   if (destinationId) {
     optionalProps = {

--- a/src/components/accessibility/skip_link.tsx
+++ b/src/components/accessibility/skip_link.tsx
@@ -26,7 +26,7 @@ import { PropsForAnchor, PropsForButton, ExclusiveUnion } from '../common';
 type Positions = 'static' | 'fixed' | 'absolute';
 export const POSITIONS = ['static', 'fixed', 'absolute'] as Positions[];
 
-export interface EuiSkipLinkProps extends EuiButtonProps {
+interface EuiSkipLinkInterface extends EuiButtonProps {
   /**
    * Change the display position of the element when focused.
    * If 'fixed', the link will be fixed to the top left of the viewport
@@ -44,22 +44,22 @@ export interface EuiSkipLinkProps extends EuiButtonProps {
 }
 
 type propsForAnchor = PropsForAnchor<
-  EuiSkipLinkProps,
+  EuiSkipLinkInterface,
   {
     buttonRef?: Ref<HTMLAnchorElement>;
   }
 >;
 
 type propsForButton = PropsForButton<
-  EuiSkipLinkProps,
+  EuiSkipLinkInterface,
   {
     buttonRef?: Ref<HTMLButtonElement>;
   }
 >;
 
-type Props = ExclusiveUnion<propsForAnchor, propsForButton>;
+export type EuiSkipLinkProps = ExclusiveUnion<propsForAnchor, propsForButton>;
 
-export const EuiSkipLink: FunctionComponent<Props> = ({
+export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
   destinationId,
   tabIndex,
   position = 'static',


### PR DESCRIPTION
A couple issues arose when trying to use this component in Kibana. 


## Props


### Interactive props

There was a simple code error where the component's props was not **all** the props. It was referencing just the `EuiSkipLinkProps` instead of the `Prop` one which includes the `PropsForAnchor` and `PropsForButton` props to allow for `onClick` and such. So TS threw an error when trying to add `onClick`

### `destinationId`

~This prop was required but is too specific to only one possible use case/consuming ability. For instance, Discover's "Skip to bottom of table" button still has an Angular wrapper and so it needed to do the functionality via an `onClick` and not an `href`. I just made this one optional.~

**Update**: Is still required

## Safari

The browser had a weird state when you couldn't click the button with a mouse when in the focus state. As soon as you mouse down, the button would disappear again. I was able to fix this by appending `:not(:active)` to the selector for when to hide the button. This seems to fix the issue.

**Before**
![Screen Recording 2020-06-26 at 11 52 AM](https://user-images.githubusercontent.com/549577/85876479-c623ab00-b7a3-11ea-8b04-73cffafd6772.gif)


**After**
![Screen Recording 2020-06-26 at 11 53 AM](https://user-images.githubusercontent.com/549577/85876486-c9b73200-b7a3-11ea-94e4-c1c2ed33cbcf.gif)



### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [x] Checked in **Safari** and **Firefox**
- [x] Props have proper **autodocs**
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
