### PR TITLE
Force rename/expansion of Primitive type -> boolean | number | string in docs

### DIFF
--- a/scripts/babel/react-docgen-typescript.js
+++ b/scripts/babel/react-docgen-typescript.js
@@ -217,10 +217,14 @@ function filterProp(
     return true;
   }
 
-  // if prop type is string | number typescript takes it as ReactText if HTMLAttributes are extended
-  // in the interace in that case replace it with "string | number"
   if (prop.type.name === 'ReactText') {
+    // if prop type is string | number typescript takes it as ReactText if HTMLAttributes are extended
+    // in the interface in that case replace it with "string | number"
     prop.type.name = 'string | number';
+  } else if (prop.type.name === 'Primitive') {
+    // "Primitive" comes from src/services/sort/comparators.ts
+    // TypeScript sees its overlap with `boolean | number | string` and decides to name the type union
+    prop.type.name = 'boolean | number | string';
   }
 
   // if prop.type is ReactElement it will be expanded to show all the  supported


### PR DESCRIPTION
### Summary

Fixes a bug in the docs' props generation, where TypeScript notices a prop with the union `boolean | number | string` overlaps the named `Primitive` type from https://github.com/elastic/eui/blob/f937facb3f7647c5c9cacb146436d472082f651f/src/services/sort/comparators.ts#L23 and uses that name instead of the expanded union.

One example is **EuiFlyout**'s `maxWidth` prop:

<img width="820" alt="maxWidth prop" src="https://user-images.githubusercontent.com/313125/90919626-023e4b00-e3a4-11ea-8c94-f105a50f534a.png">

/cc @cchaos who brought this up

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- [x] Props have proper **autodocs**
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
