### PR TITLE
[Chore] : Migrated axe-puppeteer to @axe-core/puppeteer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Migrated dependency `axe-puppeteer v1.1.1` to `@axe-core/puppeteer v4.1.1` ([#4482](https://github.com/elastic/eui/pull/4482))
 - Added `isLoading` prop and added `EuiOverlayMask` directly to `EuiConfirmModal` ([#4421](https://github.com/elastic/eui/pull/4421))
 
 **Bug fixes**

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test-staged"
   ],
   "dependencies": {
+    "@axe-core/puppeteer": "^4.1.1",
     "@types/chroma-js": "^2.0.0",
     "@types/lodash": "^4.14.160",
     "@types/numeral": "^0.0.28",
@@ -115,7 +116,6 @@
     "argparse": "^2.0.1",
     "autoprefixer": "^9.8.6",
     "axe-core": "^4.1.1",
-    "axe-puppeteer": "^1.1.1",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^24.1.0",

--- a/scripts/a11y-testing.js
+++ b/scripts/a11y-testing.js
@@ -19,7 +19,7 @@
 
 const chalk = require('chalk');
 const puppeteer = require('puppeteer');
-const { AxePuppeteer } = require('axe-puppeteer');
+const { AxePuppeteer } = require('@axe-core/puppeteer');
 
 const docsPages = async (root, page) => {
   const pagesToSkip = [

--- a/scripts/a11y-testing.js
+++ b/scripts/a11y-testing.js
@@ -108,6 +108,7 @@ const printResult = (result) =>
           },
         ],
       })
+      .exclude('iframe *')
       .analyze();
 
     if (violations.length > 0) {

--- a/scripts/a11y-testing.js
+++ b/scripts/a11y-testing.js
@@ -106,9 +106,13 @@ const printResult = (result) =>
             id: 'scrollable-region-focusable',
             selector: '[data-skip-axe="scrollable-region-focusable"]',
           },
+          {
+            // can remove after https://github.com/dequelabs/axe-core/issues/2690 is resolved
+            id: 'region',
+            selector: 'iframe, #player,',
+          },
         ],
       })
-      .exclude('iframe *')
       .analyze();
 
     if (violations.length > 0) {

--- a/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
@@ -166,6 +166,7 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
     data-focus-lock-disabled="disabled"
   >
     <div
+      aria-label="Demo Tour"
       aria-live="assertive"
       aria-modal="true"
       class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiPopover__panel-isAttached"
@@ -440,6 +441,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
     data-focus-lock-disabled="disabled"
   >
     <div
+      aria-label="Demo Tour"
       aria-live="assertive"
       aria-modal="true"
       class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiPopover__panel-isAttached"
@@ -601,6 +603,7 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
     data-focus-lock-disabled="disabled"
   >
     <div
+      aria-label="Demo Tour"
       aria-live="assertive"
       aria-modal="true"
       class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiPopover__panel-isAttached"

--- a/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
@@ -166,7 +166,6 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
     data-focus-lock-disabled="disabled"
   >
     <div
-      aria-label="Demo Tour"
       aria-live="assertive"
       aria-modal="true"
       class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiPopover__panel-isAttached"
@@ -441,7 +440,6 @@ exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
     data-focus-lock-disabled="disabled"
   >
     <div
-      aria-label="Demo Tour"
       aria-live="assertive"
       aria-modal="true"
       class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiPopover__panel-isAttached"
@@ -603,7 +601,6 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
     data-focus-lock-disabled="disabled"
   >
     <div
-      aria-label="Demo Tour"
       aria-live="assertive"
       aria-modal="true"
       class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiPopover__panel-isAttached"

--- a/src/components/popover/__snapshots__/popover.test.tsx.snap
+++ b/src/components/popover/__snapshots__/popover.test.tsx.snap
@@ -15,7 +15,6 @@ exports[`EuiPopover children is rendered 1`] = `
 
 exports[`EuiPopover is rendered 1`] = `
 <div
-  aria-label="aria-label"
   class="euiPopover euiPopover--anchorDownCenter testClass1 testClass2"
   data-test-subj="test subject string"
   id="0"

--- a/src/components/popover/__snapshots__/popover.test.tsx.snap
+++ b/src/components/popover/__snapshots__/popover.test.tsx.snap
@@ -105,6 +105,7 @@ exports[`EuiPopover props arrowChildren is rendered 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
+        aria-label="Demo Tour"
         aria-live="assertive"
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
@@ -154,6 +155,7 @@ exports[`EuiPopover props buffer 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
+        aria-label="Demo Tour"
         aria-live="assertive"
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
@@ -201,6 +203,7 @@ exports[`EuiPopover props buffer for all sides 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
+        aria-label="Demo Tour"
         aria-live="assertive"
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
@@ -274,6 +277,7 @@ exports[`EuiPopover props isOpen renders true 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
+        aria-label="Demo Tour"
         aria-live="assertive"
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
@@ -322,6 +326,7 @@ exports[`EuiPopover props offset with arrow 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
+        aria-label="Demo Tour"
         aria-live="assertive"
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
@@ -370,6 +375,7 @@ exports[`EuiPopover props offset without arrow 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
+        aria-label="Demo Tour"
         aria-live="assertive"
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen euiPopover__panel-noArrow"
@@ -416,6 +422,7 @@ exports[`EuiPopover props ownFocus defaults to false 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
+        aria-label="Demo Tour"
         aria-live="assertive"
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
@@ -464,6 +471,7 @@ exports[`EuiPopover props ownFocus renders true 1`] = `
     >
       <div
         aria-describedby="generated-id"
+        aria-label="Demo Tour"
         aria-live="off"
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
@@ -519,6 +527,7 @@ exports[`EuiPopover props panelClassName is rendered 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
+        aria-label="Demo Tour"
         aria-live="assertive"
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen test"
@@ -566,6 +575,7 @@ exports[`EuiPopover props panelPaddingSize is rendered 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
+        aria-label="Demo Tour"
         aria-live="assertive"
         aria-modal="true"
         class="euiPanel euiPanel--paddingSmall euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"

--- a/src/components/popover/__snapshots__/popover.test.tsx.snap
+++ b/src/components/popover/__snapshots__/popover.test.tsx.snap
@@ -105,7 +105,6 @@ exports[`EuiPopover props arrowChildren is rendered 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aria-label="Demo Tour"
         aria-live="assertive"
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
@@ -155,7 +154,6 @@ exports[`EuiPopover props buffer 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aria-label="Demo Tour"
         aria-live="assertive"
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
@@ -203,7 +201,6 @@ exports[`EuiPopover props buffer for all sides 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aria-label="Demo Tour"
         aria-live="assertive"
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
@@ -277,7 +274,6 @@ exports[`EuiPopover props isOpen renders true 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aria-label="Demo Tour"
         aria-live="assertive"
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
@@ -326,7 +322,6 @@ exports[`EuiPopover props offset with arrow 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aria-label="Demo Tour"
         aria-live="assertive"
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
@@ -375,7 +370,6 @@ exports[`EuiPopover props offset without arrow 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aria-label="Demo Tour"
         aria-live="assertive"
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen euiPopover__panel-noArrow"
@@ -422,7 +416,6 @@ exports[`EuiPopover props ownFocus defaults to false 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aria-label="Demo Tour"
         aria-live="assertive"
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
@@ -471,7 +464,6 @@ exports[`EuiPopover props ownFocus renders true 1`] = `
     >
       <div
         aria-describedby="generated-id"
-        aria-label="Demo Tour"
         aria-live="off"
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
@@ -527,7 +519,6 @@ exports[`EuiPopover props panelClassName is rendered 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aria-label="Demo Tour"
         aria-live="assertive"
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen test"
@@ -575,7 +566,6 @@ exports[`EuiPopover props panelPaddingSize is rendered 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aria-label="Demo Tour"
         aria-live="assertive"
         aria-modal="true"
         class="euiPanel euiPanel--paddingSmall euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -176,6 +176,10 @@ export interface EuiPopoverProps {
    * Use case is typically limited to an accompanying `EuiBeacon`
    */
   arrowChildren?: ReactNode;
+  /**
+   * IDs used in ARIA and labels
+   */
+  ariaLabelledId?: string;
 }
 
 type AnchorPosition = 'up' | 'right' | 'down' | 'left';
@@ -659,6 +663,7 @@ export class EuiPopover extends Component<Props, State> {
       display,
       onTrapDeactivation,
       buffer,
+      ariaLabelledId,
       container,
       ...rest
     } = this.props;
@@ -745,7 +750,7 @@ export class EuiPopover extends Component<Props, State> {
               tabIndex={tabIndex}
               aria-live={ariaLive}
               role="dialog"
-              aria-label="Demo Tour"
+              aria-labelledby={ariaLabelledId}
               aria-modal="true"
               aria-describedby={ariaDescribedby}
               style={this.state.popoverStyles}>

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -177,9 +177,14 @@ export interface EuiPopoverProps {
    */
   arrowChildren?: ReactNode;
   /**
-   * IDs used in ARIA and labels
+   * Provide a name to the popover panel
    */
-  ariaLabelledId?: string;
+  'aria-label'?: string;
+  /**
+   * Alternative option to `aria-label` that takes an `id`.
+   * Usually takes the `id` of the popover title
+   */
+  'aria-labelledby'?: string;
 }
 
 type AnchorPosition = 'up' | 'right' | 'down' | 'left';
@@ -663,7 +668,8 @@ export class EuiPopover extends Component<Props, State> {
       display,
       onTrapDeactivation,
       buffer,
-      ariaLabelledId,
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabelledBy,
       container,
       ...rest
     } = this.props;
@@ -750,7 +756,8 @@ export class EuiPopover extends Component<Props, State> {
               tabIndex={tabIndex}
               aria-live={ariaLive}
               role="dialog"
-              aria-labelledby={ariaLabelledId}
+              aria-label={ariaLabel}
+              aria-labelledby={ariaLabelledBy}
               aria-modal="true"
               aria-describedby={ariaDescribedby}
               style={this.state.popoverStyles}>

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -745,6 +745,7 @@ export class EuiPopover extends Component<Props, State> {
               tabIndex={tabIndex}
               aria-live={ariaLive}
               role="dialog"
+              aria-label="Demo Tour"
               aria-modal="true"
               aria-describedby={ariaDescribedby}
               style={this.state.popoverStyles}>

--- a/src/components/table/mobile/__snapshots__/table_sort_mobile.test.tsx.snap
+++ b/src/components/table/mobile/__snapshots__/table_sort_mobile.test.tsx.snap
@@ -5,7 +5,6 @@ exports[`EuiTableSortMobile is rendered 1`] = `
   class="euiTableSortMobile testClass1 testClass2"
 >
   <div
-    aria-label="aria-label"
     class="euiPopover euiPopover--anchorDownRight"
     data-test-subj="test subject string"
   >

--- a/src/components/tour/__snapshots__/tour_step.test.tsx.snap
+++ b/src/components/tour/__snapshots__/tour_step.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`EuiTourStep can be closed 1`] = `
 <div
-  aria-label="aria-label"
   class="euiPopover euiPopover--anchorLeftUp"
   data-test-subj="test subject string"
   offset="10"
@@ -19,7 +18,6 @@ exports[`EuiTourStep can be closed 1`] = `
 
 exports[`EuiTourStep can override the footer action 1`] = `
 <div
-  aria-label="aria-label"
   class="euiPopover euiPopover--anchorLeftUp"
   data-test-subj="test subject string"
   offset="10"
@@ -36,7 +34,6 @@ exports[`EuiTourStep can override the footer action 1`] = `
 
 exports[`EuiTourStep can set a minWidth 1`] = `
 <div
-  aria-label="aria-label"
   class="euiPopover euiPopover--anchorLeftUp"
   data-test-subj="test subject string"
   offset="10"
@@ -53,7 +50,6 @@ exports[`EuiTourStep can set a minWidth 1`] = `
 
 exports[`EuiTourStep can turn off the beacon 1`] = `
 <div
-  aria-label="aria-label"
   class="euiPopover euiPopover--anchorLeftUp"
   data-test-subj="test subject string"
   offset="0"
@@ -70,7 +66,6 @@ exports[`EuiTourStep can turn off the beacon 1`] = `
 
 exports[`EuiTourStep is rendered 1`] = `
 <div
-  aria-label="aria-label"
   class="euiPopover euiPopover--anchorLeftUp"
   data-test-subj="test subject string"
   offset="10"

--- a/src/components/tour/tour_step.tsx
+++ b/src/components/tour/tour_step.tsx
@@ -219,7 +219,7 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
       panelClassName={classes}
       panelStyle={newStyle || style}
       offset={hasBeacon ? 10 : 0}
-      ariaLabelledId={titleId}
+      aria-labelledby={titleId}
       arrowChildren={hasBeacon && <EuiBeacon className="euiTour__beacon" />}
       {...rest}>
       <EuiPopoverTitle className="euiTourHeader" id={titleId}>

--- a/src/components/tour/tour_step.tsx
+++ b/src/components/tour/tour_step.tsx
@@ -40,6 +40,7 @@ import {
 import { EuiTitle } from '../title';
 
 import { EuiTourStepIndicator, EuiTourStepStatus } from './tour_step_indicator';
+import { htmlIdGenerator } from '../../services';
 
 type PopoverOverrides = 'button' | 'closePopover';
 
@@ -132,6 +133,8 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
   footerAction,
   ...rest
 }) => {
+  const generatedId = htmlIdGenerator();
+  const titleId = generatedId();
   if (step === 0) {
     console.warn(
       'EuiTourStep `step` should 1-based indexing. Please update to eliminate 0 indexes.'
@@ -216,9 +219,10 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
       panelClassName={classes}
       panelStyle={newStyle || style}
       offset={hasBeacon ? 10 : 0}
+      ariaLabelledId={titleId}
       arrowChildren={hasBeacon && <EuiBeacon className="euiTour__beacon" />}
       {...rest}>
-      <EuiPopoverTitle className="euiTourHeader">
+      <EuiPopoverTitle className="euiTourHeader" id={titleId}>
         <EuiTitle size="xxxs" className="euiTourHeader__subtitle">
           <h1>{subtitle}</h1>
         </EuiTitle>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@axe-core/puppeteer@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@axe-core/puppeteer/-/puppeteer-4.1.1.tgz#e9dd2f2f13b717c057ff68c5943dec8d4ddd8acf"
+  integrity sha512-Ao9N7HL//s26hdasx3Ba18tlJgxpoO+1SmIN6eSx5vC50dqYhiRU0xp6wBKWqzo10u1jpzl/s4RFsOAuolFMBA==
+  dependencies:
+    axe-core "^4.1.1"
+
 "@babel/cli@^7.10.5":
   version "7.10.5"
   resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.10.5.tgz#57df2987c8cf89d0fc7d4b157ec59d7619f1b77a"
@@ -2762,7 +2769,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@^3.5.3, axe-core@^3.5.4:
+axe-core@^3.5.4:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.5.tgz#84315073b53fa3c0c51676c588d59da09a192227"
   integrity sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==
@@ -2771,13 +2778,6 @@ axe-core@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.1.tgz#70a7855888e287f7add66002211a423937063eaf"
   integrity sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==
-
-axe-puppeteer@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/axe-puppeteer/-/axe-puppeteer-1.1.1.tgz#e95f46e069d84d388cdc9fc0630cf2b2e78b1100"
-  integrity sha512-bU7dt3zlXrlTmaBsudeACEkQ0O4a5LNxRCdA1Qfph4mqx/DewybPCrlyDqJlHXb/W7ZSodE1fMmC+MgRLizxuQ==
-  dependencies:
-    axe-core "^3.5.3"
 
 axios@^0.18.0, axios@^0.18.1:
   version "0.18.1"


### PR DESCRIPTION
### Summary

This PR Fixes: #4436 
Migrated deprecated dependency `axe-puppeteer v1.1.1` to `@axe-core/puppeteer v4.1.1`

**Note:**

Fixed one accessibility error that occured after migrating to `@axe-core/puppeteer v4.1.1`
Now all a11y tests are passing :
<img src="https://i.imgur.com/WjYxKbv.png">

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
~~-[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
