### PR TITLE
Remove 'pointer-events:none' for EuiButton&EuiButtonEmpty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Fixed bug in all input fields placeholders in Safari that weren't vertically centered ([#3809](https://github.com/elastic/eui/pull/3809))
+- Removed `pointer-events: none` in both `EuiButton` & `EuiButtonEmpty` to not override the `pointer-events: auto` in the button mixin `euiButtonContentDisabled` ([#3824](https://github.com/elastic/eui/pull/3824))
 
 ## [`27.3.0`](https://github.com/elastic/eui/tree/v27.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
-  
+
 **Bug fixes**
 
 - Fixed bug in all input fields placeholders in Safari that weren't vertically centered ([#3809](https://github.com/elastic/eui/pull/3809))
@@ -11,7 +11,7 @@
 - Updated lodash to `v4.17.19` ([#3764](https://github.com/elastic/eui/pull/3764))
 - Added `returnKey` glyph to `EuiIcon` ([#3783](https://github.com/elastic/eui/pull/3783))
 - Added `type` prop to `EuiFieldPassword` to support toggling of obfuscation ([#3751](https://github.com/elastic/eui/pull/3751))
-  
+
 **Bug fixes**
 
 - Fixed bug in `EuiDataGrid` not calculating the width correctly ([#3789](https://github.com/elastic/eui/pull/3789))

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -40,7 +40,6 @@
 
     color: $euiButtonColorDisabledText;
     border-color: $euiButtonColorDisabled;
-    pointer-events: none;
 
     &.euiButton--fill {
       // Only increase the contrast of background color to text to 2.0 for disabled

--- a/src/components/button/button_empty/_button_empty.scss
+++ b/src/components/button/button_empty/_button_empty.scss
@@ -37,7 +37,6 @@
     @include euiButtonContentDisabled;
 
     color: $euiButtonColorDisabledText;
-    pointer-events: none;
 
     &:focus {
       background-color: transparent;


### PR DESCRIPTION
### Summary

Removed the `pointer-events: none` in both `EuiButton` and `EuiButtonEmpty` to not override the `pointer-events` in the button mixin `euiButtonContentDisabled`.

Issues: #3818

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
~~- [ ] Checked in **mobile**~~
- [x] Checked in **IE11** and **Firefox**
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
~~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~~
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
