### PR TITLE
[Docs] Remove avatar image from dg example

### DIFF
--- a/src-docs/src/views/datagrid/column_actions.js
+++ b/src-docs/src/views/datagrid/column_actions.js
@@ -57,7 +57,6 @@ for (let i = 1; i < 5; i++) {
     avatar: (
       <EuiAvatar
         size="s"
-        imageUrl={fake('{{internet.avatar}}')}
         name={fake('{{name.lastName}}, {{name.firstName}}')}
       />
     ),

--- a/src-docs/src/views/datagrid/column_cell_actions.js
+++ b/src-docs/src/views/datagrid/column_cell_actions.js
@@ -104,7 +104,6 @@ for (let i = 1; i < 5; i++) {
     avatar: (
       <EuiAvatar
         size="s"
-        imageUrl={fake('{{internet.avatar}}')}
         name={fake('{{name.lastName}}, {{name.firstName}}')}
       />
     ),

--- a/src-docs/src/views/datagrid/column_widths.js
+++ b/src-docs/src/views/datagrid/column_widths.js
@@ -34,7 +34,6 @@ for (let i = 1; i < 5; i++) {
     avatar: (
       <EuiAvatar
         size="s"
-        imageUrl={fake('{{internet.avatar}}')}
         name={fake('{{name.lastName}}, {{name.firstName}}')}
       />
     ),

--- a/src-docs/src/views/datagrid/control_columns.js
+++ b/src-docs/src/views/datagrid/control_columns.js
@@ -61,7 +61,6 @@ for (let i = 1; i < 500; i++) {
     avatar: (
       <EuiAvatar
         size="s"
-        imageUrl={fake('{{internet.avatar}}')}
         name={fake('{{name.lastName}}, {{name.firstName}}')}
       />
     ),

--- a/src-docs/src/views/datagrid/styling.js
+++ b/src-docs/src/views/datagrid/styling.js
@@ -42,7 +42,6 @@ for (let i = 1; i < 6; i++) {
     avatar: (
       <EuiAvatar
         size="s"
-        imageUrl={fake('{{internet.avatar}}')}
         name={fake('{{name.lastName}}, {{name.firstName}}')}
       />
     ),

--- a/src-docs/src/views/datagrid/styling.js
+++ b/src-docs/src/views/datagrid/styling.js
@@ -17,6 +17,7 @@ import {
 const columns = [
   {
     id: 'avatar',
+    initialWidth: 40,
   },
   {
     id: 'name',


### PR DESCRIPTION
### Summary

Faker has trouble with images. Remove it to fix a visual bug and drop to initials in the avatar column

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
