### PR TITLE
SASS globals helper file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added `paddingSize` prop to `EuiCard` ([#3638](https://github.com/elastic/eui/pull/3638))
 - Added `isClearable` and `placeholder` options to `EuiColorPicker` ([#3689](https://github.com/elastic/eui/pull/3689))
+- Added SASS helper files for EUI theme globals ([#3691](https://github.com/elastic/eui/pull/3691))
 
 ## [`26.3.0`](https://github.com/elastic/eui/tree/v26.3.0)
 

--- a/src/global_styling/mixins/_form.scss
+++ b/src/global_styling/mixins/_form.scss
@@ -68,7 +68,6 @@
 @mixin euiFormControlText {
   @include euiFont;
   font-size: $euiFontSizeS;
-  line-height: 1em; // fixes text alignment in IE
   color: $euiTextColor;
 
   // sass-lint:disable-block mixins-before-declarations
@@ -85,6 +84,7 @@
   max-width: $euiFormMaxWidth;
   width: 100%;
   height: $height;
+  line-height: $height;
 
   @if ($includeAlternates) {
     &--fullWidth {
@@ -93,6 +93,7 @@
 
     &--compressed {
       height: $euiFormControlCompressedHeight;
+      line-height: $euiFormControlCompressedHeight;
     }
 
     &--inGroup {

--- a/src/global_styling/mixins/_form.scss
+++ b/src/global_styling/mixins/_form.scss
@@ -68,6 +68,7 @@
 @mixin euiFormControlText {
   @include euiFont;
   font-size: $euiFontSizeS;
+  line-height: 1em; // fixes text alignment in IE
   color: $euiTextColor;
 
   // sass-lint:disable-block mixins-before-declarations
@@ -84,7 +85,6 @@
   max-width: $euiFormMaxWidth;
   width: 100%;
   height: $height;
-  line-height: $height;
 
   @if ($includeAlternates) {
     &--fullWidth {
@@ -93,7 +93,6 @@
 
     &--compressed {
       height: $euiFormControlCompressedHeight;
-      line-height: $euiFormControlCompressedHeight;
     }
 
     &--inGroup {

--- a/src/themes/eui-amsterdam/eui_amsterdam_globals.scss
+++ b/src/themes/eui-amsterdam/eui_amsterdam_globals.scss
@@ -2,10 +2,10 @@
 // Must be imported AFTER a colors modifier file
 
 // Functions need to be first, since we use them in our variables and mixin definitions
-@import '../global_styling/functions/index';
+@import 'global_styling/functions/index';
 
 // Variables come next, and are used in some mixins
-@import '../global_styling/variables/index';
+@import 'global_styling/variables/index';
 
 // Mixins provide generic code expansion through helpers
-@import '../global_styling/mixins/index';
+@import 'global_styling/mixins/index';

--- a/src/themes/eui-amsterdam/eui_amsterdam_globals.scss
+++ b/src/themes/eui-amsterdam/eui_amsterdam_globals.scss
@@ -1,0 +1,11 @@
+// Helper file for supplying EUI Amsterdam globals (invisibles only)
+// Must be imported AFTER a colors modifier file
+
+// Functions need to be first, since we use them in our variables and mixin definitions
+@import '../global_styling/functions/index';
+
+// Variables come next, and are used in some mixins
+@import '../global_styling/variables/index';
+
+// Mixins provide generic code expansion through helpers
+@import '../global_styling/mixins/index';

--- a/src/themes/eui-amsterdam/global_styling/functions/_index.scss
+++ b/src/themes/eui-amsterdam/global_styling/functions/_index.scss
@@ -1,1 +1,4 @@
+// Import base theme first, then override
+@import '../../../../global_styling/functions/index';
+
 @import './shadows';

--- a/src/themes/eui-amsterdam/global_styling/index.scss
+++ b/src/themes/eui-amsterdam/global_styling/index.scss
@@ -1,15 +1,12 @@
 // Core
 
 // Functions need to be first, since we use them in our variables and mixin definitions
-@import '../../../global_styling/functions/index';
 @import 'functions/index';
 
 // Variables come next, and are used in some mixins
-@import '../../../global_styling/variables/index';
 @import 'variables/index';
 
 // Mixins provide generic code expansion through helpers
-@import '../../../global_styling/mixins/index';
 @import 'mixins/index';
 
 // Utility classes provide one-off selectors for common css problems

--- a/src/themes/eui-amsterdam/global_styling/mixins/_index.scss
+++ b/src/themes/eui-amsterdam/global_styling/mixins/_index.scss
@@ -1,3 +1,6 @@
+// Import base theme first, then override
+@import '../../../../global_styling/mixins/index';
+
 @import 'button';
 @import 'panel';
 @import 'shadow';

--- a/src/themes/eui-amsterdam/global_styling/variables/_index.scss
+++ b/src/themes/eui-amsterdam/global_styling/variables/_index.scss
@@ -1,3 +1,6 @@
+// Import base theme first, then override
+@import '../../../../global_styling/variables/index';
+
 @import 'buttons';
 @import 'borders';
 @import 'flyout';

--- a/src/themes/eui/eui_globals.scss
+++ b/src/themes/eui/eui_globals.scss
@@ -1,0 +1,11 @@
+// Helper file for supplying EUI globals (invisibles only)
+// Must be imported AFTER a colors modifier file
+
+// Functions need to be first, since we use them in our variables and mixin definitions
+@import '../../global_styling/functions/index';
+
+// Variables come next, and are used in some mixins
+@import '../../global_styling/variables/index';
+
+// Mixins provide generic code expansion through helpers
+@import '../../global_styling/mixins/index';

--- a/wiki/consuming.md
+++ b/wiki/consuming.md
@@ -59,12 +59,27 @@ Most of the time, you just need the CSS, which provides the styling for the Reac
 import '@elastic/eui/dist/eui_theme_light.css';
 ```
 
-If you want access to the Sass variables, functions, and mixins in EUI then you'll need to import the SCSS file. This will require `style`, `css`, `postcss`, and `sass` loaders. You'll also want to import the SCSS file into one of your own SCSS files, to gain access to these variables, functions, and mixins.
+If you want access to the Sass variables, functions, and mixins in EUI then you'll need to import the Sass files. This will require `style`, `css`, `postcss`, and `sass` loaders. You'll also want to import the Sass file into one of your own Sass files, to gain access to these variables, functions, and mixins.
 
 ```scss
-// index.scss
-@import '../node_modules/@elastic/eui/src/theme_light.scss';
+@import '@elastic/eui/src/theme/eui/eui_colors_light.scss';
+@import '@elastic/eui/src/theme/eui/eui_global.scss';
 ```
+
+For the dark theme, import the dark colors file before the globals.
+
+```scss
+@import '@elastic/eui/src/theme/eui/eui_colors_dark.scss';
+@import '@elastic/eui/src/theme/eui/eui_global.scss';
+```
+
+If you want to use new, but in progress Amsterdam theme, you can import it similarly.
+
+```scss
+@import '@elastic/eui/src/theme/eui_amsterdam/eui_amsterdam_colors_light.scss';
+@import '@elastic/eui/src/theme/eui_amsterdam/eui_amsterdam_global.scss';
+```
+
 
 By default, EUI ships with a font stack that includes some outside, open source fonts. If your system is internet available you can include these by adding the following imports to your SCSS/CSS files, otherwise you'll need to bundle the physical fonts in your build. EUI will drop to System Fonts (which you may prefer) in their absence.
 
@@ -115,7 +130,7 @@ appendIconComponentCache({
   arrowDown: EuiIconArrowDown,
   arrowLeft: EuiIconArrowLeft,
 });
-``` 
+```
 
 ## Customizing with `className`
 


### PR DESCRIPTION
### SASS Globals

Consuming apps that want to use our invisibles have to import the functions, mixins, and variable index files separately because importing the `global_styles/index.scss` file comes with the reset and animations (non-invisibles) that would be repeated for each import.

This is too much for the apps to remember, so I made a helper file for the default and Amsterdam themes.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes, and Kibana (consumer)
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **IE11** and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
