### PR TITLE
[DATA GRID] Fix fullscreen scrolling issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed `id` usage throughout `EuiTreeView` to respect custom ids and stop conflicts in generated ids ([#4435](https://github.com/elastic/eui/pull/4435))
 - Fixed `EuiTabs` `role` if no tabs are passed in ([#4435](https://github.com/elastic/eui/pull/4435))
+- Fixed issue in `EuiDataGrid` where the horizontal scrollbar was hidden behind pagination ([#4477](https://github.com/elastic/eui/pull/4477))
 
 ## [`31.4.0`](https://github.com/elastic/eui/tree/v31.4.0)
 

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -718,7 +718,9 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
 
   // enables/disables grid controls based on available width
   const [resizeRef, setResizeRef] = useState<HTMLDivElement | null>(null);
+  const [toolbarRef, setToolbarRef] = useState<HTMLDivElement | null>(null);
   const gridDimensions = useResizeObserver(resizeRef, 'width');
+  const toolbarDemensions = useResizeObserver(toolbarRef, 'height');
   useEffect(() => {
     if (resizeRef) {
       const { width } = gridDimensions;
@@ -996,6 +998,7 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
                           <>
                             {showToolbar ? (
                               <div
+                                ref={setToolbarRef}
                                 className="euiDataGrid__controls"
                                 data-test-sub="dataGridControls">
                                 {hasRoomForGridControls ? gridControls : null}
@@ -1047,6 +1050,7 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
                                     columns={orderedVisibleColumns}
                                     columnWidths={columnWidths}
                                     defaultColumnWidth={defaultColumnWidth}
+                                    toolbarHeight={toolbarDemensions.height}
                                     leadingControlColumns={
                                       leadingControlColumns
                                     }

--- a/src/components/datagrid/data_grid_body.tsx
+++ b/src/components/datagrid/data_grid_body.tsx
@@ -88,6 +88,7 @@ export interface EuiDataGridBodyProps {
   handleHeaderMutation: MutationCallback;
   setVisibleColumns: EuiDataGridHeaderRowProps['setVisibleColumns'];
   switchColumnPos: EuiDataGridHeaderRowProps['switchColumnPos'];
+  toolbarHeight: number;
 }
 
 const defaultComparator: NonNullable<
@@ -317,6 +318,7 @@ export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
     handleHeaderMutation,
     setVisibleColumns,
     switchColumnPos,
+    toolbarHeight,
   } = props;
 
   const [headerRowRef, setHeaderRowRef] = useState<HTMLDivElement | null>(null);
@@ -560,7 +562,8 @@ export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
   let finalHeight = IS_JEST_ENVIRONMENT ? 500 : height || unconstrainedHeight;
   let finalWidth = IS_JEST_ENVIRONMENT ? 500 : width || unconstrainedWidth;
   if (isFullScreen) {
-    finalHeight = window.innerHeight;
+    finalHeight =
+      window.innerHeight - toolbarHeight - headerRowHeight - footerRowHeight;
     finalWidth = window.innerWidth;
   }
 


### PR DESCRIPTION
### Summary

Solves the worst offender in https://github.com/elastic/eui/issues/4458

Fixes the horizontal scrolling issues that the grid has when it full-screen. It has some performance issues at present that @chandlerprall is gonna check into (see comment below, it might be fine).

![image](https://user-images.githubusercontent.com/324519/106678916-81999280-6570-11eb-89cf-2f0b18a5c837.png)


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] ~Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] ~Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
