### PR TITLE
Misc. TypeScript fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 **Bug fixes**
 
 - Exported `EuiAvatarProps` ([#4690](https://github.com/elastic/eui/pull/4690))
-- Fixes type overrides in `EuiCard` ([#4690](https://github.com/elastic/eui/pull/4690))
+- Fixed type overrides in `EuiCard` ([#4690](https://github.com/elastic/eui/pull/4690))
 
 ## [`32.0.2`](https://github.com/elastic/eui/tree/v32.0.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `32.0.2`.
+**Bug fixes**
+
+- Exported `EuiAvatarProps` ([#4690](https://github.com/elastic/eui/pull/4690))
+- Fixes type overrides in `EuiCard` ([#4690](https://github.com/elastic/eui/pull/4690))
 
 ## [`32.0.2`](https://github.com/elastic/eui/tree/v32.0.2)
 

--- a/src/components/avatar/index.ts
+++ b/src/components/avatar/index.ts
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-export { EuiAvatar, checkValidColor } from './avatar';
+export { EuiAvatar, EuiAvatarProps, checkValidColor } from './avatar';

--- a/src/components/card/__snapshots__/card.test.tsx.snap
+++ b/src/components/card/__snapshots__/card.test.tsx.snap
@@ -740,6 +740,31 @@ exports[`EuiCard props titleElement 1`] = `
 </div>
 `;
 
+exports[`EuiCard props titleElement with nodes 1`] = `
+<div
+  class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiCard euiCard--centerAligned"
+>
+  <div
+    class="euiCard__content"
+  >
+    <h4
+      class="euiTitle euiTitle--small euiCard__title"
+      id="generated-idTitle"
+    >
+      Card title
+    </h4>
+    <div
+      class="euiText euiText--small euiCard__description"
+      id="generated-idDescription"
+    >
+      <p>
+        Card description
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EuiCard props titleSize 1`] = `
 <div
   class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiCard euiCard--centerAligned"

--- a/src/components/card/card.test.tsx
+++ b/src/components/card/card.test.tsx
@@ -24,6 +24,7 @@ import { requiredProps } from '../../test';
 import { EuiCard } from './card';
 
 import { EuiIcon } from '../icon';
+import { EuiI18n } from '../i18n';
 import { COLORS, SIZES } from '../panel/panel';
 
 describe('EuiCard', () => {
@@ -129,6 +130,20 @@ describe('EuiCard', () => {
       const component = render(
         <EuiCard
           title="Card title"
+          description="Card description"
+          titleElement="h4"
+        />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
+    test('titleElement with nodes', () => {
+      const component = render(
+        <EuiCard
+          title={
+            <EuiI18n token="euiCard.title" default="Card title" /> // eslint-disable-line
+          }
           description="Card description"
           titleElement="h4"
         />

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -93,7 +93,7 @@ type EuiCardPropsLayout = ExclusiveUnion<
 >;
 
 export type EuiCardProps = Omit<CommonProps, 'aria-label'> &
-  Omit<HTMLAttributes<HTMLDivElement>, 'color'> &
+  Omit<HTMLAttributes<HTMLDivElement>, 'color' | 'title' | 'onClick'> &
   EuiCardPropsLayout & {
     /**
      * Cards are required to have at least a title and a description and/or children


### PR DESCRIPTION
### Summary

Two bug fixes to aid in upgrading Kibana:

* Export `EuiAvatarProps`
* Omit `title` and `onClick` props that are overridden with different types in **EuiCard**

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~

- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately

~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
