### PR TITLE
Add aria-label to EuiTreeView snippet

### DIFF
--- a/src-docs/src/views/tree_view/tree_view_example.js
+++ b/src-docs/src/views/tree_view/tree_view_example.js
@@ -43,6 +43,7 @@ const treeViewSnippet = [
       id: 'item_two',
     }
   ]}
+  aria-label="Sample Tree View"
 />`,
 ];
 


### PR DESCRIPTION
### Summary

Added aria-label to EuiTreeView snippet for easier copy-paste from snippet experience. As aria-label parameter is required, so copy-paste from EuiTreeView snippet before this change gives a TypeScript error.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
