### PR TITLE
[EuiComboBox] Fix rowHeight and singleSelection focus issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 - Improved contrast for `EuiIcon` and `EuiButtonIcon` named colors. This affects `EuiHealth` which uses the `EuiIcon` colors. ([#4049](https://github.com/elastic/eui/pull/4049))
 - Added color `accent` to `EuiButtonIcon` ([#4049](https://github.com/elastic/eui/pull/4049))
 
+**Bug fixes**
+
+- Fixed `EuiComboBox` `rowHeight` prop causing the height of the option list to be miscalculated ([#4072](https://github.com/elastic/eui/pull/4072))
+- Fixed `EuiComboBox` not focusing on the selected option if `selectedOptions` was set without reference to `options` ([#4072](https://github.com/elastic/eui/pull/4072))
+
 **Theme: Amsterdam**
 
 - Removed `border-radius` from `EuiCallout` ([#4066](https://github.com/elastic/eui/pull/4066))

--- a/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
+++ b/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
@@ -317,7 +317,7 @@ exports[`props options list is rendered 1`] = `
       class="euiComboBoxOptionsList__rowWrap"
     >
       <div
-        style="position: relative; height: 203px; width: 0px; overflow: auto; direction: ltr;"
+        style="position: relative; height: 200px; width: 0px; overflow: auto; direction: ltr;"
       >
         <div
           id="htmlid_listbox"

--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -730,10 +730,11 @@ export class EuiComboBox<T> extends Component<
       Boolean(this.props.singleSelection) &&
       this.props.selectedOptions.length === 1
     ) {
+      const selectedOptionIndex = this.state.matchingOptions.findIndex(
+        option => option.label === this.props.selectedOptions[0].label
+      );
       this.setState({
-        activeOptionIndex: this.state.matchingOptions.indexOf(
-          this.props.selectedOptions[0]
-        ),
+        activeOptionIndex: selectedOptionIndex,
       });
     } else {
       this.clearActiveOption();

--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -365,6 +365,21 @@ export class EuiComboBox<T> extends Component<
     });
   };
 
+  focusSelectedOption = () => {
+    // If singleSelection is on and an option has been selected, set that option as active
+    if (
+      Boolean(this.props.singleSelection) &&
+      this.props.selectedOptions.length === 1
+    ) {
+      const selectedOptionIndex = this.state.matchingOptions.findIndex(
+        option => option.label === this.props.selectedOptions[0].label
+      );
+      this.setState({
+        activeOptionIndex: selectedOptionIndex,
+      });
+    }
+  };
+
   incrementActiveOptionIndex = (amount: number) => {
     // If there are no options available, do nothing.
     if (!this.state.matchingOptions.length) {
@@ -530,6 +545,7 @@ export class EuiComboBox<T> extends Component<
     }
 
     this.openList();
+    this.focusSelectedOption();
 
     this.setState({ hasFocus: true });
   };
@@ -595,6 +611,7 @@ export class EuiComboBox<T> extends Component<
           this.incrementActiveOptionIndex(-1);
         } else {
           this.openList();
+          this.focusSelectedOption();
         }
         break;
 
@@ -605,6 +622,7 @@ export class EuiComboBox<T> extends Component<
           this.incrementActiveOptionIndex(1);
         } else {
           this.openList();
+          this.focusSelectedOption();
         }
         break;
 
@@ -726,17 +744,7 @@ export class EuiComboBox<T> extends Component<
     }
 
     // If the user does this from a state in which an option has focus, then we need to reset it or clear it.
-    if (
-      Boolean(this.props.singleSelection) &&
-      this.props.selectedOptions.length === 1
-    ) {
-      const selectedOptionIndex = this.state.matchingOptions.findIndex(
-        option => option.label === this.props.selectedOptions[0].label
-      );
-      this.setState({
-        activeOptionIndex: selectedOptionIndex,
-      });
-    } else {
+    if (!Boolean(this.props.singleSelection)) {
       this.clearActiveOption();
     }
   };

--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -365,21 +365,6 @@ export class EuiComboBox<T> extends Component<
     });
   };
 
-  focusSelectedOption = () => {
-    // If singleSelection is on and an option has been selected, set that option as active
-    if (
-      Boolean(this.props.singleSelection) &&
-      this.props.selectedOptions.length === 1
-    ) {
-      const selectedOptionIndex = this.state.matchingOptions.findIndex(
-        option => option.label === this.props.selectedOptions[0].label
-      );
-      this.setState({
-        activeOptionIndex: selectedOptionIndex,
-      });
-    }
-  };
-
   incrementActiveOptionIndex = (amount: number) => {
     // If there are no options available, do nothing.
     if (!this.state.matchingOptions.length) {
@@ -545,7 +530,6 @@ export class EuiComboBox<T> extends Component<
     }
 
     this.openList();
-    this.focusSelectedOption();
 
     this.setState({ hasFocus: true });
   };
@@ -611,7 +595,6 @@ export class EuiComboBox<T> extends Component<
           this.incrementActiveOptionIndex(-1);
         } else {
           this.openList();
-          this.focusSelectedOption();
         }
         break;
 
@@ -622,7 +605,6 @@ export class EuiComboBox<T> extends Component<
           this.incrementActiveOptionIndex(1);
         } else {
           this.openList();
-          this.focusSelectedOption();
         }
         break;
 
@@ -744,7 +726,17 @@ export class EuiComboBox<T> extends Component<
     }
 
     // If the user does this from a state in which an option has focus, then we need to reset it or clear it.
-    if (!Boolean(this.props.singleSelection)) {
+    if (
+      Boolean(this.props.singleSelection) &&
+      this.props.selectedOptions.length === 1
+    ) {
+      const selectedOptionIndex = this.state.matchingOptions.findIndex(
+        option => option.label === this.props.selectedOptions[0].label
+      );
+      this.setState({
+        activeOptionIndex: selectedOptionIndex,
+      });
+    } else {
       this.clearActiveOption();
     }
   };

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
@@ -450,9 +450,12 @@ export class EuiComboBoxOptionsList<T> extends Component<
       matchingOptions.length < 7 ? matchingOptions.length : 7;
     const height = numVisibleOptions * rowHeight;
 
+    // bounded by max-height of euiComboBoxOptionsList__rowWrap
+    const boundedHeight = height > 200 ? 200 : height;
+
     const optionsList = (
       <FixedSizeList
-        height={height}
+        height={boundedHeight}
         onScroll={onScroll}
         itemCount={matchingOptions.length}
         itemSize={rowHeight}


### PR DESCRIPTION
### Summary

There're 2 issues that I discovered in EuiComboBox. 

The first issue is the miscalculation of `height` when the `rowHeight` prop is used.

![rowheight](https://user-images.githubusercontent.com/18256786/94098269-dc044300-fe5a-11ea-9af5-8688ddfd1dd0.gif)

This is because the list container uses the class `euiComboBoxOptionsList__rowWrap`, which has a `max-height` of `200px`. I added a condition to limit the height of `react-window` to `200px` and updated the snapshot as well. 

This also fixes a small visual issue: With the default rowHeight set to `29px`, the list height was `203px` (7 visible options * 29) which was actually pushing the bottom arrow of the scrollbar down by 3px.
![image](https://user-images.githubusercontent.com/18256786/94098709-ce9b8880-fe5b-11ea-8ff0-54f6f28682b7.png)

---

The second issue is only relevant when `singleSelection` is used. The selected option isn't focused or scrolled to if we didn't use the `options` variable to reference the selected value. 

![selectIndex](https://user-images.githubusercontent.com/18256786/94098955-57b2bf80-fe5c-11ea-9689-4e3cf267a0e2.gif)

This is because the `activeOptionIndex` is calculated using `indexOf`, which determines the equality between objects by reference. I replaced it with `findIndex` and compare labels instead. I realize this is a costlier function to run, but I saw `findIndex` being used in another function and thought it was okay.

Here's a [codesandbox](https://codesandbox.io/s/eui-issue-ulk5f?file=/index.js) replicating the 2 problems 

This is my first PR, so please let me know if I missed anything.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, ~~**Safari**~~, **Edge**, and **Firefox** (I don't have access to Safari)
- ~~[ ] Props have proper **autodocs**~~
- ~~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
- ~~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- ~~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
