### PR TITLE
Exported `ToastColor` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Exported `ToastColor` type ([#4290](https://github.com/elastic/eui/pull/4290))
+
 **Bug fixes**
 
 - Fixed initial focus of an `EuiButtonGroup` when first item in a popover ([#4288](https://github.com/elastic/eui/pull/4288))

--- a/src/components/toast/toast.tsx
+++ b/src/components/toast/toast.tsx
@@ -33,7 +33,7 @@ import { IconType, EuiIcon } from '../icon';
 
 import { EuiText } from '../text';
 
-type ToastColor = 'primary' | 'success' | 'warning' | 'danger';
+export type ToastColor = 'primary' | 'success' | 'warning' | 'danger';
 
 const colorToClassNameMap: { [color in ToastColor]: string } = {
   primary: 'euiToast--primary',


### PR DESCRIPTION
### Summary

Exporting the `ToastColor` type so that end-users can use it directly.

### Checklist

- ~~Check against **all themes** for compatibility in both light and dark modes~~
- ~~Checked in **mobile**~~
- ~~Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~~
- ~~Props have proper **autodocs**~~
- ~~Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
- ~~Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~~
- ~~Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
- ~~Checked for **breaking changes** and labeled appropriately~~
- ~~Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
