### PR TITLE
[EuiDataGrid] Fixed: Cell styling retains when column position is changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 
 **Bug fixes**
 
-- Fixed an errant export of two non-existant values ([#4597](https://github.com/elastic/eui/pull/4564597))
 - Fixed an errant export of two non-existant values ([#4597](https://github.com/elastic/eui/pull/4597))
 
 ## [`31.9.0`](https://github.com/elastic/eui/tree/v31.9.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ No public interface changes since `31.9.1`.
 **Bug fixes**
 
 - Fixed an errant export of two non-existant values ([#4597](https://github.com/elastic/eui/pull/4564597))
+- Fixed `EuiDataGrid` retaining cells style when column position is changed ([#4601](https://github.com/elastic/eui/pull/4601))
 
 ## [`31.9.0`](https://github.com/elastic/eui/tree/v31.9.0)
 

--- a/src-docs/src/views/datagrid/datagrid.js
+++ b/src-docs/src/views/datagrid/datagrid.js
@@ -280,6 +280,13 @@ export default () => {
             });
           }
         }
+        return () => {
+          setCellProps({
+            style: {
+              backgroundColor: 'transparent',
+            },
+          });
+        };
       }, [rowIndex, columnId, setCellProps, data]);
 
       function getFormatted() {

--- a/src-docs/src/views/datagrid/datagrid.js
+++ b/src-docs/src/views/datagrid/datagrid.js
@@ -281,11 +281,7 @@ export default () => {
           }
         }
         return () => {
-          setCellProps({
-            style: {
-              backgroundColor: 'transparent',
-            },
-          });
+          setCellProps({});
         };
       }, [rowIndex, columnId, setCellProps, data]);
 

--- a/src-docs/src/views/datagrid/footer_row.js
+++ b/src-docs/src/views/datagrid/footer_row.js
@@ -93,11 +93,7 @@ export default () => {
           }
         }
         return () => {
-          setCellProps({
-            style: {
-              backgroundColor: 'transparent',
-            },
-          });
+          setCellProps({});
         };
       }, [rowIndex, columnId, setCellProps]);
 

--- a/src-docs/src/views/datagrid/footer_row.js
+++ b/src-docs/src/views/datagrid/footer_row.js
@@ -92,6 +92,13 @@ export default () => {
             });
           }
         }
+        return () => {
+          setCellProps({
+            style: {
+              backgroundColor: 'transparent',
+            },
+          });
+        };
       }, [rowIndex, columnId, setCellProps]);
 
       return raw_data.hasOwnProperty(rowIndex)


### PR DESCRIPTION
### Summary

This PR Fixes: #4599 

Fixed `EuiDataGrid` retaining cells style when column position is changed.

**Approach:**  By adding a cleanup function inside the useEffect hook fixes this.

### Screenshots

**Before**

![ezgif-4-dda7a459aa3a](https://user-images.githubusercontent.com/55311336/109819111-b9702480-7c59-11eb-8f8f-3c2fdddfb1d7.gif)


**After**

![ezgif-4-ad1d55524d25](https://user-images.githubusercontent.com/55311336/109818257-ce988380-7c58-11eb-87c9-1c29c8350b48.gif)

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**,**Edge**, and **Firefox**
~~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~~
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
~~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~~
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
~~-[ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
