### PR TITLE
Fixed EuiImage deactivate fullscreen event propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug fixes**
 
 - Fixed ref not being handled properly in `EuiValidatableControl` when used with [react-hook-form](https://react-hook-form.com/) ([#4001](https://github.com/elastic/eui/pull/4001))
+- Fixed `EuiImage` unable to deactivate the full screen mode using the close icon ([#4033](https://github.com/elastic/eui/pull/4033))
 
 ## [`28.4.0`](https://github.com/elastic/eui/tree/v28.4.0)
 

--- a/src/components/image/__snapshots__/image.test.tsx.snap
+++ b/src/components/image/__snapshots__/image.test.tsx.snap
@@ -21,6 +21,7 @@ exports[`EuiImage is rendered and allows full screen 1`] = `
   <button
     aria-label="Open full screen alt image"
     class="euiImage__button"
+    data-test-subj="activateFullScreenButton"
     type="button"
   >
     <img

--- a/src/components/image/image.test.tsx
+++ b/src/components/image/image.test.tsx
@@ -18,8 +18,10 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test';
+import { render, mount, ReactWrapper } from 'enzyme';
+import { requiredProps, findTestSubject } from '../../test';
+import { act } from 'react-dom/test-utils';
+import { keys } from '../../services';
 
 import { EuiImage } from './image';
 
@@ -58,5 +60,94 @@ describe('EuiImage', () => {
     );
 
     expect(component).toMatchSnapshot();
+  });
+
+  describe('Full screen behaviour', () => {
+    let component: ReactWrapper;
+
+    beforeEach(() => {
+      const testProps = {
+        ...requiredProps,
+        'data-test-subj': 'euiImage',
+      };
+
+      component = mount(
+        <EuiImage
+          alt="alt"
+          size="l"
+          url="/cat.jpg"
+          allowFullScreen
+          {...testProps}
+        />
+      );
+
+      findTestSubject(component, 'activateFullScreenButton').simulate('click');
+    });
+
+    test('full screen image is rendered', () => {
+      const overlayMask = document.querySelectorAll(
+        '[data-test-subj=fullScreenOverlayMask]'
+      );
+      expect(overlayMask.length).toBe(1);
+
+      const fullScreenImage = overlayMask[0].querySelectorAll(
+        '[data-test-subj=euiImage]'
+      );
+      expect(fullScreenImage.length).toBe(1);
+    });
+
+    test('close using close icon', () => {
+      const deactivateFullScreenBtn = document.querySelectorAll(
+        '[data-test-subj=deactivateFullScreenButton]'
+      );
+      expect(deactivateFullScreenBtn.length).toBe(1);
+
+      act(() => {
+        (deactivateFullScreenBtn[0] as HTMLElement).click();
+      });
+
+      const overlayMask = document.querySelectorAll(
+        '[data-test-subj=fullScreenOverlayMask]'
+      );
+      expect(overlayMask.length).toBe(0);
+    });
+
+    test('close using ESCAPE key', () => {
+      const deactivateFullScreenBtn = document.querySelectorAll(
+        '[data-test-subj=deactivateFullScreenButton]'
+      );
+      expect(deactivateFullScreenBtn.length).toBe(1);
+
+      act(() => {
+        const escapeKeydownEvent = new KeyboardEvent('keydown', {
+          key: keys.ESCAPE,
+          bubbles: true,
+        });
+        (deactivateFullScreenBtn[0] as HTMLElement).dispatchEvent(
+          escapeKeydownEvent
+        );
+      });
+
+      const overlayMask = document.querySelectorAll(
+        '[data-test-subj=fullScreenOverlayMask]'
+      );
+      expect(overlayMask.length).toBe(0);
+    });
+
+    test('close using overlay mask', () => {
+      let overlayMask = document.querySelectorAll(
+        '[data-test-subj=fullScreenOverlayMask]'
+      );
+      expect(overlayMask.length).toBe(1);
+
+      act(() => {
+        (overlayMask[0] as HTMLElement).click();
+      });
+
+      overlayMask = document.querySelectorAll(
+        '[data-test-subj=fullScreenOverlayMask]'
+      );
+      expect(overlayMask.length).toBe(0);
+    });
   });
 });

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -159,7 +159,9 @@ export const EuiImage: FunctionComponent<EuiImageProps> = ({
   );
 
   const fullScreenDisplay = (
-    <EuiOverlayMask onClick={closeFullScreen}>
+    <EuiOverlayMask
+      data-test-subj="fullScreenOverlayMask"
+      onClick={closeFullScreen}>
       <EuiFocusTrap clickOutsideDisables={true}>
         <figure
           className="euiImage euiImage-isFullScreen"
@@ -172,6 +174,7 @@ export const EuiImage: FunctionComponent<EuiImageProps> = ({
               { alt }
             )}
             className="euiImage__button"
+            data-test-subj="deactivateFullScreenButton"
             onClick={closeFullScreen}
             onKeyDown={onKeyDown}>
             <img
@@ -204,6 +207,7 @@ export const EuiImage: FunctionComponent<EuiImageProps> = ({
           type="button"
           aria-label={fullscreenLabel}
           className="euiImage__button"
+          data-test-subj="activateFullScreenButton"
           onClick={openFullScreen}>
           <img
             src={url}

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -213,8 +213,8 @@ export const EuiImage: FunctionComponent<EuiImageProps> = ({
             {...rest}
           />
           {allowFullScreenIcon}
-          {isFullScreenActive && fullScreenDisplay}
         </button>
+        {isFullScreenActive && fullScreenDisplay}
         {optionalCaption}
       </figure>
     );


### PR DESCRIPTION
### Summary
Fixed #4032: Moved nested button out to prevent event propagation that trigger the activation of full screen mode

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs**
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
