### PR TITLE
Prevent the changelog check from running on commits to master

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,7 +1,5 @@
 name: "Changelog required"
 on:
-  push:
-    branches: [ master ]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     branches: [ master ]


### PR DESCRIPTION
### Summary

I believe this will prevent the warning emails when merging PRs into `master`
