### PR TITLE
Remove type exports from index.js

### DIFF
--- a/src/components/color_picker/color_stops/index.ts
+++ b/src/components/color_picker/color_stops/index.ts
@@ -17,5 +17,5 @@
  * under the License.
  */
 
-export { EuiColorStops, EuiColorStopsProps } from './color_stops';
+export { EuiColorStops } from './color_stops';
 export { ColorStop } from './color_stop_thumb';

--- a/src/components/color_picker/index.ts
+++ b/src/components/color_picker/index.ts
@@ -24,7 +24,11 @@ export {
 } from './color_picker_swatch';
 export { EuiHue, EuiHueProps } from './hue';
 export { EuiSaturation, EuiSaturationProps } from './saturation';
-export { EuiColorStops, EuiColorStopsProps } from './color_stops';
+export { EuiColorStops } from './color_stops';
+// TODO: Exporting `EuiColorStopsProps` from `'./color_stops'`
+// results in a duplicate d.ts entry that causes build warnings
+// and potential downstream TS project failures.
+export { EuiColorStopsProps } from './color_stops/color_stops';
 export {
   EuiColorPalettePicker,
   EuiColorPalettePickerProps,

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -31,101 +31,62 @@ export {
 
 export {
   EuiBadge,
-  EuiBadgeGroup,
-  EuiBadgeProps,
   EuiBetaBadge,
-  EuiBetaBadgeProps,
   EuiNotificationBadge,
-  EuiNotificationBadgeProps,
+  EuiBadgeGroup,
 } from './badge';
 
-export { EuiBeacon, EuiBeaconProps } from './beacon';
+export { EuiBeacon } from './beacon';
 
-export { EuiBottomBar, EuiBottomBarProps } from './bottom_bar';
+export { EuiBottomBar } from './bottom_bar';
 
-export { EuiBreadcrumbs, EuiBreadcrumbsProps } from './breadcrumbs';
+export { EuiBreadcrumbs } from './breadcrumbs';
 
 export {
   EuiButton,
-  EuiButtonProps,
   EuiButtonEmpty,
-  EuiButtonEmptyProps,
   EuiButtonIcon,
-  EuiButtonIconProps,
   EuiButtonGroup,
-  EuiButtonGroupProps,
 } from './button';
 
-export { EuiCallOut, EuiCallOutProps } from './call_out';
+export { EuiCallOut } from './call_out';
 
-export {
-  EuiCard,
-  EuiCardProps,
-  EuiCheckableCard,
-  EuiCheckableCardProps,
-} from './card';
+export { EuiCard, EuiCheckableCard } from './card';
 
-export {
-  EuiCode,
-  EuiCodeProps,
-  EuiCodeBlock,
-  EuiCodeBlockProps,
-  EuiCodeBlockImpl,
-} from './code';
+export { EuiCode, EuiCodeBlock, EuiCodeBlockImpl } from './code';
 
-export { EuiCodeEditor, EuiCodeEditorProps } from './code_editor';
+export { EuiCodeEditor } from './code_editor';
 
-export {
-  EuiCollapsibleNav,
-  EuiCollapsibleNavProps,
-  EuiCollapsibleNavGroup,
-  EuiCollapsibleNavGroupProps,
-} from './collapsible_nav';
+export { EuiCollapsibleNav, EuiCollapsibleNavGroup } from './collapsible_nav';
 
 export {
   EuiColorPalettePicker,
-  EuiColorPalettePickerProps,
   EuiColorPaletteDisplay,
-  EuiColorPaletteDisplayProps,
   EuiColorPicker,
-  EuiColorPickerProps,
   EuiColorPickerSwatch,
-  EuiColorPickerSwatchProps,
   EuiColorStops,
-  EuiColorStopsProps,
   EuiHue,
-  EuiHueProps,
   EuiSaturation,
-  EuiSaturationProps,
 } from './color_picker';
 
-export { EuiComboBox, EuiComboBoxProps } from './combo_box';
+export { EuiComboBox } from './combo_box';
 
-export {
-  EuiComment,
-  EuiCommentProps,
-  EuiCommentList,
-  EuiCommentListProps,
-} from './comment_list';
+export { EuiComment, EuiCommentList } from './comment_list';
 
 export { EuiContext, EuiI18nConsumer } from './context';
 
 export {
   EuiContextMenu,
-  EuiContextMenuProps,
   EuiContextMenuPanel,
-  EuiContextMenuPanelProps,
   EuiContextMenuItem,
-  EuiContextMenuItemProps,
 } from './context_menu';
 
-export { EuiControlBar, EuiControlBarProps } from './control_bar';
+export { EuiControlBar } from './control_bar';
 
-export { EuiCopy, EuiCopyProps } from './copy';
+export { EuiCopy } from './copy';
 
 export {
   EuiDataGrid,
-  EuiDataGridProps,
   useDataGridColumnSelector,
   useDataGridColumnSorting,
   useDataGridStyleSelector,
@@ -133,222 +94,134 @@ export {
 
 export {
   EuiDatePicker,
-  EuiDatePickerProps,
   EuiDatePickerRange,
-  EuiDatePickerRangeProps,
   EuiSuperDatePicker,
-  EuiSuperDatePickerProps,
   EuiSuperUpdateButton,
-  EuiSuperUpdateButtonProps,
   prettyDuration,
   commonDurationRanges,
 } from './date_picker';
 
-export { EuiDelayHide, EuiDelayHideProps } from './delay_hide';
-export { EuiDelayRender, EuiDelayRenderProps } from './delay_render';
+export { EuiDelayHide } from './delay_hide';
+export { EuiDelayRender } from './delay_render';
 
 export {
   EuiDescriptionList,
-  EuiDescriptionListProps,
   EuiDescriptionListTitle,
   EuiDescriptionListDescription,
 } from './description_list';
 
 export {
   EuiDragDropContext,
-  EuiDragDropContextProps,
   EuiDraggable,
-  EuiDraggableProps,
   EuiDroppable,
-  EuiDroppableProps,
   euiDragDropCopy,
   euiDragDropMove,
   euiDragDropReorder,
 } from './drag_and_drop';
 
-export { EuiEmptyPrompt, EuiEmptyPromptProps } from './empty_prompt';
+export { EuiEmptyPrompt } from './empty_prompt';
 
-export { EuiErrorBoundary, EuiErrorBoundaryProps } from './error_boundary';
+export { EuiErrorBoundary } from './error_boundary';
 
-export { EuiExpression, EuiExpressionProps } from './expression';
+export { EuiExpression } from './expression';
 
 export {
   EuiFilterButton,
-  EuiFilterButtonProps,
   EuiFilterGroup,
-  EuiFilterGroupProps,
   EuiFilterSelectItem,
-  EuiFilterSelectItemProps,
 } from './filter_group';
 
-export {
-  EuiFacetButton,
-  EuiFacetButtonProps,
-  EuiFacetGroup,
-  EuiFacetGroupProps,
-} from './facet';
+export { EuiFacetButton, EuiFacetGroup } from './facet';
 
-export {
-  EuiFlexGroup,
-  EuiFlexGroupProps,
-  EuiFlexGrid,
-  EuiFlexGridProps,
-  EuiFlexItem,
-  EuiFlexItemProps,
-} from './flex';
+export { EuiFlexGroup, EuiFlexGrid, EuiFlexItem } from './flex';
 
 export {
   EuiFlyout,
-  EuiFlyoutProps,
   EuiFlyoutBody,
-  EuiFlyoutBodyProps,
   EuiFlyoutFooter,
-  EuiFlyoutFooterProps,
   EuiFlyoutHeader,
-  EuiFlyoutHeaderProps,
 } from './flyout';
 
-export { EuiFocusTrap, EuiFocusTrapProps } from './focus_trap';
+export { EuiFocusTrap } from './focus_trap';
 
 export {
   EuiCheckbox,
-  EuiCheckboxProps,
   EuiCheckboxGroup,
-  EuiCheckboxGroupProps,
   EuiDescribedFormGroup,
-  EuiDescribedFormGroupProps,
   EuiDualRange,
-  EuiDualRangeProps,
   EuiFieldNumber,
-  EuiFieldNumberProps,
   EuiFieldPassword,
-  EuiFieldPasswordProps,
   EuiFieldSearch,
-  EuiFieldSearchProps,
   EuiFieldText,
-  EuiFieldTextProps,
   EuiFilePicker,
-  EuiFilePickerProps,
   EuiForm,
-  EuiFormProps,
   EuiFormControlLayout,
-  EuiFormControlLayoutProps,
   EuiFormControlLayoutDelimited,
-  EuiFormControlLayoutDelimitedProps,
   EuiFormErrorText,
-  EuiFormErrorTextProps,
   EuiFormFieldset,
-  EuiFormFieldsetProps,
   EuiFormHelpText,
-  EuiFormHelpTextProps,
   EuiFormLabel,
-  EuiFormLabelProps,
   EuiFormLegend,
-  EuiFormLegendProps,
   EuiFormRow,
-  EuiFormRowProps,
   EuiRadio,
-  EuiRadioProps,
   EuiRadioGroup,
-  EuiRadioGroupProps,
   EuiRange,
-  EuiRangeProps,
   EuiSelect,
-  EuiSelectProps,
   EuiSuperSelect,
-  EuiSuperSelectProps,
   EuiSuperSelectControl,
-  EuiSuperSelectControlProps,
   EuiSwitch,
-  EuiSwitchProps,
   EuiTextArea,
-  EuiTextAreaProps,
   EuiValidatableControl,
-  EuiValidatableControlProps,
 } from './form';
 
 export {
   EuiHeader,
-  EuiHeaderProps,
   EuiHeaderAlert,
-  EuiHeaderAlertProps,
   EuiHeaderBreadcrumbs,
   EuiHeaderLink,
-  EuiHeaderLinkProps,
   EuiHeaderLinks,
-  EuiHeaderLinksProps,
   EuiHeaderLogo,
-  EuiHeaderLogoProps,
   EuiHeaderSection,
-  EuiHeaderSectionProps,
   EuiHeaderSectionItem,
-  EuiHeaderSectionItemProps,
   EuiHeaderSectionItemButton,
-  EuiHeaderSectionItemButtonProps,
 } from './header';
 
-export { EuiHealth, EuiHealthProps } from './health';
+export { EuiHealth } from './health';
 
-export { EuiHighlight, EuiHighlightProps } from './highlight';
+export { EuiHighlight } from './highlight';
 
-export { EuiHorizontalRule, EuiHorizontalRuleProps } from './horizontal_rule';
+export { EuiHorizontalRule } from './horizontal_rule';
 
-export { ICON_TYPES, EuiIcon, EuiIconProps } from './icon';
+export { ICON_TYPES, EuiIcon } from './icon';
 
-export { EuiImage, EuiImageProps } from './image';
+export { EuiImage } from './image';
 
-export {
-  useInnerText,
-  EuiInnerText,
-  EuiInnerTextProps,
-  useRenderToText,
-} from './inner_text';
+export { useInnerText, EuiInnerText, useRenderToText } from './inner_text';
 
-export {
-  EuiI18n,
-  EuiI18nProps,
-  EuiI18nNumber,
-  EuiI18nNumberProps,
-  useEuiI18n,
-} from './i18n';
+export { EuiI18n, EuiI18nNumber, useEuiI18n } from './i18n';
 
 export {
   EuiLoadingKibana,
-  EuiLoadingKibanaProps,
   EuiLoadingElastic,
-  EuiLoadingElasticProps,
   EuiLoadingChart,
-  EuiLoadingChartProps,
   EuiLoadingContent,
-  EuiLoadingContentProps,
   EuiLoadingSpinner,
-  EuiLoadingSpinnerProps,
 } from './loading';
 
-export {
-  EuiKeyPadMenu,
-  EuiKeyPadMenuProps,
-  EuiKeyPadMenuItem,
-  EuiKeyPadMenuItemProps,
-} from './key_pad_menu';
+export { EuiKeyPadMenu, EuiKeyPadMenuItem } from './key_pad_menu';
 
-export { EuiLink, EuiLinkProps } from './link';
+export { EuiLink } from './link';
 
 export {
   EuiListGroup,
-  EuiListGroupProps,
   EuiListGroupItem,
-  EuiListGroupItemProps,
   EuiPinnableListGroup,
-  EuiPinnableListGroupProps,
 } from './list_group';
 
 export {
   EuiMarkdownEditor,
-  EuiMarkdownEditorProps,
   EuiMarkdownContext,
   EuiMarkdownFormat,
-  EuiMarkdownFormatProps,
   getDefaultEuiMarkdownParsingPlugins,
   getDefaultEuiMarkdownProcessingPlugins,
   getDefaultEuiMarkdownUiPlugins,
@@ -359,217 +232,113 @@ export {
   EUI_MODAL_CANCEL_BUTTON,
   EUI_MODAL_CONFIRM_BUTTON,
   EuiConfirmModal,
-  EuiConfirmModalProps,
   EuiModal,
-  EuiModalProps,
   EuiModalBody,
-  EuiModalBodyProps,
   EuiModalFooter,
-  EuiModalFooterProps,
   EuiModalHeader,
-  EuiModalHeaderProps,
   EuiModalHeaderTitle,
-  EuiModalHeaderTitleProps,
 } from './modal';
 
-export {
-  EuiMutationObserver,
-  EuiMutationObserverProps,
-} from './observer/mutation_observer';
+export { EuiMutationObserver } from './observer/mutation_observer';
 
-export {
-  EuiOutsideClickDetector,
-  EuiOutsideClickDetectorProps,
-} from './outside_click_detector';
+export { EuiOutsideClickDetector } from './outside_click_detector';
 
-export { EuiOverlayMask, EuiOverlayMaskProps } from './overlay_mask';
+export { EuiOverlayMask } from './overlay_mask';
 
 export {
   EuiPage,
-  EuiPageProps,
   EuiPageBody,
-  EuiPageBodyProps,
   EuiPageContent,
-  EuiPageContentProps,
   EuiPageContentBody,
-  EuiPageContentBodyProps,
   EuiPageContentHeader,
-  EuiPageContentHeaderProps,
   EuiPageContentHeaderSection,
-  EuiPageContentHeaderSectionProps,
   EuiPageHeader,
-  EuiPageHeaderProps,
   EuiPageHeaderContent,
-  EuiPageHeaderContentProps,
   EuiPageHeaderSection,
-  EuiPageHeaderSectionProps,
   EuiPageSideBar,
-  EuiPageSideBarProps,
 } from './page';
 
-export {
-  EuiPagination,
-  EuiPaginationProps,
-  EuiPaginationButton,
-  EuiPaginationButtonProps,
-} from './pagination';
+export { EuiPagination, EuiPaginationButton } from './pagination';
 
-export { EuiPanel, EuiPanelProps } from './panel';
+export { EuiPanel } from './panel';
 
 export {
   EuiInputPopover,
-  EuiInputPopoverProps,
   EuiPopover,
-  EuiPopoverProps,
   EuiPopoverTitle,
-  EuiPopoverTitleProps,
   EuiPopoverFooter,
-  EuiPopoverFooterProps,
   EuiWrappingPopover,
-  EuiWrappingPopoverProps,
 } from './popover';
 
-export { EuiPortal, EuiPortalProps } from './portal';
+export { EuiPortal } from './portal';
 
-export { EuiProgress, EuiProgressProps } from './progress';
+export { EuiProgress } from './progress';
 
-export { EuiTreeView, EuiTreeViewProps } from './tree_view';
+export { EuiTreeView } from './tree_view';
 
 export {
   EuiResizeObserver,
-  EuiResizeObserverProps,
   useResizeObserver,
 } from './observer/resize_observer';
 
-export { EuiSearchBar, EuiSearchBarProps, Query, Ast } from './search_bar';
+export { EuiSearchBar, Query, Ast } from './search_bar';
 
 export {
   EuiSelectable,
-  EuiSelectableProps,
   EuiSelectableList,
-  EuiSelectableListProps,
   EuiSelectableListItem,
-  EuiSelectableListItemProps,
   EuiSelectableMessage,
-  EuiSelectableMessageProps,
   EuiSelectableSearch,
-  EuiSelectableSearchProps,
   EuiSelectableTemplateSitewide,
-  EuiSelectableTemplateSitewideProps,
   euiSelectableTemplateSitewideRenderOptions,
 } from './selectable';
 
 export { EuiSideNav, EuiSideNavProps } from './side_nav';
 
-export { EuiSpacer, EuiSpacerProps } from './spacer';
+export { EuiSpacer } from './spacer';
 
-export { EuiStat, EuiStatProps } from './stat';
+export { EuiStat } from './stat';
 
-export {
-  EuiStep,
-  EuiStepProps,
-  EuiSteps,
-  EuiStepsProps,
-  EuiSubSteps,
-  EuiSubStepsProps,
-  EuiStepsHorizontal,
-  EuiStepsHorizontalProps,
-} from './steps';
+export { EuiStep, EuiSteps, EuiSubSteps, EuiStepsHorizontal } from './steps';
 
 export { EuiSuggestInput, EuiSuggestItem, EuiSuggest } from './suggest';
 
 export {
   EuiTable,
-  EuiTableProps,
   EuiTableBody,
-  EuiTableBodyProps,
   EuiTableFooter,
   EuiTableFooterCell,
-  EuiTableFooterCellProps,
   EuiTableHeader,
-  EuiTableHeaderProps,
   EuiTableHeaderButton,
-  EuiTableHeaderButtonProps,
   EuiTableHeaderCell,
-  EuiTableHeaderCellProps,
   EuiTableHeaderCellCheckbox,
-  EuiTableHeaderCellCheckboxProps,
   EuiTablePagination,
-  EuiTablePaginationProps,
   EuiTableRow,
-  EuiTableRowProps,
   EuiTableRowCell,
-  EuiTableRowCellProps,
   EuiTableRowCellCheckbox,
   EuiTableHeaderMobile,
   EuiTableSortMobile,
-  EuiTableSortMobileProps,
   EuiTableSortMobileItem,
-  EuiTableSortMobileItemProps,
 } from './table';
 
-export { EuiToken, EuiTokenProps } from './token';
+export { EuiToken } from './token';
 
-export {
-  EuiTour,
-  EuiTourProps,
-  EuiTourStep,
-  EuiTourStepProps,
-  useEuiTour,
-} from './tour';
+export { EuiTour, EuiTourStep, useEuiTour } from './tour';
 
-export {
-  EuiBasicTable,
-  EuiBasicTableProps,
-  EuiInMemoryTable,
-  EuiInMemoryTableProps,
-} from './basic_table';
+export { EuiBasicTable, EuiInMemoryTable } from './basic_table';
 
-export {
-  EuiTab,
-  EuiTabProps,
-  EuiTabs,
-  EuiTabsProps,
-  EuiTabbedContent,
-  EuiTabbedContentProps,
-} from './tabs';
+export { EuiTab, EuiTabs, EuiTabbedContent } from './tabs';
 
-export {
-  EuiText,
-  EuiTextProps,
-  EuiTextColor,
-  EuiTextColorProps,
-  EuiTextAlign,
-  EuiTextAlignProps,
-} from './text';
+export { EuiText, EuiTextColor, EuiTextAlign } from './text';
 
 export { useEuiTextDiff } from './text_diff';
 
-export { EuiTitle, EuiTitleProps } from './title';
+export { EuiTitle } from './title';
 
-export {
-  EuiGlobalToastList,
-  EuiGlobalToastListProps,
-  EuiGlobalToastListItem,
-  EuiGlobalToastListItemProps,
-  EuiToast,
-} from './toast';
+export { EuiGlobalToastList, EuiGlobalToastListItem, EuiToast } from './toast';
 
-export {
-  EuiIconTip,
-  EuiIconTipProps,
-  EuiToolTip,
-  EuiToolTipProps,
-} from './tool_tip';
+export { EuiIconTip, EuiToolTip } from './tool_tip';
 
-export {
-  EuiHideFor,
-  EuiHideForProps,
-  EuiShowFor,
-  EuiShowForProps,
-} from './responsive';
+export { EuiHideFor, EuiShowFor } from './responsive';
 
-export {
-  EuiResizableContainer,
-  EuiResizableContainerProps,
-} from './resizable_container';
+export { EuiResizableContainer } from './resizable_container';


### PR DESCRIPTION
### Summary

Rolling back `index.js` to just before #4517 merged.

A build should not have any output in the form of:

```
WARNING in ./components/color_picker/index.ts 23:0-66
"export 'EuiColorStopsProps' was not found in './color_stops'
 @ ./components/index.js
 @ ./index.js
 ```

~### Checklist~
