### PR TITLE
[EuiSelectable] call searchProps functions on search/change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed a condition in `EuiInMemoryTable` to avoid mistaken assignment of `sortName` ([#4138](https://github.com/elastic/eui/pull/4138))
 - Fixed bug in small `EuiImage`'s not respecting the optional sizes when `allowFullScreen` is set to true ([#4207](https://github.com/elastic/eui/pull/4207))
 - Fixed incorrect initial rendering of `EuiDualRange` thumbs when element width is 0 ([#4230](https://github.com/elastic/eui/pull/4230))
+- Fixed bug in `EuiSelectable` to call `searchProps.onChange` and `searchProps.onSearch` calls in `EuiSelectable` ([#4153](https://github.com/elastic/eui/pull/4153))
 
 **Theme: Amsterdam**
 

--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -333,6 +333,9 @@ export class EuiSelectable<T = {}> extends Component<
         }
       }
     );
+    if (this.props.searchProps && this.props.searchProps.onSearch) {
+      this.props.searchProps.onSearch(searchValue);
+    }
   };
 
   onContainerBlur = (e: React.FocusEvent) => {
@@ -352,6 +355,12 @@ export class EuiSelectable<T = {}> extends Component<
     }));
     if (this.props.onChange) {
       this.props.onChange(options);
+    }
+    if (this.props.searchProps && this.props.searchProps.onChange) {
+      this.props.searchProps.onChange(
+        { ...this.state.visibleOptions },
+        this.state.searchValue
+      );
     }
   };
 
@@ -390,8 +399,11 @@ export class EuiSelectable<T = {}> extends Component<
     const {
       'aria-label': searchAriaLabel,
       'aria-describedby': searchAriaDescribedby,
+      onChange: propsOnChange,
       ...cleanedSearchProps
-    } = searchProps || unknownAccessibleName;
+    } =
+      searchProps ||
+      (unknownAccessibleName as Partial<EuiSelectableSearchProps<T>>);
     const {
       'aria-label': listAriaLabel,
       'aria-describedby': listAriaDescribedby,

--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -400,10 +400,10 @@ export class EuiSelectable<T = {}> extends Component<
       'aria-label': searchAriaLabel,
       'aria-describedby': searchAriaDescribedby,
       onChange: propsOnChange,
+      onSearch,
       ...cleanedSearchProps
-    } =
-      searchProps ||
-      (unknownAccessibleName as Partial<EuiSelectableSearchProps<T>>);
+    } = (searchProps || unknownAccessibleName) as typeof searchProps &
+      typeof unknownAccessibleName;
     const {
       'aria-label': listAriaLabel,
       'aria-describedby': listAriaDescribedby,


### PR DESCRIPTION
### Summary

Resolves `onChange` issue in searchProps as mentioned in https://github.com/elastic/eui/issues/4132

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
