### PR TITLE
Don't generate 20000 rows of fake data when loading the docs

### DIFF
--- a/src-docs/src/views/datagrid/virtualization.js
+++ b/src-docs/src/views/datagrid/virtualization.js
@@ -20,31 +20,6 @@ import { EuiFormRow } from '../../../../src/components/form/form_row';
 
 const DataContext = createContext();
 
-const raw_data = [];
-
-for (let i = 1; i < 10000; i++) {
-  const email = fake('{{internet.email}}');
-  const name = fake('{{name.lastName}}, {{name.firstName}}');
-  const suffix = fake('{{name.suffix}}');
-  raw_data.push({
-    name: `${name} ${suffix}`,
-    email: <EuiLink href="">{email}</EuiLink>,
-    location: (
-      <Fragment>
-        {`${fake('{{address.city}}')}, `}
-        <EuiLink href="https://google.com">
-          {fake('{{address.country}}')}
-        </EuiLink>
-      </Fragment>
-    ),
-    date: fake('{{date.past}}'),
-    account: fake('{{finance.account}}'),
-    amount: fake('${{commerce.price}}'),
-    phone: fake('{{phone.phoneNumber}}'),
-    version: fake('{{system.semver}}'),
-  });
-}
-
 const columns = [
   {
     id: 'name',
@@ -79,6 +54,9 @@ const columns = [
   },
 ];
 
+// it is expensive to compute 10000 rows of fake data
+// instead of loading up front, generate entries on the fly
+const raw_data = [];
 function RenderCellValue({ rowIndex, columnId }) {
   const { data, adjustMountedCellCount } = useContext(DataContext);
 
@@ -86,6 +64,29 @@ function RenderCellValue({ rowIndex, columnId }) {
     adjustMountedCellCount(1);
     return () => adjustMountedCellCount(-1);
   }, [adjustMountedCellCount]);
+
+  if (data[rowIndex] == null) {
+    const email = fake('{{internet.email}}');
+    const name = fake('{{name.lastName}}, {{name.firstName}}');
+    const suffix = fake('{{name.suffix}}');
+    data[rowIndex] = {
+      name: `${name} ${suffix}`,
+      email: <EuiLink href="">{email}</EuiLink>,
+      location: (
+        <Fragment>
+          {`${fake('{{address.city}}')}, `}
+          <EuiLink href="https://google.com">
+            {fake('{{address.country}}')}
+          </EuiLink>
+        </Fragment>
+      ),
+      date: fake('{{date.past}}'),
+      account: fake('{{finance.account}}'),
+      amount: fake('${{commerce.price}}'),
+      phone: fake('{{phone.phoneNumber}}'),
+      version: fake('{{system.semver}}'),
+    };
+  }
 
   return data.hasOwnProperty(rowIndex) ? data[rowIndex][columnId] : null;
 }
@@ -185,7 +186,7 @@ export default () => {
           width={dimensionSizes[width]}
           columns={columns}
           columnVisibility={{ visibleColumns, setVisibleColumns }}
-          rowCount={raw_data.length}
+          rowCount={10000}
           renderCellValue={RenderCellValue}
           pagination={{
             ...pagination,

--- a/src-docs/src/views/datagrid/virtualization_constrained.js
+++ b/src-docs/src/views/datagrid/virtualization_constrained.js
@@ -18,31 +18,6 @@ import {
 
 const DataContext = createContext();
 
-const raw_data = [];
-
-for (let i = 1; i < 10000; i++) {
-  const email = fake('{{internet.email}}');
-  const name = fake('{{name.lastName}}, {{name.firstName}}');
-  const suffix = fake('{{name.suffix}}');
-  raw_data.push({
-    name: `${name} ${suffix}`,
-    email: <EuiLink href="">{email}</EuiLink>,
-    location: (
-      <Fragment>
-        {`${fake('{{address.city}}')}, `}
-        <EuiLink href="https://google.com">
-          {fake('{{address.country}}')}
-        </EuiLink>
-      </Fragment>
-    ),
-    date: fake('{{date.past}}'),
-    account: fake('{{finance.account}}'),
-    amount: fake('${{commerce.price}}'),
-    phone: fake('{{phone.phoneNumber}}'),
-    version: fake('{{system.semver}}'),
-  });
-}
-
 const columns = [
   {
     id: 'name',
@@ -77,6 +52,9 @@ const columns = [
   },
 ];
 
+// it is expensive to compute 10000 rows of fake data
+// instead of loading up front, generate entries on the fly
+const raw_data = [];
 function RenderCellValue({ rowIndex, columnId }) {
   const { data, adjustMountedCellCount } = useContext(DataContext);
 
@@ -85,7 +63,30 @@ function RenderCellValue({ rowIndex, columnId }) {
     return () => adjustMountedCellCount(-1);
   }, [adjustMountedCellCount]);
 
-  return data.hasOwnProperty(rowIndex) ? data[rowIndex][columnId] : null;
+  if (data[rowIndex] == null) {
+    const email = fake('{{internet.email}}');
+    const name = fake('{{name.lastName}}, {{name.firstName}}');
+    const suffix = fake('{{name.suffix}}');
+    data[rowIndex] = {
+      name: `${name} ${suffix}`,
+      email: <EuiLink href="">{email}</EuiLink>,
+      location: (
+        <Fragment>
+          {`${fake('{{address.city}}')}, `}
+          <EuiLink href="https://google.com">
+            {fake('{{address.country}}')}
+          </EuiLink>
+        </Fragment>
+      ),
+      date: fake('{{date.past}}'),
+      account: fake('{{finance.account}}'),
+      amount: fake('${{commerce.price}}'),
+      phone: fake('{{phone.phoneNumber}}'),
+      version: fake('{{system.semver}}'),
+    };
+  }
+
+  return data[rowIndex][columnId];
 }
 
 export default () => {
@@ -129,7 +130,7 @@ export default () => {
       aria-label="Virtualized data grid demo"
       columns={columns}
       columnVisibility={{ visibleColumns, setVisibleColumns }}
-      rowCount={raw_data.length}
+      rowCount={10000}
       renderCellValue={RenderCellValue}
       pagination={{
         ...pagination,


### PR DESCRIPTION
### Summary

Resolves an item in #4495

Two datagrid virtualization examples generated a combined 20000 rows of fake data when any doc page loaded, taking about 6 seconds to do so. I've updated these 2 problematic examples to instead generate the rows on-demand.

### ~Checklist~
