### PR TITLE
[Data Grid] Added closePopover action to EuiDataGridColumnCellActionProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Adjusted the shadow in `EuiComment` ([#4321](https://github.com/elastic/eui/pull/4321))
 - Added `success` and `warning` colors to `EuiButtonEmpty` ([#4325](https://github.com/elastic/eui/pull/4325))
+- Added `closePopover` prop to `EuiDataGridColumnCellActionProps` ([#4346](https://github.com/elastic/eui/pull/4346))
 
 **Bug fixes**
 

--- a/src-docs/src/views/datagrid/column_cell_actions.js
+++ b/src-docs/src/views/datagrid/column_cell_actions.js
@@ -22,15 +22,17 @@ const columns = [
     id: 'email',
     isSortable: true,
     cellActions: [
-      ({ Component, closePopover }) => {
+      ({ rowIndex, columnId, Component, closePopover }) => {
+        const row = ++rowIndex;
         return (
           <Component
             onClick={() => {
-              closePopover?.();
+              alert(`Love sent from row ${row}, column "${columnId}"`);
+              closePopover();
             }}
             iconType="heart"
-            aria-label="Close the popover if expanded">
-            Close the popover
+            aria-label={`Send love to ${row}, column "${columnId}" `}>
+            Send love
           </Component>
         );
       },

--- a/src-docs/src/views/datagrid/column_cell_actions.js
+++ b/src-docs/src/views/datagrid/column_cell_actions.js
@@ -22,16 +22,15 @@ const columns = [
     id: 'email',
     isSortable: true,
     cellActions: [
-      ({ rowIndex, columnId, Component }) => {
-        const row = ++rowIndex;
+      ({ Component, closePopover }) => {
         return (
           <Component
-            onClick={() =>
-              alert(`Love sent from row ${row}, column "${columnId}"`)
-            }
+            onClick={() => {
+              closePopover?.();
+            }}
             iconType="heart"
-            aria-label={`Send love to ${row}, column "${columnId}" `}>
-            Send love
+            aria-label="Close the popover if expanded">
+            Close the popover
           </Component>
         );
       },

--- a/src-docs/src/views/datagrid/datagrid_styling_example.js
+++ b/src-docs/src/views/datagrid/datagrid_styling_example.js
@@ -348,10 +348,7 @@ export const DataGridStylingExample = {
             provides 2 <EuiCode>cellAction</EuiCode>s.
             <br />
             The email column cell action closes the popover if it&apos;s
-            expanded through the optional <EuiCode>closePopover</EuiCode> prop.
-            <br />
-            The city column shows another action with different alert when
-            it&apos;s clicked in the popover.
+            expanded through the <EuiCode>closePopover</EuiCode> prop.
           </p>
         </Fragment>
       ),

--- a/src-docs/src/views/datagrid/datagrid_styling_example.js
+++ b/src-docs/src/views/datagrid/datagrid_styling_example.js
@@ -345,9 +345,13 @@ export const DataGridStylingExample = {
           <p>
             Below, the email and city columns provide 1{' '}
             <EuiCode>cellAction</EuiCode> each, while the country column
-            provides 2 <EuiCode>cellAction</EuiCode>s. The city column shows
-            another action with different alert when it&apos;s clicked in the
-            popover.
+            provides 2 <EuiCode>cellAction</EuiCode>s.
+            <br />
+            The email column cell action closes the popover if it&apos;s
+            expanded through the optional <EuiCode>closePopover</EuiCode> prop.
+            <br />
+            The city column shows another action with different alert when
+            it&apos;s clicked in the popover.
           </p>
         </Fragment>
       ),

--- a/src/components/datagrid/data_grid_cell.tsx
+++ b/src/components/datagrid/data_grid_cell.tsx
@@ -461,6 +461,7 @@ export class EuiDataGridCell extends Component<
             rowIndex={rowIndex}
             column={column}
             popoverIsOpen={this.state.popoverIsOpen}
+            closePopover={() => this.setState({ popoverIsOpen: false })}
             onExpandClick={() => {
               this.setState(({ popoverIsOpen }) => ({
                 popoverIsOpen: !popoverIsOpen,

--- a/src/components/datagrid/data_grid_cell_buttons.tsx
+++ b/src/components/datagrid/data_grid_cell_buttons.tsx
@@ -28,11 +28,13 @@ import { EuiButtonIcon, EuiButtonIconProps } from '../button/button_icon';
 
 export const EuiDataGridCellButtons = ({
   popoverIsOpen,
+  closePopover,
   onExpandClick,
   column,
   rowIndex,
 }: {
   popoverIsOpen: boolean;
+  closePopover: () => void;
   onExpandClick: () => void;
   column?: EuiDataGridColumn;
   rowIndex: number;
@@ -84,6 +86,7 @@ export const EuiDataGridCellButtons = ({
                 columnId={column.id}
                 Component={ButtonComponent}
                 isExpanded={false}
+                closePopover={closePopover}
               />
             );
           }

--- a/src/components/datagrid/data_grid_cell_popover.tsx
+++ b/src/components/datagrid/data_grid_cell_popover.tsx
@@ -104,6 +104,7 @@ export function EuiDataGridCellPopover({
                             <EuiButtonEmpty {...props} size="s" />
                           )}
                           isExpanded={true}
+                          closePopover={closePopover}
                         />
                       </EuiFlexItem>
                     );

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -137,6 +137,11 @@ export interface EuiDataGridColumnCellActionProps {
    * Determines whether the cell's action is displayed expanded (in the Popover)
    */
   isExpanded: boolean;
+  /**
+   * Closes the popover if a cell is expanded.
+   * The prop is provided for an expanded cell only.
+   */
+  closePopover?: () => void;
 }
 
 export interface EuiDataGridColumnVisibility {

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -141,7 +141,7 @@ export interface EuiDataGridColumnCellActionProps {
    * Closes the popover if a cell is expanded.
    * The prop is provided for an expanded cell only.
    */
-  closePopover?: () => void;
+  closePopover: () => void;
 }
 
 export interface EuiDataGridColumnVisibility {


### PR DESCRIPTION
### Summary

Allow a custom cell action to close the popover manually.
The original request in Data table vis replacement -> https://github.com/elastic/kibana/pull/70801#issuecomment-737082772

The desired result:

![cell_action](https://user-images.githubusercontent.com/31325372/101153488-92439000-3635-11eb-9382-daf243f68d1d.gif)



### Checklist

- [x] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
