### PR TITLE
Add ssh keys so new tags can be pushed to Github from Jenkins

### DIFF
--- a/.ci/jobs/elastic+eui+npm-publish.yml
+++ b/.ci/jobs/elastic+eui+npm-publish.yml
@@ -34,6 +34,9 @@
           npm install -g yarn
           yarn
 
+          # add ssh keys to ensure tags can push to Github
+          /usr/local/bin/ssh-add-from-vault elastic
+
           npm run release -- --type=${version_type} --steps=test,build,version,tag
 
           set +x

--- a/.ci/jobs/elastic+eui+npm-publish.yml
+++ b/.ci/jobs/elastic+eui+npm-publish.yml
@@ -34,14 +34,14 @@
           npm install -g yarn
           yarn
 
-          # add ssh keys to ensure tags can push to Github
-          /usr/local/bin/ssh-add-from-vault elastic
-
           npm run release -- --type=${version_type} --steps=test,build,version,tag
 
           set +x
 
           export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+
+          # add ssh keys to ensure tags can push to Github
+          /usr/local/bin/ssh-add-from-vault elastic
 
           # write npm auth to .npmrc
           NPM_TOKEN=$(vault read -field=token secret/jenkins-ci/npmjs/elasticmachine)


### PR DESCRIPTION
### Summary

Just what it says on the tin: we need some valid ssh keys before we can push new tags back to Github.

This work required some changes to workers in kibana-ci to ensure `/usr/local/bin/ssh-add-from-vault` exists. That config change should be applied sometime in the next few hours if it hasn't already.

Once this is merged, we should be clear to attempt another automated release!