### PR TITLE
[EuiSelectable] Removed Home and End Key configured behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 **Bug fixes**
 
+- Removed home and end key configured behavior from `EuiSelectable` ([#4560](https://github.com/elastic/eui/pull/4560))
 - Fixed nested indicator of last `EuiSideNav` item ([#4488](https://github.com/elastic/eui/pull/4488))
 - Fixed override possibility of text `color` in `EuiSideNavItem` ([#4488](https://github.com/elastic/eui/pull/4488))
 - Fixed blurry animation of popovers in Chrome ([#4527](https://github.com/elastic/eui/pull/4527))

--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -269,20 +269,6 @@ export class EuiSelectable<T = {}> extends Component<
         }
         break;
 
-      case keys.HOME:
-        event.preventDefault();
-        event.stopPropagation();
-        this.setState({ activeOptionIndex: 0 });
-        break;
-
-      case keys.END:
-        event.preventDefault();
-        event.stopPropagation();
-        this.setState({
-          activeOptionIndex: this.state.visibleOptions.length - 1,
-        });
-        break;
-
       default:
         this.setState({ activeOptionIndex: undefined }, this.onFocus);
         break;


### PR DESCRIPTION
### Summary

This PR Fixes:  #4553 

 Removed Home and End Key configured behavior of moving focus to first and last option of the list.

## Before

Pressing `HOME` key moves focus to first Element of the list and pressing `END` key moves focus to the last ELement of the list.

![ezgif-2-e6935b8e46e5](https://user-images.githubusercontent.com/55311336/108593682-30c0d100-739b-11eb-898c-5b3b6aff4ea8.gif)

## After

Pressing `HOME` key places the cursor on the first character and pressing `END` key places the cursor after the last character.

![ezgif-2-7e8ca2a74c1e](https://user-images.githubusercontent.com/55311336/108593655-0cfd8b00-739b-11eb-9040-8a453264c30a.gif)

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Edge**, and **Firefox**
~~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~~
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
~~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~~
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
~~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~~
