### PR TITLE
[EuiPanel] Fix selector for `button` element styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `32.0.0`.
+**Bug fixes**
+
+- Fixed block style of `EuiPanel` when rendered as a `<button>` ([#4681](https://github.com/elastic/eui/pull/4681))
 
 ## [`32.0.0`](https://github.com/elastic/eui/tree/v32.0.0)
 

--- a/src/global_styling/mixins/_panel.scss
+++ b/src/global_styling/mixins/_panel.scss
@@ -25,7 +25,7 @@
         // transition the shadow
         transition: all $euiAnimSpeedFast $euiAnimSlightResistance;
 
-        button#{&} {
+        &:enabled { // This is a good selector for buttons since it doesn't exist on divs
           // in case of button wrapper which inherently is inline-block and no width
           display: block;
           width: 100%;

--- a/src/themes/eui-amsterdam/global_styling/mixins/_panel.scss
+++ b/src/themes/eui-amsterdam/global_styling/mixins/_panel.scss
@@ -22,7 +22,7 @@
         // transition the shadow
         transition: all $euiAnimSpeedFast $euiAnimSlightResistance;
 
-        button#{&} {
+        &:enabled { // This is a good selector for buttons since it doesn't exist on divs
           // in case of button wrapper which inherently is inline-block and no width
           display: block;
           width: 100%;


### PR DESCRIPTION
In https://github.com/elastic/eui/pull/4662, I introduced a bug trying to scope specific `<button>` styles in the `euiPanel()` mixin. I mistakenly thought, but didn't check that my Sass nested selector would work. It didn't.

This PR fixes the block display of `EuiPanel.onClick` by using the `:enabled` selector instead.

**Before**
<img width="969" alt="Screen Shot 2021-04-01 at 14 24 48 PM" src="https://user-images.githubusercontent.com/549577/113337636-0a754600-92f6-11eb-9cf3-8c39ad2e8c01.png">


**After**
<img width="968" alt="Screen Shot 2021-04-01 at 14 21 59 PM" src="https://user-images.githubusercontent.com/549577/113337533-e0238880-92f5-11eb-84fa-9f00508e0ab1.png">


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
