### PR TITLE
Increase start-server-and-test timeout to address CI timeouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "start-test-server": "BABEL_MODULES=false NODE_ENV=puppeteer NODE_OPTIONS=--max-old-space-size=4096 webpack-dev-server --config src-docs/webpack.config.js --port 9999",
     "yo-component": "yo ./generator-eui/app/component.js",
     "update-token-changelog": "node ./scripts/update-token-changelog.js",
-    "start-test-server-and-a11y-test": "start-server-and-test start-test-server http-get://localhost:9999 test-a11y",
+    "start-test-server-and-a11y-test": "cross-env WAIT_ON_TIMEOUT=600000 start-server-and-test start-test-server http-get://localhost:9999 test-a11y",
     "yo-doc": "yo ./generator-eui/app/documentation.js",
     "release": "node ./scripts/release.js",
     "postinstall": "node ./scripts/postinstall.js",


### PR DESCRIPTION
### Summary

Increases `start-server-and-test`'s timeout from 5 minutes (default) to 10 minutes. This is a bandaid to help CI executions, I'm sure we can find ways to decrease build times rather than accepting the current times.

How I got here:

First thought the timeout was coming from puppeteer, and tried recreating the error by decreasing pupeeter's timeout but got a different error. Looking at the CI stacktrace closer, it appeared to be from `start-server-and-test` itself. Pulled up that docs, saw the default timeout of 5 minutes matches the time passed in CI between command & error, and successfully triggered that error locally with a timeout of 10ms.