### PR TITLE
Remove src-docs files from eui.d.ts modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `27.3.1`.
+**Bug fixes**
+
+- Removed `@elastic/eui/src-docs` entries from published _eui.d.ts_ ([#3856](https://github.com/elastic/eui/pull/3856))
 
 ## [`27.3.1`](https://github.com/elastic/eui/tree/v27.3.1)
 

--- a/scripts/dtsgenerator.js
+++ b/scripts/dtsgenerator.js
@@ -36,7 +36,8 @@ const generator = dtsGenerator({
     '**/*.testenv.ts',
     '**/*.testenv.tsx',
     'src/themes/charts/*', // A separate d.ts file is generated for the charts theme file
-    'src/test/*'  // A separate d.ts file is generated for test utils
+    'src/test/*', // A separate d.ts file is generated for test utils
+    'src-docs/**/*', // Don't include src-docs
   ],
   resolveModuleId(params) {
     if (


### PR DESCRIPTION
### Summary

Fixes #3849 by configuring our _eui.d.ts_ generation to exclude `src-docs/**/*`

Tested by running `node scripts/dtsgenerator.js` and inspecting the generated file.

I also verified all there are no other entires outside of the _src_ path with regex search `module '@elastic/eui/(?!src)` - with the sole exception of `@elastic/eui/dist/eui_theme_*.json` which is expected to be present.

~### Checklist~
