### PR TITLE
[Docs] Fix EuiToast's codesandbox link for Toast list in documentatio…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed bug in `EuiComboBox` where the input was dropping to the next line when a `EuiBadge` had a very long text ([#3968](https://github.com/elastic/eui/pull/3968))
 - Fixed type mismatch between `EuiSelectable` options extended via `EuiSelectableOption` and internal option types ([#3983](https://github.com/elastic/eui/pull/3983))
+- Fixed bug in `ToastList` where the codesanbox example in the documentation missing two buttons ([#3990](https://github.com/elastic/eui/pull/3990)) 
 
 ## [`28.3.0`](https://github.com/elastic/eui/tree/v28.3.0)
 

--- a/src-docs/src/views/toast/toast_example.js
+++ b/src-docs/src/views/toast/toast_example.js
@@ -6,20 +6,17 @@ import { renderToHtml } from '../../services';
 import { GuideSectionTypes } from '../../components';
 
 import {
-  EuiButton,
   EuiCode,
   EuiToast,
   EuiGlobalToastList,
   EuiGlobalToastListItem,
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiText,
   EuiSpacer,
 } from '../../../../src/components';
 import Guidelines from './guidelines';
 import toastConfig from './playground';
 
-import ToastList, { addToast, removeAllToasts } from './toast_list';
+import ToastList from './toast_list';
 const toastListSource = require('!!raw-loader!./toast_list');
 const toastListHtml = renderToHtml(ToastList);
 const toastListSnippet = [
@@ -127,22 +124,9 @@ export const ToastExample = {
         EuiGlobalToastListItem,
       },
       demo: (
-        <div style={{ maxWidth: 320 }}>
-          <EuiFlexGroup gutterSize="s">
-            <EuiFlexItem>
-              <EuiButton onClick={addToast}>
-                Add toast to global toast list
-              </EuiButton>
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiButton onClick={removeAllToasts} color="danger">
-                Remove all toasts
-              </EuiButton>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-
+        <>
           <ToastList />
-        </div>
+        </>
       ),
       snippet: toastListSnippet,
     },

--- a/src-docs/src/views/toast/toast_list.js
+++ b/src-docs/src/views/toast/toast_list.js
@@ -4,6 +4,9 @@ import {
   EuiCode,
   EuiGlobalToastList,
   EuiLink,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiButton,
 } from '../../../../src/components';
 
 let addToastHandler;
@@ -99,10 +102,24 @@ export default () => {
   };
 
   return (
-    <EuiGlobalToastList
-      toasts={toasts}
-      dismissToast={removeToast}
-      toastLifeTimeMs={6000}
-    />
+    <div style={{ maxWidth: 320 }}>
+      <EuiFlexGroup gutterSize="s">
+        <EuiFlexItem>
+          <EuiButton onClick={addToast}>
+            Add toast to global toast list
+          </EuiButton>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiButton onClick={removeAllToasts} color="danger">
+            Remove all toasts
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiGlobalToastList
+        toasts={toasts}
+        dismissToast={removeToast}
+        toastLifeTimeMs={6000}
+      />
+    </div>
   );
 };


### PR DESCRIPTION
…n (#3876).

### Summary

I have moved the missing piece of code from `eui/src-docs/src/views/toast/toast_example.js` to `eui/src-docs/src/views/toast/toast_list.js`in order for buttons to appear in the  **[Code Sandbox](https://codesandbox.io/s/v4eqm)**.

<img width="1357" alt="Screen Shot 2020-09-02 at 11 22 37 am" src="https://user-images.githubusercontent.com/45527642/91921583-2f2d1f00-ed0f-11ea-9387-60b299c88222.png">


### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
