### PR TITLE
[EuiSuperDatePicker]Changed to `EuiFlexGrid` view in `Recently used date ranges`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added collapsble behavior to `EuiResizableContainer` panels ([#3978](https://github.com/elastic/eui/pull/3978))
 - Updated `EuiResizablePanel` to use `EuiPanel` ([#3978](https://github.com/elastic/eui/pull/3978))
+- Updated `EuiSuperSelect` recently used list to render as `<ol>` and `<li>` elements ([#4370](https://github.com/elastic/eui/pull/4370))
 
 **Bug fixes**
 

--- a/src/components/date_picker/super_date_picker/quick_select_popover/_commonly_used_time_ranges.scss
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/_commonly_used_time_ranges.scss
@@ -1,4 +1,0 @@
-.euiCommonlyUsedTimeRanges__item {
-  font-size: $euiFontSizeS;
-  line-height: $euiFontSizeS;
-}

--- a/src/components/date_picker/super_date_picker/quick_select_popover/_index.scss
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/_index.scss
@@ -1,4 +1,3 @@
 @import 'quick_select_popover';
 @import 'quick_select';
 @import 'refresh_interval';
-@import 'commonly_used_time_ranges';

--- a/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select_popover.scss
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select_popover.scss
@@ -8,7 +8,7 @@
   max-height: $euiSizeM * 11;
   overflow: hidden;
   overflow-y: auto;
-  padding: $euiSizeXS 0; // Offset negative margin from flex items
+  padding: $euiSizeS 0 $euiSizeXS; // Offset negative margin from flex items
 }
 
 // sass-lint:disable no-important
@@ -19,4 +19,13 @@
 
 .euiQuickSelectPopover__anchor {
   height: 100%;
+}
+
+.euiQuickSelectPopover__sectionItem {
+  font-size: $euiFontSizeS;
+  line-height: $euiFontSizeS;
+
+  &:not(:last-of-type) {
+    margin-bottom: $euiSizeS;
+  }
 }

--- a/src/components/date_picker/super_date_picker/quick_select_popover/commonly_used_time_ranges.tsx
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/commonly_used_time_ranges.tsx
@@ -49,7 +49,7 @@ export const EuiCommonlyUsedTimeRanges: FunctionComponent<EuiCommonlyUsedTimeRan
       <EuiFlexItem
         key={label}
         component="li"
-        className="euiCommonlyUsedTimeRanges__item">
+        className="euiQuickSelectPopover__sectionItem">
         <EuiLink onClick={applyCommonlyUsed} data-test-subj={dataTestSubj}>
           {label}
         </EuiLink>
@@ -60,7 +60,7 @@ export const EuiCommonlyUsedTimeRanges: FunctionComponent<EuiCommonlyUsedTimeRan
   return (
     <fieldset>
       <EuiTitle size="xxxs">
-        <legend id={legendId} aria-label="Commonly used time ranges">
+        <legend id={legendId}>
           <EuiI18n
             token="euiCommonlyUsedTimeRanges.legend"
             default="Commonly used"

--- a/src/components/date_picker/super_date_picker/quick_select_popover/recently_used.tsx
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/recently_used.tsx
@@ -21,10 +21,8 @@ import React, { FunctionComponent } from 'react';
 import { prettyDuration } from '../pretty_duration';
 
 import { EuiI18n } from '../../../i18n';
-import { EuiFlexItem } from '../../../flex';
 import { htmlIdGenerator } from '../../../../services';
 import { EuiTitle } from '../../../title';
-import { EuiSpacer } from '../../../spacer';
 import { EuiLink } from '../../../link';
 import { EuiHorizontalRule } from '../../../horizontal_rule';
 import { DurationRange, ApplyTime } from '../../types';
@@ -55,15 +53,13 @@ export const EuiRecentlyUsed: FunctionComponent<EuiRecentlyUsedProps> = ({
       applyTime({ start, end });
     };
     return (
-      <EuiFlexItem
-        className="euiCommonlyUsedTimeRanges__item"
-        component="li"
-        grow={false}
+      <li
+        className="euiQuickSelectPopover__sectionItem"
         key={`${start}-${end}`}>
         <EuiLink onClick={applyRecentlyUsed}>
           {prettyDuration(start, end, commonlyUsedRanges, dateFormat)}
         </EuiLink>
-      </EuiFlexItem>
+      </li>
     );
   });
 
@@ -77,7 +73,6 @@ export const EuiRecentlyUsed: FunctionComponent<EuiRecentlyUsedProps> = ({
           />
         </legend>
       </EuiTitle>
-      <EuiSpacer size="s" />
       <div className="euiQuickSelectPopover__section">
         <ul>{links}</ul>
       </div>

--- a/src/components/date_picker/super_date_picker/quick_select_popover/recently_used.tsx
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/recently_used.tsx
@@ -17,16 +17,19 @@
  * under the License.
  */
 
-import React, { Fragment, FunctionComponent } from 'react';
+import React, { FunctionComponent } from 'react';
 import { prettyDuration } from '../pretty_duration';
 
-import { EuiFlexGroup, EuiFlexItem } from '../../../flex';
+import { EuiI18n } from '../../../i18n';
+import { EuiFlexItem } from '../../../flex';
+import { htmlIdGenerator } from '../../../../services';
 import { EuiTitle } from '../../../title';
 import { EuiSpacer } from '../../../spacer';
 import { EuiLink } from '../../../link';
-import { EuiText } from '../../../text';
 import { EuiHorizontalRule } from '../../../horizontal_rule';
 import { DurationRange, ApplyTime } from '../../types';
+
+const generateId = htmlIdGenerator();
 
 export interface EuiRecentlyUsedProps {
   applyTime: ApplyTime;
@@ -41,6 +44,8 @@ export const EuiRecentlyUsed: FunctionComponent<EuiRecentlyUsedProps> = ({
   dateFormat,
   recentlyUsedRanges = [],
 }) => {
+  const legendId = generateId();
+
   if (recentlyUsedRanges.length === 0) {
     return null;
   }
@@ -50,7 +55,11 @@ export const EuiRecentlyUsed: FunctionComponent<EuiRecentlyUsedProps> = ({
       applyTime({ start, end });
     };
     return (
-      <EuiFlexItem grow={false} key={`${start}-${end}`}>
+      <EuiFlexItem
+        className="euiCommonlyUsedTimeRanges__item"
+        component="li"
+        grow={false}
+        key={`${start}-${end}`}>
         <EuiLink onClick={applyRecentlyUsed}>
           {prettyDuration(start, end, commonlyUsedRanges, dateFormat)}
         </EuiLink>
@@ -59,18 +68,21 @@ export const EuiRecentlyUsed: FunctionComponent<EuiRecentlyUsedProps> = ({
   });
 
   return (
-    <Fragment>
+    <fieldset>
       <EuiTitle size="xxxs">
-        <span>Recently used date ranges</span>
+        <legend id={legendId}>
+          <EuiI18n
+            token="euiRecentlyUsed.legend"
+            default="Recently used date ranges"
+          />
+        </legend>
       </EuiTitle>
       <EuiSpacer size="s" />
-      <EuiText size="s" className="euiQuickSelectPopover__section">
-        <EuiFlexGroup gutterSize="s" direction="column">
-          {links}
-        </EuiFlexGroup>
-      </EuiText>
+      <div className="euiQuickSelectPopover__section">
+        <ul>{links}</ul>
+      </div>
       <EuiHorizontalRule margin="s" />
-    </Fragment>
+    </fieldset>
   );
 };
 


### PR DESCRIPTION
### Summary

Fixes #4226 
Changed to `EuiFlexGrid` view in `Recently used date ranges` under `EuiRecentlyUsed` component.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[x] Props have proper **autodocs**~ 
- ~[x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[x] Checked for **breaking changes** and labeled appropriately~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
