### PR TITLE
Fix out-of-memory in dev server; re-configure cache-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.21.3",
     "eslint-plugin-react-hooks": "^4.1.2",
+    "expose-gc": "^1.0.0",
     "faker": "^4.1.0",
     "file-loader": "^6.1.0",
     "findup": "^0.1.5",

--- a/scripts/babel/react-docgen-typescript.js
+++ b/scripts/babel/react-docgen-typescript.js
@@ -18,6 +18,7 @@
  */
 /* eslint-disable @typescript-eslint/no-var-requires */
 
+const gc = require('expose-gc/function');
 const propsParser = require('react-docgen-typescript');
 const template = require('@babel/template');
 const ts = require('typescript');
@@ -41,6 +42,8 @@ function buildProgram() {
     ...glob.sync('src/**/!(*.test).{ts,tsx}', { absolute: true }),
     ...glob.sync('src-docs/**/!(*.test).{ts,tsx}', { absolute: true }),
   ];
+  program = null;
+  gc();
   program = ts.createProgram(files, programOptions);
 }
 buildProgram();

--- a/src-docs/webpack.config.js
+++ b/src-docs/webpack.config.js
@@ -15,7 +15,15 @@ const bypassCache = NODE_ENV === 'puppeteer';
 
 function employCache(loaders) {
   if (isDevelopment && !bypassCache) {
-    return ['cache-loader'].concat(loaders);
+    return [
+      {
+        loader: 'cache-loader',
+        options: {
+          cacheDirectory: path.join(__dirname, '..', '.cache-loader'),
+        },
+      },
+      ...loaders,
+    ];
   }
 
   return loaders;
@@ -54,7 +62,7 @@ const webpackConfig = {
     rules: [
       {
         test: /\.(js|tsx?)$/,
-        loaders: employCache([
+        loader: employCache([
           {
             loader: 'babel-loader',
             options: { babelrc: false, ...babelConfig },
@@ -64,7 +72,7 @@ const webpackConfig = {
       },
       {
         test: /\.scss$/,
-        loaders: employCache([
+        loader: employCache([
           {
             loader: 'style-loader',
             options: { injectType: 'lazySingletonStyleTag' },
@@ -77,20 +85,24 @@ const webpackConfig = {
       },
       {
         test: /\.css$/,
-        loaders: employCache(['style-loader', 'css-loader']),
+        loader: employCache(['style-loader', 'css-loader']),
         exclude: /node_modules/,
       },
       {
         test: /\.(woff|woff2|ttf|eot|ico)(\?|$)/,
-        loader: 'file-loader',
+        loader: employCache(['file-loader']),
       },
       {
         test: /\.(png|jp(e*)g|svg|gif)$/,
-        loader: 'url-loader',
-        options: {
-          limit: 8000, // Convert images < 8kb to base64 strings
-          name: 'images/[hash]-[name].[ext]',
-        },
+        loader: employCache([
+          {
+            loader: 'url-loader',
+            options: {
+              limit: 8000, // Convert images < 8kb to base64 strings
+              name: 'images/[hash]-[name].[ext]',
+            },
+          },
+        ]),
       },
     ],
   },

--- a/src-docs/webpack.config.js
+++ b/src-docs/webpack.config.js
@@ -62,7 +62,7 @@ const webpackConfig = {
     rules: [
       {
         test: /\.(js|tsx?)$/,
-        loader: employCache([
+        loaders: employCache([
           {
             loader: 'babel-loader',
             options: { babelrc: false, ...babelConfig },
@@ -72,7 +72,7 @@ const webpackConfig = {
       },
       {
         test: /\.scss$/,
-        loader: employCache([
+        loaders: employCache([
           {
             loader: 'style-loader',
             options: { injectType: 'lazySingletonStyleTag' },
@@ -85,24 +85,20 @@ const webpackConfig = {
       },
       {
         test: /\.css$/,
-        loader: employCache(['style-loader', 'css-loader']),
+        loaders: employCache(['style-loader', 'css-loader']),
         exclude: /node_modules/,
       },
       {
         test: /\.(woff|woff2|ttf|eot|ico)(\?|$)/,
-        loader: employCache(['file-loader']),
+        loader: 'file-loader',
       },
       {
         test: /\.(png|jp(e*)g|svg|gif)$/,
-        loader: employCache([
-          {
-            loader: 'url-loader',
-            options: {
-              limit: 8000, // Convert images < 8kb to base64 strings
-              name: 'images/[hash]-[name].[ext]',
-            },
-          },
-        ]),
+        loader: 'url-loader',
+        options: {
+          limit: 8000, // Convert images < 8kb to base64 strings
+          name: 'images/[hash]-[name].[ext]',
+        },
       },
     ],
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6225,6 +6225,11 @@ expect@^24.9.0:
     jest-message-util "^24.9.0"
     jest-regex-util "^24.9.0"
 
+expose-gc@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/expose-gc/-/expose-gc-1.0.0.tgz#ba0e825b390cc3e7ab38fc5b945cd2b4018584b3"
+  integrity sha512-ecOHrdm+zyOCGIwX18/1RHkUWgxDqGGRiGhaNC+42jReTtudbm2ID/DMa/wpaHwqy5YQHPZvsDqRM2F2iZ0uVA==
+
 express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"


### PR DESCRIPTION
### Summary

Fixes the out-of-memory error on recompile in dev, this was caused by the `react-docgen-typescript` script building a new TS program before the previous one had been GCed. I also added the `cacheDirectory` configuration to `cache-loader` so we get cache locally in the _.cache-loader_ directory once again.

### ~Checklist~