### PR TITLE
[EuiToolTip, useInnerText] Use jest.useFakeTimers for flaky tests

### DIFF
--- a/src/components/inner_text/inner_text.test.tsx
+++ b/src/components/inner_text/inner_text.test.tsx
@@ -20,7 +20,7 @@
 import React, { useState, useEffect } from 'react';
 import { act } from 'react-dom/test-utils';
 import { render, mount } from 'enzyme';
-import { findTestSubject, requiredProps, sleep } from '../../test';
+import { findTestSubject, requiredProps } from '../../test';
 
 import { useInnerText, EuiInnerText } from './inner_text';
 import { EuiBadge } from '../badge';
@@ -63,7 +63,8 @@ describe('useInnerText', () => {
     expect(innerText).toEqual(fallback);
   });
 
-  test('handles updated elements', async () => {
+  test('handles updated elements', () => {
+    jest.useFakeTimers();
     const timeout = 500;
     const first = 'First';
     const second = 'Second';
@@ -94,12 +95,13 @@ describe('useInnerText', () => {
 
     expect(innerText).toEqual(first);
 
-    await sleep(timeout + 10);
+    jest.advanceTimersByTime(timeout + 10);
 
     expect(innerText).toEqual(second);
   });
 
-  test('handles updated content', async () => {
+  test('handles updated content', () => {
+    jest.useFakeTimers();
     const timeout = 500;
     const first = 'First';
     const second = 'Second';
@@ -127,7 +129,7 @@ describe('useInnerText', () => {
 
     // MutationObserver polyfill institutes a 30ms mutation timeout period
     const mutationObserverPolyfillPeriod = 30;
-    await sleep(timeout + mutationObserverPolyfillPeriod + 10);
+    jest.advanceTimersByTime(timeout + mutationObserverPolyfillPeriod + 10);
 
     expect(innerText).toEqual(second);
   });

--- a/src/components/tool_tip/tool_tip.test.tsx
+++ b/src/components/tool_tip/tool_tip.test.tsx
@@ -51,7 +51,7 @@ describe('EuiToolTip', () => {
     expect(takeMountedSnapshot(component)).toMatchSnapshot();
   });
 
-  test('display prop renders block', async () => {
+  test('display prop renders block', () => {
     const component = render(
       <EuiToolTip
         title="title"

--- a/src/components/tool_tip/tool_tip.test.tsx
+++ b/src/components/tool_tip/tool_tip.test.tsx
@@ -23,7 +23,6 @@ import {
   requiredProps,
   findTestSubject,
   takeMountedSnapshot,
-  sleep,
 } from '../../test';
 import { EuiToolTip } from './tool_tip';
 
@@ -38,7 +37,8 @@ describe('EuiToolTip', () => {
     expect(component).toMatchSnapshot();
   });
 
-  test('shows tooltip on focus', async () => {
+  test('shows tooltip on focus', () => {
+    jest.useFakeTimers();
     const component = mount(
       <EuiToolTip title="title" id="id" content="content" {...requiredProps}>
         <button data-test-subj="trigger">Trigger</button>
@@ -47,7 +47,7 @@ describe('EuiToolTip', () => {
 
     const trigger = findTestSubject(component, 'trigger');
     trigger.simulate('focus');
-    await sleep(260); // wait for showToolTip setTimout
+    jest.advanceTimersByTime(260); // wait for showToolTip setTimeout
     expect(takeMountedSnapshot(component)).toMatchSnapshot();
   });
 


### PR DESCRIPTION
### Summary

Replace `sleep` with ` jest.useFakeTimers` and `jest.advanceTimersByTime`.

Hoping to fix the often-seen flaky test failure related to [EuiToolTip focus timeout](https://kibana-ci.elastic.co/job/elastic+eui+pull-request-test/3440/console):

>12:45:48 FAIL src/components/tool_tip/tool_tip.test.tsx
12:45:48   ● EuiToolTip › shows tooltip on focus
12:45:48 
12:45:48     expect(received).toMatchSnapshot()
12:45:48 
12:45:48     Snapshot name: `EuiToolTip shows tooltip on focus 1`
12:45:48 
12:45:48     - Snapshot
12:45:48     + Received
12:45:48 
12:45:48       <span
12:45:48         class="euiToolTipAnchor"
12:45:48       >
12:45:48         <button
12:45:48     -     aria-describedby="id"
12:45:48           data-test-subj="trigger"
12:45:48         >
12:45:48           Trigger
12:45:48         </button>
12:45:48       </span>
12:45:48 
12:45:48       49 |     trigger.simulate('focus');
12:45:48       50 |     await sleep(260); // wait for showToolTip setTimout
12:45:48     > 51 |     expect(takeMountedSnapshot(component)).toMatchSnapshot();
12:45:48          |                                            ^
12:45:48       52 |   });

Also closes #3249

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~

- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately

~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
