### PR TITLE
[Guidelines] Clarify punctuation rules for help text

### DIFF
--- a/src-docs/src/views/guidelines/writing.js
+++ b/src-docs/src/views/guidelines/writing.js
@@ -334,17 +334,17 @@ export default () => (
 
     <GuideRule
       heading="Know when to use the ending period"
-      description="Use periods at the end of complete sentences in body text.
-      These are typically supplemental explanations and instructions.  Avoid
-      periods in titles, headings, and sentence fragments.">
+      description="Use periods at the end of help text and complete sentences 
+      in body text. These are typically supplemental explanations and
+      instructions. Avoid periods in titles, headings, and sentence fragments.">
       <GuideRuleExample
         type="do"
-        text="Do. Use periods after sentences in help text.">
+        text="Do. Use periods at the end of help text.">
         <EuiFormRow
           label="Number"
           helpText={
             <span>
-              Number must be between 1 and 5. <EuiLink>Learn more.</EuiLink>
+              Accepts 1–5. <EuiLink>Learn more.</EuiLink>
             </span>
           }>
           <EuiFieldNumber min={1} max={5} step={1} />

--- a/src-docs/src/views/guidelines/writing.js
+++ b/src-docs/src/views/guidelines/writing.js
@@ -336,7 +336,7 @@ export default () => (
       heading="Know when to use the ending period"
       description="Use periods at the end of help text and complete sentences 
       in body text. These are typically supplemental explanations and
-      instructions. Avoid periods in titles, headings, and sentence fragments.">
+      instructions. Avoid periods in titles and headings.">
       <GuideRuleExample
         type="do"
         text="Do. Use periods at the end of help text.">


### PR DESCRIPTION
### Summary

Notes that field help text should always end with a period, even if it's only a sentence fragment.

<img width="965" alt="Screen Shot 2020-08-21 at 3 15 08 PM" src="https://user-images.githubusercontent.com/40268737/90926488-35430780-e3c1-11ea-861c-31226fd9321a.PNG">


### Checklist


- [X] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**