### PR TITLE
[EuiComboBox] Fixed options list misalignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Fixed hover effect of nested clickable rows in `EuiBasicTable` ([#4566](https://github.com/elastic/eui/pull/4566))
 - Fixed visual bug in drag&drop sections when nested in an popover ([#4590](https://github.com/elastic/eui/pull/4590))
 - Fixed an errant export of `EuiSideNavProps` type from JS code ([#4604](https://github.com/elastic/eui/pull/4604))
-- Fixed misalignment `EuiComboBox` options list ([#4607](https://github.com/elastic/eui/pull/4607))
+- Fixed misaligned `EuiComboBox` options list ([#4607](https://github.com/elastic/eui/pull/4607))
 
 ## [`31.9.1`](https://github.com/elastic/eui/tree/v31.9.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed hover effect of nested clickable rows in `EuiBasicTable` ([#4566](https://github.com/elastic/eui/pull/4566))
 - Fixed visual bug in drag&drop sections when nested in an popover ([#4590](https://github.com/elastic/eui/pull/4590))
 - Fixed an errant export of `EuiSideNavProps` type from JS code ([#4604](https://github.com/elastic/eui/pull/4604))
+- Fixed misalignment `EuiComboBox` options list ([#4607](https://github.com/elastic/eui/pull/4607))
 
 ## [`31.9.1`](https://github.com/elastic/eui/tree/v31.9.1)
 

--- a/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
@@ -5,6 +5,7 @@
 .euiComboBoxOptionsList {
   // Remove transforms from popover panel
   transform: none !important; // sass-lint:disable-line no-important
+  top: 0;
 
   &.euiPopover__panel-isAttached.euiComboBoxOptionsList--top { /* 1 */
     @include euiBottomShadowFlat;


### PR DESCRIPTION
### Summary

Fixes #4472.

@chandlerprall explained how to reproduce the problem and why it is happening 
 https://github.com/elastic/eui/issues/4472#issuecomment-790043390

To test it on the docs page, use devtools to manually remove enough elements so that only 1 `EuiComboBox` is left, then mimic the clip shared in the issue.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~~
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
~~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~~
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
- [x] Checked for **breaking changes** and labeled appropriately
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
