### PR TITLE
Spacing issue resolved #4263

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 - Reduced the size of the icons and clear button for compressed `EuiFormControlLayout` ([#4374](https://github.com/elastic/eui/pull/4374))
 - Added ability for text input updates in `EuiDatePicker` ([#4243](https://github.com/elastic/eui/pull/4243))
 
+**Bug fixes**
+
+- Fixed `EuiSuperDatePicker` extra margin when `showUpdateButton` and `isAutoRefreshOnly` are active ([#4406](https://github.com/elastic/eui/pull/4406))
+
 ## [`31.0.0`](https://github.com/elastic/eui/tree/v31.0.0)
 
 - Added collapsble behavior to `EuiResizableContainer` panels ([#3978](https://github.com/elastic/eui/pull/3978))

--- a/src-docs/src/views/super_date_picker/super_date_picker.js
+++ b/src-docs/src/views/super_date_picker/super_date_picker.js
@@ -7,6 +7,8 @@ import {
   EuiFormLabel,
   EuiPanel,
   EuiText,
+  EuiFlexGroup,
+  EuiFlexItem,
 } from '../../../../src/components';
 
 export default () => {
@@ -101,17 +103,25 @@ export default () => {
 
   return (
     <Fragment>
-      <EuiSuperDatePicker
-        isLoading={isLoading}
-        start={start}
-        end={end}
-        onTimeChange={onTimeChange}
-        onRefresh={onRefresh}
-        isPaused={isPaused}
-        refreshInterval={refreshInterval}
-        onRefreshChange={onRefreshChange}
-        recentlyUsedRanges={recentlyUsedRanges}
-      />
+      <EuiFlexGroup gutterSize="none" alignItems="center">
+        <EuiFlexItem>
+          <EuiSuperDatePicker
+            isLoading={isLoading}
+            start={start}
+            end={end}
+            onTimeChange={onTimeChange}
+            onRefresh={onRefresh}
+            isPaused={isPaused}
+            refreshInterval={refreshInterval}
+            onRefreshChange={onRefreshChange}
+            recentlyUsedRanges={recentlyUsedRanges}
+            showUpdateButton={false}
+            // isAutoRefreshOnly={true}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>Test</EuiFlexItem>
+      </EuiFlexGroup>
+
       <EuiSpacer />
       {renderTimeRange()}
     </Fragment>

--- a/src-docs/src/views/super_date_picker/super_date_picker.js
+++ b/src-docs/src/views/super_date_picker/super_date_picker.js
@@ -7,8 +7,6 @@ import {
   EuiFormLabel,
   EuiPanel,
   EuiText,
-  EuiFlexGroup,
-  EuiFlexItem,
 } from '../../../../src/components';
 
 export default () => {
@@ -103,25 +101,17 @@ export default () => {
 
   return (
     <Fragment>
-      <EuiFlexGroup gutterSize="none" alignItems="center">
-        <EuiFlexItem>
-          <EuiSuperDatePicker
-            isLoading={isLoading}
-            start={start}
-            end={end}
-            onTimeChange={onTimeChange}
-            onRefresh={onRefresh}
-            isPaused={isPaused}
-            refreshInterval={refreshInterval}
-            onRefreshChange={onRefreshChange}
-            recentlyUsedRanges={recentlyUsedRanges}
-            showUpdateButton={false}
-            // isAutoRefreshOnly={true}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem>Test</EuiFlexItem>
-      </EuiFlexGroup>
-
+      <EuiSuperDatePicker
+        isLoading={isLoading}
+        start={start}
+        end={end}
+        onTimeChange={onTimeChange}
+        onRefresh={onRefresh}
+        isPaused={isPaused}
+        refreshInterval={refreshInterval}
+        onRefreshChange={onRefreshChange}
+        recentlyUsedRanges={recentlyUsedRanges}
+      />
       <EuiSpacer />
       {renderTimeRange()}
     </Fragment>

--- a/src/components/date_picker/super_date_picker/_super_date_picker.scss
+++ b/src/components/date_picker/super_date_picker/_super_date_picker.scss
@@ -6,12 +6,10 @@
 
 .euiSuperDatePicker__flexWrapper--isAutoRefreshOnly {
   width: $euiFormMaxWidth;
-  max-width: 100%
 }
 
 .euiSuperDatePicker__flexWrapper--noUpdateButton {
   width: $euiSuperDatePickerWidth;
-  
 }
 
 .euiSuperDatePicker {

--- a/src/components/date_picker/super_date_picker/_super_date_picker.scss
+++ b/src/components/date_picker/super_date_picker/_super_date_picker.scss
@@ -68,10 +68,8 @@
 }
 
 @include euiBreakpoint('xs', 's') {
-  .euiSuperDatePicker__flexWrapper,
-  .euiSuperDatePicker__flexWrapper--isAutoRefreshOnly,
-  .euiSuperDatePicker__flexWrapper--noUpdateButton {
-    width: 100%;
+  .euiSuperDatePicker__flexWrapper {
+    width: calc(100% + #{$euiSizeS});
   }
 
   .euiSuperDatePicker__prettyFormatLink {

--- a/src/components/date_picker/super_date_picker/_super_date_picker.scss
+++ b/src/components/date_picker/super_date_picker/_super_date_picker.scss
@@ -11,7 +11,7 @@
 
 .euiSuperDatePicker__flexWrapper--noUpdateButton {
   width: $euiSuperDatePickerWidth;
-  max-width: 100%
+  
 }
 
 .euiSuperDatePicker {


### PR DESCRIPTION
### Summary

I have removed "max-width:100%" from this className
![Code](https://user-images.githubusercontent.com/43985107/103208761-7c20ab00-4927-11eb-8cc1-1ae3f9771fdc.PNG)

This is because we are giving "margin:-4px" and it is creating some margin in right when we put "max-width:100%" but after removing, it is working fine.

Here is the screenshot of before and after the change.
Before:
![Before](https://user-images.githubusercontent.com/43985107/103209064-21d41a00-4928-11eb-8905-217c6716c8ae.PNG)
After:
![After](https://user-images.githubusercontent.com/43985107/103209069-28629180-4928-11eb-82fb-12e3c260f42b.PNG)



### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
