### PR TITLE
Passed buffer as 0 to fix extra gap in `EuiSuperSelect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Fixed `EuiSkipLink` interactive props and Safari click issue ([#3665](https://github.com/elastic/eui/pull/3665))
 - Fixed `z-index` issues with `EuiHeader`, `EuiFlyout`, and other portal content ([#3655](https://github.com/elastic/eui/pull/3655))
 - Fixed `color` prop error in `EuiBadge` to be more flexible with what format it accepts ([#3655](https://github.com/elastic/eui/pull/3655))
-- Fixed extra spacing issue with `EuiSuperSelect` ([#3685](https://github.com/elastic/eui/pull/3685))
+- Fixed `EuiSuperSelect` popover from moving 16px horizontally when it's close to a window edge ([#3685](https://github.com/elastic/eui/pull/3685))
 
 **Theme: Amsterdam**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed `EuiSkipLink` interactive props and Safari click issue ([#3665](https://github.com/elastic/eui/pull/3665))
 - Fixed `z-index` issues with `EuiHeader`, `EuiFlyout`, and other portal content ([#3655](https://github.com/elastic/eui/pull/3655))
 - Fixed `color` prop error in `EuiBadge` to be more flexible with what format it accepts ([#3655](https://github.com/elastic/eui/pull/3655))
+- Fixed extra spacing issue with `EuiSuperSelect` ([#3685](https://github.com/elastic/eui/pull/3685))
 
 **Theme: Amsterdam**
 

--- a/src/components/color_picker/color_palette_picker/__snapshots__/color_palette_picker.test.tsx.snap
+++ b/src/components/color_picker/color_palette_picker/__snapshots__/color_palette_picker.test.tsx.snap
@@ -591,6 +591,7 @@ exports[`EuiColorPalettePicker more props are propagated to each option 2`] = `
   >
     <EuiPopover
       anchorPosition="downCenter"
+      buffer={0}
       button={
         <EuiSuperSelectControl
           className="euiSuperSelect--isOpen__button"

--- a/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
@@ -530,6 +530,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
 >
   <EuiPopover
     anchorPosition="downCenter"
+    buffer={0}
     button={
       <EuiSuperSelectControl
         className="euiSuperSelect--isOpen__button"

--- a/src/components/form/super_select/super_select.tsx
+++ b/src/components/form/super_select/super_select.tsx
@@ -339,7 +339,8 @@ export class EuiSuperSelect<T extends string> extends Component<
         anchorPosition="downCenter"
         ownFocus={false}
         popoverRef={this.setPopoverRef}
-        hasArrow={false}>
+        hasArrow={false}
+        buffer={0}>
         <EuiScreenReaderOnly>
           <p role="alert">
             <EuiI18n


### PR DESCRIPTION
### Summary
Sent `buffer` as 0 in the `EuiSuperSelect` component to avoid extra spacing.

### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **IE11** and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

@miukimiu Some ts related error is occurring, maybe y'all can take a look into it. 
![Screenshot 2020-07-02 at 4 21 11 AM](https://user-images.githubusercontent.com/53302612/86298507-85041e80-bc1b-11ea-9409-74e05bebccbe.jpg)

Closes #3565 

