### PR TITLE
Don't export TS types from JS files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `31.9.0`.
+**Bug fixes**
+
+- Fixed an errant export of two non-existant values ([#4597](https://github.com/elastic/eui/pull/4564597))
 
 ## [`31.9.0`](https://github.com/elastic/eui/tree/v31.9.0)
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -256,9 +256,7 @@ export {
   EuiPageHeaderContent,
   EuiPageHeaderSection,
   EuiPageSideBar,
-  EuiPageSideBarProps,
   EuiPageTemplate,
-  EuiPageTemplateProps,
 } from './page';
 
 export { EuiPagination, EuiPaginationButton } from './pagination';


### PR DESCRIPTION
### Summary

Fixes #4595 by removing `EuiPageSideBarProps` and `EuiPageTemplateProps` exports from _src/components/index.js_ as they are TypeScript definitions and removed from the transpiled code.

I confirmed with `BABEL_MODULES=false yarn webpack --config=src/webpack.config.js` that these are the only two such exports.