### PR TITLE
Revert grid background color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added exports for all EUI component props matching `EuiComponentProps` name pattern. ([#4517](https://github.com/elastic/eui/pull/4517))
 - Added `truncate`, `disabled`, and `emphasize` props to `EuiSideNavItem` ([#4488](https://github.com/elastic/eui/pull/4488))
 - Added `truncate` prop to `EuiSideNav` ([#4488](https://github.com/elastic/eui/pull/4488))
+- Reverted part of [#4509](https://github.com/elastic/eui/pull/4509) and returned `EuiDataGrid`'s background content area to an empty shade ([#4542](https://github.com/elastic/eui/pull/4542))
 
 **Bug fixes**
 

--- a/src/components/datagrid/_data_grid.scss
+++ b/src/components/datagrid/_data_grid.scss
@@ -33,7 +33,7 @@
   max-width: 100%;
   width: 100%;
   z-index: 2; // Sits above the pagination below it, but below the controls above it
-  background: $euiColorLightestShade;
+  background: $euiColorEmptyShade;
 }
 
 .euiDataGrid__controls {


### PR DESCRIPTION
### Summary

This reverts the background color of the data grid content. Although the light gray works well for loading states, it isn't a good experience for fixed height grids with a low amount of items. We'll solve the loading issue in a better way in 7.13. I'm leaving the scrollbar mixin as is because I think it will be useful in other spots. 

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [ ] ~Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- [ ] ~Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [ ] ~Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
