### PR TITLE
[wiki] Update Kibana testing docs

### DIFF
--- a/wiki/component-development.md
+++ b/wiki/component-development.md
@@ -56,7 +56,7 @@ Note that `yarn link` currently does not work with Kibana. You'll need to manual
 
 1. In the `eui` folder, run `yarn build` then `npm pack`. This will create a `.tgz` file with the changes in your EUI directory. At this point you can move it anywhere.
 2. In Kibana you have two choices:
-    * Point your `package.json` files in Kibana to that file: `"@elastic/eui": "/path/to/elastic-eui-xx.x.x.tgz"` and run `yarn kbn bootstrap`.
+    * Point your `package.json` files in Kibana to that file: `"@elastic/eui": "/path/to/elastic-eui-xx.x.x.tgz"` and run `yarn kbn bootstrap --no-validate` (the flag is required when bootstrapping with a `.tgz`).
     * Alternatively (and often easier), you can run `yarn kbn bootstrap` in Kibana first, then just unpack the `.tgz` file and paste its contents into an empty `/kibana/node_modules/@elastic/eui` folder. This method avoids having to edit all the various `package.json` files in Kibana if you need to run functional tests.
 3. Regardless of the method you decide run Kibana with `FORCE_DLL_CREATION=true node scripts/kibana --dev` to make sure it doesn't use a previously cached version of EUI.
 


### PR DESCRIPTION
### Summary

Update wiki to reflect changes to the Kibana testing docs. elastic/kibana#79878 introduced a `bootstrap` flag that will again allow for using the `npm pack` method

~### Checklist~
