### PR TITLE
[DataGrid] Add will-change to CSS to improve performance in chrome full screen mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `27.3.1`.
+**Bug fixes**
+
+- Improve `EuiDataGrid` Chrome rendering performance in Full screen [#3705](https://github.com/elastic/eui/issues/3705)
 
 ## [`27.3.1`](https://github.com/elastic/eui/tree/v27.3.1)
 
@@ -53,10 +55,6 @@ No public interface changes since `27.3.1`.
 - Added `descriptionFlexItemProps` and `fieldFlexItemProps` props to `EuiDescribedFormGroup` ([#3717](https://github.com/elastic/eui/pull/3717))
 - Expanded `EuiBasicTable`'s default action's name configuration to accept a function that returns a React node ([#3739](https://github.com/elastic/eui/pull/3739))
 - Added internal use only button building blocks for reusability in other button components ([#3730](https://github.com/elastic/eui/pull/3730))
-
-**Bug fixes**
-- Improve `EuiDataGrid` Chrome rendering performance in Full screen [#3705](https://github.com/elastic/eui/issues/3705)
-
 
 ## [`27.0.0`](https://github.com/elastic/eui/tree/v27.0.0)
 - Added `paddingSize` prop to `EuiCard` ([#3638](https://github.com/elastic/eui/pull/3638))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ No public interface changes since `27.3.1`.
 - Expanded `EuiBasicTable`'s default action's name configuration to accept a function that returns a React node ([#3739](https://github.com/elastic/eui/pull/3739))
 - Added internal use only button building blocks for reusability in other button components ([#3730](https://github.com/elastic/eui/pull/3730))
 
+**Bug fixes**
+- Improve `EuiDataGrid` Chrome rendering performance in Full screen [#3705](https://github.com/elastic/eui/issues/3705)
+
+
 ## [`27.0.0`](https://github.com/elastic/eui/tree/v27.0.0)
 - Added `paddingSize` prop to `EuiCard` ([#3638](https://github.com/elastic/eui/pull/3638))
 - Added `isClearable` and `placeholder` options to `EuiColorPicker` ([#3689](https://github.com/elastic/eui/pull/3689))

--- a/src/components/datagrid/_data_grid.scss
+++ b/src/components/datagrid/_data_grid.scss
@@ -22,7 +22,7 @@
     border-top: $euiBorderThin;
   }
 
-  .euiDataGrid__verticalScroll {
+  .euiDataGrid__verticalScroll .euiDataGridRow {
     will-change: transform;
   }
 }

--- a/src/components/datagrid/_data_grid.scss
+++ b/src/components/datagrid/_data_grid.scss
@@ -21,6 +21,10 @@
     background: $euiColorLightestShade;
     border-top: $euiBorderThin;
   }
+
+  .euiDataGrid__verticalScroll {
+    will-change: transform;
+  }
 }
 
 .euiDataGrid__content {


### PR DESCRIPTION
### Summary

Significant improvement of performance issues encountered in #3705. Screens taken using Chrome 83, MacBook Pro 15'' 2019 on a retina screen, rendering 100 rows. 

Before:
![image](https://user-images.githubusercontent.com/463851/87289195-9e02ae80-c4fc-11ea-8430-6bf546464b59.gif)

After:

![image](https://user-images.githubusercontent.com/463851/87289930-9abbf280-c4fd-11ea-9b4d-1363b95ce61c.gif)

Important: pls test on a retina/high resolution monitor, there the lag is significant, and also the improvement

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
- [x] Checked in **IE11** and **Firefox** - Note: IE11 doesn't know this CSS prop
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
