### PR TITLE
[EuiColorStops] Ensure popover close on outside click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Fixed `htmlIdGenerator` import path in `button_group_button.tsx` ([#4682](https://github.com/elastic/eui/pull/4682))
+- Fixed `EuiColorStops` popover failing to close ([#4687](https://github.com/elastic/eui/pull/4687))
 
 ## [`32.0.1`](https://github.com/elastic/eui/tree/v32.0.1)
 

--- a/src/components/color_picker/color_stops/color_stop_thumb.tsx
+++ b/src/components/color_picker/color_stops/color_stop_thumb.tsx
@@ -244,7 +244,9 @@ export const EuiColorStopThumb: FunctionComponent<EuiColorStopThumbProps> = ({
 
   const handleTouchStart = (e: React.TouchEvent<HTMLButtonElement>) => {
     handleTouchInteraction(e);
-    openPopover();
+    if (!isPopoverOpen) {
+      openPopover();
+    }
   };
 
   const classes = classNames(
@@ -255,8 +257,6 @@ export const EuiColorStopThumb: FunctionComponent<EuiColorStopThumbProps> = ({
     className
   );
 
-  // console.log('render', stop);
-
   return (
     <EuiPopover
       ref={popoverRef}
@@ -265,8 +265,8 @@ export const EuiColorStopThumb: FunctionComponent<EuiColorStopThumbProps> = ({
       panelPaddingSize="s"
       isOpen={isPopoverOpen}
       closePopover={closePopover}
-      ownFocus={isPopoverOpen}
       initialFocus={numberInputRef || undefined}
+      focusTrapProps={{ clickOutsideDisables: false }}
       panelClassName={
         numberInputRef ? undefined : 'euiColorStopPopover-isLoadingPanel'
       }

--- a/src/components/popover/__snapshots__/popover.test.tsx.snap
+++ b/src/components/popover/__snapshots__/popover.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`EuiPopover props arrowChildren is rendered 1`] = `
 <div>
   <div
     class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
-    id="18"
+    id="19"
   >
     <div
       class="euiPopover__anchor"
@@ -141,7 +141,7 @@ exports[`EuiPopover props buffer 1`] = `
 <div>
   <div
     class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
-    id="19"
+    id="20"
   >
     <div
       class="euiPopover__anchor"
@@ -197,7 +197,7 @@ exports[`EuiPopover props buffer for all sides 1`] = `
 <div>
   <div
     class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
-    id="20"
+    id="21"
   >
     <div
       class="euiPopover__anchor"
@@ -258,6 +258,62 @@ exports[`EuiPopover props display block is rendered 1`] = `
     class="euiPopover__anchor"
   >
     <button />
+  </div>
+</div>
+`;
+
+exports[`EuiPopover props focusTrapProps is rendered 1`] = `
+<div>
+  <div
+    class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
+    id="16"
+  >
+    <div
+      class="euiPopover__anchor"
+    >
+      <button />
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
+    />
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
+    />
+    <div
+      data-focus-lock-disabled="disabled"
+    >
+      <div
+        aria-describedby="generated-id"
+        aria-live="off"
+        aria-modal="true"
+        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen"
+        data-autofocus="true"
+        role="dialog"
+        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+        tabindex="0"
+      >
+        <div
+          class="euiPopover__panelArrow euiPopover__panelArrow--bottom"
+          style="left: 10px; top: 0px;"
+        />
+        <p
+          class="euiScreenReaderOnly"
+          id="generated-id"
+        >
+          You are in a dialog. To close this dialog, hit escape.
+        </p>
+        <div />
+      </div>
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
+    />
   </div>
 </div>
 `;
@@ -335,7 +391,7 @@ exports[`EuiPopover props offset with arrow 1`] = `
 <div>
   <div
     class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
-    id="16"
+    id="17"
     offset="10"
   >
     <div
@@ -392,7 +448,7 @@ exports[`EuiPopover props offset without arrow 1`] = `
 <div>
   <div
     class="euiPopover euiPopover--anchorDownCenter euiPopover-isOpen"
-    id="17"
+    id="18"
     offset="10"
   >
     <div

--- a/src/components/popover/popover.test.tsx
+++ b/src/components/popover/popover.test.tsx
@@ -285,6 +285,28 @@ describe('EuiPopover', () => {
       });
     });
 
+    describe('focusTrapProps', () => {
+      test('is rendered', () => {
+        const component = mount(
+          <div>
+            <EuiPopover
+              id={getId()}
+              button={<button />}
+              closePopover={() => {}}
+              focusTrapProps={{
+                clickOutsideDisables: false,
+                noIsolation: false,
+                scrollLock: false,
+              }}
+              isOpen
+            />
+          </div>
+        );
+
+        expect(component.render()).toMatchSnapshot();
+      });
+    });
+
     describe('offset', () => {
       test('with arrow', () => {
         const component = mount(

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -30,7 +30,7 @@ import classNames from 'classnames';
 import tabbable from 'tabbable';
 
 import { CommonProps, NoArgCallback } from '../common';
-import { FocusTarget, EuiFocusTrap } from '../focus_trap';
+import { FocusTarget, EuiFocusTrap, EuiFocusTrapProps } from '../focus_trap';
 import { ReactFocusOnProps } from 'react-focus-on/dist/es5/types';
 
 import {
@@ -106,6 +106,10 @@ export interface EuiPopoverProps {
    * CSS display type for both the popover and anchor
    */
   display?: keyof typeof displayToClassNameMap;
+  focusTrapProps?: Pick<
+    EuiFocusTrapProps,
+    'clickOutsideDisables' | 'noIsolation' | 'scrollLock'
+  >;
   /**
    * Show arrow indicating to originating button
    */
@@ -681,6 +685,7 @@ export class EuiPopover extends Component<Props, State> {
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledBy,
       container,
+      focusTrapProps,
       ...rest
     } = this.props;
 
@@ -750,8 +755,9 @@ export class EuiPopover extends Component<Props, State> {
       panel = (
         <EuiPortal insert={insert}>
           <EuiFocusTrap
-            returnFocus={returnFocus} // Ignore temporary state of indecisive focus
             clickOutsideDisables={true}
+            {...focusTrapProps}
+            returnFocus={returnFocus} // Ignore temporary state of indecisive focus
             initialFocus={initialFocus}
             onDeactivation={onTrapDeactivation}
             onClickOutside={this.onClickOutside}

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -106,6 +106,9 @@ export interface EuiPopoverProps {
    * CSS display type for both the popover and anchor
    */
   display?: keyof typeof displayToClassNameMap;
+  /**
+   * Object of props passed to EuiFocusTrap
+   */
   focusTrapProps?: Pick<
     EuiFocusTrapProps,
     'clickOutsideDisables' | 'noIsolation' | 'scrollLock'


### PR DESCRIPTION
### Summary

Fixes #4679. Changes to `ownFocus` in `EuiPopover` affected the underlying focus trap on outside clicks. Clicking a color stop thumb while the popover was open would disable the underlying focus trap, causing the focus trap to no longer watch for outside clicks. We don't want the EuiColorStopThumb popover trap to be disabled on outside click; instead, we the trap should remain active while the popover is open.

I decided to expand the prop options beyond what we currently need. Can be expanded further in the future if necessary.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**

~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~

- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
