### PR TITLE
Wrap htmlIdGenerator in useRef

### DIFF
--- a/src-docs/src/views/form_layouts/form_rows.js
+++ b/src-docs/src/views/form_layouts/form_rows.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 
 import {
   EuiButton,
@@ -18,24 +18,24 @@ import {
 import { htmlIdGenerator } from '../../../../src/services';
 
 export default () => {
-  const idPrefix = htmlIdGenerator()();
+  const idPrefix = useRef(htmlIdGenerator()());
   const [isSwitchChecked, setIsSwitchChecked] = useState(false);
-  const [checkboxes] = useState([
+  const checkboxes = [
     {
-      id: `${idPrefix}0`,
+      id: `${idPrefix.current}0`,
       label: 'Option one',
     },
     {
-      id: `${idPrefix}1`,
+      id: `${idPrefix.current}1`,
       label: 'Option two is checked by default',
     },
     {
-      id: `${idPrefix}2`,
+      id: `${idPrefix.current}2`,
       label: 'Option three',
     },
-  ]);
+  ];
   const [checkboxIdToSelectedMap, setCheckboxIdToSelectedMap] = useState({
-    [`${idPrefix}1`]: true,
+    [`${idPrefix.current}1`]: true,
   });
 
   const onSwitchChange = () => {


### PR DESCRIPTION
### Summary

See issue https://github.com/elastic/eui/issues/3863 for more context & discussion

This PR uses `useRef` to wrap the call to htmlIdGenerator instead of wrapping the checkbox definitions inside of `useState`. 

Heads up--I checked the calls to htmlIdGenerator and it looks like there are more situations that could use this swap but due to the amount and that we only discussed this instance, I kept my scope to this form. No priority, just wanted to let you know!

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile** (note: rendered as mobile in chrome)
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox** 
~- [ ] Props have proper **autodocs**~ props didn't change
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~ This was a documentation example fix, no functional changes
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
