### PR TITLE
Fix vscode + eslint hanging

### DIFF
--- a/src-docs/webpack.config.js
+++ b/src-docs/webpack.config.js
@@ -136,7 +136,7 @@ const webpackConfig = {
         disableHostCheck: true,
         historyApiFallback: true,
       }
-    : null,
+    : undefined,
   node: {
     fs: 'empty',
   },

--- a/src-docs/webpack.config.js
+++ b/src-docs/webpack.config.js
@@ -7,9 +7,9 @@ const babelConfig = require('./.babelrc.js');
 const getPort = require('get-port');
 const deasync = require('deasync');
 
-const { NODE_ENV, CI } = process.env;
+const { NODE_ENV, CI, WEBPACK_DEV_SERVER } = process.env;
 
-const isDevelopment = NODE_ENV !== 'production' && CI == null;
+const isDevelopment = WEBPACK_DEV_SERVER === 'true' && CI == null;
 const isProduction = NODE_ENV === 'production';
 const bypassCache = NODE_ENV === 'puppeteer';
 
@@ -124,14 +124,19 @@ const webpackConfig = {
     // }),
   ],
 
-  devServer: {
-    contentBase: 'src-docs/build',
-    host: '0.0.0.0',
-    allowedHosts: ['*'],
-    port: getPortSync({ port: getPort.makeRange(8030, 8130), host: '0.0.0.0' }),
-    disableHostCheck: true,
-    historyApiFallback: true,
-  },
+  devServer: isDevelopment
+    ? {
+        contentBase: 'src-docs/build',
+        host: '0.0.0.0',
+        allowedHosts: ['*'],
+        port: getPortSync({
+          port: getPort.makeRange(8030, 8130),
+          host: '0.0.0.0',
+        }),
+        disableHostCheck: true,
+        historyApiFallback: true,
+      }
+    : null,
   node: {
     fs: 'empty',
   },


### PR DESCRIPTION
### Summary

Based on @myasonik's [stack trace](https://github.com/microsoft/vscode-eslint/issues/1055#issuecomment-718051933) the vscode+eslint hangup comes from the synchronous port assignment for the dev server. How? eslint -> eslint-import-resolver-webpack -> webpack.config.js -> getPortSync. Presumably, vscode is calling eslint rapidly which is exhausting the defined port range (8030-8130) and causing subsequent runs to hang. This PR modifies the webpack config to only choose a port when the `WEBPACK_DEV_SERVER` envvar is set to `true`.
