### PR TITLE
[EuiPopover] Don't apply willChange to popover after it is done opening & animating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `31.9.0`.
+**Bug fixes**
+
+- Fixed visual bug in drag&drop sections when nested in an popover ([#4590](https://github.com/elastic/eui/pull/4590))
 
 ## [`31.9.0`](https://github.com/elastic/eui/tree/v31.9.0)
 

--- a/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
@@ -170,7 +170,7 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
       aria-modal="true"
       class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiPopover__panel-isAttached"
       role="dialog"
-      style="top: 8px; left: 0px; z-index: 2000; will-change: transform, opacity;"
+      style="top: 8px; left: 0px; will-change: transform, opacity; z-index: 2000;"
     >
       <div
         class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -444,7 +444,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
       aria-modal="true"
       class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiPopover__panel-isAttached"
       role="dialog"
-      style="top: 8px; left: 0px; z-index: 2000; will-change: transform, opacity;"
+      style="top: 8px; left: 0px; will-change: transform, opacity; z-index: 2000;"
     >
       <div
         class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -605,7 +605,7 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
       aria-modal="true"
       class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--bottom euiPopover__panel-noArrow euiPopover__panel-isAttached"
       role="dialog"
-      style="top: 8px; left: 0px; z-index: 2000; will-change: transform, opacity;"
+      style="top: 8px; left: 0px; will-change: transform, opacity; z-index: 2000;"
     >
       <div
         class="euiPopover__panelArrow euiPopover__panelArrow--bottom"

--- a/src/components/popover/__snapshots__/popover.test.tsx.snap
+++ b/src/components/popover/__snapshots__/popover.test.tsx.snap
@@ -108,7 +108,7 @@ exports[`EuiPopover props arrowChildren is rendered 1`] = `
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
         role="dialog"
-        style="top: 16px; left: -22px; z-index: 2000; will-change: transform, opacity;"
+        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
       >
         <div
           class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -157,7 +157,7 @@ exports[`EuiPopover props buffer 1`] = `
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
         role="dialog"
-        style="top: 16px; left: -22px; z-index: 2000; will-change: transform, opacity;"
+        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
       >
         <div
           class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -204,7 +204,7 @@ exports[`EuiPopover props buffer for all sides 1`] = `
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
         role="dialog"
-        style="top: 16px; left: -22px; z-index: 2000; will-change: transform, opacity;"
+        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
       >
         <div
           class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -277,7 +277,7 @@ exports[`EuiPopover props isOpen renders true 1`] = `
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
         role="dialog"
-        style="top: 16px; left: -22px; z-index: 2000; will-change: transform, opacity;"
+        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
       >
         <div
           class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -325,7 +325,7 @@ exports[`EuiPopover props offset with arrow 1`] = `
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
         role="dialog"
-        style="top: 26px; left: -22px; z-index: 2000; will-change: transform, opacity;"
+        style="top: 26px; left: -22px; will-change: transform, opacity; z-index: 2000;"
       >
         <div
           class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -373,7 +373,7 @@ exports[`EuiPopover props offset without arrow 1`] = `
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen euiPopover__panel-noArrow"
         role="dialog"
-        style="top: 18px; left: -22px; z-index: 2000; will-change: transform, opacity;"
+        style="top: 18px; left: -22px; will-change: transform, opacity; z-index: 2000;"
       >
         <div
           class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -419,7 +419,7 @@ exports[`EuiPopover props ownFocus defaults to false 1`] = `
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
         role="dialog"
-        style="top: 16px; left: -22px; z-index: 2000; will-change: transform, opacity;"
+        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
       >
         <div
           class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -468,7 +468,7 @@ exports[`EuiPopover props ownFocus renders true 1`] = `
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
         data-autofocus="true"
         role="dialog"
-        style="top: 16px; left: -22px; z-index: 2000; will-change: transform, opacity;"
+        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
         tabindex="0"
       >
         <div
@@ -522,7 +522,7 @@ exports[`EuiPopover props panelClassName is rendered 1`] = `
         aria-modal="true"
         class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen test"
         role="dialog"
-        style="top: 16px; left: -22px; z-index: 2000; will-change: transform, opacity;"
+        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
       >
         <div
           class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
@@ -569,7 +569,7 @@ exports[`EuiPopover props panelPaddingSize is rendered 1`] = `
         aria-modal="true"
         class="euiPanel euiPanel--paddingSmall euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
         role="dialog"
-        style="top: 16px; left: -22px; z-index: 2000; will-change: transform, opacity;"
+        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
       >
         <div
           class="euiPopover__panelArrow euiPopover__panelArrow--bottom"

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -458,7 +458,7 @@ export class EuiPopover extends Component<Props, State> {
 
     // for each child element of `this.panel`, find any transition duration we should wait for before stabilizing
     const { durationMatch, delayMatch } = Array.prototype.slice
-      .call(this.panel ? this.panel.children : [])
+      .call(this.panel ? [this.panel, ...Array.from(this.panel.children)] : [])
       .reduce(
         ({ durationMatch, delayMatch }, element) => {
           const transitionTimings = getTransitionTimings(element);
@@ -599,8 +599,6 @@ export class EuiPopover extends Component<Props, State> {
           ? anchorBoundingBox.left
           : left,
       zIndex,
-      // Adding `will-change` to reduce risk of a blurry animation in Chrome 86+
-      willChange: 'transform, opacity',
     };
 
     const willRenderArrow = !this.props.attachToAnchor && this.props.hasArrow;
@@ -767,7 +765,13 @@ export class EuiPopover extends Component<Props, State> {
               aria-labelledby={ariaLabelledBy}
               aria-modal="true"
               aria-describedby={ariaDescribedby}
-              style={this.state.popoverStyles}>
+              style={{
+                ...this.state.popoverStyles,
+                // Adding `will-change` to reduce risk of a blurry animation in Chrome 86+
+                willChange: !this.state.isOpenStable
+                  ? 'transform, opacity'
+                  : undefined,
+              }}>
               <div className={arrowClassNames} style={this.state.arrowStyles}>
                 {arrowChildren}
               </div>


### PR DESCRIPTION
### Summary

Draft mode as I've only tested this in Chrome on Mac, but otherwise ready for review.

Fixes #4574. Caroline noticed that the `will-change` style on the popover panel broke the `display: fixed` usage by drag&drop. This update dynamically adds `will-change` only during the popover's initial open animation, removing it after any transitions/animations have finished.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
