### PR TITLE
fix(selectable): use latest state in onChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Bug fixes**
 
+- Fixed stale state argument passed to `searchProps.onChange` in an `EuiSelectable`([#4292](https://github.com/elastic/eui/pull/4292))
 - Fixed initial focus of an `EuiButtonGroup` when first item in a popover ([#4288](https://github.com/elastic/eui/pull/4288))
 
 ## [`30.4.1`](https://github.com/elastic/eui/tree/v30.4.1)

--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -349,18 +349,17 @@ export class EuiSelectable<T = {}> extends Component<
   };
 
   onOptionClick = (options: Array<EuiSelectableOption<T>>) => {
-    this.setState((state) => ({
-      visibleOptions: getMatchingOptions<T>(options, state.searchValue),
-      activeOptionIndex: this.state.activeOptionIndex,
-    }));
+    const { searchValue } = this.state;
+    const visibleOptions = getMatchingOptions<T>(options, searchValue);
+
+    this.setState({ visibleOptions });
+
     if (this.props.onChange) {
       this.props.onChange(options);
     }
+
     if (this.props.searchProps && this.props.searchProps.onChange) {
-      this.props.searchProps.onChange(
-        { ...this.state.visibleOptions },
-        this.state.searchValue
-      );
+      this.props.searchProps.onChange(visibleOptions, searchValue);
     }
   };
 


### PR DESCRIPTION
### Summary

Fixes the issue described in https://github.com/elastic/eui/issues/4262. In short, passes the latest component state to the `searchProps.onChange` callback.

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
