### PR TITLE
[webpack] Fail on missing export

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-export { EuiAccordion, EuiAccordionProps } from './accordion';
+export { EuiAccordion } from './accordion';
 
 export { EuiAspectRatio } from './aspect_ratio';
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-export { EuiAccordion } from './accordion';
+export { EuiAccordion, EuiAccordionProps } from './accordion';
 
 export { EuiAspectRatio } from './aspect_ratio';
 

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -100,9 +100,11 @@ module.exports = {
         loader: 'file-loader',
       },
     ],
+    strictExportPresence: isProduction,
   },
 
   plugins,
+
   optimization: {
     minimizer: isProduction ? [terserPlugin] : [],
   },


### PR DESCRIPTION
### Summary

Use `strictExportPresence` on production builds to prevent missing exports, namely type exports from `.js` files.
### Checklist

- [x] Revert EuiAccordionProps export
