### PR TITLE
Re-focus EuiSuperSelect input after making a value change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed a bug in `EuiResizableContainer` preventing nested containers ([#3699](https://github.com/elastic/eui/pull/3699))
 - Fixed a bug in `EuiResizableContainer` preventing resizing by arrow keys in some cases ([#3699](https://github.com/elastic/eui/pull/3699))
 - Fixed `EuiHorizontalSteps` rendering over `EuiHeader` ([#3707](https://github.com/elastic/eui/pull/3707))
+- Fixed bug where `EuiSuperSelect` lost focus after a value selection ([#3734](https://github.com/elastic/eui/pull/3734))
 
 **Breaking changes**
 

--- a/src/components/color_picker/color_palette_picker/__snapshots__/color_palette_picker.test.tsx.snap
+++ b/src/components/color_picker/color_palette_picker/__snapshots__/color_palette_picker.test.tsx.snap
@@ -710,6 +710,7 @@ exports[`EuiColorPalettePicker more props are propagated to each option 2`] = `
           value="paletteFixed"
         />
       }
+      buttonRef={[Function]}
       className="euiSuperSelect"
       closePopover={[Function]}
       display="block"

--- a/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
@@ -558,6 +558,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 2`] = `
         value="1"
       />
     }
+    buttonRef={[Function]}
     className="euiSuperSelect"
     closePopover={[Function]}
     display="block"

--- a/src/components/form/super_select/super_select.tsx
+++ b/src/components/form/super_select/super_select.tsx
@@ -101,6 +101,14 @@ export class EuiSuperSelect<T extends string> extends Component<
 
   private itemNodes: Array<HTMLButtonElement | null> = [];
   private popoverRef: HTMLDivElement | null = null;
+  private buttonRef: HTMLElement | null = null;
+  private setButtonRef = (popoverButtonRef: HTMLDivElement | null) => {
+    if (popoverButtonRef) {
+      this.buttonRef = popoverButtonRef.querySelector('button')!;
+    } else {
+      this.buttonRef = null;
+    }
+  };
   private _isMounted: boolean = false;
 
   state = {
@@ -177,6 +185,9 @@ export class EuiSuperSelect<T extends string> extends Component<
     });
     if (this.props.onChange) {
       this.props.onChange(value);
+    }
+    if (this.buttonRef) {
+      this.buttonRef.focus();
     }
   };
 
@@ -339,6 +350,7 @@ export class EuiSuperSelect<T extends string> extends Component<
         anchorPosition="downCenter"
         ownFocus={false}
         popoverRef={this.setPopoverRef}
+        buttonRef={this.setButtonRef}
         hasArrow={false}
         buffer={0}>
         <EuiScreenReaderOnly>


### PR DESCRIPTION
### Summary

Fixes #3727 by re-focusing the super select's button after a value change. Tested selection by both mouse and keyboard. I'm not really happy with using `querySelector` to get at the underlying button, but adding `forwardRef` to the super select control gets messy because of its props' generic, and I couldn't get a satisfactory version working. Please push on that if you feel it shouldn't go in as-is.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
