### PR TITLE
Stale issue/pr action

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -23,6 +23,6 @@ jobs:
           close-pr-label: 'stale-pr-closed'
           exempt-pr-labels: 'skip-stale-check'
           operations-per-run: 1000
-          remove-stal-when-updated: true
+          remove-stale-when-updated: true
           debug-only: true
           enable-statistics: true

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/stale@v3
         with:
           stale-issue-message: '👋 Hey there. This issue hasn''t had any activity for 180 days. We''ll automatically close it if that trend continues for another week. If you feel this issue is still valid and needs attention please let us know with a comment.'
-          stale-pr-message: '👋 Hey there. This PR hasn''t had any activity for 90 days. We''l automatically close it if that trend continues for another week. If you feel this issue is still valid and needs attention please let us know with a comment.'
+          stale-pr-message: '👋 Hey there. This PR hasn''t had any activity for 90 days. We''ll automatically close it if that trend continues for another week. If you feel this issue is still valid and needs attention please let us know with a comment.'
           close-issue-message: '❌ We''re automatically closing this issue due to lack of activity. Please comment if you feel this was done in error.'
           close-pr-message: '❌ We''re automatically closing this PR due to lack of activity. Please comment if you feel this was done in error.'
           days-before-pr-stale: 90

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,0 +1,27 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          stale-issue-message: ''
+          stale-pr-message: ''
+          close-issue-message: ''
+          close-pr-message: ''
+          days-before-pr-stale: 90
+          days-before-issue-stale: 180
+          days-before-close: 7
+          stale-issue-label: 'stale-issue'
+          close-issue-label: 'stale-issue-closed'
+          exempt-issue-labels: 'bug,ignore-stale-issue'
+          stale-pr-label: 'stale-pr'
+          close-pr-label: 'stale-pr-closed'
+          exempt-pr-labels: 'ignore-stale-pr'
+          operations-per-run: 1000
+          remove-stal-when-updated: true
+          debug-only: true

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -9,19 +9,19 @@ jobs:
     steps:
       - uses: actions/stale@v3
         with:
-          stale-issue-message: ''
-          stale-pr-message: ''
-          close-issue-message: ''
-          close-pr-message: ''
+          stale-issue-message: '👋 Hey there. This issue hasn''t had any activity for 180 days. We''ll automatically close it if that trend continues for another week. If you feel this issue is still valid and needs attention please let us know with a comment.'
+          stale-pr-message: '👋 Hey there. This PR hasn''t had any activity for 90 days. We''l automatically close it if that trend continues for another week. If you feel this issue is still valid and needs attention please let us know with a comment.'
+          close-issue-message: '❌ We''re automatically closing this issue due to lack of activity. Please comment if you feel this was done in error.'
+          close-pr-message: '❌ We''re automatically closing this PR due to lack of activity. Please comment if you feel this was done in error.'
           days-before-pr-stale: 90
           days-before-issue-stale: 180
           days-before-close: 7
           stale-issue-label: 'stale-issue'
           close-issue-label: 'stale-issue-closed'
-          exempt-issue-labels: 'bug,ignore-stale-issue'
+          exempt-issue-labels: 'bug,skip-stale-check'
           stale-pr-label: 'stale-pr'
           close-pr-label: 'stale-pr-closed'
-          exempt-pr-labels: 'ignore-stale-pr'
+          exempt-pr-labels: 'skip-stale-check'
           operations-per-run: 1000
           remove-stal-when-updated: true
           debug-only: true

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -25,3 +25,4 @@ jobs:
           operations-per-run: 1000
           remove-stal-when-updated: true
           debug-only: true
+          enable-statistics: true

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,7 +1,7 @@
 name: 'Close stale issues and PRs'
 on:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: '* */8 * * *'
 
 jobs:
   stale:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,10 @@ EUI has strict quality and testing standards due to its large downstream footpri
 
 If you have a preference, let us know when you make your PR, but never feel guilty about just handing it off. We're here to help.
 
+### We utilize Github actions to keep the repo tidy
+
+We use Github actions for some automation tasks to keep this repo tidy. Specifically we close out issues and PRs using [the actions/stale workflow](https://github.com/actions/stale) when we notice a lack of activity over a long period of time. This is done as much to remind us of older issues that need attention as it is to keep our total issue count managable. These action counters can easily be soft reset by commenting on the issues/PRs directly.
+
 ## Helpful documents
 
 * [Component design](wiki/component-design.md)


### PR DESCRIPTION
### Summary

Adds a Github action that checks for stale issues and PRs using https://github.com/actions/stale, which is Github's officially supported action for stale checks. To run this in a dry run mode, I've turned on Github logging for the repo, and set `debug-only: true` for the action. The docs on https://github.com/actions/stale#debugging suggest this means the action will not be run, and only be logged. This should allow us to watch how this would effect our repo.

### ~Checklist~
