### PR TITLE
Fix datagrid not fitting into containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Fixed `EuiFacetGroup` container expansion due to negative margin value ([#3871](https://github.com/elastic/eui/pull/3871))
 - Fixed `EuiComboBox` delimeter-separated option creation and empty state prompt text ([#3841](https://github.com/elastic/eui/pull/3841))
+- Fixed `EuiDataGrid` not properly resizing within a fixed height container ([#3894](https://github.com/elastic/eui/pull/3894))
 
 **Breaking changes**
 

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -177,6 +177,7 @@ Array [
     tabindex="-1"
   />,
   <div
+    class="euiDataGrid__focusWrap"
     data-focus-lock-disabled="disabled"
   >
     <div
@@ -714,6 +715,7 @@ Array [
     tabindex="-1"
   />,
   <div
+    class="euiDataGrid__focusWrap"
     data-focus-lock-disabled="disabled"
   >
     <div
@@ -1575,6 +1577,7 @@ Array [
     tabindex="-1"
   />,
   <div
+    class="euiDataGrid__focusWrap"
     data-focus-lock-disabled="disabled"
   >
     <div
@@ -2111,6 +2114,7 @@ Array [
     tabindex="-1"
   />,
   <div
+    class="euiDataGrid__focusWrap"
     data-focus-lock-disabled="disabled"
   >
     <div

--- a/src/components/datagrid/_data_grid.scss
+++ b/src/components/datagrid/_data_grid.scss
@@ -113,3 +113,7 @@
   padding: $euiSizeS;
   margin: -$euiSizeS; // Offset against the panel to make the scrollbar flush scrollbars
 }
+
+.euiDataGrid__focusWrap {
+  height: 100%;
+}

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -948,7 +948,7 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
                 <DataGridContext.Provider value={datagridContext}>
                   <EuiFocusTrap
                     disabled={!isFullScreen}
-                    style={{ height: '100%' }}>
+                    className="euiDataGrid__focusWrap">
                     <div
                       className={classes}
                       onKeyDown={handleGridKeyDown}


### PR DESCRIPTION
### Summary

Fixes https://github.com/elastic/eui/issues/3878

Related to https://github.com/theKashey/react-focus-on/pull/47 , our focus trap solution didn't accept `style` props. Regardless, it accepts `className` and we should use that instead.

![image](https://user-images.githubusercontent.com/324519/89953078-46cb2900-dbe3-11ea-9dd2-b416f7851fd6.png)

### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
