### PR TITLE
Update stale_issues.yml

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -25,4 +25,4 @@ jobs:
           operations-per-run: 1000
           remove-stale-when-updated: true
           enable-statistics: true
-          debug-only: true
+          debug-only: false


### PR DESCRIPTION
Turning the stale issue workflow back on, without any changes to the start date so it cleans up the issues from its last pass. Then I'll do another PR to update the start date.