### PR TITLE
Fix docs site when local storage theme does not exist

### DIFF
--- a/src-docs/src/components/with_theme/theme_context.tsx
+++ b/src-docs/src/components/with_theme/theme_context.tsx
@@ -3,8 +3,10 @@ import { EUI_THEMES, EUI_THEME } from '../../../../src/themes';
 // @ts-ignore importing from a JS file
 import { applyTheme } from '../../services';
 
+const THEME_NAMES = EUI_THEMES.map(({ value }) => value);
+
 const defaultState = {
-  theme: EUI_THEMES[0].value,
+  theme: THEME_NAMES[0],
   changeTheme: (themeValue: EUI_THEME['value']) => {
     applyTheme(themeValue);
   },
@@ -20,7 +22,8 @@ export class ThemeProvider extends React.Component<object, State> {
   constructor(props: object) {
     super(props);
 
-    const theme = localStorage.getItem('theme') || defaultState.theme;
+    let theme = localStorage.getItem('theme');
+    if (!theme || !THEME_NAMES.includes(theme)) theme = defaultState.theme;
     applyTheme(theme);
 
     this.state = {


### PR DESCRIPTION
### Summary

Fixes #3674 where the docs site fails to load if the theme key in local storage does not exist in the application.

Tested with:

* valid theme key
* invalid theme key
* no value in local storage

~### Checklist~