### PR TITLE
[EuiPopover] Allow adjusting `buffer` for individual window sides.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Added support for adjusting `buffer` for individual window sides of `EuiPopover`. ([#4414](https://github.com/elastic/eui/pull/4245))
 - Added `'full'` option to the `height` prop of `EuiMarkdownEditor`. Added `autoExpandPreview` and `maxHeight` props to `EuiMarkdownEditor` ([#4245](https://github.com/elastic/eui/pull/4245))
 
 ## [`31.1.0`](https://github.com/elastic/eui/tree/v31.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Added support for adjusting `buffer` for individual window sides of `EuiPopover`. ([#4414](https://github.com/elastic/eui/pull/4245))
+- Added support for adjusting `buffer` for individual window sides of `EuiPopover`. ([#4417](https://github.com/elastic/eui/pull/4417))
 - Added `'full'` option to the `height` prop of `EuiMarkdownEditor`. Added `autoExpandPreview` and `maxHeight` props to `EuiMarkdownEditor` ([#4245](https://github.com/elastic/eui/pull/4245))
 
 ## [`31.1.0`](https://github.com/elastic/eui/tree/v31.1.0)

--- a/src/components/popover/__snapshots__/popover.test.tsx.snap
+++ b/src/components/popover/__snapshots__/popover.test.tsx.snap
@@ -176,6 +176,53 @@ exports[`EuiPopover props buffer 1`] = `
 </div>
 `;
 
+exports[`EuiPopover props buffer for all sides 1`] = `
+<div>
+  <div
+    class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
+    id="19"
+  >
+    <div
+      class="euiPopover__anchor"
+    >
+      <button />
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
+    />
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
+    />
+    <div
+      data-focus-lock-disabled="disabled"
+    >
+      <div
+        aria-live="assertive"
+        aria-modal="true"
+        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
+        role="dialog"
+        style="top: 16px; left: -22px; z-index: 2000;"
+      >
+        <div
+          class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
+          style="left: 10px; top: 0px;"
+        />
+        <div />
+      </div>
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
+    />
+  </div>
+</div>
+`;
+
 exports[`EuiPopover props display block is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownCenter euiPopover--displayBlock"

--- a/src/components/popover/popover.test.tsx
+++ b/src/components/popover/popover.test.tsx
@@ -334,6 +334,22 @@ describe('EuiPopover', () => {
 
       expect(component.render()).toMatchSnapshot();
     });
+
+    test('buffer for all sides', () => {
+      const component = mount(
+        <div>
+          <EuiPopover
+            id={getId()}
+            button={<button />}
+            closePopover={() => {}}
+            buffer={[20, 40, 60, 80]}
+            isOpen
+          />
+        </div>
+      );
+
+      expect(component.render()).toMatchSnapshot();
+    });
   });
 
   describe('listener cleanup', () => {

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -167,9 +167,10 @@ export interface EuiPopoverProps {
   offset?: number;
   /**
    * Minimum distance between the popover and the bounding container;
+   * Pass an array of 4 values to adjust each side differently: `[top, right, bottom, left]`
    * Default is 16
    */
-  buffer?: number;
+  buffer?: number | number[];
   /**
    * Element to pass as the child element of the arrow;
    * Use case is typically limited to an accompanying `EuiBeacon`

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -170,7 +170,7 @@ export interface EuiPopoverProps {
    * Pass an array of 4 values to adjust each side differently: `[top, right, bottom, left]`
    * Default is 16
    */
-  buffer?: number | number[];
+  buffer?: number | [number, number, number, number];
   /**
    * Element to pass as the child element of the arrow;
    * Use case is typically limited to an accompanying `EuiBeacon`

--- a/src/services/popover/popover_positioning.ts
+++ b/src/services/popover/popover_positioning.ts
@@ -81,7 +81,7 @@ interface FindPopoverPositionArgs {
   align?: EuiPopoverPosition;
   position: EuiPopoverPosition;
   forcePosition?: boolean;
-  buffer?: number | number[];
+  buffer?: number | [number, number, number, number];
   offset?: number;
   allowCrossAxis?: boolean;
   container?: HTMLElement;
@@ -98,7 +98,9 @@ interface FindPopoverPositionResult {
   anchorBoundingBox?: EuiClientRect;
 }
 
-const getBufferValues = (buffer: number | number[]): number[] => {
+const getBufferValues = (
+  buffer: number | [number, number, number, number]
+): [number, number, number, number] => {
   if (Array.isArray(buffer)) {
     const [topBuffer, rightBuffer, bottomBuffer, leftBuffer] = buffer;
     return [topBuffer, rightBuffer, bottomBuffer, leftBuffer];
@@ -267,7 +269,7 @@ interface GetPopoverScreenCoordinatesArgs {
   containerBoundingBox: EuiClientRect;
   arrowConfig?: { arrowWidth: number; arrowBuffer: number };
   offset?: number;
-  buffer?: number | number[];
+  buffer?: number | [number, number, number, number];
 }
 
 interface GetPopoverScreenCoordinatesResult {
@@ -434,7 +436,7 @@ interface GetCrossAxisPositionArgs {
   crossAxisDimension: Dimension;
   position: EuiPopoverPosition;
   align?: EuiPopoverPosition;
-  buffer: number | number[];
+  buffer: number | [number, number, number, number];
   offset: number;
   windowBoundingBox: EuiClientRect;
   containerBoundingBox: EuiClientRect;
@@ -650,7 +652,7 @@ export function getElementBoundingBox(element: HTMLElement): EuiClientRect {
 export function getAvailableSpace(
   anchorBoundingBox: BoundingBox,
   containerBoundingBox: BoundingBox,
-  buffer: number | number[],
+  buffer: number | [number, number, number, number],
   offset: number,
   offsetSide: EuiPopoverPosition
 ): BoundingBox {

--- a/src/services/popover/popover_positioning.ts
+++ b/src/services/popover/popover_positioning.ts
@@ -81,7 +81,7 @@ interface FindPopoverPositionArgs {
   align?: EuiPopoverPosition;
   position: EuiPopoverPosition;
   forcePosition?: boolean;
-  buffer?: number;
+  buffer?: number | number[];
   offset?: number;
   allowCrossAxis?: boolean;
   container?: HTMLElement;
@@ -97,6 +97,14 @@ interface FindPopoverPositionResult {
   arrow?: { left: number; top: number };
   anchorBoundingBox?: EuiClientRect;
 }
+
+const getBufferValues = (buffer: number | number[]): number[] => {
+  if (Array.isArray(buffer)) {
+    const [topBuffer, rightBuffer, bottomBuffer, leftBuffer] = buffer;
+    return [topBuffer, rightBuffer, bottomBuffer, leftBuffer];
+  }
+  return [buffer, buffer, buffer, buffer];
+};
 
 /**
  * Calculates the absolute positioning (relative to document.body) to place a popover element
@@ -259,7 +267,7 @@ interface GetPopoverScreenCoordinatesArgs {
   containerBoundingBox: EuiClientRect;
   arrowConfig?: { arrowWidth: number; arrowBuffer: number };
   offset?: number;
-  buffer?: number;
+  buffer?: number | number[];
 }
 
 interface GetPopoverScreenCoordinatesResult {
@@ -339,6 +347,10 @@ export function getPopoverScreenCoordinates({
   const crossAxisSecondSide = positionComplements[crossAxisFirstSide]; // "left" -> "right"
   const crossAxisDimension = relatedDimension[crossAxisFirstSide]; // "left" -> "width"
 
+  const [topBuffer, rightBuffer, bottomBuffer, leftBuffer] = getBufferValues(
+    buffer
+  );
+
   const { crossAxisPosition, crossAxisArrowPosition } = getCrossAxisPosition({
     crossAxisFirstSide,
     crossAxisSecondSide,
@@ -383,10 +395,10 @@ export function getPopoverScreenCoordinates({
 
   // shrink the visible bounding box by `buffer`
   // to compute a fit value
-  combinedBoundingBox.top += buffer;
-  combinedBoundingBox.right -= buffer;
-  combinedBoundingBox.bottom -= buffer;
-  combinedBoundingBox.left += buffer;
+  combinedBoundingBox.top += topBuffer;
+  combinedBoundingBox.right -= rightBuffer;
+  combinedBoundingBox.bottom -= bottomBuffer;
+  combinedBoundingBox.left += leftBuffer;
 
   const fit = getVisibleFit(
     {
@@ -422,7 +434,7 @@ interface GetCrossAxisPositionArgs {
   crossAxisDimension: Dimension;
   position: EuiPopoverPosition;
   align?: EuiPopoverPosition;
-  buffer: number;
+  buffer: number | number[];
   offset: number;
   windowBoundingBox: EuiClientRect;
   containerBoundingBox: EuiClientRect;
@@ -638,30 +650,33 @@ export function getElementBoundingBox(element: HTMLElement): EuiClientRect {
 export function getAvailableSpace(
   anchorBoundingBox: BoundingBox,
   containerBoundingBox: BoundingBox,
-  buffer: number,
+  buffer: number | number[],
   offset: number,
   offsetSide: EuiPopoverPosition
 ): BoundingBox {
+  const [topBuffer, rightBuffer, bottomBuffer, leftBuffer] = getBufferValues(
+    buffer
+  );
   return {
     top:
       anchorBoundingBox.top -
       containerBoundingBox.top -
-      buffer -
+      topBuffer -
       (offsetSide === 'top' ? offset : 0),
     right:
       containerBoundingBox.right -
       anchorBoundingBox.right -
-      buffer -
+      rightBuffer -
       (offsetSide === 'right' ? offset : 0),
     bottom:
       containerBoundingBox.bottom -
       anchorBoundingBox.bottom -
-      buffer -
+      bottomBuffer -
       (offsetSide === 'bottom' ? offset : 0),
     left:
       anchorBoundingBox.left -
       containerBoundingBox.left -
-      buffer -
+      leftBuffer -
       (offsetSide === 'left' ? offset : 0),
   };
 }


### PR DESCRIPTION
### Summary

Fixes #4414 

Added support for adjusting `buffer` for individual window sides.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs**
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
~~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
