### PR TITLE
Tweak the stale issue action's cron setup

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,7 +1,7 @@
 name: 'Close stale issues and PRs'
 on:
   schedule:
-    - cron: '* */8 * * *'
+    - cron: '0 */8 * * *'
 
 jobs:
   stale:


### PR DESCRIPTION
### Summary

`* */8 * * *` -> `0 */8 * * *`

The former runs the action every minute of every 8th hour, the new value only runs the action once on that hour.

[https://crontab.guru/#0_*/8_*_*_*](https://crontab.guru/#0_*/8_*_*_*)

![cron](https://user-images.githubusercontent.com/313125/110855216-4e36db80-8273-11eb-90ed-bf7e37b0f61c.gif)
