### PR TITLE
Fixed disabled text styles in Safari (and iOS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed override possibility of text `color` in `EuiSideNavItem` ([#4488](https://github.com/elastic/eui/pull/4488))
 - Fixed blurry animation of popovers in Chrome ([#4527](https://github.com/elastic/eui/pull/4527))
 - Fixed styles of `disabled` times in `EuiDatePicker` ([#4524](https://github.com/elastic/eui/pull/4524))
+- Fixed `disabled` text color form fields in Safari ([#4538](https://github.com/elastic/eui/pull/4538))
 
 **Theme: Amsterdam**
 

--- a/src/global_styling/mixins/_form.scss
+++ b/src/global_styling/mixins/_form.scss
@@ -195,8 +195,10 @@
 }
 
 @mixin euiFormControlDisabledStyle {
+  // sass-lint:disable-block no-vendor-prefixes
   cursor: not-allowed;
   color: $euiFormControlDisabledColor;
+  -webkit-text-fill-color: $euiFormControlDisabledColor; // Required for Safari
   background: $euiFormBackgroundDisabledColor;
   box-shadow: inset 0 0 0 1px $euiFormBorderDisabledColor;
 

--- a/src/global_styling/reset/_reset.scss
+++ b/src/global_styling/reset/_reset.scss
@@ -104,6 +104,10 @@ a:hover, button, [role='button'] {
 input {
   margin: 0;
   padding: 0;
+
+  &:disabled {
+    opacity: 1; /* required on iOS */
+  }
 }
 
 button {

--- a/src/themes/eui-amsterdam/global_styling/reset/_reset.scss
+++ b/src/themes/eui-amsterdam/global_styling/reset/_reset.scss
@@ -110,6 +110,10 @@ a:hover, button, [role='button'] {
 input {
   margin: 0;
   padding: 0;
+
+  &:disabled {
+    opacity: 1; /* required on iOS */
+  }
 }
 
 button {


### PR DESCRIPTION
@gjones Brought to our attention that the text of filled, disabled inputs on Safari did not have proper contrast. Apparently, in Safari, there is a special `-webkit-` prefix for applying `color` to disabled text of inputs. ☹️ 

So based on [this SO](https://stackoverflow.com/questions/262158/disabled-input-text-color), I've forced `opacity` (for iOS) in the reset files, then applied the disabled text `color` in the Sass mixin to the `-webkit-` prefix.

**Before**
![Screen Recording 2021-02-17 at 04 54 57 PM](https://user-images.githubusercontent.com/549577/108274755-53f14380-7143-11eb-91fb-e6feb9197c66.gif)



**After**
![Screen Recording 2021-02-17 at 04 52 20 PM](https://user-images.githubusercontent.com/549577/108274769-581d6100-7143-11eb-9aea-c4e5cd266080.gif)



### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
