### PR TITLE
Add subdued color option to EuiButtonEmpty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added `gutterSize` prop to `EuiFacetGroup` ([#3639](https://github.com/elastic/eui/pull/3639))
 - Updated props of `EuiCode` and `EuiCodeBlock` to reflect only functional props ([#3647](https://github.com/elastic/eui/pull/3647))
+- Added `subdued` color option to `EuiButtonEmpty` ([#3667](https://github.com/elastic/eui/pull/3667))
 
 **Bug fixes**
 

--- a/src-docs/src/views/button/button_empty.js
+++ b/src-docs/src/views/button/button_empty.js
@@ -211,6 +211,76 @@ export default () => (
     <EuiFlexGroup gutterSize="s" alignItems="center">
       <EuiFlexItem grow={false}>
         <EuiButtonEmpty
+          color="subdued"
+          onClick={() => window.alert('Button clicked')}>
+          Subdued
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="subdued"
+          size="s"
+          onClick={() => window.alert('Button clicked')}>
+          small
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="subdued"
+          size="xs"
+          onClick={() => window.alert('Button clicked')}>
+          extra small
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+
+    <EuiFlexGroup gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="subdued"
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowDown">
+          Subdued
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="subdued"
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowDown">
+          small
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="subdued"
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowDown"
+          iconSide="right">
+          Subdued
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          color="subdued"
+          size="s"
+          onClick={() => window.alert('Button clicked')}
+          iconType="arrowDown"
+          iconSide="right">
+          small
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+
+    <EuiFlexGroup gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
           color="danger"
           onClick={() => window.alert('Button clicked')}
           isDisabled>

--- a/src/components/button/button_empty/__snapshots__/button_empty.test.tsx.snap
+++ b/src/components/button/button_empty/__snapshots__/button_empty.test.tsx.snap
@@ -79,6 +79,21 @@ exports[`EuiButtonEmpty props color primary is rendered 1`] = `
 </button>
 `;
 
+exports[`EuiButtonEmpty props color subdued is rendered 1`] = `
+<button
+  class="euiButtonEmpty euiButtonEmpty--subdued"
+  type="button"
+>
+  <span
+    class="euiButtonEmpty__content"
+  >
+    <span
+      class="euiButtonEmpty__text"
+    />
+  </span>
+</button>
+`;
+
 exports[`EuiButtonEmpty props color text is rendered 1`] = `
 <button
   class="euiButtonEmpty euiButtonEmpty--text"

--- a/src/components/button/button_empty/_button_empty.scss
+++ b/src/components/button/button_empty/_button_empty.scss
@@ -71,6 +71,7 @@ $euiButtonEmptyTypes: (
   disabled: $euiButtonColorDisabledText,
   ghost: $euiColorGhost,
   text: $euiTextColor,
+  subdued: $euiTextSubduedColor,
 );
 
 // Create button modifiders based upon the map.

--- a/src/components/button/button_empty/button_empty.tsx
+++ b/src/components/button/button_empty/button_empty.tsx
@@ -37,7 +37,8 @@ export type EuiButtonEmptyColor =
   | 'danger'
   | 'disabled'
   | 'text'
-  | 'ghost';
+  | 'ghost'
+  | 'subdued';
 
 const colorToClassNameMap: { [color in EuiButtonEmptyColor]: string } = {
   primary: 'euiButtonEmpty--primary',
@@ -45,6 +46,7 @@ const colorToClassNameMap: { [color in EuiButtonEmptyColor]: string } = {
   disabled: 'euiButtonEmpty--disabled',
   text: 'euiButtonEmpty--text',
   ghost: 'euiButtonEmpty--ghost',
+  subdued: 'euiButtonEmpty--subdued',
 };
 
 export const COLORS = keysOf(colorToClassNameMap);


### PR DESCRIPTION
### Summary

This PR adds the color `subdued` as an option to the **EuiButtonEmpty**.

### Why 

In one design I'm currently working on, I want to use a **EuiButtonEmpty** with an icon near a **EuiButtonIcon** with a `color="subdued"`.  

But the **EuiButtonEmpty** doesn't have the `subdued` as a color option. So it doesn't look good near the other buttons.

I could use the `text` color for all the buttons but I want them to be more subtle. 

<img width="1016" alt="emptybutton@2x" src="https://user-images.githubusercontent.com/2750668/85879125-b622c000-b7d1-11ea-802f-96a7e8783797.png">

### Design Preview

<img width="549" alt="Screenshot 2020-06-26 at 17 36 08" src="https://user-images.githubusercontent.com/2750668/85880222-912f4c80-b7d3-11ea-9bf9-421133c63e89.png">



### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [x] Checked in **IE11** and **Firefox**
- [x ] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
