### PR TITLE
Prevent EuiPopover's focus lock from resetting during element tabbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed incorrect initial rendering of `EuiDualRange` thumbs when element width is 0 ([#4230](https://github.com/elastic/eui/pull/4230))
 - Fixed bug in `EuiSelectable` to call `searchProps.onChange` and `searchProps.onSearch` calls in `EuiSelectable` ([#4153](https://github.com/elastic/eui/pull/4153))
 - Fixed truncation of the `EuiComboBox` `placeholder` text ([#4210](https://github.com/elastic/eui/pull/4210))
+- Fixed bug preventing elements in `EuiPopover` panels from being tabbed into ([#4247](https://github.com/elastic/eui/pull/4247))
 
 **Theme: Amsterdam**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 - Fixed incorrect initial rendering of `EuiDualRange` thumbs when element width is 0 ([#4230](https://github.com/elastic/eui/pull/4230))
 - Fixed bug in `EuiSelectable` to call `searchProps.onChange` and `searchProps.onSearch` calls in `EuiSelectable` ([#4153](https://github.com/elastic/eui/pull/4153))
 - Fixed truncation of the `EuiComboBox` `placeholder` text ([#4210](https://github.com/elastic/eui/pull/4210))
-- Fixed bug preventing elements in `EuiPopover` panels from being tabbed into ([#4247](https://github.com/elastic/eui/pull/4247))
 
 **Theme: Amsterdam**
 

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -266,6 +266,8 @@ function getElementFromInitialFocus(
   return initialFocus as HTMLElement | null;
 }
 
+const returnFocusConfig = { preventScroll: true };
+
 export type Props = CommonProps &
   HTMLAttributes<HTMLDivElement> &
   EuiPopoverProps;
@@ -511,12 +513,7 @@ export class EuiPopover extends Component<Props, State> {
 
   onMutation = (records: MutationRecord[]) => {
     const waitDuration = getWaitDuration(records);
-    // setTimeout to ensure the setState in positionPopoverFixed
-    // happens outside of any existing React event handling
-    // which apparently causes issues with react-focus-lock's active trap management
-    setTimeout(() => {
-      this.positionPopoverFixed();
-    }, 0);
+    this.positionPopoverFixed();
 
     performOnFrame(waitDuration, this.positionPopoverFixed);
   };
@@ -717,9 +714,7 @@ export class EuiPopover extends Component<Props, State> {
         `euiPopover__panelArrow--${this.state.arrowPosition}`
       );
 
-      const returnFocus = this.state.isOpenStable
-        ? { preventScroll: true }
-        : false;
+      const returnFocus = this.state.isOpenStable ? returnFocusConfig : false;
 
       panel = (
         <EuiPortal insert={insert}>

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -511,7 +511,12 @@ export class EuiPopover extends Component<Props, State> {
 
   onMutation = (records: MutationRecord[]) => {
     const waitDuration = getWaitDuration(records);
-    this.positionPopoverFixed();
+    // setTimeout to ensure the setState in positionPopoverFixed
+    // happens outside of any existing React event handling
+    // which apparently causes issues with react-focus-lock's active trap management
+    setTimeout(() => {
+      this.positionPopoverFixed();
+    }, 0);
 
     performOnFrame(waitDuration, this.positionPopoverFixed);
   };


### PR DESCRIPTION
### Summary

Fixes #4247 

**EuiPopover** uses a mutation observer to detect when its content's dimensions may have changed. One watched mutation occurs when the **EuiFormRow**'s label loses its `isFocused` class name. For some reason, when this resize handling occurs in response to the user tabbing the call stack looks like:

```
[React handling tab event]
MutationObserver
EuiPopover::positionPopoverFixed
EuiPopover::positionPopover
EuiPopover::setState
ReactClientsideEffect::componentDidUpdate
ReactClientsideEffect::emitChange
ReactFocusLock::handleStateChangeOnClient
ReactFocusLock::activateTrap
```

Introducing a `setTimeout` before `positionPopover` calls `setState` avoids the setState from triggering the ReactClientsideEffect lifecycles.

This is not a long-term fix, but should hold the component together until I can find a better way to mitigate the issue.

### Before
![popover_focustrap_before](https://user-images.githubusercontent.com/313125/98738478-fdff4980-2364-11eb-9126-c0c89a02cad0.gif)

### After
![popover_focustrap_after](https://user-images.githubusercontent.com/313125/98738337-c8f2f700-2364-11eb-8747-f7e111ccee51.gif)

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
