### PR TITLE
[DOCS] Fix demo for "Sizes" and "With single panel" for Context menu

### DIFF
--- a/src-docs/src/views/context_menu/context_menu_example.js
+++ b/src-docs/src/views/context_menu/context_menu_example.js
@@ -120,7 +120,7 @@ export const ContextMenuExample = {
         </p>
       ),
       snippet: smallSnippet,
-      demo: <SinglePanel />,
+      demo: <Small />,
     },
     {
       title: 'With single panel',
@@ -142,7 +142,7 @@ export const ContextMenuExample = {
         </p>
       ),
       snippet: singlePanelSnippet,
-      demo: <Small />,
+      demo: <SinglePanel />,
     },
     {
       title: 'Displaying custom elements',


### PR DESCRIPTION
### Summary

"Demo JS" of "Sizes" shows example of "With single panel" and vice versa. See:

https://elastic.github.io/eui/#/navigation/context-menu

### ~Checklist~ Docs only
