### PR TITLE
[EuiDataGrid] use schema sorting labels instead of placeholder value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug fixes**
 
 - Fixed issue with `labelDisplay` not being passed to `EuiSuggestItem` ([#4180](https://github.com/elastic/eui/pull/4180))
+- Fixed copy in `EuiDataGrid`'s header menu's sort actions ([#4199](https://github.com/elastic/eui/pull/4199))
 
 ## [`30.1.1`](https://github.com/elastic/eui/tree/v30.1.1)
 

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -225,7 +225,7 @@ exports[`EuiDataGrid render column actions renders various column actions config
     label={
       <EuiI18n
         default="Sort {schemaLabel}"
-        token="euiColumnActions.sortAsc"
+        token="euiColumnActions.sort"
         values={
           Object {
             "schemaLabel": <EuiI18n
@@ -265,7 +265,7 @@ exports[`EuiDataGrid render column actions renders various column actions config
         >
           <EuiI18n
             default="Sort {schemaLabel}"
-            token="euiColumnActions.sortAsc"
+            token="euiColumnActions.sort"
             values={
               Object {
                 "schemaLabel": <EuiI18n
@@ -306,7 +306,7 @@ exports[`EuiDataGrid render column actions renders various column actions config
     label={
       <EuiI18n
         default="Sort {schemaLabel}"
-        token="euiColumnActions.sortDesc"
+        token="euiColumnActions.sort"
         values={
           Object {
             "schemaLabel": <EuiI18n
@@ -346,7 +346,7 @@ exports[`EuiDataGrid render column actions renders various column actions config
         >
           <EuiI18n
             default="Sort {schemaLabel}"
-            token="euiColumnActions.sortDesc"
+            token="euiColumnActions.sort"
             values={
               Object {
                 "schemaLabel": <EuiI18n
@@ -524,7 +524,7 @@ exports[`EuiDataGrid render column actions renders various column actions config
     label={
       <EuiI18n
         default="Sort {schemaLabel}"
-        token="euiColumnActions.sortAsc"
+        token="euiColumnActions.sort"
         values={
           Object {
             "schemaLabel": <EuiI18n
@@ -564,7 +564,7 @@ exports[`EuiDataGrid render column actions renders various column actions config
         >
           <EuiI18n
             default="Sort {schemaLabel}"
-            token="euiColumnActions.sortAsc"
+            token="euiColumnActions.sort"
             values={
               Object {
                 "schemaLabel": <EuiI18n
@@ -605,7 +605,7 @@ exports[`EuiDataGrid render column actions renders various column actions config
     label={
       <EuiI18n
         default="Sort {schemaLabel}"
-        token="euiColumnActions.sortDesc"
+        token="euiColumnActions.sort"
         values={
           Object {
             "schemaLabel": <EuiI18n
@@ -645,7 +645,7 @@ exports[`EuiDataGrid render column actions renders various column actions config
         >
           <EuiI18n
             default="Sort {schemaLabel}"
-            token="euiColumnActions.sortDesc"
+            token="euiColumnActions.sort"
             values={
               Object {
                 "schemaLabel": <EuiI18n

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -224,8 +224,16 @@ exports[`EuiDataGrid render column actions renders various column actions config
     key="title-1"
     label={
       <EuiI18n
-        default="Sort schema asc"
+        default="Sort {schemaLabel}"
         token="euiColumnActions.sortAsc"
+        values={
+          Object {
+            "schemaLabel": <EuiI18n
+              default="A-Z"
+              token="euiColumnSortingDraggable.defaultSortAsc"
+            />,
+          }
+        }
       />
     }
     onClick={[Function]}
@@ -253,13 +261,37 @@ exports[`EuiDataGrid render column actions renders various column actions config
         </EuiIcon>
         <span
           className="euiListGroupItem__label"
-          title="Sort schema asc"
+          title="Sort A-Z"
         >
           <EuiI18n
-            default="Sort schema asc"
+            default="Sort {schemaLabel}"
             token="euiColumnActions.sortAsc"
+            values={
+              Object {
+                "schemaLabel": <EuiI18n
+                  default="A-Z"
+                  token="euiColumnSortingDraggable.defaultSortAsc"
+                />,
+              }
+            }
           >
-            Sort schema asc
+            <Component
+              schemaLabel={
+                <EuiI18n
+                  default="A-Z"
+                  token="euiColumnSortingDraggable.defaultSortAsc"
+                />
+              }
+            >
+              Sort 
+              <EuiI18n
+                default="A-Z"
+                key="1"
+                token="euiColumnSortingDraggable.defaultSortAsc"
+              >
+                A-Z
+              </EuiI18n>
+            </Component>
           </EuiI18n>
         </span>
       </button>
@@ -273,8 +305,16 @@ exports[`EuiDataGrid render column actions renders various column actions config
     key="title-2"
     label={
       <EuiI18n
-        default="Sort schema desc"
+        default="Sort {schemaLabel}"
         token="euiColumnActions.sortDesc"
+        values={
+          Object {
+            "schemaLabel": <EuiI18n
+              default="Z-A"
+              token="euiColumnSortingDraggable.defaultSortDesc"
+            />,
+          }
+        }
       />
     }
     onClick={[Function]}
@@ -302,13 +342,37 @@ exports[`EuiDataGrid render column actions renders various column actions config
         </EuiIcon>
         <span
           className="euiListGroupItem__label"
-          title="Sort schema desc"
+          title="Sort Z-A"
         >
           <EuiI18n
-            default="Sort schema desc"
+            default="Sort {schemaLabel}"
             token="euiColumnActions.sortDesc"
+            values={
+              Object {
+                "schemaLabel": <EuiI18n
+                  default="Z-A"
+                  token="euiColumnSortingDraggable.defaultSortDesc"
+                />,
+              }
+            }
           >
-            Sort schema desc
+            <Component
+              schemaLabel={
+                <EuiI18n
+                  default="Z-A"
+                  token="euiColumnSortingDraggable.defaultSortDesc"
+                />
+              }
+            >
+              Sort 
+              <EuiI18n
+                default="Z-A"
+                key="1"
+                token="euiColumnSortingDraggable.defaultSortDesc"
+              >
+                Z-A
+              </EuiI18n>
+            </Component>
           </EuiI18n>
         </span>
       </button>
@@ -459,8 +523,16 @@ exports[`EuiDataGrid render column actions renders various column actions config
     key="title-0"
     label={
       <EuiI18n
-        default="Sort schema asc"
+        default="Sort {schemaLabel}"
         token="euiColumnActions.sortAsc"
+        values={
+          Object {
+            "schemaLabel": <EuiI18n
+              default="A-Z"
+              token="euiColumnSortingDraggable.defaultSortAsc"
+            />,
+          }
+        }
       />
     }
     onClick={[Function]}
@@ -488,13 +560,37 @@ exports[`EuiDataGrid render column actions renders various column actions config
         </EuiIcon>
         <span
           className="euiListGroupItem__label"
-          title="Sort schema asc"
+          title="Sort A-Z"
         >
           <EuiI18n
-            default="Sort schema asc"
+            default="Sort {schemaLabel}"
             token="euiColumnActions.sortAsc"
+            values={
+              Object {
+                "schemaLabel": <EuiI18n
+                  default="A-Z"
+                  token="euiColumnSortingDraggable.defaultSortAsc"
+                />,
+              }
+            }
           >
-            Sort schema asc
+            <Component
+              schemaLabel={
+                <EuiI18n
+                  default="A-Z"
+                  token="euiColumnSortingDraggable.defaultSortAsc"
+                />
+              }
+            >
+              Sort 
+              <EuiI18n
+                default="A-Z"
+                key="1"
+                token="euiColumnSortingDraggable.defaultSortAsc"
+              >
+                A-Z
+              </EuiI18n>
+            </Component>
           </EuiI18n>
         </span>
       </button>
@@ -508,8 +604,16 @@ exports[`EuiDataGrid render column actions renders various column actions config
     key="title-1"
     label={
       <EuiI18n
-        default="Sort schema desc"
+        default="Sort {schemaLabel}"
         token="euiColumnActions.sortDesc"
+        values={
+          Object {
+            "schemaLabel": <EuiI18n
+              default="Z-A"
+              token="euiColumnSortingDraggable.defaultSortDesc"
+            />,
+          }
+        }
       />
     }
     onClick={[Function]}
@@ -537,13 +641,37 @@ exports[`EuiDataGrid render column actions renders various column actions config
         </EuiIcon>
         <span
           className="euiListGroupItem__label"
-          title="Sort schema desc"
+          title="Sort Z-A"
         >
           <EuiI18n
-            default="Sort schema desc"
+            default="Sort {schemaLabel}"
             token="euiColumnActions.sortDesc"
+            values={
+              Object {
+                "schemaLabel": <EuiI18n
+                  default="Z-A"
+                  token="euiColumnSortingDraggable.defaultSortDesc"
+                />,
+              }
+            }
           >
-            Sort schema desc
+            <Component
+              schemaLabel={
+                <EuiI18n
+                  default="Z-A"
+                  token="euiColumnSortingDraggable.defaultSortDesc"
+                />
+              }
+            >
+              Sort 
+              <EuiI18n
+                default="Z-A"
+                key="1"
+                token="euiColumnSortingDraggable.defaultSortDesc"
+              >
+                Z-A
+              </EuiI18n>
+            </Component>
           </EuiI18n>
         </span>
       </button>

--- a/src/components/datagrid/column_actions.tsx
+++ b/src/components/datagrid/column_actions.tsx
@@ -20,10 +20,21 @@ import React from 'react';
 import { EuiDataGridColumn, EuiDataGridSorting } from './data_grid_types';
 import { EuiI18n } from '../i18n';
 import { EuiListGroupItemProps } from '../list_group';
+import {
+  EuiDataGridSchema,
+  EuiDataGridSchemaDetector,
+  getDetailsForSchema,
+} from './data_grid_schema';
+import {
+  defaultSortAscLabel,
+  defaultSortDescLabel,
+} from './column_sorting_draggable';
 
 export function getColumnActions(
   column: EuiDataGridColumn,
   columns: EuiDataGridColumn[],
+  schema: EuiDataGridSchema,
+  schemaDetectors: EuiDataGridSchemaDetector[],
   setVisibleColumns: (columnId: string[]) => void,
   setIsPopoverOpen: (value: boolean) => void,
   sorting: EuiDataGridSorting | undefined,
@@ -118,10 +129,21 @@ export function getColumnActions(
     }
   }
 
+  const schemaDetails =
+    schema.hasOwnProperty(column.id) && schema[column.id].columnType != null
+      ? getDetailsForSchema(schemaDetectors, schema[column.id].columnType)
+      : null;
   if (column.actions?.showSortAsc !== false && sorting) {
+    const label = schemaDetails
+      ? schemaDetails.sortTextAsc
+      : defaultSortAscLabel;
     const option = {
       label: (
-        <EuiI18n token="euiColumnActions.sortAsc" default="Sort schema asc" />
+        <EuiI18n
+          token="euiColumnActions.sort"
+          default="Sort {schemaLabel}"
+          values={{ schemaLabel: label }}
+        />
       ),
       onClick: onClickSortAsc,
       isDisabled: column.isSortable === false,
@@ -141,9 +163,16 @@ export function getColumnActions(
   }
 
   if (column.actions?.showSortDesc !== false && sorting) {
+    const label = schemaDetails
+      ? schemaDetails.sortTextDesc
+      : defaultSortDescLabel;
     const option = {
       label: (
-        <EuiI18n token="euiColumnActions.sortDesc" default="Sort schema desc" />
+        <EuiI18n
+          token="euiColumnActions.sort"
+          default="Sort {schemaLabel}"
+          values={{ schemaLabel: label }}
+        />
       ),
       onClick: onClickSortDesc,
       isDisabled: column.isSortable === false,

--- a/src/components/datagrid/column_sorting_draggable.tsx
+++ b/src/components/datagrid/column_sorting_draggable.tsx
@@ -46,6 +46,13 @@ export interface EuiDataGridColumnSortingDraggableProps {
   display: string;
 }
 
+export const defaultSortAscLabel = (
+  <EuiI18n token="euiColumnSortingDraggable.defaultSortAsc" default="A-Z" />
+);
+export const defaultSortDescLabel = (
+  <EuiI18n token="euiColumnSortingDraggable.defaultSortDesc" default="Z-A" />
+);
+
 export const EuiDataGridColumnSortingDraggable: FunctionComponent<EuiDataGridColumnSortingDraggableProps> = ({
   id,
   display,
@@ -62,21 +69,10 @@ export const EuiDataGridColumnSortingDraggable: FunctionComponent<EuiDataGridCol
       : null;
 
   const textSortAsc =
-    schemaDetails != null ? (
-      schemaDetails.sortTextAsc
-    ) : (
-      <EuiI18n token="euiColumnSortingDraggable.defaultSortAsc" default="A-Z" />
-    );
+    schemaDetails != null ? schemaDetails.sortTextAsc : defaultSortAscLabel;
 
   const textSortDesc =
-    schemaDetails != null ? (
-      schemaDetails.sortTextDesc
-    ) : (
-      <EuiI18n
-        token="euiColumnSortingDraggable.defaultSortDesc"
-        default="Z-A"
-      />
-    );
+    schemaDetails != null ? schemaDetails.sortTextDesc : defaultSortDescLabel;
 
   const toggleOptions = [
     {

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -1066,6 +1066,7 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
                                           setVisibleColumns={setVisibleColumns}
                                           switchColumnPos={switchColumnPos}
                                           schema={mergedSchema}
+                                          schemaDetectors={allSchemaDetectors}
                                           sorting={sorting}
                                           headerIsInteractive={
                                             headerIsInteractive

--- a/src/components/datagrid/data_grid_header_cell.tsx
+++ b/src/components/datagrid/data_grid_header_cell.tsx
@@ -59,6 +59,7 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
     columns,
     columnWidths,
     schema,
+    schemaDetectors,
     defaultColumnWidth,
     setColumnWidth,
     setVisibleColumns,
@@ -274,6 +275,8 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
   const columnActions = getColumnActions(
     column,
     columns,
+    schema,
+    schemaDetectors,
     setVisibleColumns,
     setIsPopoverOpen,
     sorting,

--- a/src/components/datagrid/data_grid_header_row.tsx
+++ b/src/components/datagrid/data_grid_header_row.tsx
@@ -27,7 +27,10 @@ import {
   EuiDataGridControlColumn,
 } from './data_grid_types';
 import { CommonProps } from '../common';
-import { EuiDataGridSchema } from './data_grid_schema';
+import {
+  EuiDataGridSchema,
+  EuiDataGridSchemaDetector,
+} from './data_grid_schema';
 import { EuiDataGridDataRowProps } from './data_grid_data_row';
 import { EuiDataGridHeaderCell } from './data_grid_header_cell';
 import { EuiDataGridControlHeaderCell } from './data_grid_control_header_cell';
@@ -38,6 +41,7 @@ export interface EuiDataGridHeaderRowPropsSpecificProps {
   columns: EuiDataGridColumn[];
   columnWidths: EuiDataGridColumnWidths;
   schema: EuiDataGridSchema;
+  schemaDetectors: EuiDataGridSchemaDetector[];
   defaultColumnWidth?: number | null;
   setColumnWidth: (columnId: string, width: number) => void;
   setVisibleColumns: (columnId: string[]) => void;
@@ -61,6 +65,7 @@ const EuiDataGridHeaderRow = forwardRef<
     trailingControlColumns = [],
     columns,
     schema,
+    schemaDetectors,
     columnWidths,
     defaultColumnWidth,
     className,
@@ -106,6 +111,7 @@ const EuiDataGridHeaderRow = forwardRef<
           focusedCell={focusedCell}
           onCellFocus={setFocusedCell}
           schema={schema}
+          schemaDetectors={schemaDetectors}
           setColumnWidth={setColumnWidth}
           setVisibleColumns={setVisibleColumns}
           switchColumnPos={switchColumnPos}


### PR DESCRIPTION
### Summary

Came up again in #4197 but also reported in slack last week, the recently added column actions used placeholder copy for sort text instead of using the column schema's labels.

I opted to nest the existing i18n'd labels (`A-Z`, `High-Low`) into a new i18n token which prepends `Sort `. I think this combines the best of re-usability while retaining flexibility for downstream consuming applications. I confirmed these overrides work as expected (see below).

### Before

<img width="160" alt="Screen Shot 2020-10-29 at 11 47 43 AM" src="https://user-images.githubusercontent.com/313125/97612096-964c1480-19dc-11eb-8102-2066c0d47a89.png">

### After

<img width="139" alt="Screen Shot 2020-10-29 at 11 48 04 AM" src="https://user-images.githubusercontent.com/313125/97618576-d0211900-19e4-11eb-99c1-c94a4626d23e.png">

### Localized schema labels

```
      i18n={{
        mapping: {
          'euiColumnSortingDraggable.defaultSortAsc': 'Going down',
          'euiColumnSortingDraggable.defaultSortDesc': 'Going up',
          'euiDataGridSchema.currencySortTextAsc': 'Increasing',
          'euiDataGridSchema.currencySortTextDesc': 'Decreasing',
        },
      }}
```

![sort_i18n](https://user-images.githubusercontent.com/313125/97618745-09f21f80-19e5-11eb-8db1-a00bb2b9baab.gif)

### Localized schema + sort labels

```
      i18n={{
        mapping: {
          'euiColumnSortingDraggable.defaultSortAsc': 'Going down',
          'euiColumnSortingDraggable.defaultSortDesc': 'Going up',
          'euiDataGridSchema.currencySortTextAsc': 'Increasing',
          'euiDataGridSchema.currencySortTextDesc': 'Decreasing',
          'euiColumnActions.sort': 'Order: {schemaLabel}',
        },
      }}
```

<img width="166" alt="Screen Shot 2020-10-29 at 12 52 18 PM" src="https://user-images.githubusercontent.com/313125/97619263-9ef51880-19e5-11eb-98bf-881fb82553c6.png">

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
