### PR TITLE
Fix EuiHorizontalSteps rendering over EuiHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ No public interface changes since `27.0.0`.
 
 - Fixed a bug in `EuiResizableContainer` preventing nested containers ([#3699](https://github.com/elastic/eui/pull/3699))
 - Fixed a bug in `EuiResizableContainer` preventing resizing by arrow keys in some cases ([#3699](https://github.com/elastic/eui/pull/3699))
-- Fixed `EuiHorizontalSteps` rendering over `EuiHeader` ([#3699](https://github.com/elastic/eui/pull/3699))
+- Fixed `EuiHorizontalSteps` rendering over `EuiHeader` ([#3707](https://github.com/elastic/eui/pull/3707))
 
 **Breaking changes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ No public interface changes since `27.0.0`.
 
 - Fixed a bug in `EuiResizableContainer` preventing nested containers ([#3699](https://github.com/elastic/eui/pull/3699))
 - Fixed a bug in `EuiResizableContainer` preventing resizing by arrow keys in some cases ([#3699](https://github.com/elastic/eui/pull/3699))
+- Fixed `EuiHorizontalSteps` rendering over `EuiHeader` ([#3699](https://github.com/elastic/eui/pull/3699))
 
 **Breaking changes**
 

--- a/src/components/steps/_steps_horizontal.scss
+++ b/src/components/steps/_steps_horizontal.scss
@@ -82,7 +82,7 @@
 
 .euiStepHorizontal__number {
   position: relative; /* 1 */
-  z-index: $euiZLevel1; /* 1 */
+  z-index: $euiZLevel0 + 1; /* 1 */
   transition: all $euiAnimSpeedFast ease-in-out;
 }
 


### PR DESCRIPTION
### Summary

This PR closes #3704. 

The **EuiHorizontalSteps** numbers were rendering over a fixed **EuiHeader**: https://codesandbox.io/s/brave-lake-s4r7f?file=/index.js

 ### Fix

To ensure the connecting lines stay behind the number a z-index of `$euiZLevel0` was given to the lines and the numbers received a z-index of `$euiZLevel1`. But `$euiZLevel1` is too high `1000`. 

Because we only want to make the lines saying behind the number it makes sense to give a z-index to numbers just a little bit higher than the lines. So `$euiZLevel0 + 1` seems a good solution to me.


### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **IE11** and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
