### PR TITLE
[Docs] Update in_memory table with friendly spellcheck

### DIFF
--- a/src-docs/src/views/tables/in_memory/in_memory_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_section.js
@@ -45,11 +45,10 @@ export const section = {
     <div>
       <p>
         The <strong>EuiInMemoryTable</strong> is a higher level component
-        wrapper around <strong>EuiBasicTable</strong> aimed at displaying
-        tables data when all the data is in memory. It takes the full set of
-        data (all possible items) and based on its configuration, will display
-        it handling all configured functionality (pagination and sorting) for
-        you.
+        wrapper around <strong>EuiBasicTable</strong> aimed at displaying tables
+        data when all the data is in memory. It takes the full set of data (all
+        possible items) and based on its configuration, will display it handling
+        all configured functionality (pagination and sorting) for you.
       </p>
       <EuiCallOut
         title="EuiMemoryTable relies on referential equality of a column's name"

--- a/src-docs/src/views/tables/in_memory/in_memory_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_section.js
@@ -45,7 +45,7 @@ export const section = {
     <div>
       <p>
         The <strong>EuiInMemoryTable</strong> is a higher level component
-        wrapper around <strong>EuiBasicTable</strong> that aimed at displaying
+        wrapper around <strong>EuiBasicTable</strong> aimed at displaying
         tables data when all the data is in memory. It takes the full set of
         data (all possible items) and based on its configuration, will display
         it handling all configured functionality (pagination and sorting) for


### PR DESCRIPTION
### Summary

The first sentence of the description for `In-memory tables` located [here](https://elastic.github.io/eui/#/tabular-content/in-memory-tables) is either missing a word or has an extra word. 

Currently, the sentence reads:

"The `EuiInMemoryTable` is a higher level component wrapper around `EuiBasicTable` that aimed at displaying tables data when all the data is in memory."

This PR enacts the smallest possible adjustment to the sentence for it to make sense by removing the word "that" from the sentence.

It would now read:

"The `EuiInMemoryTable` is a higher level component wrapper around `EuiBasicTable` aimed at displaying tables data when all the data is in memory."

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
