### PR TITLE
Fixed 'react-ace' problem

### DIFF
--- a/src-docs/src/views/code_editor/code_editor.js
+++ b/src-docs/src/views/code_editor/code_editor.js
@@ -1,12 +1,11 @@
 import React, { useState } from 'react';
 
-import 'react-ace'; // this import can be omitted from your project, but is required for our Code Sandbox demo link to work
+import { EuiCodeEditor } from '../../../../src/components';
 import 'brace/theme/github';
 import 'brace/mode/javascript';
 import 'brace/snippets/javascript';
 import 'brace/ext/language_tools';
 
-import { EuiCodeEditor } from '../../../../src/components';
 
 export default () => {
   const [value, updateValue] = useState('');

--- a/src-docs/src/views/code_editor/code_editor.js
+++ b/src-docs/src/views/code_editor/code_editor.js
@@ -6,7 +6,6 @@ import 'brace/mode/javascript';
 import 'brace/snippets/javascript';
 import 'brace/ext/language_tools';
 
-
 export default () => {
   const [value, updateValue] = useState('');
 


### PR DESCRIPTION
### Summary

Fixed 'react-ace' problem. When `sandbox` renders `ace` not defined.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
- [x] Fixed **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
