### PR TITLE
[EuiButtonGroup] Fix position for EuiScreenReaderOnly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug fixes**
 
 - Removed unnecessary shadow on hover of `EuiButtonGroup` ([#4186](https://github.com/elastic/eui/pull/4186))
+- Fixed position of `EuiScreenReaderOnly` elements within `EuiButtonGroup` ([#4189](https://github.com/elastic/eui/pull/4189))
 
 ## [`30.1.0`](https://github.com/elastic/eui/tree/v30.1.0)
 

--- a/src/components/button/button_group/_button_group.scss
+++ b/src/components/button/button_group/_button_group.scss
@@ -1,6 +1,7 @@
 .euiButtonGroup {
   display: inline-block;
   max-width: 100%;
+  position: relative; // Ensures the EuiScreenReaderOnly component is positioned relative to this component
 }
 
 .euiButtonGroup--fullWidth {

--- a/src/components/button/button_group/_button_group.scss
+++ b/src/components/button/button_group/_button_group.scss
@@ -1,7 +1,7 @@
 .euiButtonGroup {
   display: inline-block;
   max-width: 100%;
-  // position: relative; // Ensures the EuiScreenReaderOnly component is positioned relative to this component
+  position: relative; // Ensures the EuiScreenReaderOnly component is positioned relative to this component
 }
 
 .euiButtonGroup--fullWidth {

--- a/src/components/button/button_group/_button_group.scss
+++ b/src/components/button/button_group/_button_group.scss
@@ -1,7 +1,7 @@
 .euiButtonGroup {
   display: inline-block;
   max-width: 100%;
-  position: relative; // Ensures the EuiScreenReaderOnly component is positioned relative to this component
+  // position: relative; // Ensures the EuiScreenReaderOnly component is positioned relative to this component
 }
 
 .euiButtonGroup--fullWidth {


### PR DESCRIPTION
In the recent Kibana upgrade it was found that some nested congregation of different display positions of elements can cause a weird overflow issue when used in conjunction with EuiButtonGroup and the EuiScreenReaderOnly component.

![image](https://user-images.githubusercontent.com/549577/97462644-54a46680-1915-11eb-87ff-769ef68a5308.png)


This is a quick fix by adding `position: relative` to the EuiButtonGroup to ensure the `absolute` positioned EuiScreenReaderOnly elements are positioned against **it** and not some other relative parent.

### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- ~[ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
