### PR TITLE
Simplify the markdown editor's plugin API

### DIFF
--- a/src-docs/src/views/markdown_editor/markdown_editor_with_plugins.js
+++ b/src-docs/src/views/markdown_editor/markdown_editor_with_plugins.js
@@ -217,9 +217,6 @@ function ChartMarkdownParser() {
   methods.splice(methods.indexOf('text'), 0, 'chart');
 }
 
-const chartMarkdownHandler = (h, node) => {
-  return h(node.position, 'chartDemoPlugin', node, []);
-};
 const ChartMarkdownRenderer = ({ height = 200, palette = 5 }) => {
   const customColors = {
     colors: {
@@ -252,7 +249,6 @@ const exampleParsingList = getDefaultEuiMarkdownParsingPlugins();
 exampleParsingList.push(ChartMarkdownParser);
 
 const exampleProcessingList = getDefaultEuiMarkdownProcessingPlugins();
-exampleProcessingList[0][1].handlers.chartDemoPlugin = chartMarkdownHandler;
 exampleProcessingList[1][1].components.chartDemoPlugin = ChartMarkdownRenderer;
 
 const initialExample = `## Chart plugin

--- a/src-docs/src/views/markdown_editor/markdown_plugin_example.js
+++ b/src-docs/src/views/markdown_editor/markdown_plugin_example.js
@@ -329,17 +329,12 @@ function EmojiMarkdownParser() {
       <EuiSpacer />
       <EuiCodeBlock size="s" language="javascript">{`// example plugin processor
 
-// convert remark nodes to rehype, basically a pass through 
-const emojiMarkdownHandler = (h, node) => {
-  return h(node.position, 'emojiPlugin', node, []);
-};
 // receives the configuration from the parser and renders
 const EmojiMarkdownRenderer = ({ emoji }) => {
   return <span>{emoji}</span>;
 };
 
-// add the handler & renderer for \`emojiPlugin\`
-processingList[0][1].handlers.emojiPlugin = emojiMarkdownHandler;
+// add the renderer for \`emojiPlugin\`
 processingList[1][1].components.emojiPlugin = EmojiMarkdownRenderer;`}</EuiCodeBlock>
       <EuiSpacer size="xxl" />
     </Fragment>

--- a/src-docs/src/views/markdown_editor/markdown_plugin_example.js
+++ b/src-docs/src/views/markdown_editor/markdown_plugin_example.js
@@ -309,7 +309,11 @@ function EmojiMarkdownParser() {
   // define the emoji plugin and inject it just before the existing text plugin
   tokenizers.emoji = tokenizeEmoji;
   methods.splice(methods.indexOf('text'), 0, 'emoji');
-}`}</EuiCodeBlock>
+}
+
+// add the parser for \`emojiPlugin\`
+const parsingList = getDefaultEuiMarkdownParsingPlugins();
+parsingList.push(EmojiMarkdownParser);`}</EuiCodeBlock>
       <EuiSpacer />
       <EuiHorizontalRule />
       <EuiTitle>
@@ -335,6 +339,7 @@ const EmojiMarkdownRenderer = ({ emoji }) => {
 };
 
 // add the renderer for \`emojiPlugin\`
+const processingList = getDefaultEuiMarkdownProcessingPlugins();
 processingList[1][1].components.emojiPlugin = EmojiMarkdownRenderer;`}</EuiCodeBlock>
       <EuiSpacer size="xxl" />
     </Fragment>

--- a/src/components/markdown_editor/plugins/markdown_checkbox.tsx
+++ b/src/components/markdown_editor/plugins/markdown_checkbox.tsx
@@ -18,15 +18,10 @@
  */
 
 import React, { FunctionComponent, useContext } from 'react';
-import all from 'mdast-util-to-hast/lib/all';
 import { EuiCheckbox } from '../../form/checkbox';
 import { EuiMarkdownContext } from '../markdown_context';
 import { htmlIdGenerator } from '../../../services/accessibility';
-import {
-  EuiMarkdownAstNodePosition,
-  RemarkRehypeHandler,
-  RemarkTokenizer,
-} from '../markdown_types';
+import { EuiMarkdownAstNodePosition, RemarkTokenizer } from '../markdown_types';
 import { Plugin } from 'unified';
 
 interface CheckboxNodeDetails {
@@ -81,9 +76,6 @@ const CheckboxParser: Plugin = function CheckboxParser() {
   methods.splice(methods.indexOf('list'), 0, 'checkbox'); // Run it just before default `list` plugin to inject our own idea of checkboxes.
 };
 
-const checkboxMarkdownHandler: RemarkRehypeHandler = (h, node) => {
-  return h(node.position!, 'checkboxPlugin', node, all(h, node));
-};
 const CheckboxMarkdownRenderer: FunctionComponent<CheckboxNodeDetails & {
   position: EuiMarkdownAstNodePosition;
 }> = ({ position, lead, label, isChecked, children }) => {
@@ -100,8 +92,4 @@ const CheckboxMarkdownRenderer: FunctionComponent<CheckboxNodeDetails & {
   );
 };
 
-export {
-  CheckboxParser as parser,
-  checkboxMarkdownHandler as handler,
-  CheckboxMarkdownRenderer as renderer,
-};
+export { CheckboxParser as parser, CheckboxMarkdownRenderer as renderer };

--- a/src/components/markdown_editor/plugins/markdown_default_plugins.tsx
+++ b/src/components/markdown_editor/plugins/markdown_default_plugins.tsx
@@ -28,6 +28,8 @@ import { EuiCodeBlock, EuiCode } from '../../code';
 import markdown from 'remark-parse';
 import highlight from 'remark-highlight.js';
 import emoji from 'remark-emoji';
+import { RemarkRehypeHandler } from '../markdown_types';
+import all from 'mdast-util-to-hast/lib/all';
 
 export const getDefaultEuiMarkdownParsingPlugins = (): PluggableList => [
   [markdown, {}],
@@ -39,15 +41,17 @@ export const getDefaultEuiMarkdownParsingPlugins = (): PluggableList => [
 
 export const defaultParsingPlugins = getDefaultEuiMarkdownParsingPlugins();
 
+const unknownHandler: RemarkRehypeHandler = (h, node) => {
+  return h(node.position!, node.type, node, all(h, node));
+};
+
 export const getDefaultEuiMarkdownProcessingPlugins = (): PluggableList => [
   [
     remark2rehype,
     {
       allowDangerousHtml: true,
-      handlers: {
-        tooltipPlugin: MarkdownTooltip.handler,
-        checkboxPlugin: MarkdownCheckbox.handler,
-      },
+      unknownHandler,
+      handlers: {}, // intentionally empty, allows plugins to extend if they need to
     },
   ],
   [

--- a/src/components/markdown_editor/plugins/markdown_tooltip.tsx
+++ b/src/components/markdown_editor/plugins/markdown_tooltip.tsx
@@ -18,12 +18,7 @@
  */
 
 import React, { FunctionComponent } from 'react';
-import all from 'mdast-util-to-hast/lib/all';
-import {
-  EuiMarkdownAstNodePosition,
-  RemarkRehypeHandler,
-  RemarkTokenizer,
-} from '../markdown_types';
+import { EuiMarkdownAstNodePosition, RemarkTokenizer } from '../markdown_types';
 import { EuiToolTip } from '../../tool_tip';
 import { EuiIcon } from '../../icon';
 import { EuiCodeBlock } from '../../code';
@@ -137,9 +132,6 @@ const TooltipParser: Plugin = function TooltipParser() {
   methods.splice(methods.indexOf('text'), 0, 'tooltip');
 };
 
-const tooltipMarkdownHandler: RemarkRehypeHandler = (h, node) => {
-  return h(node.position!, 'tooltipPlugin', node, all(h, node));
-};
 const tooltipMarkdownRenderer: FunctionComponent<TooltipNodeDetails & {
   position: EuiMarkdownAstNodePosition;
 }> = ({ content, children }) => {
@@ -161,6 +153,5 @@ const tooltipMarkdownRenderer: FunctionComponent<TooltipNodeDetails & {
 export {
   tooltipPlugin as plugin,
   TooltipParser as parser,
-  tooltipMarkdownHandler as handler,
   tooltipMarkdownRenderer as renderer,
 };


### PR DESCRIPTION
### Summary

Implements the recently-added `unknownHandler` option in the remark->rehype plugin, removing the need for custom (but the same) handlers which were confusing and easy to misconfigure. The opportunity to provide a custom remark->rehype node handler is maintained.

~### Checklist~
