### PR TITLE
Fixed EuiCodeEditor Read Only and Custom Mode code sandbox links

### DIFF
--- a/src-docs/src/views/code_editor/custom_mode.js
+++ b/src-docs/src/views/code_editor/custom_mode.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import 'brace/mode/text';
-
 import { EuiCodeEditor } from '../../../../src/components';
+import 'brace/mode/text';
+import 'brace/theme/github';
 
 const TextMode = window.ace.acequire('ace/mode/text').Mode;
 class MyCustomAceMode extends TextMode {

--- a/src-docs/src/views/code_editor/read_only.js
+++ b/src-docs/src/views/code_editor/read_only.js
@@ -1,9 +1,9 @@
 import React from 'react';
 
+import { EuiCodeEditor } from '../../../../src/components';
+
 import 'brace/mode/less';
 import 'brace/theme/github';
-
-import { EuiCodeEditor } from '../../../../src/components';
 
 export default () => {
   const value = '<p>This code is read only</p>';


### PR DESCRIPTION
### Summary

Fixes #3810

* Fixed the Read Only link by moving the EUI import above brace
* Fixed the Custom Mode link by moving the EUI import above brace and importing the github theme

~### Checklist~
