### PR TITLE
Fixed prop not displaying for EuiExpression

### DIFF
--- a/src/components/expression/expression.tsx
+++ b/src/components/expression/expression.tsx
@@ -22,6 +22,7 @@ import React, {
   HTMLAttributes,
   MouseEventHandler,
   ReactNode,
+  FunctionComponent,
 } from 'react';
 import classNames from 'classnames';
 import { CommonProps, keysOf, ExclusiveUnion } from '../common';
@@ -99,13 +100,14 @@ export type EuiExpressionProps = CommonProps & {
 };
 
 type Buttonlike = EuiExpressionProps &
-  ButtonHTMLAttributes<HTMLButtonElement> & {
+  Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'value'> & {
     onClick: MouseEventHandler<HTMLButtonElement>;
   };
 
-type Spanlike = EuiExpressionProps & HTMLAttributes<HTMLSpanElement>;
+type Spanlike = EuiExpressionProps &
+  Omit<HTMLAttributes<HTMLSpanElement>, 'value'>;
 
-export const EuiExpression: React.FunctionComponent<ExclusiveUnion<
+export const EuiExpression: FunctionComponent<ExclusiveUnion<
   Buttonlike,
   Spanlike
 >> = ({


### PR DESCRIPTION
### Summary

Props are not displayed for EuiExpression. It was missed in #3554 

### Checklist

~~- [ ] Check against **all themes** for compatibility in both light and dark modes~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~~
- [x] Props have proper **autodocs**

~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
~~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~~
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
~~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~~
