### PR TITLE
enable webpack sideEffects for css and scss files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
   "module": "es",
   "types": "eui.d.ts",
   "docker_image": "node:10",
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "scripts": {
     "start": "cross-env BABEL_MODULES=false webpack-dev-server --inline --hot --config=src-docs/webpack.config.js",
     "test-docker": "node ./scripts/test-docker.js",


### PR DESCRIPTION
### Summary

Closes #3397

Marks EUI's *.css and *.scss files as having sideEffects when they are imported by webpack. Setup I tested with:

<details>
<summary>package.json</summary>

```
{
  "name": "test",
  "version": "1.0.0",
  "main": "index.js",
  "license": "MIT",
  "dependencies": {
    "@babel/core": "^7.10.5",
    "@babel/preset-env": "^7.10.4",
    "@babel/preset-react": "^7.10.4",
    "@elastic/datemath": "^5.0.3",
    "@elastic/eui": "^27.2.0",
    "babel-loader": "^8.1.0",
    "css-loader": "^4.0.0",
    "lodash": "^4.17.19",
    "moment": "^2.27.0",
    "react": "^16.13.1",
    "react-dom": "^16.13.1",
    "style-loader": "^1.2.1",
    "webpack": "^4.44.0",
    "webpack-cli": "^3.3.12",
    "webpack-dev-server": "^3.11.0"
  }
}
```
</details>

<details>
<summary>webpack.config.js</summary>

```
const path = require('path');

module.exports = {
	mode: 'production',

	entry: path.resolve(__dirname, './src/index.js'),

	output: {
		path: path.resolve(__dirname, 'dist'),
		filename: 'bundle.js',
	},

	module: {
		rules: [
			{
				test: /\.(js|tsx?)$/,
				loader: 'babel-loader',
				options: {
					babelrc: false,
					presets: [
						'@babel/react',
						'@babel/env'
					],
				},
				exclude: /node_modules/,
			},
			{
				test: /\.css$/,
				loaders: [
					'style-loader',
					'css-loader',
				],
			},
		],
	},
};
```
</details>

<details>
<summary>src/index.js</summary>

```
import React from 'react';
import ReactDOM from 'react-dom';
import { EuiButton } from '@elastic/eui';
import '@elastic/eui/dist/eui_theme_dark.css';

const App = () => (
	<>
		<EuiButton onClick={() => {}}>Click Me!</EuiButton>
	</>
);

ReactDOM.render(
	<App/>,
	document.getElementById('app')
);
```
</details>

<details>
<summary>dist/index.html</summary>

```
<!DOCTYPE html>
<html>
	<body>
		<div id="app"></div>
		<script type="text/javascript" src="./bundle.js"></script>
	</body>
</html>
```
</details>

First confirmed that the css imports were tree-shaken away, and the page left unstyled. Then I manually applied the change in this PR to _node_modules/@elastic/eui/package.json_ and rebuilt, confirming the expected styles were then present.

This change somewhat makes the assumption that the usual css-loader/style-loader configuration is used, which does follow our _consuming.md_ documentation. If the files are instead processed with a loader like css modules, turning them into `import Styles from '...'`, then there is technically no side effect, as the contents are handled elsewhere - but this change would have no effect as they are already imported. However, this change could in theory bloat applications which are configured to use css modules but have an `import '@elastic/eui/dist/some_theme.css';` as that would have previously been [correctly] tree shaken out. My concern for that case is barely measurable 😁 

/cc @clintandrewhall 

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **IE11** and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
