### PR TITLE
[EuiSelectable] Partial ListProps type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Replaced `react-focus-lock` with `react-focus-on` ([#3631](https://github.com/elastic/eui/pull/3631))
 - Fixed errors in `EuiSuperDatePicker` related to invalid and `null` date formatting ([#3750](https://github.com/elastic/eui/pull/3750))
 - Fixed type definitions for `findTestSubject` and `takeMountedSnapshot` ([#3763](https://github.com/elastic/eui/pull/3763))
+- Fixed type definition for `windowProps` in `EuiSelectable` ([#3787](https://github.com/elastic/eui/pull/3787))
 
 ## [`27.1.0`](https://github.com/elastic/eui/tree/v27.1.0)
 

--- a/src/components/selectable/__snapshots__/selectable.test.tsx.snap
+++ b/src/components/selectable/__snapshots__/selectable.test.tsx.snap
@@ -31,6 +31,12 @@ exports[`EuiSelectable props isLoading 1`] = `
 />
 `;
 
+exports[`EuiSelectable props listProps 1`] = `
+<div
+  class="euiSelectable"
+/>
+`;
+
 exports[`EuiSelectable props renderOption 1`] = `
 <div
   class="euiSelectable"

--- a/src/components/selectable/selectable.test.tsx
+++ b/src/components/selectable/selectable.test.tsx
@@ -113,5 +113,20 @@ describe('EuiSelectable', () => {
 
       expect(component).toMatchSnapshot();
     });
+
+    test('listProps', () => {
+      const component = render(
+        <EuiSelectable
+          options={options}
+          listProps={{
+            windowProps: {
+              onScroll: () => {},
+            },
+          }}
+        />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
   });
 });

--- a/src/components/selectable/selectable_list/selectable_list.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.tsx
@@ -59,7 +59,7 @@ export type EuiSelectableOptionsListProps = CommonProps &
     /**
      * Any props to send specifically to the react-window `FixedSizeList`
      */
-    windowProps?: ListProps;
+    windowProps?: Partial<ListProps>;
     /**
      * Adds a border around the list to indicate the bounds;
      * Useful when the list scrolls, otherwise use your own container


### PR DESCRIPTION
### Summary

The `ListProps` interface applies to the `FixedSizeList` component, which both come from`react-window`. EUI uses `FixedSizeList` and applies all required props. EUI's layered-on `windowProps` prop allows consumers to pass any additional props directly to `FixedSizeList`, but intended to do so on an optional basis.

The solution is to add `Partial<>`

This change is required for type_check passing in Kibana.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~

- [x] Props have proper **autodocs**

~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~

- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately

~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
