### PR TITLE
[EuiInMemoryTable] Remove spacer after `childrenBetween`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added `initialFocusedItemIndex` support to `EuiContextMenuPanelDescriptor` ([#4223](https://github.com/elastic/eui/pull/4223))
 - Added `role="alert"` and `aria-live="assertive"` to `EuiForm`'s `EuiCallOut` for the errors ([#4238](https://github.com/elastic/eui/pull/4238))
 - Added `menuDown` and `menuUp` glyphs to `EuiIcon` ([#4244](https://github.com/elastic/eui/pull/4244))
+- Removed spacer after `childrenBetween` in `EuiInMemoryTable` ([#4248](https://github.com/elastic/eui/pull/4248))
 
 **Bug fixes**
 

--- a/src-docs/src/views/tables/in_memory/in_memory_search.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_search.js
@@ -9,7 +9,7 @@ import {
   EuiSwitch,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiText,
+  EuiCallOut,
   EuiCode,
 } from '../../../../../src/components';
 
@@ -152,10 +152,15 @@ export const Table = () => {
         sorting={true}
         childrenBetween={
           contentBetween && (
-            <EuiText>
-              You can inject custom content between the search bar and the table
-              using <EuiCode>childrenBetween</EuiCode>.
-            </EuiText>
+            <EuiCallOut
+              size="s"
+              title={
+                <>
+                  You can inject custom content between the search bar and the
+                  table using <EuiCode>childrenBetween</EuiCode>.
+                </>
+              }
+            />
           )
         }
       />

--- a/src-docs/src/views/tables/in_memory/in_memory_search_external.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_search_external.js
@@ -7,8 +7,8 @@ import {
   EuiHealth,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiSpacer,
-  EuiCheckableCard,
+  EuiFacetGroup,
+  EuiFacetButton,
 } from '../../../../../src/components';
 
 /*
@@ -33,20 +33,11 @@ Example country object:
 }
 */
 
-const initialState = {
-  eu: false,
-  na: false,
-  oc: false,
-  as: false,
-  af: false,
-  sa: false,
-};
-
 const store = createDataStore();
 
 export const Table = () => {
   const [query, setQuery] = useState('');
-  const [state, setState] = useState(initialState);
+  const [selectedOptionId, setSelectedOptionId] = useState(undefined);
 
   const columns = [
     {
@@ -97,72 +88,67 @@ export const Table = () => {
   ];
 
   const handleOnChange = (search) => {
-    setState(initialState);
+    setSelectedOptionId(undefined);
     setQuery(search.queryText);
     return true;
   };
 
-  const handleCheckbox = (e) => {
-    switch (e.target.id) {
-      case 'eu': {
-        const isChecked = !state.eu;
-        setQuery(
-          isChecked ? 'nationality:(NL or CZ or NO or IT or GB or GR)' : ''
-        );
-        setState({
-          ...initialState,
-          eu: isChecked,
-        });
-        break;
-      }
-      case 'na': {
-        const isChecked = !state.na;
-        setQuery(isChecked ? 'nationality:(US or CA or MX or HT)' : '');
-        setState({
-          ...initialState,
-          na: isChecked,
-        });
-        break;
-      }
-      case 'oc': {
-        const isChecked = !state.oc;
-        setQuery(isChecked ? 'nationality:(AU or FJ)' : '');
-        setState({
-          ...initialState,
-          oc: isChecked,
-        });
-        break;
-      }
-      case 'as': {
-        const isChecked = !state.as;
-        setQuery(isChecked ? 'nationality:(IL or LB)' : '');
-        setState({
-          ...initialState,
-          as: isChecked,
-        });
-        break;
-      }
-      case 'af': {
-        const isChecked = !state.af;
-        setQuery(isChecked ? 'nationality:(ZA or CG)' : '');
-        setState({
-          ...initialState,
-          af: isChecked,
-        });
-        break;
-      }
-      case 'sa': {
-        const isChecked = !state.sa;
-        setQuery(isChecked ? 'nationality:(CL)' : '');
-        setState({
-          ...initialState,
-          sa: isChecked,
-        });
-        break;
-      }
-      default:
-    }
-  };
+  const facets = [
+    {
+      id: 'eu',
+      label: 'Europe',
+      isSelected: selectedOptionId === 'eu',
+      onClick: () => {
+        setSelectedOptionId('eu');
+        setQuery('nationality:(NL or CZ or NO or IT or GB or GR)');
+      },
+    },
+    {
+      id: 'na',
+      label: 'North America',
+      isSelected: selectedOptionId === 'na',
+      onClick: () => {
+        setSelectedOptionId('na');
+        setQuery('nationality:(US or CA or MX or HT)');
+      },
+    },
+    {
+      id: 'oc',
+      label: 'Oceania',
+      isSelected: selectedOptionId === 'oc',
+      onClick: () => {
+        setSelectedOptionId('oc');
+        setQuery('nationality:(AU or FJ)');
+      },
+    },
+    {
+      id: 'as',
+      label: 'Asia',
+      isSelected: selectedOptionId === 'as',
+      onClick: () => {
+        setSelectedOptionId('as');
+        setQuery('nationality:(IL or LB)');
+      },
+    },
+    {
+      id: 'af',
+      label: 'Africa',
+      isSelected: selectedOptionId === 'af',
+      onClick: () => {
+        setSelectedOptionId('af');
+        setQuery('nationality:(ZA or CG)');
+      },
+    },
+    {
+      id: 'sa',
+      label: 'South America',
+      isSelected: selectedOptionId === 'sa',
+      onClick: () => {
+        setSelectedOptionId('sa');
+        setQuery('nationality:(CL)');
+      },
+    },
+  ];
 
   const search = {
     query,
@@ -195,73 +181,22 @@ export const Table = () => {
     <Fragment>
       <EuiFlexGroup>
         <EuiFlexItem grow={1}>
-          <div>
-            <EuiCheckableCard
-              id="af"
-              label="Africa"
-              checkableType="radio"
-              value="Africa"
-              checked={state.af}
-              onChange={handleCheckbox}
-            />
-          </div>
-          <EuiSpacer size="s" />
-          <div>
-            <EuiCheckableCard
-              id="as"
-              label="Asia"
-              checkableType="radio"
-              value="Asia"
-              checked={state.as}
-              onChange={handleCheckbox}
-            />
-          </div>
-          <EuiSpacer size="s" />
-          <div>
-            <EuiCheckableCard
-              id="eu"
-              label="Europe"
-              checkableType="radio"
-              value="Europe"
-              checked={state.eu}
-              onChange={handleCheckbox}
-            />
-          </div>
-          <EuiSpacer size="s" />
-          <div>
-            <EuiCheckableCard
-              id="na"
-              label="North America"
-              checkableType="radio"
-              value="North America"
-              checked={state.na}
-              onChange={handleCheckbox}
-            />
-          </div>
-          <EuiSpacer size="s" />
-          <div>
-            <EuiCheckableCard
-              id="oc"
-              label="Oceania"
-              checkableType="radio"
-              value="Oceania"
-              checked={state.oc}
-              onChange={handleCheckbox}
-            />
-          </div>
-          <EuiSpacer size="s" />
-          <div>
-            <EuiCheckableCard
-              id="sa"
-              label="South America"
-              checkableType="radio"
-              value="South America"
-              checked={state.sa}
-              onChange={handleCheckbox}
-            />
-          </div>
+          <EuiFacetGroup>
+            {facets.map((facet) => {
+              return (
+                <EuiFacetButton
+                  key={facet.id}
+                  id={facet.id}
+                  isSelected={facet.isSelected}
+                  // isLoading={loading}
+                  onClick={facet.onClick}>
+                  {facet.label}
+                </EuiFacetButton>
+              );
+            })}
+          </EuiFacetGroup>
         </EuiFlexItem>
-        <EuiFlexItem grow={2}>
+        <EuiFlexItem grow={3}>
           <EuiInMemoryTable
             items={store.users}
             columns={columns}

--- a/src-docs/src/views/tables/in_memory/in_memory_search_external.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_search_external.js
@@ -188,7 +188,6 @@ export const Table = () => {
                   key={facet.id}
                   id={facet.id}
                   isSelected={facet.isSelected}
-                  // isLoading={loading}
                   onClick={facet.onClick}>
                   {facet.label}
                 </EuiFacetButton>

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -2158,9 +2158,6 @@ exports[`EuiInMemoryTable with search and component between search and table 1`]
   <div>
     Children Between
   </div>
-  <EuiSpacer
-    size="l"
-  />
   <EuiBasicTable
     aria-label="aria-label"
     className="testClass1 testClass2"

--- a/src/components/basic_table/in_memory_table.tsx
+++ b/src/components/basic_table/in_memory_table.tsx
@@ -506,7 +506,12 @@ export class EuiInMemoryTable<T> extends Component<
         }
       }
 
-      return <EuiSearchBar onChange={this.onQueryChange} {...searchBarProps} />;
+      return (
+        <>
+          <EuiSearchBar onChange={this.onQueryChange} {...searchBarProps} />
+          <EuiSpacer size="l" />
+        </>
+      );
     }
   }
 
@@ -692,9 +697,7 @@ export class EuiInMemoryTable<T> extends Component<
     return (
       <div>
         {searchBar}
-        {childrenBetween != null ? <EuiSpacer size="l" /> : null}
         {childrenBetween}
-        <EuiSpacer size="l" />
         {table}
       </div>
     );


### PR DESCRIPTION
### Closes #4246

When `childrenBetween` was added, it also added a conditional spacer between it and the search bar (keeping the spacer that existed before the table). The main consumer for needing teh `childrenBetween` doesn't want this spacer/wants to manually handle this spacing that exists between the children and the table.

This PR, moves the pre-existing spacer to only display if the search bar exists and after the search bar (before the children). So if consumers addd any `childrenBetween` they will need to add their own spacer between it and the table.

The only possible implications with this change is that it does now make the pre-existing spacer conditional upon the presence of the search bar. So if consumers were using the EuiInMemoryTable **without search**, it did have a large spacer between the content that came before it which they may have accounted for. But now that space is gone.

---

I also updated one of the examples to use Facets instead of checkable cards as the more appropriate component.

### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- [x] Checked in **mobile**
- ~[ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
