### PR TITLE
[EuiComboBox, EuiPopover] Update `esc` logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed `EuiToolTip` closing during initial positioning period ([#4327](https://github.com/elastic/eui/pull/4327))
 - Added `!default` to SASS variables of `EuiCollapsibleNav` ([#4335](https://github.com/elastic/eui/pull/4335))
 - Fixed `EuiDataGrid` column property `displayAsText`. Column headers prefer `displayAsText` over `id`; `display` still takes precedence. If provided, the filter in the sort-popover will search against `displayAsText` instead of `id`. ([#4351](https://github.com/elastic/eui/pull/4351))
+- Fixed propagation of `esc` key presses closing parent popovers ([#4336](https://github.com/elastic/eui/pull/4336))
 
 
 **Theme: Amsterdam**

--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -616,8 +616,11 @@ export class EuiComboBox<T> extends Component<
         break;
 
       case keys.ESCAPE:
-        event.stopPropagation();
-        this.closeList();
+        if (this.state.isListOpen) {
+          event.preventDefault();
+          event.stopPropagation();
+          this.closeList();
+        }
         break;
 
       case keys.ENTER:

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -362,9 +362,17 @@ export class EuiPopover extends Component<Props, State> {
     }
   };
 
+  onEscapeKey = (event: Event) => {
+    if (this.props.isOpen) {
+      event.preventDefault();
+      event.stopPropagation();
+      this.closePopover();
+    }
+  };
+
   onKeyDown = (event: KeyboardEvent) => {
     if (event.key === cascadingMenuKeys.ESCAPE) {
-      this.closePopover();
+      this.onEscapeKey((event as unknown) as Event);
     }
   };
 
@@ -724,7 +732,7 @@ export class EuiPopover extends Component<Props, State> {
             initialFocus={initialFocus}
             onDeactivation={onTrapDeactivation}
             onClickOutside={this.onClickOutside}
-            onEscapeKey={this.closePopover}
+            onEscapeKey={this.onEscapeKey}
             disabled={
               !ownFocus || !this.state.isOpenStable || this.state.isClosing
             }>


### PR DESCRIPTION
### Summary

Fixes #4306, in which an EuiComboBox inside an EuiPopover would close both the options list _and_ the popover when hitting <kbd>escape</kbd>. Adds additional logic to the key press handler.

The reason for the change is the move to having `react-focus-on` (via EuiFocusTrap) handle <kbd>escape</kbd> (previously EuiFocusTrap had its own logic). `react-focus-on` attaches the `onKeyDown` event to the `document` and uses `!event.defaultPrevented` as its  prevention logic.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~

- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
