### PR TITLE
Fix for EuiSelectableTemplateSitewide closing when clicking a non-focusable element in its popover

### DIFF
--- a/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
@@ -26,7 +26,6 @@ import React, {
   useEffect,
 } from 'react';
 import classNames from 'classnames';
-import { useCombinedRefs } from '../../../services';
 import { EuiSelectable, EuiSelectableProps } from '../selectable';
 import { EuiPopoverTitle, EuiPopoverFooter } from '../../popover';
 import { EuiPopover, Props as PopoverProps } from '../../popover/popover';
@@ -44,6 +43,7 @@ import {
 } from '../../../services/breakpoint';
 import { throttle } from '../../color_picker/utils';
 import { EuiSpacer } from '../../spacer';
+import { EuiOutsideClickDetector } from '../../outside_click_detector';
 
 export type EuiSelectableTemplateSitewideProps = Partial<
   Omit<EuiSelectableProps<{ [key: string]: any }>, 'options'>
@@ -131,7 +131,6 @@ export const EuiSelectableTemplateSitewide: FunctionComponent<EuiSelectableTempl
   /**
    * Popover helpers
    */
-  const [popoverRef, setPopoverRef] = useState<HTMLElement | null>(null);
   const [popoverIsOpen, setPopoverIsOpen] = useState(false);
   const { closePopover: _closePopover, panelRef, width, ...popoverRest } = {
     ...popoverProps,
@@ -148,7 +147,6 @@ export const EuiSelectableTemplateSitewide: FunctionComponent<EuiSelectableTempl
 
   // Width applied to the internal div
   const popoverWidth: CSSProperties['width'] = width || 600;
-  const setPanelRef = useCombinedRefs([setPopoverRef, panelRef]);
 
   /**
    * Search helpers
@@ -163,15 +161,6 @@ export const EuiSelectableTemplateSitewide: FunctionComponent<EuiSelectableTempl
   const onSearchInput = (e: React.FormEvent<HTMLInputElement>) => {
     searchProps && searchProps.onInput && searchProps.onInput(e);
     setPopoverIsOpen(true);
-  };
-
-  const searchOnBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    searchProps && searchProps.onBlur && searchProps.onBlur(e);
-    if (canShowPopoverButton) return;
-
-    if (!popoverRef?.contains(e.relatedTarget as HTMLElement)) {
-      setPopoverIsOpen(false);
-    }
   };
 
   /**
@@ -234,68 +223,69 @@ export const EuiSelectableTemplateSitewide: FunctionComponent<EuiSelectableTempl
   }
 
   return (
-    <EuiSelectable
-      isLoading={isLoading}
-      options={formattedOptions}
-      renderOption={euiSelectableTemplateSitewideRenderOptions}
-      singleSelection={true}
-      searchProps={{
-        placeholder: searchPlaceholder,
-        isClearable: true,
-        ...searchProps,
-        onFocus: searchOnFocus,
-        onBlur: searchOnBlur,
-        onInput: onSearchInput,
-        className: searchClasses,
-      }}
-      listProps={{
-        rowHeight: 68,
-        showIcons: false,
-        onFocusBadge: {
-          iconSide: 'right',
-          children: (
-            <EuiI18n
-              token="euiSelectableTemplateSitewide.onFocusBadgeGoTo"
-              default="Go to"
-            />
-          ),
-        },
-        ...listProps,
-        className: listClasses,
-      }}
-      loadingMessage={loadingMessage}
-      emptyMessage={emptyMessage}
-      noMatchesMessage={emptyMessage}
-      {...rest}
-      className={classes}
-      searchable>
-      {(list, search) => (
-        <EuiPopover
-          panelPaddingSize="none"
-          isOpen={popoverIsOpen}
-          ownFocus={!!popoverTrigger}
-          display={popoverTrigger ? 'inlineBlock' : 'block'}
-          {...popoverRest}
-          panelRef={setPanelRef}
-          button={popoverTrigger ? popoverTrigger : search}
-          closePopover={closePopover}>
-          <div style={{ width: popoverWidth, maxWidth: '100%' }}>
-            {popoverTitle || popoverTrigger ? (
-              <EuiPopoverTitle>
-                {popoverTitle}
-                {popoverTitle && search && <EuiSpacer />}
-                {search}
-              </EuiPopoverTitle>
-            ) : (
-              undefined
-            )}
-            {list}
-            {popoverFooter && (
-              <EuiPopoverFooter>{popoverFooter}</EuiPopoverFooter>
-            )}
-          </div>
-        </EuiPopover>
-      )}
-    </EuiSelectable>
+    <EuiOutsideClickDetector onOutsideClick={() => setPopoverIsOpen(false)}>
+      <EuiSelectable
+        isLoading={isLoading}
+        options={formattedOptions}
+        renderOption={euiSelectableTemplateSitewideRenderOptions}
+        singleSelection={true}
+        searchProps={{
+          placeholder: searchPlaceholder,
+          isClearable: true,
+          ...searchProps,
+          onFocus: searchOnFocus,
+          onInput: onSearchInput,
+          className: searchClasses,
+        }}
+        listProps={{
+          rowHeight: 68,
+          showIcons: false,
+          onFocusBadge: {
+            iconSide: 'right',
+            children: (
+              <EuiI18n
+                token="euiSelectableTemplateSitewide.onFocusBadgeGoTo"
+                default="Go to"
+              />
+            ),
+          },
+          ...listProps,
+          className: listClasses,
+        }}
+        loadingMessage={loadingMessage}
+        emptyMessage={emptyMessage}
+        noMatchesMessage={emptyMessage}
+        {...rest}
+        className={classes}
+        searchable>
+        {(list, search) => (
+          <EuiPopover
+            panelPaddingSize="none"
+            isOpen={popoverIsOpen}
+            ownFocus={!!popoverTrigger}
+            display={popoverTrigger ? 'inlineBlock' : 'block'}
+            {...popoverRest}
+            panelRef={panelRef}
+            button={popoverTrigger ? popoverTrigger : search}
+            closePopover={closePopover}>
+            <div style={{ width: popoverWidth, maxWidth: '100%' }}>
+              {popoverTitle || popoverTrigger ? (
+                <EuiPopoverTitle>
+                  {popoverTitle}
+                  {popoverTitle && search && <EuiSpacer />}
+                  {search}
+                </EuiPopoverTitle>
+              ) : (
+                undefined
+              )}
+              {list}
+              {popoverFooter && (
+                <EuiPopoverFooter>{popoverFooter}</EuiPopoverFooter>
+              )}
+            </div>
+          </EuiPopover>
+        )}
+      </EuiSelectable>
+    </EuiOutsideClickDetector>
   );
 };


### PR DESCRIPTION
### Summary

Switches the existing onBlur handler to rely on **EuiOutsideClickDetector** instead. Our outside click detection is already setup to properly track clicks through React's portal content.

![sitewide_template_onclick](https://user-images.githubusercontent.com/313125/93515604-1c594380-f8e6-11ea-8811-9dde774dbcb9.gif)

This change, in its current form, breaks closing the popover when tabbing out of the input box. Because of the existing complexity in this component I wanted to have a discussion around this instead of blindly fixing and risking breaking something else. My thoughts:

* onKeyDown could test for a `tab` and close the popover
* onBlur hander could be re-added with an update to only close the popover if there is a `relatedTarget` defined

I'm leaning toward the 2nd one, but very open to suggestions.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [x] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
