### PR TITLE
Add test-env mock for EuiFocusTrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added `isLoading` and `isLoadingMessage` props to `EuiAccordion` ([#3879](https://github.com/elastic/eui/pull/3879))
+- Added `testenv` mock for `EuiFocusTrap` ([#3930](https://github.com/elastic/eui/pull/3930))
 
 **Bug fixes**
 

--- a/src/components/focus_trap/focus_trap.testenv.tsx
+++ b/src/components/focus_trap/focus_trap.testenv.tsx
@@ -1,0 +1,31 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+
+export const EuiFocusTrap = ({
+  children,
+  'data-test-subj': dataTestSubj,
+}: any) => {
+  return (
+    <div data-eui="EuiFocusTrap" data-test-subj={dataTestSubj}>
+      {children}
+    </div>
+  );
+};


### PR DESCRIPTION
### Summary

The [most recent EUI upgrade](https://github.com/elastic/kibana/pull/74004) in Kibana [increased Jest test flakiness](https://github.com/elastic/kibana/issues/74814) and ultimately exposed [recently changed EuiFocusTrap dependencies](https://github.com/elastic/eui/pull/3631) to significantly lengthen unit test run times (leading to timeout-based failures).

This PR introduces a testenv mock for EuiFocusTrap which will prevent library internals from unnecessarily interfering with downstream unit tests.

The effective result in Kibana is up to 85% faster runs in affected unit tests, 0 behavioral changes, and surprisingly few snapshot updates. 

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
