### PR TITLE
In-memory table docs linked to search bar (#4061)

### DIFF
--- a/src-docs/src/views/tables/in_memory/in_memory_search_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_search_section.js
@@ -24,12 +24,13 @@ export const searchSection = {
   text: (
     <div>
       <p>
-        The example shows how to configure <strong>EuiInMemoryTable</strong> to
-        display a search bar.
-        You can read more about search bar{' '}
+        The example shows how to configure <strong>EuiInMemoryTable </strong>
+        to display a search bar by passing the search prop. You can read more
+        about the search bar&apos;s properties and its syntax{' '}
         <Link to="/forms/search-bar">
           <strong>here</strong>
-        </Link>{' '}.
+        </Link>{' '}
+        .
       </p>
     </div>
   ),

--- a/src-docs/src/views/tables/in_memory/in_memory_search_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_search_section.js
@@ -4,6 +4,7 @@ import { renderToHtml } from '../../../services';
 
 import { Table } from './in_memory_search';
 import { propsInfo } from './props_info';
+import { Link } from 'react-router-dom';
 
 const source = require('!!raw-loader!./in_memory_search');
 const html = renderToHtml(Table);
@@ -25,6 +26,10 @@ export const searchSection = {
       <p>
         The example shows how to configure <strong>EuiInMemoryTable</strong> to
         display a search bar.
+        You can read more about search bar{' '}
+        <Link to="/forms/search-bar">
+          <strong>here</strong>
+        </Link>{' '}.
       </p>
     </div>
   ),


### PR DESCRIPTION
### Summary
Linked the In-memory table example with search bar to the search bar syntax docs.
[Link of issue](https://github.com/elastic/eui/issues/4061)
This is my first PR. Let me know if you have any feedback!

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
