### PR TITLE
[WIP][rtl][css] Fix button margins for RTL langs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Fixed bug in `EuiComboBox` where the input was dropping to the next line when a `EuiBadge` had a very long text ([#3968](https://github.com/elastic/eui/pull/3968))
+- Fixed `EuiButton` CSS for RTL languages - e.g. uses `margin-inline-start` instead of `margin-left`.  The left/right do not work properly with RTL, and should be avoided.
 
 ## [`28.3.0`](https://github.com/elastic/eui/tree/v28.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 **Bug fixes**
 
 - Fixed bug in `EuiComboBox` where the input was dropping to the next line when a `EuiBadge` had a very long text ([#3968](https://github.com/elastic/eui/pull/3968))
-- Fixed `EuiButton` CSS for RTL languages - e.g. uses `margin-inline-start` instead of `margin-left`.  The left/right do not work properly with RTL, and should be avoided.
+- Fixed `EuiButton` CSS for RTL languages by using `margin-inline-[pos]` instead of `margin-[pos]` ([#3974](https://github.com/elastic/eui/pull/3974))
 
 ## [`28.3.0`](https://github.com/elastic/eui/tree/v28.3.0)
 

--- a/src/global_styling/mixins/_button.scss
+++ b/src/global_styling/mixins/_button.scss
@@ -72,8 +72,8 @@
     flex-direction: row-reverse;
 
     > * + * {
-      margin-left: 0; // 1, 2
-      margin-right: $euiSizeS; // 1, 2
+      margin-inline-start: 0; // 1, 2
+      margin-inline-end: $euiSizeS; // 1, 2
     }
   } @else {
     display: flex;
@@ -81,7 +81,7 @@
     align-items: center;
 
     > * + * {
-      margin-left: $euiSizeS; // 1
+      margin-inline-start: $euiSizeS; // 1
     }
   }
 }


### PR DESCRIPTION
### Summary

When showing a button in RTL, margin-left/right shows up incorrectly. The needed CSS seems to be `margin-inline-start/end`.  Partially relates to #3960 

Those values do not exist in IE, so not sure if we can introduce these or not just yet.  I tested these changes with a search bar's filters and `EuiHeaderLink` with icons.

english | current RTL | desired RTL 
---|---|---
![image](https://user-images.githubusercontent.com/1641515/91629484-7629b600-e997-11ea-8a29-85a7871443d4.png) | ![image](https://user-images.githubusercontent.com/1641515/91629493-95c0de80-e997-11ea-92ed-68c6af62c4c3.png) | ![image](https://user-images.githubusercontent.com/1641515/91629489-8b9ee000-e997-11ea-87c7-367749d876e2.png)

The above changes can be achieved with this CSS override.

```css
.euiButtonContent > * + * {
    margin-left: unset;
    -webkit-margin-start: 8px;
    margin-inline-start: 8px; }

.euiButtonContent--iconRight > * + * {
    margin-left: unset;
    margin-right: unset;
    -webkit-margin-start: 0;
    margin-inline-start: 0;
    -webkit-margin-end: 8px;
    margin-inline-end: 8px; }

.euiFacetButton__content > * + * {
    margin-left: unset;
    -webkit-margin-start: 8px;
    margin-inline-start: 8px; }
```


### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
