### PR TITLE
clean up raw-loader imports in a few places

### DIFF
--- a/src-docs/src/components/codesandbox/link.js
+++ b/src-docs/src/components/codesandbox/link.js
@@ -21,7 +21,8 @@ import { EuiSpacer } from '../../../../src/components';
  * 6. We pass the files and dependencies as params to CS through a POST call.
  * */
 
-const displayTogglesRawCode = require('!!raw-loader!../../views/form_controls/display_toggles');
+const displayTogglesRawCode = require('!!raw-loader!../../views/form_controls/display_toggles')
+  .default;
 
 /* 1 */
 export const CodeSandboxLink = ({ children, content }) => {

--- a/src-docs/src/views/code/code_block.js
+++ b/src-docs/src/views/code/code_block.js
@@ -2,11 +2,11 @@ import React from 'react';
 
 import { EuiCodeBlock, EuiSpacer } from '../../../../src/components';
 
-const htmlCode = require('!!raw-loader!./code_examples/example.html');
+const htmlCode = require('!!raw-loader!./code_examples/example.html').default;
 
-const jsCode = require('!!raw-loader!./code_examples/example.js');
+const jsCode = require('!!raw-loader!./code_examples/example.js').default;
 
-const sqlCode = require('!!raw-loader!./code_examples/example.sql');
+const sqlCode = require('!!raw-loader!./code_examples/example.sql').default;
 
 export default () => (
   <div>

--- a/src-docs/src/views/code/playground.js
+++ b/src-docs/src/views/code/playground.js
@@ -2,7 +2,7 @@ import { PropTypes } from 'react-view';
 import { EuiCodeBlock, EuiCode } from '../../../../src/components/';
 import { propUtilityForPlayground } from '../../services/playground';
 
-const codeDemo = `\n{\`${require('!!raw-loader!./code_examples/example.html')}\`}\n`;
+const codeDemo = `\n{\`${require('!!raw-loader!./code_examples/example.html').default}\`}\n`;
 
 export const codeBlockConfig = () => {
   const docgenInfo = Array.isArray(EuiCodeBlock.__docgenInfo)

--- a/src-docs/src/views/code/playground.js
+++ b/src-docs/src/views/code/playground.js
@@ -2,7 +2,9 @@ import { PropTypes } from 'react-view';
 import { EuiCodeBlock, EuiCode } from '../../../../src/components/';
 import { propUtilityForPlayground } from '../../services/playground';
 
-const codeDemo = `\n{\`${require('!!raw-loader!./code_examples/example.html').default}\`}\n`;
+const codeDemo = `\n{\`${
+  require('!!raw-loader!./code_examples/example.html').default
+}\`}\n`;
 
 export const codeBlockConfig = () => {
   const docgenInfo = Array.isArray(EuiCodeBlock.__docgenInfo)

--- a/src-docs/src/views/package/changelog.js
+++ b/src-docs/src/views/package/changelog.js
@@ -3,7 +3,8 @@ import React from 'react';
 import { EuiMarkdownFormat } from '../../../../src';
 import { GuidePage } from '../../components/guide_page';
 
-const changelogSource = require('!!raw-loader!../../../../CHANGELOG.md').default;
+const changelogSource = require('!!raw-loader!../../../../CHANGELOG.md')
+  .default;
 
 export const Changelog = {
   name: 'Changelog',

--- a/src-docs/src/views/package/changelog.js
+++ b/src-docs/src/views/package/changelog.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { EuiMarkdownFormat } from '../../../../src';
 import { GuidePage } from '../../components/guide_page';
 
-const changelogSource = require('!!raw-loader!../../../../CHANGELOG.md');
+const changelogSource = require('!!raw-loader!../../../../CHANGELOG.md').default;
 
 export const Changelog = {
   name: 'Changelog',


### PR DESCRIPTION
### Summary

More places affected by the `raw-loader` upgrade. This time I searched for !!raw-loader and inspected every use outside of an *_example.js* file - where the import's `default` is handled in another way.

Fixes:
* https://elastic.github.io/eui/#/forms/form-controls Demo JS tab
* https://elastic.github.io/eui/#/editors-syntax/code **Code block** section
* https://elastic.github.io/eui/#/editors-syntax/code/playground - Playground tab, first example reads "[object Module]"
* https://elastic.github.io/eui/#/package/changelog 🤦 
