### PR TITLE
[EuiPopover] Added `will-change` via JS to help with fuzzy animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `31.7.0`.
+**Bug fixes**
+
+- Fixed blurry animation of popovers in Chrome ([#4527](https://github.com/elastic/eui/pull/4527))
 
 ## [`31.7.0`](https://github.com/elastic/eui/tree/v31.7.0)
 

--- a/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
@@ -170,7 +170,7 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
       aria-modal="true"
       class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiPopover__panel-isAttached"
       role="dialog"
-      style="top: 8px; left: 0px; z-index: 2000;"
+      style="top: 8px; left: 0px; z-index: 2000; will-change: transform, opacity;"
     >
       <div
         class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -444,7 +444,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
       aria-modal="true"
       class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiPopover__panel-isAttached"
       role="dialog"
-      style="top: 8px; left: 0px; z-index: 2000;"
+      style="top: 8px; left: 0px; z-index: 2000; will-change: transform, opacity;"
     >
       <div
         class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -605,7 +605,7 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
       aria-modal="true"
       class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiPopover__panel-isAttached"
       role="dialog"
-      style="top: 8px; left: 0px; z-index: 2000;"
+      style="top: 8px; left: 0px; z-index: 2000; will-change: transform, opacity;"
     >
       <div
         class="euiPopover__panelArrow euiPopover__panelArrow--bottom"

--- a/src/components/popover/__snapshots__/popover.test.tsx.snap
+++ b/src/components/popover/__snapshots__/popover.test.tsx.snap
@@ -108,7 +108,7 @@ exports[`EuiPopover props arrowChildren is rendered 1`] = `
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
         role="dialog"
-        style="top: 16px; left: -22px; z-index: 2000;"
+        style="top: 16px; left: -22px; z-index: 2000; will-change: transform, opacity;"
       >
         <div
           class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -157,7 +157,7 @@ exports[`EuiPopover props buffer 1`] = `
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
         role="dialog"
-        style="top: 16px; left: -22px; z-index: 2000;"
+        style="top: 16px; left: -22px; z-index: 2000; will-change: transform, opacity;"
       >
         <div
           class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -204,7 +204,7 @@ exports[`EuiPopover props buffer for all sides 1`] = `
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
         role="dialog"
-        style="top: 16px; left: -22px; z-index: 2000;"
+        style="top: 16px; left: -22px; z-index: 2000; will-change: transform, opacity;"
       >
         <div
           class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -277,7 +277,7 @@ exports[`EuiPopover props isOpen renders true 1`] = `
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
         role="dialog"
-        style="top: 16px; left: -22px; z-index: 2000;"
+        style="top: 16px; left: -22px; z-index: 2000; will-change: transform, opacity;"
       >
         <div
           class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -325,7 +325,7 @@ exports[`EuiPopover props offset with arrow 1`] = `
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
         role="dialog"
-        style="top: 26px; left: -22px; z-index: 2000;"
+        style="top: 26px; left: -22px; z-index: 2000; will-change: transform, opacity;"
       >
         <div
           class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -373,7 +373,7 @@ exports[`EuiPopover props offset without arrow 1`] = `
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen euiPopover__panel-noArrow"
         role="dialog"
-        style="top: 18px; left: -22px; z-index: 2000;"
+        style="top: 18px; left: -22px; z-index: 2000; will-change: transform, opacity;"
       >
         <div
           class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -419,7 +419,7 @@ exports[`EuiPopover props ownFocus defaults to false 1`] = `
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
         role="dialog"
-        style="top: 16px; left: -22px; z-index: 2000;"
+        style="top: 16px; left: -22px; z-index: 2000; will-change: transform, opacity;"
       >
         <div
           class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -468,7 +468,7 @@ exports[`EuiPopover props ownFocus renders true 1`] = `
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
         data-autofocus="true"
         role="dialog"
-        style="top: 16px; left: -22px; z-index: 2000;"
+        style="top: 16px; left: -22px; z-index: 2000; will-change: transform, opacity;"
         tabindex="0"
       >
         <div
@@ -522,7 +522,7 @@ exports[`EuiPopover props panelClassName is rendered 1`] = `
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen test"
         role="dialog"
-        style="top: 16px; left: -22px; z-index: 2000;"
+        style="top: 16px; left: -22px; z-index: 2000; will-change: transform, opacity;"
       >
         <div
           class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -569,7 +569,7 @@ exports[`EuiPopover props panelPaddingSize is rendered 1`] = `
         aria-modal="true"
         class="euiPanel euiPanel--paddingSmall euiPanel--borderRadiusMedium euiPanel--plain euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
         role="dialog"
-        style="top: 16px; left: -22px; z-index: 2000;"
+        style="top: 16px; left: -22px; z-index: 2000; will-change: transform, opacity;"
       >
         <div
           class="euiPopover__panelArrow euiPopover__panelArrow--bottom"

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -599,6 +599,7 @@ export class EuiPopover extends Component<Props, State> {
           ? anchorBoundingBox.left
           : left,
       zIndex,
+      willChange: 'transform, opacity',
     };
 
     const willRenderArrow = !this.props.attachToAnchor && this.props.hasArrow;

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -599,6 +599,7 @@ export class EuiPopover extends Component<Props, State> {
           ? anchorBoundingBox.left
           : left,
       zIndex,
+      // Adding `will-change` to reduce risk of a blurry animation in Chrome 86+
       willChange: 'transform, opacity',
     };
 


### PR DESCRIPTION
### Fixes #4521 

According to these two links:

- https://developers.google.com/web/fundamentals/design-and-ux/animations/animations-and-performance
- https://developer.mozilla.org/en-US/docs/Web/CSS/will-change

The best way to enhance animations in the browser is with `will-change` but adding this statically to class in CSS is costly so it's best to add it via JS only on instantiation. Luckily, we already were applying a `style` prop to the EuiPopover panel only when mounted so it was an obvious place to add this property.

**before**

https://user-images.githubusercontent.com/549577/108101213-eb2b9d80-7054-11eb-8e91-2ab9e052ca40.mp4




**after**

https://user-images.githubusercontent.com/549577/108101230-ef57bb00-7054-11eb-92ca-73fe94d78320.mp4




### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
