### PR TITLE
Remove EuiPageSideProps from src/components/index.js export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Added `panelProps` to `EuiPopover` ([#4573](https://github.com/elastic/eui/pull/4573))
 
+**Bug fixes**
+
+- Fixed an errant export of `EuiSideNavProps` type from JS code ([#4604](https://github.com/elastic/eui/pull/4604))
+
 ## [`31.9.1`](https://github.com/elastic/eui/tree/v31.9.1)
 
 **Bug fixes**

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -294,7 +294,7 @@ export {
   euiSelectableTemplateSitewideRenderOptions,
 } from './selectable';
 
-export { EuiSideNav, EuiSideNavProps } from './side_nav';
+export { EuiSideNav } from './side_nav';
 
 export { EuiSpacer } from './spacer';
 


### PR DESCRIPTION
### Summary

Removes an additional exported type identified in https://github.com/elastic/eui/pull/4597#issuecomment-789284284. This one wasn't reported during a webpack build presumably because its source file does `export * from` compared to the explicit `export { ComponentProps}` pattern which exported the others. This is the last occurrence of `props` in _src/components/index.js_.

Looked into making CI fail if webpack issued the warning about an unknown import but decided against for a few reasons:
* looks like it requires adding a plugin e.g. https://www.npmjs.com/package/fail-on-errors-webpack-plugin
* we'd have to shoe-horn it into the CI environment for `dist` build or devserver+axe configurations, which is brittle
* final conversion of index.js->TypeScript will need to handle this in an entirely different way

So to me it isn't worth it, but I can be told otherwise :)