### PR TITLE
Fix externally-needed markdown editor types

### DIFF
--- a/src-docs/src/views/markdown_editor/markdown_editor_with_plugins.js
+++ b/src-docs/src/views/markdown_editor/markdown_editor_with_plugins.js
@@ -106,7 +106,9 @@ const chartDemoPlugin = {
                     { value: 5, text: 'green' },
                   ]}
                   value={palette}
-                  onChange={e => setPalette(parseInt(e.target.value, 10))}
+                  onChange={e =>
+                    setPalette(parseInt(e.currentTarget.value, 10))
+                  }
                 />
               </EuiFormRow>
 
@@ -118,7 +120,7 @@ const chartDemoPlugin = {
                   step={10}
                   showValue
                   valueAppend="px"
-                  onChange={e => setHeight(parseInt(e.target.value, 10))}
+                  onChange={e => setHeight(parseInt(e.currentTarget.value, 10))}
                 />
               </EuiFormRow>
             </EuiForm>

--- a/src/components/markdown_editor/index.ts
+++ b/src/components/markdown_editor/index.ts
@@ -31,4 +31,5 @@ export {
   EuiMarkdownFormatting,
   EuiMarkdownEditorUiPlugin,
   RemarkRehypeHandler,
+  RemarkTokenizer,
 } from './markdown_types';

--- a/src/components/markdown_editor/markdown_editor.tsx
+++ b/src/components/markdown_editor/markdown_editor.tsx
@@ -57,7 +57,10 @@ import {
   defaultProcessingPlugins,
 } from './plugins/markdown_default_plugins';
 
-type CommonMarkdownEditorProps = HTMLAttributes<HTMLDivElement> &
+type CommonMarkdownEditorProps = Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'onChange'
+> &
   CommonProps & {
     /** aria-label OR aria-labelledby must be set */
     'aria-label'?: string;

--- a/src/components/markdown_editor/markdown_types.ts
+++ b/src/components/markdown_editor/markdown_types.ts
@@ -55,14 +55,14 @@ export interface RemarkRehypeHandler {
   (h: RemarkRehypeHandlerCallback, node: UnistNode): RehypeNode;
 }
 
-export interface EuiMarkdownEditorUiPluginEditorProps {
-  node?: object | null;
+export interface EuiMarkdownEditorUiPluginEditorProps<NodeShape> {
+  node: NodeShape | null;
   onCancel: () => void;
   onSave: (markdown: string, config: EuiMarkdownStringTagConfig) => void;
 }
 
 export const isPluginWithImmediateFormatting = (
-  x: PluginWithImmediateFormatting | PluginWithDelayedFormatting
+  x: PluginWithImmediateFormatting | PluginWithDelayedFormatting<any>
 ): x is PluginWithImmediateFormatting => {
   return x.hasOwnProperty('formatting');
 };
@@ -72,19 +72,19 @@ export interface PluginWithImmediateFormatting {
   editor?: never;
 }
 
-export interface PluginWithDelayedFormatting {
+export interface PluginWithDelayedFormatting<NodeShape> {
   formatting?: never;
-  editor: ComponentType<EuiMarkdownEditorUiPluginEditorProps>;
+  editor: ComponentType<EuiMarkdownEditorUiPluginEditorProps<NodeShape>>;
 }
 
-export type EuiMarkdownEditorUiPlugin = {
+export type EuiMarkdownEditorUiPlugin<NodeShape = any> = {
   name: string;
   button: {
     label: string;
     iconType: IconType;
   };
   helpText?: ReactNode;
-} & (PluginWithImmediateFormatting | PluginWithDelayedFormatting);
+} & (PluginWithImmediateFormatting | PluginWithDelayedFormatting<NodeShape>);
 
 export interface EuiMarkdownFormatting {
   prefix?: string;

--- a/src/components/markdown_editor/plugins/markdown_default_plugins.tsx
+++ b/src/components/markdown_editor/plugins/markdown_default_plugins.tsx
@@ -45,7 +45,22 @@ const unknownHandler: RemarkRehypeHandler = (h, node) => {
   return h(node.position!, node.type, node, all(h, node));
 };
 
-export const getDefaultEuiMarkdownProcessingPlugins = (): PluggableList => [
+interface Remark2RehypeOptions {
+  allowDangerousHtml: boolean;
+  handlers: { [key: string]: RemarkRehypeHandler };
+  [key: string]: any;
+}
+
+interface Rehype2ReactOptions {
+  components: { [key: string]: React.ComponentType<any> };
+  [key: string]: any;
+}
+
+export const getDefaultEuiMarkdownProcessingPlugins = (): [
+  [typeof remark2rehype, Remark2RehypeOptions], // first is well known
+  [typeof rehype2react, Rehype2ReactOptions], // second is well known
+  ...PluggableList // any additional are generic
+] => [
   [
     remark2rehype,
     {


### PR DESCRIPTION
### Summary

Built EUI with the markdown editor & attempted the reproduce the chart plugin example, found some missing/incomplete types. Made these changes, rebuilt & confirmed in a create-react-app that they make the plugin example usable.