### PR TITLE
Add Github action to check for changelog edits

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,18 @@
+name: "Changelog required"
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dangoslen/changelog-enforcer@v2
+      with:
+        changeLogPath: 'CHANGELOG.md'
+        skipLabels: 'skip-changelog'
+        missingUpdateErrorMessage: 'You need to edit the changelog.md file in this PR before it can be merged. Use the `skip-changelog` label to bypass this check.'


### PR DESCRIPTION
### Summary

This adds a Github Action based on a [published Github action](https://github.com/marketplace/actions/changelog-enforcer) that will check for an edit to `CHANGELOG.md`. It checks every time you push, similar to our other CI items. It can be skipped by using the `skip-changelog` label.

I've tested this scenario a couple times on a private repo. Yell if you want to see a demo. I thought about removing the CL checklist item, but I think it's still a good way to surface the link to the changelog.

![image](https://user-images.githubusercontent.com/324519/108911790-994ac080-75dc-11eb-9d22-4a9c6342b2e7.png)

![image](https://user-images.githubusercontent.com/324519/108911808-9e0f7480-75dc-11eb-9b56-3615c2cef41c.png)

![image](https://user-images.githubusercontent.com/324519/108911849-ab2c6380-75dc-11eb-92fb-1c9e9d7c45c4.png)


