### PR TITLE
[EuiTabs] Add large size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added `EuiOverlayMask` directly to `EuiModal` ([#4480](https://github.com/elastic/eui/pull/4480))
+- Added `size='l'` prop to `EuiTabs` ([#4501](https://github.com/elastic/eui/pull/4501))
 
 **Bug fixes**
 

--- a/src-docs/src/components/guide_page/guide_page.js
+++ b/src-docs/src/components/guide_page/guide_page.js
@@ -92,7 +92,7 @@ const GuidePageComponent = ({
             </EuiTitle>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiTabs display="condensed">
+            <EuiTabs size="l" display="condensed">
               {tabs.length > 1 && renderTabs()}
             </EuiTabs>
           </EuiFlexItem>

--- a/src-docs/src/views/tabs/playground.js
+++ b/src-docs/src/views/tabs/playground.js
@@ -2,7 +2,7 @@ import {
   propUtilityForPlayground,
   dummyFunction,
 } from '../../services/playground';
-import { EuiTab } from '../../../../src/components/';
+import { EuiTab, EuiTabs } from '../../../../src/components/';
 import { PropTypes } from 'react-view';
 
 export const tabConfig = () => {
@@ -38,6 +38,38 @@ export const tabConfig = () => {
       imports: {
         '@elastic/eui': {
           named: ['EuiTab'],
+        },
+      },
+      customProps: {
+        onClick: dummyFunction,
+      },
+    },
+  };
+};
+
+export const tabsConfig = () => {
+  const docgenInfo = Array.isArray(EuiTabs.__docgenInfo)
+    ? EuiTabs.__docgenInfo[0]
+    : EuiTabs.__docgenInfo;
+  const propsToUse = propUtilityForPlayground(docgenInfo.props);
+
+  propsToUse.children = {
+    value: '<EuiTab>Tab 1</EuiTab><EuiTab isSelected>Tab 2</EuiTab>',
+    type: PropTypes.ReactNode,
+    hidden: false,
+  };
+
+  return {
+    config: {
+      componentName: 'EuiTabs',
+      props: propsToUse,
+      scope: {
+        EuiTabs,
+        EuiTab,
+      },
+      imports: {
+        '@elastic/eui': {
+          named: ['EuiTabs', 'EuiTab'],
         },
       },
       customProps: {

--- a/src-docs/src/views/tabs/tabs.js
+++ b/src-docs/src/views/tabs/tabs.js
@@ -6,6 +6,7 @@ import {
   EuiTab,
   EuiSpacer,
 } from '../../../../src/components';
+import { EuiTitle } from '../../../../src/components/title';
 
 const tabs = [
   {
@@ -63,11 +64,24 @@ export default () => {
 
   return (
     <Fragment>
+      <EuiTitle size="xxs">
+        <span>Small</span>
+      </EuiTitle>
+      <EuiTabs size="s">{renderTabs()}</EuiTabs>
+
+      <EuiSpacer />
+      <EuiTitle size="xxs">
+        <span>Medium (default)</span>
+      </EuiTitle>
+
       <EuiTabs>{renderTabs()}</EuiTabs>
 
       <EuiSpacer />
+      <EuiTitle size="xxs">
+        <span>Large</span>
+      </EuiTitle>
 
-      <EuiTabs size="s">{renderTabs()}</EuiTabs>
+      <EuiTabs size="l">{renderTabs()}</EuiTabs>
     </Fragment>
   );
 };

--- a/src-docs/src/views/tabs/tabs.js
+++ b/src-docs/src/views/tabs/tabs.js
@@ -5,8 +5,8 @@ import {
   EuiTabs,
   EuiTab,
   EuiSpacer,
+  EuiTitle,
 } from '../../../../src/components';
-import { EuiTitle } from '../../../../src/components/title';
 
 const tabs = [
   {

--- a/src-docs/src/views/tabs/tabs_example.js
+++ b/src-docs/src/views/tabs/tabs_example.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+
 import { renderToHtml } from '../../services';
 
 import { GuideSectionTypes } from '../../components';
@@ -50,9 +52,14 @@ export const TabsExample = {
       text: (
         <p>
           <strong>EuiTabs</strong> allow a <EuiCode>size</EuiCode> prop. In
-          general you should always use the default size, but in rare cases
-          (like putting tabs within a popover of other small menu) it is OK to
-          use the smaller sizing.
+          general you should always use the default (medium) size. The small
+          size is best for when placing inside popovers or other small
+          containers. Reserve using the large size for when using as primary
+          page navigation, like inside of{' '}
+          <Link to="/layout/page">
+            <strong>EuiPageHeader</strong>
+          </Link>
+          .
         </p>
       ),
       props: {
@@ -60,10 +67,16 @@ export const TabsExample = {
         EuiTab,
       },
       demo: <Tabs />,
-      snippet: `<EuiTabs>
+      snippet: [
+        `<EuiTabs>
   <EuiTab onClick={onClick}>Example 1</EuiTab>
   <EuiTab onClick={onClick}>Example 2</EuiTab>
 </EuiTabs>`,
+        `<EuiTabs size="s>
+  <EuiTab onClick={onClick}>Example 1</EuiTab>
+  <EuiTab onClick={onClick}>Example 2</EuiTab>
+</EuiTabs>`,
+      ],
     },
     {
       title: 'Condensed tabs',

--- a/src-docs/src/views/tabs/tabs_example.js
+++ b/src-docs/src/views/tabs/tabs_example.js
@@ -9,7 +9,7 @@ import {
   EuiTab,
   EuiTabbedContent,
 } from '../../../../src/components';
-import { tabConfig } from './playground';
+import { tabConfig, tabsConfig } from './playground';
 
 import Tabs from './tabs';
 const tabsSource = require('!!raw-loader!./tabs');
@@ -162,5 +162,5 @@ export const TabsExample = {
       demo: <Controlled />,
     },
   ],
-  playground: tabConfig,
+  playground: [tabConfig, tabsConfig],
 };

--- a/src/components/tabs/__snapshots__/tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/tabs.test.tsx.snap
@@ -1,8 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiTabs props display can be condensed 1`] = `
+exports[`EuiTabs props display condensed is rendered 1`] = `
 <div
   class="euiTabs euiTabs--condensed"
+  role="tablist"
+>
+  children
+</div>
+`;
+
+exports[`EuiTabs props display default is rendered 1`] = `
+<div
+  class="euiTabs"
   role="tablist"
 >
   children
@@ -18,7 +27,25 @@ exports[`EuiTabs props expand is rendered 1`] = `
 </div>
 `;
 
-exports[`EuiTabs props size can be small 1`] = `
+exports[`EuiTabs props size l is rendered 1`] = `
+<div
+  class="euiTabs euiTabs--large"
+  role="tablist"
+>
+  children
+</div>
+`;
+
+exports[`EuiTabs props size m is rendered 1`] = `
+<div
+  class="euiTabs"
+  role="tablist"
+>
+  children
+</div>
+`;
+
+exports[`EuiTabs props size s is rendered 1`] = `
 <div
   class="euiTabs euiTabs--small"
   role="tablist"

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -109,6 +109,15 @@
     }
   }
 
+  .euiTabs--small.euiTabs--condensed & {
+    padding-top: ($euiSizeM / 2);
+    padding-bottom: ($euiSizeM / 2);
+  }
+
+  .euiTabs--large.euiTabs--condensed & + .euiTab {
+    margin-left: $euiSizeL;
+  }
+
   // Expand Tabs Group Modifier
 
   .euiTabs--expand & {

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -53,16 +53,6 @@
     }
   }
 
-  &.euiTab-isDisabled {
-    color: $euiColorMediumShade;
-
-    &:hover {
-      color: $euiColorMediumShade;
-      cursor: not-allowed;
-      text-decoration: none;
-    }
-  }
-
   &.euiTab-isSelected {
     color: $euiColorPrimary;
     cursor: default;
@@ -76,6 +66,20 @@
       left: 0;
       position: absolute;
       width: 100%;
+    }
+  }
+
+  &.euiTab-isDisabled {
+    color: $euiColorDisabledText;
+
+    &:hover {
+      color: $euiColorDisabledText;
+      cursor: not-allowed;
+      text-decoration: none;
+    }
+
+    &::after {
+      background-color: $euiColorDisabledText;
     }
   }
 

--- a/src/components/tabs/_variables.scss
+++ b/src/components/tabs/_variables.scss
@@ -1,2 +1,3 @@
 $euiTabFontSize: $euiFontSize !default;
 $euiTabFontSizeS: $euiFontSizeS !default;
+$euiTabFontSizeL: $euiFontSizeM !default;

--- a/src/components/tabs/tabs.test.tsx
+++ b/src/components/tabs/tabs.test.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
 
-import { EuiTabs } from './tabs';
+import { EuiTabs, SIZES, DISPLAYS } from './tabs';
 
 describe('EuiTabs', () => {
   test('renders', () => {
@@ -32,18 +32,24 @@ describe('EuiTabs', () => {
 
   describe('props', () => {
     describe('size', () => {
-      test('can be small', () => {
-        const component = render(<EuiTabs size="s">children</EuiTabs>);
-        expect(component).toMatchSnapshot();
+      SIZES.forEach((size) => {
+        it(`${size} is rendered`, () => {
+          const component = render(<EuiTabs size={size}>children</EuiTabs>);
+
+          expect(component).toMatchSnapshot();
+        });
       });
     });
 
     describe('display', () => {
-      test('can be condensed', () => {
-        const component = render(
-          <EuiTabs display="condensed">children</EuiTabs>
-        );
-        expect(component).toMatchSnapshot();
+      DISPLAYS.forEach((display) => {
+        it(`${display} is rendered`, () => {
+          const component = render(
+            <EuiTabs display={display}>children</EuiTabs>
+          );
+
+          expect(component).toMatchSnapshot();
+        });
       });
     });
 

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -38,6 +38,7 @@ export type EuiTabsDisplaySizes = keyof typeof displayToClassNameMap;
 const sizeToClassNameMap = {
   s: 'euiTabs--small',
   m: null,
+  l: 'euiTabs--large',
 };
 
 export const SIZES = keysOf(sizeToClassNameMap);

--- a/src/themes/eui-amsterdam/overrides/_index.scss
+++ b/src/themes/eui-amsterdam/overrides/_index.scss
@@ -21,6 +21,7 @@
 @import 'progress';
 @import 'range';
 @import 'steps';
+@import 'tabs';
 @import 'text';
 @import 'toast';
 @import 'tooltip';

--- a/src/themes/eui-amsterdam/overrides/_tabs.scss
+++ b/src/themes/eui-amsterdam/overrides/_tabs.scss
@@ -1,9 +1,10 @@
+// Fixed heights ensure proper alignment with pixel grid
+
 .euiTab {
   font-weight: $euiFontWeightMedium;
   height: $euiSizeXXL + $euiSizeS;
 }
 
-// Adjust overall heights
 .euiTabs--small .euiTab {
   height: $euiSizeXXL;
 }

--- a/src/themes/eui-amsterdam/overrides/_tabs.scss
+++ b/src/themes/eui-amsterdam/overrides/_tabs.scss
@@ -1,0 +1,14 @@
+.euiTab {
+  font-weight: $euiFontWeightMedium;
+  height: $euiSizeXXL + $euiSizeS;
+}
+
+// Adjust overall heights
+.euiTabs--small .euiTab {
+  height: $euiSizeXXL;
+}
+
+.euiTabs--large .euiTab {
+  @include fontSize($euiTabFontSizeL);
+  height: $euiSizeXXL + $euiSizeS;
+}


### PR DESCRIPTION
### Mainly affects the Amsterdam theme

This PR is to align the styles of EuiTabs with the latest from the Amsterdam design assets. The main problem we had was that the smaller (`14px`) font size affected both the medium and small sizes of tabs. This is actually good for maintaining font size consistency, but we had needs for a larger set as well. One that bumped the font size back up to `16px`.


What the results are is that:

Tab size | Default theme | Amsterdam theme
------------ | ------------- | ------------
`s` | `14px` | `14px`
`m` | `16px` | `14px`
`l` | `16px` | `16px`

This might seem weird on the surface that only `medium` (default) tab font sizes are different across themes, but this is intentional. And this affects both the default and `condensed` displays.

**Default theme**
<img width="966" alt="Screen Shot 2021-02-08 at 15 54 44 PM" src="https://user-images.githubusercontent.com/549577/107280253-147d7580-6a26-11eb-915c-32a37b760b07.png">


**Amsterdam theme**
<img width="968" alt="Screen Shot 2021-02-08 at 15 54 36 PM" src="https://user-images.githubusercontent.com/549577/107280260-1810fc80-6a26-11eb-8e2c-490f6c1a659e.png">


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
