### PR TITLE
[EuiDataGrid] Fix size of rightmost cell resizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 - Added `eql` glyph in `EuiIcon` ([#4110](https://github.com/elastic/eui/pull/4110))
 - Added `testenv` mock for `htmlIdGenerator` ([#4212](https://github.com/elastic/eui/pull/4212)) 
 
+**Bug fixes**
+
+- Fixed cell resizer overlapping of `EuiDataGrid` rightmost header cell ([#4071](https://github.com/elastic/eui/pull/4268))
+
+
 **Theme: Amsterdam**
 
 - Removed faux border from `EuiAvatar` ([#4255](https://github.com/elastic/eui/pull/4255))

--- a/src/components/datagrid/_data_grid_column_resizer.scss
+++ b/src/components/datagrid/_data_grid_column_resizer.scss
@@ -38,6 +38,7 @@
 
     .euiDataGridColumnResizer {
       right: 0;
+      width: $euiSize / 2;
 
       &:after {
         left: auto;


### PR DESCRIPTION
### Summary

The rightmost cell header resize element was overlapping the header menu, so it was difficult to click this element. This PR resizes the width of this element to prevent this overlapping.

Before:
![Bildschirmfoto 2020-11-16 um 11 26 42](https://user-images.githubusercontent.com/463851/99243214-a51a3000-2800-11eb-8f00-409b593637e0.png)

After:
![Bildschirmfoto 2020-11-16 um 11 27 54](https://user-images.githubusercontent.com/463851/99243231-ac413e00-2800-11eb-855e-c8da4d40de82.png)

Fixes #4233


### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
