### PR TITLE
Actually export the datagrid hooks 🤦‍♂️

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Exported `useDataGridColumnSelector`, `useDataGridColumnSorting`, and `useDataGridStyleSelector` hooks ([#4271](https://github.com/elastic/eui/pull/4271))
+
 **Theme: Amsterdam**
 
 - Unify colors with the Elastic brand ([#4284](https://github.com/elastic/eui/pull/4284))
@@ -10,7 +12,6 @@
 - Added `eql` glyph in `EuiIcon` ([#4110](https://github.com/elastic/eui/pull/4110))
 - Added `testenv` mock for `htmlIdGenerator` ([#4212](https://github.com/elastic/eui/pull/4212))
 - Added several Sass mixins for handling of unified focus/hover states ([#4242](https://github.com/elastic/eui/pull/4242))
-- Exported `useDataGridColumnSelector`, `useDataGridColumnSorting`, and `useDataGridStyleSelector` hooks ([#4271](https://github.com/elastic/eui/pull/4271))
 
 **Bug fixes**
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -85,7 +85,12 @@ export { EuiControlBar } from './control_bar';
 
 export { EuiCopy } from './copy';
 
-export { EuiDataGrid } from './datagrid';
+export {
+  EuiDataGrid,
+  useDataGridColumnSelector,
+  useDataGridColumnSorting,
+  useDataGridStyleSelector,
+} from './datagrid';
 
 export {
   EuiDatePicker,


### PR DESCRIPTION
### Summary

Previous PR (#4271) didn't export the hooks from _src/components/index.js_ - turns out that's a necessary step. I'll make a follow-up release after this merges.

### ~Checklist~
