### PR TITLE
Solution for issue: 4077

### DIFF
--- a/src/components/code/_code_block.tsx
+++ b/src/components/code/_code_block.tsx
@@ -210,12 +210,12 @@ export const EuiCodeBlockImpl: FunctionComponent<Props> = ({
   const getCopyButton = (textToCopy?: string) => {
     let copyButton: JSX.Element | undefined;
 
-    if (isCopyable && textToCopy) {
+    if (isCopyable) {
       copyButton = (
         <div className="euiCodeBlock__copyButton">
           <EuiI18n token="euiCodeBlock.copyButton" default="Copy">
             {(copyButton: string) => (
-              <EuiCopy textToCopy={textToCopy}>
+              <EuiCopy textToCopy={textToCopy?textToCopy:""}>
                 {(copy) => (
                   <EuiButtonIcon
                     size="s"

--- a/src/components/inner_text/inner_text.tsx
+++ b/src/components/inner_text/inner_text.tsx
@@ -42,9 +42,12 @@ export function useInnerText(
         // while the result of `textContent` could correctly be non-`null` due to
         // differing reliance on browser layout calculations.
         // We prefer the result of `innerText`, if available.
-        'innerText' in node
-          ? node.innerText
-          : node.textContent || innerTextFallback
+
+        // 'innerText' in node
+        //   ? node.innerText
+        //   : node.textContent || innerTextFallback
+
+        node.textContent === null ? undefined: node.textContent
       );
     },
     [innerTextFallback]


### PR DESCRIPTION
### Summary

Hi,

I have recreated this issue #4077  and I discovered that it is not present in HTML as shown below:

Before the expand button clicked:
![Before](https://user-images.githubusercontent.com/43985107/103653434-89264580-4f8a-11eb-9a59-ecbb74ec5e64.png)

After the expand button clicked:
![After](https://user-images.githubusercontent.com/43985107/103653450-8e839000-4f8a-11eb-8bec-62c6b040159e.png)

In my opinion, the error causing code is:
![problemCode](https://user-images.githubusercontent.com/43985107/103653514-a3602380-4f8a-11eb-9668-be808c404a4a.png)

Here, in my opinion, "textToCopy" is undefined when it renders which is creating all these issues. And when we expand it, the component re-renders and the copy button got displayed.

So I am thinking of removing "textToCopy" from the if statement.

My Changes:
![Mychanges](https://user-images.githubusercontent.com/43985107/103653597-c2f74c00-4f8a-11eb-89f2-b7fa969a1e48.png)


### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
