### PR TITLE
Remove 'master' section of changelog in docs

### DIFF
--- a/src-docs/src/views/package/changelog.js
+++ b/src-docs/src/views/package/changelog.js
@@ -3,8 +3,10 @@ import React from 'react';
 import { EuiMarkdownFormat } from '../../../../src';
 import { GuidePage } from '../../components/guide_page';
 
-const changelogSource = require('!!raw-loader!../../../../CHANGELOG.md')
-  .default;
+const changelogSource = require('!!raw-loader!../../../../CHANGELOG.md').default.replace(
+  /## \[`master`\].+?##/s, // remove the `master` heading & contents
+  '##'
+);
 
 export const Changelog = {
   name: 'Changelog',


### PR DESCRIPTION
### Summary

Remove the `master` section from the docs' changelog rendering. It's pretty meaningless in local development and misleading in the published version.

<img width="932" alt="Screen Shot 2020-09-24 at 2 17 57 PM" src="https://user-images.githubusercontent.com/313125/94195836-c6017d00-fe70-11ea-8dfa-fe713605670a.png">
