### PR TITLE
Add some hack fixes for Chrome’s jitter of button contents 

### DIFF
--- a/src/global_styling/mixins/_button.scss
+++ b/src/global_styling/mixins/_button.scss
@@ -16,6 +16,9 @@
 @mixin euiButtonFocus {
   @include euiCanAnimate {
     transition: transform $euiAnimSpeedNormal ease-in-out, background $euiAnimSpeedNormal ease-in-out;
+    // The next 2 properties fixes Chrome's jitter of the button contents when residing within a centered layout
+    perspective: 1;
+    backface-visibility: hidden;
 
     &:hover:not([class*='isDisabled']) {
       transform: translateY(-1px);


### PR DESCRIPTION
…when residing within a centered layout

This was a fix I found that just sort of forces an extra transform calculation. It's not perfect as you can see in the after video, but it should hopefully make it less noticeable. The other option was `will-change: transform` but there's a big warning about performance issues with that.

**BEFORE**

https://user-images.githubusercontent.com/549577/106643601-f0b6bd00-6557-11eb-8242-4874fc653bad.mp4




**AFTER**


https://user-images.githubusercontent.com/549577/106643605-f3b1ad80-6557-11eb-8391-b61abf905360.mp4



### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
