### PR TITLE
Disable file watching in CI build

### DIFF
--- a/scripts/babel/react-docgen-typescript.js
+++ b/scripts/babel/react-docgen-typescript.js
@@ -27,8 +27,9 @@ const util = require('util');
 const { SyntaxKind } = require('typescript');
 const chokidar = require('chokidar');
 
-const { NODE_ENV, CI } = process.env;
-const isDevelopment = NODE_ENV !== 'production' && CI == null;
+const { NODE_ENV, CI, WEBPACK_DEV_SERVER } = process.env;
+const isDevelopment = WEBPACK_DEV_SERVER === 'true' && CI == null;
+const bypassWatch = NODE_ENV === 'puppeteer' || NODE_ENV === 'production';
 
 /**
  * To support extended props from tsx files.
@@ -48,7 +49,7 @@ function buildProgram() {
 }
 buildProgram();
 
-if (isDevelopment) {
+if (isDevelopment && !bypassWatch) {
   chokidar
     .watch(['./src/**/*.(ts|tsx)', './src-docs/**/*.(ts|tsx)'], {
       ignoreInitial: true, // don't emit `add` event during file discovery

--- a/src-docs/webpack.config.js
+++ b/src-docs/webpack.config.js
@@ -139,7 +139,7 @@ const webpackConfig = {
         // /app/ represents the entire docker environment
         watchOptions: isPuppeteer
           ? {
-              ignored: /app/,
+              ignored: '**/*',
             }
           : undefined,
       }

--- a/src-docs/webpack.config.js
+++ b/src-docs/webpack.config.js
@@ -11,10 +11,10 @@ const { NODE_ENV, CI, WEBPACK_DEV_SERVER } = process.env;
 
 const isDevelopment = WEBPACK_DEV_SERVER === 'true' && CI == null;
 const isProduction = NODE_ENV === 'production';
-const bypassCache = NODE_ENV === 'puppeteer';
+const isPuppeteer = NODE_ENV === 'puppeteer';
 
 function employCache(loaders) {
-  if (isDevelopment && !bypassCache) {
+  if (isDevelopment && !isPuppeteer) {
     return [
       {
         loader: 'cache-loader',
@@ -135,6 +135,11 @@ const webpackConfig = {
         }),
         disableHostCheck: true,
         historyApiFallback: true,
+        watchOptions: isPuppeteer
+          ? {
+              ignored: /app/,
+            }
+          : undefined,
       }
     : undefined,
   node: {

--- a/src-docs/webpack.config.js
+++ b/src-docs/webpack.config.js
@@ -135,6 +135,8 @@ const webpackConfig = {
         }),
         disableHostCheck: true,
         historyApiFallback: true,
+        // prevent file watching while running on CI
+        // /app/ represents the entire docker environment
         watchOptions: isPuppeteer
           ? {
               ignored: /app/,


### PR DESCRIPTION
### Summary

Fixes #4576

`chokidar` by way of `webpack-dev-server` by way of `yarn start-test-server-and-a11y-test` was watching all files and hitting memory limits. This prevents watching the entire docker environment using [devServer.watchOptions.ignored](https://webpack.js.org/configuration/watch/#watchoptionsignored).

~### Checklist~
