### PR TITLE
[EuiDataGrid] Update jest environment rendering to include all cells

### DIFF
--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -1051,7 +1051,7 @@ Array [
             >
               <div
                 class="euiDataGrid__virtualized"
-                style="position:relative;height:500px;width:500px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+                style="position:relative;height:9007199254740991px;width:9007199254740991px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
               >
                 <div
                   style="height:102px;width:200px"
@@ -1386,7 +1386,7 @@ Array [
             >
               <div
                 class="euiDataGrid__virtualized"
-                style="position:relative;height:500px;width:500px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+                style="position:relative;height:9007199254740991px;width:9007199254740991px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
               >
                 <div
                   style="height:102px;width:300px"
@@ -2018,7 +2018,7 @@ Array [
             >
               <div
                 class="euiDataGrid__virtualized"
-                style="position:relative;height:500px;width:500px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+                style="position:relative;height:9007199254740991px;width:9007199254740991px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
               >
                 <div
                   style="height:102px;width:200px"
@@ -2352,7 +2352,7 @@ Array [
             >
               <div
                 class="euiDataGrid__virtualized"
-                style="position:relative;height:500px;width:500px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+                style="position:relative;height:9007199254740991px;width:9007199254740991px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
               >
                 <div
                   style="height:102px;width:200px"

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -908,6 +908,7 @@ describe('EuiDataGrid', () => {
             "euiDataGridRowCell euiDataGridRowCell--datetime",
             "euiDataGridRowCell euiDataGridRowCell--datetime",
             "euiDataGridRowCell euiDataGridRowCell--datetime",
+            "euiDataGridRowCell euiDataGridRowCell--datetime euiDataGridRowCell--lastColumn",
           ]
         `);
       });

--- a/src/components/datagrid/data_grid_body.tsx
+++ b/src/components/datagrid/data_grid_body.tsx
@@ -560,8 +560,12 @@ export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
     }
   }, [wrapperRef]);
 
-  let finalHeight = IS_JEST_ENVIRONMENT ? 500 : height || unconstrainedHeight;
-  let finalWidth = IS_JEST_ENVIRONMENT ? 500 : width || unconstrainedWidth;
+  let finalHeight = IS_JEST_ENVIRONMENT
+    ? Number.MAX_SAFE_INTEGER
+    : height || unconstrainedHeight;
+  let finalWidth = IS_JEST_ENVIRONMENT
+    ? Number.MAX_SAFE_INTEGER
+    : width || unconstrainedWidth;
   if (isFullScreen) {
     finalHeight =
       window.innerHeight - toolbarHeight - headerRowHeight - footerRowHeight;


### PR DESCRIPTION
### Summary

Closes #4514. Instead of falling back to 500x500 height/width when rendering the datagrid within Jest, now using `Number.MAX_SAFE_INTEGER`. Tried first with `Infinity` but the values are passed in a `style` object which doesn't support `Infinity`.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
