### PR TITLE
[DOCS] Coverted some examples to functional component

### DIFF
--- a/src-docs/src/views/datagrid/schema.js
+++ b/src-docs/src/views/datagrid/schema.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { fake } from 'faker';
 
 import {
@@ -35,7 +35,7 @@ const columns = [
   },
 ];
 
-const data = [];
+const storeData = [];
 
 for (let i = 1; i < 5; i++) {
   let json;
@@ -61,7 +61,7 @@ for (let i = 1; i < 5; i++) {
     ]);
   }
 
-  data.push({
+  storeData.push({
     default: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
     boolean: fake('{{random.boolean}}'),
     numeric: fake('{{finance.account}}'),
@@ -103,8 +103,8 @@ const Franchise = (props) => {
 };
 
 const DataGridSchema = () => {
-  const [dataState, setDataState] = useState(data);
-  console.log(dataState);
+  const [data, setData] = useState(storeData);
+
   const [sortingColumns, setSortingColumns] = useState([
     { id: 'custom', direction: 'asc' },
   ]);
@@ -112,11 +112,12 @@ const DataGridSchema = () => {
     pageIndex: 0,
     pageSize: 10,
   });
-  const [visibleColumns, setVisibleColumnsState] = useState(
+  const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
   );
+
   const setSorting = (sortingColumns) => {
-    const dataState = [...dataState].sort((a, b) => {
+    const sortedData = [...data].sort((a, b) => {
       for (let i = 0; i < sortingColumns.length; i++) {
         const column = sortingColumns[i];
         const aValue = a[column.id];
@@ -128,18 +129,27 @@ const DataGridSchema = () => {
 
       return 0;
     });
-    setDataState(dataState);
+
+    setData(sortedData);
     setSortingColumns(sortingColumns);
   };
 
-  const setPageIndex = (pageIndex) =>
-    setPagination({ ...pagination, pageIndex });
+  const setPageIndex = useCallback(
+    (pageIndex) => {
+      setPagination({ ...pagination, pageIndex });
+    },
+    [setPagination]
+  );
 
-  const setPageSize = (pageSize) =>
-    setPagination({ ...pagination, pageIndex: 0, pageSize });
+  const setPageSize = useCallback(
+    (pageSize) => {
+      setPagination({ ...pagination, pageIndex: 0, pageSize });
+    },
+    [setPagination]
+  );
 
-  const setVisibleColumns = (visibleColumns) =>
-    setVisibleColumnsState(visibleColumns);
+  const handleVisibleColumns = (visibleColumns) =>
+    setVisibleColumns(visibleColumns);
 
   return (
     <EuiDataGrid
@@ -147,12 +157,12 @@ const DataGridSchema = () => {
       columns={columns}
       columnVisibility={{
         visibleColumns: visibleColumns,
-        setVisibleColumns: setVisibleColumns,
+        setVisibleColumns: handleVisibleColumns,
       }}
-      rowCount={dataState.length}
+      rowCount={data.length}
       inMemory={{ level: 'sorting' }}
       renderCellValue={({ rowIndex, columnId, isDetails }) => {
-        const value = dataState[rowIndex][columnId];
+        const value = data[rowIndex][columnId];
 
         if (columnId === 'custom' && isDetails) {
           return <Franchise name={value} />;

--- a/src-docs/src/views/datagrid/schema.js
+++ b/src-docs/src/views/datagrid/schema.js
@@ -138,14 +138,14 @@ const DataGridSchema = () => {
     (pageIndex) => {
       setPagination({ ...pagination, pageIndex });
     },
-    [setPagination]
+    [pagination, setPagination]
   );
 
   const setPageSize = useCallback(
     (pageSize) => {
       setPagination({ ...pagination, pageIndex: 0, pageSize });
     },
-    [setPagination]
+    [pagination, setPagination]
   );
 
   const handleVisibleColumns = (visibleColumns) =>

--- a/src-docs/src/views/datagrid/styling.js
+++ b/src-docs/src/views/datagrid/styling.js
@@ -1,4 +1,4 @@
-import React, { useState, Fragment } from 'react';
+import React, { useState, Fragment, useCallback } from 'react';
 import { fake } from 'faker';
 
 import {
@@ -253,7 +253,7 @@ const DataGrid = () => {
   const [footerSelected, setFooterSelected] = useState('overline');
   const [showSortSelector, setShowSortSelector] = useState(true);
   const [showStyleSelector, setShowStyleSelector] = useState(true);
-  const [showColumnSelectorState, setShowColumnSelectorState] = useState(true);
+  const [showColumnSelector, setShowColumnSelector] = useState(true);
   const [allowHideColumns, setAllowHideColumns] = useState(true);
   const [allowOrderingColumns, setAllowOrderingColumns] = useState(true);
   const [showFullScreenSelector, setShowFullScreenSelector] = useState(true);
@@ -265,7 +265,7 @@ const DataGrid = () => {
     pageIndex: 0,
     pageSize: 50,
   });
-  const [visibleColumns, setVisibleColumnsState] = useState(
+  const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
   );
 
@@ -306,7 +306,7 @@ const DataGrid = () => {
   };
 
   const onShowColumnSelectorChange = (optionId) => {
-    setShowColumnSelectorState(optionId === 'true');
+    setShowColumnSelector(optionId === 'true');
   };
 
   const onAllowHideColumnsChange = (optionId) => {
@@ -345,14 +345,22 @@ const DataGrid = () => {
     setIsToolbarPopoverOpen(false);
   };
 
-  const setPageIndex = (pageIndex) =>
-    setPagination({ ...pagination, pageIndex });
+  const setPageIndex = useCallback(
+    (pageIndex) => {
+      setPagination({ ...pagination, pageIndex });
+    },
+    [setPagination]
+  );
 
-  const setPageSize = (pageSize) =>
-    setPagination({ ...pagination, pageSize, pageIndex: 0 });
+  const setPageSize = useCallback(
+    (pageSize) => {
+      setPagination({ ...pagination, pageSize, pageIndex: 0 });
+    },
+    [setPagination]
+  );
 
-  const setVisibleColumns = (visibleColumns) =>
-    setVisibleColumnsState(visibleColumns);
+  const handleVisibleColumns = (visibleColumns) =>
+    setVisibleColumns(visibleColumns);
 
   const styleButton = (
     <EuiButton
@@ -373,19 +381,19 @@ const DataGrid = () => {
       toolbarVisibility options
     </EuiButton>
   );
-  let showColumnSelector = showColumnSelectorState;
+  let displayColumnSelector = showColumnSelector;
   if (
-    showColumnSelector === true &&
+    displayColumnSelector === true &&
     (allowHideColumns === false || allowOrderingColumns === false)
   ) {
-    showColumnSelector = {
+    displayColumnSelector = {
       allowHide: allowHideColumns,
       allowReorder: allowOrderingColumns,
     };
   }
 
   const toolbarVisibilityOptions = {
-    showColumnSelector: showColumnSelector,
+    showColumnSelector: displayColumnSelector,
     showStyleSelector: showStyleSelector,
     showSortSelector: showSortSelector,
     showFullScreenSelector: showFullScreenSelector,
@@ -558,11 +566,11 @@ const DataGrid = () => {
                       buttonSize="compressed"
                       legend="Border"
                       options={showColumnSelectorOptions}
-                      idSelected={showColumnSelector.toString()}
+                      idSelected={displayColumnSelector.toString()}
                       onChange={onShowColumnSelectorChange}
                     />
                   </EuiFormRow>
-                  {showColumnSelector && (
+                  {displayColumnSelector && (
                     <>
                       <EuiFormRow
                         display="columnCompressed"
@@ -628,7 +636,7 @@ const DataGrid = () => {
         columns={columns}
         columnVisibility={{
           visibleColumns: visibleColumns,
-          setVisibleColumns: setVisibleColumns,
+          setVisibleColumns: handleVisibleColumns,
         }}
         rowCount={data.length}
         gridStyle={{

--- a/src-docs/src/views/datagrid/styling.js
+++ b/src-docs/src/views/datagrid/styling.js
@@ -349,14 +349,14 @@ const DataGrid = () => {
     (pageIndex) => {
       setPagination({ ...pagination, pageIndex });
     },
-    [setPagination]
+    [pagination, setPagination]
   );
 
   const setPageSize = useCallback(
     (pageSize) => {
       setPagination({ ...pagination, pageSize, pageIndex: 0 });
     },
-    [setPagination]
+    [pagination, setPagination]
   );
 
   const handleVisibleColumns = (visibleColumns) =>

--- a/src-docs/src/views/datagrid/styling.js
+++ b/src-docs/src/views/datagrid/styling.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { useState, Fragment } from 'react';
 import { fake } from 'faker';
 
 import {
@@ -61,646 +61,596 @@ const footerCellValues = {
 const renderFooterCellValue = ({ columnId }) =>
   footerCellValues[columnId] || null;
 
-export default class DataGrid extends Component {
-  constructor(props) {
-    super(props);
-    this.borderOptions = [
-      {
-        id: 'all',
-        label: 'All',
-      },
-      {
-        id: 'horizontal',
-        label: 'Horizontal only',
-      },
-      {
-        id: 'none',
-        label: 'None',
-      },
-    ];
+const DataGrid = () => {
+  const borderOptions = [
+    {
+      id: 'all',
+      label: 'All',
+    },
+    {
+      id: 'horizontal',
+      label: 'Horizontal only',
+    },
+    {
+      id: 'none',
+      label: 'None',
+    },
+  ];
 
-    this.fontSizeOptions = [
-      {
-        id: 's',
-        label: 'Small',
-      },
-      {
-        id: 'm',
-        label: 'Medium',
-      },
-      {
-        id: 'l',
-        label: 'Large',
-      },
-    ];
+  const fontSizeOptions = [
+    {
+      id: 's',
+      label: 'Small',
+    },
+    {
+      id: 'm',
+      label: 'Medium',
+    },
+    {
+      id: 'l',
+      label: 'Large',
+    },
+  ];
 
-    this.cellPaddingOptions = [
-      {
-        id: 's',
-        label: 'Small',
-      },
-      {
-        id: 'm',
-        label: 'Medium',
-      },
-      {
-        id: 'l',
-        label: 'Large',
-      },
-    ];
+  const cellPaddingOptions = [
+    {
+      id: 's',
+      label: 'Small',
+    },
+    {
+      id: 'm',
+      label: 'Medium',
+    },
+    {
+      id: 'l',
+      label: 'Large',
+    },
+  ];
 
-    this.stripeOptions = [
-      {
-        id: 'true',
-        label: 'Stripes on',
-      },
-      {
-        id: 'false',
-        label: 'Stripes off',
-      },
-    ];
+  const stripeOptions = [
+    {
+      id: 'true',
+      label: 'Stripes on',
+    },
+    {
+      id: 'false',
+      label: 'Stripes off',
+    },
+  ];
 
-    this.rowHoverOptions = [
-      {
-        id: 'none',
-        label: 'None',
-      },
-      {
-        id: 'highlight',
-        label: 'Highlight',
-      },
-    ];
+  const rowHoverOptions = [
+    {
+      id: 'none',
+      label: 'None',
+    },
+    {
+      id: 'highlight',
+      label: 'Highlight',
+    },
+  ];
 
-    this.headerOptions = [
-      {
-        id: 'shade',
-        label: 'Shade',
-      },
-      {
-        id: 'underline',
-        label: 'Underline',
-      },
-    ];
+  const headerOptions = [
+    {
+      id: 'shade',
+      label: 'Shade',
+    },
+    {
+      id: 'underline',
+      label: 'Underline',
+    },
+  ];
 
-    this.footerOptions = [
-      {
-        id: 'shade',
-        label: 'Shade',
-      },
-      {
-        id: 'overline',
-        label: 'Overline',
-      },
-      {
-        id: 'striped',
-        label: 'Striped',
-      },
-    ];
+  const footerOptions = [
+    {
+      id: 'shade',
+      label: 'Shade',
+    },
+    {
+      id: 'overline',
+      label: 'Overline',
+    },
+    {
+      id: 'striped',
+      label: 'Striped',
+    },
+  ];
 
-    this.showSortSelectorOptions = [
-      {
-        id: 'true',
-        label: 'True',
-      },
-      {
-        id: 'false',
-        label: 'False',
-      },
-    ];
+  const showSortSelectorOptions = [
+    {
+      id: 'true',
+      label: 'True',
+    },
+    {
+      id: 'false',
+      label: 'False',
+    },
+  ];
 
-    this.showStyleSelectorOptions = [
-      {
-        id: 'true',
-        label: 'True',
-      },
-      {
-        id: 'false',
-        label: 'False',
-      },
-    ];
+  const showStyleSelectorOptions = [
+    {
+      id: 'true',
+      label: 'True',
+    },
+    {
+      id: 'false',
+      label: 'False',
+    },
+  ];
 
-    this.showColumnSelectorOptions = [
-      {
-        id: 'true',
-        label: 'True',
-      },
-      {
-        id: 'false',
-        label: 'False',
-      },
-    ];
+  const showColumnSelectorOptions = [
+    {
+      id: 'true',
+      label: 'True',
+    },
+    {
+      id: 'false',
+      label: 'False',
+    },
+  ];
 
-    this.allowHideColumnsOptions = [
-      {
-        id: 'true',
-        label: 'True',
-      },
-      {
-        id: 'false',
-        label: 'False',
-      },
-    ];
+  const allowHideColumnsOptions = [
+    {
+      id: 'true',
+      label: 'True',
+    },
+    {
+      id: 'false',
+      label: 'False',
+    },
+  ];
 
-    this.allowOrderingColumnsOptions = [
-      {
-        id: 'true',
-        label: 'True',
-      },
-      {
-        id: 'false',
-        label: 'False',
-      },
-    ];
+  const allowOrderingColumnsOptions = [
+    {
+      id: 'true',
+      label: 'True',
+    },
+    {
+      id: 'false',
+      label: 'False',
+    },
+  ];
 
-    this.showFullScreenSelectorOptions = [
-      {
-        id: 'true',
-        label: 'True',
-      },
-      {
-        id: 'false',
-        label: 'False',
-      },
-    ];
+  const showFullScreenSelectorOptions = [
+    {
+      id: 'true',
+      label: 'True',
+    },
+    {
+      id: 'false',
+      label: 'False',
+    },
+  ];
 
-    this.showToolbarOptions = [
-      {
-        id: 'true',
-        label: 'True',
-      },
-      {
-        id: 'false',
-        label: 'False',
-      },
-    ];
+  const showToolbarOptions = [
+    {
+      id: 'true',
+      label: 'True',
+    },
+    {
+      id: 'false',
+      label: 'False',
+    },
+  ];
 
-    this.toolbarPropTypeIsBooleanOptions = [
-      {
-        id: 'true',
-        label: 'Boolean',
-      },
-      {
-        id: 'false',
-        label: 'Object',
-      },
-    ];
+  const toolbarPropTypeIsBooleanOptions = [
+    {
+      id: 'true',
+      label: 'Boolean',
+    },
+    {
+      id: 'false',
+      label: 'Object',
+    },
+  ];
+  const [borderSelected, setBorderSelected] = useState('none');
+  const [fontSizeSelected, setFontSizeSelected] = useState('s');
+  const [cellPaddingSelected, setCellPaddingSelected] = useState('s');
+  const [stripesSelected, setStripesSelected] = useState(true);
+  const [rowHoverSelected, setRowHoverSelected] = useState('none');
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [isToolbarPopoverOpen, setIsToolbarPopoverOpen] = useState(false);
+  const [headerSelected, setHeaderSelected] = useState('underline');
+  const [footerSelected, setFooterSelected] = useState('overline');
+  const [showSortSelector, setShowSortSelector] = useState(true);
+  const [showStyleSelector, setShowStyleSelector] = useState(true);
+  const [showColumnSelectorState, setShowColumnSelectorState] = useState(true);
+  const [allowHideColumns, setAllowHideColumns] = useState(true);
+  const [allowOrderingColumns, setAllowOrderingColumns] = useState(true);
+  const [showFullScreenSelector, setShowFullScreenSelector] = useState(true);
+  const [showToolbar, setShowToolbar] = useState(true);
+  const [toolbarPropTypeIsBoolean, setToolbarPropTypeIsBoolean] = useState(
+    true
+  );
+  const [pagination, setPagination] = useState({
+    pageIndex: 0,
+    pageSize: 50,
+  });
+  const [visibleColumns, setVisibleColumnsState] = useState(
+    columns.map(({ id }) => id)
+  );
 
-    this.state = {
-      borderSelected: 'none',
-      fontSizeSelected: 's',
-      cellPaddingSelected: 's',
-      stripesSelected: true,
-      rowHoverSelected: 'none',
-      isPopoverOpen: false,
-      isToolbarPopoverOpen: false,
-      headerSelected: 'underline',
-      footerSelected: 'overline',
-      showSortSelector: true,
-      showStyleSelector: true,
-      showColumnSelector: true,
-      allowHideColumns: true,
-      allowOrderingColumns: true,
-      showFullScreenSelector: true,
-      showToolbar: true,
-      toolbarPropTypeIsBoolean: true,
+  const onBorderChange = (optionId) => {
+    setBorderSelected(optionId);
+  };
 
-      pagination: {
-        pageIndex: 0,
-        pageSize: 50,
-      },
+  const onFontSizeChange = (optionId) => {
+    setFontSizeSelected(optionId);
+  };
 
-      visibleColumns: columns.map(({ id }) => id),
+  const onCellPaddingChange = (optionId) => {
+    setCellPaddingSelected(optionId);
+  };
+
+  const onStripesChange = (optionId) => {
+    setStripesSelected(optionId === 'true');
+  };
+
+  const onRowHoverChange = (optionId) => {
+    setRowHoverSelected(optionId);
+  };
+
+  const onHeaderChange = (optionId) => {
+    setHeaderSelected(optionId);
+  };
+
+  const onFooterChange = (optionId) => {
+    setFooterSelected(optionId);
+  };
+
+  const onShowSortSelectorChange = (optionId) => {
+    setShowSortSelector(optionId === 'true');
+  };
+
+  const onShowStyleSelectorChange = (optionId) => {
+    setShowStyleSelector(optionId === 'true');
+  };
+
+  const onShowColumnSelectorChange = (optionId) => {
+    setShowColumnSelectorState(optionId === 'true');
+  };
+
+  const onAllowHideColumnsChange = (optionId) => {
+    setAllowHideColumns(optionId === 'true');
+  };
+
+  const onAllowOrderingColumnsChange = (optionId) => {
+    setAllowOrderingColumns(optionId === 'true');
+  };
+
+  const onShowFullScreenSelectorChange = (optionId) => {
+    setShowFullScreenSelector(optionId === 'true');
+  };
+
+  const onShowToolbarChange = (optionId) => {
+    setShowToolbar(optionId === 'true');
+  };
+
+  const onToolbarPropTypeIsBooleanChange = (optionId) => {
+    setToolbarPropTypeIsBoolean(optionId === 'true');
+  };
+
+  const onPopoverButtonClick = () => {
+    setIsPopoverOpen(!isPopoverOpen);
+  };
+
+  const onToolbarPopoverButtonClick = () => {
+    setIsToolbarPopoverOpen(!isPopoverOpen);
+  };
+
+  const closePopover = () => {
+    setIsPopoverOpen(false);
+  };
+
+  const closeToolbarPopover = () => {
+    setIsToolbarPopoverOpen(false);
+  };
+
+  const setPageIndex = (pageIndex) =>
+    setPagination({ ...pagination, pageIndex });
+
+  const setPageSize = (pageSize) =>
+    setPagination({ ...pagination, pageSize, pageIndex: 0 });
+
+  const setVisibleColumns = (visibleColumns) =>
+    setVisibleColumnsState(visibleColumns);
+
+  const styleButton = (
+    <EuiButton
+      iconType="gear"
+      iconSide="right"
+      size="s"
+      onClick={onPopoverButtonClick}>
+      gridStyle options
+    </EuiButton>
+  );
+
+  const toolbarButton = (
+    <EuiButton
+      iconType="gear"
+      iconSide="right"
+      size="s"
+      onClick={onToolbarPopoverButtonClick}>
+      toolbarVisibility options
+    </EuiButton>
+  );
+  let showColumnSelector = showColumnSelectorState;
+  if (
+    showColumnSelector === true &&
+    (allowHideColumns === false || allowOrderingColumns === false)
+  ) {
+    showColumnSelector = {
+      allowHide: allowHideColumns,
+      allowReorder: allowOrderingColumns,
     };
   }
 
-  onBorderChange = (optionId) => {
-    this.setState({
-      borderSelected: optionId,
-    });
+  const toolbarVisibilityOptions = {
+    showColumnSelector: showColumnSelector,
+    showStyleSelector: showStyleSelector,
+    showSortSelector: showSortSelector,
+    showFullScreenSelector: showFullScreenSelector,
   };
 
-  onFontSizeChange = (optionId) => {
-    this.setState({
-      fontSizeSelected: optionId,
-    });
-  };
+  let toolbarConfig;
 
-  onCellPaddingChange = (optionId) => {
-    this.setState({
-      cellPaddingSelected: optionId,
-    });
-  };
-
-  onStripesChange = (optionId) => {
-    this.setState({
-      stripesSelected: optionId === 'true',
-    });
-  };
-
-  onRowHoverChange = (optionId) => {
-    this.setState({
-      rowHoverSelected: optionId,
-    });
-  };
-
-  onHeaderChange = (optionId) => {
-    this.setState({
-      headerSelected: optionId,
-    });
-  };
-
-  onFooterChange = (optionId) => {
-    this.setState({
-      footerSelected: optionId,
-    });
-  };
-
-  onShowSortSelectorChange = (optionId) => {
-    this.setState({
-      showSortSelector: optionId === 'true',
-    });
-  };
-
-  onShowStyleSelectorChange = (optionId) => {
-    this.setState({
-      showStyleSelector: optionId === 'true',
-    });
-  };
-
-  onShowColumnSelectorChange = (optionId) => {
-    this.setState({
-      showColumnSelector: optionId === 'true',
-    });
-  };
-
-  onAllowHideColumnsChange = (optionId) => {
-    this.setState({
-      allowHideColumns: optionId === 'true',
-    });
-  };
-
-  onAllowOrderingColumnsChange = (optionId) => {
-    this.setState({
-      allowOrderingColumns: optionId === 'true',
-    });
-  };
-
-  onShowFullScreenSelectorChange = (optionId) => {
-    this.setState({
-      showFullScreenSelector: optionId === 'true',
-    });
-  };
-
-  onShowToolbarChange = (optionId) => {
-    this.setState({
-      showToolbar: optionId === 'true',
-    });
-  };
-
-  onToolbarPropTypeIsBooleanChange = (optionId) => {
-    this.setState({
-      toolbarPropTypeIsBoolean: optionId === 'true',
-    });
-  };
-
-  onPopoverButtonClick() {
-    this.setState({
-      isPopoverOpen: !this.state.isPopoverOpen,
-    });
+  if (toolbarPropTypeIsBoolean) {
+    toolbarConfig = showToolbar;
+  } else {
+    toolbarConfig = toolbarVisibilityOptions;
   }
 
-  onToolbarPopoverButtonClick() {
-    this.setState({
-      isToolbarPopoverOpen: !this.state.isPopoverOpen,
-    });
-  }
+  return (
+    <div>
+      <EuiFlexGroup gutterSize="s">
+        <EuiFlexItem grow={false}>
+          <EuiPopover
+            id="styleButton"
+            button={styleButton}
+            isOpen={isPopoverOpen}
+            anchorPosition="rightUp"
+            closePopover={closePopover}>
+            <div style={{ width: 380 }}>
+              <EuiFormRow label="Border" display="columnCompressed">
+                <EuiButtonGroup
+                  isFullWidth
+                  buttonSize="compressed"
+                  legend="Border"
+                  options={borderOptions}
+                  idSelected={borderSelected}
+                  onChange={onBorderChange}
+                />
+              </EuiFormRow>
 
-  closePopover() {
-    this.setState({
-      isPopoverOpen: false,
-    });
-  }
+              <EuiFormRow label="Cell padding" display="columnCompressed">
+                <EuiButtonGroup
+                  isFullWidth
+                  buttonSize="compressed"
+                  legend="Cell padding"
+                  options={cellPaddingOptions}
+                  idSelected={cellPaddingSelected}
+                  onChange={onCellPaddingChange}
+                />
+              </EuiFormRow>
 
-  closeToolbarPopover() {
-    this.setState({
-      isToolbarPopoverOpen: false,
-    });
-  }
+              <EuiFormRow label="Font size" display="columnCompressed">
+                <EuiButtonGroup
+                  isFullWidth
+                  buttonSize="compressed"
+                  legend="Fornt size"
+                  options={fontSizeOptions}
+                  idSelected={fontSizeSelected}
+                  onChange={onFontSizeChange}
+                />
+              </EuiFormRow>
 
-  setPageIndex = (pageIndex) =>
-    this.setState(({ pagination }) => ({
-      pagination: { ...pagination, pageIndex },
-    }));
+              <EuiFormRow label="Stripes" display="columnCompressed">
+                <EuiButtonGroup
+                  isFullWidth
+                  buttonSize="compressed"
+                  legend="Stripes"
+                  options={stripeOptions}
+                  idSelected={stripesSelected.toString()}
+                  onChange={onStripesChange}
+                />
+              </EuiFormRow>
 
-  setPageSize = (pageSize) =>
-    this.setState(({ pagination }) => ({
-      pagination: { ...pagination, pageSize, pageIndex: 0 },
-    }));
+              <EuiFormRow label="Hover row" display="columnCompressed">
+                <EuiButtonGroup
+                  isFullWidth
+                  buttonSize="compressed"
+                  legend="Hover row"
+                  options={rowHoverOptions}
+                  idSelected={rowHoverSelected}
+                  onChange={onRowHoverChange}
+                />
+              </EuiFormRow>
 
-  setVisibleColumns = (visibleColumns) => this.setState({ visibleColumns });
+              <EuiFormRow label="Header" display="columnCompressed">
+                <EuiButtonGroup
+                  isFullWidth
+                  buttonSize="compressed"
+                  legend="Header"
+                  options={headerOptions}
+                  idSelected={headerSelected}
+                  onChange={onHeaderChange}
+                />
+              </EuiFormRow>
 
-  render() {
-    const { pagination } = this.state;
-
-    const styleButton = (
-      <EuiButton
-        iconType="gear"
-        iconSide="right"
-        size="s"
-        onClick={this.onPopoverButtonClick.bind(this)}>
-        gridStyle options
-      </EuiButton>
-    );
-
-    const toolbarButton = (
-      <EuiButton
-        iconType="gear"
-        iconSide="right"
-        size="s"
-        onClick={this.onToolbarPopoverButtonClick.bind(this)}>
-        toolbarVisibility options
-      </EuiButton>
-    );
-
-    let showColumnSelector = this.state.showColumnSelector;
-    if (
-      this.state.showColumnSelector === true &&
-      (this.state.allowHideColumns === false ||
-        this.state.allowOrderingColumns === false)
-    ) {
-      showColumnSelector = {
-        allowHide: this.state.allowHideColumns,
-        allowReorder: this.state.allowOrderingColumns,
-      };
-    }
-
-    const toolbarVisibilityOptions = {
-      showColumnSelector: showColumnSelector,
-      showStyleSelector: this.state.showStyleSelector,
-      showSortSelector: this.state.showSortSelector,
-      showFullScreenSelector: this.state.showFullScreenSelector,
-    };
-
-    let toolbarConfig;
-
-    if (this.state.toolbarPropTypeIsBoolean) {
-      toolbarConfig = this.state.showToolbar;
-    } else {
-      toolbarConfig = toolbarVisibilityOptions;
-    }
-
-    return (
-      <div>
-        <EuiFlexGroup gutterSize="s">
-          <EuiFlexItem grow={false}>
-            <EuiPopover
-              id="styleButton"
-              button={styleButton}
-              isOpen={this.state.isPopoverOpen}
-              anchorPosition="rightUp"
-              closePopover={this.closePopover.bind(this)}>
-              <div style={{ width: 380 }}>
-                <EuiFormRow label="Border" display="columnCompressed">
-                  <EuiButtonGroup
-                    isFullWidth
-                    buttonSize="compressed"
-                    legend="Border"
-                    options={this.borderOptions}
-                    idSelected={this.state.borderSelected}
-                    onChange={this.onBorderChange}
-                  />
-                </EuiFormRow>
-
-                <EuiFormRow label="Cell padding" display="columnCompressed">
-                  <EuiButtonGroup
-                    isFullWidth
-                    buttonSize="compressed"
-                    legend="Cell padding"
-                    options={this.cellPaddingOptions}
-                    idSelected={this.state.cellPaddingSelected}
-                    onChange={this.onCellPaddingChange}
-                  />
-                </EuiFormRow>
-
-                <EuiFormRow label="Font size" display="columnCompressed">
-                  <EuiButtonGroup
-                    isFullWidth
-                    buttonSize="compressed"
-                    legend="Fornt size"
-                    options={this.fontSizeOptions}
-                    idSelected={this.state.fontSizeSelected}
-                    onChange={this.onFontSizeChange}
-                  />
-                </EuiFormRow>
-
-                <EuiFormRow label="Stripes" display="columnCompressed">
-                  <EuiButtonGroup
-                    isFullWidth
-                    buttonSize="compressed"
-                    legend="Stripes"
-                    options={this.stripeOptions}
-                    idSelected={this.state.stripesSelected.toString()}
-                    onChange={this.onStripesChange}
-                  />
-                </EuiFormRow>
-
-                <EuiFormRow label="Hover row" display="columnCompressed">
-                  <EuiButtonGroup
-                    isFullWidth
-                    buttonSize="compressed"
-                    legend="Hover row"
-                    options={this.rowHoverOptions}
-                    idSelected={this.state.rowHoverSelected}
-                    onChange={this.onRowHoverChange}
-                  />
-                </EuiFormRow>
-
-                <EuiFormRow label="Header" display="columnCompressed">
-                  <EuiButtonGroup
-                    isFullWidth
-                    buttonSize="compressed"
-                    legend="Header"
-                    options={this.headerOptions}
-                    idSelected={this.state.headerSelected}
-                    onChange={this.onHeaderChange}
-                  />
-                </EuiFormRow>
-
-                <EuiFormRow label="Footer" display="columnCompressed">
-                  <EuiButtonGroup
-                    isFullWidth
-                    buttonSize="compressed"
-                    legend="Footer"
-                    options={this.footerOptions}
-                    idSelected={this.state.footerSelected}
-                    onChange={this.onFooterChange}
-                  />
-                </EuiFormRow>
-              </div>
-            </EuiPopover>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiPopover
-              id="toolbarVisibility"
-              button={toolbarButton}
-              isOpen={this.state.isToolbarPopoverOpen}
-              anchorPosition="rightUp"
-              closePopover={this.closeToolbarPopover.bind(this)}>
-              <div style={{ width: 400 }}>
-                <EuiFormRow
-                  display="columnCompressed"
-                  label="toolbarVisibility prop">
-                  <EuiButtonGroup
-                    isFullWidth
-                    buttonSize="compressed"
-                    legend="Border"
-                    options={this.toolbarPropTypeIsBooleanOptions}
-                    idSelected={this.state.toolbarPropTypeIsBoolean.toString()}
-                    onChange={this.onToolbarPropTypeIsBooleanChange}
-                  />
-                </EuiFormRow>
-                {this.state.toolbarPropTypeIsBoolean === false ? (
-                  <Fragment>
-                    <EuiFormRow
-                      display="columnCompressed"
-                      label="Show style selector">
-                      <EuiButtonGroup
-                        isFullWidth
-                        buttonSize="compressed"
-                        legend="Border"
-                        options={this.showStyleSelectorOptions}
-                        idSelected={this.state.showStyleSelector.toString()}
-                        onChange={this.onShowStyleSelectorChange}
-                      />
-                    </EuiFormRow>
-
-                    <EuiFormRow
-                      display="columnCompressed"
-                      label="Show sort selector">
-                      <EuiButtonGroup
-                        isFullWidth
-                        buttonSize="compressed"
-                        legend="Border"
-                        options={this.showSortSelectorOptions}
-                        idSelected={this.state.showSortSelector.toString()}
-                        onChange={this.onShowSortSelectorChange}
-                      />
-                    </EuiFormRow>
-
-                    <EuiFormRow
-                      display="columnCompressed"
-                      label="Show full screen selector">
-                      <EuiButtonGroup
-                        isFullWidth
-                        buttonSize="compressed"
-                        legend="Border"
-                        options={this.showFullScreenSelectorOptions}
-                        idSelected={this.state.showFullScreenSelector.toString()}
-                        onChange={this.onShowFullScreenSelectorChange}
-                      />
-                    </EuiFormRow>
-
-                    <EuiFormRow
-                      display="columnCompressed"
-                      label="Show column selector">
-                      <EuiButtonGroup
-                        isFullWidth
-                        buttonSize="compressed"
-                        legend="Border"
-                        options={this.showColumnSelectorOptions}
-                        idSelected={this.state.showColumnSelector.toString()}
-                        onChange={this.onShowColumnSelectorChange}
-                      />
-                    </EuiFormRow>
-                    {this.state.showColumnSelector && (
-                      <>
-                        <EuiFormRow
-                          display="columnCompressed"
-                          label="Allow hiding columns"
-                          style={{ marginLeft: 32 }}>
-                          <EuiButtonGroup
-                            isFullWidth
-                            buttonSize="compressed"
-                            legend="Border"
-                            options={this.allowHideColumnsOptions}
-                            idSelected={this.state.allowHideColumns.toString()}
-                            onChange={this.onAllowHideColumnsChange}
-                          />
-                        </EuiFormRow>
-                        <EuiFormRow
-                          display="columnCompressed"
-                          label="Allow ordering columns"
-                          style={{ marginLeft: 32 }}>
-                          <EuiButtonGroup
-                            isFullWidth
-                            buttonSize="compressed"
-                            legend="Border"
-                            options={this.allowOrderingColumnsOptions}
-                            idSelected={this.state.allowOrderingColumns.toString()}
-                            onChange={this.onAllowOrderingColumnsChange}
-                          />
-                        </EuiFormRow>
-                      </>
-                    )}
-                  </Fragment>
-                ) : (
-                  <EuiFormRow display="columnCompressed" label="Show toolbar">
+              <EuiFormRow label="Footer" display="columnCompressed">
+                <EuiButtonGroup
+                  isFullWidth
+                  buttonSize="compressed"
+                  legend="Footer"
+                  options={footerOptions}
+                  idSelected={footerSelected}
+                  onChange={onFooterChange}
+                />
+              </EuiFormRow>
+            </div>
+          </EuiPopover>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiPopover
+            id="toolbarVisibility"
+            button={toolbarButton}
+            isOpen={isToolbarPopoverOpen}
+            anchorPosition="rightUp"
+            closePopover={closeToolbarPopover}>
+            <div style={{ width: 400 }}>
+              <EuiFormRow
+                display="columnCompressed"
+                label="toolbarVisibility prop">
+                <EuiButtonGroup
+                  isFullWidth
+                  buttonSize="compressed"
+                  legend="Border"
+                  options={toolbarPropTypeIsBooleanOptions}
+                  idSelected={toolbarPropTypeIsBoolean.toString()}
+                  onChange={onToolbarPropTypeIsBooleanChange}
+                />
+              </EuiFormRow>
+              {toolbarPropTypeIsBoolean === false ? (
+                <Fragment>
+                  <EuiFormRow
+                    display="columnCompressed"
+                    label="Show style selector">
                     <EuiButtonGroup
                       isFullWidth
                       buttonSize="compressed"
                       legend="Border"
-                      options={this.showToolbarOptions}
-                      idSelected={this.state.showToolbar.toString()}
-                      onChange={this.onShowToolbarChange}
+                      options={showStyleSelectorOptions}
+                      idSelected={showStyleSelector.toString()}
+                      onChange={onShowStyleSelectorChange}
                     />
                   </EuiFormRow>
-                )}
-              </div>
-            </EuiPopover>
-          </EuiFlexItem>
-        </EuiFlexGroup>
 
-        {this.state.footerSelected === 'striped' ? (
-          <>
-            <EuiSpacer />
+                  <EuiFormRow
+                    display="columnCompressed"
+                    label="Show sort selector">
+                    <EuiButtonGroup
+                      isFullWidth
+                      buttonSize="compressed"
+                      legend="Border"
+                      options={showSortSelectorOptions}
+                      idSelected={showSortSelector.toString()}
+                      onChange={onShowSortSelectorChange}
+                    />
+                  </EuiFormRow>
 
-            <EuiCallOut
-              size="s"
-              title="A striped footer will be shaded depending on whether it is an even or an odd row considering the rest of the rows in the datagrid. Needs to be used with stripes={true}."
-            />
-          </>
-        ) : null}
+                  <EuiFormRow
+                    display="columnCompressed"
+                    label="Show full screen selector">
+                    <EuiButtonGroup
+                      isFullWidth
+                      buttonSize="compressed"
+                      legend="Border"
+                      options={showFullScreenSelectorOptions}
+                      idSelected={showFullScreenSelector.toString()}
+                      onChange={onShowFullScreenSelectorChange}
+                    />
+                  </EuiFormRow>
 
-        <EuiSpacer />
+                  <EuiFormRow
+                    display="columnCompressed"
+                    label="Show column selector">
+                    <EuiButtonGroup
+                      isFullWidth
+                      buttonSize="compressed"
+                      legend="Border"
+                      options={showColumnSelectorOptions}
+                      idSelected={showColumnSelector.toString()}
+                      onChange={onShowColumnSelectorChange}
+                    />
+                  </EuiFormRow>
+                  {showColumnSelector && (
+                    <>
+                      <EuiFormRow
+                        display="columnCompressed"
+                        label="Allow hiding columns"
+                        style={{ marginLeft: 32 }}>
+                        <EuiButtonGroup
+                          isFullWidth
+                          buttonSize="compressed"
+                          legend="Border"
+                          options={allowHideColumnsOptions}
+                          idSelected={allowHideColumns.toString()}
+                          onChange={onAllowHideColumnsChange}
+                        />
+                      </EuiFormRow>
+                      <EuiFormRow
+                        display="columnCompressed"
+                        label="Allow ordering columns"
+                        style={{ marginLeft: 32 }}>
+                        <EuiButtonGroup
+                          isFullWidth
+                          buttonSize="compressed"
+                          legend="Border"
+                          options={allowOrderingColumnsOptions}
+                          idSelected={allowOrderingColumns.toString()}
+                          onChange={onAllowOrderingColumnsChange}
+                        />
+                      </EuiFormRow>
+                    </>
+                  )}
+                </Fragment>
+              ) : (
+                <EuiFormRow display="columnCompressed" label="Show toolbar">
+                  <EuiButtonGroup
+                    isFullWidth
+                    buttonSize="compressed"
+                    legend="Border"
+                    options={showToolbarOptions}
+                    idSelected={showToolbar.toString()}
+                    onChange={onShowToolbarChange}
+                  />
+                </EuiFormRow>
+              )}
+            </div>
+          </EuiPopover>
+        </EuiFlexItem>
+      </EuiFlexGroup>
 
-        <EuiDataGrid
-          aria-label="Top EUI contributors"
-          columns={columns}
-          columnVisibility={{
-            visibleColumns: this.state.visibleColumns,
-            setVisibleColumns: this.setVisibleColumns,
-          }}
-          rowCount={data.length}
-          gridStyle={{
-            border: this.state.borderSelected,
-            fontSize: this.state.fontSizeSelected,
-            cellPadding: this.state.cellPaddingSelected,
-            stripes: this.state.stripesSelected,
-            rowHover: this.state.rowHoverSelected,
-            header: this.state.headerSelected,
-            footer: this.state.footerSelected,
-          }}
-          toolbarVisibility={toolbarConfig}
-          renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
-          renderFooterCellValue={renderFooterCellValue}
-          pagination={{
-            ...pagination,
-            pageSizeOptions: [5, 10, 25],
-            onChangeItemsPerPage: this.setPageSize,
-            onChangePage: this.setPageIndex,
-          }}
-        />
-      </div>
-    );
-  }
-}
+      {footerSelected === 'striped' ? (
+        <>
+          <EuiSpacer />
+
+          <EuiCallOut
+            size="s"
+            title="A striped footer will be shaded depending on whether it is an even or an odd row considering the rest of the rows in the datagrid. Needs to be used with stripes={true}."
+          />
+        </>
+      ) : null}
+
+      <EuiSpacer />
+
+      <EuiDataGrid
+        aria-label="Top EUI contributors"
+        columns={columns}
+        columnVisibility={{
+          visibleColumns: visibleColumns,
+          setVisibleColumns: setVisibleColumns,
+        }}
+        rowCount={data.length}
+        gridStyle={{
+          border: borderSelected,
+          fontSize: fontSizeSelected,
+          cellPadding: cellPaddingSelected,
+          stripes: stripesSelected,
+          rowHover: rowHoverSelected,
+          header: headerSelected,
+          footer: footerSelected,
+        }}
+        toolbarVisibility={toolbarConfig}
+        renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
+        renderFooterCellValue={renderFooterCellValue}
+        pagination={{
+          ...pagination,
+          pageSizeOptions: [5, 10, 25],
+          onChangeItemsPerPage: setPageSize,
+          onChangePage: setPageIndex,
+        }}
+      />
+    </div>
+  );
+};
+export default DataGrid;

--- a/src-docs/src/views/form_controls/display_toggles.js
+++ b/src-docs/src/views/form_controls/display_toggles.js
@@ -1,4 +1,4 @@
-import React, { cloneElement, Component, Fragment } from 'react';
+import React, { cloneElement, useState, Fragment } from 'react';
 import PropTypes from 'prop-types';
 
 import {
@@ -12,203 +12,170 @@ import {
   EuiSpacer,
 } from '../../../../src/components';
 
-export class DisplayToggles extends Component {
-  constructor(props) {
-    super(props);
+export const DisplayToggles = ({
+  canIsDisabled,
+  canDisabled,
+  canReadOnly,
+  canLoading,
+  canCompressed,
+  canFullWidth,
+  canPrepend,
+  canAppend,
+  canInvalid,
+  children,
+  extras,
+  spacerSize,
+}) => {
+  const [disabled, setDisabled] = useState(false);
+  const [readOnly, setReadOnly] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [compressed, setCompressed] = useState(false);
+  const [fullWidth, setFullWidth] = useState(false);
+  const [prepend, setPrepend] = useState(false);
+  const [append, setAppend] = useState(false);
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [invalid, setInvalid] = useState(false);
 
-    this.state = {
-      disabled: false,
-      readOnly: false,
-      loading: false,
-      compressed: false,
-      fullWidth: false,
-      prepend: false,
-      append: false,
-      isPopoverOpen: false,
-      invalid: false,
-    };
-  }
+  const canProps = {};
+  if (canDisabled) canProps.disabled = disabled;
+  if (canIsDisabled) canProps.isDisabled = disabled;
+  if (canReadOnly) canProps.readOnly = readOnly;
+  if (canLoading) canProps.isLoading = loading;
+  if (canFullWidth) canProps.fullWidth = fullWidth;
+  if (canCompressed) canProps.compressed = compressed;
+  if (canPrepend && prepend) canProps.prepend = 'Prepend';
+  if (canAppend && append) canProps.append = 'Append';
+  if (canInvalid) canProps.isInvalid = invalid;
 
-  updateProperty = (checked, property) => {
-    const currentState = { ...this.state };
-    currentState[property] = checked;
-    this.setState(currentState);
-    this.props.onUpdate && this.props.onUpdate(currentState);
-  };
-
-  render() {
-    const {
-      canIsDisabled,
-      canDisabled,
-      canReadOnly,
-      canLoading,
-      canCompressed,
-      canFullWidth,
-      canPrepend,
-      canAppend,
-      canInvalid,
-      children,
-      extras,
-      spacerSize,
-    } = this.props;
-
-    const canProps = {};
-    if (canDisabled) canProps.disabled = this.state.disabled;
-    if (canIsDisabled) canProps.isDisabled = this.state.disabled;
-    if (canReadOnly) canProps.readOnly = this.state.readOnly;
-    if (canLoading) canProps.isLoading = this.state.loading;
-    if (canFullWidth) canProps.fullWidth = this.state.fullWidth;
-    if (canCompressed) canProps.compressed = this.state.compressed;
-    if (canPrepend && this.state.prepend) canProps.prepend = 'Prepend';
-    if (canAppend && this.state.append) canProps.append = 'Append';
-    if (canInvalid) canProps.isInvalid = this.state.invalid;
-
-    return (
-      <Fragment>
-        {cloneElement(children, canProps)}
-        <EuiSpacer size={spacerSize} />
-        <EuiPopover
-          panelPaddingSize="s"
-          isOpen={this.state.isPopoverOpen}
-          closePopover={() => {
-            this.setState({ isPopoverOpen: false });
-          }}
-          button={
-            <EuiButtonEmpty
-              iconType="controlsHorizontal"
-              size="xs"
-              onClick={() => {
-                this.setState({ isPopoverOpen: !this.state.isPopoverOpen });
-              }}>
-              Display toggles
-            </EuiButtonEmpty>
-          }>
-          <div>
-            <EuiFlexGroup
-              wrap={true}
-              direction="column"
-              gutterSize="s"
-              responsive={false}>
-              {(canDisabled || canIsDisabled) && (
-                <EuiFlexItem grow={false}>
-                  <EuiSwitch
-                    compressed
-                    label={'disabled'}
-                    checked={this.state.disabled}
-                    onChange={(e) =>
-                      this.updateProperty(e.target.checked, 'disabled')
-                    }
-                  />
-                </EuiFlexItem>
-              )}
-              {canReadOnly && (
-                <EuiFlexItem grow={false}>
-                  <EuiSwitch
-                    compressed
-                    label={'readOnly'}
-                    checked={this.state.readOnly}
-                    onChange={(e) =>
-                      this.updateProperty(e.target.checked, 'readOnly')
-                    }
-                  />
-                </EuiFlexItem>
-              )}
-              {canLoading && (
-                <EuiFlexItem grow={false}>
-                  <EuiSwitch
-                    compressed
-                    label={'loading'}
-                    checked={this.state.loading}
-                    onChange={(e) =>
-                      this.updateProperty(e.target.checked, 'loading')
-                    }
-                  />
-                </EuiFlexItem>
-              )}
-              {canInvalid && (
-                <EuiFlexItem grow={false}>
-                  <EuiSwitch
-                    compressed
-                    label={'invalid'}
-                    checked={this.state.invalid}
-                    onChange={(e) =>
-                      this.updateProperty(e.target.checked, 'invalid')
-                    }
-                  />
-                </EuiFlexItem>
-              )}
-              {canFullWidth && (
-                <EuiFlexItem grow={false}>
-                  <EuiSwitch
-                    compressed
-                    label={'fullWidth'}
-                    checked={this.state.fullWidth}
-                    onChange={(e) =>
-                      this.updateProperty(e.target.checked, 'fullWidth')
-                    }
-                  />
-                </EuiFlexItem>
-              )}
-              {canCompressed && (
-                <EuiFlexItem grow={false}>
-                  <EuiSwitch
-                    compressed
-                    label={
-                      <span>
-                        compressed{' '}
-                        <EuiToolTip content="Compressed usages are very specific. Click to view full compressed documentation">
-                          <a href="/#/forms/compressed-forms">
-                            <EuiIcon type="help" />
-                          </a>
-                        </EuiToolTip>
-                      </span>
-                    }
-                    checked={this.state.compressed}
-                    onChange={(e) =>
-                      this.updateProperty(e.target.checked, 'compressed')
-                    }
-                  />
-                </EuiFlexItem>
-              )}
-              {canPrepend && (
-                <EuiFlexItem grow={false}>
-                  <EuiSwitch
-                    compressed
-                    label={'prepend'}
-                    checked={this.state.prepend}
-                    onChange={(e) =>
-                      this.updateProperty(e.target.checked, 'prepend')
-                    }
-                  />
-                </EuiFlexItem>
-              )}
-              {canAppend && (
-                <EuiFlexItem grow={false}>
-                  <EuiSwitch
-                    compressed
-                    label={'append'}
-                    checked={this.state.append}
-                    onChange={(e) =>
-                      this.updateProperty(e.target.checked, 'append')
-                    }
-                  />
-                </EuiFlexItem>
-              )}
-              {extras &&
-                extras.map((extra, index) => {
-                  return (
-                    <EuiFlexItem key={index} grow={false}>
-                      {extra}
-                    </EuiFlexItem>
-                  );
-                })}
-            </EuiFlexGroup>
-          </div>
-        </EuiPopover>
-      </Fragment>
-    );
-  }
-}
+  return (
+    <Fragment>
+      {cloneElement(children, canProps)}
+      <EuiSpacer size={spacerSize} />
+      <EuiPopover
+        panelPaddingSize="s"
+        isOpen={isPopoverOpen}
+        closePopover={() => {
+          setIsPopoverOpen(false);
+        }}
+        button={
+          <EuiButtonEmpty
+            iconType="controlsHorizontal"
+            size="xs"
+            onClick={() => {
+              setIsPopoverOpen(!isPopoverOpen);
+            }}>
+            Display toggles
+          </EuiButtonEmpty>
+        }>
+        <div>
+          <EuiFlexGroup
+            wrap={true}
+            direction="column"
+            gutterSize="s"
+            responsive={false}>
+            {(canDisabled || canIsDisabled) && (
+              <EuiFlexItem grow={false}>
+                <EuiSwitch
+                  compressed
+                  label={'disabled'}
+                  checked={disabled}
+                  onChange={(e) => setDisabled(e.target.checked)}
+                />
+              </EuiFlexItem>
+            )}
+            {canReadOnly && (
+              <EuiFlexItem grow={false}>
+                <EuiSwitch
+                  compressed
+                  label={'readOnly'}
+                  checked={readOnly}
+                  onChange={(e) => setReadOnly(e.target.checked)}
+                />
+              </EuiFlexItem>
+            )}
+            {canLoading && (
+              <EuiFlexItem grow={false}>
+                <EuiSwitch
+                  compressed
+                  label={'loading'}
+                  checked={loading}
+                  onChange={(e) => setLoading(e.target.checked)}
+                />
+              </EuiFlexItem>
+            )}
+            {canInvalid && (
+              <EuiFlexItem grow={false}>
+                <EuiSwitch
+                  compressed
+                  label={'invalid'}
+                  checked={invalid}
+                  onChange={(e) => setInvalid(e.target.checked)}
+                />
+              </EuiFlexItem>
+            )}
+            {canFullWidth && (
+              <EuiFlexItem grow={false}>
+                <EuiSwitch
+                  compressed
+                  label={'fullWidth'}
+                  checked={fullWidth}
+                  onChange={(e) => setFullWidth(e.target.checked)}
+                />
+              </EuiFlexItem>
+            )}
+            {canCompressed && (
+              <EuiFlexItem grow={false}>
+                <EuiSwitch
+                  compressed
+                  label={
+                    <span>
+                      compressed{' '}
+                      <EuiToolTip content="Compressed usages are very specific. Click to view full compressed documentation">
+                        <a href="/#/forms/compressed-forms">
+                          <EuiIcon type="help" />
+                        </a>
+                      </EuiToolTip>
+                    </span>
+                  }
+                  checked={compressed}
+                  onChange={(e) => setCompressed(e.target.checked)}
+                />
+              </EuiFlexItem>
+            )}
+            {canPrepend && (
+              <EuiFlexItem grow={false}>
+                <EuiSwitch
+                  compressed
+                  label={'prepend'}
+                  checked={prepend}
+                  onChange={(e) => setPrepend(e.target.checked)}
+                />
+              </EuiFlexItem>
+            )}
+            {canAppend && (
+              <EuiFlexItem grow={false}>
+                <EuiSwitch
+                  compressed
+                  label={'append'}
+                  checked={append}
+                  onChange={(e) => setAppend(e.target.checked)}
+                />
+              </EuiFlexItem>
+            )}
+            {extras &&
+              extras.map((extra, index) => {
+                return (
+                  <EuiFlexItem key={index} grow={false}>
+                    {extra}
+                  </EuiFlexItem>
+                );
+              })}
+          </EuiFlexGroup>
+        </div>
+      </EuiPopover>
+    </Fragment>
+  );
+};
 
 DisplayToggles.propTypes = {
   canIsDisabled: PropTypes.bool,


### PR DESCRIPTION
### Summary

Making progress: #3150 

**Converted some  examples from class component to functional component**
- [example1](https://elastic.github.io/eui/#/tabular-content/data-grid-styling-and-control)
- [example2](https://elastic.github.io/eui/#/tabular-content/data-grid-schemas-and-popovers)
- [example3](http://localhost:8030/#/forms/form-controls)


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Edge**, and **Firefox**
~~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~~
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
~~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~~
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
~~- [ ] Checked for **breaking changes** and labeled appropriately~~
~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
~~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~~
