### PR TITLE
Import minimal lodash packages

### DIFF
--- a/src-docs/src/views/collapsible_nav/collapsible_nav_all.tsx
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav_all.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import _ from 'lodash';
+import find from 'lodash/find';
+import findIndex from 'lodash/findIndex';
 
 import {
   EuiCollapsibleNav,
@@ -97,7 +98,7 @@ export default () => {
   >(JSON.parse(String(localStorage.getItem('pinnedItems'))) || []);
 
   const addPin = (item: any) => {
-    if (!item || _.find(pinnedItems, { label: item.label })) {
+    if (!item || find(pinnedItems, { label: item.label })) {
       return;
     }
     item.pinned = true;
@@ -107,7 +108,7 @@ export default () => {
   };
 
   const removePin = (item: any) => {
-    const pinIndex = _.findIndex(pinnedItems, { label: item.label });
+    const pinIndex = findIndex(pinnedItems, { label: item.label });
     if (pinIndex > -1) {
       item.pinned = false;
       const newPinnedItems = pinnedItems;

--- a/src-docs/src/views/elastic_charts/category_chart.js
+++ b/src-docs/src/views/elastic_charts/category_chart.js
@@ -1,5 +1,6 @@
 import React, { useState, Fragment, useContext } from 'react';
-import { orderBy, round } from 'lodash';
+import orderBy from 'lodash/orderBy';
+import round from 'lodash/round';
 
 import { ThemeContext } from '../../components';
 import { Chart, Settings, Axis } from '@elastic/charts';

--- a/src-docs/src/views/elastic_charts/pie_alts.js
+++ b/src-docs/src/views/elastic_charts/pie_alts.js
@@ -1,6 +1,10 @@
 /* eslint-disable no-nested-ternary */
 import React, { useState, Fragment, useContext } from 'react';
-import _ from 'lodash';
+import groupBy from 'lodash/groupBy';
+import mapValues from 'lodash/mapValues';
+import orderBy from 'lodash/orderBy';
+import sortBy from 'lodash/sortBy';
+import sumBy from 'lodash/sumBy';
 
 import { ThemeContext } from '../../components';
 import { Chart, Settings, Axis, BarSeries } from '@elastic/charts';
@@ -58,21 +62,21 @@ export default () => {
   let usesRainData;
   if (formatted && formattedData) {
     data = ordered
-      ? _.orderBy(DAYS_OF_RAIN, ['precipitation', 'days'], ['desc', 'asc'])
+      ? orderBy(DAYS_OF_RAIN, ['precipitation', 'days'], ['desc', 'asc'])
       : DAYS_OF_RAIN;
     usesRainData = true;
     color = euiPaletteForTemperature(3);
   } else {
     const DATASET = grouped ? GITHUB_DATASET_MOD : GITHUB_DATASET;
-    data = _.orderBy(DATASET, 'issueType', 'asc');
+    data = orderBy(DATASET, 'issueType', 'asc');
 
     if (ordered) {
-      const totals = _.mapValues(_.groupBy(DATASET, 'vizType'), (groups) =>
-        _.sumBy(groups, 'count')
+      const totals = mapValues(groupBy(DATASET, 'vizType'), (groups) =>
+        sumBy(groups, 'count')
       );
 
-      data = _.orderBy(DATASET, 'issueType', 'desc');
-      const sortedData = _.sortBy(data, [
+      data = orderBy(DATASET, 'issueType', 'desc');
+      const sortedData = sortBy(data, [
         ({ vizType }) => totals[vizType],
       ]).reverse();
       data = sortedData;

--- a/src-docs/src/views/elastic_charts/sparklines.js
+++ b/src-docs/src/views/elastic_charts/sparklines.js
@@ -1,5 +1,5 @@
 import React, { useContext, Fragment } from 'react';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import { ThemeContext } from '../../components';
 import {
   Chart,

--- a/src/components/token/token.tsx
+++ b/src/components/token/token.tsx
@@ -18,7 +18,7 @@
  */
 
 import React, { FunctionComponent, HTMLAttributes } from 'react';
-import { defaults } from 'lodash';
+import defaults from 'lodash/defaults';
 import classNames from 'classnames';
 import { CommonProps, keysOf } from '../common';
 import { isColorDark, hexToRgb } from '../../services';


### PR DESCRIPTION
### Summary

While I'm also bought into the larger goal of removing lodash completely, these changes are a halfway house towards that goal. With these changes, only used lodash modules should (I'm unsure how to verify this) end up in the `eui` bundle.

> const throttle = require('lodash/throttle'), only the subset of lodash code your package uses will be bundled in projects that use your package.
> [Reference](https://lodash.com/per-method-packages)

Part of https://github.com/elastic/eui/issues/360

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
