### PR TITLE
[EuiBadge] : Handle invalid color entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Bug fixes**
 
+- Fixed invalid color entry passed to `EuiBadge` color prop ([#4481](https://github.com/elastic/eui/pull/4481))
 - Fixed `id` usage throughout `EuiTreeView` to respect custom ids and stop conflicts in generated ids ([#4435](https://github.com/elastic/eui/pull/4435))
 - Fixed `EuiTabs` `role` if no tabs are passed in ([#4435](https://github.com/elastic/eui/pull/4435))
 

--- a/src/components/badge/__snapshots__/badge.test.tsx.snap
+++ b/src/components/badge/__snapshots__/badge.test.tsx.snap
@@ -195,6 +195,7 @@ exports[`EuiBadge props color accepts hex 1`] = `
 exports[`EuiBadge props color accepts rgba 1`] = `
 <span
   class="euiBadge euiBadge--iconLeft"
+  style="background-color:rgba(255,255,255,1);color:#000"
 >
   <span
     class="euiBadge__content"

--- a/src/components/badge/__snapshots__/badge.test.tsx.snap
+++ b/src/components/badge/__snapshots__/badge.test.tsx.snap
@@ -195,7 +195,6 @@ exports[`EuiBadge props color accepts hex 1`] = `
 exports[`EuiBadge props color accepts rgba 1`] = `
 <span
   class="euiBadge euiBadge--iconLeft"
-  style="background-color:rgba(255,255,255,1);color:#000"
 >
   <span
     class="euiBadge__content"

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -149,7 +149,6 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
   style,
   ...rest
 }) => {
-  const validColor = checkValidColor(color);
   const isHrefValid = !href || validateHref(href);
   const isDisabled = _isDisabled || !isHrefValid;
 
@@ -161,7 +160,7 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
   let colorHex = null;
 
   // Check if a valid color name was provided
-  if (validColor) {
+  try {
     if (COLORS.indexOf(color) > -1) {
       // Get the hex equivalent for the provided color name
       colorHex = colorToHexMap[color];
@@ -203,6 +202,8 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
         ...optionalCustomStyles,
       };
     }
+  } catch (err) {
+    handleInvalidColor(color);
   }
   const classes = classNames(
     'euiBadge',
@@ -370,7 +371,7 @@ function setTextColor(bgColor: string) {
   return textColor;
 }
 
-function checkValidColor(color: null | IconColor | string) {
+function handleInvalidColor(color: null | IconColor | string) {
   const isNamedColor = (color && COLORS.includes(color)) || color === 'hollow';
   const isValidColorString = color && chromaValid(parseColor(color) || '');
   if (!isNamedColor && !isValidColorString) {
@@ -379,7 +380,5 @@ function checkValidColor(color: null | IconColor | string) {
         `character hex value, rgb(a) value, hsv value, hollow, or one of the following: ${COLORS}. ` +
         `Instead got ${color}.`
     );
-    return false;
   }
-  return true;
 }

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -149,8 +149,7 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
   style,
   ...rest
 }) => {
-  checkValidColor(color);
-
+  const validColor = checkValidColor(color);
   const isHrefValid = !href || validateHref(href);
   const isDisabled = _isDisabled || !isHrefValid;
 
@@ -162,48 +161,49 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
   let colorHex = null;
 
   // Check if a valid color name was provided
-  if (COLORS.indexOf(color) > -1) {
-    // Get the hex equivalent for the provided color name
-    colorHex = colorToHexMap[color];
+  if (validColor) {
+    if (COLORS.indexOf(color) > -1) {
+      // Get the hex equivalent for the provided color name
+      colorHex = colorToHexMap[color];
 
-    // Set dark or light text color based upon best contrast
-    textColor = setTextColor(colorHex);
+      // Set dark or light text color based upon best contrast
+      textColor = setTextColor(colorHex);
 
-    optionalCustomStyles = {
-      backgroundColor: colorHex,
-      color: textColor,
-      ...optionalCustomStyles,
-    };
-  } else if (color !== 'hollow') {
-    // This is a custom color that is neither from the base palette nor hollow
-    // Let's do our best to ensure that it provides sufficient contrast
+      optionalCustomStyles = {
+        backgroundColor: colorHex,
+        color: textColor,
+        ...optionalCustomStyles,
+      };
+    } else if (color !== 'hollow') {
+      // This is a custom color that is neither from the base palette nor hollow
+      // Let's do our best to ensure that it provides sufficient contrast
 
-    // Set dark or light text color based upon best contrast
-    textColor = setTextColor(color);
+      // Set dark or light text color based upon best contrast
+      textColor = setTextColor(color);
 
-    // Check the contrast
-    wcagContrast = getColorContrast(textColor, color);
+      // Check the contrast
+      wcagContrast = getColorContrast(textColor, color);
 
-    if (wcagContrast < wcagContrastBase) {
-      // It's low contrast, so lets show a warning in the console
-      console.warn(
-        'Warning: ',
-        color,
-        ' badge has low contrast of ',
-        wcagContrast.toFixed(2),
-        '. Should be above ',
-        wcagContrastBase,
-        '.'
-      );
+      if (wcagContrast < wcagContrastBase) {
+        // It's low contrast, so lets show a warning in the console
+        console.warn(
+          'Warning: ',
+          color,
+          ' badge has low contrast of ',
+          wcagContrast.toFixed(2),
+          '. Should be above ',
+          wcagContrastBase,
+          '.'
+        );
+      }
+
+      optionalCustomStyles = {
+        backgroundColor: color,
+        color: textColor,
+        ...optionalCustomStyles,
+      };
     }
-
-    optionalCustomStyles = {
-      backgroundColor: color,
-      color: textColor,
-      ...optionalCustomStyles,
-    };
   }
-
   const classes = classNames(
     'euiBadge',
     {
@@ -371,15 +371,15 @@ function setTextColor(bgColor: string) {
 }
 
 function checkValidColor(color: null | IconColor | string) {
-  const colorExists = !!color;
   const isNamedColor = (color && COLORS.includes(color)) || color === 'hollow';
   const isValidColorString = color && chromaValid(parseColor(color) || '');
-
-  if (!colorExists && !isNamedColor && !isValidColorString) {
+  if (!isNamedColor && !isValidColorString) {
     console.warn(
       'EuiBadge expects a valid color. This can either be a three or six ' +
         `character hex value, rgb(a) value, hsv value, hollow, or one of the following: ${COLORS}. ` +
         `Instead got ${color}.`
     );
+    return false;
   }
+  return true;
 }


### PR DESCRIPTION
Signed-off-by: Akash Gupta <akashgp9@gmail.com>

### Summary

This PR Fixes #3765 
Handling invalid color entry passed to EuiBadge color prop

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Edge**, and **Firefox**
~~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
