### PR TITLE
[Docs] Removed all `isNew` declarations on components over 6 months old

### DIFF
--- a/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
@@ -32,7 +32,6 @@ const collapsibleNavAllHtml = renderToHtml(CollapsibleNavAll);
 
 export const CollapsibleNavExample = {
   title: 'Collapsible nav',
-  isNew: true,
   intro: (
     <EuiText>
       <p>

--- a/src-docs/src/views/comment/comment_example.js
+++ b/src-docs/src/views/comment/comment_example.js
@@ -67,7 +67,7 @@ const commentActionsSnippet = `<EuiComment username="janed" actions={customActio
   {body}
 </EuiComment>`;
 
-const commentListSnippet = `<EuiCommentList 
+const commentListSnippet = `<EuiCommentList
   comments={[
     {
       username: username,
@@ -80,7 +80,6 @@ const commentListSnippet = `<EuiCommentList
 
 export const CommentListExample = {
   title: 'Comment list',
-  isNew: true,
   sections: [
     {
       source: [

--- a/src-docs/src/views/elastic_charts/pie_example.js
+++ b/src-docs/src/views/elastic_charts/pie_example.js
@@ -117,7 +117,6 @@ const orderingTooltip = (
 
 export const ElasticChartsPieExample = {
   title: 'Part to whole comparisons',
-  isNew: true,
   intro: (
     <Fragment>
       <ExternalBadge />

--- a/src-docs/src/views/markdown_editor/mardown_editor_example.js
+++ b/src-docs/src/views/markdown_editor/mardown_editor_example.js
@@ -66,7 +66,6 @@ const markdownEditorHeightSnippet = [
 export const MarkdownEditorExample = {
   title: 'Markdown editor',
   beta: true,
-  isNew: true,
   intro: (
     <Fragment>
       <EuiText>

--- a/src-docs/src/views/markdown_editor/mardown_format_example.js
+++ b/src-docs/src/views/markdown_editor/mardown_format_example.js
@@ -23,7 +23,6 @@ const markdownFormatSinkHtml = renderToHtml(MarkdownFormatSink);
 export const MarkdownFormatExample = {
   title: 'Markdown format',
   beta: true,
-  isNew: true,
   intro: (
     <Fragment>
       <EuiText>

--- a/src-docs/src/views/markdown_editor/markdown_plugin_example.js
+++ b/src-docs/src/views/markdown_editor/markdown_plugin_example.js
@@ -132,7 +132,6 @@ const uiPluginConcepts = [
 export const MarkdownPluginExample = {
   title: 'Markdown plugins',
   beta: true,
-  isNew: true,
   intro: (
     <Fragment>
       <EuiText>

--- a/src-docs/src/views/resizable_container/resizable_container_example.js
+++ b/src-docs/src/views/resizable_container/resizable_container_example.js
@@ -183,7 +183,6 @@ const collapsibleExtSnippet = `<EuiResizableContainer style={{ height: '400px' }
 
 export const ResizableContainerExample = {
   title: 'Resizable container',
-  isNew: true,
   intro: (
     <EuiText>
       <p>

--- a/src-docs/src/views/text_diff/text_diff_example.js
+++ b/src-docs/src/views/text_diff/text_diff_example.js
@@ -17,7 +17,6 @@ const customComponentsHtml = renderToHtml(TextDiffCustomComponents);
 
 export const TextDiffExample = {
   title: 'Text diff',
-  isNew: true,
   sections: [
     {
       source: [

--- a/src-docs/src/views/tour/tour_example.js
+++ b/src-docs/src/views/tour/tour_example.js
@@ -53,7 +53,6 @@ const fullHtml = renderToHtml(FullScreen);
 
 export const TourExample = {
   title: 'Tour',
-  isNew: true,
   beta: true,
   intro: (
     <EuiText>


### PR DESCRIPTION
We've kept some of these **NEW** badges on a little too long so I've cleaned up the usages to remove them from any that were applied more than 6 months ago. This pretty much wiped out **all** the badges since the youngest one was 7 months old. 

**Are there any components we **missed** putting the `isNew` badge **on**?**

There's been talk about creating some automatic timer for these, but I didn't feel like going down that rabbit hole at the moment. I just wanted to clean up the usages before the next release that will contain the docs layout redesign.

### ~Checklist~