### PR TITLE
[EuiDataGrid] Use `displayAsText` for column sort search and columns headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Fixed `EuiErrorBoundary` error message not showing in non-Chromium browsers ([#4324](https://github.com/elastic/eui/pull/4324))
 - Fixed `EuiToolTip` closing during initial positioning period ([#4327](https://github.com/elastic/eui/pull/4327))
 - Added `!default` to SASS variables of `EuiCollapsibleNav` ([#4335](https://github.com/elastic/eui/pull/4335))
+- Fixed `EuiDataGrid` column property `displayAsText`. Column headers prefer `displayAsText` over `id`; `display` still takes precedence. If provided, the filter in the sort-popover will search against `displayAsText` instead of `id`. ([#4351](https://github.com/elastic/eui/pull/4351))
+
 
 **Theme: Amsterdam**
 

--- a/src-docs/src/views/datagrid/datagrid.js
+++ b/src-docs/src/views/datagrid/datagrid.js
@@ -84,6 +84,8 @@ const columns = [
   },
   {
     id: 'email',
+    displayAsText: 'Email address',
+    initialWidth: 130,
     cellActions: [
       ({ rowIndex, columnId, Component }) => {
         const data = useContext(DataContext);
@@ -100,9 +102,11 @@ const columns = [
   },
   {
     id: 'location',
+    displayAsText: 'Location',
   },
   {
     id: 'account',
+    displayAsText: 'Account',
     actions: {
       showHide: { label: 'Custom hide label' },
       showMoveLeft: false,
@@ -140,19 +144,23 @@ const columns = [
   },
   {
     id: 'date',
+    displayAsText: 'Date',
     defaultSortDirection: 'desc',
   },
   {
     id: 'amount',
+    displayAsText: 'Amount',
   },
   {
     id: 'phone',
+    displayAsText: 'Phone',
     isSortable: false,
   },
   {
     id: 'version',
+    displayAsText: 'Version',
     defaultSortDirection: 'desc',
-    initialWidth: 65,
+    initialWidth: 70,
     isResizable: false,
     actions: false,
   },

--- a/src/components/datagrid/column_selector.tsx
+++ b/src/components/datagrid/column_selector.tsx
@@ -117,7 +117,10 @@ export const useDataGridColumnSelector = (
   });
 
   const filteredColumns = sortedColumns.filter(
-    (id) => id.toLowerCase().indexOf(columnSearchText.toLowerCase()) !== -1
+    (id) =>
+      (displayValues[id] || id)
+        .toLowerCase()
+        .indexOf(columnSearchText.toLowerCase()) !== -1
   );
 
   const isDragEnabled = allowColumnReorder && columnSearchText.length === 0; // only allow drag-and-drop when not filtering columns

--- a/src/components/datagrid/data_grid_header_cell.tsx
+++ b/src/components/datagrid/data_grid_header_cell.tsx
@@ -70,7 +70,7 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
     headerIsInteractive,
     className,
   } = props;
-  const { id, display } = column;
+  const { id, display, displayAsText } = column;
 
   const width = columnWidths[id] || defaultColumnWidth;
 
@@ -308,12 +308,16 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
         </EuiScreenReaderOnly>
       )}
       {!showColumnActions ? (
-        <div className="euiDataGridHeaderCell__content">{display || id}</div>
+        <div className="euiDataGridHeaderCell__content">
+          {display || displayAsText || id}
+        </div>
       ) : (
         <button
           className="euiDataGridHeaderCell__button"
           onClick={() => setIsPopoverOpen(true)}>
-          <div className="euiDataGridHeaderCell__content">{display || id}</div>
+          <div className="euiDataGridHeaderCell__content">
+            {display || displayAsText || id}
+          </div>
           <EuiPopover
             className="euiDataGridHeaderCell__popover"
             panelPaddingSize="none"


### PR DESCRIPTION
### Summary

- Datagrids now use `displayAsText` column prop as a heading (#4114). Will use `display` over `displayAsText`, and `displayAsText` over `id`.
- Column search now compares input against the `displayAsText` column prop (#4204). Will still use `id` if `displayAsText` was not provided.  

#### Before

![before](https://user-images.githubusercontent.com/15386491/101209432-a1ddcb80-366b-11eb-8ab0-1ae8ad89d14e.PNG)

#### After

![after](https://user-images.githubusercontent.com/15386491/101209437-a3a78f00-366b-11eb-94d3-1c1780839dbd.PNG)

### Checklist

Other than changelog, I don't think any of these apply; I thought I'd wait for a review before editting the changelog. Should I add a test or two?

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
