### PR TITLE
[EUISuperDatePicker] Show update button only if the value is changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Bug fixes**
 
+- Fixed `EuiSuperDatePicker` got stuck in update mode if the value is not changed ([#4025](https://github.com/elastic/eui/pull/4025))
 - Fixed ref not being handled properly in `EuiValidatableControl` when used with [react-hook-form](https://react-hook-form.com/) ([#4001](https://github.com/elastic/eui/pull/4001))
 
 ## [`28.4.0`](https://github.com/elastic/eui/tree/v28.4.0)

--- a/src/components/date_picker/super_date_picker/super_date_picker.tsx
+++ b/src/components/date_picker/super_date_picker/super_date_picker.tsx
@@ -231,7 +231,9 @@ export class EuiSuperDatePicker extends Component<
       start,
       end,
       isInvalid,
-      hasChanged: true,
+      hasChanged: !(
+        this.state.prevProps.start === start && this.state.prevProps.end === end
+      ),
     });
 
     if (!this.props.showUpdateButton) {


### PR DESCRIPTION
### Summary

Fixes #4025 

- EuiSuperDatePicker update button only shows if the value is changed.

Before:

![Screen Cast 2020-09-11 at 2 41 23 PM](https://user-images.githubusercontent.com/10515204/92900035-f5f65c80-f43c-11ea-9bca-4dd4a63e690a.gif)

After:

![Screen Cast 2020-09-11 at 2 42 46 PM](https://user-images.githubusercontent.com/10515204/92900230-2211dd80-f43d-11ea-984f-c20b1927f37b.gif)



### Checklist

~~- [ ] Check against **all themes** for compatibility in both light and dark modes~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
~~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~~
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
- [x] Checked for **breaking changes** and labeled appropriately

~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
