### PR TITLE
[EuiToggle] Fix `onChange` prop type override

### DIFF
--- a/src/components/toggle/toggle.tsx
+++ b/src/components/toggle/toggle.tsx
@@ -30,7 +30,7 @@ export const TYPES = Object.keys(typeToInputTypeMap);
 
 export type ToggleType = keyof typeof typeToInputTypeMap;
 
-export type EuiToggleProps = HTMLAttributes<HTMLDivElement> &
+export type EuiToggleProps = Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> &
   CommonProps & {
     id?: string;
     /**


### PR DESCRIPTION
### Summary

The `div.onChange` prop needs to be properly removed before the override `onChange` can get picked up by the docgen script.

~### Checklist~
