### PR TITLE
[Amsterdam] New tab styles

### DIFF
--- a/src/themes/eui-amsterdam/overrides/_index.scss
+++ b/src/themes/eui-amsterdam/overrides/_index.scss
@@ -11,6 +11,7 @@
 @import 'overlay_mask';
 @import 'popover';
 @import 'progress';
+@import 'tabs';
 @import 'text';
 @import 'form_control_layout';
 @import 'form_control_layout_delimited';

--- a/src/themes/eui-amsterdam/overrides/_tabs.scss
+++ b/src/themes/eui-amsterdam/overrides/_tabs.scss
@@ -1,0 +1,17 @@
+.euiTabs {
+  background-color: $euiColorLightestShade;
+  border-radius: $euiBorderRadius;
+  padding: 0 .75rem;
+
+  // Unsets the bottom border on tab groups
+  &:not(.euiTabs--condensed)::before {
+    height: .25rem;
+    background-color: $euiColoEmptyShade;
+  }
+}
+
+.euiTab {
+  &:focus {
+    background-color: transparentize($color: $euiColorLightShade, $amount: .7);
+  }
+}

--- a/src/themes/eui-amsterdam/overrides/_tabs.scss
+++ b/src/themes/eui-amsterdam/overrides/_tabs.scss
@@ -5,8 +5,8 @@
 
   // Unsets the bottom border on tab groups
   &:not(.euiTabs--condensed)::before {
-    height: .25rem;
-    background-color: $euiColoEmptyShade;
+    // height: .25rem;
+    background-color: $euiColorLightestShade;
   }
 }
 


### PR DESCRIPTION
### Summary

Introduces new tab styles for the Amsterdam theme.

<img width="998" alt="Screen Shot 2020-09-24 at 9 01 21 AM" src="https://user-images.githubusercontent.com/739960/94171221-dcdeaa00-fe45-11ea-9301-f1224cc2e5f3.png">

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Checked in Kibana within existing apps
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

### Special Attention
There will be some instances that require special attention when migrating in Kibana.
1. Solutions (like Observability) that use tabs as navigation will need to address some CSS overrides. 
<img width="1569" alt="Screen Shot 2020-09-23 at 1 54 44 PM" src="https://user-images.githubusercontent.com/739960/94172592-88d4c500-fe47-11ea-8bba-efbd76328ca3.png">

2. [Discuss] Use cases where tab content with a shaded background is adjacent to the tab bar will need a spacer or margin.
![image](https://user-images.githubusercontent.com/739960/94172525-72c70480-fe47-11ea-81ed-54977bfcebf6.png)
