### PR TITLE
[EuiResizableContainer] Initialize after DOM is ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 **Bug fixes**
 
 - Fixed heights of `append` and `prepend` in `EuiComboBox` ([#4410](https://github.com/elastic/eui/pull/4410))
+- Fixed `EuiResizableContainer` initialization timing based on DOM readiness ([#4447](https://github.com/elastic/eui/pull/4447))
 
 ## [`31.3.0`](https://github.com/elastic/eui/tree/v31.3.0)
 

--- a/src-docs/src/views/resizable_container/resizable_container_basic.js
+++ b/src-docs/src/views/resizable_container/resizable_container_basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { EuiText, EuiResizableContainer } from '../../../../src/components';
 import { fake } from 'faker';
 
@@ -10,23 +10,34 @@ const text = (
   </>
 );
 
-export default () => (
-  <EuiResizableContainer style={{ height: '200px' }}>
-    {(EuiResizablePanel, EuiResizableButton) => (
-      <>
-        <EuiResizablePanel initialSize={50} minSize="30%">
-          <EuiText>
-            <div>{text}</div>
-            <a href="">Hello world</a>
-          </EuiText>
-        </EuiResizablePanel>
+export default () => {
+  const dom = useRef();
+  const [styles, setStyles] = useState({ display: 'none' });
+  useEffect(() => {
+    if (!dom.current) return;
+    dom.current.innerHTML = 'YOLO';
+  });
+  useEffect(() => {
+    setTimeout(() => setStyles({ display: 'flex' }), 1000);
+  }, []);
+  return (
+    <EuiResizableContainer style={{ ...styles, height: '200px' }}>
+      {(EuiResizablePanel, EuiResizableButton) => (
+        <>
+          <EuiResizablePanel initialSize={50} minSize="30%">
+            <EuiText>
+              <div>{text}</div>
+              <a href="">Hello world</a>
+            </EuiText>
+          </EuiResizablePanel>
 
-        <EuiResizableButton />
+          <EuiResizableButton />
 
-        <EuiResizablePanel initialSize={50} minSize="200px">
-          <EuiText>{text}</EuiText>
-        </EuiResizablePanel>
-      </>
-    )}
-  </EuiResizableContainer>
-);
+          <EuiResizablePanel initialSize={50} minSize="200px">
+            <div ref={dom} />
+          </EuiResizablePanel>
+        </>
+      )}
+    </EuiResizableContainer>
+  );
+};

--- a/src-docs/src/views/resizable_container/resizable_container_basic.js
+++ b/src-docs/src/views/resizable_container/resizable_container_basic.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React from 'react';
 import { EuiText, EuiResizableContainer } from '../../../../src/components';
 import { fake } from 'faker';
 
@@ -10,34 +10,23 @@ const text = (
   </>
 );
 
-export default () => {
-  const dom = useRef();
-  const [styles, setStyles] = useState({ display: 'none' });
-  useEffect(() => {
-    if (!dom.current) return;
-    dom.current.innerHTML = 'YOLO';
-  });
-  useEffect(() => {
-    setTimeout(() => setStyles({ display: 'flex' }), 1000);
-  }, []);
-  return (
-    <EuiResizableContainer style={{ ...styles, height: '200px' }}>
-      {(EuiResizablePanel, EuiResizableButton) => (
-        <>
-          <EuiResizablePanel initialSize={50} minSize="30%">
-            <EuiText>
-              <div>{text}</div>
-              <a href="">Hello world</a>
-            </EuiText>
-          </EuiResizablePanel>
+export default () => (
+  <EuiResizableContainer style={{ height: '200px' }}>
+    {(EuiResizablePanel, EuiResizableButton) => (
+      <>
+        <EuiResizablePanel initialSize={50} minSize="30%">
+          <EuiText>
+            <div>{text}</div>
+            <a href="">Hello world</a>
+          </EuiText>
+        </EuiResizablePanel>
 
-          <EuiResizableButton />
+        <EuiResizableButton />
 
-          <EuiResizablePanel initialSize={50} minSize="200px">
-            <div ref={dom} />
-          </EuiResizablePanel>
-        </>
-      )}
-    </EuiResizableContainer>
-  );
-};
+        <EuiResizablePanel initialSize={50} minSize="200px">
+          <EuiText>{text}</EuiText>
+        </EuiResizablePanel>
+      </>
+    )}
+  </EuiResizableContainer>
+);

--- a/src/components/resizable_container/resizable_container.tsx
+++ b/src/components/resizable_container/resizable_container.tsx
@@ -128,7 +128,9 @@ export const EuiResizableContainer: FunctionComponent<EuiResizableContainerProps
   );
 
   useEffect(() => {
-    initialize();
+    if (containerSize.width > 0 && containerSize.height > 0) {
+      initialize();
+    }
   }, [initialize, containerSize]);
 
   const onMouseDown = useCallback(

--- a/src/components/resizable_container/resizable_container.tsx
+++ b/src/components/resizable_container/resizable_container.tsx
@@ -275,7 +275,7 @@ export const EuiResizableContainer: FunctionComponent<EuiResizableContainerProps
         onTouchMove={onMouseMove}
         onTouchEnd={onMouseUp}
         {...rest}>
-        {!!reducerState.containerSize && render()}
+        {render()}
       </div>
     </EuiResizableContainerContextProvider>
   );


### PR DESCRIPTION
### Summary

Fixes a problem discovered in https://github.com/elastic/kibana/pull/86934.
EuiResizableContainer is initially hidden (`display: none;`) and overlaid with a loading screen while data is loaded. When the data is loaded, the visualization is rendered onto a target DOM element via `ref` reference inside the EuiResizablePanel. EuiResizableContainer is mounted at this point but rerenders when it becomes visible and gains calculable size dimensions. That rerender changes/remounts the target `div` and alters the `ref`, effectively disconnecting the visualization from the DOM.

The solution is to not initialize EuiResizableContainer until it is visible/has calculable dimensions. There are likely other ways to solve this problem in the implementation (e.g., not using`display: none;`; watching for `ref` changes), but we have the information readily available in component state to prevent this kind of unnecessary rerender/remount. 

Docs change is a rudimentary example that will be reverted prior to merging. Comment out the real changes to see the problem. Alternatively, use the linked branch to test in the true Kibana environment.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~

- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples

~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~

- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
