### PR TITLE
Prevent combobox from complaining about long search values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 - Updated lodash to `v4.17.19` ([#3764](https://github.com/elastic/eui/pull/3764))
 - Added `returnKey` glyph to `EuiIcon` ([#3783](https://github.com/elastic/eui/pull/3783))
 
+**Bug fixes**
+
+- Fixed `EuiComboBox` marking some very long inputs as invalid ([#3797](https://github.com/elastic/eui/pull/3797))
+
 ## [`27.2.0`](https://github.com/elastic/eui/tree/v27.2.0)
 
 - Added `analyzeEvent` glyph in `EuiIcon` ([#3729](https://github.com/elastic/eui/pull/3729))

--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -294,7 +294,13 @@ export class EuiComboBox<T> extends Component<
     });
   };
 
-  closeList = () => {
+  closeList = (event?: Event) => {
+    if (event && event.target === this.searchInputRefInstance) {
+      // really long search values / custom entries triggers a scroll event on the input
+      // which the EuiComboBoxOptionsList passes through here
+      return;
+    }
+
     this.clearActiveOption();
     this.setState({
       listZIndex: undefined,
@@ -674,7 +680,7 @@ export class EuiComboBox<T> extends Component<
     }
 
     if (singleSelection) {
-      requestAnimationFrame(this.closeList);
+      requestAnimationFrame(() => this.closeList());
     } else {
       this.setState({
         activeOptionIndex: this.state.matchingOptions.indexOf(addedOption),

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
@@ -75,7 +75,7 @@ export type EuiComboBoxOptionsListProps<T> = CommonProps &
     isLoading?: boolean;
     listRef: RefCallback<HTMLDivElement>;
     matchingOptions: Array<EuiComboBoxOptionOption<T>>;
-    onCloseList: () => void;
+    onCloseList: (event: Event) => void;
     onCreateOption?: (
       searchValue: string,
       options: Array<EuiComboBoxOptionOption<T>>
@@ -174,7 +174,7 @@ export class EuiComboBoxOptionsList<T> extends Component<
       event.target &&
       this.listRefInstance.contains(event.target as Node) === false
     ) {
-      this.props.onCloseList();
+      this.props.onCloseList(event);
     }
   };
 


### PR DESCRIPTION
### Summary

Fixes #3791 

Turns out a very long search/custom value in the combobox triggers a `scroll` event on the input itself. This is not captured by the options list, and causes the list box to close. When the input has focus but the list box is closed, the input is considered invalid.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
- [x] Checked in **Safari** and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
