### PR TITLE
Fixes docs page navbar showing only in homepage in mobile

### DIFF
--- a/src/components/side_nav/_side_nav.scss
+++ b/src/components/side_nav/_side_nav.scss
@@ -62,6 +62,7 @@
   }
 
   .euiSideNav__content {
+    overflow: hidden;
     visibility: hidden;
     opacity: 0;
     max-height: 0;


### PR DESCRIPTION
### Summary
Fixes #3965 

Before:

![image](https://user-images.githubusercontent.com/10515204/92083344-83a1ce80-ede3-11ea-97d9-28fb45e88b73.png)

After:

![image](https://user-images.githubusercontent.com/10515204/92083376-93b9ae00-ede3-11ea-9fd7-c2f6e6ac2eb8.png)


### Checklist

~~- [ ] Check against **all themes** for compatibility in both light and dark modes~~
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
~~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~~
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
~~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~~
