### PR TITLE
Add value props to EuiSelect props

### DIFF
--- a/src/components/form/select/select.tsx
+++ b/src/components/form/select/select.tsx
@@ -37,7 +37,10 @@ export interface EuiSelectOption
   text: React.ReactNode;
 }
 
-export type EuiSelectProps = SelectHTMLAttributes<HTMLSelectElement> &
+export type EuiSelectProps = Omit<
+  SelectHTMLAttributes<HTMLSelectElement>,
+  'value'
+> &
   CommonProps & {
     options?: EuiSelectOption[];
     isInvalid?: boolean;
@@ -49,6 +52,7 @@ export type EuiSelectProps = SelectHTMLAttributes<HTMLSelectElement> &
      */
     hasNoInitialSelection?: boolean;
     inputRef?: Ref<HTMLSelectElement>;
+    value?: string | number;
 
     /**
      * when `true` creates a shorter height input


### PR DESCRIPTION
### Summary

Fixes #3933 

- Add `value` props to `EuiSelectProps`
- Verified generation of prop in props page

### Checklist

~~- [ ] Check against **all themes** for compatibility in both light and dark modes~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~~
- [x] Props have proper **autodocs**

~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
~~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~~
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
~~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~~
