### PR TITLE
[EuiMarkdownEditor] Add a markdown link validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 - Added `!default` to SASS variables of `EuiCollapsibleNav` ([#4335](https://github.com/elastic/eui/pull/4335))
 - Fixed `EuiDataGrid` column property `displayAsText`. Column headers prefer `displayAsText` over `id`; `display` still takes precedence. If provided, the filter in the sort-popover will search against `displayAsText` instead of `id`. ([#4351](https://github.com/elastic/eui/pull/4351))
 - Fixed propagation of `esc` key presses closing parent popovers ([#4336](https://github.com/elastic/eui/pull/4336))
-
+- Limited the links allowed in `EuiMarkdownEditor` to http, https, or starting with a forward slash ([#4362](https://github.com/elastic/eui/pull/4362))
+- Aligned components with an `href` prop to React's practice of disallowing `javascript:` protocols ([#4362](https://github.com/elastic/eui/pull/4362))
 
 **Theme: Amsterdam**
 

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "tabbable": "^3.0.0",
     "text-diff": "^1.0.1",
     "unified": "^9.2.0",
+    "url-parse": "^1.4.7",
     "uuid": "^8.3.0",
     "vfile": "^4.2.0"
   },
@@ -108,6 +109,7 @@
     "@types/react-router-dom": "^5.1.5",
     "@types/resize-observer-browser": "^0.1.3",
     "@types/tabbable": "^3.1.0",
+    "@types/url-parse": "^1.4.3",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^3.10.1",
     "@typescript-eslint/parser": "^3.10.1",

--- a/src-docs/src/views/link/link_example.js
+++ b/src-docs/src/views/link/link_example.js
@@ -10,12 +10,16 @@ import linkConfig from './playground';
 
 import Link from './link';
 import { LinkDisable } from './link_disable';
+import { LinkValidation } from './link_validation';
 
 const linkSource = require('!!raw-loader!./link');
 const linkHtml = renderToHtml(Link);
 
 const linkDisableSource = require('!!raw-loader!./link_disable');
 const linkDisableHtml = renderToHtml(LinkDisable);
+
+const linkValidationSource = require('!!raw-loader!./link_validation');
+const linkValidationHtml = renderToHtml(LinkValidation);
 
 const linkSnippet = [
   `<EuiLink href="#"><!-- Link text --></EuiLink>
@@ -76,6 +80,36 @@ export const LinkExample = {
       ),
       props: { EuiLink },
       demo: <LinkDisable />,
+    },
+    {
+      title: 'Link validation',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: linkValidationSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: linkValidationHtml,
+        },
+      ],
+      text: (
+        <p>
+          To make links more secure for users, <strong>EuiLink</strong> and
+          other components that accept an <EuiCode>href</EuiCode> prop become
+          disabled if that <EuiCode>href</EuiCode> uses the{' '}
+          <EuiCode>javascript:</EuiCode> protocol. This helps protect consuming
+          applications from cross-site scripting (XSS) attacks and mirrors
+          React&apos;s{' '}
+          <EuiLink
+            href="https://github.com/facebook/react/blob/940f48b999a3131e77b2545bd7ae252ef27ae6d1/packages/react-dom/src/shared/sanitizeURL.js#L37"
+            target="_blank">
+            planned behavior
+          </EuiLink>{' '}
+          to prevent rendering of <EuiCode>javascript:</EuiCode> links.
+        </p>
+      ),
+      demo: <LinkValidation />,
     },
   ],
   playground: linkConfig,

--- a/src-docs/src/views/link/link_validation.js
+++ b/src-docs/src/views/link/link_validation.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { EuiLink } from '../../../../src/components';
+
+const urls = [
+  'https://elastic.co',
+  '//elastic.co',
+  'relative/url/somewhere',
+  'http://username:password@example.com/',
+  // eslint-disable-next-line no-script-url
+  'javascript:alert()',
+];
+
+export const LinkValidation = () => {
+  return (
+    <>
+      {urls.map((url) => (
+        <div key={url}>
+          <EuiLink color="secondary" href={url}>
+            {url}
+          </EuiLink>
+        </div>
+      ))}
+    </>
+  );
+};

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -36,6 +36,7 @@ import {
 import { EuiInnerText } from '../inner_text';
 import { EuiIcon, IconColor, IconType } from '../icon';
 import { chromaValid, parseColor } from '../color_picker/utils';
+import { validateHref } from '../../services/security/href_validator';
 
 type IconSide = 'left' | 'right';
 
@@ -136,7 +137,7 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
   iconType,
   iconSide = 'left',
   className,
-  isDisabled,
+  isDisabled: _isDisabled,
   onClick,
   iconOnClick,
   onClickAriaLabel,
@@ -149,6 +150,9 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
   ...rest
 }) => {
   checkValidColor(color);
+
+  const isHrefValid = !href || validateHref(href);
+  const isDisabled = _isDisabled || !isHrefValid;
 
   let optionalCustomStyles: object | undefined = style;
   let textColor = null;
@@ -215,6 +219,7 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
     'euiBadge__icon',
     closeButtonProps && closeButtonProps.className
   );
+
   const Element = href && !isDisabled ? 'a' : 'button';
   const relObj: {
     href?: string;

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -383,6 +383,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                               <button
                                 className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
                                 data-test-subj="tablePaginationPopoverButton"
+                                disabled={false}
                                 onClick={[Function]}
                                 type="button"
                               >

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -42,6 +42,7 @@ import {
   EuiButtonContentType,
   EuiButtonContent,
 } from './button_content';
+import { validateHref } from '../../services/security/href_validator';
 
 export type ButtonColor =
   | 'primary'
@@ -250,8 +251,8 @@ export type Props = ExclusiveUnion<
 >;
 
 export const EuiButton: FunctionComponent<Props> = ({
-  isDisabled,
-  disabled,
+  isDisabled: _isDisabled,
+  disabled: _disabled,
   href,
   target,
   rel,
@@ -259,6 +260,10 @@ export const EuiButton: FunctionComponent<Props> = ({
   buttonRef,
   ...rest
 }) => {
+  const isHrefValid = !href || validateHref(href);
+  const disabled = _disabled || !isHrefValid;
+  const isDisabled = _isDisabled || !isHrefValid;
+
   const buttonIsDisabled = rest.isLoading || isDisabled || disabled;
   const element = href && !isDisabled ? 'a' : 'button';
 

--- a/src/components/button/button_empty/button_empty.tsx
+++ b/src/components/button/button_empty/button_empty.tsx
@@ -33,6 +33,7 @@ import {
   EuiButtonContentProps,
   EuiButtonContentType,
 } from '../button_content';
+import { validateHref } from '../../../services/security/href_validator';
 
 export type EuiButtonEmptyColor =
   | 'primary'
@@ -126,8 +127,8 @@ export const EuiButtonEmpty: FunctionComponent<EuiButtonEmptyProps> = ({
   color = 'primary',
   size,
   flush,
-  isDisabled,
-  disabled,
+  isDisabled: _isDisabled,
+  disabled: _disabled,
   isLoading,
   href,
   target,
@@ -139,6 +140,10 @@ export const EuiButtonEmpty: FunctionComponent<EuiButtonEmptyProps> = ({
   isSelected,
   ...rest
 }) => {
+  const isHrefValid = !href || validateHref(href);
+  const disabled = _disabled || !isHrefValid;
+  const isDisabled = _isDisabled || !isHrefValid;
+
   // If in the loading state, force disabled to true
   const buttonIsDisabled = isLoading || isDisabled || disabled;
 

--- a/src/components/button/button_icon/button_icon.tsx
+++ b/src/components/button/button_icon/button_icon.tsx
@@ -37,6 +37,7 @@ import {
 import { IconType, IconSize, EuiIcon } from '../../icon';
 
 import { ButtonSize } from '../button';
+import { validateHref } from '../../../services/security/href_validator';
 
 export type EuiButtonIconColor =
   | 'accent'
@@ -104,7 +105,7 @@ export const EuiButtonIcon: FunctionComponent<Props> = ({
   iconType,
   iconSize = 'm',
   color = 'primary',
-  isDisabled,
+  isDisabled: _isDisabled,
   href,
   type = 'button',
   target,
@@ -113,6 +114,9 @@ export const EuiButtonIcon: FunctionComponent<Props> = ({
   isSelected,
   ...rest
 }) => {
+  const isHrefValid = !href || validateHref(href);
+  const isDisabled = _isDisabled || !isHrefValid;
+
   const ariaHidden = rest['aria-hidden'];
   const isAriaHidden = ariaHidden === 'true' || ariaHidden === true;
 

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -37,6 +37,7 @@ import {
   euiCardSelectableColor,
 } from './card_select';
 import { htmlIdGenerator } from '../../services/accessibility';
+import { validateHref } from '../../services/security/href_validator';
 
 type CardAlignment = 'left' | 'center' | 'right';
 
@@ -176,7 +177,7 @@ export const SIZES = keysOf(paddingSizeToClassNameMap);
 export const EuiCard: FunctionComponent<EuiCardProps> = ({
   className,
   description,
-  isDisabled,
+  isDisabled: _isDisabled,
   title,
   titleElement = 'span',
   titleSize = 's',
@@ -198,6 +199,9 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
   paddingSize = 'm',
   ...rest
 }) => {
+  const isHrefValid = !href || validateHref(href);
+  const isDisabled = _isDisabled || !isHrefValid;
+
   /**
    * For a11y, we simulate the same click that's provided on the title when clicking the whole card
    * without having to make the whole card a button or anchor tag.

--- a/src/components/context_menu/__snapshots__/context_menu_panel.test.tsx.snap
+++ b/src/components/context_menu/__snapshots__/context_menu_panel.test.tsx.snap
@@ -449,7 +449,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
       <EuiResizeObserver onResize={[Function: onResize]}>
         <div>
           <EuiContextMenuItem data-counter={0} buttonRef={[Function: bound ]}>
-            <button disabled={[undefined]} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={0}>
+            <button disabled={false} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={0}>
               <span className=\\"euiContextMenu__itemLayout\\">
                 <span className=\\"euiContextMenuItem__text\\">
                   Option A
@@ -458,7 +458,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
             </button>
           </EuiContextMenuItem>
           <EuiContextMenuItem data-counter={1} buttonRef={[Function: bound ]}>
-            <button disabled={[undefined]} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={1}>
+            <button disabled={false} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={1}>
               <span className=\\"euiContextMenu__itemLayout\\">
                 <span className=\\"euiContextMenuItem__text\\">
                   Option B
@@ -480,7 +480,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
       <EuiResizeObserver onResize={[Function: onResize]}>
         <div>
           <EuiContextMenuItem data-counter={0} buttonRef={[Function: bound ]}>
-            <button disabled={[undefined]} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={0}>
+            <button disabled={false} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={0}>
               <span className=\\"euiContextMenu__itemLayout\\">
                 <span className=\\"euiContextMenuItem__text\\">
                   Option A
@@ -489,7 +489,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
             </button>
           </EuiContextMenuItem>
           <EuiContextMenuItem data-counter={1} buttonRef={[Function: bound ]}>
-            <button disabled={[undefined]} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={1}>
+            <button disabled={false} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={1}>
               <span className=\\"euiContextMenu__itemLayout\\">
                 <span className=\\"euiContextMenuItem__text\\">
                   Option B
@@ -539,7 +539,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
       <EuiResizeObserver onResize={[Function: onResize]}>
         <div>
           <EuiContextMenuItem data-counter={0} buttonRef={[Function: bound ]}>
-            <button disabled={[undefined]} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={0}>
+            <button disabled={false} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={0}>
               <span className=\\"euiContextMenu__itemLayout\\">
                 <span className=\\"euiContextMenuItem__text\\">
                   Option A
@@ -548,7 +548,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
             </button>
           </EuiContextMenuItem>
           <EuiContextMenuItem data-counter={1} buttonRef={[Function: bound ]}>
-            <button disabled={[undefined]} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={1}>
+            <button disabled={false} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={1}>
               <span className=\\"euiContextMenu__itemLayout\\">
                 <span className=\\"euiContextMenuItem__text\\">
                   Option B
@@ -570,7 +570,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
       <EuiResizeObserver onResize={[Function: onResize]}>
         <div>
           <EuiContextMenuItem data-counter={2} buttonRef={[Function: bound ]}>
-            <button disabled={[undefined]} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={2}>
+            <button disabled={false} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={2}>
               <span className=\\"euiContextMenu__itemLayout\\">
                 <span className=\\"euiContextMenuItem__text\\">
                   Option A
@@ -579,7 +579,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
             </button>
           </EuiContextMenuItem>
           <EuiContextMenuItem data-counter={3} buttonRef={[Function: bound ]}>
-            <button disabled={[undefined]} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={3}>
+            <button disabled={false} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={3}>
               <span className=\\"euiContextMenu__itemLayout\\">
                 <span className=\\"euiContextMenuItem__text\\">
                   Option B

--- a/src/components/context_menu/context_menu_item.tsx
+++ b/src/components/context_menu/context_menu_item.tsx
@@ -33,6 +33,7 @@ import { EuiIcon } from '../icon';
 import { EuiToolTip, ToolTipPositions } from '../tool_tip';
 
 import { getSecureRelForTarget } from '../../services';
+import { validateHref } from '../../services/security/href_validator';
 
 export type EuiContextMenuItemIcon = ReactElement<any> | string | HTMLElement;
 
@@ -90,7 +91,7 @@ export class EuiContextMenuItem extends Component<Props> {
       hasPanel,
       icon,
       buttonRef,
-      disabled,
+      disabled: _disabled,
       layoutAlign = 'center',
       toolTipTitle,
       toolTipContent,
@@ -101,6 +102,9 @@ export class EuiContextMenuItem extends Component<Props> {
       ...rest
     } = this.props;
     let iconInstance;
+
+    const isHrefValid = !href || validateHref(href);
+    const disabled = _disabled || !isHrefValid;
 
     if (icon) {
       switch (typeof icon) {

--- a/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
+++ b/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
@@ -304,7 +304,9 @@ exports[`EuiControlBar props leftOffset is rendered 1`] = `
                 className="euiControlBar__button"
                 color="ghost"
                 data-test-subj="dts"
+                disabled={false}
                 element="button"
+                isDisabled={false}
                 onClick={[Function]}
                 size="s"
                 type="button"
@@ -312,6 +314,7 @@ exports[`EuiControlBar props leftOffset is rendered 1`] = `
                 <button
                   className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
                   data-test-subj="dts"
+                  disabled={false}
                   onClick={[Function]}
                   style={
                     Object {
@@ -625,7 +628,9 @@ exports[`EuiControlBar props maxHeight is rendered 1`] = `
                 className="euiControlBar__button"
                 color="ghost"
                 data-test-subj="dts"
+                disabled={false}
                 element="button"
+                isDisabled={false}
                 onClick={[Function]}
                 size="s"
                 type="button"
@@ -633,6 +638,7 @@ exports[`EuiControlBar props maxHeight is rendered 1`] = `
                 <button
                   className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
                   data-test-subj="dts"
+                  disabled={false}
                   onClick={[Function]}
                   style={
                     Object {
@@ -945,7 +951,9 @@ exports[`EuiControlBar props mobile is rendered 1`] = `
                 className="euiControlBar__button"
                 color="ghost"
                 data-test-subj="dts"
+                disabled={false}
                 element="button"
+                isDisabled={false}
                 onClick={[Function]}
                 size="s"
                 type="button"
@@ -953,6 +961,7 @@ exports[`EuiControlBar props mobile is rendered 1`] = `
                 <button
                   className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
                   data-test-subj="dts"
+                  disabled={false}
                   onClick={[Function]}
                   style={
                     Object {
@@ -1178,7 +1187,9 @@ exports[`EuiControlBar props position is rendered 1`] = `
             className="euiControlBar__button"
             color="ghost"
             data-test-subj="dts"
+            disabled={false}
             element="button"
+            isDisabled={false}
             onClick={[Function]}
             size="s"
             type="button"
@@ -1186,6 +1197,7 @@ exports[`EuiControlBar props position is rendered 1`] = `
             <button
               className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
               data-test-subj="dts"
+              disabled={false}
               onClick={[Function]}
               style={
                 Object {
@@ -1483,7 +1495,9 @@ exports[`EuiControlBar props rightOffset is rendered 1`] = `
                 className="euiControlBar__button"
                 color="ghost"
                 data-test-subj="dts"
+                disabled={false}
                 element="button"
+                isDisabled={false}
                 onClick={[Function]}
                 size="s"
                 type="button"
@@ -1491,6 +1505,7 @@ exports[`EuiControlBar props rightOffset is rendered 1`] = `
                 <button
                   className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
                   data-test-subj="dts"
+                  disabled={false}
                   onClick={[Function]}
                   style={
                     Object {
@@ -1808,7 +1823,9 @@ exports[`EuiControlBar props showContent is rendered 1`] = `
                 className="euiControlBar__button"
                 color="ghost"
                 data-test-subj="dts"
+                disabled={false}
                 element="button"
+                isDisabled={false}
                 onClick={[Function]}
                 size="s"
                 type="button"
@@ -1816,6 +1833,7 @@ exports[`EuiControlBar props showContent is rendered 1`] = `
                 <button
                   className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
                   data-test-subj="dts"
+                  disabled={false}
                   onClick={[Function]}
                   style={
                     Object {
@@ -2133,7 +2151,9 @@ exports[`EuiControlBar props size is rendered 1`] = `
                 className="euiControlBar__button"
                 color="ghost"
                 data-test-subj="dts"
+                disabled={false}
                 element="button"
+                isDisabled={false}
                 onClick={[Function]}
                 size="s"
                 type="button"
@@ -2141,6 +2161,7 @@ exports[`EuiControlBar props size is rendered 1`] = `
                 <button
                   className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
                   data-test-subj="dts"
+                  disabled={false}
                   onClick={[Function]}
                   style={
                     Object {

--- a/src/components/header/header_logo.tsx
+++ b/src/components/header/header_logo.tsx
@@ -27,6 +27,7 @@ import classNames from 'classnames';
 import { EuiIcon, IconType } from '../icon';
 import { CommonProps } from '../common';
 import { getSecureRelForTarget } from '../../services';
+import { validateHref } from '../../services/security/href_validator';
 
 export type EuiHeaderLogoProps = CommonProps &
   AnchorHTMLAttributes<HTMLAnchorElement> & {
@@ -53,9 +54,10 @@ export const EuiHeaderLogo: FunctionComponent<EuiHeaderLogoProps> = ({
 }) => {
   const classes = classNames('euiHeaderLogo', className);
   const secureRel = getSecureRelForTarget({ href, rel, target });
+  const isHrefValid = !href || validateHref(href);
   return (
     <a
-      href={href}
+      href={isHrefValid ? href : ''}
       rel={secureRel}
       target={target}
       className={classes}

--- a/src/components/key_pad_menu/key_pad_menu_item.tsx
+++ b/src/components/key_pad_menu/key_pad_menu_item.tsx
@@ -33,6 +33,7 @@ import { EuiBetaBadge } from '../badge/beta_badge';
 import { getSecureRelForTarget } from '../../services';
 
 import { IconType } from '../icon';
+import { validateHref } from '../../services/security/href_validator';
 
 const renderContent = (
   children: ReactNode,
@@ -94,7 +95,7 @@ export type EuiKeyPadMenuItemProps = CommonProps &
   EuiKeyPadMenuItemCommonProps;
 
 export const EuiKeyPadMenuItem: FunctionComponent<EuiKeyPadMenuItemProps> = ({
-  isDisabled,
+  isDisabled: _isDisabled,
   label,
   children,
   className,
@@ -106,6 +107,9 @@ export const EuiKeyPadMenuItem: FunctionComponent<EuiKeyPadMenuItemProps> = ({
   target,
   ...rest
 }) => {
+  const isHrefValid = !href || validateHref(href);
+  const isDisabled = _isDisabled || !isHrefValid;
+
   const classes = classNames(
     'euiKeyPadMenuItem',
     {

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -29,6 +29,7 @@ import { EuiI18n, useEuiI18n } from '../i18n';
 import { CommonProps, ExclusiveUnion, keysOf } from '../common';
 import { getSecureRelForTarget } from '../../services';
 import { EuiScreenReaderOnly } from '../accessibility';
+import { validateHref } from '../../services/security/href_validator';
 
 export type EuiLinkType = 'button' | 'reset' | 'submit';
 export type EuiLinkColor =
@@ -99,7 +100,7 @@ const EuiLink = forwardRef<HTMLAnchorElement | HTMLButtonElement, EuiLinkProps>(
       rel,
       type = 'button',
       onClick,
-      disabled,
+      disabled: _disabled,
       ...rest
     },
     ref
@@ -124,7 +125,10 @@ const EuiLink = forwardRef<HTMLAnchorElement | HTMLButtonElement, EuiLinkProps>(
       </EuiScreenReaderOnly>
     );
 
-    if (href === undefined) {
+    const isHrefValid = !href || validateHref(href);
+    const disabled = _disabled || !isHrefValid;
+
+    if (href === undefined || !isHrefValid) {
       const buttonProps = {
         className: classNames(
           'euiLink',

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -105,6 +105,9 @@ const EuiLink = forwardRef<HTMLAnchorElement | HTMLButtonElement, EuiLinkProps>(
     },
     ref
   ) => {
+    const isHrefValid = !href || validateHref(href);
+    const disabled = _disabled || !isHrefValid;
+
     const externalLinkIcon = (
       <EuiIcon
         aria-label={useEuiI18n('euiLink.external.ariaLabel', 'External link')}
@@ -124,9 +127,6 @@ const EuiLink = forwardRef<HTMLAnchorElement | HTMLButtonElement, EuiLinkProps>(
         </span>
       </EuiScreenReaderOnly>
     );
-
-    const isHrefValid = !href || validateHref(href);
-    const disabled = _disabled || !isHrefValid;
 
     if (href === undefined || !isHrefValid) {
       const buttonProps = {

--- a/src/components/list_group/list_group_item.tsx
+++ b/src/components/list_group/list_group_item.tsx
@@ -36,6 +36,7 @@ import { useInnerText } from '../inner_text';
 import { ExclusiveUnion, CommonProps } from '../common';
 
 import { getSecureRelForTarget } from '../../services';
+import { validateHref } from '../../services/security/href_validator';
 
 type ItemSize = 'xs' | 's' | 'm' | 'l';
 const sizeToClassNameMap: { [size in ItemSize]: string } = {
@@ -147,7 +148,7 @@ export type EuiListGroupItemProps = CommonProps &
 export const EuiListGroupItem: FunctionComponent<EuiListGroupItemProps> = ({
   label,
   isActive = false,
-  isDisabled = false,
+  isDisabled: _isDisabled = false,
   href,
   target,
   rel,
@@ -163,6 +164,9 @@ export const EuiListGroupItem: FunctionComponent<EuiListGroupItemProps> = ({
   buttonRef,
   ...rest
 }) => {
+  const isHrefValid = !href || validateHref(href);
+  const isDisabled = _isDisabled || !isHrefValid;
+
   const classes = classNames(
     'euiListGroupItem',
     sizeToClassNameMap[size],

--- a/src/components/markdown_editor/plugins/markdown_default_plugins.tsx
+++ b/src/components/markdown_editor/plugins/markdown_default_plugins.tsx
@@ -22,6 +22,7 @@ import remark2rehype from 'remark-rehype';
 import rehype2react from 'rehype-react';
 import * as MarkdownTooltip from './markdown_tooltip';
 import * as MarkdownCheckbox from './markdown_checkbox';
+import { markdownLinkValidator } from './markdown_link_validator';
 import React, { createElement } from 'react';
 import { EuiLink } from '../../link';
 import { EuiCodeBlock, EuiCode } from '../../code';
@@ -37,6 +38,7 @@ export const getDefaultEuiMarkdownParsingPlugins = (): PluggableList => [
   [emoji, { emoticon: true }],
   [MarkdownTooltip.parser, {}],
   [MarkdownCheckbox.parser, {}],
+  [markdownLinkValidator, {}],
 ];
 
 export const defaultParsingPlugins = getDefaultEuiMarkdownParsingPlugins();

--- a/src/components/markdown_editor/plugins/markdown_link_validator.test.tsx
+++ b/src/components/markdown_editor/plugins/markdown_link_validator.test.tsx
@@ -18,6 +18,7 @@
  */
 
 import { validateUrl, mutateLinkToText } from './markdown_link_validator';
+import { validateHref } from '../../../services/security/href_validator';
 
 describe('validateURL', () => {
   it('approves of https:', () => {
@@ -48,6 +49,8 @@ describe('validateURL', () => {
   it('rejects javascript', () => {
     // eslint-disable-next-line no-script-url
     expect(validateUrl('javascript:')).toBeFalsy();
+    // eslint-disable-next-line no-script-url
+    expect(validateHref('javascript:alert()')).toBeFalsy();
   });
 });
 

--- a/src/components/markdown_editor/plugins/markdown_link_validator.test.tsx
+++ b/src/components/markdown_editor/plugins/markdown_link_validator.test.tsx
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { validateUrl, mutateLinkToText } from './markdown_link_validator';
+
+describe('validateURL', () => {
+  it('approves of https:', () => {
+    expect(validateUrl('https:')).toBeTruthy();
+  });
+  it('approves of http:', () => {
+    expect(validateUrl('http:')).toBeTruthy();
+  });
+  it('approves of absolute relative links', () => {
+    expect(validateUrl('/')).toBeTruthy();
+  });
+  it('approves of relative protocols', () => {
+    expect(validateUrl('//')).toBeTruthy();
+  });
+  it('rejects a url starting with http with not an s following', () => {
+    expect(validateUrl('httpm:')).toBeFalsy();
+  });
+  it('rejects a directory relative link', () => {
+    expect(validateUrl('./')).toBeFalsy();
+    expect(validateUrl('../')).toBeFalsy();
+  });
+  it('rejects a word', () => {
+    expect(validateUrl('word')).toBeFalsy();
+  });
+  it('rejects gopher', () => {
+    expect(validateUrl('gopher:')).toBeFalsy();
+  });
+  it('rejects javascript', () => {
+    // eslint-disable-next-line no-script-url
+    expect(validateUrl('javascript:')).toBeFalsy();
+  });
+});
+
+describe('mutateLinkToText', () => {
+  it('mutates', () => {
+    expect(
+      mutateLinkToText({
+        type: 'link',
+        url: 'https://cats.com',
+        title: null,
+        children: [{ value: 'Cats' }],
+      })
+    ).toMatchInlineSnapshot(`
+      Object {
+        "type": "text",
+        "value": "[Cats](https://cats.com)",
+      }
+    `);
+    expect(
+      mutateLinkToText({
+        type: 'link',
+        url: 'https://cats.com',
+        title: null,
+        children: [],
+      })
+    ).toMatchInlineSnapshot(`
+      Object {
+        "type": "text",
+        "value": "[](https://cats.com)",
+      }
+    `);
+  });
+});

--- a/src/components/markdown_editor/plugins/markdown_link_validator.tsx
+++ b/src/components/markdown_editor/plugins/markdown_link_validator.tsx
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import visit from 'unist-util-visit';
+
+interface LinkOrTextNode {
+  type: string;
+  url?: string;
+  title?: string | null;
+  value?: string;
+  children?: Array<{ value: string }>;
+}
+
+export function markdownLinkValidator() {
+  return (ast: any) => {
+    visit(ast, 'link', (_node: unknown) => {
+      const node = _node as LinkOrTextNode;
+
+      if (!validateUrl(node.url!)) {
+        mutateLinkToText(node);
+      }
+    });
+  };
+}
+
+export function mutateLinkToText(node: LinkOrTextNode) {
+  node.type = 'text';
+  node.value = `[${node.children![0]?.value || ''}](${node.url})`;
+  delete node.children;
+  delete node.title;
+  delete node.url;
+  return node;
+}
+
+export function validateUrl(url: string) {
+  // A link is valid if it starts with http:, https:, or /
+  return /^(https?:|\/)/.test(url);
+}

--- a/src/components/side_nav/side_nav_item.tsx
+++ b/src/components/side_nav/side_nav_item.tsx
@@ -30,6 +30,7 @@ import { CommonProps } from '../common';
 import { EuiIcon } from '../icon';
 
 import { getSecureRelForTarget } from '../../services';
+import { validateHref } from '../../services/security/href_validator';
 
 type ItemProps = CommonProps & {
   href?: string;
@@ -124,7 +125,7 @@ export function EuiSideNavItem<
   isParent,
   icon,
   onClick,
-  href,
+  href: _href,
   rel,
   target,
   items,
@@ -134,6 +135,8 @@ export function EuiSideNavItem<
   className,
   ...rest
 }: EuiSideNavItemProps<T>) {
+  const isHrefValid = !_href || validateHref(_href);
+  const href = isHrefValid ? _href : '';
   let childItems;
 
   if (items && isOpen) {

--- a/src/components/tabs/tab.tsx
+++ b/src/components/tabs/tab.tsx
@@ -26,6 +26,7 @@ import React, {
 import classNames from 'classnames';
 import { CommonProps, ExclusiveUnion } from '../common';
 import { getSecureRelForTarget } from '../../services';
+import { validateHref } from '../../services/security/href_validator';
 
 export interface EuiTabProps extends CommonProps {
   isSelected?: boolean;
@@ -49,12 +50,15 @@ export const EuiTab: FunctionComponent<Props> = ({
   isSelected,
   children,
   className,
-  disabled,
+  disabled: _disabled,
   href,
   target,
   rel,
   ...rest
 }) => {
+  const isHrefValid = !href || validateHref(href);
+  const disabled = _disabled || !isHrefValid;
+
   const classes = classNames('euiTab', className, {
     'euiTab-isSelected': isSelected,
     'euiTab-isDisabled': disabled,

--- a/src/components/tabs/tabbed_content/__snapshots__/tabbed_content.test.tsx.snap
+++ b/src/components/tabs/tabbed_content/__snapshots__/tabbed_content.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`EuiTabbedContent behavior when uncontrolled, the selected tab should up
             aria-controls="generated-id"
             aria-selected={false}
             className="euiTab"
+            disabled={false}
             id="es"
             onClick={[Function]}
             role="tab"
@@ -120,6 +121,7 @@ exports[`EuiTabbedContent behavior when uncontrolled, the selected tab should up
             aria-selected={true}
             className="euiTab euiTab-isSelected"
             data-test-subj="kibanaTab"
+            disabled={false}
             id="kibana"
             onClick={[Function]}
             role="tab"

--- a/src/services/security/href_validator.test.tsx
+++ b/src/services/security/href_validator.test.tsx
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { validateHref } from './href_validator';
+
+describe('validateHref', () => {
+  it('approves of https:', () => {
+    expect(validateHref('https:')).toBeTruthy();
+  });
+  it('approves of http:', () => {
+    expect(validateHref('http:')).toBeTruthy();
+  });
+  it('approves of absolute relative hrefs', () => {
+    expect(validateHref('/')).toBeTruthy();
+  });
+  it('approves of relative protocols', () => {
+    expect(validateHref('//')).toBeTruthy();
+  });
+  it('approves of url starting with http with not an s following', () => {
+    expect(validateHref('httpm:')).toBeTruthy();
+  });
+  it('approves of directory relative href', () => {
+    expect(validateHref('./')).toBeTruthy();
+    expect(validateHref('../')).toBeTruthy();
+  });
+  it('approves of word', () => {
+    expect(validateHref('word')).toBeTruthy();
+  });
+  it('approves of gopher', () => {
+    expect(validateHref('gopher:')).toBeTruthy();
+  });
+  it('approves of authenticated hrefs', () => {
+    expect(validateHref('http://username:password@example.com/')).toBeTruthy();
+  });
+  it('rejects javascript', () => {
+    // eslint-disable-next-line no-script-url
+    expect(validateHref('javascript:')).toBeFalsy();
+    // eslint-disable-next-line no-script-url
+    expect(validateHref('javascript:alert()')).toBeFalsy();
+  });
+});

--- a/src/services/security/href_validator.tsx
+++ b/src/services/security/href_validator.tsx
@@ -1,0 +1,27 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import URL from 'url-parse';
+
+export function validateHref(href: string) {
+  // check href and treat it as invalid if it uses the javascript: protocol
+  const parts = new URL(href);
+  // eslint-disable-next-line no-script-url
+  return parts.protocol !== 'javascript:';
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1857,6 +1857,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
+"@types/url-parse@^1.4.3":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@types/url-parse/-/url-parse-1.4.3.tgz#fba49d90f834951cb000a674efee3d6f20968329"
+  integrity sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw==
+
 "@types/uuid@^8.3.0":
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
@@ -12932,10 +12937,10 @@ querystring@0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
-querystringify@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.0.tgz#7ded8dfbf7879dcc60d0a644ac6754b283ad17ef"
-  integrity sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 quick-lru@^1.0.0:
   version "1.1.0"
@@ -16273,12 +16278,12 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-parse@^1.4.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.3.tgz#bfaee455c889023219d757e045fa6a684ec36c15"
-  integrity sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==
+url-parse@^1.4.3, url-parse@^1.4.7:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
+  integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
   dependencies:
-    querystringify "^2.0.0"
+    querystringify "^2.1.1"
     requires-port "^1.0.0"
 
 url-to-options@^1.0.1:


### PR DESCRIPTION
### Summary

Closes #4331 

### markdown parsing

https://eui.elastic.co/pr_4362/#/editors-syntax/markdown-editor

Look how only the valid urls get rendered as links, and the rest render their text. Ooooh. Ahhhh. Valid markdown links start with http:/https: or a forward slash.

![validate-url](https://user-images.githubusercontent.com/5943972/101402782-12156880-3889-11eb-997e-920bf8d0f53b.gif)

### href validation

https://eui.elastic.co/pr_4362/#/navigation/link#link-validation

**EuiLink** docs updated with a section on the validation. I [Chandler] initially planned on creating a new prop to disable the validation, but with React planning on similarly removing this functionality I'm going to be optimistic that no one will miss having this option available. In contrast to markdown's validation which only allows a small approved list of url patterns, the href validation only prevents `javascript:`.

<img width="957" alt="Screen Shot 2020-12-08 at 12 42 19 PM" src="https://user-images.githubusercontent.com/313125/101534447-6afe0300-3954-11eb-8e5c-f4824ecd1159.png">

Components affected:

- [x] EuiLink
- [x] EuiBadge
- [x] EuiBreadcrumb (fowards to EuiLink)
- [x] EuiButton
- [x] EuiButtonEmpty
- [x] EuiButtonIcon
- [x] EuiCard
- [x] EuiContextMenuItem
- [x] EuiHeaderLogo
- [x] EuiKeyPadMenuItem
- [x] EuiListGroupItem
- [x] EuiSideNavItem
- [x] EuiTab
- [x] EuiControlBar (forwards to EuiButton)
- [x] EuiPaginationButton (fowards to EuiButtonEmpty)

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
