### PR TITLE
[Playground] Added check for IE11 for playground services

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -2,56 +2,61 @@ module.exports = {
   // We need to preserve comments as they are used by webpack for
   // naming chunks during code-splitting. The compression step during
   // bundling will remove them later.
-  "comments": true,
+  comments: true,
 
-  "presets": [
-    ["@babel/env", {
-      "targets": {
-        "browsers": [
-          "last 2 versions",
-          "> 5%",
-          "Safari 7" // for PhantomJS support
-        ]
-      },
-      "useBuiltIns": process.env.NO_COREJS_POLYFILL ? false : "usage",
-      "corejs": "2",
-      "modules": process.env.BABEL_MODULES ? process.env.BABEL_MODULES : "commonjs" // babel's default is commonjs
-    }],
-    ["@babel/typescript", { isTSX: true, allExtensions: true }],
-    "@babel/react"
-  ],
-  "plugins": [
-    "@babel/plugin-syntax-dynamic-import",
-    "pegjs-inline-precompile",
-    "./scripts/babel/proptypes-from-ts-props",
-    "add-module-exports",
+  presets: [
     [
-      "react-docgen",
+      '@babel/env',
       {
-        "resolver": "findAllExportedComponentDefinitions"
-      }
+        targets: {
+          browsers: [
+            'last 2 versions',
+            '> 5%',
+            'Safari 7', // for PhantomJS support
+            'Explorer >= 10',
+          ],
+        },
+        useBuiltIns: process.env.NO_COREJS_POLYFILL ? false : 'usage',
+        corejs: '2',
+        modules: process.env.BABEL_MODULES
+          ? process.env.BABEL_MODULES
+          : 'commonjs', // babel's default is commonjs
+      },
+    ],
+    ['@babel/typescript', { isTSX: true, allExtensions: true }],
+    '@babel/react',
+  ],
+  plugins: [
+    '@babel/plugin-syntax-dynamic-import',
+    '@babel/plugin-transform-destructuring',
+    'pegjs-inline-precompile',
+    './scripts/babel/proptypes-from-ts-props',
+    'add-module-exports',
+    [
+      'react-docgen',
+      {
+        resolver: 'findAllExportedComponentDefinitions',
+      },
     ],
     // stage 3
-    "@babel/proposal-object-rest-spread",
+    '@babel/proposal-object-rest-spread',
     // stage 2
-    "@babel/proposal-class-properties",
+    '@babel/proposal-class-properties',
     [
-      "inline-react-svg",
+      'inline-react-svg',
       {
-        "ignorePattern": "images/*",
-        "svgo": {
-          "plugins": [
-            { "cleanupIDs": false },
-            { "removeViewBox": false }
-          ]
-        }
-      }
+        ignorePattern: 'images/*',
+        svgo: {
+          plugins: [{ cleanupIDs: false }, { removeViewBox: false }],
+        },
+      },
     ],
   ],
 
-  "env": {
-    "test": {
-      "plugins": ["dynamic-import-node"]
-    }
-  }
+  env: {
+    test: {
+      plugins: ['dynamic-import-node'],
+    },
+  },
+  sourceType: 'unambiguous',
 };

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test-staged"
   ],
   "dependencies": {
+    "@babel/plugin-transform-destructuring": "^7.10.4",
     "@types/chroma-js": "^2.0.0",
     "@types/lodash": "^4.14.116",
     "@types/numeral": "^0.0.25",
@@ -57,12 +58,12 @@
     "classnames": "^2.2.5",
     "highlight.js": "^9.12.0",
     "html": "^1.0.0",
-    "html-format": "^1.0.1",
     "keymirror": "^0.1.1",
     "lodash": "^4.17.11",
     "numeral": "^2.0.6",
     "prop-types": "^15.6.0",
     "react-ace": "^7.0.5",
+    "react-app-polyfill": "^1.0.6",
     "react-beautiful-dnd": "^13.0.0",
     "react-focus-lock": "^1.17.7",
     "react-input-autosize": "^2.2.2",

--- a/src-docs/src/index.js
+++ b/src-docs/src/index.js
@@ -1,6 +1,11 @@
+import 'react-app-polyfill/ie11';
+import 'react-app-polyfill/stable';
+
 // specifically polyfill Object.entries for IE11 support (used by @elastic/charts)
 import 'core-js/modules/es7.object.entries';
 import 'core-js/modules/es6.number.is-finite';
+// import 'core-js/es6/map';
+// import 'core-js/es6/set';
 
 import React, { createElement } from 'react';
 import ReactDOM from 'react-dom';

--- a/src-docs/src/routes.js
+++ b/src-docs/src/routes.js
@@ -262,7 +262,18 @@ const createExample = (example, customTitle) => {
   );
 
   let playgroundComponent;
-  if (playground) {
+  // react-live doesn't work in IE11
+  if (
+    typeof window !== 'undefined' &&
+    typeof document !== 'undefined' &&
+    !!window.MSInputMethodContext &&
+    !!document.documentMode
+  ) {
+    console.warn(
+      "Playground service isn't available in IE11! Please use Edge or another modern browser."
+    );
+    playgroundComponent = null;
+  } else if (playground) {
     playgroundComponent = playgroundCreator(playground());
   }
 

--- a/src-docs/src/services/playground/playground.js
+++ b/src-docs/src/services/playground/playground.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import classNames from 'classnames';
-import format from 'html-format';
+// import format from 'html-format';
 
 import { useView, Compiler, Error, Placeholder } from 'react-view';
 import { EuiSpacer, EuiTitle, EuiCodeBlock } from '../../../../src/components';
@@ -25,8 +25,8 @@ export default ({ config, setGhostBackground }) => {
     if (newCode.endsWith(');')) {
       newCode = newCode.replace(/(\);)$/m, '');
     }
-
-    return format(newCode.trim(), ' '.repeat(4));
+    return newCode.trim();
+    // return format(newCode.trim(), ' '.repeat(4));
   };
 
   const Playground = () => {

--- a/src-docs/webpack.config.js
+++ b/src-docs/webpack.config.js
@@ -43,13 +43,36 @@ const webpackConfig = {
   module: {
     rules: [
       {
-        test: /\.(js|tsx?)$/,
-        loaders: useCache(['babel-loader']), // eslint-disable-line react-hooks/rules-of-hooks
-        exclude: [/node_modules/, /packages(\/|\\)react-datepicker/],
+        test: /\.(jsx|ts|js|tsx?)$/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-env'],
+            plugins: [
+              '@babel/plugin-transform-runtime',
+              '@babel/plugin-transform-destructuring',
+            ],
+          },
+        },
+        exclude: [
+          // /[\\/]node_modules[\\/](?!(react-view)[\\/])/,
+          // /node_modules\/(?![@babel\/code-frame])/,
+          // /node_modules\/(?!(react-view|@babel\/code-frame|@babel\/parser|@babel\/generator|@babel\/traverse|@babel\/types|@babel\/template|@babel\/highlight|@babel\/helpers))/,
+          /node_modules\/(?!(react-view|@babel\/code-frame))/,
+          /packages(\/|\\)react-datepicker/,
+        ],
       },
+      //         exclude: /[\\/]node_modules[\\/](?!(@elastic\/eslint-config-kibana|@svgr\/plugin-jsx|@svgr\/plugin-svgo|@typescript-eslint\/eslint-plugin|@typescript-eslint\/experimental-utils|adm-zip|agent-base|aggregate-error|angular-estree-parser|ansi-align|ansi-colors|ansi-styles|append-transform|are-you-es5|ast-types-flow|astral-regex|axe-puppeteer|boxen|caller-callsite|callsites|camelcase|chalk|chromedriver|circular-dependency-plugin|clean-stack|cli-cursor|codesandbox|configstore|constants-browserify|content-type-parser|core-js-compat|cross-env|cross-spawn|crypto-random-string|css-color-names|css-declaration-sorter|cssnano|cssnano-preset-default|cssnano-util-get-arguments|cssnano-util-get-match|cssnano-util-raw-cache|cssnano-util-same-parent|dargs|dashdash|datauri|decompress-response|default-gateway|default-require-extensions|del|diff-sequences|dot-prop|editorconfig-to-prettier|enhanced-resolve|eslint|eslint-config-prettier|eslint-plugin-import|eslint-plugin-jest|eslint-plugin-prettier|eslint-plugin-react|eslint-rule-composer|eslint-scope|eslint-utils|eslint-visitor-keys|espree|execa|expect|figgy-pudding|file-entry-cache|find-cache-dir|find-up|fs-extra|fs-minipass|fullname|genfun|gensync|get-port|get-stream|getpass|gh-got|github-username|global-dirs|global-modules-path|growl|hoek|html-element-attributes|html-encoding-sniffer|http-cache-semantics|ignore|ignore-walk|import-fresh|import-lazy|import-local|infer-owner|internal-ip|interpret|ip-regex|is-color-stop|is-fullwidth-code-point|is-generator-fn|is-installed-globally|is-scoped|is-wsl|is2|isemail|isurl|items|jest|jest-changed-files|jest-config|jest-diff|jest-docblock|jest-each|jest-environment-jsdom|jest-environment-node|jest-get-type|jest-haste-map|jest-jasmine2|jest-leak-detector|jest-matcher-utils|jest-message-util|jest-mock|jest-regex-util|jest-resolve|jest-resolve-dependencies|jest-runner|jest-runtime|jest-serializer|jest-snapshot|jest-util|jest-worker|joi|jsdom|jsesc|json-parse-better-errors|kleur|latest-version|load-json-file|loader-utils|locate-path|lodash-es|log-symbols|make-dir|make-fetch-happen|map-age-cleaner|mem|mimic-fn|mimic-response|minipass|minizlib|n-readlines|ncp|node-fetch-npm|nodeclient-spectre|npm-bundled|npm-package-arg|npm-packlist|npm-pick-manifest|npm-run-path|open|ora|os-locale|p-any|p-cancelable|p-defer|p-each-series|p-finally|p-is-promise|p-limit|p-locate|p-map|p-reduce|p-some|p-timeout|p-try|parent-module|passwd-user|path-exists|path-type|pirates|pkg-dir|postcss-cli|postcss-inline-svg|postcss-normalize-display-values|postcss-normalize-positions|postcss-normalize-repeat-style|postcss-normalize-string|postcss-normalize-timing-functions|postcss-normalize-unicode|postcss-normalize-whitespace|postcss-values-parser|pre-commit|prettier|prettier-linter-helpers|pretty-bytes|pretty-format|promise-inflight|promisify-node|protoduck|puppeteer|react-docgen|react-view|read-chunk|read-pkg|read-pkg-up|realpath-native|rechoir|regexpp|remark-math|resolve-cwd|resolve-from|restore-cursor|sane|sass-lint-auto-fix|sauce-connect-launcher|schema-utils|scoped-regex|selfsigned|sisteransi|slash|slice-ansi|sort-on|ssri|start-server-and-test|string-length|string-width|strip-bom|stylehacks|symbol-tree|term-size|terser|test-exclude|tmp|to-fast-properties|topo|tr46|tsutils|unicode-match-property-ecmascript|unicode-match-property-value-ecmascript|unique-string|universalify|untildify|update-notifier|url-to-options|v8-compile-cache|vnopts|w3c-hr-time|wdio-spec-reporter|wdio-sync|webidl-conversions|whatwg-encoding|widest-line|worker-farm|write-file-atomic|ws|xdg-basedir|xml-name-validator|yargs|yargs-parser|yeoman-environment|yeoman-generator|yosay)[\\/])/,
+
+      // {
+      //   test: /\.(js|tsx?)$/,
+      //   loaders: useCache(['babel-loader']), // eslint-disable-line react-hooks/rules-of-hooks
+      //   exclude: [/node_modules/, /packages(\/|\\)react-datepicker/],
+      // },
       {
         test: /\.scss$/,
-        loaders: useCache([ // eslint-disable-line react-hooks/rules-of-hooks, prettier/prettier
+        loaders: useCache([
+          // eslint-disable-line react-hooks/rules-of-hooks, prettier/prettier
           'style-loader/useable',
           'css-loader',
           'postcss-loader',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -52,5 +52,6 @@
   "include": [
     "./src/**/*",
     "./src-docs/**/*",
+    "./node_modules/react-view/**/*",
   ],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -750,6 +750,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
+"@babel/plugin-transform-destructuring@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz#70ddd2b3d1bea83d01509e9bb25ddb3a74fc85e5"
+  integrity sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
 "@babel/plugin-transform-destructuring@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.3.tgz#20ddfbd9e4676906b1056ee60af88590cc7aaa0b"
@@ -1987,7 +1994,7 @@ acorn@^5.5.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
-acorn@^6.2.1:
+acorn@^6.0.6, acorn@^6.2.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
@@ -2443,7 +2450,7 @@ arrify@^1.0.0, arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
-asap@~2.0.3:
+asap@~2.0.3, asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
@@ -4382,6 +4389,11 @@ core-js@^2.6.5:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
+
+core-js@^3.5.0:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
+  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -6827,6 +6839,14 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
+find-up@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
+  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
+  dependencies:
+    locate-path "^5.0.0"
+    path-exists "^4.0.0"
+
 find-versions@^1.0.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/find-versions/-/find-versions-1.2.1.tgz#cbde9f12e38575a0af1be1b9a2c5d5fd8f186b62"
@@ -7912,11 +7932,6 @@ html-entities@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
   integrity sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=
-
-html-format@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/html-format/-/html-format-1.0.1.tgz#3f518be1a1123e2d378716aef662c07ed2a0e008"
-  integrity sha512-ePp+h+akaQiLeCGPefWQ4QJXVXhWx4sU4ZxJVFlaY0AeVgh/tnHGTL27ao09JrdEEelXYMAWi4ynKKheck4tdw==
 
 html-minifier@^3.2.3:
   version "3.5.8"
@@ -9978,6 +9993,13 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+locate-path@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
+  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
+  dependencies:
+    p-locate "^4.1.0"
+
 lodash-es@^4.2.1:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
@@ -11881,6 +11903,13 @@ p-limit@^2.0.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
+  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -11894,6 +11923,13 @@ p-locate@^3.0.0:
   integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
   dependencies:
     p-limit "^2.0.0"
+
+p-locate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
+  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
+  dependencies:
+    p-limit "^2.2.0"
 
 p-map@^1.1.1:
   version "1.2.0"
@@ -12182,6 +12218,11 @@ path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
   integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
+
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -13157,6 +13198,13 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+promise@^8.0.3:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-8.1.0.tgz#697c25c3dfe7435dd79fcd58c38a135888eaf05e"
+  integrity sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==
+  dependencies:
+    asap "~2.0.6"
+
 promisify-node@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/promisify-node/-/promisify-node-0.3.0.tgz#b4b55acf90faa7d2b8b90ca396899086c03060cf"
@@ -13375,6 +13423,13 @@ raf@^3.4.0:
   dependencies:
     performance-now "^2.1.0"
 
+raf@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
+  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
+  dependencies:
+    performance-now "^2.1.0"
+
 railroad-diagrams@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
@@ -13477,6 +13532,18 @@ react-ace@^7.0.5:
     lodash.get "^4.4.2"
     lodash.isequal "^4.5.0"
     prop-types "^15.7.2"
+
+react-app-polyfill@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/react-app-polyfill/-/react-app-polyfill-1.0.6.tgz#890f8d7f2842ce6073f030b117de9130a5f385f0"
+  integrity sha512-OfBnObtnGgLGfweORmdZbyEz+3dgVePQBb3zipiaDsMHV1NpWm0rDFYIVXFV/AK+x4VIIfWHhrdMIeoTLyRr2g==
+  dependencies:
+    core-js "^3.5.0"
+    object-assign "^4.1.1"
+    promise "^8.0.3"
+    raf "^3.4.1"
+    regenerator-runtime "^0.13.3"
+    whatwg-fetch "^3.0.0"
 
 react-beautiful-dnd@^13.0.0:
   version "13.0.0"
@@ -14025,6 +14092,11 @@ regenerator-runtime@^0.13.2:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+
+regenerator-runtime@^0.13.3:
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
+  integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
 
 regenerator-runtime@^0.13.4:
   version "0.13.4"
@@ -17151,6 +17223,11 @@ whatwg-fetch@>=0.10.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
+
+whatwg-fetch@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.2.0.tgz#8e134f701f0a4ab5fda82626f113e2b647fd16dc"
+  integrity sha512-SdGPoQMMnzVYThUbSrEvqTlkvC1Ux27NehaJ/GUHBfNrh5Mjg+1/uRyFMwVnxO2MrikMWvWAqUGgQOfVU4hT7w==
 
 whatwg-url@^6.4.0:
   version "6.4.0"


### PR DESCRIPTION
### Summary

`react-live` doesn't work for IE11 (react-view is based on react-live) thereby disabling it for IE11.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
- [ ] Checked in **mobile**
- [ ] Checked in **IE11** and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
