### PR TITLE
[EuiBadge] Add button type to prevent form submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed `EuiTabs` `role` if no tabs are passed in ([#4435](https://github.com/elastic/eui/pull/4435))
 - Fixed `EuiPopover` with initial `isOpen` working with `EuiOutsideClickDetector` ([#4461](https://github.com/elastic/eui/pull/4461))
 - Fixed `EuiDataGridCellPopover` needing 2 state updates to close ([#4461](https://github.com/elastic/eui/pull/4461))
+- Fixed `EuiBadge` with `iconOnClick` from catching form submit events ([#4479](https://github.com/elastic/eui/pull/4479))
 
 ## [`31.4.0`](https://github.com/elastic/eui/tree/v31.4.0)
 

--- a/src-docs/src/views/combo_box/combo_box.js
+++ b/src-docs/src/views/combo_box/combo_box.js
@@ -1,32 +1,87 @@
 import React, { useState } from 'react';
 
-import { EuiComboBox, EuiFieldText } from '../../../../src/components';
+import { EuiComboBox } from '../../../../src/components';
+import { DisplayToggles } from '../form_controls/display_toggles';
 
+const optionsStatic = [
+  {
+    label: 'Titan',
+    'data-test-subj': 'titanOption',
+  },
+  {
+    label: 'Enceladus is disabled',
+    disabled: true,
+  },
+  {
+    label: 'Mimas',
+  },
+  {
+    label: 'Dione',
+  },
+  {
+    label: 'Iapetus',
+  },
+  {
+    label: 'Phoebe',
+  },
+  {
+    label: 'Rhea',
+  },
+  {
+    label:
+      "Pandora is one of Saturn's moons, named for a Titaness of Greek mythology",
+  },
+  {
+    label: 'Tethys',
+  },
+  {
+    label: 'Hyperion',
+  },
+];
 export default () => {
-  const [name, setName] = useState('');
+  const [options, setOptions] = useState(optionsStatic);
+  const [selectedOptions, setSelected] = useState([options[2], options[4]]);
 
-  const onSubmit = (ev) => {
-    ev.preventDefault();
-    ev.stopPropagation();
-    window.alert('form submitted');
+  const onChange = (selectedOptions) => {
+    setSelected(selectedOptions);
   };
 
-  const options = [
-    { label: 'Chandler', color: 'hotpink' },
-    { label: 'Rachel', color: 'green' },
-  ];
+  const onCreateOption = (searchValue, flattenedOptions = []) => {
+    const normalizedSearchValue = searchValue.trim().toLowerCase();
 
-  const [selectedOptions, setSelectedOptions] = useState([]);
+    if (!normalizedSearchValue) {
+      return;
+    }
+
+    const newOption = {
+      label: searchValue,
+    };
+
+    // Create the option if it doesn't exist.
+    if (
+      flattenedOptions.findIndex(
+        (option) => option.label.trim().toLowerCase() === normalizedSearchValue
+      ) === -1
+    ) {
+      setOptions([...options, newOption]);
+    }
+
+    // Select the option.
+    setSelected([...selectedOptions, newOption]);
+  };
 
   return (
-    <form onSubmit={onSubmit}>
-      <EuiFieldText value={name} onChange={(ev) => setName(ev.target.value)} />
+    /* DisplayToggles wrapper for Docs only */
+    <DisplayToggles canDisabled={false} canReadOnly={false}>
       <EuiComboBox
+        placeholder="Select or create options"
         options={options}
-        onChange={(options) => setSelectedOptions(options)}
         selectedOptions={selectedOptions}
+        onChange={onChange}
+        onCreateOption={onCreateOption}
+        isClearable={true}
+        data-test-subj="demoComboBox"
       />
-      {/* <input type="submit" /> */}
-    </form>
+    </DisplayToggles>
   );
 };

--- a/src-docs/src/views/combo_box/combo_box.js
+++ b/src-docs/src/views/combo_box/combo_box.js
@@ -1,87 +1,32 @@
 import React, { useState } from 'react';
 
-import { EuiComboBox } from '../../../../src/components';
-import { DisplayToggles } from '../form_controls/display_toggles';
+import { EuiComboBox, EuiFieldText } from '../../../../src/components';
 
-const optionsStatic = [
-  {
-    label: 'Titan',
-    'data-test-subj': 'titanOption',
-  },
-  {
-    label: 'Enceladus is disabled',
-    disabled: true,
-  },
-  {
-    label: 'Mimas',
-  },
-  {
-    label: 'Dione',
-  },
-  {
-    label: 'Iapetus',
-  },
-  {
-    label: 'Phoebe',
-  },
-  {
-    label: 'Rhea',
-  },
-  {
-    label:
-      "Pandora is one of Saturn's moons, named for a Titaness of Greek mythology",
-  },
-  {
-    label: 'Tethys',
-  },
-  {
-    label: 'Hyperion',
-  },
-];
 export default () => {
-  const [options, setOptions] = useState(optionsStatic);
-  const [selectedOptions, setSelected] = useState([options[2], options[4]]);
+  const [name, setName] = useState('');
 
-  const onChange = (selectedOptions) => {
-    setSelected(selectedOptions);
+  const onSubmit = (ev) => {
+    ev.preventDefault();
+    ev.stopPropagation();
+    window.alert('form submitted');
   };
 
-  const onCreateOption = (searchValue, flattenedOptions = []) => {
-    const normalizedSearchValue = searchValue.trim().toLowerCase();
+  const options = [
+    { label: 'Chandler', color: 'hotpink' },
+    { label: 'Rachel', color: 'green' },
+  ];
 
-    if (!normalizedSearchValue) {
-      return;
-    }
-
-    const newOption = {
-      label: searchValue,
-    };
-
-    // Create the option if it doesn't exist.
-    if (
-      flattenedOptions.findIndex(
-        (option) => option.label.trim().toLowerCase() === normalizedSearchValue
-      ) === -1
-    ) {
-      setOptions([...options, newOption]);
-    }
-
-    // Select the option.
-    setSelected([...selectedOptions, newOption]);
-  };
+  const [selectedOptions, setSelectedOptions] = useState([]);
 
   return (
-    /* DisplayToggles wrapper for Docs only */
-    <DisplayToggles canDisabled={false} canReadOnly={false}>
+    <form onSubmit={onSubmit}>
+      <EuiFieldText value={name} onChange={(ev) => setName(ev.target.value)} />
       <EuiComboBox
-        placeholder="Select or create options"
         options={options}
+        onChange={(options) => setSelectedOptions(options)}
         selectedOptions={selectedOptions}
-        onChange={onChange}
-        onCreateOption={onCreateOption}
-        isClearable={true}
-        data-test-subj="demoComboBox"
       />
-    </DisplayToggles>
+      {/* <input type="submit" /> */}
+    </form>
   );
 };

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -249,6 +249,7 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
       }
       optionalIcon = (
         <button
+          type="button"
           className="euiBadge__iconButton"
           aria-label={iconOnClickAriaLabel}
           disabled={isDisabled}


### PR DESCRIPTION
### Summary

Fixes #4273 by adding `type=button` to the "remove" button on the EuiBadge items rendered by EuiComboBox.
The problem comes from the default button `type=submit` being triggered when <kbd>Enter</kbd> was hit on an input element in a form with `onSubmit`/`action`.

> What should happen? The onSubmit handler of the form should be triggered, the combo box should not react at all

This is half true. The combobox should indeed not react, but the form should not submit without a `type=submit` element in the form. [The spec](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#implicit-submission) says that in a form with no submit buttons, implicit submission will be done if only one input is present.

So you can see in the to-be-reverted docs change that the combobox no longer steals focus, but the form will not be submitted without uncommenting the submit input.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~

- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples

~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~

- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
