### PR TITLE
[EuiComboBox] Added loading icon to combobox input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Added `loading` icon to `EuiComboBox` input when `isLoading` is `true` ([#4015](https://github.com/elastic/eui/pull/4015))
 - Added `fold` and `unfold` glyphs to `EuiIcon` ([#3994](https://github.com/elastic/eui/pull/3994))
 
 **Bug fixes**

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -48,6 +48,10 @@
     &.euiComboBox__inputWrap-isClearable {
       @include euiFormControlLayoutPadding(2); /* 2 */
     }
+
+    &.euiComboBox__inputWrap-isLoading {
+      @include euiFormControlLayoutPadding(3);
+    }
   }
 
   /**

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -4,7 +4,7 @@
 
   /**
    * 1. Allow pills to truncate their text with an ellipsis.
-   * 2. Don't allow pills to overlap with the caret or clear button.
+   * 2. Don't allow pills to overlap with the caret, loading icon or clear button.
    * 3. The height on combo can be larger than normal text inputs.
    */
 
@@ -50,7 +50,11 @@
     }
 
     &.euiComboBox__inputWrap-isLoading {
-      @include euiFormControlLayoutPadding(3);
+      @include euiFormControlLayoutPadding(2); /* 2 */
+    }
+
+    &.euiComboBox__inputWrap-isLoading.euiComboBox__inputWrap-isClearable {
+      @include euiFormControlLayoutPadding(3); /* 2 */
     }
   }
 
@@ -113,6 +117,14 @@
 
       &.euiComboBox__inputWrap-isClearable {
         @include euiFormControlLayoutPadding(2, $compressed: true); /* 2 */
+      }
+
+      &.euiComboBox__inputWrap-isLoading {
+        @include euiFormControlLayoutPadding(2, $compressed: true); /* 2 */
+      }
+
+      &.euiComboBox__inputWrap-isLoading.euiComboBox__inputWrap-isClearable {
+        @include euiFormControlLayoutPadding(3, $compressed: true); /* 2 */
       }
     }
   }

--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -1051,6 +1051,7 @@ export class EuiComboBox<T> extends Component<
           value={value}
           append={singleSelection ? append : undefined}
           prepend={singleSelection ? prepend : undefined}
+          isLoading={isLoading}
         />
         {optionsList}
       </div>

--- a/src/components/combo_box/combo_box_input/combo_box_input.tsx
+++ b/src/components/combo_box/combo_box_input/combo_box_input.tsx
@@ -263,6 +263,7 @@ export class EuiComboBoxInput<T> extends Component<
       'euiComboBox__inputWrap--compressed': compressed,
       'euiComboBox__inputWrap--fullWidth': fullWidth,
       'euiComboBox__inputWrap--noWrap': singleSelection,
+      'euiComboBox__inputWrap-isLoading': isLoading,
       'euiComboBox__inputWrap-isClearable': onClear,
       'euiComboBox__inputWrap--inGroup': prepend || append,
     });

--- a/src/components/combo_box/combo_box_input/combo_box_input.tsx
+++ b/src/components/combo_box/combo_box_input/combo_box_input.tsx
@@ -71,6 +71,7 @@ export interface EuiComboBoxInputProps<T> extends CommonProps {
   value?: string;
   prepend?: EuiFormControlLayoutProps['prepend'];
   append?: EuiFormControlLayoutProps['append'];
+  isLoading?: boolean;
 }
 
 interface EuiComboBoxInputState {
@@ -157,6 +158,7 @@ export class EuiComboBoxInput<T> extends Component<
       value,
       prepend,
       append,
+      isLoading,
     } = this.props;
 
     const singleSelection = Boolean(singleSelectionProp);
@@ -269,6 +271,7 @@ export class EuiComboBoxInput<T> extends Component<
       <EuiFormControlLayout
         icon={icon}
         {...clickProps}
+        isLoading={isLoading}
         compressed={compressed}
         fullWidth={fullWidth}
         prepend={prepend}


### PR DESCRIPTION
### Summary

Fixes: #3852

- Add loading icon to EuiComboBox input when isLoading is true.

![Screen Cast 2020-09-05 at 6 49 33 PM](https://user-images.githubusercontent.com/10515204/92305903-222b5c80-efa9-11ea-83f4-536f7453a0fe.gif)


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
~~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples`~~
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
- [x] Checked for **breaking changes** and labeled appropriately
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
