### PR TITLE
Added `labelProps` prop to [EuiSwitch, EuiRadio, EuiCheckbox] 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Added `labelProps` prop to `EuiRadio`, `EuiSwitch` and `EuiCheckbox`. ([#4515](https://github.com/elastic/eui/pull/4515))
+- Added `labelProps` prop to `EuiRadio`, `EuiSwitch` and `EuiCheckbox`. ([#4516](https://github.com/elastic/eui/pull/4516))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Added `labelProps` prop to `EuiRadio`, `EuiSwitch` and `EuiCheckbox`. ([#4516](https://github.com/elastic/eui/pull/4516))
+- Added `labelProps` prop to `EuiRadio`, `EuiSwitch` and `EuiCheckbox` ([#4516](https://github.com/elastic/eui/pull/4516))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `31.7.0`.
+- Added `labelProps` prop to `EuiRadio`, `EuiSwitch` and `EuiCheckbox`. ([#4515](https://github.com/elastic/eui/pull/4515))
+
+**Bug fixes**
 
 ## [`31.7.0`](https://github.com/elastic/eui/tree/v31.7.0)
 

--- a/src/components/form/checkbox/__snapshots__/checkbox.test.tsx.snap
+++ b/src/components/form/checkbox/__snapshots__/checkbox.test.tsx.snap
@@ -72,6 +72,21 @@ exports[`EuiCheckbox props label is rendered 1`] = `
 </div>
 `;
 
+exports[`EuiCheckbox props labelProps is rendered 1`] = `
+<div
+  class="euiCheckbox euiCheckbox--noLabel"
+>
+  <input
+    class="euiCheckbox__input"
+    id="id"
+    type="checkbox"
+  />
+  <div
+    class="euiCheckbox__square"
+  />
+</div>
+`;
+
 exports[`EuiCheckbox props type inList is rendered 1`] = `
 <div
   class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"

--- a/src/components/form/checkbox/__snapshots__/checkbox.test.tsx.snap
+++ b/src/components/form/checkbox/__snapshots__/checkbox.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`EuiCheckbox props label is rendered 1`] = `
 
 exports[`EuiCheckbox props labelProps is rendered 1`] = `
 <div
-  class="euiCheckbox euiCheckbox--noLabel"
+  class="euiCheckbox"
 >
   <input
     class="euiCheckbox__input"
@@ -84,6 +84,14 @@ exports[`EuiCheckbox props labelProps is rendered 1`] = `
   <div
     class="euiCheckbox__square"
   />
+  <label
+    aria-label="aria-label"
+    class="euiCheckbox__label testClass1 testClass2"
+    data-test-subj="test subject string"
+    for="id"
+  >
+    Label
+  </label>
 </div>
 `;
 

--- a/src/components/form/checkbox/checkbox.test.tsx
+++ b/src/components/form/checkbox/checkbox.test.tsx
@@ -63,7 +63,11 @@ describe('EuiCheckbox', () => {
 
     test('labelProps is rendered', () => {
       const component = render(
-        <EuiCheckbox {...checkboxRequiredProps} labelProps={requiredProps} />
+        <EuiCheckbox
+          {...checkboxRequiredProps}
+          label="Label"
+          labelProps={requiredProps}
+        />
       );
 
       expect(component).toMatchSnapshot();

--- a/src/components/form/checkbox/checkbox.test.tsx
+++ b/src/components/form/checkbox/checkbox.test.tsx
@@ -61,6 +61,13 @@ describe('EuiCheckbox', () => {
       expect(component).toMatchSnapshot();
     });
 
+    test('labelProps is rendered', () => {
+      const component = render(
+        <EuiCheckbox {...checkboxRequiredProps} labelProps={requiredProps} />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
     describe('type', () => {
       TYPES.forEach((value) => {
         test(`${value} is rendered`, () => {

--- a/src/components/form/checkbox/checkbox.tsx
+++ b/src/components/form/checkbox/checkbox.tsx
@@ -22,6 +22,7 @@ import React, {
   ChangeEventHandler,
   ReactNode,
   InputHTMLAttributes,
+  LabelHTMLAttributes,
 } from 'react';
 import classNames from 'classnames';
 
@@ -51,9 +52,9 @@ export interface EuiCheckboxProps
   compressed?: boolean;
   indeterminate?: boolean;
   /**
-   * Object of props passed to the <input/>
+   * Object of props passed to the <label/>
    */
-  labelProps?: CommonProps & InputHTMLAttributes<HTMLInputElement>;
+  labelProps?: CommonProps & LabelHTMLAttributes<HTMLLabelElement>;
 }
 
 export class EuiCheckbox extends Component<EuiCheckboxProps> {
@@ -97,15 +98,17 @@ export class EuiCheckbox extends Component<EuiCheckboxProps> {
         'euiCheckbox--noLabel': !label,
         'euiCheckbox--compressed': compressed,
       },
-      className,
+      className
+    );
+    const labelClasses = classNames(
+      'euiCheckbox__label',
       labelProps?.className
     );
-
     let optionalLabel;
 
     if (label) {
       optionalLabel = (
-        <label className="euiCheckbox__label" htmlFor={id}>
+        <label {...labelProps} className={labelClasses} htmlFor={id}>
           {label}
         </label>
       );
@@ -114,7 +117,6 @@ export class EuiCheckbox extends Component<EuiCheckboxProps> {
     return (
       <div className={classes}>
         <input
-          {...labelProps}
           className="euiCheckbox__input"
           type="checkbox"
           id={id}

--- a/src/components/form/checkbox/checkbox.tsx
+++ b/src/components/form/checkbox/checkbox.tsx
@@ -50,6 +50,10 @@ export interface EuiCheckboxProps
    */
   compressed?: boolean;
   indeterminate?: boolean;
+  /**
+   * Object of props passed to the <input/>
+   */
+  labelProps?: CommonProps & InputHTMLAttributes<HTMLInputElement>;
 }
 
 export class EuiCheckbox extends Component<EuiCheckboxProps> {
@@ -82,6 +86,7 @@ export class EuiCheckbox extends Component<EuiCheckboxProps> {
       compressed,
       indeterminate,
       inputRef,
+      labelProps,
       ...rest
     } = this.props;
 
@@ -92,7 +97,8 @@ export class EuiCheckbox extends Component<EuiCheckboxProps> {
         'euiCheckbox--noLabel': !label,
         'euiCheckbox--compressed': compressed,
       },
-      className
+      className,
+      labelProps?.className
     );
 
     let optionalLabel;
@@ -108,6 +114,7 @@ export class EuiCheckbox extends Component<EuiCheckboxProps> {
     return (
       <div className={classes}>
         <input
+          {...labelProps}
           className="euiCheckbox__input"
           type="checkbox"
           id={id}

--- a/src/components/form/radio/__snapshots__/radio.test.tsx.snap
+++ b/src/components/form/radio/__snapshots__/radio.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`EuiRadio props label is rendered 1`] = `
 
 exports[`EuiRadio props labelProps is rendered 1`] = `
 <div
-  class="euiRadio euiRadio--noLabel testClass1 testClass2"
+  class="euiRadio"
 >
   <input
     class="euiRadio__input"
@@ -84,6 +84,14 @@ exports[`EuiRadio props labelProps is rendered 1`] = `
   <div
     class="euiRadio__circle"
   />
+  <label
+    aria-label="aria-label"
+    class="euiRadio__label testClass1 testClass2"
+    data-test-subj="test subject string"
+    for="id"
+  >
+    Label
+  </label>
 </div>
 `;
 

--- a/src/components/form/radio/__snapshots__/radio.test.tsx.snap
+++ b/src/components/form/radio/__snapshots__/radio.test.tsx.snap
@@ -72,6 +72,21 @@ exports[`EuiRadio props label is rendered 1`] = `
 </div>
 `;
 
+exports[`EuiRadio props labelProps is rendered 1`] = `
+<div
+  class="euiRadio euiRadio--noLabel testClass1 testClass2"
+>
+  <input
+    class="euiRadio__input"
+    id="id"
+    type="radio"
+  />
+  <div
+    class="euiRadio__circle"
+  />
+</div>
+`;
+
 exports[`EuiRadio props value is rendered 1`] = `
 <div
   class="euiRadio euiRadio--noLabel"

--- a/src/components/form/radio/radio.test.tsx
+++ b/src/components/form/radio/radio.test.tsx
@@ -67,7 +67,12 @@ describe('EuiRadio', () => {
 
     test('labelProps is rendered', () => {
       const component = render(
-        <EuiRadio id="id" onChange={() => {}} labelProps={requiredProps} />
+        <EuiRadio
+          id="id"
+          onChange={() => {}}
+          label="Label"
+          labelProps={requiredProps}
+        />
       );
 
       expect(component).toMatchSnapshot();

--- a/src/components/form/radio/radio.test.tsx
+++ b/src/components/form/radio/radio.test.tsx
@@ -64,5 +64,13 @@ describe('EuiRadio', () => {
 
       expect(component).toMatchSnapshot();
     });
+
+    test('labelProps is rendered', () => {
+      const component = render(
+        <EuiRadio id="id" onChange={() => {}} labelProps={requiredProps} />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
   });
 });

--- a/src/components/form/radio/radio.tsx
+++ b/src/components/form/radio/radio.tsx
@@ -77,8 +77,7 @@ export const EuiRadio: FunctionComponent<EuiRadioProps> = ({
       'euiRadio--noLabel': !label,
       'euiRadio--compressed': compressed,
     },
-    className,
-    labelProps?.className
+    className
   );
   const labelClasses = classNames('euiRadio__label', labelProps?.className);
   let optionalLabel;

--- a/src/components/form/radio/radio.tsx
+++ b/src/components/form/radio/radio.tsx
@@ -21,7 +21,7 @@ import React, {
   FunctionComponent,
   ChangeEventHandler,
   HTMLAttributes,
-  InputHTMLAttributes,
+  LabelHTMLAttributes,
   ReactNode,
 } from 'react';
 import classNames from 'classnames';
@@ -39,9 +39,9 @@ export interface RadioProps {
   disabled?: boolean;
   onChange: ChangeEventHandler<HTMLInputElement>;
   /**
-   * Object of props passed to the <input/>
+   * Object of props passed to the <label/>
    */
-  labelProps?: CommonProps & InputHTMLAttributes<HTMLInputElement>;
+  labelProps?: CommonProps & LabelHTMLAttributes<HTMLLabelElement>;
 }
 
 interface idWithLabel extends RadioProps {
@@ -80,12 +80,12 @@ export const EuiRadio: FunctionComponent<EuiRadioProps> = ({
     className,
     labelProps?.className
   );
-
+  const labelClasses = classNames('euiRadio__label', labelProps?.className);
   let optionalLabel;
 
   if (label) {
     optionalLabel = (
-      <label className="euiRadio__label" htmlFor={id}>
+      <label {...labelProps} className={labelClasses} htmlFor={id}>
         {label}
       </label>
     );
@@ -94,7 +94,6 @@ export const EuiRadio: FunctionComponent<EuiRadioProps> = ({
   return (
     <div className={classes} {...rest}>
       <input
-        {...labelProps}
         className="euiRadio__input"
         type="radio"
         id={id}

--- a/src/components/form/radio/radio.tsx
+++ b/src/components/form/radio/radio.tsx
@@ -21,6 +21,7 @@ import React, {
   FunctionComponent,
   ChangeEventHandler,
   HTMLAttributes,
+  InputHTMLAttributes,
   ReactNode,
 } from 'react';
 import classNames from 'classnames';
@@ -37,6 +38,10 @@ export interface RadioProps {
   checked?: boolean;
   disabled?: boolean;
   onChange: ChangeEventHandler<HTMLInputElement>;
+  /**
+   * Object of props passed to the <input/>
+   */
+  labelProps?: CommonProps & InputHTMLAttributes<HTMLInputElement>;
 }
 
 interface idWithLabel extends RadioProps {
@@ -63,6 +68,7 @@ export const EuiRadio: FunctionComponent<EuiRadioProps> = ({
   disabled,
   compressed,
   autoFocus,
+  labelProps,
   ...rest
 }) => {
   const classes = classNames(
@@ -71,7 +77,8 @@ export const EuiRadio: FunctionComponent<EuiRadioProps> = ({
       'euiRadio--noLabel': !label,
       'euiRadio--compressed': compressed,
     },
-    className
+    className,
+    labelProps?.className
   );
 
   let optionalLabel;
@@ -87,6 +94,7 @@ export const EuiRadio: FunctionComponent<EuiRadioProps> = ({
   return (
     <div className={classes} {...rest}>
       <input
+        {...labelProps}
         className="euiRadio__input"
         type="radio"
         id={id}
@@ -97,7 +105,6 @@ export const EuiRadio: FunctionComponent<EuiRadioProps> = ({
         disabled={disabled}
         autoFocus={autoFocus}
       />
-
       <div className="euiRadio__circle" />
 
       {optionalLabel}

--- a/src/components/form/switch/__snapshots__/switch.test.tsx.snap
+++ b/src/components/form/switch/__snapshots__/switch.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`EuiSwitch is rendered 1`] = `
 </div>
 `;
 
-exports[`labelProps is rendered 1`] = `
+exports[`EuiSwitch labelProps is rendered 1`] = `
 <div
   class="euiSwitch"
 >

--- a/src/components/form/switch/__snapshots__/switch.test.tsx.snap
+++ b/src/components/form/switch/__snapshots__/switch.test.tsx.snap
@@ -83,3 +83,46 @@ exports[`EuiSwitch is rendered 1`] = `
   </span>
 </div>
 `;
+
+exports[`labelProps is rendered 1`] = `
+<div
+  class="euiSwitch"
+>
+  <button
+    aria-checked="false"
+    aria-labelledby="generated-id"
+    class="euiSwitch__button"
+    id="generated-id"
+    role="switch"
+    type="button"
+  >
+    <span
+      class="euiSwitch__body"
+    >
+      <span
+        class="euiSwitch__thumb"
+      />
+      <span
+        class="euiSwitch__track"
+      >
+        <span
+          class="euiSwitch__icon"
+          data-euiicon-type="cross"
+        />
+        <span
+          class="euiSwitch__icon euiSwitch__icon--checked"
+          data-euiicon-type="check"
+        />
+      </span>
+    </span>
+  </button>
+  <span
+    aria-label="aria-label"
+    class="euiSwitch__label testClass1 testClass2"
+    data-test-subj="test subject string"
+    id="generated-id"
+  >
+    Label
+  </span>
+</div>
+`;

--- a/src/components/form/switch/switch.test.tsx
+++ b/src/components/form/switch/switch.test.tsx
@@ -44,3 +44,13 @@ describe('EuiSwitch', () => {
     expect(component).toMatchSnapshot();
   });
 });
+
+describe('labelProps', () => {
+  it('is rendered', () => {
+    const component = render(
+      <EuiSwitch {...props} labelProps={requiredProps} />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/components/form/switch/switch.test.tsx
+++ b/src/components/form/switch/switch.test.tsx
@@ -43,14 +43,13 @@ describe('EuiSwitch', () => {
 
     expect(component).toMatchSnapshot();
   });
-});
+  describe('labelProps', () => {
+    it('is rendered', () => {
+      const component = render(
+        <EuiSwitch {...props} labelProps={requiredProps} />
+      );
 
-describe('labelProps', () => {
-  it('is rendered', () => {
-    const component = render(
-      <EuiSwitch {...props} labelProps={requiredProps} />
-    );
-
-    expect(component).toMatchSnapshot();
+      expect(component).toMatchSnapshot();
+    });
   });
 });

--- a/src/components/form/switch/switch.tsx
+++ b/src/components/form/switch/switch.tsx
@@ -19,6 +19,7 @@
 
 import React, {
   ButtonHTMLAttributes,
+  HTMLAttributes,
   FunctionComponent,
   ReactNode,
   useState,
@@ -57,9 +58,9 @@ export type EuiSwitchProps = CommonProps &
     compressed?: boolean;
     type?: 'submit' | 'reset' | 'button';
     /**
-     * Object of props passed to the <button/>
+     * Object of props passed to the <span/>
      */
-    labelProps?: CommonProps & ButtonHTMLAttributes<HTMLButtonElement>;
+    labelProps?: CommonProps & HTMLAttributes<HTMLSpanElement>;
   };
 
 export const EuiSwitch: FunctionComponent<EuiSwitchProps> = ({
@@ -96,10 +97,9 @@ export const EuiSwitch: FunctionComponent<EuiSwitchProps> = ({
     {
       'euiSwitch--compressed': compressed,
     },
-    className,
-    labelProps?.className
+    className
   );
-
+  const labelClasses = classNames('euiSwitch__label', labelProps?.className);
   if (showLabel === false && typeof label !== 'string') {
     console.warn(
       'EuiSwitch `label` must be a string when `showLabel` is false.'
@@ -109,7 +109,6 @@ export const EuiSwitch: FunctionComponent<EuiSwitchProps> = ({
   return (
     <div className={classes}>
       <button
-        {...labelProps}
         id={switchId}
         aria-checked={checked || false}
         className="euiSwitch__button"
@@ -142,7 +141,11 @@ export const EuiSwitch: FunctionComponent<EuiSwitchProps> = ({
         // <button> + <label> has poor screen reader support.
         // Click handler added to simulate natural, secondary <label> interactivity.
         // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-        <span className="euiSwitch__label" id={labelId} onClick={onClick}>
+        <span
+          {...labelProps}
+          className={labelClasses}
+          id={labelId}
+          onClick={onClick}>
           {label}
         </span>
       )}

--- a/src/components/form/switch/switch.tsx
+++ b/src/components/form/switch/switch.tsx
@@ -56,6 +56,10 @@ export type EuiSwitchProps = CommonProps &
     disabled?: boolean;
     compressed?: boolean;
     type?: 'submit' | 'reset' | 'button';
+    /**
+     * Object of props passed to the <button/>
+     */
+    labelProps?: CommonProps & ButtonHTMLAttributes<HTMLButtonElement>;
   };
 
 export const EuiSwitch: FunctionComponent<EuiSwitchProps> = ({
@@ -68,6 +72,7 @@ export const EuiSwitch: FunctionComponent<EuiSwitchProps> = ({
   className,
   showLabel = true,
   type = 'button',
+  labelProps,
   ...rest
 }) => {
   const [switchId] = useState(id || htmlIdGenerator()());
@@ -91,7 +96,8 @@ export const EuiSwitch: FunctionComponent<EuiSwitchProps> = ({
     {
       'euiSwitch--compressed': compressed,
     },
-    className
+    className,
+    labelProps?.className
   );
 
   if (showLabel === false && typeof label !== 'string') {
@@ -103,6 +109,7 @@ export const EuiSwitch: FunctionComponent<EuiSwitchProps> = ({
   return (
     <div className={classes}>
       <button
+        {...labelProps}
         id={switchId}
         aria-checked={checked || false}
         className="euiSwitch__button"

--- a/src/components/form/switch/switch.tsx
+++ b/src/components/form/switch/switch.tsx
@@ -58,7 +58,7 @@ export type EuiSwitchProps = CommonProps &
     compressed?: boolean;
     type?: 'submit' | 'reset' | 'button';
     /**
-     * Object of props passed to the <span/>
+     * Object of props passed to the label's <span/>
      */
     labelProps?: CommonProps & HTMLAttributes<HTMLSpanElement>;
   };
@@ -77,7 +77,7 @@ export const EuiSwitch: FunctionComponent<EuiSwitchProps> = ({
   ...rest
 }) => {
   const [switchId] = useState(id || htmlIdGenerator()());
-  const [labelId] = useState(htmlIdGenerator()());
+  const [labelId] = useState(labelProps?.id || htmlIdGenerator()());
 
   const onClick = useCallback(
     (e: React.MouseEvent<HTMLButtonElement | HTMLParagraphElement>) => {


### PR DESCRIPTION
### Summary

This PR Fixes #3660 
Added `labelProps` prop to EuiSwitch, EuiRadio and EuiCheckbox.
- data test subject can be added now.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Edge**, and **Firefox**
- x ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
~~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~~
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
