### PR TITLE
Data grid: Take scrollbar into account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed `id` usage throughout `EuiTreeView` to respect custom ids and stop conflicts in generated ids ([#4435](https://github.com/elastic/eui/pull/4435))
 - Fixed `EuiTabs` `role` if no tabs are passed in ([#4435](https://github.com/elastic/eui/pull/4435))
+- Fixed unnecessary horizontal scroll bar in data grid ([#4468](https://github.com/elastic/eui/pull/4468))
 
 ## [`31.4.0`](https://github.com/elastic/eui/tree/v31.4.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 - Fixed invalid color entry passed to `EuiBadge` color prop ([#4481](https://github.com/elastic/eui/pull/4481))
 - Fixed `EuiCodeBlock` focus-state if content overflows ([#4463]https://github.com/elastic/eui/pull/4463)
-- Fixed unnecessary horizontal scroll bar in data grid ([#4468](https://github.com/elastic/eui/pull/4468))
+- Fixed issues in `EuiDataGrid` around unnecessary scroll bars and container heights not updating ([#4468](https://github.com/elastic/eui/pull/4468))
 
 ## [`31.5.0`](https://github.com/elastic/eui/tree/v31.5.0)
 

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -799,7 +799,11 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
 
   // compute the default column width from the container's clientWidth and count of visible columns
   const defaultColumnWidth = useDefaultColumnWidth(
-    gridDimensions.width,
+    // use clientWidth of the virtualization container to take scroll bar into account
+    // if that's not possible fall back to the size of the wrapper element
+    (resizeRef?.getElementsByClassName('euiDataGrid__virtualized')[0] as
+      | HTMLDivElement
+      | undefined)?.clientWidth || gridDimensions.width,
     leadingControlColumns,
     trailingControlColumns,
     orderedVisibleColumns

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -301,7 +301,7 @@ function renderPagination(props: EuiDataGridProps, controls: string) {
  * Returns the size of the cell container minus the scroll bar width.
  * To do so, this hook is listening for size changes of the container itself,
  * as well as pagination changes to make sure every update is caught.
- * 
+ *
  * This is necessary because there is no callback/event fired by the browser
  * indicating the scroll bar state has changed.
  * @param resizeRef the wrapper element containging the data grid

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -59,7 +59,7 @@ import {
 import { EuiDataGridCellProps } from './data_grid_cell';
 import { EuiButtonEmpty } from '../button';
 import { keys, htmlIdGenerator } from '../../services';
-import { EuiDataGridBody } from './data_grid_body';
+import { EuiDataGridBody, VIRTUALIZED_CONTAINER_CLASS } from './data_grid_body';
 import { useDataGridColumnSelector } from './column_selector';
 import { useDataGridStyleSelector, startingStyles } from './style_selector';
 import { EuiTablePagination } from '../table/table_pagination';
@@ -801,7 +801,7 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
   const defaultColumnWidth = useDefaultColumnWidth(
     // use clientWidth of the virtualization container to take scroll bar into account
     // if that's not possible fall back to the size of the wrapper element
-    (resizeRef?.getElementsByClassName('euiDataGrid__virtualized')[0] as
+    (resizeRef?.getElementsByClassName(VIRTUALIZED_CONTAINER_CLASS)[0] as
       | HTMLDivElement
       | undefined)?.clientWidth || gridDimensions.width,
     leadingControlColumns,

--- a/src/components/datagrid/data_grid_body.tsx
+++ b/src/components/datagrid/data_grid_body.tsx
@@ -90,6 +90,8 @@ export interface EuiDataGridBodyProps {
   switchColumnPos: EuiDataGridHeaderRowProps['switchColumnPos'];
 }
 
+export const VIRTUALIZED_CONTAINER_CLASS = 'euiDataGrid__virtualized';
+
 const defaultComparator: NonNullable<
   EuiDataGridSchemaDetector['comparator']
 > = (a, b, direction) => {
@@ -581,7 +583,7 @@ export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
               <Grid
                 ref={gridRef}
                 innerElementType={InnerElement}
-                className="euiDataGrid__virtualized"
+                className={VIRTUALIZED_CONTAINER_CLASS}
                 columnCount={
                   leadingControlColumns.length +
                   columns.length +

--- a/src/components/datagrid/data_grid_body.tsx
+++ b/src/components/datagrid/data_grid_body.tsx
@@ -291,7 +291,7 @@ const InnerElement: VariableSizeGridProps['innerElementType'] = forwardRef<
 InnerElement.displayName = 'EuiDataGridInnerElement';
 
 const INITIAL_ROW_HEIGHT = 34;
-const SCROLLBAR_HEIGHT = 15;
+const SCROLLBAR_HEIGHT = 16;
 const IS_JEST_ENVIRONMENT = global.hasOwnProperty('_isJest');
 
 export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
@@ -524,10 +524,10 @@ export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
   const [height, setHeight] = useState<number | undefined>(undefined);
   const [width, setWidth] = useState<number | undefined>(undefined);
 
-  // reset height constraint when rowCount changes
+  // reset height constraint when rowCount or fullscreen setting changes
   useEffect(() => {
     setHeight(undefined);
-  }, [rowCount]);
+  }, [rowCount, isFullScreen]);
 
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const wrapperDimensions = useResizeObserver(wrapperRef.current);


### PR DESCRIPTION
### Summary

Fixes https://github.com/elastic/eui/issues/4457

I'm surprised it was that easy, but it works fine for the cases I tested (maybe I missed some?). This PR makes sure the vertical scroll bar is taken into account on auto-sizing data grid columns.

To do so, it's simply looking up the `clientWidth` property of the virtualization container instead of the width of the wrapper container as a reference width. To guard against unforeseen race conditions, it's falling back to the container width if that doesn't work for some reason.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
-~ [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
