### PR TITLE
A couple fixes for 7.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Added `both` option to `flush` prop of `EuiButtonEmpty` ([#4084](https://github.com/elastic/eui/pull/4084))
+
+**Bug fixes**
+
+- Fixed `EuiRange` and `EuiDualRange` display of internal spacer ([#4084](https://github.com/elastic/eui/pull/4084))
+- Fixed `EuiFieldSearch` padding for the different states ([#4084](https://github.com/elastic/eui/pull/4084))
+- Fixed `EuiCheckableCard` disabled but checked styles ([#4084](https://github.com/elastic/eui/pull/4084))
+
 **Theme: Amsterdam**
 
 - Fixed `line-height` on `EuiTitle` ([#4079](https://github.com/elastic/eui/pull/4079))

--- a/src-docs/src/views/button/button_empty_flush.js
+++ b/src-docs/src/views/button/button_empty_flush.js
@@ -15,5 +15,9 @@ export default () => (
     <EuiFlexItem grow={false}>
       <EuiButtonEmpty flush="right">Flush right</EuiButtonEmpty>
     </EuiFlexItem>
+
+    <EuiFlexItem grow={false}>
+      <EuiButtonEmpty flush="both">Flush both</EuiButtonEmpty>
+    </EuiFlexItem>
   </EuiFlexGroup>
 );

--- a/src-docs/src/views/button/button_example.js
+++ b/src-docs/src/views/button/button_example.js
@@ -253,6 +253,7 @@ export const ButtonExample = {
           the other content in the container.
         </p>
       ),
+      props: { EuiButtonEmpty },
       snippet: buttonOptionFlushSnippet,
       demo: <ButtonOptionFlush />,
     },

--- a/src-docs/src/views/card/card_checkable.js
+++ b/src-docs/src/views/card/card_checkable.js
@@ -74,7 +74,7 @@ export default () => {
           label="Option three (disabled)"
           name={radioName}
           value="radio3"
-          checked={radio === 'radio3'}
+          checked={true}
           onChange={() => setRadio('radio3')}
           disabled
         />

--- a/src-docs/src/views/card/card_checkable.js
+++ b/src-docs/src/views/card/card_checkable.js
@@ -74,7 +74,7 @@ export default () => {
           label="Option three (disabled)"
           name={radioName}
           value="radio3"
-          checked={true}
+          checked={radio === 'radio3'}
           onChange={() => setRadio('radio3')}
           disabled
         />

--- a/src/components/button/button_empty/__snapshots__/button_empty.test.tsx.snap
+++ b/src/components/button/button_empty/__snapshots__/button_empty.test.tsx.snap
@@ -113,6 +113,21 @@ exports[`EuiButtonEmpty props contentProps is rendered 1`] = `
 </button>
 `;
 
+exports[`EuiButtonEmpty props flush both is rendered 1`] = `
+<button
+  class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--flushBoth"
+  type="button"
+>
+  <span
+    class="euiButtonContent euiButtonEmpty__content"
+  >
+    <span
+      class="euiButtonEmpty__text"
+    />
+  </span>
+</button>
+`;
+
 exports[`EuiButtonEmpty props flush left is rendered 1`] = `
 <button
   class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--flushLeft"

--- a/src/components/button/button_empty/_button_empty.scss
+++ b/src/components/button/button_empty/_button_empty.scss
@@ -49,6 +49,24 @@
   }
 }
 
+
+.euiButtonEmpty--flushLeft,
+.euiButtonEmpty--flushRight,
+.euiButtonEmpty--flushBoth {
+  .euiButtonEmpty__content {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.euiButtonEmpty--flushLeft {
+  margin-right: $euiSizeS;
+}
+
+.euiButtonEmpty--flushRight {
+  margin-left: $euiSizeS;
+}
+
 // Modifier naming and colors.
 $euiButtonEmptyTypes: (
   primary: $euiColorPrimary,
@@ -84,22 +102,3 @@ $euiButtonEmptyTypes: (
   }
 }
 
-.euiButtonEmpty--flushLeft {
-  margin-right: $euiSizeS;
-
-  .euiButtonEmpty__content {
-    border-left: none;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-.euiButtonEmpty--flushRight {
-  margin-left: $euiSizeS;
-
-  .euiButtonEmpty__content {
-    border-right: none;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}

--- a/src/components/button/button_empty/button_empty.tsx
+++ b/src/components/button/button_empty/button_empty.tsx
@@ -64,6 +64,7 @@ export type EuiButtonEmptySizes = keyof typeof sizeToClassNameMap;
 const flushTypeToClassNameMap = {
   left: 'euiButtonEmpty--flushLeft',
   right: 'euiButtonEmpty--flushRight',
+  both: 'euiButtonEmpty--flushBoth',
 };
 
 export const FLUSH_TYPES = keysOf(flushTypeToClassNameMap);
@@ -79,7 +80,7 @@ interface CommonEuiButtonEmptyProps extends EuiButtonContentProps, CommonProps {
   color?: EuiButtonEmptyColor;
   size?: EuiButtonEmptySizes;
   /**
-   * Ensure the text of the button sits flush to the left or right side of its container
+   * Ensure the text of the button sits flush to the left, right, or both sides of its container
    */
   flush?: keyof typeof flushTypeToClassNameMap;
   /**

--- a/src/components/card/checkable_card/_checkable_card.scss
+++ b/src/components/card/checkable_card/_checkable_card.scss
@@ -5,17 +5,15 @@
   overflow: hidden; // Hides background color inside panel rounded corners
 
   &:not(.euiCheckableCard-isDisabled) {
+    &.euiCheckableCard-isChecked {
+      border-color: $euiColorPrimary;
+    }
+
     &:focus-within {
       @include euiFocusRing;
     }
   }
 }
-
-.euiCheckableCard-isChecked {
-  border-color: $euiColorPrimary;
-}
-
-
 
 .euiCheckableCard__row {
   display: flex;

--- a/src/components/form/field_search/_field_search.scss
+++ b/src/components/form/field_search/_field_search.scss
@@ -21,11 +21,31 @@
     display: none; /* 2 */
   }
 
-  &.euiFieldSearch--compressed {
-    @include euiFormControlWithIcon($isIconOptional: false, $side: 'left', $compressed: true);
-  }
-
   &.euiFieldSearch-isClearable {
     @include euiFormControlLayoutPadding(1)
+  }
+
+  &.euiFieldSearch-isLoading {
+    @include euiFormControlLayoutPadding(1);
+  }
+
+  &.euiFieldSearch-isLoading.euiFieldSearch-isClearable {
+    @include euiFormControlLayoutPadding(2);
+  }
+
+  &.euiFieldSearch--compressed {
+    @include euiFormControlWithIcon($isIconOptional: false, $side: 'left', $compressed: true);
+
+    &.euiFieldSearch-isClearable {
+      @include euiFormControlLayoutPadding(1, $compressed: true);
+    }
+
+    &.euiFieldSearch-isLoading {
+      @include euiFormControlLayoutPadding(1, $compressed: true);
+    }
+
+    &.euiFieldSearch-isLoading.euiFieldSearch-isClearable {
+      @include euiFormControlLayoutPadding(2, $compressed: true);
+    }
   }
 }

--- a/src/components/form/range/__snapshots__/dual_range.test.tsx.snap
+++ b/src/components/form/range/__snapshots__/dual_range.test.tsx.snap
@@ -5,9 +5,6 @@ exports[`EuiDualRange allows value prop to accept empty strings 1`] = `
   class="euiRangeWrapper euiDualRange"
 >
   <div
-    class="euiRange__horizontalSpacer"
-  />
-  <div
     aria-hidden="false"
     class="euiRangeTrack"
   >
@@ -22,9 +19,6 @@ exports[`EuiDualRange allows value prop to accept empty strings 1`] = `
       type="range"
     />
   </div>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;
 
@@ -32,9 +26,6 @@ exports[`EuiDualRange allows value prop to accept numbers 1`] = `
 <div
   class="euiRangeWrapper euiDualRange"
 >
-  <div
-    class="euiRange__horizontalSpacer"
-  />
   <div
     aria-hidden="false"
     class="euiRangeTrack"
@@ -58,9 +49,6 @@ exports[`EuiDualRange allows value prop to accept numbers 1`] = `
       type="range"
     />
   </div>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;
 
@@ -144,9 +132,6 @@ exports[`EuiDualRange is rendered 1`] = `
   class="euiRangeWrapper euiDualRange testClass1 testClass2"
 >
   <div
-    class="euiRange__horizontalSpacer"
-  />
-  <div
     aria-hidden="false"
     class="euiRangeTrack"
   >
@@ -172,9 +157,6 @@ exports[`EuiDualRange is rendered 1`] = `
       type="range"
     />
   </div>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;
 
@@ -182,9 +164,6 @@ exports[`EuiDualRange props compressed should render 1`] = `
 <div
   class="euiRangeWrapper euiRangeWrapper--compressed euiDualRange"
 >
-  <div
-    class="euiRange__horizontalSpacer"
-  />
   <div
     aria-hidden="false"
     class="euiRangeTrack"
@@ -208,9 +187,6 @@ exports[`EuiDualRange props compressed should render 1`] = `
       type="range"
     />
   </div>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;
 
@@ -218,9 +194,6 @@ exports[`EuiDualRange props custom ticks should render 1`] = `
 <div
   class="euiRangeWrapper euiDualRange"
 >
-  <div
-    class="euiRange__horizontalSpacer"
-  />
   <div
     aria-hidden="false"
     class="euiRangeTrack"
@@ -269,9 +242,6 @@ exports[`EuiDualRange props custom ticks should render 1`] = `
       type="range"
     />
   </div>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;
 
@@ -279,9 +249,6 @@ exports[`EuiDualRange props disabled should render 1`] = `
 <div
   class="euiRangeWrapper euiDualRange"
 >
-  <div
-    class="euiRange__horizontalSpacer"
-  />
   <div
     aria-hidden="false"
     class="euiRangeTrack euiRangeTrack--disabled"
@@ -306,9 +273,6 @@ exports[`EuiDualRange props disabled should render 1`] = `
       type="range"
     />
   </div>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;
 
@@ -316,9 +280,6 @@ exports[`EuiDualRange props fullWidth should render 1`] = `
 <div
   class="euiRangeWrapper euiRangeWrapper--fullWidth euiDualRange"
 >
-  <div
-    class="euiRange__horizontalSpacer"
-  />
   <div
     aria-hidden="false"
     class="euiRangeTrack"
@@ -342,9 +303,6 @@ exports[`EuiDualRange props fullWidth should render 1`] = `
       type="range"
     />
   </div>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;
 
@@ -429,9 +387,6 @@ exports[`EuiDualRange props labels should render 1`] = `
 <div
   class="euiRangeWrapper euiDualRange"
 >
-  <div
-    class="euiRange__horizontalSpacer"
-  />
   <label
     class="euiRangeLabel euiRangeLabel--min"
   >
@@ -465,9 +420,6 @@ exports[`EuiDualRange props labels should render 1`] = `
   >
     100
   </label>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;
 
@@ -475,9 +427,6 @@ exports[`EuiDualRange props levels should render 1`] = `
 <div
   class="euiRangeWrapper euiDualRange"
 >
-  <div
-    class="euiRange__horizontalSpacer"
-  />
   <div
     aria-hidden="false"
     class="euiRangeTrack"
@@ -513,9 +462,6 @@ exports[`EuiDualRange props levels should render 1`] = `
       type="range"
     />
   </div>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;
 
@@ -523,9 +469,6 @@ exports[`EuiDualRange props range should render 1`] = `
 <div
   class="euiRangeWrapper euiDualRange"
 >
-  <div
-    class="euiRange__horizontalSpacer"
-  />
   <div
     aria-hidden="false"
     class="euiRangeTrack"
@@ -549,9 +492,6 @@ exports[`EuiDualRange props range should render 1`] = `
       type="range"
     />
   </div>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;
 
@@ -609,9 +549,6 @@ exports[`EuiDualRange props ticks should render 1`] = `
 <div
   class="euiRangeWrapper euiDualRange"
 >
-  <div
-    class="euiRange__horizontalSpacer"
-  />
   <div
     aria-hidden="false"
     class="euiRangeTrack"
@@ -695,8 +632,5 @@ exports[`EuiDualRange props ticks should render 1`] = `
       type="range"
     />
   </div>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;

--- a/src/components/form/range/__snapshots__/range.test.tsx.snap
+++ b/src/components/form/range/__snapshots__/range.test.tsx.snap
@@ -29,9 +29,6 @@ exports[`EuiRange allows value prop to accept a number 1`] = `
       </output>
     </div>
   </div>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;
 
@@ -54,9 +51,6 @@ exports[`EuiRange allows value prop to accept empty string 1`] = `
       value=""
     />
   </div>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;
 
@@ -82,9 +76,6 @@ exports[`EuiRange is rendered 1`] = `
       value="8"
     />
   </div>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;
 
@@ -107,9 +98,6 @@ exports[`EuiRange props compressed should render 1`] = `
       value="8"
     />
   </div>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;
 
@@ -157,9 +145,6 @@ exports[`EuiRange props custom ticks should render 1`] = `
       value="8"
     />
   </div>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;
 
@@ -183,9 +168,6 @@ exports[`EuiRange props disabled should render 1`] = `
       value="8"
     />
   </div>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;
 
@@ -208,9 +190,6 @@ exports[`EuiRange props fullWidth should render 1`] = `
       value="8"
     />
   </div>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;
 
@@ -292,9 +271,6 @@ exports[`EuiRange props labels should render 1`] = `
   >
     100
   </label>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;
 
@@ -329,9 +305,6 @@ exports[`EuiRange props levels should render 1`] = `
       value="20"
     />
   </div>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;
 
@@ -362,9 +335,6 @@ exports[`EuiRange props range should render 1`] = `
       value="8"
     />
   </div>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;
 
@@ -480,9 +450,6 @@ exports[`EuiRange props ticks should render 1`] = `
       value="8"
     />
   </div>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;
 
@@ -515,8 +482,5 @@ exports[`EuiRange props value should render 1`] = `
       </output>
     </div>
   </div>
-  <div
-    class="euiRange__horizontalSpacer"
-  />
 </div>
 `;

--- a/src/components/form/range/dual_range.tsx
+++ b/src/components/form/range/dual_range.tsx
@@ -534,7 +534,7 @@ export class EuiDualRange extends Component<EuiDualRangeProps> {
         className={classes}
         fullWidth={fullWidth}
         compressed={compressed}>
-        {!showInputOnly && (
+        {showInput && !showInputOnly && (
           <>
             {minInput}
             <div className="euiRange__horizontalSpacer" />
@@ -632,7 +632,7 @@ export class EuiDualRange extends Component<EuiDualRangeProps> {
           )}
         </EuiRangeTrack>
         {showLabels && <EuiRangeLabel disabled={disabled}>{max}</EuiRangeLabel>}
-        {!showInputOnly && (
+        {showInput && !showInputOnly && (
           <>
             <div className="euiRange__horizontalSpacer" />
             {maxInput}

--- a/src/components/form/range/range.tsx
+++ b/src/components/form/range/range.tsx
@@ -310,7 +310,7 @@ export class EuiRange extends Component<EuiRangeProps> {
             {max}
           </EuiRangeLabel>
         )}
-        {!showInputOnly && (
+        {showInput && !showInputOnly && (
           <>
             <div className="euiRange__horizontalSpacer" />
             {theInput}


### PR DESCRIPTION
**Mostly stylistic fixes...**

# 1. [EuiButtonEmpty] Added `both` to `flush` prop

Closes #4012. Made this a priority to help the Core UI (@MichaelMarcialis).

<img width="342" alt="Screen Shot 2020-09-30 at 14 28 20 PM" src="https://user-images.githubusercontent.com/549577/94725076-386ad500-0329-11eb-8c93-18f28934b227.png">

# 2. [EuiRange & EuiDualRange] Fix when to display the `.euiRange__horizontalSpacer`

This spacer was only supposed to show when the input is being displayed inline. The logic wasn't correct though, which made it always show unless it was the input with dropdown style.

<img width="1132" alt="Screen Shot 2020-09-30 at 14 31 23 PM" src="https://user-images.githubusercontent.com/549577/94725379-a8795b00-0329-11eb-82e6-ceedfe75db67.png">

# 3. [EuiFieldSearch] Fix padding for different states

The current padding affording for the clearable icon wasn't also affording for being mixed with `isLoading` and `compressed` states. This adds more mixin usages for these states.

<img width="981" alt="Screen Shot 2020-09-30 at 14 35 04 PM" src="https://user-images.githubusercontent.com/549577/94725725-3b19fa00-032a-11eb-9d79-2a761fe25869.png">

# 4. [EuiCheckableCard] Better disabled but checked styles

I saw this usage in Kibana where a checked card was also disabled but the blue border was too prominant.

![image](https://user-images.githubusercontent.com/549577/94725801-52f17e00-032a-11eb-809f-8f7679cc66b7.png)

So this PR simply moves the addition of the blue border to only occur if the item is checked but not disabled.

<img width="1028" alt="Screen Shot 2020-09-30 at 14 37 04 PM" src="https://user-images.githubusercontent.com/549577/94725910-7e746880-032a-11eb-973b-b4a232cdf6bb.png">



### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
