### PR TITLE
Fixed EuiTextColor props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 - Added footer row to `EuiDataGrid` via the `renderFooterCellValue` prop ([#3770](https://github.com/elastic/eui/pull/3770))
 - Added column header menu to `EuiDataGrid` ([#3087](https://github.com/elastic/eui/pull/3087))
 
+**Bug fixes**
+
+- Fixed `EuiTextColor` playground error due to `color` prop not captured by the documentation generator ([#4058](https://github.com/elastic/eui/pull/4058))
+
 ## [`29.0.0`](https://github.com/elastic/eui/tree/v29.0.0)
 
 - Added `.browserslistrc` for global browser support reference ([#4022](https://github.com/elastic/eui/pull/4022))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 **Bug fixes**
 
-- Fixed `EuiTextColor` playground error due to `color` prop not captured by the documentation generator ([#4058](https://github.com/elastic/eui/pull/4058))
+- Fixed `EuiTextColor` playground error due to `color` prop not getting captured by the documentation generator ([#4058](https://github.com/elastic/eui/pull/4058))
 
 ## [`29.0.0`](https://github.com/elastic/eui/tree/v29.0.0)
 

--- a/src/components/text/text_color.tsx
+++ b/src/components/text/text_color.tsx
@@ -36,8 +36,10 @@ export type TextColor = keyof typeof colorsToClassNameMap;
 export const COLORS = keysOf(colorsToClassNameMap);
 
 type Props = CommonProps &
-  HTMLAttributes<HTMLDivElement> &
-  HTMLAttributes<HTMLSpanElement> & {
+  Omit<
+    HTMLAttributes<HTMLDivElement> & HTMLAttributes<HTMLSpanElement>,
+    'color'
+  > & {
     color?: TextColor;
     /**
      * Determines the root element
@@ -49,7 +51,7 @@ export const EuiTextColor: FunctionComponent<Props> = ({
   children,
   color = 'default',
   className,
-  component: Component = 'span',
+  component = 'span',
   ...rest
 }) => {
   const classes = classNames(
@@ -57,6 +59,7 @@ export const EuiTextColor: FunctionComponent<Props> = ({
     colorsToClassNameMap[color],
     className
   );
+  const Component = component;
 
   return (
     <Component className={classes} {...rest}>


### PR DESCRIPTION
### Summary

Fixes #4057: Override the `color` prop inherit from the `HTMLDivElement` and `HTMLSpanElement`

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs**
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
