### PR TITLE
Fix doc to not intercept hash links

### DIFF
--- a/src-docs/src/views/link_wrapper.js
+++ b/src-docs/src/views/link_wrapper.js
@@ -21,11 +21,8 @@ export const LinkWrapper = ({ children }) => {
       if (anchor && anchor.nodeName === 'A') {
         const href = anchor.getAttribute('href');
         // check if this is an internal link
-        if (href.startsWith('#')) {
-          if (href !== '#') {
-            // a lone # character is used in the docs as a placeholder/demo value and should be ignored
-            history.push(href.replace('#', ''));
-          }
+        if (href.startsWith('#/')) {
+          history.push(href.replace('#', ''));
           e.preventDefault();
         }
       }

--- a/src/components/table/table_pagination/table_pagination.tsx
+++ b/src/components/table/table_pagination/table_pagination.tsx
@@ -73,7 +73,6 @@ export class EuiTablePagination extends Component<Props, State> {
       onChangeItemsPerPage = () => {},
       onChangePage,
       pageCount,
-      'aria-controls': ariaControls,
       ...rest
     } = this.props;
 
@@ -132,7 +131,6 @@ export class EuiTablePagination extends Component<Props, State> {
 
         <EuiFlexItem grow={false}>
           <EuiPagination
-            aria-controls={ariaControls}
             pageCount={pageCount}
             activePage={activePage}
             onPageClick={onChangePage}


### PR DESCRIPTION
### Summary

Updates the docs' link interception routing to only match against urls starting with `#/`, instead of `#`. This was caught in the data grid examples where the previous implementation broke their pagination.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
