### PR TITLE
[EuiContextMenu] Add line separator as menu item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added `.browserslistrc` for global browser support reference ([#4022](https://github.com/elastic/eui/pull/4022))
+- Added horizontal line separator to `EuiContextMenu` ([#4018](https://github.com/elastic/eui/pull/4018))
 
 **Bug fixes**
 

--- a/src-docs/src/views/context_menu/context_menu_example.js
+++ b/src-docs/src/views/context_menu/context_menu_example.js
@@ -10,7 +10,6 @@ import {
   EuiContextMenu,
   EuiContextMenuItem,
   EuiContextMenuPanel,
-  EuiLink,
 } from '../../../../src/components';
 
 import ContextMenu from './context_menu';
@@ -125,19 +124,13 @@ export const ContextMenuExample = {
           </p>
           <p>
             You can add separator lines in the <EuiCode>items</EuiCode> prop if
-            you define an items as{' '}
+            you define an item as{' '}
             <EuiCode language="ts">{'{isSeparator: true}'}</EuiCode>. This will
             pass the rest of its fields as props to a{' '}
             <Link to="/layout/horizontal-rule">
               <strong>EuiHorizontalRule</strong>
             </Link>{' '}
-            component. Separators can also have a{' '}
-            <EuiLink
-              href="https://reactjs.org/docs/lists-and-keys.html#keys"
-              target="_blank">
-              <EuiCode>key</EuiCode> prop
-            </EuiLink>
-            , used by React for list rendering.
+            component.
           </p>
         </div>
       ),

--- a/src-docs/src/views/context_menu/context_menu_example.js
+++ b/src-docs/src/views/context_menu/context_menu_example.js
@@ -124,10 +124,10 @@ export const ContextMenuExample = {
             panel tree.
           </p>
           <p>
-            You can add separator lines through <EuiCode>items</EuiCode> prop if
-            you define items as{' '}
-            <EuiCode language="ts">{'{isSeparator: true}'}</EuiCode>. Separator
-            passes through rest of its fields as props to{' '}
+            You can add separator lines in the <EuiCode>items</EuiCode> prop if
+            you define an items as{' '}
+            <EuiCode language="ts">{'{isSeparator: true}'}</EuiCode>. This will
+            pass the rest of its fields as props to a{' '}
             <Link to="/layout/horizontal-rule">
               <strong>EuiHorizontalRule</strong>
             </Link>{' '}

--- a/src-docs/src/views/context_menu/context_menu_example.js
+++ b/src-docs/src/views/context_menu/context_menu_example.js
@@ -8,8 +8,9 @@ import { GuideSectionTypes } from '../../components';
 import {
   EuiCode,
   EuiContextMenu,
-  EuiContextMenuPanel,
   EuiContextMenuItem,
+  EuiContextMenuPanel,
+  EuiLink,
 } from '../../../../src/components';
 
 import ContextMenu from './context_menu';
@@ -121,6 +122,22 @@ export const ContextMenuExample = {
             that a specific context menu panel has a certain width, add{' '}
             <EuiCode language="ts">width: [number of pixels]</EuiCode> to the
             panel tree.
+          </p>
+          <p>
+            You can add separator lines through <EuiCode>items</EuiCode> prop if
+            you define items as{' '}
+            <EuiCode language="ts">{'{isSeparator: true}'}</EuiCode>. Separator
+            passes through rest of its fields as props to{' '}
+            <Link to="/layout/horizontal-rule">
+              <strong>EuiHorizontalRule</strong>
+            </Link>{' '}
+            component. Separators can also have a{' '}
+            <EuiLink
+              href="https://reactjs.org/docs/lists-and-keys.html#keys"
+              target="_blank">
+              <EuiCode>key</EuiCode> prop
+            </EuiLink>
+            , used by React for list rendering.
           </p>
         </div>
       ),

--- a/src-docs/src/views/context_menu/context_menu_with_content.js
+++ b/src-docs/src/views/context_menu/context_menu_with_content.js
@@ -61,6 +61,8 @@ export default () => {
         },
         {
           isSeparator: true,
+          key: 'sep',
+          margin: 'none',
         },
         {
           name: 'See more',

--- a/src-docs/src/views/context_menu/context_menu_with_content.js
+++ b/src-docs/src/views/context_menu/context_menu_with_content.js
@@ -60,8 +60,7 @@ export default () => {
           },
         },
         {
-          name: 'more-separator',
-          isLine: true,
+          isSeparator: true,
         },
         {
           name: 'See more',

--- a/src-docs/src/views/context_menu/context_menu_with_content.js
+++ b/src-docs/src/views/context_menu/context_menu_with_content.js
@@ -62,7 +62,6 @@ export default () => {
         {
           isSeparator: true,
           key: 'sep',
-          margin: 'none',
         },
         {
           name: 'See more',

--- a/src-docs/src/views/context_menu/context_menu_with_content.js
+++ b/src-docs/src/views/context_menu/context_menu_with_content.js
@@ -60,6 +60,10 @@ export default () => {
           },
         },
         {
+          name: 'more-separator',
+          isLine: true,
+        },
+        {
           name: 'See more',
           icon: 'plusInCircle',
           panel: {

--- a/src/components/context_menu/__snapshots__/context_menu.test.tsx.snap
+++ b/src/components/context_menu/__snapshots__/context_menu.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`EuiContextMenu panel item can be a separator line 1`] = `
           </span>
         </button>
         <hr
-          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginLarge"
+          class="euiHorizontalRule euiHorizontalRule--full"
         />
         <button
           class="euiContextMenuItem"

--- a/src/components/context_menu/__snapshots__/context_menu.test.tsx.snap
+++ b/src/components/context_menu/__snapshots__/context_menu.test.tsx.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiContextMenu can pass-through horizontal rule props 1`] = `
+<div
+  class="euiContextMenu"
+>
+  <div
+    class="euiContextMenuPanel euiContextMenu__panel"
+    tabindex="0"
+  >
+    <div
+      class="euiPopoverTitle"
+    >
+      <span
+        class="euiContextMenu__itemLayout"
+      >
+        Testing separator
+      </span>
+    </div>
+    <div>
+      <div>
+        <hr
+          class="euiHorizontalRule euiHorizontalRule--half euiHorizontalRule--marginSmall"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EuiContextMenu is rendered 1`] = `
 <div
   aria-label="aria-label"
@@ -42,7 +70,7 @@ exports[`EuiContextMenu panel item can be a separator line 1`] = `
           </span>
         </button>
         <hr
-          class="euiHorizontalRule euiHorizontalRule--full"
+          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginLarge"
         />
         <button
           class="euiContextMenuItem"

--- a/src/components/context_menu/__snapshots__/context_menu.test.tsx.snap
+++ b/src/components/context_menu/__snapshots__/context_menu.test.tsx.snap
@@ -8,6 +8,62 @@ exports[`EuiContextMenu is rendered 1`] = `
 />
 `;
 
+exports[`EuiContextMenu panel item can be a separator line 1`] = `
+<div
+  class="euiContextMenu"
+>
+  <div
+    class="euiContextMenuPanel euiContextMenu__panel"
+    tabindex="0"
+  >
+    <div
+      class="euiPopoverTitle"
+    >
+      <span
+        class="euiContextMenu__itemLayout"
+      >
+        Testing separator
+      </span>
+    </div>
+    <div>
+      <div>
+        <button
+          class="euiContextMenuItem"
+          type="button"
+        >
+          <span
+            class="euiContextMenu__itemLayout"
+          >
+            <span
+              class="euiContextMenuItem__text"
+            >
+              Foo
+            </span>
+          </span>
+        </button>
+        <hr
+          class="euiHorizontalRule euiHorizontalRule--full"
+        />
+        <button
+          class="euiContextMenuItem"
+          type="button"
+        >
+          <span
+            class="euiContextMenu__itemLayout"
+          >
+            <span
+              class="euiContextMenuItem__text"
+            >
+              Bar
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EuiContextMenu panel item can contain JSX 1`] = `
 <div
   class="euiContextMenu"

--- a/src/components/context_menu/__snapshots__/context_menu_panel.test.tsx.snap
+++ b/src/components/context_menu/__snapshots__/context_menu_panel.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`EuiContextMenu panel item can be a separator line 1`] = `
           </span>
         </button>
         <hr
-          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginLarge"
+          class="euiHorizontalRule euiHorizontalRule--full"
         />
         <button
           class="euiContextMenuItem"

--- a/src/components/context_menu/__snapshots__/context_menu_panel.test.tsx.snap
+++ b/src/components/context_menu/__snapshots__/context_menu_panel.test.tsx.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiContextMenu can pass-through horizontal rule props 1`] = `
+<div
+  class="euiContextMenu"
+>
+  <div
+    class="euiContextMenuPanel euiContextMenu__panel"
+    tabindex="0"
+  >
+    <div
+      class="euiPopoverTitle"
+    >
+      <span
+        class="euiContextMenu__itemLayout"
+      >
+        Testing separator
+      </span>
+    </div>
+    <div>
+      <div>
+        <hr
+          class="euiHorizontalRule euiHorizontalRule--half euiHorizontalRule--marginSmall"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EuiContextMenu is rendered 1`] = `
 <div
   aria-label="aria-label"
@@ -42,7 +70,7 @@ exports[`EuiContextMenu panel item can be a separator line 1`] = `
           </span>
         </button>
         <hr
-          class="euiHorizontalRule euiHorizontalRule--full"
+          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginLarge"
         />
         <button
           class="euiContextMenuItem"

--- a/src/components/context_menu/__snapshots__/context_menu_panel.test.tsx.snap
+++ b/src/components/context_menu/__snapshots__/context_menu_panel.test.tsx.snap
@@ -8,6 +8,62 @@ exports[`EuiContextMenu is rendered 1`] = `
 />
 `;
 
+exports[`EuiContextMenu panel item can be a separator line 1`] = `
+<div
+  class="euiContextMenu"
+>
+  <div
+    class="euiContextMenuPanel euiContextMenu__panel"
+    tabindex="0"
+  >
+    <div
+      class="euiPopoverTitle"
+    >
+      <span
+        class="euiContextMenu__itemLayout"
+      >
+        Testing separator
+      </span>
+    </div>
+    <div>
+      <div>
+        <button
+          class="euiContextMenuItem"
+          type="button"
+        >
+          <span
+            class="euiContextMenu__itemLayout"
+          >
+            <span
+              class="euiContextMenuItem__text"
+            >
+              Foo
+            </span>
+          </span>
+        </button>
+        <hr
+          class="euiHorizontalRule euiHorizontalRule--full"
+        />
+        <button
+          class="euiContextMenuItem"
+          type="button"
+        >
+          <span
+            class="euiContextMenu__itemLayout"
+          >
+            <span
+              class="euiContextMenuItem__text"
+            >
+              Bar
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EuiContextMenu panel item can contain JSX 1`] = `
 <div
   class="euiContextMenu"

--- a/src/components/context_menu/context_menu.test.tsx
+++ b/src/components/context_menu/context_menu.test.tsx
@@ -103,7 +103,7 @@ describe('EuiContextMenu', () => {
             title: 'Testing separator',
             items: [
               { name: 'Foo', key: 'foo' },
-              { isLine: true, name: 'separator' },
+              { isSeparator: true },
               { name: 'Bar', key: 'bar' },
             ],
           },

--- a/src/components/context_menu/context_menu.test.tsx
+++ b/src/components/context_menu/context_menu.test.tsx
@@ -94,6 +94,27 @@ describe('EuiContextMenu', () => {
     expect(component).toMatchSnapshot();
   });
 
+  it('panel item can be a separator line', () => {
+    const component = render(
+      <EuiContextMenu
+        panels={[
+          {
+            id: 3,
+            title: 'Testing separator',
+            items: [
+              { name: 'Foo', key: 'foo' },
+              { isLine: true, name: 'separator' },
+              { name: 'Bar', key: 'bar' },
+            ],
+          },
+        ]}
+        initialPanelId={3}
+      />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
   describe('props', () => {
     describe('panels and initialPanelId', () => {
       it('renders the referenced panel', () => {

--- a/src/components/context_menu/context_menu.test.tsx
+++ b/src/components/context_menu/context_menu.test.tsx
@@ -115,6 +115,30 @@ describe('EuiContextMenu', () => {
     expect(component).toMatchSnapshot();
   });
 
+  it('can pass-through horizontal rule props', () => {
+    const component = render(
+      <EuiContextMenu
+        panels={[
+          {
+            id: 3,
+            title: 'Testing separator',
+            items: [
+              {
+                isSeparator: true,
+                key: 'separator',
+                margin: 's',
+                size: 'half',
+              },
+            ],
+          },
+        ]}
+        initialPanelId={3}
+      />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
   describe('props', () => {
     describe('panels and initialPanelId', () => {
       it('renders the referenced panel', () => {

--- a/src/components/context_menu/context_menu.tsx
+++ b/src/components/context_menu/context_menu.tsx
@@ -35,10 +35,11 @@ import {
   EuiContextMenuItem,
   EuiContextMenuItemProps,
 } from './context_menu_item';
+import { EuiHorizontalRule } from '../horizontal_rule';
 
 export type EuiContextMenuPanelId = string | number;
 
-export type EuiContextMenuPanelItemDescriptor = Omit<
+export type EuiContextMenuPanelItemDescriptorEntry = Omit<
   EuiContextMenuItemProps,
   'hasPanel'
 > & {
@@ -46,6 +47,15 @@ export type EuiContextMenuPanelItemDescriptor = Omit<
   key?: string;
   panel?: EuiContextMenuPanelId;
 };
+
+export interface EuiContextMenuPanelItemSeparator {
+  isSeparator: true;
+  key?: string;
+}
+
+export type EuiContextMenuPanelItemDescriptor =
+  | EuiContextMenuPanelItemDescriptorEntry
+  | EuiContextMenuPanelItemSeparator;
 
 export interface EuiContextMenuPanelDescriptor {
   id: EuiContextMenuPanelId;
@@ -60,6 +70,11 @@ export type EuiContextMenuProps = CommonProps &
     panels?: EuiContextMenuPanelDescriptor[];
     initialPanelId?: EuiContextMenuPanelId;
   };
+
+const isItemSeparator = (
+  item: EuiContextMenuPanelItemDescriptor
+): item is EuiContextMenuPanelItemSeparator =>
+  (item as EuiContextMenuPanelItemSeparator).isSeparator === true;
 
 function mapIdsToPanels(panels: EuiContextMenuPanelDescriptor[]) {
   const map: { [id: string]: EuiContextMenuPanelDescriptor } = {};
@@ -77,6 +92,7 @@ function mapIdsToPreviousPanels(panels: EuiContextMenuPanelDescriptor[]) {
   panels.forEach(panel => {
     if (Array.isArray(panel.items)) {
       panel.items.forEach(item => {
+        if (isItemSeparator(item)) return;
         const isCloseable = item.panel !== undefined;
         if (isCloseable) {
           idToPreviousPanelIdMap[item.panel!] = panel.id;
@@ -98,6 +114,7 @@ function mapPanelItemsToPanels(panels: EuiContextMenuPanelDescriptor[]) {
 
     if (panel.items) {
       panel.items.forEach((item, index) => {
+        if (isItemSeparator(item)) return;
         if (item.panel) {
           idAndItemIndexToPanelIdMap[panel.id][index] = item.panel;
         }
@@ -227,7 +244,8 @@ export class EuiContextMenu extends Component<EuiContextMenuProps, State> {
       // Set focus on the item which shows the panel we're leaving.
       const previousPanel = this.state.idToPanelMap[previousPanelId];
       const focusedItemIndex = previousPanel.items!.findIndex(
-        item => item.panel === this.state.incomingPanelId
+        item =>
+          !isItemSeparator(item) && item.panel === this.state.incomingPanelId
       );
 
       if (focusedItemIndex !== -1) {
@@ -277,6 +295,10 @@ export class EuiContextMenu extends Component<EuiContextMenuProps, State> {
 
   renderItems(items: EuiContextMenuPanelItemDescriptor[] = []) {
     return items.map((item, index) => {
+      if (isItemSeparator(item)) {
+        return <EuiHorizontalRule key={item.key || index} margin="none" />;
+      }
+
       const {
         panel,
         name,

--- a/src/components/context_menu/context_menu.tsx
+++ b/src/components/context_menu/context_menu.tsx
@@ -298,7 +298,7 @@ export class EuiContextMenu extends Component<EuiContextMenuProps, State> {
     return items.map((item, index) => {
       if (isItemSeparator(item)) {
         const { isSeparator: omit, key = index, ...rest } = item;
-        return <EuiHorizontalRule key={key} {...rest} />;
+        return <EuiHorizontalRule key={key} margin="none" {...rest} />;
       }
 
       const {

--- a/src/components/context_menu/context_menu.tsx
+++ b/src/components/context_menu/context_menu.tsx
@@ -35,7 +35,7 @@ import {
   EuiContextMenuItem,
   EuiContextMenuItemProps,
 } from './context_menu_item';
-import { EuiHorizontalRule } from '../horizontal_rule';
+import { EuiHorizontalRule, EuiHorizontalRuleProps } from '../horizontal_rule';
 
 export type EuiContextMenuPanelId = string | number;
 
@@ -48,7 +48,8 @@ export type EuiContextMenuPanelItemDescriptorEntry = Omit<
   panel?: EuiContextMenuPanelId;
 };
 
-export interface EuiContextMenuPanelItemSeparator {
+export interface EuiContextMenuPanelItemSeparator
+  extends EuiHorizontalRuleProps {
   isSeparator: true;
   key?: string;
 }
@@ -296,7 +297,8 @@ export class EuiContextMenu extends Component<EuiContextMenuProps, State> {
   renderItems(items: EuiContextMenuPanelItemDescriptor[] = []) {
     return items.map((item, index) => {
       if (isItemSeparator(item)) {
-        return <EuiHorizontalRule key={item.key || index} margin="none" />;
+        const { isSeparator: omit, key = index, ...rest } = item;
+        return <EuiHorizontalRule key={key} {...rest} />;
       }
 
       const {

--- a/src/components/context_menu/context_menu.tsx
+++ b/src/components/context_menu/context_menu.tsx
@@ -25,7 +25,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { CommonProps } from '../common';
+import { CommonProps, ExclusiveUnion } from '../common';
 import {
   EuiContextMenuPanel,
   EuiContextMenuPanelTransitionDirection,
@@ -54,9 +54,10 @@ export interface EuiContextMenuPanelItemSeparator
   key?: string;
 }
 
-export type EuiContextMenuPanelItemDescriptor =
-  | EuiContextMenuPanelItemDescriptorEntry
-  | EuiContextMenuPanelItemSeparator;
+export type EuiContextMenuPanelItemDescriptor = ExclusiveUnion<
+  EuiContextMenuPanelItemDescriptorEntry,
+  EuiContextMenuPanelItemSeparator
+>;
 
 export interface EuiContextMenuPanelDescriptor {
   id: EuiContextMenuPanelId;

--- a/src/components/context_menu/context_menu_item.tsx
+++ b/src/components/context_menu/context_menu_item.tsx
@@ -33,7 +33,6 @@ import { EuiIcon } from '../icon';
 import { EuiToolTip, ToolTipPositions } from '../tool_tip';
 
 import { getSecureRelForTarget } from '../../services';
-import { EuiHorizontalRule } from '../horizontal_rule';
 
 export type EuiContextMenuItemIcon = ReactElement<any> | string | HTMLElement;
 
@@ -64,7 +63,6 @@ export interface EuiContextMenuItemProps extends CommonProps {
    * How to align icon with content of button
    */
   layoutAlign?: EuiContextMenuItemLayoutAlignment;
-  isLine?: boolean;
 }
 
 type Props = CommonProps &
@@ -100,14 +98,9 @@ export class EuiContextMenuItem extends Component<Props> {
       href,
       target,
       rel,
-      isLine,
       ...rest
     } = this.props;
     let iconInstance;
-
-    if (isLine) {
-      return <EuiHorizontalRule margin="none" />;
-    }
 
     if (icon) {
       switch (typeof icon) {

--- a/src/components/context_menu/context_menu_item.tsx
+++ b/src/components/context_menu/context_menu_item.tsx
@@ -33,6 +33,7 @@ import { EuiIcon } from '../icon';
 import { EuiToolTip, ToolTipPositions } from '../tool_tip';
 
 import { getSecureRelForTarget } from '../../services';
+import { EuiHorizontalRule } from '../horizontal_rule';
 
 export type EuiContextMenuItemIcon = ReactElement<any> | string | HTMLElement;
 
@@ -63,6 +64,7 @@ export interface EuiContextMenuItemProps extends CommonProps {
    * How to align icon with content of button
    */
   layoutAlign?: EuiContextMenuItemLayoutAlignment;
+  isLine?: boolean;
 }
 
 type Props = CommonProps &
@@ -98,10 +100,14 @@ export class EuiContextMenuItem extends Component<Props> {
       href,
       target,
       rel,
+      isLine,
       ...rest
     } = this.props;
-
     let iconInstance;
+
+    if (isLine) {
+      return <EuiHorizontalRule margin="none" />;
+    }
 
     if (icon) {
       switch (typeof icon) {

--- a/src/components/context_menu/context_menu_panel.tsx
+++ b/src/components/context_menu/context_menu_panel.tsx
@@ -32,6 +32,7 @@ import { EuiIcon } from '../icon';
 import { EuiPopoverTitle } from '../popover';
 import { EuiResizeObserver } from '../observer/resize_observer';
 import { cascadingMenuKeys } from '../../services';
+import { EuiContextMenuItem } from './context_menu_item';
 
 export type EuiContextMenuPanelHeightChangeHandler = (height: number) => void;
 export type EuiContextMenuPanelTransitionType = 'in' | 'out';
@@ -471,9 +472,11 @@ export class EuiContextMenuPanel extends Component<Props, State> {
     const content =
       items && items.length
         ? items.map((MenuItem, index) =>
-            cloneElement(MenuItem, {
-              buttonRef: this.menuItemRef.bind(this, index),
-            })
+            MenuItem.type === EuiContextMenuItem
+              ? cloneElement(MenuItem, {
+                  buttonRef: this.menuItemRef.bind(this, index),
+                })
+              : MenuItem
           )
         : children;
 

--- a/src/components/horizontal_rule/horizontal_rule.tsx
+++ b/src/components/horizontal_rule/horizontal_rule.tsx
@@ -25,7 +25,9 @@ import { CommonProps } from '../common';
 export type EuiHorizontalRuleSize = keyof typeof sizeToClassNameMap;
 export type EuiHorizontalRuleMargin = keyof typeof marginToClassNameMap;
 
-export interface EuiHorizontalRuleProps {
+export interface EuiHorizontalRuleProps
+  extends CommonProps,
+    HTMLAttributes<HTMLHRElement> {
   /**
    * Defines the width of the HR.
    */
@@ -53,9 +55,7 @@ const marginToClassNameMap = {
 
 export const MARGINS = Object.keys(marginToClassNameMap);
 
-export const EuiHorizontalRule: FunctionComponent<CommonProps &
-  HTMLAttributes<HTMLHRElement> &
-  EuiHorizontalRuleProps> = ({
+export const EuiHorizontalRule: FunctionComponent<EuiHorizontalRuleProps> = ({
   className,
   size = 'full',
   margin = 'l',

--- a/src/components/horizontal_rule/index.ts
+++ b/src/components/horizontal_rule/index.ts
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-export { EuiHorizontalRule } from './horizontal_rule';
+export { EuiHorizontalRule, EuiHorizontalRuleProps } from './horizontal_rule';


### PR DESCRIPTION
### Summary

This is a Proof-of-Concept for line separator that we need for https://github.com/elastic/kibana/issues/66051

![image](https://user-images.githubusercontent.com/9773803/92467366-c68fe780-f1d1-11ea-899c-2d8e1fb4721b.png)


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
