### PR TITLE
Fixed: Unable to properly highlight input text with mouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - Fixed the return type of `getDefaultEuiMarkdownUiPlugins` ([#4567](https://github.com/elastic/eui/pull/4567))
 - Fixed inverse handling of boolean sorting in `EuiDataGrid` ([#4561](https://github.com/elastic/eui/pull/4561))
+- Fixed highlighting issue if input text in `EuiComboBox`  
 
 ## Feature: EuiPageTemplate ([#4517](https://github.com/elastic/eui/pull/4517))
 

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -17,7 +17,7 @@
     @include euiFormControlStyle($includeStates: false, $includeSizes: true);
     @include euiFormControlWithIcon($isIconOptional: true);
     @include euiFormControlSize(auto, $includeAlternates: true);
-    padding: $euiSizeXS $euiSizeS;
+    padding: 0;
     display: flex; /* 1 */
     outline: none; // Fixes an intermittent focus ring in Firefox
 
@@ -34,9 +34,7 @@
     }
 
     &:not(.euiComboBox__inputWrap--noWrap) {
-      padding-top: $euiSizeXS;
-      padding-bottom: $euiSizeXS;
-      padding-left: $euiSizeXS;
+      padding: 0;
       height: auto;  /* 3 */
       flex-wrap: wrap; /* 1 */
       align-content: flex-start;
@@ -79,12 +77,12 @@
     > input {
       @include euiFont;
       appearance: none; /* 3 */
-      padding: 0;
+      padding: 4px;
       border: none;
       background: transparent;
       font-size: $euiFontSizeS;
       color: $euiTextColor;
-      margin: $euiSizeXS;
+      margin: 0;
       line-height: $euiLineHeight; /* 4 */
     }
   }


### PR DESCRIPTION
### Summary

This pr solves the issue https://github.com/elastic/eui/issues/4552

I just removed the space taken between the container div and the input tag which is been taken by the outer div by means on padding and replaced it with space of the input so that now anyone highlighting the input will be in input and not select other nodes.

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
