### PR TITLE
[EuiSelectable] Focus option after search value change

### DIFF
--- a/src-docs/src/views/selectable/selectable_custom_render.js
+++ b/src-docs/src/views/selectable/selectable_custom_render.js
@@ -13,7 +13,6 @@ import { createDataStore } from '../tables/data_store';
 export default () => {
   const countries = createDataStore().countries.map(country => {
     return {
-      id: country.code,
       label: `${country.name}`,
       prepend: country.flag,
       append: <EuiBadge>{country.code}</EuiBadge>,

--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -194,7 +194,6 @@ export class EuiSelectable extends Component<
   };
 
   onFocus = () => {
-    console.log(this.state.visibleOptions);
     if (!this.state.visibleOptions.length || this.state.activeOptionIndex) {
       return;
     }
@@ -525,7 +524,6 @@ export class EuiSelectable extends Component<
             searchValue={searchValue}
             activeOptionIndex={activeOptionIndex}
             setActiveOptionIndex={(index, cb) => {
-              console.log('set');
               this.setState({ activeOptionIndex: index }, cb);
             }}
             onOptionClick={this.onOptionClick}

--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -326,6 +326,7 @@ export class EuiSelectable extends Component<
   onOptionClick = (options: EuiSelectableOption[]) => {
     this.setState(state => ({
       visibleOptions: getMatchingOptions(options, state.searchValue),
+      activeOptionIndex: this.state.activeOptionIndex,
     }));
     if (this.props.onChange) {
       this.props.onChange(options);

--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -518,9 +518,9 @@ export class EuiSelectable extends Component<
             visibleOptions={visibleOptions}
             searchValue={searchValue}
             activeOptionIndex={activeOptionIndex}
-            setActiveOptionIndex={index =>
-              this.setState({ activeOptionIndex: index })
-            }
+            setActiveOptionIndex={(index, cb) => {
+              this.setState({ activeOptionIndex: index }, cb);
+            }}
             onOptionClick={this.onOptionClick}
             singleSelection={singleSelection}
             ref={this.optionsListRef}

--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -194,7 +194,7 @@ export class EuiSelectable extends Component<
   };
 
   onFocus = () => {
-    if (!this.state.visibleOptions.length) {
+    if (!this.state.visibleOptions.length || this.state.activeOptionIndex) {
       return;
     }
 

--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -194,6 +194,7 @@ export class EuiSelectable extends Component<
   };
 
   onFocus = () => {
+    console.log(this.state.visibleOptions);
     if (!this.state.visibleOptions.length || this.state.activeOptionIndex) {
       return;
     }
@@ -254,6 +255,10 @@ export class EuiSelectable extends Component<
           activeOptionIndex: this.state.visibleOptions.length - 1,
         });
         break;
+
+      default:
+        this.setState({ activeOptionIndex: undefined }, this.onFocus);
+        break;
     }
   };
 
@@ -307,6 +312,7 @@ export class EuiSelectable extends Component<
       {
         visibleOptions,
         searchValue,
+        activeOptionIndex: undefined,
       },
       () => {
         if (this.state.isFocused) {
@@ -519,6 +525,7 @@ export class EuiSelectable extends Component<
             searchValue={searchValue}
             activeOptionIndex={activeOptionIndex}
             setActiveOptionIndex={(index, cb) => {
+              console.log('set');
               this.setState({ activeOptionIndex: index }, cb);
             }}
             onOptionClick={this.onOptionClick}

--- a/src/components/selectable/selectable_list/selectable_list.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.tsx
@@ -106,7 +106,7 @@ export type EuiSelectableListProps = EuiSelectableOptionsListProps & {
   searchable?: boolean;
   makeOptionId: (index: number | undefined) => string;
   listId: string;
-  setActiveOptionIndex: (index: number) => void;
+  setActiveOptionIndex: (index: number, cb?: () => void) => void;
 };
 
 export class EuiSelectableList extends Component<EuiSelectableListProps> {
@@ -336,16 +336,17 @@ export class EuiSelectableList extends Component<EuiSelectableListProps> {
     const { allowExclusions } = this.props;
 
     this.props.setActiveOptionIndex(
-      this.props.options.findIndex(({ label }) => label === option.label)
+      this.props.options.findIndex(({ label }) => label === option.label),
+      () => {
+        if (option.checked === 'on' && allowExclusions) {
+          this.onExcludeOption(option);
+        } else if (option.checked === 'on' || option.checked === 'off') {
+          this.onRemoveOption(option);
+        } else {
+          this.onAddOption(option);
+        }
+      }
     );
-
-    if (option.checked === 'on' && allowExclusions) {
-      this.onExcludeOption(option);
-    } else if (option.checked === 'on' || option.checked === 'off') {
-      this.onRemoveOption(option);
-    } else {
-      this.onAddOption(option);
-    }
   };
 
   private onAddOption = (addedOption: EuiSelectableOption) => {

--- a/src/components/selectable/selectable_list/selectable_list.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.tsx
@@ -336,10 +336,10 @@ export class EuiSelectableList extends Component<EuiSelectableListProps> {
       return;
     }
 
-    const { allowExclusions } = this.props;
+    const { allowExclusions, options, visibleOptions = options } = this.props;
 
     this.props.setActiveOptionIndex(
-      this.props.options.findIndex(({ label }) => label === option.label),
+      visibleOptions.findIndex(({ label }) => label === option.label),
       () => {
         if (option.checked === 'on' && allowExclusions) {
           this.onExcludeOption(option);

--- a/src/components/selectable/selectable_list/selectable_list.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.tsx
@@ -223,6 +223,9 @@ export class EuiSelectableList extends Component<EuiSelectableListProps> {
         id={this.props.makeOptionId(index)}
         style={style}
         key={key || label.toLowerCase()}
+        onMouseDown={() => {
+          this.props.setActiveOptionIndex(index);
+        }}
         onClick={() => this.onAddOrRemoveOption(option)}
         ref={ref ? ref.bind(null, index) : undefined}
         isFocused={this.props.activeOptionIndex === index}

--- a/src/components/selectable/selectable_list/selectable_list_item.tsx
+++ b/src/components/selectable/selectable_list/selectable_list_item.tsx
@@ -163,10 +163,6 @@ export class EuiSelectableListItem extends Component<
       );
     }
 
-    if (allowExclusions) {
-      console.log({ state, instruction });
-    }
-
     return (
       <li
         // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role

--- a/src/components/selectable/selectable_search/selectable_search.test.tsx
+++ b/src/components/selectable/selectable_search/selectable_search.test.tsx
@@ -26,7 +26,12 @@ import { EuiSelectableSearch } from './selectable_search';
 describe('EuiSelectableSearch', () => {
   test('is rendered', () => {
     const component = render(
-      <EuiSelectableSearch options={[]} listId="list" {...requiredProps} />
+      <EuiSelectableSearch
+        options={[]}
+        listId="list"
+        onChange={() => {}}
+        {...requiredProps}
+      />
     );
 
     expect(component).toMatchSnapshot();
@@ -35,7 +40,12 @@ describe('EuiSelectableSearch', () => {
   describe('props', () => {
     test('defaultValue', () => {
       const component = render(
-        <EuiSelectableSearch options={[]} listId="list" defaultValue="Mi" />
+        <EuiSelectableSearch
+          options={[]}
+          listId="list"
+          onChange={() => {}}
+          defaultValue="Mi"
+        />
       );
 
       expect(component).toMatchSnapshot();

--- a/src/components/selectable/selectable_search/selectable_search.tsx
+++ b/src/components/selectable/selectable_search/selectable_search.tsx
@@ -29,7 +29,7 @@ export type EuiSelectableSearchProps = Omit<EuiFieldSearchProps, 'onChange'> &
     /**
      * Passes back (matchingOptions, searchValue)
      */
-    onChange?: (
+    onChange: (
       matchingOptions: EuiSelectableOption[],
       searchValue: string
     ) => void;
@@ -59,22 +59,17 @@ export class EuiSelectableSearch extends Component<
   }
 
   componentDidMount() {
-    const { options } = this.props;
     const { searchValue } = this.state;
-    const matchingOptions = getMatchingOptions(options, searchValue);
-    this.passUpMatches(matchingOptions, searchValue);
+    const matchingOptions = getMatchingOptions(this.props.options, searchValue);
+    this.props.onChange(matchingOptions, searchValue);
   }
 
   onSearchChange = (value: string) => {
-    this.setState({ searchValue: value });
-    const { options } = this.props;
-    const matchingOptions = getMatchingOptions(options, value);
-    this.passUpMatches(matchingOptions, value);
-  };
-
-  passUpMatches = (matches: EuiSelectableOption[], searchValue: string) => {
-    if (this.props.onChange) {
-      this.props.onChange(matches, searchValue);
+    if (value !== this.state.searchValue) {
+      this.setState({ searchValue: value }, () => {
+        const matchingOptions = getMatchingOptions(this.props.options, value);
+        this.props.onChange(matchingOptions, value);
+      });
     }
   };
 


### PR DESCRIPTION
### Summary

Fixes [bug report](https://github.com/elastic/eui/pull/3169#pullrequestreview-438550377) from @cchaos:
> The only thing I felt odd in the functionality was when the list was filtered down from the search box, and an option is selected it loses focus where as it would normally stay focused.

Also fixes [follow-up bug](https://github.com/elastic/eui/pull/3670#issuecomment-651872086) also found by @cchaos of selecting an option after searching would lose focus.

### Breaking changes
- `options` passed into **EuiSelectable** cannot have an `id` (an `id` is generated internally)
	- This feels kind of risky but this wasn't documented as a possibility before so it shouldn't be too bad (out of 23 uses in Kibana, none passed in an `id`)
- Requires an `onChange` to be passed into **EuiSelectableSearch**
	- Not meant to be used outside of EUI and isn't documented individually though is exported so probably won't have much impact
	- The component doesn't do anything without it, so simplified the types to expected usage