### PR TITLE
Update EuiHeaderSectionItemButton to avoid re-renders

### DIFF
--- a/src/components/header/header_section/header_section_item_button.tsx
+++ b/src/components/header/header_section/header_section_item_button.tsx
@@ -22,7 +22,6 @@ import React, {
   forwardRef,
   useImperativeHandle,
   useRef,
-  useState,
 } from 'react';
 import classNames from 'classnames';
 import {
@@ -66,9 +65,9 @@ export const EuiHeaderSectionItemButton = forwardRef<
      */
     ref
   ) => {
-    const [buttonRef, setButtonRef] = useState<
-      HTMLAnchorElement | HTMLButtonElement | null
-    >();
+    const buttonRef = useRef<HTMLAnchorElement | HTMLButtonElement | null>(
+      null
+    );
     const animationTargetRef = useRef<HTMLSpanElement | null>(null);
 
     useImperativeHandle<
@@ -77,128 +76,124 @@ export const EuiHeaderSectionItemButton = forwardRef<
     >(
       ref,
       () => {
-        if (buttonRef) {
-          (buttonRef as any).euiAnimate = () => {
-            const keyframes: Keyframe[] = [
-              { transform: 'rotate(0)', offset: 0, easing: 'ease-in-out' },
-              {
-                transform: 'rotate(30deg)',
-                offset: 0.01,
-                easing: 'ease-in-out',
-              },
-              {
-                transform: 'rotate(-28deg)',
-                offset: 0.03,
-                easing: 'ease-in-out',
-              },
-              {
-                transform: 'rotate(34deg)',
-                offset: 0.05,
-                easing: 'ease-in-out',
-              },
-              {
-                transform: 'rotate(-32deg)',
-                offset: 0.07,
-                easing: 'ease-in-out',
-              },
-              {
-                transform: 'rotate(30deg)',
-                offset: 0.09,
-                easing: 'ease-in-out',
-              },
-              {
-                transform: 'rotate(-28deg)',
-                offset: 0.11,
-                easing: 'ease-in-out',
-              },
-              {
-                transform: 'rotate(26deg)',
-                offset: 0.13,
-                easing: 'ease-in-out',
-              },
-              {
-                transform: 'rotate(-24deg)',
-                offset: 0.15,
-                easing: 'ease-in-out',
-              },
-              {
-                transform: 'rotate(22deg)',
-                offset: 0.17,
-                easing: 'ease-in-out',
-              },
-              {
-                transform: 'rotate(-20deg)',
-                offset: 0.19,
-                easing: 'ease-in-out',
-              },
-              {
-                transform: 'rotate(18deg)',
-                offset: 0.21,
-                easing: 'ease-in-out',
-              },
-              {
-                transform: 'rotate(-16deg)',
-                offset: 0.23,
-                easing: 'ease-in-out',
-              },
-              {
-                transform: 'rotate(14deg)',
-                offset: 0.25,
-                easing: 'ease-in-out',
-              },
-              {
-                transform: 'rotate(-12deg)',
-                offset: 0.27,
-                easing: 'ease-in-out',
-              },
-              {
-                transform: 'rotate(10deg)',
-                offset: 0.29,
-                easing: 'ease-in-out',
-              },
-              {
-                transform: 'rotate(-8deg)',
-                offset: 0.31,
-                easing: 'ease-in-out',
-              },
-              {
-                transform: 'rotate(6deg)',
-                offset: 0.33,
-                easing: 'ease-in-out',
-              },
-              {
-                transform: 'rotate(-4deg)',
-                offset: 0.35,
-                easing: 'ease-in-out',
-              },
-              {
-                transform: 'rotate(2deg)',
-                offset: 0.37,
-                easing: 'ease-in-out',
-              },
-              {
-                transform: 'rotate(-1deg)',
-                offset: 0.39,
-                easing: 'ease-in-out',
-              },
-              {
-                transform: 'rotate(1deg)',
-                offset: 0.41,
-                easing: 'ease-in-out',
-              },
-              { transform: 'rotate(0)', offset: 0.43, easing: 'ease-in-out' },
-              { transform: 'rotate(0)', offset: 1, easing: 'ease-in-out' },
-            ];
-            animationTargetRef.current?.animate(keyframes, {
-              duration: 5000,
-            });
-          };
-          return buttonRef as EuiHeaderSectionItemButtonRef;
-        } else {
-          return null;
-        }
+        (buttonRef.current as any).euiAnimate = () => {
+          const keyframes: Keyframe[] = [
+            { transform: 'rotate(0)', offset: 0, easing: 'ease-in-out' },
+            {
+              transform: 'rotate(30deg)',
+              offset: 0.01,
+              easing: 'ease-in-out',
+            },
+            {
+              transform: 'rotate(-28deg)',
+              offset: 0.03,
+              easing: 'ease-in-out',
+            },
+            {
+              transform: 'rotate(34deg)',
+              offset: 0.05,
+              easing: 'ease-in-out',
+            },
+            {
+              transform: 'rotate(-32deg)',
+              offset: 0.07,
+              easing: 'ease-in-out',
+            },
+            {
+              transform: 'rotate(30deg)',
+              offset: 0.09,
+              easing: 'ease-in-out',
+            },
+            {
+              transform: 'rotate(-28deg)',
+              offset: 0.11,
+              easing: 'ease-in-out',
+            },
+            {
+              transform: 'rotate(26deg)',
+              offset: 0.13,
+              easing: 'ease-in-out',
+            },
+            {
+              transform: 'rotate(-24deg)',
+              offset: 0.15,
+              easing: 'ease-in-out',
+            },
+            {
+              transform: 'rotate(22deg)',
+              offset: 0.17,
+              easing: 'ease-in-out',
+            },
+            {
+              transform: 'rotate(-20deg)',
+              offset: 0.19,
+              easing: 'ease-in-out',
+            },
+            {
+              transform: 'rotate(18deg)',
+              offset: 0.21,
+              easing: 'ease-in-out',
+            },
+            {
+              transform: 'rotate(-16deg)',
+              offset: 0.23,
+              easing: 'ease-in-out',
+            },
+            {
+              transform: 'rotate(14deg)',
+              offset: 0.25,
+              easing: 'ease-in-out',
+            },
+            {
+              transform: 'rotate(-12deg)',
+              offset: 0.27,
+              easing: 'ease-in-out',
+            },
+            {
+              transform: 'rotate(10deg)',
+              offset: 0.29,
+              easing: 'ease-in-out',
+            },
+            {
+              transform: 'rotate(-8deg)',
+              offset: 0.31,
+              easing: 'ease-in-out',
+            },
+            {
+              transform: 'rotate(6deg)',
+              offset: 0.33,
+              easing: 'ease-in-out',
+            },
+            {
+              transform: 'rotate(-4deg)',
+              offset: 0.35,
+              easing: 'ease-in-out',
+            },
+            {
+              transform: 'rotate(2deg)',
+              offset: 0.37,
+              easing: 'ease-in-out',
+            },
+            {
+              transform: 'rotate(-1deg)',
+              offset: 0.39,
+              easing: 'ease-in-out',
+            },
+            {
+              transform: 'rotate(1deg)',
+              offset: 0.41,
+              easing: 'ease-in-out',
+            },
+            { transform: 'rotate(0)', offset: 0.43, easing: 'ease-in-out' },
+            { transform: 'rotate(0)', offset: 1, easing: 'ease-in-out' },
+          ];
+          animationTargetRef.current?.animate(keyframes, {
+            duration: 5000,
+          });
+        };
+        return buttonRef.current as EuiHeaderSectionItemButtonRef;
       },
-      [buttonRef]
+      []
     );
 
     const classes = classNames('euiHeaderSectionItemButton', className);
@@ -237,7 +232,7 @@ export const EuiHeaderSectionItemButton = forwardRef<
       <EuiButtonEmpty
         className={classes}
         color="text"
-        buttonRef={setButtonRef}
+        buttonRef={buttonRef}
         {...rest}>
         <span ref={animationTargetRef} className={animationClasses}>
           {children}


### PR DESCRIPTION
### Summary

Fixes a failing unit test on master caused by **EuiHeaderSectionItemButton** re-rendering during the mount lifecycle as it tracks its internal buttonRef value.

Turns out the function component mount lifecycle is `mount -> update refs -> useImperativeHandle`, and I falsely believed it was `mount -> useImperativeHandle -> update refs`, which caused some null values to sneak in plus 2 additional renders.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles]~(https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
