### PR TITLE
Update and expand use of EuiSelectable option type generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Fixed bug in `EuiComboBox` where the input was dropping to the next line when a `EuiBadge` had a very long text ([#3968](https://github.com/elastic/eui/pull/3968))
+- Fixed type mismatch between `EuiSelectable` options extended via `EuiSelectableOption` and internal option types ([#3983](https://github.com/elastic/eui/pull/3983))
 
 ## [`28.3.0`](https://github.com/elastic/eui/tree/v28.3.0)
 

--- a/src/components/selectable/__snapshots__/selectable.test.tsx.snap
+++ b/src/components/selectable/__snapshots__/selectable.test.tsx.snap
@@ -1,17 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiSelectable custom options optional properties 1`] = `
-<div
-  class="euiSelectable"
-/>
-`;
-
-exports[`EuiSelectable custom options required properties 1`] = `
-<div
-  class="euiSelectable"
-/>
-`;
-
 exports[`EuiSelectable is rendered 1`] = `
 <div
   class="euiSelectable testClass1 testClass2"

--- a/src/components/selectable/__snapshots__/selectable.test.tsx.snap
+++ b/src/components/selectable/__snapshots__/selectable.test.tsx.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiSelectable custom options optional properties 1`] = `
+<div
+  class="euiSelectable"
+/>
+`;
+
+exports[`EuiSelectable custom options required properties 1`] = `
+<div
+  class="euiSelectable"
+/>
+`;
+
 exports[`EuiSelectable is rendered 1`] = `
 <div
   class="euiSelectable testClass1 testClass2"

--- a/src/components/selectable/matching_options.ts
+++ b/src/components/selectable/matching_options.ts
@@ -19,36 +19,36 @@
 
 import { EuiSelectableOption } from './selectable_option';
 
-const getSearchableLabel = (
-  option: EuiSelectableOption,
+const getSearchableLabel = <T>(
+  option: EuiSelectableOption<T>,
   normalize: boolean = true
 ): string => {
   const searchableLabel = option.searchableLabel || option.label;
   return normalize ? searchableLabel.trim().toLowerCase() : searchableLabel;
 };
 
-const getSelectedOptionForSearchValue = (
+const getSelectedOptionForSearchValue = <T>(
   searchValue: string,
-  selectedOptions: EuiSelectableOption[]
+  selectedOptions: Array<EuiSelectableOption<T>>
 ) => {
   const normalizedSearchValue = searchValue.toLowerCase();
   return selectedOptions.find(
-    option => getSearchableLabel(option) === normalizedSearchValue
+    option => getSearchableLabel<T>(option) === normalizedSearchValue
   );
 };
 
-const collectMatchingOption = (
-  accumulator: EuiSelectableOption[],
-  option: EuiSelectableOption,
+const collectMatchingOption = <T>(
+  accumulator: Array<EuiSelectableOption<T>>,
+  option: EuiSelectableOption<T>,
   normalizedSearchValue: string,
   isPreFiltered?: boolean,
-  selectedOptions?: EuiSelectableOption[]
+  selectedOptions?: Array<EuiSelectableOption<T>>
 ) => {
   // Don't show options that have already been requested if
   // the selectedOptions list exists
   if (selectedOptions) {
-    const selectedOption = getSelectedOptionForSearchValue(
-      getSearchableLabel(option, false),
+    const selectedOption = getSelectedOptionForSearchValue<T>(
+      getSearchableLabel<T>(option, false),
       selectedOptions
     );
     if (selectedOption) {
@@ -68,17 +68,17 @@ const collectMatchingOption = (
     return;
   }
 
-  const normalizedOption = getSearchableLabel(option);
+  const normalizedOption = getSearchableLabel<T>(option);
   if (normalizedOption.includes(normalizedSearchValue)) {
     accumulator.push(option);
   }
 };
 
-export const getMatchingOptions = (
+export const getMatchingOptions = <T>(
   /**
    * All available options to match against
    */
-  options: EuiSelectableOption[],
+  options: Array<EuiSelectableOption<T>>,
   /**
    * String to match option.label || option.searchableLabel against
    */
@@ -91,13 +91,13 @@ export const getMatchingOptions = (
    * To exclude selected options from the search list,
    * pass the array of selected options
    */
-  selectedOptions?: EuiSelectableOption[]
+  selectedOptions?: Array<EuiSelectableOption<T>>
 ) => {
   const normalizedSearchValue = searchValue.toLowerCase();
-  const matchingOptions: EuiSelectableOption[] = [];
+  const matchingOptions: Array<EuiSelectableOption<T>> = [];
 
   options.forEach(option => {
-    collectMatchingOption(
+    collectMatchingOption<T>(
       matchingOptions,
       option,
       normalizedSearchValue,

--- a/src/components/selectable/selectable.test.tsx
+++ b/src/components/selectable/selectable.test.tsx
@@ -129,4 +129,65 @@ describe('EuiSelectable', () => {
       expect(component).toMatchSnapshot();
     });
   });
+
+  describe('custom options', () => {
+    test('optional properties', () => {
+      type OptionalOption = EuiSelectableOption<{ value?: string }>;
+      const options: OptionalOption[] = [
+        {
+          label: 'Titan',
+          'data-test-subj': 'titanOption',
+          value: 'titan',
+        },
+        {
+          label: 'Enceladus',
+          value: 'enceladus',
+        },
+        {
+          label:
+            "Pandora is one of Saturn's moons, named for a Titaness of Greek mythology",
+        },
+      ];
+
+      const onChange = (options: OptionalOption[]) => {
+        jest.fn(() => options);
+      };
+
+      const component = render(
+        <EuiSelectable<OptionalOption> options={options} onChange={onChange} />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
+    test('required properties', () => {
+      type ExtendedOption = EuiSelectableOption<{ value: string }>;
+      const options: ExtendedOption[] = [
+        {
+          label: 'Titan',
+          'data-test-subj': 'titanOption',
+          value: 'titan',
+        },
+        {
+          label: 'Enceladus',
+          value: 'enceladus',
+        },
+        {
+          label:
+            "Pandora is one of Saturn's moons, named for a Titaness of Greek mythology",
+          value: 'pandora',
+        },
+      ];
+
+      const onChange = (options: ExtendedOption[]) => {
+        jest.fn(() => options);
+      };
+
+      const component = render(
+        <EuiSelectable<ExtendedOption> options={options} onChange={onChange} />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+  });
 });

--- a/src/components/selectable/selectable.test.tsx
+++ b/src/components/selectable/selectable.test.tsx
@@ -18,8 +18,8 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
+import { mount, render } from 'enzyme';
+import { requiredProps } from '../../test';
 
 import { EuiSelectable } from './selectable';
 import { EuiSelectableOption } from './selectable_option';
@@ -153,11 +153,15 @@ describe('EuiSelectable', () => {
         jest.fn(() => options);
       };
 
-      const component = render(
-        <EuiSelectable<OptionalOption> options={options} onChange={onChange} />
+      const component = mount(
+        <EuiSelectable<OptionalOption> options={options} onChange={onChange}>
+          {list => list}
+        </EuiSelectable>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(
+        (component.find('EuiSelectableList').props() as any).visibleOptions
+      ).toEqual(options);
     });
 
     test('required properties', () => {
@@ -183,11 +187,17 @@ describe('EuiSelectable', () => {
         jest.fn(() => options);
       };
 
-      const component = render(
-        <EuiSelectable<ExtendedOption> options={options} onChange={onChange} />
+      const component = mount(
+        <EuiSelectable<ExtendedOption> options={options} onChange={onChange}>
+          {list => list}
+        </EuiSelectable>
       );
 
-      expect(component).toMatchSnapshot();
+      component.update();
+
+      expect(
+        (component.find('EuiSelectableList').props() as any).visibleOptions
+      ).toEqual(options);
     });
   });
 });

--- a/src/components/selectable/selectable_list/selectable_list.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.tsx
@@ -34,8 +34,9 @@ import {
   areEqual,
 } from 'react-window';
 
-interface ListChildComponentProps extends ReactWindowListChildComponentProps {
-  data: EuiSelectableOption[];
+interface ListChildComponentProps<T>
+  extends ReactWindowListChildComponentProps {
+  data: Array<EuiSelectableOption<T>>;
 }
 
 // Consumer Configurable Props via `EuiSelectable.listProps`
@@ -73,15 +74,15 @@ export type EuiSelectableOptionsListProps = CommonProps &
     onFocusBadge?: EuiSelectableListItemProps['onFocusBadge'];
   };
 
-export type EuiSelectableListProps = EuiSelectableOptionsListProps & {
+export type EuiSelectableListProps<T> = EuiSelectableOptionsListProps & {
   /**
    * All possible options
    */
-  options: EuiSelectableOption[];
+  options: Array<EuiSelectableOption<T>>;
   /**
    * Filtered options list (if applicable)
    */
-  visibleOptions?: EuiSelectableOption[];
+  visibleOptions?: Array<EuiSelectableOption<T>>;
   /**
    * Search value to highlight on the option render
    */
@@ -89,13 +90,13 @@ export type EuiSelectableListProps = EuiSelectableOptionsListProps & {
   /**
    * Returns the array of options with altered checked state
    */
-  onOptionClick: (options: EuiSelectableOption[]) => void;
+  onOptionClick: (options: Array<EuiSelectableOption<T>>) => void;
   /**
    * Custom render for the label portion of the option;
    * Takes (option, searchValue), returns ReactNode
    */
   renderOption?: (
-    option: EuiSelectableOption,
+    option: EuiSelectableOption<T>,
     searchValue: string
   ) => ReactNode;
   /**
@@ -115,7 +116,7 @@ export type EuiSelectableListProps = EuiSelectableOptionsListProps & {
   setActiveOptionIndex: (index: number, cb?: () => void) => void;
 };
 
-export class EuiSelectableList extends Component<EuiSelectableListProps> {
+export class EuiSelectableList<T> extends Component<EuiSelectableListProps<T>> {
   static defaultProps = {
     rowHeight: 32,
     searchValue: '',
@@ -190,11 +191,11 @@ export class EuiSelectableList extends Component<EuiSelectableListProps> {
     }
   }
 
-  constructor(props: EuiSelectableListProps) {
+  constructor(props: EuiSelectableListProps<T>) {
     super(props);
   }
 
-  ListRow = memo(({ data, index, style }: ListChildComponentProps) => {
+  ListRow = memo(({ data, index, style }: ListChildComponentProps<T>) => {
     const option = data[index];
     const {
       label,
@@ -215,6 +216,7 @@ export class EuiSelectableList extends Component<EuiSelectableListProps> {
           role="presentation"
           className="euiSelectableList__groupLabel"
           style={style}
+          // @ts-ignore complex
           {...(optionRest as HTMLAttributes<HTMLLIElement>)}>
           {prepend}
           {label}
@@ -237,7 +239,6 @@ export class EuiSelectableList extends Component<EuiSelectableListProps> {
         ref={ref ? ref.bind(null, index) : undefined}
         isFocused={this.props.activeOptionIndex === index}
         title={searchableLabel || label}
-        showIcons={this.props.showIcons}
         checked={checked}
         disabled={disabled}
         prepend={prepend}
@@ -246,6 +247,7 @@ export class EuiSelectableList extends Component<EuiSelectableListProps> {
         aria-setsize={data.length - labelCount}
         onFocusBadge={this.props.onFocusBadge}
         allowExclusions={this.props.allowExclusions}
+        // @ts-ignore complex
         {...(optionRest as EuiSelectableListItemProps)}>
         {this.props.renderOption ? (
           this.props.renderOption(option, this.props.searchValue)
@@ -340,7 +342,7 @@ export class EuiSelectableList extends Component<EuiSelectableListProps> {
     );
   }
 
-  onAddOrRemoveOption = (option: EuiSelectableOption) => {
+  onAddOrRemoveOption = (option: EuiSelectableOption<T>) => {
     if (option.disabled) {
       return;
     }
@@ -361,7 +363,7 @@ export class EuiSelectableList extends Component<EuiSelectableListProps> {
     );
   };
 
-  private onAddOption = (addedOption: EuiSelectableOption) => {
+  private onAddOption = (addedOption: EuiSelectableOption<T>) => {
     const { onOptionClick, options, singleSelection } = this.props;
 
     const updatedOptions = options.map(option => {
@@ -382,7 +384,7 @@ export class EuiSelectableList extends Component<EuiSelectableListProps> {
     onOptionClick(updatedOptions);
   };
 
-  private onRemoveOption = (removedOption: EuiSelectableOption) => {
+  private onRemoveOption = (removedOption: EuiSelectableOption<T>) => {
     const { onOptionClick, singleSelection, options } = this.props;
 
     const updatedOptions = options.map(option => {
@@ -398,7 +400,7 @@ export class EuiSelectableList extends Component<EuiSelectableListProps> {
     onOptionClick(updatedOptions);
   };
 
-  private onExcludeOption = (excludedOption: EuiSelectableOption) => {
+  private onExcludeOption = (excludedOption: EuiSelectableOption<T>) => {
     const { onOptionClick, options } = this.props;
     excludedOption.checked = 'off';
 

--- a/src/components/selectable/selectable_option.tsx
+++ b/src/components/selectable/selectable_option.tsx
@@ -22,7 +22,7 @@ import { CommonProps, ExclusiveUnion } from '../common';
 
 export type EuiSelectableOptionCheckedType = 'on' | 'off' | undefined;
 
-export type EuiSelectableOptionBase<T> = CommonProps & {
+export type EuiSelectableOptionBase = CommonProps & {
   /**
    * Visible label of option.
    * Must be unique across items if `key` is not supplied
@@ -59,18 +59,28 @@ export type EuiSelectableOptionBase<T> = CommonProps & {
    */
   append?: React.ReactNode;
   ref?: (optionIndex: number) => void;
-} & T;
+  /**
+   * Disallow `id` from being set.
+   * Option item `id`s are coordinated at a higher level for a11y reasons.
+   */
+  id?: never;
+};
 
-export type EuiSelectableGroupLabelOption<T> = Omit<
-  EuiSelectableOptionBase<T>,
+type _EuiSelectableGroupLabelOption = Omit<
+  EuiSelectableOptionBase,
   'isGroupLabel'
 > &
-  HTMLAttributes<HTMLDivElement> & {
+  Exclude<HTMLAttributes<HTMLDivElement>, 'id'> & {
     isGroupLabel: true;
   };
 
-export type EuiSelectableLIOption<T> = EuiSelectableOptionBase<T> &
-  HTMLAttributes<HTMLLIElement>;
+export type EuiSelectableGroupLabelOption<T> = _EuiSelectableGroupLabelOption &
+  T;
+
+type _EuiSelectableLIOption = EuiSelectableOptionBase &
+  Exclude<HTMLAttributes<HTMLLIElement>, 'id'>;
+
+export type EuiSelectableLIOption<T> = _EuiSelectableLIOption & T;
 
 export type EuiSelectableOption<T = {}> = ExclusiveUnion<
   EuiSelectableGroupLabelOption<T>,

--- a/src/components/selectable/selectable_search/selectable_search.tsx
+++ b/src/components/selectable/selectable_search/selectable_search.tsx
@@ -24,16 +24,19 @@ import { EuiFieldSearch, EuiFieldSearchProps } from '../../form';
 import { getMatchingOptions } from '../matching_options';
 import { EuiSelectableOption } from '../selectable_option';
 
-export type EuiSelectableSearchProps = Omit<EuiFieldSearchProps, 'onChange'> &
+export type EuiSelectableSearchProps<T> = Omit<
+  EuiFieldSearchProps,
+  'onChange'
+> &
   CommonProps & {
     /**
      * Passes back (matchingOptions, searchValue)
      */
     onChange: (
-      matchingOptions: EuiSelectableOption[],
+      matchingOptions: Array<EuiSelectableOption<T>>,
       searchValue: string
     ) => void;
-    options: EuiSelectableOption[];
+    options: Array<EuiSelectableOption<T>>;
     defaultValue: string;
     /**
      * The id of the visible list to create the appropriate aria controls
@@ -45,15 +48,15 @@ export interface EuiSelectableSearchState {
   searchValue: string;
 }
 
-export class EuiSelectableSearch extends Component<
-  EuiSelectableSearchProps,
+export class EuiSelectableSearch<T> extends Component<
+  EuiSelectableSearchProps<T>,
   EuiSelectableSearchState
 > {
   static defaultProps = {
     defaultValue: '',
   };
 
-  constructor(props: EuiSelectableSearchProps) {
+  constructor(props: EuiSelectableSearchProps<T>) {
     super(props);
 
     this.state = {
@@ -63,14 +66,20 @@ export class EuiSelectableSearch extends Component<
 
   componentDidMount() {
     const { searchValue } = this.state;
-    const matchingOptions = getMatchingOptions(this.props.options, searchValue);
+    const matchingOptions = getMatchingOptions<T>(
+      this.props.options,
+      searchValue
+    );
     this.props.onChange(matchingOptions, searchValue);
   }
 
   onSearchChange = (value: string) => {
     if (value !== this.state.searchValue) {
       this.setState({ searchValue: value }, () => {
-        const matchingOptions = getMatchingOptions(this.props.options, value);
+        const matchingOptions = getMatchingOptions<T>(
+          this.props.options,
+          value
+        );
         this.props.onChange(matchingOptions, value);
       });
     }

--- a/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
@@ -38,7 +38,7 @@ import {
 } from './selectable_template_sitewide_option';
 
 export type EuiSelectableTemplateSitewideProps = Partial<
-  Omit<EuiSelectableProps, 'options'>
+  Omit<EuiSelectableProps<{ [key: string]: any }>, 'options'>
 > & {
   /**
    * Extends the typical EuiSelectable #Options with the addition of pre-composed elements


### PR DESCRIPTION
### Summary

Fixes #3966, where the addition of a generic extension of `EuiSelectableOption` needed to be further propagated to all aspects of `EuiSelectable` and related components. More types and components accept a generic (defaulted to `{}`).

To aid TypeScript parsing, the `id` prop was more explicitly restricted (`never` instead of `Omit`, which could have been reinstated with the new generic).

Tested in Kibana with expected updates flagged

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~

- [x] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**

~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~

- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
