### PR TITLE
[Props] Explicit import of `Component` and `FunctionComponent`

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -18,6 +18,7 @@
  */
 
 import React, {
+  forwardRef,
   FunctionComponent,
   Ref,
   ButtonHTMLAttributes,
@@ -136,7 +137,7 @@ export type EuiButtonDisplayProps = EuiButtonProps &
  * EuiButton is largely responsible for providing relevant props
  * and the logic for element-specific attributes
  */
-const EuiButtonDisplay = React.forwardRef<HTMLElement, EuiButtonDisplayProps>(
+const EuiButtonDisplay = forwardRef<HTMLElement, EuiButtonDisplayProps>(
   (
     {
       element = 'button',

--- a/src/components/context/context.tsx
+++ b/src/components/context/context.tsx
@@ -17,7 +17,13 @@
  * under the License.
  */
 
-import React, { createContext, ReactChild, ReactNode } from 'react';
+import React, {
+  createContext,
+  Context,
+  FunctionComponent,
+  ReactChild,
+  ReactNode,
+} from 'react';
 
 export interface RenderableValues {
   // undefined values are ignored, but including support here improves usability
@@ -36,7 +42,7 @@ export interface I18nShape {
   locale?: string;
 }
 
-const I18nContext: React.Context<I18nShape> = createContext({});
+const I18nContext: Context<I18nShape> = createContext({});
 const { Provider: EuiI18nProvider, Consumer: EuiI18nConsumer } = I18nContext;
 
 export interface EuiContextProps {
@@ -47,7 +53,7 @@ export interface EuiContextProps {
   children: ReactNode;
 }
 
-const EuiContext: React.FunctionComponent<EuiContextProps> = ({
+const EuiContext: FunctionComponent<EuiContextProps> = ({
   i18n = {},
   children,
 }) => <EuiI18nProvider value={i18n}>{children}</EuiI18nProvider>;

--- a/src/components/form/described_form_group/described_form_group.tsx
+++ b/src/components/form/described_form_group/described_form_group.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { ReactNode, HTMLAttributes } from 'react';
+import React, { FunctionComponent, ReactNode, HTMLAttributes } from 'react';
 
 import classNames from 'classnames';
 
@@ -70,7 +70,7 @@ export type EuiDescribedFormGroupProps = CommonProps &
     fieldFlexItemProps?: PropsOf<typeof EuiFlexItem>;
   };
 
-export const EuiDescribedFormGroup: React.FunctionComponent<EuiDescribedFormGroupProps> = ({
+export const EuiDescribedFormGroup: FunctionComponent<EuiDescribedFormGroupProps> = ({
   children,
   className,
   gutterSize = 'l',

--- a/src/components/i18n/i18n_number.tsx
+++ b/src/components/i18n/i18n_number.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { ReactChild, ReactElement } from 'react';
+import React, { FunctionComponent, ReactChild, ReactElement } from 'react';
 import { EuiI18nConsumer } from '../context';
 import { ExclusiveUnion } from '../common';
 
@@ -48,7 +48,7 @@ function hasValues(x: EuiI18nNumberProps): x is EuiI18nNumberValuesShape {
   return x.values != null;
 }
 
-const EuiI18nNumber: React.FunctionComponent<EuiI18nNumberProps> = (props) => (
+const EuiI18nNumber: FunctionComponent<EuiI18nNumberProps> = (props) => (
   <EuiI18nConsumer>
     {(i18nConfig) => {
       const formatNumber = i18nConfig.formatNumber || defaultFormatNumber;

--- a/src/components/portal/portal.tsx
+++ b/src/components/portal/portal.tsx
@@ -22,7 +22,7 @@
  * into portals.
  */
 
-import React from 'react';
+import { Component, ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { keysOf } from '../common';
 
@@ -46,12 +46,12 @@ export interface EuiPortalProps {
   /**
    * ReactNode to render as this component's content
    */
-  children: React.ReactNode;
+  children: ReactNode;
   insert?: { sibling: HTMLElement; position: EuiPortalInsertPosition };
   portalRef?: (ref: HTMLDivElement | null) => void;
 }
 
-export class EuiPortal extends React.Component<EuiPortalProps> {
+export class EuiPortal extends Component<EuiPortalProps> {
   portalNode: HTMLDivElement;
   constructor(props: EuiPortalProps) {
     super(props);

--- a/src/components/selectable/selectable_message/selectable_message.tsx
+++ b/src/components/selectable/selectable_message/selectable_message.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { HTMLAttributes } from 'react';
+import React, { FunctionComponent, HTMLAttributes } from 'react';
 import { CommonProps } from '../../common';
 import classNames from 'classnames';
 import { EuiText } from '../../text';
@@ -33,7 +33,7 @@ export type EuiSelectableMessageProps = Omit<
     bordered?: boolean;
   };
 
-export const EuiSelectableMessage: React.FunctionComponent<EuiSelectableMessageProps> = ({
+export const EuiSelectableMessage: FunctionComponent<EuiSelectableMessageProps> = ({
   children,
   className,
   bordered = false,


### PR DESCRIPTION
### Summary

Fixes #4666 and other similar (though unrecorded) issues.

A [known bug in `react-docgen-typescript`](https://github.com/styleguidist/react-docgen-typescript/issues/323) causes React component types (`Component` and `FunctionComponent`) prefixed with `React.` to be excluded from parsing. This results in missing docgen info and errors in the props table.

Fix is to remove `React.` prefixes in the few, old cases where they still exist.

~### Checklist~
