### PR TITLE
Update EuiFieldSearch to show a clear button when defaultValue is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed bug in `EuiBasicTable` not fully expanding tall rows (height > 1000px) ([#3855](https://github.com/elastic/eui/pull/3855))
 - Added `regressionJob`, `outlierDetectionJob` and `classificationJob` icons to Machine Learning icon set, updated others. ([#3931](https://github.com/elastic/eui/pull/3931))
 - Fixed bug in `EuiDataGrid` which sometimes prevented header cells from being focusabled ([#3943](https://github.com/elastic/eui/pull/3943))
+- Fixed bug in `EuiFieldSearch` where a default value would not include the clear button ([#3958](https://github.com/elastic/eui/pull/3958))
 
 ## [`28.2.0`](https://github.com/elastic/eui/tree/v28.2.0)
 

--- a/src-docs/src/views/search_bar/controlled_search_bar.js
+++ b/src-docs/src/views/search_bar/controlled_search_bar.js
@@ -57,7 +57,7 @@ const loadTags = () => {
   });
 };
 
-const initialQuery = EuiSearchBar.Query.MATCH_ALL;
+const initialQuery = 'status:open';
 
 export const ControlledSearchBar = () => {
   const [query, setQuery] = useState(initialQuery);

--- a/src/components/form/field_search/field_search.tsx
+++ b/src/components/form/field_search/field_search.tsx
@@ -91,7 +91,9 @@ export class EuiFieldSearch extends Component<
   };
 
   state = {
-    value: this.props.value || '',
+    value:
+      this.props.value ||
+      (this.props.defaultValue ? `${this.props.defaultValue}` : ''),
   };
 
   inputElement: HTMLInputElement | null = null;

--- a/src/components/selectable/selectable_search/__snapshots__/selectable_search.test.tsx.snap
+++ b/src/components/selectable/selectable_search/__snapshots__/selectable_search.test.tsx.snap
@@ -70,6 +70,20 @@ exports[`EuiSelectableSearch props defaultValue 1`] = `
         />
       </span>
     </div>
+    <div
+      class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+    >
+      <button
+        aria-label="Clear input"
+        class="euiFormControlLayoutClearButton"
+        type="button"
+      >
+        <div
+          class="euiFormControlLayoutClearButton__icon"
+          data-euiicon-type="cross"
+        />
+      </button>
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
### Summary

Fixes #3950 

**EuiFieldSearch** did not include its `defaultValue` prop (inherited from `InputHTMLAttributes`) when generating its value state. **EuiSearchBox** provides the initial query value to the search field via`defaultValue`.

* updated **EuiFieldSearch** to respect `defaultValue`
* updated **EuiSearchBar**'s _Controlled search bar_ example to set an initial query for better usage demonstration

#### Before
<img width="791" alt="Screen Shot 2020-08-24 at 10 08 08 AM" src="https://user-images.githubusercontent.com/313125/91068567-bc76c200-e5f1-11ea-987c-f92a5170aa66.png">

#### After
<img width="791" alt="Screen Shot 2020-08-24 at 10 07 19 AM" src="https://user-images.githubusercontent.com/313125/91068514-a23ce400-e5f1-11ea-8541-aae6eca2712a.png">

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
