### PR TITLE
Updates to EuiSelectableTemplateSitewide and some other fixes for the new header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Added `.browserslistrc` for global browser support reference ([#4022](https://github.com/elastic/eui/pull/4022))
 - Added ability to specify `color` of `EuiHeaderLink` ([#4008](https://github.com/elastic/eui/pull/4008))
 - Added `boolean` type to the `notification` prop of `EuiHeaderSectionItemButton` to show a simple dot ([#4008](https://github.com/elastic/eui/pull/4008))
-- Added `popoverButton` and `popoverButtonMaxBreakpoint` props to `EuiSelectableTemplateSitewide` for responsive capabilities ([#4008](https://github.com/elastic/eui/pull/4008))
+- Added `popoverButton` and `popoverButtonBreakpoints` props to `EuiSelectableTemplateSitewide` for responsive capabilities ([#4008](https://github.com/elastic/eui/pull/4008))
 - Added `isWithinMaxBreakpoint` service ([#4008](https://github.com/elastic/eui/pull/4008))
 
 **Bug fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,22 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added `.browserslistrc` for global browser support reference ([#4022](https://github.com/elastic/eui/pull/4022))
+- Added ability to specify `color` of `EuiHeaderLink` ([#4008](https://github.com/elastic/eui/pull/4008))
+- Added `boolean` type to the `notification` prop of `EuiHeaderSectionItemButton` to show a simple dot ([#4008](https://github.com/elastic/eui/pull/4008))
+- Added `popoverButton` and `popoverButtonMaxBreakpoint` props to `EuiSelectableTemplateSitewide` for responsive capabilities ([#4008](https://github.com/elastic/eui/pull/4008))
+- Added `isWithinMaxBreakpoint` service ([#4008](https://github.com/elastic/eui/pull/4008))
 
 **Bug fixes**
 
 - Fixed ref not being handled properly in `EuiValidatableControl` when used with [react-hook-form](https://react-hook-form.com/) ([#4001](https://github.com/elastic/eui/pull/4001))
+- Fixed `EuiNotificationBadge` `color` prop type ([#4008](https://github.com/elastic/eui/pull/4008))
+- Fixed z-index of `EuiBottomBar` to stay under header ([#4008](https://github.com/elastic/eui/pull/4008))
+- Fixed regression of `EuiSelectable` not abiding by the `showIcons` prop ([#4008](https://github.com/elastic/eui/pull/4008))
+- Fixed contrast of search input of `EuiSelectableTemplateSitewide` in dark header ([#4008](https://github.com/elastic/eui/pull/4008))
+
+**Breaking changes**
+
+- Changed `EuiHideFor` and `EuiShowFor` from using media queries to hide content to not rendering the content. Children are now required and `display` has been removed ([#4008](https://github.com/elastic/eui/pull/4008))
 
 ## [`28.4.0`](https://github.com/elastic/eui/tree/v28.4.0)
 

--- a/src-docs/src/components/guide_section/guide_section.js
+++ b/src-docs/src/components/guide_section/guide_section.js
@@ -525,7 +525,7 @@ export class GuideSection extends Component {
         wrap>
         <EuiFlexItem grow={false}>
           <EuiTitle size="s">
-            <h3>{componentName}</h3>
+            <h3 id={componentName}>{componentName}</h3>
           </EuiTitle>
         </EuiFlexItem>
         {extendedTypesElements.length > 0 && (

--- a/src-docs/src/views/header/header_dark.tsx
+++ b/src-docs/src/views/header/header_dark.tsx
@@ -52,7 +52,7 @@ export default ({ theme }: { theme: any }) => (
           </EuiBadge>,
           <EuiHeaderSectionItemButton
             aria-label="Notifications"
-            notification={'•'}>
+            notification={'2'}>
             <EuiIcon type="cheer" size="m" />
           </EuiHeaderSectionItemButton>,
           <EuiHeaderSectionItemButton aria-label="Account menu">

--- a/src-docs/src/views/header/header_dark.tsx
+++ b/src-docs/src/views/header/header_dark.tsx
@@ -51,7 +51,7 @@ export default ({ theme }: { theme: any }) => (
             Production logs
           </EuiBadge>,
           <EuiHeaderSectionItemButton
-            aria-label="Notifications"
+            aria-label="2 Notifications"
             notification={'2'}>
             <EuiIcon type="cheer" size="m" />
           </EuiHeaderSectionItemButton>,

--- a/src-docs/src/views/header/header_elastic_pattern.js
+++ b/src-docs/src/views/header/header_elastic_pattern.js
@@ -299,8 +299,8 @@ export default ({ theme }) => {
                 items: [
                   <EuiShowFor sizes={['xs', 's']}>{search}</EuiShowFor>,
                   <EuiHeaderSectionItemButton
-                    aria-label="Notifications"
                     notification={true}
+                    aria-label="Notifictations: Updates available"
                     onClick={() =>
                       setIsAlertFlyoutVisible(!isAlertFlyoutVisible)
                     }>

--- a/src-docs/src/views/header/header_elastic_pattern.js
+++ b/src-docs/src/views/header/header_elastic_pattern.js
@@ -253,7 +253,7 @@ export default ({ theme }) => {
           <EuiIcon type="search" size="m" />
         </EuiHeaderSectionItemButton>
       }
-      popoverButtonMaxBreakpoint="s"
+      popoverButtonBreakpoints={['xs', 's']}
       emptyMessage={
         <EuiSelectableMessage style={{ minHeight: 300 }}>
           <p>

--- a/src-docs/src/views/header/header_elastic_pattern.js
+++ b/src-docs/src/views/header/header_elastic_pattern.js
@@ -317,13 +317,13 @@ export default ({ theme }) => {
               {
                 items: [
                   <EuiHeaderLinks>
-                    <EuiHeaderLink>Share</EuiHeaderLink>
-                    <EuiHeaderLink>Clone</EuiHeaderLink>
+                    <EuiHeaderLink color="primary">Share</EuiHeaderLink>
+                    <EuiHeaderLink color="primary">Clone</EuiHeaderLink>
                     <EuiButton
                       iconType="minimize"
                       style={{ minWidth: 80 }}
                       size="s"
-                      color="secondary"
+                      color="primary"
                       onClick={() => {
                         setFullScreen(false);
                         document.body.classList.remove(

--- a/src-docs/src/views/header/header_elastic_pattern.js
+++ b/src-docs/src/views/header/header_elastic_pattern.js
@@ -299,7 +299,7 @@ export default ({ theme }) => {
                   <EuiShowFor sizes={['xs', 's']}>{search}</EuiShowFor>,
                   <EuiHeaderSectionItemButton
                     aria-label="Notifications"
-                    notification={'•'}
+                    notification={true}
                     onClick={() =>
                       setIsAlertFlyoutVisible(!isAlertFlyoutVisible)
                     }>

--- a/src-docs/src/views/header/header_elastic_pattern.js
+++ b/src-docs/src/views/header/header_elastic_pattern.js
@@ -248,11 +248,12 @@ export default ({ theme }) => {
         append: '⌘K',
         compressed: true,
       }}
-      mobileToggle={
+      popoverButton={
         <EuiHeaderSectionItemButton aria-label="Sitewide search">
           <EuiIcon type="search" size="m" />
         </EuiHeaderSectionItemButton>
       }
+      popoverButtonMaxBreakpoint="s"
       emptyMessage={
         <EuiSelectableMessage style={{ minHeight: 300 }}>
           <p>

--- a/src-docs/src/views/header/header_elastic_pattern.js
+++ b/src-docs/src/views/header/header_elastic_pattern.js
@@ -238,6 +238,35 @@ export default ({ theme }) => {
     </EuiPopover>
   );
 
+  /**
+   * Sitewide search
+   */
+  const search = (
+    <EuiSelectableTemplateSitewide
+      options={[]}
+      searchProps={{
+        append: '⌘K',
+        compressed: true,
+      }}
+      mobileToggle={
+        <EuiHeaderSectionItemButton aria-label="Sitewide search">
+          <EuiIcon type="search" size="m" />
+        </EuiHeaderSectionItemButton>
+      }
+      emptyMessage={
+        <EuiSelectableMessage style={{ minHeight: 300 }}>
+          <p>
+            Please see the component page for{' '}
+            <Link to="/forms/selectable">
+              <strong>EuiSelectableTemplateSitewide</strong>
+            </Link>{' '}
+            on how to configure your sitewide search.
+          </p>
+        </EuiSelectableMessage>
+      }
+    />
+  );
+
   return (
     <>
       <EuiButton onClick={() => setFullScreen(true)} iconType="fullScreen">
@@ -255,35 +284,19 @@ export default ({ theme }) => {
                   <EuiHeaderLogo iconType="logoElastic" href="">
                     Elastic
                   </EuiHeaderLogo>,
-                ],
-                borders: 'none',
-              },
-              {
-                items: [
-                  <EuiSelectableTemplateSitewide
-                    options={[]}
-                    searchProps={{
-                      append: '⌘K',
-                      compressed: true,
-                    }}
-                    emptyMessage={
-                      <EuiSelectableMessage style={{ minHeight: 300 }}>
-                        <p>
-                          Please see the component page for{' '}
-                          <Link to="/forms/selectable">
-                            <strong>EuiSelectableTemplateSitewide</strong>
-                          </Link>{' '}
-                          on how to configure your sitewide search.
-                        </p>
-                      </EuiSelectableMessage>
-                    }
-                  />,
-                ],
-                borders: 'none',
-              },
-              {
-                items: [
                   deploymentMenu,
+                ],
+                borders: 'none',
+              },
+              {
+                items: [
+                  <EuiShowFor sizes={['m', 'l', 'xl']}>{search}</EuiShowFor>,
+                ],
+                borders: 'none',
+              },
+              {
+                items: [
+                  <EuiShowFor sizes={['xs', 's']}>{search}</EuiShowFor>,
                   <EuiHeaderSectionItemButton
                     aria-label="Notifications"
                     notification={'•'}

--- a/src-docs/src/views/header/header_elastic_pattern.js
+++ b/src-docs/src/views/header/header_elastic_pattern.js
@@ -332,7 +332,9 @@ export default ({ theme }) => {
                 items: [
                   <EuiHeaderLinks>
                     <EuiHeaderLink color="primary">Share</EuiHeaderLink>
-                    <EuiHeaderLink color="primary">Clone</EuiHeaderLink>
+                    <EuiHeaderLink color="primary" iconType="copy">
+                      Clone
+                    </EuiHeaderLink>
                     <EuiButton
                       iconType="minimize"
                       style={{ minWidth: 80 }}

--- a/src-docs/src/views/header/header_example.js
+++ b/src-docs/src/views/header/header_example.js
@@ -305,7 +305,6 @@ export const HeaderExample = {
       props: {
         EuiHeaderAlert,
       },
-      snippet: headerLinksSnippet,
       demo: <HeaderAlert />,
     },
     {

--- a/src-docs/src/views/header/header_updates.js
+++ b/src-docs/src/views/header/header_updates.js
@@ -120,7 +120,7 @@ export default ({ flyoutOrPopover = 'flyout' }) => {
         { showBadge } ? 'Updates available' : 'No updates'
       }`}
       onClick={() => showFlyout()}
-      notification={showBadge && '•'}>
+      notification={showBadge}>
       <EuiIcon type="cheer" size="m" />
     </EuiHeaderSectionItemButton>
   );

--- a/src-docs/src/views/header/header_updates.js
+++ b/src-docs/src/views/header/header_updates.js
@@ -117,7 +117,7 @@ export default ({ flyoutOrPopover = 'flyout' }) => {
       aria-expanded={isFlyoutVisible}
       aria-haspopup="true"
       aria-label={`News feed: ${
-        { showBadge } ? 'Updates available' : 'No updates'
+        showBadge ? 'Updates available' : 'No updates'
       }`}
       onClick={() => showFlyout()}
       notification={showBadge}>

--- a/src-docs/src/views/responsive/responsive.js
+++ b/src-docs/src/views/responsive/responsive.js
@@ -1,48 +1,62 @@
 import React from 'react';
 
-import { EuiCode, EuiHideFor, EuiShowFor } from '../../../../src/components';
+import {
+  EuiCode,
+  EuiHideFor,
+  EuiShowFor,
+  EuiText,
+  EuiSpacer,
+} from '../../../../src/components';
 
 export default () => (
-  <div>
+  <EuiText>
     <EuiHideFor sizes={['xs']}>
-      Hiding from <EuiCode>xs</EuiCode> screens only
+      <p>
+        Hiding from <EuiCode>xs</EuiCode> screens only
+      </p>
     </EuiHideFor>
-    <br />
     <EuiHideFor sizes={['xs', 's']}>
-      Hiding from <EuiCode>xs, s</EuiCode> screens
+      <p>
+        Hiding from <EuiCode>xs, s</EuiCode> screens
+      </p>
     </EuiHideFor>
-    <br />
     <EuiHideFor sizes={['xs', 's', 'm', 'l']}>
-      Hiding from <EuiCode>xs, s, m, l</EuiCode> screens
+      <p>
+        Hiding from <EuiCode>xs, s, m, l</EuiCode> screens
+      </p>
     </EuiHideFor>
-    <br />
     <EuiHideFor sizes={['xl']}>
-      Hiding from <EuiCode>xl</EuiCode> screens only
+      <p>
+        Hiding from <EuiCode>xl</EuiCode> screens only
+      </p>
     </EuiHideFor>
 
-    <br />
-    <br />
+    <EuiSpacer size="xxl" />
 
     <EuiShowFor sizes={['xs']}>
-      Showing for <EuiCode>xs</EuiCode> screens only
+      <p>
+        Showing for <EuiCode>xs</EuiCode> screens only
+      </p>
     </EuiShowFor>
-    <br />
     <EuiShowFor sizes={['xs', 's']}>
-      Showing for <EuiCode>xs, s</EuiCode> screens
+      <p>
+        Showing for <EuiCode>xs, s</EuiCode> screens
+      </p>
     </EuiShowFor>
-    <br />
     <EuiShowFor sizes={['xs', 's', 'm', 'l']}>
-      Showing for <EuiCode>xs, s, m, l</EuiCode> screens
+      <p>
+        Showing for <EuiCode>xs, s, m, l</EuiCode> screens
+      </p>
     </EuiShowFor>
-    <br />
     <EuiShowFor sizes={['xl']}>
-      Showing for <EuiCode>xl</EuiCode> screen only
+      <p>
+        Showing for <EuiCode>xl</EuiCode> screen only
+      </p>
     </EuiShowFor>
-    <EuiShowFor sizes={['m', 'l', 'xl']} display="block">
-      <div>
-        Showing for <EuiCode>m, l, xl</EuiCode> screen only as{' '}
-        <EuiCode>block</EuiCode>
-      </div>
+    <EuiShowFor sizes={['m', 'l', 'xl']}>
+      <p>
+        Showing for <EuiCode>m, l, xl</EuiCode> screen only
+      </p>
     </EuiShowFor>
-  </div>
+  </EuiText>
 );

--- a/src-docs/src/views/responsive/responsive_example.js
+++ b/src-docs/src/views/responsive/responsive_example.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { renderToHtml } from '../../services';
-import sizes from '!!sass-vars-to-js-loader!../../../../src/global_styling/variables/_responsive.scss';
 
 import { GuideSectionTypes } from '../../components';
 
@@ -12,6 +11,9 @@ import {
   EuiCodeBlock,
 } from '../../../../src/components';
 
+import { BREAKPOINTS, BREAKPOINT_KEYS } from '../../../../src/services';
+import { EuiBreakpointSize } from '!!prop-loader!../../../../src/services/breakpoint';
+
 import Responsive from './responsive';
 const responsiveSource = require('!!raw-loader!./responsive');
 const responsiveHtml = renderToHtml(Responsive);
@@ -19,17 +21,16 @@ const responsiveSnippet = [
   `<EuiHideFor sizes={['xs', 's']}>
   <!-- Content to hide from xs and s screens -->
 </EuiHideFor>`,
-  `<EuiShowFor sizes={['l', 'xl']} display="block">
-  <!-- <div>Content only showing for l and xl screens and displaying in block</div> -->
+  `<EuiShowFor sizes={['l', 'xl']}>
+  <!-- <div>Content only showing for l and xl screens</div> -->
 </EuiShowFor>`,
 ];
 
 function renderSizes(size, index) {
-  let code = `'${size}': ${sizes.euiBreakpoints[size]}px`;
+  let code = `'${size}': ${BREAKPOINTS[size]}px`;
 
-  if (index < sizes.euiBreakpointKeys.length - 1) {
-    code += ` (to ${sizes.euiBreakpoints[sizes.euiBreakpointKeys[index + 1]] -
-      1}px)`;
+  if (index > 0) {
+    code += ` (to ${BREAKPOINTS[BREAKPOINT_KEYS[index - 1]] - 1}px)`;
   } else {
     code += ' +';
   }
@@ -55,27 +56,28 @@ export const ResponsiveExample = {
       text: (
         <div>
           <p>
-            Pass an array of named breakpoints to either the{' '}
-            <strong>EuiShowFor</strong> or <strong>EuiHideFor</strong>{' '}
-            components to make them responsive.
+            These components will either render or not render their children
+            based on the current window width. Pass an array of named
+            breakpoints to the <EuiCode>sizes</EuiCode> prop to either show or
+            hide their children respectively.
           </p>
 
           <p>
-            The sizing correlates with our{' '}
-            <EuiCode language="scss">$euiBreakpoints</EuiCode> SASS map. The
-            named breakpoint starts at the pixel value provided and ends before
-            the next one.
+            The sizing options correlate with the keys in the{' '}
+            <EuiCode language="ts">EuiBreakpoints</EuiCode> type. The named
+            breakpoint starts at the pixel value provided and ends before the
+            next one.
           </p>
 
           <EuiCodeBlock language="scss" paddingSize="s">
-            {sizes.euiBreakpointKeys.map(function(size, index) {
+            {BREAKPOINT_KEYS.map(function(size, index) {
               return renderSizes(size, index);
             })}
           </EuiCodeBlock>
         </div>
       ),
       snippet: responsiveSnippet,
-      props: { EuiShowFor, EuiHideFor },
+      props: { EuiShowFor, EuiHideFor, EuiBreakpointSize },
       demo: <Responsive />,
     },
   ],

--- a/src-docs/src/views/selectable/search.tsx
+++ b/src-docs/src/views/selectable/search.tsx
@@ -97,7 +97,7 @@ export default () => {
         className: 'customPopoverClass',
       }}
       popoverButton={<EuiButton>Mobile toggle</EuiButton>}
-      popoverButtonMaxBreakpoint="s"
+      popoverButtonBreakpoints={['xs', 's']}
       popoverFooter={
         <EuiText color="subdued" size="xs">
           <EuiFlexGroup

--- a/src-docs/src/views/selectable/search.tsx
+++ b/src-docs/src/views/selectable/search.tsx
@@ -96,7 +96,8 @@ export default () => {
       popoverProps={{
         className: 'customPopoverClass',
       }}
-      mobileToggle={<EuiButton>Mobile toggle</EuiButton>}
+      popoverButton={<EuiButton>Mobile toggle</EuiButton>}
+      popoverButtonMaxBreakpoint="s"
       popoverFooter={
         <EuiText color="subdued" size="xs">
           <EuiFlexGroup

--- a/src-docs/src/views/selectable/search.tsx
+++ b/src-docs/src/views/selectable/search.tsx
@@ -6,6 +6,7 @@ import { EuiSelectableTemplateSitewide } from '../../../../src/components/select
 import { EuiSelectableTemplateSitewideOption } from '../../../../src/components/selectable/selectable_templates/selectable_template_sitewide_option';
 import { EuiFlexGroup, EuiFlexItem } from '../../../../src/components/flex';
 import { EuiLink } from '../../../../src/components/link';
+import { EuiButton } from '../../../../src/components/button';
 
 export default () => {
   const [searchValue, setSearchValue] = useState('');
@@ -95,6 +96,7 @@ export default () => {
       popoverProps={{
         className: 'customPopoverClass',
       }}
+      mobileToggle={<EuiButton>Mobile toggle</EuiButton>}
       popoverFooter={
         <EuiText color="subdued" size="xs">
           <EuiFlexGroup

--- a/src-docs/src/views/selectable/selectable_example.js
+++ b/src-docs/src/views/selectable/selectable_example.js
@@ -561,9 +561,9 @@ export const SelectableExample = {
           <p>
             This is a great way to handle reducing the size of the component for
             smaller screens. The component offers a helper prop called{' '}
-            <EuiCode>popoverButtonMaxBreakpoint</EuiCode> which will only use
-            the <EuiCode>popoverButton</EuiCode> if the window width is equal to
-            or smaller than the named breakpoint.
+            <EuiCode>popoverButtonBreakpoints</EuiCode> which will only render
+            the <EuiCode>popoverButton</EuiCode> if the window size matches
+            named breakpoint(s).
           </p>
         </Fragment>
       ),

--- a/src-docs/src/views/selectable/selectable_example.js
+++ b/src-docs/src/views/selectable/selectable_example.js
@@ -550,6 +550,21 @@ export const SelectableExample = {
             options with the selected option having{' '}
             <EuiCode>{"checked: 'on'"}</EuiCode>.
           </p>
+          <h3>Popover toggle and responsiveness</h3>
+          <p>
+            The default display is to render the search input inline which
+            triggers a popover with the results. Or you can decide to trigger
+            the whole selectable component from a single button. By passing your
+            own button to <EuiCode>popoverButton</EuiCode>, the component will
+            use this to trigger the popover, putting the search inside.
+          </p>
+          <p>
+            This is a great way to handle reducing the size of the component for
+            smaller screens. The component offers a helper prop called{' '}
+            <EuiCode>popoverButtonMaxBreakpoint</EuiCode> which will only use
+            the <EuiCode>popoverButton</EuiCode> if the window width is equal to
+            or smaller than the named breakpoint.
+          </p>
         </Fragment>
       ),
       props: { EuiSelectableTemplateSitewide, Options, MetaData },

--- a/src/components/badge/notification_badge/badge_notification.tsx
+++ b/src/components/badge/notification_badge/badge_notification.tsx
@@ -27,7 +27,7 @@ const colorToClassMap: { [color: string]: string | null } = {
 };
 
 export const COLORS: BadgeNotificationColor[] = keysOf(colorToClassMap);
-export type BadgeNotificationColor = keyof typeof colorToClassMap;
+export type BadgeNotificationColor = 'accent' | 'subdued';
 
 const sizeToClassNameMap = {
   s: null,

--- a/src/components/badge/notification_badge/badge_notification.tsx
+++ b/src/components/badge/notification_badge/badge_notification.tsx
@@ -21,13 +21,13 @@ import React, { HTMLAttributes, ReactNode, FunctionComponent } from 'react';
 import classNames from 'classnames';
 import { CommonProps, keysOf } from '../../common';
 
-const colorToClassMap: { [color: string]: string | null } = {
+const colorToClassMap = {
   accent: null,
   subdued: 'euiNotificationBadge--subdued',
 };
 
 export const COLORS: BadgeNotificationColor[] = keysOf(colorToClassMap);
-export type BadgeNotificationColor = 'accent' | 'subdued';
+export type BadgeNotificationColor = keyof typeof colorToClassMap;
 
 const sizeToClassNameMap = {
   s: null,

--- a/src/components/bottom_bar/_bottom_bar.scss
+++ b/src/components/bottom_bar/_bottom_bar.scss
@@ -7,7 +7,7 @@
   right: 0;
   left: 0;
   animation: euiBottomBarAppear $euiAnimSpeedSlow $euiAnimSlightResistance;
-  z-index: $euiZNavigation;
+  z-index: $euiZHeader - 2;
 
   &.euiBottomBar--paddingSmall {
     padding: $euiSizeS;

--- a/src/components/header/_mixins.scss
+++ b/src/components/header/_mixins.scss
@@ -31,12 +31,11 @@
   }
 
   .euiHeaderNotification,
-  .euiHeaderSectionItemButton__notification {
+  .euiHeaderSectionItemButton__notification--badge {
     box-shadow: 0 0 0 1px $backgroundColor;
   }
 
   .euiHeaderSectionItemButton__notification--dot {
-    box-shadow: none;
     stroke: $backgroundColor;
   }
 }

--- a/src/components/header/_mixins.scss
+++ b/src/components/header/_mixins.scss
@@ -34,4 +34,9 @@
   .euiHeaderSectionItemButton__notification {
     box-shadow: 0 0 0 1px $backgroundColor;
   }
+
+  .euiHeaderSectionItemButton__notification--dot {
+    box-shadow: none;
+    stroke: $backgroundColor;
+  }
 }

--- a/src/components/header/header_links/__snapshots__/header_link.test.tsx.snap
+++ b/src/components/header/header_links/__snapshots__/header_link.test.tsx.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiHeaderLink can render as specific color 1`] = `
+<button
+  class="euiButtonEmpty euiButtonEmpty--danger euiHeaderLink"
+  type="button"
+>
+  <span
+    class="euiButtonContent euiButtonEmpty__content"
+  >
+    <span
+      class="euiButtonEmpty__text"
+    />
+  </span>
+</button>
+`;
+
 exports[`EuiHeaderLink is rendered 1`] = `
 <button
   aria-label="aria-label"

--- a/src/components/header/header_links/_header_link.scss
+++ b/src/components/header/header_links/_header_link.scss
@@ -16,9 +16,4 @@
       justify-content: flex-start;
     }
   }
-
-  button:not(.euiHeaderLink),
-  a:not(.euiHeaderLink) {
-    margin: $euiSizeXS;
-  }
 }

--- a/src/components/header/header_links/_header_link.scss
+++ b/src/components/header/header_links/_header_link.scss
@@ -16,4 +16,9 @@
       justify-content: flex-start;
     }
   }
+
+  button:not(.euiHeaderLink),
+  a:not(.euiHeaderLink) {
+    margin: $euiSizeXS;
+  }
 }

--- a/src/components/header/header_links/header_link.test.tsx
+++ b/src/components/header/header_links/header_link.test.tsx
@@ -35,4 +35,10 @@ describe('EuiHeaderLink', () => {
 
     expect(component).toMatchSnapshot();
   });
+
+  test('can render as specific color', () => {
+    const component = render(<EuiHeaderLink color="danger" />);
+
+    expect(component).toMatchSnapshot();
+  });
 });

--- a/src/components/header/header_links/header_link.tsx
+++ b/src/components/header/header_links/header_link.tsx
@@ -21,10 +21,12 @@ import React, { FunctionComponent } from 'react';
 import classNames from 'classnames';
 
 import { EuiButtonEmpty, EuiButtonEmptyProps } from '../../button';
-import { IconType } from '../../icon';
 
 export type EuiHeaderLinkProps = EuiButtonEmptyProps & {
-  iconType?: IconType;
+  /**
+   * Simple prop to update color based on active state.
+   * Can be overridden with `color`
+   */
   isActive?: boolean;
 };
 
@@ -42,9 +44,9 @@ export const EuiHeaderLink: FunctionComponent<EuiHeaderLinkProps> = ({
   );
 
   const props = {
+    color: isActive ? 'primary' : 'text',
     ...rest,
     className: classes,
-    color: isActive ? 'primary' : 'text',
   };
 
   return <EuiButtonEmpty {...(props as EuiButtonEmptyProps)} />;

--- a/src/components/header/header_section/__snapshots__/header_section_item_button.test.tsx.snap
+++ b/src/components/header/header_section/__snapshots__/header_section_item_button.test.tsx.snap
@@ -20,16 +20,29 @@ exports[`EuiHeaderSectionItemButton renders children 1`] = `
 </button>
 `;
 
-exports[`EuiHeaderSectionItemButton renders notification children 1`] = `
+exports[`EuiHeaderSectionItemButton renders notification as a badge 1`] = `
 <button
   class="euiHeaderSectionItem__button"
   type="button"
 >
   <span
-    class="euiNotificationBadge euiHeaderSectionItemButton__notification"
+    class="euiNotificationBadge euiHeaderSectionItemButton__notification euiHeaderSectionItemButton__notification--badge"
   >
     1
   </span>
+</button>
+`;
+
+exports[`EuiHeaderSectionItemButton renders notification as a dot 1`] = `
+<button
+  class="euiHeaderSectionItem__button"
+  type="button"
+>
+  <div
+    class="euiHeaderSectionItemButton__notification euiHeaderSectionItemButton__notification--dot"
+    color="accent"
+    data-euiicon-type="dot"
+  />
 </button>
 `;
 
@@ -39,7 +52,7 @@ exports[`EuiHeaderSectionItemButton renders notification color 1`] = `
   type="button"
 >
   <span
-    class="euiNotificationBadge euiNotificationBadge--subdued euiHeaderSectionItemButton__notification"
+    class="euiNotificationBadge euiNotificationBadge--subdued euiHeaderSectionItemButton__notification euiHeaderSectionItemButton__notification--badge"
   >
     1
   </span>

--- a/src/components/header/header_section/_header_section_item.scss
+++ b/src/components/header/header_section/_header_section_item.scss
@@ -16,6 +16,7 @@
 }
 
 .euiHeaderSectionItem__button {
+  position: relative; // For positioning the notification
   height: $euiHeaderChildSize;
   min-width: $euiHeaderChildSize;
   text-align: center;
@@ -56,6 +57,13 @@
   box-shadow: 0 0 0 1px $euiHeaderBackgroundColor;
 }
 
+.euiHeaderSectionItemButton__notification--dot {
+  right: 0;
+  top: 0;
+  box-shadow: none;
+  stroke: $euiHeaderBackgroundColor;
+}
+
 @include euiBreakpoint('xs') {
   .euiHeaderSectionItem,
   .euiHeaderSectionItem__button {
@@ -71,12 +79,18 @@
 
   // On small screens just show a small dot indicating there are notifications
   .euiHeaderNotification,
-  .euiHeaderSectionItemButton__notification {
+  .euiHeaderSectionItemButton__notification--badge {
     @include size($euiSizeS);
     top: 20%;
     min-width: 0;
     border-radius: $euiSizeS;
     color: $euiColorAccent;
     overflow: hidden;
+  }
+
+  // Using specificty to override the default icon size
+  .euiHeaderSectionItemButton__notification.euiHeaderSectionItemButton__notification--dot {
+    @include size($euiSize);
+    top: 9%;
   }
 }

--- a/src/components/header/header_section/_header_section_item.scss
+++ b/src/components/header/header_section/_header_section_item.scss
@@ -52,15 +52,17 @@
 .euiHeaderNotification,
 .euiHeaderSectionItemButton__notification {
   position: absolute;
+}
+
+.euiHeaderSectionItemButton__notification--badge {
   top: 9%;
   right: 9%;
   box-shadow: 0 0 0 1px $euiHeaderBackgroundColor;
 }
 
 .euiHeaderSectionItemButton__notification--dot {
-  right: 0;
   top: 0;
-  box-shadow: none;
+  right: 0;
   stroke: $euiHeaderBackgroundColor;
 }
 

--- a/src/components/header/header_section/header_section_item_button.test.tsx
+++ b/src/components/header/header_section/header_section_item_button.test.tsx
@@ -41,8 +41,16 @@ describe('EuiHeaderSectionItemButton', () => {
   });
 
   describe('renders notification', () => {
-    test('children', () => {
+    test('as a badge', () => {
       const component = render(<EuiHeaderSectionItemButton notification="1" />);
+
+      expect(component).toMatchSnapshot();
+    });
+
+    test('as a dot', () => {
+      const component = render(
+        <EuiHeaderSectionItemButton notification={true} />
+      );
 
       expect(component).toMatchSnapshot();
     });

--- a/src/components/header/header_section/header_section_item_button.tsx
+++ b/src/components/header/header_section/header_section_item_button.tsx
@@ -25,13 +25,15 @@ import {
   EuiNotificationBadgeProps,
   EuiNotificationBadge,
 } from '../../badge/notification_badge/badge_notification';
+import { EuiIcon } from '../../icon';
 
-type Props = CommonProps &
+export type EuiHeaderSectionItemButtonProps = CommonProps &
   ButtonHTMLAttributes<HTMLButtonElement> & {
     /**
-     * Inserts the node into a EuiBadgeNotification and places it appropriately against the button
+     * Inserts the node into a EuiBadgeNotification and places it appropriately against the button.
+     * Or pass `true` to render a simple dot
      */
-    notification?: EuiNotificationBadgeProps['children'];
+    notification?: EuiNotificationBadgeProps['children'] | boolean;
     /**
      * Changes the color of the notification background
      */
@@ -42,23 +44,41 @@ export type EuiHeaderSectionItemButtonRef = HTMLButtonElement;
 
 export const EuiHeaderSectionItemButton = React.forwardRef<
   EuiHeaderSectionItemButtonRef,
-  PropsWithChildren<Props>
+  PropsWithChildren<EuiHeaderSectionItemButtonProps>
 >(
   (
-    { onClick, children, className, notification, notificationColor, ...rest },
+    {
+      onClick,
+      children,
+      className,
+      notification,
+      notificationColor = 'accent',
+      ...rest
+    },
     ref
   ) => {
     const classes = classNames('euiHeaderSectionItem__button', className);
 
     let notificationBadge;
     if (notification) {
-      notificationBadge = (
-        <EuiNotificationBadge
-          className="euiHeaderSectionItemButton__notification"
-          color={notificationColor}>
-          {notification}
-        </EuiNotificationBadge>
-      );
+      if (notification === true) {
+        notificationBadge = (
+          <EuiIcon
+            className="euiHeaderSectionItemButton__notification euiHeaderSectionItemButton__notification--dot"
+            color={notificationColor}
+            type="dot"
+            size="l"
+          />
+        );
+      } else {
+        notificationBadge = (
+          <EuiNotificationBadge
+            className="euiHeaderSectionItemButton__notification euiHeaderSectionItemButton__notification--badge"
+            color={notificationColor}>
+            {notification}
+          </EuiNotificationBadge>
+        );
+      }
     }
 
     return (

--- a/src/components/responsive/__snapshots__/hide_for.test.tsx.snap
+++ b/src/components/responsive/__snapshots__/hide_for.test.tsx.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiHideFor l is rendered 1`] = `null`;
+exports[`EuiHideFor l is rendered 1`] = `
+<span>
+  Child
+</span>
+`;
 
 exports[`EuiHideFor m is rendered 1`] = `
 <span>
@@ -8,19 +12,11 @@ exports[`EuiHideFor m is rendered 1`] = `
 </span>
 `;
 
-exports[`EuiHideFor renders 1`] = `
-<span>
-  Child
-</span>
-`;
+exports[`EuiHideFor renders 1`] = `null`;
 
 exports[`EuiHideFor renders for multiple breakpoints 1`] = `null`;
 
-exports[`EuiHideFor s is rendered 1`] = `
-<span>
-  Child
-</span>
-`;
+exports[`EuiHideFor s is rendered 1`] = `null`;
 
 exports[`EuiHideFor xl is rendered 1`] = `
 <span>

--- a/src/components/responsive/__snapshots__/hide_for.test.tsx.snap
+++ b/src/components/responsive/__snapshots__/hide_for.test.tsx.snap
@@ -1,55 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiHideFor l is rendered 1`] = `
-<span
-  class="eui-hideFor--l"
-/>
-`;
+exports[`EuiHideFor l is rendered 1`] = `null`;
 
-exports[`EuiHideFor m is rendered 1`] = `
-<span
-  class="eui-hideFor--m"
-/>
-`;
+exports[`EuiHideFor m is rendered 1`] = `null`;
 
-exports[`EuiHideFor renders and copies classes 1`] = `
-<div
-  class="eui-hideFor--xs"
->
-  Child
-</div>
-`;
+exports[`EuiHideFor renders 1`] = `null`;
 
-exports[`EuiHideFor renders for multiple breakpoints 1`] = `
-<span
-  class="eui-hideFor--xs eui-hideFor--l"
->
-  Child
-</span>
-`;
+exports[`EuiHideFor renders for multiple breakpoints 1`] = `null`;
 
-exports[`EuiHideFor renders wraps children in a span 1`] = `
-<span
-  class="eui-hideFor--xs"
->
-  Child
-</span>
-`;
+exports[`EuiHideFor s is rendered 1`] = `null`;
 
-exports[`EuiHideFor s is rendered 1`] = `
-<span
-  class="eui-hideFor--s"
-/>
-`;
+exports[`EuiHideFor xl is rendered 1`] = `null`;
 
-exports[`EuiHideFor xl is rendered 1`] = `
-<span
-  class="eui-hideFor--xl"
-/>
-`;
-
-exports[`EuiHideFor xs is rendered 1`] = `
-<span
-  class="eui-hideFor--xs"
-/>
-`;
+exports[`EuiHideFor xs is rendered 1`] = `null`;

--- a/src/components/responsive/__snapshots__/hide_for.test.tsx.snap
+++ b/src/components/responsive/__snapshots__/hide_for.test.tsx.snap
@@ -2,14 +2,34 @@
 
 exports[`EuiHideFor l is rendered 1`] = `null`;
 
-exports[`EuiHideFor m is rendered 1`] = `null`;
+exports[`EuiHideFor m is rendered 1`] = `
+<span>
+  Child
+</span>
+`;
 
-exports[`EuiHideFor renders 1`] = `null`;
+exports[`EuiHideFor renders 1`] = `
+<span>
+  Child
+</span>
+`;
 
 exports[`EuiHideFor renders for multiple breakpoints 1`] = `null`;
 
-exports[`EuiHideFor s is rendered 1`] = `null`;
+exports[`EuiHideFor s is rendered 1`] = `
+<span>
+  Child
+</span>
+`;
 
-exports[`EuiHideFor xl is rendered 1`] = `null`;
+exports[`EuiHideFor xl is rendered 1`] = `
+<span>
+  Child
+</span>
+`;
 
-exports[`EuiHideFor xs is rendered 1`] = `null`;
+exports[`EuiHideFor xs is rendered 1`] = `
+<span>
+  Child
+</span>
+`;

--- a/src/components/responsive/__snapshots__/show_for.test.tsx.snap
+++ b/src/components/responsive/__snapshots__/show_for.test.tsx.snap
@@ -4,9 +4,17 @@ exports[`EuiShowFor l is rendered 1`] = `null`;
 
 exports[`EuiShowFor m is rendered 1`] = `null`;
 
-exports[`EuiShowFor renders 1`] = `null`;
+exports[`EuiShowFor renders 1`] = `
+<span>
+  Child
+</span>
+`;
 
-exports[`EuiShowFor renders for multiple breakpoints 1`] = `null`;
+exports[`EuiShowFor renders for multiple breakpoints 1`] = `
+<span>
+  Child
+</span>
+`;
 
 exports[`EuiShowFor s is rendered 1`] = `
 <span>

--- a/src/components/responsive/__snapshots__/show_for.test.tsx.snap
+++ b/src/components/responsive/__snapshots__/show_for.test.tsx.snap
@@ -1,73 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiShowFor block is rendered 1`] = `
-<span
-  class="eui-showFor--xs--block"
-/>
-`;
+exports[`EuiShowFor l is rendered 1`] = `null`;
 
-exports[`EuiShowFor flex is rendered 1`] = `
-<span
-  class="eui-showFor--xs--flex"
-/>
-`;
+exports[`EuiShowFor m is rendered 1`] = `null`;
 
-exports[`EuiShowFor inlineBlock is rendered 1`] = `
-<span
-  class="eui-showFor--xs--inlineBlock"
-/>
-`;
+exports[`EuiShowFor renders 1`] = `null`;
 
-exports[`EuiShowFor l is rendered 1`] = `
-<span
-  class="eui-showFor--l"
-/>
-`;
+exports[`EuiShowFor renders for multiple breakpoints 1`] = `null`;
 
-exports[`EuiShowFor m is rendered 1`] = `
-<span
-  class="eui-showFor--m"
-/>
-`;
+exports[`EuiShowFor s is rendered 1`] = `null`;
 
-exports[`EuiShowFor renders and copies classes 1`] = `
-<div
-  class="eui-showFor--xs"
->
-  Child
-</div>
-`;
+exports[`EuiShowFor xl is rendered 1`] = `null`;
 
-exports[`EuiShowFor renders for multiple breakpoints 1`] = `
-<span
-  class="eui-showFor--xs eui-showFor--l"
->
-  Child
-</span>
-`;
-
-exports[`EuiShowFor renders wraps children in a span 1`] = `
-<span
-  class="eui-showFor--xs"
->
-  Child
-</span>
-`;
-
-exports[`EuiShowFor s is rendered 1`] = `
-<span
-  class="eui-showFor--s"
-/>
-`;
-
-exports[`EuiShowFor xl is rendered 1`] = `
-<span
-  class="eui-showFor--xl"
-/>
-`;
-
-exports[`EuiShowFor xs is rendered 1`] = `
-<span
-  class="eui-showFor--xs"
-/>
-`;
+exports[`EuiShowFor xs is rendered 1`] = `null`;

--- a/src/components/responsive/__snapshots__/show_for.test.tsx.snap
+++ b/src/components/responsive/__snapshots__/show_for.test.tsx.snap
@@ -8,7 +8,11 @@ exports[`EuiShowFor renders 1`] = `null`;
 
 exports[`EuiShowFor renders for multiple breakpoints 1`] = `null`;
 
-exports[`EuiShowFor s is rendered 1`] = `null`;
+exports[`EuiShowFor s is rendered 1`] = `
+<span>
+  Child
+</span>
+`;
 
 exports[`EuiShowFor xl is rendered 1`] = `null`;
 

--- a/src/components/responsive/hide_for.test.tsx
+++ b/src/components/responsive/hide_for.test.tsx
@@ -19,38 +19,21 @@
 
 import React from 'react';
 import { render } from 'enzyme';
-import { requiredProps } from '../../test';
 
 import { EuiHideForBreakpoints, EuiHideFor } from './hide_for';
 
 const BREAKPOINTS: EuiHideForBreakpoints[] = ['xs', 's', 'm', 'l', 'xl'];
 
 describe('EuiHideFor', () => {
-  test('renders wraps children in a span', () => {
-    const component = render(
-      <EuiHideFor sizes={['xs']} {...requiredProps}>
-        Child
-      </EuiHideFor>
-    );
-
-    expect(component).toMatchSnapshot();
-  });
-
-  test('renders and copies classes', () => {
-    const component = render(
-      <EuiHideFor sizes={['xs']}>
-        <div>Child</div>
-      </EuiHideFor>
-    );
+  test('renders', () => {
+    const component = render(<EuiHideFor sizes={['xs']}>Child</EuiHideFor>);
 
     expect(component).toMatchSnapshot();
   });
 
   BREAKPOINTS.forEach(size => {
     test(`${size} is rendered`, () => {
-      const component = render(
-        <EuiHideFor sizes={[size]} {...requiredProps} />
-      );
+      const component = render(<EuiHideFor sizes={[size]}>Child</EuiHideFor>);
 
       expect(component).toMatchSnapshot();
     });

--- a/src/components/responsive/hide_for.test.tsx
+++ b/src/components/responsive/hide_for.test.tsx
@@ -26,14 +26,22 @@ const BREAKPOINTS: EuiHideForBreakpoints[] = ['xs', 's', 'm', 'l', 'xl'];
 
 describe('EuiHideFor', () => {
   test('renders', () => {
-    const component = render(<EuiHideFor sizes={['xs']}>Child</EuiHideFor>);
+    const component = render(
+      <EuiHideFor sizes={['xs']}>
+        <span>Child</span>
+      </EuiHideFor>
+    );
 
     expect(component).toMatchSnapshot();
   });
 
   BREAKPOINTS.forEach(size => {
     test(`${size} is rendered`, () => {
-      const component = render(<EuiHideFor sizes={[size]}>Child</EuiHideFor>);
+      const component = render(
+        <EuiHideFor sizes={[size]}>
+          <span>Child</span>
+        </EuiHideFor>
+      );
 
       expect(component).toMatchSnapshot();
     });
@@ -41,7 +49,9 @@ describe('EuiHideFor', () => {
 
   test('renders for multiple breakpoints', () => {
     const component = render(
-      <EuiHideFor sizes={['xs', 'l']}>Child</EuiHideFor>
+      <EuiHideFor sizes={['xs', 'l']}>
+        <span>Child</span>
+      </EuiHideFor>
     );
 
     expect(component).toMatchSnapshot();

--- a/src/components/responsive/hide_for.test.tsx
+++ b/src/components/responsive/hide_for.test.tsx
@@ -25,9 +25,13 @@ import { EuiHideForBreakpoints, EuiHideFor } from './hide_for';
 const BREAKPOINTS: EuiHideForBreakpoints[] = ['xs', 's', 'm', 'l', 'xl'];
 
 describe('EuiHideFor', () => {
+  // @ts-ignore innerWidth might be read only but we can still override it for the sake of testing
+  beforeAll(() => (window.innerWidth = 670));
+  afterAll(() => 1024); // reset to jsdom's default
+
   test('renders', () => {
     const component = render(
-      <EuiHideFor sizes={['xs']}>
+      <EuiHideFor sizes={['s']}>
         <span>Child</span>
       </EuiHideFor>
     );
@@ -49,7 +53,7 @@ describe('EuiHideFor', () => {
 
   test('renders for multiple breakpoints', () => {
     const component = render(
-      <EuiHideFor sizes={['xs', 'l']}>
+      <EuiHideFor sizes={['s', 'l']}>
         <span>Child</span>
       </EuiHideFor>
     );

--- a/src/components/responsive/hide_for.tsx
+++ b/src/components/responsive/hide_for.tsx
@@ -63,7 +63,7 @@ export const EuiHideFor: FunctionComponent<EuiHideForProps> = ({
     return () => {
       window.removeEventListener('resize', functionToCallOnWindowResize);
     };
-  }, [sizes, functionToCallOnWindowResize]);
+  }, [functionToCallOnWindowResize]);
 
   if (sizes.includes(currentBreakpoint as EuiBreakpointSize)) {
     return null;

--- a/src/components/responsive/hide_for.tsx
+++ b/src/components/responsive/hide_for.tsx
@@ -29,6 +29,9 @@ import { throttle } from '../color_picker/utils';
 export type EuiHideForBreakpoints = EuiBreakpointSize;
 
 export interface EuiHideForProps {
+  /**
+   * Required otherwise nothing ever gets returned
+   */
   children: ReactNode;
   /**
    * List of all the responsive sizes to hide the children for.

--- a/src/components/responsive/hide_for.tsx
+++ b/src/components/responsive/hide_for.tsx
@@ -31,8 +31,8 @@ export type EuiHideForBreakpoints = EuiBreakpointSize;
 export interface EuiHideForProps {
   children: ReactNode;
   /**
-   * List of all the responsive sizes to show the children for.
-   * Options are `'xs' | 's' | 'm' | 'l' | 'xl'`
+   * List of all the responsive sizes to hide the children for.
+   * Array of #EuiBreakpointSize
    */
   sizes: EuiHideForBreakpoints[];
 }

--- a/src/components/responsive/hide_for.tsx
+++ b/src/components/responsive/hide_for.tsx
@@ -17,14 +17,19 @@
  * under the License.
  */
 
-import React, { FunctionComponent, ReactElement } from 'react';
-import classNames from 'classnames';
-import { CommonProps } from '../common';
+import React, {
+  ReactNode,
+  FunctionComponent,
+  useState,
+  useEffect,
+} from 'react';
+import { EuiBreakpointSize, getBreakpoint } from '../../services/breakpoint';
+import { throttle } from '../color_picker/utils';
 
-export type EuiHideForBreakpoints = 'xs' | 's' | 'm' | 'l' | 'xl';
+export type EuiHideForBreakpoints = EuiBreakpointSize;
 
 export interface EuiHideForProps {
-  children?: React.ReactNode;
+  children: ReactNode;
   /**
    * List of all the responsive sizes to show the children for.
    * Options are `'xs' | 's' | 'm' | 'l' | 'xl'`
@@ -32,33 +37,34 @@ export interface EuiHideForProps {
   sizes: EuiHideForBreakpoints[];
 }
 
-const responsiveSizesToClassNameMap = {
-  xs: 'eui-hideFor--xs',
-  s: 'eui-hideFor--s',
-  m: 'eui-hideFor--m',
-  l: 'eui-hideFor--l',
-  xl: 'eui-hideFor--xl',
-};
-
 export const EuiHideFor: FunctionComponent<EuiHideForProps> = ({
   children,
   sizes,
 }) => {
-  const utilityClasses = sizes.map(function(item) {
-    return responsiveSizesToClassNameMap[item];
-  });
+  const [currentBreakpoint, setCurrentBreakpoint] = useState(
+    getBreakpoint(typeof window === 'undefined' ? -Infinity : window.innerWidth)
+  );
 
-  if (React.isValidElement(children)) {
-    return (
-      <React.Fragment>
-        {React.Children.map(children, (child: ReactElement<CommonProps>) =>
-          React.cloneElement(child, {
-            className: classNames(child.props.className, utilityClasses),
-          })
-        )}
-      </React.Fragment>
-    );
-  } else {
-    return <span className={classNames(utilityClasses)}>{children}</span>;
+  const functionToCallOnWindowResize = throttle(() => {
+    const newBreakpoint = getBreakpoint(window.innerWidth);
+    if (newBreakpoint !== currentBreakpoint) {
+      setCurrentBreakpoint(newBreakpoint);
+    }
+    // reacts every 50ms to resize changes and always gets the final update
+  }, 50);
+
+  // Add window resize handlers
+  useEffect(() => {
+    window.addEventListener('resize', functionToCallOnWindowResize);
+
+    return () => {
+      window.removeEventListener('resize', functionToCallOnWindowResize);
+    };
+  }, [sizes, functionToCallOnWindowResize]);
+
+  if (sizes.includes(currentBreakpoint as EuiBreakpointSize)) {
+    return null;
   }
+
+  return <>{children}</>;
 };

--- a/src/components/responsive/show_for.test.tsx
+++ b/src/components/responsive/show_for.test.tsx
@@ -30,14 +30,22 @@ describe('EuiShowFor', () => {
   afterAll(() => 1024); // reset to jsdom's default
 
   test('renders', () => {
-    const component = render(<EuiShowFor sizes={['xs']}>Child</EuiShowFor>);
+    const component = render(
+      <EuiShowFor sizes={['xs']}>
+        <span>Child</span>
+      </EuiShowFor>
+    );
 
     expect(component).toMatchSnapshot();
   });
 
   BREAKPOINTS.forEach(size => {
     test(`${size} is rendered`, () => {
-      const component = render(<EuiShowFor sizes={[size]}>Child</EuiShowFor>);
+      const component = render(
+        <EuiShowFor sizes={[size]}>
+          <span>Child</span>
+        </EuiShowFor>
+      );
 
       expect(component).toMatchSnapshot();
     });
@@ -45,7 +53,9 @@ describe('EuiShowFor', () => {
 
   test('renders for multiple breakpoints', () => {
     const component = render(
-      <EuiShowFor sizes={['xs', 'l']}>Child</EuiShowFor>
+      <EuiShowFor sizes={['xs', 'l']}>
+        <span>Child</span>
+      </EuiShowFor>
     );
 
     expect(component).toMatchSnapshot();

--- a/src/components/responsive/show_for.test.tsx
+++ b/src/components/responsive/show_for.test.tsx
@@ -19,41 +19,21 @@
 
 import React from 'react';
 import { render } from 'enzyme';
-import { requiredProps } from '../../test';
 
-import {
-  EuiShowForBreakpoints,
-  EuiShowForDisplay,
-  EuiShowFor,
-} from './show_for';
+import { EuiShowForBreakpoints, EuiShowFor } from './show_for';
 
 const BREAKPOINTS: EuiShowForBreakpoints[] = ['xs', 's', 'm', 'l', 'xl'];
-const DISPLAYS: EuiShowForDisplay[] = ['block', 'inlineBlock', 'flex'];
 
 describe('EuiShowFor', () => {
-  test('renders wraps children in a span', () => {
-    const component = render(
-      <EuiShowFor sizes={['xs']} {...requiredProps}>
-        Child
-      </EuiShowFor>
-    );
-
-    expect(component).toMatchSnapshot();
-  });
-
-  test('renders and copies classes', () => {
-    const component = render(
-      <EuiShowFor sizes={['xs']}>
-        <div>Child</div>
-      </EuiShowFor>
-    );
+  test('renders', () => {
+    const component = render(<EuiShowFor sizes={['xs']}>Child</EuiShowFor>);
 
     expect(component).toMatchSnapshot();
   });
 
   BREAKPOINTS.forEach(size => {
     test(`${size} is rendered`, () => {
-      const component = render(<EuiShowFor sizes={[size]} />);
+      const component = render(<EuiShowFor sizes={[size]}>Child</EuiShowFor>);
 
       expect(component).toMatchSnapshot();
     });
@@ -65,13 +45,5 @@ describe('EuiShowFor', () => {
     );
 
     expect(component).toMatchSnapshot();
-  });
-
-  DISPLAYS.forEach(display => {
-    test(`${display} is rendered`, () => {
-      const component = render(<EuiShowFor sizes={['xs']} display={display} />);
-
-      expect(component).toMatchSnapshot();
-    });
   });
 });

--- a/src/components/responsive/show_for.test.tsx
+++ b/src/components/responsive/show_for.test.tsx
@@ -25,6 +25,10 @@ import { EuiShowForBreakpoints, EuiShowFor } from './show_for';
 const BREAKPOINTS: EuiShowForBreakpoints[] = ['xs', 's', 'm', 'l', 'xl'];
 
 describe('EuiShowFor', () => {
+  // @ts-ignore innerWidth might be read only but we can still override it for the sake of testing
+  beforeAll(() => (window.innerWidth = 670));
+  afterAll(() => 1024); // reset to jsdom's default
+
   test('renders', () => {
     const component = render(<EuiShowFor sizes={['xs']}>Child</EuiShowFor>);
 

--- a/src/components/responsive/show_for.test.tsx
+++ b/src/components/responsive/show_for.test.tsx
@@ -31,7 +31,7 @@ describe('EuiShowFor', () => {
 
   test('renders', () => {
     const component = render(
-      <EuiShowFor sizes={['xs']}>
+      <EuiShowFor sizes={['s']}>
         <span>Child</span>
       </EuiShowFor>
     );
@@ -53,7 +53,7 @@ describe('EuiShowFor', () => {
 
   test('renders for multiple breakpoints', () => {
     const component = render(
-      <EuiShowFor sizes={['xs', 'l']}>
+      <EuiShowFor sizes={['s', 'l']}>
         <span>Child</span>
       </EuiShowFor>
     );

--- a/src/components/responsive/show_for.tsx
+++ b/src/components/responsive/show_for.tsx
@@ -17,55 +17,54 @@
  * under the License.
  */
 
-import React, { FunctionComponent, ReactElement } from 'react';
-import classNames from 'classnames';
-import { CommonProps } from '../common';
+import React, {
+  ReactNode,
+  FunctionComponent,
+  useState,
+  useEffect,
+} from 'react';
+import { EuiBreakpointSize, getBreakpoint } from '../../services/breakpoint';
+import { throttle } from '../color_picker/utils';
 
-export type EuiShowForBreakpoints = 'xs' | 's' | 'm' | 'l' | 'xl';
-export type EuiShowForDisplay = 'block' | 'inlineBlock' | 'flex';
+export type EuiShowForBreakpoints = EuiBreakpointSize;
 
 export interface EuiShowForProps {
-  children?: React.ReactNode;
+  children: ReactNode;
   /**
    * List of all the responsive sizes to show the children for.
    * Options are `'xs' | 's' | 'm' | 'l' | 'xl'`
    */
   sizes: EuiShowForBreakpoints[];
-  /**
-   * Optional display as property. Leaving as `undefined` renders as `inline`.
-   */
-  display?: EuiShowForDisplay;
 }
-
-const responsiveSizesToClassNameMap = {
-  xs: 'eui-showFor--xs',
-  s: 'eui-showFor--s',
-  m: 'eui-showFor--m',
-  l: 'eui-showFor--l',
-  xl: 'eui-showFor--xl',
-};
 
 export const EuiShowFor: FunctionComponent<EuiShowForProps> = ({
   children,
   sizes,
-  display,
 }) => {
-  const utilityClasses = sizes.map(function(item) {
-    const append = display ? `--${display}` : '';
-    return `${responsiveSizesToClassNameMap[item]}${append}`;
-  });
+  const [currentBreakpoint, setCurrentBreakpoint] = useState(
+    getBreakpoint(typeof window === 'undefined' ? -Infinity : window.innerWidth)
+  );
 
-  if (React.isValidElement(children)) {
-    return (
-      <React.Fragment>
-        {React.Children.map(children, (child: ReactElement<CommonProps>) =>
-          React.cloneElement(child, {
-            className: classNames(child.props.className, utilityClasses),
-          })
-        )}
-      </React.Fragment>
-    );
-  } else {
-    return <span className={classNames(utilityClasses)}>{children}</span>;
+  const functionToCallOnWindowResize = throttle(() => {
+    const newBreakpoint = getBreakpoint(window.innerWidth);
+    if (newBreakpoint !== currentBreakpoint) {
+      setCurrentBreakpoint(newBreakpoint);
+    }
+    // reacts every 50ms to resize changes and always gets the final update
+  }, 50);
+
+  // Add window resize handlers
+  useEffect(() => {
+    window.addEventListener('resize', functionToCallOnWindowResize);
+
+    return () => {
+      window.removeEventListener('resize', functionToCallOnWindowResize);
+    };
+  }, [sizes, functionToCallOnWindowResize]);
+
+  if (sizes.includes(currentBreakpoint as EuiBreakpointSize)) {
+    return <>{children}</>;
   }
+
+  return null;
 };

--- a/src/components/responsive/show_for.tsx
+++ b/src/components/responsive/show_for.tsx
@@ -29,6 +29,9 @@ import { throttle } from '../color_picker/utils';
 export type EuiShowForBreakpoints = EuiBreakpointSize;
 
 export interface EuiShowForProps {
+  /**
+   * Required otherwise nothing ever gets returned
+   */
   children: ReactNode;
   /**
    * List of all the responsive sizes to show the children for.

--- a/src/components/responsive/show_for.tsx
+++ b/src/components/responsive/show_for.tsx
@@ -32,7 +32,7 @@ export interface EuiShowForProps {
   children: ReactNode;
   /**
    * List of all the responsive sizes to show the children for.
-   * Options are `'xs' | 's' | 'm' | 'l' | 'xl'`
+   * Array of #EuiBreakpointSize
    */
   sizes: EuiShowForBreakpoints[];
 }

--- a/src/components/selectable/selectable_list/selectable_list.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.tsx
@@ -238,6 +238,7 @@ export class EuiSelectableList<T> extends Component<EuiSelectableListProps<T>> {
         onClick={() => this.onAddOrRemoveOption(option)}
         ref={ref ? ref.bind(null, index) : undefined}
         isFocused={this.props.activeOptionIndex === index}
+        showIcons={this.props.showIcons}
         title={searchableLabel || label}
         checked={checked}
         disabled={disabled}

--- a/src/components/selectable/selectable_templates/__snapshots__/selectable_template_sitewide.test.tsx.snap
+++ b/src/components/selectable/selectable_templates/__snapshots__/selectable_template_sitewide.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`EuiSelectableTemplateSitewide is rendered 1`] = `
 </div>
 `;
 
-exports[`EuiSelectableTemplateSitewide props popoverButton is not rendered with popoverButtonMaxBreakpoint xs 1`] = `
+exports[`EuiSelectableTemplateSitewide props popoverButton is not rendered with popoverButtonBreakpoints xs 1`] = `
 <div
   class="euiSelectable euiSelectableTemplateSitewide"
 >
@@ -111,7 +111,7 @@ exports[`EuiSelectableTemplateSitewide props popoverButton is rendered 1`] = `
 </div>
 `;
 
-exports[`EuiSelectableTemplateSitewide props popoverButton is rendered with popoverButtonMaxBreakpoint m 1`] = `
+exports[`EuiSelectableTemplateSitewide props popoverButton is rendered with popoverButtonBreakpoints m 1`] = `
 <div
   class="euiSelectable euiSelectableTemplateSitewide"
 >

--- a/src/components/selectable/selectable_templates/__snapshots__/selectable_template_sitewide.test.tsx.snap
+++ b/src/components/selectable/selectable_templates/__snapshots__/selectable_template_sitewide.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`EuiSelectableTemplateSitewide is rendered 1`] = `
   data-test-subj="test subject string"
 >
   <div
-    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+    class="euiPopover euiPopover--anchorDownCenter"
   >
     <div
       class="euiPopover__anchor"
@@ -52,7 +52,7 @@ exports[`EuiSelectableTemplateSitewide props popoverFooter is rendered 1`] = `
   class="euiSelectable euiSelectableTemplateSitewide"
 >
   <div
-    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+    class="euiPopover euiPopover--anchorDownCenter"
   >
     <div
       class="euiPopover__anchor"
@@ -98,7 +98,7 @@ exports[`EuiSelectableTemplateSitewide props popoverProps is rendered 1`] = `
   class="euiSelectable euiSelectableTemplateSitewide"
 >
   <div
-    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock customPopoverClass"
+    class="euiPopover euiPopover--anchorDownCenter customPopoverClass"
   >
     <div
       class="euiPopover__anchor"
@@ -144,7 +144,7 @@ exports[`EuiSelectableTemplateSitewide props popoverTitle is rendered 1`] = `
   class="euiSelectable euiSelectableTemplateSitewide"
 >
   <div
-    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+    class="euiPopover euiPopover--anchorDownCenter"
   >
     <div
       class="euiPopover__anchor"

--- a/src/components/selectable/selectable_templates/__snapshots__/selectable_template_sitewide.test.tsx.snap
+++ b/src/components/selectable/selectable_templates/__snapshots__/selectable_template_sitewide.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`EuiSelectableTemplateSitewide is rendered 1`] = `
   data-test-subj="test subject string"
 >
   <div
-    class="euiPopover euiPopover--anchorDownCenter"
+    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
   >
     <div
       class="euiPopover__anchor"
@@ -47,12 +47,94 @@ exports[`EuiSelectableTemplateSitewide is rendered 1`] = `
 </div>
 `;
 
-exports[`EuiSelectableTemplateSitewide props popoverFooter is rendered 1`] = `
+exports[`EuiSelectableTemplateSitewide props popoverButton is not rendered with popoverButtonMaxBreakpoint xs 1`] = `
+<div
+  class="euiSelectable euiSelectableTemplateSitewide"
+>
+  <div
+    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
+  >
+    <div
+      class="euiPopover__anchor"
+    >
+      <div
+        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      >
+        <div
+          class="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-activedescendant=""
+            aria-haspopup="listbox"
+            aria-label="Filter options"
+            autocomplete="off"
+            class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable euiSelectableSearch euiSelectableTemplateSitewide__search"
+            placeholder="Search for anything..."
+            type="search"
+            value=""
+          />
+          <div
+            class="euiFormControlLayoutIcons"
+          >
+            <span
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <div
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="search"
+              />
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiSelectableTemplateSitewide props popoverButton is rendered 1`] = `
 <div
   class="euiSelectable euiSelectableTemplateSitewide"
 >
   <div
     class="euiPopover euiPopover--anchorDownCenter"
+  >
+    <div
+      class="euiPopover__anchor"
+    >
+      <button>
+        Button
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiSelectableTemplateSitewide props popoverButton is rendered with popoverButtonMaxBreakpoint m 1`] = `
+<div
+  class="euiSelectable euiSelectableTemplateSitewide"
+>
+  <div
+    class="euiPopover euiPopover--anchorDownCenter"
+  >
+    <div
+      class="euiPopover__anchor"
+    >
+      <button>
+        Button
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiSelectableTemplateSitewide props popoverFooter is rendered 1`] = `
+<div
+  class="euiSelectable euiSelectableTemplateSitewide"
+>
+  <div
+    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
   >
     <div
       class="euiPopover__anchor"
@@ -98,7 +180,7 @@ exports[`EuiSelectableTemplateSitewide props popoverProps is rendered 1`] = `
   class="euiSelectable euiSelectableTemplateSitewide"
 >
   <div
-    class="euiPopover euiPopover--anchorDownCenter customPopoverClass"
+    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock customPopoverClass"
   >
     <div
       class="euiPopover__anchor"
@@ -144,7 +226,7 @@ exports[`EuiSelectableTemplateSitewide props popoverTitle is rendered 1`] = `
   class="euiSelectable euiSelectableTemplateSitewide"
 >
   <div
-    class="euiPopover euiPopover--anchorDownCenter"
+    class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"
   >
     <div
       class="euiPopover__anchor"

--- a/src/components/selectable/selectable_templates/__snapshots__/selectable_template_sitewide_option.test.tsx.snap
+++ b/src/components/selectable/selectable_templates/__snapshots__/selectable_template_sitewide_option.test.tsx.snap
@@ -23,7 +23,7 @@ Array [
       },
     ],
     "prepend": undefined,
-    "title": "Basic data application •  Application",
+    "title": "Basic data application • Application",
     "url": "welcome-dashboards",
   },
   Object {
@@ -50,7 +50,7 @@ Array [
       size="l"
       type="user"
     />,
-    "title": "Platform with deployment highlighted •  Account, personal-databoard",
+    "title": "Platform with deployment highlighted • Account, personal-databoard",
   },
   Object {
     "append": undefined,
@@ -84,7 +84,7 @@ Array [
       type="alert"
     />,
     "searchableLabel": "Totally custom with pink metadata",
-    "title": "Other metas •  Article, Case, Text, I have a custom type",
+    "title": "Other metas • Article, Case, Text, I have a custom type",
   },
 ]
 `;

--- a/src/components/selectable/selectable_templates/_selectable_template_sitewide.scss
+++ b/src/components/selectable/selectable_templates/_selectable_template_sitewide.scss
@@ -2,7 +2,11 @@
 // These selectors aren't targetable via EuiFieldSearch
 .euiHeader--dark .euiSelectableTemplateSitewide .euiFormControlLayout {
   background-color: transparent;
-  box-shadow: inset 0 0 0 1px transparentize($euiColorGhost, .7);
+
+  &--group,
+  input {
+    box-shadow: inset 0 0 0 1px transparentize($euiColorGhost, .7);
+  }
 
   &:not(:focus-within) {
     color: transparentize($euiColorGhost, .3);

--- a/src/components/selectable/selectable_templates/_selectable_template_sitewide.scss
+++ b/src/components/selectable/selectable_templates/_selectable_template_sitewide.scss
@@ -7,13 +7,20 @@
   &:not(:focus-within) {
     color: transparentize($euiColorGhost, .3);
 
+    input {
+      // Increase contrast of placeholder text
+      @include euiPlaceholderPerBrowser {
+        color: transparentize($euiColorGhost, .6);
+      }
+
+      // Inherit color from form control layout
+      color: inherit;
+      background-color: transparent;
+    }
+
     .euiFormControlLayout__append {
       background-color: transparent;
       color: inherit;
     }
-  }
-
-  input:not(:focus) {
-    background-color: transparent;
   }
 }

--- a/src/components/selectable/selectable_templates/selectable_template_sitewide.test.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide.test.tsx
@@ -148,24 +148,24 @@ describe('EuiSelectableTemplateSitewide', () => {
         expect(component).toMatchSnapshot();
       });
 
-      test('is rendered with popoverButtonMaxBreakpoint m', () => {
+      test('is rendered with popoverButtonBreakpoints m', () => {
         const component = render(
           <EuiSelectableTemplateSitewide
             options={options}
             popoverButton={<button>Button</button>}
-            popoverButtonMaxBreakpoint={'m'}
+            popoverButtonBreakpoints={['xs', 's', 'm']}
           />
         );
 
         expect(component).toMatchSnapshot();
       });
 
-      test('is not rendered with popoverButtonMaxBreakpoint xs', () => {
+      test('is not rendered with popoverButtonBreakpoints xs', () => {
         const component = render(
           <EuiSelectableTemplateSitewide
             options={options}
             popoverButton={<button>Button</button>}
-            popoverButtonMaxBreakpoint={'xs'}
+            popoverButtonBreakpoints={['xs']}
           />
         );
 

--- a/src/components/selectable/selectable_templates/selectable_template_sitewide.test.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide.test.tsx
@@ -131,5 +131,46 @@ describe('EuiSelectableTemplateSitewide', () => {
 
       expect(component).toMatchSnapshot();
     });
+
+    describe('popoverButton', () => {
+      // @ts-ignore innerWidth might be read only but we can still override it for the sake of testing
+      beforeAll(() => (window.innerWidth = 670));
+      afterAll(() => 1024); // reset to jsdom's default
+
+      test('is rendered', () => {
+        const component = render(
+          <EuiSelectableTemplateSitewide
+            options={options}
+            popoverButton={<button>Button</button>}
+          />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+
+      test('is rendered with popoverButtonMaxBreakpoint m', () => {
+        const component = render(
+          <EuiSelectableTemplateSitewide
+            options={options}
+            popoverButton={<button>Button</button>}
+            popoverButtonMaxBreakpoint={'m'}
+          />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+
+      test('is not rendered with popoverButtonMaxBreakpoint xs', () => {
+        const component = render(
+          <EuiSelectableTemplateSitewide
+            options={options}
+            popoverButton={<button>Button</button>}
+            popoverButtonMaxBreakpoint={'xs'}
+          />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
@@ -156,9 +156,9 @@ export const EuiSelectableTemplateSitewide: FunctionComponent<EuiSelectableTempl
    * Search helpers
    */
   const searchOnFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+    searchProps && searchProps.onFocus && searchProps.onFocus(e);
     if (canShowPopoverButton) return;
 
-    searchProps && searchProps.onFocus && searchProps.onFocus(e);
     setPopoverIsOpen(true);
   };
 
@@ -168,9 +168,9 @@ export const EuiSelectableTemplateSitewide: FunctionComponent<EuiSelectableTempl
   };
 
   const searchOnBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    searchProps && searchProps.onBlur && searchProps.onBlur(e);
     if (canShowPopoverButton) return;
 
-    searchProps && searchProps.onBlur && searchProps.onBlur(e);
     if (!popoverRef?.contains(e.relatedTarget as HTMLElement)) {
       setPopoverIsOpen(false);
     }

--- a/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
@@ -85,7 +85,7 @@ export const EuiSelectableTemplateSitewide: FunctionComponent<EuiSelectableTempl
   listProps,
   isLoading,
   mobileToggle,
-  mobileBreakpointMax = 's',
+  mobileBreakpointMax = 'm',
   ...rest
 }) => {
   /**

--- a/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
@@ -40,7 +40,7 @@ import {
 } from './selectable_template_sitewide_option';
 import {
   EuiBreakpointSize,
-  isWithinMaxBreakpoint,
+  isWithinBreakpoints,
 } from '../../../services/breakpoint';
 import { throttle } from '../../color_picker/utils';
 import { EuiSpacer } from '../../spacer';
@@ -71,10 +71,10 @@ export type EuiSelectableTemplateSitewideProps = Partial<
    */
   popoverButton?: ReactElement;
   /**
-   * Pass a max breakpoint at which to show the `popoverButton`.
+   * Pass an array of named breakpoints for which to show the `popoverButton`.
    * If `undefined`, the `popoverButton` will always show (if provided)
    */
-  popoverButtonMaxBreakpoint?: EuiBreakpointSize;
+  popoverButtonBreakpoints?: EuiBreakpointSize[];
 };
 
 export const EuiSelectableTemplateSitewide: FunctionComponent<EuiSelectableTemplateSitewideProps> = ({
@@ -88,25 +88,23 @@ export const EuiSelectableTemplateSitewide: FunctionComponent<EuiSelectableTempl
   listProps,
   isLoading,
   popoverButton,
-  popoverButtonMaxBreakpoint,
+  popoverButtonBreakpoints,
   ...rest
 }) => {
   /**
    * Breakpoint management
    */
   const [canShowPopoverButton, setCanShowPopoverButton] = useState(
-    typeof window !== 'undefined' &&
-      isWithinMaxBreakpoint(
-        window.innerWidth,
-        popoverButtonMaxBreakpoint || Infinity
-      )
+    typeof window !== 'undefined' && popoverButtonBreakpoints
+      ? isWithinBreakpoints(window.innerWidth, popoverButtonBreakpoints)
+      : true
   );
 
   const functionToCallOnWindowResize = throttle(() => {
-    const newWidthIsWithinBreakpoint = isWithinMaxBreakpoint(
-      window.innerWidth,
-      popoverButtonMaxBreakpoint || Infinity
-    );
+    const newWidthIsWithinBreakpoint = popoverButtonBreakpoints
+      ? isWithinBreakpoints(window.innerWidth, popoverButtonBreakpoints)
+      : true;
+
     if (newWidthIsWithinBreakpoint !== canShowPopoverButton) {
       setCanShowPopoverButton(newWidthIsWithinBreakpoint);
     }

--- a/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
@@ -120,7 +120,7 @@ export const EuiSelectableTemplateSitewide: FunctionComponent<EuiSelectableTempl
     return () => {
       window.removeEventListener('resize', functionToCallOnWindowResize);
     };
-  }, [popoverButton, popoverButtonMaxBreakpoint, functionToCallOnWindowResize]);
+  }, [functionToCallOnWindowResize]);
 
   /**
    * i18n text
@@ -156,6 +156,8 @@ export const EuiSelectableTemplateSitewide: FunctionComponent<EuiSelectableTempl
    * Search helpers
    */
   const searchOnFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+    if (canShowPopoverButton) return;
+
     searchProps && searchProps.onFocus && searchProps.onFocus(e);
     setPopoverIsOpen(true);
   };
@@ -166,6 +168,8 @@ export const EuiSelectableTemplateSitewide: FunctionComponent<EuiSelectableTempl
   };
 
   const searchOnBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    if (canShowPopoverButton) return;
+
     searchProps && searchProps.onBlur && searchProps.onBlur(e);
     if (!popoverRef?.contains(e.relatedTarget as HTMLElement)) {
       setPopoverIsOpen(false);
@@ -224,6 +228,10 @@ export const EuiSelectableTemplateSitewide: FunctionComponent<EuiSelectableTempl
     popoverTrigger = React.cloneElement(popoverButton, {
       ...popoverButton.props,
       onClick: togglePopover,
+      onKeyDown: (e: KeyboardEvent) => {
+        // Selectable preventsDefault on Enter which kills browser controls for pressing the button
+        e.stopPropagation();
+      },
     });
   }
 

--- a/src/components/selectable/selectable_templates/selectable_template_sitewide_option.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide_option.tsx
@@ -74,12 +74,15 @@ export const euiSelectableTemplateSitewideFormatOptions = (
   options: EuiSelectableTemplateSitewideOption[]
 ) => {
   return options.map((item: EuiSelectableTemplateSitewideOption) => {
+    let title = item.label;
+    if (item.meta && item.meta.length) {
+      title += ` •${renderOptionMeta(item.meta, '', true)}`;
+    }
+
     return {
       key: item.label,
       label: item.label,
-      title: `${item.label}${item.meta &&
-        item.meta.length &&
-        ' • '}${renderOptionMeta(item.meta, '', true)}`,
+      title,
       ...item,
       className: classNames(
         'euiSelectableTemplateSitewide__listItem',

--- a/src/services/breakpoint.test.ts
+++ b/src/services/breakpoint.test.ts
@@ -17,10 +17,14 @@
  * under the License.
  */
 
-import { getBreakpoint, EuiBreakpoints } from './breakpoint';
+import {
+  getBreakpoint,
+  EuiBreakpoints,
+  isWithinMaxBreakpoint,
+} from './breakpoint';
 
 describe('getBreakpoint', () => {
-  describe('default BREAKPOINTS', () => {
+  describe('with default BREAKPOINTS', () => {
     it("should return 'xs' for 320", () => {
       expect(getBreakpoint(320)).toBe('xs');
     });
@@ -46,7 +50,7 @@ describe('getBreakpoint', () => {
     xs: 320,
   };
 
-  describe('custom breakpoints', () => {
+  describe('with custom breakpoints', () => {
     it("should return 'undefined' for 240", () => {
       expect(getBreakpoint(240, CUSTOM_BREAKPOINTS)).toBe(undefined);
     });
@@ -64,6 +68,61 @@ describe('getBreakpoint', () => {
     });
     it("should return 'xl' for 1400", () => {
       expect(getBreakpoint(1400, CUSTOM_BREAKPOINTS)).toBe('xl');
+    });
+  });
+});
+
+describe('isWithinMaxBreakpoint', () => {
+  describe('with default BREAKPOINTS', () => {
+    it("should return 'true' for 'xs' and 320", () => {
+      expect(isWithinMaxBreakpoint(320, 'xs')).toBe(true);
+    });
+    it("should return 'true' for 's' and 667", () => {
+      expect(isWithinMaxBreakpoint(667, 's')).toBe(true);
+    });
+    it("should return 'true' for 'm' and 812", () => {
+      expect(isWithinMaxBreakpoint(812, 'm')).toBe(true);
+    });
+    it("should return 'true' for 'l' and 1078", () => {
+      expect(isWithinMaxBreakpoint(1078, 'l')).toBe(true);
+    });
+    it("should return 'true' for 'xl' and 1400", () => {
+      expect(isWithinMaxBreakpoint(1400, 'xl')).toBe(true);
+    });
+  });
+
+  const CUSTOM_BREAKPOINTS: EuiBreakpoints = {
+    xl: 1400,
+    l: 1078,
+    m: 812,
+    s: 667,
+    xs: 320,
+  };
+
+  describe('with custom breakpoints', () => {
+    it("should return 'false' for 'xs' and 240", () => {
+      expect(isWithinMaxBreakpoint(240, 'xs', CUSTOM_BREAKPOINTS)).toBe(false);
+    });
+    it("should return 'true' for 'xs' and 575", () => {
+      expect(isWithinMaxBreakpoint(575, 'xs', CUSTOM_BREAKPOINTS)).toBe(true);
+    });
+    it("should return 'true' for 's' and 768", () => {
+      expect(isWithinMaxBreakpoint(768, 's', CUSTOM_BREAKPOINTS)).toBe(true);
+    });
+    it("should return 'true' for 'm' and 992", () => {
+      expect(isWithinMaxBreakpoint(992, 'm', CUSTOM_BREAKPOINTS)).toBe(true);
+    });
+    it("should return 'true' for 'l' and 1200", () => {
+      expect(isWithinMaxBreakpoint(1200, 'l', CUSTOM_BREAKPOINTS)).toBe(true);
+    });
+    it("should return 'true' for 'xl' and 1400", () => {
+      expect(isWithinMaxBreakpoint(1400, 'xl', CUSTOM_BREAKPOINTS)).toBe(true);
+    });
+  });
+
+  describe('with max as a number', () => {
+    it("should return 'true' for a 320 width and a '480' max", () => {
+      expect(isWithinMaxBreakpoint(320, 480)).toBe(true);
     });
   });
 });

--- a/src/services/breakpoint.test.ts
+++ b/src/services/breakpoint.test.ts
@@ -21,7 +21,16 @@ import {
   getBreakpoint,
   EuiBreakpoints,
   isWithinMaxBreakpoint,
+  isWithinBreakpoints,
 } from './breakpoint';
+
+const CUSTOM_BREAKPOINTS: EuiBreakpoints = {
+  xl: 1400,
+  l: 1078,
+  m: 812,
+  s: 667,
+  xs: 320,
+};
 
 describe('getBreakpoint', () => {
   describe('with default BREAKPOINTS', () => {
@@ -41,14 +50,6 @@ describe('getBreakpoint', () => {
       expect(getBreakpoint(1400)).toBe('xl');
     });
   });
-
-  const CUSTOM_BREAKPOINTS: EuiBreakpoints = {
-    xl: 1400,
-    l: 1078,
-    m: 812,
-    s: 667,
-    xs: 320,
-  };
 
   describe('with custom breakpoints', () => {
     it("should return 'undefined' for 240", () => {
@@ -91,14 +92,6 @@ describe('isWithinMaxBreakpoint', () => {
     });
   });
 
-  const CUSTOM_BREAKPOINTS: EuiBreakpoints = {
-    xl: 1400,
-    l: 1078,
-    m: 812,
-    s: 667,
-    xs: 320,
-  };
-
   describe('with custom breakpoints', () => {
     it("should return 'false' for 'xs' and 240", () => {
       expect(isWithinMaxBreakpoint(240, 'xs', CUSTOM_BREAKPOINTS)).toBe(false);
@@ -123,6 +116,57 @@ describe('isWithinMaxBreakpoint', () => {
   describe('with max as a number', () => {
     it("should return 'true' for a 320 width and a '480' max", () => {
       expect(isWithinMaxBreakpoint(320, 480)).toBe(true);
+    });
+  });
+
+  describe('isWithinBreakpoints', () => {
+    describe('with default BREAKPOINTS', () => {
+      it("should return 'true' for 'xs' and 320", () => {
+        expect(isWithinBreakpoints(320, ['xs'])).toBe(true);
+      });
+      it("should return 'true' for 's' and 667", () => {
+        expect(isWithinBreakpoints(667, ['s'])).toBe(true);
+      });
+      it("should return 'true' for 'm' and 812", () => {
+        expect(isWithinBreakpoints(812, ['m'])).toBe(true);
+      });
+      it("should return 'true' for 'l' and 1078", () => {
+        expect(isWithinBreakpoints(1078, ['l'])).toBe(true);
+      });
+      it("should return 'true' for 'xl' and 1400", () => {
+        expect(isWithinBreakpoints(1400, ['xl'])).toBe(true);
+      });
+    });
+
+    describe('with custom breakpoints', () => {
+      it("should return 'false' for 'xs' and 240", () => {
+        expect(isWithinBreakpoints(240, ['xs'], CUSTOM_BREAKPOINTS)).toBe(
+          false
+        );
+      });
+      it("should return 'true' for 'xs' and 575", () => {
+        expect(isWithinBreakpoints(575, ['xs'], CUSTOM_BREAKPOINTS)).toBe(true);
+      });
+      it("should return 'true' for 's' and 768", () => {
+        expect(isWithinBreakpoints(768, ['s'], CUSTOM_BREAKPOINTS)).toBe(true);
+      });
+      it("should return 'true' for 'm' and 992", () => {
+        expect(isWithinBreakpoints(992, ['m'], CUSTOM_BREAKPOINTS)).toBe(true);
+      });
+      it("should return 'true' for 'l' and 1200", () => {
+        expect(isWithinBreakpoints(1200, ['l'], CUSTOM_BREAKPOINTS)).toBe(true);
+      });
+      it("should return 'true' for 'xl' and 1400", () => {
+        expect(isWithinBreakpoints(1400, ['xl'], CUSTOM_BREAKPOINTS)).toBe(
+          true
+        );
+      });
+    });
+
+    describe('with multiple sizes', () => {
+      it("should return 'true' for a 667 width and ['xs', 's']", () => {
+        expect(isWithinBreakpoints(667, ['xs', 's'])).toBe(true);
+      });
     });
   });
 });

--- a/src/services/breakpoint.ts
+++ b/src/services/breakpoint.ts
@@ -50,7 +50,32 @@ export const BREAKPOINT_KEYS = keysOf(BREAKPOINTS);
 export function getBreakpoint(
   width: number,
   breakpoints: EuiBreakpoints = BREAKPOINTS
-): string | undefined {
+): EuiBreakpointSize | undefined {
   // Find the breakpoint (key) whose value is <= windowWidth starting with largest first
   return keysOf(BREAKPOINTS).find(key => breakpoints[key] <= width);
+}
+
+/**
+ * Given the current `width` and a max breakpoint key,
+ * this function returns true or false if the `width` falls within the max
+ * breakpoint or any breakpoints below
+ *
+ * @param {number} width Can either be the full window width or any width
+ * @param {EuiBreakpointSize | number} max The named breakpoint or custom number to check against
+ * @param {EuiBreakpoints} breakpoints An object with keys for sizing and values for minimum width
+ * @returns {boolean} Will return `false` if it can't find a value for the `max` breakpoint
+ */
+export function isWithinMaxBreakpoint(
+  width: number,
+  max: EuiBreakpointSize | number,
+  breakpoints: EuiBreakpoints = BREAKPOINTS
+): boolean {
+  if (typeof max === 'number') {
+    return width <= max;
+  } else {
+    const currentBreakpoint = getBreakpoint(width, breakpoints);
+    return currentBreakpoint
+      ? breakpoints[currentBreakpoint] <= breakpoints[max]
+      : false;
+  }
 }

--- a/src/services/breakpoint.ts
+++ b/src/services/breakpoint.ts
@@ -79,3 +79,22 @@ export function isWithinMaxBreakpoint(
       : false;
   }
 }
+
+/**
+ * Given the current `width` and an array of breakpoint keys,
+ * this function returns true or false if the `width` falls within
+ * any of the named breakpoints
+ *
+ * @param {number} width Can either be the full window width or any width
+ * @param {EuiBreakpointSize[]} sizes An array of named breakpoints
+ * @param {EuiBreakpoints} breakpoints An object with keys for sizing and values for minimum width
+ * @returns {boolean} Returns `true` if current breakpoint name is included in `sizes`
+ */
+export function isWithinBreakpoints(
+  width: number,
+  sizes: EuiBreakpointSize[],
+  breakpoints: EuiBreakpoints = BREAKPOINTS
+): boolean {
+  const currentBreakpoint = getBreakpoint(width, breakpoints);
+  return currentBreakpoint ? sizes.includes(currentBreakpoint) : false;
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -35,7 +35,12 @@ export {
   CENTER_ALIGNMENT,
 } from './alignment';
 
-export { BREAKPOINTS, BREAKPOINT_KEYS, getBreakpoint } from './breakpoint';
+export {
+  BREAKPOINTS,
+  BREAKPOINT_KEYS,
+  getBreakpoint,
+  isWithinMaxBreakpoint,
+} from './breakpoint';
 
 export {
   isColorDark,

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -35,6 +35,8 @@ export {
   CENTER_ALIGNMENT,
 } from './alignment';
 
+export { BREAKPOINTS, BREAKPOINT_KEYS, getBreakpoint } from './breakpoint';
+
 export {
   isColorDark,
   isValidHex,

--- a/src/themes/eui-amsterdam/overrides/_header.scss
+++ b/src/themes/eui-amsterdam/overrides/_header.scss
@@ -13,7 +13,7 @@
 
 .euiHeaderLogo {
   @include euiBreakpoint('xs') {
-    padding: 0 $euiSizeXS;
+    padding-left: $euiSizeXS;
   }
 
   padding-left: $euiSizeS;


### PR DESCRIPTION
# Fixes #3988

Updates the text color of the search input when in the dark header to be more visible. The placeholder still shouldn't be too prominent, so it's only slightly lighter.

<img width="797" alt="Screen Shot 2020-09-04 at 17 46 21 PM" src="https://user-images.githubusercontent.com/549577/92287043-96490000-eed6-11ea-9774-ce8519a15368.png">

# Fixes #3946

**EuiHeaderSectionItemButton** now accepts a `boolean` for `notification` and when set tp `true` will simply display a dot icon.

<img width="453" alt="Screen Shot 2020-09-04 at 12 11 51 PM" src="https://user-images.githubusercontent.com/549577/92261667-d80e8200-eea7-11ea-8542-77a54a214a70.png">

# Handling of a "mobile" version of EuiSelectableTemplateSitewide

New props were added to the component for providing the ability to trigger the whole component with a separate button. This prop is called `popoverButton`. Which, when provided, will display this inline while putting the search component inside of the popover. It also adds `popoverButtonMaxBreakpoint` to allow setting a certain point as to **when** to stop using the `popoverButton`.

If neither are provided, it simply continues to display as before. Here is an example of it working in the header.

![Screen Recording 2020-09-04 at 12 20 19 PM](https://user-images.githubusercontent.com/549577/92262440-1eb0ac00-eea9-11ea-9dfd-b3714e9fbe91.gif)

# EuiHeaderLink colors

Prior to this PR, they would always render as text color for inactive and blue for active, but now consumers can pass any color that is accepted by `EuiLink`. This supports Kibana's use of moving the menu link to the header. The main reason for this is so that they can get the mobile version out-of-the-box.

<img width="661" alt="Screen Shot 2020-09-04 at 12 28 39 PM" src="https://user-images.githubusercontent.com/549577/92263164-2f155680-eeaa-11ea-86e5-89a75a4bb05f.png">

# EuiSelectable fix

The **EuiSelectableList** accidentally had it's `showIcon` prop removed during #3983. This adds that back in.


# ⚠️ Breaking changes

In the header example above, it was necessary to use the **EuiHideFor** and **EuiShowFor** components to move the display from the center items to the right side items in smaller windows. The original problem was that these components were simply hiding the elements with `display: none` but still causing them to render which duplicate a lot of code and can cause id & ref clashes.

Now that we have access to our breakpoints in JS, I've converted these components from using classes to simply rendering or not rendering their children based on the window width. This does now require `children` and may break instances of people using custom SASS breakpoints that **override** EUI's defaults. This shouldn't be the case in any of Elastic products, so I feel mostly safe there.

Also removes the `display` prop of **EuiShowFor** as we're no longer rendering a wrapping element.

--

I'm going to say that this PR closes out #3490 and #3489 in preference of opening up more specific issues that arise. 🎉 
But all the bits should be in there and available by EUI.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
