### PR TITLE
Export intermediary intefaces for props

### DIFF
--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -69,7 +69,7 @@ type DrillProps<T> = Pick<
   | 'selectedOptions'
 >;
 
-interface _EuiComboBoxProps<T>
+export interface _EuiComboBoxProps<T>
   extends CommonProps,
     Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>,
     DrillProps<T> {

--- a/src/components/popover/input_popover.tsx
+++ b/src/components/popover/input_popover.tsx
@@ -33,7 +33,7 @@ import { EuiPopover, EuiPopoverProps } from './popover';
 import { EuiResizeObserver } from '../observer/resize_observer';
 import { cascadingMenuKeys } from '../../services';
 
-interface _EuiInputPopoverProps
+export interface _EuiInputPopoverProps
   extends Omit<EuiPopoverProps, 'button' | 'buttonRef'> {
   disableFocusTrap?: boolean;
   fullWidth?: boolean;


### PR DESCRIPTION
- combo_box
- input_popver

### Summary

While attempting to generate typescript declaration files involving the implicit use of EuiComboBox's prop types via generics, a fatal error was encountered:

```
src/combobox/index.tsx:4:14 - error TS4023: Exported variable 'ComboBox' has or is using name '_EuiComboBoxProps' from external module "@elastic/eui/src/components/combo_box/combo_box" but cannot be named.
```

In order to resolve this error, the recommended approach outlined in https://github.com/microsoft/TypeScript/issues/5711 is to explicitly import the named type in the file where the type is implicitly used. However, because these types are not exported, they cannot be imported in a project consuming @elastic/eui.

This PR is a straightforward fix to this problem, and exports this previously unexported interface. A text search was done to identify other similar interfaces that are unexported - input_popover was modified in a similar way for futureproofing.

A reproduction project is available at https://github.com/DylanCulfogienis/bit-eui-typescript-repro/tree/nobit. To reproduce this error, run the following commands:

```
git clone https://github.com/DylanCulfogienis/bit-eui-typescript-repro.git --branch nobit
yarn install
./node_modules/.bin/tsc
```

Unsure if this fits within Elastic's workflow for Eui, but would it be possible to backprop this patch to major version 29? If not I can try and upgrade our project's copy of Eui.

### Checklist

This is not a UI feature or change, but rather is a very small extension to module exports. I will still go through the checklist if instructed by Elastic staff.

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
