### PR TITLE
some i18n tokens missing in the docs

### DIFF
--- a/scripts/babel/fetch-i18n-strings.js
+++ b/scripts/babel/fetch-i18n-strings.js
@@ -23,6 +23,21 @@ function handleHookPath(path) {
 
   const arguments = path.node.arguments;
 
+  if (arguments[0].type === 'ArrayExpression' && arguments[1].type === 'ArrayExpression') {
+    const tokens = arguments[0].elements.map(({value}) => value);
+    const defaults = arguments[1].elements.map(({value}) => value);
+    const highlighting = 'string';
+    tokens.forEach((token, i) => {
+      symbols.push({
+        token,
+        defString: defaults[i],
+        highlighting,
+        loc: path.node.loc,
+      });
+    })
+    return symbols
+  }
+
   if (arguments[0].type !== 'StringLiteral') return symbols;
 
   const token = arguments[0].value;
@@ -78,6 +93,27 @@ function handleJSXPath(path) {
       highlighting,
       loc: path.node.loc
     });
+  } else if (attributes.hasOwnProperty('tokens') && attributes.hasOwnProperty('defaults')) {
+    const tokensNode = attributes.tokens;
+    const defsStringNode = attributes.defaults;
+    const tokensString = getCodeForExpression(tokensNode.expression);
+    const defsString = getCodeForExpression(defsStringNode.expression);
+    const highlighting = 'string';
+    try {
+      const tokens = eval(tokensString);
+      const defs = eval(defsString);
+      tokens.forEach((token, i) => {
+        symbols.push({
+          token: token,
+          defString: defs[i],
+          highlighting,
+          loc: path.node.loc
+        });
+      });
+    } catch (e) {
+      console.error(`Unable to parse JSX expression tokens:\n${tokensString}\ndefaults:\n${defsString}\n`);
+      process.exit(1);
+    }
   }
 
   return symbols;

--- a/scripts/babel/fetch-i18n-strings.js
+++ b/scripts/babel/fetch-i18n-strings.js
@@ -34,8 +34,8 @@ function handleHookPath(path) {
         highlighting,
         loc: path.node.loc,
       });
-    })
-    return symbols
+    });
+    return symbols;
   }
 
   if (arguments[0].type !== 'StringLiteral') return symbols;


### PR DESCRIPTION
### Summary
due to the script did not support i18n multi-value lookup feature, some i18n token missing in the docs, 
e.g. `euiColorPicker.openLabel`

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
