### PR TITLE
[Docs] Show all `HTMLAttributes` types

### DIFF
--- a/src-docs/src/components/guide_section/guide_section_parts/guide_section_props_description.tsx
+++ b/src-docs/src/components/guide_section/guide_section_parts/guide_section_props_description.tsx
@@ -26,14 +26,17 @@ export const GuideSectionPropsDescription: FunctionComponent<GuideSectionPropsDe
 
   const { description, extendedInterfaces } = docgenInfo;
 
-  const extendedTypes = extendedInterfaces
+  const extendedTypes: string[] = extendedInterfaces
     ? extendedInterfaces.filter((type: any) => !!extendedTypesInfo[type])
     : [];
 
+  // if all extendedTypes are HTMLAttributes, show them all
   // if there is an HTMLAttributes type present among others, remove HTMLAttributes
-  if (extendedTypes.includes('HTMLAttributes') && extendedTypes.length > 1) {
-    const htmlAttributesIndex = extendedTypes.indexOf('HTMLAttributes');
-    extendedTypes.splice(htmlAttributesIndex, 1);
+  if (!extendedTypes.every((type) => type.indexOf('HTMLAttributes') > -1)) {
+    if (extendedTypes.includes('HTMLAttributes') && extendedTypes.length > 1) {
+      const htmlAttributesIndex = extendedTypes.indexOf('HTMLAttributes');
+      extendedTypes.splice(htmlAttributesIndex, 1);
+    }
   }
 
   const extendedTypesElements = extendedTypes.map((type: any, index: any) => (


### PR DESCRIPTION
### Summary

Show all `HTMLAttributes` type extensions unless there is more appropriate custom type extension

~### Checklist~
