### PR TITLE
[Docs] Add fragment URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "@types/react": "^16.9.34",
     "@types/react-dom": "^16.9.6",
     "@types/react-is": "^16.7.1",
+    "@types/react-router-dom": "^5.1.5",
     "@types/resize-observer-browser": "^0.1.3",
     "@types/tabbable": "^3.1.0",
     "@types/uuid": "^8.3.0",

--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -96,20 +96,6 @@ export class GuidePageChrome extends Component {
     }, 250);
   };
 
-  onClickLink = id => {
-    // Scroll to element.
-    scrollToSelector(`#${id}`);
-
-    if (this._isMounted)
-      this.setState(
-        {
-          search: '',
-          isSideNavOpenOnMobile: false,
-        },
-        this.scrollNavSectionIntoView
-      );
-  };
-
   onClickRoute = () => {
     if (this._isMounted)
       this.setState(
@@ -119,12 +105,6 @@ export class GuidePageChrome extends Component {
         },
         this.scrollNavSectionIntoView
       );
-
-    // To delay scroll to top when switched to a new page
-    setTimeout(() => {
-      if (document.body) document.body.scrollTop = 0;
-      if (document.documentElement) document.documentElement.scrollTop = 0;
-    }, 0);
   };
 
   onButtonClick() {
@@ -229,8 +209,7 @@ export class GuidePageChrome extends Component {
       return {
         id: `subSection-${id}`,
         name,
-        href,
-        onClick: this.onClickLink.bind(this, id),
+        href: href.concat(`#${id}`),
       };
     });
   };

--- a/src-docs/src/components/scroll_to_hash.tsx
+++ b/src-docs/src/components/scroll_to_hash.tsx
@@ -1,0 +1,22 @@
+import { useEffect, FunctionComponent } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollToHash: FunctionComponent = () => {
+  const location = useLocation();
+  useEffect(() => {
+    setTimeout(() => {
+      const element = document.getElementById(location.hash.replace('#', ''));
+      if (element) {
+        element.scrollIntoView({ behavior: 'smooth' });
+      } else {
+        window.scrollTo({
+          behavior: 'auto',
+          top: 0,
+        });
+      }
+    }, 500);
+  }, [location]);
+  return null;
+};
+
+export default ScrollToHash;

--- a/src-docs/src/components/scroll_to_hash.tsx
+++ b/src-docs/src/components/scroll_to_hash.tsx
@@ -4,17 +4,15 @@ import { useLocation } from 'react-router-dom';
 const ScrollToHash: FunctionComponent = () => {
   const location = useLocation();
   useEffect(() => {
-    setTimeout(() => {
-      const element = document.getElementById(location.hash.replace('#', ''));
-      if (element) {
-        element.scrollIntoView({ behavior: 'smooth' });
-      } else {
-        window.scrollTo({
-          behavior: 'auto',
-          top: 0,
-        });
-      }
-    }, 500);
+    const element = document.getElementById(location.hash.replace('#', ''));
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth' });
+    } else {
+      window.scrollTo({
+        behavior: 'auto',
+        top: 0,
+      });
+    }
   }, [location]);
   return null;
 };

--- a/src-docs/src/index.js
+++ b/src-docs/src/index.js
@@ -20,6 +20,7 @@ import themeDark from './theme_dark.scss';
 import themeAmsterdamLight from './theme_amsterdam_light.scss';
 import themeAmsterdamDark from './theme_amsterdam_dark.scss';
 import { ThemeProvider } from './components/with_theme/theme_context';
+import ScrollToHash from './components/scroll_to_hash';
 
 registerTheme('light', [themeLight]);
 registerTheme('dark', [themeDark]);
@@ -50,6 +51,7 @@ ReactDOM.render(
   <Provider store={store}>
     <ThemeProvider>
       <Router history={history}>
+        <ScrollToHash />
         <Switch>
           {routes.map(
             ({ name, path, sections, isNew, component, from, to }, i) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1418,6 +1418,11 @@
   resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.4.tgz#8c3496bd1b50cc04aeefd691140aa571d4dbfa34"
   integrity sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==
 
+"@types/history@*":
+  version "4.7.8"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.8.tgz#49348387983075705fe8f4e02fb67f7daaec4934"
+  integrity sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.0.tgz#551a4589b6ee2cc9c1dff08056128aec29b94880"
@@ -1530,6 +1535,23 @@
   resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-16.7.1.tgz#d3f1c68c358c00ce116b55ef5410cf486dd08539"
   integrity sha512-dMLFD2cCsxtDgMkTydQCM0PxDq8vwc6uN5M/jRktDfYvH3nQj6pjC9OrCXS2lKlYoYTNJorI/dI8x9dpLshexQ==
   dependencies:
+    "@types/react" "*"
+
+"@types/react-router-dom@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.1.5.tgz#7c334a2ea785dbad2b2dcdd83d2cf3d9973da090"
+  integrity sha512-ArBM4B1g3BWLGbaGvwBGO75GNFbLDUthrDojV2vHLih/Tq8M+tgvY1DSwkuNrPSwdp/GUL93WSEpTZs8nVyJLw==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.8.tgz#4614e5ba7559657438e17766bb95ef6ed6acc3fa"
+  integrity sha512-HzOyJb+wFmyEhyfp4D4NYrumi+LQgQL/68HvJO+q6XtuHSDvw6Aqov7sCAhjbNq3bUPgPqbdvjXC5HeB2oEAPg==
+  dependencies:
+    "@types/history" "*"
     "@types/react" "*"
 
 "@types/react-virtualized-auto-sizer@^1.0.0":


### PR DESCRIPTION
### Summary

I've been thinking about what I was trying to solve with moving our docs to static. One of the things was the **deep linking to EUI doc sections**.

Because moving the docs to static (does it even make sense?) or using the elastic docs might take some time I'm just checking if this PR could be an option to solve this issue.

This PR introduces:

* A fragment URL like `/navigation/button#flush-empty-button`. By clicking to any nav subsection an hash with the subsection ID is added to the end of the URL. But it's also possible to pass directly the URL to the address bar.
* When the URL changes we check if it contains a `fragment URL`. If yes,  the page scroll to that ID element. If not it scrolls to the top. 

### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
