### PR TITLE
[EuiMarkdownEditor] Fixed firefox textarea margin

### DIFF
--- a/src/components/markdown_editor/_markdown_editor_text_area.scss
+++ b/src/components/markdown_editor/_markdown_editor_text_area.scss
@@ -13,6 +13,8 @@
   background-color: $euiFormBackgroundColor;
   background-repeat: no-repeat;
   background-size: 0% 100%;
+  // Removes default firefox margin
+  margin: 0;
 
   // sass-lint:disable-block indentation
   transition:


### PR DESCRIPTION
### Summary

Just a small Firefox fix. There was this weird margins on top and bottom of the `<textarea />`.  

<img width="1014" alt="md-firefox-textarea-margin@2x" src="https://user-images.githubusercontent.com/2750668/88561544-772d9780-d027-11ea-9e63-fd78eed3adfe.png">


### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- ~[ ] Checked in **mobile**~
- [x] Checked in **IE11** and **Firefox**
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
