### PR TITLE
[WIP][TEST] Repl all physical-to-logical units

### DIFF
--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -44,7 +44,7 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   bottom: 0;
 
   .guideSideNav__identity {
-    border-bottom: $euiBorderThin;
+    border-block-end: $euiBorderThin;
     padding: $euiSize;
   }
 
@@ -76,13 +76,13 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   }
 
   .guideSideNav__newBadge {
-    margin-left: $euiSizeXS;
-    margin-right: $euiSizeXS;
+    margin-inline-start: $euiSizeXS;
+    margin-inline-end: $euiSizeXS;
   }
 
   // Shift the margin on the badge when selected and the dropdown arrow no longer shows
   .euiSideNavItemButton-isSelected .guideSideNav__newBadge {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 }
 
@@ -92,12 +92,13 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
 
 .guidePageContent {
   flex: 1 1 auto;
-  padding: $euiSize $euiSizeXL;
+  padding-block: $euiSize;
+  padding-inline: $euiSizeXL;
   min-height: 100vh;
   background-color: $euiColorEmptyShade;
-  border-left: $euiBorderThin;
+  border-inline-start: $euiBorderThin;
   max-width: 1000px;
-  margin-left: 240px;
+  margin-inline-start: 240px;
 }
 
 .guideDemo__highlightLayout {
@@ -148,7 +149,7 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   padding: $euiSizeS;
   color: $euiColorEmptyShade;
   font-size: $euiFontSizeS;
-  margin-top: $euiSizeS;
+  margin-block-start: $euiSizeS;
   line-height: 1.5;
   height: 64px;
 
@@ -183,7 +184,7 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
 
   svg,
   img {
-    margin-bottom: $euiSizeS;
+    margin-block-end: $euiSizeS;
   }
 }
 
@@ -222,7 +223,7 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   height: $euiSizeM / 2;
   background-color: currentColor;
   vertical-align: middle;
-  margin-right: $euiSizeS;
+  margin-inline-end: $euiSizeS;
 }
 
 .guideCharts__customLegendLine--thin {
@@ -299,7 +300,7 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   }
 
   .guidePageContent {
-    margin-left: 0;
+    margin-inline-start: 0;
     width: 100%;
   }
 }

--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -92,8 +92,10 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
 
 .guidePageContent {
   flex: 1 1 auto;
-  padding-block: $euiSize;
-  padding-inline: $euiSizeXL;
+  padding-block-start: $euiSize;
+  padding-block-end: $euiSize;
+  padding-inline-start: $euiSizeXL;
+  padding-inline-end: $euiSizeXL;
   min-height: 100vh;
   background-color: $euiColorEmptyShade;
   border-inline-start: $euiBorderThin;

--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -15,7 +15,7 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
 
 .euiBody--headerIsFixed {
   .guideSideNav {
-    top: $euiHeaderHeightCompensation;
+    inset-block-start: $euiHeaderHeightCompensation;
   }
 }
 
@@ -23,7 +23,7 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   @include euiHeaderAffordForFixed($euiHeaderHeightCompensation * 2);
 
   .guideSideNav {
-    top: $euiHeaderHeightCompensation * 2;
+    inset-block-start: $euiHeaderHeightCompensation * 2;
   }
 
   .euiHeader:not(.euiHeader--fixed) {
@@ -40,8 +40,8 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
 .guideSideNav {
   width: $guideSideNavWidth;
   position: fixed;
-  top: 0;
-  bottom: 0;
+  inset-block-start: 0;
+  inset-block-end: 0;
 
   .guideSideNav__identity {
     border-block-end: $euiBorderThin;
@@ -59,8 +59,8 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
     width: $guideSideNavWidth;
     padding: $euiSize;
     position: absolute;
-    bottom: 0;
-    top: 132px;
+    inset-block-end: 0;
+    inset-block-start: 132px;
     overflow-y: auto;
   }
 }
@@ -96,16 +96,16 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   padding-block-end: $euiSize;
   padding-inline-start: $euiSizeXL;
   padding-inline-end: $euiSizeXL;
-  min-height: 100vh;
+  min-block-size: 100vh;
   background-color: $euiColorEmptyShade;
   border-inline-start: $euiBorderThin;
-  max-width: 1000px;
+  max-inline-size: 1000px;
   margin-inline-start: 240px;
 }
 
 .guideDemo__highlightLayout {
   .euiPageBody {
-    min-height: 460px;
+    min-block-size: 460px;
   }
 
   div {
@@ -214,8 +214,8 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   font-size: $euiFontSizeXS;
   position: absolute;
   width: 93px;
-  right: 0;
-  bottom: 0;
+  inset-inline-end: 0;
+  inset-block-end: 0;
   padding: $euiSizeXS;
 }
 
@@ -236,8 +236,8 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
   position: fixed;
   width: 100%;
   height: 100%;
-  left: 0;
-  top: 0;
+  inset-inline-start: 0;
+  inset-block-start: 0;
 }
 
 .euiDataGridRowCell--favoriteFranchise {
@@ -278,14 +278,14 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
     // This is a temporary hack till we fix how classes pass into form controls
     .euiFormControlLayout,
     input[type='search'] {
-      max-width: 100%;
+      max-inline-size: 100%;
     }
 
     .guideSideNav__content {
       position: relative;
       width: auto;
-      top: auto;
-      bottom: auto;
+      inset-block-start: auto;
+      inset-block-end: auto;
       padding: 0;
       overflow-y: hidden;
     }

--- a/src-docs/src/components/guide_components_amsterdam.scss
+++ b/src-docs/src/components/guide_components_amsterdam.scss
@@ -4,5 +4,5 @@
 
 .guidePageContent {
   @include euiBottomShadowFlat;
-  border-left: none;
+  border-inline-start: none;
 }

--- a/src-docs/src/components/guide_rule/_guide_rule.scss
+++ b/src-docs/src/components/guide_rule/_guide_rule.scss
@@ -1,20 +1,20 @@
 .guideRule {
-  margin-top: $euiSizeXXL;
+  margin-block-start: $euiSizeXXL;
 
   + .guideRule {
-    margin-top: $euiSizeL;
+    margin-block-start: $euiSizeL;
 
     &.guideRule--hasDescription {
-      margin-top: $euiSizeXXL * 1.5;
+      margin-block-start: $euiSizeXXL * 1.5;
     }
 
     &.guideRule--hasHeading {
-      margin-top: $euiSizeXXL * 2;
+      margin-block-start: $euiSizeXXL * 2;
     }
   }
 
   .guideRule__title + &:not(.guideRule--hasHeading) {
-    margin-top: 0;
+    margin-block-start: 0;
   }
 }
 

--- a/src-docs/src/components/guide_rule/_guide_rule_description.scss
+++ b/src-docs/src/components/guide_rule/_guide_rule_description.scss
@@ -1,3 +1,3 @@
 .guideRule__description {
-  margin-bottom: $euiSizeXL;
+  margin-block-end: $euiSizeXL;
 }

--- a/src-docs/src/components/guide_rule/_guide_rule_example.scss
+++ b/src-docs/src/components/guide_rule/_guide_rule_example.scss
@@ -5,8 +5,8 @@
 
 .guideRule__example {
   .guideRule__example__panel {
-    border-bottom: 2px solid;
-    margin-bottom: $euiSizeS;
+    border-block-end: 2px solid;
+    margin-block-end: $euiSizeS;
     flex-grow: 1; /* 1 */
 
     &:not(.euiPanel) {
@@ -15,7 +15,7 @@
   }
 
   pre {
-    margin-bottom: 0;
+    margin-block-end: 0;
     padding: 0;
   }
 
@@ -28,7 +28,7 @@
   // Coloring
   &.guideRule__example--do {
     .guideRule__example__panel {
-      border-bottom-color: $euiColorSuccess;
+      border-block-end-color: $euiColorSuccess;
     }
 
     .guideRule__caption {
@@ -38,7 +38,7 @@
 
   &.guideRule__example--dont {
     .guideRule__example__panel {
-      border-bottom-color: $euiColorDanger;
+      border-block-end-color: $euiColorDanger;
     }
 
     .guideRule__caption {

--- a/src-docs/src/components/guide_rule/_guide_rule_example.scss
+++ b/src-docs/src/components/guide_rule/_guide_rule_example.scss
@@ -10,7 +10,7 @@
     flex-grow: 1; /* 1 */
 
     &:not(.euiPanel) {
-      padding-bottom: $euiSize; // only change the bottom padding if it's not an euiPanel
+      padding-block-end: $euiSize; // only change the bottom padding if it's not an euiPanel
     }
   }
 

--- a/src-docs/src/components/guide_rule/_guide_rule_title.scss
+++ b/src-docs/src/components/guide_rule/_guide_rule_title.scss
@@ -1,6 +1,6 @@
 .guideRule__title {
-  margin-top: $euiSizeXXL;
-  border-top: 1px solid $euiBorderColor;
-  padding-top: $euiSizeXXL;
-  margin-bottom: $euiSizeS;
+  margin-block-start: $euiSizeXXL;
+  border-block-start: 1px solid $euiBorderColor;
+  padding-block-start: $euiSizeXXL;
+  margin-block-end: $euiSizeS;
 }

--- a/src-docs/src/components/guide_section/_guide_section.scss
+++ b/src-docs/src/components/guide_section/_guide_section.scss
@@ -1,6 +1,6 @@
 .guideSection {
   & + .guideSection {
-    margin-top: $euiSizeXL * 2;
+    margin-block-start: $euiSizeXL * 2;
   }
 }
 
@@ -9,6 +9,6 @@
 }
 
 .guideSection__tableCodeBlock {
-  padding-left: $euiSizeXS;
-  padding-right: $euiSizeXS;
+  padding-inline-start: $euiSizeXS;
+  padding-inline-end: $euiSizeXS;
 }

--- a/src-docs/src/services/playground/_playground_compiler.scss
+++ b/src-docs/src/services/playground/_playground_compiler.scss
@@ -6,8 +6,10 @@
 }
 
 .playgroundCompiler__ghostBackground {
-  padding-block: 0;
-  padding-inline: $euiSize;
+  padding-block-start: 0;
+  padding-block-end: 0;
+  padding-inline-start: $euiSize;
+  padding-inline-end: $euiSize;
 
   @if (lightness($euiTextColor) < 50) {
     background: $euiColorDarkestShade;

--- a/src-docs/src/services/playground/_playground_compiler.scss
+++ b/src-docs/src/services/playground/_playground_compiler.scss
@@ -6,7 +6,8 @@
 }
 
 .playgroundCompiler__ghostBackground {
-  padding: 0 $euiSize;
+  padding-block: 0;
+  padding-inline: $euiSize;
 
   @if (lightness($euiTextColor) < 50) {
     background: $euiColorDarkestShade;

--- a/src-docs/src/services/playground/_playground_knobs.scss
+++ b/src-docs/src/services/playground/_playground_knobs.scss
@@ -1,7 +1,7 @@
 $knobTableRowMinHeight: 42px;
 
 .playgroundKnobs__rowCell {
-  min-height: $knobTableRowMinHeight;
+  min-block-size: $knobTableRowMinHeight;
   display: block;
 }
 

--- a/src-docs/src/views/guidelines/colors/_color_section.scss
+++ b/src-docs/src/views/guidelines/colors/_color_section.scss
@@ -1,7 +1,7 @@
 @include euiBreakpoint('m', 'l', 'xl') {
   .guideColorsPage__stickySlider {
     position: sticky;
-    top: 0;
+    inset-block-start: 0;
     z-index: $euiZLevel1;
   }
 }
@@ -11,5 +11,5 @@
   margin-block-end: $euiSizeXS / 2;
   border-radius: $euiBorderRadius;
   width: 100%;
-  max-width: 300px;
+  max-inline-size: 300px;
 }

--- a/src-docs/src/views/guidelines/colors/_color_section.scss
+++ b/src-docs/src/views/guidelines/colors/_color_section.scss
@@ -8,7 +8,7 @@
 
 .guideColorSection__button {
   padding: $euiSizeXS;
-  margin-bottom: $euiSizeXS / 2;
+  margin-block-end: $euiSizeXS / 2;
   border-radius: $euiBorderRadius;
   width: 100%;
   max-width: 300px;

--- a/src-docs/src/views/guidelines/index.scss
+++ b/src-docs/src/views/guidelines/index.scss
@@ -243,13 +243,13 @@
   height: $euiSize;
   background: $euiColorDarkestShade;
   position: absolute;
-  left: 0;
+  inset-inline-start: 0;
 }
 
 .guideSass__animRow:hover .guideSass__animChild {
   transition-property: left;
   transition-timing-function: linear;
-  left: calc(100% - #{$euiSize});
+  inset-inline-start: calc(100% - #{$euiSize});
 }
 
 .guideSass__animRow--euiAnimSpeedExtraFast:hover .guideSass__animChild {

--- a/src-docs/src/views/guidelines/index.scss
+++ b/src-docs/src/views/guidelines/index.scss
@@ -104,7 +104,7 @@
 
 .guideSass__sizeItem {
   width: $euiSizeXXL;
-  text-align: right;
+  text-align: end;
 }
 
 .guideSass__fontSizeExample + .guideSass__fontSizeExample {

--- a/src-docs/src/views/guidelines/index.scss
+++ b/src-docs/src/views/guidelines/index.scss
@@ -3,7 +3,7 @@
 // -------------------------------------
 .guidelineColor__palette {
   padding: $euiSize;
-  padding-bottom: $euiSizeXL;
+  padding-block-end: $euiSizeXL;
 }
 
 .guidelineColor__swatch {
@@ -48,7 +48,7 @@
 // Sass guideline page
 // -------------------------------------
 .guideSass__swatchItem + .guideSass__swatchItem {
-  margin-top: $euiSize;
+  margin-block-start: $euiSize;
 }
 
 .guideSass__swatch {
@@ -79,11 +79,11 @@
 }
 
 .guideSass__levelRow {
-  padding-left: $euiSizeS;
+  padding-inline-start: $euiSizeS;
 }
 
 .guideSass__levelRow + .guideSass__levelRow {
-  margin-top: $euiSizeS;
+  margin-block-start: $euiSizeS;
 }
 
 .guideSass__level {
@@ -94,7 +94,7 @@
 }
 
 .guideSass__sizeRow + .guideSass__sizeRow {
-  margin-top: $euiSize;
+  margin-block-start: $euiSize;
 }
 
 .guideSass__size {
@@ -108,11 +108,11 @@
 }
 
 .guideSass__fontSizeExample + .guideSass__fontSizeExample {
-  margin-top: $euiSizeL;
+  margin-block-start: $euiSizeL;
 }
 
 .guideSass__fontSize {
-  margin-bottom: $euiSizeS;
+  margin-block-end: $euiSizeS;
 }
 
 .guideSass__fontSize--euiFontSizeXS {
@@ -149,7 +149,7 @@
   border-radius: $euiBorderRadius;
 
   & + .guideSass__shadow {
-    margin-top: $euiSizeXL;
+    margin-block-start: $euiSizeXL;
   }
 }
 
@@ -177,7 +177,8 @@
 
 .guideSass__overflowShadowsX {
   @include euiXScrollWithShadows;
-  padding: $euiSizeS $euiSizeS 0;
+  padding-block: $euiSizeS 0;
+  padding-inline: $euiSizeS;
 
   .guideSass__overflowShadowTextX {
     width: 150%;
@@ -225,13 +226,13 @@
 }
 
 .guideSass__animRow + .guideSass__animRow {
-  margin-top: $euiSizeL;
+  margin-block-start: $euiSizeL;
 }
 
 .guideSass__animParent {
   background: $euiColorLightestShade;
   height: $euiSize;
-  margin-top: $euiSizeS;
+  margin-block-start: $euiSizeS;
   position: relative;
 }
 
@@ -286,7 +287,7 @@
 
 .guideSass__themedBox {
   padding: $euiSize;
-  border-left: $euiBorderThick;
+  border-inline-start: $euiBorderThick;
 }
 
 // sass-lint:disable no-color-literals
@@ -309,7 +310,7 @@
   background: $backgroundColor;
   color: makeHighContrastColor($euiColorWarning, $backgroundColor);
   padding: $euiSize;
-  border-left: $euiBorderThick;
+  border-inline-start: $euiBorderThick;
   border-color: $euiColorWarning;
 
   .square {

--- a/src-docs/src/views/guidelines/index.scss
+++ b/src-docs/src/views/guidelines/index.scss
@@ -177,8 +177,10 @@
 
 .guideSass__overflowShadowsX {
   @include euiXScrollWithShadows;
-  padding-block: $euiSizeS 0;
-  padding-inline: $euiSizeS;
+  padding-block-start: $euiSizeS;
+  padding-block-end: 0;
+  padding-inline-start: $euiSizeS;
+  padding-inline-end: $euiSizeS;
 
   .guideSass__overflowShadowTextX {
     width: 150%;

--- a/src-docs/src/views/suggest/_global_filter_group.scss
+++ b/src-docs/src/views/suggest/_global_filter_group.scss
@@ -2,12 +2,13 @@
 @import 'saved_queries';
 
 .globalFilterGroup__filterBar {
-  margin-top: $euiSizeXS;
+  margin-block-start: $euiSizeXS;
 }
 
 // sass-lint:disable quotes
 .globalFilterGroup__branch {
-  padding: $euiSize $euiSize $euiSizeS $euiSizeS;
+  padding-block: $euiSize $euiSizeS;
+  padding-inline: $euiSizeS $euiSize;
   background-repeat: no-repeat;
   background-position: right top;
   background-image: url("data:image/svg+xml,%0A%3Csvg width='28px' height='28px' viewBox='0 0 28 28' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='#{hexToRGB($euiColorLightShade)}'%3E%3Crect x='14' y='27' width='14' height='1'%3E%3C/rect%3E%3Crect x='0' y='0' width='1' height='14'%3E%3C/rect%3E%3C/g%3E%3C/svg%3E");

--- a/src-docs/src/views/suggest/_global_filter_group.scss
+++ b/src-docs/src/views/suggest/_global_filter_group.scss
@@ -7,8 +7,10 @@
 
 // sass-lint:disable quotes
 .globalFilterGroup__branch {
-  padding-block: $euiSize $euiSizeS;
-  padding-inline: $euiSizeS $euiSize;
+  padding-block-start: $euiSize;
+  padding-block-end: $euiSizeS;
+  padding-inline-start: $euiSizeS;
+  padding-inline-end: $euiSize;
   background-repeat: no-repeat;
   background-position: right top;
   background-image: url("data:image/svg+xml,%0A%3Csvg width='28px' height='28px' viewBox='0 0 28 28' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='#{hexToRGB($euiColorLightShade)}'%3E%3Crect x='14' y='27' width='14' height='1'%3E%3C/rect%3E%3Crect x='0' y='0' width='1' height='14'%3E%3C/rect%3E%3C/g%3E%3C/svg%3E");

--- a/src-docs/src/views/suggest/_global_filter_group.scss
+++ b/src-docs/src/views/suggest/_global_filter_group.scss
@@ -27,5 +27,5 @@
 }
 
 .globalFilterBar__flexItem {
-  max-width: calc(100% - #{$euiSizeXS}); // Width minus margin around each flex itm
+  max-inline-size: calc(100% - #{$euiSizeXS}); // Width minus margin around each flex itm
 }

--- a/src-docs/src/views/suggest/_global_filter_item.scss
+++ b/src-docs/src/views/suggest/_global_filter_item.scss
@@ -21,9 +21,9 @@
   &::before {
     content: '';
     position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
+    inset-block-start: 0;
+    inset-block-end: 0;
+    inset-inline-start: 0;
     width: $euiSizeXS;
     background-color: $euiColorSuccess;
     border-top-left-radius: $euiBorderRadius / 2;

--- a/src-docs/src/views/suggest/_saved_queries.scss
+++ b/src-docs/src/views/suggest/_saved_queries.scss
@@ -27,8 +27,11 @@
 
 .savedQueryManagement__list {
   @include euiYScrollWithShadows;
-  max-height: inherit; // Fixes overflow for applied max-height
+  max-block-size: inherit; // Fixes overflow for applied max-height
   // Left/Right padding is calculated to match the left alignment of the
   // popover text and buttons
-  padding: ($euiSizeM / 2) $euiSizeXS !important; // sass-lint:disable-line no-important
+  padding-block-start: ($euiSizeM / 2) !important; // sass-lint:disable-line no-important
+  padding-block-end: ($euiSizeM / 2) !important; // sass-lint:disable-line no-important
+  padding-inline-start: $euiSizeXS !important; // sass-lint:disable-line no-important
+  padding-inline-end: $euiSizeXS !important; // sass-lint:disable-line no-important
 }

--- a/src-docs/src/views/suggest/_saved_queries.scss
+++ b/src-docs/src/views/suggest/_saved_queries.scss
@@ -13,8 +13,10 @@
 }
 
 .savedQueryManagement__text {
-  padding-block: $euiSizeM ($euiSizeM / 2);
-  padding-inline: $euiSizeM;
+  padding-block-start: $euiSizeM;
+  padding-block-end: ($euiSizeM / 2);
+  padding-inline-start: $euiSizeM;
+  padding-inline-end: $euiSizeM;
 }
 
 .savedQueryManagement__listWrapper {

--- a/src-docs/src/views/suggest/_saved_queries.scss
+++ b/src-docs/src/views/suggest/_saved_queries.scss
@@ -21,7 +21,7 @@
 
 .savedQueryManagement__listWrapper {
   // Addition height will ensure one item is "cutoff" to indicate more below the scroll
-  max-height: $euiFormMaxWidth + $euiSize;
+  max-block-size: $euiFormMaxWidth + $euiSize;
   overflow-y: hidden;
 }
 

--- a/src-docs/src/views/suggest/_saved_queries.scss
+++ b/src-docs/src/views/suggest/_saved_queries.scss
@@ -9,11 +9,12 @@
 }
 
 .savedQueriesInput {
-  padding-bottom: $euiSizeXL * 6;
+  padding-block-end: $euiSizeXL * 6;
 }
 
 .savedQueryManagement__text {
-  padding: $euiSizeM $euiSizeM ($euiSizeM / 2);
+  padding-block: $euiSizeM ($euiSizeM / 2);
+  padding-inline: $euiSizeM;
 }
 
 .savedQueryManagement__listWrapper {

--- a/src/components/accessibility/_skip_link.scss
+++ b/src/components/accessibility/_skip_link.scss
@@ -13,8 +13,8 @@
 
   &.euiSkipLink--fixed:focus {
     position: fixed;
-    top: $euiSizeXS;
-    left: $euiSizeXS;
+    inset-block-start: $euiSizeXS;
+    inset-inline-start: $euiSizeXS;
     z-index: $euiZHeader + 1;
   }
 }

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -5,7 +5,7 @@
 
 .euiAccordion__button {
   @include euiFontSize;
-  text-align: left;
+  text-align: start;
   width: 100%;
   flex-grow: 1;
   display: flex;

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -104,6 +104,6 @@ $paddingSizes: (
   align-items: center;
 
   .euiAccordion__spinner {
-    margin-right: $euiSizeXS;
+    margin-inline-end: $euiSizeXS;
   }
 }

--- a/src/components/accordion/_accordion_form.scss
+++ b/src/components/accordion/_accordion_form.scss
@@ -12,7 +12,8 @@
 }
 
 .euiAccordionForm__button {
-  padding: $euiSize $euiSize $euiSize 0;
+  padding-block: $euiSize 0;
+  padding-inline: $euiSize;
 
   &:hover {
     text-decoration: none;
@@ -24,11 +25,11 @@
 }
 
 .euiAccordionForm {
-  border-top: $euiBorderThin;
-  border-bottom: $euiBorderThin;
+  border-block-start: $euiBorderThin;
+  border-block-end: $euiBorderThin;
 
   & + .euiAccordionForm {
-    border-top: none;
+    border-block-start: none;
   }
 
   &:hover {

--- a/src/components/accordion/_accordion_form.scss
+++ b/src/components/accordion/_accordion_form.scss
@@ -13,8 +13,8 @@
 
 .euiAccordionForm__button {
   padding-block-start: $euiSize;
-  padding-block-end: 0;
-  padding-inline-start: $euiSize;
+  padding-block-end: $euiSize;
+  padding-inline-start: 0;
   padding-inline-end: $euiSize;
 
   &:hover {

--- a/src/components/accordion/_accordion_form.scss
+++ b/src/components/accordion/_accordion_form.scss
@@ -12,8 +12,10 @@
 }
 
 .euiAccordionForm__button {
-  padding-block: $euiSize 0;
-  padding-inline: $euiSize;
+  padding-block-start: $euiSize;
+  padding-block-end: 0;
+  padding-inline-start: $euiSize;
+  padding-inline-end: $euiSize;
 
   &:hover {
     text-decoration: none;

--- a/src/components/accordion/_mixins.scss
+++ b/src/components/accordion/_mixins.scss
@@ -5,10 +5,10 @@
 
 @mixin euiAccordionIconMargin($align: left) {
   @if $align == left {
-    margin-left: $euiSizeXS;
-    margin-right: $euiSizeS;
+    margin-inline-start: $euiSizeXS;
+    margin-inline-end: $euiSizeS;
   } @else {
-    margin-left: $euiSizeS;
-    margin-right: $euiSizeXS;
+    margin-inline-start: $euiSizeS;
+    margin-inline-end: $euiSizeXS;
   }
 }

--- a/src/components/aspect_ratio/_aspect_ratio.scss
+++ b/src/components/aspect_ratio/_aspect_ratio.scss
@@ -4,8 +4,8 @@
   > * {
     // sass-lint:disable-block no-important
     position: absolute !important;
-    top: 0 !important;
-    left: 0 !important;
+    inset-block-start: 0 !important;
+    inset-inline-start: 0 !important;
     width: 100% !important;
     height: 100% !important;
   }

--- a/src/components/badge/_badge.scss
+++ b/src/components/badge/_badge.scss
@@ -5,8 +5,10 @@
   font-size: $euiFontSizeXS;
   font-weight: $euiFontWeightMedium;
   line-height: $euiSize + 2px; /* 1 */
-  padding-block: 0;
-  padding-inline: $euiSizeS;
+  padding-block-start: 0;
+  padding-block-end: 0;
+  padding-inline-start: $euiSizeS;
+  padding-inline-end: $euiSizeS;
   display: inline-block;
   text-decoration: none;
   border-radius: $euiBorderRadius / 2;

--- a/src/components/badge/_badge.scss
+++ b/src/components/badge/_badge.scss
@@ -5,7 +5,8 @@
   font-size: $euiFontSizeXS;
   font-weight: $euiFontWeightMedium;
   line-height: $euiSize + 2px; /* 1 */
-  padding: 0 $euiSizeS;
+  padding-block: 0;
+  padding-inline: $euiSizeS;
   display: inline-block;
   text-decoration: none;
   border-radius: $euiBorderRadius / 2;
@@ -31,7 +32,7 @@
   }
 
   + .euiBadge {
-    margin-left: $euiSizeXS;
+    margin-inline-start: $euiSizeXS;
   }
 
   .euiBadge__content {
@@ -64,7 +65,7 @@
   .euiBadge__iconButton {
     flex: 0 0 auto;
     font-size: 0; // Makes the button only as large as the icon so it aligns vertically better
-    margin-left: $euiSizeXS;
+    margin-inline-start: $euiSizeXS;
 
     &:focus {
       background-color: transparentize($euiColorGhost, .2);
@@ -92,7 +93,7 @@
     flex: 0 0 auto;
 
     &:not(:only-child) {
-      margin-left: $euiSizeXS;
+      margin-inline-start: $euiSizeXS;
     }
   }
 
@@ -103,8 +104,8 @@
 
     .euiBadge__iconButton,
     .euiBadge__icon:not(:only-child) {
-      margin-right: $euiSizeXS;
-      margin-left: 0;
+      margin-inline-end: $euiSizeXS;
+      margin-inline-start: 0;
     }
   }
 }

--- a/src/components/badge/_badge.scss
+++ b/src/components/badge/_badge.scss
@@ -20,7 +20,7 @@
   max-inline-size: 100%;
   // The badge will only ever be as wide as its content
   // So, make the text left aligned to ensure all badges line up the same
-  text-align: left;
+  text-align: start;
 
   &.euiBadge-isDisabled {
     // sass-lint:disable-block no-important

--- a/src/components/badge/_badge.scss
+++ b/src/components/badge/_badge.scss
@@ -17,7 +17,7 @@
   white-space: nowrap;
   vertical-align: middle;
   cursor: default;
-  max-width: 100%;
+  max-inline-size: 100%;
   // The badge will only ever be as wide as its content
   // So, make the text left aligned to ensure all badges line up the same
   text-align: left;

--- a/src/components/badge/_badge.scss
+++ b/src/components/badge/_badge.scss
@@ -38,7 +38,7 @@
   }
 
   .euiBadge__content {
-    min-height: $euiSize + ($euiBorderWidthThin * 2); // Ensure proper height in case of just displaying an icon
+    min-block-size: $euiSize + ($euiBorderWidthThin * 2); // Ensure proper height in case of just displaying an icon
     display: flex;
     align-items: center;
     overflow: hidden;

--- a/src/components/badge/badge_group/_badge_group.scss
+++ b/src/components/badge/badge_group/_badge_group.scss
@@ -5,7 +5,7 @@ $euiBadgeGroupGutterTypes: (
 
 .euiBadgeGroup__item {
   display: inline-block;
-  max-width: 100%;
+  max-inline-size: 100%;
 }
 
 // Gutter Sizes
@@ -17,7 +17,7 @@ $euiBadgeGroupGutterTypes: (
 
     & > .euiBadgeGroup__item {
       margin: $halfGutterSize;
-      max-width: calc(100% - #{$gutterSize});
+      max-inline-size: calc(100% - #{$gutterSize});
     }
   }
 }

--- a/src/components/badge/beta_badge/_beta_badge.scss
+++ b/src/components/badge/beta_badge/_beta_badge.scss
@@ -1,6 +1,7 @@
 .euiBetaBadge {
   display: inline-block;
-  padding: 0 $euiSize;
+  padding-block: 0;
+  padding-inline: $euiSize;
   border-radius: $euiSizeL;
   box-shadow: inset 0 0 0 1px $euiBorderColor;
   vertical-align: super; // if displayed inline with text
@@ -26,6 +27,6 @@
 
   .euiBetaBadge__icon {
     position: relative;
-    margin-top: -1px;
+    margin-block-start: -1px;
   }
 }

--- a/src/components/badge/beta_badge/_beta_badge.scss
+++ b/src/components/badge/beta_badge/_beta_badge.scss
@@ -1,7 +1,9 @@
 .euiBetaBadge {
   display: inline-block;
-  padding-block: 0;
-  padding-inline: $euiSize;
+  padding-block-start: 0;
+  padding-block-end: 0;
+  padding-inline-start: $euiSize;
+  padding-inline-end: $euiSize;
   border-radius: $euiSizeL;
   box-shadow: inset 0 0 0 1px $euiBorderColor;
   vertical-align: super; // if displayed inline with text

--- a/src/components/badge/notification_badge/_notification_badge.scss
+++ b/src/components/badge/notification_badge/_notification_badge.scss
@@ -7,8 +7,8 @@
   line-height: $euiSize;
   height: $euiSize;
   min-width: $euiSize;
-  padding-left: $euiSizeXS;
-  padding-right: $euiSizeXS;
+  padding-inline-start: $euiSizeXS;
+  padding-inline-end: $euiSizeXS;
   vertical-align: middle;
   text-align: center;
   transition: all $euiAnimSpeedFast ease-in;

--- a/src/components/badge/notification_badge/_notification_badge.scss
+++ b/src/components/badge/notification_badge/_notification_badge.scss
@@ -6,7 +6,7 @@
   font-weight: $euiFontWeightMedium;
   line-height: $euiSize;
   height: $euiSize;
-  min-width: $euiSize;
+  min-inline-size: $euiSize;
   padding-inline-start: $euiSizeXS;
   padding-inline-end: $euiSizeXS;
   vertical-align: middle;
@@ -24,7 +24,7 @@
   $size: $euiSize + $euiSizeXS;
   line-height: $size;
   height: $size;
-  min-width: $euiSizeL;
+  min-inline-size: $euiSizeL;
 }
 
 .euiNotificationBadge--subdued {

--- a/src/components/basic_table/_basic_table.scss
+++ b/src/components/basic_table/_basic_table.scss
@@ -23,22 +23,22 @@
 
 @keyframes euiBasicTableLoading {
   from {
-    left: 0;
+    inset-inline-start: 0;
     width: 0;
   }
 
   20% {
-    left: 0;
+    inset-inline-start: 0;
     width: 40%;
   }
 
   80% {
-    left: 60%;
+    inset-inline-start: 60%;
     width: 40%;
   }
 
   100% {
-    left: 100%;
+    inset-inline-start: 100%;
     width: 0;
   }
 }

--- a/src/components/beacon/_beacon.scss
+++ b/src/components/beacon/_beacon.scss
@@ -9,8 +9,8 @@
     content: '';
     height: 100%;
     width: 100%;
-    left: 0;
-    top: 0;
+    inset-inline-start: 0;
+    inset-block-start: 0;
     background-color: transparent;
     border-radius: 50%;
     box-shadow: 0 0 1px 1px $euiColorVis0;

--- a/src/components/bottom_bar/_bottom_bar.scss
+++ b/src/components/bottom_bar/_bottom_bar.scss
@@ -3,9 +3,9 @@
   background: tintOrShade($euiColorFullShade, 25%, 100%);
   color: $euiColorEmptyShade;
   position: fixed;
-  bottom: 0;
-  right: 0;
-  left: 0;
+  inset-block-end: 0;
+  inset-inline-end: 0;
+  inset-inline-start: 0;
   animation: euiBottomBarAppear $euiAnimSpeedSlow $euiAnimSlightResistance;
   z-index: $euiZNavigation;
 

--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -50,19 +50,19 @@
   overflow: hidden;
 
   .euiBreadcrumb:not(.euiBreadcrumb--collapsed) {
-    max-width: $euiBreadcrumbTruncateWidth;
+    max-inline-size: $euiBreadcrumbTruncateWidth;
     overflow: hidden;
     text-overflow: ellipsis;
 
     &.euiBreadcrumb--last {
-      max-width: none;
+      max-inline-size: none;
     }
   }
 }
 
 .euiBreadcrumb--truncate {
   @include euiTextTruncate;
-  max-width: $euiBreadcrumbTruncateWidth;
+  max-inline-size: $euiBreadcrumbTruncateWidth;
   text-align: center;
   vertical-align: top; // overflow hidden causes misalignment of links and slashes, this fixes that
 }

--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -16,7 +16,7 @@
   margin-bottom: $euiSizeXS; /* 1 */
 
   &:not(.euiBreadcrumb--last) {
-    margin-right: $euiBreadcrumbSpacing;
+    margin-inline-end: $euiBreadcrumbSpacing;
     color: $euiTextSubduedColor;
   }
 }
@@ -32,7 +32,7 @@
 .euiBreadcrumbSeparator {
   flex-shrink: 0;
   display: inline-block;
-  margin-right: $euiBreadcrumbSpacing;
+  margin-inline-end: $euiBreadcrumbSpacing;
   width: 1px;
   height: $euiSize;
   transform: translateY(-1px) rotate(15deg);

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -10,7 +10,8 @@
   min-width: $euiButtonMinWidth;
 
   .euiButton__content {
-    padding: 0 ($euiSize - $euiSizeXS);
+    padding-block: 0;
+    padding-inline: ($euiSize - $euiSizeXS);
   }
 
   .euiButton__text {

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -7,7 +7,7 @@
   @include euiSlightShadow;
 
   border-radius: $euiBorderRadius;
-  min-width: $euiButtonMinWidth;
+  min-inline-size: $euiButtonMinWidth;
 
   .euiButton__content {
     padding-block-start: 0;

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -10,8 +10,10 @@
   min-width: $euiButtonMinWidth;
 
   .euiButton__content {
-    padding-block: 0;
-    padding-inline: ($euiSize - $euiSizeXS);
+    padding-block-start: 0;
+    padding-block-end: 0;
+    padding-inline-start: ($euiSize - $euiSizeXS);
+    padding-inline-end: ($euiSize - $euiSizeXS);
   }
 
   .euiButton__text {

--- a/src/components/button/button_empty/_button_empty.scss
+++ b/src/components/button/button_empty/_button_empty.scss
@@ -16,7 +16,8 @@
   transition-duration: $euiAnimSpeedFast; /* 2 */
 
   .euiButtonEmpty__content {
-    padding: 0 $euiSizeS;
+    padding-block: 0;
+    padding-inline: $euiSizeS;
   }
 
   .euiButtonEmpty__text {
@@ -85,21 +86,21 @@ $euiButtonEmptyTypes: (
 }
 
 .euiButtonEmpty--flushLeft {
-  margin-right: $euiSizeS;
+  margin-inline-end: $euiSizeS;
 
   .euiButtonEmpty__content {
-    border-left: none;
-    padding-left: 0;
-    padding-right: 0;
+    border-inline-start: none;
+    padding-inline-start: 0;
+    padding-inline-end: 0;
   }
 }
 
 .euiButtonEmpty--flushRight {
-  margin-left: $euiSizeS;
+  margin-inline-start: $euiSizeS;
 
   .euiButtonEmpty__content {
-    border-right: none;
-    padding-left: 0;
-    padding-right: 0;
+    border-inline-end: none;
+    padding-inline-start: 0;
+    padding-inline-end: 0;
   }
 }

--- a/src/components/button/button_empty/_button_empty.scss
+++ b/src/components/button/button_empty/_button_empty.scss
@@ -16,8 +16,10 @@
   transition-duration: $euiAnimSpeedFast; /* 2 */
 
   .euiButtonEmpty__content {
-    padding-block: 0;
-    padding-inline: $euiSizeS;
+    padding-block-start: 0;
+    padding-block-end: 0;
+    padding-inline-start: $euiSizeS;
+    padding-inline-end: $euiSizeS;
   }
 
   .euiButtonEmpty__text {

--- a/src/components/button/button_group/_button_group.scss
+++ b/src/components/button/button_group/_button_group.scss
@@ -19,7 +19,7 @@
 }
 
 .euiButtonGroup__toggle {
-  margin-left: -1px;
+  margin-inline-start: -1px;
   z-index: 1;
 
   // DO NOT Transform
@@ -59,7 +59,7 @@
   }
 
   &:first-child {
-    margin-left: 0;
+    margin-inline-start: 0;
 
     .euiButtonGroup__button {
       border-top-left-radius: $euiBorderRadius;
@@ -112,8 +112,8 @@
     }
 
     .euiButton__content {
-      padding-left: $euiSizeS;
-      padding-right: $euiSizeS;
+      padding-inline-start: $euiSizeS;
+      padding-inline-end: $euiSizeS;
     }
   }
 

--- a/src/components/button/button_group/_button_group.scss
+++ b/src/components/button/button_group/_button_group.scss
@@ -1,11 +1,11 @@
 .euiButtonGroup {
-  max-width: 100%;
+  max-inline-size: 100%;
   display: flex;
 }
 
 .euiButtonGroup__fieldset {
   display: inline-block;
-  max-width: 100%;
+  max-inline-size: 100%;
 
   &--fullWidth {
     display: block;
@@ -81,10 +81,10 @@
 
   .euiButtonGroup__toggle {
     flex: 1;
-    min-width: 0;
+    min-inline-size: 0;
 
     .euiButtonGroup__button {
-      min-width: 0;
+      min-inline-size: 0;
     }
   }
 }
@@ -99,7 +99,7 @@
     // sass-lint:disable-block no-important
     box-shadow: none !important;
     font-size: $euiFontSizeS;
-    min-width: 0;
+    min-inline-size: 0;
     border: none;
     border-radius: $euiBorderRadius;
     // Offset the background color from the border by 2px
@@ -119,7 +119,7 @@
 
   .euiButtonGroup__toggle {
     flex: 1;
-    min-width: 0;
+    min-inline-size: 0;
   }
 
   .euiButtonToggle__input:enabled:hover + .euiButtonGroup__button,

--- a/src/components/button/button_icon/_button_icon.scss
+++ b/src/components/button/button_icon/_button_icon.scss
@@ -5,8 +5,8 @@
   background-color: transparent;
   box-shadow: none;
   height: auto;
-  min-height: $euiSizeL;
-  min-width: $euiSizeL;
+  min-block-size: $euiSizeL;
+  min-inline-size: $euiSizeL;
   line-height: 0; // ensures the icon creates the line-height and so it's always vertically centered
   padding: $euiSizeXS;
   border-radius: $euiBorderRadius;

--- a/src/components/button/button_toggle/_button_toggle.scss
+++ b/src/components/button/button_toggle/_button_toggle.scss
@@ -30,7 +30,8 @@
     min-width: 0;
 
     .euiButton__content {
-      padding: 0 $euiSizeS;
+      padding-block: 0;
+      padding-inline: $euiSizeS;
     }
 
     .euiButton__text:empty {

--- a/src/components/button/button_toggle/_button_toggle.scss
+++ b/src/components/button/button_toggle/_button_toggle.scss
@@ -30,8 +30,10 @@
     min-width: 0;
 
     .euiButton__content {
-      padding-block: 0;
-      padding-inline: $euiSizeS;
+      padding-block-start: 0;
+      padding-block-end: 0;
+      padding-inline-start: $euiSizeS;
+      padding-inline-end: $euiSizeS;
     }
 
     .euiButton__text:empty {

--- a/src/components/button/button_toggle/_button_toggle.scss
+++ b/src/components/button/button_toggle/_button_toggle.scss
@@ -27,7 +27,7 @@
   }
 
   &.euiButtonToggle--isIconOnly {
-    min-width: 0;
+    min-inline-size: 0;
 
     .euiButton__content {
       padding-block-start: 0;

--- a/src/components/call_out/_call_out.scss
+++ b/src/components/call_out/_call_out.scss
@@ -1,6 +1,6 @@
 .euiCallOut {
   padding: $euiSize;
-  border-left: $euiSizeXS / 2 solid transparent;
+  border-inline-start: $euiSizeXS / 2 solid transparent;
 
   &.euiCallOut--small {
     padding: $euiSizeS;

--- a/src/components/call_out/_call_out.scss
+++ b/src/components/call_out/_call_out.scss
@@ -14,7 +14,7 @@
 
   .euiCallOutHeader__title {
     @include euiCallOutTitle;
-    margin-bottom: 0; // In case it's nested inside EuiText
+    margin-block-end: 0; // In case it's nested inside EuiText
   }
 }
 

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -124,7 +124,7 @@
         width: calc(100% + (#{$paddingAmount} * 2));
         inset-inline-start: $paddingAmount * -1;
         inset-block-start: $paddingAmount * -1;
-        margin-bottom: $paddingAmount * -1; // ensure the parent is only as tall as the image
+        margin-block-end: $paddingAmount * -1; // ensure the parent is only as tall as the image
 
         // IF both exist, position the icon centered on top of image
         + .euiCard__icon {

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -76,11 +76,11 @@
   }
 
   &.euiCard--leftAligned {
-    text-align: left;
+    text-align: start;
     align-items: flex-start;
 
     .euiCard__titleButton {
-      text-align: left;
+      text-align: start;
     }
   }
 
@@ -90,11 +90,11 @@
   }
 
   &.euiCard--rightAligned {
-    text-align: right;
+    text-align: end;
     align-items: flex-end;
 
     .euiCard__titleButton {
-      text-align: right;
+      text-align: end;
     }
   }
 
@@ -220,7 +220,7 @@
 
 .euiCard.euiCard--horizontal {
   .euiCard__content {
-    text-align: left; /* 3 */
+    text-align: start; /* 3 */
   }
 }
 

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -122,8 +122,8 @@
 
       .euiCard__image {
         width: calc(100% + (#{$paddingAmount} * 2));
-        left: $paddingAmount * -1;
-        top: $paddingAmount * -1;
+        inset-inline-start: $paddingAmount * -1;
+        inset-block-start: $paddingAmount * -1;
         margin-bottom: $paddingAmount * -1; // ensure the parent is only as tall as the image
 
         // IF both exist, position the icon centered on top of image
@@ -157,8 +157,8 @@
     // IF both exist, position the icon centered on top of image
     + .euiCard__icon {
       position: absolute;
-      top: 50%;
-      left: 50%;
+      inset-block-start: 50%;
+      inset-inline-start: 50%;
     }
   }
 

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -115,7 +115,7 @@
     padding: $paddingAmount;
 
     &.euiCard--isSelectable {
-      padding-bottom: $paddingAmount + $euiCardBottomNodeHeight;
+      padding-block-end: $paddingAmount + $euiCardBottomNodeHeight;
     }
 
     .euiCard__top {
@@ -163,17 +163,17 @@
   }
 
   .euiCard__icon {
-    margin-top: $euiCardSpacing / 2;
+    margin-block-start: $euiCardSpacing / 2;
   }
 }
 
 .euiCard__footer:not(:empty) {
   flex-grow: 0; /* 1 */
-  margin-top: $euiCardSpacing;
+  margin-block-start: $euiCardSpacing;
 }
 
 .euiCard--hasChildren .euiCard__description {
-  margin-bottom: $euiCardSpacing;
+  margin-block-end: $euiCardSpacing;
 }
 
 // Selectable cards don't work well without a border
@@ -195,14 +195,14 @@
 
 // If an icon or image exists, add some space
 .euiCard__top + .euiCard__content {
-  margin-top: $euiCardSpacing;
+  margin-block-start: $euiCardSpacing;
 }
 
 .euiCard__content {
   flex-grow: 1; /* 1 */
 
   .euiCard__description {
-    margin-top: $euiCardSpacing / 2;
+    margin-block-start: $euiCardSpacing / 2;
   }
 
   .euiCard__titleAnchor,
@@ -234,11 +234,11 @@
   .euiCard__top,
   .euiCard__content {
     width: auto; // Makes sure the top shrinks and the content grows
-    margin-top: 0;
+    margin-block-start: 0;
   }
 
   .euiCard__top .euiCard__icon {
-    margin-top: 0;
-    margin-right: $euiSize;
+    margin-block-start: 0;
+    margin-inline-end: $euiSize;
   }
 }

--- a/src/components/card/_mixins.scss
+++ b/src/components/card/_mixins.scss
@@ -1,7 +1,7 @@
 @mixin euiCardBottomNodePosition {
   position: absolute;
-  bottom: 0;
-  left: 0;
+  inset-block-end: 0;
+  inset-inline-start: 0;
   height: $euiCardBottomNodeHeight !important;  // sass-lint:disable-line no-important -- To override .euiButtonEmpty--xSmall
   width: 100%;
   overflow: hidden;

--- a/src/components/card/checkable_card/_checkable_card.scss
+++ b/src/components/card/checkable_card/_checkable_card.scss
@@ -40,8 +40,8 @@
   font-size: $euiFontSize;
   line-height: $euiSizeL;
   padding-block-start: $euiSizeS;
-  padding-block-end: $euiSize;
-  padding-inline-start: $euiSizeS;
+  padding-block-end: $euiSizeS;
+  padding-inline-start: $euiSize;
   padding-inline-end: $euiSizeS;
   cursor: pointer;
 }
@@ -53,7 +53,7 @@
 
 .euiCheckableCard__children {
   padding-block-start:  0;
-  padding-block-end:  $euiSize;
-  padding-inline-start:  $euiSizeS;
+  padding-block-end:  $euiSizeS;
+  padding-inline-start:  $euiSize;
   padding-inline-end:  $euiSizeS;
 }

--- a/src/components/card/checkable_card/_checkable_card.scss
+++ b/src/components/card/checkable_card/_checkable_card.scss
@@ -39,8 +39,10 @@
   flex-grow: 1;
   font-size: $euiFontSize;
   line-height: $euiSizeL;
-  padding-block: $euiSizeS $euiSize;
-  padding-inline: $euiSizeS;
+  padding-block-start: $euiSizeS;
+  padding-block-end: $euiSize;
+  padding-inline-start: $euiSizeS;
+  padding-inline-end: $euiSizeS;
   cursor: pointer;
 }
 
@@ -50,6 +52,8 @@
 }
 
 .euiCheckableCard__children {
-  padding-block:  0 $euiSize;
-  padding-inline:  $euiSizeS;
+  padding-block-start:  0;
+  padding-block-end:  $euiSize;
+  padding-inline-start:  $euiSizeS;
+  padding-inline-end:  $euiSizeS;
 }

--- a/src/components/card/checkable_card/_checkable_card.scss
+++ b/src/components/card/checkable_card/_checkable_card.scss
@@ -39,7 +39,8 @@
   flex-grow: 1;
   font-size: $euiFontSize;
   line-height: $euiSizeL;
-  padding: $euiSizeS $euiSizeS $euiSizeS $euiSize;
+  padding-block: $euiSizeS $euiSize;
+  padding-inline: $euiSizeS;
   cursor: pointer;
 }
 
@@ -49,5 +50,6 @@
 }
 
 .euiCheckableCard__children {
-  padding:  0 $euiSizeS $euiSizeS $euiSize;
+  padding-block:  0 $euiSize;
+  padding-inline:  $euiSizeS;
 }

--- a/src/components/code/_code_block.scss
+++ b/src/components/code/_code_block.scss
@@ -147,13 +147,17 @@
     white-space: pre;
     color: $euiTextColor;
     font-size: 90%; /* 1 */
-    padding-block: 0;
-    padding-inline: $euiSizeS;
+    padding-block-start: 0;
+    padding-block-end: 0;
+    padding-inline-start: $euiSizeS;
+    padding-inline-end: $euiSizeS;
     background: $euiCodeBlockBackgroundColor;
 
     .euiCodeBlock__pre {
-      padding-block: 0;
-      padding-inline: $euiSizeXS;
+      padding-block-start: 0;
+      padding-block-end: 0;
+      padding-inline-start: $euiSizeXS;
+      padding-inline-end: $euiSizeXS;
     }
 
     .euiCodeBlock__code {

--- a/src/components/code/_code_block.scss
+++ b/src/components/code/_code_block.scss
@@ -35,7 +35,7 @@
   }
 
   .euiCodeBlock__fullScreenButton + .euiCodeBlock__copyButton {
-    margin-top: $euiSizeXS;
+    margin-block-start: $euiSizeXS;
   }
 
   &.euiCodeBlock-isFullScreen {
@@ -72,11 +72,11 @@
   $controlsPadding: $euiSizeL + $euiSizeXS;
 
   &.euiCodeBlock--hasControls .euiCodeBlock__pre--whiteSpacePreWrap {
-    padding-right: $controlsPadding;
+    padding-inline-end: $controlsPadding;
   }
 
   &.euiCodeBlock--hasControls .euiCodeBlock__pre--whiteSpacePre {
-    margin-right: $controlsPadding;
+    margin-inline-end: $controlsPadding;
   }
 
   // Small padding
@@ -91,11 +91,11 @@
     }
 
     &.euiCodeBlock--hasControls .euiCodeBlock__pre--whiteSpacePreWrap {
-      padding-right: $euiSizeS + $controlsPadding;
+      padding-inline-end: $euiSizeS + $controlsPadding;
     }
 
     &.euiCodeBlock--hasControls .euiCodeBlock__pre--whiteSpacePre {
-      margin-right: $euiSizeS + $controlsPadding;
+      margin-inline-end: $euiSizeS + $controlsPadding;
     }
   }
 
@@ -111,11 +111,11 @@
     }
 
     &.euiCodeBlock--hasControls .euiCodeBlock__pre--whiteSpacePreWrap {
-      padding-right: $euiSize + $controlsPadding;
+      padding-inline-end: $euiSize + $controlsPadding;
     }
 
     &.euiCodeBlock--hasControls .euiCodeBlock__pre--whiteSpacePre {
-      margin-right: $euiSize + $controlsPadding;
+      margin-inline-end: $euiSize + $controlsPadding;
     }
   }
 
@@ -131,11 +131,11 @@
     }
 
     &.euiCodeBlock--hasControls .euiCodeBlock__pre--whiteSpacePreWrap {
-      padding-right: $euiSizeL + $controlsPadding;
+      padding-inline-end: $euiSizeL + $controlsPadding;
     }
 
     &.euiCodeBlock--hasControls .euiCodeBlock__pre--whiteSpacePre {
-      margin-right: $euiSizeL + $controlsPadding;
+      margin-inline-end: $euiSizeL + $controlsPadding;
     }
   }
 
@@ -147,11 +147,13 @@
     white-space: pre;
     color: $euiTextColor;
     font-size: 90%; /* 1 */
-    padding: 0 $euiSizeS;
+    padding-block: 0;
+    padding-inline: $euiSizeS;
     background: $euiCodeBlockBackgroundColor;
 
     .euiCodeBlock__pre {
-      padding: 0 $euiSizeXS;
+      padding-block: 0;
+      padding-inline: $euiSizeXS;
     }
 
     .euiCodeBlock__code {
@@ -249,8 +251,8 @@
 
   .hljs-addition,
   .hljs-deletion {
-    padding-left: $euiSizeXS;
-    margin-left: -$euiSizeXS;
+    padding-inline-start: $euiSizeXS;
+    margin-inline-start: -$euiSizeXS;
   }
 
   .hljs-addition {

--- a/src/components/code/_code_block.scss
+++ b/src/components/code/_code_block.scss
@@ -1,5 +1,5 @@
 .euiCodeBlock {
-  max-width: 100%;
+  max-inline-size: 100%;
   display: block;
   position: relative;
   background: $euiCodeBlockBackgroundColor;
@@ -30,8 +30,8 @@
 
   .euiCodeBlock__controls {
     position: absolute;
-    top: 0;
-    right: 0;
+    inset-block-start: 0;
+    inset-inline-end: 0;
   }
 
   .euiCodeBlock__fullScreenButton + .euiCodeBlock__copyButton {
@@ -40,10 +40,10 @@
 
   &.euiCodeBlock-isFullScreen {
     position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    inset-block-start: 0;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
+    inset-block-end: 0;
 
     .euiCodeBlock__pre {
       // sass-lint:disable-block no-important
@@ -51,8 +51,8 @@
     }
 
     .euiCodeBlock__controls {
-      top: $euiSizeXS;
-      right: $euiSizeXS;
+      inset-block-start: $euiSizeXS;
+      inset-inline-end: $euiSizeXS;
     }
   }
 
@@ -86,8 +86,8 @@
     }
 
     .euiCodeBlock__controls {
-      top: $euiSizeS;
-      right: $euiSizeS;
+      inset-block-start: $euiSizeS;
+      inset-inline-end: $euiSizeS;
     }
 
     &.euiCodeBlock--hasControls .euiCodeBlock__pre--whiteSpacePreWrap {
@@ -106,8 +106,8 @@
     }
 
     .euiCodeBlock__controls {
-      top: $euiSize;
-      right: $euiSize;
+      inset-block-start: $euiSize;
+      inset-inline-end: $euiSize;
     }
 
     &.euiCodeBlock--hasControls .euiCodeBlock__pre--whiteSpacePreWrap {
@@ -126,8 +126,8 @@
     }
 
     .euiCodeBlock__controls {
-      top: $euiSizeL;
-      right: $euiSizeL;
+      inset-block-start: $euiSizeL;
+      inset-inline-end: $euiSizeL;
     }
 
     &.euiCodeBlock--hasControls .euiCodeBlock__pre--whiteSpacePreWrap {

--- a/src/components/code_editor/_code_editor.scss
+++ b/src/components/code_editor/_code_editor.scss
@@ -14,10 +14,10 @@
 
 .euiCodeEditorKeyboardHint {
   position: absolute;
-  top: 0;
-  bottom: 0;
-  right: 0;
-  left: 0;
+  inset-block-start: 0;
+  inset-block-end: 0;
+  inset-inline-end: 0;
+  inset-inline-start: 0;
   background: transparentize($euiColorGhost, .3);
   display: flex;
   flex-direction: column;

--- a/src/components/collapsible_nav/_collapsible_nav.scss
+++ b/src/components/collapsible_nav/_collapsible_nav.scss
@@ -4,7 +4,7 @@
 
 .euiCollapsibleNav {
   @include euiFlyout;
-  border-left: none;
+  border-inline-start: none;
   right: auto;
   left: 0;
   width: $euiCollapsibleNavWidth;
@@ -17,8 +17,9 @@
   position: absolute;
   right: 0;
   top: $euiSize;
-  margin-right: -27%;
-  padding: $euiSizeM 0;
+  margin-inline-end: -27%;
+  padding-block: $euiSizeM;
+  padding-inline: 0;
   line-height: 1;
   border-radius: $euiBorderRadius;
 
@@ -54,7 +55,7 @@
 @include euiBreakpoint('xs') {
   // At tiny screens, reduce the close button to a simple `x`
   .euiCollapsibleNav__closeButton {
-    margin-right: -15%;
+    margin-inline-end: -15%;
 
     .euiCollapsibleNav__closeButtonText {
       // But be sure the text can still be read by a screen reader

--- a/src/components/collapsible_nav/_collapsible_nav.scss
+++ b/src/components/collapsible_nav/_collapsible_nav.scss
@@ -50,7 +50,7 @@
 
 .euiBody--collapsibleNavIsDocked {
   // Shrink the content from the left so it's no longer overlapped by the nav drawer (ALWAYS)
-  padding-left: $euiCollapsibleNavWidth !important; // sass-lint:disable-line no-important
+  padding-inline-start: $euiCollapsibleNavWidth !important; // sass-lint:disable-line no-important
   transition: padding $euiAnimSpeedFast $euiAnimSlightResistance;
 }
 

--- a/src/components/collapsible_nav/_collapsible_nav.scss
+++ b/src/components/collapsible_nav/_collapsible_nav.scss
@@ -5,18 +5,18 @@
 .euiCollapsibleNav {
   @include euiFlyout;
   border-inline-start: none;
-  right: auto;
-  left: 0;
+  inset-inline-end: auto;
+  inset-inline-start: 0;
   width: $euiCollapsibleNavWidth;
-  max-width: 80vw;
+  max-inline-size: 80vw;
   animation: euiCollapsibleNavIn $euiAnimSpeedNormal $euiAnimSlightResistance;
   clip-path: polygon(0 0, 150% 0, 150% 100%, 0 100%); // Must include the width of the close button too
 }
 
 .euiCollapsibleNav__closeButton {
   position: absolute;
-  right: 0;
-  top: $euiSize;
+  inset-inline-end: 0;
+  inset-block-start: $euiSize;
   margin-inline-end: -27%;
   padding-block-start: $euiSizeM;
   padding-block-end: $euiSizeM;

--- a/src/components/collapsible_nav/_collapsible_nav.scss
+++ b/src/components/collapsible_nav/_collapsible_nav.scss
@@ -18,8 +18,10 @@
   right: 0;
   top: $euiSize;
   margin-inline-end: -27%;
-  padding-block: $euiSizeM;
-  padding-inline: 0;
+  padding-block-start: $euiSizeM;
+  padding-block-end: $euiSizeM;
+  padding-inline-start: 0;
+  padding-inline-end: 0;
   line-height: 1;
   border-radius: $euiBorderRadius;
 

--- a/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
+++ b/src/components/collapsible_nav/collapsible_nav_group/_collapsible_nav_group.scss
@@ -1,6 +1,6 @@
 .euiCollapsibleNavGroup {
   &:not(:first-child) {
-    border-top: $euiBorderThin;
+    border-block-start: $euiBorderThin;
   }
 
   // This class does not accept a custom classname
@@ -45,7 +45,7 @@
 }
 
 .euiCollapsibleNavGroup--withHeading .euiCollapsibleNavGroup__children {
-  padding-top: 0;
+  padding-block-start: 0;
 }
 
 @keyframes euiCollapsibleNavGroupDarkFocusRingAnimate {

--- a/src/components/color_picker/_color_picker.scss
+++ b/src/components/color_picker/_color_picker.scss
@@ -45,6 +45,6 @@
 
 .euiColorPicker__alphaRange {
   .euiRangeInput {
-    min-width: 0;
+    min-inline-size: 0;
   }
 }

--- a/src/components/color_picker/_color_picker.scss
+++ b/src/components/color_picker/_color_picker.scss
@@ -28,7 +28,7 @@
 .euiColorPicker__popoverPanel--pickerOnly {
   // Override of EuiPanel padding
   // sass-lint:disable no-important
-  padding-bottom: 0 !important;
+  padding-block-end: 0 !important;
 }
 
 // sass-lint:disable no-important

--- a/src/components/color_picker/_hue.scss
+++ b/src/components/color_picker/_hue.scss
@@ -22,7 +22,7 @@
   &:before,
   &:after {
     content: '';
-    left: 0;
+    inset-inline-start: 0;
     position: absolute;
     height: $euiSizeS;
     background: $euiColorEmptyShade;
@@ -30,7 +30,7 @@
   }
 
   &:after {
-    bottom: 0;
+    inset-block-end: 0;
   }
 }
 

--- a/src/components/color_picker/_hue.scss
+++ b/src/components/color_picker/_hue.scss
@@ -11,7 +11,8 @@
     #FF0094 100%
    );
   height: $euiSizeL;
-  margin: $euiSizeXS 0;
+  margin-block: $euiSizeXS;
+  margin-inline: 0;
   position: relative;
 
 
@@ -53,11 +54,11 @@
   // sass-lint:disable-block no-vendor-prefixes
   &::-webkit-slider-thumb {
     -webkit-appearance: none;
-    margin-top: 0;
+    margin-block-start: 0;
   }
 
   &::-ms-thumb {
-    margin-top: 0;
+    margin-block-start: 0;
   }
 
   &::-ms-track {

--- a/src/components/color_picker/_hue.scss
+++ b/src/components/color_picker/_hue.scss
@@ -44,7 +44,10 @@
   position: relative;
   height: $euiSizeL;
   width: calc(100% + 2px); // Allow for overlap
-  margin: 0 -1px; // Use ^ overlap to allow thumb to fully cover gradient ends
+  margin-block-start: 0; // Use ^ overlap to allow thumb to fully cover gradient ends
+  margin-block-end: 0;
+  margin-inline-start: -1px;
+  margin-inline-end: -1px;
   appearance: none;
   background: transparent;
   z-index: 2; // Needed to place the thumb above the :after pseudo border from .euiRange

--- a/src/components/color_picker/_hue.scss
+++ b/src/components/color_picker/_hue.scss
@@ -11,8 +11,10 @@
     #FF0094 100%
    );
   height: $euiSizeL;
-  margin-block: $euiSizeXS;
-  margin-inline: 0;
+  margin-block-start: $euiSizeXS;
+  margin-block-end: $euiSizeXS;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
   position: relative;
 
 

--- a/src/components/color_picker/_saturation.scss
+++ b/src/components/color_picker/_saturation.scss
@@ -10,7 +10,7 @@
   .euiSaturation__lightness,
   .euiSaturation__saturation {
     position: absolute;
-    top: -1px; // hides a slight color inconsistency
+    inset-block-start: -1px; // hides a slight color inconsistency
     inset-block-end: 0;
     inset-inline-start: 0;
     inset-inline-end: 0;

--- a/src/components/color_picker/_saturation.scss
+++ b/src/components/color_picker/_saturation.scss
@@ -2,7 +2,7 @@
 .euiSaturation {
   position: relative;
   width: 100%;
-  padding-bottom: 100%;
+  padding-block-end: 100%;
   border-radius: $euiBorderRadius / 2;
   touch-action: none; // prevent TouchMove events from scrolling page
   z-index: 3; // Required to be above the hue slider, which can overlap
@@ -30,8 +30,8 @@
     height: $euiColorPickerIndicatorSize;
     width: $euiColorPickerIndicatorSize;
     border-radius: 100%;
-    margin-top: $euiColorPickerIndicatorSize * -.5;
-    margin-left: $euiColorPickerIndicatorSize * -.5;
+    margin-block-start: $euiColorPickerIndicatorSize * -.5;
+    margin-inline-start: $euiColorPickerIndicatorSize * -.5;
     border: 1px solid $euiColorDarkestShade;
 
     &:before {

--- a/src/components/color_picker/_saturation.scss
+++ b/src/components/color_picker/_saturation.scss
@@ -11,9 +11,9 @@
   .euiSaturation__saturation {
     position: absolute;
     top: -1px; // hides a slight color inconsistency
-    bottom: 0;
-    left: 0;
-    right: 0;
+    inset-block-end: 0;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
     border-radius: $euiBorderRadius / 2;
   }
 
@@ -37,10 +37,10 @@
     &:before {
       content: '';
       position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
+      inset-block-start: 0;
+      inset-inline-start: 0;
+      inset-inline-end: 0;
+      inset-block-end: 0;
       border-radius: 100%;
       border: 1px solid $euiColorLightestShade;
     }

--- a/src/components/color_picker/color_palette_picker/_color_palette_picker.scss
+++ b/src/components/color_picker/color_palette_picker/_color_palette_picker.scss
@@ -11,6 +11,6 @@
   }
 
   &__itemTitle + &__itemGradient {
-    margin-top: $euiSizeXS;
+    margin-block-start: $euiSizeXS;
   }
 }

--- a/src/components/color_picker/color_stops/_color_stops.scss
+++ b/src/components/color_picker/color_stops/_color_stops.scss
@@ -11,7 +11,7 @@
   right: 0;
   top: 50%;
   height: $euiRangeThumbHeight;
-  margin-top: $euiRangeThumbHeight * -.5;
+  margin-block-start: $euiRangeThumbHeight * -.5;
 
   &:hover:not(.euiColorStops__addContainer-isDisabled) {
     cursor: pointer;
@@ -44,7 +44,7 @@
   top: 50%;
   width: $euiRangeThumbWidth;
   height: $euiRangeThumbHeight;
-  margin-top: $euiRangeThumbHeight * -.5;
+  margin-block-start: $euiRangeThumbHeight * -.5;
 }
 
 .euiColorStopPopover-hasFocus {
@@ -74,7 +74,7 @@
 .euiColorStopThumb.euiRangeThumb:not(:disabled) {
   // sass-lint:disable-block no-color-literals, indentation
   top: 0;
-  margin-top: 0;
+  margin-block-start: 0;
   pointer-events: auto;
   cursor: grab;
   border: solid ($euiSizeXS - 1px) $euiColorEmptyShade;

--- a/src/components/color_picker/color_stops/_color_stops.scss
+++ b/src/components/color_picker/color_stops/_color_stops.scss
@@ -7,9 +7,9 @@
 .euiColorStops__addContainer {
   display: block;
   position: absolute;
-  left: 0;
-  right: 0;
-  top: 50%;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
+  inset-block-start: 50%;
   height: $euiRangeThumbHeight;
   margin-block-start: $euiRangeThumbHeight * -.5;
 
@@ -26,7 +26,7 @@
   @include euiCustomControl($type: 'round');
   @include euiRangeThumbStyle;
   position: absolute;
-  top: 0;
+  inset-block-start: 0;
   height: $euiRangeThumbHeight;
   width: $euiRangeThumbHeight;
   background-color: $euiColorLightestShade;
@@ -41,7 +41,7 @@
 
 .euiColorStopPopover.euiPopover {
   position: absolute;
-  top: 50%;
+  inset-block-start: 50%;
   width: $euiRangeThumbWidth;
   height: $euiRangeThumbHeight;
   margin-block-start: $euiRangeThumbHeight * -.5;
@@ -62,8 +62,8 @@
     content: '';
     display: block;
     position: absolute;
-    left: 0;
-    top: 0;
+    inset-inline-start: 0;
+    inset-block-start: 0;
     height: $euiRangeThumbHeight;
     width: $euiRangeThumbHeight;
     border-radius: $euiRangeThumbHeight;
@@ -73,7 +73,7 @@
 
 .euiColorStopThumb.euiRangeThumb:not(:disabled) {
   // sass-lint:disable-block no-color-literals, indentation
-  top: 0;
+  inset-block-start: 0;
   margin-block-start: 0;
   pointer-events: auto;
   cursor: grab;

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -32,7 +32,7 @@
 
       // Ensure the input doesn't drop to the next line when the EuiBadge has a very long text
       // Overrides the default EuiBadge max-width that is 100%
-      max-width: calc(100% - #{$euiSizeXS * .5} - #{$inputMinWidth});
+      max-inline-size: calc(100% - #{$euiSizeXS * .5} - #{$inputMinWidth});
     }
 
     &:not(.euiComboBox__inputWrap--noWrap) {

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -17,8 +17,10 @@
     @include euiFormControlStyle($includeStates: false, $includeSizes: true);
     @include euiFormControlWithIcon($isIconOptional: true);
     @include euiFormControlSize(auto, $includeAlternates: true);
-    padding-block: $euiSizeXS;
-    padding-inline: $euiSizeS;
+    padding-block-start: $euiSizeXS;
+    padding-block-end: $euiSizeXS;
+    padding-inline-start: $euiSizeS;
+    padding-inline-end: $euiSizeS;
     display: flex; /* 1 */
 
     // sass-lint:disable-block mixins-before-declarations

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -17,7 +17,8 @@
     @include euiFormControlStyle($includeStates: false, $includeSizes: true);
     @include euiFormControlWithIcon($isIconOptional: true);
     @include euiFormControlSize(auto, $includeAlternates: true);
-    padding: $euiSizeXS $euiSizeS;
+    padding-block: $euiSizeXS;
+    padding-inline: $euiSizeS;
     display: flex; /* 1 */
 
     // sass-lint:disable-block mixins-before-declarations
@@ -33,9 +34,9 @@
     }
 
     &:not(.euiComboBox__inputWrap--noWrap) {
-      padding-top: $euiSizeXS;
-      padding-bottom: $euiSizeXS;
-      padding-left: $euiSizeXS;
+      padding-block-start: $euiSizeXS;
+      padding-block-end: $euiSizeXS;
+      padding-inline-start: $euiSizeXS;
       height: auto;  /* 3 */
       flex-wrap: wrap; /* 1 */
       align-content: flex-start;
@@ -109,8 +110,8 @@
   &.euiComboBox--compressed {
     .euiComboBox__inputWrap {
       line-height: $euiFormControlCompressedHeight; /* 2 */
-      padding-top: 0;
-      padding-bottom: 0;
+      padding-block-start: 0;
+      padding-block-end: 0;
 
       // sass-lint:disable-block mixins-before-declarations
       @include euiFormControlLayoutPadding(1, $compressed: true); /* 2 */

--- a/src/components/combo_box/combo_box_input/_combo_box_input.scss
+++ b/src/components/combo_box/combo_box_input/_combo_box_input.scss
@@ -1,5 +1,5 @@
 .euiComboBox__input {
-  max-width: 100%;
+  max-inline-size: 100%;
 
   // Ensure that no input states are visible on the hidden input
   input[aria-hidden='true'] {

--- a/src/components/combo_box/combo_box_input/_combo_box_pill.scss
+++ b/src/components/combo_box/combo_box_input/_combo_box_pill.scss
@@ -14,8 +14,10 @@
 
   .euiComboBox--compressed &,
   .euiComboBox--compressed & + & /* 1 */ {
-    margin-block: ($euiSizeXS + 1px) 0;
-    margin-inline: 0 $euiSizeXS;
+    margin-block-start: ($euiSizeXS + 1px);
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    margin-inline-end: $euiSizeXS;
   }
 
   &--plainText {

--- a/src/components/combo_box/combo_box_input/_combo_box_pill.scss
+++ b/src/components/combo_box/combo_box_input/_combo_box_pill.scss
@@ -14,7 +14,8 @@
 
   .euiComboBox--compressed &,
   .euiComboBox--compressed & + & /* 1 */ {
-    margin: ($euiSizeXS + 1px) $euiSizeXS 0 0;
+    margin-block: ($euiSizeXS + 1px) 0;
+    margin-inline: 0 $euiSizeXS;
   }
 
   &--plainText {

--- a/src/components/combo_box/combo_box_input/_combo_box_placeholder.scss
+++ b/src/components/combo_box/combo_box_input/_combo_box_placeholder.scss
@@ -1,8 +1,10 @@
 .euiComboBoxPlaceholder {
   position: absolute;
   pointer-events: none;
-  padding-block: 0;
-  padding-inline: $euiSizeXS;
+  padding-block-start: 0;
+  padding-block-end: 0;
+  padding-inline-start: $euiSizeXS;
+  padding-inline-end: $euiSizeXS;
   line-height: $euiSizeXL;
   color: $euiColorMediumShade;
   margin-bottom: 0 !important; // sass-lint:disable-line no-important

--- a/src/components/combo_box/combo_box_input/_combo_box_placeholder.scss
+++ b/src/components/combo_box/combo_box_input/_combo_box_placeholder.scss
@@ -7,5 +7,5 @@
   padding-inline-end: $euiSizeXS;
   line-height: $euiSizeXL;
   color: $euiColorMediumShade;
-  margin-bottom: 0 !important; // sass-lint:disable-line no-important
+  margin-block-end: 0 !important; // sass-lint:disable-line no-important
 }

--- a/src/components/combo_box/combo_box_input/_combo_box_placeholder.scss
+++ b/src/components/combo_box/combo_box_input/_combo_box_placeholder.scss
@@ -1,7 +1,8 @@
 .euiComboBoxPlaceholder {
   position: absolute;
   pointer-events: none;
-  padding: 0 $euiSizeXS;
+  padding-block: 0;
+  padding-inline: $euiSizeXS;
   line-height: $euiSizeXL;
   color: $euiColorMediumShade;
   margin-bottom: 0 !important; // sass-lint:disable-line no-important

--- a/src/components/combo_box/combo_box_options_list/_combo_box_option.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_option.scss
@@ -1,8 +1,8 @@
 .euiComboBoxOption {
   font-size: $euiFontSizeS;
   padding-block-start: $euiSizeXS;
-  padding-block-end: #{$euiSizeM + $euiSizeXS};
-  padding-inline-start: $euiSizeXS;
+  padding-block-end: $euiSizeXS;
+  padding-inline-start: #{$euiSizeM + $euiSizeXS};
   padding-inline-end: $euiSizeS;
   width: 100%;
   text-align: left;

--- a/src/components/combo_box/combo_box_options_list/_combo_box_option.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_option.scss
@@ -1,7 +1,9 @@
 .euiComboBoxOption {
   font-size: $euiFontSizeS;
-  padding-block: $euiSizeXS #{$euiSizeM + $euiSizeXS};
-  padding-inline: $euiSizeXS $euiSizeS;
+  padding-block-start: $euiSizeXS;
+  padding-block-end: #{$euiSizeM + $euiSizeXS};
+  padding-inline-start: $euiSizeXS;
+  padding-inline-end: $euiSizeS;
   width: 100%;
   text-align: left;
   border: $euiBorderThin;

--- a/src/components/combo_box/combo_box_options_list/_combo_box_option.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_option.scss
@@ -5,7 +5,7 @@
   padding-inline-start: #{$euiSizeM + $euiSizeXS};
   padding-inline-end: $euiSizeS;
   width: 100%;
-  text-align: left;
+  text-align: start;
   border: $euiBorderThin;
   border-color: transparent;
   display: flex;
@@ -36,7 +36,7 @@
 
   .euiComboBoxOption__emptyStateText {
     flex: 1;
-    text-align: left;
+    text-align: start;
     margin-block-end: 0;
   }
 
@@ -51,5 +51,5 @@
   overflow: hidden;
   white-space: nowrap;
   flex: 1;
-  text-align: left;
+  text-align: start;
 }

--- a/src/components/combo_box/combo_box_options_list/_combo_box_option.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_option.scss
@@ -1,6 +1,7 @@
 .euiComboBoxOption {
   font-size: $euiFontSizeS;
-  padding: $euiSizeXS $euiSizeS $euiSizeXS #{$euiSizeM + $euiSizeXS};
+  padding-block: $euiSizeXS #{$euiSizeM + $euiSizeXS};
+  padding-inline: $euiSizeXS $euiSizeS;
   width: 100%;
   text-align: left;
   border: $euiBorderThin;
@@ -34,12 +35,12 @@
   .euiComboBoxOption__emptyStateText {
     flex: 1;
     text-align: left;
-    margin-bottom: 0;
+    margin-block-end: 0;
   }
 
   .euiComboBoxOption__enterBadge {
     align-self: flex-start;
-    margin-left: $euiSizeXS;
+    margin-inline-start: $euiSizeXS;
   }
 }
 

--- a/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
@@ -51,6 +51,6 @@
 
 .euiComboBoxOptionsList__rowWrap {
   padding: 0;
-  max-height: 200px;
+  max-block-size: 200px;
   overflow: hidden;
 }

--- a/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
@@ -31,7 +31,7 @@
 .euiComboBoxOptionsList--bottom {
   // sass-lint:disable-block no-important
   border-radius: 0 0 $euiBorderRadius $euiBorderRadius !important;
-  border-top: none !important;
+  border-block-start: none !important;
 }
 
 .euiComboBoxOptionsList--top {

--- a/src/components/comment_list/_comment.scss
+++ b/src/components/comment_list/_comment.scss
@@ -2,7 +2,7 @@
   font-size: $euiFontSizeS;
   display: flex;
   padding-block-end: $euiSize;
-  min-height: $euiSize * 3.5;
+  min-block-size: $euiSize * 3.5;
 
   .euiCommentEvent {
     flex-grow: 1;
@@ -16,8 +16,8 @@
     &::before {
       content: '';
       position: absolute;
-      left: $euiSizeXXL / 2;
-      top: $euiSizeL;
+      inset-inline-start: $euiSizeXXL / 2;
+      inset-block-start: $euiSizeL;
       width: $euiSizeXS / 2;
       background-color: $euiColorLightShade;
       height: calc(100% + #{$euiSizeL});

--- a/src/components/comment_list/_comment.scss
+++ b/src/components/comment_list/_comment.scss
@@ -1,7 +1,7 @@
 .euiComment {
   font-size: $euiFontSizeS;
   display: flex;
-  padding-bottom: $euiSize;
+  padding-block-end: $euiSize;
   min-height: $euiSize * 3.5;
 
   .euiCommentEvent {
@@ -11,7 +11,7 @@
   .euiCommentTimeline {
     position: relative;
     flex-grow: 0;
-    margin-right: $euiSize;
+    margin-inline-end: $euiSize;
 
     &::before {
       content: '';

--- a/src/components/comment_list/_comment_event.scss
+++ b/src/components/comment_list/_comment_event.scss
@@ -16,7 +16,7 @@
   flex-wrap: wrap;
 
   > div {
-    padding-right: $euiSizeXS;
+    padding-inline-end: $euiSizeXS;
   }
 }
 
@@ -30,8 +30,9 @@
   .euiCommentEvent__header {
     min-height: $euiSizeXXL;
     background-color: $euiColorLightestShade;
-    border-bottom: $euiBorderThin;
-    padding: $euiSizeXS $euiSizeS;
+    border-block-end: $euiBorderThin;
+    padding-block: $euiSizeXS;
+    padding-inline: $euiSizeS;
 
     /**
      * Fix for IE when using align-items:center in an item that has min-height
@@ -62,14 +63,15 @@
 .euiCommentEvent--update {
   .euiCommentEvent__header {
     justify-content: flex-start;
-    padding: $euiSizeXS 0;
+    padding-block: $euiSizeXS;
+    padding-inline: 0;
   }
 
   .euiCommentEvent__headerData {
-    padding-right: $euiSizeS;
+    padding-inline-end: $euiSizeS;
   }
 
   .euiCommentEvent__body {
-    padding-top: $euiSizeXS;
+    padding-block-start: $euiSizeXS;
   }
 }

--- a/src/components/comment_list/_comment_event.scss
+++ b/src/components/comment_list/_comment_event.scss
@@ -31,8 +31,10 @@
     min-height: $euiSizeXXL;
     background-color: $euiColorLightestShade;
     border-block-end: $euiBorderThin;
-    padding-block: $euiSizeXS;
-    padding-inline: $euiSizeS;
+    padding-block-start: $euiSizeXS;
+    padding-block-end: $euiSizeXS;
+    padding-inline-start: $euiSizeS;
+    padding-inline-end: $euiSizeS;
 
     /**
      * Fix for IE when using align-items:center in an item that has min-height
@@ -63,8 +65,10 @@
 .euiCommentEvent--update {
   .euiCommentEvent__header {
     justify-content: flex-start;
-    padding-block: $euiSizeXS;
-    padding-inline: 0;
+    padding-block-start: $euiSizeXS;
+    padding-block-end: $euiSizeXS;
+    padding-inline-start: 0;
+    padding-inline-end: 0;
   }
 
   .euiCommentEvent__headerData {

--- a/src/components/comment_list/_comment_event.scss
+++ b/src/components/comment_list/_comment_event.scss
@@ -28,7 +28,7 @@
   border: $euiBorderThin;
 
   .euiCommentEvent__header {
-    min-height: $euiSizeXXL;
+    min-block-size: $euiSizeXXL;
     background-color: $euiColorLightestShade;
     border-block-end: $euiBorderThin;
     padding-block-start: $euiSizeXS;
@@ -45,7 +45,7 @@
       &::after {
         content: '';
         // Calculates the minimum height based on full header's min-height minus the vertical padding
-        min-height: $euiSizeXXL - $euiSizeS;
+        min-block-size: $euiSizeXXL - $euiSizeS;
         font-size: 0;
         display: block;
       }

--- a/src/components/comment_list/_comment_timeline.scss
+++ b/src/components/comment_list/_comment_timeline.scss
@@ -1,5 +1,5 @@
 .euiCommentTimeline__content {
-  min-width: $euiSizeXXL;
+  min-inline-size: $euiSizeXXL;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/context_menu/_context_menu.scss
+++ b/src/components/context_menu/_context_menu.scss
@@ -2,7 +2,7 @@ $euiContextMenuWidth: $euiSize * 16;
 
 .euiContextMenu {
   width: $euiContextMenuWidth;
-  max-width: 100%;
+  max-inline-size: 100%;
   position: relative;
   overflow: hidden;
   transition: height $euiAnimSpeedFast $euiAnimSlightResistance;

--- a/src/components/context_menu/_context_menu.scss
+++ b/src/components/context_menu/_context_menu.scss
@@ -23,5 +23,5 @@ $euiContextMenuWidth: $euiSize * 16;
 }
 
 .euiContextMenu__icon {
-  margin-right: $euiSizeS;
+  margin-inline-end: $euiSizeS;
 }

--- a/src/components/context_menu/_context_menu_item.scss
+++ b/src/components/context_menu/_context_menu_item.scss
@@ -2,7 +2,7 @@
   display: block;
   padding: $euiSizeM;
   width: 100%;
-  text-align: left;
+  text-align: start;
   color: $euiTextColor;
 
   &:hover,

--- a/src/components/context_menu/_context_menu_panel.scss
+++ b/src/components/context_menu/_context_menu_panel.scss
@@ -37,7 +37,7 @@
   @include euiPopoverTitle;
 
   width: 100%;
-  text-align: left;
+  text-align: start;
 
   &:hover,
   &:focus {

--- a/src/components/control_bar/_control_bar.scss
+++ b/src/components/control_bar/_control_bar.scss
@@ -6,10 +6,10 @@
   // This large box shadow helps prevent a flicker of dark
   // background when the content is shown and hidden
   box-shadow: inset 0 $euiControlBarInitialHeight 0 $euiControlBarBackground, inset 0 600rem 0 $euiPageBackgroundColor;
-  bottom: 0;
+  inset-block-end: 0;
   transform: translateY(0);
   height: $euiControlBarInitialHeight;
-  max-height: $euiControlBarMaxHeight;
+  max-block-size: $euiControlBarMaxHeight;
 
   &--fixed {
     position: fixed;
@@ -34,19 +34,19 @@
   &-isOpen.euiControlBar--large {
     animation-name: euiControlBarOpenPanelLarge;
     height: $euiControlBarMaxHeight;
-    bottom: map-get($euiControlBarHeights, 'l') * -1;
+    inset-block-end: map-get($euiControlBarHeights, 'l') * -1;
   }
 
   &-isOpen.euiControlBar--medium {
     animation-name: euiControlBarOpenPanelMedium;
     height: map-get($euiControlBarHeights, 'm');
-    bottom: map-get($euiControlBarHeights, 'm') * -1;
+    inset-block-end: map-get($euiControlBarHeights, 'm') * -1;
   }
 
   &-isOpen.euiControlBar--small {
     animation-name: euiControlBarOpenPanelSmall;
     height: map-get($euiControlBarHeights, 's');
-    bottom: map-get($euiControlBarHeights, 's') * -1;
+    inset-block-end: map-get($euiControlBarHeights, 's') * -1;
   }
 }
 
@@ -86,8 +86,8 @@
 
 .euiControlBar__buttonIcon {
   flex-shrink: 0;
-  min-width: $euiControlBarInitialHeight;
-  min-height: $euiControlBarInitialHeight;
+  min-inline-size: $euiControlBarInitialHeight;
+  min-block-size: $euiControlBarInitialHeight;
 }
 
 .euiControlBar__button {

--- a/src/components/control_bar/_control_bar.scss
+++ b/src/components/control_bar/_control_bar.scss
@@ -57,8 +57,10 @@
   align-items: center;
   overflow-y: hidden; // Ensures the movement of buttons in :focus don't cause scrollbars
   overflow-x: auto;
-  padding-block: 0;
-  padding-inline: $euiSizeM;
+  padding-block-start: 0;
+  padding-block-end: 0;
+  padding-inline-start: $euiSizeM;
+  padding-inline-end: $euiSizeM;
 }
 
 .euiControlBar__content {
@@ -129,8 +131,10 @@
 .euiControlBar__text {
   @include euiTextTruncate;
   @include euiFontSizeS;
-  padding-block: 0;
-  padding-inline: $euiSizeS;
+  padding-block-start: 0;
+  padding-block-end: 0;
+  padding-inline-start: $euiSizeS;
+  padding-inline-end: $euiSizeS;
   color: $euiControlBarText;
 
   &:last-child {
@@ -142,8 +146,10 @@
   @include euiTextTruncate;
   @include euiFontSizeS;
   color: $euiControlBarText;
-  padding-block: 0;
-  padding-inline: $euiSize;
+  padding-block-start: 0;
+  padding-block-end: 0;
+  padding-inline-start: $euiSize;
+  padding-inline-end: $euiSize;
   text-align: center;
   height: 100%;
 

--- a/src/components/control_bar/_control_bar.scss
+++ b/src/components/control_bar/_control_bar.scss
@@ -57,7 +57,8 @@
   align-items: center;
   overflow-y: hidden; // Ensures the movement of buttons in :focus don't cause scrollbars
   overflow-x: auto;
-  padding: 0 $euiSizeM;
+  padding-block: 0;
+  padding-inline: $euiSizeM;
 }
 
 .euiControlBar__content {
@@ -77,8 +78,8 @@
 
 .euiControlBar__icon {
   flex-shrink: 0;
-  margin-left: $euiSizeS;
-  margin-right: $euiSizeS;
+  margin-inline-start: $euiSizeS;
+  margin-inline-end: $euiSizeS;
 }
 
 .euiControlBar__buttonIcon {
@@ -90,7 +91,7 @@
 .euiControlBar__button {
   flex-shrink: 0;
   border-radius: $euiBorderRadius / 2;
-  margin-left: $euiSizeXS;
+  margin-inline-start: $euiSizeXS;
   font-size: $euiFontSizeS;
 
   &:enabled:hover {
@@ -99,7 +100,7 @@
   }
 
   &:last-child {
-    margin-right: $euiSizeXS;
+    margin-inline-end: $euiSizeXS;
   }
 }
 
@@ -128,11 +129,12 @@
 .euiControlBar__text {
   @include euiTextTruncate;
   @include euiFontSizeS;
-  padding: 0 $euiSizeS;
+  padding-block: 0;
+  padding-inline: $euiSizeS;
   color: $euiControlBarText;
 
   &:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
 }
 
@@ -140,7 +142,8 @@
   @include euiTextTruncate;
   @include euiFontSizeS;
   color: $euiControlBarText;
-  padding: 0 $euiSize;
+  padding-block: 0;
+  padding-inline: $euiSize;
   text-align: center;
   height: 100%;
 

--- a/src/components/datagrid/_data_grid.scss
+++ b/src/components/datagrid/_data_grid.scss
@@ -17,9 +17,9 @@
   background: $euiColorEmptyShade;
 
   .euiDataGrid__pagination {
-    padding-bottom: $euiSizeXS;
+    padding-block-end: $euiSizeXS;
     background: $euiColorLightestShade;
-    border-top: $euiBorderThin;
+    border-block-start: $euiBorderThin;
   }
 
   .euiDataGrid__verticalScroll .euiDataGridRow {
@@ -48,7 +48,7 @@
   flex-grow: 0;
 
   > * {
-    margin-left: $euiSizeXS / 2;
+    margin-inline-start: $euiSizeXS / 2;
   }
 }
 
@@ -75,16 +75,16 @@
 
 @include euiDataGridStyles(bordersHorizontal) {
   .euiDataGrid__controls {
-    border-right: none;
-    border-left: none;
-    border-top: none;
+    border-inline-end: none;
+    border-inline-start: none;
+    border-block-start: none;
     background: $euiColorEmptyShade;
   }
 }
 
 .euiDataGrid__pagination {
 
-  padding-top: $euiSizeXS;
+  padding-block-start: $euiSizeXS;
   flex-grow: 0;
 }
 

--- a/src/components/datagrid/_data_grid.scss
+++ b/src/components/datagrid/_data_grid.scss
@@ -9,10 +9,10 @@
 .euiDataGrid--fullScreen {
   height: 100%;
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  inset-block-start: 0;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
+  inset-block-end: 0;
   z-index: $euiZModal;
   background: $euiColorEmptyShade;
 
@@ -34,7 +34,7 @@
   overflow: auto;
   font-feature-settings: 'tnum' 1; // Tabular numbers
   scroll-padding: 0;
-  max-width: 100%;
+  max-inline-size: 100%;
   width: 100%;
   z-index: 2; // Sits above the pagination below it, but below the controls above it
 }
@@ -109,7 +109,7 @@
 
 .euiDataGrid__controlScroll {
   @include euiYScrollWithShadows;
-  max-height: $euiDataGridPopoverMaxHeight;
+  max-block-size: $euiDataGridPopoverMaxHeight;
   padding: $euiSizeS;
   margin: -$euiSizeS; // Offset against the panel to make the scrollbar flush scrollbars
 }

--- a/src/components/datagrid/_data_grid_column_resizer.scss
+++ b/src/components/datagrid/_data_grid_column_resizer.scss
@@ -1,8 +1,8 @@
   // Resizer straddles the column border and is an invisible hitzone for dragging
 .euiDataGridColumnResizer {
   position: absolute;
-  top: 0;
-  right: -$euiSizeS;
+  inset-block-start: 0;
+  inset-inline-end: -$euiSizeS;
   height: 100%;
   width: $euiSize;
   cursor: ew-resize;
@@ -13,9 +13,9 @@
   &:after {
     content: '';
     position: absolute;
-    left: $euiSizeS - 1px;
-    top: 0;
-    bottom: 0;
+    inset-inline-start: $euiSizeS - 1px;
+    inset-block-start: 0;
+    inset-block-end: 0;
     width: $euiDataGridColumnResizerWidth;
     background-color: $euiColorPrimary;
   }
@@ -37,11 +37,11 @@
   &:last-child {
 
     .euiDataGridColumnResizer {
-      right: 0;
+      inset-inline-end: 0;
 
       &:after {
-        left: auto;
-        right: 0;
+        inset-inline-start: auto;
+        inset-inline-end: 0;
       }
     }
   }

--- a/src/components/datagrid/_data_grid_column_selector.scss
+++ b/src/components/datagrid/_data_grid_column_selector.scss
@@ -11,7 +11,8 @@
 .euiDataGridColumnSelector__columnList {
   @include euiYScrollWithShadows;
   max-height: 400px;
-  margin: 0 (-$euiSizeS);
+  margin-block: 0;
+  margin-inline: (-$euiSizeS);
 }
 
 .euiDataGridColumnSelector__itemLabel {
@@ -23,7 +24,7 @@
   // sass-lint:disable-block no-important
   transform: none !important;
   transition: none !important;
-  margin-top: -$euiSizeS;
+  margin-block-start: -$euiSizeS;
   // IE11 needs a min-width
   min-width: $euiSize * 12;
 }

--- a/src/components/datagrid/_data_grid_column_selector.scss
+++ b/src/components/datagrid/_data_grid_column_selector.scss
@@ -10,7 +10,7 @@
 // Because we only want this to scroll vertically, we need to offset inner euiFlexGroup negative padding by adding padding
 .euiDataGridColumnSelector__columnList {
   @include euiYScrollWithShadows;
-  max-height: 400px;
+  max-block-size: 400px;
   margin-block-start: 0;
   margin-block-end: 0;
   margin-inline-start: (-$euiSizeS);
@@ -28,5 +28,5 @@
   transition: none !important;
   margin-block-start: -$euiSizeS;
   // IE11 needs a min-width
-  min-width: $euiSize * 12;
+  min-inline-size: $euiSize * 12;
 }

--- a/src/components/datagrid/_data_grid_column_selector.scss
+++ b/src/components/datagrid/_data_grid_column_selector.scss
@@ -11,8 +11,10 @@
 .euiDataGridColumnSelector__columnList {
   @include euiYScrollWithShadows;
   max-height: 400px;
-  margin-block: 0;
-  margin-inline: (-$euiSizeS);
+  margin-block-start: 0;
+  margin-block-end: 0;
+  margin-inline-start: (-$euiSizeS);
+  margin-inline-end: (-$euiSizeS);
 }
 
 .euiDataGridColumnSelector__itemLabel {

--- a/src/components/datagrid/_data_grid_column_sorting.scss
+++ b/src/components/datagrid/_data_grid_column_sorting.scss
@@ -13,7 +13,7 @@
   transition: none !important;
   margin-block-start: -$euiSizeS;
   // IE11 needs a min-width
-  min-width: $euiSize * 12;
+  min-inline-size: $euiSize * 12;
 }
 
 .euiDataGridColumnSorting__button {
@@ -26,7 +26,7 @@
 
 .euiDataGridColumnSorting__fieldList {
   @include euiYScrollWithShadows;
-  max-height: 300px;
+  max-block-size: 300px;
 }
 
 .euiDataGridColumnSorting__field {
@@ -44,7 +44,7 @@
   padding-inline-start: $euiSizeL;
 
   .euiDataGridColumnSorting__order {
-    min-width: 200px;
+    min-inline-size: 200px;
     border: none;
 
     // Hack to overwrite some nested, unreachable component code with button groups

--- a/src/components/datagrid/_data_grid_column_sorting.scss
+++ b/src/components/datagrid/_data_grid_column_sorting.scss
@@ -11,7 +11,7 @@
   // sass-lint:disable-block no-important
   transform: none !important;
   transition: none !important;
-  margin-top: -$euiSizeS;
+  margin-block-start: -$euiSizeS;
   // IE11 needs a min-width
   min-width: $euiSize * 12;
 }
@@ -41,7 +41,7 @@
 }
 
 .euiDataGridColumnSorting__orderButtons {
-  padding-left: $euiSizeL;
+  padding-inline-start: $euiSizeL;
 
   .euiDataGridColumnSorting__order {
     min-width: 200px;

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -1,6 +1,6 @@
 .euiDataGridRow {
   display: inline-flex;
-  min-width: 100%; // Needed to prevent wraps. Inline flex is tricky
+  min-inline-size: 100%; // Needed to prevent wraps. Inline flex is tricky
 }
 
 @include euiDataGridRowCell {

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -17,7 +17,7 @@
 
   // Hack to allow for all the focus guard stuff
   > * {
-    max-width: 100%;
+    max-inline-size: 100%;
     width: 100%;
   }
 
@@ -81,13 +81,13 @@
   @include euiScrollBar;
   overflow: auto;
   // sass-lint:disable-block no-important
-  max-width: 400px !important;
-  max-height: 400px !important;
+  max-inline-size: 400px !important;
+  max-block-size: 400px !important;
 }
 
 .euiDataGridRowCell__expand {
   width: 100%;
-  max-width: 100%;
+  max-inline-size: 100%;
 }
 
 .euiDataGridRowCell__expandFlex {
@@ -112,13 +112,13 @@
 
 .euiDataGridRowCell__expandButtonIcon {
   height: $euiSizeM;
-  min-height: $euiSizeM;
+  min-block-size: $euiSizeM;
   background: $euiColorPrimary;
   color: $euiColorGhost;
   border-radius: $euiBorderRadius / 2;
   padding: 0;
   width: 0;
-  min-width: 0;
+  min-inline-size: 0;
   overflow: hidden;
   visibility: hidden;
 

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -53,11 +53,11 @@
   }
 
   &.euiDataGridRowCell--numeric {
-    text-align: right;
+    text-align: end;
   }
 
   &.euiDataGridRowCell--currency {
-    text-align: right;
+    text-align: end;
   }
 
 

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -7,8 +7,8 @@
   @include euiFontSizeS;
 
   padding: $euiDataGridCellPaddingM;
-  border-right: $euiDataGridVerticalBorder;
-  border-bottom: $euiBorderThin;
+  border-inline-end: $euiDataGridVerticalBorder;
+  border-block-end: $euiBorderThin;
   flex: 0 0 auto;
   background: $euiColorEmptyShade;
   position: relative;
@@ -22,22 +22,22 @@
   }
 
   &:first-of-type {
-    border-left: $euiBorderThin;
+    border-inline-start: $euiBorderThin;
   }
 
   &:last-of-type {
-    border-right-color: $euiBorderColor;
+    border-inline-end-color: $euiBorderColor;
   }
 
   &:focus {
     border: 1px solid transparent;
-    margin-top: -1px;
+    margin-block-start: -1px;
     box-shadow: 0 0 0 2px $euiFocusRingColor;
     border-radius: 1px;
     z-index: 2; // Needed so it sits above potential striping in the next row
 
     .euiDataGridRowCell__expandButton {
-      margin-left: $euiDataGridCellPaddingM;
+      margin-inline-start: $euiDataGridCellPaddingM;
     }
 
     .euiDataGridRowCell__expandButtonIcon {
@@ -49,7 +49,7 @@
 
   &:focus:not(:first-of-type) {
     // Needed because the focus state adds a border, which needs to be subtracted from padding
-    padding-left: $euiDataGridCellPaddingM - 1px;
+    padding-inline-start: $euiDataGridCellPaddingM - 1px;
   }
 
   &.euiDataGridRowCell--numeric {
@@ -106,7 +106,7 @@
 
   &-isActive,
   &:focus {
-    margin-left: $euiDataGridCellPaddingM;
+    margin-inline-start: $euiDataGridCellPaddingM;
   }
 }
 
@@ -160,8 +160,8 @@
 
 @include euiDataGridStyles(bordersHorizontal) {
   @include euiDataGridRowCell {
-    border-right-color: transparent;
-    border-left-color: transparent;
+    border-inline-end-color: transparent;
+    border-inline-start-color: transparent;
   }
 }
 
@@ -185,7 +185,7 @@
 
     &:focus:not(:first-of-type) {
       // Needed because the focus state adds a border, which needs to be subtracted from padding
-      padding-left: $euiDataGridCellPaddingS - 1px;
+      padding-inline-start: $euiDataGridCellPaddingS - 1px;
     }
   }
 }
@@ -196,7 +196,7 @@
 
     &:focus:not(:first-of-type) {
       // Needed because the focus state adds a border, which needs to be subtracted from padding
-      padding-left: $euiDataGridCellPaddingL - 1px;
+      padding-inline-start: $euiDataGridCellPaddingL - 1px;
     }
   }
 }

--- a/src/components/datagrid/_data_grid_header_row.scss
+++ b/src/components/datagrid/_data_grid_header_row.scss
@@ -1,6 +1,6 @@
 .euiDataGridHeader {
   display: inline-flex;
-  min-width: 100%; // Needed to prevent wraps. Inline flex is tricky
+  min-inline-size: 100%; // Needed to prevent wraps. Inline flex is tricky
   z-index: 3; // Needs to sit above the content and focused cells
   background: $euiColorLightestShade;
   position: sticky; // In IE11 this does not work, but doesn't cause a break.

--- a/src/components/datagrid/_data_grid_header_row.scss
+++ b/src/components/datagrid/_data_grid_header_row.scss
@@ -4,7 +4,7 @@
   z-index: 3; // Needs to sit above the content and focused cells
   background: $euiColorLightestShade;
   position: sticky; // In IE11 this does not work, but doesn't cause a break.
-  top: 0;
+  inset-block-start: 0;
 }
 
 @include euiDataGridHeaderCell {
@@ -18,7 +18,7 @@
   display: flex;
 
   > * {
-    max-width: 100%;
+    max-inline-size: 100%;
     width: 100%;
   }
 

--- a/src/components/datagrid/_data_grid_header_row.scss
+++ b/src/components/datagrid/_data_grid_header_row.scss
@@ -58,17 +58,17 @@
 
 @include euiDataGridStyles(headerUnderline) {
   @include euiDataGridHeaderCell {
-    border-top: none;
-    border-left: none;
-    border-right: none;
-    border-bottom: $euiBorderThick;
-    border-bottom-color: $euiTextColor;
+    border-block-start: none;
+    border-inline-start: none;
+    border-inline-end: none;
+    border-block-end: $euiBorderThick;
+    border-block-end-color: $euiTextColor;
   }
 }
 
 @include euiDataGridStyles(bordersNone, headerUnderline) {
   @include euiDataGridHeaderCell {
-    border-bottom: $euiBorderThick;
+    border-block-end: $euiBorderThick;
     border-color: $euiTextColor;
   }
 }
@@ -81,20 +81,20 @@
 
 @include euiDataGridStyles(headerShade, bordersAll) {
   @include euiDataGridHeaderCell {
-    border-right: $euiBorderThin;
-    border-bottom: $euiBorderThin;
-    border-left: none;
+    border-inline-end: $euiBorderThin;
+    border-block-end: $euiBorderThin;
+    border-inline-start: none;
 
     &:first-of-type {
-      border-left: $euiBorderThin;
+      border-inline-start: $euiBorderThin;
     }
   }
 }
 
 @include euiDataGridStyles(headerShade, bordersHorizontal) {
   @include euiDataGridHeaderCell {
-    border-top: none;
-    border-bottom: $euiBorderThin;
+    border-block-start: none;
+    border-block-end: $euiBorderThin;
   }
 }
 
@@ -107,9 +107,9 @@
 
 @include euiDataGridStyles(borderhorizontal) {
   @include euiDataGridHeaderCell {
-    border-top: none;
-    border-right: none;
-    border-left: none;
+    border-block-start: none;
+    border-inline-end: none;
+    border-inline-start: none;
   }
 }
 
@@ -141,12 +141,12 @@
 
 @include euiDataGridStyles(noControls, bordersAll) {
   @include euiDataGridHeaderCell {
-    border-top: $euiBorderThin;
+    border-block-start: $euiBorderThin;
   }
 }
 
 @include euiDataGridStyles(noControls, bordersHorizontal) {
   @include euiDataGridHeaderCell {
-    border-top: $euiBorderThin;
+    border-block-start: $euiBorderThin;
   }
 }

--- a/src/components/datagrid/_data_grid_header_row.scss
+++ b/src/components/datagrid/_data_grid_header_row.scss
@@ -23,11 +23,11 @@
   }
 
   &.euiDataGridHeaderCell--numeric {
-    text-align: right;
+    text-align: end;
   }
 
   &.euiDataGridHeaderCell--currency {
-    text-align: right;
+    text-align: end;
   }
 
   &:focus {

--- a/src/components/date_picker/_date_picker.scss
+++ b/src/components/date_picker/_date_picker.scss
@@ -154,8 +154,8 @@
 
 .react-datepicker__header__dropdown {
   padding-block-start: $euiSize;
-  padding-block-end: 0;
-  padding-inline-start: $euiSizeS;
+  padding-block-end: $euiSizeS;
+  padding-inline-start: 0;
   padding-inline-end: 0;
 }
 

--- a/src/components/date_picker/_date_picker.scss
+++ b/src/components/date_picker/_date_picker.scss
@@ -153,8 +153,10 @@
 }
 
 .react-datepicker__header__dropdown {
-  padding-block: $euiSize 0;
-  padding-inline: $euiSizeS 0;
+  padding-block-start: $euiSize;
+  padding-block-end: 0;
+  padding-inline-start: $euiSizeS;
+  padding-inline-end: 0;
 }
 
 .react-datepicker__year-dropdown-container--select,
@@ -164,8 +166,10 @@
 .react-datepicker__month-dropdown-container--scroll,
 .react-datepicker__month-year-dropdown-container--scroll {
   display: inline-block;
-  margin-block: 0;
-  margin-inline: $euiSizeXS;
+  margin-block-start: 0;
+  margin-block-end: 0;
+  margin-inline-start: $euiSizeXS;
+  margin-inline-end: $euiSizeXS;
 }
 
 .react-datepicker__current-month,
@@ -287,8 +291,10 @@
 // }
 
 .react-datepicker__month {
-  margin-block: 0 $euiSize;
-  margin-inline: $euiSize;
+  margin-block-start: 0;
+  margin-block-end: $euiSize;
+  margin-inline-start: $euiSize;
+  margin-inline-end: $euiSize;
   text-align: center;
   border-radius: $euiBorderRadius;
 }
@@ -297,8 +303,10 @@
   border-inline-start: $euiBorderColor;
   width: auto;
   display: flex;
-  padding-block: $euiSize;
-  padding-inline: 0;
+  padding-block-start: $euiSize;
+  padding-block-end: $euiSize;
+  padding-inline-start: 0;
+  padding-inline-end: 0;
   border-radius: 0 $euiBorderRadius $euiBorderRadius 0;
   flex-grow: 1;
 
@@ -328,8 +336,10 @@
         align-items: center;
 
         li.react-datepicker__time-list-item {
-          padding-block: $euiSizeXS;
-          padding-inline: $euiSizeS;
+          padding-block-start: $euiSizeXS;
+          padding-block-end: $euiSizeXS;
+          padding-inline-start: $euiSizeS;
+          padding-inline-end: $euiSizeS;
           margin-block-end: $euiSizeXS;
           text-align: right;
           color: $euiColorDarkShade;
@@ -371,8 +381,10 @@
   width: $euiSizeXL;
   line-height: $euiSizeXL - $euiSizeXS;
   text-align: center;
-  margin-block: 0;
-  margin-inline: $euiSizeXS;
+  margin-block-start: 0;
+  margin-block-end: 0;
+  margin-inline-start: $euiSizeXS;
+  margin-inline-end: $euiSizeXS;
   &.react-datepicker__week-number--clickable {
     cursor: pointer;
     &:hover {
@@ -395,8 +407,10 @@
   width: $euiSizeXL;
   line-height: $euiSizeXL - $euiSizeXS;
   text-align: center;
-  margin-block: 0;
-  margin-inline: $euiSizeXS / 2;
+  margin-block-start: 0;
+  margin-block-end: 0;
+  margin-inline-start: $euiSizeXS / 2;
+  margin-inline-end: $euiSizeXS / 2;
 }
 
 .react-datepicker__day-name {
@@ -447,8 +461,10 @@
   &--selected,
   &--in-selecting-range {
     height: $euiSizeXL;
-    margin-block: 0;
-    margin-inline: $euiSizeXS / 2;
+    margin-block-start: 0;
+    margin-block-end: 0;
+    margin-inline-start: $euiSizeXS / 2;
+    margin-inline-end: $euiSizeXS / 2;
     border-radius: $euiBorderRadius;
     background-color: $euiColorPrimary;
     line-height: $euiSizeL + $euiSizeXS;

--- a/src/components/date_picker/_date_picker.scss
+++ b/src/components/date_picker/_date_picker.scss
@@ -187,7 +187,7 @@
   cursor: pointer;
   position: absolute;
   // Pixel pushing because these are icons against text
-  top: $euiSize + ($euiSizeXS / 2);
+  inset-block-start: $euiSize + ($euiSizeXS / 2);
   width: 0;
   padding: 0;
   z-index: 1;
@@ -196,7 +196,7 @@
 
   &--previous {
     @include datePicker__arrow;
-    left: $euiSize + $euiSizeXS;
+    inset-inline-start: $euiSize + $euiSizeXS;
     height: $euiSize;
     width: $euiSize;
     transform: rotate(90deg);
@@ -227,7 +227,7 @@
   &--next {
     @include datePicker__arrow;
     // Pixel value because of some padding on the icon
-    right: 20px;
+    inset-inline-end: 20px;
     height: $euiSize;
     width: $euiSize;
     transform: rotate(-90deg);
@@ -235,7 +235,7 @@
     &--with-time:not(&--with-today-button) {
       // This a pixel value against the width of the cal. It needs
       // to be left because the timepicker adds more width
-      left: 248px;
+      inset-inline-start: 248px;
     }
 
     &:hover, &:focus {
@@ -262,13 +262,13 @@
 
   &--years {
     position: relative;
-    top: 0;
+    inset-block-start: 0;
     display: block;
     margin-inline-start: auto;
     margin-inline-end: auto;
 
     &-previous {
-      top: $euiSizeXS;
+      inset-block-start: $euiSizeXS;
       border-block-start-color: $euiColorLightestShade;
 
       &:hover {
@@ -277,7 +277,7 @@
     }
 
     &-upcoming {
-      top: -$euiSizeXS;
+      inset-block-start: -$euiSizeXS;
       border-block-end-color: $euiColorLightestShade;
 
       &:hover {
@@ -548,10 +548,10 @@
   position: absolute;
   width: 100%;
   height: 100%;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  right: 0;
+  inset-inline-start: 0;
+  inset-block-start: 0;
+  inset-block-end: 0;
+  inset-inline-end: 0;
   z-index: 1;
   text-align: center;
   border-radius: $euiBorderRadius;
@@ -628,8 +628,8 @@
 
 .react-datepicker__screenReaderOnly {
   position: absolute;
-  left: -10000px;
-  top: auto;
+  inset-inline-start: -10000px;
+  inset-block-start: auto;
   width: 1px;
   height: 1px;
   overflow: hidden;
@@ -692,7 +692,7 @@
 
   // This resizes EUI's normal form control to be the width of the calendar
   .euiDatePicker--inline {
-    max-width: $euiDatePickerCalendarWidth;
+    max-inline-size: $euiDatePickerCalendarWidth;
     display: block;
   }
 

--- a/src/components/date_picker/_date_picker.scss
+++ b/src/components/date_picker/_date_picker.scss
@@ -79,7 +79,7 @@
 
         .react-datepicker__time-list li.react-datepicker__time-list-item {
           font-size: $euiFontSizeS;
-          text-align: left;
+          text-align: start;
           padding-inline-start: $euiSizeXL + $euiSizeXS;
           padding-inline-end: $euiSizeXL + $euiSizeXS;
           color: $euiTextColor;
@@ -341,7 +341,7 @@
           padding-inline-start: $euiSizeS;
           padding-inline-end: $euiSizeS;
           margin-block-end: $euiSizeXS;
-          text-align: right;
+          text-align: end;
           color: $euiColorDarkShade;
           white-space: nowrap;
           // IE needs this to fix collapsing flex

--- a/src/components/date_picker/_date_picker.scss
+++ b/src/components/date_picker/_date_picker.scss
@@ -80,8 +80,8 @@
         .react-datepicker__time-list li.react-datepicker__time-list-item {
           font-size: $euiFontSizeS;
           text-align: left;
-          padding-left: $euiSizeXL + $euiSizeXS;
-          padding-right: $euiSizeXL + $euiSizeXS;
+          padding-inline-start: $euiSizeXL + $euiSizeXS;
+          padding-inline-end: $euiSizeXL + $euiSizeXS;
           color: $euiTextColor;
 
           &.react-datepicker__time-list-item--selected {
@@ -94,7 +94,7 @@
 
 
   .react-datepicker__time-container {
-    border-left: 0;
+    border-inline-start: 0;
   }
 
   // .react-datepicker__triangle {
@@ -128,14 +128,14 @@
   }
 
   &[data-placement^="right"] {
-    margin-left: 0;
+    margin-inline-start: 0;
 
     // .react-datepicker__triangle {
     // }
   }
 
   &[data-placement^="left"] {
-    margin-right: 0;
+    margin-inline-end: 0;
 
     // .react-datepicker__triangle {
     // }
@@ -153,7 +153,8 @@
 }
 
 .react-datepicker__header__dropdown {
-  padding: $euiSize 0 $euiSizeS 0;
+  padding-block: $euiSize 0;
+  padding-inline: $euiSizeS 0;
 }
 
 .react-datepicker__year-dropdown-container--select,
@@ -163,7 +164,8 @@
 .react-datepicker__month-dropdown-container--scroll,
 .react-datepicker__month-year-dropdown-container--scroll {
   display: inline-block;
-  margin: 0 $euiSizeXS;
+  margin-block: 0;
+  margin-inline: $euiSizeXS;
 }
 
 .react-datepicker__current-month,
@@ -258,24 +260,24 @@
     position: relative;
     top: 0;
     display: block;
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
 
     &-previous {
       top: $euiSizeXS;
-      border-top-color: $euiColorLightestShade;
+      border-block-start-color: $euiColorLightestShade;
 
       &:hover {
-        border-top-color: darken($euiColorLightestShade, 10%);
+        border-block-start-color: darken($euiColorLightestShade, 10%);
       }
     }
 
     &-upcoming {
       top: -$euiSizeXS;
-      border-bottom-color: $euiColorLightestShade;
+      border-block-end-color: $euiColorLightestShade;
 
       &:hover {
-        border-bottom-color: darken($euiColorLightestShade, 10%);
+        border-block-end-color: darken($euiColorLightestShade, 10%);
       }
     }
   }
@@ -285,16 +287,18 @@
 // }
 
 .react-datepicker__month {
-  margin: 0 $euiSize $euiSize $euiSize;
+  margin-block: 0 $euiSize;
+  margin-inline: $euiSize;
   text-align: center;
   border-radius: $euiBorderRadius;
 }
 
 .react-datepicker__time-container {
-  border-left: $euiBorderColor;
+  border-inline-start: $euiBorderColor;
   width: auto;
   display: flex;
-  padding: $euiSize 0;
+  padding-block: $euiSize;
+  padding-inline: 0;
   border-radius: 0 $euiBorderRadius $euiBorderRadius 0;
   flex-grow: 1;
 
@@ -305,7 +309,7 @@
     position: relative;
     flex-grow: 1;
     display: flex;
-    padding-left: $euiSizeXS;
+    padding-inline-start: $euiSizeXS;
     flex-direction: column;
 
     .react-datepicker__time-box {
@@ -324,8 +328,9 @@
         align-items: center;
 
         li.react-datepicker__time-list-item {
-          padding: $euiSizeXS $euiSizeS;
-          margin-bottom: $euiSizeXS;
+          padding-block: $euiSizeXS;
+          padding-inline: $euiSizeS;
+          margin-block-end: $euiSizeXS;
           text-align: right;
           color: $euiColorDarkShade;
           white-space: nowrap;
@@ -366,7 +371,8 @@
   width: $euiSizeXL;
   line-height: $euiSizeXL - $euiSizeXS;
   text-align: center;
-  margin: 0 $euiSizeXS;
+  margin-block: 0;
+  margin-inline: $euiSizeXS;
   &.react-datepicker__week-number--clickable {
     cursor: pointer;
     &:hover {
@@ -389,7 +395,8 @@
   width: $euiSizeXL;
   line-height: $euiSizeXL - $euiSizeXS;
   text-align: center;
-  margin: 0 $euiSizeXS / 2;
+  margin-block: 0;
+  margin-inline: $euiSizeXS / 2;
 }
 
 .react-datepicker__day-name {
@@ -430,17 +437,18 @@
     background-color: transparentize($euiColorPrimary, .9);
     color: $euiColorFullShade;
     border-radius: 0;
-    border-top: solid 6px $euiColorEmptyShade;
-    border-bottom: solid 6px $euiColorEmptyShade;
-    border-right: none;
-    border-left: none;
+    border-block-start: solid 6px $euiColorEmptyShade;
+    border-block-end: solid 6px $euiColorEmptyShade;
+    border-inline-end: none;
+    border-inline-start: none;
     line-height: $euiSizeL - $euiSizeXS;
   }
 
   &--selected,
   &--in-selecting-range {
     height: $euiSizeXL;
-    margin: 0 $euiSizeXS / 2;
+    margin-block: 0;
+    margin-inline: $euiSizeXS / 2;
     border-radius: $euiBorderRadius;
     background-color: $euiColorPrimary;
     line-height: $euiSizeL + $euiSizeXS;
@@ -508,7 +516,7 @@
 
     .react-datepicker__year-read-view--down-arrow,
     .react-datepicker__month-read-view--down-arrow {
-      border-top-color: darken($euiColorLightestShade, 10%);
+      border-block-start-color: darken($euiColorLightestShade, 10%);
     }
   }
 
@@ -589,11 +597,11 @@
     background-color: $euiColorLightestShade;
 
     .react-datepicker__navigation--years-upcoming {
-      border-bottom-color: darken($euiColorLightestShade, 10%);
+      border-block-end-color: darken($euiColorLightestShade, 10%);
     }
 
     .react-datepicker__navigation--years-previous {
-      border-top-color: darken($euiColorLightestShade, 10%);
+      border-block-start-color: darken($euiColorLightestShade, 10%);
     }
   }
 
@@ -640,8 +648,8 @@
   background: $euiFocusBackgroundColor;
 
   .react-datepicker__day--in-range:not(.react-datepicker__day--selected) {
-    border-top-color: $euiFocusBackgroundColor;
-    border-bottom-color: $euiFocusBackgroundColor;
+    border-block-start-color: $euiFocusBackgroundColor;
+    border-block-end-color: $euiFocusBackgroundColor;
   }
 }
 .react-datepicker__navigation:focus {

--- a/src/components/date_picker/_date_picker_range.scss
+++ b/src/components/date_picker/_date_picker_range.scss
@@ -23,7 +23,7 @@
 
   .react-datepicker-popper .euiFieldText.euiDatePicker {
     // set any subsequent children in popper back to left align
-    text-align: left;
+    text-align: start;
   }
 
   &--inGroup {

--- a/src/components/date_picker/_date_picker_range.scss
+++ b/src/components/date_picker/_date_picker_range.scss
@@ -41,8 +41,8 @@
     background-color: transparent !important; // override .euiFormControlLayout--group .euiText
     line-height: 1 !important;
     flex: 0 0 auto;
-    padding-left: $euiFormControlPadding / 2;
-    padding-right: $euiFormControlPadding / 2;
+    padding-inline-start: $euiFormControlPadding / 2;
+    padding-inline-end: $euiFormControlPadding / 2;
   }
 }
 

--- a/src/components/date_picker/super_date_picker/_mixins.scss
+++ b/src/components/date_picker/super_date_picker/_mixins.scss
@@ -2,7 +2,8 @@
   @include euiFormControlText;
   display: block;
   width: 100%;
-  padding: 0 $euiSizeS;
+  padding-block: 0;
+  padding-inline: $euiSizeS;
   line-height: $euiFormControlLayoutGroupInputHeight;
   height: $euiFormControlLayoutGroupInputHeight;
   word-break: break-all;

--- a/src/components/date_picker/super_date_picker/_mixins.scss
+++ b/src/components/date_picker/super_date_picker/_mixins.scss
@@ -2,8 +2,10 @@
   @include euiFormControlText;
   display: block;
   width: 100%;
-  padding-block: 0;
-  padding-inline: $euiSizeS;
+  padding-block-start: 0;
+  padding-block-end: 0;
+  padding-inline-start: $euiSizeS;
+  padding-inline-end: $euiSizeS;
   line-height: $euiFormControlLayoutGroupInputHeight;
   height: $euiFormControlLayoutGroupInputHeight;
   word-break: break-all;

--- a/src/components/date_picker/super_date_picker/_super_date_picker.scss
+++ b/src/components/date_picker/super_date_picker/_super_date_picker.scss
@@ -41,7 +41,7 @@
   @include euiSuperDatePickerText;
   display: flex;
   justify-content: space-between;
-  text-align: left;
+  text-align: start;
 
   &:not(:disabled):hover,
   &:focus {

--- a/src/components/date_picker/super_date_picker/_super_date_picker.scss
+++ b/src/components/date_picker/super_date_picker/_super_date_picker.scss
@@ -1,6 +1,6 @@
 .euiSuperDatePicker__flexWrapper {
   // Need to offset 8px because of negative margins added by small size gutter
-  max-width: calc(100% + #{$euiSizeS});
+  max-inline-size: calc(100% + #{$euiSizeS});
   width: $euiSuperDatePickerWidth + $euiSuperDatePickerButtonWidth + $euiSizeS;
 }
 
@@ -17,14 +17,14 @@
 .euiSuperDatePicker {
   // sass-lint:disable-block no-important
   // Allow it to always grow to fit the container since the default form max width is too small
-  max-width: 100% !important;
+  max-inline-size: 100% !important;
 
   > .euiFormControlLayout__childrenWrapper {
     flex: 1 1 100%;
     overflow: hidden;
 
     > .euiDatePickerRange {
-      max-width: none;
+      max-inline-size: none;
       width: auto;
       border-radius: 0 $euiFormControlBorderRadius $euiFormControlBorderRadius 0;
     }

--- a/src/components/date_picker/super_date_picker/_super_date_picker.scss
+++ b/src/components/date_picker/super_date_picker/_super_date_picker.scss
@@ -65,7 +65,7 @@
 
 .euiSuperDatePicker__prettyFormatLink {
   color: $euiLinkColor;
-  padding-left: $euiSizeXS; // Adds some separation between date text and link
+  padding-inline-start: $euiSizeXS; // Adds some separation between date text and link
   flex-shrink: 0;
 }
 
@@ -78,6 +78,6 @@
 
   .euiSuperDatePicker__prettyFormatLink {
     flex-shrink: 1;
-    min-width: 3em; // Ensures at least "Show" is always visible
+    min-inline-size: 3em; // Ensures at least "Show" is always visible
   }
 }

--- a/src/components/date_picker/super_date_picker/_super_date_picker.scss
+++ b/src/components/date_picker/super_date_picker/_super_date_picker.scss
@@ -34,7 +34,7 @@
 .euiSuperDatePicker__startPopoverButton {
   // Fixes margin around delimiter
   // Only needed on first popover since basic .euiFormControlLayout takes care of the last one
-  margin-right: -$euiSizeM;
+  margin-inline-end: -$euiSizeM;
 }
 
 .euiSuperDatePicker__prettyFormat {

--- a/src/components/date_picker/super_date_picker/_super_update_button.scss
+++ b/src/components/date_picker/super_date_picker/_super_update_button.scss
@@ -1,11 +1,11 @@
 .euiSuperUpdateButton {
   // Just wide enough for all 3 states
-  min-width: $euiSuperDatePickerButtonWidth;
+  min-inline-size: $euiSuperDatePickerButtonWidth;
 }
 
 @include euiBreakpoint('xs', 's') {
   .euiSuperUpdateButton {
-    min-width: 0;
+    min-inline-size: 0;
 
     .euiSuperUpdateButton__text {
       display: none;

--- a/src/components/date_picker/super_date_picker/date_popover/_absolute_tab.scss
+++ b/src/components/date_picker/super_date_picker/date_popover/_absolute_tab.scss
@@ -1,3 +1,4 @@
 .euiSuperDatePicker__absoluteDateFormRow {
-  padding: 0 $euiSizeS $euiSizeS;
+  padding-block: 0 $euiSizeS;
+  padding-inline: $euiSizeS;
 }

--- a/src/components/date_picker/super_date_picker/date_popover/_absolute_tab.scss
+++ b/src/components/date_picker/super_date_picker/date_popover/_absolute_tab.scss
@@ -1,4 +1,6 @@
 .euiSuperDatePicker__absoluteDateFormRow {
-  padding-block: 0 $euiSizeS;
-  padding-inline: $euiSizeS;
+  padding-block-start: 0;
+  padding-block-end: $euiSizeS;
+  padding-inline-start: $euiSizeS;
+  padding-inline-end: $euiSizeS;
 }

--- a/src/components/date_picker/super_date_picker/date_popover/_date_popover_button.scss
+++ b/src/components/date_picker/super_date_picker/date_popover/_date_popover_button.scss
@@ -41,9 +41,9 @@
 }
 
 .euiDatePopoverButton--start {
-  text-align: right;
+  text-align: end;
 }
 
 .euiDatePopoverButton--end {
-  text-align: left;
+  text-align: start;
 }

--- a/src/components/date_picker/super_date_picker/date_popover/_date_popover_content.scss
+++ b/src/components/date_picker/super_date_picker/date_popover/_date_popover_content.scss
@@ -1,6 +1,6 @@
 .euiDatePopoverContent {
   width: $euiFormMaxWidth;
-  max-width: 100%;
+  max-inline-size: 100%;
 }
 
 .euiDatePopoverContent__padded {

--- a/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select.scss
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select.scss
@@ -1,4 +1,4 @@
 .euiQuickSelect__applyButton {
   // Allow the button to shrink
-  min-width: 0;
+  min-inline-size: 0;
 }

--- a/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select_popover.scss
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select_popover.scss
@@ -1,11 +1,11 @@
 .euiQuickSelectPopover__content {
   width: $euiFormMaxWidth;
-  max-width: 100%;
+  max-inline-size: 100%;
 }
 
 .euiQuickSelectPopover__section {
   @include euiScrollBar;
-  max-height: $euiSizeM * 11;
+  max-block-size: $euiSizeM * 11;
   overflow: hidden;
   overflow-y: auto;
   padding: $euiSizeXS 0; // Offset negative margin from flex items

--- a/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select_popover.scss
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select_popover.scss
@@ -8,7 +8,10 @@
   max-block-size: $euiSizeM * 11;
   overflow: hidden;
   overflow-y: auto;
-  padding: $euiSizeXS 0; // Offset negative margin from flex items
+  padding-block-start: $euiSizeXS; // Offset negative margin from flex items
+  padding-block-end: $euiSizeXS;
+  padding-inline-start: 0;
+  padding-inline-end: 0;
 }
 
 // sass-lint:disable no-important

--- a/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select_popover.scss
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select_popover.scss
@@ -14,7 +14,7 @@
 // sass-lint:disable no-important
 .euiQuickSelectPopover__buttonText {
   // Override specificity from universal and sibling selectors
-  margin-right: $euiSizeXS !important;
+  margin-inline-end: $euiSizeXS !important;
 }
 
 .euiQuickSelectPopover__anchor {

--- a/src/components/date_picker/super_date_picker/quick_select_popover/_refresh_interval.scss
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/_refresh_interval.scss
@@ -1,4 +1,4 @@
 .euiRefreshInterval__startButton {
   // Just enough to keep it the same size for "Start" and "Stop"
-  min-width: 90px;
+  min-inline-size: 90px;
 }

--- a/src/components/description_list/_description_list.scss
+++ b/src/components/description_list/_description_list.scss
@@ -94,7 +94,7 @@
     // Align the title to smash against the description.
     &.euiDescriptionList--center {
       .euiDescriptionList__title {
-        text-align: right;
+        text-align: end;
       }
     }
 

--- a/src/components/description_list/_description_list.scss
+++ b/src/components/description_list/_description_list.scss
@@ -177,10 +177,14 @@
       font-weight: $euiFontWeightRegular;
       background: $euiColorLightestShade;
       border: $euiBorderThin;
-      padding-block:  0;
-      padding-inline:  $euiSizeXS;
-      margin-block: 0;
-      margin-inline: $euiSizeXS;
+      padding-block-start:  0;
+      padding-block-end:  0;
+      padding-inline-start:  $euiSizeXS;
+      padding-inline-end:  $euiSizeXS;
+      margin-block-start: 0;
+      margin-block-end: 0;
+      margin-inline-start: $euiSizeXS;
+      margin-inline-end: $euiSizeXS;
 
       // Make sure the first <dt> doesn't get a margin.
       &:first-of-type {

--- a/src/components/description_list/_description_list.scss
+++ b/src/components/description_list/_description_list.scss
@@ -6,11 +6,11 @@
     .euiDescriptionList__title {
       @include euiTitle('xs');
       line-height: $euiLineHeight;
-      margin-top: $euiSize;
+      margin-block-start: $euiSize;
 
       // Make sure the first <dt> doesn't get a margin.
       &:first-of-type {
-        margin-top: 0;
+        margin-block-start: 0;
       }
     }
 
@@ -69,26 +69,26 @@
     flex-wrap: wrap;
 
     > * {
-      margin-top: $euiSize;
+      margin-block-start: $euiSize;
     }
 
     // First two items don't have margin
     > *:first-child,
     > :nth-child(2) {
-      margin-top: 0;
+      margin-block-start: 0;
     }
 
     .euiDescriptionList__title {
       @include euiTitle('xs');
       line-height: $euiLineHeight;
       width: 50%; // Flex-basis doesn't work in IE with padding
-      padding-right: $euiSizeS;
+      padding-inline-end: $euiSizeS;
     }
 
     .euiDescriptionList__description {
       @include euiFontSize;
       width: 50%; // Flex-basis doesn't work in IE with padding
-      padding-left: $euiSizeS;
+      padding-inline-start: $euiSizeS;
     }
 
     // Align the title to smash against the description.
@@ -146,7 +146,7 @@
 
       .euiDescriptionList__description {
         @include euiFontSizeS;
-        margin-top: 0;
+        margin-block-start: 0;
       }
 
       &.euiDescriptionList--center {
@@ -177,12 +177,14 @@
       font-weight: $euiFontWeightRegular;
       background: $euiColorLightestShade;
       border: $euiBorderThin;
-      padding:  0 $euiSizeXS;
-      margin: 0 $euiSizeXS;
+      padding-block:  0;
+      padding-inline:  $euiSizeXS;
+      margin-block: 0;
+      margin-inline: $euiSizeXS;
 
       // Make sure the first <dt> doesn't get a margin.
       &:first-of-type {
-        margin-left: 0;
+        margin-inline-start: 0;
       }
     }
 

--- a/src/components/empty_prompt/_empty_prompt.scss
+++ b/src/components/empty_prompt/_empty_prompt.scss
@@ -1,7 +1,7 @@
 @import '../text/_variables';
 
 .euiEmptyPrompt {
-  max-width: $euiTextConstrainedMaxWidth;
+  max-inline-size: $euiTextConstrainedMaxWidth;
   text-align: center;
   padding: $euiSizeL;
   margin: auto;

--- a/src/components/expression/_expression.scss
+++ b/src/components/expression/_expression.scss
@@ -33,7 +33,7 @@
   }
 
   &.euiExpression--truncate {
-    max-width: 100%;
+    max-inline-size: 100%;
 
     .euiExpression__description,
     .euiExpression__value {

--- a/src/components/expression/_expression.scss
+++ b/src/components/expression/_expression.scss
@@ -10,8 +10,10 @@
   border-block-end: $euiBorderWidthThick solid transparent;
   display: inline-block; /* 1 */
   text-align: left;
-  padding-block: ($euiSizeXS / 2);
-  padding-inline: 0;
+  padding-block-start: ($euiSizeXS / 2);
+  padding-block-end: ($euiSizeXS / 2);
+  padding-inline-start: 0;
+  padding-inline-end: 0;
   transition: all $euiAnimSpeedNormal ease-in-out;
   color: $euiTextColor;
 

--- a/src/components/expression/_expression.scss
+++ b/src/components/expression/_expression.scss
@@ -7,26 +7,27 @@
   @include euiFontSizeS;
   @include euiCodeFont;
 
-  border-bottom: $euiBorderWidthThick solid transparent;
+  border-block-end: $euiBorderWidthThick solid transparent;
   display: inline-block; /* 1 */
   text-align: left;
-  padding: ($euiSizeXS / 2) 0;
+  padding-block: ($euiSizeXS / 2);
+  padding-inline: 0;
   transition: all $euiAnimSpeedNormal ease-in-out;
   color: $euiTextColor;
 
   &:focus {
-    border-bottom-style: solid;
+    border-block-end-style: solid;
   }
 
   & + .euiExpression {
-    margin-left: $euiSizeS;
+    margin-inline-start: $euiSizeS;
   }
 
   &.euiExpression--columns {
     border-color: transparent;
     // Ensures there's no flash of the dashed style before turning solid for the active state
-    border-bottom-style: solid;
-    margin-bottom: $euiSizeXS;
+    border-block-end-style: solid;
+    margin-block-end: $euiSizeXS;
   }
 
   &.euiExpression--truncate {
@@ -48,20 +49,20 @@
 
 .euiExpression-isClickable {
   cursor: pointer;
-  border-bottom: $euiBorderEditable;
+  border-block-end: $euiBorderEditable;
 
   &:hover:not(:disabled) {
-    border-bottom-style: solid;
+    border-block-end-style: solid;
     transform: translateY(-1px);
   }
 }
 
 .euiExpression__icon {
-  margin-left: $euiSizeXS;
+  margin-inline-start: $euiSizeXS;
 }
 
 .euiExpression-isActive {
-  border-bottom-style: solid;
+  border-block-end-style: solid;
 }
 
 .euiExpression--columns {
@@ -86,7 +87,7 @@
 
   .euiExpression__description {
     text-align: right;
-    margin-right: $euiSizeS;
+    margin-inline-end: $euiSizeS;
     flex-shrink: 0; // Ensures it doesn't get smaller in case the value is really long
   }
 
@@ -95,7 +96,7 @@
   }
 
   .euiExpression__icon {
-    margin-top: $euiSizeXS;
+    margin-block-start: $euiSizeXS;
   }
 }
 
@@ -106,7 +107,7 @@
     }
 
     &.euiExpression-isActive {
-      border-bottom-color: $color;
+      border-block-end-color: $color;
       border-color: $color;
     }
 

--- a/src/components/expression/_expression.scss
+++ b/src/components/expression/_expression.scss
@@ -9,7 +9,7 @@
 
   border-block-end: $euiBorderWidthThick solid transparent;
   display: inline-block; /* 1 */
-  text-align: left;
+  text-align: start;
   padding-block-start: ($euiSizeXS / 2);
   padding-block-end: ($euiSizeXS / 2);
   padding-inline-start: 0;
@@ -88,7 +88,7 @@
   }
 
   .euiExpression__description {
-    text-align: right;
+    text-align: end;
     margin-inline-end: $euiSizeS;
     flex-shrink: 0; // Ensures it doesn't get smaller in case the value is really long
   }

--- a/src/components/facet/_facet_button.scss
+++ b/src/components/facet/_facet_button.scss
@@ -7,7 +7,7 @@
   @include euiFontSizeS;
 
   height: $euiButtonHeightSmall;
-  text-align: left;
+  text-align: start;
   text-decoration: none;
   transition: all $euiAnimSpeedFast ease-in;
 

--- a/src/components/facet/_facet_group.scss
+++ b/src/components/facet/_facet_group.scss
@@ -2,8 +2,8 @@
   .euiFacetGroup--#{$gutterName} {
     .euiFacetButton {
       // Split the margin between top and bottom
-      margin-top: $gutterSize / 2;
-      margin-bottom: $gutterSize / 2;
+      margin-block-start: $gutterSize / 2;
+      margin-block-end: $gutterSize / 2;
     }
 
     &.euiFacetGroup--horizontal {
@@ -12,10 +12,10 @@
       $gutterAdjustment: $euiSizeM + $gutterSize;
 
       // Collapse margin on the right side of the group to allow it to extend the full width
-      margin-left: -#{$gutterAdjustment};
+      margin-inline-start: -#{$gutterAdjustment};
 
       .euiFacetButton {
-        margin-left: $gutterAdjustment;
+        margin-inline-start: $gutterAdjustment;
         // Adjust the max-width so it fits within the allotted margin
         max-width: calc(100% - #{$gutterAdjustment});
       }

--- a/src/components/facet/_facet_group.scss
+++ b/src/components/facet/_facet_group.scss
@@ -17,7 +17,7 @@
       .euiFacetButton {
         margin-inline-start: $gutterAdjustment;
         // Adjust the max-width so it fits within the allotted margin
-        max-width: calc(100% - #{$gutterAdjustment});
+        max-inline-size: calc(100% - #{$gutterAdjustment});
       }
     }
   }

--- a/src/components/filter_group/_filter_button.scss
+++ b/src/components/filter_group/_filter_button.scss
@@ -57,5 +57,5 @@
 .euiFilterButton__textShift {
   @include euiTextShift;
   @include euiTextTruncate;
-  min-width: $euiSize * 3;
+  min-inline-size: $euiSize * 3;
 }

--- a/src/components/filter_group/_filter_button.scss
+++ b/src/components/filter_group/_filter_button.scss
@@ -3,7 +3,7 @@
   height: $euiFormControlHeight;
   width: auto;
   border: 1px solid $euiFormBorderColor;
-  border-right: none;
+  border-inline-end: none;
   font-size: $euiFontSizeS;
 
   &:disabled {
@@ -36,8 +36,8 @@
 }
 
 .euiFilterButton--withNext + .euiFilterButton {
-  margin-left: $euiSizeXS * -1;
-  border-left: none;
+  margin-inline-start: $euiSizeXS * -1;
+  border-inline-start: none;
 }
 
 .euiFilterButton-isSelected {
@@ -50,7 +50,7 @@
 }
 
 .euiFilterButton__notification {
-  margin-left: $euiSizeS;
+  margin-inline-start: $euiSizeS;
   vertical-align: text-bottom;
 }
 

--- a/src/components/filter_group/_filter_group.scss
+++ b/src/components/filter_group/_filter_group.scss
@@ -1,7 +1,7 @@
 .euiFilterGroup {
   display: inline-flex;
   max-width: 100%;
-  border-right: 1px solid $euiFormBorderColor;
+  border-inline-end: 1px solid $euiFormBorderColor;
   box-shadow: 0 1px 2px -1px transparentize($euiShadowColor, .8), 0 3px 3px -2px transparentize($euiShadowColor, .8);
   overflow-x: auto;
 

--- a/src/components/filter_group/_filter_group.scss
+++ b/src/components/filter_group/_filter_group.scss
@@ -1,13 +1,13 @@
 .euiFilterGroup {
   display: inline-flex;
-  max-width: 100%;
+  max-inline-size: 100%;
   border-inline-end: 1px solid $euiFormBorderColor;
   box-shadow: 0 1px 2px -1px transparentize($euiShadowColor, .8), 0 3px 3px -2px transparentize($euiShadowColor, .8);
   overflow-x: auto;
 
   > * {
     flex: 1 1 auto;
-    min-width: $euiSize * 3;
+    min-inline-size: $euiSize * 3;
   }
 
   > .euiFilterButton--noGrow  {
@@ -15,11 +15,11 @@
   }
 
   > .euiFilterButton-hasNotification {
-    min-width: $euiSize * 6;
+    min-inline-size: $euiSize * 6;
   }
 
   > .euiFilterButton--hasIcon {
-    min-width: $euiSize * 8;
+    min-inline-size: $euiSize * 8;
   }
 
   // Force popover anchors to expand for now

--- a/src/components/filter_group/_filter_select_item.scss
+++ b/src/components/filter_group/_filter_select_item.scss
@@ -1,12 +1,13 @@
 .euiFilterSelectItem {
   @include euiFontSizeS;
 
-  padding: $euiSizeXS $euiSizeM;
+  padding-block: $euiSizeXS;
+  padding-inline: $euiSizeM;
   display: block; // Necessary to make sure it doesn't force the whole popover to be too wide
   width: 100%;
   text-align: left;
   color: $euiTextColor;
-  border-bottom: $euiBorderThin;
+  border-block-end: $euiBorderThin;
   border-color: darken($euiColorLightestShade, 2%);
 
   &:hover,

--- a/src/components/filter_group/_filter_select_item.scss
+++ b/src/components/filter_group/_filter_select_item.scss
@@ -7,7 +7,7 @@
   padding-inline-end: $euiSizeM;
   display: block; // Necessary to make sure it doesn't force the whole popover to be too wide
   width: 100%;
-  text-align: left;
+  text-align: start;
   color: $euiTextColor;
   border-block-end: $euiBorderThin;
   border-color: darken($euiColorLightestShade, 2%);

--- a/src/components/filter_group/_filter_select_item.scss
+++ b/src/components/filter_group/_filter_select_item.scss
@@ -1,8 +1,10 @@
 .euiFilterSelectItem {
   @include euiFontSizeS;
 
-  padding-block: $euiSizeXS;
-  padding-inline: $euiSizeM;
+  padding-block-start: $euiSizeXS;
+  padding-block-end: $euiSizeXS;
+  padding-inline-start: $euiSizeM;
+  padding-inline-end: $euiSizeM;
   display: block; // Necessary to make sure it doesn't force the whole popover to be too wide
   width: 100%;
   text-align: left;

--- a/src/components/filter_group/_filter_select_item.scss
+++ b/src/components/filter_group/_filter_select_item.scss
@@ -43,7 +43,7 @@
   @include euiScrollBar;
 
   overflow-y: auto;
-  max-height: $euiSize * 30;
+  max-block-size: $euiSize * 30;
 }
 
 .euiFilterSelect__note {

--- a/src/components/flex/_flex_grid.scss
+++ b/src/components/flex/_flex_grid.scss
@@ -1,7 +1,7 @@
 .euiFlexGrid {
   display: flex;
   flex-wrap: wrap;
-  margin-bottom: 0;
+  margin-block-end: 0;
 
   > .euiFlexItem {
     flex-grow: 0;
@@ -92,8 +92,8 @@ $fractions: (
 @include euiBreakpoint('xs', 's') {
   .euiFlexGrid.euiFlexGrid--responsive {
     // sass-lint:disable-block no-important
-    margin-left: 0 !important;
-    margin-right: 0 !important;
+    margin-inline-start: 0 !important;
+    margin-inline-end: 0 !important;
     column-count: 1 !important;
   }
 }

--- a/src/components/flex/_flex_group.scss
+++ b/src/components/flex/_flex_group.scss
@@ -103,7 +103,7 @@ $gutterTypes: (
 @include euiBreakpoint('xs', 's') {
   .euiFlexGroup--responsive {
     flex-wrap: wrap;
-    margin-left: 0;
-    margin-right: 0;
+    margin-inline-start: 0;
+    margin-inline-end: 0;
   }
 }

--- a/src/components/flex/_flex_group.scss
+++ b/src/components/flex/_flex_group.scss
@@ -10,7 +10,7 @@
 
   .euiFlexItem {
     @include internetExplorerOnly {
-      min-width: 1px;
+      min-inline-size: 1px;
     }
 
     flex-grow: 1;

--- a/src/components/flex/_flex_item.scss
+++ b/src/components/flex/_flex_item.scss
@@ -34,8 +34,8 @@
     // sass-lint:disable-block no-important
     width: 100% !important;
     flex-basis: 100% !important;
-    margin-left: 0 !important;
-    margin-right: 0 !important;
-    margin-bottom: $euiSize !important;
+    margin-inline-start: 0 !important;
+    margin-inline-end: 0 !important;
+    margin-block-end: $euiSize !important;
   }
 }

--- a/src/components/flyout/_flyout.scss
+++ b/src/components/flyout/_flyout.scss
@@ -8,8 +8,8 @@
 .euiFlyout__closeButton {
   background-color: transparentize($euiColorEmptyShade, .1);
   position: absolute;
-  right: $euiSizeL - 7px;
-  top: $euiSizeL - 7px;
+  inset-inline-end: $euiSizeL - 7px;
+  inset-block-start: $euiSizeL - 7px;
   z-index: 3;
 }
 
@@ -37,11 +37,11 @@ $flyoutSizes: (
 
 @each $name, $sizing in $flyoutSizes {
   .euiFlyout--#{$name} {
-    min-width: map-get($sizing, min);
+    min-inline-size: map-get($sizing, min);
     width: map-get($sizing, width);
 
     &.euiFlyout--maxWidth-default {
-      max-width: map-get($sizing, max);
+      max-inline-size: map-get($sizing, max);
     }
   }
 }
@@ -65,8 +65,8 @@ $flyoutSizes: (
 @include euiBreakpoint('xs', 's') {
   // sass-lint:disable-block no-important
   .euiFlyout:not(.euiFlyout--small) {  /* 1 */
-    left: 0;
-    min-width: 0;
+    inset-inline-start: 0;
+    min-inline-size: 0;
     width: auto;
     border-inline-start: none;
     max-width: 100vw !important; /* 2 */
@@ -75,6 +75,6 @@ $flyoutSizes: (
   .euiFlyout--small {
     width: 90vw; // ensure that it's only partially showing the main content
     min-width: 0; /* 1 */
-    max-width: map-get(map-get($flyoutSizes, 'small'), 'max');
+    max-inline-size: map-get(map-get($flyoutSizes, 'small'), 'max');
   }
 }

--- a/src/components/flyout/_flyout.scss
+++ b/src/components/flyout/_flyout.scss
@@ -68,7 +68,7 @@ $flyoutSizes: (
     left: 0;
     min-width: 0;
     width: auto;
-    border-left: none;
+    border-inline-start: none;
     max-width: 100vw !important; /* 2 */
   }
 

--- a/src/components/flyout/_flyout_body.scss
+++ b/src/components/flyout/_flyout_body.scss
@@ -15,8 +15,8 @@
   .euiFlyoutBody__banner .euiCallOut {
     border: none; // Remove border from callout when it is a flyout banner
     border-radius: 0; // Ensures no border-radius in all themes
-    padding-left: $euiSizeL; // Align callout's content with flyout's title
-    padding-right: $euiSizeL; // Align callout's content with flyout's title
+    padding-inline-start: $euiSizeL; // Align callout's content with flyout's title
+    padding-inline-end: $euiSizeL; // Align callout's content with flyout's title
   }
 
   .euiFlyoutBody__overflowContent {

--- a/src/components/flyout/_flyout_footer.scss
+++ b/src/components/flyout/_flyout_footer.scss
@@ -1,5 +1,6 @@
 .euiFlyoutFooter {
   background: $euiColorLightestShade;
   flex-grow: 0;
-  padding: $euiSize $euiSizeL;
+  padding-block: $euiSize;
+  padding-inline: $euiSizeL;
 }

--- a/src/components/flyout/_flyout_footer.scss
+++ b/src/components/flyout/_flyout_footer.scss
@@ -1,6 +1,8 @@
 .euiFlyoutFooter {
   background: $euiColorLightestShade;
   flex-grow: 0;
-  padding-block: $euiSize;
-  padding-inline: $euiSizeL;
+  padding-block-start: $euiSize;
+  padding-block-end: $euiSize;
+  padding-inline-start: $euiSizeL;
+  padding-inline-end: $euiSizeL;
 }

--- a/src/components/flyout/_flyout_header.scss
+++ b/src/components/flyout/_flyout_header.scss
@@ -1,9 +1,10 @@
 .euiFlyoutHeader {
   flex-grow: 0;
-  padding: $euiSizeL $euiSizeXXL 0 $euiSizeL;
+  padding-block: $euiSizeL;
+  padding-inline: 0 $euiSizeXXL;
 }
 
 .euiFlyoutHeader--hasBorder {
-  padding-bottom: $euiSizeL;
-  border-bottom: $euiBorderThin;
+  padding-block-end: $euiSizeL;
+  border-block-end: $euiBorderThin;
 }

--- a/src/components/flyout/_flyout_header.scss
+++ b/src/components/flyout/_flyout_header.scss
@@ -1,8 +1,8 @@
 .euiFlyoutHeader {
   flex-grow: 0;
   padding-block-start: $euiSizeL;
-  padding-block-end: $euiSizeL;
-  padding-inline-start: 0;
+  padding-block-end: 0;
+  padding-inline-start: $euiSizeL;
   padding-inline-end: $euiSizeXXL;
 }
 

--- a/src/components/flyout/_flyout_header.scss
+++ b/src/components/flyout/_flyout_header.scss
@@ -1,7 +1,9 @@
 .euiFlyoutHeader {
   flex-grow: 0;
-  padding-block: $euiSizeL;
-  padding-inline: 0 $euiSizeXXL;
+  padding-block-start: $euiSizeL;
+  padding-block-end: $euiSizeL;
+  padding-inline-start: 0;
+  padding-inline-end: $euiSizeXXL;
 }
 
 .euiFlyoutHeader--hasBorder {

--- a/src/components/flyout/_mixins.scss
+++ b/src/components/flyout/_mixins.scss
@@ -5,9 +5,9 @@
   // sass-lint:disable mixins-before-declarations
   @include euiBottomShadowLarge($adjustBorders: true);
   position: fixed;
-  top: 0;
-  bottom: 0;
-  right: 0;
+  inset-block-start: 0;
+  inset-block-end: 0;
+  inset-inline-end: 0;
   height: 100%;
   z-index: $euiZFlyout;
   background: $euiColorEmptyShade;

--- a/src/components/flyout/_mixins.scss
+++ b/src/components/flyout/_mixins.scss
@@ -1,6 +1,6 @@
 
 @mixin euiFlyout {
-  border-left: $euiFlyoutBorder;
+  border-inline-start: $euiFlyoutBorder;
   // The mixin augments the above
   // sass-lint:disable mixins-before-declarations
   @include euiBottomShadowLarge($adjustBorders: true);

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -4,5 +4,5 @@
 }
 
 .euiForm__errors {
-  margin-bottom: $euiSize;
+  margin-block-end: $euiSize;
 }

--- a/src/components/form/checkbox/_checkbox.scss
+++ b/src/components/form/checkbox/_checkbox.scss
@@ -19,8 +19,8 @@
 
       display: inline-block;
       position: absolute;
-      left: 0;
-      top: (($euiSizeL - $euiCheckBoxSize) / 2) - 1px;
+      inset-inline-start: 0;
+      inset-block-start: (($euiSizeL - $euiCheckBoxSize) / 2) - 1px;
     }
 
     &:checked {
@@ -76,11 +76,11 @@
 
   &.euiCheckbox--inList,
   &.euiCheckbox--noLabel {
-    min-height: $euiCheckBoxSize;
-    min-width: $euiCheckBoxSize;
+    min-block-size: $euiCheckBoxSize;
+    min-inline-size: $euiCheckBoxSize;
 
     .euiCheckbox__square {
-      top: 0;
+      inset-block-start: 0;
     }
 
     .euiCheckbox__input {

--- a/src/components/form/checkbox/_checkbox.scss
+++ b/src/components/form/checkbox/_checkbox.scss
@@ -6,7 +6,7 @@
 
     ~ .euiCheckbox__label {
       display: inline-block;
-      padding-left: ($euiCheckBoxSize * 1.5);
+      padding-inline-start: ($euiCheckBoxSize * 1.5);
       line-height: $euiSizeL;
       font-size: $euiFontSizeS;
       position: relative;

--- a/src/components/form/checkbox/_checkbox_group.scss
+++ b/src/components/form/checkbox/_checkbox_group.scss
@@ -1,7 +1,7 @@
 .euiCheckboxGroup__item + .euiCheckboxGroup__item {
-  margin-top: $euiSizeXS;
+  margin-block-start: $euiSizeXS;
 
   &.euiCheckbox--compressed {
-    margin-top: 0;
+    margin-block-start: 0;
   }
 }

--- a/src/components/form/described_form_group/_described_form_group.scss
+++ b/src/components/form/described_form_group/_described_form_group.scss
@@ -2,7 +2,7 @@
   max-width: $euiFormMaxWidth * 2;
 
   + * {
-    margin-top: $euiSizeL;
+    margin-block-start: $euiSizeL;
   }
 
   &.euiDescribedFormGroup--fullWidth {
@@ -10,7 +10,7 @@
   }
 
   .euiDescribedFormGroup__description {
-    padding-top: $euiSizeS;
+    padding-block-start: $euiSizeS;
   }
 
   .euiDescribedFormGroup__fields {
@@ -28,10 +28,10 @@
 
   @include euiBreakpoint('xs', 's') {
     .euiDescribedFormGroup__fields {
-      padding-top: 0;
+      padding-block-start: 0;
 
       > .euiFormRow--hasEmptyLabelSpace:first-child {
-        padding-top: 0;
+        padding-block-start: 0;
       }
     }
   }

--- a/src/components/form/described_form_group/_described_form_group.scss
+++ b/src/components/form/described_form_group/_described_form_group.scss
@@ -14,7 +14,7 @@
   }
 
   .euiDescribedFormGroup__fields {
-    min-width: 0; // Needed to support shrinking appropriately with viewport (prevents x-axis content overflow)
+    min-inline-size: 0; // Needed to support shrinking appropriately with viewport (prevents x-axis content overflow)
   }
 
   .euiDescribedFormGroup__fieldPadding {

--- a/src/components/form/described_form_group/_described_form_group.scss
+++ b/src/components/form/described_form_group/_described_form_group.scss
@@ -1,12 +1,12 @@
 .euiDescribedFormGroup {
-  max-width: $euiFormMaxWidth * 2;
+  max-inline-size: $euiFormMaxWidth * 2;
 
   + * {
     margin-block-start: $euiSizeL;
   }
 
   &.euiDescribedFormGroup--fullWidth {
-    max-width: 100%;
+    max-inline-size: 100%;
   }
 
   .euiDescribedFormGroup__description {

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -20,8 +20,8 @@
 // The input is an invisible dropzone / button
 .euiFilePicker__input {
   position: absolute;
-  left: 0;
-  top: 0;
+  inset-inline-start: 0;
+  inset-block-start: 0;
   width: 100%;
   height: 100%;
   opacity: 0;
@@ -42,13 +42,13 @@
 
 .euiFilePicker__icon {
   position: absolute;
-  left: $euiSizeM;
-  top: $euiSizeM;
+  inset-inline-start: $euiSizeM;
+  inset-block-start: $euiSizeM;
   transition: transform $euiAnimSpeedFast $euiAnimSlightResistance;
 
   .euiFilePicker--compressed & {
-    top: $euiSizeS;
-    left: $euiSizeS;
+    inset-block-start: $euiSizeS;
+    inset-inline-start: $euiSizeS;
   }
 
   .euiFilePicker--large & {
@@ -122,11 +122,11 @@
 .euiFilePicker__clearButton,
 .euiFilePicker__loadingSpinner {
   position: absolute;
-  right: $euiSizeM;
-  top: $euiSizeM;
+  inset-inline-end: $euiSizeM;
+  inset-block-start: $euiSizeM;
 
   .euiFilePicker--compressed & {
-    top: $euiSizeS;
+    inset-block-start: $euiSizeS;
   }
 }
 
@@ -142,8 +142,8 @@
 
   .euiFilePicker--large & {
     position: relative;
-    top: 0;
-    right: 0;
+    inset-block-start: 0;
+    inset-inline-end: 0;
   }
 }
 

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -89,8 +89,10 @@
 
   .euiFilePicker--large & {
     height: $euiFilePickerTallHeight; /* 4 */
-    padding-block: 0;
-    padding-inline: $euiSizeL;
+    padding-block-start: 0;
+    padding-block-end: 0;
+    padding-inline-start: $euiSizeL;
+    padding-inline-end: $euiSizeL;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -53,7 +53,7 @@
 
   .euiFilePicker--large & {
     position: static;
-    margin-bottom: $euiSize;
+    margin-block-end: $euiSize;
   }
 }
 
@@ -67,9 +67,9 @@
   @include euiFormControlDefaultShadow;
   @include euiFormControlWithIcon; /* 2 */
   height: $euiFormControlHeight;
-  padding-top: $euiFormControlPadding;
-  padding-right: $euiFormControlPadding;
-  padding-bottom: $euiFormControlPadding;
+  padding-block-start: $euiFormControlPadding;
+  padding-inline-end: $euiFormControlPadding;
+  padding-block-end: $euiFormControlPadding;
   pointer-events: none; /* 1 */
   border-radius: $euiFormControlBorderRadius;
 
@@ -89,7 +89,8 @@
 
   .euiFilePicker--large & {
     height: $euiFilePickerTallHeight; /* 4 */
-    padding: 0 $euiSizeL;
+    padding-block: 0;
+    padding-inline: $euiSizeL;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/components/form/form_control_layout/_form_control_layout.scss
+++ b/src/components/form/form_control_layout/_form_control_layout.scss
@@ -97,7 +97,7 @@
 
   > .euiFormControlLayout__prepend,
   > .euiFormControlLayout__append {
-    max-width: 50%; // Make sure max-width only applies to the outer most append/prepend element
+    max-inline-size: 50%; // Make sure max-width only applies to the outer most append/prepend element
   }
 
   // sass-lint:disable-block no-important

--- a/src/components/form/form_control_layout/_form_control_layout.scss
+++ b/src/components/form/form_control_layout/_form_control_layout.scss
@@ -45,8 +45,10 @@
 
     &.euiIcon,
     .euiIcon {
-      padding-block: 0;
-      padding-inline: $euiSizeS;
+      padding-block-start: 0;
+      padding-block-end: 0;
+      padding-inline-start: $euiSizeS;
+      padding-inline-end: $euiSizeS;
       width: $euiSizeXL;
       border-radius: 0;
       background-color: $euiFormInputGroupLabelBackground;
@@ -69,8 +71,10 @@
   }
 
   .euiButtonIcon {
-    padding-block: 0;
-    padding-inline: $euiSizeS;
+    padding-block-start: 0;
+    padding-block-end: 0;
+    padding-inline-start: $euiSizeS;
+    padding-inline-end: $euiSizeS;
     width: $euiSizeXL;
     border-radius: 0;
     background-color: $euiFormInputGroupLabelBackground;
@@ -83,8 +87,10 @@
   .euiToolTipAnchor > .euiIcon {
     height: 100%;
     background-color: $euiFormInputGroupLabelBackground;
-    padding-block: 0;
-    padding-inline: $euiSizeS;
+    padding-block-start: 0;
+    padding-block-end: 0;
+    padding-inline-start: $euiSizeS;
+    padding-inline-end: $euiSizeS;
     width: $euiSizeXL;
     border-radius: 0;
   }

--- a/src/components/form/form_control_layout/_form_control_layout.scss
+++ b/src/components/form/form_control_layout/_form_control_layout.scss
@@ -45,7 +45,8 @@
 
     &.euiIcon,
     .euiIcon {
-      padding: 0 $euiSizeS;
+      padding-block: 0;
+      padding-inline: $euiSizeS;
       width: $euiSizeXL;
       border-radius: 0;
       background-color: $euiFormInputGroupLabelBackground;
@@ -68,7 +69,8 @@
   }
 
   .euiButtonIcon {
-    padding: 0 $euiSizeS;
+    padding-block: 0;
+    padding-inline: $euiSizeS;
     width: $euiSizeXL;
     border-radius: 0;
     background-color: $euiFormInputGroupLabelBackground;
@@ -81,7 +83,8 @@
   .euiToolTipAnchor > .euiIcon {
     height: 100%;
     background-color: $euiFormInputGroupLabelBackground;
-    padding: 0 $euiSizeS;
+    padding-block: 0;
+    padding-inline: $euiSizeS;
     width: $euiSizeXL;
     border-radius: 0;
   }
@@ -105,7 +108,7 @@
 
     // If the next sibling is not the input, pull it closer to the text to reduce space
     + *:not(.euiFormControlLayout__childrenWrapper) {
-      margin-left: -$euiFormControlPadding;
+      margin-inline-start: -$euiFormControlPadding;
     }
   }
 
@@ -113,7 +116,7 @@
   > *:not(.euiFormControlLayout__childrenWrapper) {
     + .euiFormLabel,
     + .euiText {
-      margin-left: -$euiFormControlPadding;
+      margin-inline-start: -$euiFormControlPadding;
     }
   }
 
@@ -121,15 +124,15 @@
   // BORDERS on buttons only
 
   .euiButtonEmpty {
-    border-right: $euiFormInputGroupBorder;
+    border-inline-end: $euiFormInputGroupBorder;
   }
 
   // Any buttons after the children wrapper or inside any elements after the children wrapper
   // Need to swap border sides
   .euiFormControlLayout__childrenWrapper ~ .euiButtonEmpty,
   .euiFormControlLayout__childrenWrapper ~ * .euiButtonEmpty {
-    border-right: none;
-    border-left: $euiFormInputGroupBorder;
+    border-inline-end: none;
+    border-inline-start: $euiFormInputGroupBorder;
   }
 
   //
@@ -147,7 +150,7 @@
 
       // If the next sibling is not the input, pull it closer to the text to reduce space
       + *:not(.euiFormControlLayout__childrenWrapper) {
-        margin-left: -$euiFormControlCompressedPadding;
+        margin-inline-start: -$euiFormControlCompressedPadding;
       }
     }
 
@@ -155,7 +158,7 @@
     > *:not(.euiFormControlLayout__childrenWrapper) {
       + .euiFormLabel,
       + .euiText {
-        margin-left: -$euiFormControlCompressedPadding;
+        margin-inline-start: -$euiFormControlCompressedPadding;
       }
     }
   }

--- a/src/components/form/form_control_layout/_form_control_layout_delimited.scss
+++ b/src/components/form/form_control_layout/_form_control_layout_delimited.scss
@@ -20,13 +20,13 @@
       height: 100%;
       padding-top: 0; // Fixes IE
       padding-bottom: 0; // Fixes IE
-      padding-left: $euiFormControlCompressedPadding;
-      padding-right: $euiFormControlCompressedPadding;
+      padding-inline-start: $euiFormControlCompressedPadding;
+      padding-inline-end: $euiFormControlCompressedPadding;
     }
 
     .euiFormControlLayoutIcons {
-      padding-left: $euiFormControlCompressedPadding;
-      padding-right: $euiFormControlCompressedPadding;
+      padding-inline-start: $euiFormControlCompressedPadding;
+      padding-inline-end: $euiFormControlCompressedPadding;
     }
   }
 
@@ -55,8 +55,8 @@
     // Absolutely positioning the icons doesn't work because they
     // overlay only one of controls making the layout unbalanced
     position: static; // Overrider absolute
-    padding-left: $euiFormControlPadding;
-    padding-right: $euiFormControlPadding;
+    padding-inline-start: $euiFormControlPadding;
+    padding-inline-end: $euiFormControlPadding;
     flex-shrink: 0; // Fixes IE
 
     &:not(.euiFormControlLayoutIcons--right) {
@@ -83,6 +83,6 @@
   background-color: transparent !important; // Override .euiFormControlLayout--group > .euiFormLabel
   line-height: 1 !important; // Override EuiText line-height
   flex: 0 0 auto;
-  padding-left: $euiFormControlPadding / 2;
-  padding-right: $euiFormControlPadding / 2;
+  padding-inline-start: $euiFormControlPadding / 2;
+  padding-inline-end: $euiFormControlPadding / 2;
 }

--- a/src/components/form/form_control_layout/_form_control_layout_delimited.scss
+++ b/src/components/form/form_control_layout/_form_control_layout_delimited.scss
@@ -34,7 +34,7 @@
   &[class*='--fullWidth'] .euiFormControlLayout__childrenWrapper,
   &[class*='--fullWidth'] input {
     width: 100%;
-    max-width: none;
+    max-inline-size: none;
   }
 
   // Target when the euiFormControlLayout is disabled without specifying the full class name in case it ever changes
@@ -74,7 +74,7 @@
   min-width: 0; // Fixes FF
 
   .euiFormControlLayoutDelimited[class*='--compressed'] & {
-    max-width: none;
+    max-inline-size: none;
   }
 }
 

--- a/src/components/form/form_control_layout/_form_control_layout_delimited.scss
+++ b/src/components/form/form_control_layout/_form_control_layout_delimited.scss
@@ -18,8 +18,8 @@
 
     .euiFormControlLayoutDelimited__input {
       height: 100%;
-      padding-top: 0; // Fixes IE
-      padding-bottom: 0; // Fixes IE
+      padding-block-start: 0; // Fixes IE
+      padding-block-end: 0; // Fixes IE
       padding-inline-start: $euiFormControlCompressedPadding;
       padding-inline-end: $euiFormControlCompressedPadding;
     }
@@ -71,7 +71,7 @@
   border-radius: 0 !important;
   text-align: center;
   height: 100%;
-  min-width: 0; // Fixes FF
+  min-inline-size: 0; // Fixes FF
 
   .euiFormControlLayoutDelimited[class*='--compressed'] & {
     max-inline-size: none;

--- a/src/components/form/form_control_layout/_form_control_layout_icons.scss
+++ b/src/components/form/form_control_layout/_form_control_layout_icons.scss
@@ -1,9 +1,9 @@
 .euiFormControlLayoutIcons {
   pointer-events: none;
   position: absolute;
-  top: 0;
-  bottom: 0;
-  left: $euiFormControlPadding;
+  inset-block-start: 0;
+  inset-block-end: 0;
+  inset-inline-start: $euiFormControlPadding;
   display: flex;
   align-items: center;
 
@@ -12,17 +12,17 @@
   }
 
   .euiFormControlLayout--compressed & {
-    left: $euiFormControlCompressedPadding;
+    inset-inline-start: $euiFormControlCompressedPadding;
   }
 }
 
 .euiFormControlLayoutIcons--right {
-  left: auto;
-  right: $euiFormControlPadding;
+  inset-inline-start: auto;
+  inset-inline-end: $euiFormControlPadding;
 
   .euiFormControlLayout--compressed & {
-    left: auto;
-    right: $euiFormControlCompressedPadding;
+    inset-inline-start: auto;
+    inset-inline-end: $euiFormControlCompressedPadding;
   }
 }
 

--- a/src/components/form/form_control_layout/_form_control_layout_icons.scss
+++ b/src/components/form/form_control_layout/_form_control_layout_icons.scss
@@ -8,7 +8,7 @@
   align-items: center;
 
   > * + * {
-    margin-left: $euiFormControlPadding / 2;
+    margin-inline-start: $euiFormControlPadding / 2;
   }
 
   .euiFormControlLayout--compressed & {

--- a/src/components/form/form_error_text/_form_error_text.scss
+++ b/src/components/form/form_error_text/_form_error_text.scss
@@ -1,5 +1,5 @@
 .euiFormErrorText {
   @include euiFontSizeXS;
-  padding-top: $euiSizeXS;
+  padding-block-start: $euiSizeXS;
   color: $euiColorDanger;
 }

--- a/src/components/form/form_fieldset/_form_legend.scss
+++ b/src/components/form/form_fieldset/_form_legend.scss
@@ -2,10 +2,10 @@
   @include euiFormLabel;
 
   &:not(.euiFormLegend-isHidden) {
-    margin-bottom: $euiSizeS;
+    margin-block-end: $euiSizeS;
 
     &.euiFormLegend--compressed {
-      margin-bottom: $euiSizeXS;
+      margin-block-end: $euiSizeXS;
     }
   }
 }

--- a/src/components/form/form_help_text/_form_help_text.scss
+++ b/src/components/form/form_help_text/_form_help_text.scss
@@ -1,5 +1,5 @@
 .euiFormHelpText {
   @include euiFontSizeXS;
-  padding-top: $euiSizeXS;
+  padding-block-start: $euiSizeXS;
   color: $euiColorDarkShade;
 }

--- a/src/components/form/form_row/_form_row.scss
+++ b/src/components/form/form_row/_form_row.scss
@@ -40,7 +40,7 @@
   .euiFormRow__label {
     @include euiTextBreakWord;
     hyphens: auto;
-    max-width: 100%; // Fixes IE
+    max-inline-size: 100%; // Fixes IE
   }
 
   .euiFormRow__labelWrapper {
@@ -60,7 +60,7 @@
   }
 
   + .euiFormRow--horizontal.euiFormRow--hasSwitch {
-    margin-top: $euiSizeM; // More spacing since we reduced the height to match that of the switch
+    margin-block-start: $euiSizeM; // More spacing since we reduced the height to match that of the switch
   }
 
   &.euiFormRow--hasSwitch {
@@ -74,12 +74,12 @@
       width: auto;
 
       .euiSwitch--compressed {
-        margin-top: $euiSizeXS / 2; // Better vertical alignment of a compressed switch to the horizontal label
+        margin-block-start: $euiSizeXS / 2; // Better vertical alignment of a compressed switch to the horizontal label
       }
     }
 
     + .euiFormRow--horizontal {
-      margin-top: $euiSizeM; // More spacing since we reduced the height to match that of the switch
+      margin-block-start: $euiSizeM; // More spacing since we reduced the height to match that of the switch
     }
   }
 }

--- a/src/components/form/form_row/_form_row.scss
+++ b/src/components/form/form_row/_form_row.scss
@@ -5,7 +5,7 @@
 .euiFormRow {
   display: flex; /* 1 */
   flex-direction: column; /* 1 */
-  max-width: $euiFormMaxWidth;
+  max-inline-size: $euiFormMaxWidth;
 
   + .euiFormRow,
   + .euiButton {
@@ -14,14 +14,14 @@
 }
 
 .euiFormRow--fullWidth {
-  max-width: 100%;
+  max-inline-size: 100%;
 }
 
 .euiFormRow--hasEmptyLabelSpace {
   margin-top: ($euiFontSizeXS * $euiLineHeight) + $euiSizeXS; /* 2 */
   // the following ensure that contents that aren't inherently the same height
   // as inputs will align to the vertical center
-  min-height: $euiFormControlHeight;
+  min-block-size: $euiFormControlHeight;
   padding-block-end: 0;
   justify-content: center;
 }
@@ -67,7 +67,7 @@
     .euiFormRow__labelWrapper {
       line-height: $euiSwitchHeight - 1px; // The 1px less helps the alignment of the text baseline
       width: auto;
-      min-width: calc(33% - #{$euiSizeS});
+      min-inline-size: calc(33% - #{$euiSizeS});
     }
 
     .euiFormRow__fieldWrapper {
@@ -85,17 +85,17 @@
 }
 
 .euiFormRow__fieldWrapperDisplayOnly {
-  min-height: $euiFormControlHeight;
+  min-block-size: $euiFormControlHeight;
   display: flex;
   align-items: center;
 }
 
 .euiFormRow--compressed {
   &.euiFormRow--hasEmptyLabelSpace {
-    min-height: $euiFormControlCompressedHeight;
+    min-block-size: $euiFormControlCompressedHeight;
   }
 
   .euiFormRow__fieldWrapperDisplayOnly {
-    min-height: $euiFormControlCompressedHeight;
+    min-block-size: $euiFormControlCompressedHeight;
   }
 }

--- a/src/components/form/form_row/_form_row.scss
+++ b/src/components/form/form_row/_form_row.scss
@@ -9,7 +9,7 @@
 
   + .euiFormRow,
   + .euiButton {
-    margin-top: $euiSize;
+    margin-block-start: $euiSize;
   }
 }
 
@@ -22,7 +22,7 @@
   // the following ensure that contents that aren't inherently the same height
   // as inputs will align to the vertical center
   min-height: $euiFormControlHeight;
-  padding-bottom: 0;
+  padding-block-end: 0;
   justify-content: center;
 }
 
@@ -30,7 +30,7 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  margin-bottom: $euiSizeXS;
+  margin-block-end: $euiSizeXS;
 }
 
 .euiFormRow--horizontal {
@@ -47,8 +47,8 @@
     display: block;
     line-height: $euiFormControlCompressedHeight - 1px; // The 1px less helps the alignment of the text baseline
     width: calc(33% - #{$euiSizeS});
-    margin-right: $euiSizeS;
-    margin-bottom: 0;
+    margin-inline-end: $euiSizeS;
+    margin-block-end: 0;
   }
 
   .euiFormRow__fieldWrapper {
@@ -56,7 +56,7 @@
   }
 
   + .euiFormRow--horizontal {
-    margin-top: $euiSizeS;
+    margin-block-start: $euiSizeS;
   }
 
   + .euiFormRow--horizontal.euiFormRow--hasSwitch {

--- a/src/components/form/radio/_radio.scss
+++ b/src/components/form/radio/_radio.scss
@@ -19,8 +19,8 @@
 
       display: inline-block;
       position: absolute;
-      left: 0;
-      top: (($euiSizeL - $euiRadioSize) / 2) - 1px;
+      inset-inline-start: 0;
+      inset-block-start: (($euiSizeL - $euiRadioSize) / 2) - 1px;
     }
 
     &:checked {
@@ -64,11 +64,11 @@
 
   &.euiRadio--inList,
   &.euiRadio--noLabel {
-    min-height: $euiRadioSize;
-    min-width: $euiRadioSize;
+    min-block-size: $euiRadioSize;
+    min-inline-size: $euiRadioSize;
 
     .euiRadio__circle {
-      top: 0;
+      inset-block-start: 0;
     }
 
     .euiRadio__input {

--- a/src/components/form/radio/_radio.scss
+++ b/src/components/form/radio/_radio.scss
@@ -6,7 +6,7 @@
 
     ~ .euiRadio__label {
       display: inline-block;
-      padding-left: ($euiRadioSize * 1.5);
+      padding-inline-start: ($euiRadioSize * 1.5);
       line-height: $euiSizeL;
       font-size: $euiFontSizeS;
       position: relative;

--- a/src/components/form/radio/_radio_group.scss
+++ b/src/components/form/radio/_radio_group.scss
@@ -1,7 +1,7 @@
 .euiRadioGroup__item + .euiRadioGroup__item {
-  margin-top: $euiSizeXS;
+  margin-block-start: $euiSizeXS;
 
   &.euiRadio--compressed {
-    margin-top: 0;
+    margin-block-start: 0;
   }
 }

--- a/src/components/form/range/_range_highlight.scss
+++ b/src/components/form/range/_range_highlight.scss
@@ -1,8 +1,8 @@
 .euiRangeHighlight {
   position: absolute;
-  left: 0;
+  inset-inline-start: 0;
   width: 100%;
-  top: calc(50% - #{($euiRangeHighlightHeight / 2)});
+  inset-block-start: calc(50% - #{($euiRangeHighlightHeight / 2)});
   overflow: hidden;
 
   &__progress {
@@ -16,10 +16,10 @@
   }
 
   &--hasTicks {
-    top: ($euiFormControlHeight / 4) - ($euiRangeHighlightHeight / 2);
+    inset-block-start: ($euiFormControlHeight / 4) - ($euiRangeHighlightHeight / 2);
   }
 
   &--hasTicks.euiRangeHighlight--compressed {
-    top: ($euiFormControlCompressedHeight / 4) - ($euiRangeHighlightHeight / 2);
+    inset-block-start: ($euiFormControlCompressedHeight / 4) - ($euiRangeHighlightHeight / 2);
   }
 }

--- a/src/components/form/range/_range_input.scss
+++ b/src/components/form/range/_range_input.scss
@@ -1,6 +1,6 @@
 .euiRangeInput {
   width: auto;
-  min-width: $euiSize * 4;
+  min-inline-size: $euiSize * 4;
 
   .euiRange__popover & {
     // sass-lint:disable no-important

--- a/src/components/form/range/_range_label.scss
+++ b/src/components/form/range/_range_label.scss
@@ -5,11 +5,11 @@
   }
 
   &--min {
-    margin-right: $euiSizeS;
+    margin-inline-end: $euiSizeS;
   }
 
   &--max {
-    margin-left: $euiSizeS;
+    margin-inline-start: $euiSizeS;
   }
 
   &--isDisabled {

--- a/src/components/form/range/_range_levels.scss
+++ b/src/components/form/range/_range_levels.scss
@@ -2,19 +2,19 @@
   display: flex;
   justify-content: stretch;
   position: absolute;
-  left: 0;
-  right: 0;
-  top: ($euiFormControlHeight / 2) + 2px;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
+  inset-block-start: ($euiFormControlHeight / 2) + 2px;
 
   &--hasTicks {
-    top: ($euiFormControlHeight / 4) + 2px;
+    inset-block-start: ($euiFormControlHeight / 4) + 2px;
   }
 
   &--compressed {
-    top: ($euiFormControlCompressedHeight / 2) + 2px;
+    inset-block-start: ($euiFormControlCompressedHeight / 2) + 2px;
 
     &.euiRangeLevels--hasTicks {
-      top: ($euiFormControlCompressedHeight / 4) + 2px;
+      inset-block-start: ($euiFormControlCompressedHeight / 4) + 2px;
     }
   }
 }

--- a/src/components/form/range/_range_slider.scss
+++ b/src/components/form/range/_range_slider.scss
@@ -86,11 +86,11 @@
   // sass-lint:disable-block no-vendor-prefixes
   &::-webkit-slider-thumb {
     -webkit-appearance: none;
-    margin-top: ((-$euiRangeTrackBorderWidth * 2 + $euiRangeTrackHeight) / 2) - ($euiRangeThumbHeight / 2);
+    margin-block-start: ((-$euiRangeTrackBorderWidth * 2 + $euiRangeTrackHeight) / 2) - ($euiRangeThumbHeight / 2);
   }
 
   &::-ms-thumb {
-    margin-top: 0;
+    margin-block-start: 0;
   }
 
   &::-moz-focus-outer {

--- a/src/components/form/range/_range_thumb.scss
+++ b/src/components/form/range/_range_thumb.scss
@@ -3,8 +3,8 @@
   @include euiRangeThumbStyle;
   content: '';
   position: absolute;
-  left: 0;
-  top: 50%;
+  inset-inline-start: 0;
+  inset-block-start: 50%;
   margin-block-start: -($euiRangeThumbHeight / 2);
   pointer-events: none;
 
@@ -13,6 +13,6 @@
   }
 
   &--hasTicks {
-    top: 25%;
+    inset-block-start: 25%;
   }
 }

--- a/src/components/form/range/_range_thumb.scss
+++ b/src/components/form/range/_range_thumb.scss
@@ -5,7 +5,7 @@
   position: absolute;
   left: 0;
   top: 50%;
-  margin-top: -($euiRangeThumbHeight / 2);
+  margin-block-start: -($euiRangeThumbHeight / 2);
   pointer-events: none;
 
   &:focus {

--- a/src/components/form/range/_range_ticks.scss
+++ b/src/components/form/range/_range_ticks.scss
@@ -1,8 +1,8 @@
 .euiRangeTicks {
   position: absolute;
-  left: ($euiRangeThumbWidth / 2);
-  right: ($euiRangeThumbWidth / 2);
-  top: $euiSizeS;
+  inset-inline-start: ($euiRangeThumbWidth / 2);
+  inset-inline-end: ($euiRangeThumbWidth / 2);
+  inset-block-start: $euiSizeS;
   display: flex;
 }
 
@@ -20,8 +20,8 @@
     background-color: $euiColorDarkShade;
     border-radius: 100%;
     position: absolute;
-    top: 0;
-    left: calc(50% - #{($euiSizeXS/2)});
+    inset-block-start: 0;
+    inset-inline-start: calc(50% - #{($euiSizeXS/2)});
   }
 
   &--isCustom {
@@ -45,7 +45,7 @@
 }
 
 .euiRangeTicks--compressed {
-  top: $euiSizeS - 2px;
+  inset-block-start: $euiSizeS - 2px;
 
   .euiRangeTick {
     padding-block-start: $euiSize - 2px;

--- a/src/components/form/range/_range_ticks.scss
+++ b/src/components/form/range/_range_ticks.scss
@@ -11,7 +11,7 @@
   text-overflow: ellipsis;
   font-size: $euiFontSizeXS;
   position: relative;
-  padding-top: $euiSize;
+  padding-block-start: $euiSize;
 
   &::before {
     @include size($euiSizeXS);
@@ -48,6 +48,6 @@
   top: $euiSizeS - 2px;
 
   .euiRangeTick {
-    padding-top: $euiSize - 2px;
+    padding-block-start: $euiSize - 2px;
   }
 }

--- a/src/components/form/range/_range_tooltip.scss
+++ b/src/components/form/range/_range_tooltip.scss
@@ -17,8 +17,10 @@
   border: 1px solid $euiTooltipBackgroundColor;
   position: absolute;
   border-radius: $euiBorderRadius;
-  padding-block: ($euiSizeXS / 2);
-  padding-inline: $euiSizeS;
+  padding-block-start: ($euiSizeXS / 2);
+  padding-block-end: ($euiSizeXS / 2);
+  padding-inline-start: $euiSizeS;
+  padding-inline-end: $euiSizeS;
   background-color: $euiTooltipBackgroundColor;
   color: $euiColorGhost;
   max-width: 256px;

--- a/src/components/form/range/_range_tooltip.scss
+++ b/src/components/form/range/_range_tooltip.scss
@@ -6,7 +6,7 @@
   top: 0;
   bottom: 0;
   width: calc(100% - #{$euiRangeThumbWidth});
-  margin-left: $euiRangeThumbWidth / 2;
+  margin-inline-start: $euiRangeThumbWidth / 2;
   pointer-events: none;
 }
 
@@ -17,7 +17,8 @@
   border: 1px solid $euiTooltipBackgroundColor;
   position: absolute;
   border-radius: $euiBorderRadius;
-  padding: ($euiSizeXS / 2) $euiSizeS;
+  padding-block: ($euiSizeXS / 2);
+  padding-inline: $euiSizeS;
   background-color: $euiTooltipBackgroundColor;
   color: $euiColorGhost;
   max-width: 256px;
@@ -49,7 +50,7 @@
 
   // Positions the arrow
   &.euiRangeTooltip__value--right {
-    margin-left: $euiSizeL;
+    margin-inline-start: $euiSizeL;
 
     &:before,
     &:after {
@@ -57,12 +58,12 @@
     }
 
     &::before {
-      margin-left: -1px;
+      margin-inline-start: -1px;
     }
   }
 
   &.euiRangeTooltip__value--left {
-    margin-right: $euiSizeL;
+    margin-inline-end: $euiSizeL;
 
     &:before,
     &:after {
@@ -71,7 +72,7 @@
     }
 
     &::before {
-      margin-right: -1px;
+      margin-inline-end: -1px;
     }
   }
 

--- a/src/components/form/range/_range_tooltip.scss
+++ b/src/components/form/range/_range_tooltip.scss
@@ -2,9 +2,9 @@
   // Keeps tooltip (value) aligned to percentage of actual slider
   display: block;
   position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
+  inset-inline-start: 0;
+  inset-block-start: 0;
+  inset-block-end: 0;
   width: calc(100% - #{$euiRangeThumbWidth});
   margin-inline-start: $euiRangeThumbWidth / 2;
   pointer-events: none;
@@ -23,8 +23,8 @@
   padding-inline-end: $euiSizeS;
   background-color: $euiTooltipBackgroundColor;
   color: $euiColorGhost;
-  max-width: 256px;
-  top: 50%;
+  max-inline-size: 256px;
+  inset-block-start: 50%;
   transition:
     box-shadow $euiAnimSpeedNormal $euiAnimSlightResistance,
     transform $euiAnimSpeedNormal $euiAnimSlightResistance;
@@ -37,8 +37,8 @@
   &::before {
     content: '';
     position: absolute;
-    bottom: -$arrowSize / 2;
-    left: 50%;
+    inset-block-end: -$arrowSize / 2;
+    inset-inline-start: 50%;
     transform-origin: center;
     background-color: $euiTooltipBackgroundColor;
     width: $arrowSize;
@@ -56,7 +56,7 @@
 
     &:before,
     &:after {
-      left: $arrowMinusSize;
+      inset-inline-start: $arrowMinusSize;
     }
 
     &::before {
@@ -69,8 +69,8 @@
 
     &:before,
     &:after {
-      left: auto;
-      right: $arrowMinusSize;
+      inset-inline-start: auto;
+      inset-inline-end: $arrowMinusSize;
     }
 
     &::before {
@@ -84,16 +84,16 @@
 
     &:before,
     &:after {
-      bottom: 50%;
+      inset-block-end: 50%;
       transform: translateY(50%) rotateZ(45deg);
     }
   }
 
   &--hasTicks {
-    top: ($euiFormControlHeight / 4);
+    inset-block-start: ($euiFormControlHeight / 4);
 
     .euiRangeTooltip--compressed & {
-      top: ($euiFormControlCompressedHeight / 4);
+      inset-block-start: ($euiFormControlCompressedHeight / 4);
     }
   }
 }

--- a/src/components/form/super_select/_super_select.scss
+++ b/src/components/form/super_select/_super_select.scss
@@ -13,7 +13,7 @@
 
 .euiSuperSelect__listbox {
   @include euiScrollBar;
-  max-height: 300px;
+  max-block-size: 300px;
   overflow: hidden;
   overflow-y: auto;
 }

--- a/src/components/form/super_select/_super_select.scss
+++ b/src/components/form/super_select/_super_select.scss
@@ -7,7 +7,7 @@
 .euiSuperSelect {
   &:not(.euiSuperSelect--fullWidth) { /* 1 */
     // sass-lint:disable-block no-important
-    max-width: $euiFormMaxWidth !important; // override default popover styles
+    max-inline-size: $euiFormMaxWidth !important; // override default popover styles
   }
 }
 

--- a/src/components/form/super_select/_super_select.scss
+++ b/src/components/form/super_select/_super_select.scss
@@ -19,7 +19,7 @@
 }
 
 .euiSuperSelect__popoverPanel[class*='bottom'] { /* 3 */
-  border-top-color: transparentize($euiBorderColor, .2);
+  border-block-start-color: transparentize($euiBorderColor, .2);
   border-top-right-radius: 0; /* 2 */
   border-top-left-radius: 0; /* 2 */
 }
@@ -27,7 +27,7 @@
 .euiSuperSelect__popoverPanel[class*='top'] { /* 3 */
   @include euiBottomShadowFlat; /* 2 */
 
-  border-bottom-color: transparentize($euiBorderColor, .2);
+  border-block-end-color: transparentize($euiBorderColor, .2);
   border-bottom-right-radius: 0; /* 2 */
   border-bottom-left-radius: 0; /* 2 */
 }
@@ -48,5 +48,5 @@
 }
 
 .euiSuperSelect__item--hasDividers:not(:last-of-type) {
-  border-bottom: $euiBorderThin;
+  border-block-end: $euiBorderThin;
 }

--- a/src/components/form/super_select/_super_select_control.scss
+++ b/src/components/form/super_select/_super_select_control.scss
@@ -10,7 +10,7 @@
   @include euiFormControlIsLoading($isNextToIcon: true);
 
   display: block; /* 3 */
-  text-align: left;
+  text-align: start;
   line-height: $euiFormControlHeight; /* 2 */
   padding-top: 0; /* 2 */
   padding-bottom: 0; /* 2 */

--- a/src/components/form/switch/_switch.scss
+++ b/src/components/form/switch/_switch.scss
@@ -6,7 +6,7 @@
 
   .euiSwitch__label {
     cursor: pointer;
-    padding-left: $euiSizeS;
+    padding-inline-start: $euiSizeS;
     line-height: $euiSwitchHeight;
     font-size: $euiFontSizeS;
     vertical-align: middle;

--- a/src/components/form/switch/_switch.scss
+++ b/src/components/form/switch/_switch.scss
@@ -2,7 +2,7 @@
   position: relative;
   display: inline-flex;
   align-items: flex-start;
-  min-height: $euiSwitchHeight;
+  min-block-size: $euiSwitchHeight;
 
   .euiSwitch__label {
     cursor: pointer;
@@ -52,15 +52,15 @@
 
       // When input is not checked, we shift around the positioning of the thumb and the icon
       .euiSwitch__thumb { // move the thumb left
-        left: 0;
+        inset-inline-start: 0;
       }
 
       .euiSwitch__icon { // move the icon right
-        right: -$euiSizeS;
+        inset-inline-end: -$euiSizeS;
 
         &.euiSwitch__icon--checked {
-          right: auto;
-          left: -($euiSwitchWidth - ($euiSwitchThumbSize / 2));
+          inset-inline-end: auto;
+          inset-inline-start: -($euiSwitchWidth - ($euiSwitchThumbSize / 2));
         }
       }
     }
@@ -82,25 +82,25 @@
 
     position: absolute;
     display: inline-block;
-    left: $euiSwitchWidth - $euiSwitchThumbSize;
+    inset-inline-start: $euiSwitchWidth - $euiSwitchThumbSize;
     transition: border-color $euiAnimSpeedNormal $euiAnimSlightBounce, background-color $euiAnimSpeedNormal $euiAnimSlightBounce, left $euiAnimSpeedNormal $euiAnimSlightBounce, transform $euiAnimSpeedNormal $euiAnimSlightBounce;
   }
 
   .euiSwitch__track {
     position: absolute;
-    left: 0;
-    top: 0;
-    right: 0;
-    bottom: 0;
+    inset-inline-start: 0;
+    inset-block-start: 0;
+    inset-inline-end: 0;
+    inset-block-end: 0;
     overflow: hidden;
     border-radius: $euiSwitchHeight;
   }
 
   .euiSwitch__icon {
     position: absolute;
-    right: -($euiSwitchWidth - ($euiSwitchThumbSize / 2));
-    top: ($euiSwitchHeight - $euiSwitchIconHeight) / 2;
-    bottom: 0;
+    inset-inline-end: -($euiSwitchWidth - ($euiSwitchThumbSize / 2));
+    inset-block-start: ($euiSwitchHeight - $euiSwitchIconHeight) / 2;
+    inset-block-end: 0;
     width: $euiSwitchWidth - ($euiSwitchThumbSize / 2) + $euiSizeS;
     height: $euiSwitchIconHeight;
     transition: left $euiAnimSpeedNormal $euiAnimSlightBounce, right $euiAnimSpeedNormal $euiAnimSlightBounce;
@@ -108,8 +108,8 @@
   }
 
   .euiSwitch__icon--checked {
-    right: auto;
-    left: -$euiSizeS;
+    inset-inline-end: auto;
+    inset-inline-start: -$euiSizeS;
     fill: $euiColorEmptyShade;
   }
 
@@ -125,7 +125,7 @@
 
   // Compressed switches operate very similar to the normal versions, but are smaller, contain no icon signifiers
   &.euiSwitch--compressed {
-    min-height: $euiSwitchHeightCompressed;
+    min-block-size: $euiSwitchHeightCompressed;
 
     .euiSwitch__label {
       line-height: $euiSwitchHeightCompressed;
@@ -140,8 +140,8 @@
     .euiSwitch__thumb {
       @include euiCustomControl($type: 'round', $size: ($euiSwitchThumbSizeCompressed) - 2px);
 
-      left: ($euiSwitchWidthCompressed) - (($euiSwitchThumbSizeCompressed) - 2px) - 1px;
-      top: 1px;
+      inset-inline-start: ($euiSwitchWidthCompressed) - (($euiSwitchThumbSizeCompressed) - 2px) - 1px;
+      inset-block-start: 1px;
       transition: border-color $euiAnimSpeedNormal $euiAnimSlightBounce, background-color $euiAnimSpeedNormal $euiAnimSlightBounce, left $euiAnimSpeedNormal $euiAnimSlightBounce, transform $euiAnimSpeedNormal $euiAnimSlightBounce;
     }
 
@@ -152,7 +152,7 @@
 
   // Mini styling is similar to compressed, but even smaller. It's undocumented because it has very specific uses.
   &.euiSwitch--mini {
-    min-height: $euiSwitchHeightMini;
+    min-block-size: $euiSwitchHeightMini;
 
     .euiSwitch__label {
       line-height: $euiSwitchHeightMini;
@@ -168,8 +168,8 @@
     .euiSwitch__thumb {
       @include euiCustomControl($type: 'round', $size: ($euiSwitchThumbSizeMini) - 2px);
 
-      left: ($euiSwitchWidthMini) - (($euiSwitchThumbSizeMini) - 2px) - 1px;
-      top: 1px;
+      inset-inline-start: ($euiSwitchWidthMini) - (($euiSwitchThumbSizeMini) - 2px) - 1px;
+      inset-block-start: 1px;
       transition: border-color $euiAnimSpeedNormal $euiAnimSlightBounce, background-color $euiAnimSpeedNormal $euiAnimSlightBounce, left $euiAnimSpeedNormal $euiAnimSlightBounce, transform $euiAnimSpeedNormal $euiAnimSlightBounce;
     }
 
@@ -184,7 +184,7 @@
 
     .euiSwitch__button[aria-checked='false'] {
       .euiSwitch__thumb {
-        left: 1px;
+        inset-inline-start: 1px;
       }
     }
 

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -9,7 +9,7 @@
   display: flex;
   justify-content: space-between;
   background: $euiHeaderBackgroundColor;
-  border-bottom: 1px solid $euiHeaderBorderColor;
+  border-block-end: 1px solid $euiHeaderBorderColor;
 
   &--fixed {
     position: fixed;

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -13,14 +13,14 @@
 
   &--fixed {
     position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
+    inset-block-start: 0;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
   }
 }
 
 .euiHeader--fixed + .euiHeader--fixed {
-  top: $euiHeaderHeightCompensation;
+  inset-block-start: $euiHeaderHeightCompensation;
 }
 
 .euiHeader--dark {

--- a/src/components/header/_header_logo.scss
+++ b/src/components/header/_header_logo.scss
@@ -6,7 +6,7 @@
   position: relative;
   height: $euiHeaderChildSize;
   line-height: $euiHeaderChildSize;
-  min-width: $euiHeaderChildSize + 1px;
+  min-inline-size: $euiHeaderChildSize + 1px;
   padding-block-start: 0;
   padding-block-end: 0;
   padding-inline-start: $euiSizeM;

--- a/src/components/header/_header_logo.scss
+++ b/src/components/header/_header_logo.scss
@@ -7,8 +7,10 @@
   height: $euiHeaderChildSize;
   line-height: $euiHeaderChildSize;
   min-width: $euiHeaderChildSize + 1px;
-  padding-block: 0 $euiSizeM;
-  padding-inline: 0 ($euiSizeM + 1px);
+  padding-block-start: 0;
+  padding-block-end: $euiSizeM;
+  padding-inline-start: 0;
+  padding-inline-end: ($euiSizeM + 1px);
   display: inline-flex;
   align-items: center;
   vertical-align: middle;
@@ -32,8 +34,10 @@
 
 @include euiBreakpoint('xs') {
   .euiHeaderLogo {
-    padding-block: 0;
-    padding-inline: $euiSizeM;
+    padding-block-start: 0;
+    padding-block-end: 0;
+    padding-inline-start: $euiSizeM;
+    padding-inline-end: $euiSizeM;
   }
 
   .euiHeaderLogo__icon.euiIcon--xLarge {

--- a/src/components/header/_header_logo.scss
+++ b/src/components/header/_header_logo.scss
@@ -8,8 +8,8 @@
   line-height: $euiHeaderChildSize;
   min-width: $euiHeaderChildSize + 1px;
   padding-block-start: 0;
-  padding-block-end: $euiSizeM;
-  padding-inline-start: 0;
+  padding-block-end: 0;
+  padding-inline-start: $euiSizeM;
   padding-inline-end: ($euiSizeM + 1px);
   display: inline-flex;
   align-items: center;

--- a/src/components/header/_header_logo.scss
+++ b/src/components/header/_header_logo.scss
@@ -7,7 +7,8 @@
   height: $euiHeaderChildSize;
   line-height: $euiHeaderChildSize;
   min-width: $euiHeaderChildSize + 1px;
-  padding: 0 ($euiSizeM + 1px) 0 $euiSizeM;
+  padding-block: 0 $euiSizeM;
+  padding-inline: 0 ($euiSizeM + 1px);
   display: inline-flex;
   align-items: center;
   vertical-align: middle;
@@ -25,13 +26,14 @@
 
 .euiHeaderLogo__text {
   @include euiTitle('s');
-  padding-left: $euiSize;
+  padding-inline-start: $euiSize;
   font-weight: $euiFontWeightLight;
 }
 
 @include euiBreakpoint('xs') {
   .euiHeaderLogo {
-    padding: 0 $euiSizeM;
+    padding-block: 0;
+    padding-inline: $euiSizeM;
   }
 
   .euiHeaderLogo__icon.euiIcon--xLarge {

--- a/src/components/header/_mixins.scss
+++ b/src/components/header/_mixins.scss
@@ -1,6 +1,6 @@
 @mixin euiHeaderDarkTheme($backgroundColor) {
   background-color: $backgroundColor;
-  border-bottom-color: lightOrDarkTheme($backgroundColor, $euiHeaderBorderColor);
+  border-block-end-color: lightOrDarkTheme($backgroundColor, $euiHeaderBorderColor);
 
   .euiHeaderLogo__text,
   .euiHeaderLink,

--- a/src/components/header/header_alert/_header_alert.scss
+++ b/src/components/header/header_alert/_header_alert.scss
@@ -1,5 +1,5 @@
 .euiHeaderAlert {
-  min-width: 300px;
+  min-inline-size: 300px;
   position: relative;
   margin-block-end: $euiSizeL;
   padding-block-start: 0;
@@ -12,8 +12,8 @@
   .euiHeaderAlert__dismiss {
     opacity: 0;
     position: absolute;
-    right: $euiSize - 4px;
-    top: $euiSize - 4px;
+    inset-inline-end: $euiSize - 4px;
+    inset-block-start: $euiSize - 4px;
     transition: opacity $euiAnimSpeedNormal ease-in;
   }
 

--- a/src/components/header/header_alert/_header_alert.scss
+++ b/src/components/header/header_alert/_header_alert.scss
@@ -2,8 +2,10 @@
   min-width: 300px;
   position: relative;
   margin-block-end: $euiSizeL;
-  padding-block: 0 $euiSizeL;
-  padding-inline: $euiSizeS;
+  padding-block-start: 0;
+  padding-block-end: $euiSizeL;
+  padding-inline-start: $euiSizeS;
+  padding-inline-end: $euiSizeS;
   border-block-end: $euiBorderThin;
   border-block-start: none;
 

--- a/src/components/header/header_alert/_header_alert.scss
+++ b/src/components/header/header_alert/_header_alert.scss
@@ -1,10 +1,11 @@
 .euiHeaderAlert {
   min-width: 300px;
   position: relative;
-  margin-bottom: $euiSizeL;
-  padding: 0 $euiSizeS $euiSizeL;
-  border-bottom: $euiBorderThin;
-  border-top: none;
+  margin-block-end: $euiSizeL;
+  padding-block: 0 $euiSizeL;
+  padding-inline: $euiSizeS;
+  border-block-end: $euiBorderThin;
+  border-block-start: none;
 
   .euiHeaderAlert__dismiss {
     opacity: 0;
@@ -21,12 +22,12 @@
 
   .euiHeaderAlert__title {
     @include euiTitle('xs');
-    margin-bottom: $euiSizeS;
+    margin-block-end: $euiSizeS;
   }
 
   .euiHeaderAlert__text {
     @include euiFontSizeS;
-    margin-bottom: $euiSize;
+    margin-block-end: $euiSize;
   }
 
   .euiHeaderAlert__action {

--- a/src/components/header/header_breadcrumbs/_header_breadcrumbs.scss
+++ b/src/components/header/header_breadcrumbs/_header_breadcrumbs.scss
@@ -1,8 +1,8 @@
 // Breadcrumb navigation included in the header.
 
 .euiHeaderBreadcrumbs {
-  margin-left: $euiSizeM;
-  margin-right: $euiSizeM;
+  margin-inline-start: $euiSizeM;
+  margin-inline-end: $euiSizeM;
   display: flex;
   align-items: center;
   flex-grow: 1;

--- a/src/components/header/header_links/_header_links.scss
+++ b/src/components/header/header_links/_header_links.scss
@@ -12,8 +12,10 @@
 
   > * {
     // Apply margins to any children
-    margin-block: 0;
-    margin-inline: $euiSizeS;
+    margin-block-start: 0;
+    margin-block-end: 0;
+    margin-inline-start: $euiSizeS;
+    margin-inline-end: $euiSizeS;
   }
 }
 

--- a/src/components/header/header_links/_header_links.scss
+++ b/src/components/header/header_links/_header_links.scss
@@ -12,7 +12,8 @@
 
   > * {
     // Apply margins to any children
-    margin: 0 $euiSizeS;
+    margin-block: 0;
+    margin-inline: $euiSizeS;
   }
 }
 

--- a/src/components/header/header_section/_header_section_item.scss
+++ b/src/components/header/header_section/_header_section_item.scss
@@ -8,16 +8,16 @@
   &:after {
     position: absolute;
     content: '';
-    top: $euiSize;
-    bottom: 0;
+    inset-block-start: $euiSize;
+    inset-block-end: 0;
     background: $euiBorderColor;
-    left: 0;
+    inset-inline-start: 0;
   }
 }
 
 .euiHeaderSectionItem__button {
   height: $euiHeaderChildSize;
-  min-width: $euiHeaderChildSize;
+  min-inline-size: $euiHeaderChildSize;
   text-align: center;
   font-size: 0; // aligns icons better vertically
 
@@ -32,7 +32,7 @@
 
 .euiHeaderSectionItem--borderLeft {
   &:after {
-    left: 0;
+    inset-inline-start: 0;
     width: 1px;
   }
 }
@@ -40,8 +40,8 @@
 .euiHeaderSectionItem--borderRight {
   &:after {
     width: 1px;
-    left: auto;
-    right: 0;
+    inset-inline-start: auto;
+    inset-inline-end: 0;
   }
 }
 
@@ -51,15 +51,15 @@
 .euiHeaderNotification,
 .euiHeaderSectionItemButton__notification {
   position: absolute;
-  top: 9%;
-  right: 9%;
+  inset-block-start: 9%;
+  inset-inline-end: 9%;
   box-shadow: 0 0 0 1px $euiHeaderBackgroundColor;
 }
 
 @include euiBreakpoint('xs') {
   .euiHeaderSectionItem,
   .euiHeaderSectionItem__button {
-    min-width: $euiHeaderChildSize * .75;
+    min-inline-size: $euiHeaderChildSize * .75;
   }
 
   .euiHeaderSectionItem--borderLeft,
@@ -73,8 +73,8 @@
   .euiHeaderNotification,
   .euiHeaderSectionItemButton__notification {
     @include size($euiSizeS);
-    top: 20%;
-    min-width: 0;
+    inset-block-start: 20%;
+    min-inline-size: 0;
     border-radius: $euiSizeS;
     color: $euiColorAccent;
     overflow: hidden;

--- a/src/components/horizontal_rule/_horizontal_rule.scss
+++ b/src/components/horizontal_rule/_horizontal_rule.scss
@@ -33,7 +33,9 @@ $ruleMargins: (
 
 @each $name, $size in $ruleMargins {
   .euiHorizontalRule--#{$name} {
-    margin-block: $size;
-    margin-inline: 0;
+    margin-block-start: $size;
+    margin-block-end: $size;
+    margin-inline-start: 0;
+    margin-inline-end: 0;
   }
 }

--- a/src/components/horizontal_rule/_horizontal_rule.scss
+++ b/src/components/horizontal_rule/_horizontal_rule.scss
@@ -11,14 +11,14 @@
 
   &.euiHorizontalRule--half {
     width: 50%;
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
   }
 
   &.euiHorizontalRule--quarter {
     width: 25%;
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
   }
 }
 
@@ -33,6 +33,7 @@ $ruleMargins: (
 
 @each $name, $size in $ruleMargins {
   .euiHorizontalRule--#{$name} {
-    margin: $size 0;
+    margin-block: $size;
+    margin-inline: 0;
   }
 }

--- a/src/components/image/_image.scss
+++ b/src/components/image/_image.scss
@@ -6,7 +6,7 @@
 // Main <figure> that wraps images.
 .euiImage {
   display: inline-block;
-  max-width: 100%;
+  max-inline-size: 100%;
   position: relative;
   min-height: 1px; /* 1 */
   line-height: 0; // Fixes cropping when image is resized by forcing its height to be determined by the image not line-height
@@ -86,8 +86,8 @@
   visibility: hidden;
   fill-opacity: 0;
   position: absolute;
-  right: $euiSize;
-  top: $euiSize;
+  inset-inline-end: $euiSize;
+  inset-block-start: $euiSize;
   transition: fill-opacity $euiAnimSpeedSlow $euiAnimSlightResistance;
   cursor: pointer;
 }
@@ -95,8 +95,8 @@
 // The FullScreen image that optionally pops up on click.
 .euiImage-isFullScreen {
   position: relative;
-  max-height: 80vh;
-  max-width: 80vw;
+  max-block-size: 80vh;
+  max-inline-size: 80vw;
   animation: euiImageFullScreen $euiAnimSpeedExtraSlow $euiAnimSlightBounce;
 
   &:hover {
@@ -111,13 +111,13 @@
 
   &__icon {
     position: absolute;
-    right: $euiSize;
-    top: $euiSize;
+    inset-inline-end: $euiSize;
+    inset-block-start: $euiSize;
   }
 
   &__img {
-    max-height: 80vh;
-    max-width: 80vw;
+    max-block-size: 80vh;
+    max-inline-size: 80vw;
     vertical-align: middle;
     cursor: pointer;
     transition: all $euiAnimSpeedFast $euiAnimSlightResistance;

--- a/src/components/key_pad_menu/_key_pad_menu.scss
+++ b/src/components/key_pad_menu/_key_pad_menu.scss
@@ -69,8 +69,8 @@
 
     .euiKeyPadMenuItem__betaBadgeWrapper {
       position: absolute;
-      top: $euiSizeXS;
-      right: $euiSizeS;
+      inset-block-start: $euiSizeXS;
+      inset-inline-end: $euiSizeS;
       z-index: 3;
 
       // sass-lint:disable-block nesting-depth

--- a/src/components/key_pad_menu/_key_pad_menu.scss
+++ b/src/components/key_pad_menu/_key_pad_menu.scss
@@ -98,7 +98,7 @@
 .euiKeyPadMenuItem__icon {
   transition: transform $euiAnimSpeedNormal $euiAnimSlightBounce;
   transform: translateY(2px);
-  margin-bottom: $euiSizeM;
+  margin-block-end: $euiSizeM;
 }
 
 .euiKeyPadMenuItem__label {

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -13,7 +13,7 @@ $textColors: (
   @include euiLink;
 
   .euiLink__externalIcon {
-    margin-left: $euiSizeXS;
+    margin-inline-start: $euiSizeXS;
   }
 
   &.euiLink-disabled {

--- a/src/components/link/_mixins.scss
+++ b/src/components/link/_mixins.scss
@@ -1,5 +1,5 @@
 @mixin euiLink {
-  text-align: left;
+  text-align: start;
 
   &:hover {
     text-decoration: underline;

--- a/src/components/list_group/_list_group.scss
+++ b/src/components/list_group/_list_group.scss
@@ -26,7 +26,7 @@
     padding: $gutterSize;
 
     .euiListGroupItem:not(:first-of-type) {
-      margin-top: $gutterSize;
+      margin-block-start: $gutterSize;
     }
   }
 }

--- a/src/components/list_group/_list_group.scss
+++ b/src/components/list_group/_list_group.scss
@@ -17,7 +17,7 @@
 }
 
 .euiListGroup-maxWidthDefault {
-  max-width: $euiFormMaxWidth;
+  max-inline-size: $euiFormMaxWidth;
 }
 
 // Gutter Sizes

--- a/src/components/list_group/_list_group_item.scss
+++ b/src/components/list_group/_list_group_item.scss
@@ -72,11 +72,11 @@
   align-items: center;
   flex: 1 0 auto; // The flex-shrink and flex-basis values are needed for IE11
   text-align: left;
-  max-width: 100%;
+  max-inline-size: 100%;
   font-weight: inherit;
 
   .euiListGroupItem-hasExtraAction & {
-    max-width: calc(100% - #{$euiSizeXL});
+    max-inline-size: calc(100% - #{$euiSizeXL});
   }
 
   @each $colorName, $color in $euiListGroupItemColorTypes {

--- a/src/components/list_group/_list_group_item.scss
+++ b/src/components/list_group/_list_group_item.scss
@@ -64,8 +64,10 @@
 .euiListGroupItem__text,
 .euiListGroupItem__button {
   line-height: $euiSizeL;
-  padding-block: $euiSizeXS;
-  padding-inline: $euiSizeS;
+  padding-block-start: $euiSizeXS;
+  padding-block-end: $euiSizeXS;
+  padding-inline-start: $euiSizeS;
+  padding-inline-end: $euiSizeS;
   display: flex;
   align-items: center;
   flex: 1 0 auto; // The flex-shrink and flex-basis values are needed for IE11

--- a/src/components/list_group/_list_group_item.scss
+++ b/src/components/list_group/_list_group_item.scss
@@ -71,7 +71,7 @@
   display: flex;
   align-items: center;
   flex: 1 0 auto; // The flex-shrink and flex-basis values are needed for IE11
-  text-align: left;
+  text-align: start;
   max-inline-size: 100%;
   font-weight: inherit;
 

--- a/src/components/list_group/_list_group_item.scss
+++ b/src/components/list_group/_list_group_item.scss
@@ -64,7 +64,8 @@
 .euiListGroupItem__text,
 .euiListGroupItem__button {
   line-height: $euiSizeL;
-  padding: $euiSizeXS $euiSizeS;
+  padding-block: $euiSizeXS;
+  padding-inline: $euiSizeS;
   display: flex;
   align-items: center;
   flex: 1 0 auto; // The flex-shrink and flex-basis values are needed for IE11
@@ -95,7 +96,7 @@
 
 .euiListGroupItem__extraAction {
   opacity: 0;
-  margin-right: $euiSizeS;
+  margin-inline-end: $euiSizeS;
   transition: opacity $euiAnimSpeedFast;
 
   .euiListGroupItem:not(.euiListGroupItem-isDisabled):focus &,
@@ -107,7 +108,7 @@
 }
 
 .euiListGroupItem__icon {
-  margin-right: $euiSizeM;
+  margin-inline-end: $euiSizeM;
   flex-grow: 0;
   flex-shrink: 0;
 }

--- a/src/components/loading/_loading_chart.scss
+++ b/src/components/loading/_loading_chart.scss
@@ -9,8 +9,8 @@
   height: 100%;
   width: $euiSizeS;
   display: inline-block;
-  margin-bottom: -$euiSize;
-  margin-left: $euiSizeXS / 2;
+  margin-block-end: -$euiSize;
+  margin-inline-start: $euiSizeXS / 2;
   animation: euiLoadingChart 1s infinite;
 
   &:nth-child(1) {
@@ -58,8 +58,8 @@
 
   > span {
     width: $euiSizeXS / 2;
-    margin-left: $euiSizeXS / 2;
-    margin-bottom: $euiSizeS;
+    margin-inline-start: $euiSizeXS / 2;
+    margin-block-end: $euiSizeS;
   }
 }
 
@@ -68,8 +68,8 @@
 
   > span {
     width: $euiSizeXS;
-    margin-left: $euiSizeXS / 2;
-    margin-bottom: $euiSizeL / 2;
+    margin-inline-start: $euiSizeXS / 2;
+    margin-block-end: $euiSizeL / 2;
   }
 }
 
@@ -78,8 +78,8 @@
 
   > span {
     width: $euiSizeS;
-    margin-left: $euiSizeXS;
-    margin-bottom: $euiSizeXL / 2;
+    margin-inline-start: $euiSizeXS;
+    margin-block-end: $euiSizeXL / 2;
   }
 }
 

--- a/src/components/loading/_loading_content.scss
+++ b/src/components/loading/_loading_content.scss
@@ -7,7 +7,7 @@
   display: block;
   width: 100%;
   height: $euiSize;
-  margin-bottom: $euiSizeS;
+  margin-block-end: $euiSizeS;
   border-radius: $euiBorderRadius;
   overflow: hidden;
 

--- a/src/components/loading/_loading_kibana.scss
+++ b/src/components/loading/_loading_kibana.scss
@@ -7,7 +7,7 @@
     position: absolute;
     content: '';
     width: 90%;
-    left: 5%;
+    inset-inline-start: 5%;
     border-radius: 50%;
     opacity: .2;
     z-index: 1;
@@ -37,7 +37,7 @@
   &:before,
   &:after {
     height: $euiSizeXS - 1; /* 1 */
-    bottom: -$euiSizeXS;
+    inset-block-end: -$euiSizeXS;
   }
 
   .euiLoadingKibana__icon {
@@ -55,7 +55,7 @@
   &:before,
   &:after {
     height: $euiSizeS - 2; /* 1 */
-    bottom: -$euiSizeS;
+    inset-block-end: -$euiSizeS;
   }
 
   .euiLoadingKibana__icon {
@@ -69,7 +69,7 @@
   &:before,
   &:after {
     height: $euiSizeS;
-    bottom: -$euiSizeM;
+    inset-block-end: -$euiSizeM;
   }
 
   .euiLoadingKibana__icon {

--- a/src/components/markdown_editor/_markdown_editor_drop_zone.scss
+++ b/src/components/markdown_editor/_markdown_editor_drop_zone.scss
@@ -3,13 +3,13 @@
   display: flex;
   position: relative;
   flex-direction: column;
-  min-height: 150px;
-  max-height: 600px;
+  min-block-size: 150px;
+  max-block-size: 600px;
 
   &__input {
     position: absolute;
-    left: 0;
-    top: 0;
+    inset-inline-start: 0;
+    inset-block-start: 0;
     width: 100%;
     height: 100%;
     opacity: 0;

--- a/src/components/markdown_editor/_markdown_editor_footer.scss
+++ b/src/components/markdown_editor/_markdown_editor_footer.scss
@@ -16,7 +16,7 @@
 
   > button,
   > span {
-    margin-right: $euiSizeXS;
+    margin-inline-end: $euiSizeXS;
     align-self: center;
   }
 
@@ -29,7 +29,8 @@
     border-radius: $euiBorderRadius;
 
     > span {
-      padding: 0 $euiSizeXS;
+      padding-block: 0;
+      padding-inline: $euiSizeXS;
     }
   }
 }

--- a/src/components/markdown_editor/_markdown_editor_footer.scss
+++ b/src/components/markdown_editor/_markdown_editor_footer.scss
@@ -24,7 +24,7 @@
   // So when we have an error this button appears smoothly 
   .euiMarkdownEditorFooter__uploadError {
     position: relative;
-    left: -1px;
+    inset-inline-start: -1px;
     line-height: 1;
     border-radius: $euiBorderRadius;
 

--- a/src/components/markdown_editor/_markdown_editor_footer.scss
+++ b/src/components/markdown_editor/_markdown_editor_footer.scss
@@ -29,8 +29,10 @@
     border-radius: $euiBorderRadius;
 
     > span {
-      padding-block: 0;
-      padding-inline: $euiSizeXS;
+      padding-block-start: 0;
+      padding-block-end: 0;
+      padding-inline-start: $euiSizeXS;
+      padding-inline-end: $euiSizeXS;
     }
   }
 }

--- a/src/components/markdown_editor/_markdown_editor_text_area.scss
+++ b/src/components/markdown_editor/_markdown_editor_text_area.scss
@@ -3,7 +3,7 @@
   @include euiScrollBar;
   width: 100%;
   height: 100%;
-  min-height: 150px;
+  min-block-size: 150px;
   padding: $euiSizeM;
   border: $euiBorderThin;
   border-block-end: none;

--- a/src/components/markdown_editor/_markdown_editor_text_area.scss
+++ b/src/components/markdown_editor/_markdown_editor_text_area.scss
@@ -6,7 +6,7 @@
   min-height: 150px;
   padding: $euiSizeM;
   border: $euiBorderThin;
-  border-bottom: none;
+  border-block-end: none;
   // Overrides the euiFormControlText line-height that is very small
   line-height: $euiLineHeight;
   resize: vertical;

--- a/src/components/markdown_editor/_markdown_editor_toolbar.scss
+++ b/src/components/markdown_editor/_markdown_editor_toolbar.scss
@@ -4,7 +4,7 @@
   background: $euiColorLightestShade;
   border: $euiBorderThin;
   border-color: $euiColorLightShade;
-  border-bottom: none;
+  border-block-end: none;
   padding: $euiSizeXS;
 
   &__buttons {
@@ -14,7 +14,7 @@
     align-items: center;
 
     > * {
-      margin-right: $euiSizeXS;
+      margin-inline-end: $euiSizeXS;
     }
   }
 
@@ -22,8 +22,8 @@
     content: '';
     height: $euiSizeL;
     display: block;
-    margin-left: $euiSizeXS;
-    padding-right: $euiSizeXS;
-    border-left: 1px solid $euiColorLightShade;
+    margin-inline-start: $euiSizeXS;
+    padding-inline-end: $euiSizeXS;
+    border-inline-start: 1px solid $euiColorLightShade;
   }
 }

--- a/src/components/markdown_editor/_markdown_format.scss
+++ b/src/components/markdown_editor/_markdown_format.scss
@@ -151,8 +151,10 @@ $browserDefaultFontSize: 16px;
 
   // 4. Blockquotes
   blockquote {
-    padding-block: 0;
-    padding-inline: 1em;
+    padding-block-start: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1em;
+    padding-inline-end: 1em;
     border-inline-start: $euiMarkdownSizeXXS solid $euiMarkdownAlphaLightShade;
   }
 
@@ -165,8 +167,10 @@ $browserDefaultFontSize: 16px;
     border: none;
     height: 1px;
     background-color: $euiMarkdownAlphaLightShade;
-    margin-block: $euiMarkdownSizeL;
-    margin-inline: 0;
+    margin-block-start: $euiMarkdownSizeL;
+    margin-block-end: $euiMarkdownSizeL;
+    margin-inline-start: 0;
+    margin-inline-end: 0;
   }
 
   hr::before {
@@ -241,8 +245,10 @@ $browserDefaultFontSize: 16px;
   }
 
   .task-list-item input {
-    margin-block: 0 -1.6em;
-    margin-inline: .25em .2em;
+    margin-block-start: 0;
+    margin-block-end: -1.6em;
+    margin-inline-start: .25em;
+    margin-inline-end: .2em;
     vertical-align: middle;
   }
 
@@ -263,8 +269,10 @@ $browserDefaultFontSize: 16px;
 
   table th,
   table td {
-    padding-block: $euiMarkdownSizeXXS;
-    padding-inline: $euiMarkdownSizeXS;
+    padding-block-start: $euiMarkdownSizeXXS;
+    padding-block-end: $euiMarkdownSizeXXS;
+    padding-inline-start: $euiMarkdownSizeXS;
+    padding-inline-end: $euiMarkdownSizeXS;
     border-block-start: 1px solid $euiMarkdownAlphaLightShade;
     border-block-end: 1px solid $euiMarkdownAlphaLightShade;
 

--- a/src/components/markdown_editor/_markdown_format.scss
+++ b/src/components/markdown_editor/_markdown_format.scss
@@ -246,8 +246,8 @@ $browserDefaultFontSize: 16px;
 
   .task-list-item input {
     margin-block-start: 0;
-    margin-block-end: -1.6em;
-    margin-inline-start: .25em;
+    margin-block-end: .25em;
+    margin-inline-start: -1.6em;
     margin-inline-end: .2em;
     vertical-align: middle;
   }

--- a/src/components/markdown_editor/_markdown_format.scss
+++ b/src/components/markdown_editor/_markdown_format.scss
@@ -60,22 +60,22 @@ $browserDefaultFontSize: 16px;
 
   > div > *:first-child {
     // sass-lint:disable-block no-important
-    margin-top: 0 !important;
+    margin-block-start: 0 !important;
   }
 
   > div > * {
-    margin-top: 0;
-    margin-bottom: $euiMarkdownSize;
+    margin-block-start: 0;
+    margin-block-end: $euiMarkdownSize;
   }
 
   > div > *:last-child,
   .euiCheckbox {
     // sass-lint:disable-block no-important
-    margin-bottom: 0 !important;
+    margin-block-end: 0 !important;
   }
 
   .euiCheckbox + *:not(.euiCheckbox) {
-    margin-top: $euiMarkdownSize;
+    margin-block-start: $euiMarkdownSize;
   }
 
   p,
@@ -85,8 +85,8 @@ $browserDefaultFontSize: 16px;
   dl,
   pre,
   table {
-    margin-top: 0;
-    margin-bottom: $euiMarkdownSize;
+    margin-block-start: 0;
+    margin-block-end: $euiMarkdownSize;
     line-height: 1.5em;
   }
 
@@ -101,8 +101,8 @@ $browserDefaultFontSize: 16px;
   h4,
   h5,
   h6 {
-    margin-top: 0;
-    margin-bottom: $euiMarkdownSizeXS;
+    margin-block-start: 0;
+    margin-block-end: $euiMarkdownSizeXS;
   }
 
   h1 {
@@ -151,12 +151,13 @@ $browserDefaultFontSize: 16px;
 
   // 4. Blockquotes
   blockquote {
-    padding: 0 1em;
-    border-left: $euiMarkdownSizeXXS solid $euiMarkdownAlphaLightShade;
+    padding-block: 0;
+    padding-inline: 1em;
+    border-inline-start: $euiMarkdownSizeXXS solid $euiMarkdownAlphaLightShade;
   }
 
   &--reversed blockquote {
-    border-left-color: $euiMarkdownAlphaLightShadeReversed;
+    border-inline-start-color: $euiMarkdownAlphaLightShadeReversed;
   }
 
   // 5. Horizontal rules
@@ -164,7 +165,8 @@ $browserDefaultFontSize: 16px;
     border: none;
     height: 1px;
     background-color: $euiMarkdownAlphaLightShade;
-    margin: $euiMarkdownSizeL 0;
+    margin-block: $euiMarkdownSizeL;
+    margin-inline: 0;
   }
 
   hr::before {
@@ -181,9 +183,9 @@ $browserDefaultFontSize: 16px;
   // 6. Lists
   ul,
   ol {
-    padding-left: $euiMarkdownSizeL;
-    margin-top: 0;
-    margin-bottom: $euiMarkdownSize;
+    padding-inline-start: $euiMarkdownSizeL;
+    margin-block-start: 0;
+    margin-block-end: $euiMarkdownSize;
   }
 
   ul {
@@ -211,23 +213,23 @@ $browserDefaultFontSize: 16px;
   }
 
   dd {
-    margin-left: 0;
+    margin-inline-start: 0;
   }
 
   ul ul,
   ul ol,
   ol ol,
   ol ul {
-    margin-top: 0;
-    margin-bottom: 0;
+    margin-block-start: 0;
+    margin-block-end: 0;
   }
 
   li > p {
-    margin-bottom: $euiMarkdownSizeXS;
+    margin-block-end: $euiMarkdownSizeXS;
   }
 
   li + li {
-    margin-top: $euiMarkdownSizeXXS;
+    margin-block-start: $euiMarkdownSizeXXS;
   }
 
   .task-list-item {
@@ -235,11 +237,12 @@ $browserDefaultFontSize: 16px;
   }
 
   .task-list-item + .task-list-item {
-    margin-top: $euiMarkdownSizeXXS;
+    margin-block-start: $euiMarkdownSizeXXS;
   }
 
   .task-list-item input {
-    margin: 0 .2em .25em -1.6em;
+    margin-block: 0 -1.6em;
+    margin-inline: .25em .2em;
     vertical-align: middle;
   }
 
@@ -248,7 +251,7 @@ $browserDefaultFontSize: 16px;
     display: block;
     width: 100%;
     overflow: auto;
-    border-left: 1px solid $euiMarkdownAlphaLightShade;
+    border-inline-start: 1px solid $euiMarkdownAlphaLightShade;
     border-spacing: 0;
     border-collapse: collapse;
   }
@@ -260,17 +263,18 @@ $browserDefaultFontSize: 16px;
 
   table th,
   table td {
-    padding: $euiMarkdownSizeXXS $euiMarkdownSizeXS;
-    border-top: 1px solid $euiMarkdownAlphaLightShade;
-    border-bottom: 1px solid $euiMarkdownAlphaLightShade;
+    padding-block: $euiMarkdownSizeXXS;
+    padding-inline: $euiMarkdownSizeXS;
+    border-block-start: 1px solid $euiMarkdownAlphaLightShade;
+    border-block-end: 1px solid $euiMarkdownAlphaLightShade;
 
     &:last-child {
-      border-right: 1px solid $euiMarkdownAlphaLightShade;
+      border-inline-end: 1px solid $euiMarkdownAlphaLightShade;
     }
   }
 
   table tr {
     background-color: transparent;
-    border-top: 1px solid $euiMarkdownAlphaLightShade;
+    border-block-start: 1px solid $euiMarkdownAlphaLightShade;
   }
 }

--- a/src/components/markdown_editor/_markdown_format.scss
+++ b/src/components/markdown_editor/_markdown_format.scss
@@ -144,7 +144,7 @@ $browserDefaultFontSize: 16px;
 
   // 3. Images
   img {
-    max-width: 100%;
+    max-inline-size: 100%;
     box-sizing: content-box;
     border-style: none;
   }

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -22,7 +22,7 @@
     flex: 1 1 auto;
     display: flex;
     flex-direction: column;
-    max-height: 75vh; // We overflow the modal body based off this
+    max-block-size: 75vh; // We overflow the modal body based off this
     overflow: hidden; // Ensure long, non-breaking text doesn't expand beyond the modal bounds
   }
 }
@@ -146,7 +146,10 @@
 
   .euiModalFooter {
     background: $euiColorLightestShade;
-    padding: $euiSizeM $euiSizeL !important; // sass-lint:disable-line no-important
+    padding-block-start: $euiSizeM !important; // sass-lint:disable-line no-important
+    padding-block-end: $euiSizeM !important; // sass-lint:disable-line no-important
+    padding-inline-start: $euiSizeL !important; // sass-lint:disable-line no-important
+    padding-inline-end: $euiSizeL !important; // sass-lint:disable-line no-important
     width: 100vw;
     justify-content: stretch;
 

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -40,8 +40,8 @@
   justify-content: space-between;
   align-items: center;
   padding-block-start: $euiSizeL;
-  padding-block-end: $euiSizeL;
-  padding-inline-start: $euiSize;
+  padding-block-end: $euiSize;
+  padding-inline-start: $euiSizeL;
   padding-inline-end: $euiSizeXXL;
   flex-grow: 0;
   flex-shrink: 0;

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -39,7 +39,8 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: $euiSizeL $euiSizeXXL $euiSize $euiSizeL;
+  padding-block: $euiSizeL;
+  padding-inline: $euiSize $euiSizeXXL;
   flex-grow: 0;
   flex-shrink: 0;
 }
@@ -57,30 +58,32 @@
 
   .euiModalBody__overflow {
     @include euiYScrollWithShadows;
-    padding: $euiSizeS $euiSizeL;
+    padding-block: $euiSizeS;
+    padding-inline: $euiSizeL;
   }
 }
 
 .euiModalFooter {
   display: flex;
   justify-content: flex-end;
-  padding: $euiSize $euiSizeL $euiSizeL;
+  padding-block: $euiSize $euiSizeL;
+  padding-inline: $euiSizeL;
   flex-grow: 0;
   flex-shrink: 0; // ensure the height of the footer is based off its contents and doesn't squish
 
   > * + * {
-    margin-left: $euiSize;
+    margin-inline-start: $euiSize;
   }
 }
 
 // If a body doesn't exist, remove some extra padding from footer
 .euiModalHeader + .euiModalFooter {
-  padding-top: $euiSizeS;
+  padding-block-start: $euiSizeS;
 }
 
 // If a footer doesn't exist (body is the last element) add padding to the bottom
 .euiModalBody:last-of-type .euiModalBody__overflow {
-  padding-bottom: $euiSizeL;
+  padding-block-end: $euiSizeL;
 }
 
 
@@ -145,7 +148,7 @@
       flex: 1;
 
       + * {
-        margin-left: 0;
+        margin-inline-start: 0;
       }
     }
   }
@@ -154,7 +157,7 @@
     width: 100vw;
 
     .euiModalBody__overflow {
-      padding-bottom: $euiSizeL;
+      padding-block-end: $euiSizeL;
     }
   }
 }

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -39,8 +39,10 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-block: $euiSizeL;
-  padding-inline: $euiSize $euiSizeXXL;
+  padding-block-start: $euiSizeL;
+  padding-block-end: $euiSizeL;
+  padding-inline-start: $euiSize;
+  padding-inline-end: $euiSizeXXL;
   flex-grow: 0;
   flex-shrink: 0;
 }
@@ -58,16 +60,20 @@
 
   .euiModalBody__overflow {
     @include euiYScrollWithShadows;
-    padding-block: $euiSizeS;
-    padding-inline: $euiSizeL;
+    padding-block-start: $euiSizeS;
+    padding-block-end: $euiSizeS;
+    padding-inline-start: $euiSizeL;
+    padding-inline-end: $euiSizeL;
   }
 }
 
 .euiModalFooter {
   display: flex;
   justify-content: flex-end;
-  padding-block: $euiSize $euiSizeL;
-  padding-inline: $euiSizeL;
+  padding-block-start: $euiSize;
+  padding-block-end: $euiSizeL;
+  padding-inline-start: $euiSizeL;
+  padding-inline-end: $euiSizeL;
   flex-grow: 0;
   flex-shrink: 0; // ensure the height of the footer is based off its contents and doesn't squish
 

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -15,7 +15,7 @@
   background-color: $euiColorEmptyShade;
   border-radius: $euiBorderRadius;
   z-index: $euiZModal;
-  min-width: $euiFormMaxWidth;
+  min-inline-size: $euiFormMaxWidth;
   animation: euiModal $euiAnimSpeedSlow $euiAnimSlightBounce;
 
   .euiModal__flex { /* 1 */
@@ -28,11 +28,11 @@
 }
 
 .euiModal--maxWidth-default {
-  max-width: map-get($euiBreakpoints, 'm');
+  max-inline-size: map-get($euiBreakpoints, 'm');
 }
 
 .euiModal--confirmation {
-  min-width: $euiFormMaxWidth;
+  min-inline-size: $euiFormMaxWidth;
 }
 
 .euiModalHeader {
@@ -98,8 +98,8 @@
 .euiModal__closeIcon {
   background-color: transparentize($euiColorEmptyShade, .1);
   position: absolute;
-  right: $euiSizeXS;
-  top: $euiSizeXS;
+  inset-inline-end: $euiSizeXS;
+  inset-block-start: $euiSizeXS;
   z-index: 3;
 }
 
@@ -121,22 +121,22 @@
     // sass-lint:disable-block no-important
     position: fixed;
     width: 100vw !important;
-    max-width: none !important;
-    min-width: 0 !important;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    top: 0;
+    max-inline-size: none !important;
+    min-inline-size: 0 !important;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
+    inset-block-end: 0;
+    inset-block-start: 0;
     border-radius: 0;
     border: none;
 
     &.euiModal--confirmation {
       @include euiBottomShadowLarge($euiShadowColorLarge, $reverse: true);
-      top: auto;
+      inset-block-start: auto;
     }
 
     .euiModal__flex { /* 1 */
-      max-height: 100vh;
+      max-block-size: 100vh;
     }
   }
 

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -21,7 +21,7 @@
     height: 100%;
 
     &-hasFooter {
-      margin-bottom: $euiSizeXXL;
+      margin-block-end: $euiSizeXXL;
     }
   }
 
@@ -35,7 +35,8 @@
     z-index: $euiZHeader + 1;
 
     .euiListGroupItem__button {
-      padding: $euiSizeM $euiSize;
+      padding-block: $euiSizeM;
+      padding-inline: $euiSize;
     }
 
     .navDrawerExpandButton-isCollapsed .euiListGroupItem__button {
@@ -89,7 +90,7 @@
   height: 100%;
 
   .euiNavDrawerPage__pageBody {
-    margin-left: $euiNavDrawerWidthCollapsed;
+    margin-inline-start: $euiNavDrawerWidthCollapsed;
   }
 }
 
@@ -99,7 +100,7 @@
 
     &.euiNavDrawer-isExpanded .euiNavDrawerMenu {
       .euiListGroupItem__icon {
-        margin-right: $euiSizeM;
+        margin-inline-end: $euiSizeM;
       }
     }
 
@@ -111,7 +112,7 @@
     // No expand toggle on mobile
 
     .euiNavDrawerMenu-hasFooter {
-      margin-bottom: 0;
+      margin-block-end: 0;
     }
 
     .euiNavDrawer__expandButton {
@@ -120,7 +121,7 @@
   }
 
   .euiNavDrawerPage .euiNavDrawerPage__pageBody {
-    margin-left: 0;
+    margin-inline-start: 0;
   }
 }
 

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -35,8 +35,10 @@
     z-index: $euiZHeader + 1;
 
     .euiListGroupItem__button {
-      padding-block: $euiSizeM;
-      padding-inline: $euiSize;
+      padding-block-start: $euiSizeM;
+      padding-block-end: $euiSizeM;
+      padding-inline-start: $euiSize;
+      padding-inline-end: $euiSize;
     }
 
     .navDrawerExpandButton-isCollapsed .euiListGroupItem__button {

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -4,8 +4,8 @@
   width: $euiNavDrawerWidthCollapsed;
   height: calc(100% - #{$euiNavDrawerTopPosition});
   position: fixed;
-  left: 0;
-  top: $euiNavDrawerTopPosition;
+  inset-inline-start: 0;
+  inset-block-start: $euiNavDrawerTopPosition;
   overflow: hidden;
   z-index: $euiZHeader;
   background: $euiHeaderBackgroundColor;
@@ -29,7 +29,7 @@
     @include euiBottomShadowFlat;
     background-color: $euiColorEmptyShade;
     position: fixed;
-    bottom: 0;
+    inset-block-end: 0;
     width: $euiNavDrawerWidthCollapsed;
     transition: width $euiAnimSpeedExtraFast;
     z-index: $euiZHeader + 1;
@@ -42,7 +42,7 @@
     }
 
     .navDrawerExpandButton-isCollapsed .euiListGroupItem__button {
-      max-width: 100%;
+      max-inline-size: 100%;
     }
   }
 
@@ -64,7 +64,7 @@
       }
 
       .euiListGroup:not(.euiNavDrawer__expandButton) .euiListGroupItem__button {
-        max-width: $euiSizeXL;
+        max-inline-size: $euiSizeXL;
       }
 
       .euiListGroupItem__extraAction {

--- a/src/components/nav_drawer/_nav_drawer.scss
+++ b/src/components/nav_drawer/_nav_drawer.scss
@@ -137,7 +137,7 @@
   .euiNavDrawer-isLocked {
     + .euiNavDrawerPage .euiNavDrawerPage__pageBody {
       // Shrink the content from the left so it's no longer overlapped by the nav drawer (ALWAYS)
-      margin-left: $euiNavDrawerWidthExpanded !important; // sass-lint:disable-line no-important
+      margin-inline-start: $euiNavDrawerWidthExpanded !important; // sass-lint:disable-line no-important
       transition: margin $euiAnimSpeedFast $euiAnimSlightResistance;
     }
 

--- a/src/components/nav_drawer/_nav_drawer_flyout.scss
+++ b/src/components/nav_drawer/_nav_drawer_flyout.scss
@@ -2,8 +2,10 @@
   @include euiScrollBar;
   width: 0;
   height: 100%;
-  padding-block: $euiSizeM;
-  padding-inline: $euiSizeS;
+  padding-block-start: $euiSizeM;
+  padding-block-end: $euiSizeM;
+  padding-inline-start: $euiSizeS;
+  padding-inline-end: $euiSizeS;
   overflow-y: auto;
   background-color: $euiNavDrawerBackgroundColor;
   border-inline-start: $euiBorderThin;
@@ -23,8 +25,10 @@
   }
 
   .euiNavDrawerFlyout__title {
-    margin-block: 0 $euiSizeXS;
-    margin-inline: $euiSizeS;
+    margin-block-start: 0;
+    margin-block-end: $euiSizeXS;
+    margin-inline-start: $euiSizeS;
+    margin-inline-end: $euiSizeS;
   }
 
   .euiNavDrawerFlyout__listGroup {

--- a/src/components/nav_drawer/_nav_drawer_flyout.scss
+++ b/src/components/nav_drawer/_nav_drawer_flyout.scss
@@ -2,10 +2,11 @@
   @include euiScrollBar;
   width: 0;
   height: 100%;
-  padding: $euiSizeM $euiSizeS;
+  padding-block: $euiSizeM;
+  padding-inline: $euiSizeS;
   overflow-y: auto;
   background-color: $euiNavDrawerBackgroundColor;
-  border-left: $euiBorderThin;
+  border-inline-start: $euiBorderThin;
   box-shadow: $euiNavDrawerSideShadow;
   visibility: hidden;
   opacity: 0;
@@ -22,11 +23,12 @@
   }
 
   .euiNavDrawerFlyout__title {
-    margin: 0 $euiSizeS $euiSizeXS;
+    margin-block: 0 $euiSizeXS;
+    margin-inline: $euiSizeS;
   }
 
   .euiNavDrawerFlyout__listGroup {
-    padding-left: 0;
-    padding-right: 0;
+    padding-inline-start: 0;
+    padding-inline-end: 0;
   }
 }

--- a/src/components/nav_drawer/_nav_drawer_group.scss
+++ b/src/components/nav_drawer/_nav_drawer_group.scss
@@ -13,7 +13,7 @@
   }
 
   .euiListGroupItem__icon {
-    max-width: $euiSize;
+    max-inline-size: $euiSize;
   }
 }
 
@@ -32,9 +32,9 @@
   border-radius: 50%;
 
   &:after {
-    top: -$euiSizeXS;
-    left: -$euiSizeXS;
-    right: -$euiSizeXS;
-    bottom: -$euiSizeXS;
+    inset-block-start: -$euiSizeXS;
+    inset-inline-start: -$euiSizeXS;
+    inset-inline-end: -$euiSizeXS;
+    inset-block-end: -$euiSizeXS;
   }
 }

--- a/src/components/overlay_mask/_overlay_mask.scss
+++ b/src/components/overlay_mask/_overlay_mask.scss
@@ -7,7 +7,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding-bottom: 10vh;
+  padding-block-end: 10vh;
   animation: euiAnimFadeIn $euiAnimSpeedFast ease-in;
 
   $backgroundColor: $euiColorEmptyShade;

--- a/src/components/overlay_mask/_overlay_mask.scss
+++ b/src/components/overlay_mask/_overlay_mask.scss
@@ -1,9 +1,9 @@
 .euiOverlayMask {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  inset-block-start: 0;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
+  inset-block-end: 0;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/page/_page.scss
+++ b/src/components/page/_page.scss
@@ -10,7 +10,7 @@
   }
 
   &--restrictWidth-default {
-    max-width: 1000px;
+    max-inline-size: 1000px;
   }
 
   @include euiBreakpoint('xs', 's') {

--- a/src/components/page/_page.scss
+++ b/src/components/page/_page.scss
@@ -5,8 +5,8 @@
 
   &--restrictWidth-default,
   &--restrictWidth-custom {
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
   }
 
   &--restrictWidth-default {

--- a/src/components/page/page_body/_page_body.scss
+++ b/src/components/page/page_body/_page_body.scss
@@ -8,8 +8,8 @@
 
   &--restrictWidth-default,
   &--restrictWidth-custom {
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
   }
 
   &--restrictWidth-default {

--- a/src/components/page/page_body/_page_body.scss
+++ b/src/components/page/page_body/_page_body.scss
@@ -4,7 +4,7 @@
   align-items: stretch;
   flex: 1 1 100%;
   // Make sure that inner flex layouts don't get larger than this container
-  max-width: 100%;
+  max-inline-size: 100%;
 
   &--restrictWidth-default,
   &--restrictWidth-custom {
@@ -13,7 +13,7 @@
   }
 
   &--restrictWidth-default {
-    max-width: 1000px;
+    max-inline-size: 1000px;
   }
 }
 

--- a/src/components/page/page_content/_page_content.scss
+++ b/src/components/page/page_content/_page_content.scss
@@ -3,16 +3,16 @@
 
   &.euiPageContent--verticalCenter {
     align-self: center;
-    margin-top: auto;
-    margin-bottom: auto;
+    margin-block-start: auto;
+    margin-block-end: auto;
     flex-grow: 0;
   }
 
   &.euiPageContent--horizontalCenter {
     width: auto;
     max-width: 100%; // Fixes IE
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
     flex-grow: 0; // Offsets the properties of .euiPanel within flexboxes
   }
 

--- a/src/components/page/page_content/_page_content.scss
+++ b/src/components/page/page_content/_page_content.scss
@@ -10,7 +10,7 @@
 
   &.euiPageContent--horizontalCenter {
     width: auto;
-    max-width: 100%; // Fixes IE
+    max-inline-size: 100%; // Fixes IE
     margin-inline-start: auto;
     margin-inline-end: auto;
     flex-grow: 0; // Offsets the properties of .euiPanel within flexboxes

--- a/src/components/page/page_content/_page_content_header.scss
+++ b/src/components/page/page_content/_page_content_header.scss
@@ -7,7 +7,7 @@
   // Adjust vertical spacing based on content padding prop
   @each $modifier, $amount in $euiPanelPaddingModifiers {
     .euiPageContent[class*='#{$modifier}'] & {
-      margin-bottom: $amount;
+      margin-block-end: $amount;
     }
   }
 }

--- a/src/components/page/page_content/_page_content_header_section.scss
+++ b/src/components/page/page_content/_page_content_header_section.scss
@@ -1,6 +1,6 @@
 .euiPageContentHeaderSection {
   & + & {
-    margin-left: $euiSizeXL;
+    margin-inline-start: $euiSizeXL;
   }
 }
 
@@ -9,8 +9,8 @@
   @each $modifier, $amount in $euiPanelPaddingModifiers {
     .euiPageContent[class*='#{$modifier}'] .euiPageContentHeader--responsive {
       .euiPageContentHeaderSection + .euiPageContentHeaderSection {
-        margin-left: 0;
-        margin-top: $amount / 2;
+        margin-inline-start: 0;
+        margin-block-start: $amount / 2;
       }
     }
   }

--- a/src/components/page/page_header/_page_header.scss
+++ b/src/components/page/page_header/_page_header.scss
@@ -8,8 +8,10 @@
 
 @include euiBreakpoint('xs', 's') {
   .euiPageHeader {
-    padding-block: $euiSize;
-    padding-inline: 0;
+    padding-block-start: $euiSize;
+    padding-block-end: $euiSize;
+    padding-inline-start: 0;
+    padding-inline-end: 0;
     margin-block-end: 0;
   }
 

--- a/src/components/page/page_header/_page_header.scss
+++ b/src/components/page/page_header/_page_header.scss
@@ -1,5 +1,5 @@
 .euiPageHeader {
-  margin-bottom: $euiSize;
+  margin-block-end: $euiSize;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -8,8 +8,9 @@
 
 @include euiBreakpoint('xs', 's') {
   .euiPageHeader {
-    padding: $euiSize 0;
-    margin-bottom: 0;
+    padding-block: $euiSize;
+    padding-inline: 0;
+    margin-block-end: 0;
   }
 
   .euiPageHeader--responsive {

--- a/src/components/page/page_header/_page_header_section.scss
+++ b/src/components/page/page_header/_page_header_section.scss
@@ -1,6 +1,6 @@
 .euiPageHeaderSection {
   & + & {
-    margin-left: $euiSizeXL;
+    margin-inline-start: $euiSizeXL;
   }
 }
 
@@ -9,8 +9,8 @@
     width: 100%;
 
     + .euiPageHeaderSection {
-      margin-left: 0;
-      margin-top: $euiSize;
+      margin-inline-start: 0;
+      margin-block-start: $euiSize;
     }
   }
 }

--- a/src/components/page/page_side_bar/_page_side_bar.scss
+++ b/src/components/page/page_side_bar/_page_side_bar.scss
@@ -4,7 +4,7 @@
 .euiPageSideBar {
   min-width: $euiSize * 12; /* 1 */
   flex: 0 1 0%; /* 1 */
-  margin-right: $euiSizeL;
+  margin-inline-end: $euiSizeL;
 }
 
 @include euiBreakpoint('xs', 's') {

--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -7,11 +7,11 @@
     align-items: center;
 
     > *:first-child {
-      margin-right: $euiSizeXS;
+      margin-inline-end: $euiSizeXS;
     }
 
     > *:last-child {
-      margin-left: $euiSizeXS;
+      margin-inline-start: $euiSizeXS;
     }
   }
 }

--- a/src/components/pagination/_pagination_button.scss
+++ b/src/components/pagination/_pagination_button.scss
@@ -26,8 +26,10 @@
   align-items: baseline;
   color: $euiButtonColorDisabledText;
   font-size: $euiFontSizeS;
-  padding-block: 0;
-  padding-inline: $euiSizeS;
+  padding-block-start: 0;
+  padding-block-end: 0;
+  padding-inline-start: $euiSizeS;
+  padding-inline-end: $euiSizeS;
   height: $euiSizeL;
   padding-block-start: $euiSizeM / 2;
 }

--- a/src/components/pagination/_pagination_button.scss
+++ b/src/components/pagination/_pagination_button.scss
@@ -26,9 +26,10 @@
   align-items: baseline;
   color: $euiButtonColorDisabledText;
   font-size: $euiFontSizeS;
-  padding: 0 $euiSizeS;
+  padding-block: 0;
+  padding-inline: $euiSizeS;
   height: $euiSizeL;
-  padding-top: $euiSizeM / 2;
+  padding-block-start: $euiSizeM / 2;
 }
 
 @include euiBreakpoint('xs', 's') {

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -9,7 +9,7 @@
 
     // Overwrite @hasBetaBadge max-width depending upon padding
     .euiPanel__betaBadgeWrapper {
-      max-width: calc(100% - #{$amount*2});
+      max-inline-size: calc(100% - #{$amount*2});
     }
   }
 }

--- a/src/components/popover/_input_popover.scss
+++ b/src/components/popover/_input_popover.scss
@@ -1,7 +1,7 @@
 .euiInputPopover {
-  max-width: $euiFormMaxWidth;
+  max-inline-size: $euiFormMaxWidth;
 
   &.euiInputPopover--fullWidth {
-    max-width: 100%;
+    max-inline-size: 100%;
   }
 }

--- a/src/components/popover/_popover.scss
+++ b/src/components/popover/_popover.scss
@@ -8,7 +8,7 @@
   display: inline-block;
   position: relative;
   vertical-align: middle;
-  max-width: 100%;
+  max-inline-size: 100%;
 }
 
 .euiPopover__anchor {
@@ -74,14 +74,14 @@
 
     &.euiPopover__panelArrow--top {
       &:before {
-        bottom: -$euiPopoverArrowSize + 2;
+        inset-block-end: -$euiPopoverArrowSize + 2;
         border-inline-start: $euiPopoverArrowSize solid transparent;
         border-inline-end: $euiPopoverArrowSize solid transparent;
         border-block-start: $euiPopoverArrowSize solid $euiBorderColor;
       }
 
       &:after {
-        bottom: -$euiPopoverArrowSize + 3;
+        inset-block-end: -$euiPopoverArrowSize + 3;
         border-inline-start: $euiPopoverArrowSize solid transparent;
         border-inline-end: $euiPopoverArrowSize solid transparent;
         border-block-start: $euiPopoverArrowSize solid $euiColorEmptyShade;
@@ -90,16 +90,16 @@
 
     &.euiPopover__panelArrow--right {
       &:before {
-        left: -$euiPopoverArrowSize;
-        top: 50%;
+        inset-inline-start: -$euiPopoverArrowSize;
+        inset-block-start: 50%;
         border-block-start: $euiPopoverArrowSize solid transparent;
         border-block-end: $euiPopoverArrowSize solid transparent;
         border-inline-end: $euiPopoverArrowSize solid $euiBorderColor;
       }
 
       &:after {
-        left: -$euiPopoverArrowSize + 1;
-        top: 50%;
+        inset-inline-start: -$euiPopoverArrowSize + 1;
+        inset-block-start: 50%;
         border-block-start: $euiPopoverArrowSize solid transparent;
         border-block-end: $euiPopoverArrowSize solid transparent;
         border-inline-end: $euiPopoverArrowSize solid $euiColorEmptyShade;
@@ -108,14 +108,14 @@
 
     &.euiPopover__panelArrow--bottom {
       &:before {
-        top: -$euiPopoverArrowSize;
+        inset-block-start: -$euiPopoverArrowSize;
         border-inline-start: $euiPopoverArrowSize solid transparent;
         border-inline-end: $euiPopoverArrowSize solid transparent;
         border-block-end: $euiPopoverArrowSize solid $euiBorderColor;
       }
 
       &:after {
-        top: -$euiPopoverArrowSize + 1;
+        inset-block-start: -$euiPopoverArrowSize + 1;
         border-inline-start: $euiPopoverArrowSize solid transparent;
         border-inline-end: $euiPopoverArrowSize solid transparent;
         border-block-end: $euiPopoverArrowSize solid $euiColorEmptyShade;
@@ -124,16 +124,16 @@
 
     &.euiPopover__panelArrow--left {
       &:before {
-        right: -$euiPopoverArrowSize + 1;
-        top: 50%;
+        inset-inline-end: -$euiPopoverArrowSize + 1;
+        inset-block-start: 50%;
         border-block-start: $euiPopoverArrowSize solid transparent;
         border-block-end: $euiPopoverArrowSize solid transparent;
         border-inline-start: $euiPopoverArrowSize solid $euiBorderColor;
       }
 
       &:after {
-        right: -$euiPopoverArrowSize + 2;
-        top: 50%;
+        inset-inline-end: -$euiPopoverArrowSize + 2;
+        inset-block-start: 50%;
         border-block-start: $euiPopoverArrowSize solid transparent;
         border-block-end: $euiPopoverArrowSize solid transparent;
         border-inline-start: $euiPopoverArrowSize solid $euiColorEmptyShade;

--- a/src/components/popover/_popover.scss
+++ b/src/components/popover/_popover.scss
@@ -75,16 +75,16 @@
     &.euiPopover__panelArrow--top {
       &:before {
         bottom: -$euiPopoverArrowSize + 2;
-        border-left: $euiPopoverArrowSize solid transparent;
-        border-right: $euiPopoverArrowSize solid transparent;
-        border-top: $euiPopoverArrowSize solid $euiBorderColor;
+        border-inline-start: $euiPopoverArrowSize solid transparent;
+        border-inline-end: $euiPopoverArrowSize solid transparent;
+        border-block-start: $euiPopoverArrowSize solid $euiBorderColor;
       }
 
       &:after {
         bottom: -$euiPopoverArrowSize + 3;
-        border-left: $euiPopoverArrowSize solid transparent;
-        border-right: $euiPopoverArrowSize solid transparent;
-        border-top: $euiPopoverArrowSize solid $euiColorEmptyShade;
+        border-inline-start: $euiPopoverArrowSize solid transparent;
+        border-inline-end: $euiPopoverArrowSize solid transparent;
+        border-block-start: $euiPopoverArrowSize solid $euiColorEmptyShade;
       }
     }
 
@@ -92,33 +92,33 @@
       &:before {
         left: -$euiPopoverArrowSize;
         top: 50%;
-        border-top: $euiPopoverArrowSize solid transparent;
-        border-bottom: $euiPopoverArrowSize solid transparent;
-        border-right: $euiPopoverArrowSize solid $euiBorderColor;
+        border-block-start: $euiPopoverArrowSize solid transparent;
+        border-block-end: $euiPopoverArrowSize solid transparent;
+        border-inline-end: $euiPopoverArrowSize solid $euiBorderColor;
       }
 
       &:after {
         left: -$euiPopoverArrowSize + 1;
         top: 50%;
-        border-top: $euiPopoverArrowSize solid transparent;
-        border-bottom: $euiPopoverArrowSize solid transparent;
-        border-right: $euiPopoverArrowSize solid $euiColorEmptyShade;
+        border-block-start: $euiPopoverArrowSize solid transparent;
+        border-block-end: $euiPopoverArrowSize solid transparent;
+        border-inline-end: $euiPopoverArrowSize solid $euiColorEmptyShade;
       }
     }
 
     &.euiPopover__panelArrow--bottom {
       &:before {
         top: -$euiPopoverArrowSize;
-        border-left: $euiPopoverArrowSize solid transparent;
-        border-right: $euiPopoverArrowSize solid transparent;
-        border-bottom: $euiPopoverArrowSize solid $euiBorderColor;
+        border-inline-start: $euiPopoverArrowSize solid transparent;
+        border-inline-end: $euiPopoverArrowSize solid transparent;
+        border-block-end: $euiPopoverArrowSize solid $euiBorderColor;
       }
 
       &:after {
         top: -$euiPopoverArrowSize + 1;
-        border-left: $euiPopoverArrowSize solid transparent;
-        border-right: $euiPopoverArrowSize solid transparent;
-        border-bottom: $euiPopoverArrowSize solid $euiColorEmptyShade;
+        border-inline-start: $euiPopoverArrowSize solid transparent;
+        border-inline-end: $euiPopoverArrowSize solid transparent;
+        border-block-end: $euiPopoverArrowSize solid $euiColorEmptyShade;
       }
     }
 
@@ -126,17 +126,17 @@
       &:before {
         right: -$euiPopoverArrowSize + 1;
         top: 50%;
-        border-top: $euiPopoverArrowSize solid transparent;
-        border-bottom: $euiPopoverArrowSize solid transparent;
-        border-left: $euiPopoverArrowSize solid $euiBorderColor;
+        border-block-start: $euiPopoverArrowSize solid transparent;
+        border-block-end: $euiPopoverArrowSize solid transparent;
+        border-inline-start: $euiPopoverArrowSize solid $euiBorderColor;
       }
 
       &:after {
         right: -$euiPopoverArrowSize + 2;
         top: 50%;
-        border-top: $euiPopoverArrowSize solid transparent;
-        border-bottom: $euiPopoverArrowSize solid transparent;
-        border-left: $euiPopoverArrowSize solid $euiColorEmptyShade;
+        border-block-start: $euiPopoverArrowSize solid transparent;
+        border-block-end: $euiPopoverArrowSize solid transparent;
+        border-inline-start: $euiPopoverArrowSize solid $euiColorEmptyShade;
       }
     }
   }
@@ -147,7 +147,7 @@
   }
 
   &.euiPopover__panel-isAttached.euiPopover__panel--bottom {
-    border-top-color: transparentize($euiBorderColor, .2);
+    border-block-start-color: transparentize($euiBorderColor, .2);
     border-top-right-radius: 0;
     border-top-left-radius: 0;
   }
@@ -155,7 +155,7 @@
   &.euiPopover__panel-isAttached.euiPopover__panel--top {
     @include euiBottomShadowFlat;
 
-    border-bottom-color: transparentize($euiBorderColor, .2);
+    border-block-end-color: transparentize($euiBorderColor, .2);
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
   }

--- a/src/components/popover/_popover_footer.scss
+++ b/src/components/popover/_popover_footer.scss
@@ -8,7 +8,8 @@
   @each $modifier, $amount in $euiPanelPaddingModifiers {
     .euiPopover__panel.euiPanel--#{$modifier} & {
       padding: $amount;
-      margin: $amount ($amount * -1) ($amount * -1);
+      margin-block: $amount ($amount * -1);
+      margin-inline: ($amount * -1);
     }
   }
 }

--- a/src/components/popover/_popover_footer.scss
+++ b/src/components/popover/_popover_footer.scss
@@ -8,8 +8,10 @@
   @each $modifier, $amount in $euiPanelPaddingModifiers {
     .euiPopover__panel.euiPanel--#{$modifier} & {
       padding: $amount;
-      margin-block: $amount ($amount * -1);
-      margin-inline: ($amount * -1);
+      margin-block-start: $amount;
+      margin-block-end: ($amount * -1);
+      margin-inline-start: ($amount * -1);
+      margin-inline-end: ($amount * -1);
     }
   }
 }

--- a/src/components/popover/_popover_title.scss
+++ b/src/components/popover/_popover_title.scss
@@ -7,8 +7,10 @@
 
   @each $modifier, $amount in $euiPanelPaddingModifiers {
     .euiPopover__panel.euiPanel--#{$modifier} & {
-      padding: $euiSizeM $amount;
-      margin: ($amount * -1) ($amount * -1) $amount;
+      padding-block: $euiSizeM;
+      padding-inline: $amount;
+      margin-block: ($amount * -1) $amount;
+      margin-inline: ($amount * -1);
     }
   }
 

--- a/src/components/popover/_popover_title.scss
+++ b/src/components/popover/_popover_title.scss
@@ -7,10 +7,14 @@
 
   @each $modifier, $amount in $euiPanelPaddingModifiers {
     .euiPopover__panel.euiPanel--#{$modifier} & {
-      padding-block: $euiSizeM;
-      padding-inline: $amount;
-      margin-block: ($amount * -1) $amount;
-      margin-inline: ($amount * -1);
+      padding-block-start: $euiSizeM;
+      padding-block-end: $euiSizeM;
+      padding-inline-start: $amount;
+      padding-inline-end: $amount;
+      margin-block-start: ($amount * -1);
+      margin-block-end: $amount;
+      margin-inline-start: ($amount * -1);
+      margin-inline-end: ($amount * -1);
     }
   }
 

--- a/src/components/progress/_progress.scss
+++ b/src/components/progress/_progress.scss
@@ -53,9 +53,9 @@ $euiProgressSizes: (
     position: absolute;
     content: '';
     width: 100%;
-    top: 0;
-    bottom: 0;
-    left: 0;
+    inset-block-start: 0;
+    inset-block-end: 0;
+    inset-inline-start: 0;
     transform: scaleX(0) translateX(0%);
     animation: euiProgress 1s $euiAnimSlightResistance infinite;
   }
@@ -73,9 +73,9 @@ $euiProgressSizes: (
 
 .euiProgress--fixed,
 .euiProgress--absolute {
-  top: 0;
-  left: 0;
-  right: 0;
+  inset-block-start: 0;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
   background-color: transparent;
 
   &.euiProgress--native {

--- a/src/components/progress/_progress.scss
+++ b/src/components/progress/_progress.scss
@@ -153,7 +153,7 @@ $euiProgressColors: (
   // Only restrict the valueText if it's the sibling of the label
   // Gives width precedence to the value text forcing consumers to round their values
   + .euiProgress__valueText {
-    padding-left: $euiSizeXS;
+    padding-inline-start: $euiSizeXS;
     flex-grow: 1;
     text-align: right;
     flex-shrink: 0;
@@ -163,7 +163,7 @@ $euiProgressColors: (
 .euiProgress__valueText {
   // Tabular numbers ensure the line up nicely when right-aligned
   font-feature-settings: 'tnum' 1;
-  margin-left: auto;
+  margin-inline-start: auto;
 }
 
 .euiProgress__data--l {

--- a/src/components/progress/_progress.scss
+++ b/src/components/progress/_progress.scss
@@ -155,7 +155,7 @@ $euiProgressColors: (
   + .euiProgress__valueText {
     padding-inline-start: $euiSizeXS;
     flex-grow: 1;
-    text-align: right;
+    text-align: end;
     flex-shrink: 0;
   }
 }

--- a/src/components/resizable_container/_resizable_button.scss
+++ b/src/components/resizable_container/_resizable_button.scss
@@ -9,8 +9,8 @@
     content: '';
     display: block;
     position: absolute;
-    top: 50%;
-    left: 50%;
+    inset-block-start: 50%;
+    inset-inline-start: 50%;
     background-color: $euiColorDarkestShade;
     transition: (
       width $euiResizableButtonTransitionSpeed ease,

--- a/src/components/search_bar/_search_bar.scss
+++ b/src/components/search_bar/_search_bar.scss
@@ -1,10 +1,10 @@
 .euiSearchBar__searchHolder {
-  min-width: $euiFormMaxWidth / 2;
+  min-inline-size: $euiFormMaxWidth / 2;
 }
 
 @include euiBreakpoint('m', 'l', 'xl') {
   .euiSearchBar__filtersHolder {
     // Helps with flex-wrapping
-    max-width: calc(100% - #{$euiSize});
+    max-inline-size: calc(100% - #{$euiSize});
   }
 }

--- a/src/components/selectable/selectable_list/_selectable_list.scss
+++ b/src/components/selectable/selectable_list/_selectable_list.scss
@@ -24,6 +24,6 @@
   @include euiTitle('xxxs');
   display: flex;
   align-items: center;
-  border-bottom: $euiSelectableListItemBorder;
+  border-block-end: $euiSelectableListItemBorder;
   padding: $euiSelectableListItemPadding;
 }

--- a/src/components/selectable/selectable_list/_selectable_list_item.scss
+++ b/src/components/selectable/selectable_list/_selectable_list_item.scss
@@ -2,7 +2,7 @@
   @include euiFontSizeS;
   display: inline-flex; // Necessary to make sure it doesn't force the whole popover to be too wide
   width: 100%;
-  text-align: left;
+  text-align: start;
   color: $euiTextColor;
   cursor: pointer;
 

--- a/src/components/selectable/selectable_list/_selectable_list_item.scss
+++ b/src/components/selectable/selectable_list/_selectable_list_item.scss
@@ -7,7 +7,7 @@
   cursor: pointer;
 
   &:not(:last-of-type) {
-    border-bottom: $euiSelectableListItemBorder;
+    border-block-end: $euiSelectableListItemBorder;
   }
 
   &-isFocused:not([aria-disabled='true']),
@@ -35,12 +35,12 @@
 
 .euiSelectableListItem__icon,
 .euiSelectableListItem__prepend {
-  margin-right: $euiSizeM;
+  margin-inline-end: $euiSizeM;
   flex-shrink: 0;
 }
 
 .euiSelectableListItem__append {
-  margin-left: $euiSizeM;
+  margin-inline-start: $euiSizeM;
   flex-shrink: 0;
 }
 

--- a/src/components/selectable/selectable_templates/_selectable_template_sitewide_option.scss
+++ b/src/components/selectable/selectable_templates/_selectable_template_sitewide_option.scss
@@ -14,14 +14,15 @@
 
 .euiSelectableTemplateSitewide__optionMetasList {
   display: block;
-  margin-top: $euiSizeXS;
+  margin-block-start: $euiSizeXS;
   font-size: $euiFontSizeXS;
   color: $euiTextSubduedColor;
 }
 
 .euiSelectableTemplateSitewide__optionMeta:not(:last-of-type)::after {
   content: '•';
-  margin: 0 $euiSizeXS;
+  margin-block: 0;
+  margin-inline: $euiSizeXS;
   color: $euiTextSubduedColor;
 }
 

--- a/src/components/selectable/selectable_templates/_selectable_template_sitewide_option.scss
+++ b/src/components/selectable/selectable_templates/_selectable_template_sitewide_option.scss
@@ -21,8 +21,10 @@
 
 .euiSelectableTemplateSitewide__optionMeta:not(:last-of-type)::after {
   content: '•';
-  margin-block: 0;
-  margin-inline: $euiSizeXS;
+  margin-block-start: 0;
+  margin-block-end: 0;
+  margin-inline-start: $euiSizeXS;
+  margin-inline-end: $euiSizeXS;
   color: $euiTextSubduedColor;
 }
 

--- a/src/components/side_nav/_side_nav.scss
+++ b/src/components/side_nav/_side_nav.scss
@@ -7,7 +7,7 @@
   padding-inline-start: $euiSizeL;
   padding-inline-end: $euiSizeL;
   width: 100%;
-  text-align: left;
+  text-align: start;
 
   /**
    * 1. This toggle also works with EUI link, but we need the outline

--- a/src/components/side_nav/_side_nav.scss
+++ b/src/components/side_nav/_side_nav.scss
@@ -41,8 +41,8 @@
   display: flex;
   align-items: center;
   justify-content: space-around;
-  right: -$euiSizeXXL;
-  top: $euiSizeXL;
+  inset-inline-end: -$euiSizeXXL;
+  inset-block-start: $euiSizeXL;
 }
 
 @include euiBreakpoint('xs', 's') {
@@ -68,7 +68,7 @@
     overflow: hidden;
     visibility: hidden;
     opacity: 0;
-    max-height: 0;
+    max-block-size: 0;
     margin-block-start: 0;
     margin-block-end: 0;
     margin-inline-start: $euiSizeL;

--- a/src/components/side_nav/_side_nav.scss
+++ b/src/components/side_nav/_side_nav.scss
@@ -2,8 +2,10 @@
 .euiSideNav__mobileToggle {
   display: none;
   border-block-end: $euiBorderThin;
-  padding-block: $euiSize;
-  padding-inline: $euiSizeL;
+  padding-block-start: $euiSize;
+  padding-block-end: $euiSize;
+  padding-inline-start: $euiSizeL;
+  padding-inline-end: $euiSizeL;
   width: 100%;
   text-align: left;
 
@@ -67,7 +69,9 @@
     visibility: hidden;
     opacity: 0;
     max-height: 0;
-    margin-block: 0;
-    margin-inline: $euiSizeL;
+    margin-block-start: 0;
+    margin-block-end: 0;
+    margin-inline-start: $euiSizeL;
+    margin-inline-end: $euiSizeL;
   }
 }

--- a/src/components/side_nav/_side_nav.scss
+++ b/src/components/side_nav/_side_nav.scss
@@ -1,8 +1,9 @@
 // These mobile children are hidden in everything but mobile view.
 .euiSideNav__mobileToggle {
   display: none;
-  border-bottom: $euiBorderThin;
-  padding: $euiSize $euiSizeL;
+  border-block-end: $euiBorderThin;
+  padding-block: $euiSize;
+  padding-inline: $euiSizeL;
   width: 100%;
   text-align: left;
 
@@ -66,6 +67,7 @@
     visibility: hidden;
     opacity: 0;
     max-height: 0;
-    margin: 0 $euiSizeL;
+    margin-block: 0;
+    margin-inline: $euiSizeL;
   }
 }

--- a/src/components/side_nav/_side_nav_item.scss
+++ b/src/components/side_nav/_side_nav_item.scss
@@ -7,8 +7,10 @@
   text-align: left; /* 1 */
   display: block;
   width: 100%;
-  padding-block: $euiSizeXS / 2;
-  padding-inline: 0;
+  padding-block-start: $euiSizeXS / 2;
+  padding-block-end: $euiSizeXS / 2;
+  padding-inline-start: 0;
+  padding-inline-end: 0;
   color: $euiTextColor; /* 2 */
 
   &.euiSideNavItemButton--isClickable {

--- a/src/components/side_nav/_side_nav_item.scss
+++ b/src/components/side_nav/_side_nav_item.scss
@@ -71,11 +71,11 @@
   &:after { /* 1 */
     position: absolute;
     content: '';
-    top: 0;
-    bottom: $euiSizeM;
+    inset-block-start: 0;
+    inset-block-end: $euiSizeM;
     width: 1px;
     background: $euiBorderColor;
-    left: 0;
+    inset-inline-start: 0;
   }
 }
 
@@ -144,8 +144,8 @@
     &:after {
       position: absolute; /* 1 */
       content: '';
-      top: 50%;
-      left: 0;
+      inset-block-start: 50%;
+      inset-inline-start: 0;
       width: $euiSizeXS;
       height: 1px;
       background: $euiBorderColor;

--- a/src/components/side_nav/_side_nav_item.scss
+++ b/src/components/side_nav/_side_nav_item.scss
@@ -4,7 +4,7 @@
  */
 .euiSideNavItemButton {
   @include euiFontSizeS;
-  text-align: left; /* 1 */
+  text-align: start; /* 1 */
   display: block;
   width: 100%;
   padding-block-start: $euiSizeXS / 2;

--- a/src/components/side_nav/_side_nav_item.scss
+++ b/src/components/side_nav/_side_nav_item.scss
@@ -7,7 +7,8 @@
   text-align: left; /* 1 */
   display: block;
   width: 100%;
-  padding: $euiSizeXS / 2 0;
+  padding-block: $euiSizeXS / 2;
+  padding-inline: 0;
   color: $euiTextColor; /* 2 */
 
   &.euiSideNavItemButton--isClickable {
@@ -41,7 +42,7 @@
 }
 
 .euiSideNavItemButton__icon {
-  margin-right: $euiSizeS;
+  margin-inline-end: $euiSizeS;
 }
 
 /**
@@ -78,14 +79,14 @@
 
 .euiSideNavItem--root {
   &.euiSideNavItem--rootIcon > .euiSideNavItem__items {
-    margin-left: $euiSizeL;
+    margin-inline-start: $euiSizeL;
   }
 
   /**
    * 1. Create padding around focus area without indenting the item itself.
    */
   & > .euiSideNavItemButton {
-    margin-bottom: $euiSizeS;
+    margin-block-end: $euiSizeS;
     padding: 0;
     padding-left: $euiSizeS; /* 1 */
     padding-right: $euiSizeS; /* 1 */
@@ -100,7 +101,7 @@
 
   & > .euiSideNavItem__items {
     position: static;
-    margin-left: 0;
+    margin-inline-start: 0;
 
     &:after {
       display: none;
@@ -108,7 +109,7 @@
   }
 
   & + & {
-    margin-top: $euiSizeXL;
+    margin-block-start: $euiSizeXL;
   }
 }
 
@@ -124,7 +125,7 @@
   }
 
   & > .euiSideNavItem__items {
-    margin-left: $euiSizeS;
+    margin-inline-start: $euiSizeS;
     width: 100%;
   }
 }
@@ -135,7 +136,7 @@
    */
   & > .euiSideNavItemButton {
     position: relative; /* 1 */
-    padding-left: $euiSizeS;
+    padding-inline-start: $euiSizeS;
     padding-right: $euiSizeS; /* 1 */
 
     &:after {
@@ -150,7 +151,7 @@
   }
 
   & > .euiSideNavItem__items {
-    margin-left: $euiSize;
+    margin-inline-start: $euiSize;
   }
 
   .euiSideNavItemButton__icon {

--- a/src/components/stat/_stat.scss
+++ b/src/components/stat/_stat.scss
@@ -28,7 +28,7 @@
   }
 
   &.euiStat--leftAligned {
-    text-align: left;
+    text-align: start;
     align-items: flex-start;
   }
 
@@ -38,7 +38,7 @@
   }
 
   &.euiStat--rightAligned {
-    text-align: right;
+    text-align: end;
     align-items: flex-end;
   }
 }

--- a/src/components/steps/_step_number.scss
+++ b/src/components/steps/_step_number.scss
@@ -3,14 +3,14 @@
 
   .euiStepNumber__icon {
     position: relative;
-    top: -2px;
+    inset-block-start: -2px;
   }
 
   &--small {
     @include createStepsNumber($euiStepNumberSmallSize, $euiFontSizeXS);
 
     .euiStepNumber__icon {
-      top: -1px;
+      inset-block-start: -1px;
     }
   }
 

--- a/src/components/steps/_steps.scss
+++ b/src/components/steps/_steps.scss
@@ -60,10 +60,14 @@
 }
 
 .euiStep__content {
-  padding-block: $euiSize $euiSizeXL;
-  padding-inline: $euiSize;
-  margin-block: $euiSizeS;
-  margin-inline: 0;
+  padding-block-start: $euiSize;
+  padding-block-end: $euiSizeXL;
+  padding-inline-start: $euiSize;
+  padding-inline-end: $euiSize;
+  margin-block-start: $euiSizeS;
+  margin-block-end: $euiSizeS;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
 
   // Align the content's contents with the title
   padding-inline-start: ($euiStepNumberSize / 2) + $euiStepNumberMargin;

--- a/src/components/steps/_steps.scss
+++ b/src/components/steps/_steps.scss
@@ -26,10 +26,10 @@
 
     .euiStep__content {
       // Align the content's contents with the title
-      padding-left: ($euiStepNumberSmallSize / 2) + $euiStepNumberMargin;
+      padding-inline-start: ($euiStepNumberSmallSize / 2) + $euiStepNumberMargin;
 
       // Align content border to horizontal center of step number
-      margin-left: ($euiStepNumberSmallSize / 2);
+      margin-inline-start: ($euiStepNumberSmallSize / 2);
     }
   }
 }
@@ -40,7 +40,7 @@
 
 .euiStep__circle {
   flex-shrink: 0;
-  margin-right: $euiStepNumberMargin;
+  margin-inline-end: $euiStepNumberMargin;
   vertical-align: top; /* 1 */
 
   &[class*='complete'],
@@ -60,12 +60,14 @@
 }
 
 .euiStep__content {
-  padding: $euiSize $euiSize $euiSizeXL;
-  margin: $euiSizeS 0;
+  padding-block: $euiSize $euiSizeXL;
+  padding-inline: $euiSize;
+  margin-block: $euiSizeS;
+  margin-inline: 0;
 
   // Align the content's contents with the title
-  padding-left: ($euiStepNumberSize / 2) + $euiStepNumberMargin;
+  padding-inline-start: ($euiStepNumberSize / 2) + $euiStepNumberMargin;
 
   // Align content border to horizontal center of step number
-  margin-left: ($euiStepNumberSize / 2);
+  margin-inline-start: ($euiStepNumberSize / 2);
 }

--- a/src/components/steps/_steps_horizontal.scss
+++ b/src/components/steps/_steps_horizontal.scss
@@ -21,8 +21,10 @@
 .euiStepHorizontal {
   flex-grow: 1; /* 2 */
   flex-basis: 0%; /* 2 */
-  padding-block: $euiSizeL $euiSize;
-  padding-inline: $euiSize;
+  padding-block-start: $euiSizeL;
+  padding-block-end: $euiSize;
+  padding-inline-start: $euiSize;
+  padding-inline-end: $euiSize;
   display: flex; /* 3 */
   flex-direction: column; /* 3 */
   align-items: center; /* 3 */

--- a/src/components/steps/_steps_horizontal.scss
+++ b/src/components/steps/_steps_horizontal.scss
@@ -21,7 +21,8 @@
 .euiStepHorizontal {
   flex-grow: 1; /* 2 */
   flex-basis: 0%; /* 2 */
-  padding: $euiSizeL $euiSize $euiSize;
+  padding-block: $euiSizeL $euiSize;
+  padding-inline: $euiSize;
   display: flex; /* 3 */
   flex-direction: column; /* 3 */
   align-items: center; /* 3 */
@@ -88,7 +89,7 @@
 
 .euiStepHorizontal__title {
   @include euiTitle('xs');
-  margin-top: $euiSizeS;
+  margin-block-start: $euiSizeS;
   font-weight: $euiFontWeightRegular;
   text-align: center;
   max-width: 100%; // IE Fix for wrapping text
@@ -121,7 +122,7 @@
 @include euiBreakpoint('xs', 's') {
   .euiStepHorizontal {
     // reduce top padding and shift lines
-    padding-top: $euiSize;
+    padding-block-start: $euiSize;
 
     &:before,
     &:after {

--- a/src/components/steps/_steps_horizontal.scss
+++ b/src/components/steps/_steps_horizontal.scss
@@ -60,17 +60,17 @@
     position: absolute;
     width: 50%;
     height: 1px;
-    top: $euiSizeL + ($euiStepNumberSize / 2);
+    inset-block-start: $euiSizeL + ($euiStepNumberSize / 2);
     background-color: $euiColorLightShade;
     z-index: $euiZLevel0; /* 1 */
   }
 
   &::before {
-    left: 0;
+    inset-inline-start: 0;
   }
 
   &::after {
-    right: 0;
+    inset-inline-end: 0;
   }
 
   // Remove the respective lines if the first or last child
@@ -128,7 +128,7 @@
 
     &:before,
     &:after {
-      top: $euiSize + $euiStepNumberSize / 2;
+      inset-block-start: $euiSize + $euiStepNumberSize / 2;
     }
   }
 

--- a/src/components/steps/_steps_horizontal.scss
+++ b/src/components/steps/_steps_horizontal.scss
@@ -94,7 +94,7 @@
   margin-block-start: $euiSizeS;
   font-weight: $euiFontWeightRegular;
   text-align: center;
-  max-width: 100%; // IE Fix for wrapping text
+  max-inline-size: 100%; // IE Fix for wrapping text
 
   .euiStepHorizontal-isDisabled & {
     color: $euiColorDarkShade;

--- a/src/components/steps/_sub_steps.scss
+++ b/src/components/steps/_sub_steps.scss
@@ -1,10 +1,10 @@
 .euiSubSteps {
   padding: $euiSize;
   background-color: $euiColorLightestShade;
-  margin-bottom: $euiSize;
+  margin-block-end: $euiSize;
 
   > *:last-child {
-    margin-bottom: 0;
+    margin-block-end: 0;
   }
 
   // change ordered list from numbers to lowercase letters

--- a/src/components/suggest/_suggest_item.scss
+++ b/src/components/suggest/_suggest_item.scss
@@ -55,8 +55,10 @@
     font-family: $euiCodeFontFamily;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding-block: $euiSizeXS;
-    padding-inline: $euiSizeS;
+    padding-block-start: $euiSizeXS;
+    padding-block-end: $euiSizeXS;
+    padding-inline-start: $euiSizeS;
+    padding-inline-end: $euiSizeS;
     color: $euiTextColor;
 
     &.euiSuggestItem__labelDisplay--expand {

--- a/src/components/suggest/_suggest_item.scss
+++ b/src/components/suggest/_suggest_item.scss
@@ -55,7 +55,8 @@
     font-family: $euiCodeFontFamily;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding: $euiSizeXS $euiSizeS;
+    padding-block: $euiSizeXS;
+    padding-inline: $euiSizeS;
     color: $euiTextColor;
 
     &.euiSuggestItem__labelDisplay--expand {
@@ -73,11 +74,11 @@
   .euiSuggestItem__description {
     color: $euiColorDarkShade;
     flex-basis: auto;
-    padding-top: $euiSizeXS * .5;
+    padding-block-start: $euiSizeXS * .5;
 
     &:empty {
       flex-grow: 0;
-      margin-left: 0;
+      margin-inline-start: 0;
     }
   }
 }

--- a/src/components/suggest/_suggest_item.scss
+++ b/src/components/suggest/_suggest_item.scss
@@ -7,7 +7,7 @@
 
   &.euiSuggestItem-isClickable {
     width: 100%;
-    text-align: left;
+    text-align: start;
 
     &:hover,
     &:focus {

--- a/src/components/suggest/_suggest_item.scss
+++ b/src/components/suggest/_suggest_item.scss
@@ -51,7 +51,7 @@
 
   .euiSuggestItem__label {
     flex-basis: 50%;
-    min-width: 50%;
+    min-inline-size: 50%;
     font-family: $euiCodeFontFamily;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/components/table/_mixins.scss
+++ b/src/components/table/_mixins.scss
@@ -1,7 +1,7 @@
 @mixin euiTableCell {
   vertical-align: middle;
-  border-top: $euiBorderThin;
-  border-bottom: $euiBorderThin;
+  border-block-start: $euiBorderThin;
+  border-block-end: $euiBorderThin;
   font-weight: inherit;
   text-align: inherit;
 }

--- a/src/components/table/_responsive.scss
+++ b/src/components/table/_responsive.scss
@@ -41,7 +41,7 @@
       display: block;
       color: $euiColorDarkShade;
       padding: $euiSizeS;
-      padding-bottom: 0;
+      padding-block-end: 0;
       margin-bottom: -$euiSizeS; // pull up cell content closer
       min-height: $euiSizeL; // aligns contents of cells if header doesn't exist
 
@@ -68,7 +68,7 @@
       display: flex;
       flex-wrap: wrap;
       padding: $euiTableCellContentPadding;
-      margin-bottom: $euiTableCellContentPadding;
+      margin-block-end: $euiTableCellContentPadding;
 
       &:hover {
         background-color: transparent;
@@ -77,7 +77,7 @@
       &.euiTableRow-isExpandable,
       &.euiTableRow-hasActions {
         @include euiTableActionsBackgroundMobile;
-        padding-right: $euiSizeXXL;
+        padding-inline-end: $euiSizeXXL;
         position: relative;
       }
 
@@ -111,7 +111,7 @@
       }
 
       &.euiTableRow-isSelectable {
-        padding-left: $euiTableCellCheckboxWidth + ($euiTableCellContentPadding / 2);
+        padding-inline-start: $euiTableCellCheckboxWidth + ($euiTableCellContentPadding / 2);
         position: relative;
 
         .euiTableRowCellCheckbox {
@@ -134,10 +134,10 @@
       &.euiTableRow-isExpandedRow {
         @include euiTableActionsBackgroundMobile;
         @include euiBottomShadowSmall;
-        margin-top: -$euiTableCellContentPadding * 2;
+        margin-block-start: -$euiTableCellContentPadding * 2;
         position: relative;
         z-index: 2; // on top of its parent/previous row
-        border-top: none;
+        border-block-start: none;
         border-top-left-radius: 0;
         border-top-right-radius: 0;
         padding-left: $euiSizeS; // override selectable as the padding is already applied via the contents
@@ -169,7 +169,7 @@
     // never show hidden items and always show hover items on mobile,
     .euiTableRow-hasActions .euiTableCellContent--showOnHover {
       > * {
-        margin-left: 0;
+        margin-inline-start: 0;
       }
 
       .expandedItemActions__completelyHide {
@@ -179,8 +179,8 @@
       .euiTableCellContent__hoverItem {
         opacity: 1;
         filter: none;
-        margin-left: 0;
-        margin-bottom: $euiSizeS;
+        margin-inline-start: 0;
+        margin-block-end: $euiSizeS;
       }
     }
 

--- a/src/components/table/_responsive.scss
+++ b/src/components/table/_responsive.scss
@@ -42,8 +42,8 @@
       color: $euiColorDarkShade;
       padding: $euiSizeS;
       padding-block-end: 0;
-      margin-bottom: -$euiSizeS; // pull up cell content closer
-      min-height: $euiSizeL; // aligns contents of cells if header doesn't exist
+      margin-block-end: -$euiSizeS; // pull up cell content closer
+      min-block-size: $euiSizeL; // aligns contents of cells if header doesn't exist
 
       // Remove min-height of cell header if it's the only cell
       .euiTableRowCell:only-child & {
@@ -86,7 +86,7 @@
         min-inline-size: 0;
         width: $euiSizeL;
         position: absolute;
-        top: $euiTableCellContentPadding + (($euiTableCellContentPadding * $euiLineHeight) - $euiTableCellContentPadding) + $euiSizeXS; // same as row padding-top + cell padding + 1/2 line height
+        inset-block-start: $euiTableCellContentPadding + (($euiTableCellContentPadding * $euiLineHeight) - $euiTableCellContentPadding) + $euiSizeXS; // same as row padding-top + cell padding + 1/2 line height
         inset-inline-end: $euiTableCellContentPadding;
 
         &::before {
@@ -106,7 +106,7 @@
       &.euiTableRow-hasActions.euiTableRow-isExpandable {
         .euiTableRowCell--isExpander {
           inset-block-start: auto;
-          bottom: $euiSize; // same as row padding-bottom
+          inset-block-end: $euiSize; // same as row padding-bottom
         }
       }
 
@@ -140,7 +140,7 @@
         border-block-start: none;
         border-top-left-radius: 0;
         border-top-right-radius: 0;
-        padding-left: $euiSizeS; // override selectable as the padding is already applied via the contents
+        padding-inline-start: $euiSizeS; // override selectable as the padding is already applied via the contents
 
         &:hover {
           background-color: $euiColorEmptyShade; // keep white background to cover triggering row's border

--- a/src/components/table/_responsive.scss
+++ b/src/components/table/_responsive.scss
@@ -47,7 +47,7 @@
 
       // Remove min-height of cell header if it's the only cell
       .euiTableRowCell:only-child & {
-        min-height: 0;
+        min-block-size: 0;
       }
     }
 
@@ -83,11 +83,11 @@
 
       &.euiTableRow-isExpandable .euiTableRowCell--isExpander,
       &.euiTableRow-hasActions .euiTableRowCell--hasActions {
-        min-width: 0;
+        min-inline-size: 0;
         width: $euiSizeL;
         position: absolute;
         top: $euiTableCellContentPadding + (($euiTableCellContentPadding * $euiLineHeight) - $euiTableCellContentPadding) + $euiSizeXS; // same as row padding-top + cell padding + 1/2 line height
-        right: $euiTableCellContentPadding;
+        inset-inline-end: $euiTableCellContentPadding;
 
         &::before {
           display: none; // Don't display table headers
@@ -105,7 +105,7 @@
 
       &.euiTableRow-hasActions.euiTableRow-isExpandable {
         .euiTableRowCell--isExpander {
-          top: auto;
+          inset-block-start: auto;
           bottom: $euiSize; // same as row padding-bottom
         }
       }
@@ -116,8 +116,8 @@
 
         .euiTableRowCellCheckbox {
           position: absolute;
-          left: $euiTableCellContentPadding / 2;
-          top: $euiSizeS;
+          inset-inline-start: $euiTableCellContentPadding / 2;
+          inset-block-start: $euiSizeS;
         }
       }
 
@@ -158,7 +158,7 @@
 
     .euiTableRowCell {
       display: block; /* IE requires block to grow and wrap. */
-      min-width: 50%;
+      min-inline-size: 50%;
       border: none;
     }
 

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -39,7 +39,7 @@
   border-block-start: none;
 
   .euiTableHeaderButton {
-    text-align: left;
+    text-align: start;
     font-weight: $euiFontWeightMedium;
   }
 
@@ -153,7 +153,7 @@
 
 .euiTableCellContent--alignRight {
   justify-content: flex-end;
-  text-align: right;
+  text-align: end;
 }
 
 .euiTableCellContent--alignCenter {

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -36,7 +36,7 @@
   @include euiTableCell;
   @include euiTitle('xxs');
   font-weight: $euiFontWeightMedium;
-  border-top: none;
+  border-block-start: none;
 
   .euiTableHeaderButton {
     text-align: left;
@@ -68,7 +68,7 @@
 }
 
 .euiTableSortIcon {
-  margin-left: $euiSizeXS;
+  margin-inline-start: $euiSizeXS;
   flex-shrink: 0; // makes sure the icon doesn't change size because the text is long
 
   .euiTableHeaderButton-isSorted & {
@@ -78,7 +78,7 @@
 
 .euiTableHeaderCellCheckbox {
   @include euiTableCellCheckbox;
-  border-top: none;
+  border-block-start: none;
 }
 
 .euiTableRow {
@@ -92,7 +92,7 @@
     }
 
     &.euiTableRow-isSelectable .euiTableCellContent {
-      padding-left: $euiTableCellCheckboxWidth + $euiTableCellContentPadding;
+      padding-inline-start: $euiTableCellCheckboxWidth + $euiTableCellContentPadding;
     }
   }
 
@@ -127,7 +127,7 @@
 // Must come after .euiTableRowCell selector for border to be removed
 .euiTableFooterCell {
   background-color: $euiColorLightestShade;
-  border-bottom: none;
+  border-block-end: none;
 }
 
 /**
@@ -181,7 +181,7 @@
 
 .euiTableCellContent--showOnHover {
   > *:not(:first-child) {
-    margin-left: $euiSizeS;
+    margin-inline-start: $euiSizeS;
   }
 }
 

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -147,7 +147,7 @@
 
 .euiTableCellContent__text {
   @include euiTextBreakWord; /* 4 */
-  min-width: 0;
+  min-inline-size: 0;
   text-overflow: ellipsis;
 }
 
@@ -223,15 +223,15 @@
 
 @keyframes growExpandedRow {
   0% {
-    max-height: 0;
+    max-block-size: 0;
   }
 
   99% {
-    max-height: 100vh;
+    max-block-size: 100vh;
   }
 
   100% {
-    max-height: unset;
+    max-block-size: unset;
   }
 }
 

--- a/src/components/table/mobile/_mobile.scss
+++ b/src/components/table/mobile/_mobile.scss
@@ -9,8 +9,10 @@
   .euiTableHeaderMobile {
     display: flex;
     justify-content: flex-end;
-    padding-block: $euiTableCellContentPadding;
-    padding-inline: 0;
+    padding-block-start: $euiTableCellContentPadding;
+    padding-block-end: $euiTableCellContentPadding;
+    padding-inline-start: 0;
+    padding-inline-end: 0;
   }
 
   .euiTableSortMobile {

--- a/src/components/table/mobile/_mobile.scss
+++ b/src/components/table/mobile/_mobile.scss
@@ -9,7 +9,8 @@
   .euiTableHeaderMobile {
     display: flex;
     justify-content: flex-end;
-    padding: $euiTableCellContentPadding 0;
+    padding-block: $euiTableCellContentPadding;
+    padding-inline: 0;
   }
 
   .euiTableSortMobile {

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -29,7 +29,8 @@
   background-color: transparent;
   cursor: pointer;
   line-height: $euiLineHeight;
-  padding: $euiSizeM $euiSize;
+  padding-block: $euiSizeM;
+  padding-inline: $euiSize;
   position: relative;
   transition: color $euiAnimSpeedNormal $euiAnimSlightResistance, background-color $euiAnimSpeedNormal $euiAnimSlightResistance;
 
@@ -89,7 +90,8 @@
 
   .euiTabs--condensed & {
     font-weight: $euiFontWeightSemiBold;
-    padding: $euiSizeS $euiSizeXS;
+    padding-block: $euiSizeS;
+    padding-inline: $euiSizeXS;
 
     &:focus {
       background-color: $euiFocusBackgroundColor;
@@ -104,7 +106,7 @@
     }
 
     & + .euiTab {
-      margin-left: $euiSize;
+      margin-inline-start: $euiSize;
     }
   }
 

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -29,8 +29,10 @@
   background-color: transparent;
   cursor: pointer;
   line-height: $euiLineHeight;
-  padding-block: $euiSizeM;
-  padding-inline: $euiSize;
+  padding-block-start: $euiSizeM;
+  padding-block-end: $euiSizeM;
+  padding-inline-start: $euiSize;
+  padding-inline-end: $euiSize;
   position: relative;
   transition: color $euiAnimSpeedNormal $euiAnimSlightResistance, background-color $euiAnimSpeedNormal $euiAnimSlightResistance;
 
@@ -90,8 +92,10 @@
 
   .euiTabs--condensed & {
     font-weight: $euiFontWeightSemiBold;
-    padding-block: $euiSizeS;
-    padding-inline: $euiSizeXS;
+    padding-block-start: $euiSizeS;
+    padding-block-end: $euiSizeS;
+    padding-inline-start: $euiSizeXS;
+    padding-inline-end: $euiSizeXS;
 
     &:focus {
       background-color: $euiFocusBackgroundColor;

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -1,7 +1,7 @@
 .euiTabs {
   @include euiScrollBar;
   display: flex;
-  max-width: 100%;
+  max-inline-size: 100%;
   overflow-x: auto;
   overflow-y: hidden; // don't scroll vertically when scrolling horizontally
   position: relative;
@@ -14,12 +14,12 @@
 
   &:not(.euiTabs--condensed)::before {
     background-color: $euiColorLightShade;
-    bottom: 0;
+    inset-block-end: 0;
     content: '';
     height: 1px;
-    left: 0;
+    inset-inline-start: 0;
     position: absolute;
-    right: 0;
+    inset-inline-end: 0;
   }
 }
 
@@ -46,12 +46,12 @@
 
     &::before {
       background-color: $euiColorLightShade;
-      bottom: 0;
+      inset-block-end: 0;
       content: '';
       height: 1px;
-      left: 0;
+      inset-inline-start: 0;
       position: absolute;
-      right: 0;
+      inset-inline-end: 0;
     }
   }
 
@@ -72,10 +72,10 @@
     &::after {
       animation: euiTab $euiAnimSpeedFast $euiAnimSlightResistance;
       background-color: $euiColorPrimary;
-      bottom: 0;
+      inset-block-end: 0;
       content: ' ';
       height: $euiBorderWidthThick;
-      left: 0;
+      inset-inline-start: 0;
       position: absolute;
       width: 100%;
     }

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -224,7 +224,7 @@
 
   > :last-child,
   .euiTextColor > :last-child {
-    margin-bottom: 0 !important; // sass-lint:disable-line no-important
+    margin-block-end: 0 !important; // sass-lint:disable-line no-important
   }
 }
 

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -154,17 +154,17 @@
       content: '';
       height: 2px;
       width: 50%;
-      right: 0;
+      inset-inline-end: 0;
       transform: translateX(-50%);
       background: $euiColorDarkShade;
     }
 
     &:before {
-      top: 0;
+      inset-block-start: 0;
     }
 
     &:after {
-      bottom: 0;
+      inset-block-end: 0;
     }
   }
 
@@ -216,10 +216,10 @@
   @include euiScaleText($euiFontSize);
 
   &.euiText--constrainedWidth {
-    max-width: $euiTextConstrainedMaxWidth;
+    max-inline-size: $euiTextConstrainedMaxWidth;
     // If the max-width is way too short of the width of the container,
     // at least make it 2/3 of its parent
-    min-width: 75%;
+    min-inline-size: 75%;
   }
 
   > :last-child,

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -11,12 +11,12 @@
   blockquote,
   img,
   pre {
-    margin-bottom: convertToRem($baseLineHeightMultiplier * 3);
+    margin-block-end: convertToRem($baseLineHeightMultiplier * 3);
   }
 
   ul,
   ol {
-    margin-left: convertToRem($baseLineHeightMultiplier * 3);
+    margin-inline-start: convertToRem($baseLineHeightMultiplier * 3);
   }
 
   blockquote {
@@ -30,11 +30,11 @@
   h4,
   h5,
   h6 {
-    margin-bottom: convertToRem($baseLineHeightMultiplier * 1);
+    margin-block-end: convertToRem($baseLineHeightMultiplier * 1);
   }
 
   dd + dt {
-    margin-top: convertToRem($baseLineHeightMultiplier * 2);
+    margin-block-start: convertToRem($baseLineHeightMultiplier * 2);
   }
 
   * + h2,
@@ -42,7 +42,7 @@
   * + h4,
   * + h5,
   * + h6 {
-    margin-top: convertToRem($baseLineHeightMultiplier * 4);
+    margin-block-start: convertToRem($baseLineHeightMultiplier * 4);
   }
 
   h1 {
@@ -138,14 +138,14 @@
   blockquote {
     position: relative;
     text-align: center;
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
     font-family: Georgia, Times, Times New Roman, serif;
     font-style: italic;
     letter-spacing: normal;
 
     p:last-child {
-      margin-bottom: 0;
+      margin-block-end: 0;
     }
 
     &:before,

--- a/src/components/text/_text_align.scss
+++ b/src/components/text/_text_align.scss
@@ -1,9 +1,9 @@
 .euiTextAlign--left {
-  text-align: left;
+  text-align: start;
 }
 
 .euiTextAlign--right {
-  text-align: right;
+  text-align: end;
 }
 
 .euiTextAlign--center {

--- a/src/components/title/_title.scss
+++ b/src/components/title/_title.scss
@@ -1,6 +1,6 @@
 .euiTitle {
   + .euiTitle {
-    margin-top: $euiSizeL;
+    margin-block-start: $euiSizeL;
   }
 }
 

--- a/src/components/toast/_global_toast_list.scss
+++ b/src/components/toast/_global_toast_list.scss
@@ -43,7 +43,7 @@
 }
 
 .euiGlobalToastListItem {
-  margin-bottom: $euiSize;
+  margin-block-end: $euiSize;
   animation: $euiAnimSpeedNormal euiShowToast $euiAnimSlightResistance;
   opacity: 1;
 
@@ -56,7 +56,7 @@
   }
 
   &:last-child {
-    margin-bottom: 0;
+    margin-block-end: 0;
   }
 
   &.euiGlobalToastListItem-isDismissed {
@@ -83,8 +83,8 @@
    */
   .euiGlobalToastList:not(:empty) {
     left: 0;
-    padding-left: $euiSize;
-    padding-right: $euiSize;
+    padding-inline-start: $euiSize;
+    padding-inline-end: $euiSize;
     width: 100%; /* 1 */
   }
 }

--- a/src/components/toast/_global_toast_list.scss
+++ b/src/components/toast/_global_toast_list.scss
@@ -9,7 +9,7 @@
   align-items: stretch;
   position: fixed;
   z-index: $euiZToastList;
-  bottom: 0;
+  inset-block-end: 0;
   width: $euiToastWidth + ($euiSize * 5); /* 2 */
   max-height: 100vh; /* 1 */
   overflow-y: auto;
@@ -33,12 +33,12 @@
 }
 
 .euiGlobalToastList--right:not(:empty) {
-  right: 0;
+  inset-inline-end: 0;
   padding-left: $euiSize * 4; /* 2 */
 }
 
 .euiGlobalToastList--left:not(:empty) {
-  left: 0;
+  inset-inline-start: 0;
   padding-right: $euiSize * 4; /* 2 */
 }
 
@@ -82,7 +82,7 @@
    * 1. Mobile we make these 100%. Matching change happens on the item as well.
    */
   .euiGlobalToastList:not(:empty) {
-    left: 0;
+    inset-inline-start: 0;
     padding-inline-start: $euiSize;
     padding-inline-end: $euiSize;
     width: 100%; /* 1 */

--- a/src/components/toast/_toast.scss
+++ b/src/components/toast/_toast.scss
@@ -58,7 +58,7 @@ $euiToastTypes: (
 // Create button modifiers based upon the map.
 @each $name, $color in $euiToastTypes {
   .euiToast--#{$name} {
-    border-top: 2px solid $color;
+    border-block-start: 2px solid $color;
   }
 }
 
@@ -93,7 +93,7 @@ $euiToastTypes: (
 }
 
 .euiToastHeader--withBody {
-  margin-bottom: $euiSizeM;
+  margin-block-end: $euiSizeM;
 }
 
 /**

--- a/src/components/toast/_toast.scss
+++ b/src/components/toast/_toast.scss
@@ -20,8 +20,8 @@
   */
 .euiToast__closeButton {
   position: absolute;
-  top: $euiSize;
-  right: $euiSize;
+  inset-block-start: $euiSize;
+  inset-inline-end: $euiSize;
   line-height: 0; /* 1 */
   appearance: none;
   opacity: 0;

--- a/src/components/token/_token.scss
+++ b/src/components/token/_token.scss
@@ -24,7 +24,8 @@
   height: $euiSizeM;
 
   &.euiToken--rectangle {
-    padding: 0 $euiSizeXS;
+    padding-block: 0;
+    padding-inline: $euiSizeXS;
   }
 }
 
@@ -33,7 +34,8 @@
   height: $euiSize;
 
   &.euiToken--rectangle {
-    padding: 0 $euiSizeXS;
+    padding-block: 0;
+    padding-inline: $euiSizeXS;
   }
 }
 
@@ -42,7 +44,8 @@
   height: $euiSizeL;
 
   &.euiToken--rectangle {
-    padding: 0 $euiSizeS;
+    padding-block: 0;
+    padding-inline: $euiSizeS;
   }
 }
 
@@ -51,7 +54,8 @@
   height: $euiSizeXL;
 
   &.euiToken--rectangle {
-    padding: 0 ($euiSize * .5);
+    padding-block: 0;
+    padding-inline: ($euiSize * .5);
   }
 }
 

--- a/src/components/token/_token.scss
+++ b/src/components/token/_token.scss
@@ -24,8 +24,10 @@
   height: $euiSizeM;
 
   &.euiToken--rectangle {
-    padding-block: 0;
-    padding-inline: $euiSizeXS;
+    padding-block-start: 0;
+    padding-block-end: 0;
+    padding-inline-start: $euiSizeXS;
+    padding-inline-end: $euiSizeXS;
   }
 }
 
@@ -34,8 +36,10 @@
   height: $euiSize;
 
   &.euiToken--rectangle {
-    padding-block: 0;
-    padding-inline: $euiSizeXS;
+    padding-block-start: 0;
+    padding-block-end: 0;
+    padding-inline-start: $euiSizeXS;
+    padding-inline-end: $euiSizeXS;
   }
 }
 
@@ -44,8 +48,10 @@
   height: $euiSizeL;
 
   &.euiToken--rectangle {
-    padding-block: 0;
-    padding-inline: $euiSizeS;
+    padding-block-start: 0;
+    padding-block-end: 0;
+    padding-inline-start: $euiSizeS;
+    padding-inline-end: $euiSizeS;
   }
 }
 
@@ -54,8 +60,10 @@
   height: $euiSizeXL;
 
   &.euiToken--rectangle {
-    padding-block: 0;
-    padding-inline: ($euiSize * .5);
+    padding-block-start: 0;
+    padding-block-end: 0;
+    padding-inline-start: ($euiSize * .5);
+    padding-inline-end: ($euiSize * .5);
   }
 }
 

--- a/src/components/tour/_tour.scss
+++ b/src/components/tour/_tour.scss
@@ -3,13 +3,13 @@
 }
 
 .euiTourHeader {
-  border-bottom: none;
+  border-block-end: none;
   // Overriding default `EuiPopoverTitle` styles
   margin-bottom: $euiSizeS !important; // sass-lint:disable-line no-important
 
 
   .euiTourHeader__title { // nested for additional specificity to override EuiTitle styles
-    margin-top: 0;
+    margin-block-start: 0;
     text-transform: capitalize;
   }
 }
@@ -50,7 +50,7 @@
 
   .euiPopover__panelArrow.euiPopover__panelArrow--top {
     &:after {
-      border-top-color: $euiColorLightestShade;
+      border-block-start-color: $euiColorLightestShade;
     }
 
     .euiTour__beacon {

--- a/src/components/tour/_tour.scss
+++ b/src/components/tour/_tour.scss
@@ -1,5 +1,5 @@
 .euiTour--minWidth-default {
-  min-width: $euiSizeL * 10;
+  min-inline-size: $euiSizeL * 10;
 }
 
 .euiTourHeader {
@@ -35,16 +35,16 @@
   .euiPopover__panelArrow.euiPopover__panelArrow--right {
     .euiTour__beacon {
       opacity: 1;
-      top: $euiPopoverArrowSize / 2;
-      left: -$euiPopoverArrowSize * 2;
+      inset-block-start: $euiPopoverArrowSize / 2;
+      inset-inline-start: -$euiPopoverArrowSize * 2;
     }
   }
 
   .euiPopover__panelArrow.euiPopover__panelArrow--left {
     .euiTour__beacon {
       opacity: 1;
-      top: $euiPopoverArrowSize / 2;
-      left: $euiPopoverArrowSize;
+      inset-block-start: $euiPopoverArrowSize / 2;
+      inset-inline-start: $euiPopoverArrowSize;
     }
   }
 
@@ -55,16 +55,16 @@
 
     .euiTour__beacon {
       opacity: 1;
-      top: $euiPopoverArrowSize;
-      left: $euiPopoverArrowSize / 2;
+      inset-block-start: $euiPopoverArrowSize;
+      inset-inline-start: $euiPopoverArrowSize / 2;
     }
   }
 
   .euiPopover__panelArrow.euiPopover__panelArrow--bottom {
     .euiTour__beacon {
       opacity: 1;
-      top: -$euiPopoverArrowSize * 2;
-      left: $euiPopoverArrowSize / 2;
+      inset-block-start: -$euiPopoverArrowSize * 2;
+      inset-inline-start: $euiPopoverArrowSize / 2;
     }
   }
 }

--- a/src/components/tour/_tour.scss
+++ b/src/components/tour/_tour.scss
@@ -5,7 +5,7 @@
 .euiTourHeader {
   border-block-end: none;
   // Overriding default `EuiPopoverTitle` styles
-  margin-bottom: $euiSizeS !important; // sass-lint:disable-line no-important
+  margin-block-end: $euiSizeS !important; // sass-lint:disable-line no-important
 
 
   .euiTourHeader__title { // nested for additional specificity to override EuiTitle styles
@@ -21,7 +21,7 @@
 .euiTourFooter {
   background-color: $euiColorLightestShade;
   // Overriding default `EuiPopoverFooter` styles
-  margin-top: $euiSizeL !important; // sass-lint:disable-line no-important
+  margin-block-start: $euiSizeL !important; // sass-lint:disable-line no-important
 }
 
 .euiTour {

--- a/src/components/tree_view/tree_view.scss
+++ b/src/components/tree_view/tree_view.scss
@@ -8,14 +8,14 @@
 }
 
 .euiTreeView__node {
-  max-height: $euiSizeXL;
+  max-block-size: $euiSizeXL;
   overflow: hidden;
   cursor: pointer;
   line-height: $euiSizeXL;
 }
 
 .euiTreeView__node--expanded {
-  max-height: 100vh;
+  max-block-size: 100vh;
   overflow: auto;
 }
 
@@ -62,7 +62,7 @@
 
 .euiTreeView--compressed {
   .euiTreeView__node {
-    max-height: $euiSizeL;
+    max-block-size: $euiSizeL;
     line-height: $euiSizeL;
 
     .euiTreeView__nodeInner {
@@ -87,7 +87,7 @@
   }
 
   .euiTreeView__node--expanded {
-    max-height: 100vh;
+    max-block-size: 100vh;
     overflow: auto;
   }
 }

--- a/src/components/tree_view/tree_view.scss
+++ b/src/components/tree_view/tree_view.scss
@@ -71,8 +71,10 @@
     }
 
     .euiTreeView__iconWrapper {
-      margin-block: 0;
-      margin-inline: 0 ($euiSizeS * .75);
+      margin-block-start: 0;
+      margin-block-end: 0;
+      margin-inline-start: 0;
+      margin-inline-end: ($euiSizeS * .75);
     }
 
     .euiTreeView__nodeLabel {

--- a/src/components/tree_view/tree_view.scss
+++ b/src/components/tree_view/tree_view.scss
@@ -4,7 +4,7 @@
 }
 
 .euiTreeView .euiTreeView {
-  padding-left: $euiSizeL;
+  padding-inline-start: $euiSizeL;
 }
 
 .euiTreeView__node {
@@ -22,7 +22,7 @@
 .euiTreeView__nodeInner {
   @include euiTextTruncate;
 
-  padding-left: $euiSizeS;
+  padding-inline-start: $euiSizeS;
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -51,12 +51,12 @@
 }
 
 .euiTreeView__iconWrapper {
-  margin-top: -($euiSizeXS / 2);
-  margin-right: $euiSizeS;
+  margin-block-start: -($euiSizeXS / 2);
+  margin-inline-end: $euiSizeS;
 
   // This helps tokens appear vertically centered
   .euiToken {
-    margin-top: $euiSizeXS / 2;
+    margin-block-start: $euiSizeXS / 2;
   }
 }
 
@@ -71,11 +71,12 @@
     }
 
     .euiTreeView__iconWrapper {
-      margin: 0 ($euiSizeS * .75) 0 0;
+      margin-block: 0;
+      margin-inline: 0 ($euiSizeS * .75);
     }
 
     .euiTreeView__nodeLabel {
-      margin-top: -1px;
+      margin-block-start: -1px;
     }
 
     .euiTreeView__iconPlaceholder {
@@ -91,30 +92,30 @@
 
 .euiTreeView--withArrows {
   .euiTreeView__expansionArrow {
-    margin-right: $euiSizeXS;
+    margin-inline-end: $euiSizeXS;
   }
 
   &.euiTreeView {
     .euiTreeView__nodeInner--withArrows {
       .euiTreeView__iconWrapper {
-        margin-left: 0;
+        margin-inline-start: 0;
       }
     }
 
     .euiTreeView__iconWrapper {
-      margin-left: $euiSize + $euiSizeXS;
+      margin-inline-start: $euiSize + $euiSizeXS;
     }
   }
 
   &.euiTreeView--compressed {
     .euiTreeView__nodeInner--withArrows {
       .euiTreeView__iconWrapper {
-        margin-left: 0;
+        margin-inline-start: 0;
       }
     }
 
     .euiTreeView__iconWrapper {
-      margin-left: $euiSize;
+      margin-inline-start: $euiSize;
     }
   }
 }

--- a/src/global_styling/mixins/_beta_badge.scss
+++ b/src/global_styling/mixins/_beta_badge.scss
@@ -13,7 +13,7 @@
       inset-inline-start: 50%;
       transform: translateX(-50%);
       z-index: 3; // get above abs positioned image
-      min-width: 40%; // 1
+      min-inline-size: 40%; // 1
       max-inline-size: calc(100% - #{($spacing * 2)});
 
       .euiToolTipAnchor,

--- a/src/global_styling/mixins/_beta_badge.scss
+++ b/src/global_styling/mixins/_beta_badge.scss
@@ -9,12 +9,12 @@
 
     #{$selector}__betaBadgeWrapper {
       position: absolute;
-      top: ($euiSizeL / -2);
-      left: 50%;
+      inset-block-start: ($euiSizeL / -2);
+      inset-inline-start: 50%;
       transform: translateX(-50%);
       z-index: 3; // get above abs positioned image
       min-width: 40%; // 1
-      max-width: calc(100% - #{($spacing * 2)});
+      max-inline-size: calc(100% - #{($spacing * 2)});
 
       .euiToolTipAnchor,
       #{$selector}__betaBadge {

--- a/src/global_styling/mixins/_button.scss
+++ b/src/global_styling/mixins/_button.scss
@@ -8,7 +8,7 @@
   line-height: $euiButtonHeight; // prevents descenders from getting cut off
   text-align: center;
   white-space: nowrap;
-  max-width: 100%;
+  max-inline-size: 100%;
   vertical-align: middle;
 }
 

--- a/src/global_styling/mixins/_form.scss
+++ b/src/global_styling/mixins/_form.scss
@@ -85,13 +85,13 @@
   $includeAlternates: false
 ) {
   // Default
-  max-width: $euiFormMaxWidth;
+  max-inline-size: $euiFormMaxWidth;
   width: 100%;
   height: $height;
 
   @if ($includeAlternates) {
     &--fullWidth {
-      max-width: 100%;
+      max-inline-size: 100%;
     }
 
     &--compressed {

--- a/src/global_styling/mixins/_header.scss
+++ b/src/global_styling/mixins/_header.scss
@@ -4,7 +4,7 @@
   // The `&` allows for grouping inside another specific body class.
   // When not applied inside of another selector, it simply renders with the single class
   &.euiBody--headerIsFixed {
-    padding-top: $headerHeight;
+    padding-block-start: $headerHeight;
 
     // When the EuiHeader is fixed, we need to account for it in the position of the flyout
     .euiFlyout,

--- a/src/global_styling/mixins/_header.scss
+++ b/src/global_styling/mixins/_header.scss
@@ -9,7 +9,7 @@
     // When the EuiHeader is fixed, we need to account for it in the position of the flyout
     .euiFlyout,
     .euiCollapsibleNav {
-      top: $headerHeight;
+      inset-block-start: $headerHeight;
       height: calc(100% - #{$headerHeight});
     }
   }

--- a/src/global_styling/mixins/_helpers.scss
+++ b/src/global_styling/mixins/_helpers.scss
@@ -12,10 +12,10 @@
 
   &:after {
     position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    inset-block-start: 0;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
+    inset-block-end: 0;
     border-radius: $borderRadius;
     content: '';
     pointer-events: none;
@@ -74,8 +74,8 @@
 // Hiding elements offscreen to only be read by screen reader
 @mixin euiScreenReaderOnly {
   position: absolute;
-  left: -10000px;
-  top: auto;
+  inset-inline-start: -10000px;
+  inset-block-start: auto;
   width: 1px;
   height: 1px;
   overflow: hidden;

--- a/src/global_styling/mixins/_panel.scss
+++ b/src/global_styling/mixins/_panel.scss
@@ -18,7 +18,7 @@
         // in case of button wrapper which inherently is inline-block and no width
         display: block;
         width: 100%;
-        text-align: left;
+        text-align: start;
 
         // transition the shadow
         transition: all $euiAnimSpeedFast $euiAnimSlightResistance;

--- a/src/global_styling/mixins/_panel.scss
+++ b/src/global_styling/mixins/_panel.scss
@@ -35,10 +35,10 @@
         @include euiBottomShadowMedium;
 
         @if (lightness($euiTextColor) < 50) {
-          border-bottom-color: transparentize($euiShadowColor, .5);
+          border-block-end-color: transparentize($euiShadowColor, .5);
         } @else {
           // Applied again here in case dark theme overrides light
-          border-bottom-color: $euiBorderColor;
+          border-block-end-color: $euiBorderColor;
         }
 
         &#{$selector}--isClickable:hover,

--- a/src/global_styling/mixins/_popover.scss
+++ b/src/global_styling/mixins/_popover.scss
@@ -2,7 +2,7 @@
   @include euiTitle('xxs');
   padding: $euiSizeM;
   text-transform: uppercase;
-  border-bottom: $euiBorderThin;
+  border-block-end: $euiBorderThin;
 
   // Subtract 1px from the border radius since it's inside another container that also has the border radius
   // -- makes for better rounded corners
@@ -13,7 +13,7 @@
 @mixin euiPopoverFooter {
   @include euiFontSizeS;
   padding: $euiSizeM;
-  border-top: $euiBorderThin;
+  border-block-start: $euiBorderThin;
 
   // Subtract 1px from the border radius since it's inside another container that also has the border radius
   // -- makes for better rounded corners

--- a/src/global_styling/mixins/_shadow.scss
+++ b/src/global_styling/mixins/_shadow.scss
@@ -41,8 +41,8 @@
   // Never adjust borders if the border color is already on the dark side (dark theme)
   @if ($adjustBorders and not (lightness($euiBorderColor) < 50)) {
     border-color: tint($color, 75%);
-    border-top-color: tint($color, 80%);
-    border-bottom-color: tint($color, 55%);
+    border-block-start-color: tint($color, 80%);
+    border-block-end-color: tint($color, 55%);
   }
 }
 
@@ -71,8 +71,8 @@
   // Never adjust borders if the border color is already on the dark side (dark theme)
   @if ($adjustBorders and not (lightness($euiBorderColor) < 50)) {
     border-color: tint($color, 70%);
-    border-top-color: tint($color, 85%);
-    border-bottom-color: tint($color, 55%);
+    border-block-start-color: tint($color, 85%);
+    border-block-end-color: tint($color, 55%);
   }
 }
 

--- a/src/global_styling/mixins/_tool_tip.scss
+++ b/src/global_styling/mixins/_tool_tip.scss
@@ -18,9 +18,9 @@
 
 @mixin euiToolTipTitle {
   font-weight: $euiFontWeightBold;
-  border-bottom: solid 1px tintOrShade($euiColorFullShade, 35%, 80%);
-  padding-bottom: $euiSizeXS;
-  margin-bottom: $euiSizeXS;
+  border-block-end: solid 1px tintOrShade($euiColorFullShade, 35%, 80%);
+  padding-block-end: $euiSizeXS;
+  margin-block-end: $euiSizeXS;
 }
 
 @mixin euiToolTipAnimation($side: 'top') {

--- a/src/global_styling/mixins/_tool_tip.scss
+++ b/src/global_styling/mixins/_tool_tip.scss
@@ -4,7 +4,7 @@
   background-color: $euiTooltipBackgroundColor;
   color: $euiColorGhost;
   z-index: $euiZLevel9;
-  max-width: 256px;
+  max-inline-size: 256px;
   overflow-wrap: break-word;
 
   @if ($size == 's') {

--- a/src/global_styling/mixins/_typography.scss
+++ b/src/global_styling/mixins/_typography.scss
@@ -107,7 +107,7 @@
 
 @mixin euiTextTruncate {
   // sass-lint:disable-block no-important
-  max-width: 100%; // 1
+  max-inline-size: 100%; // 1
   overflow: hidden !important;
   text-overflow: ellipsis !important;
   white-space: nowrap !important;

--- a/src/themes/eui-amsterdam/global_styling/mixins/_panel.scss
+++ b/src/themes/eui-amsterdam/global_styling/mixins/_panel.scss
@@ -18,7 +18,7 @@
         // in case of button wrapper which inherently is inline-block and no width
         display: block;
         width: 100%;
-        text-align: left;
+        text-align: start;
 
         // transition the shadow
         transition: all $euiAnimSpeedFast $euiAnimSlightResistance;

--- a/src/themes/eui-amsterdam/global_styling/mixins/_panel.scss
+++ b/src/themes/eui-amsterdam/global_styling/mixins/_panel.scss
@@ -35,10 +35,10 @@
         @include euiBottomShadowMedium;
 
         @if (lightness($euiTextColor) < 50) {
-          border-bottom-color: transparentize($euiShadowColor, .5);
+          border-block-end-color: transparentize($euiShadowColor, .5);
         } @else {
           // Applied again here in case dark theme overrides light
-          border-bottom-color: $euiBorderColor;
+          border-block-end-color: $euiBorderColor;
         }
 
         &#{$selector}--isClickable:hover,

--- a/src/themes/eui-amsterdam/overrides/_call_out.scss
+++ b/src/themes/eui-amsterdam/overrides/_call_out.scss
@@ -1,6 +1,6 @@
 .euiCallOut {
   border-radius: $euiBorderRadius;
-  border-left: none;
+  border-inline-start: none;
 
   .euiCallOutHeader__title {
     font-weight: $euiFontWeightMedium;

--- a/src/themes/eui-amsterdam/overrides/_header.scss
+++ b/src/themes/eui-amsterdam/overrides/_header.scss
@@ -2,8 +2,8 @@
 
 .euiHeader {
   height: $euiHeaderHeight;
-  padding-left: $euiSizeS;
-  padding-right: $euiSizeS;
+  padding-inline-start: $euiSizeS;
+  padding-inline-end: $euiSizeS;
 }
 
 // Remove borders without deleting the prop just yet
@@ -13,11 +13,12 @@
 
 .euiHeaderLogo {
   @include euiBreakpoint('xs') {
-    padding: 0 $euiSizeXS;
+    padding-block: 0;
+    padding-inline: $euiSizeXS;
   }
 
-  padding-left: $euiSizeS;
-  padding-right: $euiSizeS;
+  padding-inline-start: $euiSizeS;
+  padding-inline-end: $euiSizeS;
   min-width: $euiHeaderChildSize;
 }
 
@@ -26,7 +27,7 @@
 }
 
 .euiHeader--default + .euiHeader--default {
-  border-top: $euiBorderThin;
+  border-block-start: $euiBorderThin;
 }
 
 // Breadcrumbs
@@ -34,8 +35,8 @@
 .euiHeaderBreadcrumbs {
   font-size: $euiFontSizeXS;
   line-height: $euiSize;
-  margin-left: $euiSizeS;
-  margin-right: $euiSizeS;
+  margin-inline-start: $euiSizeS;
+  margin-inline-end: $euiSizeS;
 
   // No separators
   .euiBreadcrumbSeparator {
@@ -48,7 +49,8 @@
     @include euiButtonDefaultStyle($euiTextColor);
     line-height: $euiSize;
     font-weight: $euiFontWeightMedium;
-    padding: $euiSizeXS $euiSize;
+    padding-block: $euiSizeXS;
+    padding-inline: $euiSize;
     clip-path: polygon(0 0, calc(100% - #{$euiSizeS}) 0, 100% 50%, calc(100% - #{$euiSizeS}) 100%, 0 100%, $euiSizeS 50%);
 
     // If it's a link the easiest way to detect is via our .euiLink class since it can accept either href or onClick
@@ -72,11 +74,11 @@
     }
 
     &:not(.euiBreadcrumb--last) {
-      margin-right: -$euiSizeXS;
+      margin-inline-end: -$euiSizeXS;
     }
 
     &:first-child {
-      padding-left: $euiSizeM;
+      padding-inline-start: $euiSizeM;
       border-radius: $euiBorderRadius 0 0 $euiBorderRadius;
       clip-path: polygon(0 0, calc(100% - #{$euiSizeS}) 0, 100% 50%, calc(100% - #{$euiSizeS}) 100%, 0 100%);
     }
@@ -84,15 +86,15 @@
 
   .euiBreadcrumb--last {
     border-radius: 0 $euiBorderRadius $euiBorderRadius 0;
-    padding-right: $euiSizeM;
+    padding-inline-end: $euiSizeM;
     clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%, #{$euiSizeS} 50%);
   }
 
   // In case the item is first AND last, aka only, just make it a fully rounded item
   .euiBreadcrumb:only-child {
     clip-path: none;
-    padding-left: $euiSizeM;
-    padding-right: $euiSizeM;
+    padding-inline-start: $euiSizeM;
+    padding-inline-end: $euiSizeM;
     border-radius: $euiBorderRadius;
   }
 }

--- a/src/themes/eui-amsterdam/overrides/_header.scss
+++ b/src/themes/eui-amsterdam/overrides/_header.scss
@@ -13,8 +13,10 @@
 
 .euiHeaderLogo {
   @include euiBreakpoint('xs') {
-    padding-block: 0;
-    padding-inline: $euiSizeXS;
+    padding-block-start: 0;
+    padding-block-end: 0;
+    padding-inline-start: $euiSizeXS;
+    padding-inline-end: $euiSizeXS;
   }
 
   padding-inline-start: $euiSizeS;
@@ -49,8 +51,10 @@
     @include euiButtonDefaultStyle($euiTextColor);
     line-height: $euiSize;
     font-weight: $euiFontWeightMedium;
-    padding-block: $euiSizeXS;
-    padding-inline: $euiSize;
+    padding-block-start: $euiSizeXS;
+    padding-block-end: $euiSizeXS;
+    padding-inline-start: $euiSize;
+    padding-inline-end: $euiSize;
     clip-path: polygon(0 0, calc(100% - #{$euiSizeS}) 0, 100% 50%, calc(100% - #{$euiSizeS}) 100%, 0 100%, $euiSizeS 50%);
 
     // If it's a link the easiest way to detect is via our .euiLink class since it can accept either href or onClick

--- a/src/themes/eui-amsterdam/overrides/_header.scss
+++ b/src/themes/eui-amsterdam/overrides/_header.scss
@@ -21,7 +21,7 @@
 
   padding-inline-start: $euiSizeS;
   padding-inline-end: $euiSizeS;
-  min-width: $euiHeaderChildSize;
+  min-inline-size: $euiHeaderChildSize;
 }
 
 .euiHeaderLogo__text {

--- a/src/themes/eui-amsterdam/overrides/_popover.scss
+++ b/src/themes/eui-amsterdam/overrides/_popover.scss
@@ -10,7 +10,7 @@
     &.euiPopover__panelArrow--top {
       &:before {
         bottom: -$euiPopoverArrowSize;
-        border-top-color: $euiShadowColor;
+        border-block-start-color: $euiShadowColor;
         clip-path: polygon(#{-$arrowShadowCompensation} 0, #{$euiPopoverArrowSize * 2 + $arrowShadowCompensation} 0, #{$euiPopoverArrowSize * 2 + $arrowShadowCompensation} #{$euiPopoverArrowSize + $arrowShadowCompensation}, #{-$arrowShadowCompensation} #{$euiPopoverArrowSize + $arrowShadowCompensation});
       }
 
@@ -21,7 +21,7 @@
 
     &.euiPopover__panelArrow--right {
       &:before {
-        border-right-color: $euiShadowColor;
+        border-inline-end-color: $euiShadowColor;
         clip-path: polygon(#{-$arrowShadowCompensation} #{-$arrowShadowCompensation}, $euiPopoverArrowSize #{-$arrowShadowCompensation}, $euiPopoverArrowSize #{$euiPopoverArrowSize * 2 + $arrowShadowCompensation}, #{-$arrowShadowCompensation} #{$euiPopoverArrowSize * 2 + $arrowShadowCompensation});
       }
 
@@ -32,7 +32,7 @@
 
     &.euiPopover__panelArrow--bottom {
       &:before {
-        border-bottom-color: $euiShadowColor;
+        border-block-end-color: $euiShadowColor;
         clip-path: polygon(#{-$arrowShadowCompensation} #{-$arrowShadowCompensation}, #{$euiPopoverArrowSize * 2 + $arrowShadowCompensation} #{-$arrowShadowCompensation}, #{$euiPopoverArrowSize * 2 + $arrowShadowCompensation} $euiPopoverArrowSize, #{-$arrowShadowCompensation} $euiPopoverArrowSize);
       }
 
@@ -44,7 +44,7 @@
     &.euiPopover__panelArrow--left {
       &:before {
         right: -$euiPopoverArrowSize;
-        border-left-color: $euiShadowColor;
+        border-inline-start-color: $euiShadowColor;
         clip-path: polygon(0 #{-$arrowShadowCompensation}, #{$euiPopoverArrowSize + $arrowShadowCompensation} #{-$arrowShadowCompensation}, #{$euiPopoverArrowSize + $arrowShadowCompensation} #{$euiPopoverArrowSize * 2 + $arrowShadowCompensation}, 0 #{$euiPopoverArrowSize * 2 + $arrowShadowCompensation});
       }
 

--- a/src/themes/eui-amsterdam/overrides/_popover.scss
+++ b/src/themes/eui-amsterdam/overrides/_popover.scss
@@ -9,13 +9,13 @@
 
     &.euiPopover__panelArrow--top {
       &:before {
-        bottom: -$euiPopoverArrowSize;
+        inset-block-end: -$euiPopoverArrowSize;
         border-block-start-color: $euiShadowColor;
         clip-path: polygon(#{-$arrowShadowCompensation} 0, #{$euiPopoverArrowSize * 2 + $arrowShadowCompensation} 0, #{$euiPopoverArrowSize * 2 + $arrowShadowCompensation} #{$euiPopoverArrowSize + $arrowShadowCompensation}, #{-$arrowShadowCompensation} #{$euiPopoverArrowSize + $arrowShadowCompensation});
       }
 
       &:after {
-        bottom: -$euiPopoverArrowSize + 1;
+        inset-block-end: -$euiPopoverArrowSize + 1;
       }
     }
 
@@ -26,7 +26,7 @@
       }
 
       &:after {
-        left: -$euiPopoverArrowSize + 1;
+        inset-inline-start: -$euiPopoverArrowSize + 1;
       }
     }
 
@@ -37,19 +37,19 @@
       }
 
       &:after {
-        top: -$euiPopoverArrowSize + 1;
+        inset-block-start: -$euiPopoverArrowSize + 1;
       }
     }
 
     &.euiPopover__panelArrow--left {
       &:before {
-        right: -$euiPopoverArrowSize;
+        inset-inline-end: -$euiPopoverArrowSize;
         border-inline-start-color: $euiShadowColor;
         clip-path: polygon(0 #{-$arrowShadowCompensation}, #{$euiPopoverArrowSize + $arrowShadowCompensation} #{-$arrowShadowCompensation}, #{$euiPopoverArrowSize + $arrowShadowCompensation} #{$euiPopoverArrowSize * 2 + $arrowShadowCompensation}, 0 #{$euiPopoverArrowSize * 2 + $arrowShadowCompensation});
       }
 
       &:after {
-        right: -$euiPopoverArrowSize + 1;
+        inset-inline-end: -$euiPopoverArrowSize + 1;
       }
     }
   }


### PR DESCRIPTION
** DO NOT MERGE **

This is a test to see and discuss how EUI Docs will appear if all margin, padding, and borders are replaced with the logical units rather than the physical ones.  Example: `margin-left` -> `margin-inline-start`.

The replacements were done with a script
https://gist.github.com/nyurik/d438cb56a9059a0660ce4176ef94576f

### Summary

Provide a detailed summary of your PR. Explain how you arrived at your solution. If it includes changes to UI elements include a screenshot or gif.

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
