### PR TITLE
Move @axe-core/puppeteer to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "test-staged"
   ],
   "dependencies": {
-    "@axe-core/puppeteer": "^4.1.1",
     "@types/chroma-js": "^2.0.0",
     "@types/lodash": "^4.14.160",
     "@types/numeral": "^0.0.28",
@@ -84,6 +83,7 @@
     "vfile": "^4.2.0"
   },
   "devDependencies": {
+    "@axe-core/puppeteer": "^4.1.1",
     "@babel/cli": "^7.10.5",
     "@babel/core": "^7.11.4",
     "@babel/plugin-proposal-class-properties": "^7.10.4",


### PR DESCRIPTION
### Summary

Avoids including a [yellow list licensed dependency in Kibana](https://github.com/elastic/open-source/blob/master/elastic-product-policy.md#yellow-list) by correctly moving @axe-core/puppeteer out of dependencies into devDependencies.

~### Checklist~
