### PR TITLE
[EuiCallout] Remove border radius from Amsterdam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 - Fixed `EuiTextColor` playground error due to `color` prop not getting captured by the documentation generator ([#4058](https://github.com/elastic/eui/pull/4058))
 
+**Theme: Amsterdam**
+
+- Removed `border-radius` from `EuiCallout` ([#4066](https://github.com/elastic/eui/pull/4066))
+
 ## [`29.0.0`](https://github.com/elastic/eui/tree/v29.0.0)
 
 - Added `.browserslistrc` for global browser support reference ([#4022](https://github.com/elastic/eui/pull/4022))

--- a/src/themes/eui-amsterdam/overrides/_call_out.scss
+++ b/src/themes/eui-amsterdam/overrides/_call_out.scss
@@ -1,5 +1,4 @@
 .euiCallOut {
-  border-radius: $euiBorderRadius;
   border-left: none;
 
   .euiCallOutHeader__title {


### PR DESCRIPTION
### Summary

We decided to remove border radius on EuiCallout because there were some situations where the callout looked very similar to the new hollow button style. 

![image](https://user-images.githubusercontent.com/847805/93909518-d0cfdc80-fccd-11ea-946a-d43c2b8d9a3b.png)


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [ ] ~Checked in **mobile**~
- [ ] ~Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- [ ] ~Props have proper **autodocs**~
- [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [ ] ~Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**`~
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
