### PR TITLE
docs: i18n interpolation

### DIFF
--- a/src-docs/src/views/i18n/i18n_example.js
+++ b/src-docs/src/views/i18n/i18n_example.js
@@ -16,6 +16,22 @@ const basicSnippet = [
 `,
 ];
 
+import I18nInterpolation from './i18n_interpolation';
+const i18nInterpolationSource = require('!!raw-loader!./i18n_interpolation');
+const i18nInterpolationHtml = renderToHtml(I18nInterpolation);
+const interpolationSnippet = [
+  `useEuiI18n('filename.greeting', 'Hello, {planet}', { planet: 'world' })
+`,
+  `<EuiI18n
+  token="filename.greeting"
+  default="Hello, {planet}"
+  values={{
+    planet: 'world'
+  }}
+/>
+`,
+];
+
 import I18nAttribute from './i18n_attribute';
 const i18nAttributeSource = require('!!raw-loader!./i18n_attribute');
 const i18nAttributeHtml = renderToHtml(I18nAttribute);
@@ -89,6 +105,34 @@ export const I18nExample = {
       ),
       snippet: basicSnippet,
       demo: <I18nBasic />,
+    },
+    {
+      title: 'Interpolation',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: i18nInterpolationSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: i18nInterpolationHtml,
+        },
+      ],
+      text: (
+        <p>
+          <strong>useEuiI18n</strong> and <strong>EuiI18n</strong> support
+          variable interpolation. In a translation like{' '}
+          <EuiCode>{'Signed in as {name} ({email})'}</EuiCode>, two values can
+          be interpolated (<EuiCode>name</EuiCode> and <EuiCode>email</EuiCode>
+          ). These values can be specified by passing a{' '}
+          <EuiCode>values</EuiCode> prop to <strong>EuiI18n</strong>, or by
+          passing an object of values as the third argument to{' '}
+          <strong>useEuiI18n</strong>. Interpolation values can be passed as a
+          string, number, or a React Component.
+        </p>
+      ),
+      snippet: interpolationSnippet,
+      demo: <I18nInterpolation />,
     },
     {
       title: 'Using localized values in attributes',

--- a/src-docs/src/views/i18n/i18n_interpolation.js
+++ b/src-docs/src/views/i18n/i18n_interpolation.js
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+
+import {
+  EuiButton,
+  EuiI18n,
+  EuiMark,
+  EuiSpacer,
+  EuiTitle,
+  useEuiI18n,
+} from '../../../../src/components';
+
+export default () => {
+  const [count, setCount] = useState(1);
+
+  return (
+    <>
+      <EuiTitle size="xs">
+        <h3>useEuiI18n with string interpolation</h3>
+      </EuiTitle>
+      <p>
+        {useEuiI18n(
+          'euiI18nInterpolation.clickedCount',
+          'Clicked on button {count} times.',
+          {
+            count,
+          }
+        )}
+      </p>
+
+      <EuiSpacer size="l" />
+
+      <EuiTitle size="xs">
+        <h3>EuiI18n with string interpolation</h3>
+      </EuiTitle>
+      <p>
+        <EuiI18n
+          token="euiI18nInterpolation.clickedCount"
+          default="Clicked on button {count} times."
+          values={{
+            count,
+          }}
+        />
+      </p>
+
+      <EuiSpacer size="l" />
+
+      <EuiTitle size="xs">
+        <h3>useEuiI18n with component interpolation</h3>
+      </EuiTitle>
+      <p>
+        {useEuiI18n(
+          'euiI18nInterpolation.clickedCount',
+          'Clicked on button {count} times.',
+          {
+            count: <EuiMark color="primary">{count}</EuiMark>,
+          }
+        )}
+      </p>
+
+      <EuiSpacer size="l" />
+
+      <EuiTitle size="xs">
+        <h3>EuiI18n with component interpolation</h3>
+      </EuiTitle>
+      <p>
+        <EuiI18n
+          token="euiI18nInterpolation.clickedCount"
+          default="Clicked on button {count} times."
+          values={{
+            count: <EuiMark color="primary">{count}</EuiMark>,
+          }}
+        />
+      </p>
+
+      <EuiSpacer size="l" />
+
+      <EuiButton onClick={() => setCount(count + 1)} size="s">
+        Increase count
+      </EuiButton>
+    </>
+  );
+};


### PR DESCRIPTION
### Summary

Added minimal documentation for value interpolation via `Eui18n` and `useEuiI18n`. An additional example of component interpolation could also be added here if required (as requested in #4044). I was unsure if it would be preferred to add a new section + examples, or combine that example into my existing one. This additional example would highlight that passing components as values (to interpolate a `EuiButton`, or `strong` tag, for example) works. Please let me know what's preferred.

### Checklist

- [ ] ~Check against **all themes** for compatibility in both light and dark modes~
- [ ] ~Checked in **mobile**~
- [ ] ~Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- [ ] ~Props have proper **autodocs**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] ~Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] ~A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~

Closes #3835
Related to #4044
