### PR TITLE
Don't re-generate DataGridContext from pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `28.0.0`.
+**Bug fixes**
+
+- Fixed bug in `EuiDataGrid` when a new pagination object would cause every cell to render ([#3919](https://github.com/elastic/eui/pull/3919))
 
 ## [`28.0.0`](https://github.com/elastic/eui/tree/v28.0.0)
 

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -886,17 +886,15 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
   const datagridContext = useMemo(
     () => ({
       onFocusUpdate: (cell: EuiDataGridFocusedCell, updateFocus: Function) => {
-        if (pagination) {
-          const key = `${cell[0]}-${cell[1]}`;
-          cellsUpdateFocus.current.set(key, updateFocus);
+        const key = `${cell[0]}-${cell[1]}`;
+        cellsUpdateFocus.current.set(key, updateFocus);
 
-          return () => {
-            cellsUpdateFocus.current.delete(key);
-          };
-        }
+        return () => {
+          cellsUpdateFocus.current.delete(key);
+        };
       },
     }),
-    [pagination]
+    []
   );
 
   const gridIds = htmlIdGenerator();


### PR DESCRIPTION
### Summary

Fixes #3880 

`DataGridContext` has been dependent on the `pagination` prop, so any re-renders of an EuiDataGrid+pagination (or its parent) has been triggering all cells to re-render. There's no need for that context to be pagination-dependent, so that has been removed.

I also verified a datagrid with no pagination continues to work as expected

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
