### PR TITLE
Fix zIndex for two popup ups

### DIFF
--- a/src-docs/src/views/datagrid/styling.js
+++ b/src-docs/src/views/datagrid/styling.js
@@ -428,7 +428,7 @@ export default class DataGrid extends Component {
               button={styleButton}
               isOpen={this.state.isPopoverOpen}
               anchorPosition="rightUp"
-              zIndex={2}
+              zIndex={3}
               closePopover={this.closePopover.bind(this)}>
               <div style={{ width: 300 }}>
                 <EuiFormRow label="Border" display="columnCompressed">
@@ -505,7 +505,7 @@ export default class DataGrid extends Component {
               button={toolbarButton}
               isOpen={this.state.isToolbarPopoverOpen}
               anchorPosition="rightUp"
-              zIndex={2}
+              zIndex={3}
               closePopover={this.closeToolbarPopover.bind(this)}>
               <div style={{ width: 400 }}>
                 <EuiFormRow


### PR DESCRIPTION
Clicking both buttons on https://eui.elastic.co/#/tabular-content/data-grid-styling-and-toolbar demo brings up partially hidden popups because their z-index is too low. Increasing by one seems to do the trick.

![image](https://user-images.githubusercontent.com/1641515/87844824-4f07a100-c88f-11ea-943e-04c50ec0dd02.png)
