### PR TITLE
Export props for components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Added source exports for `EuiBottomBarProps`, `EuiContextProps`, `EuiCopyProps`, `EuiDelayRenderProps`, `EuiImageProps`, `EuiMutationObserverProps`, `EuiResizeObserverProps`, `EuiOutsideClickDetectorProps`, `EuiPortal`. ([#4517](https://github.com/elastic/eui/pull/4517))
+- Added exports for all EUI component prps matching `EuiComponentProps` name pattern. ([#4517](https://github.com/elastic/eui/pull/4517))
 
 **Breaking changes**
 
-- Renamed `Props` export from `EuiBottomBar` to `EuiBottomBarProps` ([#4517](https://github.com/elastic/eui/pull/4517))
+- Renamed local component `Props` named exports to `EuiComponentProps` ([#4517](https://github.com/elastic/eui/pull/4517))
 
 ## [`31.7.0`](https://github.com/elastic/eui/tree/v31.7.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Added exports for all EUI component prps matching `EuiComponentProps` name pattern. ([#4517](https://github.com/elastic/eui/pull/4517))
+- Added exports for all EUI component props matching `EuiComponentProps` name pattern. ([#4517](https://github.com/elastic/eui/pull/4517))
 
 **Breaking changes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `31.7.0`.
+- Added source exports for `EuiBottomBarProps`, `EuiContextProps`, `EuiCopyProps`, `EuiDelayRenderProps`, `EuiImageProps`, `EuiMutationObserverProps`, `EuiResizeObserverProps`, `EuiOutsideClickDetectorProps`, `EuiPortal`. ([#4517](https://github.com/elastic/eui/pull/4517))
+
+**Breaking changes**
+
+- Renamed `Props` export from `EuiBottomBar` to `EuiBottomBarProps` ([#4517](https://github.com/elastic/eui/pull/4517))
 
 ## [`31.7.0`](https://github.com/elastic/eui/tree/v31.7.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 - Added exports for all EUI component props matching `EuiComponentProps` name pattern. ([#4517](https://github.com/elastic/eui/pull/4517))
 
-**Breaking changes**
-
-- Renamed local component `Props` named exports to `EuiComponentProps` ([#4517](https://github.com/elastic/eui/pull/4517))
 
 ## [`31.7.0`](https://github.com/elastic/eui/tree/v31.7.0)
 

--- a/src/components/badge/beta_badge/beta_badge.tsx
+++ b/src/components/badge/beta_badge/beta_badge.tsx
@@ -74,7 +74,7 @@ type BadgeProps = {
   title?: string;
 } & ExclusiveUnion<LabelAsNode, LabelAsString>;
 
-type EuiBetaBadgeProps = CommonProps &
+export type EuiBetaBadgeProps = CommonProps &
   Omit<HTMLAttributes<HTMLSpanElement>, 'title'> &
   BadgeProps;
 

--- a/src/components/badge/beta_badge/index.ts
+++ b/src/components/badge/beta_badge/index.ts
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-export { EuiBetaBadge } from './beta_badge';
+export { EuiBetaBadge, EuiBetaBadgeProps } from './beta_badge';

--- a/src/components/badge/index.ts
+++ b/src/components/badge/index.ts
@@ -19,7 +19,7 @@
 
 export { EuiBadge, EuiBadgeProps } from './badge';
 
-export { EuiBetaBadge } from './beta_badge';
+export { EuiBetaBadge, EuiBetaBadgeProps } from './beta_badge';
 
 export { EuiNotificationBadge } from './notification_badge';
 

--- a/src/components/badge/notification_badge/index.ts
+++ b/src/components/badge/notification_badge/index.ts
@@ -17,4 +17,7 @@
  * under the License.
  */
 
-export { EuiNotificationBadge } from './badge_notification';
+export {
+  EuiNotificationBadge,
+  EuiNotificationBadgeProps,
+} from './badge_notification';

--- a/src/components/bottom_bar/bottom_bar.tsx
+++ b/src/components/bottom_bar/bottom_bar.tsx
@@ -36,7 +36,7 @@ export const paddingSizeToClassNameMap: {
   l: 'euiBottomBar--paddingLarge',
 };
 
-interface Props extends CommonProps {
+export interface EuiBottomBarProps extends CommonProps {
   /**
    * Padding applied to the bar. Default is 'm'.
    */
@@ -59,7 +59,7 @@ interface Props extends CommonProps {
   landmarkHeading?: string;
 }
 
-export class EuiBottomBar extends Component<Props> {
+export class EuiBottomBar extends Component<EuiBottomBarProps> {
   static defaultProps = {
     paddingSize: 'm',
     affordForDisplacement: true,
@@ -78,7 +78,7 @@ export class EuiBottomBar extends Component<Props> {
     }
   }
 
-  componentDidUpdate(prevProps: Props) {
+  componentDidUpdate(prevProps: EuiBottomBarProps) {
     if (prevProps.affordForDisplacement !== this.props.affordForDisplacement) {
       if (this.props.affordForDisplacement) {
         // start affording for displacement

--- a/src/components/bottom_bar/index.ts
+++ b/src/components/bottom_bar/index.ts
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-export { EuiBottomBar } from './bottom_bar';
+export { EuiBottomBar, EuiBottomBarProps } from './bottom_bar';

--- a/src/components/color_picker/index.ts
+++ b/src/components/color_picker/index.ts
@@ -18,14 +18,20 @@
  */
 
 export { EuiColorPicker, EuiColorPickerProps } from './color_picker';
-export { EuiColorPickerSwatch } from './color_picker_swatch';
-export { EuiHue } from './hue';
-export { EuiSaturation } from './saturation';
-export { EuiColorStops } from './color_stops';
+export {
+  EuiColorPickerSwatch,
+  EuiColorPickerSwatchProps,
+} from './color_picker_swatch';
+export { EuiHue, EuiHueProps } from './hue';
+export { EuiSaturation, EuiSaturationProps } from './saturation';
+export { EuiColorStops, EuiColorStopsProps } from './color_stops';
 export {
   EuiColorPalettePicker,
   EuiColorPalettePickerProps,
   EuiColorPalettePickerPaletteProps,
 } from './color_palette_picker';
 
-export { EuiColorPaletteDisplay } from './color_palette_display';
+export {
+  EuiColorPaletteDisplay,
+  EuiColorPaletteDisplayProps,
+} from './color_palette_display';

--- a/src/components/context/context.tsx
+++ b/src/components/context/context.tsx
@@ -39,7 +39,7 @@ export interface I18nShape {
 const I18nContext: React.Context<I18nShape> = createContext({});
 const { Provider: EuiI18nProvider, Consumer: EuiI18nConsumer } = I18nContext;
 
-interface EuiContextProps {
+export interface EuiContextProps {
   i18n: I18nShape;
   /**
    * ReactNode to render as this component's content

--- a/src/components/context/index.ts
+++ b/src/components/context/index.ts
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-export { EuiContext, EuiI18nConsumer } from './context';
+export { EuiContext, EuiI18nConsumer, EuiContextProps } from './context';

--- a/src/components/context_menu/index.ts
+++ b/src/components/context_menu/index.ts
@@ -19,6 +19,7 @@
 
 export {
   EuiContextMenu,
+  EuiContextMenuProps,
   EuiContextMenuPanelDescriptor,
   EuiContextMenuPanelItemDescriptor,
 } from './context_menu';
@@ -30,6 +31,7 @@ export {
 
 export {
   EuiContextMenuItem,
+  EuiContextMenuItemProps,
   EuiContextMenuItemIcon,
   EuiContextMenuItemLayoutAlignment,
 } from './context_menu_item';

--- a/src/components/control_bar/index.ts
+++ b/src/components/control_bar/index.ts
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-export { EuiControlBar } from './control_bar';
+export { EuiControlBar, EuiControlBarProps } from './control_bar';

--- a/src/components/copy/copy.tsx
+++ b/src/components/copy/copy.tsx
@@ -22,7 +22,7 @@ import { CommonProps } from '../common';
 import { copyToClipboard } from '../../services';
 import { EuiToolTip, EuiToolTipProps } from '../tool_tip';
 
-interface EuiCopyProps
+export interface EuiCopyProps
   extends CommonProps,
     Partial<Omit<EuiToolTipProps, 'children'>> {
   /**

--- a/src/components/copy/index.ts
+++ b/src/components/copy/index.ts
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-export { EuiCopy } from './copy';
+export { EuiCopy, EuiCopyProps } from './copy';

--- a/src/components/delay_hide/index.ts
+++ b/src/components/delay_hide/index.ts
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-export { EuiDelayHide } from './delay_hide';
+export { EuiDelayHide, EuiDelayHideProps } from './delay_hide';

--- a/src/components/delay_render/delay_render.tsx
+++ b/src/components/delay_render/delay_render.tsx
@@ -19,7 +19,7 @@
 
 import { Component } from 'react';
 
-interface EuiDelayRenderProps {
+export interface EuiDelayRenderProps {
   delay: number;
 }
 

--- a/src/components/delay_render/index.ts
+++ b/src/components/delay_render/index.ts
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-export { EuiDelayRender } from './delay_render';
+export { EuiDelayRender, EuiDelayRenderProps } from './delay_render';

--- a/src/components/description_list/index.ts
+++ b/src/components/description_list/index.ts
@@ -17,7 +17,10 @@
  * under the License.
  */
 
-export { EuiDescriptionList } from './description_list';
+export {
+  EuiDescriptionList,
+  EuiDescriptionListProps,
+} from './description_list';
 
 export { EuiDescriptionListTitle } from './description_list_title';
 

--- a/src/components/drag_and_drop/drag_drop_context.tsx
+++ b/src/components/drag_and_drop/drag_drop_context.tsx
@@ -30,13 +30,15 @@ import {
 
 type EuiDraggingType = string | null;
 
-interface EuiDraggingContext {
+export interface EuiDragDropContextProps {
   isDraggingType: EuiDraggingType;
 }
 
-export const EuiDragDropContextContext = createContext<EuiDraggingContext>({
-  isDraggingType: null,
-});
+export const EuiDragDropContextContext = createContext<EuiDragDropContextProps>(
+  {
+    isDraggingType: null,
+  }
+);
 
 export const EuiDragDropContext: FunctionComponent<DragDropContextProps> = ({
   onBeforeDragStart,

--- a/src/components/drag_and_drop/index.ts
+++ b/src/components/drag_and_drop/index.ts
@@ -17,9 +17,12 @@
  * under the License.
  */
 
-export { EuiDragDropContext } from './drag_drop_context';
-export { EuiDraggable } from './draggable';
-export { EuiDroppable } from './droppable';
+export {
+  EuiDragDropContext,
+  EuiDragDropContextProps,
+} from './drag_drop_context';
+export { EuiDraggable, EuiDraggableProps } from './draggable';
+export { EuiDroppable, EuiDroppableProps } from './droppable';
 export {
   euiDragDropCopy,
   euiDragDropMove,

--- a/src/components/expression/index.ts
+++ b/src/components/expression/index.ts
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-export { EuiExpression } from './expression';
+export { EuiExpression, EuiExpressionProps } from './expression';

--- a/src/components/flex/index.ts
+++ b/src/components/flex/index.ts
@@ -23,6 +23,6 @@ export {
   EuiFlexGroupGutterSize,
 } from './flex_group';
 
-export { EuiFlexGrid } from './flex_grid';
+export { EuiFlexGrid, EuiFlexGridProps } from './flex_grid';
 
-export { EuiFlexItem } from './flex_item';
+export { EuiFlexItem, EuiFlexItemProps } from './flex_item';

--- a/src/components/focus_trap/index.ts
+++ b/src/components/focus_trap/index.ts
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-export { EuiFocusTrap, FocusTarget } from './focus_trap';
+export { EuiFocusTrap, EuiFocusTrapProps, FocusTarget } from './focus_trap';

--- a/src/components/header/header_links/index.ts
+++ b/src/components/header/header_links/index.ts
@@ -17,6 +17,6 @@
  * under the License.
  */
 
-export { EuiHeaderLink } from './header_link';
+export { EuiHeaderLink, EuiHeaderLinkProps } from './header_link';
 
-export { EuiHeaderLinks } from './header_links';
+export { EuiHeaderLinks, EuiHeaderLinksProps } from './header_links';

--- a/src/components/header/header_section/header_section.tsx
+++ b/src/components/header/header_section/header_section.tsx
@@ -29,13 +29,13 @@ const sideToClassNameMap: { [side in HeaderSectionSide]: string } = {
   right: 'euiHeaderSection--right',
 };
 
-type Props = CommonProps &
+export type EuiHeaderSectionProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {
     side?: HeaderSectionSide;
     grow?: boolean;
   };
 
-export const EuiHeaderSection: FunctionComponent<Props> = ({
+export const EuiHeaderSection: FunctionComponent<EuiHeaderSectionProps> = ({
   side = 'left',
   children,
   className,

--- a/src/components/header/header_section/index.ts
+++ b/src/components/header/header_section/index.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-export { EuiHeaderSection } from './header_section';
+export { EuiHeaderSection, EuiHeaderSectionProps } from './header_section';
 
 export {
   EuiHeaderSectionItem,

--- a/src/components/header/index.ts
+++ b/src/components/header/index.ts
@@ -23,7 +23,12 @@ export { EuiHeaderAlert, EuiHeaderAlertProps } from './header_alert';
 
 export { EuiHeaderBreadcrumbs } from './header_breadcrumbs';
 
-export { EuiHeaderLink, EuiHeaderLinks } from './header_links';
+export {
+  EuiHeaderLink,
+  EuiHeaderLinkProps,
+  EuiHeaderLinks,
+  EuiHeaderLinksProps,
+} from './header_links';
 
 export { EuiHeaderLogo, EuiHeaderLogoProps } from './header_logo';
 

--- a/src/components/highlight/index.ts
+++ b/src/components/highlight/index.ts
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-export { EuiHighlight } from './highlight';
+export { EuiHighlight, EuiHighlightProps } from './highlight';

--- a/src/components/i18n/i18n.tsx
+++ b/src/components/i18n/i18n.tsx
@@ -98,7 +98,7 @@ interface I18nTokensShape<T extends any[]> {
   children: (x: Array<T[number]>) => ReactChild;
 }
 
-type EuiI18nProps<
+export type EuiI18nProps<
   T,
   DEFAULT extends Renderable<T>,
   DEFAULTS extends any[]

--- a/src/components/i18n/i18n_number.tsx
+++ b/src/components/i18n/i18n_number.tsx
@@ -39,7 +39,7 @@ interface EuiI18nNumberValuesShape {
   children: (x: ReactChild[]) => ReactElement<any>;
 }
 
-type EuiI18nNumberProps = ExclusiveUnion<
+export type EuiI18nNumberProps = ExclusiveUnion<
   EuiI18nNumberValueShape,
   EuiI18nNumberValuesShape
 >;

--- a/src/components/i18n/index.ts
+++ b/src/components/i18n/index.ts
@@ -17,5 +17,5 @@
  * under the License.
  */
 
-export { EuiI18n, useEuiI18n } from './i18n';
-export { EuiI18nNumber } from './i18n_number';
+export { EuiI18n, EuiI18nProps, useEuiI18n } from './i18n';
+export { EuiI18nNumber, EuiI18nNumberProps } from './i18n_number';

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -71,7 +71,9 @@ const fullScreenIconColorMap: { [color in FullScreenIconColor]: string } = {
   dark: 'default',
 };
 
-interface EuiImageProps extends CommonProps, HTMLAttributes<HTMLImageElement> {
+export interface EuiImageProps
+  extends CommonProps,
+    HTMLAttributes<HTMLImageElement> {
   /**
    * Separate from the caption is a title on the alt tag itself.
    * This one is required for accessibility.

--- a/src/components/image/index.ts
+++ b/src/components/image/index.ts
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-export { EuiImage } from './image';
+export { EuiImage, EuiImageProps } from './image';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -31,62 +31,101 @@ export {
 
 export {
   EuiBadge,
-  EuiBetaBadge,
-  EuiNotificationBadge,
   EuiBadgeGroup,
+  EuiBadgeProps,
+  EuiBetaBadge,
+  EuiBetaBadgeProps,
+  EuiNotificationBadge,
+  EuiNotificationBadgeProps,
 } from './badge';
 
-export { EuiBeacon } from './beacon';
+export { EuiBeacon, EuiBeaconProps } from './beacon';
 
-export { EuiBottomBar } from './bottom_bar';
+export { EuiBottomBar, EuiBottomBarProps } from './bottom_bar';
 
-export { EuiBreadcrumbs } from './breadcrumbs';
+export { EuiBreadcrumbs, EuiBreadcrumbsProps } from './breadcrumbs';
 
 export {
   EuiButton,
+  EuiButtonProps,
   EuiButtonEmpty,
+  EuiButtonEmptyProps,
   EuiButtonIcon,
+  EuiButtonIconProps,
   EuiButtonGroup,
+  EuiButtonGroupProps,
 } from './button';
 
-export { EuiCallOut } from './call_out';
+export { EuiCallOut, EuiCallOutProps } from './call_out';
 
-export { EuiCard, EuiCheckableCard } from './card';
+export {
+  EuiCard,
+  EuiCardProps,
+  EuiCheckableCard,
+  EuiCheckableCardProps,
+} from './card';
 
-export { EuiCode, EuiCodeBlock, EuiCodeBlockImpl } from './code';
+export {
+  EuiCode,
+  EuiCodeProps,
+  EuiCodeBlock,
+  EuiCodeBlockProps,
+  EuiCodeBlockImpl,
+} from './code';
 
-export { EuiCodeEditor } from './code_editor';
+export { EuiCodeEditor, EuiCodeEditorProps } from './code_editor';
 
-export { EuiCollapsibleNav, EuiCollapsibleNavGroup } from './collapsible_nav';
+export {
+  EuiCollapsibleNav,
+  EuiCollapsibleNavProps,
+  EuiCollapsibleNavGroup,
+  EuiCollapsibleNavGroupProps,
+} from './collapsible_nav';
 
 export {
   EuiColorPalettePicker,
+  EuiColorPalettePickerProps,
   EuiColorPaletteDisplay,
+  EuiColorPaletteDisplayProps,
   EuiColorPicker,
+  EuiColorPickerProps,
   EuiColorPickerSwatch,
+  EuiColorPickerSwatchProps,
   EuiColorStops,
+  EuiColorStopsProps,
   EuiHue,
+  EuiHueProps,
   EuiSaturation,
+  EuiSaturationProps,
 } from './color_picker';
 
-export { EuiComboBox } from './combo_box';
+export { EuiComboBox, EuiComboBoxProps } from './combo_box';
 
-export { EuiComment, EuiCommentList } from './comment_list';
+export {
+  EuiComment,
+  EuiCommentProps,
+  EuiCommentList,
+  EuiCommentListProps,
+} from './comment_list';
 
 export { EuiContext, EuiI18nConsumer } from './context';
 
 export {
   EuiContextMenu,
+  EuiContextMenuProps,
   EuiContextMenuPanel,
+  EuiContextMenuPanelProps,
   EuiContextMenuItem,
+  EuiContextMenuItemProps,
 } from './context_menu';
 
-export { EuiControlBar } from './control_bar';
+export { EuiControlBar, EuiControlBarProps } from './control_bar';
 
-export { EuiCopy } from './copy';
+export { EuiCopy, EuiCopyProps } from './copy';
 
 export {
   EuiDataGrid,
+  EuiDataGridProps,
   useDataGridColumnSelector,
   useDataGridColumnSorting,
   useDataGridStyleSelector,
@@ -94,111 +133,184 @@ export {
 
 export {
   EuiDatePicker,
+  EuiDatePickerProps,
   EuiDatePickerRange,
+  EuiDatePickerRangeProps,
   EuiSuperDatePicker,
+  EuiSuperDatePickerProps,
   EuiSuperUpdateButton,
+  EuiSuperUpdateButtonProps,
   prettyDuration,
   commonDurationRanges,
 } from './date_picker';
 
-export { EuiDelayHide } from './delay_hide';
-export { EuiDelayRender } from './delay_render';
+export { EuiDelayHide, EuiDelayHideProps } from './delay_hide';
+export { EuiDelayRender, EuiDelayRenderProps } from './delay_render';
 
 export {
   EuiDescriptionList,
+  EuiDescriptionListProps,
   EuiDescriptionListTitle,
   EuiDescriptionListDescription,
 } from './description_list';
 
 export {
   EuiDragDropContext,
+  EuiDragDropContextProps,
   EuiDraggable,
+  EuiDraggableProps,
   EuiDroppable,
+  EuiDroppableProps,
   euiDragDropCopy,
   euiDragDropMove,
   euiDragDropReorder,
 } from './drag_and_drop';
 
-export { EuiEmptyPrompt } from './empty_prompt';
+export { EuiEmptyPrompt, EuiEmptyPromptProps } from './empty_prompt';
 
-export { EuiErrorBoundary } from './error_boundary';
+export { EuiErrorBoundary, EuiErrorBoundaryProps } from './error_boundary';
 
-export { EuiExpression } from './expression';
+export { EuiExpression, EuiExpressionProps } from './expression';
 
 export {
   EuiFilterButton,
+  EuiFilterButtonProps,
   EuiFilterGroup,
+  EuiFilterGroupProps,
   EuiFilterSelectItem,
+  EuiFilterSelectItemProps,
 } from './filter_group';
 
-export { EuiFacetButton, EuiFacetGroup } from './facet';
+export {
+  EuiFacetButton,
+  EuiFacetButtonProps,
+  EuiFacetGroup,
+  EuiFacetGroupProps,
+} from './facet';
 
-export { EuiFlexGroup, EuiFlexGrid, EuiFlexItem } from './flex';
+export {
+  EuiFlexGroup,
+  EuiFlexGroupProps,
+  EuiFlexGrid,
+  EuiFlexGridProps,
+  EuiFlexItem,
+  EuiFlexItemProps,
+} from './flex';
 
 export {
   EuiFlyout,
+  EuiFlyoutProps,
   EuiFlyoutBody,
+  EuiFlyoutBodyProps,
   EuiFlyoutFooter,
+  EuiFlyoutFooterProps,
   EuiFlyoutHeader,
+  EuiFlyoutHeaderProps,
 } from './flyout';
 
-export { EuiFocusTrap } from './focus_trap';
+export { EuiFocusTrap, EuiFocusTrapProps } from './focus_trap';
 
 export {
   EuiCheckbox,
+  EuiCheckboxProps,
   EuiCheckboxGroup,
+  EuiCheckboxGroupProps,
   EuiDescribedFormGroup,
+  EuiDescribedFormGroupProps,
   EuiDualRange,
+  EuiDualRangeProps,
   EuiFieldNumber,
+  EuiFieldNumberProps,
   EuiFieldPassword,
+  EuiFieldPasswordProps,
   EuiFieldSearch,
+  EuiFieldSearchProps,
   EuiFieldText,
+  EuiFieldTextProps,
   EuiFilePicker,
+  EuiFilePickerProps,
   EuiForm,
+  EuiFormProps,
   EuiFormControlLayout,
+  EuiFormControlLayoutProps,
   EuiFormControlLayoutDelimited,
+  EuiFormControlLayoutDelimitedProps,
   EuiFormErrorText,
+  EuiFormErrorTextProps,
   EuiFormFieldset,
+  EuiFormFieldsetProps,
   EuiFormHelpText,
+  EuiFormHelpTextProps,
   EuiFormLabel,
+  EuiFormLabelProps,
   EuiFormLegend,
+  EuiFormLegendProps,
   EuiFormRow,
+  EuiFormRowProps,
   EuiRadio,
+  EuiRadioProps,
   EuiRadioGroup,
+  EuiRadioGroupProps,
   EuiRange,
+  EuiRangeProps,
   EuiSelect,
+  EuiSelectProps,
   EuiSuperSelect,
+  EuiSuperSelectProps,
   EuiSuperSelectControl,
+  EuiSuperSelectControlProps,
   EuiSwitch,
+  EuiSwitchProps,
   EuiTextArea,
+  EuiTextAreaProps,
   EuiValidatableControl,
+  EuiValidatableControlProps,
 } from './form';
 
 export {
   EuiHeader,
+  EuiHeaderProps,
   EuiHeaderAlert,
+  EuiHeaderAlertProps,
   EuiHeaderBreadcrumbs,
   EuiHeaderLink,
+  EuiHeaderLinkProps,
   EuiHeaderLinks,
+  EuiHeaderLinksProps,
   EuiHeaderLogo,
+  EuiHeaderLogoProps,
   EuiHeaderSection,
+  EuiHeaderSectionProps,
   EuiHeaderSectionItem,
+  EuiHeaderSectionItemProps,
   EuiHeaderSectionItemButton,
+  EuiHeaderSectionItemButtonProps,
 } from './header';
 
-export { EuiHealth } from './health';
+export { EuiHealth, EuiHealthProps } from './health';
 
-export { EuiHighlight } from './highlight';
+export { EuiHighlight, EuiHighlightProps } from './highlight';
 
-export { EuiHorizontalRule } from './horizontal_rule';
+export { EuiHorizontalRule, EuiHorizontalRuleProps } from './horizontal_rule';
 
-export { ICON_TYPES, EuiIcon } from './icon';
+export { ICON_TYPES, EuiIcon, EuiIconProps } from './icon';
 
-export { EuiImage } from './image';
+export { EuiImage, EuiImageProps } from './image';
 
-export { useInnerText, EuiInnerText, useRenderToText } from './inner_text';
+export {
+  useInnerText,
+  EuiInnerText,
+  EuiInnerTextProps,
+  useRenderToText,
+} from './inner_text';
 
-export { EuiI18n, EuiI18nNumber, useEuiI18n } from './i18n';
+export {
+  EuiI18n,
+  EuiI18nProps,
+  EuiI18nNumber,
+  EuiI18nNumberProps,
+  useEuiI18n,
+} from './i18n';
 
 export {
   EuiLoadingKibana,
@@ -208,20 +320,30 @@ export {
   EuiLoadingSpinner,
 } from './loading';
 
-export { EuiKeyPadMenu, EuiKeyPadMenuItem } from './key_pad_menu';
+export {
+  EuiKeyPadMenu,
+  EuiKeyPadMenuProps,
+  EuiKeyPadMenuItem,
+  EuiKeyPadMenuItemProps,
+} from './key_pad_menu';
 
-export { EuiLink } from './link';
+export { EuiLink, EuiLinkProps } from './link';
 
 export {
   EuiListGroup,
+  EuiListGroupProps,
   EuiListGroupItem,
+  EuiListGroupItemProps,
   EuiPinnableListGroup,
+  EuiPinnableListGroupProps,
 } from './list_group';
 
 export {
   EuiMarkdownEditor,
+  EuiMarkdownEditorProps,
   EuiMarkdownContext,
   EuiMarkdownFormat,
+  EuiMarkdownFormatProps,
   getDefaultEuiMarkdownParsingPlugins,
   getDefaultEuiMarkdownProcessingPlugins,
   getDefaultEuiMarkdownUiPlugins,
@@ -232,113 +354,217 @@ export {
   EUI_MODAL_CANCEL_BUTTON,
   EUI_MODAL_CONFIRM_BUTTON,
   EuiConfirmModal,
+  EuiConfirmModalProps,
   EuiModal,
+  EuiModalProps,
   EuiModalBody,
+  EuiModalBodyProps,
   EuiModalFooter,
+  EuiModalFooterProps,
   EuiModalHeader,
+  EuiModalHeaderProps,
   EuiModalHeaderTitle,
+  EuiModalHeaderTitleProps,
 } from './modal';
 
-export { EuiMutationObserver } from './observer/mutation_observer';
+export {
+  EuiMutationObserver,
+  EuiMutationObserverProps,
+} from './observer/mutation_observer';
 
-export { EuiOutsideClickDetector } from './outside_click_detector';
+export {
+  EuiOutsideClickDetector,
+  EuiOutsideClickDetectorProps,
+} from './outside_click_detector';
 
-export { EuiOverlayMask } from './overlay_mask';
+export { EuiOverlayMask, EuiOverlayMaskProps } from './overlay_mask';
 
 export {
   EuiPage,
+  EuiPageProps,
   EuiPageBody,
+  EuiPageBodyProps,
   EuiPageContent,
+  EuiPageContentProps,
   EuiPageContentBody,
+  EuiPageContentBodyProps,
   EuiPageContentHeader,
+  EuiPageContentHeaderProps,
   EuiPageContentHeaderSection,
+  EuiPageContentHeaderSectionProps,
   EuiPageHeader,
+  EuiPageHeaderProps,
   EuiPageHeaderContent,
+  EuiPageHeaderContentProps,
   EuiPageHeaderSection,
+  EuiPageHeaderSectionProps,
   EuiPageSideBar,
+  EuiPageSideBarProps,
 } from './page';
 
-export { EuiPagination, EuiPaginationButton } from './pagination';
+export {
+  EuiPagination,
+  EuiPaginationProps,
+  EuiPaginationButton,
+  EuiPaginationButtonProps,
+} from './pagination';
 
-export { EuiPanel } from './panel';
+export { EuiPanel, EuiPanelProps } from './panel';
 
 export {
   EuiInputPopover,
+  EuiInputPopoverProps,
   EuiPopover,
+  EuiPopoverProps,
   EuiPopoverTitle,
+  EuiPopoverTitleProps,
   EuiPopoverFooter,
+  EuiPopoverFooterProps,
   EuiWrappingPopover,
+  EuiWrappingPopoverProps,
 } from './popover';
 
-export { EuiPortal } from './portal';
+export { EuiPortal, EuiPortalProps } from './portal';
 
-export { EuiProgress } from './progress';
+export { EuiProgress, EuiProgressProps } from './progress';
 
-export { EuiTreeView } from './tree_view';
+export { EuiTreeView, EuiTreeViewProps } from './tree_view';
 
 export {
   EuiResizeObserver,
+  EuiResizeObserverProps,
   useResizeObserver,
 } from './observer/resize_observer';
 
-export { EuiSearchBar, Query, Ast } from './search_bar';
+export { EuiSearchBar, EuiSearchBarProps, Query, Ast } from './search_bar';
 
 export {
   EuiSelectable,
+  EuiSelectableProps,
   EuiSelectableList,
+  EuiSelectableListProps,
   EuiSelectableListItem,
+  EuiSelectableListItemProps,
   EuiSelectableMessage,
+  EuiSelectableMessageProps,
   EuiSelectableSearch,
+  EuiSelectableSearchProps,
   EuiSelectableTemplateSitewide,
+  EuiSelectableTemplateSitewideProps,
   euiSelectableTemplateSitewideRenderOptions,
 } from './selectable';
 
-export { EuiSideNav } from './side_nav';
+export { EuiSideNav, EuiSideNavProps } from './side_nav';
 
-export { EuiSpacer } from './spacer';
+export { EuiSpacer, EuiSpacerProps } from './spacer';
 
-export { EuiStat } from './stat';
+export { EuiStat, EuiStatProps } from './stat';
 
-export { EuiStep, EuiSteps, EuiSubSteps, EuiStepsHorizontal } from './steps';
+export {
+  EuiStep,
+  EuiStepProps,
+  EuiSteps,
+  EuiStepsProps,
+  EuiSubSteps,
+  EuiSubStepsProps,
+  EuiStepsHorizontal,
+  EuiStepsHorizontalProps,
+} from './steps';
 
 export { EuiSuggestInput, EuiSuggestItem, EuiSuggest } from './suggest';
 
 export {
   EuiTable,
+  EuiTableProps,
   EuiTableBody,
+  EuiTableBodyProps,
   EuiTableFooter,
   EuiTableFooterCell,
+  EuiTableFooterCellProps,
   EuiTableHeader,
+  EuiTableHeaderProps,
   EuiTableHeaderButton,
+  EuiTableHeaderButtonProps,
   EuiTableHeaderCell,
+  EuiTableHeaderCellProps,
   EuiTableHeaderCellCheckbox,
+  EuiTableHeaderCellCheckboxProps,
   EuiTablePagination,
+  EuiTablePaginationProps,
   EuiTableRow,
+  EuiTableRowProps,
   EuiTableRowCell,
+  EuiTableRowCellProps,
   EuiTableRowCellCheckbox,
   EuiTableHeaderMobile,
   EuiTableSortMobile,
+  EuiTableSortMobileProps,
   EuiTableSortMobileItem,
+  EuiTableSortMobileItemProps,
 } from './table';
 
-export { EuiToken } from './token';
+export { EuiToken, EuiTokenProps } from './token';
 
-export { EuiTour, EuiTourStep, useEuiTour } from './tour';
+export {
+  EuiTour,
+  EuiTourProps,
+  EuiTourStep,
+  EuiTourStepProps,
+  useEuiTour,
+} from './tour';
 
-export { EuiBasicTable, EuiInMemoryTable } from './basic_table';
+export {
+  EuiBasicTable,
+  EuiBasicTableProps,
+  EuiInMemoryTable,
+  EuiInMemoryTableProps,
+} from './basic_table';
 
-export { EuiTab, EuiTabs, EuiTabbedContent } from './tabs';
+export {
+  EuiTab,
+  EuiTabProps,
+  EuiTabs,
+  EuiTabsProps,
+  EuiTabbedContent,
+  EuiTabbedContentProps,
+} from './tabs';
 
-export { EuiText, EuiTextColor, EuiTextAlign } from './text';
+export {
+  EuiText,
+  EuiTextProps,
+  EuiTextColor,
+  EuiTextColorProps,
+  EuiTextAlign,
+  EuiTextAlignProps,
+} from './text';
 
 export { useEuiTextDiff } from './text_diff';
 
-export { EuiTitle } from './title';
+export { EuiTitle, EuiTitleProps } from './title';
 
-export { EuiGlobalToastList, EuiGlobalToastListItem, EuiToast } from './toast';
+export {
+  EuiGlobalToastList,
+  EuiGlobalToastListProps,
+  EuiGlobalToastListItem,
+  EuiGlobalToastListItemProps,
+  EuiToast,
+} from './toast';
 
-export { EuiIconTip, EuiToolTip } from './tool_tip';
+export {
+  EuiIconTip,
+  EuiIconTipProps,
+  EuiToolTip,
+  EuiToolTipProps,
+} from './tool_tip';
 
-export { EuiHideFor, EuiShowFor } from './responsive';
+export {
+  EuiHideFor,
+  EuiHideForProps,
+  EuiShowFor,
+  EuiShowForProps,
+} from './responsive';
 
-export { EuiResizableContainer } from './resizable_container';
+export {
+  EuiResizableContainer,
+  EuiResizableContainerProps,
+} from './resizable_container';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -314,10 +314,15 @@ export {
 
 export {
   EuiLoadingKibana,
+  EuiLoadingKibanaProps,
   EuiLoadingElastic,
+  EuiLoadingElasticProps,
   EuiLoadingChart,
+  EuiLoadingChartProps,
   EuiLoadingContent,
+  EuiLoadingContentProps,
   EuiLoadingSpinner,
+  EuiLoadingSpinnerProps,
 } from './loading';
 
 export {

--- a/src/components/inner_text/index.ts
+++ b/src/components/inner_text/index.ts
@@ -17,5 +17,5 @@
  * under the License.
  */
 
-export { useInnerText, EuiInnerText } from './inner_text';
+export { useInnerText, EuiInnerText, EuiInnerTextProps } from './inner_text';
 export { useRenderToText } from './render_to_text';

--- a/src/components/key_pad_menu/index.ts
+++ b/src/components/key_pad_menu/index.ts
@@ -17,6 +17,6 @@
  * under the License.
  */
 
-export { EuiKeyPadMenu } from './key_pad_menu';
+export { EuiKeyPadMenu, EuiKeyPadMenuProps } from './key_pad_menu';
 
-export { EuiKeyPadMenuItem } from './key_pad_menu_item';
+export { EuiKeyPadMenuItem, EuiKeyPadMenuItemProps } from './key_pad_menu_item';

--- a/src/components/loading/index.ts
+++ b/src/components/loading/index.ts
@@ -19,6 +19,6 @@
 
 export { EuiLoadingKibana, EuiLoadingKibanaProps } from './loading_kibana';
 export { EuiLoadingElastic, EuiLoadingElasticProps } from './loading_elastic';
-export { EuiLoadingChart } from './loading_chart';
-export { EuiLoadingContent } from './loading_content';
-export { EuiLoadingSpinner } from './loading_spinner';
+export { EuiLoadingChart, EuiLoadingChartProps } from './loading_chart';
+export { EuiLoadingContent, EuiLoadingContentProps } from './loading_content';
+export { EuiLoadingSpinner, EuiLoadingSpinnerProps } from './loading_spinner';

--- a/src/components/loading/index.ts
+++ b/src/components/loading/index.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-export { EuiLoadingKibana } from './loading_kibana';
-export { EuiLoadingElastic } from './loading_elastic';
+export { EuiLoadingKibana, EuiLoadingKibanaProps } from './loading_kibana';
+export { EuiLoadingElastic, EuiLoadingElasticProps } from './loading_elastic';
 export { EuiLoadingChart } from './loading_chart';
 export { EuiLoadingContent } from './loading_content';
 export { EuiLoadingSpinner } from './loading_spinner';

--- a/src/components/loading/loading_chart.tsx
+++ b/src/components/loading/loading_chart.tsx
@@ -31,16 +31,18 @@ export const SIZES = keysOf(sizeToClassNameMap);
 
 export type EuiLoadingChartSize = keyof typeof sizeToClassNameMap;
 
-export const EuiLoadingChart: FunctionComponent<
-  CommonProps &
-    HTMLAttributes<HTMLDivElement> & {
-      /**
-       * Makes the loader animation black and white
-       */
-      mono?: boolean;
-      size?: EuiLoadingChartSize;
-    }
-> = ({ size = 'm', mono = false, className, ...rest }) => {
+export type EuiLoadingChartProps = CommonProps &
+  HTMLAttributes<HTMLDivElement> & {
+    size?: EuiLoadingChartSize;
+    mono?: boolean;
+  };
+
+export const EuiLoadingChart: FunctionComponent<EuiLoadingChartProps> = ({
+  size = 'm',
+  mono = false,
+  className,
+  ...rest
+}) => {
   const classes = classNames(
     'euiLoadingChart',
     { 'euiLoadingChart--mono': mono },

--- a/src/components/loading/loading_content.tsx
+++ b/src/components/loading/loading_content.tsx
@@ -23,12 +23,16 @@ import { CommonProps } from '../common';
 
 export type LineRange = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
 
-export const EuiLoadingContent: FunctionComponent<
-  CommonProps &
-    HTMLAttributes<HTMLDivElement> & {
-      lines?: LineRange;
-    }
-> = ({ lines = 3, className, ...rest }) => {
+export type EuiLoadingContentProps = CommonProps &
+  HTMLAttributes<HTMLDivElement> & {
+    lines?: LineRange;
+  };
+
+export const EuiLoadingContent: FunctionComponent<EuiLoadingContentProps> = ({
+  lines = 3,
+  className,
+  ...rest
+}) => {
   const classes = classNames('euiLoadingContent', className);
   const lineElements = [];
 

--- a/src/components/loading/loading_spinner.tsx
+++ b/src/components/loading/loading_spinner.tsx
@@ -32,12 +32,16 @@ export const SIZES = keysOf(sizeToClassNameMap);
 
 export type EuiLoadingSpinnerSize = keyof typeof sizeToClassNameMap;
 
-export const EuiLoadingSpinner: FunctionComponent<
-  CommonProps &
-    HTMLAttributes<HTMLDivElement> & {
-      size?: EuiLoadingSpinnerSize;
-    }
-> = ({ size = 'm', className, ...rest }) => {
+export type EuiLoadingSpinnerProps = CommonProps &
+  HTMLAttributes<HTMLDivElement> & {
+    size?: EuiLoadingSpinnerSize;
+  };
+
+export const EuiLoadingSpinner: FunctionComponent<EuiLoadingSpinnerProps> = ({
+  size = 'm',
+  className,
+  ...rest
+}) => {
   const classes = classNames(
     'euiLoadingSpinner',
     sizeToClassNameMap[size],

--- a/src/components/markdown_editor/index.ts
+++ b/src/components/markdown_editor/index.ts
@@ -24,7 +24,7 @@ export {
   getDefaultEuiMarkdownUiPlugins,
 } from './plugins/markdown_default_plugins';
 export { EuiMarkdownContext } from './markdown_context';
-export { EuiMarkdownFormat } from './markdown_format';
+export { EuiMarkdownFormat, EuiMarkdownFormatProps } from './markdown_format';
 export {
   EuiMarkdownParseError,
   EuiMarkdownAstNode,

--- a/src/components/markdown_editor/markdown_format.tsx
+++ b/src/components/markdown_editor/markdown_format.tsx
@@ -25,7 +25,7 @@ import {
   defaultParsingPlugins,
 } from './plugins/markdown_default_plugins';
 
-interface EuiMarkdownFormatProps {
+export interface EuiMarkdownFormatProps {
   children: string;
   /** array of unified plugins to parse content into an AST */
   parsingPluginList?: PluggableList;

--- a/src/components/observer/mutation_observer/index.ts
+++ b/src/components/observer/mutation_observer/index.ts
@@ -17,4 +17,8 @@
  * under the License.
  */
 
-export { EuiMutationObserver, useMutationObserver } from './mutation_observer';
+export {
+  EuiMutationObserver,
+  EuiMutationObserverProps,
+  useMutationObserver,
+} from './mutation_observer';

--- a/src/components/observer/mutation_observer/mutation_observer.ts
+++ b/src/components/observer/mutation_observer/mutation_observer.ts
@@ -21,7 +21,7 @@ import { ReactNode, useEffect } from 'react';
 
 import { EuiObserver } from '../observer';
 
-interface Props {
+export interface EuiMutationObserverProps {
   /**
    * ReactNode to render as this component's content
    */
@@ -30,7 +30,7 @@ interface Props {
   observerOptions?: MutationObserverInit;
 }
 
-export class EuiMutationObserver extends EuiObserver<Props> {
+export class EuiMutationObserver extends EuiObserver<EuiMutationObserverProps> {
   name = 'EuiMutationObserver';
 
   // the `onMutation` prop may change while the observer is bound, abstracting

--- a/src/components/observer/resize_observer/index.ts
+++ b/src/components/observer/resize_observer/index.ts
@@ -17,4 +17,8 @@
  * under the License.
  */
 
-export { EuiResizeObserver, useResizeObserver } from './resize_observer';
+export {
+  EuiResizeObserver,
+  EuiResizeObserverProps,
+  useResizeObserver,
+} from './resize_observer';

--- a/src/components/observer/resize_observer/resize_observer.tsx
+++ b/src/components/observer/resize_observer/resize_observer.tsx
@@ -20,7 +20,7 @@
 import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { EuiObserver, Observer } from '../observer';
 
-interface Props {
+export interface EuiResizeObserverProps {
   /**
    * ReactNode to render as this component's content
    */
@@ -41,7 +41,7 @@ const mutationObserverOptions = {
   subtree: true, // Account for deep child nodes
 };
 
-export class EuiResizeObserver extends EuiObserver<Props> {
+export class EuiResizeObserver extends EuiObserver<EuiResizeObserverProps> {
   name = 'EuiResizeObserver';
 
   state = {

--- a/src/components/outside_click_detector/index.ts
+++ b/src/components/outside_click_detector/index.ts
@@ -17,4 +17,7 @@
  * under the License.
  */
 
-export { EuiOutsideClickDetector } from './outside_click_detector';
+export {
+  EuiOutsideClickDetector,
+  EuiOutsideClickDetectorProps,
+} from './outside_click_detector';

--- a/src/components/outside_click_detector/outside_click_detector.ts
+++ b/src/components/outside_click_detector/outside_click_detector.ts
@@ -31,7 +31,7 @@ export interface EuiEvent extends Event {
   euiGeneratedBy: string[];
 }
 
-interface Props {
+export interface EuiOutsideClickDetectorProps {
   /**
    * ReactNode to render as this component's content
    */
@@ -44,7 +44,9 @@ interface Props {
   onTouchEnd?: (event: ReactMouseEvent) => void;
 }
 
-export class EuiOutsideClickDetector extends Component<Props> {
+export class EuiOutsideClickDetector extends Component<
+  EuiOutsideClickDetectorProps
+> {
   // We are working with the assumption that a click event is
   // equivalent to a sequential, compound press and release of
   // the pointing device (mouse, finger, stylus, etc.).
@@ -60,7 +62,7 @@ export class EuiOutsideClickDetector extends Component<Props> {
 
   private capturedDownIds: string[];
 
-  constructor(props: Props) {
+  constructor(props: EuiOutsideClickDetectorProps) {
     super(props);
 
     // the id is used to identify which EuiOutsideClickDetector

--- a/src/components/pagination/index.ts
+++ b/src/components/pagination/index.ts
@@ -17,6 +17,9 @@
  * under the License.
  */
 
-export { EuiPagination } from './pagination';
+export { EuiPagination, EuiPaginationProps } from './pagination';
 
-export { EuiPaginationButton } from './pagination_button';
+export {
+  EuiPaginationButton,
+  EuiPaginationButtonProps,
+} from './pagination_button';

--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -67,7 +67,7 @@ export type PanelColor = typeof COLORS[number];
 export type PanelPaddingSize = typeof SIZES[number];
 export type PanelBorderRadius = typeof BORDER_RADII[number];
 
-export interface PanelProps extends CommonProps {
+export interface _EuiPanelProps extends CommonProps {
   /**
    * Adds a medium shadow to the panel;
    * Clickable cards will still get a shadow on hover
@@ -110,11 +110,11 @@ export interface PanelProps extends CommonProps {
 }
 
 interface Divlike
-  extends PanelProps,
+  extends _EuiPanelProps,
     Omit<HTMLAttributes<HTMLDivElement>, 'onClick' | 'color'> {}
 
 interface Buttonlike
-  extends PanelProps,
+  extends _EuiPanelProps,
     Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'color'> {}
 
 export type EuiPanelProps = ExclusiveUnion<Divlike, Buttonlike>;

--- a/src/components/popover/index.ts
+++ b/src/components/popover/index.ts
@@ -17,8 +17,11 @@
  * under the License.
  */
 
-export { EuiInputPopover } from './input_popover';
+export { EuiInputPopover, EuiInputPopoverProps } from './input_popover';
 export { EuiPopover, EuiPopoverProps, PopoverAnchorPosition } from './popover';
-export { EuiPopoverTitle } from './popover_title';
-export { EuiPopoverFooter } from './popover_footer';
-export { EuiWrappingPopover } from './wrapping_popover';
+export { EuiPopoverTitle, EuiPopoverTitleProps } from './popover_title';
+export { EuiPopoverFooter, EuiPopoverFooterProps } from './popover_footer';
+export {
+  EuiWrappingPopover,
+  EuiWrappingPopoverProps,
+} from './wrapping_popover';

--- a/src/components/popover/input_popover.tsx
+++ b/src/components/popover/input_popover.tsx
@@ -33,7 +33,7 @@ import { EuiPopover, EuiPopoverProps } from './popover';
 import { EuiResizeObserver } from '../observer/resize_observer';
 import { cascadingMenuKeys } from '../../services';
 
-interface EuiInputPopoverProps
+interface _EuiInputPopoverProps
   extends Omit<EuiPopoverProps, 'button' | 'buttonRef'> {
   disableFocusTrap?: boolean;
   fullWidth?: boolean;
@@ -42,11 +42,11 @@ interface EuiInputPopoverProps
   onPanelResize?: (width?: number) => void;
 }
 
-type Props = CommonProps &
+export type EuiInputPopoverProps = CommonProps &
   HTMLAttributes<HTMLDivElement> &
-  EuiInputPopoverProps;
+  _EuiInputPopoverProps;
 
-export const EuiInputPopover: FunctionComponent<Props> = ({
+export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
   children,
   className,
   disableFocusTrap = false,

--- a/src/components/popover/wrapping_popover.tsx
+++ b/src/components/popover/wrapping_popover.tsx
@@ -21,7 +21,7 @@ import React, { Component } from 'react';
 import { EuiPopover, Props as EuiPopoverProps } from './popover';
 import { EuiPortal } from '../portal';
 
-interface Props extends EuiPopoverProps {
+export interface EuiWrappingPopoverProps extends EuiPopoverProps {
   button: HTMLElement;
 }
 
@@ -30,7 +30,7 @@ interface Props extends EuiPopoverProps {
  * then the button element is moved into the popover dom.
  * On unmount, the button is moved back to its original location.
  */
-export class EuiWrappingPopover extends Component<Props> {
+export class EuiWrappingPopover extends Component<EuiWrappingPopoverProps> {
   private portal: HTMLElement | null = null;
   private anchor: HTMLElement | null = null;
 

--- a/src/components/portal/index.ts
+++ b/src/components/portal/index.ts
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-export { EuiPortal } from './portal';
+export { EuiPortal, EuiPortalProps } from './portal';

--- a/src/components/portal/portal.tsx
+++ b/src/components/portal/portal.tsx
@@ -42,7 +42,7 @@ export const INSERT_POSITIONS: EuiPortalInsertPosition[] = keysOf(
 
 type EuiPortalInsertPosition = keyof typeof insertPositions;
 
-interface EuiPortalProps {
+export interface EuiPortalProps {
   /**
    * ReactNode to render as this component's content
    */

--- a/src/components/progress/index.ts
+++ b/src/components/progress/index.ts
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-export { EuiProgress } from './progress';
+export { EuiProgress, EuiProgressProps } from './progress';

--- a/src/components/resizable_container/resizable_panel.tsx
+++ b/src/components/resizable_container/resizable_panel.tsx
@@ -35,7 +35,7 @@ import { EuiPanel } from '../panel';
 import {
   PanelPaddingSize,
   panelPaddingValues,
-  PanelProps,
+  _EuiPanelProps,
 } from '../panel/panel';
 import { useEuiI18n } from '../i18n';
 import {
@@ -98,7 +98,7 @@ const paddingSizeToClassNameMap = {
   l: 'euiResizablePanel--paddingLarge',
 };
 export interface EuiResizablePanelProps
-  extends PanelProps,
+  extends _EuiPanelProps,
     CommonProps,
     Partial<EuiResizablePanelControls> {
   /**

--- a/src/components/responsive/index.ts
+++ b/src/components/responsive/index.ts
@@ -17,5 +17,5 @@
  * under the License.
  */
 
-export { EuiHideFor } from './hide_for';
-export { EuiShowFor } from './show_for';
+export { EuiHideFor, EuiHideForProps } from './hide_for';
+export { EuiShowFor, EuiShowForProps } from './show_for';

--- a/src/components/selectable/index.ts
+++ b/src/components/selectable/index.ts
@@ -20,12 +20,20 @@
 export { EuiSelectable, EuiSelectableProps } from './selectable';
 export {
   EuiSelectableList,
+  EuiSelectableListProps,
   EuiSelectableListItem,
+  EuiSelectableListItemProps,
   EuiSelectableOptionsListProps,
 } from './selectable_list';
-export { EuiSelectableMessage } from './selectable_message';
+export {
+  EuiSelectableMessage,
+  EuiSelectableMessageProps,
+} from './selectable_message';
 export { EuiSelectableOption } from './selectable_option';
-export { EuiSelectableSearch } from './selectable_search';
+export {
+  EuiSelectableSearch,
+  EuiSelectableSearchProps,
+} from './selectable_search';
 export {
   EuiSelectableTemplateSitewide,
   EuiSelectableTemplateSitewideProps,

--- a/src/components/selectable/selectable_list/index.ts
+++ b/src/components/selectable/selectable_list/index.ts
@@ -19,6 +19,10 @@
 
 export {
   EuiSelectableList,
+  EuiSelectableListProps,
   EuiSelectableOptionsListProps,
 } from './selectable_list';
-export { EuiSelectableListItem } from './selectable_list_item';
+export {
+  EuiSelectableListItem,
+  EuiSelectableListItemProps,
+} from './selectable_list_item';

--- a/src/components/selectable/selectable_message/index.ts
+++ b/src/components/selectable/selectable_message/index.ts
@@ -17,4 +17,7 @@
  * under the License.
  */
 
-export { EuiSelectableMessage } from './selectable_message';
+export {
+  EuiSelectableMessage,
+  EuiSelectableMessageProps,
+} from './selectable_message';

--- a/src/components/selectable/selectable_search/index.ts
+++ b/src/components/selectable/selectable_search/index.ts
@@ -17,4 +17,7 @@
  * under the License.
  */
 
-export { EuiSelectableSearch } from './selectable_search';
+export {
+  EuiSelectableSearch,
+  EuiSelectableSearchProps,
+} from './selectable_search';

--- a/src/components/side_nav/index.ts
+++ b/src/components/side_nav/index.ts
@@ -17,6 +17,6 @@
  * under the License.
  */
 
-export { EuiSideNav } from './side_nav';
+export { EuiSideNav, EuiSideNavProps } from './side_nav';
 
 export * from './side_nav_types';

--- a/src/components/spacer/index.ts
+++ b/src/components/spacer/index.ts
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-export { EuiSpacer } from './spacer';
+export { EuiSpacer, EuiSpacerProps } from './spacer';

--- a/src/components/stat/index.ts
+++ b/src/components/stat/index.ts
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-export { EuiStat } from './stat';
+export { EuiStat, EuiStatProps } from './stat';

--- a/src/components/table/index.ts
+++ b/src/components/table/index.ts
@@ -18,17 +18,38 @@
  */
 
 export { EuiTable, EuiTableProps } from './table';
-export { EuiTableBody } from './table_body';
+export { EuiTableBody, EuiTableBodyProps } from './table_body';
 export { EuiTableFooter } from './table_footer';
-export { EuiTableFooterCell } from './table_footer_cell';
-export { EuiTableHeader } from './table_header';
-export { EuiTableHeaderButton } from './table_header_button';
-export { EuiTableHeaderCell } from './table_header_cell';
-export { EuiTableHeaderCellCheckbox } from './table_header_cell_checkbox';
-export { EuiTablePagination } from './table_pagination';
+export {
+  EuiTableFooterCell,
+  EuiTableFooterCellProps,
+} from './table_footer_cell';
+export { EuiTableHeader, EuiTableHeaderProps } from './table_header';
+export {
+  EuiTableHeaderButton,
+  EuiTableHeaderButtonProps,
+} from './table_header_button';
+export {
+  EuiTableHeaderCell,
+  EuiTableHeaderCellProps,
+} from './table_header_cell';
+export {
+  EuiTableHeaderCellCheckbox,
+  EuiTableHeaderCellCheckboxProps,
+} from './table_header_cell_checkbox';
+export {
+  EuiTablePagination,
+  EuiTablePaginationProps,
+} from './table_pagination';
 export { EuiTableHeaderMobile } from './mobile/table_header_mobile';
-export { EuiTableSortMobile } from './mobile/table_sort_mobile';
-export { EuiTableSortMobileItem } from './mobile/table_sort_mobile_item';
-export { EuiTableRow } from './table_row';
-export { EuiTableRowCell } from './table_row_cell';
+export {
+  EuiTableSortMobile,
+  EuiTableSortMobileProps,
+} from './mobile/table_sort_mobile';
+export {
+  EuiTableSortMobileItem,
+  EuiTableSortMobileItemProps,
+} from './mobile/table_sort_mobile_item';
+export { EuiTableRow, EuiTableRowProps } from './table_row';
+export { EuiTableRowCell, EuiTableRowCellProps } from './table_row_cell';
 export { EuiTableRowCellCheckbox } from './table_row_cell_checkbox';

--- a/src/components/table/mobile/index.tsx
+++ b/src/components/table/mobile/index.tsx
@@ -19,6 +19,12 @@
 
 export { EuiTableHeaderMobile } from './table_header_mobile';
 
-export { EuiTableSortMobile } from './table_sort_mobile';
+export {
+  EuiTableSortMobile,
+  EuiTableSortMobileProps,
+} from './table_sort_mobile';
 
-export { EuiTableSortMobileItem } from './table_sort_mobile_item';
+export {
+  EuiTableSortMobileItem,
+  EuiTableSortMobileItemProps,
+} from './table_sort_mobile_item';

--- a/src/components/table/mobile/table_sort_mobile_item.tsx
+++ b/src/components/table/mobile/table_sort_mobile_item.tsx
@@ -23,7 +23,7 @@ import { CommonProps } from '../../common';
 
 import { EuiContextMenuItem } from '../../context_menu';
 
-interface Props extends CommonProps {
+export interface EuiTableSortMobileItemProps extends CommonProps {
   /**
    * Callback to know when an item has been clicked
    */
@@ -40,7 +40,7 @@ interface Props extends CommonProps {
   ariaLabel?: string;
 }
 
-export const EuiTableSortMobileItem: FunctionComponent<Props> = ({
+export const EuiTableSortMobileItem: FunctionComponent<EuiTableSortMobileItemProps> = ({
   children,
   onSort,
   isSorted,

--- a/src/components/table/table_body.tsx
+++ b/src/components/table/table_body.tsx
@@ -20,11 +20,11 @@
 import React, { FunctionComponent, Ref } from 'react';
 import { CommonProps } from '../common';
 
-type Props = CommonProps & {
+export type EuiTableBodyProps = CommonProps & {
   bodyRef?: Ref<HTMLTableSectionElement>;
 };
 
-export const EuiTableBody: FunctionComponent<Props> = ({
+export const EuiTableBody: FunctionComponent<EuiTableBodyProps> = ({
   children,
   className,
   bodyRef,

--- a/src/components/table/table_footer_cell.tsx
+++ b/src/components/table/table_footer_cell.tsx
@@ -30,13 +30,13 @@ import {
 
 import { resolveWidthAsStyle } from './utils';
 
-type Props = CommonProps &
+export type EuiTableFooterCellProps = CommonProps &
   TdHTMLAttributes<HTMLTableCellElement> & {
     align?: HorizontalAlignment;
     width?: string | number;
   };
 
-export const EuiTableFooterCell: FunctionComponent<Props> = ({
+export const EuiTableFooterCell: FunctionComponent<EuiTableFooterCellProps> = ({
   children,
   align = LEFT_ALIGNMENT,
   className,

--- a/src/components/table/table_header_button.tsx
+++ b/src/components/table/table_header_button.tsx
@@ -24,12 +24,12 @@ import { EuiInnerText } from '../inner_text';
 
 import { IconType, EuiIcon } from '../icon';
 
-type Props = CommonProps &
+export type EuiTableHeaderButtonProps = CommonProps &
   ButtonHTMLAttributes<HTMLButtonElement> & {
     iconType?: IconType;
   };
 
-export const EuiTableHeaderButton: FunctionComponent<Props> = ({
+export const EuiTableHeaderButton: FunctionComponent<EuiTableHeaderButtonProps> = ({
   children,
   className,
   iconType,

--- a/src/components/table/table_header_cell.tsx
+++ b/src/components/table/table_header_cell.tsx
@@ -40,7 +40,7 @@ import { EuiI18n } from '../i18n';
 
 export type TableHeaderCellScope = 'col' | 'row' | 'colgroup' | 'rowgroup';
 
-type Props = CommonProps &
+export type EuiTableHeaderCellProps = CommonProps &
   Omit<ThHTMLAttributes<HTMLTableHeaderCellElement>, 'align' | 'scope'> & {
     align?: HorizontalAlignment;
     /**
@@ -81,7 +81,7 @@ type Props = CommonProps &
     width?: string | number;
   };
 
-export const EuiTableHeaderCell: FunctionComponent<Props> = ({
+export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
   children,
   align = LEFT_ALIGNMENT,
   onSort,

--- a/src/components/table/table_pagination/index.ts
+++ b/src/components/table/table_pagination/index.ts
@@ -17,4 +17,7 @@
  * under the License.
  */
 
-export { EuiTablePagination } from './table_pagination';
+export {
+  EuiTablePagination,
+  EuiTablePaginationProps,
+} from './table_pagination';

--- a/src/components/table/table_pagination/table_pagination.tsx
+++ b/src/components/table/table_pagination/table_pagination.tsx
@@ -29,7 +29,7 @@ import { EuiI18n } from '../../i18n';
 export type PageChangeHandler = (pageIndex: number) => void;
 export type ItemsPerPageChangeHandler = (pageSize: number) => void;
 
-export interface Props {
+export interface EuiTablePaginationProps {
   activePage?: number;
   hidePerPageOptions?: boolean;
   itemsPerPage?: number;
@@ -47,7 +47,10 @@ interface State {
   isPopoverOpen: boolean;
 }
 
-export class EuiTablePagination extends Component<Props, State> {
+export class EuiTablePagination extends Component<
+  EuiTablePaginationProps,
+  State
+> {
   state = {
     isPopoverOpen: false,
   };

--- a/src/components/table/table_row.tsx
+++ b/src/components/table/table_row.tsx
@@ -21,7 +21,7 @@ import React, { FunctionComponent, HTMLAttributes } from 'react';
 import classNames from 'classnames';
 import { CommonProps } from '../common';
 
-interface EuiTableRowProps {
+export interface EuiTableRowProps {
   /**
    * Indicates if the table has a single column of checkboxes for selecting
    * rows (affects mobile only)

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -95,7 +95,7 @@ interface EuiTableRowCellMobileOptionsShape {
   width?: CSSProperties['width'];
 }
 
-interface EuiTableRowCellProps {
+export interface EuiTableRowCellProps {
   /**
    * Indicates if the column is dedicated to icon-only actions (currently
    * affects mobile only)

--- a/src/components/tabs/index.ts
+++ b/src/components/tabs/index.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-export { EuiTab } from './tab';
+export { EuiTab, EuiTabProps } from './tab';
 export { EuiTabs, EuiTabsProps } from './tabs';
 export {
   EuiTabbedContent,

--- a/src/components/text/index.ts
+++ b/src/components/text/index.ts
@@ -18,5 +18,5 @@
  */
 
 export { EuiText, EuiTextProps } from './text';
-export { EuiTextColor } from './text_color';
-export { EuiTextAlign } from './text_align';
+export { EuiTextColor, EuiTextColorProps } from './text_color';
+export { EuiTextAlign, EuiTextAlignProps } from './text_align';

--- a/src/components/text/text_align.tsx
+++ b/src/components/text/text_align.tsx
@@ -31,12 +31,12 @@ export type TextAlignment = keyof typeof alignmentToClassNameMap;
 
 export const ALIGNMENTS = keysOf(alignmentToClassNameMap);
 
-type Props = CommonProps &
+export type EuiTextAlignProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {
     textAlign?: TextAlignment;
   };
 
-export const EuiTextAlign: FunctionComponent<Props> = ({
+export const EuiTextAlign: FunctionComponent<EuiTextAlignProps> = ({
   children,
   className,
   textAlign = 'left',

--- a/src/components/text/text_color.tsx
+++ b/src/components/text/text_color.tsx
@@ -35,7 +35,7 @@ export type TextColor = keyof typeof colorsToClassNameMap;
 
 export const COLORS = keysOf(colorsToClassNameMap);
 
-type Props = CommonProps &
+export type EuiTextColorProps = CommonProps &
   Omit<
     HTMLAttributes<HTMLDivElement> & HTMLAttributes<HTMLSpanElement>,
     'color'
@@ -47,7 +47,7 @@ type Props = CommonProps &
     component?: 'div' | 'span';
   };
 
-export const EuiTextColor: FunctionComponent<Props> = ({
+export const EuiTextColor: FunctionComponent<EuiTextColorProps> = ({
   children,
   color = 'default',
   className,

--- a/src/components/toast/index.ts
+++ b/src/components/toast/index.ts
@@ -21,7 +21,11 @@ export { EuiToast } from './toast';
 
 export {
   EuiGlobalToastList,
+  EuiGlobalToastListProps,
   Toast as EuiGlobalToastListToast,
 } from './global_toast_list';
 
-export { EuiGlobalToastListItem } from './global_toast_list_item';
+export {
+  EuiGlobalToastListItem,
+  EuiGlobalToastListItemProps,
+} from './global_toast_list_item';

--- a/src/components/tool_tip/icon_tip.tsx
+++ b/src/components/tool_tip/icon_tip.tsx
@@ -21,7 +21,7 @@ import React, { FunctionComponent } from 'react';
 
 import { PropsOf } from '../common';
 import { EuiIcon, IconSize, IconType } from '../icon';
-import { EuiToolTip, Props as EuiToolTipProps } from './tool_tip';
+import { EuiToolTip, EuiToolTipProps } from './tool_tip';
 
 export interface EuiIconTipProps {
   /**

--- a/src/components/tool_tip/index.ts
+++ b/src/components/tool_tip/index.ts
@@ -17,10 +17,6 @@
  * under the License.
  */
 
-export {
-  EuiToolTip,
-  ToolTipPositions,
-  Props as EuiToolTipProps,
-} from './tool_tip';
+export { EuiToolTip, ToolTipPositions, EuiToolTipProps } from './tool_tip';
 
-export { EuiIconTip } from './icon_tip';
+export { EuiIconTip, EuiIconTipProps } from './icon_tip';

--- a/src/components/tool_tip/tool_tip.tsx
+++ b/src/components/tool_tip/tool_tip.tsx
@@ -80,7 +80,7 @@ const DEFAULT_TOOLTIP_STYLES: ToolTipStyles = {
   visibility: 'hidden',
 };
 
-export interface Props {
+export interface EuiToolTipProps {
   /**
    * Passes onto the the trigger.
    */
@@ -133,7 +133,7 @@ interface State {
   id: string;
 }
 
-export class EuiToolTip extends Component<Props, State> {
+export class EuiToolTip extends Component<EuiToolTipProps, State> {
   _isMounted = false;
   anchor: null | HTMLElement = null;
   popover: null | HTMLElement = null;
@@ -147,7 +147,7 @@ export class EuiToolTip extends Component<Props, State> {
     id: this.props.id || htmlIdGenerator()(),
   };
 
-  static defaultProps: Partial<Props> = {
+  static defaultProps: Partial<EuiToolTipProps> = {
     position: 'top',
     delay: 'regular',
   };
@@ -168,7 +168,7 @@ export class EuiToolTip extends Component<Props, State> {
     window.removeEventListener('mousemove', this.hasFocusMouseMoveListener);
   }
 
-  componentDidUpdate(prevProps: Props, prevState: State) {
+  componentDidUpdate(prevProps: EuiToolTipProps, prevState: State) {
     if (prevState.visible === false && this.state.visible === true) {
       requestAnimationFrame(this.testAnchor);
     }

--- a/src/components/tree_view/index.ts
+++ b/src/components/tree_view/index.ts
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-export { EuiTreeView } from './tree_view';
+export { EuiTreeView, EuiTreeViewProps } from './tree_view';


### PR DESCRIPTION
### Summary

Killed some time while waiting on my kids to come home from school. This will need discussion.

While building out doc components I ran into a couple places where the props were not properly exported. I decided to do an audit of what EUI exports and fixed the changes. I also corrected some naming inconsistencies to match our normal patterns (ex: using `_EuiSomething` for internally referenced props).

## Changes

- Props are now exported for all components down to the dist. This I believe means we can now use `import { EuiComponentNameProps } from @elastic/eui/` without reaching into source.

## Breaking changes

- Used `EuiComponentNameProps` naming schema for all exported props. In less than a dozen instances, we exported them simply as `Props`. We weren't really exporting these in a lot of cases, but I think it's worthwhile to label this as a breaking change. My guess is this will cause a minor upgrade pain in Kibana/Cloud.

### Checklist

- [ ] ~Check against **all themes** for compatibility in both light and dark mode~
- [ ] ~Checked in **mobile**~
- [ ] ~Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [ ] ~Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
