### PR TITLE
Expand `findTestSubject` utility type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed `EuiComboBox` always showing a scrollbar ([#3744](https://github.com/elastic/eui/pull/3744))
 - Replaced `react-focus-lock` with `react-focus-on` ([#3631](https://github.com/elastic/eui/pull/3631))
 - Fixed errors in `EuiSuperDatePicker` related to invalid and `null` date formatting ([#3750](https://github.com/elastic/eui/pull/3750))
+- Fixed type definitions for `findTestSubject` and `takeMountedSnapshot` ([#3763](https://github.com/elastic/eui/pull/3763))
 
 ## [`27.1.0`](https://github.com/elastic/eui/tree/v27.1.0)
 

--- a/src/test/find_test_subject.ts
+++ b/src/test/find_test_subject.ts
@@ -38,11 +38,15 @@ const MATCHERS = [
   '*=', // Contains substring
 ] as const;
 
-export const findTestSubject = <T = {}>(
-  mountedComponent: ShallowWrapper<T> | ReactWrapper<T>,
+type FindTestSubject<T extends ShallowWrapper | ReactWrapper> = (
+  mountedComponent: T,
   testSubjectSelector: string,
-  matcher: typeof MATCHERS[number] = '~='
-) => {
+  matcher?: typeof MATCHERS[number]
+) => ReturnType<T['find']>;
+
+export const findTestSubject: FindTestSubject<
+  ShallowWrapper<any> | ReactWrapper<any>
+> = (mountedComponent, testSubjectSelector, matcher = '~=') => {
   if (!MATCHERS.includes(matcher)) {
     throw new Error(
       `Matcher ${matcher} not found in list of allowed matchers: ${MATCHERS.join(

--- a/src/test/find_test_subject.ts
+++ b/src/test/find_test_subject.ts
@@ -19,12 +19,6 @@
 
 import { ReactWrapper, ShallowWrapper } from 'enzyme';
 
-type FindTestSubject<T extends ShallowWrapper | ReactWrapper> = (
-  mountedComponent: T,
-  testSubjectSelector: string,
-  matcher?: '=' | '~=' | '|=' | '^=' | '$=' | '*='
-) => ReturnType<T['find']>;
-
 /**
  * Find node which matches a specific test subject selector. Returns ReactWrappers around DOM element,
  * https://github.com/airbnb/enzyme/tree/master/docs/api/ReactWrapper.
@@ -42,12 +36,12 @@ const MATCHERS = [
   '^=', // Begins with substring
   '$=', // Ends with substring
   '*=', // Contains substring
-];
+] as const;
 
-export const findTestSubject: FindTestSubject<ShallowWrapper | ReactWrapper> = (
-  mountedComponent,
-  testSubjectSelector,
-  matcher = '~='
+export const findTestSubject = <T = {}>(
+  mountedComponent: ShallowWrapper<T> | ReactWrapper<T>,
+  testSubjectSelector: string,
+  matcher: typeof MATCHERS[number] = '~='
 ) => {
   if (!MATCHERS.includes(matcher)) {
     throw new Error(

--- a/src/test/take_mounted_snapshot.ts
+++ b/src/test/take_mounted_snapshot.ts
@@ -30,8 +30,8 @@ interface TakeMountedSnapshotOptions {
  * containing both React components and HTML elements. This function removes the React components,
  * leaving only HTML elements in the snapshot.
  */
-export const takeMountedSnapshot = <T = {}>(
-  mountedComponent: ReactWrapper<T, {}, Component>,
+export const takeMountedSnapshot = (
+  mountedComponent: ReactWrapper<any, {}, Component>,
   options: TakeMountedSnapshotOptions = {}
 ) => {
   const opts: TakeMountedSnapshotOptions = {

--- a/src/test/take_mounted_snapshot.ts
+++ b/src/test/take_mounted_snapshot.ts
@@ -30,8 +30,8 @@ interface TakeMountedSnapshotOptions {
  * containing both React components and HTML elements. This function removes the React components,
  * leaving only HTML elements in the snapshot.
  */
-export const takeMountedSnapshot = (
-  mountedComponent: ReactWrapper<{}, {}, Component>,
+export const takeMountedSnapshot = <T = {}>(
+  mountedComponent: ReactWrapper<T, {}, Component>,
   options: TakeMountedSnapshotOptions = {}
 ) => {
   const opts: TakeMountedSnapshotOptions = {


### PR DESCRIPTION
### Summary

Noticed during Kibana upgrade prep that certain uses of `findTestSubject` require more explicit prop typing (`ReactWrapper<MyComponentProps>` vs `ReactWrapper<{}>`). This expands two functions in EUI's test utils to be accept `any` props.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~

- [x] Checked for **breaking changes** and labeled appropriately

~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
