### PR TITLE
Added a11y tests for some pages

### DIFF
--- a/scripts/a11y-testing.js
+++ b/scripts/a11y-testing.js
@@ -23,21 +23,14 @@ const { AxePuppeteer } = require('@axe-core/puppeteer');
 
 const docsPages = async (root, page) => {
   const pagesToSkip = [
-    `${root}#/layout/resizable-container`,
     `${root}#/layout/page`, // Has duplicate `<main>` element
     `${root}#/layout/page-header`, // Has duplicate `<header>` element
     `${root}#/tabular-content/tables`,
     `${root}#/tabular-content/in-memory-tables`,
     `${root}#/display/aspect-ratio`,
-    `${root}#/display/code`,
-    `${root}#/display/drag-and-drop`,
-    `${root}#/forms/compressed-forms`,
-    `${root}#/forms/super-select`,
     `${root}#/forms/combo-box`,
     `${root}#/forms/color-selection`,
-    `${root}#/forms/code-editor`,
     `${root}#/forms/date-picker`,
-    `${root}#/forms/suggest`,
     `${root}#/forms/super-date-picker`,
     `${root}#/tabular-content/data-grid`,
     `${root}#/tabular-content/data-grid-in-memory-settings`,
@@ -47,8 +40,6 @@ const docsPages = async (root, page) => {
     `${root}#/tabular-content/data-grid-control-columns`,
     `${root}#/tabular-content/data-grid-footer-row`,
     `${root}#/tabular-content/data-grid-virtualization`,
-    `${root}#/elastic-charts/creating-charts`,
-    `${root}#/elastic-charts/part-to-whole-comparisons`,
   ];
 
   return [

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_custom_handle.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_custom_handle.js
@@ -47,7 +47,7 @@ export default () => {
               <EuiPanel className="custom" paddingSize="m">
                 <EuiFlexGroup>
                   <EuiFlexItem grow={false}>
-                    <div {...provided.dragHandleProps}>
+                    <div {...provided.dragHandleProps} aria-label="Drag Handle">
                       <EuiIcon type="grab" />
                     </div>
                   </EuiFlexItem>

--- a/src-docs/src/views/form_compressed/complex_example.js
+++ b/src-docs/src/views/form_compressed/complex_example.js
@@ -25,8 +25,8 @@ import {
 import { htmlIdGenerator } from '../../../../src/services';
 
 export default () => {
-  const idPrefix = htmlIdGenerator();
-  const idPrefix1 = htmlIdGenerator();
+  const idPrefix = htmlIdGenerator()();
+  const idPrefix1 = htmlIdGenerator()();
 
   const typeStyleToggleButtons = [
     {
@@ -134,6 +134,7 @@ export default () => {
           compressed
           showInput="inputWithPopover"
           showLabels
+          aria-label="EuiDualRange within compressed form"
           prepend="Zoom levels"
         />
       </EuiFormRow>

--- a/src-docs/src/views/suggest/hashtag_popover.js
+++ b/src-docs/src/views/suggest/hashtag_popover.js
@@ -30,6 +30,7 @@ export default (props) => {
       onClick={togglePopover}
       size="xs"
       iconType="arrowDown"
+      aria-label="hashtag button"
       iconSide="right">
       <EuiIcon type="number" />
     </EuiButtonEmpty>

--- a/src-docs/src/views/suggest/hashtag_popover.js
+++ b/src-docs/src/views/suggest/hashtag_popover.js
@@ -30,7 +30,7 @@ export default (props) => {
       onClick={togglePopover}
       size="xs"
       iconType="arrowDown"
-      aria-label="hashtag button"
+      aria-label="Saved Queries popover"
       iconSide="right">
       <EuiIcon type="number" />
     </EuiButtonEmpty>

--- a/src-docs/src/views/suggest/saved_queries.js
+++ b/src-docs/src/views/suggest/saved_queries.js
@@ -123,7 +123,7 @@ export default () => {
             onBlur={onFieldBlur}
             prepend={<HashtagPopover value={value} />}
             append={append}
-            aria-label="EuiSuggest input field"
+            aria-label="Filter"
             suggestions={sampleItems}
             onItemClick={onItemClick}
             onInputChange={getInputValue}

--- a/src-docs/src/views/suggest/saved_queries.js
+++ b/src-docs/src/views/suggest/saved_queries.js
@@ -123,6 +123,7 @@ export default () => {
             onBlur={onFieldBlur}
             prepend={<HashtagPopover value={value} />}
             append={append}
+            aria-label="EuiSuggest input field"
             suggestions={sampleItems}
             onItemClick={onItemClick}
             onInputChange={getInputValue}


### PR DESCRIPTION
### Summary

Makes progress on: #2679 
Adding  automated a11y test for docs pages.

### Checklist

**Forms**

- [x] form_compressed
- [x] Suggest saved queries
- [x] Suggest hastag popover

**Display** 

- [x] drag and drop

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
