### PR TITLE
Export some datagrid hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added `eql` glyph in `EuiIcon` ([#4110](https://github.com/elastic/eui/pull/4110))
 - Added `testenv` mock for `htmlIdGenerator` ([#4212](https://github.com/elastic/eui/pull/4212))
 - Added several Sass mixins for handling of unified focus/hover states ([#4242](https://github.com/elastic/eui/pull/4242))
+- Exported `useDataGridColumnSelector`, `useDataGridColumnSorting`, and `useDataGridStyleSelector` hooks ([#4271](https://github.com/elastic/eui/pull/4271))
 
 **Theme: Amsterdam**
 

--- a/src/components/datagrid/column_selector.tsx
+++ b/src/components/datagrid/column_selector.tsx
@@ -56,7 +56,7 @@ const getShowColumnSelectorValue = (
   return showColumnSelector[valueName] !== false;
 };
 
-export const useColumnSelector = (
+export const useDataGridColumnSelector = (
   availableColumns: EuiDataGridColumn[],
   columnVisibility: EuiDataGridColumnVisibility,
   showColumnSelector: EuiDataGridToolBarVisibilityOptions['showColumnSelector'],

--- a/src/components/datagrid/column_sorting.tsx
+++ b/src/components/datagrid/column_sorting.tsx
@@ -45,7 +45,7 @@ import {
 } from './data_grid_schema';
 import { EuiToken } from '../token';
 
-export const useColumnSorting = (
+export const useDataGridColumnSorting = (
   columns: EuiDataGridColumn[],
   sorting: EuiDataGridSorting | undefined,
   schema: EuiDataGridSchema,

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -61,8 +61,8 @@ import { EuiDataGridCellProps } from './data_grid_cell';
 import { EuiButtonEmpty } from '../button';
 import { keys, htmlIdGenerator } from '../../services';
 import { EuiDataGridBody } from './data_grid_body';
-import { useColumnSelector } from './column_selector';
-import { useStyleSelector, startingStyles } from './style_selector';
+import { useDataGridColumnSelector } from './column_selector';
+import { useDataGridStyleSelector, startingStyles } from './style_selector';
 import { EuiTablePagination } from '../table/table_pagination';
 import { EuiFocusTrap } from '../focus_trap';
 import {
@@ -76,7 +76,7 @@ import {
   useDetectSchema,
   schemaDetectors as providedSchemaDetectors,
 } from './data_grid_schema';
-import { useColumnSorting } from './column_sorting';
+import { useDataGridColumnSorting } from './column_sorting';
 import { EuiMutationObserver } from '../observer/mutation_observer';
 import { DataGridContext } from './data_grid_context';
 
@@ -769,20 +769,22 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
     orderedVisibleColumns,
     setVisibleColumns,
     switchColumnPos,
-  ] = useColumnSelector(
+  ] = useDataGridColumnSelector(
     columns,
     columnVisibility,
     checkOrDefaultToolBarDiplayOptions(toolbarVisibility, 'showColumnSelector'),
     displayValues
   );
-  const columnSorting = useColumnSorting(
+  const columnSorting = useDataGridColumnSorting(
     orderedVisibleColumns,
     sorting,
     mergedSchema,
     allSchemaDetectors,
     displayValues
   );
-  const [styleSelector, gridStyles] = useStyleSelector(gridStyleWithDefaults);
+  const [styleSelector, gridStyles] = useDataGridStyleSelector(
+    gridStyleWithDefaults
+  );
 
   // compute the default column width from the container's clientWidth and count of visible columns
   const defaultColumnWidth = useDefaultColumnWidth(

--- a/src/components/datagrid/index.ts
+++ b/src/components/datagrid/index.ts
@@ -36,5 +36,8 @@ export {
   EuiDataGridSchemaDetector,
   SchemaTypeScore,
 } from './data_grid_schema';
+export { useDataGridColumnSelector } from './column_selector';
+export { useDataGridColumnSorting } from './column_sorting';
+export { useDataGridStyleSelector } from './style_selector';
 
 export * from './data_grid_types';

--- a/src/components/datagrid/style_selector.tsx
+++ b/src/components/datagrid/style_selector.tsx
@@ -49,7 +49,7 @@ const densityStyles: { [key: string]: Partial<EuiDataGridStyle> } = {
   },
 };
 
-export const useStyleSelector = (
+export const useDataGridStyleSelector = (
   initialStyles: EuiDataGridStyle
 ): [ReactElement, EuiDataGridStyle] => {
   // track styles specified by the user at run time


### PR DESCRIPTION
### Summary

Exports the `useDataGridColumnSelector`, `useDataGridColumnSorting`, and `useDataGridStyleSelector` hooks from datagrid. This was asked for by @XavierM to help unify the UX in the security timeline, as the full **EuiDataGrid** does not support their row renderer need.

There was not a great way to export these on the **EuiDataGrid** object, mostly because of TypeScript, so I renamed the hooks for clarity.

I did not write documentation. I'm unsure how we want to document hooks and will bring this up with the team in our weekly discussion.

/cc @kertal this might be interesting for Discover's re-implementation of some of the popover experiences.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs**~
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
