### PR TITLE
Update DemoJS docs tab processing to match new raw-loader import format

### DIFF
--- a/src-docs/src/components/guide_section/guide_section.js
+++ b/src-docs/src/components/guide_section/guide_section.js
@@ -193,7 +193,7 @@ export class GuideSection extends Component {
       renderedCode = code;
 
       if (name === 'javascript') {
-        renderedCode = renderedCode
+        renderedCode = renderedCode.default
           .replace(
             /(from )'(..\/)+src\/services(\/?';)/g,
             "from '@elastic/eui/lib/services';"
@@ -643,7 +643,7 @@ export class GuideSection extends Component {
 
   renderCodeSandBoxButton() {
     return (
-      <CodeSandboxLink content={this.props.source[0].code}>
+      <CodeSandboxLink content={this.props.source[0].code.default}>
         <EuiButtonEmpty size="xs" iconType="logoCodesandbox">
           Try out this demo on Code Sandbox
         </EuiButtonEmpty>


### PR DESCRIPTION
### Summary

`raw-loader` was upgraded in #4022 which changed the result of `require`ing to an ESModule format instead of returning the default export. This PR accesses updates the guide component to add `.default` when accessing the string value.

A more correct change would be to update every instance of `require('!!raw-loader!` to `import from '!!raw-loader!` but that

1. introduces an eslint warning
2. requires an automated change to every single example file

These should be solvable, but I'm opting for a quick fix to get the DemoJS tabs working again before going down the more complex path.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
