### PR TITLE
Break up release.js

### DIFF
--- a/.ci/jobs/elastic+eui+npm-publish.yml
+++ b/.ci/jobs/elastic+eui+npm-publish.yml
@@ -34,6 +34,8 @@
           npm install -g yarn
           yarn
 
+          npm run release -- --type=${version_type} --steps=test,build,version,tag
+
           set +x
 
           export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
@@ -49,4 +51,4 @@
 
           set -x
 
-          npm run release -- --type=${version_type}
+          npm run release -- --type=${version_type} --steps=publish,docs

--- a/.ci/jobs/elastic+eui+npm-publish.yml
+++ b/.ci/jobs/elastic+eui+npm-publish.yml
@@ -49,5 +49,4 @@
 
           set -x
 
-          export VERSION_TYPE=${version_type}
-          npm run release
+          npm run release -- --type=${version_type}

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "@types/uuid": "^3.4.4",
     "@typescript-eslint/eslint-plugin": "^3.2.0",
     "@typescript-eslint/parser": "^3.2.0",
+    "argparse": "^1.0.10",
     "autoprefixer": "^7.1.5",
     "axe-core": "^3.3.2",
     "axe-puppeteer": "^1.0.0",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -81,10 +81,6 @@ function parseArguments() {
     choices: Object.values(humanReadableTypes),
   });
 
-  parser.addArgument('--mfa', {
-    help: 'Multi-factor authentication code used by npm',
-  });
-
   parser.addArgument('--dry-run', {
     action: 'storeTrue',
     defaultValue: false,
@@ -215,10 +211,9 @@ async function getOneTimePassword() {
   console.log('');
   console.log(chalk.magenta('The @elastic organization requires membership and 2FA to publish'));
 
-  if (args.mfa) {
-    // skip prompting user for manual input if --mfa argument is present
-    console.log(chalk.magenta('2FA code provided by ---mfa argument'));
-    return args.mfa;
+  if (process.env.NPM_OTP) {
+    console.log(chalk.magenta('2FA code provided by NPM_OTP environment variable'));
+    return process.env.NPM_OTP;
   }
 
   console.log(chalk.magenta('What is your one-time password?'));

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -109,7 +109,7 @@ function parseArguments() {
   const args = parser.parseArgs();
 
   // validate --steps argument
-  const steps = args.steps.trim().split(',');
+  const steps = args.steps.split(',').map(step => step.trim());
   const diff = steps.filter(x => allSteps.indexOf(x) === -1);
   if (diff.length > 0) {
     console.error(`Invalid --step value(s): ${diff.join(', ')}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1924,6 +1924,13 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+argparse@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
+  dependencies:
+    sprintf-js "~1.0.2"
+
 argparse@^1.0.7:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"


### PR DESCRIPTION
### Summary

Adds argument parsing to release.js so we can set a `--type` arg (major, minor or patch) instead of using a `VERSION_TYPE` env var, and adds a `--steps` arg (comma-separated list of release steps) so that we can run the first half of the release, then fetch MFA creds at the very last second before publishing to npm and finishing other post-release steps.

(I kept `NPM_OTP` an env var instead of converting it to an argument to make it easy to not leak the token into the public CI job logs.)

Also added a `--dry-run` flag so that you can test `npm run release` without actually making any public changes.