### PR TITLE
Shift focus to accordion content when expanded

### DIFF
--- a/src/components/accordion/__snapshots__/accordion.test.tsx.snap
+++ b/src/components/accordion/__snapshots__/accordion.test.tsx.snap
@@ -46,6 +46,7 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
     <div
       className="euiAccordion__childWrapper"
       id="12"
+      tabIndex={-1}
     >
       <EuiResizeObserver
         onResize={[Function]}
@@ -107,6 +108,7 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
     <div
       className="euiAccordion__childWrapper"
       id="11"
+      tabIndex={-1}
     >
       <EuiResizeObserver
         onResize={[Function]}
@@ -154,6 +156,7 @@ exports[`EuiAccordion is rendered 1`] = `
   <div
     class="euiAccordion__childWrapper"
     id="0"
+    tabindex="-1"
   >
     <div>
       <div
@@ -186,6 +189,7 @@ exports[`EuiAccordion props arrowDisplay none is rendered 1`] = `
   <div
     class="euiAccordion__childWrapper"
     id="6"
+    tabindex="-1"
   >
     <div>
       <div
@@ -230,6 +234,7 @@ exports[`EuiAccordion props arrowDisplay right is rendered 1`] = `
   <div
     class="euiAccordion__childWrapper"
     id="5"
+    tabindex="-1"
   >
     <div>
       <div
@@ -278,6 +283,7 @@ exports[`EuiAccordion props buttonContent is rendered 1`] = `
   <div
     class="euiAccordion__childWrapper"
     id="2"
+    tabindex="-1"
   >
     <div>
       <div
@@ -318,6 +324,7 @@ exports[`EuiAccordion props buttonContentClassName is rendered 1`] = `
   <div
     class="euiAccordion__childWrapper"
     id="1"
+    tabindex="-1"
   >
     <div>
       <div
@@ -365,6 +372,7 @@ exports[`EuiAccordion props extraAction is rendered 1`] = `
   <div
     class="euiAccordion__childWrapper"
     id="3"
+    tabindex="-1"
   >
     <div>
       <div
@@ -405,6 +413,7 @@ exports[`EuiAccordion props forceState is rendered 1`] = `
   <div
     class="euiAccordion__childWrapper"
     id="7"
+    tabindex="-1"
   >
     <div>
       <div
@@ -449,6 +458,7 @@ exports[`EuiAccordion props initialIsOpen is rendered 1`] = `
   <div
     class="euiAccordion__childWrapper"
     id="4"
+    tabindex="-1"
   >
     <div>
       <div
@@ -500,6 +510,7 @@ exports[`EuiAccordion props isLoading is rendered 1`] = `
   <div
     class="euiAccordion__childWrapper"
     id="9"
+    tabindex="-1"
   >
     <div>
       <div
@@ -551,6 +562,7 @@ exports[`EuiAccordion props isLoadingMessage is rendered 1`] = `
   <div
     class="euiAccordion__childWrapper"
     id="10"
+    tabindex="-1"
   >
     <div>
       <div

--- a/src/components/accordion/__snapshots__/accordion.test.tsx.snap
+++ b/src/components/accordion/__snapshots__/accordion.test.tsx.snap
@@ -44,8 +44,10 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
       </button>
     </div>
     <div
+      aria-labelledby="generated-id"
       className="euiAccordion__childWrapper"
       id="12"
+      role="region"
       tabIndex={-1}
     >
       <EuiResizeObserver
@@ -106,8 +108,10 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
       </button>
     </div>
     <div
+      aria-labelledby="generated-id"
       className="euiAccordion__childWrapper"
       id="11"
+      role="region"
       tabIndex={-1}
     >
       <EuiResizeObserver
@@ -154,8 +158,10 @@ exports[`EuiAccordion is rendered 1`] = `
     </button>
   </div>
   <div
+    aria-labelledby="generated-id"
     class="euiAccordion__childWrapper"
     id="0"
+    role="region"
     tabindex="-1"
   >
     <div>
@@ -187,8 +193,10 @@ exports[`EuiAccordion props arrowDisplay none is rendered 1`] = `
     </button>
   </div>
   <div
+    aria-labelledby="generated-id"
     class="euiAccordion__childWrapper"
     id="6"
+    role="region"
     tabindex="-1"
   >
     <div>
@@ -232,8 +240,10 @@ exports[`EuiAccordion props arrowDisplay right is rendered 1`] = `
     </button>
   </div>
   <div
+    aria-labelledby="generated-id"
     class="euiAccordion__childWrapper"
     id="5"
+    role="region"
     tabindex="-1"
   >
     <div>
@@ -281,8 +291,10 @@ exports[`EuiAccordion props buttonContent is rendered 1`] = `
     </button>
   </div>
   <div
+    aria-labelledby="generated-id"
     class="euiAccordion__childWrapper"
     id="2"
+    role="region"
     tabindex="-1"
   >
     <div>
@@ -322,8 +334,10 @@ exports[`EuiAccordion props buttonContentClassName is rendered 1`] = `
     </button>
   </div>
   <div
+    aria-labelledby="generated-id"
     class="euiAccordion__childWrapper"
     id="1"
+    role="region"
     tabindex="-1"
   >
     <div>
@@ -370,8 +384,10 @@ exports[`EuiAccordion props extraAction is rendered 1`] = `
     </div>
   </div>
   <div
+    aria-labelledby="generated-id"
     class="euiAccordion__childWrapper"
     id="3"
+    role="region"
     tabindex="-1"
   >
     <div>
@@ -411,8 +427,10 @@ exports[`EuiAccordion props forceState is rendered 1`] = `
     </button>
   </div>
   <div
+    aria-labelledby="generated-id"
     class="euiAccordion__childWrapper"
     id="7"
+    role="region"
     tabindex="-1"
   >
     <div>
@@ -456,8 +474,10 @@ exports[`EuiAccordion props initialIsOpen is rendered 1`] = `
     </button>
   </div>
   <div
+    aria-labelledby="generated-id"
     class="euiAccordion__childWrapper"
     id="4"
+    role="region"
     tabindex="-1"
   >
     <div>
@@ -508,8 +528,10 @@ exports[`EuiAccordion props isLoading is rendered 1`] = `
     </div>
   </div>
   <div
+    aria-labelledby="generated-id"
     class="euiAccordion__childWrapper"
     id="9"
+    role="region"
     tabindex="-1"
   >
     <div>
@@ -560,8 +582,10 @@ exports[`EuiAccordion props isLoadingMessage is rendered 1`] = `
     </div>
   </div>
   <div
+    aria-labelledby="generated-id"
     class="euiAccordion__childWrapper"
     id="10"
+    role="region"
     tabindex="-1"
   >
     <div>

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -73,6 +73,10 @@
   transition:
     height $euiAnimSpeedNormal $euiAnimSlightResistance,
     opacity $euiAnimSpeedNormal $euiAnimSlightResistance;
+
+  &:focus {
+    outline: 1px solid blue;
+  }
 }
 
 $paddingSizes: (

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -73,10 +73,6 @@
   transition:
     height $euiAnimSpeedNormal $euiAnimSlightResistance,
     opacity $euiAnimSpeedNormal $euiAnimSlightResistance;
-
-  &:focus {
-    outline: 1px solid blue;
-  }
 }
 
 $paddingSizes: (

--- a/src/components/accordion/accordion.test.tsx
+++ b/src/components/accordion/accordion.test.tsx
@@ -191,5 +191,19 @@ describe('EuiAccordion', () => {
       expect(onToggleHandler).toBeCalled();
       expect(onToggleHandler).toBeCalledWith(false);
     });
+
+    it('moves focus to the content when expanded', () => {
+      const component = mount<EuiAccordion>(<EuiAccordion id={getId()} />);
+      const accordionClass = component.instance();
+      const childWrapper = accordionClass.childWrapper;
+
+      expect(childWrapper).not.toBeFalsy();
+      expect(childWrapper).not.toBe(document.activeElement);
+
+      // click button
+      component.find('button').simulate('click');
+
+      expect(childWrapper).toBe(document.activeElement);
+    });
   });
 });

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -292,6 +292,8 @@ export class EuiAccordion extends Component<
             this.childWrapper = node;
           }}
           tabIndex={-1}
+          role="region"
+          aria-labelledby={buttonId}
           id={id}>
           <EuiResizeObserver onResize={this.setChildContentHeight}>
             {(resizeRef) => (

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -142,6 +142,9 @@ export class EuiAccordion extends Component<
           isOpen: !prevState.isOpen,
         }),
         () => {
+          if (this.state.isOpen && this.childWrapper) {
+            this.childWrapper.focus();
+          }
           this.props.onToggle && this.props.onToggle(this.state.isOpen);
         }
       );
@@ -288,6 +291,7 @@ export class EuiAccordion extends Component<
           ref={(node) => {
             this.childWrapper = node;
           }}
+          tabIndex={-1}
           id={id}>
           <EuiResizeObserver onResize={this.setChildContentHeight}>
             {(resizeRef) => (

--- a/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
+++ b/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
@@ -280,6 +280,7 @@ exports[`EuiCollapsibleNavGroup when isCollapsible is true will render an accord
   <div
     class="euiAccordion__childWrapper"
     id="id"
+    tabindex="-1"
   >
     <div>
       <div

--- a/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
+++ b/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
@@ -278,8 +278,10 @@ exports[`EuiCollapsibleNavGroup when isCollapsible is true will render an accord
     </button>
   </div>
   <div
+    aria-labelledby="generated-id"
     class="euiAccordion__childWrapper"
     id="id"
+    role="region"
     tabindex="-1"
   >
     <div>


### PR DESCRIPTION
### Summary

Closes #4224 by adding a `tabIndex={-1}` to the accordion's children wrapper and calling `.focus()` when it expands.

This is a draft because I added `outline: 1px solid blue;` to the focus state on `.euiAccordion__childWrapper` and would like help finding the right style to apply.

### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
