### PR TITLE
Chore/decouple button content

### DIFF
--- a/src/components/accessibility/__snapshots__/skip_link.test.tsx.snap
+++ b/src/components/accessibility/__snapshots__/skip_link.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiSkipLink is rendered 1`] = `
-<a
+<label
   aria-label="aria-label"
   class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--static testClass1 testClass2 euiButton--fill"
   data-test-subj="test subject string"
@@ -17,11 +17,11 @@ exports[`EuiSkipLink is rendered 1`] = `
       Skip
     </span>
   </span>
-</a>
+</label>
 `;
 
 exports[`EuiSkipLink props onClick is rendered 1`] = `
-<a
+<label
   class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--static euiButton--fill"
   href="#somewhere"
   rel="noreferrer"
@@ -33,11 +33,11 @@ exports[`EuiSkipLink props onClick is rendered 1`] = `
       class="euiButton__text"
     />
   </span>
-</a>
+</label>
 `;
 
 exports[`EuiSkipLink props position absolute is rendered 1`] = `
-<a
+<label
   class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--absolute euiButton--fill"
   href="#somewhere"
   rel="noreferrer"
@@ -49,11 +49,11 @@ exports[`EuiSkipLink props position absolute is rendered 1`] = `
       class="euiButton__text"
     />
   </span>
-</a>
+</label>
 `;
 
 exports[`EuiSkipLink props position fixed is rendered 1`] = `
-<a
+<label
   class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--fixed euiButton--fill"
   href="#somewhere"
   rel="noreferrer"
@@ -66,11 +66,11 @@ exports[`EuiSkipLink props position fixed is rendered 1`] = `
       class="euiButton__text"
     />
   </span>
-</a>
+</label>
 `;
 
 exports[`EuiSkipLink props position static is rendered 1`] = `
-<a
+<label
   class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--static euiButton--fill"
   href="#somewhere"
   rel="noreferrer"
@@ -82,11 +82,11 @@ exports[`EuiSkipLink props position static is rendered 1`] = `
       class="euiButton__text"
     />
   </span>
-</a>
+</label>
 `;
 
 exports[`EuiSkipLink props tabIndex is rendered 1`] = `
-<a
+<label
   class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--static euiButton--fill"
   href="#somewhere"
   rel="noreferrer"
@@ -99,5 +99,5 @@ exports[`EuiSkipLink props tabIndex is rendered 1`] = `
       class="euiButton__text"
     />
   </span>
-</a>
+</label>
 `;

--- a/src/components/accessibility/__snapshots__/skip_link.test.tsx.snap
+++ b/src/components/accessibility/__snapshots__/skip_link.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiSkipLink is rendered 1`] = `
-<label
+<a
   aria-label="aria-label"
   class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--static testClass1 testClass2 euiButton--fill"
   data-test-subj="test subject string"
@@ -17,11 +17,11 @@ exports[`EuiSkipLink is rendered 1`] = `
       Skip
     </span>
   </span>
-</label>
+</a>
 `;
 
 exports[`EuiSkipLink props onClick is rendered 1`] = `
-<label
+<a
   class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--static euiButton--fill"
   href="#somewhere"
   rel="noreferrer"
@@ -33,11 +33,11 @@ exports[`EuiSkipLink props onClick is rendered 1`] = `
       class="euiButton__text"
     />
   </span>
-</label>
+</a>
 `;
 
 exports[`EuiSkipLink props position absolute is rendered 1`] = `
-<label
+<a
   class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--absolute euiButton--fill"
   href="#somewhere"
   rel="noreferrer"
@@ -49,11 +49,11 @@ exports[`EuiSkipLink props position absolute is rendered 1`] = `
       class="euiButton__text"
     />
   </span>
-</label>
+</a>
 `;
 
 exports[`EuiSkipLink props position fixed is rendered 1`] = `
-<label
+<a
   class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--fixed euiButton--fill"
   href="#somewhere"
   rel="noreferrer"
@@ -66,11 +66,11 @@ exports[`EuiSkipLink props position fixed is rendered 1`] = `
       class="euiButton__text"
     />
   </span>
-</label>
+</a>
 `;
 
 exports[`EuiSkipLink props position static is rendered 1`] = `
-<label
+<a
   class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--static euiButton--fill"
   href="#somewhere"
   rel="noreferrer"
@@ -82,11 +82,11 @@ exports[`EuiSkipLink props position static is rendered 1`] = `
       class="euiButton__text"
     />
   </span>
-</label>
+</a>
 `;
 
 exports[`EuiSkipLink props tabIndex is rendered 1`] = `
-<label
+<a
   class="euiButton euiButton--primary euiButton--small euiScreenReaderOnly--showOnFocus euiSkipLink euiSkipLink--static euiButton--fill"
   href="#somewhere"
   rel="noreferrer"
@@ -99,5 +99,5 @@ exports[`EuiSkipLink props tabIndex is rendered 1`] = `
       class="euiButton__text"
     />
   </span>
-</label>
+</a>
 `;

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -401,13 +401,11 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                     className="euiButtonEmpty__content"
                                   >
                                     <EuiIcon
-                                      aria-hidden="true"
                                       className="euiButtonContent__icon"
                                       size="m"
                                       type="arrowDown"
                                     >
                                       <div
-                                        aria-hidden="true"
                                         className="euiButtonContent__icon"
                                         data-euiicon-type="arrowDown"
                                         size="m"

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -388,35 +388,45 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                 onClick={[Function]}
                                 type="button"
                               >
-                                <span
+                                <EuiButtonContent
                                   className="euiButtonEmpty__content"
+                                  iconType="arrowDown"
+                                  textProps={
+                                    Object {
+                                      "className": "euiButtonEmpty__text",
+                                    }
+                                  }
                                 >
-                                  <EuiIcon
-                                    aria-hidden="true"
-                                    className="euiButtonEmpty__icon"
-                                    size="m"
-                                    type="arrowDown"
-                                  >
-                                    <div
-                                      aria-hidden="true"
-                                      className="euiButtonEmpty__icon"
-                                      data-euiicon-type="arrowDown"
-                                      size="m"
-                                    />
-                                  </EuiIcon>
                                   <span
-                                    className="euiButtonEmpty__text"
+                                    className="euiButtonEmpty__content"
                                   >
-                                    <EuiI18n
-                                      default="Rows per page"
-                                      token="euiTablePagination.rowsPerPage"
+                                    <EuiIcon
+                                      aria-hidden="true"
+                                      className="euiButton__icon"
+                                      size="m"
+                                      type="arrowDown"
                                     >
-                                      Rows per page
-                                    </EuiI18n>
-                                    : 
-                                    2
+                                      <div
+                                        aria-hidden="true"
+                                        className="euiButton__icon"
+                                        data-euiicon-type="arrowDown"
+                                        size="m"
+                                      />
+                                    </EuiIcon>
+                                    <span
+                                      className="euiButtonEmpty__text"
+                                    >
+                                      <EuiI18n
+                                        default="Rows per page"
+                                        token="euiTablePagination.rowsPerPage"
+                                      >
+                                        Rows per page
+                                      </EuiI18n>
+                                      : 
+                                      2
+                                    </span>
                                   </span>
-                                </span>
+                                </EuiButtonContent>
                               </button>
                             </EuiButtonEmpty>
                           </div>
@@ -545,15 +555,24 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                         onClick={[Function]}
                                         rel="noreferrer"
                                       >
-                                        <span
+                                        <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          textProps={
+                                            Object {
+                                              "className": "euiButtonEmpty__text",
+                                            }
+                                          }
                                         >
                                           <span
-                                            className="euiButtonEmpty__text"
+                                            className="euiButtonEmpty__content"
                                           >
-                                            1
+                                            <span
+                                              className="euiButtonEmpty__text"
+                                            >
+                                              1
+                                            </span>
                                           </span>
-                                        </span>
+                                        </EuiButtonContent>
                                       </a>
                                     </EuiButtonEmpty>
                                   </EuiI18n>
@@ -617,15 +636,24 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                         onClick={[Function]}
                                         type="button"
                                       >
-                                        <span
+                                        <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          textProps={
+                                            Object {
+                                              "className": "euiButtonEmpty__text",
+                                            }
+                                          }
                                         >
                                           <span
-                                            className="euiButtonEmpty__text"
+                                            className="euiButtonEmpty__content"
                                           >
-                                            2
+                                            <span
+                                              className="euiButtonEmpty__text"
+                                            >
+                                              2
+                                            </span>
                                           </span>
-                                        </span>
+                                        </EuiButtonContent>
                                       </button>
                                     </EuiButtonEmpty>
                                   </EuiI18n>

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -402,13 +402,13 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                   >
                                     <EuiIcon
                                       aria-hidden="true"
-                                      className="euiButton__icon"
+                                      className="euiButtonContent__icon"
                                       size="m"
                                       type="arrowDown"
                                     >
                                       <div
                                         aria-hidden="true"
-                                        className="euiButton__icon"
+                                        className="euiButtonContent__icon"
                                         data-euiicon-type="arrowDown"
                                         size="m"
                                       />

--- a/src/components/button/__snapshots__/button.test.tsx.snap
+++ b/src/components/button/__snapshots__/button.test.tsx.snap
@@ -184,7 +184,7 @@ exports[`EuiButton props iconSide right is rendered 1`] = `
   type="button"
 >
   <span
-    class="euiButton__content euiButton--iconRight"
+    class="euiButton__content"
   >
     <div
       aria-hidden="true"

--- a/src/components/button/__snapshots__/button.test.tsx.snap
+++ b/src/components/button/__snapshots__/button.test.tsx.snap
@@ -166,7 +166,7 @@ exports[`EuiButton props iconSide left is rendered 1`] = `
   >
     <div
       aria-hidden="true"
-      class="euiButton__icon"
+      class="euiButtonContent__icon"
       data-euiicon-type="user"
     />
     <span
@@ -188,7 +188,7 @@ exports[`EuiButton props iconSide right is rendered 1`] = `
   >
     <div
       aria-hidden="true"
-      class="euiButton__icon"
+      class="euiButtonContent__icon"
       data-euiicon-type="user"
     />
     <span
@@ -210,7 +210,7 @@ exports[`EuiButton props iconType is rendered 1`] = `
   >
     <div
       aria-hidden="true"
-      class="euiButton__icon"
+      class="euiButtonContent__icon"
       data-euiicon-type="user"
     />
     <span
@@ -262,7 +262,7 @@ exports[`EuiButton props isLoading is rendered 1`] = `
     class="euiButton__content"
   >
     <span
-      class="euiLoadingSpinner euiLoadingSpinner--medium euiButton__spinner"
+      class="euiLoadingSpinner euiLoadingSpinner--medium euiButtonContent__spinner"
     />
     <span
       class="euiButton__text"

--- a/src/components/button/__snapshots__/button.test.tsx.snap
+++ b/src/components/button/__snapshots__/button.test.tsx.snap
@@ -165,7 +165,6 @@ exports[`EuiButton props iconSide left is rendered 1`] = `
     class="euiButton__content"
   >
     <div
-      aria-hidden="true"
       class="euiButtonContent__icon"
       data-euiicon-type="user"
     />
@@ -187,7 +186,6 @@ exports[`EuiButton props iconSide right is rendered 1`] = `
     class="euiButton__content"
   >
     <div
-      aria-hidden="true"
       class="euiButtonContent__icon"
       data-euiicon-type="user"
     />
@@ -209,7 +207,6 @@ exports[`EuiButton props iconType is rendered 1`] = `
     class="euiButton__content"
   >
     <div
-      aria-hidden="true"
       class="euiButtonContent__icon"
       data-euiicon-type="user"
     />
@@ -222,7 +219,7 @@ exports[`EuiButton props iconType is rendered 1`] = `
 
 exports[`EuiButton props isDisabled is rendered 1`] = `
 <button
-  class="euiButton euiButton--primary"
+  class="euiButton euiButton--primary euiButton-isDisabled"
   disabled=""
   type="button"
 >
@@ -238,7 +235,7 @@ exports[`EuiButton props isDisabled is rendered 1`] = `
 
 exports[`EuiButton props isDisabled renders a button even when href is defined 1`] = `
 <button
-  class="euiButton euiButton--primary"
+  class="euiButton euiButton--primary euiButton-isDisabled"
   disabled=""
   type="button"
 >
@@ -254,7 +251,7 @@ exports[`EuiButton props isDisabled renders a button even when href is defined 1
 
 exports[`EuiButton props isLoading is rendered 1`] = `
 <button
-  class="euiButton euiButton--primary"
+  class="euiButton euiButton--primary euiButton-isDisabled"
   disabled=""
   type="button"
 >

--- a/src/components/button/__snapshots__/button.test.tsx.snap
+++ b/src/components/button/__snapshots__/button.test.tsx.snap
@@ -184,7 +184,7 @@ exports[`EuiButton props iconSide right is rendered 1`] = `
   type="button"
 >
   <span
-    class="euiButton__content"
+    class="euiButton__content euiButton--iconRight"
   >
     <div
       aria-hidden="true"

--- a/src/components/button/__snapshots__/button_content.test.tsx.snap
+++ b/src/components/button/__snapshots__/button_content.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiButtonContent is rendered 1`] = `
+<span
+  aria-label="aria-label"
+  class="euiButton__content testClass1 testClass2"
+  data-test-subj="test subject string"
+>
+  <span
+    class="euiButton__text"
+  />
+</span>
+`;

--- a/src/components/button/__snapshots__/button_content.test.tsx.snap
+++ b/src/components/button/__snapshots__/button_content.test.tsx.snap
@@ -3,11 +3,9 @@
 exports[`EuiButtonContent is rendered 1`] = `
 <span
   aria-label="aria-label"
-  class="euiButton__content testClass1 testClass2"
+  class="testClass1 testClass2"
   data-test-subj="test subject string"
 >
-  <span
-    class="euiButton__text"
-  />
+  <span />
 </span>
 `;

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -44,18 +44,11 @@
   }
 
   &:disabled {
+    @include euiButtonContentDisabled;
+
     color: $euiButtonColorDisabledText;
     border-color: $euiButtonColorDisabled;
     pointer-events: none;
-
-    .euiButton__content {
-      pointer-events: auto;
-      cursor: not-allowed;
-    }
-
-    .euiButton__spinner {
-      border-color: euiLoadingSpinnerBorderColors(currentColor);
-    }
 
     &.euiButton--fill {
       // Only increase the contrast of background color to text to 2.0 for disabled

--- a/src/components/button/_button_content.scss
+++ b/src/components/button/_button_content.scss
@@ -1,0 +1,3 @@
+// .euiButtonContent {
+
+// }

--- a/src/components/button/_button_content.scss
+++ b/src/components/button/_button_content.scss
@@ -1,3 +1,3 @@
-// .euiButtonContent {
-
-// }
+.euiButtonContent--iconRight {
+  @include euiButtonContent($isReverse: true);
+}

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -32,11 +32,11 @@ import {
   PropsForButton,
   keysOf,
 } from '../common';
-import { EuiLoadingSpinner } from '../loading';
 
 import { getSecureRelForTarget } from '../../services';
 
-import { IconType, EuiIcon } from '../icon';
+import { IconType } from '../icon';
+import { EuiButtonContentProps, EuiButtonContent } from './button_content';
 
 export type ButtonIconSide = 'left' | 'right';
 
@@ -94,7 +94,7 @@ export interface EuiButtonProps extends CommonProps {
   /**
    * Object of props passed to the <span/> wrapping the button's content
    */
-  contentProps?: HTMLAttributes<HTMLSpanElement>;
+  contentProps?: EuiButtonContentProps;
   /**
    * Object of props passed to the <span/> wrapping the component's {children}
    */
@@ -155,39 +155,15 @@ export const EuiButton: FunctionComponent<Props> = ({
     }
   );
 
-  const contentClassNames = classNames(
-    'euiButton__content',
-    contentProps && contentProps.className
-  );
-
-  const textClassNames = classNames(
-    'euiButton__text',
-    textProps && textProps.className
-  );
-
-  // Add an icon to the button if one exists.
-  let buttonIcon;
-
-  if (isLoading) {
-    buttonIcon = <EuiLoadingSpinner className="euiButton__spinner" size="m" />;
-  } else if (iconType) {
-    buttonIcon = (
-      <EuiIcon
-        className="euiButton__icon"
-        type={iconType}
-        size="m"
-        aria-hidden="true"
-      />
-    );
-  }
-
   const innerNode = (
-    <span {...contentProps} className={contentClassNames}>
-      {buttonIcon}
-      <span {...textProps} className={textClassNames}>
-        {children}
-      </span>
-    </span>
+    <EuiButtonContent
+      isLoading={isLoading}
+      iconType={iconType}
+      iconSide={iconSide}
+      textProps={textProps}
+      {...contentProps}>
+      {children}
+    </EuiButtonContent>
   );
 
   // <Element> elements don't respect the `disabled` attribute. So if we're disabled, we'll just pretend

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -155,13 +155,24 @@ export const EuiButton: FunctionComponent<Props> = ({
     }
   );
 
+  const contentClassNames = classNames(
+    'euiButton__content',
+    contentProps && contentProps.className
+  );
+
+  const textClassNames = classNames(
+    'euiButton__text',
+    textProps && textProps.className
+  );
+
   const innerNode = (
     <EuiButtonContent
       isLoading={isLoading}
       iconType={iconType}
-      iconSide={iconSide}
-      textProps={textProps}
-      {...contentProps}>
+      textProps={{ className: textClassNames, ...textProps }}
+      {...contentProps}
+      // className has to come last to override contentProps.className
+      className={contentClassNames}>
       {children}
     </EuiButtonContent>
   );

--- a/src/components/button/button_content.test.tsx
+++ b/src/components/button/button_content.test.tsx
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { render } from 'enzyme';
+import { requiredProps } from '../../test/required_props';
+
+import { EuiButtonContent } from './button_content';
+
+describe('EuiButtonContent', () => {
+  test('is rendered', () => {
+    const component = render(<EuiButtonContent {...requiredProps} />);
+
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/components/button/button_content.tsx
+++ b/src/components/button/button_content.tsx
@@ -22,24 +22,13 @@
  */
 
 import React, { HTMLAttributes, FunctionComponent } from 'react';
-import { CommonProps, keysOf } from '../common';
-import classNames from 'classnames';
+import { CommonProps } from '../common';
 import { EuiLoadingSpinner } from '../loading';
 import { EuiIcon, IconType } from '../icon';
-
-export type ButtonIconSide = 'left' | 'right';
-
-const iconSideToClassNameMap: { [side in ButtonIconSide]: string | null } = {
-  left: null,
-  right: 'euiButton--iconRight',
-};
-
-export const ICON_SIDES = keysOf(iconSideToClassNameMap);
 
 export type EuiButtonContentProps = HTMLAttributes<HTMLSpanElement> &
   CommonProps & {
     iconType?: IconType;
-    iconSide?: ButtonIconSide;
     isLoading?: boolean;
     /**
      * Object of props passed to the <span/> wrapping the component's {children}
@@ -49,24 +38,11 @@ export type EuiButtonContentProps = HTMLAttributes<HTMLSpanElement> &
 
 export const EuiButtonContent: FunctionComponent<EuiButtonContentProps> = ({
   children,
-  className,
   textProps,
   isLoading,
   iconType,
-  iconSide,
-  ...rest
+  ...contentProps
 }) => {
-  const contentClassNames = classNames(
-    'euiButton__content',
-    iconSide ? iconSideToClassNameMap[iconSide] : null,
-    className
-  );
-
-  const textClassNames = classNames(
-    'euiButton__text',
-    textProps && textProps.className
-  );
-
   // Add an icon to the button if one exists.
   let buttonIcon;
 
@@ -84,11 +60,9 @@ export const EuiButtonContent: FunctionComponent<EuiButtonContentProps> = ({
   }
 
   return (
-    <span {...rest} className={contentClassNames}>
+    <span {...contentProps}>
       {buttonIcon}
-      <span {...textProps} className={textClassNames}>
-        {children}
-      </span>
+      <span {...textProps}>{children}</span>
     </span>
   );
 };

--- a/src/components/button/button_content.tsx
+++ b/src/components/button/button_content.tsx
@@ -22,13 +22,24 @@
  */
 
 import React, { HTMLAttributes, FunctionComponent } from 'react';
-import { CommonProps } from '../common';
+import classNames from 'classnames';
+import { CommonProps, keysOf } from '../common';
 import { EuiLoadingSpinner } from '../loading';
 import { EuiIcon, IconType } from '../icon';
+
+export type ButtonIconSide = 'left' | 'right';
+
+const iconSideToClassNameMap: { [side in ButtonIconSide]: string | null } = {
+  left: null,
+  right: 'euiButtonContent--iconRight',
+};
+
+export const ICON_SIDES = keysOf(iconSideToClassNameMap);
 
 export type EuiButtonContentProps = HTMLAttributes<HTMLSpanElement> &
   CommonProps & {
     iconType?: IconType;
+    iconSide?: ButtonIconSide;
     isLoading?: boolean;
     /**
      * Object of props passed to the <span/> wrapping the component's {children}
@@ -41,6 +52,7 @@ export const EuiButtonContent: FunctionComponent<EuiButtonContentProps> = ({
   textProps,
   isLoading,
   iconType,
+  iconSide,
   ...contentProps
 }) => {
   // Add an icon to the button if one exists.
@@ -52,17 +64,17 @@ export const EuiButtonContent: FunctionComponent<EuiButtonContentProps> = ({
     );
   } else if (iconType) {
     buttonIcon = (
-      <EuiIcon
-        className="euiButtonContent__icon"
-        type={iconType}
-        size="m"
-        aria-hidden="true"
-      />
+      <EuiIcon className="euiButtonContent__icon" type={iconType} size="m" />
     );
   }
 
+  const contentClassNames = classNames(
+    iconSide ? iconSideToClassNameMap[iconSide] : null,
+    contentProps && contentProps.className
+  );
+
   return (
-    <span {...contentProps}>
+    <span {...contentProps} className={contentClassNames}>
       {buttonIcon}
       <span {...textProps}>{children}</span>
     </span>

--- a/src/components/button/button_content.tsx
+++ b/src/components/button/button_content.tsx
@@ -1,0 +1,94 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * This component is simply a helper component for reuse within other button components
+ */
+
+import React, { HTMLAttributes, FunctionComponent } from 'react';
+import { CommonProps, keysOf } from '../common';
+import classNames from 'classnames';
+import { EuiLoadingSpinner } from '../loading';
+import { EuiIcon, IconType } from '../icon';
+
+export type ButtonIconSide = 'left' | 'right';
+
+const iconSideToClassNameMap: { [side in ButtonIconSide]: string | null } = {
+  left: null,
+  right: 'euiButton--iconRight',
+};
+
+export const ICON_SIDES = keysOf(iconSideToClassNameMap);
+
+export type EuiButtonContentProps = HTMLAttributes<HTMLSpanElement> &
+  CommonProps & {
+    iconType?: IconType;
+    iconSide?: ButtonIconSide;
+    isLoading?: boolean;
+    /**
+     * Object of props passed to the <span/> wrapping the component's {children}
+     */
+    textProps?: HTMLAttributes<HTMLSpanElement> & CommonProps;
+  };
+
+export const EuiButtonContent: FunctionComponent<EuiButtonContentProps> = ({
+  children,
+  className,
+  textProps,
+  isLoading,
+  iconType,
+  iconSide,
+  ...rest
+}) => {
+  const contentClassNames = classNames(
+    'euiButton__content',
+    iconSide ? iconSideToClassNameMap[iconSide] : null,
+    className
+  );
+
+  const textClassNames = classNames(
+    'euiButton__text',
+    textProps && textProps.className
+  );
+
+  // Add an icon to the button if one exists.
+  let buttonIcon;
+
+  if (isLoading) {
+    buttonIcon = <EuiLoadingSpinner className="euiButton__spinner" size="m" />;
+  } else if (iconType) {
+    buttonIcon = (
+      <EuiIcon
+        className="euiButton__icon"
+        type={iconType}
+        size="m"
+        aria-hidden="true"
+      />
+    );
+  }
+
+  return (
+    <span {...rest} className={contentClassNames}>
+      {buttonIcon}
+      <span {...textProps} className={textClassNames}>
+        {children}
+      </span>
+    </span>
+  );
+};

--- a/src/components/button/button_content.tsx
+++ b/src/components/button/button_content.tsx
@@ -47,11 +47,13 @@ export const EuiButtonContent: FunctionComponent<EuiButtonContentProps> = ({
   let buttonIcon;
 
   if (isLoading) {
-    buttonIcon = <EuiLoadingSpinner className="euiButton__spinner" size="m" />;
+    buttonIcon = (
+      <EuiLoadingSpinner className="euiButtonContent__spinner" size="m" />
+    );
   } else if (iconType) {
     buttonIcon = (
       <EuiIcon
-        className="euiButton__icon"
+        className="euiButtonContent__icon"
         type={iconType}
         size="m"
         aria-hidden="true"

--- a/src/components/button/button_empty/__snapshots__/button_empty.test.tsx.snap
+++ b/src/components/button/button_empty/__snapshots__/button_empty.test.tsx.snap
@@ -150,7 +150,6 @@ exports[`EuiButtonEmpty props iconSide left is rendered 1`] = `
     class="euiButtonEmpty__content"
   >
     <div
-      aria-hidden="true"
       class="euiButtonContent__icon"
       data-euiicon-type="user"
     />
@@ -172,7 +171,6 @@ exports[`EuiButtonEmpty props iconSide right is rendered 1`] = `
     class="euiButtonEmpty__content"
   >
     <div
-      aria-hidden="true"
       class="euiButtonContent__icon"
       data-euiicon-type="user"
     />
@@ -194,7 +192,6 @@ exports[`EuiButtonEmpty props iconType is rendered 1`] = `
     class="euiButtonEmpty__content"
   >
     <div
-      aria-hidden="true"
       class="euiButtonContent__icon"
       data-euiicon-type="user"
     />

--- a/src/components/button/button_empty/__snapshots__/button_empty.test.tsx.snap
+++ b/src/components/button/button_empty/__snapshots__/button_empty.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`EuiButtonEmpty props iconSide left is rendered 1`] = `
   >
     <div
       aria-hidden="true"
-      class="euiButtonEmpty__icon"
+      class="euiButton__icon"
       data-euiicon-type="user"
     />
     <span
@@ -173,7 +173,7 @@ exports[`EuiButtonEmpty props iconSide right is rendered 1`] = `
   >
     <div
       aria-hidden="true"
-      class="euiButtonEmpty__icon"
+      class="euiButton__icon"
       data-euiicon-type="user"
     />
     <span
@@ -195,7 +195,7 @@ exports[`EuiButtonEmpty props iconType is rendered 1`] = `
   >
     <div
       aria-hidden="true"
-      class="euiButtonEmpty__icon"
+      class="euiButton__icon"
       data-euiicon-type="user"
     />
     <span

--- a/src/components/button/button_empty/__snapshots__/button_empty.test.tsx.snap
+++ b/src/components/button/button_empty/__snapshots__/button_empty.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`EuiButtonEmpty props iconSide left is rendered 1`] = `
   >
     <div
       aria-hidden="true"
-      class="euiButton__icon"
+      class="euiButtonContent__icon"
       data-euiicon-type="user"
     />
     <span
@@ -173,7 +173,7 @@ exports[`EuiButtonEmpty props iconSide right is rendered 1`] = `
   >
     <div
       aria-hidden="true"
-      class="euiButton__icon"
+      class="euiButtonContent__icon"
       data-euiicon-type="user"
     />
     <span
@@ -195,7 +195,7 @@ exports[`EuiButtonEmpty props iconType is rendered 1`] = `
   >
     <div
       aria-hidden="true"
-      class="euiButton__icon"
+      class="euiButtonContent__icon"
       data-euiicon-type="user"
     />
     <span

--- a/src/components/button/button_empty/_button_empty.scss
+++ b/src/components/button/button_empty/_button_empty.scss
@@ -41,21 +41,10 @@
   }
 
   &:disabled {
+    @include euiButtonContentDisabled;
+
     color: $euiButtonColorDisabledText;
     pointer-events: none;
-
-    .euiButtonEmpty__content {
-      pointer-events: auto;
-      cursor: not-allowed;
-    }
-
-    .euiButton__icon {
-      fill: currentColor;
-    }
-
-    .euiButton__spinner {
-      border-color: euiLoadingSpinnerBorderColors(currentColor);
-    }
 
     &:focus {
       background-color: transparent;

--- a/src/components/button/button_empty/_button_empty.scss
+++ b/src/components/button/button_empty/_button_empty.scss
@@ -49,8 +49,12 @@
       cursor: not-allowed;
     }
 
-    .euiButtonEmpty__icon {
+    .euiButton__icon {
       fill: currentColor;
+    }
+
+    .euiButton__spinner {
+      border-color: euiLoadingSpinnerBorderColors(currentColor);
     }
 
     &:focus {

--- a/src/components/button/button_empty/button_empty.tsx
+++ b/src/components/button/button_empty/button_empty.tsx
@@ -27,10 +27,10 @@ import {
   PropsForButton,
   keysOf,
 } from '../../common';
-import { EuiLoadingSpinner } from '../../loading';
 import { getSecureRelForTarget } from '../../../services';
-import { IconType, EuiIcon } from '../../icon';
+import { IconType } from '../../icon';
 import { ButtonIconSide } from '../button';
+import { EuiButtonContent, EuiButtonContentProps } from '../button_content';
 
 export type EuiButtonEmptyColor =
   | 'primary'
@@ -94,7 +94,7 @@ interface CommonEuiButtonEmptyProps extends CommonProps {
   /**
    * Passes props to `euiButtonEmpty__content` span
    */
-  contentProps?: Partial<HTMLAttributes<HTMLSpanElement>>;
+  contentProps?: EuiButtonContentProps;
 
   /**
    * Passes props to `euiButtonEmpty__text` span
@@ -152,29 +152,16 @@ export const EuiButtonEmpty: FunctionComponent<EuiButtonEmptyProps> = ({
     textProps && textProps.className
   );
 
-  // Add an icon to the button if one exists.
-  let buttonIcon;
-
-  if (isLoading) {
-    buttonIcon = <EuiLoadingSpinner className="euiButton__spinner" size="m" />;
-  } else if (iconType) {
-    buttonIcon = (
-      <EuiIcon
-        className="euiButtonEmpty__icon"
-        type={iconType}
-        size="m"
-        aria-hidden="true"
-      />
-    );
-  }
-
   const innerNode = (
-    <span {...contentProps} className={contentClassNames}>
-      {buttonIcon}
-      <span {...textProps} className={textClassNames}>
-        {children}
-      </span>
-    </span>
+    <EuiButtonContent
+      isLoading={isLoading}
+      iconType={iconType}
+      textProps={{ className: textClassNames, ...textProps }}
+      {...contentProps}
+      // className has to come last to override contentProps.className
+      className={contentClassNames}>
+      {children}
+    </EuiButtonContent>
   );
 
   // <a> elements don't respect the `disabled` attribute. So if we're disabled, we'll just pretend

--- a/src/components/button/button_group/__snapshots__/button_group.test.tsx.snap
+++ b/src/components/button/button_group/__snapshots__/button_group.test.tsx.snap
@@ -920,7 +920,7 @@ exports[`EuiButtonGroup props isDisabled is rendered 1`] = `
         type="radio"
       />
       <button
-        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button euiButton-isDisabled"
         disabled=""
         id="button00"
         tabindex="-1"
@@ -948,7 +948,7 @@ exports[`EuiButtonGroup props isDisabled is rendered 1`] = `
         type="radio"
       />
       <button
-        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button euiButton-isDisabled"
         disabled=""
         id="button01"
         tabindex="-1"
@@ -976,7 +976,7 @@ exports[`EuiButtonGroup props isDisabled is rendered 1`] = `
         type="radio"
       />
       <button
-        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+        class="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button euiButton-isDisabled"
         disabled=""
         id="button02"
         tabindex="-1"

--- a/src/components/card/__snapshots__/card_select.test.tsx.snap
+++ b/src/components/card/__snapshots__/card_select.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`EuiCardSelect props isSelected 1`] = `
   >
     <div
       aria-hidden="true"
-      class="euiButton__icon"
+      class="euiButtonContent__icon"
       data-euiicon-type="check"
     />
     <span

--- a/src/components/card/__snapshots__/card_select.test.tsx.snap
+++ b/src/components/card/__snapshots__/card_select.test.tsx.snap
@@ -90,7 +90,6 @@ exports[`EuiCardSelect props isSelected 1`] = `
     class="euiButtonEmpty__content"
   >
     <div
-      aria-hidden="true"
       class="euiButtonContent__icon"
       data-euiicon-type="check"
     />

--- a/src/components/card/__snapshots__/card_select.test.tsx.snap
+++ b/src/components/card/__snapshots__/card_select.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`EuiCardSelect props isSelected 1`] = `
   >
     <div
       aria-hidden="true"
-      class="euiButtonEmpty__icon"
+      class="euiButton__icon"
       data-euiicon-type="check"
     />
     <span

--- a/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
@@ -62,11 +62,11 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButtonEmpty__icon"
+              class="euiButton__icon"
               data-euiicon-type="cross"
             />
             <span
-              class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
+              class="euiCollapsibleNav__closeButtonText"
             >
               close
             </span>
@@ -117,11 +117,11 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButtonEmpty__icon"
+              class="euiButton__icon"
               data-euiicon-type="cross"
             />
             <span
-              class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
+              class="euiCollapsibleNav__closeButtonText"
             >
               close
             </span>
@@ -174,11 +174,11 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButtonEmpty__icon"
+              class="euiButton__icon"
               data-euiicon-type="cross"
             />
             <span
-              class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
+              class="euiCollapsibleNav__closeButtonText"
             >
               close
             </span>
@@ -225,11 +225,11 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButtonEmpty__icon"
+              class="euiButton__icon"
               data-euiicon-type="cross"
             />
             <span
-              class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
+              class="euiCollapsibleNav__closeButtonText"
             >
               close
             </span>
@@ -276,11 +276,11 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButtonEmpty__icon"
+              class="euiButton__icon"
               data-euiicon-type="cross"
             />
             <span
-              class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
+              class="euiCollapsibleNav__closeButtonText"
             >
               close
             </span>
@@ -325,11 +325,11 @@ exports[`EuiCollapsibleNav props isDocked 1`] = `
         >
           <div
             aria-hidden="true"
-            class="euiButtonEmpty__icon"
+            class="euiButton__icon"
             data-euiicon-type="cross"
           />
           <span
-            class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
+            class="euiCollapsibleNav__closeButtonText"
           >
             close
           </span>
@@ -375,11 +375,11 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButtonEmpty__icon"
+              class="euiButton__icon"
               data-euiicon-type="cross"
             />
             <span
-              class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
+              class="euiCollapsibleNav__closeButtonText"
             >
               close
             </span>
@@ -431,11 +431,11 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButtonEmpty__icon"
+              class="euiButton__icon"
               data-euiicon-type="cross"
             />
             <span
-              class="euiButtonEmpty__text euiCollapsibleNav__closeButtonText"
+              class="euiCollapsibleNav__closeButtonText"
             >
               close
             </span>

--- a/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
@@ -61,7 +61,6 @@ Array [
             class="euiButtonEmpty__content"
           >
             <div
-              aria-hidden="true"
               class="euiButtonContent__icon"
               data-euiicon-type="cross"
             />
@@ -116,7 +115,6 @@ Array [
             class="euiButtonEmpty__content"
           >
             <div
-              aria-hidden="true"
               class="euiButtonContent__icon"
               data-euiicon-type="cross"
             />
@@ -173,7 +171,6 @@ Array [
             class="euiButtonEmpty__content"
           >
             <div
-              aria-hidden="true"
               class="euiButtonContent__icon"
               data-euiicon-type="cross"
             />
@@ -224,7 +221,6 @@ Array [
             class="euiButtonEmpty__content"
           >
             <div
-              aria-hidden="true"
               class="euiButtonContent__icon"
               data-euiicon-type="cross"
             />
@@ -275,7 +271,6 @@ Array [
             class="euiButtonEmpty__content"
           >
             <div
-              aria-hidden="true"
               class="euiButtonContent__icon"
               data-euiicon-type="cross"
             />
@@ -324,7 +319,6 @@ exports[`EuiCollapsibleNav props isDocked 1`] = `
           class="euiButtonEmpty__content"
         >
           <div
-            aria-hidden="true"
             class="euiButtonContent__icon"
             data-euiicon-type="cross"
           />
@@ -374,7 +368,6 @@ Array [
             class="euiButtonEmpty__content"
           >
             <div
-              aria-hidden="true"
               class="euiButtonContent__icon"
               data-euiicon-type="cross"
             />
@@ -430,7 +423,6 @@ Array [
             class="euiButtonEmpty__content"
           >
             <div
-              aria-hidden="true"
               class="euiButtonContent__icon"
               data-euiicon-type="cross"
             />

--- a/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
@@ -62,7 +62,7 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButton__icon"
+              class="euiButtonContent__icon"
               data-euiicon-type="cross"
             />
             <span
@@ -117,7 +117,7 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButton__icon"
+              class="euiButtonContent__icon"
               data-euiicon-type="cross"
             />
             <span
@@ -174,7 +174,7 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButton__icon"
+              class="euiButtonContent__icon"
               data-euiicon-type="cross"
             />
             <span
@@ -225,7 +225,7 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButton__icon"
+              class="euiButtonContent__icon"
               data-euiicon-type="cross"
             />
             <span
@@ -276,7 +276,7 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButton__icon"
+              class="euiButtonContent__icon"
               data-euiicon-type="cross"
             />
             <span
@@ -325,7 +325,7 @@ exports[`EuiCollapsibleNav props isDocked 1`] = `
         >
           <div
             aria-hidden="true"
-            class="euiButton__icon"
+            class="euiButtonContent__icon"
             data-euiicon-type="cross"
           />
           <span
@@ -375,7 +375,7 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButton__icon"
+              class="euiButtonContent__icon"
               data-euiicon-type="cross"
             />
             <span
@@ -431,7 +431,7 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButton__icon"
+              class="euiButtonContent__icon"
               data-euiicon-type="cross"
             />
             <span

--- a/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
+++ b/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
@@ -305,15 +305,19 @@ exports[`EuiControlBar props leftOffset is rendered 1`] = `
                 onClick={[Function]}
                 type="button"
               >
-                <span
-                  className="euiButton__content"
+                <EuiButtonContent
+                  iconSide="left"
                 >
                   <span
-                    className="euiButton__text"
+                    className="euiButton__content"
                   >
-                    Sound the Alarm
+                    <span
+                      className="euiButton__text"
+                    >
+                      Sound the Alarm
+                    </span>
                   </span>
-                </span>
+                </EuiButtonContent>
               </button>
             </EuiButton>
             <div
@@ -600,15 +604,19 @@ exports[`EuiControlBar props maxHeight is rendered 1`] = `
                 onClick={[Function]}
                 type="button"
               >
-                <span
-                  className="euiButton__content"
+                <EuiButtonContent
+                  iconSide="left"
                 >
                   <span
-                    className="euiButton__text"
+                    className="euiButton__content"
                   >
-                    Sound the Alarm
+                    <span
+                      className="euiButton__text"
+                    >
+                      Sound the Alarm
+                    </span>
                   </span>
-                </span>
+                </EuiButtonContent>
               </button>
             </EuiButton>
             <div
@@ -894,15 +902,19 @@ exports[`EuiControlBar props mobile is rendered 1`] = `
                 onClick={[Function]}
                 type="button"
               >
-                <span
-                  className="euiButton__content"
+                <EuiButtonContent
+                  iconSide="left"
                 >
                   <span
-                    className="euiButton__text"
+                    className="euiButton__content"
                   >
-                    Sound the Alarm
+                    <span
+                      className="euiButton__text"
+                    >
+                      Sound the Alarm
+                    </span>
                   </span>
-                </span>
+                </EuiButtonContent>
               </button>
             </EuiButton>
             <div
@@ -1101,15 +1113,19 @@ exports[`EuiControlBar props position is rendered 1`] = `
             onClick={[Function]}
             type="button"
           >
-            <span
-              className="euiButton__content"
+            <EuiButtonContent
+              iconSide="left"
             >
               <span
-                className="euiButton__text"
+                className="euiButton__content"
               >
-                Sound the Alarm
+                <span
+                  className="euiButton__text"
+                >
+                  Sound the Alarm
+                </span>
               </span>
-            </span>
+            </EuiButtonContent>
           </button>
         </EuiButton>
         <div
@@ -1380,15 +1396,19 @@ exports[`EuiControlBar props rightOffset is rendered 1`] = `
                 onClick={[Function]}
                 type="button"
               >
-                <span
-                  className="euiButton__content"
+                <EuiButtonContent
+                  iconSide="left"
                 >
                   <span
-                    className="euiButton__text"
+                    className="euiButton__content"
                   >
-                    Sound the Alarm
+                    <span
+                      className="euiButton__text"
+                    >
+                      Sound the Alarm
+                    </span>
                   </span>
-                </span>
+                </EuiButtonContent>
               </button>
             </EuiButton>
             <div
@@ -1679,15 +1699,19 @@ exports[`EuiControlBar props showContent is rendered 1`] = `
                 onClick={[Function]}
                 type="button"
               >
-                <span
-                  className="euiButton__content"
+                <EuiButtonContent
+                  iconSide="left"
                 >
                   <span
-                    className="euiButton__text"
+                    className="euiButton__content"
                   >
-                    Sound the Alarm
+                    <span
+                      className="euiButton__text"
+                    >
+                      Sound the Alarm
+                    </span>
                   </span>
-                </span>
+                </EuiButtonContent>
               </button>
             </EuiButton>
             <div
@@ -1978,15 +2002,19 @@ exports[`EuiControlBar props size is rendered 1`] = `
                 onClick={[Function]}
                 type="button"
               >
-                <span
-                  className="euiButton__content"
+                <EuiButtonContent
+                  iconSide="left"
                 >
                   <span
-                    className="euiButton__text"
+                    className="euiButton__content"
                   >
-                    Sound the Alarm
+                    <span
+                      className="euiButton__text"
+                    >
+                      Sound the Alarm
+                    </span>
                   </span>
-                </span>
+                </EuiButtonContent>
               </button>
             </EuiButton>
             <div

--- a/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
+++ b/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
@@ -299,31 +299,41 @@ exports[`EuiControlBar props leftOffset is rendered 1`] = `
               onClick={[Function]}
               size="s"
             >
-              <button
-                className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+              <EuiButtonDisplay
+                className="euiControlBar__button"
+                color="ghost"
                 data-test-subj="dts"
+                element="button"
                 onClick={[Function]}
+                size="s"
                 type="button"
               >
-                <EuiButtonContent
-                  className="euiButton__content"
-                  textProps={
-                    Object {
-                      "className": "euiButton__text",
-                    }
-                  }
+                <button
+                  className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+                  data-test-subj="dts"
+                  onClick={[Function]}
+                  type="button"
                 >
-                  <span
+                  <EuiButtonContent
                     className="euiButton__content"
+                    textProps={
+                      Object {
+                        "className": "euiButton__text",
+                      }
+                    }
                   >
                     <span
-                      className="euiButton__text"
+                      className="euiButton__content"
                     >
-                      Sound the Alarm
+                      <span
+                        className="euiButton__text"
+                      >
+                        Sound the Alarm
+                      </span>
                     </span>
-                  </span>
-                </EuiButtonContent>
-              </button>
+                  </EuiButtonContent>
+                </button>
+              </EuiButtonDisplay>
             </EuiButton>
             <div
               className="euiControlBar__text"
@@ -603,31 +613,41 @@ exports[`EuiControlBar props maxHeight is rendered 1`] = `
               onClick={[Function]}
               size="s"
             >
-              <button
-                className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+              <EuiButtonDisplay
+                className="euiControlBar__button"
+                color="ghost"
                 data-test-subj="dts"
+                element="button"
                 onClick={[Function]}
+                size="s"
                 type="button"
               >
-                <EuiButtonContent
-                  className="euiButton__content"
-                  textProps={
-                    Object {
-                      "className": "euiButton__text",
-                    }
-                  }
+                <button
+                  className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+                  data-test-subj="dts"
+                  onClick={[Function]}
+                  type="button"
                 >
-                  <span
+                  <EuiButtonContent
                     className="euiButton__content"
+                    textProps={
+                      Object {
+                        "className": "euiButton__text",
+                      }
+                    }
                   >
                     <span
-                      className="euiButton__text"
+                      className="euiButton__content"
                     >
-                      Sound the Alarm
+                      <span
+                        className="euiButton__text"
+                      >
+                        Sound the Alarm
+                      </span>
                     </span>
-                  </span>
-                </EuiButtonContent>
-              </button>
+                  </EuiButtonContent>
+                </button>
+              </EuiButtonDisplay>
             </EuiButton>
             <div
               className="euiControlBar__text"
@@ -906,31 +926,41 @@ exports[`EuiControlBar props mobile is rendered 1`] = `
               onClick={[Function]}
               size="s"
             >
-              <button
-                className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+              <EuiButtonDisplay
+                className="euiControlBar__button"
+                color="ghost"
                 data-test-subj="dts"
+                element="button"
                 onClick={[Function]}
+                size="s"
                 type="button"
               >
-                <EuiButtonContent
-                  className="euiButton__content"
-                  textProps={
-                    Object {
-                      "className": "euiButton__text",
-                    }
-                  }
+                <button
+                  className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+                  data-test-subj="dts"
+                  onClick={[Function]}
+                  type="button"
                 >
-                  <span
+                  <EuiButtonContent
                     className="euiButton__content"
+                    textProps={
+                      Object {
+                        "className": "euiButton__text",
+                      }
+                    }
                   >
                     <span
-                      className="euiButton__text"
+                      className="euiButton__content"
                     >
-                      Sound the Alarm
+                      <span
+                        className="euiButton__text"
+                      >
+                        Sound the Alarm
+                      </span>
                     </span>
-                  </span>
-                </EuiButtonContent>
-              </button>
+                  </EuiButtonContent>
+                </button>
+              </EuiButtonDisplay>
             </EuiButton>
             <div
               className="euiControlBar__text"
@@ -1122,31 +1152,41 @@ exports[`EuiControlBar props position is rendered 1`] = `
           onClick={[Function]}
           size="s"
         >
-          <button
-            className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+          <EuiButtonDisplay
+            className="euiControlBar__button"
+            color="ghost"
             data-test-subj="dts"
+            element="button"
             onClick={[Function]}
+            size="s"
             type="button"
           >
-            <EuiButtonContent
-              className="euiButton__content"
-              textProps={
-                Object {
-                  "className": "euiButton__text",
-                }
-              }
+            <button
+              className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+              data-test-subj="dts"
+              onClick={[Function]}
+              type="button"
             >
-              <span
+              <EuiButtonContent
                 className="euiButton__content"
+                textProps={
+                  Object {
+                    "className": "euiButton__text",
+                  }
+                }
               >
                 <span
-                  className="euiButton__text"
+                  className="euiButton__content"
                 >
-                  Sound the Alarm
+                  <span
+                    className="euiButton__text"
+                  >
+                    Sound the Alarm
+                  </span>
                 </span>
-              </span>
-            </EuiButtonContent>
-          </button>
+              </EuiButtonContent>
+            </button>
+          </EuiButtonDisplay>
         </EuiButton>
         <div
           className="euiControlBar__text"
@@ -1410,31 +1450,41 @@ exports[`EuiControlBar props rightOffset is rendered 1`] = `
               onClick={[Function]}
               size="s"
             >
-              <button
-                className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+              <EuiButtonDisplay
+                className="euiControlBar__button"
+                color="ghost"
                 data-test-subj="dts"
+                element="button"
                 onClick={[Function]}
+                size="s"
                 type="button"
               >
-                <EuiButtonContent
-                  className="euiButton__content"
-                  textProps={
-                    Object {
-                      "className": "euiButton__text",
-                    }
-                  }
+                <button
+                  className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+                  data-test-subj="dts"
+                  onClick={[Function]}
+                  type="button"
                 >
-                  <span
+                  <EuiButtonContent
                     className="euiButton__content"
+                    textProps={
+                      Object {
+                        "className": "euiButton__text",
+                      }
+                    }
                   >
                     <span
-                      className="euiButton__text"
+                      className="euiButton__content"
                     >
-                      Sound the Alarm
+                      <span
+                        className="euiButton__text"
+                      >
+                        Sound the Alarm
+                      </span>
                     </span>
-                  </span>
-                </EuiButtonContent>
-              </button>
+                  </EuiButtonContent>
+                </button>
+              </EuiButtonDisplay>
             </EuiButton>
             <div
               className="euiControlBar__text"
@@ -1718,31 +1768,41 @@ exports[`EuiControlBar props showContent is rendered 1`] = `
               onClick={[Function]}
               size="s"
             >
-              <button
-                className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+              <EuiButtonDisplay
+                className="euiControlBar__button"
+                color="ghost"
                 data-test-subj="dts"
+                element="button"
                 onClick={[Function]}
+                size="s"
                 type="button"
               >
-                <EuiButtonContent
-                  className="euiButton__content"
-                  textProps={
-                    Object {
-                      "className": "euiButton__text",
-                    }
-                  }
+                <button
+                  className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+                  data-test-subj="dts"
+                  onClick={[Function]}
+                  type="button"
                 >
-                  <span
+                  <EuiButtonContent
                     className="euiButton__content"
+                    textProps={
+                      Object {
+                        "className": "euiButton__text",
+                      }
+                    }
                   >
                     <span
-                      className="euiButton__text"
+                      className="euiButton__content"
                     >
-                      Sound the Alarm
+                      <span
+                        className="euiButton__text"
+                      >
+                        Sound the Alarm
+                      </span>
                     </span>
-                  </span>
-                </EuiButtonContent>
-              </button>
+                  </EuiButtonContent>
+                </button>
+              </EuiButtonDisplay>
             </EuiButton>
             <div
               className="euiControlBar__text"
@@ -2026,31 +2086,41 @@ exports[`EuiControlBar props size is rendered 1`] = `
               onClick={[Function]}
               size="s"
             >
-              <button
-                className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+              <EuiButtonDisplay
+                className="euiControlBar__button"
+                color="ghost"
                 data-test-subj="dts"
+                element="button"
                 onClick={[Function]}
+                size="s"
                 type="button"
               >
-                <EuiButtonContent
-                  className="euiButton__content"
-                  textProps={
-                    Object {
-                      "className": "euiButton__text",
-                    }
-                  }
+                <button
+                  className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
+                  data-test-subj="dts"
+                  onClick={[Function]}
+                  type="button"
                 >
-                  <span
+                  <EuiButtonContent
                     className="euiButton__content"
+                    textProps={
+                      Object {
+                        "className": "euiButton__text",
+                      }
+                    }
                   >
                     <span
-                      className="euiButton__text"
+                      className="euiButton__content"
                     >
-                      Sound the Alarm
+                      <span
+                        className="euiButton__text"
+                      >
+                        Sound the Alarm
+                      </span>
                     </span>
-                  </span>
-                </EuiButtonContent>
-              </button>
+                  </EuiButtonContent>
+                </button>
+              </EuiButtonDisplay>
             </EuiButton>
             <div
               className="euiControlBar__text"

--- a/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
+++ b/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
@@ -306,7 +306,12 @@ exports[`EuiControlBar props leftOffset is rendered 1`] = `
                 type="button"
               >
                 <EuiButtonContent
-                  iconSide="left"
+                  className="euiButton__content"
+                  textProps={
+                    Object {
+                      "className": "euiButton__text",
+                    }
+                  }
                 >
                   <span
                     className="euiButton__content"
@@ -605,7 +610,12 @@ exports[`EuiControlBar props maxHeight is rendered 1`] = `
                 type="button"
               >
                 <EuiButtonContent
-                  iconSide="left"
+                  className="euiButton__content"
+                  textProps={
+                    Object {
+                      "className": "euiButton__text",
+                    }
+                  }
                 >
                   <span
                     className="euiButton__content"
@@ -903,7 +913,12 @@ exports[`EuiControlBar props mobile is rendered 1`] = `
                 type="button"
               >
                 <EuiButtonContent
-                  iconSide="left"
+                  className="euiButton__content"
+                  textProps={
+                    Object {
+                      "className": "euiButton__text",
+                    }
+                  }
                 >
                   <span
                     className="euiButton__content"
@@ -1114,7 +1129,12 @@ exports[`EuiControlBar props position is rendered 1`] = `
             type="button"
           >
             <EuiButtonContent
-              iconSide="left"
+              className="euiButton__content"
+              textProps={
+                Object {
+                  "className": "euiButton__text",
+                }
+              }
             >
               <span
                 className="euiButton__content"
@@ -1397,7 +1417,12 @@ exports[`EuiControlBar props rightOffset is rendered 1`] = `
                 type="button"
               >
                 <EuiButtonContent
-                  iconSide="left"
+                  className="euiButton__content"
+                  textProps={
+                    Object {
+                      "className": "euiButton__text",
+                    }
+                  }
                 >
                   <span
                     className="euiButton__content"
@@ -1700,7 +1725,12 @@ exports[`EuiControlBar props showContent is rendered 1`] = `
                 type="button"
               >
                 <EuiButtonContent
-                  iconSide="left"
+                  className="euiButton__content"
+                  textProps={
+                    Object {
+                      "className": "euiButton__text",
+                    }
+                  }
                 >
                   <span
                     className="euiButton__content"
@@ -2003,7 +2033,12 @@ exports[`EuiControlBar props size is rendered 1`] = `
                 type="button"
               >
                 <EuiButtonContent
-                  iconSide="left"
+                  className="euiButton__content"
+                  textProps={
+                    Object {
+                      "className": "euiButton__text",
+                    }
+                  }
                 >
                   <span
                     className="euiButton__content"

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`EuiDataGrid pagination renders 1`] = `
           >
             <div
               aria-hidden="true"
-              class="euiButton__icon"
+              class="euiButtonContent__icon"
               data-euiicon-type="arrowDown"
             />
             <span
@@ -208,7 +208,7 @@ Array [
               >
                 <div
                   aria-hidden="true"
-                  class="euiButton__icon"
+                  class="euiButtonContent__icon"
                   data-euiicon-type="listAdd"
                 />
                 <span
@@ -237,7 +237,7 @@ Array [
               >
                 <div
                   aria-hidden="true"
-                  class="euiButton__icon"
+                  class="euiButtonContent__icon"
                   data-euiicon-type="tableDensityExpanded"
                 />
                 <span
@@ -259,7 +259,7 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButton__icon"
+              class="euiButtonContent__icon"
               data-euiicon-type="fullScreen"
             />
             <span
@@ -749,7 +749,7 @@ Array [
               >
                 <div
                   aria-hidden="true"
-                  class="euiButton__icon"
+                  class="euiButtonContent__icon"
                   data-euiicon-type="listAdd"
                 />
                 <span
@@ -778,7 +778,7 @@ Array [
               >
                 <div
                   aria-hidden="true"
-                  class="euiButton__icon"
+                  class="euiButtonContent__icon"
                   data-euiicon-type="tableDensityExpanded"
                 />
                 <span
@@ -800,7 +800,7 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButton__icon"
+              class="euiButtonContent__icon"
               data-euiicon-type="fullScreen"
             />
             <span
@@ -1611,7 +1611,7 @@ Array [
               >
                 <div
                   aria-hidden="true"
-                  class="euiButton__icon"
+                  class="euiButtonContent__icon"
                   data-euiicon-type="listAdd"
                 />
                 <span
@@ -1640,7 +1640,7 @@ Array [
               >
                 <div
                   aria-hidden="true"
-                  class="euiButton__icon"
+                  class="euiButtonContent__icon"
                   data-euiicon-type="tableDensityExpanded"
                 />
                 <span
@@ -1662,7 +1662,7 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButton__icon"
+              class="euiButtonContent__icon"
               data-euiicon-type="fullScreen"
             />
             <span
@@ -2151,7 +2151,7 @@ Array [
               >
                 <div
                   aria-hidden="true"
-                  class="euiButton__icon"
+                  class="euiButtonContent__icon"
                   data-euiicon-type="listAdd"
                 />
                 <span
@@ -2180,7 +2180,7 @@ Array [
               >
                 <div
                   aria-hidden="true"
-                  class="euiButton__icon"
+                  class="euiButtonContent__icon"
                   data-euiicon-type="tableDensityExpanded"
                 />
                 <span
@@ -2202,7 +2202,7 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButton__icon"
+              class="euiButtonContent__icon"
               data-euiicon-type="fullScreen"
             />
             <span

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -62,7 +62,6 @@ exports[`EuiDataGrid pagination renders 1`] = `
             class="euiButtonEmpty__content"
           >
             <div
-              aria-hidden="true"
               class="euiButtonContent__icon"
               data-euiicon-type="arrowDown"
             />
@@ -207,7 +206,6 @@ Array [
                 class="euiButtonEmpty__content"
               >
                 <div
-                  aria-hidden="true"
                   class="euiButtonContent__icon"
                   data-euiicon-type="listAdd"
                 />
@@ -236,7 +234,6 @@ Array [
                 class="euiButtonEmpty__content"
               >
                 <div
-                  aria-hidden="true"
                   class="euiButtonContent__icon"
                   data-euiicon-type="tableDensityExpanded"
                 />
@@ -258,7 +255,6 @@ Array [
             class="euiButtonEmpty__content"
           >
             <div
-              aria-hidden="true"
               class="euiButtonContent__icon"
               data-euiicon-type="fullScreen"
             />
@@ -748,7 +744,6 @@ Array [
                 class="euiButtonEmpty__content"
               >
                 <div
-                  aria-hidden="true"
                   class="euiButtonContent__icon"
                   data-euiicon-type="listAdd"
                 />
@@ -777,7 +772,6 @@ Array [
                 class="euiButtonEmpty__content"
               >
                 <div
-                  aria-hidden="true"
                   class="euiButtonContent__icon"
                   data-euiicon-type="tableDensityExpanded"
                 />
@@ -799,7 +793,6 @@ Array [
             class="euiButtonEmpty__content"
           >
             <div
-              aria-hidden="true"
               class="euiButtonContent__icon"
               data-euiicon-type="fullScreen"
             />
@@ -1610,7 +1603,6 @@ Array [
                 class="euiButtonEmpty__content"
               >
                 <div
-                  aria-hidden="true"
                   class="euiButtonContent__icon"
                   data-euiicon-type="listAdd"
                 />
@@ -1639,7 +1631,6 @@ Array [
                 class="euiButtonEmpty__content"
               >
                 <div
-                  aria-hidden="true"
                   class="euiButtonContent__icon"
                   data-euiicon-type="tableDensityExpanded"
                 />
@@ -1661,7 +1652,6 @@ Array [
             class="euiButtonEmpty__content"
           >
             <div
-              aria-hidden="true"
               class="euiButtonContent__icon"
               data-euiicon-type="fullScreen"
             />
@@ -2150,7 +2140,6 @@ Array [
                 class="euiButtonEmpty__content"
               >
                 <div
-                  aria-hidden="true"
                   class="euiButtonContent__icon"
                   data-euiicon-type="listAdd"
                 />
@@ -2179,7 +2168,6 @@ Array [
                 class="euiButtonEmpty__content"
               >
                 <div
-                  aria-hidden="true"
                   class="euiButtonContent__icon"
                   data-euiicon-type="tableDensityExpanded"
                 />
@@ -2201,7 +2189,6 @@ Array [
             class="euiButtonEmpty__content"
           >
             <div
-              aria-hidden="true"
               class="euiButtonContent__icon"
               data-euiicon-type="fullScreen"
             />

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`EuiDataGrid pagination renders 1`] = `
           >
             <div
               aria-hidden="true"
-              class="euiButtonEmpty__icon"
+              class="euiButton__icon"
               data-euiicon-type="arrowDown"
             />
             <span
@@ -208,7 +208,7 @@ Array [
               >
                 <div
                   aria-hidden="true"
-                  class="euiButtonEmpty__icon"
+                  class="euiButton__icon"
                   data-euiicon-type="listAdd"
                 />
                 <span
@@ -237,7 +237,7 @@ Array [
               >
                 <div
                   aria-hidden="true"
-                  class="euiButtonEmpty__icon"
+                  class="euiButton__icon"
                   data-euiicon-type="tableDensityExpanded"
                 />
                 <span
@@ -259,7 +259,7 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButtonEmpty__icon"
+              class="euiButton__icon"
               data-euiicon-type="fullScreen"
             />
             <span
@@ -749,7 +749,7 @@ Array [
               >
                 <div
                   aria-hidden="true"
-                  class="euiButtonEmpty__icon"
+                  class="euiButton__icon"
                   data-euiicon-type="listAdd"
                 />
                 <span
@@ -778,7 +778,7 @@ Array [
               >
                 <div
                   aria-hidden="true"
-                  class="euiButtonEmpty__icon"
+                  class="euiButton__icon"
                   data-euiicon-type="tableDensityExpanded"
                 />
                 <span
@@ -800,7 +800,7 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButtonEmpty__icon"
+              class="euiButton__icon"
               data-euiicon-type="fullScreen"
             />
             <span
@@ -1611,7 +1611,7 @@ Array [
               >
                 <div
                   aria-hidden="true"
-                  class="euiButtonEmpty__icon"
+                  class="euiButton__icon"
                   data-euiicon-type="listAdd"
                 />
                 <span
@@ -1640,7 +1640,7 @@ Array [
               >
                 <div
                   aria-hidden="true"
-                  class="euiButtonEmpty__icon"
+                  class="euiButton__icon"
                   data-euiicon-type="tableDensityExpanded"
                 />
                 <span
@@ -1662,7 +1662,7 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButtonEmpty__icon"
+              class="euiButton__icon"
               data-euiicon-type="fullScreen"
             />
             <span
@@ -2151,7 +2151,7 @@ Array [
               >
                 <div
                   aria-hidden="true"
-                  class="euiButtonEmpty__icon"
+                  class="euiButton__icon"
                   data-euiicon-type="listAdd"
                 />
                 <span
@@ -2180,7 +2180,7 @@ Array [
               >
                 <div
                   aria-hidden="true"
-                  class="euiButtonEmpty__icon"
+                  class="euiButton__icon"
                   data-euiicon-type="tableDensityExpanded"
                 />
                 <span
@@ -2202,7 +2202,7 @@ Array [
           >
             <div
               aria-hidden="true"
-              class="euiButtonEmpty__icon"
+              class="euiButton__icon"
               data-euiicon-type="fullScreen"
             />
             <span

--- a/src/components/filter_group/__snapshots__/filter_button.test.tsx.snap
+++ b/src/components/filter_group/__snapshots__/filter_button.test.tsx.snap
@@ -49,7 +49,6 @@ exports[`EuiFilterButton props iconType and iconSide is rendered 1`] = `
     class="euiButtonEmpty__content"
   >
     <div
-      aria-hidden="true"
       class="euiButtonContent__icon"
       data-euiicon-type="user"
     />

--- a/src/components/filter_group/__snapshots__/filter_button.test.tsx.snap
+++ b/src/components/filter_group/__snapshots__/filter_button.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`EuiFilterButton is rendered 1`] = `
     class="euiButtonEmpty__content"
   >
     <span
-      class="euiButtonEmpty__text"
+      class=""
     >
       <span
         class="euiFilterButton__textShift"
@@ -30,7 +30,7 @@ exports[`EuiFilterButton props grow can be turned off 1`] = `
     class="euiButtonEmpty__content"
   >
     <span
-      class="euiButtonEmpty__text"
+      class=""
     >
       <span
         class="euiFilterButton__textShift"
@@ -50,11 +50,11 @@ exports[`EuiFilterButton props iconType and iconSide is rendered 1`] = `
   >
     <div
       aria-hidden="true"
-      class="euiButtonEmpty__icon"
+      class="euiButton__icon"
       data-euiicon-type="user"
     />
     <span
-      class="euiButtonEmpty__text"
+      class=""
     >
       <span
         class="euiFilterButton__textShift"
@@ -74,7 +74,7 @@ exports[`EuiFilterButton props isDisabled is rendered 1`] = `
     class="euiButtonEmpty__content"
   >
     <span
-      class="euiButtonEmpty__text"
+      class=""
     >
       <span
         class="euiFilterButton__textShift"
@@ -93,7 +93,7 @@ exports[`EuiFilterButton props isSelected is rendered 1`] = `
     class="euiButtonEmpty__content"
   >
     <span
-      class="euiButtonEmpty__text"
+      class=""
     >
       <span
         class="euiFilterButton__textShift"
@@ -112,7 +112,7 @@ exports[`EuiFilterButton props numActiveFilters and hasActiveFilters is rendered
     class="euiButtonEmpty__content"
   >
     <span
-      class="euiButtonEmpty__text"
+      class=""
     >
       <span
         class="euiFilterButton__textShift"
@@ -131,7 +131,7 @@ exports[`EuiFilterButton props numFilters is rendered 1`] = `
     class="euiButtonEmpty__content"
   >
     <span
-      class="euiButtonEmpty__text euiFilterButton__text-hasNotification"
+      class="euiFilterButton__text-hasNotification"
     >
       <span
         class="euiFilterButton__textShift"
@@ -156,7 +156,7 @@ exports[`EuiFilterButton props type is rendered 1`] = `
     class="euiButtonEmpty__content"
   >
     <span
-      class="euiButtonEmpty__text"
+      class=""
     >
       <span
         class="euiFilterButton__textShift"
@@ -175,7 +175,7 @@ exports[`EuiFilterButton props withNext is rendered 1`] = `
     class="euiButtonEmpty__content"
   >
     <span
-      class="euiButtonEmpty__text"
+      class=""
     >
       <span
         class="euiFilterButton__textShift"
@@ -196,7 +196,7 @@ exports[`EuiFilterButton renders zero properly 1`] = `
     class="euiButtonEmpty__content"
   >
     <span
-      class="euiButtonEmpty__text euiFilterButton__text-hasNotification"
+      class="euiFilterButton__text-hasNotification"
     >
       <span
         class="euiFilterButton__textShift"

--- a/src/components/filter_group/__snapshots__/filter_button.test.tsx.snap
+++ b/src/components/filter_group/__snapshots__/filter_button.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`EuiFilterButton props iconType and iconSide is rendered 1`] = `
   >
     <div
       aria-hidden="true"
-      class="euiButton__icon"
+      class="euiButtonContent__icon"
       data-euiicon-type="user"
     />
     <span

--- a/src/components/table/mobile/__snapshots__/table_sort_mobile.test.tsx.snap
+++ b/src/components/table/mobile/__snapshots__/table_sort_mobile.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`EuiTableSortMobile is rendered 1`] = `
         >
           <div
             aria-hidden="true"
-            class="euiButtonEmpty__icon"
+            class="euiButton__icon"
             data-euiicon-type="arrowDown"
           />
           <span

--- a/src/components/table/mobile/__snapshots__/table_sort_mobile.test.tsx.snap
+++ b/src/components/table/mobile/__snapshots__/table_sort_mobile.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`EuiTableSortMobile is rendered 1`] = `
         >
           <div
             aria-hidden="true"
-            class="euiButton__icon"
+            class="euiButtonContent__icon"
             data-euiicon-type="arrowDown"
           />
           <span

--- a/src/components/table/mobile/__snapshots__/table_sort_mobile.test.tsx.snap
+++ b/src/components/table/mobile/__snapshots__/table_sort_mobile.test.tsx.snap
@@ -20,7 +20,6 @@ exports[`EuiTableSortMobile is rendered 1`] = `
           class="euiButtonEmpty__content"
         >
           <div
-            aria-hidden="true"
             class="euiButtonContent__icon"
             data-euiicon-type="arrowDown"
           />

--- a/src/components/table/table_pagination/__snapshots__/table_pagination.test.tsx.snap
+++ b/src/components/table/table_pagination/__snapshots__/table_pagination.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`EuiTablePagination is rendered 1`] = `
           >
             <div
               aria-hidden="true"
-              class="euiButtonEmpty__icon"
+              class="euiButton__icon"
               data-euiicon-type="arrowDown"
             />
             <span

--- a/src/components/table/table_pagination/__snapshots__/table_pagination.test.tsx.snap
+++ b/src/components/table/table_pagination/__snapshots__/table_pagination.test.tsx.snap
@@ -22,7 +22,6 @@ exports[`EuiTablePagination is rendered 1`] = `
             class="euiButtonEmpty__content"
           >
             <div
-              aria-hidden="true"
               class="euiButtonContent__icon"
               data-euiicon-type="arrowDown"
             />

--- a/src/components/table/table_pagination/__snapshots__/table_pagination.test.tsx.snap
+++ b/src/components/table/table_pagination/__snapshots__/table_pagination.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`EuiTablePagination is rendered 1`] = `
           >
             <div
               aria-hidden="true"
-              class="euiButton__icon"
+              class="euiButtonContent__icon"
               data-euiicon-type="arrowDown"
             />
             <span

--- a/src/global_styling/mixins/_button.scss
+++ b/src/global_styling/mixins/_button.scss
@@ -63,8 +63,8 @@
   width: 100%;
   vertical-align: middle;
 
-  .euiButton__icon,
-  .euiButton__spinner {
+  .euiButtonContent__icon,
+  .euiButtonContent__spinner {
     flex-shrink: 0; // Ensures the icons/spinner don't scale down below their intended size
   }
 
@@ -83,6 +83,19 @@
     > * + * {
       margin-left: $euiSizeS; // 1
     }
+  }
+}
+
+@mixin euiButtonContentDisabled {
+  pointer-events: auto;
+  cursor: not-allowed;
+
+  .euiButtonContent__icon {
+    fill: currentColor;
+  }
+
+  .euiButtonContent__spinner {
+    border-color: euiLoadingSpinnerBorderColors(currentColor);
   }
 }
 


### PR DESCRIPTION
### Pre-requisite to finishing #3099

**EuiButtonGroup** will not be able to use `<EuiButton>` directly, and therefore, we will need to rebuild a lot of styles so that they can look/accept the same params as **EuiButton,** but render as a `<label>`.

Instead of just allowing **EuiButton** to render as a `<label>` to anyone (since this can easily be abused), there are 2 pre-requisites to make it easier to re-apply **EuiButton** content and styles that this PR does.

1. **EuiButtonContent** 

This is a new internal-only component that just pulls out the spans creating the content span that encompasses the icon and text span. Now used by both **EuiButton** and **EuiButtonEmpty** (possibly others in the future).

2. **EuiButtonDisplay**

Also an inernal-only component, and truly an internal to **EuiButton** only component as well. This is basically all of the original code for EuiButton but with the additional prop of `element` which can be span, a, button, label, etc...

Then the EuiButton code itself is just the `a` vs `button` that it passes to `<EuiButtonDisplay>`.


### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
