### PR TITLE
Allowed onClick prop in conjunction with href prop in EuiBadge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed z-index of `EuiBottomBar` to stay under header ([#4008](https://github.com/elastic/eui/pull/4008))
 - Fixed regression of `EuiSelectable` not abiding by the `showIcons` prop ([#4008](https://github.com/elastic/eui/pull/4008))
 - Fixed contrast of search input of `EuiSelectableTemplateSitewide` in dark header ([#4008](https://github.com/elastic/eui/pull/4008))
+- Allowed `onClick` prop when `href` prop is provided in `EuiBadge` ([#4035](https://github.com/elastic/eui/pull/4035))
 
 **Breaking changes**
 

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -229,7 +229,8 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
     relObj.href = href;
     relObj.target = target;
     relObj.rel = getSecureRelForTarget({ href, target, rel });
-  } else if (onClick) {
+  }
+  if (onClick) {
     relObj.onClick = onClick;
   }
 


### PR DESCRIPTION
### Summary

Fixed #4031: Allowed `onClick` prop when `href` prop is provided in `EuiBadge`

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs**
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
