### PR TITLE
Fixed an issue caused by using Link component instead of anchor (a)  tag

### DIFF
--- a/src-docs/src/views/markdown_editor/markdown_editor_errors.js
+++ b/src-docs/src/views/markdown_editor/markdown_editor_errors.js
@@ -45,7 +45,7 @@ export default () => {
         className="euiFormRow__text">
         Utilize error text or{' '}
         <strong>
-          <a href="/forms/form-validation">EuiFormRow</a>
+          <a href="/#/forms/form-validation">EuiFormRow</a>
         </strong>{' '}
         for more permanent error feedback
       </EuiFormErrorText>

--- a/src-docs/src/views/markdown_editor/markdown_editor_errors.js
+++ b/src-docs/src/views/markdown_editor/markdown_editor_errors.js
@@ -1,7 +1,5 @@
 import React, { useCallback, useState, useRef } from 'react';
 
-import { Link } from 'react-router-dom';
-
 import {
   EuiMarkdownEditor,
   EuiSpacer,
@@ -47,7 +45,7 @@ export default () => {
         className="euiFormRow__text">
         Utilize error text or{' '}
         <strong>
-          <Link to="/forms/form-validation">EuiFormRow</Link>
+          <a href="/forms/form-validation">EuiFormRow</a>
         </strong>{' '}
         for more permanent error feedback
       </EuiFormErrorText>


### PR DESCRIPTION
### Summary

Hey, this is my first pull request. It fixes issue #4275 and required a very small change. All I had to do was replace the Link Component with an anchor tag.

The Link component from **react-router-dom** was breaking the code.

I also deleted the line that imported the Link component from **react-router-dom** because it wasn't being used anywhere else in that file.

Since it was such a small change, I didn't have to check all the checkboxes, checked all the ones I thought would be relevant to my change.

If my request does not meet your standards, or it breaks the app in any way, I would really like some advice or suggestions on how I could improve it so that I could continue contributing to this project in the future.

To be more clear, the anchor tag here is added by me.
![image](https://user-images.githubusercontent.com/20359739/103148304-2f509f00-4784-11eb-8538-e25de60d38c6.png)



### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
