### PR TITLE
[Docs] Added the ability to navigate through the docs pages using keyboard arrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ No public interface changes since `31.9.1`.
 **Bug fixes**
 
 - Fixed the ability to navigate through the docs pages using the left/right keyboard arrows ([#4600](https://github.com/elastic/eui/pull/4600))
-- Fixed an errant export of two non-existant values ([#4597](https://github.com/elastic/eui/pull/4564597))
+- Fixed an errant export of two non-existant values ([#4597](https://github.com/elastic/eui/pull/4597))
 
 ## [`31.9.0`](https://github.com/elastic/eui/tree/v31.9.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ No public interface changes since `31.9.1`.
 
 **Bug fixes**
 
+- Fixed the ability to navigate through the docs pages using the left/right keyboard arrows ([#4600](https://github.com/elastic/eui/pull/4600))
 - Fixed an errant export of two non-existant values ([#4597](https://github.com/elastic/eui/pull/4564597))
 
 ## [`31.9.0`](https://github.com/elastic/eui/tree/v31.9.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ No public interface changes since `31.9.1`.
 
 **Bug fixes**
 
-- Fixed the ability to navigate through the docs pages using the left/right keyboard arrows ([#4600](https://github.com/elastic/eui/pull/4600))
 - Fixed an errant export of two non-existant values ([#4597](https://github.com/elastic/eui/pull/4597))
 
 ## [`31.9.0`](https://github.com/elastic/eui/tree/v31.9.0)

--- a/src-docs/src/routes.js
+++ b/src-docs/src/routes.js
@@ -1,5 +1,7 @@
 import React, { createElement, Fragment } from 'react';
 
+import { createHashHistory } from 'history';
+
 import { GuidePage, GuideSection } from './components';
 
 import { EuiErrorBoundary } from '../../src/components';
@@ -500,6 +502,7 @@ const allRoutes = navigation.reduce((accummulatedRoutes, section) => {
 }, []);
 
 export default {
+  history: createHashHistory(), // eslint-disable-line react-hooks/rules-of-hooks
   navigation,
 
   getRouteForPath: (path) => {

--- a/src-docs/src/routes.js
+++ b/src-docs/src/routes.js
@@ -502,7 +502,7 @@ const allRoutes = navigation.reduce((accummulatedRoutes, section) => {
 }, []);
 
 export default {
-  history: createHashHistory(), // eslint-disable-line react-hooks/rules-of-hooks
+  history: createHashHistory(),
   navigation,
 
   getRouteForPath: (path) => {

--- a/src-docs/src/views/app_view.js
+++ b/src-docs/src/views/app_view.js
@@ -113,7 +113,7 @@ export class AppView extends Component {
       const route = getRoute(currentRoute.name);
 
       if (route) {
-        routes.history.push(route.path);
+        routes.history.push(`/${route.path}`);
       }
     }
   };


### PR DESCRIPTION
### Summary

This PR Fixes: #4585 

Added the ability to navigate through the docs pages using the left/right keyboard arrows.
[Discussion](https://github.com/elastic/eui/commit/8d29c3115db72529a9a5d206328a6c027556b4d2#diff-a3e37e779466cbffa21938778433d0ce534a612da61784a6596511b7fb4a44fe)

![ezgif-2-fa3f196f6ee3](https://user-images.githubusercontent.com/55311336/109785350-0dffa980-7c32-11eb-950a-8096e2fb11ca.gif)



### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Edge**, and **Firefox**
~~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~~
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
~~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~~
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
