### PR TITLE
Fix dropdown styles in Amsterdam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@
 **Bug fixes**
 
 - Fixed initial focus of an `EuiButtonGroup` when first item in a popover ([#4288](https://github.com/elastic/eui/pull/4288))
+- Fixed visible scrollbar in `EuiComboBox` list ([#4301](https://github.com/elastic/eui/pull/4301))
+- Removed hiding of time select on small screens for `EuiDatePicker` ([#4301](https://github.com/elastic/eui/pull/4301))
 
 **Theme: Amsterdam**
 
 - Fixed styles for `EuiMarkdownEditor` ([#4289](https://github.com/elastic/eui/pull/4289))
+- Rounded all corners of dropdown type of inputs ([#4301](https://github.com/elastic/eui/pull/4301))
 
 ## [`30.4.1`](https://github.com/elastic/eui/tree/v30.4.1)
 

--- a/src-docs/src/views/color_picker/color_palette_display.js
+++ b/src-docs/src/views/color_picker/color_palette_display.js
@@ -192,6 +192,8 @@ export default () => {
                 checked={selectionType}
                 onChange={() => setSelectionType(!selectionType)}
                 compressed
+                showLabel={false}
+                label="Display as fixed"
               />
             </EuiFormRow>
           </EuiPopover>

--- a/src/components/color_picker/color_palette_picker/__snapshots__/color_palette_picker.test.tsx.snap
+++ b/src/components/color_picker/color_palette_picker/__snapshots__/color_palette_picker.test.tsx.snap
@@ -2,47 +2,49 @@
 
 exports[`EuiColorPalettePicker is rendered 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiSuperSelect"
 >
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value=""
-    />
-    <div
-      class="euiFormControlLayout"
-    >
+    <div>
+      <input
+        type="hidden"
+        value=""
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
-        >
-          Select an option: , is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-label="aria-label"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl testClass1 testClass2"
-          data-test-subj="test subject string"
-          type="button"
-        />
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
+          >
+            Select an option: , is selected
+          </span>
+          <button
+            aria-haspopup="true"
+            aria-label="aria-label"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl testClass1 testClass2"
+            data-test-subj="test subject string"
+            type="button"
+          />
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
           >
             <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="arrowDown"
-            />
-          </span>
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="arrowDown"
+              />
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -52,49 +54,51 @@ exports[`EuiColorPalettePicker is rendered 1`] = `
 
 exports[`EuiColorPalettePicker is rendered with a selected custom text 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiSuperSelect"
 >
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value="custom"
-    />
-    <div
-      class="euiFormControlLayout"
-    >
+    <div>
+      <input
+        type="hidden"
+        value="custom"
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
-        >
-          Select an option: Plain text as a custom option, is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-label="aria-label"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl testClass1 testClass2"
-          data-test-subj="test subject string"
-          type="button"
-        >
-          Plain text as a custom option
-        </button>
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
+          >
+            Select an option: Plain text as a custom option, is selected
+          </span>
+          <button
+            aria-haspopup="true"
+            aria-label="aria-label"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl testClass1 testClass2"
+            data-test-subj="test subject string"
+            type="button"
+          >
+            Plain text as a custom option
+          </button>
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
           >
             <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="arrowDown"
-            />
-          </span>
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="arrowDown"
+              />
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -104,95 +108,97 @@ exports[`EuiColorPalettePicker is rendered with a selected custom text 1`] = `
 
 exports[`EuiColorPalettePicker is rendered with a selected fixed palette 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiSuperSelect"
 >
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value="paletteFixed"
-    />
-    <div
-      class="euiFormControlLayout"
-    >
+    <div>
+      <input
+        type="hidden"
+        value="paletteFixed"
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
-        >
-          Select an option: 
-          <span
-            class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
-          >
-            <span
-              class="euiColorPaletteDisplayFixed__bleedArea"
-            >
-              <span
-                style="background-color:#1fb0b2;width:20%"
-              />
-              <span
-                style="background-color:#ffdb6d;width:20%"
-              />
-              <span
-                style="background-color:#ee9191;width:20%"
-              />
-              <span
-                style="background-color:#ffffff;width:20%"
-              />
-              <span
-                style="background-color:#888094;width:20%"
-              />
-            </span>
-          </span>
-          , is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-label="aria-label"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl testClass1 testClass2"
-          data-test-subj="test subject string"
-          type="button"
-        >
-          <span
-            class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
-          >
-            <span
-              class="euiColorPaletteDisplayFixed__bleedArea"
-            >
-              <span
-                style="background-color:#1fb0b2;width:20%"
-              />
-              <span
-                style="background-color:#ffdb6d;width:20%"
-              />
-              <span
-                style="background-color:#ee9191;width:20%"
-              />
-              <span
-                style="background-color:#ffffff;width:20%"
-              />
-              <span
-                style="background-color:#888094;width:20%"
-              />
-            </span>
-          </span>
-        </button>
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
+          >
+            Select an option: 
+            <span
+              class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
+            >
+              <span
+                class="euiColorPaletteDisplayFixed__bleedArea"
+              >
+                <span
+                  style="background-color:#1fb0b2;width:20%"
+                />
+                <span
+                  style="background-color:#ffdb6d;width:20%"
+                />
+                <span
+                  style="background-color:#ee9191;width:20%"
+                />
+                <span
+                  style="background-color:#ffffff;width:20%"
+                />
+                <span
+                  style="background-color:#888094;width:20%"
+                />
+              </span>
+            </span>
+            , is selected
+          </span>
+          <button
+            aria-haspopup="true"
+            aria-label="aria-label"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl testClass1 testClass2"
+            data-test-subj="test subject string"
+            type="button"
           >
             <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="arrowDown"
-            />
-          </span>
+              class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
+            >
+              <span
+                class="euiColorPaletteDisplayFixed__bleedArea"
+              >
+                <span
+                  style="background-color:#1fb0b2;width:20%"
+                />
+                <span
+                  style="background-color:#ffdb6d;width:20%"
+                />
+                <span
+                  style="background-color:#ee9191;width:20%"
+                />
+                <span
+                  style="background-color:#ffffff;width:20%"
+                />
+                <span
+                  style="background-color:#888094;width:20%"
+                />
+              </span>
+            </span>
+          </button>
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          >
+            <span
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="arrowDown"
+              />
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -202,57 +208,59 @@ exports[`EuiColorPalettePicker is rendered with a selected fixed palette 1`] = `
 
 exports[`EuiColorPalettePicker is rendered with a selected gradient palette 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiSuperSelect"
 >
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value="paletteLinear"
-    />
-    <div
-      class="euiFormControlLayout"
-    >
+    <div>
+      <input
+        type="hidden"
+        value="paletteLinear"
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
-        >
-          Select an option: 
-          <span
-            class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
-            style="background:linear-gradient(to right, #1fb0b2 0%, #ffdb6d 25%, #ee9191 50%, #ffffff 75%, #888094 100%)"
-          />
-          , is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-label="aria-label"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl testClass1 testClass2"
-          data-test-subj="test subject string"
-          type="button"
-        >
-          <span
-            class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
-            style="background:linear-gradient(to right, #1fb0b2 0%, #ffdb6d 25%, #ee9191 50%, #ffffff 75%, #888094 100%)"
-          />
-        </button>
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
+          >
+            Select an option: 
+            <span
+              class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
+              style="background:linear-gradient(to right, #1fb0b2 0%, #ffdb6d 25%, #ee9191 50%, #ffffff 75%, #888094 100%)"
+            />
+            , is selected
+          </span>
+          <button
+            aria-haspopup="true"
+            aria-label="aria-label"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl testClass1 testClass2"
+            data-test-subj="test subject string"
+            type="button"
           >
             <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="arrowDown"
+              class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
+              style="background:linear-gradient(to right, #1fb0b2 0%, #ffdb6d 25%, #ee9191 50%, #ffffff 75%, #888094 100%)"
             />
-          </span>
+          </button>
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          >
+            <span
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="arrowDown"
+              />
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -262,57 +270,59 @@ exports[`EuiColorPalettePicker is rendered with a selected gradient palette 1`] 
 
 exports[`EuiColorPalettePicker is rendered with a selected gradient palette with stops 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiSuperSelect"
 >
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value="paletteLinearStops"
-    />
-    <div
-      class="euiFormControlLayout"
-    >
+    <div>
+      <input
+        type="hidden"
+        value="paletteLinearStops"
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
-        >
-          Select an option: 
-          <span
-            class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
-            style="background:linear-gradient(to right, #54B399 0%, #D36086 53%, #9170B8 74%, #F5A700 100%)"
-          />
-          , is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-label="aria-label"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl testClass1 testClass2"
-          data-test-subj="test subject string"
-          type="button"
-        >
-          <span
-            class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
-            style="background:linear-gradient(to right, #54B399 0%, #D36086 53%, #9170B8 74%, #F5A700 100%)"
-          />
-        </button>
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
+          >
+            Select an option: 
+            <span
+              class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
+              style="background:linear-gradient(to right, #54B399 0%, #D36086 53%, #9170B8 74%, #F5A700 100%)"
+            />
+            , is selected
+          </span>
+          <button
+            aria-haspopup="true"
+            aria-label="aria-label"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl testClass1 testClass2"
+            data-test-subj="test subject string"
+            type="button"
           >
             <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="arrowDown"
+              class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
+              style="background:linear-gradient(to right, #54B399 0%, #D36086 53%, #9170B8 74%, #F5A700 100%)"
             />
-          </span>
+          </button>
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          >
+            <span
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="arrowDown"
+              />
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -322,49 +332,51 @@ exports[`EuiColorPalettePicker is rendered with a selected gradient palette with
 
 exports[`EuiColorPalettePicker is rendered with the prop selectionDisplay set as title  1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiSuperSelect"
 >
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value="paletteFixed"
-    />
-    <div
-      class="euiFormControlLayout"
-    >
+    <div>
+      <input
+        type="hidden"
+        value="paletteFixed"
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
-        >
-          Select an option: Palette 1, is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-label="aria-label"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl testClass1 testClass2"
-          data-test-subj="test subject string"
-          type="button"
-        >
-          Palette 1
-        </button>
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
+          >
+            Select an option: Palette 1, is selected
+          </span>
+          <button
+            aria-haspopup="true"
+            aria-label="aria-label"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl testClass1 testClass2"
+            data-test-subj="test subject string"
+            type="button"
+          >
+            Palette 1
+          </button>
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
           >
             <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="arrowDown"
-            />
-          </span>
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="arrowDown"
+              />
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -374,94 +386,96 @@ exports[`EuiColorPalettePicker is rendered with the prop selectionDisplay set as
 
 exports[`EuiColorPalettePicker more props are propagated to each option 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiSuperSelect"
 >
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value="paletteFixed"
-    />
-    <div
-      class="euiFormControlLayout"
-    >
+    <div>
+      <input
+        type="hidden"
+        value="paletteFixed"
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
-        >
-          Select an option: 
-          <span
-            class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
-          >
-            <span
-              class="euiColorPaletteDisplayFixed__bleedArea"
-            >
-              <span
-                style="background-color: rgb(31, 176, 178); width: 20%;"
-              />
-              <span
-                style="background-color: rgb(255, 219, 109); width: 20%;"
-              />
-              <span
-                style="background-color: rgb(238, 145, 145); width: 20%;"
-              />
-              <span
-                style="background-color: rgb(255, 255, 255); width: 20%;"
-              />
-              <span
-                style="background-color: rgb(136, 128, 148); width: 20%;"
-              />
-            </span>
-          </span>
-          , is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl euiSuperSelect--isOpen__button"
-          data-test-subj="colorPalettePicker"
-          type="button"
-        >
-          <span
-            class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
-          >
-            <span
-              class="euiColorPaletteDisplayFixed__bleedArea"
-            >
-              <span
-                style="background-color: rgb(31, 176, 178); width: 20%;"
-              />
-              <span
-                style="background-color: rgb(255, 219, 109); width: 20%;"
-              />
-              <span
-                style="background-color: rgb(238, 145, 145); width: 20%;"
-              />
-              <span
-                style="background-color: rgb(255, 255, 255); width: 20%;"
-              />
-              <span
-                style="background-color: rgb(136, 128, 148); width: 20%;"
-              />
-            </span>
-          </span>
-        </button>
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
+          >
+            Select an option: 
+            <span
+              class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
+            >
+              <span
+                class="euiColorPaletteDisplayFixed__bleedArea"
+              >
+                <span
+                  style="background-color: rgb(31, 176, 178); width: 20%;"
+                />
+                <span
+                  style="background-color: rgb(255, 219, 109); width: 20%;"
+                />
+                <span
+                  style="background-color: rgb(238, 145, 145); width: 20%;"
+                />
+                <span
+                  style="background-color: rgb(255, 255, 255); width: 20%;"
+                />
+                <span
+                  style="background-color: rgb(136, 128, 148); width: 20%;"
+                />
+              </span>
+            </span>
+            , is selected
+          </span>
+          <button
+            aria-haspopup="true"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl euiSuperSelect--isOpen__button"
+            data-test-subj="colorPalettePicker"
+            type="button"
           >
             <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="arrowDown"
-            />
-          </span>
+              class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
+            >
+              <span
+                class="euiColorPaletteDisplayFixed__bleedArea"
+              >
+                <span
+                  style="background-color: rgb(31, 176, 178); width: 20%;"
+                />
+                <span
+                  style="background-color: rgb(255, 219, 109); width: 20%;"
+                />
+                <span
+                  style="background-color: rgb(238, 145, 145); width: 20%;"
+                />
+                <span
+                  style="background-color: rgb(255, 255, 255); width: 20%;"
+                />
+                <span
+                  style="background-color: rgb(136, 128, 148); width: 20%;"
+                />
+              </span>
+            </span>
+          </button>
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          >
+            <span
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="arrowDown"
+              />
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
+++ b/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
@@ -309,7 +309,7 @@ exports[`props options list is rendered 1`] = `
     </div>
   </div>
   <div
-    class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiComboBoxOptionsList euiComboBoxOptionsList--bottom"
+    class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiComboBoxOptionsList euiPopover__panel euiPopover__panel-isAttached euiPopover__panel-noArrow euiPopover__panel-isOpen euiPopover__panel--bottom"
     data-test-subj="comboBoxOptionsList alsoGetsAppliedToOptionsList-optionsList"
     style="z-index: 100;"
   >

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -19,6 +19,7 @@
     @include euiFormControlSize(auto, $includeAlternates: true);
     padding: $euiSizeXS $euiSizeS;
     display: flex; /* 1 */
+    outline: none; // Fixes an intermittent focus ring in Firefox
 
     // sass-lint:disable-block mixins-before-declarations
     // to override the padding added above

--- a/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
@@ -1,56 +1,30 @@
 /**
- * 1. Make width match that of the input and tweak position to match.
- * 2. Put the list at the top of the screen, otherwise it will cause a scrollbar to show up when
- *    the portal is appended to the body. This would throw off our logic for positioning the
- *    list beneath the input.
- * 3. The height can expand, hence auto
- * 4. Using specificity to override panel shadow
+ * 1. Using specificity to override panel shadow
+ * 2. Prevent really long input from overflowing the container.
  */
 .euiComboBoxOptionsList {
-  // z-index is programmatically added to the options list by JavaScript
-  @include euiFormControlSize(auto, $includeAlternates: true); /* 3 */
-  position: absolute; /* 2 */
-  top: 0; /* 2 */
+  // Remove transforms from popover panel
+  transform: none !important; // sass-lint:disable-line no-important
 
-  .ReactVirtualized__List {
-    @include euiScrollBar;
-  }
-
-  &.euiComboBoxOptionsList--bottom { /* 4 */
-    @include euiBottomShadowMedium;
-  }
-
-  &.euiComboBoxOptionsList--top { /* 4 */
-    // sass-lint:disable-block indentation
-    box-shadow:
-      0 -2px 4px -1px transparentize($euiShadowColor, .8),
-      0 0 2px 0 transparentize($euiShadowColor, .8);
+  &.euiPopover__panel-isAttached.euiComboBoxOptionsList--top { /* 1 */
+    @include euiBottomShadowFlat;
   }
 }
 
-.euiComboBoxOptionsList--bottom {
-  // sass-lint:disable-block no-important
-  border-radius: 0 0 $euiBorderRadius $euiBorderRadius !important;
-  border-top: none !important;
-}
-
-.euiComboBoxOptionsList--top {
-  // sass-lint:disable-block no-important
-  border-radius: $euiBorderRadius $euiBorderRadius 0 0 !important;
-}
-
-/**
-  * 1. Prevent really long input from overflowing the container.
-  */
 .euiComboBoxOptionsList__empty {
+  @include euiTextBreakWord; /* 2 */
   padding: $euiSizeS;
   text-align: center;
   color: $euiColorDarkShade;
-  word-wrap: break-word; /* 1 */
+  word-wrap: break-word;
 }
 
 .euiComboBoxOptionsList__rowWrap {
   padding: 0;
-  max-height: 200px;
+  max-height: 200px; // Also used/set in the JS file
   overflow: hidden;
+
+  > div { // Targets the element for FixedSizeList that doesn't have a selector
+    @include euiScrollBar;
+  }
 }

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
@@ -53,13 +53,6 @@ import {
 import { CommonProps } from '../../common';
 import { EuiBadge } from '../../badge/';
 
-const positionToClassNameMap: {
-  [position in EuiComboBoxOptionsListPosition]: string;
-} = {
-  top: 'euiComboBoxOptionsList--top',
-  bottom: 'euiComboBoxOptionsList--bottom',
-};
-
 const OPTION_CONTENT_CLASSNAME = 'euiComboBoxOption__content';
 
 export type EuiComboBoxOptionsListProps<T> = CommonProps &
@@ -303,7 +296,7 @@ export class EuiComboBoxOptionsList<T> extends Component<
       onScroll,
       optionRef,
       options,
-      position,
+      position = 'bottom',
       renderOption,
       rootId,
       rowHeight,
@@ -447,7 +440,7 @@ export class EuiComboBoxOptionsList<T> extends Component<
 
     const numVisibleOptions =
       matchingOptions.length < 7 ? matchingOptions.length : 7;
-    const height = numVisibleOptions * rowHeight;
+    const height = numVisibleOptions * (rowHeight + 1); // Add one for the border
 
     // bounded by max-height of euiComboBoxOptionsList__rowWrap
     const boundedHeight = height > 200 ? 200 : height;
@@ -466,12 +459,17 @@ export class EuiComboBoxOptionsList<T> extends Component<
       </FixedSizeList>
     );
 
+    /**
+     * Reusing the EuiPopover__panel classes to help with consistency/maintenance.
+     * But this should really be converted to user the popover component.
+     */
     const classes = classNames(
       'euiComboBoxOptionsList',
-      position ? positionToClassNameMap[position] : '',
-      {
-        'euiComboBoxOptionsList--fullWidth': fullWidth,
-      }
+      'euiPopover__panel',
+      'euiPopover__panel-isAttached',
+      'euiPopover__panel-noArrow',
+      'euiPopover__panel-isOpen',
+      `euiPopover__panel--${position}`
     );
 
     return (

--- a/src/components/date_picker/_date_picker.scss
+++ b/src/components/date_picker/_date_picker.scss
@@ -663,21 +663,6 @@
   display: flex;
 }
 
-// We drop the time picker on mobile. They can still type in the time directly.
-@include euiBreakpoint('xs','s') {
-
-  // This resizes EUI's normal form control to be the width of the calendar
-  .euiDatePicker--inline {
-    max-width: $euiDatePickerCalendarWidth;
-    display: block;
-  }
-
-  // This hides the time entirely
-  .react-datepicker__time-container {
-    display: none;
-  }
-}
-
 // The below is for the portal version of react-datepicker which we do not use.
 // It is shown here just to know what their baseline includes.
 

--- a/src/components/date_picker/_date_picker.scss
+++ b/src/components/date_picker/_date_picker.scss
@@ -121,7 +121,7 @@
   &[data-placement^="top"] {
     @include euiBottomShadowFlat;
 
-    border-radius: $euiBorderRadius $euiBorderRadius 0 0 !important;
+    border-radius: $euiBorderRadius $euiBorderRadius 0 0;
 
     // .react-datepicker__triangle {
     // }

--- a/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
@@ -2,47 +2,49 @@
 
 exports[`EuiSuperSelect is rendered 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiSuperSelect"
 >
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value=""
-    />
-    <div
-      class="euiFormControlLayout"
-    >
+    <div>
+      <input
+        type="hidden"
+        value=""
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
-        >
-          Select an option: , is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-label="aria-label"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl testClass1 testClass2"
-          data-test-subj="test subject string"
-          type="button"
-        />
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
+          >
+            Select an option: , is selected
+          </span>
+          <button
+            aria-haspopup="true"
+            aria-label="aria-label"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl testClass1 testClass2"
+            data-test-subj="test subject string"
+            type="button"
+          />
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
           >
             <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="arrowDown"
-            />
-          </span>
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="arrowDown"
+              />
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -52,47 +54,49 @@ exports[`EuiSuperSelect is rendered 1`] = `
 
 exports[`EuiSuperSelect props compressed is rendered 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiSuperSelect"
 >
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value=""
-    />
-    <div
-      class="euiFormControlLayout euiFormControlLayout--compressed"
-    >
+    <div>
+      <input
+        type="hidden"
+        value=""
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout euiFormControlLayout--compressed"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
-        >
-          Select an option: , is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-label="aria-label"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl euiSuperSelectControl--compressed testClass1 testClass2"
-          data-test-subj="test subject string"
-          type="button"
-        />
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
+          >
+            Select an option: , is selected
+          </span>
+          <button
+            aria-haspopup="true"
+            aria-label="aria-label"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl euiSuperSelectControl--compressed testClass1 testClass2"
+            data-test-subj="test subject string"
+            type="button"
+          />
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
           >
             <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="arrowDown"
-            />
-          </span>
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="arrowDown"
+              />
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -102,46 +106,48 @@ exports[`EuiSuperSelect props compressed is rendered 1`] = `
 
 exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiSuperSelect"
 >
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value=""
-    />
-    <div
-      class="euiFormControlLayout"
-    >
+    <div>
+      <input
+        type="hidden"
+        value=""
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
-        >
-          Select an option: , is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl euiSuperSelect--isOpen__button"
-          data-test-subj="superSelect"
-          type="button"
-        />
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
+          >
+            Select an option: , is selected
+          </span>
+          <button
+            aria-haspopup="true"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl euiSuperSelect--isOpen__button"
+            data-test-subj="superSelect"
+            type="button"
+          />
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
           >
             <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="arrowDown"
-            />
-          </span>
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="arrowDown"
+              />
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -162,68 +168,89 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
     <div
       aria-live="assertive"
       aria-modal="true"
-      class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
+      class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiPopover__panel-isAttached"
       role="dialog"
-      style="top: 8px; left: -22px; z-index: 2000;"
+      style="top: 8px; left: 0px; z-index: 2000;"
     >
       <div
         class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
       />
       <div>
-        <p
-          class="euiScreenReaderOnly"
-          role="alert"
-        >
-          You are in a form selector of 2 items and must select a single option. Use the up and down keys to navigate or escape to close.
-        </p>
         <div
-          class="euiSuperSelect__listbox"
-          role="listbox"
+          data-focus-guard="true"
+          style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
           tabindex="0"
+        />
+        <div
+          data-focus-guard="true"
+          style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+          tabindex="1"
+        />
+        <div
+          data-focus-lock-disabled="false"
         >
-          <button
-            aria-selected="false"
-            class="euiContextMenuItem euiSuperSelect__item"
-            id="1"
-            role="option"
-            type="button"
-          >
-            <span
-              class="euiContextMenu__itemLayout"
+          <div>
+            <p
+              class="euiScreenReaderOnly"
+              role="alert"
             >
-              <span
-                class="euiContextMenu__icon"
-                data-euiicon-type="empty"
-              />
-              <span
-                class="euiContextMenuItem__text"
-              >
-                Custom Display #1
-              </span>
-            </span>
-          </button>
-          <button
-            aria-selected="false"
-            class="euiContextMenuItem euiSuperSelect__item"
-            id="2"
-            role="option"
-            type="button"
-          >
-            <span
-              class="euiContextMenu__itemLayout"
+              You are in a form selector of 2 items and must select a single option. Use the up and down keys to navigate or escape to close.
+            </p>
+            <div
+              class="euiSuperSelect__listbox"
+              role="listbox"
+              tabindex="0"
             >
-              <span
-                class="euiContextMenu__icon"
-                data-euiicon-type="empty"
-              />
-              <span
-                class="euiContextMenuItem__text"
+              <button
+                aria-selected="false"
+                class="euiContextMenuItem euiSuperSelect__item"
+                id="1"
+                role="option"
+                type="button"
               >
-                Custom Display #2
-              </span>
-            </span>
-          </button>
+                <span
+                  class="euiContextMenu__itemLayout"
+                >
+                  <span
+                    class="euiContextMenu__icon"
+                    data-euiicon-type="empty"
+                  />
+                  <span
+                    class="euiContextMenuItem__text"
+                  >
+                    Custom Display #1
+                  </span>
+                </span>
+              </button>
+              <button
+                aria-selected="false"
+                class="euiContextMenuItem euiSuperSelect__item"
+                id="2"
+                role="option"
+                type="button"
+              >
+                <span
+                  class="euiContextMenu__itemLayout"
+                >
+                  <span
+                    class="euiContextMenu__icon"
+                    data-euiicon-type="empty"
+                  />
+                  <span
+                    class="euiContextMenuItem__text"
+                  >
+                    Custom Display #2
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
         </div>
+        <div
+          data-focus-guard="true"
+          style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+          tabindex="0"
+        />
       </div>
     </div>
   </div>
@@ -237,47 +264,49 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
 
 exports[`EuiSuperSelect props fullWidth is rendered 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect euiSuperSelect--fullWidth"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiInputPopover--fullWidth euiSuperSelect"
 >
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value=""
-    />
-    <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
-    >
+    <div>
+      <input
+        type="hidden"
+        value=""
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout euiFormControlLayout--fullWidth"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
-        >
-          Select an option: , is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-label="aria-label"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl euiSuperSelectControl--fullWidth testClass1 testClass2"
-          data-test-subj="test subject string"
-          type="button"
-        />
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
+          >
+            Select an option: , is selected
+          </span>
+          <button
+            aria-haspopup="true"
+            aria-label="aria-label"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl euiSuperSelectControl--fullWidth testClass1 testClass2"
+            data-test-subj="test subject string"
+            type="button"
+          />
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
           >
             <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="arrowDown"
-            />
-          </span>
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="arrowDown"
+              />
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -287,59 +316,61 @@ exports[`EuiSuperSelect props fullWidth is rendered 1`] = `
 
 exports[`EuiSuperSelect props is rendered with a prepend and append 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiSuperSelect"
 >
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value=""
-    />
-    <div
-      class="euiFormControlLayout euiFormControlLayout--group"
-    >
-      <label
-        class="euiFormLabel euiFormControlLayout__prepend"
-      >
-        prepend
-      </label>
+    <div>
+      <input
+        type="hidden"
+        value=""
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout euiFormControlLayout--group"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
+        <label
+          class="euiFormLabel euiFormControlLayout__prepend"
         >
-          Select an option: , is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-label="aria-label"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl euiSuperSelectControl--inGroup testClass1 testClass2"
-          data-test-subj="test subject string"
-          type="button"
-        />
+          prepend
+        </label>
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
+          >
+            Select an option: , is selected
+          </span>
+          <button
+            aria-haspopup="true"
+            aria-label="aria-label"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl euiSuperSelectControl--inGroup testClass1 testClass2"
+            data-test-subj="test subject string"
+            type="button"
+          />
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
           >
             <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="arrowDown"
-            />
-          </span>
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="arrowDown"
+              />
+            </span>
+          </div>
         </div>
+        <label
+          class="euiFormLabel euiFormControlLayout__append"
+        >
+          append
+        </label>
       </div>
-      <label
-        class="euiFormLabel euiFormControlLayout__append"
-      >
-        append
-      </label>
     </div>
   </div>
 </div>
@@ -347,48 +378,50 @@ exports[`EuiSuperSelect props is rendered with a prepend and append 1`] = `
 
 exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiSuperSelect"
 >
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value="1"
-    />
-    <div
-      class="euiFormControlLayout"
-    >
+    <div>
+      <input
+        type="hidden"
+        value="1"
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
-        >
-          Select an option: Option #1, is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl euiSuperSelect--isOpen__button"
-          data-test-subj="superSelect"
-          type="button"
-        >
-          Option #1
-        </button>
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
+          >
+            Select an option: Option #1, is selected
+          </span>
+          <button
+            aria-haspopup="true"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl euiSuperSelect--isOpen__button"
+            data-test-subj="superSelect"
+            type="button"
+          >
+            Option #1
+          </button>
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
           >
             <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="arrowDown"
-            />
-          </span>
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="arrowDown"
+              />
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -409,71 +442,92 @@ exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
     <div
       aria-live="assertive"
       aria-modal="true"
-      class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
+      class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiPopover__panel-isAttached"
       role="dialog"
-      style="top: 8px; left: -22px; z-index: 2000;"
+      style="top: 8px; left: 0px; z-index: 2000;"
     >
       <div
         class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
       />
       <div>
-        <p
-          class="euiScreenReaderOnly"
-          role="alert"
-        >
-          You are in a form selector of 2 items and must select a single option. Use the up and down keys to navigate or escape to close.
-        </p>
         <div
-          aria-activedescendant="1"
-          class="euiSuperSelect__listbox"
-          role="listbox"
+          data-focus-guard="true"
+          style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
           tabindex="0"
+        />
+        <div
+          data-focus-guard="true"
+          style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+          tabindex="1"
+        />
+        <div
+          data-focus-lock-disabled="false"
         >
-          <button
-            aria-selected="true"
-            class="euiContextMenuItem euiSuperSelect__item euiContextMenuItem-isDisabled"
-            disabled=""
-            id="1"
-            role="option"
-            type="button"
-          >
-            <span
-              class="euiContextMenu__itemLayout"
+          <div>
+            <p
+              class="euiScreenReaderOnly"
+              role="alert"
             >
-              <span
-                class="euiContextMenu__icon"
-                data-euiicon-type="check"
-              />
-              <span
-                class="euiContextMenuItem__text"
-              >
-                Option #1
-              </span>
-            </span>
-          </button>
-          <button
-            aria-selected="false"
-            class="euiContextMenuItem euiSuperSelect__item"
-            data-test-subj="option two"
-            id="2"
-            role="option"
-            type="button"
-          >
-            <span
-              class="euiContextMenu__itemLayout"
+              You are in a form selector of 2 items and must select a single option. Use the up and down keys to navigate or escape to close.
+            </p>
+            <div
+              aria-activedescendant="1"
+              class="euiSuperSelect__listbox"
+              role="listbox"
+              tabindex="0"
             >
-              <span
-                class="euiContextMenu__icon"
-                data-euiicon-type="empty"
-              />
-              <span
-                class="euiContextMenuItem__text"
+              <button
+                aria-selected="true"
+                class="euiContextMenuItem euiSuperSelect__item euiContextMenuItem-isDisabled"
+                disabled=""
+                id="1"
+                role="option"
+                type="button"
               >
-                Option #2
-              </span>
-            </span>
-          </button>
+                <span
+                  class="euiContextMenu__itemLayout"
+                >
+                  <span
+                    class="euiContextMenu__icon"
+                    data-euiicon-type="check"
+                  />
+                  <span
+                    class="euiContextMenuItem__text"
+                  >
+                    Option #1
+                  </span>
+                </span>
+              </button>
+              <button
+                aria-selected="false"
+                class="euiContextMenuItem euiSuperSelect__item"
+                data-test-subj="option two"
+                id="2"
+                role="option"
+                type="button"
+              >
+                <span
+                  class="euiContextMenu__itemLayout"
+                >
+                  <span
+                    class="euiContextMenu__icon"
+                    data-euiicon-type="empty"
+                  />
+                  <span
+                    class="euiContextMenuItem__text"
+                  >
+                    Option #2
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
         </div>
+        <div
+          data-focus-guard="true"
+          style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+          tabindex="0"
+        />
       </div>
     </div>
   </div>
@@ -487,46 +541,48 @@ exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
 
 exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiSuperSelect"
 >
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value=""
-    />
-    <div
-      class="euiFormControlLayout"
-    >
+    <div>
+      <input
+        type="hidden"
+        value=""
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
-        >
-          Select an option: , is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl euiSuperSelect--isOpen__button"
-          data-test-subj="superSelect"
-          type="button"
-        />
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
+          >
+            Select an option: , is selected
+          </span>
+          <button
+            aria-haspopup="true"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl euiSuperSelect--isOpen__button"
+            data-test-subj="superSelect"
+            type="button"
+          />
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
           >
             <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="arrowDown"
-            />
-          </span>
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="arrowDown"
+              />
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -547,68 +603,89 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
     <div
       aria-live="assertive"
       aria-modal="true"
-      class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiSuperSelect__popoverPanel"
+      class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiPopover__panel-isAttached"
       role="dialog"
-      style="top: 8px; left: -22px; z-index: 2000;"
+      style="top: 8px; left: 0px; z-index: 2000;"
     >
       <div
         class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
       />
       <div>
-        <p
-          class="euiScreenReaderOnly"
-          role="alert"
-        >
-          You are in a form selector of 2 items and must select a single option. Use the up and down keys to navigate or escape to close.
-        </p>
         <div
-          class="euiSuperSelect__listbox"
-          role="listbox"
+          data-focus-guard="true"
+          style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
           tabindex="0"
+        />
+        <div
+          data-focus-guard="true"
+          style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+          tabindex="1"
+        />
+        <div
+          data-focus-lock-disabled="false"
         >
-          <button
-            aria-selected="false"
-            class="euiContextMenuItem euiSuperSelect__item"
-            id="1"
-            role="option"
-            type="button"
-          >
-            <span
-              class="euiContextMenu__itemLayout"
+          <div>
+            <p
+              class="euiScreenReaderOnly"
+              role="alert"
             >
-              <span
-                class="euiContextMenu__icon"
-                data-euiicon-type="empty"
-              />
-              <span
-                class="euiContextMenuItem__text"
-              >
-                Option #1
-              </span>
-            </span>
-          </button>
-          <button
-            aria-selected="false"
-            class="euiContextMenuItem euiSuperSelect__item"
-            id="2"
-            role="option"
-            type="button"
-          >
-            <span
-              class="euiContextMenu__itemLayout"
+              You are in a form selector of 2 items and must select a single option. Use the up and down keys to navigate or escape to close.
+            </p>
+            <div
+              class="euiSuperSelect__listbox"
+              role="listbox"
+              tabindex="0"
             >
-              <span
-                class="euiContextMenu__icon"
-                data-euiicon-type="empty"
-              />
-              <span
-                class="euiContextMenuItem__text"
+              <button
+                aria-selected="false"
+                class="euiContextMenuItem euiSuperSelect__item"
+                id="1"
+                role="option"
+                type="button"
               >
-                Option #2
-              </span>
-            </span>
-          </button>
+                <span
+                  class="euiContextMenu__itemLayout"
+                >
+                  <span
+                    class="euiContextMenu__icon"
+                    data-euiicon-type="empty"
+                  />
+                  <span
+                    class="euiContextMenuItem__text"
+                  >
+                    Option #1
+                  </span>
+                </span>
+              </button>
+              <button
+                aria-selected="false"
+                class="euiContextMenuItem euiSuperSelect__item"
+                id="2"
+                role="option"
+                type="button"
+              >
+                <span
+                  class="euiContextMenu__itemLayout"
+                >
+                  <span
+                    class="euiContextMenu__icon"
+                    data-euiicon-type="empty"
+                  />
+                  <span
+                    class="euiContextMenuItem__text"
+                  >
+                    Option #2
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
         </div>
+        <div
+          data-focus-guard="true"
+          style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+          tabindex="0"
+        />
       </div>
     </div>
   </div>
@@ -622,45 +699,47 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
 
 exports[`EuiSuperSelect props select component is rendered 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiSuperSelect"
 >
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value=""
-    />
-    <div
-      class="euiFormControlLayout"
-    >
+    <div>
+      <input
+        type="hidden"
+        value=""
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
-        >
-          Select an option: , is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl"
-          type="button"
-        />
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
+          >
+            Select an option: , is selected
+          </span>
+          <button
+            aria-haspopup="true"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl"
+            type="button"
+          />
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
           >
             <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="arrowDown"
-            />
-          </span>
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="arrowDown"
+              />
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -670,47 +749,49 @@ exports[`EuiSuperSelect props select component is rendered 1`] = `
 
 exports[`EuiSuperSelect props valueSelected is rendered 1`] = `
 <div
-  class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock euiSuperSelect"
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiSuperSelect"
 >
   <div
     class="euiPopover__anchor"
   >
-    <input
-      type="hidden"
-      value="2"
-    />
-    <div
-      class="euiFormControlLayout"
-    >
+    <div>
+      <input
+        type="hidden"
+        value="2"
+      />
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
-        <span
-          class="euiScreenReaderOnly"
-          id="generated-id"
-        >
-          Select an option: Option #2, is selected
-        </span>
-        <button
-          aria-haspopup="true"
-          aria-labelledby="undefined generated-id"
-          class="euiSuperSelectControl"
-          type="button"
-        >
-          Option #2
-        </button>
         <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <span
-            class="euiFormControlLayoutCustomIcon"
+            class="euiScreenReaderOnly"
+            id="generated-id"
+          >
+            Select an option: Option #2, is selected
+          </span>
+          <button
+            aria-haspopup="true"
+            aria-labelledby="undefined generated-id"
+            class="euiSuperSelectControl"
+            type="button"
+          >
+            Option #2
+          </button>
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
           >
             <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="arrowDown"
-            />
-          </span>
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="arrowDown"
+              />
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/form/super_select/_super_select.scss
+++ b/src/components/form/super_select/_super_select.scss
@@ -1,35 +1,8 @@
-/*
- * 1. Make popover the same width as the form control
- * 2. Style popover similar to combobox
- * 3. Use attribute selector to match popover position without needing the full popover class name
- */
-
-.euiSuperSelect {
-  &:not(.euiSuperSelect--fullWidth) { /* 1 */
-    // sass-lint:disable-block no-important
-    max-width: $euiFormMaxWidth !important; // override default popover styles
-  }
-}
-
 .euiSuperSelect__listbox {
   @include euiScrollBar;
   max-height: 300px;
   overflow: hidden;
   overflow-y: auto;
-}
-
-.euiSuperSelect__popoverPanel[class*='bottom'] { /* 3 */
-  border-top-color: transparentize($euiBorderColor, .2);
-  border-top-right-radius: 0; /* 2 */
-  border-top-left-radius: 0; /* 2 */
-}
-
-.euiSuperSelect__popoverPanel[class*='top'] { /* 3 */
-  @include euiBottomShadowFlat; /* 2 */
-
-  border-bottom-color: transparentize($euiBorderColor, .2);
-  border-bottom-right-radius: 0; /* 2 */
-  border-bottom-left-radius: 0; /* 2 */
 }
 
 .euiSuperSelect__item {

--- a/src/components/form/super_select/super_select.tsx
+++ b/src/components/form/super_select/super_select.tsx
@@ -28,7 +28,7 @@ import {
   EuiSuperSelectControlProps,
   EuiSuperSelectOption,
 } from './super_select_control';
-import { EuiPopover } from '../../popover';
+import { EuiInputPopover } from '../../popover';
 import {
   EuiContextMenuItem,
   EuiContextMenuItemLayoutAlignment,
@@ -100,20 +100,10 @@ export class EuiSuperSelect<T extends string> extends Component<
   };
 
   private itemNodes: Array<HTMLButtonElement | null> = [];
-  private popoverRef: HTMLDivElement | null = null;
-  private buttonRef: HTMLElement | null = null;
-  private setButtonRef = (popoverButtonRef: HTMLDivElement | null) => {
-    if (popoverButtonRef) {
-      this.buttonRef = popoverButtonRef.querySelector('button')!;
-    } else {
-      this.buttonRef = null;
-    }
-  };
   private _isMounted: boolean = false;
 
   state = {
     isPopoverOpen: this.props.isOpen || false,
-    menuWidth: undefined,
   };
 
   componentDidMount() {
@@ -129,10 +119,6 @@ export class EuiSuperSelect<T extends string> extends Component<
 
   setItemNode = (node: HTMLButtonElement | null, index: number) => {
     this.itemNodes[index] = node;
-  };
-
-  setPopoverRef = (ref: HTMLDivElement | null) => {
-    this.popoverRef = ref;
   };
 
   openPopover = () => {
@@ -154,11 +140,6 @@ export class EuiSuperSelect<T extends string> extends Component<
         if (!this._isMounted) {
           return;
         }
-        this.setState({
-          menuWidth: this.popoverRef
-            ? this.popoverRef.getBoundingClientRect().width - 2 // account for border not inner shadow
-            : undefined,
-        });
 
         if (this.props.valueOfSelected != null) {
           if (indexOfSelected != null) {
@@ -185,9 +166,6 @@ export class EuiSuperSelect<T extends string> extends Component<
     });
     if (this.props.onChange) {
       this.props.onChange(value);
-    }
-    if (this.buttonRef) {
-      this.buttonRef.focus();
     }
   };
 
@@ -274,17 +252,7 @@ export class EuiSuperSelect<T extends string> extends Component<
       ...rest
     } = this.props;
 
-    const popoverClasses = classNames(
-      'euiSuperSelect',
-      {
-        'euiSuperSelect--fullWidth': fullWidth,
-      },
-      popoverClassName
-    );
-
-    const popoverPanelClasses = classNames('euiSuperSelect__popoverPanel', {
-      [`${popoverClassName}__popoverPanel`]: !!popoverClassName,
-    });
+    const popoverClasses = classNames('euiSuperSelect', popoverClassName);
 
     const buttonClasses = classNames(
       {
@@ -339,20 +307,13 @@ export class EuiSuperSelect<T extends string> extends Component<
     });
 
     return (
-      <EuiPopover
+      <EuiInputPopover
         className={popoverClasses}
-        display="block"
-        panelClassName={popoverPanelClasses}
-        button={button}
+        input={button}
         isOpen={isOpen || this.state.isPopoverOpen}
         closePopover={this.closePopover}
         panelPaddingSize="none"
-        anchorPosition="downCenter"
-        ownFocus={false}
-        popoverRef={this.setPopoverRef}
-        buttonRef={this.setButtonRef}
-        hasArrow={false}
-        buffer={0}>
+        fullWidth={fullWidth}>
         <EuiScreenReaderOnly>
           <p role="alert">
             <EuiI18n
@@ -367,11 +328,10 @@ export class EuiSuperSelect<T extends string> extends Component<
           className="euiSuperSelect__listbox"
           role="listbox"
           aria-activedescendant={valueOfSelected}
-          style={{ width: this.state.menuWidth }}
           tabIndex={0}>
           {items}
         </div>
-      </EuiPopover>
+      </EuiInputPopover>
     );
   }
 }

--- a/src/components/popover/_popover.scss
+++ b/src/components/popover/_popover.scss
@@ -25,25 +25,32 @@
 
 /**
  * 1. Can expand further, but it looks weird if it's smaller than the originating button.
- * 2. Animation happens on the panel.
+ * 2. Animation happens on the panel. But don't animate when using the attached mode like for inputs
  * 3. Make sure the panel stays within the window.
  */
 .euiPopover__panel {
   // Ignore linting for legibility of transition property, and the mixin performs an overwrite
-  // sass-lint:disable-block indentation, mixins-before-declarations
+  // sass-lint:disable-block indentation
+  @include euiBottomShadow($adjustBorders: true);
   position: absolute;
   min-width: $euiButtonMinWidth; /* 1 */
   max-width: calc(100vw - #{$euiSizeXL}); /* 3 */
   backface-visibility: hidden;
   pointer-events: none;
-  transition: /* 2 */
-    opacity $euiAnimSlightBounce $euiAnimSpeedSlow,
-    visibility $euiAnimSlightBounce $euiAnimSpeedSlow,
-    transform $euiAnimSlightBounce ($euiAnimSpeedSlow + 100ms);
   opacity: 0; /* 2 */
   visibility: hidden; /* 2 */
-  transform: translateY(0) translateX(0) translateZ(0); /* 2 */
-  @include euiBottomShadow($adjustBorders: true);
+  transition: /* 2 */
+    opacity $euiAnimSlightBounce $euiAnimSpeedSlow,
+    visibility $euiAnimSlightBounce $euiAnimSpeedSlow;
+
+  // Don't animate when using the attached mode like for inputs
+  &:not(.euiPopover__panel-isAttached) {
+    transform: translateY(0) translateX(0) translateZ(0); /* 2 */
+    transition: /* 2 */
+      opacity $euiAnimSlightBounce $euiAnimSpeedSlow,
+      visibility $euiAnimSlightBounce $euiAnimSpeedSlow,
+      transform $euiAnimSlightBounce ($euiAnimSpeedSlow + 100ms);
+  }
 
   &.euiPopover__panel-isOpen {
     opacity: 1;
@@ -161,10 +168,12 @@
   }
 }
 
+.euiPopover__panel.euiPopover__panel-isAttached.euiPopover__panel--top,  /* 2 */
 .euiPopover__panel.euiPopover__panel-isOpen.euiPopover__panel--top {
   transform: translateY($euiPopoverTranslateDistance) translateZ(0);
 }
 
+.euiPopover__panel.euiPopover__panel-isAttached.euiPopover__panel--bottom,  /* 2 */
 .euiPopover__panel.euiPopover__panel-isOpen.euiPopover__panel--bottom {
   transform: translateY(-$euiPopoverTranslateDistance) translateZ(0);
 }

--- a/src/global_styling/mixins/_popover.scss
+++ b/src/global_styling/mixins/_popover.scss
@@ -3,20 +3,10 @@
   padding: $euiSizeM;
   text-transform: uppercase;
   border-bottom: $euiBorderThin;
-
-  // Subtract 1px from the border radius since it's inside another container that also has the border radius
-  // -- makes for better rounded corners
-  border-top-left-radius: $euiBorderRadius - 1px;
-  border-top-right-radius: $euiBorderRadius - 1px;
 }
 
 @mixin euiPopoverFooter {
   @include euiFontSizeS;
   padding: $euiSizeM;
   border-top: $euiBorderThin;
-
-  // Subtract 1px from the border radius since it's inside another container that also has the border radius
-  // -- makes for better rounded corners
-  border-bottom-left-radius: $euiBorderRadius - 1px;
-  border-bottom-right-radius: $euiBorderRadius - 1px;
 }

--- a/src/themes/eui-amsterdam/global_styling/reset/_reset.scss
+++ b/src/themes/eui-amsterdam/global_styling/reset/_reset.scss
@@ -66,7 +66,7 @@ html {
 }
 
 body {
-  line-height: 1;
+  line-height: $euiBodyLineHeight;
 }
 
 *:focus {

--- a/src/themes/eui-amsterdam/overrides/_date_picker.scss
+++ b/src/themes/eui-amsterdam/overrides/_date_picker.scss
@@ -1,0 +1,18 @@
+.euiDatePicker {
+  &.euiDatePicker--shadow {
+    .react-datepicker-popper,
+    .react-datepicker-popper[data-placement^='top'] {
+      border: none;
+      border-radius: $euiBorderRadius;
+    }
+  }
+}
+
+
+.euiDatePickerRange {
+  border-radius: $euiFormControlBorderRadius;
+}
+
+.euiDatePicker.euiDatePicker--shadow.euiDatePicker--inline .react-datepicker {
+  border: none;
+}

--- a/src/themes/eui-amsterdam/overrides/_index.scss
+++ b/src/themes/eui-amsterdam/overrides/_index.scss
@@ -5,6 +5,7 @@
 @import 'call_out';
 @import 'code_block';
 @import 'context_menu';
+@import 'date_picker';
 @import 'filter_group';
 @import 'form_control_layout';
 @import 'form_control_layout_delimited';

--- a/src/themes/eui-amsterdam/overrides/_popover.scss
+++ b/src/themes/eui-amsterdam/overrides/_popover.scss
@@ -1,4 +1,17 @@
 .euiPopover__panel {
+
+  &.euiPopover__panel-isAttached {
+    @include euiBottomShadowMedium;
+
+    // Reset border radius to panel's
+    // Specificity also helps override default theme
+    @each $modifier, $amount in $euiPanelBorderRadiusModifiers {
+      &.euiPanel--#{$modifier} {
+        border-radius: $amount;
+      }
+    }
+  }
+
   .euiPopover__panelArrow {
     &:before {
       filter: blur($euiSizeXS - 1px);


### PR DESCRIPTION
### This also includes some updates to the components of the default theme but shouldn't be any visual changes.

## Changed EuiSuperSelect from using EuiPopover with custom styles to EuiInputPopover

This allowed me to remove a lot of placement logic that was already present in EuiInputPopover.

## EuiComboBox now uses the same classes as EuiPopover's panel

Instead of duplicating styles and the increase in maintenance, I've copied the `euiPopover__panel` classes onto the EuiPanel within EuiComboBox to help maintain consistency of styles. I've added a comment in the code indicating that in a future re-factor of this component, it should just straight up use the EuiPopover component.

Also fixed the scrollbar and extra height issues.

![image](https://user-images.githubusercontent.com/549577/100020382-c1444100-2dad-11eb-845a-bfe1c4f1421c.png)

## Removed animation from EuiInputPopover (or whenever it is "attached")

This animation was just too much when it would end up connected to the input. So I only added the transition if the `attached` class doesn't exist.

**Before**
![Screen Recording 2020-11-23 at 05 04 52 PM](https://user-images.githubusercontent.com/549577/100020739-4fb8c280-2dae-11eb-9805-7866b218f89e.gif)

**After**
![Screen Recording 2020-11-23 at 05 05 25 PM](https://user-images.githubusercontent.com/549577/100020731-4b8ca500-2dae-11eb-960e-ccd5467928d2.gif)

## Fixed the date picker's dropdown and the datepicker range's input radius

This one was overlooked during the form updates. There's still more work to do on the datepicker itself, but this just fixes the immediate.

![image](https://user-images.githubusercontent.com/549577/100021106-f4d39b00-2dae-11eb-901a-935a04ec66d6.png)

### Also fixed #4218 by just completely removing the breakpoint that would hide the time select on mobile.

The picker just barely fit on a `320px` wide screen anyway. We'll circle back to better mobile support when we re-write this component.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
