### PR TITLE
[EuiColorStops] Fixed: Standard, Random & Fixed Examples are using same state

### DIFF
--- a/src-docs/src/views/color_picker/color_stops.js
+++ b/src-docs/src/views/color_picker/color_stops.js
@@ -5,7 +5,13 @@ import { EuiColorStops, EuiFormRow } from '../../../../src/components';
 import { useColorStopsState } from '../../../../src/services';
 
 export default () => {
-  const [colorStops, setColorStops, addColor] = useColorStopsState(true);
+  const [standardColorStops, setStandardColorStops] = useColorStopsState(true);
+  const [
+    randomColorStops,
+    setRandomColorStops,
+    addRandomColor,
+  ] = useColorStopsState(true);
+  const [fixedColorStops, setFixedColorStops] = useColorStopsState(true);
 
   const [extendedColorStops, setExtendedColorStops] = useState([
     {
@@ -46,8 +52,8 @@ export default () => {
       <EuiFormRow label="Standard">
         <EuiColorStops
           label="Standard"
-          onChange={setColorStops}
-          colorStops={colorStops}
+          onChange={setStandardColorStops}
+          colorStops={standardColorStops}
           min={0}
           max={100}
         />
@@ -55,11 +61,11 @@ export default () => {
       <EuiFormRow label="Random new color">
         <EuiColorStops
           label="Random new color"
-          onChange={setColorStops}
-          colorStops={colorStops}
+          onChange={setRandomColorStops}
+          colorStops={randomColorStops}
           min={0}
           max={100}
-          addColor={addColor}
+          addColor={addRandomColor}
         />
       </EuiFormRow>
       <EuiFormRow label="Extended range">
@@ -74,8 +80,8 @@ export default () => {
       <EuiFormRow label="Fixed color segments">
         <EuiColorStops
           label="Fixed color segments"
-          onChange={setColorStops}
-          colorStops={colorStops}
+          onChange={setFixedColorStops}
+          colorStops={fixedColorStops}
           min={0}
           max={100}
           stopType="fixed"


### PR DESCRIPTION
### Summary

Fixed: Standard, Random & Fixed Examples are using same state.
Issue Link:-  Closes https://github.com/elastic/eui/issues/4609

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
