### PR TITLE
Add optional support for environment variables to override prompts in release.js

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -125,9 +125,29 @@ async function getVersionTypeFromChangelog() {
   console.log(chalk.gray(unreleasedchanges));
   console.log('');
   console.log(`${chalk.magenta('The recommended version update for these changes is')} ${chalk.blue(humanReadableRecommendation)}`);
-  console.log(`${chalk.magenta('What part of the package version do you want to bump?')} ${chalk.gray('(major, minor, patch)')}`);
 
-  return await promptUserForVersionType();
+  // checking for VERSION_TYPE environment variable, which overrides prompts to
+  // the user to choose a version type; this is used by CI to automate releases
+  const envVersion = process.env.VERSION_TYPE;
+  if (envVersion) {
+    // detected version type preference set
+    console.log(`${chalk.magenta('VERSION_TYPE environment variable identifed, set to')} ${chalk.blue(envVersion)}`);
+
+    if (['major', 'minor', 'patch'].indexOf(envVersion) === -1) {
+      console.error(`${chalk.magenta('VERSION_TYPE environment variable is not "major", "minor" or "patch"')}`);
+      process.exit(1);
+    }
+
+    if (envVersion !== recommendedType) {
+      console.warn(`${chalk.yellow('WARNING: VERSION_TYPE does not match recommended version update')}`);
+    }
+
+    return envVersion;
+  } else {
+    console.log(`${chalk.magenta('What part of the package version do you want to bump?')} ${chalk.gray('(major, minor, patch)')}`);
+
+    return await promptUserForVersionType();
+  }
 }
 
 async function promptUserForVersionType() {

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -182,6 +182,13 @@ async function getOneTimePassword() {
   console.log(chalk.magenta(`Preparing to publish @elastic/eui@${version} to npm registry`));
   console.log('');
   console.log(chalk.magenta('The @elastic organization requires membership and 2FA to publish'));
+
+  if (process.env.NPM_OTP) {
+    // skip prompting user for manual input if NPM_OTP env var is present
+    console.log(chalk.magenta('2FA code provided by NPM_OTP environment variable'));
+    return process.env.NPM_OTP;
+  }
+
   console.log(chalk.magenta('What is your one-time password?'));
 
   return await promptUserForOneTimePassword();


### PR DESCRIPTION
### Summary

Updates release.js script to check for `VERSION_TYPE` and `NPM_OTP` environment variables before prompting for manual input. This will help support automating future EUI releases.

### Checklist

 n/a
