### PR TITLE
Add !default to all EuiCollapsibleNav SASS variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed `EuiErrorBoundary` error message not showing in non-Chromium browsers ([#4324](https://github.com/elastic/eui/pull/4324))
 - Fixed `EuiToolTip` closing during initial positioning period ([#4327](https://github.com/elastic/eui/pull/4327))
+- Added `!default` to SASS variables of `EuiCollapsibleNav` ([#4335](https://github.com/elastic/eui/pull/4335))
 
 **Theme: Amsterdam**
 

--- a/src/components/collapsible_nav/_variables.scss
+++ b/src/components/collapsible_nav/_variables.scss
@@ -1,14 +1,14 @@
 // Sizing
-$euiCollapsibleNavWidth: $euiSize * 20; // ~ 320px
+$euiCollapsibleNavWidth: $euiSize * 20 !default; // ~ 320px
 
-$euiCollapsibleNavGroupLightBackgroundColor: $euiPageBackgroundColor;
+$euiCollapsibleNavGroupLightBackgroundColor: $euiPageBackgroundColor !default;
 
 $euiCollapsibleNavGroupDarkBackgroundColor: lightOrDarkTheme(
   shade($euiColorDarkestShade, 20%),
   shade($euiColorLightestShade, 50%),
-);
+) !default;
 
 $euiCollapsibleNavGroupDarkHighContrastColor: makeGraphicContrastColor(
   $euiColorPrimary,
   $euiCollapsibleNavGroupDarkBackgroundColor
-);
+) !default;


### PR DESCRIPTION
Allow for overriding collapsible nav SASS vars. Fixes #4334 

### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
