### PR TITLE
Make sidenav coloring more consistant for open nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Adjusted coloring of `EuiSideNav` to be more consistent across open states ([#3926](https://github.com/elastic/eui/pull/3926))
+
 **Bug fixes**
 
 - Fixed bug in `EuiBasicTable` not fully expanding tall rows (height > 1000px) ([#3855](https://github.com/elastic/eui/pull/3855))

--- a/src/components/side_nav/_side_nav_item.scss
+++ b/src/components/side_nav/_side_nav_item.scss
@@ -23,6 +23,10 @@
   }
 
   &.euiSideNavItemButton-isSelected {
+    .euiSideNavItemButton__icon {
+      fill: $euiColorPrimary;
+    }
+
     .euiSideNavItemButton__label {
       color: $euiColorPrimary;
       font-weight: $euiFontWeightBold;
@@ -147,6 +151,10 @@
 
   & > .euiSideNavItem__items {
     margin-left: $euiSize;
+  }
+
+  .euiSideNavItemButton__icon {
+    fill: $euiTextSubduedColor;
   }
 
   .euiSideNavItemButton__label {

--- a/src/components/side_nav/_side_nav_item.scss
+++ b/src/components/side_nav/_side_nav_item.scss
@@ -8,7 +8,7 @@
   display: block;
   width: 100%;
   padding: $euiSizeXS / 2 0;
-  color: $euiColorDarkestShade; /* 2 */
+  color: $euiTextColor; /* 2 */
 
   &.euiSideNavItemButton--isClickable {
     &:hover .euiSideNavItemButton__label {
@@ -48,7 +48,7 @@
 }
 
 .euiSideNavItemButton__label {
-  color: $euiColorFullShade;
+  color: $euiTitleColor;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -150,7 +150,7 @@
   }
 
   .euiSideNavItemButton__label {
-    color: $euiColorDarkShade;
+    color: $euiTextSubduedColor;
   }
 }
 

--- a/src/components/side_nav/_side_nav_item.scss
+++ b/src/components/side_nav/_side_nav_item.scss
@@ -48,7 +48,7 @@
 }
 
 .euiSideNavItemButton__label {
-  color: $euiColorDarkShade;
+  color: $euiColorDarkestShade;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -148,12 +148,9 @@
   & > .euiSideNavItem__items {
     margin-left: $euiSize;
   }
-}
 
-.euiSideNavItem--hasChildItems {
-  & > .euiSideNavItemButton-isOpen {
-    .euiSideNavItemButton__label {
-      color: $euiColorFullShade;
-    }
-  }
-}
+  .euiSideNavItemButton__label {
+    color: $euiColorDarkShade;
+
+}}
+

--- a/src/components/side_nav/_side_nav_item.scss
+++ b/src/components/side_nav/_side_nav_item.scss
@@ -8,7 +8,7 @@
   display: block;
   width: 100%;
   padding: $euiSizeXS / 2 0;
-  color: $euiColorFullShade; /* 2 */
+  color: $euiColorDarkestShade; /* 2 */
 
   &.euiSideNavItemButton--isClickable {
     &:hover .euiSideNavItemButton__label {
@@ -25,7 +25,7 @@
   &.euiSideNavItemButton-isSelected {
     .euiSideNavItemButton__label {
       color: $euiColorPrimary;
-      font-weight: $euiFontWeightMedium;
+      font-weight: $euiFontWeightBold;
       text-decoration: underline;
     }
   }
@@ -48,7 +48,7 @@
 }
 
 .euiSideNavItemButton__label {
-  color: $euiColorDarkestShade;
+  color: $euiColorFullShade;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -151,6 +151,6 @@
 
   .euiSideNavItemButton__label {
     color: $euiColorDarkShade;
-
-}}
+  }
+}
 


### PR DESCRIPTION
### Summary

Replaces https://github.com/elastic/eui/pull/3926 which was already approved by @cchaos  

Minor change to the sidenav coloring to make it more consistant for navs in their various open / close states. The current setup over-assumes that you'll be using open states as a location reference. This might be something we want to change based on a prop, but in general I think this way is a more consistent default.

## Before

![image](https://user-images.githubusercontent.com/324519/90342180-14db0d80-dfbb-11ea-9a1c-5283e5b2ad4c.png)

## After

![image](https://user-images.githubusercontent.com/324519/90713448-33aaff80-e25a-11ea-8dfb-3588826393e4.png)

## Why this is important

When working with trees where you force them open to show heigharchy, you'd wonder why the coloring was highlighted differently.

![image](https://user-images.githubusercontent.com/324519/90342258-861ac080-dfbb-11ea-96ae-01f5b542f67a.png)

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [ ] ~Checked in **mobile**~
- [ ] ~Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- [ ] ~Props have proper **autodocs**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [ ] ~Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
