### PR TITLE
[EuiSelectableTemplateSitewide] external control via ref methods

### DIFF
--- a/src/components/selectable/index.ts
+++ b/src/components/selectable/index.ts
@@ -31,4 +31,5 @@ export {
   EuiSelectableTemplateSitewideProps,
   EuiSelectableTemplateSitewideOption,
   EuiSelectableTemplateSitewideMetaData,
+  EuiSelectableImperativeHandle,
 } from './selectable_templates';

--- a/src/components/selectable/selectable_templates/index.ts
+++ b/src/components/selectable/selectable_templates/index.ts
@@ -20,6 +20,7 @@
 export {
   EuiSelectableTemplateSitewide,
   EuiSelectableTemplateSitewideProps,
+  EuiSelectableImperativeHandle,
 } from './selectable_template_sitewide';
 
 export {


### PR DESCRIPTION
### Summary

Closes #4206 by creating a ref for **EuiSelectableTemplateSitewide** which exposes the ability to set the popover state and search value.

* `setSearchValue` and `setIsPopoverOpen` methods to **EuiSelectableTemplateSitewide**`'s ref
* 3 behaviour tests for EuiSelectableTemplateSitewide
* shenanigans around React's input event handling & **EuiFieldSearch**'s keyup nonsense
* shenanigans to merge `inputRef` usages

Will add documentation if/when the source changes are accepted.

Tested with the new jest tests & by setting the docs' example ref on the window and:

![selectabletemplatesitewide_handle](https://user-images.githubusercontent.com/313125/97756379-62e2b600-1ac0-11eb-98ba-5f121f15905e.gif)

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs**~
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
