### PR TITLE
forwardRef documentation, forwardRef tests for EuiHeaderSectionItemButton

### DIFF
--- a/src/components/header/header_section/header_section_item_button.test.tsx
+++ b/src/components/header/header_section/header_section_item_button.test.tsx
@@ -18,7 +18,7 @@
  */
 
 import React from 'react';
-import { render, shallow } from 'enzyme';
+import { mount, render, shallow } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
 
 import { EuiHeaderSectionItemButton } from './header_section_item_button';
@@ -92,6 +92,26 @@ describe('EuiHeaderSectionItemButton', () => {
       $button.simulate('click');
 
       expect(onClickHandler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('ref', () => {
+    it('is the button element', () => {
+      const ref = jest.fn();
+      const component = mount(<EuiHeaderSectionItemButton ref={ref} />);
+
+      expect(ref).toHaveBeenCalledTimes(1);
+      expect(ref).toHaveBeenCalledWith(component.find('button').getDOMNode());
+    });
+
+    it('is the anchor element', () => {
+      const ref = jest.fn();
+      const component = mount(
+        <EuiHeaderSectionItemButton href="#" ref={ref} />
+      );
+
+      expect(ref).toHaveBeenCalledTimes(1);
+      expect(ref).toHaveBeenCalledWith(component.find('a').getDOMNode());
     });
   });
 });

--- a/wiki/component-development.md
+++ b/wiki/component-development.md
@@ -129,7 +129,7 @@ export const MyComponent = forwardRef<
     ref
   ) => {
     return (
-      <div ref={ref}>
+      <div ref={ref} {...rest}>
         ...
       </div>
     );

--- a/wiki/component-development.md
+++ b/wiki/component-development.md
@@ -112,7 +112,7 @@ interface FooProps extends DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElem
 
 ### forwardRef
 
-As needed, React's `forwardRef` should be used to provide access to an element created by a component, with few exceptions this should be the component's outermost element. We impose two additional requirements when using `forwardRef`:
+React's `forwardRef` should be used to provide access to the component's outermost element. We impose two additional requirements when using `forwardRef`:
 
 1. use `forwardRef` instead of `React.forwardRef`, otherwise [react-docgen-typescript](https://www.npmjs.com/package/react-docgen-typescript) does not understand it and the component's props will not be rendered in our documentation
 2. the resulting component must have a `displayName`, this is useful when the component is included in a snapshot or when inspected in devtools. There is an eslint rule which checks for this.  

--- a/wiki/component-development.md
+++ b/wiki/component-development.md
@@ -101,11 +101,50 @@ interface FooProps extends HTMLAttributes<HTMLDivElement> {
 }
 ```
 
-If your component forwards the `ref` through to an underlying element, the interface is further extended with `DetailedHTMLProps`
+If your component forwards a `ref` through to an underlying element, the interface is further extended with `DetailedHTMLProps`
 
 ```ts
 // passes extra props and forwards the ref to a button
 interface FooProps extends DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {
   title: string
 }
+```
+
+### forwardRef
+
+As needed, React's `forwardRef` should be used to provide access to an element created by a component, with few exceptions this should be the component's outermost element. We impose two additional requirements when using `forwardRef`:
+
+1. use `forwardRef` instead of `React.forwardRef`, otherwise [react-docgen-typescript](https://www.npmjs.com/package/react-docgen-typescript) does not understand it and the component's props will not be rendered in our documentation
+2. the resulting component must have a `displayName`, this is useful when the component is included in a snapshot or when inspected in devtools. There is an eslint rule which checks for this.  
+
+```ts
+interface MyComponentProps {...}
+
+export const MyComponent = forwardRef<
+  HTMLDivElement, // type of element or component the ref will be passed to
+  MyComponentProps // what properties apart from `ref` the component accepts
+>(
+  (
+    { destructure, props, here, ...rest },
+    ref
+  ) => {
+    return (
+      <div ref={ref}>
+        ...
+      </div>
+    );
+  }
+);
+
+MyComponent.displayName = 'MyComponent';
+```
+
+These should be used as needed (or as that need is expected), otherwise the ref's value could conflate with additional methods or values and be difficult to implement or consume. For example, **EuiMarkdownEditor**'s ref includes both its textarea element and a method for interacting with the abstract syntax tree. https://github.com/elastic/eui/blob/v31.10.0/src/components/markdown_editor/markdown_editor.tsx#L331
+
+```ts
+useImperativeHandle(
+  ref,
+  () => ({ textarea: textareaRef.current, replaceNode }),
+  [replaceNode]
+);
 ```

--- a/wiki/component-development.md
+++ b/wiki/component-development.md
@@ -153,7 +153,7 @@ export const EuiMarkdownEditor = forwardRef<
   (props, ref) => {
     ...
 
-    // combines the textarea element & `replaceNode` into a single object, which is then passed back to the owning component's ref value
+    // combines the textarea element & `replaceNode` into a single object, which is then passed back to the forwarded `ref`
     useImperativeHandle(
       ref,
       () => ({ textarea: textareaRef.current, replaceNode }),

--- a/wiki/component-development.md
+++ b/wiki/component-development.md
@@ -101,7 +101,7 @@ interface FooProps extends HTMLAttributes<HTMLDivElement> {
 }
 ```
 
-If your component forwards a `ref` through to an underlying element, the interface is further extended with `DetailedHTMLProps`
+If your component forwards a `ref` through to an underlying element, the interface needs to be further extended with `DetailedHTMLProps`
 
 ```ts
 // passes extra props and forwards the ref to a button
@@ -118,6 +118,8 @@ React's `forwardRef` should be used to provide access to the component's outermo
 2. the resulting component must have a `displayName`, this is useful when the component is included in a snapshot or when inspected in devtools. There is an eslint rule which checks for this.  
 
 ```ts
+import React, { createRef } from 'react';
+
 interface MyComponentProps {...}
 
 export const MyComponent = forwardRef<
@@ -139,12 +141,26 @@ export const MyComponent = forwardRef<
 MyComponent.displayName = 'MyComponent';
 ```
 
-These should be used as needed (or as that need is expected), otherwise the ref's value could conflate with additional methods or values and be difficult to implement or consume. For example, **EuiMarkdownEditor**'s ref includes both its textarea element and a method for interacting with the abstract syntax tree. https://github.com/elastic/eui/blob/v31.10.0/src/components/markdown_editor/markdown_editor.tsx#L331
+`forwardRef`s should be used as needed, otherwise the ref's value could conflate with additional methods or values and be difficult to implement or consume. For example, **EuiMarkdownEditor**'s ref includes both its textarea element and the `replaceNode` method for interacting with the abstract syntax tree. https://github.com/elastic/eui/blob/v31.10.0/src/components/markdown_editor/markdown_editor.tsx#L331
 
 ```ts
-useImperativeHandle(
-  ref,
-  () => ({ textarea: textareaRef.current, replaceNode }),
-  [replaceNode]
+import React, { useImperativeHandle } from 'react';
+
+export const EuiMarkdownEditor = forwardRef<
+  EuiMarkdownEditorRef,
+  EuiMarkdownEditorProps
+  >(
+  (props, ref) => {
+    ...
+
+    // combines the textarea element & `replaceNode` into a single object, which is then passed back to the owning component's ref value
+    useImperativeHandle(
+      ref,
+      () => ({ textarea: textareaRef.current, replaceNode }),
+      [replaceNode]
+    );
+
+    ...
+  }
 );
 ```


### PR DESCRIPTION
### Summary

* Added documentation for using `forwardRef` in EUI
* Added two unit tests for **EuiHeaderSectionItemButton**'s ref

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
