### PR TITLE
[Docs] Prevent encoded urls with a section ID to fail

### DIFF
--- a/src-docs/src/index.js
+++ b/src-docs/src/index.js
@@ -56,11 +56,25 @@ ReactDOM.render(
           {routes.map(
             ({ name, path, sections, isNew, component, from, to }, i) => {
               const mainComponent = () => (
-                <Route key={i} path={`/${path}`}>
-                  <AppContainer currentRoute={{ name, path, sections, isNew }}>
-                    {createElement(component, {})}
-                  </AppContainer>
-                </Route>
+                <Route
+                  key={i}
+                  path={`/${path}`}
+                  render={props => {
+                    const { location } = props;
+                    // prevents encoded urls with a section id to fail
+                    if (location.pathname.includes('%23')) {
+                      const url = decodeURIComponent(location.pathname);
+                      return <Redirect push to={url} />;
+                    } else {
+                      return (
+                        <AppContainer
+                          currentRoute={{ name, path, sections, isNew }}>
+                          {createElement(component, {})}
+                        </AppContainer>
+                      );
+                    }
+                  }}
+                />
               );
 
               if (from)


### PR DESCRIPTION
### Summary

After a few attempts here's my solution to prevent encoded URLs with a section ID like [https://eui.elastic.co/pr_4069/#/navigation/button%23ghost](https://eui.elastic.co/pr_4069/#/navigation/button%23ghost ) to fail in Chrome and other browsers.

### Solution

I'm checking if the pathname contains a `%23` which is the encoded #. If it contains I'll decode it and redirect the URL to it. 

Feel free to find better solutions! 🎉 

### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~

