### PR TITLE
EuiStat change tags to use components inside.

### DIFF
--- a/src/components/stat/stat.tsx
+++ b/src/components/stat/stat.tsx
@@ -114,25 +114,25 @@ export const EuiStat: FunctionComponent<
 
   const descriptionDisplay = (
     <EuiText size="s" className="euiStat__description">
-      <p aria-hidden="true">{description}</p>
+      <span aria-hidden="true">{description}</span>
     </EuiText>
   );
 
   const titleDisplay = isColorClass(titleColor) ? (
     <EuiTitle size={titleSize} className={titleClasses}>
-      <p aria-hidden="true">{isLoading ? '--' : title}</p>
+      <span aria-hidden="true">{isLoading ? '--' : title}</span>
     </EuiTitle>
   ) : (
     <EuiTitle size={titleSize} className={titleClasses}>
-      <p aria-hidden="true" style={{ color: `${titleColor}` }}>
+      <span aria-hidden="true" style={{ color: `${titleColor}` }}>
         {isLoading ? '--' : title}
-      </p>
+      </span>
     </EuiTitle>
   );
 
   const screenReader = (
     <EuiScreenReaderOnly>
-      <p>
+      <span>
         {isLoading ? (
           <EuiI18n token="euiStat.loadingText" default="Statistic is loading" />
         ) : (
@@ -140,7 +140,7 @@ export const EuiStat: FunctionComponent<
             {reverse ? `${title} ${description}` : `${description} ${title}`}
           </Fragment>
         )}
-      </p>
+      </span>
     </EuiScreenReaderOnly>
   );
 


### PR DESCRIPTION
### Summary

Hi guys!
With this PR a modification is made to the _EuiStat_ component. When rendering title and description it was done as a "_p_" tag this caused an error if you work with any component within it.
With these changes you can already include Eui components or custom components within Stat.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
