### PR TITLE
[EuiSelectable+EuiComboBox] recent regresion fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Replaced `react-focus-lock` with `react-focus-on` ([#3631](https://github.com/elastic/eui/pull/3631))
 - Fixed errors in `EuiSuperDatePicker` related to invalid and `null` date formatting ([#3750](https://github.com/elastic/eui/pull/3750))
 - Fixed type definitions for `findTestSubject` and `takeMountedSnapshot` ([#3763](https://github.com/elastic/eui/pull/3763))
+- Fixes `EuiComboBox` not allow clicks on previously virtualized items inside of `EuiFormRow` ([#3784](https://github.com/elastic/eui/pull/3784))
+- Removes `<space>` as a way to select options in `EuiSelectable` ([#3784](https://github.com/elastic/eui/pull/3784))
 
 ## [`27.1.0`](https://github.com/elastic/eui/tree/v27.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
 - Replaced `react-focus-lock` with `react-focus-on` ([#3631](https://github.com/elastic/eui/pull/3631))
 - Fixed errors in `EuiSuperDatePicker` related to invalid and `null` date formatting ([#3750](https://github.com/elastic/eui/pull/3750))
 - Fixed type definitions for `findTestSubject` and `takeMountedSnapshot` ([#3763](https://github.com/elastic/eui/pull/3763))
-- Fixes `EuiComboBox` not allow clicks on previously virtualized items inside of `EuiFormRow` ([#3784](https://github.com/elastic/eui/pull/3784))
-- Removes `<space>` as a way to select options in `EuiSelectable` ([#3784](https://github.com/elastic/eui/pull/3784))
+- Fixed `EuiComboBox` not allowing clicks on previously virtualized items when inside of `EuiFormRow` ([#3784](https://github.com/elastic/eui/pull/3784))
+- Removed `[Space]` as a way to select options in `EuiSelectable` ([#3784](https://github.com/elastic/eui/pull/3784))
 
 ## [`27.1.0`](https://github.com/elastic/eui/tree/v27.1.0)
 

--- a/src/components/form/form_row/form_row.tsx
+++ b/src/components/form/form_row/form_row.tsx
@@ -139,8 +139,14 @@ export class EuiFormRow extends Component<EuiFormRowProps, EuiFormRowState> {
       onChildFocus(...args);
     }
 
-    this.setState({
-      isFocused: true,
+    this.setState(({ isFocused }) => {
+      if (!isFocused) {
+        return {
+          isFocused: true,
+        };
+      } else {
+        return null;
+      }
     });
   };
 

--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -231,7 +231,6 @@ export class EuiSelectable extends Component<
         break;
 
       case keys.ENTER:
-      case keys.SPACE:
         event.preventDefault();
         event.stopPropagation();
         if (this.state.activeOptionIndex != null && optionsList) {

--- a/src/components/selectable/selectable_list/selectable_list_item.tsx
+++ b/src/components/selectable/selectable_list/selectable_list_item.tsx
@@ -135,7 +135,7 @@ export class EuiSelectableListItem extends Component<
           <span>
             <EuiI18n
               token="euiSelectableListItem.includedOptionInstructions"
-              default="To exclude this option, press enter or space."
+              default="To exclude this option, press enter."
             />
           </span>
         </EuiScreenReaderOnly>
@@ -156,7 +156,7 @@ export class EuiSelectableListItem extends Component<
           <span>
             <EuiI18n
               token="euiSelectableListItem.excludedOptionInstructions"
-              default="To deselect this option, press enter or space."
+              default="To deselect this option, press enter."
             />
           </span>
         </EuiScreenReaderOnly>


### PR DESCRIPTION
### Summary

Fixes two regressions caused by the recent [selectable-a11y branch](https://github.com/elastic/eui/pull/3169).

1. Adding <kbd>space</kbd> as a option for how to selection items removes the ability to have items with <space> in them so reverting this change.
2. With the new `react-window` library replacing `react-virtualized`, this in conjunction with **EuiFormRow** was causing an extra rerender on click of virtualized elements which broke clicking... Adding a check in **EuiFormRow** for if the thing needs to rerender fixes it.

### Checklist

- [x] Checked in **mobile**
- [x] Checked in **Firefox**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked in **IE11**~
~- [ ] Check against **all themes** for compatibility in both light and dark modes~