### PR TITLE
[EuiListGroupItem] Increase font size of size M in Amsterdam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Removed the shadow in `EuiComment` ([#4321](https://github.com/elastic/eui/pull/4321))
 - Reduced font size for `xs` size in `EuiButtonEmpty` ([#4325](https://github.com/elastic/eui/pull/4325))
+- Increased font size for `m` size of `EuiListGroupItem` ([#4340](https://github.com/elastic/eui/pull/4340))
 
 ## [`30.5.1`](https://github.com/elastic/eui/tree/v30.5.1)
 

--- a/src/themes/eui-amsterdam/overrides/_index.scss
+++ b/src/themes/eui-amsterdam/overrides/_index.scss
@@ -12,6 +12,7 @@
 @import 'form_control_layout_delimited';
 @import 'form_controls';
 @import 'header';
+@import 'list_group_item';
 @import 'image';
 @import 'mark';
 @import 'markdown_editor';

--- a/src/themes/eui-amsterdam/overrides/_list_group_item.scss
+++ b/src/themes/eui-amsterdam/overrides/_list_group_item.scss
@@ -1,0 +1,3 @@
+.euiListGroupItem--medium {
+  font-size: $euiFontSizeM;
+}


### PR DESCRIPTION
### Summary

- [Amsterdam] Adjust font size for size M of `EuiListGroupItem`

<img width="420" alt="Frame 3" src="https://user-images.githubusercontent.com/4016496/101118253-b14f0d00-35b6-11eb-8740-d1f3e678e947.png">


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
