### PR TITLE
[EuiToolTip] Add `display` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Added `max-width: 100%` to `EuiKeyPadMenu` to allow it to shrink when its container is smaller than its fixed width ([ #4092](https://github.com/elastic/eui/pull/4092))
 
-- Added `display` prop to `EuiTooltip` to be a means of quick customization for handling display values of `block` or `inline` for the tooltip and anchor; instead of manually adding a class into the prop anchorClassName. ([#4096](https://github.com/elastic/eui/pull/4096))
+- Added `display` prop to `EuiTooltip` ([#4096](https://github.com/elastic/eui/pull/4096))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Added `max-width: 100%` to `EuiKeyPadMenu` to allow it to shrink when its container is smaller than its fixed width ([ #4092](https://github.com/elastic/eui/pull/4092))
 
+- Added `display` prop to `EuiTooltip` to be a means of quick customization for handling display values of `block` or `inline` for the tooltip and anchor; instead of manually adding a class into the prop anchorClassName. ([#4096](https://github.com/elastic/eui/pull/4096))
+
 **Bug fixes**
 
 - Fixed `EuiFieldSearch` padding when `isClearable` but has no `value` ([#4089](https://github.com/elastic/eui/pull/4089))

--- a/src/components/basic_table/__snapshots__/default_item_action.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/default_item_action.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`DefaultItemAction render - button 1`] = `
 <EuiToolTip
   content="action 1"
   delay="long"
+  display="inlineBlock"
   position="top"
 >
   <EuiButtonEmpty
@@ -22,6 +23,7 @@ exports[`DefaultItemAction render - default button 1`] = `
 <EuiToolTip
   content="action 1"
   delay="long"
+  display="inlineBlock"
   position="top"
 >
   <EuiButtonEmpty
@@ -40,6 +42,7 @@ exports[`DefaultItemAction render - icon 1`] = `
 <EuiToolTip
   content="action 1"
   delay="long"
+  display="inlineBlock"
   position="top"
 >
   <EuiButtonIcon
@@ -65,6 +68,7 @@ exports[`DefaultItemAction render - name 1`] = `
 <EuiToolTip
   content="action 1"
   delay="long"
+  display="inlineBlock"
   position="top"
 >
   <EuiButtonEmpty

--- a/src/components/copy/__snapshots__/copy.test.tsx.snap
+++ b/src/components/copy/__snapshots__/copy.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`EuiCopy is rendered 1`] = `
   className="testClass1 testClass2"
   data-test-subj="test subject string"
   delay="regular"
+  display="inlineBlock"
   onMouseOut={[Function]}
   position="top"
 >

--- a/src/components/date_picker/super_date_picker/__snapshots__/super_update_button.test.tsx.snap
+++ b/src/components/date_picker/super_date_picker/__snapshots__/super_update_button.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`EuiSuperUpdateButton is rendered 1`] = `
 <EuiToolTip
   delay="regular"
+  display="inlineBlock"
   position="bottom"
 >
   <EuiButton
@@ -36,6 +37,7 @@ exports[`EuiSuperUpdateButton isDisabled 1`] = `
     />
   }
   delay="regular"
+  display="inlineBlock"
   position="bottom"
 >
   <EuiButton
@@ -63,6 +65,7 @@ exports[`EuiSuperUpdateButton isDisabled 1`] = `
 exports[`EuiSuperUpdateButton isLoading 1`] = `
 <EuiToolTip
   delay="regular"
+  display="inlineBlock"
   position="bottom"
 >
   <EuiButton
@@ -96,6 +99,7 @@ exports[`EuiSuperUpdateButton needsUpdate 1`] = `
     />
   }
   delay="regular"
+  display="inlineBlock"
   position="bottom"
 >
   <EuiButton
@@ -123,6 +127,7 @@ exports[`EuiSuperUpdateButton needsUpdate 1`] = `
 exports[`EuiSuperUpdateButton showTooltip 1`] = `
 <EuiToolTip
   delay="regular"
+  display="inlineBlock"
   position="bottom"
 >
   <EuiButton

--- a/src/components/tool_tip/__snapshots__/tool_tip.test.tsx.snap
+++ b/src/components/tool_tip/__snapshots__/tool_tip.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`EuiToolTip is rendered 1`] = `
 
 exports[`EuiToolTip props display block is rendered 1`] = `
 <span
-  class="euiToolTipAnchor"
+  class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
 >
   <button>
     Trigger

--- a/src/components/tool_tip/__snapshots__/tool_tip.test.tsx.snap
+++ b/src/components/tool_tip/__snapshots__/tool_tip.test.tsx.snap
@@ -10,6 +10,16 @@ exports[`EuiToolTip is rendered 1`] = `
 </span>
 `;
 
+exports[`EuiToolTip props display block is rendered 1`] = `
+<span
+  class="euiToolTipAnchor"
+>
+  <button>
+    Trigger
+  </button>
+</span>
+`;
+
 exports[`EuiToolTip shows tooltip on focus 1`] = `
 <span
   class="euiToolTipAnchor"

--- a/src/components/tool_tip/_tool_tip.scss
+++ b/src/components/tool_tip/_tool_tip.scss
@@ -55,14 +55,6 @@
   }
 }
 
-.euiToolTip--displayBlock {
-  display: block;
-
-  .euiToolTipAnchor {
-    display: block;
-  }
-}
-
 .euiToolTipAnchor {
   display: inline-block;
 
@@ -73,6 +65,10 @@
   *[disabled] {
     pointer-events: none;
   }
+}
+
+.euiToolTipAnchor--displayBlock {
+  display: block;
 }
 
 // Keyframes to animate in the tooltip.

--- a/src/components/tool_tip/_tool_tip.scss
+++ b/src/components/tool_tip/_tool_tip.scss
@@ -55,6 +55,14 @@
   }
 }
 
+.euiToolTip--displayBlock {
+  display: block;
+
+  .euiToolTipAnchor {
+    display: block;
+  }
+}
+
 .euiToolTipAnchor {
   display: inline-block;
 

--- a/src/components/tool_tip/tool_tip.test.tsx
+++ b/src/components/tool_tip/tool_tip.test.tsx
@@ -54,4 +54,18 @@ describe('EuiToolTip', () => {
     await sleep(260); // wait for showToolTip setTimout
     expect(takeMountedSnapshot(component)).toMatchSnapshot();
   });
+
+  describe('props', () => {
+    describe('display block', () => {
+      test('is rendered', () => {
+        const component = render(
+          <EuiToolTip display="block" {...requiredProps}>
+            <button>Trigger</button>
+          </EuiToolTip>
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+  });
 });

--- a/src/components/tool_tip/tool_tip.tsx
+++ b/src/components/tool_tip/tool_tip.tsx
@@ -49,7 +49,7 @@ export const POSITIONS = keysOf(positionsToClassNameMap);
 
 const displayToClassNameMap = {
   inlineBlock: undefined,
-  block: 'euiToolTip--displayBlock',
+  block: 'euiToolTipAnchor--displayBlock',
 };
 
 export const DISPLAY = Object.keys(displayToClassNameMap);
@@ -101,7 +101,7 @@ export interface Props {
    */
   delay: ToolTipDelay;
   /**
-   * CSS display type for both the tooltip and anchor
+   * CSS display type for the tooltip anchor
    */
   display?: keyof typeof displayToClassNameMap;
   /**
@@ -307,11 +307,14 @@ export class EuiToolTip extends Component<Props, State> {
     const classes = classNames(
       'euiToolTip',
       positionsToClassNameMap[this.state.calculatedPosition],
-      display ? displayToClassNameMap[display] : null,
       className
     );
 
-    const anchorClasses = classNames('euiToolTipAnchor', anchorClassName);
+    const anchorClasses = classNames(
+      'euiToolTipAnchor',
+      display ? displayToClassNameMap[display] : null,
+      anchorClassName
+    );
 
     let tooltip;
     if (visible && (content || title)) {

--- a/src/components/tool_tip/tool_tip.tsx
+++ b/src/components/tool_tip/tool_tip.tsx
@@ -47,6 +47,13 @@ const positionsToClassNameMap: { [key in ToolTipPositions]: string } = {
 
 export const POSITIONS = keysOf(positionsToClassNameMap);
 
+const displayToClassNameMap = {
+  inlineBlock: undefined,
+  block: 'euiPopover--displayBlock',
+};
+
+export const DISPLAY = Object.keys(displayToClassNameMap);
+
 export type ToolTipDelay = 'regular' | 'long';
 
 const delayToMsMap: { [key in ToolTipDelay]: number } = {
@@ -94,6 +101,10 @@ export interface Props {
    */
   delay: ToolTipDelay;
   /**
+   * CSS display type for the tooltip
+   */
+  display?: keyof typeof displayToClassNameMap;
+  /**
    * An optional title for your tooltip.
    */
   title?: ReactNode;
@@ -138,6 +149,7 @@ export class EuiToolTip extends Component<Props, State> {
   static defaultProps: Partial<Props> = {
     position: 'top',
     delay: 'regular',
+    display: 'inlineBlock',
   };
 
   clearAnimationTimeout = () => {
@@ -286,6 +298,7 @@ export class EuiToolTip extends Component<Props, State> {
       content,
       title,
       delay,
+      display,
       ...rest
     } = this.props;
 
@@ -294,6 +307,7 @@ export class EuiToolTip extends Component<Props, State> {
     const classes = classNames(
       'euiToolTip',
       positionsToClassNameMap[this.state.calculatedPosition],
+      display ? displayToClassNameMap[display] : null,
       className
     );
 

--- a/src/components/tool_tip/tool_tip.tsx
+++ b/src/components/tool_tip/tool_tip.tsx
@@ -101,7 +101,7 @@ export interface Props {
    */
   delay: ToolTipDelay;
   /**
-   * CSS display type for the tooltip
+   * CSS display type for both the tooltip and anchor
    */
   display?: keyof typeof displayToClassNameMap;
   /**

--- a/src/components/tool_tip/tool_tip.tsx
+++ b/src/components/tool_tip/tool_tip.tsx
@@ -49,7 +49,7 @@ export const POSITIONS = keysOf(positionsToClassNameMap);
 
 const displayToClassNameMap = {
   inlineBlock: undefined,
-  block: 'euiPopover--displayBlock',
+  block: 'euiToolTip--displayBlock',
 };
 
 export const DISPLAY = Object.keys(displayToClassNameMap);


### PR DESCRIPTION
### Summary

This feature adds a `display` prop to the EuiTooltip component to be a means of quick customization for handling display values, instead of manually adding a class into the prop `anchorClassName`.

A similar implementation of this exists in the EuiPopover component.

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
