### PR TITLE
[Docs] Fix link to toast usage guidelines

### DIFF
--- a/src-docs/src/views/toast/toast_example.js
+++ b/src-docs/src/views/toast/toast_example.js
@@ -103,7 +103,7 @@ export const ToastExample = {
     <EuiText>
       <p>
         Be sure to read the full{' '}
-        <Link to="/guidelines/toasts">toast usage guidelines</Link>.
+        <Link to="/guidelines/toast">toast usage guidelines</Link>.
       </p>
       <EuiSpacer />
     </EuiText>


### PR DESCRIPTION
### Summary

No major changes, just found a typo and fixed it 😄

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
