### PR TITLE
Prevent markdown plugin extensions from interacting with each other

### DIFF
--- a/src-docs/src/views/markdown_editor/markdown_editor_with_plugins.js
+++ b/src-docs/src/views/markdown_editor/markdown_editor_with_plugins.js
@@ -11,8 +11,8 @@ import {
 import { EUI_CHARTS_THEME_LIGHT } from '../../../../src/themes/charts/themes';
 
 import {
-  EuiMarkdownDefaultParsingPlugins,
-  EuiMarkdownDefaultProcessingPlugins,
+  getDefaultEuiMarkdownParsingPlugins,
+  getDefaultEuiMarkdownProcessingPlugins,
   EuiMarkdownEditor,
   EuiMarkdownFormat,
   EuiSpacer,
@@ -248,12 +248,10 @@ const ChartMarkdownRenderer = ({ height = 200, palette = 5 }) => {
   );
 };
 
-const exampleParsingList = [
-  ...EuiMarkdownDefaultParsingPlugins,
-  ChartMarkdownParser,
-];
+const exampleParsingList = getDefaultEuiMarkdownParsingPlugins();
+exampleParsingList.push(ChartMarkdownParser);
 
-const exampleProcessingList = [...EuiMarkdownDefaultProcessingPlugins]; // pretend mutation doesn't happen immediately next 😅
+const exampleProcessingList = getDefaultEuiMarkdownProcessingPlugins();
 exampleProcessingList[0][1].handlers.chartDemoPlugin = chartMarkdownHandler;
 exampleProcessingList[1][1].components.chartDemoPlugin = ChartMarkdownRenderer;
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -218,8 +218,8 @@ export {
   EuiMarkdownEditor,
   EuiMarkdownContext,
   EuiMarkdownFormat,
-  EuiMarkdownDefaultParsingPlugins,
-  EuiMarkdownDefaultProcessingPlugins,
+  getDefaultEuiMarkdownParsingPlugins,
+  getDefaultEuiMarkdownProcessingPlugins,
 } from './markdown_editor';
 export { EuiMark } from './mark';
 

--- a/src/components/markdown_editor/index.ts
+++ b/src/components/markdown_editor/index.ts
@@ -19,8 +19,8 @@
 
 export { EuiMarkdownEditor, EuiMarkdownEditorProps } from './markdown_editor';
 export {
-  EuiMarkdownDefaultParsingPlugins,
-  EuiMarkdownDefaultProcessingPlugins,
+  getDefaultEuiMarkdownParsingPlugins,
+  getDefaultEuiMarkdownProcessingPlugins,
 } from './plugins/markdown_default_plugins';
 export { EuiMarkdownContext } from './markdown_context';
 export { EuiMarkdownFormat } from './markdown_format';

--- a/src/components/markdown_editor/markdown_editor.tsx
+++ b/src/components/markdown_editor/markdown_editor.tsx
@@ -52,8 +52,8 @@ import { EuiModal } from '../modal';
 import { ContextShape, EuiMarkdownContext } from './markdown_context';
 import * as MarkdownTooltip from './plugins/markdown_tooltip';
 import {
-  EuiMarkdownDefaultParsingPlugins,
-  EuiMarkdownDefaultProcessingPlugins,
+  defaultParsingPlugins,
+  defaultProcessingPlugins,
 } from './plugins/markdown_default_plugins';
 
 type CommonMarkdownEditorProps = HTMLAttributes<HTMLDivElement> &
@@ -125,8 +125,8 @@ export const EuiMarkdownEditor = React.forwardRef<
       value,
       onChange,
       height = 150,
-      parsingPluginList = EuiMarkdownDefaultParsingPlugins,
-      processingPluginList = EuiMarkdownDefaultProcessingPlugins,
+      parsingPluginList = defaultParsingPlugins,
+      processingPluginList = defaultProcessingPlugins,
       uiPlugins = [],
       onParse,
       errors = [],

--- a/src/components/markdown_editor/markdown_format.tsx
+++ b/src/components/markdown_editor/markdown_format.tsx
@@ -20,8 +20,8 @@
 import React, { FunctionComponent, useMemo } from 'react';
 import unified, { PluggableList } from 'unified';
 import {
-  EuiMarkdownDefaultProcessingPlugins,
-  EuiMarkdownDefaultParsingPlugins,
+  defaultProcessingPlugins,
+  defaultParsingPlugins,
 } from './plugins/markdown_default_plugins';
 
 interface EuiMarkdownFormatProps {
@@ -34,8 +34,8 @@ interface EuiMarkdownFormatProps {
 
 export const EuiMarkdownFormat: FunctionComponent<EuiMarkdownFormatProps> = ({
   children,
-  parsingPluginList = EuiMarkdownDefaultParsingPlugins,
-  processingPluginList = EuiMarkdownDefaultProcessingPlugins,
+  parsingPluginList = defaultParsingPlugins,
+  processingPluginList = defaultProcessingPlugins,
 }) => {
   const processor = useMemo(
     () =>

--- a/src/components/markdown_editor/plugins/markdown_default_plugins.tsx
+++ b/src/components/markdown_editor/plugins/markdown_default_plugins.tsx
@@ -29,7 +29,7 @@ import markdown from 'remark-parse';
 import highlight from 'remark-highlight.js';
 import emoji from 'remark-emoji';
 
-export const EuiMarkdownDefaultParsingPlugins: PluggableList = [
+export const getDefaultEuiMarkdownParsingPlugins = (): PluggableList => [
   [markdown, {}],
   [highlight, {}],
   [emoji, { emoticon: true }],
@@ -37,7 +37,9 @@ export const EuiMarkdownDefaultParsingPlugins: PluggableList = [
   [MarkdownCheckbox.parser, {}],
 ];
 
-export const EuiMarkdownDefaultProcessingPlugins: PluggableList = [
+export const defaultParsingPlugins = getDefaultEuiMarkdownParsingPlugins();
+
+export const getDefaultEuiMarkdownProcessingPlugins = (): PluggableList => [
   [
     remark2rehype,
     {
@@ -67,3 +69,5 @@ export const EuiMarkdownDefaultProcessingPlugins: PluggableList = [
     },
   ],
 ];
+
+export const defaultProcessingPlugins = getDefaultEuiMarkdownProcessingPlugins();


### PR DESCRIPTION
### Summary

Moves the default parsing&processing plugin arrays behind a constructor function, which prevents consumers from mutating the defaults & cross-polluting/leaking between apps.

~### Checklist~

