### PR TITLE
Limit dev-server watched files to only TS/TSX

### DIFF
--- a/scripts/babel/react-docgen-typescript.js
+++ b/scripts/babel/react-docgen-typescript.js
@@ -19,7 +19,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 const gc = require('expose-gc/function');
-const fs = require('fs');
 const propsParser = require('react-docgen-typescript');
 const template = require('@babel/template');
 const ts = require('typescript');
@@ -50,17 +49,13 @@ function buildProgram() {
 buildProgram();
 
 if (isDevelopment) {
-  const watched = chokidar
+  chokidar
     .watch(['./src/**/*.(ts|tsx)', './src-docs/**/*.(ts|tsx)'], {
       ignoreInitial: true, // don't emit `add` event during file discovery
       ignored: ['__snapshots__', /\.test\./],
     })
     .on('add', buildProgram)
-    .on('change', buildProgram)
-    .on('ready', () => {
-      console.log(watched.getWatched());
-      fs.writeFileSync('/Users/chanderprall/projects/eui/watched', JSON.stringify(watched.getWatched(), null, 2));
-    });
+    .on('change', buildProgram);
 }
 
 module.exports = function({ types }) {

--- a/scripts/babel/react-docgen-typescript.js
+++ b/scripts/babel/react-docgen-typescript.js
@@ -19,6 +19,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 const gc = require('expose-gc/function');
+const fs = require('fs');
 const propsParser = require('react-docgen-typescript');
 const template = require('@babel/template');
 const ts = require('typescript');
@@ -49,12 +50,17 @@ function buildProgram() {
 buildProgram();
 
 if (isDevelopment) {
-  chokidar
-    .watch(['./src', './src-docs'], {
+  const watched = chokidar
+    .watch(['./src/**/*.(ts|tsx)', './src-docs/**/*.(ts|tsx)'], {
       ignoreInitial: true, // don't emit `add` event during file discovery
+      ignored: ['__snapshots__', /\.test\./],
     })
     .on('add', buildProgram)
-    .on('change', buildProgram);
+    .on('change', buildProgram)
+    .on('ready', () => {
+      console.log(watched.getWatched());
+      fs.writeFileSync('/Users/chanderprall/projects/eui/watched', JSON.stringify(watched.getWatched(), null, 2));
+    });
 }
 
 module.exports = function({ types }) {


### PR DESCRIPTION
### Summary

Should dramatically help protect against the too-many-file-watchers we see on some CI runs. Also helps reduce memory usage & speed up dev server start time. Logging the array of folders/files chokidar is watching, the line count of `JSON.stringify(chokidarWatcher.getWatched(), null, 2)` went from 4472 lines to 1013