### PR TITLE
[EuiSearchBar] Add option to display the number of selected options in the filters

### DIFF
--- a/src/components/filter_group/filter_button.tsx
+++ b/src/components/filter_group/filter_button.tsx
@@ -116,7 +116,7 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
         {children}
       </span>
 
-      {numFiltersDefined && (
+      {(numFiltersDefined || numActiveFilters) && (
         <EuiI18n
           token="euiFilterButton.filterBadge"
           values={{
@@ -131,7 +131,7 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
                 size="m"
                 aria-label={filterBadge}
                 color={isDisabled || !hasActiveFilters ? 'subdued' : 'accent'}>
-                {numActiveFilters || numFilters}
+                {numFilters || numActiveFilters}
               </EuiNotificationBadge>
             );
           }}

--- a/src/components/search_bar/filters/field_value_selection_filter.tsx
+++ b/src/components/search_bar/filters/field_value_selection_filter.tsx
@@ -28,7 +28,6 @@ import { EuiSpacer } from '../../spacer';
 import { EuiIcon } from '../../icon';
 import { Query } from '../query';
 import { Clause, Operator, OperatorType, Value } from '../query/ast';
-import { EuiNotificationBadge } from '../../badge/notification_badge';
 
 export interface FieldValueOptionType {
   field?: string;
@@ -351,18 +350,13 @@ export class FieldValueSelectionFilter extends Component<
         iconSide="right"
         onClick={this.onButtonClick.bind(this)}
         hasActiveFilters={active}
+        numFilters={this.state.options?.all.length}
+        numActiveFilters={this.state.options?.all.length}
         grow>
         {config.name}
-        <EuiNotificationBadge
-          style={{
-            marginLeft: 5,
-          }}
-          size="m">
-          {this.state.options?.all.length}
-        </EuiNotificationBadge>
       </EuiFilterButton>
     );
-
+    
     const searchBox = this.renderSearchBox();
     const content = this.renderContent(
       config.field,

--- a/src/components/search_bar/filters/field_value_selection_filter.tsx
+++ b/src/components/search_bar/filters/field_value_selection_filter.tsx
@@ -28,6 +28,7 @@ import { EuiSpacer } from '../../spacer';
 import { EuiIcon } from '../../icon';
 import { Query } from '../query';
 import { Clause, Operator, OperatorType, Value } from '../query/ast';
+import { EuiNotificationBadge } from '../../badge/notification_badge';
 
 export interface FieldValueOptionType {
   field?: string;
@@ -352,6 +353,13 @@ export class FieldValueSelectionFilter extends Component<
         hasActiveFilters={active}
         grow>
         {config.name}
+        <EuiNotificationBadge
+          style={{
+            marginLeft: 5,
+          }}
+          size="m">
+          {this.state.options?.all.length}
+        </EuiNotificationBadge>
       </EuiFilterButton>
     );
 


### PR DESCRIPTION
### Summary
This pull request solves #4304 . It adds as an enhancement the following features to the `EuiFilterButton` for the `EuiSearchBar`:
* Shows in the button, the number of filters in the popover, if none are selected
* The number of active filters (selected) in the popover (WIP)

Screenshots: 
![](https://user-images.githubusercontent.com/26821140/102176683-f4b74e80-3ec7-11eb-88f1-db6a217405a4.png)

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
