### PR TITLE
CI job to publish a new version of EUI to npm

### DIFF
--- a/.ci/jobs/elastic+eui+npm-publish.yml
+++ b/.ci/jobs/elastic+eui+npm-publish.yml
@@ -27,11 +27,11 @@
 
           export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
 
-          export GITHUB_TOKEN=$(vault read -field=github_token secret/kibana-issues/dev/kibanamachine)
           # write npm auth to .npmrc
           NPM_TOKEN=$(vault read -field=token secret/jenkins-ci/npmjs/elasticmachine)
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
 
+          # get 2FA code
           export NPM_OTP=$(vault read --field=code totp/code/npmjs-elasticmachine)
 
           unset VAULT_ROLE_ID VAULT_SECRET_ID VAULT_ADDR VAULT_TOKEN VAULT_ACCOUNT

--- a/.ci/jobs/elastic+eui+npm-publish.yml
+++ b/.ci/jobs/elastic+eui+npm-publish.yml
@@ -1,0 +1,50 @@
+---
+- job:
+    name: elastic+eui+npm-publish
+    display-name: elastic / eui - npm-publish
+    description: "Publish a version of EUI to @elastic/eui on npm"
+    scm:
+      - git:
+          refspec: +refs/heads/*:refs/remotes/origin/*
+    triggers: []
+    node: linux && immutable && docker
+    vault:
+      # auth/approle/role/kibana-issues/role-id
+      role_id: 443f9500-f443-19ba-d698-1a48e104f8ba
+    parameters:
+      - choice:
+          name: version_type
+          description: What semantic version change should be published
+          choices:
+            - major
+            - minor
+            - patch
+    builders:
+      - shell: |-
+          #!/usr/local/bin/runbld
+          set -eo pipefail
+          set +x
+
+          export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+
+          export GITHUB_TOKEN=$(vault read -field=github_token secret/kibana-issues/dev/kibanamachine)
+          # write npm auth to .npmrc
+          NPM_TOKEN=$(vault read -field=token secret/jenkins-ci/npmjs/elasticmachine)
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+
+          export NPM_OTP=$(vault read --field=code totp/code/npmjs-elasticmachine)
+
+          unset VAULT_ROLE_ID VAULT_SECRET_ID VAULT_ADDR VAULT_TOKEN VAULT_ACCOUNT
+
+          set -x
+
+          export NVM_DIR="/var/lib/jenkins/.nvm"
+          [[ -s "$NVM_DIR/nvm.sh" ]] && . "$NVM_DIR/nvm.sh"
+
+          nvm install 10
+
+          nvm use 10 --delete-prefix
+          npm install -g yarn
+
+          export VERSION_TYPE=${version_type}
+          npm run release


### PR DESCRIPTION
### Summary

Adds an ⚠️EXPERIMENTAL⚠️ job to publish a new release to npm using release.js.

For a number of reasons, I am not able to fully test this locally. Not least of which is the fact that actually publishing to npm during my testing is not something I wanted to do.

All that said, I would love to merge this so that it can be run by a member of the EUI team for their next release and see how it goes! If it doesn't fully succeed, we'd just have to do some manual cleanup, like remove tags from the repo and, hopefully this is unlikely, unpublish the package from npm.

### Checklist

n/a