### PR TITLE
[EuiBasicTable] Fix limited expandable row height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 No public interface changes since `28.1.0`.
 
+
+**Bug fixes**
+
+- Fixed bug in `EuiBasicTable` not fully expanding tall rows (height > 1000px) ([#3855](https://github.com/elastic/eui/pull/3855))
+
 ## [`28.1.0`](https://github.com/elastic/eui/tree/v28.1.0)
 
 - Added `isLoading` and `isLoadingMessage` props to `EuiAccordion` ([#3879](https://github.com/elastic/eui/pull/3879))

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -225,9 +225,11 @@
   0% {
     max-height: 0;
   }
+
   90% {
     max-height: 1000px;
   }
+  
   100% {
     max-height: max-content;
   }

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -229,7 +229,7 @@
   90% {
     max-height: 1000px;
   }
-  
+
   100% {
     max-height: max-content;
   }

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -225,9 +225,11 @@
   0% {
     max-height: 0;
   }
-
-  100% {
+  90% {
     max-height: 1000px;
+  }
+  100% {
+    max-height: max-content;
   }
 }
 

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -226,8 +226,8 @@
     max-height: 0;
   }
 
-  90% {
-    max-height: 1000px;
+  99% {
+    max-height: 100vh;
   }
 
   100% {

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -231,7 +231,7 @@
   }
 
   100% {
-    max-height: max-content;
+    max-height: unset;
   }
 }
 


### PR DESCRIPTION
### Summary
In some cases the max-height of a table row needs to be more than 1000px when expanded - for example when the table contains a large sub-table. I tried setting `100% { max-height: max-content}`, but the expansion animation was not smooth, so instead added a two step animation -- to 1000px at 90%, and to `max-content` at 100%.   I do not know if `max-content` is the right choice here, not an expert TBH.

Fixes #3854

### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- [x] Checked in **mobile**
- [x] Checked in **Safari** and **Firefox**
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
