### PR TITLE
[EuiImage] Allow `src` as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added `panelProps` to `EuiPopover` ([#4573](https://github.com/elastic/eui/pull/4573))
+- Added `src` prop to `EuiImage` as an alternative to `url` ([#4611](https://github.com/elastic/eui/pull/4611))
 
 **Bug fixes**
 

--- a/src-docs/src/views/image/float.js
+++ b/src-docs/src/views/image/float.js
@@ -13,7 +13,7 @@ export default () => (
       caption="Random nature image"
       allowFullScreen
       alt="Random nature image"
-      url="https://picsum.photos/800/500"
+      src="https://picsum.photos/800/500"
     />
     <p>{fake('{{lorem.paragraphs}}')}</p>
     <p>{fake('{{lorem.paragraphs}}')}</p>
@@ -26,7 +26,7 @@ export default () => (
       allowFullScreen
       caption="Another random image"
       alt="Random nature image"
-      url="https://picsum.photos/300/300"
+      src="https://picsum.photos/300/300"
     />
     <p>{fake('{{lorem.paragraphs}}')}</p>
     <p>{fake('{{lorem.paragraphs}}')}</p>

--- a/src-docs/src/views/image/image.js
+++ b/src-docs/src/views/image/image.js
@@ -8,6 +8,6 @@ export default () => (
     hasShadow
     caption="Random nature image"
     alt="Random nature image"
-    url="https://picsum.photos/300/300"
+    src="https://picsum.photos/300/300"
   />
 );

--- a/src-docs/src/views/image/image_example.js
+++ b/src-docs/src/views/image/image_example.js
@@ -5,6 +5,8 @@ import { renderToHtml } from '../../services';
 import { GuideSectionTypes } from '../../components';
 
 import { EuiCode, EuiImage } from '../../../../src/components';
+EuiImage.__docgenInfo.props.src.required = true;
+
 import imageConfig from './playground';
 
 import Image from './image';

--- a/src-docs/src/views/image/image_example.js
+++ b/src-docs/src/views/image/image_example.js
@@ -12,7 +12,7 @@ const imageSource = require('!!raw-loader!./image');
 const imageHtml = renderToHtml(Image);
 const imageSnippet = `<EuiImage
   alt={description}
-  url={someUrl}
+  src={someSrc}
 />
 `;
 
@@ -22,7 +22,7 @@ const imageSizesHtml = renderToHtml(ImageSizes);
 const imageSizesSnippet = `<EuiImage
   size="l"
   alt={description}
-  url={someUrl}
+  src={someSrc}
 />
 `;
 
@@ -32,7 +32,7 @@ const imageZoomHtml = renderToHtml(ImageZoom);
 const imageZoomSnippet = `<EuiImage
   allowFullScreen
   alt={description}
-  url={someUrl}
+  src={someSrc}
 />
 `;
 
@@ -43,7 +43,7 @@ const imageFloatSource = require('!!raw-loader!./float');
 const imageFloatHtml = renderToHtml(ImageFloat);
 const imageFloatSnippet = `<EuiImage
   alt={description}
-  url={someUrl}
+  src={someSrc}
   float="left"
   margin="l"
 />

--- a/src-docs/src/views/image/image_size.js
+++ b/src-docs/src/views/image/image_size.js
@@ -10,7 +10,7 @@ export default () => (
       size={50}
       caption="Custom size (50)"
       alt="Accessible image alt goes here"
-      url="https://source.unsplash.com/1000x1000/?Nature"
+      src="https://source.unsplash.com/1000x1000/?Nature"
     />
     <EuiSpacer />
     <EuiImage
@@ -19,7 +19,7 @@ export default () => (
       allowFullScreen
       caption="Small"
       alt="Accessible image alt goes here"
-      url="https://source.unsplash.com/1000x1000/?Nature"
+      src="https://source.unsplash.com/1000x1000/?Nature"
     />
     <EuiSpacer />
     <EuiImage
@@ -28,7 +28,7 @@ export default () => (
       allowFullScreen
       caption="Medium"
       alt="Accessible image alt goes here"
-      url="https://source.unsplash.com/1000x1000/?Nature"
+      src="https://source.unsplash.com/1000x1000/?Nature"
     />
     <EuiSpacer />
     <EuiImage
@@ -37,7 +37,7 @@ export default () => (
       allowFullScreen
       caption="Large"
       alt="Accessible image alt goes here"
-      url="https://source.unsplash.com/1000x1000/?Nature"
+      src="https://source.unsplash.com/1000x1000/?Nature"
     />
     <EuiSpacer />
     <EuiImage
@@ -46,7 +46,7 @@ export default () => (
       allowFullScreen
       caption="Extra large"
       alt="Accessible image alt goes here"
-      url="https://source.unsplash.com/1000x1000/?Nature"
+      src="https://source.unsplash.com/1000x1000/?Nature"
     />
     <EuiSpacer />
     <EuiImage
@@ -54,7 +54,7 @@ export default () => (
       allowFullScreen
       caption="Original"
       alt="Accessible image alt goes here"
-      url="https://source.unsplash.com/1000x1000/?Nature"
+      src="https://source.unsplash.com/1000x1000/?Nature"
     />
     <EuiSpacer />
     <EuiImage
@@ -63,7 +63,7 @@ export default () => (
       size="fullWidth"
       caption="Full width"
       alt="Accessible image alt goes here"
-      url="https://source.unsplash.com/1000x1000/?Nature"
+      src="https://source.unsplash.com/1000x1000/?Nature"
     />
   </div>
 );

--- a/src-docs/src/views/image/image_zoom.js
+++ b/src-docs/src/views/image/image_zoom.js
@@ -15,7 +15,7 @@ export default () => (
         allowFullScreen
         caption="Click me"
         alt="Accessible image alt goes here"
-        url="https://source.unsplash.com/2000x1000/?Nature"
+        src="https://source.unsplash.com/2000x1000/?Nature"
       />
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
@@ -26,7 +26,7 @@ export default () => (
         caption="Click me"
         alt="Accessible image alt goes here"
         fullScreenIconColor="dark"
-        url="https://source.unsplash.com/1000x2000/?Nature"
+        src="https://source.unsplash.com/1000x2000/?Nature"
       />
     </EuiFlexItem>
   </EuiFlexGroup>

--- a/src-docs/src/views/image/playground.js
+++ b/src-docs/src/views/image/playground.js
@@ -21,7 +21,7 @@ export default () => {
     },
     defaultValue: 'original',
   };
-  propsToUse.url.value = 'https://source.unsplash.com/100x100/?Nature';
+  propsToUse.src.value = 'https://source.unsplash.com/100x100/?Nature';
   propsToUse.alt.value = 'image_alt';
 
   return {

--- a/src/components/image/__snapshots__/image.test.tsx.snap
+++ b/src/components/image/__snapshots__/image.test.tsx.snap
@@ -95,3 +95,15 @@ exports[`EuiImage is rendered with custom size 1`] = `
   />
 </figure>
 `;
+
+exports[`EuiImage is rendered with src 1`] = `
+<figure
+  class="euiImage euiImage--floatLeft euiImage--original"
+>
+  <img
+    alt="alt"
+    class="euiImage__img"
+    src="/cat.jpg"
+  />
+</figure>
+`;

--- a/src/components/image/image.test.tsx
+++ b/src/components/image/image.test.tsx
@@ -48,6 +48,14 @@ describe('EuiImage', () => {
     expect(component).toMatchSnapshot();
   });
 
+  test('is rendered with src', () => {
+    const component = render(
+      <EuiImage alt="alt" float="left" src="/cat.jpg" />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
   test('is rendered with a float', () => {
     const component = render(
       <EuiImage alt="alt" float="left" url="/cat.jpg" />

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -74,12 +74,12 @@ const fullScreenIconColorMap: { [color in FullScreenIconColor]: string } = {
 type _EuiImageSrcOrUrl = ExclusiveUnion<
   {
     /**
-     * Requires either `url` or `src` but defaults to using `url` if both are provided
+     * Requires either `src` or `url` but defaults to using `src` if both are provided
      */
-    url: string;
+    src: string;
   },
   {
-    src: string;
+    url: string;
   }
 >;
 
@@ -229,7 +229,7 @@ export const EuiImage: FunctionComponent<EuiImageProps> = ({
               onClick={closeFullScreen}
               onKeyDown={onKeyDown}>
               <img
-                src={url || src}
+                src={src || url}
                 alt={alt}
                 className="euiImage-isFullScreen__img"
                 {...rest}
@@ -264,7 +264,7 @@ export const EuiImage: FunctionComponent<EuiImageProps> = ({
           onClick={openFullScreen}>
           <img
             style={customStyle}
-            src={url || src}
+            src={src || url}
             alt={alt}
             className="euiImage__img"
             {...rest}
@@ -280,7 +280,7 @@ export const EuiImage: FunctionComponent<EuiImageProps> = ({
       <figure className={classes} aria-label={optionalCaptionText}>
         <img
           style={customStyle}
-          src={url || src}
+          src={src || url}
           className="euiImage__img"
           alt={alt}
           {...rest}

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -25,7 +25,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { CommonProps } from '../common';
+import { CommonProps, ExclusiveUnion } from '../common';
 import { EuiOverlayMask } from '../overlay_mask';
 
 import { EuiIcon } from '../icon';
@@ -71,51 +71,63 @@ const fullScreenIconColorMap: { [color in FullScreenIconColor]: string } = {
   dark: 'default',
 };
 
-export interface EuiImageProps
-  extends CommonProps,
-    HTMLAttributes<HTMLImageElement> {
-  /**
-   * Separate from the caption is a title on the alt tag itself.
-   * This one is required for accessibility.
-   */
-  alt: string;
-  /**
-   * Accepts `s` / `m` / `l` / `xl` / `original` / `fullWidth` / or a CSS size of `number` or `string`.
-   * `fullWidth` will set the figure to stretch to 100% of its container.
-   * `string` and `number` types will max both the width or height, whichever is greater.
-   */
-  size?: ImageSize | number | string;
-  /**
-   * Changes the color of the icon that floats above the image when it can be clicked to fullscreen.
-   * The default value of `light` is fine unless your image has a white background, in which case you should change it to `dark`.
-   */
-  fullScreenIconColor?: FullScreenIconColor;
-  url: string;
-  /**
-   * Provides the visible caption to the image
-   */
-  caption?: ReactNode;
-  /**
-   * When set to `true` (default) will apply a slight shadow to the image
-   */
-  hasShadow?: boolean;
-  /**
-   * When set to `true` will make the image clickable to a larger version
-   */
-  allowFullScreen?: boolean;
-  /**
-   * Float the image to the left or right. Useful in large text blocks.
-   */
-  float?: Floats;
-  /**
-   * Margin around the image.
-   */
-  margin?: Margins;
-}
+type _EuiImageSrcOrUrl = ExclusiveUnion<
+  {
+    /**
+     * Requires either `url` or `src` but defaults to using `url` if both are provided
+     */
+    url: string;
+  },
+  {
+    src: string;
+  }
+>;
+
+export type EuiImageProps = CommonProps &
+  _EuiImageSrcOrUrl &
+  HTMLAttributes<HTMLImageElement> & {
+    /**
+     * Separate from the caption is a title on the alt tag itself.
+     * This one is required for accessibility.
+     */
+    alt: string;
+    /**
+     * Accepts `s` / `m` / `l` / `xl` / `original` / `fullWidth` / or a CSS size of `number` or `string`.
+     * `fullWidth` will set the figure to stretch to 100% of its container.
+     * `string` and `number` types will max both the width or height, whichever is greater.
+     */
+    size?: ImageSize | number | string;
+    /**
+     * Changes the color of the icon that floats above the image when it can be clicked to fullscreen.
+     * The default value of `light` is fine unless your image has a white background, in which case you should change it to `dark`.
+     */
+    fullScreenIconColor?: FullScreenIconColor;
+    /**
+     * Provides the visible caption to the image
+     */
+    caption?: ReactNode;
+    /**
+     * When set to `true` (default) will apply a slight shadow to the image
+     */
+    hasShadow?: boolean;
+    /**
+     * When set to `true` will make the image clickable to a larger version
+     */
+    allowFullScreen?: boolean;
+    /**
+     * Float the image to the left or right. Useful in large text blocks.
+     */
+    float?: Floats;
+    /**
+     * Margin around the image.
+     */
+    margin?: Margins;
+  };
 
 export const EuiImage: FunctionComponent<EuiImageProps> = ({
   className,
   url,
+  src,
   size = 'original',
   caption,
   hasShadow,
@@ -217,7 +229,7 @@ export const EuiImage: FunctionComponent<EuiImageProps> = ({
               onClick={closeFullScreen}
               onKeyDown={onKeyDown}>
               <img
-                src={url}
+                src={url || src}
                 alt={alt}
                 className="euiImage-isFullScreen__img"
                 {...rest}
@@ -252,7 +264,7 @@ export const EuiImage: FunctionComponent<EuiImageProps> = ({
           onClick={openFullScreen}>
           <img
             style={customStyle}
-            src={url}
+            src={url || src}
             alt={alt}
             className="euiImage__img"
             {...rest}
@@ -268,7 +280,7 @@ export const EuiImage: FunctionComponent<EuiImageProps> = ({
       <figure className={classes} aria-label={optionalCaptionText}>
         <img
           style={customStyle}
-          src={url}
+          src={url || src}
           className="euiImage__img"
           alt={alt}
           {...rest}


### PR DESCRIPTION
This `url` prop for EuiImage has tripped me up many times. I constantly try to use the typical HTML `src` attribute and it takes me several minutes and docs lookup to find my mistake. 

This PR just creates an exclusive union that requires **either** `url` or `src` but since they can also conflict if not using TS, it defaults to `src` since this feels more standard and aligns to the final `<img>` tag.

### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- ~[ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] **Updated** **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
