### PR TITLE
[DOCS] EuiGlobalToastList Use string instead of number for toast id

### DIFF
--- a/src-docs/src/views/toast/toast_list.js
+++ b/src-docs/src/views/toast/toast_list.js
@@ -96,7 +96,7 @@ export default () => {
     ];
 
     return {
-      id: toastId++,
+      id: `toast${toastId++}`,
       ...toasts[Math.floor(Math.random() * toasts.length)],
     };
   };


### PR DESCRIPTION
### Summary

Fixes #2790 

- Fixed documentation issue of using number as toast id.

### Checklist

~~- [ ] Check against **all themes** for compatibility in both light and dark modes~~
~~- [ ] Checked in **mobile**~~
~~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~~
~~- [ ] Props have proper **autodocs**~~
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
~~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~~
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
~~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~~
