### PR TITLE
[EuiComboBox] Truncate long placeholder text with ellipsis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,11 @@
 - Fixed a condition in `EuiInMemoryTable` to avoid mistaken assignment of `sortName` ([#4138](https://github.com/elastic/eui/pull/4138))
 - Fixed bug in small `EuiImage`'s not respecting the optional sizes when `allowFullScreen` is set to true ([#4207](https://github.com/elastic/eui/pull/4207))
 - Fixed incorrect initial rendering of `EuiDualRange` thumbs when element width is 0 ([#4230](https://github.com/elastic/eui/pull/4230))
+- Fixed truncation of the `EuiComboBox` `placeholder` text ([#4210](https://github.com/elastic/eui/pull/4210))
 
 **Theme: Amsterdam**
 
 - Fixed base `line-heights` for within `euiFontSize[size]()` SASS mixins ([#4229](https://github.com/elastic/eui/pull/4229))
-
-**Bug fixes**
-
-- Fixed `EuiComboBox` `placeholder`. Added truncation with ellipsis to correctly display long placeholder texts ([#4210](https://github.com/elastic/eui/pull/4210))
 
 ## [`30.2.0`](https://github.com/elastic/eui/tree/v30.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 - Fixed base `line-heights` for within `euiFontSize[size]()` SASS mixins ([#4229](https://github.com/elastic/eui/pull/4229))
 
+**Bug fixes**
+
+- Fixed `EuiComboBox` `placeholder`. Added truncation with ellipsis to correctly display long placeholder texts ([#4210](https://github.com/elastic/eui/pull/4210))
+
 ## [`30.2.0`](https://github.com/elastic/eui/tree/v30.2.0)
 
 - Added `labelWidth` and `descriptionDisplay` props to `EuiSuggestItem` ([#4180](https://github.com/elastic/eui/pull/4180))

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -4,7 +4,7 @@
 
   /**
    * 1. Allow pills to truncate their text with an ellipsis.
-   * 2. Don't allow pills to overlap with the caret, loading icon or clear button.
+   * 2. Don't allow pills/placeholder to overlap with the caret, loading icon or clear button.
    * 3. The height on combo can be larger than normal text inputs.
    */
 
@@ -51,6 +51,10 @@
 
     &.euiComboBox__inputWrap-isLoading {
       @include euiFormControlLayoutPadding(2); /* 2 */
+
+      .euiComboBoxPlaceholder {
+        @include euiFormControlLayoutPadding(2); /* 2 */
+      }
     }
 
     &.euiComboBox__inputWrap-isLoading.euiComboBox__inputWrap-isClearable {
@@ -121,6 +125,10 @@
 
       &.euiComboBox__inputWrap-isLoading {
         @include euiFormControlLayoutPadding(2, $compressed: true); /* 2 */
+
+        .euiComboBoxPlaceholder {
+          @include euiFormControlLayoutPadding(2, $compressed: true); /* 2 */
+        }
       }
 
       &.euiComboBox__inputWrap-isLoading.euiComboBox__inputWrap-isClearable {

--- a/src/components/combo_box/combo_box_input/_combo_box_placeholder.scss
+++ b/src/components/combo_box/combo_box_input/_combo_box_placeholder.scss
@@ -5,4 +5,11 @@
   line-height: $euiSizeXL;
   color: $euiColorMediumShade;
   margin-bottom: 0 !important; // sass-lint:disable-line no-important
+
+  // Truncate placeholder with ellipsis if it's too long
+  // https://css-tricks.com/almanac/properties/t/text-overflow/
+  width: calc(100% - 28px); // 28px is a quick fix to give space for the combobox arrow
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/src/components/combo_box/combo_box_input/_combo_box_placeholder.scss
+++ b/src/components/combo_box/combo_box_input/_combo_box_placeholder.scss
@@ -1,6 +1,6 @@
 .euiComboBoxPlaceholder {
   @include euiTextTruncate;
-  // Afford for the caret. The loading state is accounted ford in _combo_box.scss
+  // Afford for the caret. The loading state is accounted for in _combo_box.scss
   @include euiFormControlLayoutPadding(1, 'right');
   position: absolute;
   pointer-events: none;

--- a/src/components/combo_box/combo_box_input/_combo_box_placeholder.scss
+++ b/src/components/combo_box/combo_box_input/_combo_box_placeholder.scss
@@ -1,15 +1,11 @@
 .euiComboBoxPlaceholder {
+  @include euiTextTruncate;
+  // Afford for the caret. The loading state is accounted ford in _combo_box.scss
+  @include euiFormControlLayoutPadding(1, 'right');
   position: absolute;
   pointer-events: none;
-  padding: 0 $euiSizeXS;
+  padding-left: $euiSizeXS;
   line-height: $euiSizeXL;
   color: $euiColorMediumShade;
   margin-bottom: 0 !important; // sass-lint:disable-line no-important
-
-  // Truncate placeholder with ellipsis if it's too long
-  // https://css-tricks.com/almanac/properties/t/text-overflow/
-  width: calc(100% - 28px); // 28px is a quick fix to give space for the combobox arrow
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }


### PR DESCRIPTION
### Summary

Addresses the following issue in the `security_solution` plugin's UI: https://github.com/elastic/kibana/issues/81284
Basically there's a bunch of comboboxes which have long placeholders, and here's how it looks like:

![](https://user-images.githubusercontent.com/61860752/95730975-9342eb80-0c9c-11eb-928f-6e73de2aabe0.jpg)

I added a quick fix: truncation with CSS.

### Screenshots

http://localhost:8030/#/forms/combo-box

Before:

![Screenshot 2020-11-02 at 16 11 40](https://user-images.githubusercontent.com/7359339/97884340-3fb94000-1d26-11eb-9c2b-1f27ce86676c.png)

After:

![Screenshot 2020-11-02 at 15 53 54](https://user-images.githubusercontent.com/7359339/97883578-5612cc00-1d25-11eb-8cd8-05f588a90cf4.png)

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
