### PR TITLE
[EuiComboBox] Fixed prepend and append heights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `31.3.0`.
+**Bug fixes**
+
+- Fixed heights of `append` and `prepend` in `EuiComboBox` ([#4410](https://github.com/elastic/eui/pull/4406))
 
 ## [`31.3.0`](https://github.com/elastic/eui/tree/v31.3.0)
 

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -137,4 +137,11 @@
       }
     }
   }
+
+  // Overrides the euiFormControlLayout prepend and append height that is 100%
+  .euiFormControlLayout__prepend,
+  .euiFormControlLayout__append {
+    // sass-lint:disable-block no-important
+    height: auto !important;
+  }
 }


### PR DESCRIPTION
### Summary

The initial fix for #4407 was reverted in #4432. This new PR fixes #4407.

<img width="872" alt="combobox@2x" src="https://user-images.githubusercontent.com/2750668/105354781-f07a0180-5be8-11eb-9566-fb73d0558892.png">

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
