### PR TITLE
[Docs] Fix typo in table mobile options code example

### DIFF
--- a/src-docs/src/views/tables/mobile/mobile_section.js
+++ b/src-docs/src/views/tables/mobile/mobile_section.js
@@ -16,7 +16,7 @@ const exampleItem = `{
   mobileOptions: {
     render: (item) => (<span>{item.firstName} {item.lastName}</span>), // Custom renderer for mobile view only
     header: false,   // Won't show inline header in mobile view
-    width: '100%' // Applies a specific width
+    width: '100%', // Applies a specific width
     enlarge: true,   // Increase text size compared to rest of cells
     truncateText: false, // Only works if a 'render()' is also provided
   }


### PR DESCRIPTION
### Summary

Provide a detailed summary of your PR. Explain how you arrived at your solution. If it includes changes to UI elements include a screenshot or gif.

The code example used in the responsive tables section on this [page](https://elastic.github.io/eui/#/tabular-content/tables) has a missing comma after the width: '100%' attribute.

This pr adds that comma in to make the code valid.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
