### PR TITLE
[WIP] Custom paging button and usable hook for EuiPagination

### DIFF
--- a/src-docs/src/views/pagination/custom_button.js
+++ b/src-docs/src/views/pagination/custom_button.js
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+
+import { EuiPagination, EuiButtonIcon } from '../../../../src/components';
+
+export default function() {
+  const [activePage, setActivePage] = useState(0);
+  const PAGE_COUNT = 10;
+
+  const goToPage = pageNumber => {
+    setActivePage(pageNumber);
+  };
+
+  const CustomButton = ({ isActive, onClick }) => (
+    <EuiButtonIcon
+      iconType="dot"
+      color={isActive ? 'primary' : 'text'}
+      onClick={onClick}
+    />
+  );
+
+  return (
+    <EuiPagination
+      aria-label="Custom button example"
+      button={CustomButton}
+      pageCount={PAGE_COUNT}
+      activePage={activePage}
+      onPageClick={activePage => goToPage(activePage)}
+    />
+  );
+}

--- a/src-docs/src/views/pagination/pagination_example.js
+++ b/src-docs/src/views/pagination/pagination_example.js
@@ -86,6 +86,18 @@ const compressedSnippet = `<EuiPagination
 />
 `;
 
+import CustomButton from './custom_button';
+const customButtonSource = require('!!raw-loader!./compressed');
+const customButtonHtml = renderToHtml(Compressed);
+const customButtonSnippet = `<EuiPagination
+aria-label="my pagination"
+pageCount={pageCount}
+activePage={activePage}
+onPageClick={goToPage}
+button = {MyButton}
+/>
+`;
+
 export const PaginationExample = {
   title: 'Pagination',
   sections: [
@@ -201,6 +213,22 @@ export const PaginationExample = {
       ),
       snippet: customizablePaginationSnippet,
       demo: <CustomizablePagination />,
+    },
+    {
+      title: 'Custom button',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: customButtonSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: customButtonHtml,
+        },
+      ],
+      text: <p>You can use a custom button instead of the default.</p>,
+      snippet: customButtonSnippet,
+      demo: <CustomButton />,
     },
   ],
   playground: paginationConfig,

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -500,7 +500,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                         <ul
                           className="euiPagination__list"
                         >
-                          <PaginationButton
+                          <Button
                             key="0"
                             pageIndex={0}
                           >
@@ -579,8 +579,8 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                 </EuiI18n>
                               </EuiPaginationButton>
                             </li>
-                          </PaginationButton>
-                          <PaginationButton
+                          </Button>
+                          <Button
                             key="1"
                             pageIndex={1}
                           >
@@ -661,7 +661,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                 </EuiI18n>
                               </EuiPaginationButton>
                             </li>
-                          </PaginationButton>
+                          </Button>
                         </ul>
                         <EuiI18n
                           default="Next page, {page}"

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -258,7 +258,11 @@ export {
   EuiPageSideBar,
 } from './page';
 
-export { EuiPagination, EuiPaginationButton } from './pagination';
+export {
+  EuiPagination,
+  EuiPaginationButton,
+  usePagination,
+} from './pagination';
 
 export { EuiPanel } from './panel';
 

--- a/src/components/pagination/index.ts
+++ b/src/components/pagination/index.ts
@@ -20,3 +20,5 @@
 export { EuiPagination } from './pagination';
 
 export { EuiPaginationButton } from './pagination_button';
+
+export { usePagination } from './use_pagination';

--- a/src/components/pagination/use_pagination.tsx
+++ b/src/components/pagination/use_pagination.tsx
@@ -1,0 +1,136 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { ReactElement, useState } from 'react';
+
+import { EuiI18n } from '../i18n';
+
+export interface PaginationButtonProps {
+  pageIndex: number;
+  inList?: boolean;
+}
+
+export type PaginationButton = (props: PaginationButtonProps) => ReactElement;
+
+interface Props {
+  pageCount: number;
+  activePage: number;
+  maxVisiblePages?: number;
+}
+
+const MAX_VISIBLE_PAGES = 5;
+
+type Hook = (
+  Button: PaginationButton,
+  { pageCount, activePage }: Props
+) => [
+  {
+    activePage: number;
+    firstPageButtons: ReactElement[];
+    selectablePageButtons: ReactElement[];
+    lastPageButtons: ReactElement[];
+  },
+  { setActivePage: (page: number) => void }
+];
+
+export const usePagination: Hook = (
+  Button,
+  {
+    pageCount = 1,
+    activePage: activePageProp = 1,
+    maxVisiblePages = MAX_VISIBLE_PAGES,
+  }
+) => {
+  const NUMBER_SURROUNDING_PAGES = Math.floor(maxVisiblePages * 0.5);
+  const [activePage, setActivePage] = useState(activePageProp);
+  const selectablePageButtons: ReactElement[] = [];
+  const firstPageInRange = Math.max(
+    0,
+    Math.min(activePage - NUMBER_SURROUNDING_PAGES, pageCount - maxVisiblePages)
+  );
+  const lastPageInRange = Math.min(
+    pageCount,
+    firstPageInRange + maxVisiblePages
+  );
+
+  for (let i = firstPageInRange, index = 0; i < lastPageInRange; i++, index++) {
+    selectablePageButtons.push(<Button pageIndex={i} key={i} />);
+  }
+
+  const firstPageButtons = [];
+
+  if (firstPageInRange > 0) {
+    firstPageButtons.push(<Button pageIndex={0} key={0} />);
+
+    if (firstPageInRange > 1 && firstPageInRange !== 2) {
+      firstPageButtons.push(
+        <EuiI18n
+          key="startingEllipses"
+          token="euiUsePagination.firstRangeAriaLabel"
+          default="Skipping pages 2 to {lastPage}"
+          values={{ lastPage: firstPageInRange }}>
+          {(firstRangeAriaLabel: string) => (
+            <li
+              aria-label={firstRangeAriaLabel}
+              className="euiPaginationButton-isPlaceholder euiPagination__item">
+              &hellip;
+            </li>
+          )}
+        </EuiI18n>
+      );
+    } else if (firstPageInRange === 2) {
+      firstPageButtons.push(<Button pageIndex={1} key={1} />);
+    }
+  }
+
+  const lastPageButtons = [];
+
+  if (lastPageInRange < pageCount) {
+    if (lastPageInRange + 1 === pageCount - 1) {
+      lastPageButtons.push(
+        <Button pageIndex={lastPageInRange} key={lastPageInRange} />
+      );
+    } else if (lastPageInRange < pageCount - 1) {
+      lastPageButtons.push(
+        <EuiI18n
+          key="endingEllipses"
+          token="euiUsePagination.lastRangeAriaLabel"
+          default="Skipping pages {firstPage} to {lastPage}"
+          values={{ firstPage: lastPageInRange + 1, lastPage: pageCount - 1 }}>
+          {(lastRangeAriaLabel: string) => (
+            <li
+              aria-label={lastRangeAriaLabel}
+              className="euiPaginationButton-isPlaceholder euiPagination__item">
+              &hellip;
+            </li>
+          )}
+        </EuiI18n>
+      );
+    }
+
+    lastPageButtons.push(
+      <Button pageIndex={pageCount - 1} key={pageCount - 1} />
+    );
+  }
+
+  return [
+    { activePage, firstPageButtons, selectablePageButtons, lastPageButtons },
+    { setActivePage },
+  ];
+};


### PR DESCRIPTION
### Summary

> Took a stab at addressing https://github.com/elastic/eui/issues/3949... and this is my first EUI PR! :-)

This is a proposal to extract the paging logic into a reusable hook for components beyond EUI, and allow a custom paging button.

![Screen Shot 2020-08-24 at 10 42 44 PM](https://user-images.githubusercontent.com/297604/91120393-2d9e8f80-e65b-11ea-8f90-1d32e09af57c.png)

An example use case would be a component I'm using in proof-of-concept in Canvas, where I have a vertical paging unit with page previews.  The paging logic that's been written would be incredibly useful, and we'd benefit from updates with any EUI release.  Regardless, I can now also pass a custom button implementation and use the `EuiPagination` control outright.

I'm absolutely _certain_ there are improvements/more "EUI-esque" changes to be made to this branch.  Feel free to comment here or in the issue, (and pushes to this branch are always welcome!)

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
