### PR TITLE
[EuiButtonGroup] Fix initial focus when in a popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `30.4.1`.
+**Bug fixes**
+
+- Fixed initial focus of an `EuiButtonGroup` when first item in a popover ([#4288](https://github.com/elastic/eui/pull/4288))
 
 ## [`30.4.1`](https://github.com/elastic/eui/tree/v30.4.1)
 
 - Exported `useDataGridColumnSelector`, `useDataGridColumnSorting`, and `useDataGridStyleSelector` hooks ([#4271](https://github.com/elastic/eui/pull/4271))
-
-**Bug fixes**
-
-- Fixed initial focus of an `EuiButtonGroup` when first item in a popover ([#4288](https://github.com/elastic/eui/pull/4288))
 
 **Theme: Amsterdam**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+**Bug fixes**
+
+- Fixed initial focus of an `EuiButtonGroup` when first item in a popover ([#4288](https://github.com/elastic/eui/pull/4288))
+
 **Theme: Amsterdam**
 
 - Unify colors with the Elastic brand ([#4284](https://github.com/elastic/eui/pull/4284))

--- a/src-docs/src/views/form_compressed/form_compressed_example.js
+++ b/src-docs/src/views/form_compressed/form_compressed_example.js
@@ -26,6 +26,10 @@ import FormHelp from './form_horizontal_help';
 const formHelpSource = require('!!raw-loader!./form_horizontal_help');
 const formHelpHtml = renderToHtml(FormHelp);
 
+import FormPopover from './form_compressed_popover';
+const formPopoverSource = require('!!raw-loader!./form_compressed_popover');
+const formPopoverHtml = renderToHtml(FormPopover);
+
 import ComplexExample from './complex_example';
 const ComplexExampleSource = require('!!raw-loader!./complex_example');
 const ComplexExampleHtml = renderToHtml(ComplexExample);
@@ -184,6 +188,28 @@ export const FormCompressedExample = {
   <EuiFieldText compressed />
 </EuiFormRow>`,
       ],
+    },
+    {
+      title: 'In a popover',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: formPopoverSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: formPopoverHtml,
+        },
+      ],
+      text: (
+        <Fragment>
+          <p>
+            Always use the compressed version of forms and elements when they
+            exist inside of a<Link to="/layout/popover">popover</Link>.
+          </p>
+        </Fragment>
+      ),
+      demo: <FormPopover />,
     },
     {
       title: 'Complex example',

--- a/src-docs/src/views/form_compressed/form_compressed_popover.js
+++ b/src-docs/src/views/form_compressed/form_compressed_popover.js
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+
+import {
+  EuiFieldText,
+  EuiFormRow,
+  EuiSelect,
+  EuiButton,
+  EuiPopover,
+  EuiButtonGroup,
+} from '../../../../src/components';
+
+export default () => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [granularityIdSelected, setGranularityIdSelected] = useState(
+    'granularityButton1'
+  );
+
+  const onButtonClick = () =>
+    setIsPopoverOpen((isPopoverOpen) => !isPopoverOpen);
+  const closePopover = () => setIsPopoverOpen(false);
+
+  const onGranularityChange = (optionId) => {
+    setGranularityIdSelected(optionId);
+  };
+
+  const button = (
+    <EuiButton iconType="arrowDown" iconSide="right" onClick={onButtonClick}>
+      Open form in popover
+    </EuiButton>
+  );
+
+  const granularityToggleButtons = [
+    {
+      id: 'granularityButton1',
+      label: 'Left',
+    },
+    {
+      id: 'granularityButton2',
+      label: 'Middle',
+    },
+    {
+      id: 'granularityButton3',
+      label: 'Right',
+    },
+  ];
+
+  return (
+    <EuiPopover
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}>
+      <div style={{ width: 300 }}>
+        <EuiFormRow label="Button group" display="columnCompressed">
+          <EuiButtonGroup
+            legend="Granulariy of zoom levels"
+            options={granularityToggleButtons}
+            idSelected={granularityIdSelected}
+            onChange={onGranularityChange}
+            buttonSize="compressed"
+            isFullWidth
+          />
+        </EuiFormRow>
+        <EuiFormRow label="Text field" display="columnCompressed">
+          <EuiFieldText name="first" compressed />
+        </EuiFormRow>
+
+        <EuiFormRow label={'Select'} display="columnCompressed">
+          <EuiSelect
+            options={[
+              { value: 'option_one', text: 'Option one' },
+              { value: 'option_two', text: 'Option two' },
+              { value: 'option_three', text: 'Option three' },
+            ]}
+            compressed
+          />
+        </EuiFormRow>
+      </div>
+    </EuiPopover>
+  );
+};

--- a/src/components/button/button_group/_button_group.scss
+++ b/src/components/button/button_group/_button_group.scss
@@ -22,7 +22,6 @@
   max-width: 100%;
   display: flex;
   overflow: hidden;
-  transition: all $euiAnimSpeedNormal ease-in-out;
 }
 
 .euiButtonGroup--isDisabled .euiButtonGroup__buttons {


### PR DESCRIPTION
By removing the `transition: all` on the `.euiButtonGroup__buttons` selector. This was safe to remove because no interaction states were directly applied to this selector. It was probably leftover from before the a11y fix.

Also added an example to the compressed forms page.

### Fixes  #4266


**Before**

![Screen Recording 2020-11-19 at 11 57 30 AM](https://user-images.githubusercontent.com/549577/99699095-941b2a00-2a5f-11eb-9b30-83b03bfc7521.gif)


**After**

![Screen Recording 2020-11-19 at 12 02 01 PM](https://user-images.githubusercontent.com/549577/99699115-98dfde00-2a5f-11eb-9381-70bbf367c4fc.gif)


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
