### PR TITLE
Ref in props tab for froward ref components

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "puppeteer": "^2.0.0",
     "raw-loader": "^0.5.1",
     "react": "^16.12.0",
-    "react-docgen-typescript": "^1.17.1",
+    "react-docgen-typescript": "^1.20.2",
     "react-dom": "^16.12.0",
     "react-redux": "^5.1.2",
     "react-router": "^5.2.0",

--- a/scripts/babel/react-docgen-typescript.js
+++ b/scripts/babel/react-docgen-typescript.js
@@ -64,6 +64,7 @@ module.exports = function({ types }) {
             'DragDropContextProps',
             'DraggableProps',
             'DroppableProps',
+            'RefAttributes',
           ];
 
           let docgenResults = [];

--- a/src/components/markdown_editor/markdown_editor.tsx
+++ b/src/components/markdown_editor/markdown_editor.tsx
@@ -26,6 +26,7 @@ import React, {
   useState,
   useCallback,
   useRef,
+  forwardRef,
 } from 'react';
 
 import unified, { PluggableList, Processor } from 'unified';
@@ -141,7 +142,7 @@ function padWithNewlinesIfNeeded(textarea: HTMLTextAreaElement, text: string) {
   return text;
 }
 
-export const EuiMarkdownEditor = React.forwardRef<
+export const EuiMarkdownEditor = forwardRef<
   EuiMarkdownEditorRef,
   EuiMarkdownEditorProps
 >(

--- a/yarn.lock
+++ b/yarn.lock
@@ -14254,10 +14254,10 @@ react-clientside-effect@^1.2.2:
   dependencies:
     "@babel/runtime" "^7.0.0"
 
-react-docgen-typescript@^1.17.1:
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-1.17.1.tgz#6df6a5bf9b340e45ed3f1590515013ba71d3078b"
-  integrity sha512-JahR6AvNOQ2+HC+jIzMuFw6VctUnComz84W5AlRVF53wOq2yRR0xosQ3NShjU7mC27McgfzoFKKzL5UBN86FXw==
+react-docgen-typescript@^1.20.2:
+  version "1.20.2"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-1.20.2.tgz#78f4a14f18a4e236e31051961c75583133752d46"
+  integrity sha512-tW1cZErh4AxDJIFiTxny9AfMeSwm+NI7BsXXuAXPvoIxToglFWvmJWsJF6sYhSA3zNu3zhFOIMdRMXTzQAyCpA==
 
 react-dom@^16.12.0:
   version "16.12.0"


### PR DESCRIPTION
### Summary

Makes progress on #3056 

- Updated react-docgen-typescript
- Show ref as  a prop in props tab if component is a forward ref component

### Checklist

- [x] Props have proper **autodocs**

