### PR TITLE
[EuiDataGrid] Add sorting icon if the column is sorted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Adjusted the shadow in `EuiComment` ([#4321](https://github.com/elastic/eui/pull/4321))
 - Added `success` and `warning` colors to `EuiButtonEmpty` ([#4325](https://github.com/elastic/eui/pull/4325))
+- Added a sorting indicator on the `EuiDataGridColumn` which indicates the sorting direction and is being displayed only when the column is sorted ([#4343](https://github.com/elastic/eui/pull/4343))
 
 **Bug fixes**
 

--- a/src/components/datagrid/_data_grid_header_row.scss
+++ b/src/components/datagrid/_data_grid_header_row.scss
@@ -53,6 +53,10 @@
       outline: none;
     }
 
+    .euiDataGridHeaderCell__sortingArrow {
+      margin-right: $euiSizeXS;
+    }
+
     .euiDataGridHeaderCell__content {
       @include euiTextTruncate;
       overflow: hidden;

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -1889,7 +1889,7 @@ Array [
   });
 
   describe('render sorting arrows', () => {
-    it('renders sorting arrows only when they are sorted', () => {
+    it('renders sorting arrows when direction is given', () => {
       const component = mount(
         <EuiDataGrid
           aria-labelledby="#test"
@@ -1903,6 +1903,39 @@ Array [
           columns={[
             { id: 'A', isSortable: true },
             { id: 'B', isSortable: true },
+          ]}
+          columnVisibility={{
+            visibleColumns: ['A', 'B'],
+            setVisibleColumns: () => {},
+          }}
+          rowCount={2}
+          renderCellValue={({ rowIndex, columnId }) =>
+            `${rowIndex}-${columnId}`
+          }
+        />
+      );
+      const arrowA = findTestSubject(
+        component,
+        'dataGridHeaderCellSortingIcon-A'
+      );
+      expect(arrowA.length).toBe(1);
+
+      const arrowB = findTestSubject(
+        component,
+        'dataGridHeaderCellSortingIcon-B'
+      );
+      expect(arrowB.length).toBe(1);
+    });
+
+    it('does not render the arrows if the column is not sorted', () => {
+      const component = mount(
+        <EuiDataGrid
+          aria-labelledby="#test"
+          sorting={{
+            columns: [],
+            onSort: () => {},
+          }}
+          columns={[
             {
               id: 'C',
               isSortable: true,
@@ -1917,7 +1950,7 @@ Array [
             },
           ]}
           columnVisibility={{
-            visibleColumns: ['A', 'B', 'C'],
+            visibleColumns: ['C'],
             setVisibleColumns: () => {},
           }}
           rowCount={2}
@@ -1926,24 +1959,37 @@ Array [
           }
         />
       );
-
-      const arrowA = findTestSubject(
-        component,
-        'dataGridHeaderCellSortingIcon-A'
-      );
-      expect(arrowA.length).toBe(1);
-
-      const arrowB = findTestSubject(
-        component,
-        'dataGridHeaderCellSortingIcon-B'
-      );
-      expect(arrowB.length).toBe(1);
-
       const arrowC = findTestSubject(
         component,
         'dataGridHeaderCellSortingIcon-C'
       );
       expect(arrowC.length).toBe(0);
+    });
+
+    it('renders the icons if they are sorted but user is not allowed to perform any action', () => {
+      const component = mount(
+        <EuiDataGrid
+          aria-labelledby="#test"
+          sorting={{
+            columns: [{ id: 'D', direction: 'asc' }],
+            onSort: () => {},
+          }}
+          columns={[{ id: 'D', actions: false }]}
+          columnVisibility={{
+            visibleColumns: ['D'],
+            setVisibleColumns: () => {},
+          }}
+          rowCount={2}
+          renderCellValue={({ rowIndex, columnId }) =>
+            `${rowIndex}-${columnId}`
+          }
+        />
+      );
+      const arrowD = findTestSubject(
+        component,
+        'dataGridHeaderCellSortingIcon-D'
+      );
+      expect(arrowD.length).toBe(1);
     });
   });
 

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -1888,6 +1888,65 @@ Array [
     });
   });
 
+  describe('render sorting arrows', () => {
+    it('renders sorting arrows only when they are sorted', () => {
+      const component = mount(
+        <EuiDataGrid
+          aria-labelledby="#test"
+          sorting={{
+            columns: [
+              { id: 'A', direction: 'asc' },
+              { id: 'B', direction: 'desc' },
+            ],
+            onSort: () => {},
+          }}
+          columns={[
+            { id: 'A', isSortable: true },
+            { id: 'B', isSortable: true },
+            {
+              id: 'C',
+              isSortable: true,
+              actions: {
+                showHide: false,
+                showMoveRight: false,
+                showMoveLeft: false,
+                showSortAsc: false,
+                showSortDesc: false,
+                additional: [{ label: 'test' }],
+              },
+            },
+          ]}
+          columnVisibility={{
+            visibleColumns: ['A', 'B', 'C'],
+            setVisibleColumns: () => {},
+          }}
+          rowCount={2}
+          renderCellValue={({ rowIndex, columnId }) =>
+            `${rowIndex}-${columnId}`
+          }
+        />
+      );
+
+      const arrowA = findTestSubject(
+        component,
+        'dataGridHeaderCellSortingIcon-A'
+      );
+      expect(arrowA.length).toBe(1);
+
+      const arrowB = findTestSubject(
+        component,
+        'dataGridHeaderCellSortingIcon-B'
+      );
+      expect(arrowB.length).toBe(1);
+
+      const arrowC = findTestSubject(
+        component,
+        'dataGridHeaderCellSortingIcon-C'
+      );
+      expect(arrowC.length).toBe(0);
+    });
+  });
+
   describe('render column cell actions', () => {
     it('renders various column cell actions configurations', () => {
       const alertFn = jest.fn();

--- a/src/components/datagrid/data_grid_header_cell.tsx
+++ b/src/components/datagrid/data_grid_header_cell.tsx
@@ -288,8 +288,8 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
   const sortingArrow = sortedColumn ? (
     <EuiIcon
       type={sortedColumn.direction === 'asc' ? 'sortUp' : 'sortDown'}
-      size="m"
       color="text"
+      className="euiDataGridHeaderCell__sortingArrow"
       data-test-subj={`dataGridHeaderCellSortingIcon-${id}`}
     />
   ) : null;

--- a/src/components/datagrid/data_grid_header_cell.tsx
+++ b/src/components/datagrid/data_grid_header_cell.tsx
@@ -285,6 +285,14 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
 
   const showColumnActions = columnActions && columnActions.length > 0;
   const sortedColumn = sorting?.columns.find((col) => col.id === id);
+  const sortingArrow = sortedColumn ? (
+    <EuiIcon
+      type={sortedColumn.direction === 'asc' ? 'sortUp' : 'sortDown'}
+      size="m"
+      color="text"
+      data-test-subj={`dataGridHeaderCellSortingIcon-${id}`}
+    />
+  ) : null;
 
   return (
     <div
@@ -309,19 +317,15 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
         </EuiScreenReaderOnly>
       )}
       {!showColumnActions ? (
-        <div className="euiDataGridHeaderCell__content">{display || id}</div>
+        <>
+          {sortingArrow}
+          <div className="euiDataGridHeaderCell__content">{display || id}</div>
+        </>
       ) : (
         <button
           className="euiDataGridHeaderCell__button"
           onClick={() => setIsPopoverOpen(true)}>
-          {sortedColumn && (
-            <EuiIcon
-              type={sortedColumn.direction === 'asc' ? 'sortUp' : 'sortDown'}
-              size="m"
-              color="text"
-              data-test-subj={`dataGridHeaderCellSortingIcon-${id}`}
-            />
-          )}
+          {sortingArrow}
           <div className="euiDataGridHeaderCell__content">{display || id}</div>
           <EuiPopover
             className="euiDataGridHeaderCell__popover"

--- a/src/components/datagrid/data_grid_header_cell.tsx
+++ b/src/components/datagrid/data_grid_header_cell.tsx
@@ -284,6 +284,7 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
   );
 
   const showColumnActions = columnActions && columnActions.length > 0;
+  const sortedColumn = sorting?.columns.find((col) => col.id === id);
 
   return (
     <div
@@ -313,6 +314,14 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
         <button
           className="euiDataGridHeaderCell__button"
           onClick={() => setIsPopoverOpen(true)}>
+          {sortedColumn && (
+            <EuiIcon
+              type={sortedColumn.direction === 'asc' ? 'sortUp' : 'sortDown'}
+              size="m"
+              color="text"
+              data-test-subj={`dataGridHeaderCellSortingIcon-${id}`}
+            />
+          )}
           <div className="euiDataGridHeaderCell__content">{display || id}</div>
           <EuiPopover
             className="euiDataGridHeaderCell__popover"


### PR DESCRIPTION
### Summary

It adds a sorting indicator on the EuiDataGridColumn which renders only when the column is sorted and indicates the sorting direction.

![image](https://user-images.githubusercontent.com/17003240/101145355-57842c80-3622-11eb-990d-395c2040313d.png)

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari** and **Firefox**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
