### PR TITLE
[Amsterdam] Small styling adjustments in tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Removed the shadow in `EuiComment` ([#4321](https://github.com/elastic/eui/pull/4321))
 - Reduced font size for `xs` size in `EuiButtonEmpty` ([#4325](https://github.com/elastic/eui/pull/4325))
 - Increased font size for `m` size of `EuiListGroupItem` ([#4340](https://github.com/elastic/eui/pull/4340))
+- Reduced padding in `EuiToolTip` ([#4353](https://github.com/elastic/eui/pull/4353))
 
 ## [`30.5.1`](https://github.com/elastic/eui/tree/v30.5.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Reduced font size for `xs` size in `EuiButtonEmpty` ([#4325](https://github.com/elastic/eui/pull/4325))
 - Increased font size for `m` size of `EuiListGroupItem` ([#4340](https://github.com/elastic/eui/pull/4340))
 - Reduced padding in `EuiToolTip` ([#4353](https://github.com/elastic/eui/pull/4353))
+- Reduced border-radius in `EuiRange`'s tooltip ([#4353](https://github.com/elastic/eui/pull/4353))
 
 ## [`30.5.1`](https://github.com/elastic/eui/tree/v30.5.1)
 

--- a/src/themes/eui-amsterdam/overrides/_index.scss
+++ b/src/themes/eui-amsterdam/overrides/_index.scss
@@ -20,6 +20,7 @@
 @import 'overlay_mask';
 @import 'popover';
 @import 'progress';
+@import 'range';
 @import 'text';
 @import 'toast';
 @import 'tooltip';

--- a/src/themes/eui-amsterdam/overrides/_index.scss
+++ b/src/themes/eui-amsterdam/overrides/_index.scss
@@ -22,3 +22,4 @@
 @import 'progress';
 @import 'text';
 @import 'toast';
+@import 'tooltip';

--- a/src/themes/eui-amsterdam/overrides/_range.scss
+++ b/src/themes/eui-amsterdam/overrides/_range.scss
@@ -1,3 +1,3 @@
 .euiRangeTooltip__value {
-  border-radius: $euiSizeXS;
+  border-radius: $euiBorderRadiusSmall;
 }

--- a/src/themes/eui-amsterdam/overrides/_range.scss
+++ b/src/themes/eui-amsterdam/overrides/_range.scss
@@ -1,0 +1,3 @@
+.euiRangeTooltip__value {
+  border-radius: $euiSizeXS;
+}

--- a/src/themes/eui-amsterdam/overrides/_tooltip.scss
+++ b/src/themes/eui-amsterdam/overrides/_tooltip.scss
@@ -1,0 +1,3 @@
+.euiToolTip {
+  padding: $euiSizeS;
+}


### PR DESCRIPTION
### Summary

- Reduce padding in `EuiToolTip` and therefore overall size to better align with smaller font size.

<img width="325" alt="Frame 3" src="https://user-images.githubusercontent.com/4016496/101221058-eb6eec00-3654-11eb-9afc-8fcfb52f3e27.png">

- Reduce `EuiRange`'s tooltip border-radius

<img width="438" alt="Frame 4" src="https://user-images.githubusercontent.com/4016496/101282869-7828bf80-37a5-11eb-8d52-ff0cfc81142b.png">

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
