### PR TITLE
[Markdown] Support for markdown block text insertion

### DIFF
--- a/src-docs/src/views/markdown_editor/markdown_editor.js
+++ b/src-docs/src/views/markdown_editor/markdown_editor.js
@@ -27,7 +27,10 @@ const dropHandlers = [
       return new Promise(resolve => {
         setTimeout(() => {
           const url = URL.createObjectURL(item);
-          resolve(`![${item.name}](${url})`);
+          resolve({
+            text: `![${item.name}](${url})`,
+            config: { block: true },
+          });
         }, 1000);
       });
     },

--- a/src-docs/src/views/markdown_editor/markdown_editor_with_plugins.js
+++ b/src-docs/src/views/markdown_editor/markdown_editor_with_plugins.js
@@ -140,7 +140,9 @@ const chartDemoPlugin = {
 
           <EuiButton
             onClick={() =>
-              onSave(`!{chart${JSON.stringify({ palette, height })}}`)
+              onSave(`!{chart${JSON.stringify({ palette, height })}}`, {
+                block: true,
+              })
             }
             fill>
             Save

--- a/src-docs/src/views/markdown_editor/markdown_plugin_example.js
+++ b/src-docs/src/views/markdown_editor/markdown_plugin_example.js
@@ -109,7 +109,7 @@ const uiPluginConcepts = [
     ),
   },
   {
-    title: 'formatter',
+    title: 'formatting',
     description: (
       <span>
         If no <strong>editor</strong> is provided, this is an object defining

--- a/src/components/markdown_editor/markdown_actions.ts
+++ b/src/components/markdown_editor/markdown_actions.ts
@@ -17,6 +17,31 @@
  * under the License.
  */
 
+// The text-formatting logic & code in this file come from
+// https://github.com/github/markdown-toolbar-element/blob/main/src/index.ts
+// under the following MIT license
+/*
+Copyright (c) 2017-2018 GitHub, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
 import {
   EuiMarkdownEditorUiPlugin,
   EuiMarkdownFormatting,
@@ -143,6 +168,7 @@ class MarkdownActions {
   /**
    * Sets the default styling object and then superimposes the changes to make on top of
    * it. Calls the `styleSelectedText` helper function that does the heavy lifting.
+   * Adapted from https://github.com/github/markdown-toolbar-element/blob/main/src/index.ts
    *
    * @param {object} incomingStyle
    * @memberof MarkdownActions
@@ -239,6 +265,7 @@ function wordSelectionEnd(text: string, i: number, multiline: boolean): number {
 
 const MAX_TRIES = 10;
 const TRY_TIMEOUT = 10 /*ms*/;
+// modified from https://github.com/github/markdown-toolbar-element/blob/main/src/index.ts
 export function insertText(
   textarea: HTMLTextAreaElement,
   { text, selectionStart, selectionEnd }: SelectionRange
@@ -292,6 +319,7 @@ export function insertText(
   focusTextarea();
 }
 
+// from https://github.com/github/markdown-toolbar-element/blob/main/src/index.ts
 function styleSelectedText(
   textarea: HTMLTextAreaElement,
   styleArgs: StyleArgs

--- a/src/components/markdown_editor/markdown_editor_drop_zone.tsx
+++ b/src/components/markdown_editor/markdown_editor_drop_zone.tsx
@@ -25,13 +25,15 @@ import {
   EuiMarkdownEditorUiPlugin,
   EuiMarkdownParseError,
   EuiMarkdownDropHandler,
+  EuiMarkdownStringTagConfig,
+  EuiMarkdownDragAndDropResult,
 } from './markdown_types';
 
 interface EuiMarkdownEditorDropZoneProps {
   uiPlugins: EuiMarkdownEditorUiPlugin[];
   errors: EuiMarkdownParseError[];
   dropHandlers: EuiMarkdownDropHandler[];
-  insertText: (text: string) => void;
+  insertText: (text: string, config: EuiMarkdownStringTagConfig) => void;
   hasUnacceptedItems: boolean;
   setHasUnacceptedItems: (hasUnacceptedItems: boolean) => void;
 }
@@ -160,7 +162,9 @@ export const EuiMarkdownEditorDropZone: FunctionComponent<EuiMarkdownEditorDropZ
 
       toggleUploadingFiles(true);
 
-      const resolved: Array<string | Promise<string>> = [];
+      const resolved: Array<
+        EuiMarkdownDragAndDropResult | Promise<EuiMarkdownDragAndDropResult>
+      > = [];
       for (let i = 0; i < acceptedFiles.length; i++) {
         const file = acceptedFiles[i];
         const handler = fileHandlers[i];
@@ -169,7 +173,7 @@ export const EuiMarkdownEditorDropZone: FunctionComponent<EuiMarkdownEditorDropZ
 
       Promise.all(resolved)
         .then(results => {
-          results.forEach(result => insertText(result));
+          results.forEach(({ text, config }) => insertText(text, config));
         })
         .catch(() => {})
         .then(() => {

--- a/src/components/markdown_editor/markdown_types.ts
+++ b/src/components/markdown_editor/markdown_types.ts
@@ -58,7 +58,7 @@ export interface RemarkRehypeHandler {
 export interface EuiMarkdownEditorUiPluginEditorProps {
   node?: object | null;
   onCancel: () => void;
-  onSave: (markdown: string) => void;
+  onSave: (markdown: string, config: EuiMarkdownStringTagConfig) => void;
 }
 
 export const isPluginWithImmediateFormatting = (
@@ -115,5 +115,16 @@ export type EuiMarkdownParseError = string | VFileMessage | Error;
 export interface EuiMarkdownDropHandler {
   supportedFiles: string[];
   accepts: (itemType: string) => boolean;
-  getFormattingForItem: (file: File) => string | Promise<string>;
+  getFormattingForItem: (
+    file: File
+  ) => EuiMarkdownDragAndDropResult | Promise<EuiMarkdownDragAndDropResult>;
+}
+
+export interface EuiMarkdownStringTagConfig {
+  block: boolean;
+}
+
+export interface EuiMarkdownDragAndDropResult {
+  text: string;
+  config: EuiMarkdownStringTagConfig;
 }


### PR DESCRIPTION
### Summary

Settled on keeping a distinction between a Formatting object & string to represent changes. The formatting objects, used by a plugin's UI button to directly modify the text, are used when the change is _presentational_ e.g. bold, italic. Our extended markdown formats, like the chart plugin's JSON insertion, do not interact with the text/presentation but are brand new values, so no custom formatting rules make sense. I think that's a fair (and good) distinction.

* Added license information for markdown tag formatting code
* Added support for markdown insertion to be block-level (testable via the chart plugin example and drag&drop)
* Corrected a documentation bug

~### Checklist~
