### PR TITLE
refactor(selectable): avoid prop conflicts

### DIFF
--- a/src/components/selectable/selectable_search/selectable_search.tsx
+++ b/src/components/selectable/selectable_search/selectable_search.tsx
@@ -83,6 +83,10 @@ export class EuiSelectableSearch<T> extends Component<
         this.props.onChange(matchingOptions, value);
       });
     }
+
+    if (this.props.onSearch) {
+      this.props.onSearch(value);
+    }
   };
 
   render() {
@@ -114,7 +118,6 @@ export class EuiSelectableSearch<T> extends Component<
       <EuiFieldSearch
         className={classes}
         placeholder={placeholder}
-        onSearch={this.onSearchChange}
         incremental
         defaultValue={defaultValue}
         fullWidth
@@ -122,6 +125,7 @@ export class EuiSelectableSearch<T> extends Component<
         aria-haspopup="listbox"
         {...ariaPropsIfListIsPresent}
         {...rest}
+        onSearch={this.onSearchChange}
       />
     );
   }


### PR DESCRIPTION
### Summary

I'm planning to open another PR to address https://github.com/elastic/eui/issues/4262. While looking starting working on that, I noticed some code patterns that I see as problematic. The issue I see is that we have cases of props conflicting with each other (in this case top-level props conflicting with `seachProps`). The current code mostly fixes these issues by creating a `...cleanedSearchProps`, which is all of `searchProps` minus some de-structured values. While this approach works, it's quite unstable. Another engineer could easily confuse these unused variables as "useless", and remove them. Similarly, we need to jump through some hoops to keep TypeScript happy about this approach (in this type casting).

The approach I have taken instead is to not spread `...searchProps` over all others. Instead, I have continued to spread these, but added a couple of explicit overrides afterwards.

As this change doesn't explicitly fix an open issue, and is to some extent an opinionated change. I'm interested in hearing some thoughts on my approach from the Elastic team. Thanks!

### Related to

https://github.com/elastic/eui/issues/4132
https://github.com/elastic/eui/issues/4262

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
