### PR TITLE
[EuiPagination] Fixed wrong page count with `compressed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Fixed bug in all input fields placeholders in Safari that weren't vertically centered ([#3809](https://github.com/elastic/eui/pull/3809))
+- Fixed bug in `EuiPagination` showing wrong page count when `compressed` prop is true. ([#3827](https://github.com/elastic/eui/pull/3827))
 
 ## [`27.3.0`](https://github.com/elastic/eui/tree/v27.3.0)
 

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -255,7 +255,7 @@ export const EuiPagination: FunctionComponent<Props> = ({
       <PaginationButton pageIndex={activePage} inList={false} />
     );
     const lastPageButtonCompressed = (
-      <PaginationButton pageIndex={pageCount} inList={false} />
+      <PaginationButton pageIndex={pageCount - 1} inList={false} />
     );
     return (
       <nav className={classes} {...rest}>


### PR DESCRIPTION
### Summary

Fix for #3826.

```js
if (compressed) {
    const firstPageButtonCompressed = (
      <PaginationButton pageIndex={activePage} inList={false} />
    );
    const lastPageButtonCompressed = (
      <PaginationButton pageIndex={pageCount} inList={false} />
    );
}
```

EuiPagination was passing one based `pageCount` prop to PaginationButton's `pageIndex` prop directly, which is zero based, which caused wrong page count when used with `compressed`.


#### Before
<img width="548" alt="Screen Shot 2020-07-30 at 9 08 00 PM" src="https://user-images.githubusercontent.com/10908841/88923325-8113fc80-d2ac-11ea-8a65-248156e8e7c0.png">

#### After
<img width="518" alt="Screen Shot 2020-07-30 at 9 34 20 PM" src="https://user-images.githubusercontent.com/10908841/88923330-83765680-d2ac-11ea-9293-6e39865040a9.png">


