### PR TITLE
[EuiSteps] Updates for Amsterdam and added `disabled` and `loading` states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Adjusted the shadow in `EuiComment` ([#4321](https://github.com/elastic/eui/pull/4321))
 - Added `success` and `warning` colors to `EuiButtonEmpty` ([#4325](https://github.com/elastic/eui/pull/4325))
+- Added `disabled` and `loading` `status` to `EuiStep` ([#4338](https://github.com/elastic/eui/pull/4338))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Removed the shadow in `EuiComment` ([#4321](https://github.com/elastic/eui/pull/4321))
 - Reduced font size for `xs` size in `EuiButtonEmpty` ([#4325](https://github.com/elastic/eui/pull/4325))
 - Increased font size for `m` size of `EuiListGroupItem` ([#4340](https://github.com/elastic/eui/pull/4340))
+- Consolidated `EuiStepNumber` indicators for `EuiSteps` and `EuiHorizontalSteps` ([#4338](https://github.com/elastic/eui/pull/4338))
 
 ## [`30.5.1`](https://github.com/elastic/eui/tree/v30.5.1)
 

--- a/src-docs/src/services/playground/simulateFunction.js
+++ b/src-docs/src/services/playground/simulateFunction.js
@@ -1,10 +1,13 @@
 import { PropTypes } from 'react-view';
 
-export const simulateFunction = (prop = { custom: {} }) => {
+export const simulateFunction = (
+  prop = { custom: {} },
+  defaultValue = false
+) => {
   const newProp = {
     ...prop,
     type: PropTypes.Custom,
-    value: undefined,
+    value: defaultValue,
     custom: {
       ...prop.custom,
       use: 'switch',

--- a/src-docs/src/views/steps/playground.js
+++ b/src-docs/src/views/steps/playground.js
@@ -1,8 +1,10 @@
 import { PropTypes } from 'react-view';
-import { EuiStep } from '../../../../src/components/';
+import { EuiStep, EuiStepHorizontal } from '../../../../src/components/steps';
 import {
   propUtilityForPlayground,
   createOptionalEnum,
+  simulateFunction,
+  dummyFunction,
 } from '../../services/playground';
 
 export const stepConfig = () => {
@@ -32,6 +34,37 @@ export const stepConfig = () => {
         '@elastic/eui': {
           named: ['EuiStep'],
         },
+      },
+    },
+  };
+};
+
+export const stepHorizontalConfig = () => {
+  const docgenInfo = Array.isArray(EuiStepHorizontal.__docgenInfo)
+    ? EuiStepHorizontal.__docgenInfo[0]
+    : EuiStepHorizontal.__docgenInfo;
+  const propsToUse = propUtilityForPlayground(docgenInfo.props);
+
+  propsToUse.title.value = 'Horizontal step';
+
+  propsToUse.status = createOptionalEnum(propsToUse.status);
+
+  propsToUse.onClick = simulateFunction(propsToUse.onClick, true);
+
+  return {
+    config: {
+      componentName: 'EuiStepHorizontal',
+      props: propsToUse,
+      scope: {
+        EuiStepHorizontal,
+      },
+      imports: {
+        '@elastic/eui': {
+          named: ['EuiStepHorizontal'],
+        },
+      },
+      customProps: {
+        onClick: dummyFunction,
       },
     },
   };

--- a/src-docs/src/views/steps/steps.js
+++ b/src-docs/src/views/steps/steps.js
@@ -9,24 +9,39 @@ import {
 
 const firstSetOfSteps = [
   {
-    title:
-      'Step 1 with a long title to check what happens during wrapping which should have been fixed.',
-    children: <p>Do this first</p>,
+    title: 'Step 1',
+    children: (
+      <EuiText>
+        <p>Do this first</p>
+      </EuiText>
+    ),
   },
   {
     title: 'Step 2',
-    children: <p>Then this</p>,
+    children: (
+      <EuiText>
+        <p>Then this</p>
+      </EuiText>
+    ),
   },
 ];
 
 const nextSetOfSteps = [
   {
     title: 'Good step',
-    children: <p>Do this first</p>,
+    children: (
+      <EuiText>
+        <p>Do this first</p>
+      </EuiText>
+    ),
   },
   {
     title: 'Better step',
-    children: <p>Then this</p>,
+    children: (
+      <EuiText>
+        <p>Then this</p>
+      </EuiText>
+    ),
   },
 ];
 
@@ -34,14 +49,14 @@ export default () => (
   <div>
     <EuiSteps steps={firstSetOfSteps} />
 
+    <EuiSpacer size="m" />
     <EuiText>
-      <EuiSpacer size="m" />
       <p>
         Set <EuiCode>firstStepNumber</EuiCode> to continue step numbering after
         any type of break in the content
       </p>
-      <EuiSpacer size="m" />
     </EuiText>
+    <EuiSpacer size="m" />
 
     <EuiSteps
       firstStepNumber={firstSetOfSteps.length + 1}

--- a/src-docs/src/views/steps/steps_complex.js
+++ b/src-docs/src/views/steps/steps_complex.js
@@ -7,15 +7,19 @@ import {
   EuiCodeBlock,
   EuiSubSteps,
 } from '../../../../src/components';
+import { EuiSpacer } from '../../../../src/components/spacer';
 
 const steps = [
   {
     title: 'Step 1 has intro plus code snippet',
     children: (
-      <EuiText>
-        <p>Run this code snippet to install things.</p>
+      <>
+        <EuiText>
+          <p>Run this code snippet to install things.</p>
+        </EuiText>
+        <EuiSpacer />
         <EuiCodeBlock language="bash">npm install</EuiCodeBlock>
-      </EuiText>
+      </>
     ),
   },
   {
@@ -50,7 +54,7 @@ const steps = [
           Now that you&apos;ve completed step 2, go find the{' '}
           <EuiCode>thing</EuiCode>.
         </p>
-        <p className="euiStep__subSteps">
+        <p>
           Go to <strong>Overview &gt;&gt; Endpoints</strong> note{' '}
           <strong>Elasticsearch</strong> as <EuiCode>&lt;thing&gt;</EuiCode>.
         </p>

--- a/src-docs/src/views/steps/steps_example.js
+++ b/src-docs/src/views/steps/steps_example.js
@@ -14,7 +14,7 @@ import {
 
 import { EuiStepHorizontal } from '../../../../src/components/steps/step_horizontal';
 
-import { stepConfig } from './playground';
+import { stepConfig, stepHorizontalConfig } from './playground';
 
 import Steps from './steps';
 const stepsSource = require('!!raw-loader!./steps');
@@ -24,7 +24,7 @@ const stepsSnippet = [
   steps={[
     {
       title: 'Step 1',
-      children: <p>Do this first</p>,
+      children: <EuiText><p>Do this first</p></EuiText>,
     },
   ]}
 />`,
@@ -33,7 +33,7 @@ const stepsSnippet = [
   steps={[
     {
       title: 'Step 3',
-      children: <p>Do this third first</p>,
+      children: <EuiText><p>Do this third first</p></EuiText>,
     },
   ]}
 />`,
@@ -42,6 +42,51 @@ const stepsSnippet = [
 import StepsComplex from './steps_complex';
 const stepsComplexSource = require('!!raw-loader!./steps_complex');
 const stepsComplexHtml = renderToHtml(StepsComplex);
+const stepsComplexSnippet = [
+  `<EuiSteps
+  steps={[
+    {
+      title: 'Step 1 has intro plus code snippet',
+      children: (
+        <>
+          <EuiText>
+            <p>Run this code snippet to install things.</p>
+          </EuiText>
+          <EuiSpacer />
+          <EuiCodeBlock language="bash">npm install</EuiCodeBlock>
+        </>
+      ),
+    },
+  ]}
+/>`,
+  `<EuiSteps
+  steps={[
+    {
+      title: 'Step 2 has sub steps',
+      children: (
+        <EuiText>
+          <p>
+            In order to complete this step, do the following things <strong>in order</strong>.
+          </p>
+          <EuiSubSteps>
+            <ol>
+              <li>Do thing 1</li>
+              <li>Do thing 2</li>
+              <li>Do thing 3</li>
+            </ol>
+          </EuiSubSteps>
+          <p>Here are some bullet point reminders.</p>
+          <ul>
+            <li>Reminder 1</li>
+            <li>Reminder 2</li>
+            <li>Reminder 3</li>
+          </ul>
+        </EuiText>
+      ),
+    },
+  ]}
+/>`,
+];
 
 import HeadingElementSteps from './heading_element_steps';
 const headingElementStepsSource = require('!!raw-loader!./heading_element_steps');
@@ -75,9 +120,7 @@ const statusSnippet = `<EuiSteps
 import StepsTitleSizes from './steps_title_sizes';
 const stepsTitleSizesSource = require('!!raw-loader!./steps_title_sizes');
 const stepsTitleSizesHtml = renderToHtml(StepsTitleSizes);
-const stepsTitleSizesSnippet = `<EuiSteps titleSize="xs" steps={[{
-  title: 'Completed step',
-}]} />
+const stepsTitleSizesSnippet = `<EuiSteps titleSize="xs" steps={steps} />
 `;
 
 export const StepsExample = {
@@ -97,7 +140,11 @@ export const StepsExample = {
       text: (
         <p>
           <strong>EuiSteps</strong> presents procedural content in a numbered
-          outline format.
+          outline format. It is best used when presenting instructional content
+          that must be conducted in a particular order. It requires a{' '}
+          <EuiCode>title</EuiCode> and <EuiCode>children</EuiCode> to be present
+          and will automatically increment the step number based on the initial{' '}
+          <EuiCode>firstStepNumber</EuiCode>.
         </p>
       ),
       props: { EuiSteps, EuiStep },
@@ -125,6 +172,7 @@ export const StepsExample = {
       ),
       demo: <StepsComplex />,
       props: { EuiSubSteps },
+      snippet: stepsComplexSnippet,
     },
     {
       title: 'Heading elements',
@@ -174,7 +222,8 @@ export const StepsExample = {
           Steps can optionally include <EuiCode>status</EuiCode> prop that will
           alter the look of the number prefix. The options are{' '}
           <EuiCode>incomplete</EuiCode>, <EuiCode>complete</EuiCode>,{' '}
-          <EuiCode>warning</EuiCode>, and <EuiCode>danger</EuiCode>. This is
+          <EuiCode>warning</EuiCode>, <EuiCode>danger</EuiCode>,{' '}
+          <EuiCode>disabled</EuiCode> and <EuiCode>loading</EuiCode>. This is
           used mostly as a final step when you need to make some sort of final
           check.
         </p>
@@ -240,5 +289,5 @@ export const StepsExample = {
       props: { EuiStepsHorizontal, EuiStepHorizontal },
     },
   ],
-  playground: stepConfig,
+  playground: [stepConfig, stepHorizontalConfig],
 };

--- a/src/components/steps/__snapshots__/step.test.tsx.snap
+++ b/src/components/steps/__snapshots__/step.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`EuiStep is rendered 1`] = `
       </span>
       <span
         aria-hidden="true"
+        class="euiStepNumber__number"
       >
         1
       </span>
@@ -56,6 +57,7 @@ exports[`EuiStep props headingElement 1`] = `
       </span>
       <span
         aria-hidden="true"
+        class="euiStepNumber__number"
       >
         1
       </span>
@@ -142,7 +144,7 @@ exports[`EuiStep props status danger is rendered 1`] = `
 
 exports[`EuiStep props status disabled is rendered 1`] = `
 <div
-  class="euiStep"
+  class="euiStep euiStep-isDisabled"
 >
   <div
     class="euiStep__titleWrapper"
@@ -157,6 +159,7 @@ exports[`EuiStep props status disabled is rendered 1`] = `
       </span>
       <span
         aria-hidden="true"
+        class="euiStepNumber__number"
       >
         1
       </span>
@@ -191,6 +194,12 @@ exports[`EuiStep props status incomplete is rendered 1`] = `
         class="euiScreenReaderOnly"
       >
         Step 1 is incomplete
+      </span>
+      <span
+        aria-hidden="true"
+        class="euiStepNumber__number"
+      >
+        1
       </span>
     </span>
     <p
@@ -288,6 +297,7 @@ exports[`EuiStep props step 1`] = `
       </span>
       <span
         aria-hidden="true"
+        class="euiStepNumber__number"
       >
         5
       </span>
@@ -325,6 +335,7 @@ exports[`EuiStep props titleSize 1`] = `
       </span>
       <span
         aria-hidden="true"
+        class="euiStepNumber__number"
       >
         1
       </span>

--- a/src/components/steps/__snapshots__/step.test.tsx.snap
+++ b/src/components/steps/__snapshots__/step.test.tsx.snap
@@ -209,6 +209,36 @@ exports[`EuiStep props status incomplete is rendered 1`] = `
 </div>
 `;
 
+exports[`EuiStep props status loading is rendered 1`] = `
+<div
+  class="euiStep"
+>
+  <div
+    class="euiStep__titleWrapper"
+  >
+    <span
+      class="euiStepNumber euiStepNumber--loading euiStep__circle"
+    >
+      <span
+        class="euiLoadingSpinner euiLoadingSpinner--medium euiStepNumber__icon"
+      />
+    </span>
+    <p
+      class="euiTitle euiTitle--small euiStep__title"
+    >
+      First step
+    </p>
+  </div>
+  <div
+    class="euiStep__content"
+  >
+    <p>
+      Do this
+    </p>
+  </div>
+</div>
+`;
+
 exports[`EuiStep props status warning is rendered 1`] = `
 <div
   class="euiStep"

--- a/src/components/steps/__snapshots__/step.test.tsx.snap
+++ b/src/components/steps/__snapshots__/step.test.tsx.snap
@@ -234,7 +234,7 @@ exports[`EuiStep props status loading is rendered 1`] = `
         Step 1 is loading
       </span>
       <span
-        class="euiLoadingSpinner euiLoadingSpinner--medium euiStepNumber__icon"
+        class="euiLoadingSpinner euiLoadingSpinner--xLarge euiStepNumber__loader"
       />
     </span>
     <p

--- a/src/components/steps/__snapshots__/step.test.tsx.snap
+++ b/src/components/steps/__snapshots__/step.test.tsx.snap
@@ -229,6 +229,11 @@ exports[`EuiStep props status loading is rendered 1`] = `
       class="euiStepNumber euiStepNumber--loading euiStep__circle"
     >
       <span
+        class="euiScreenReaderOnly"
+      >
+        Step 1 is loading
+      </span>
+      <span
         class="euiLoadingSpinner euiLoadingSpinner--medium euiStepNumber__icon"
       />
     </span>

--- a/src/components/steps/__snapshots__/step_horizontal.test.tsx.snap
+++ b/src/components/steps/__snapshots__/step_horizontal.test.tsx.snap
@@ -180,7 +180,7 @@ exports[`EuiStepHorizontal props status loading is rendered 1`] = `
       Step 1 is loading
     </span>
     <span
-      class="euiLoadingSpinner euiLoadingSpinner--medium euiStepNumber__icon"
+      class="euiLoadingSpinner euiLoadingSpinner--xLarge euiStepNumber__loader"
     />
   </span>
   <span

--- a/src/components/steps/__snapshots__/step_horizontal.test.tsx.snap
+++ b/src/components/steps/__snapshots__/step_horizontal.test.tsx.snap
@@ -175,6 +175,11 @@ exports[`EuiStepHorizontal props status loading is rendered 1`] = `
     class="euiStepNumber euiStepNumber--loading euiStepHorizontal__number"
   >
     <span
+      class="euiScreenReaderOnly"
+    >
+      Step 1 is loading
+    </span>
+    <span
       class="euiLoadingSpinner euiLoadingSpinner--medium euiStepNumber__icon"
     />
   </span>

--- a/src/components/steps/__snapshots__/step_horizontal.test.tsx.snap
+++ b/src/components/steps/__snapshots__/step_horizontal.test.tsx.snap
@@ -162,6 +162,24 @@ exports[`EuiStepHorizontal props status incomplete is rendered 1`] = `
 </button>
 `;
 
+exports[`EuiStepHorizontal props status loading is rendered 1`] = `
+<button
+  class="euiStepHorizontal euiStepHorizontal-isIncomplete"
+  title="Step 1"
+>
+  <span
+    class="euiStepNumber euiStepNumber--loading euiStepHorizontal__number"
+  >
+    <span
+      class="euiLoadingSpinner euiLoadingSpinner--medium euiStepNumber__icon"
+    />
+  </span>
+  <span
+    class="euiStepHorizontal__title"
+  />
+</button>
+`;
+
 exports[`EuiStepHorizontal props status warning is rendered 1`] = `
 <button
   class="euiStepHorizontal euiStepHorizontal-isIncomplete"

--- a/src/components/steps/__snapshots__/step_horizontal.test.tsx.snap
+++ b/src/components/steps/__snapshots__/step_horizontal.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`EuiStepHorizontal is rendered 1`] = `
     </span>
     <span
       aria-hidden="true"
+      class="euiStepNumber__number"
     >
       1
     </span>
@@ -62,6 +63,7 @@ exports[`EuiStepHorizontal props isSelected 1`] = `
     </span>
     <span
       aria-hidden="true"
+      class="euiStepNumber__number"
     >
       1
     </span>
@@ -127,6 +129,7 @@ exports[`EuiStepHorizontal props status disabled is rendered 1`] = `
     </span>
     <span
       aria-hidden="true"
+      class="euiStepNumber__number"
     >
       1
     </span>
@@ -152,6 +155,7 @@ exports[`EuiStepHorizontal props status incomplete is rendered 1`] = `
     </span>
     <span
       aria-hidden="true"
+      class="euiStepNumber__number"
     >
       1
     </span>
@@ -215,6 +219,7 @@ exports[`EuiStepHorizontal props step 1`] = `
     </span>
     <span
       aria-hidden="true"
+      class="euiStepNumber__number"
     >
       5
     </span>
@@ -240,6 +245,7 @@ exports[`EuiStepHorizontal props title 1`] = `
     </span>
     <span
       aria-hidden="true"
+      class="euiStepNumber__number"
     >
       1
     </span>

--- a/src/components/steps/__snapshots__/step_number.test.tsx.snap
+++ b/src/components/steps/__snapshots__/step_number.test.tsx.snap
@@ -124,7 +124,7 @@ exports[`EuiStepNumber props status loading is rendered 1`] = `
     Step 1 is loading
   </span>
   <span
-    class="euiLoadingSpinner euiLoadingSpinner--medium euiStepNumber__icon"
+    class="euiLoadingSpinner euiLoadingSpinner--xLarge euiStepNumber__loader"
   />
 </span>
 `;

--- a/src/components/steps/__snapshots__/step_number.test.tsx.snap
+++ b/src/components/steps/__snapshots__/step_number.test.tsx.snap
@@ -104,6 +104,16 @@ exports[`EuiStepNumber props status incomplete is rendered 1`] = `
 </span>
 `;
 
+exports[`EuiStepNumber props status loading is rendered 1`] = `
+<span
+  class="euiStepNumber euiStepNumber--loading"
+>
+  <span
+    class="euiLoadingSpinner euiLoadingSpinner--medium euiStepNumber__icon"
+  />
+</span>
+`;
+
 exports[`EuiStepNumber props status warning is rendered 1`] = `
 <span
   class="euiStepNumber euiStepNumber--warning"

--- a/src/components/steps/__snapshots__/step_number.test.tsx.snap
+++ b/src/components/steps/__snapshots__/step_number.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`EuiStepNumber is rendered 1`] = `
   </span>
   <span
     aria-hidden="true"
+    class="euiStepNumber__number"
   />
 </span>
 `;
@@ -28,6 +29,7 @@ exports[`EuiStepNumber props has titleSize is rendered 1`] = `
   </span>
   <span
     aria-hidden="true"
+    class="euiStepNumber__number"
   >
     1
   </span>
@@ -42,6 +44,12 @@ exports[`EuiStepNumber props isHollow is rendered 1`] = `
     class="euiScreenReaderOnly"
   >
     Step 1
+  </span>
+  <span
+    aria-hidden="true"
+    class="euiStepNumber__number"
+  >
+    1
   </span>
 </span>
 `;
@@ -81,6 +89,7 @@ exports[`EuiStepNumber props status disabled is rendered 1`] = `
   </span>
   <span
     aria-hidden="true"
+    class="euiStepNumber__number"
   >
     1
   </span>
@@ -98,6 +107,7 @@ exports[`EuiStepNumber props status incomplete is rendered 1`] = `
   </span>
   <span
     aria-hidden="true"
+    class="euiStepNumber__number"
   >
     1
   </span>

--- a/src/components/steps/__snapshots__/step_number.test.tsx.snap
+++ b/src/components/steps/__snapshots__/step_number.test.tsx.snap
@@ -119,6 +119,11 @@ exports[`EuiStepNumber props status loading is rendered 1`] = `
   class="euiStepNumber euiStepNumber--loading"
 >
   <span
+    class="euiScreenReaderOnly"
+  >
+    Step 1 is loading
+  </span>
+  <span
     class="euiLoadingSpinner euiLoadingSpinner--medium euiStepNumber__icon"
   />
 </span>

--- a/src/components/steps/__snapshots__/steps.test.tsx.snap
+++ b/src/components/steps/__snapshots__/steps.test.tsx.snap
@@ -22,6 +22,7 @@ exports[`EuiSteps renders step title inside "headingElement" element 1`] = `
         </span>
         <span
           aria-hidden="true"
+          class="euiStepNumber__number"
         >
           1
         </span>
@@ -56,6 +57,7 @@ exports[`EuiSteps renders step title inside "headingElement" element 1`] = `
         </span>
         <span
           aria-hidden="true"
+          class="euiStepNumber__number"
         >
           2
         </span>
@@ -87,6 +89,12 @@ exports[`EuiSteps renders step title inside "headingElement" element 1`] = `
           class="euiScreenReaderOnly"
         >
           Step 3 is incomplete
+        </span>
+        <span
+          aria-hidden="true"
+          class="euiStepNumber__number"
+        >
+          3
         </span>
       </span>
       <h2
@@ -128,6 +136,7 @@ exports[`EuiSteps renders steps 1`] = `
         </span>
         <span
           aria-hidden="true"
+          class="euiStepNumber__number"
         >
           1
         </span>
@@ -162,6 +171,7 @@ exports[`EuiSteps renders steps 1`] = `
         </span>
         <span
           aria-hidden="true"
+          class="euiStepNumber__number"
         >
           2
         </span>
@@ -193,6 +203,12 @@ exports[`EuiSteps renders steps 1`] = `
           class="euiScreenReaderOnly"
         >
           Step 3 is incomplete
+        </span>
+        <span
+          aria-hidden="true"
+          class="euiStepNumber__number"
+        >
+          3
         </span>
       </span>
       <p
@@ -234,6 +250,7 @@ exports[`EuiSteps renders steps with firstStepNumber 1`] = `
         </span>
         <span
           aria-hidden="true"
+          class="euiStepNumber__number"
         >
           10
         </span>
@@ -268,6 +285,7 @@ exports[`EuiSteps renders steps with firstStepNumber 1`] = `
         </span>
         <span
           aria-hidden="true"
+          class="euiStepNumber__number"
         >
           11
         </span>
@@ -299,6 +317,12 @@ exports[`EuiSteps renders steps with firstStepNumber 1`] = `
           class="euiScreenReaderOnly"
         >
           Step 12 is incomplete
+        </span>
+        <span
+          aria-hidden="true"
+          class="euiStepNumber__number"
+        >
+          12
         </span>
       </span>
       <p
@@ -340,6 +364,7 @@ exports[`EuiSteps renders steps with titleSize 1`] = `
         </span>
         <span
           aria-hidden="true"
+          class="euiStepNumber__number"
         >
           1
         </span>
@@ -374,6 +399,7 @@ exports[`EuiSteps renders steps with titleSize 1`] = `
         </span>
         <span
           aria-hidden="true"
+          class="euiStepNumber__number"
         >
           2
         </span>
@@ -405,6 +431,12 @@ exports[`EuiSteps renders steps with titleSize 1`] = `
           class="euiScreenReaderOnly"
         >
           Step 3 is incomplete
+        </span>
+        <span
+          aria-hidden="true"
+          class="euiStepNumber__number"
+        >
+          3
         </span>
       </span>
       <p

--- a/src/components/steps/__snapshots__/steps_horizontal.test.tsx.snap
+++ b/src/components/steps/__snapshots__/steps_horizontal.test.tsx.snap
@@ -47,6 +47,7 @@ exports[`EuiStepsHorizontal is rendered 1`] = `
         </span>
         <span
           aria-hidden="true"
+          class="euiStepNumber__number"
         >
           2
         </span>
@@ -75,6 +76,7 @@ exports[`EuiStepsHorizontal is rendered 1`] = `
         </span>
         <span
           aria-hidden="true"
+          class="euiStepNumber__number"
         >
           3
         </span>
@@ -104,6 +106,7 @@ exports[`EuiStepsHorizontal is rendered 1`] = `
         </span>
         <span
           aria-hidden="true"
+          class="euiStepNumber__number"
         >
           4
         </span>

--- a/src/components/steps/_step_number.scss
+++ b/src/components/steps/_step_number.scss
@@ -2,6 +2,7 @@
   @include createStepsNumber;
 
   .euiStepNumber__icon {
+    vertical-align: middle;
     position: relative;
     top: -2px;
   }
@@ -15,10 +16,18 @@
   }
 
   &--complete {
-    // Thicken the checkmark but adding a slight stroke.
+    // Thicken the checkmark by adding a slight stroke.
     .euiStepNumber__icon {
       stroke: currentColor;
       stroke-width: .5px;
+    }
+  }
+
+  @include euiCanAnimate {
+    &--complete,
+    &--warning,
+    &--danger {
+      animation: euiGrow $euiAnimSpeedFast $euiAnimSlightBounce;
     }
   }
 
@@ -39,10 +48,6 @@
 
       color: $textColor;
       background-color: $backgroundColor;
-
-      &.euiStepNumber-isHollow {
-        border-color: $color;
-      }
     }
   }
 }

--- a/src/components/steps/_step_number.scss
+++ b/src/components/steps/_step_number.scss
@@ -31,6 +31,10 @@
     }
   }
 
+  &--loading {
+    background: transparent;
+  }
+
   &.euiStepNumber-isHollow {
     background-color: transparent;
     border: 2px solid $euiColorPrimary;

--- a/src/components/steps/_step_number.scss
+++ b/src/components/steps/_step_number.scss
@@ -34,6 +34,10 @@
   &.euiStepNumber-isHollow {
     background-color: transparent;
     border: 2px solid $euiColorPrimary;
+
+    .euiStepNumber__number {
+      display: none;
+    }
   }
 
   // Create modifiers based upon the map

--- a/src/components/steps/_steps.scss
+++ b/src/components/steps/_steps.scss
@@ -42,17 +42,6 @@
   flex-shrink: 0;
   margin-right: $euiStepNumberMargin;
   vertical-align: top; /* 1 */
-
-  &[class*='complete'],
-  &[class*='warning'],
-  &[class*='danger'] {
-    animation: euiGrow $euiAnimSpeedFast $euiAnimSlightBounce;
-  }
-
-  &[class*='incomplete'] {
-    border-color: $euiColorPrimary;
-    animation: none;
-  }
 }
 
 .euiStep__title {

--- a/src/components/steps/_steps_horizontal.scss
+++ b/src/components/steps/_steps_horizontal.scss
@@ -107,7 +107,7 @@
 
 // Selected state
 .euiStepHorizontal-isSelected {
-  .euiStepHorizontal__number:not([class*='danger']):not([class*='warning']) {
+  .euiStepHorizontal__number:not([class*='danger']):not([class*='warning']):not([class*='loading']) {
     @include euiSlightShadow(desaturate($euiColorPrimary, 20%));
   }
 

--- a/src/components/steps/_steps_horizontal.scss
+++ b/src/components/steps/_steps_horizontal.scss
@@ -41,16 +41,16 @@
   // focus & hover state
   &:focus:not(.euiStepHorizontal-isDisabled),
   &:hover:not(.euiStepHorizontal-isDisabled) {
-    .euiStepHorizontal__number {
-      @include euiFocusRing(large);
-
-      // sass-lint:disable-block indentation
-      transition: background-color $euiAnimSpeedNormal $euiAnimSlightResistance,
-                  color $euiAnimSpeedNormal $euiAnimSlightResistance;
-    }
-
     .euiStepHorizontal__title {
       text-decoration: underline;
+    }
+  }
+
+  &:focus:not(.euiStepHorizontal-isDisabled) {
+    outline: none;
+
+    .euiStepHorizontal__number {
+      @include euiFocusRing(large);
     }
   }
 

--- a/src/components/steps/_steps_horizontal.scss
+++ b/src/components/steps/_steps_horizontal.scss
@@ -64,7 +64,7 @@
   &::after {
     content: '';
     position: absolute;
-    width: 50%;
+    width: calc(50% - #{$euiStepNumberSize / 2});
     height: 1px;
     top: $euiSizeL + ($euiStepNumberSize / 2);
     background-color: $euiColorLightShade;

--- a/src/components/steps/_variables.scss
+++ b/src/components/steps/_variables.scss
@@ -8,4 +8,5 @@ $euiStepStatusColorsToFade: (
   danger: $euiColorDanger,
   disabled: $euiColorDarkShade,
   incomplete: $euiColorDarkShade,
+  loading: $euiColorDarkShade,
 ) !default;

--- a/src/components/steps/_variables.scss
+++ b/src/components/steps/_variables.scss
@@ -8,5 +8,4 @@ $euiStepStatusColorsToFade: (
   danger: $euiColorDanger,
   disabled: $euiColorDarkShade,
   incomplete: $euiColorDarkShade,
-  loading: $euiColorDarkShade,
 ) !default;

--- a/src/components/steps/index.ts
+++ b/src/components/steps/index.ts
@@ -23,6 +23,8 @@ export { EuiSteps, EuiStepsProps } from './steps';
 
 export { EuiSubSteps, EuiSubStepsProps } from './sub_steps';
 
+export { EuiStepHorizontal } from './step_horizontal';
+
 export {
   EuiStepsHorizontal,
   EuiStepsHorizontalProps,

--- a/src/components/steps/step.tsx
+++ b/src/components/steps/step.tsx
@@ -70,6 +70,7 @@ export const EuiStep: FunctionComponent<EuiStepProps> = ({
     'euiStep',
     {
       'euiStep--small': titleSize === 'xs',
+      'euiStep-isDisabled': status === 'disabled',
     },
     className
   );

--- a/src/components/steps/step_horizontal.tsx
+++ b/src/components/steps/step_horizontal.tsx
@@ -38,14 +38,19 @@ export interface EuiStepHorizontalProps
   extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick'>,
     CommonProps {
   /**
-   * Is the current step
+   * **DEPRECATED IN AMSTERDAM**
+   * Adds to the line before the indicator for showing current progress
    */
   isSelected?: boolean;
   /**
-   * Is a previous step that has been completed
+   * **DEPRECATED IN AMSTERDAM**
+   * Adds to the line after the indicator for showing current progress
    */
   isComplete?: boolean;
   onClick: MouseEventHandler<HTMLButtonElement>;
+  /**
+   * Makes the whole step button disabled.
+   */
   disabled?: boolean;
   /**
    * The number of the step in the list of steps
@@ -53,6 +58,7 @@ export interface EuiStepHorizontalProps
   step?: number;
   title?: string;
   /**
+   * Visual representation of the step number indicator.
    * May replace the number provided in props.step with alternate styling.
    * The `isSelected`, `isComplete`, and `disabled` props will override these.
    */

--- a/src/components/steps/step_number.tsx
+++ b/src/components/steps/step_number.tsx
@@ -31,23 +31,19 @@ import {
   useI18nStep,
   useI18nWarningStep,
 } from './step_strings';
+import { EuiLoadingSpinner } from '../loading';
 
 const statusToClassNameMap = {
-  complete: 'euiStepNumber--complete',
   incomplete: 'euiStepNumber--incomplete',
+  disabled: 'euiStepNumber--disabled',
+  loading: 'euiStepNumber--loading',
   warning: 'euiStepNumber--warning',
   danger: 'euiStepNumber--danger',
-  disabled: 'euiStepNumber--disabled',
+  complete: 'euiStepNumber--complete',
 };
 
 export const STATUS = keysOf(statusToClassNameMap);
-
-export type EuiStepStatus =
-  | 'complete'
-  | 'incomplete'
-  | 'warning'
-  | 'danger'
-  | 'disabled';
+export type EuiStepStatus = typeof STATUS[number];
 
 export interface EuiStepNumberProps
   extends CommonProps,
@@ -58,7 +54,8 @@ export interface EuiStepNumberProps
   status?: EuiStepStatus;
   number?: number;
   /**
-   * Uses a border and removes the step number
+   * **DEPRECATED IN AMSTERDAM**
+   * Uses a border and removes the step number.
    */
   isHollow?: boolean;
   /**
@@ -81,6 +78,7 @@ export const EuiStepNumber: FunctionComponent<EuiStepNumberProps> = ({
   const errorsAriaLabel = useI18nErrorsStep({ number });
   const incompleteAriaLabel = useI18nIncompleteStep({ number });
   const disabledAriaLabel = useI18nDisabledStep({ number });
+  const loadingAriaLabel = useI18nDisabledStep({ number });
 
   const classes = classNames(
     'euiStepNumber',
@@ -93,6 +91,7 @@ export const EuiStepNumber: FunctionComponent<EuiStepNumberProps> = ({
   let screenReaderText = stepAriaLabel;
   if (status === 'incomplete') screenReaderText = incompleteAriaLabel;
   else if (status === 'disabled') screenReaderText = disabledAriaLabel;
+  else if (status === 'loading') screenReaderText = loadingAriaLabel;
 
   let numberOrIcon = (
     <>
@@ -129,6 +128,10 @@ export const EuiStepNumber: FunctionComponent<EuiStepNumberProps> = ({
         size={iconSize}
         aria-label={errorsAriaLabel}
       />
+    );
+  } else if (status === 'loading') {
+    numberOrIcon = (
+      <EuiLoadingSpinner className="euiStepNumber__icon" size={iconSize} />
     );
   }
 

--- a/src/components/steps/step_number.tsx
+++ b/src/components/steps/step_number.tsx
@@ -138,7 +138,10 @@ export const EuiStepNumber: FunctionComponent<EuiStepNumberProps> = ({
         <EuiScreenReaderOnly>
           <span>{screenReaderText}</span>
         </EuiScreenReaderOnly>
-        <EuiLoadingSpinner className="euiStepNumber__icon" size={iconSize} />
+        <EuiLoadingSpinner
+          className="euiStepNumber__loader"
+          size={iconSize === 's' ? 'l' : 'xl'}
+        />
       </>
     );
   }

--- a/src/components/steps/step_number.tsx
+++ b/src/components/steps/step_number.tsx
@@ -98,7 +98,9 @@ export const EuiStepNumber: FunctionComponent<EuiStepNumberProps> = ({
       <EuiScreenReaderOnly>
         <span>{screenReaderText}</span>
       </EuiScreenReaderOnly>
-      {!isHollow && <span aria-hidden="true">{number}</span>}
+      <span className="euiStepNumber__number" aria-hidden="true">
+        {number}
+      </span>
     </>
   );
 

--- a/src/components/steps/step_number.tsx
+++ b/src/components/steps/step_number.tsx
@@ -30,6 +30,7 @@ import {
   useI18nIncompleteStep,
   useI18nStep,
   useI18nWarningStep,
+  useI18nLoadingStep,
 } from './step_strings';
 import { EuiLoadingSpinner } from '../loading';
 
@@ -78,7 +79,7 @@ export const EuiStepNumber: FunctionComponent<EuiStepNumberProps> = ({
   const errorsAriaLabel = useI18nErrorsStep({ number });
   const incompleteAriaLabel = useI18nIncompleteStep({ number });
   const disabledAriaLabel = useI18nDisabledStep({ number });
-  const loadingAriaLabel = useI18nDisabledStep({ number });
+  const loadingAriaLabel = useI18nLoadingStep({ number });
 
   const classes = classNames(
     'euiStepNumber',
@@ -133,7 +134,12 @@ export const EuiStepNumber: FunctionComponent<EuiStepNumberProps> = ({
     );
   } else if (status === 'loading') {
     numberOrIcon = (
-      <EuiLoadingSpinner className="euiStepNumber__icon" size={iconSize} />
+      <>
+        <EuiScreenReaderOnly>
+          <span>{screenReaderText}</span>
+        </EuiScreenReaderOnly>
+        <EuiLoadingSpinner className="euiStepNumber__icon" size={iconSize} />
+      </>
     );
   }
 

--- a/src/components/steps/step_strings.tsx
+++ b/src/components/steps/step_strings.tsx
@@ -130,3 +130,22 @@ export const useI18nDisabledStep = ({ number, title }: Props): string => {
 
   return title ? string : simpleString;
 };
+
+export const useI18nLoadingStep = ({ number, title }: Props): string => {
+  const string = useEuiI18n(
+    'euiStepStrings.loading',
+    'Step {number}: {title} is loading',
+    {
+      number,
+      title,
+    }
+  );
+
+  const simpleString = useEuiI18n(
+    'euiStepStrings.simpleLoading',
+    'Step {number} is loading',
+    { number }
+  );
+
+  return title ? string : simpleString;
+};

--- a/src/global_styling/mixins/_button.scss
+++ b/src/global_styling/mixins/_button.scss
@@ -14,7 +14,7 @@
 
 // Adds the focus (and hover) animation for translating up 1px
 @mixin euiButtonFocus {
-  @media screen and (prefers-reduced-motion: no-preference) {
+  @include euiCanAnimate {
     transition: transform $euiAnimSpeedNormal ease-in-out, background $euiAnimSpeedNormal ease-in-out;
 
     &:hover:not([class*='isDisabled']) {

--- a/src/global_styling/mixins/_helpers.scss
+++ b/src/global_styling/mixins/_helpers.scss
@@ -88,3 +88,10 @@
     @content;
   }
 }
+
+// Doesn't have reduced motion turned on
+@mixin euiCanAnimate {
+  @media screen and (prefers-reduced-motion: no-preference) {
+    @content;
+  }
+}

--- a/src/themes/eui-amsterdam/global_styling/variables/_index.scss
+++ b/src/themes/eui-amsterdam/global_styling/variables/_index.scss
@@ -8,5 +8,6 @@
 @import 'form';
 @import 'header';
 @import 'panel';
+@import 'steps';
 @import 'typography';
 @import 'shadows';

--- a/src/themes/eui-amsterdam/global_styling/variables/_steps.scss
+++ b/src/themes/eui-amsterdam/global_styling/variables/_steps.scss
@@ -1,0 +1,8 @@
+// Modifier naming and colors for step status'
+// Disabled/Loading/Incomplete are handled manually
+$euiStepStatusColors: (
+  default: $euiColorPrimary,
+  complete: $euiColorSuccess,
+  warning: $euiColorWarning,
+  danger: $euiColorDanger,
+);

--- a/src/themes/eui-amsterdam/overrides/_index.scss
+++ b/src/themes/eui-amsterdam/overrides/_index.scss
@@ -19,5 +19,6 @@
 @import 'overlay_mask';
 @import 'popover';
 @import 'progress';
+@import 'steps';
 @import 'text';
 @import 'toast';

--- a/src/themes/eui-amsterdam/overrides/_steps.scss
+++ b/src/themes/eui-amsterdam/overrides/_steps.scss
@@ -52,7 +52,6 @@
   }
 }
 
-.euiStepNumber--loading,
 .euiStepNumber--disabled {
   $backgroundColorSimulated: mix($euiPageBackgroundColor, $euiButtonColorDisabled, 90%);
   background-color: transparentize($euiButtonColorDisabled, .9);

--- a/src/themes/eui-amsterdam/overrides/_steps.scss
+++ b/src/themes/eui-amsterdam/overrides/_steps.scss
@@ -1,7 +1,10 @@
+// Make the disabled step title the same disabled text color
 .euiStepHorizontal-isDisabled .euiStepHorizontal__title,
 .euiStep-isDisabled .euiStep__title {
   color: $euiColorDisabledText;
 }
+
+// STEP NUMBER CHANGES
 
 .euiStepNumber {
   .euiStepNumber__icon {
@@ -83,4 +86,9 @@
 .euiStep__content {
   padding-bottom: ($euiSizeXL + $euiSizeS);
   margin-bottom: 0;
+}
+
+// Remove forced background from horizontal steps
+.euiStepsHorizontal {
+  background: none;
 }

--- a/src/themes/eui-amsterdam/overrides/_steps.scss
+++ b/src/themes/eui-amsterdam/overrides/_steps.scss
@@ -1,0 +1,86 @@
+.euiStepHorizontal-isDisabled .euiStepHorizontal__title,
+.euiStep-isDisabled .euiStep__title {
+  color: $euiColorDisabledText;
+}
+
+.euiStepNumber {
+  .euiStepNumber__icon {
+    position: relative;
+    top: -1px;
+  }
+
+  &--small {
+    .euiStepNumber__icon {
+      top: -1px;
+    }
+  }
+
+  &--complete,
+  &--danger {
+    // Thicken the checkmark by adding a slight stroke.
+    .euiStepNumber__icon {
+      stroke: currentColor;
+      stroke-width: .5px;
+    }
+  }
+
+  // Create modifiers based upon the map
+  @each $name, $color in $euiStepStatusColors {
+    &--#{$name} {
+      background-color: $color;
+      color: chooseLightOrDarkText($color, $euiColorGhost, $euiColorInk);
+    }
+  }
+
+  &.euiStepNumber--incomplete {
+    background-color: transparent;
+    color: $euiTextColor;
+    border: $euiBorderThick;
+
+    // Don't hide the step number when "hollow"
+    .euiStepNumber__number {
+      display: unset;
+      position: relative;
+      top: -2px;
+    }
+  }
+}
+
+.euiStepNumber--loading,
+.euiStepNumber--disabled {
+  $backgroundColorSimulated: mix($euiPageBackgroundColor, $euiButtonColorDisabled, 90%);
+  background-color: transparentize($euiButtonColorDisabled, .9);
+  color: makeDisabledContrastColor($euiButtonColorDisabled, $backgroundColorSimulated);
+}
+
+.euiStepHorizontal__title {
+  font-weight: $euiFontWeightBold;
+}
+
+.euiStepHorizontal {
+  // create the connecting lines
+  &::before,
+  &::after {
+    @include makeLineProgress;
+    background-color: $euiBorderColor;
+  }
+}
+
+// Make the line connect to the numbers
+
+.euiStep {
+  &:not(:last-of-type) {
+    background-position: left $euiSizeXL;
+  }
+
+  &--small {
+    &:not(:last-of-type) {
+      background-position: -#{$euiSizeXS} $euiSizeL;
+    }
+  }
+}
+
+.euiStep__content {
+  padding-bottom: ($euiSizeXL + $euiSizeS);
+  margin-bottom: 0;
+}

--- a/src/themes/eui-amsterdam/overrides/_steps.scss
+++ b/src/themes/eui-amsterdam/overrides/_steps.scss
@@ -7,6 +7,8 @@
 // STEP NUMBER CHANGES
 
 .euiStepNumber {
+  outline-color: $euiColorPrimary;
+
   .euiStepNumber__icon {
     position: relative;
     top: -1px;
@@ -32,6 +34,7 @@
     &--#{$name} {
       background-color: $color;
       color: chooseLightOrDarkText($color, $euiColorGhost, $euiColorInk);
+      outline-color: chooseLightOrDarkText($color, $color, $euiColorInk) !important; // sass-lint:disable-line no-important
     }
   }
 
@@ -92,3 +95,9 @@
 .euiStepsHorizontal {
   background: none;
 }
+
+// Fix outline in Chrome for horizontal steps
+.euiStepHorizontal:focus:not(.euiStepHorizontal-isDisabled) .euiStepHorizontal__number:not(:focus-visible) {
+  outline: $euiFocusRingSize solid $euiColorPrimary;
+}
+


### PR DESCRIPTION
Also updated the docs a bit too.

## Added `disabled` as a `status` for EuiStep

Closes #3339

<img width="970" alt="Screen Shot 2020-12-03 at 15 10 14 PM" src="https://user-images.githubusercontent.com/549577/101082639-c5284e00-3579-11eb-9a18-ac7e392e8735.png">

## Added `loading` as a `status` for EuiStep

Closes #4322 

<img width="962" alt="Screen Shot 2020-12-03 at 15 11 46 PM" src="https://user-images.githubusercontent.com/549577/101082718-e5580d00-3579-11eb-897e-ce9773221937.png">

## Updated Amsterdam styling

We aligned the styles between Vertical and Horizontal steps and removed center line indicators.

### The design

![image](https://user-images.githubusercontent.com/549577/101084195-9c08bd00-357b-11eb-8674-46762b184bc9.png)


### BEFORE

![image](https://user-images.githubusercontent.com/549577/101084225-a4f98e80-357b-11eb-8cae-567c40b500d2.png)


### AFTER

![image](https://user-images.githubusercontent.com/549577/101084240-aaef6f80-357b-11eb-866d-7b8fd3b94cd3.png)


---

## Some notes

1. A few of the props are then obsolete in Amsterdam as they're overridden by the overall style of the `status`. I've marked these as `**DEPRECATED IN AMSTERDAM**`.
2. The previous design would not render the number if the step is `incomplete`, while the new one does. I ended up changing this to always render the number but hide visually in the default theme.


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
