### PR TITLE
esc keypress places focus on button now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Limited the links allowed in `EuiMarkdownEditor` to http, https, or starting with a forward slash ([#4362](https://github.com/elastic/eui/pull/4362))
 - Aligned components with an `href` prop to React's practice of disallowing `javascript:` protocols ([#4362](https://github.com/elastic/eui/pull/4362))
 - Fixed form submit bug in `EuiButtonGroup` by adding an optional `type` prop for `EuiButtonGroupOption` ([#4368](https://github.com/elastic/eui/pull/4368))
+- The ESC keypress now places focus on the button. ([#4377](https://github.com/elastic/eui/pull/4377))
 
 **Theme: Amsterdam**
 

--- a/src/components/context_menu/context_menu.tsx
+++ b/src/components/context_menu/context_menu.tsx
@@ -385,7 +385,7 @@ export class EuiContextMenu extends Component<EuiContextMenuProps, State> {
             ? this.state.transitionDirection
             : undefined
         }
-        hasFocus={transitionType === 'in'}
+        hasFocus={transitionType === 'out'}
         items={this.state.idToRenderedItemsMap[panelId]}
         initialFocusedItemIndex={
           this.state.isUsingKeyboardToNavigate


### PR DESCRIPTION
### Summary

Fixes #4225 
ESC keypress places focus on the button now.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
