### PR TITLE
Fix EuiTitle lineheight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ No public interface changes since `29.2.0`.
 
 - Removed `border-radius` from `EuiCallout` ([#4066](https://github.com/elastic/eui/pull/4066))
 - Updated styles for `EuiToast` ([#4076](https://github.com/elastic/eui/pull/4076))
+- Fixed `line-height` on `EuiTitle` ([#4079](https://github.com/elastic/eui/pull/4079))
 
 ## [`29.1.0`](https://github.com/elastic/eui/tree/v29.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `29.2.0`.
+**Theme: Amsterdam**
+
+- Fixed `line-height` on `EuiTitle` ([#4079](https://github.com/elastic/eui/pull/4079))
 
 ## [`29.2.0`](https://github.com/elastic/eui/tree/v29.2.0)
 
@@ -10,8 +12,7 @@ No public interface changes since `29.2.0`.
 **Theme: Amsterdam**
 
 - Removed `border-radius` from `EuiCallout` ([#4066](https://github.com/elastic/eui/pull/4066))
-- Updarted styles for `EuiToast` ([#4076](https://github.com/elastic/eui/pull/4076))
-- Fixed `line-height` on `EuiTitle` ([#4079](https://github.com/elastic/eui/pull/4079))
+- Updated styles for `EuiToast` ([#4076](https://github.com/elastic/eui/pull/4076))
 
 ## [`29.1.0`](https://github.com/elastic/eui/tree/v29.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ No public interface changes since `29.2.0`.
 **Theme: Amsterdam**
 
 - Removed `border-radius` from `EuiCallout` ([#4066](https://github.com/elastic/eui/pull/4066))
-- Updated styles for `EuiToast` ([#4076](https://github.com/elastic/eui/pull/4076))
+- Updarted styles for `EuiToast` ([#4076](https://github.com/elastic/eui/pull/4076))
 - Fixed `line-height` on `EuiTitle` ([#4079](https://github.com/elastic/eui/pull/4079))
 
 ## [`29.1.0`](https://github.com/elastic/eui/tree/v29.1.0)

--- a/src/themes/eui-amsterdam/global_styling/variables/_typography.scss
+++ b/src/themes/eui-amsterdam/global_styling/variables/_typography.scss
@@ -14,7 +14,7 @@ $euiFontSizeL:     ceil($euiFontSize * 1.57); // 22px // h3
 $euiFontSizeXL:   floor($euiFontSize * 1.93); // 27px // h2
 $euiFontSizeXXL:  floor($euiFontSize * 2.43); // 34px // h1
 
-// Use 8px incrememnts for base gridline
+// Use 8px increments for base gridline
 @function lineHeightFromBaseline($multiplier: 3) {
   @return convertToRem(($euiSize/2)*$multiplier);
 }

--- a/src/themes/eui-amsterdam/global_styling/variables/_typography.scss
+++ b/src/themes/eui-amsterdam/global_styling/variables/_typography.scss
@@ -14,6 +14,11 @@ $euiFontSizeL:     ceil($euiFontSize * 1.57); // 22px // h3
 $euiFontSizeXL:   floor($euiFontSize * 1.93); // 27px // h2
 $euiFontSizeXXL:  floor($euiFontSize * 2.43); // 34px // h1
 
+// Use 8px incrememnts for base gridline
+@function lineHeightFromBaseline($multiplier: 3) {
+  @return convertToRem(($euiSize/2)*$multiplier);
+}
+
 $euiTitles: (
   'xxxs': (
     'font-size': $euiFontSizeXS,


### PR DESCRIPTION
### Summary

This PR fixes an unintended (i think?) consequence of reducing `$euiFontSize` to `14px` which caused `EuiTitle` to use line-heights that increment in units of `7px` (42, 35, 28, 21). I think we should keep `EuiTitle` line-heights as they are in the base theme so that they increment in units of `8px` (48, 40, 32, 24).

### Digging in

![image](https://user-images.githubusercontent.com/847805/94197912-73ca5700-fe84-11ea-9fc9-9f7455e89692.png)

Since our `lineHeightFromBaseline` function references `$euiFontSize` and divides it by 2, changing the font size variable caused our baseline to increment in units of `7px` (14 / 2 = 7) for `EuiTitle`. 

![image](https://user-images.githubusercontent.com/847805/94198018-99576080-fe84-11ea-9ae5-0fa076908bdf.png)

`EuiTitle` is the only component that uses the `lineHeightFromBaseline` function. Because EuiTitle is used in so many places, this `7px` increment throws a lot of components off of our imaginary grid. This can cause elements to align in weird ways, for example:

![image](https://user-images.githubusercontent.com/847805/94207814-6ae28100-fe96-11ea-89bd-7dcf02e1beba.png)

It also feels strange that the medium scale for `EuiText` `h1` uses a 48px line height, whereas the large size for `EuiTitle` uses a 42px line height:

<details><summary>See screenshot</summary>

![Screen Shot 2020-09-24 at 6 42 21 PM](https://user-images.githubusercontent.com/847805/94207550-ceb87a00-fe95-11ea-9e70-a59ac900efc3.png)

</details>

What do you think?

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [ ] ~Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- [ ] ~Props have proper **autodocs**~
- [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [ ] ~Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
