### PR TITLE
[Docs] Fixing up Icons page

### DIFF
--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -156,6 +156,7 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
 
 .guideDemo__ghostBackground {
   @if (lightness($euiTextColor) < 50) {
+    color: $euiColorGhost;
     background: $euiColorDarkestShade !important; // Override EuiPanel specificity
   }
 }

--- a/src-docs/src/components/with_theme/theme_context.tsx
+++ b/src-docs/src/components/with_theme/theme_context.tsx
@@ -6,7 +6,7 @@ import { applyTheme } from '../../services';
 const THEME_NAMES = EUI_THEMES.map(({ value }) => value);
 
 const defaultState = {
-  theme: THEME_NAMES[0],
+  theme: THEME_NAMES[2],
   changeTheme: (themeValue: EUI_THEME['value']) => {
     applyTheme(themeValue);
   },

--- a/src-docs/src/services/playground/iconValidator.js
+++ b/src-docs/src/services/playground/iconValidator.js
@@ -5,10 +5,10 @@ import { PropTypes } from 'react-view';
 
 const iconOptions = mapOptions(iconTypes.concat(logoTypes));
 
-export const iconValidator = (prop = { custom: {} }) => {
+export const iconValidator = (prop = { custom: {} }, value) => {
   const newProp = {
     ...prop,
-    value: undefined,
+    value: value,
     type: PropTypes.String,
     custom: {
       ...prop.custom,

--- a/src-docs/src/views/icon/accessibility.js
+++ b/src-docs/src/views/icon/accessibility.js
@@ -1,9 +1,0 @@
-import React from 'react';
-
-import { EuiIcon } from '../../../../src/components';
-
-export default () => (
-  <div>
-    <EuiIcon type="search" size="l" title="Find information" />
-  </div>
-);

--- a/src-docs/src/views/icon/apps.js
+++ b/src-docs/src/views/icon/apps.js
@@ -1,14 +1,3 @@
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-
-// This example JS is overly complex for simple icon usage
-// and is set up this way for ease of use in our docs.
-//
-// Check the snippet tab for a more common usage.
-
 import React from 'react';
 
 import {
@@ -16,8 +5,9 @@ import {
   EuiFlexItem,
   EuiIcon,
   EuiPanel,
-  EuiText,
   EuiCopy,
+  EuiCodeBlock,
+  EuiSpacer,
 } from '../../../../src/components';
 
 const iconTypes = [
@@ -70,23 +60,35 @@ const iconTypes = [
 ];
 
 export default () => (
-  <EuiFlexGrid columns={4}>
-    {iconTypes.map((iconType) => (
-      <EuiFlexItem
-        className="guideDemo__icon"
-        key={iconType}
-        style={{ width: '200px' }}>
-        <EuiCopy textToCopy={iconType} afterMessage={`${iconType} copied`}>
-          {(copy) => (
-            <EuiPanel onClick={copy} className="eui-textCenter">
-              <EuiIcon type={iconType} size="xl" />
-              <EuiText size="s">
-                <p>{iconType}</p>
-              </EuiText>
-            </EuiPanel>
-          )}
-        </EuiCopy>
-      </EuiFlexItem>
-    ))}
-  </EuiFlexGrid>
+  <>
+    <EuiCodeBlock language="html" isCopyable paddingSize="m">
+      {'<EuiIcon type="addDataApp" size="xl" />'}
+    </EuiCodeBlock>
+    <EuiSpacer />
+    <EuiFlexGrid direction="column" columns={3}>
+      {iconTypes.map((iconType) => (
+        <EuiFlexItem key={iconType}>
+          <EuiCopy
+            display="block"
+            textToCopy={iconType}
+            afterMessage={`${iconType} copied`}>
+            {(copy) => (
+              <EuiPanel
+                hasShadow={false}
+                hasBorder={false}
+                onClick={copy}
+                paddingSize="s">
+                <EuiIcon
+                  className="eui-alignMiddle"
+                  type={iconType}
+                  size="xl"
+                />{' '}
+                &emsp; <small>{iconType}</small>
+              </EuiPanel>
+            )}
+          </EuiCopy>
+        </EuiFlexItem>
+      ))}
+    </EuiFlexGrid>
+  </>
 );

--- a/src-docs/src/views/icon/custom_tokens.js
+++ b/src-docs/src/views/icon/custom_tokens.js
@@ -1,0 +1,87 @@
+import React from 'react';
+
+import {
+  EuiToken,
+  EuiCodeBlock,
+  EuiSplitPanel,
+  EuiSpacer,
+} from '../../../../src/components';
+
+export default () => (
+  <>
+    <EuiSplitPanel.Outer hasShadow={false} direction="row">
+      <EuiSplitPanel.Inner grow={false} style={{ minWidth: 96 }}>
+        <EuiToken iconType="tokenStruct" size="xs" color="gray" />
+      </EuiSplitPanel.Inner>
+      <EuiSplitPanel.Inner paddingSize="none" color="subdued">
+        <EuiCodeBlock
+          language="html"
+          isCopyable
+          transparentBackground
+          paddingSize="m">
+          {'<EuiToken iconType="tokenStruct" size="xs" color="gray" />'}
+        </EuiCodeBlock>
+      </EuiSplitPanel.Inner>
+    </EuiSplitPanel.Outer>
+    <EuiSpacer />
+    <EuiSplitPanel.Outer hasShadow={false} direction="row">
+      <EuiSplitPanel.Inner grow={false} style={{ minWidth: 96 }}>
+        <EuiToken iconType="tokenStruct" fill="none" />
+      </EuiSplitPanel.Inner>
+      <EuiSplitPanel.Inner paddingSize="none" color="subdued">
+        <EuiCodeBlock
+          language="html"
+          isCopyable
+          transparentBackground
+          paddingSize="m">
+          {'<EuiToken iconType="tokenStruct" fill="none" />'}
+        </EuiCodeBlock>
+      </EuiSplitPanel.Inner>
+    </EuiSplitPanel.Outer>
+    <EuiSpacer />
+    <EuiSplitPanel.Outer hasShadow={false} direction="row">
+      <EuiSplitPanel.Inner grow={false} style={{ minWidth: 96 }}>
+        <EuiToken
+          iconType="tokenStruct"
+          size="m"
+          shape="circle"
+          color="#FF0000"
+        />
+      </EuiSplitPanel.Inner>
+      <EuiSplitPanel.Inner paddingSize="none" color="subdued">
+        <EuiCodeBlock
+          language="html"
+          isCopyable
+          transparentBackground
+          paddingSize="m">
+          {
+            '<EuiToken iconType="tokenStruct" size="m" shape="circle" color="#FF0000" />'
+          }
+        </EuiCodeBlock>
+      </EuiSplitPanel.Inner>
+    </EuiSplitPanel.Outer>
+    <EuiSpacer />
+    <EuiSplitPanel.Outer hasShadow={false} direction="row">
+      <EuiSplitPanel.Inner grow={false} style={{ minWidth: 96 }}>
+        <EuiToken
+          iconType="faceNeutral"
+          size="l"
+          color="euiColorVis7"
+          shape="rectangle"
+          fill="dark"
+        />
+      </EuiSplitPanel.Inner>
+      <EuiSplitPanel.Inner paddingSize="none" color="subdued">
+        <EuiCodeBlock
+          language="html"
+          isCopyable
+          transparentBackground
+          paddingSize="m">
+          {
+            '<EuiToken iconType="faceNeutral" size="l" color="euiColorVis7" shape="rectangle" fill="dark" />'
+          }
+        </EuiCodeBlock>
+      </EuiSplitPanel.Inner>
+    </EuiSplitPanel.Outer>
+  </>
+);

--- a/src-docs/src/views/icon/custom_tokens.js
+++ b/src-docs/src/views/icon/custom_tokens.js
@@ -9,8 +9,11 @@ import {
 
 export default () => (
   <>
-    <EuiSplitPanel.Outer hasShadow={false} direction="row">
-      <EuiSplitPanel.Inner grow={false} style={{ minWidth: 96 }}>
+    <EuiSplitPanel.Outer hasShadow={false} hasBorder={true} direction="row">
+      <EuiSplitPanel.Inner
+        className="eui-textCenter"
+        grow={false}
+        style={{ minWidth: 96 }}>
         <EuiToken iconType="tokenStruct" size="xs" color="gray" />
       </EuiSplitPanel.Inner>
       <EuiSplitPanel.Inner paddingSize="none" color="subdued">
@@ -24,8 +27,11 @@ export default () => (
       </EuiSplitPanel.Inner>
     </EuiSplitPanel.Outer>
     <EuiSpacer />
-    <EuiSplitPanel.Outer hasShadow={false} direction="row">
-      <EuiSplitPanel.Inner grow={false} style={{ minWidth: 96 }}>
+    <EuiSplitPanel.Outer hasShadow={false} hasBorder={true} direction="row">
+      <EuiSplitPanel.Inner
+        className="eui-textCenter"
+        grow={false}
+        style={{ minWidth: 96 }}>
         <EuiToken iconType="tokenStruct" fill="none" />
       </EuiSplitPanel.Inner>
       <EuiSplitPanel.Inner paddingSize="none" color="subdued">
@@ -39,8 +45,11 @@ export default () => (
       </EuiSplitPanel.Inner>
     </EuiSplitPanel.Outer>
     <EuiSpacer />
-    <EuiSplitPanel.Outer hasShadow={false} direction="row">
-      <EuiSplitPanel.Inner grow={false} style={{ minWidth: 96 }}>
+    <EuiSplitPanel.Outer hasShadow={false} hasBorder={true} direction="row">
+      <EuiSplitPanel.Inner
+        className="eui-textCenter"
+        grow={false}
+        style={{ minWidth: 96 }}>
         <EuiToken
           iconType="tokenStruct"
           size="m"
@@ -61,8 +70,11 @@ export default () => (
       </EuiSplitPanel.Inner>
     </EuiSplitPanel.Outer>
     <EuiSpacer />
-    <EuiSplitPanel.Outer hasShadow={false} direction="row">
-      <EuiSplitPanel.Inner grow={false} style={{ minWidth: 96 }}>
+    <EuiSplitPanel.Outer hasShadow={false} hasBorder={true} direction="row">
+      <EuiSplitPanel.Inner
+        className="eui-textCenter"
+        grow={false}
+        style={{ minWidth: 96 }}>
         <EuiToken
           iconType="faceNeutral"
           size="l"

--- a/src-docs/src/views/icon/editor.js
+++ b/src-docs/src/views/icon/editor.js
@@ -1,14 +1,3 @@
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-
-// This example JS is overly complex for simple icon usage
-// and is set up this way for ease of use in our docs.
-//
-// Check the snippet tab for a more common usage.
-
 import React from 'react';
 
 import {
@@ -16,7 +5,6 @@ import {
   EuiFlexItem,
   EuiIcon,
   EuiPanel,
-  EuiText,
   EuiCopy,
 } from '../../../../src/components';
 
@@ -52,19 +40,21 @@ const iconTypes = [
 ];
 
 export default () => (
-  <EuiFlexGrid columns={4}>
+  <EuiFlexGrid direction="column" columns={3}>
     {iconTypes.map((iconType) => (
-      <EuiFlexItem
-        className="guideDemo__icon"
-        key={iconType}
-        style={{ width: '200px' }}>
-        <EuiCopy textToCopy={iconType} afterMessage={`${iconType} copied`}>
+      <EuiFlexItem key={iconType}>
+        <EuiCopy
+          display="block"
+          textToCopy={iconType}
+          afterMessage={`${iconType} copied`}>
           {(copy) => (
-            <EuiPanel onClick={copy} className="eui-textCenter">
-              <EuiIcon type={iconType} />
-              <EuiText size="s">
-                <p>{iconType}</p>
-              </EuiText>
+            <EuiPanel
+              hasShadow={false}
+              hasBorder={false}
+              onClick={copy}
+              paddingSize="s">
+              <EuiIcon className="eui-alignMiddle" type={iconType} /> &emsp;{' '}
+              <small>{iconType}</small>
             </EuiPanel>
           )}
         </EuiCopy>

--- a/src-docs/src/views/icon/icon_colors.js
+++ b/src-docs/src/views/icon/icon_colors.js
@@ -1,14 +1,3 @@
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-
-// This example JS is overly complex for simple icon usage
-// and is set up this way for ease of use in our docs.
-//
-// Check the snippet tab for a more common usage.
-
 import React from 'react';
 
 import classNames from 'classnames';
@@ -18,9 +7,9 @@ import {
   EuiFlexItem,
   EuiIcon,
   EuiPanel,
-  EuiText,
-  EuiCallOut,
   EuiSpacer,
+  EuiCodeBlock,
+  EuiCopy,
 } from '../../../../src/components';
 
 const iconColors = [
@@ -39,83 +28,31 @@ const iconColors = [
 ];
 
 export default () => (
-  <div>
-    <EuiFlexGrid columns={4}>
+  <>
+    <EuiCodeBlock language="html" isCopyable paddingSize="m">
+      {'<EuiIcon type="brush" color="primary" />'}
+    </EuiCodeBlock>
+    <EuiSpacer />
+    <EuiFlexGrid direction="column" columns={3}>
       {iconColors.map((iconColor) => (
-        <EuiFlexItem
-          className="guideDemo__icon"
-          key={iconColor}
-          style={{ width: '340px' }}>
-          <EuiPanel
-            color="transparent"
-            className={classNames({
-              guideDemo__ghostBackground: iconColor === 'ghost',
-            })}>
-            <EuiIcon type="brush" color={iconColor} />
-            <EuiText
-              size="s"
-              color={iconColor === 'ghost' ? 'ghost' : 'default'}>
-              <p>{iconColor}</p>
-            </EuiText>
-          </EuiPanel>
+        <EuiFlexItem key={iconColor}>
+          <EuiCopy display="block" textToCopy={`color="${iconColor}"`}>
+            {(copy) => (
+              <EuiPanel
+                hasShadow={false}
+                hasBorder={false}
+                onClick={copy}
+                className={classNames({
+                  guideDemo__ghostBackground: iconColor === 'ghost',
+                })}
+                paddingSize="s">
+                <EuiIcon type="brush" color={iconColor} />
+                &emsp; <small>{iconColor}</small>
+              </EuiPanel>
+            )}
+          </EuiCopy>
         </EuiFlexItem>
       ))}
     </EuiFlexGrid>
-
-    <EuiSpacer />
-
-    <EuiCallOut
-      color="warning"
-      title="App icons have special, restricted coloring considerations"
-      size="s"
-    />
-
-    <EuiSpacer />
-
-    <EuiFlexGrid columns={4}>
-      <EuiFlexItem className="guideDemo__icon" style={{ width: '255px' }}>
-        <EuiPanel>
-          <EuiIcon type="gisApp" size="xl" />
-          <EuiText size="s">
-            <p>
-              Default coloring of <strong>App</strong> icons is two-toned
-            </p>
-          </EuiText>
-        </EuiPanel>
-      </EuiFlexItem>
-      <EuiFlexItem className="guideDemo__icon" style={{ width: '255px' }}>
-        <EuiPanel>
-          <EuiIcon type="gisApp" color="text" size="xl" />
-          <EuiText size="s">
-            <p>
-              <strong>Special:</strong> the text color makes{' '}
-              <strong>App</strong> icons fully that color
-            </p>
-          </EuiText>
-        </EuiPanel>
-      </EuiFlexItem>
-      <EuiFlexItem className="guideDemo__icon" style={{ width: '255px' }}>
-        <EuiPanel>
-          <EuiIcon type="createAdvancedJob" color="primary" size="xl" />
-          <EuiText size="s">
-            <p>
-              <strong>Special:</strong> the primary color makes{' '}
-              <strong>App</strong> icons fully that color
-            </p>
-          </EuiText>
-        </EuiPanel>
-      </EuiFlexItem>
-      <EuiFlexItem className="guideDemo__icon" style={{ width: '255px' }}>
-        <EuiPanel>
-          <EuiIcon type="createAdvancedJob" color="#DA8B45" size="xl" />
-          <EuiText size="s">
-            <p>
-              <strong>Special:</strong> a custom color makes{' '}
-              <strong>App</strong> icons fully that color
-            </p>
-          </EuiText>
-        </EuiPanel>
-      </EuiFlexItem>
-    </EuiFlexGrid>
-  </div>
+  </>
 );

--- a/src-docs/src/views/icon/icon_colors_apps.js
+++ b/src-docs/src/views/icon/icon_colors_apps.js
@@ -1,0 +1,72 @@
+import React from 'react';
+
+import {
+  EuiIcon,
+  EuiSpacer,
+  EuiCodeBlock,
+  EuiSplitPanel,
+} from '../../../../src/components';
+
+export default () => (
+  <>
+    <EuiSplitPanel.Outer hasShadow={false} direction="row">
+      <EuiSplitPanel.Inner grow={false} style={{ minWidth: 96 }}>
+        <EuiIcon type="gisApp" size="xl" />
+      </EuiSplitPanel.Inner>
+      <EuiSplitPanel.Inner paddingSize="s" color="subdued">
+        <EuiCodeBlock
+          language="html"
+          isCopyable
+          transparentBackground
+          paddingSize="m">
+          {'<EuiIcon type="gisApp" size="xl" />'}
+        </EuiCodeBlock>
+      </EuiSplitPanel.Inner>
+    </EuiSplitPanel.Outer>
+    <EuiSpacer />
+    <EuiSplitPanel.Outer hasShadow={false} direction="row">
+      <EuiSplitPanel.Inner grow={false} style={{ minWidth: 96 }}>
+        <EuiIcon type="gisApp" color="text" size="xl" />
+      </EuiSplitPanel.Inner>
+      <EuiSplitPanel.Inner paddingSize="s" color="subdued">
+        <EuiCodeBlock
+          language="html"
+          isCopyable
+          transparentBackground
+          paddingSize="m">
+          {'<EuiIcon type="gisApp" color="text" size="xl" />'}
+        </EuiCodeBlock>
+      </EuiSplitPanel.Inner>
+    </EuiSplitPanel.Outer>
+    <EuiSpacer />
+    <EuiSplitPanel.Outer hasShadow={false} direction="row">
+      <EuiSplitPanel.Inner grow={false} style={{ minWidth: 96 }}>
+        <EuiIcon type="gisApp" color="primary" size="xl" />
+      </EuiSplitPanel.Inner>
+      <EuiSplitPanel.Inner paddingSize="s" color="subdued">
+        <EuiCodeBlock
+          language="html"
+          isCopyable
+          transparentBackground
+          paddingSize="m">
+          {'<EuiIcon type="gisApp" color="primary" size="xl" />'}
+        </EuiCodeBlock>
+      </EuiSplitPanel.Inner>
+    </EuiSplitPanel.Outer>
+    <EuiSpacer />
+    <EuiSplitPanel.Outer hasShadow={false} direction="row">
+      <EuiSplitPanel.Inner grow={false} style={{ minWidth: 96 }}>
+        <EuiIcon type="gisApp" color="#DA8B45" size="xl" />
+      </EuiSplitPanel.Inner>
+      <EuiSplitPanel.Inner paddingSize="s" color="subdued">
+        <EuiCodeBlock
+          language="html"
+          isCopyable
+          transparentBackground
+          paddingSize="m">
+          {'<EuiIcon type="gisApp" color="#DA8B45" size="xl" />'}
+        </EuiCodeBlock>
+      </EuiSplitPanel.Inner>
+    </EuiSplitPanel.Outer>
+  </>
+);

--- a/src-docs/src/views/icon/icon_colors_apps.js
+++ b/src-docs/src/views/icon/icon_colors_apps.js
@@ -9,8 +9,11 @@ import {
 
 export default () => (
   <>
-    <EuiSplitPanel.Outer hasShadow={false} direction="row">
-      <EuiSplitPanel.Inner grow={false} style={{ minWidth: 96 }}>
+    <EuiSplitPanel.Outer hasShadow={false} hasBorder={true} direction="row">
+      <EuiSplitPanel.Inner
+        className="eui-textCenter"
+        grow={false}
+        style={{ minWidth: 96 }}>
         <EuiIcon type="gisApp" size="xl" />
       </EuiSplitPanel.Inner>
       <EuiSplitPanel.Inner paddingSize="s" color="subdued">
@@ -24,8 +27,11 @@ export default () => (
       </EuiSplitPanel.Inner>
     </EuiSplitPanel.Outer>
     <EuiSpacer />
-    <EuiSplitPanel.Outer hasShadow={false} direction="row">
-      <EuiSplitPanel.Inner grow={false} style={{ minWidth: 96 }}>
+    <EuiSplitPanel.Outer hasShadow={false} hasBorder={true} direction="row">
+      <EuiSplitPanel.Inner
+        className="eui-textCenter"
+        grow={false}
+        style={{ minWidth: 96 }}>
         <EuiIcon type="gisApp" color="text" size="xl" />
       </EuiSplitPanel.Inner>
       <EuiSplitPanel.Inner paddingSize="s" color="subdued">
@@ -39,8 +45,11 @@ export default () => (
       </EuiSplitPanel.Inner>
     </EuiSplitPanel.Outer>
     <EuiSpacer />
-    <EuiSplitPanel.Outer hasShadow={false} direction="row">
-      <EuiSplitPanel.Inner grow={false} style={{ minWidth: 96 }}>
+    <EuiSplitPanel.Outer hasShadow={false} hasBorder={true} direction="row">
+      <EuiSplitPanel.Inner
+        className="eui-textCenter"
+        grow={false}
+        style={{ minWidth: 96 }}>
         <EuiIcon type="gisApp" color="primary" size="xl" />
       </EuiSplitPanel.Inner>
       <EuiSplitPanel.Inner paddingSize="s" color="subdued">
@@ -54,8 +63,11 @@ export default () => (
       </EuiSplitPanel.Inner>
     </EuiSplitPanel.Outer>
     <EuiSpacer />
-    <EuiSplitPanel.Outer hasShadow={false} direction="row">
-      <EuiSplitPanel.Inner grow={false} style={{ minWidth: 96 }}>
+    <EuiSplitPanel.Outer hasShadow={false} hasBorder={true} direction="row">
+      <EuiSplitPanel.Inner
+        className="eui-textCenter"
+        grow={false}
+        style={{ minWidth: 96 }}>
         <EuiIcon type="gisApp" color="#DA8B45" size="xl" />
       </EuiSplitPanel.Inner>
       <EuiSplitPanel.Inner paddingSize="s" color="subdued">

--- a/src-docs/src/views/icon/icon_example.js
+++ b/src-docs/src/views/icon/icon_example.js
@@ -8,6 +8,7 @@ import {
   EuiLink,
   EuiText,
   EuiCallOut,
+  EuiSpacer,
 } from '../../../../src/components';
 
 import iconConfig from './playground';
@@ -144,21 +145,24 @@ export const IconExample = {
       demo: <Tokens />,
     },
     {
+      wrapText: false,
       text: (
         <>
-          <h3>Custom tokens</h3>
-          <p>
-            By default, an <EuiCode>iconType</EuiCode> with the token prefix
-            (i.e. those listed above) will have predefined styles. However, any
-            valid <EuiCode>iconType</EuiCode> can be passed and, in either case,
-            the <EuiCode>shape</EuiCode>, <EuiCode>size</EuiCode>,{' '}
-            <EuiCode>color</EuiCode>, and <EuiCode>fill</EuiCode> can be
-            customized.
-          </p>
+          <EuiText>
+            <h3>Custom tokens</h3>
+            <p>
+              By default, an <EuiCode>iconType</EuiCode> with the token prefix
+              (i.e. those listed above) will have predefined styles. However, any
+              valid <EuiCode>iconType</EuiCode> can be passed and, in either case,
+              the <EuiCode>shape</EuiCode>, <EuiCode>size</EuiCode>,{' '}
+              <EuiCode>color</EuiCode>, and <EuiCode>fill</EuiCode> can be
+              customized.
+            </p>
+          </EuiText>
+          <EuiSpacer />
+          <CustomTokens />
         </>
       ),
-      props: { EuiToken },
-      demo: <CustomTokens />,
     },
     {
       title: 'Sizes',
@@ -193,14 +197,20 @@ export const IconExample = {
       demo: <IconColors />,
     },
     {
+      wrapText: false,
       text: (
-        <p>
-          Two-tone icons, like our app style icons, will behave similarly to
-          normal glyphs when provided a specific color by applying the color to
-          <strong>all</strong> the shapes within.
-        </p>
+        <>
+          <EuiText>
+            <p>
+              Two-tone icons, like our app style icons, will behave similarly to
+              normal glyphs when provided a specific color by applying the color to
+              <strong>all</strong> the shapes within.
+            </p>
+          </EuiText>
+          <EuiSpacer />
+          <AppIconColors />
+        </>
       ),
-      demo: <AppIconColors />,
     },
     {
       title: 'Custom SVGs',

--- a/src-docs/src/views/icon/icon_example.js
+++ b/src-docs/src/views/icon/icon_example.js
@@ -37,18 +37,16 @@ const iconTypesSource = require('!!raw-loader!./icon_types');
 
 export const IconExample = {
   title: 'Icons',
-  intro: (
-    <EuiText>
-      <p>
-        <strong>EuiIcon</strong> is a handy component for using our custom
-        glyphs and logos. The <EuiCode>type</EuiCode> prop accepts either an
-        enumerated name from one of the sets below, a location to a custom SVG
-        asset, or a React Element.
-      </p>
-    </EuiText>
-  ),
   sections: [
     {
+      text: (
+        <p>
+          <strong>EuiIcon</strong> is a handy component for using our custom
+          glyphs and logos. The <EuiCode>type</EuiCode> prop accepts either an
+          enumerated name from one of the sets below, a location to a custom SVG
+          asset, or a React Element.
+        </p>
+      ),
       demo: <EuiIcon type="grid" />,
       props: { EuiIcon },
       playground: iconConfig,
@@ -56,9 +54,10 @@ export const IconExample = {
     {
       text: (
         <EuiCallOut
+          iconType="accessibility"
           title={
             <>
-              For better accessibility it's always recommended to give a
+              For better accessibility it&apos;s always recommended to give a
               descriptive <EuiCode>title</EuiCode> based on the icon use.
             </>
           }
@@ -134,10 +133,10 @@ export const IconExample = {
           <p>
             Tokens are most commonly used to visually signify field or code
             types. An <strong>EuiToken</strong> accepts any valid{' '}
-            <strong>EuiIcon</strong> as its
-            <EuiCode>iconType</EuiCode> property. However, icons designed
-            specifically for use in the <strong>EuiToken</strong> are prefixed
-            with &quot;token&quot; in their name and have pre-defined styles.
+            <strong>EuiIcon</strong> as its <EuiCode>iconType</EuiCode>{' '}
+            property. However, icons designed specifically for use in the{' '}
+            <strong>EuiToken</strong> are prefixed with &quot;token&quot; in
+            their name and have pre-defined styles.
           </p>
         </>
       ),
@@ -152,9 +151,9 @@ export const IconExample = {
             <h3>Custom tokens</h3>
             <p>
               By default, an <EuiCode>iconType</EuiCode> with the token prefix
-              (i.e. those listed above) will have predefined styles. However, any
-              valid <EuiCode>iconType</EuiCode> can be passed and, in either case,
-              the <EuiCode>shape</EuiCode>, <EuiCode>size</EuiCode>,{' '}
+              (i.e. those listed above) will have predefined styles. However,
+              any valid <EuiCode>iconType</EuiCode> can be passed and, in either
+              case, the <EuiCode>shape</EuiCode>, <EuiCode>size</EuiCode>,{' '}
               <EuiCode>color</EuiCode>, and <EuiCode>fill</EuiCode> can be
               customized.
             </p>
@@ -189,9 +188,9 @@ export const IconExample = {
           </EuiLink>
           &nbsp;which will be passed down through the inline-style{' '}
           <EuiCode>fill</EuiCode>&nbsp; property.{' '}
-          <strong>We recommend relying on the EUI named color palette</strong>
-          &nbsp; unless the custom color is initiated by the user (like as a
-          graph color).
+          <strong>We recommend relying on the EUI named color palette</strong>{' '}
+          unless the custom color is initiated by the user (like as a graph
+          color).
         </p>
       ),
       demo: <IconColors />,
@@ -203,8 +202,8 @@ export const IconExample = {
           <EuiText>
             <p>
               Two-tone icons, like our app style icons, will behave similarly to
-              normal glyphs when provided a specific color by applying the color to
-              <strong>all</strong> the shapes within.
+              normal glyphs when provided a specific color by applying the color
+              to <strong>all</strong> the shapes within.
             </p>
           </EuiText>
           <EuiSpacer />
@@ -220,10 +219,10 @@ export const IconExample = {
             The <EuiCode>type</EuiCode> prop can accept a valid enum, string or
             React SVG Element. When using a custom SVG, please make sure it sits
             on a square canvas and preferably utilizes one of EUI&apos;s sizes
-            (16x16, 32x32...etc).
+            (<EuiCode>16x16</EuiCode> or <EuiCode>32x32</EuiCode>).
           </p>
           <p>
-            When using custom SVGs for simple glyphs,
+            When using custom SVGs for simple glyphs,{' '}
             <strong>remove all fill attributes</strong> on the SVG and utilize
             the CSS helpers if you have complex logos that need to work with
             theming.

--- a/src-docs/src/views/icon/icon_example.js
+++ b/src-docs/src/views/icon/icon_example.js
@@ -1,7 +1,4 @@
 import React from 'react';
-
-import { renderToHtml } from '../../services';
-
 import { GuideSectionTypes } from '../../components';
 
 import {
@@ -10,113 +7,80 @@ import {
   EuiToken,
   EuiLink,
   EuiText,
-  EuiSpacer,
   EuiCallOut,
 } from '../../../../src/components';
+
 import iconConfig from './playground';
 
 import Icons from './icons';
-const iconsSnippet = '<EuiIcon type="alert" />';
 
 import Tokens from './tokens';
-const tokensSnippet = [
-  '<EuiToken iconType="tokenAnnotation" />',
-  `<EuiToken
-  iconType="tokenElement"
-  color="euiColorVis07"
-  shape="circle"
-/>`,
-  `<EuiToken
-  iconType="visMapCoordinate"
-  size="l"
-  color="#FF0000"
-  shape="rectangle"
-  fill="dark"
-/>`,
-];
+
+import CustomTokens from './custom_tokens';
 
 import Apps from './apps';
-const appsSnippet = '<EuiIcon type="addDataApp" size="xl" />';
 
 import Editor from './editor';
-const editorSnippet = '<EuiIcon type="editorAlignLeft" />';
 
 import Ml from './ml';
-const mlSnippet = '<EuiIcon type="dataVisualizer" size="xl" />';
 
 import Logos from './logos';
-const logosSnippet = '<EuiIcon type="logoElasticsearch" size="xl" />';
-
-import LogosThird from './logos_third';
-const logosThirdSnippet = '<EuiIcon type="logoApache" size="xl" />';
 
 import IconSizes from './icon_sizes';
-const iconSizesSnippet = '<EuiIcon type="logoElasticStack" size="xl" />';
 
 import IconColors from './icon_colors';
-const iconColorsSnippet = [
-  '<EuiIcon type="brush" color="primary" />',
-  '<EuiIcon type="brush" color="#DA8B45" />',
-];
+import AppIconColors from './icon_colors_apps';
 
 import IconTypes from './icon_types';
 const iconTypesSource = require('!!raw-loader!./icon_types');
-const iconTypesHtml = renderToHtml(IconTypes);
-const iconTypesSnippet = [
-  '<EuiIcon type="logoElastic" size="xl" />',
-  '<EuiIcon type={reactSVGElement} size="xl" />',
-  '<EuiIcon type="https://upload.wikimedia.org/wikipedia/commons/0/02/SVG_logo.svg" size="xl" title="My SVG logo" />',
-  '<EuiButton iconType={reactSVGElement}>Works in other components too</EuiButton>',
-];
 
 export const IconExample = {
   title: 'Icons',
   intro: (
-    <div>
-      <EuiText>
-        <p>
-          <strong>EuiIcon</strong> is a handy component for using our custom
-          glyphs and logos. The <EuiCode>type</EuiCode> prop accepts either an
-          enumerated name from one of the sets below, a location to a custom SVG
-          asset, or a React Element.
-        </p>
-        <p>
-          When using custom SVGs please{' '}
-          <strong>remove all fill attributes</strong> on the SVG and utilize the
-          CSS helpers if you have complex logos that need to work with theming.
-        </p>
-      </EuiText>
-      <EuiSpacer />
-      <EuiCallOut
-        title={
-          <>
-            For better accessibility it's always recommended to give a
-            descriptive <EuiCode>title</EuiCode> based on the icon use.
-          </>
-        }
-        color="warning">
-        <p>
-          If no title is provided the icon is going to be purely decorative and
-          it will get by default an <EuiCode language="js">aria-hidden=true</EuiCode>.
-        </p>
-      </EuiCallOut>
-    </div>
+    <EuiText>
+      <p>
+        <strong>EuiIcon</strong> is a handy component for using our custom
+        glyphs and logos. The <EuiCode>type</EuiCode> prop accepts either an
+        enumerated name from one of the sets below, a location to a custom SVG
+        asset, or a React Element.
+      </p>
+    </EuiText>
   ),
   sections: [
     {
+      demo: <EuiIcon type="grid" />,
+      props: { EuiIcon },
+      playground: iconConfig,
+    },
+    {
+      text: (
+        <EuiCallOut
+          title={
+            <>
+              For better accessibility it's always recommended to give a
+              descriptive <EuiCode>title</EuiCode> based on the icon use.
+            </>
+          }
+          color="warning">
+          <p>
+            If no title is provided the icon is going to be purely decorative
+            and it will get by default an{' '}
+            <EuiCode language="js">aria-hidden=true</EuiCode>.
+          </p>
+        </EuiCallOut>
+      ),
+    },
+    {
       title: 'Glyphs',
       text: (
-        <div>
+        <>
           <p>
             Glyphs are small, monochromatic icons that typically should always
             use the default size of{' '}
-            <EuiCode language="js">size=&quot;m&quot;</EuiCode>. They tend to be
-            pixel perfect and don&apos;t scale very well into larger sizes.
+            <EuiCode language="js">size=&quot;m&quot;</EuiCode>.
           </p>
-        </div>
+        </>
       ),
-      props: { EuiIcon },
-      snippet: iconsSnippet,
       demo: <Icons />,
     },
     {
@@ -127,48 +91,7 @@ export const IconExample = {
           used within <strong>EuiButtonGroup</strong> components.
         </p>
       ),
-      snippet: editorSnippet,
       demo: <Editor />,
-    },
-    {
-      title: 'Apps',
-      text: (
-        <p>
-          App logos are usually displayed at <EuiCode>32x32</EuiCode> or above
-          and can contain multiple colors.
-        </p>
-      ),
-      snippet: appsSnippet,
-      demo: <Apps />,
-    },
-    {
-      title: 'Tokens',
-      text: (
-        <div>
-          <p>
-            Tokens are most commonly used to visually signify field or code
-            types. An <strong>EuiToken</strong> accepts any valid{' '}
-            <strong>EuiIcon</strong> as its
-            <EuiCode>iconType</EuiCode> property. However, icons designed
-            specifically for use in the <strong>EuiToken</strong> are prefixed
-            with &quot;token&quot; in their name and have pre-defined styles.
-          </p>
-        </div>
-      ),
-      props: { EuiToken },
-      snippet: tokensSnippet,
-      demo: <Tokens />,
-    },
-    {
-      title: 'Machine learning icons',
-      text: (
-        <p>
-          ML has some specific icons for job creation. Again, these are made for{' '}
-          <EuiCode>32x32</EuiCode>.
-        </p>
-      ),
-      snippet: mlSnippet,
-      demo: <Ml />,
     },
     {
       title: 'Elastic logos',
@@ -179,8 +102,63 @@ export const IconExample = {
           handle flipping colors for dark mode.
         </p>
       ),
-      snippet: logosSnippet,
       demo: <Logos />,
+    },
+    {
+      title: 'Apps',
+      text: (
+        <p>
+          App logos are usually displayed at <EuiCode>32x32</EuiCode> or above
+          and can contain multiple colors.
+        </p>
+      ),
+      demo: <Apps />,
+    },
+    {
+      text: (
+        <>
+          <h3>Machine learning icons</h3>
+          <p>
+            Machine learning has some specific icons for job creation. Again,
+            these are made for <EuiCode>32x32</EuiCode>.
+          </p>
+        </>
+      ),
+      demo: <Ml />,
+    },
+    {
+      title: 'Tokens',
+      text: (
+        <>
+          <p>
+            Tokens are most commonly used to visually signify field or code
+            types. An <strong>EuiToken</strong> accepts any valid{' '}
+            <strong>EuiIcon</strong> as its
+            <EuiCode>iconType</EuiCode> property. However, icons designed
+            specifically for use in the <strong>EuiToken</strong> are prefixed
+            with &quot;token&quot; in their name and have pre-defined styles.
+          </p>
+        </>
+      ),
+      props: { EuiToken },
+      demo: <Tokens />,
+    },
+    {
+      text: (
+        <>
+          <h3>Custom tokens</h3>
+          <p>
+            By default, an <EuiCode>iconType</EuiCode> with the token prefix
+            (i.e. those listed above) will have predefined styles. However, any
+            valid <EuiCode>iconType</EuiCode> can be passed and, in either case,
+            the <EuiCode>shape</EuiCode>, <EuiCode>size</EuiCode>,{' '}
+            <EuiCode>color</EuiCode>, and <EuiCode>fill</EuiCode> can be
+            customized.
+          </p>
+        </>
+      ),
+      props: { EuiToken },
+      demo: <CustomTokens />,
     },
     {
       title: 'Sizes',
@@ -191,7 +169,6 @@ export const IconExample = {
           icon.
         </p>
       ),
-      snippet: iconSizesSnippet,
       demo: <IconSizes />,
     },
     {
@@ -213,46 +190,44 @@ export const IconExample = {
           graph color).
         </p>
       ),
-      snippet: iconColorsSnippet,
       demo: <IconColors />,
+    },
+    {
+      text: (
+        <p>
+          Two-tone icons, like our app style icons, will behave similarly to
+          normal glyphs when provided a specific color by applying the color to
+          <strong>all</strong> the shapes within.
+        </p>
+      ),
+      demo: <AppIconColors />,
     },
     {
       title: 'Custom SVGs',
       text: (
-        <p>
-          The <EuiCode>type</EuiCode> prop can accept a valid enum, string or
-          React SVG Element. When using a custom SVG, please make sure it sits
-          on a square canvas and preferably utilizes one of EUI&apos;s sizes
-          (16x16, 32x32...etc). For IE11 compatibility, the SVG file{' '}
-          <em>must</em> contain a <EuiCode>viewBox</EuiCode>.
-        </p>
+        <>
+          <p>
+            The <EuiCode>type</EuiCode> prop can accept a valid enum, string or
+            React SVG Element. When using a custom SVG, please make sure it sits
+            on a square canvas and preferably utilizes one of EUI&apos;s sizes
+            (16x16, 32x32...etc).
+          </p>
+          <p>
+            When using custom SVGs for simple glyphs,
+            <strong>remove all fill attributes</strong> on the SVG and utilize
+            the CSS helpers if you have complex logos that need to work with
+            theming.
+          </p>
+        </>
       ),
       source: [
         {
           type: GuideSectionTypes.JS,
           code: iconTypesSource,
         },
-        {
-          type: GuideSectionTypes.HTML,
-          code: iconTypesHtml,
-        },
       ],
       props: { EuiIcon },
-      snippet: iconTypesSnippet,
       demo: <IconTypes />,
     },
-    {
-      title: 'Third party logos',
-      text: (
-        <p>
-          EUI's library of third party logos are mostly maintained for legacy
-          usages. <strong>EuiIcon</strong> now accepts custom SVG and image
-          content which is how we recommend displaying external logos.
-        </p>
-      ),
-      snippet: logosThirdSnippet,
-      demo: <LogosThird />,
-    },
   ],
-  playground: iconConfig,
 };

--- a/src-docs/src/views/icon/icon_sizes.js
+++ b/src-docs/src/views/icon/icon_sizes.js
@@ -1,14 +1,3 @@
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-
-// This example JS is overly complex for simple icon usage
-// and is set up this way for ease of use in our docs.
-//
-// Check the snippet tab for a more common usage.
-
 import React from 'react';
 
 import {
@@ -16,25 +5,47 @@ import {
   EuiFlexItem,
   EuiIcon,
   EuiPanel,
-  EuiText,
+  EuiCodeBlock,
+  EuiSpacer,
+  EuiCopy,
 } from '../../../../src/components';
 
 const iconSizes = ['s', 'm', 'l', 'xl', 'xxl', 'original'];
+const iconSizesText = [
+  'small',
+  'medium',
+  'large',
+  'x-large',
+  'xx-large',
+  'original',
+];
 
 export default () => (
-  <EuiFlexGrid columns={4}>
-    {iconSizes.map((iconSize) => (
-      <EuiFlexItem
-        className="guideDemo__icon"
-        key={iconSize}
-        style={{ width: '340px' }}>
-        <EuiPanel>
-          <EuiIcon type="logoElasticStack" size={iconSize} />
-          <EuiText size="s">
-            <p>{iconSize}</p>
-          </EuiText>
-        </EuiPanel>
-      </EuiFlexItem>
-    ))}
-  </EuiFlexGrid>
+  <>
+    <EuiCodeBlock language="html" isCopyable paddingSize="m">
+      {'<EuiIcon type="logoElasticsearch" size="xl" />'}
+    </EuiCodeBlock>
+    <EuiSpacer />
+    <EuiFlexGrid direction="column" columns={3}>
+      {iconSizes.map((iconSize, index) => (
+        <EuiFlexItem key={iconSize}>
+          <EuiCopy
+            display="block"
+            textToCopy={iconSize}
+            afterMessage={`${iconSize} copied`}>
+            {(copy) => (
+              <EuiPanel
+                hasShadow={false}
+                hasBorder={false}
+                onClick={copy}
+                paddingSize="s">
+                <EuiIcon type="logoElasticStack" size={iconSize} /> &emsp;{' '}
+                {iconSizesText[index]}
+              </EuiPanel>
+            )}
+          </EuiCopy>
+        </EuiFlexItem>
+      ))}
+    </EuiFlexGrid>
+  </>
 );

--- a/src-docs/src/views/icon/icon_types.js
+++ b/src-docs/src/views/icon/icon_types.js
@@ -16,7 +16,10 @@ import reactSvg from '../../images/custom.svg';
 export default () => (
   <div>
     <EuiSplitPanel.Outer hasShadow={false} direction="row">
-      <EuiSplitPanel.Inner grow={false} style={{ minWidth: 96 }}>
+      <EuiSplitPanel.Inner
+        className="eui-textCenter"
+        grow={false}
+        style={{ minWidth: 96 }}>
         <EuiIcon
           type="https://upload.wikimedia.org/wikipedia/commons/0/02/SVG_logo.svg"
           size="xl"
@@ -25,6 +28,7 @@ export default () => (
       </EuiSplitPanel.Inner>
       <EuiSplitPanel.Inner paddingSize="s" color="subdued">
         <EuiCodeBlock
+          className="eui-textBreakWord"
           language="html"
           isCopyable
           transparentBackground
@@ -37,7 +41,10 @@ export default () => (
     </EuiSplitPanel.Outer>
     <EuiSpacer />
     <EuiSplitPanel.Outer hasShadow={false} direction="row">
-      <EuiSplitPanel.Inner grow={false} style={{ minWidth: 96 }}>
+      <EuiSplitPanel.Inner
+        className="eui-textCenter"
+        grow={false}
+        style={{ minWidth: 96 }}>
         <EuiIcon type={reactSvg} size="xl" title="Custom SVG icon" />
       </EuiSplitPanel.Inner>
       <EuiSplitPanel.Inner paddingSize="s" color="subdued">

--- a/src-docs/src/views/icon/icon_types.js
+++ b/src-docs/src/views/icon/icon_types.js
@@ -1,57 +1,62 @@
 import React from 'react';
 
 import {
-  EuiFlexGrid,
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
-  EuiPanel,
   EuiText,
   EuiSpacer,
   EuiButton,
+  EuiSplitPanel,
+  EuiCodeBlock,
 } from '../../../../src/components';
 
 import reactSvg from '../../images/custom.svg';
 
 export default () => (
   <div>
-    <EuiFlexGrid columns={4}>
-      <EuiFlexItem className="guideDemo__icon" style={{ width: '200px' }}>
-        <EuiPanel>
-          <EuiIcon type="logoElastic" size="xl" />
-          <EuiText size="s">
-            <p>logoElastic</p>
-          </EuiText>
-        </EuiPanel>
-      </EuiFlexItem>
-      <EuiFlexItem className="guideDemo__icon" style={{ width: '200px' }}>
-        <EuiPanel>
-          <EuiIcon
-            type="https://upload.wikimedia.org/wikipedia/commons/0/02/SVG_logo.svg"
-            size="xl"
-            title="My SVG logo"
-          />
-          <EuiText size="s">
-            <p>http://some.svg</p>
-          </EuiText>
-        </EuiPanel>
-      </EuiFlexItem>
-      <EuiFlexItem className="guideDemo__icon" style={{ width: '200px' }}>
-        <EuiPanel>
-          <EuiIcon type={reactSvg} size="xl" title="Custom SVG icon" />
-          <EuiText size="s">
-            <p>{'{reactSvg}'}</p>
-          </EuiText>
-        </EuiPanel>
-      </EuiFlexItem>
-    </EuiFlexGrid>
+    <EuiSplitPanel.Outer hasShadow={false} direction="row">
+      <EuiSplitPanel.Inner grow={false} style={{ minWidth: 96 }}>
+        <EuiIcon
+          type="https://upload.wikimedia.org/wikipedia/commons/0/02/SVG_logo.svg"
+          size="xl"
+          title="My SVG logo"
+        />
+      </EuiSplitPanel.Inner>
+      <EuiSplitPanel.Inner paddingSize="s" color="subdued">
+        <EuiCodeBlock
+          language="html"
+          isCopyable
+          transparentBackground
+          paddingSize="m">
+          {
+            '<EuiIcon type="https://upload.wikimedia.org/wikipedia/commons/0/02/SVG_logo.svg" size="xl" title="My SVG logo" />'
+          }
+        </EuiCodeBlock>
+      </EuiSplitPanel.Inner>
+    </EuiSplitPanel.Outer>
+    <EuiSpacer />
+    <EuiSplitPanel.Outer hasShadow={false} direction="row">
+      <EuiSplitPanel.Inner grow={false} style={{ minWidth: 96 }}>
+        <EuiIcon type={reactSvg} size="xl" title="Custom SVG icon" />
+      </EuiSplitPanel.Inner>
+      <EuiSplitPanel.Inner paddingSize="s" color="subdued">
+        <EuiCodeBlock
+          language="html"
+          isCopyable
+          transparentBackground
+          paddingSize="m">
+          {'<EuiIcon type={reactSvg} size="xl" title="Custom SVG icon" />'}
+        </EuiCodeBlock>
+      </EuiSplitPanel.Inner>
+    </EuiSplitPanel.Outer>
 
     <EuiSpacer />
 
     <EuiText>
       <p>
         Any component that utlizes <strong>EuiIcon</strong> can use custom SVGs
-        as well
+        as well.
       </p>
     </EuiText>
 

--- a/src-docs/src/views/icon/icons.js
+++ b/src-docs/src/views/icon/icons.js
@@ -1,14 +1,3 @@
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-
-// This example JS is overly complex for simple icon usage
-// and is set up this way for ease of use in our docs.
-//
-// Check the snippet tab for a more common usage.
-
 import React from 'react';
 
 import {
@@ -16,8 +5,9 @@ import {
   EuiFlexItem,
   EuiIcon,
   EuiPanel,
-  EuiText,
   EuiCopy,
+  EuiCodeBlock,
+  EuiSpacer,
 } from '../../../../src/components';
 
 export const iconTypes = [
@@ -238,23 +228,31 @@ export const iconTypes = [
 ];
 
 export default () => (
-  <EuiFlexGrid columns={4}>
-    {iconTypes.map((iconType) => (
-      <EuiFlexItem
-        className="guideDemo__icon"
-        key={iconType}
-        style={{ width: '200px' }}>
-        <EuiCopy textToCopy={iconType} afterMessage={`${iconType} copied`}>
-          {(copy) => (
-            <EuiPanel onClick={copy} className="eui-textCenter">
-              <EuiIcon type={iconType} />
-              <EuiText size="s">
-                <p>{iconType}</p>
-              </EuiText>
-            </EuiPanel>
-          )}
-        </EuiCopy>
-      </EuiFlexItem>
-    ))}
-  </EuiFlexGrid>
+  <>
+    <EuiCodeBlock language="html" isCopyable paddingSize="m">
+      {'<EuiIcon type="alert" />'}
+    </EuiCodeBlock>
+    <EuiSpacer />
+    <EuiFlexGrid direction="column" columns={3}>
+      {iconTypes.map((iconType) => (
+        <EuiFlexItem key={iconType}>
+          <EuiCopy
+            display="block"
+            textToCopy={iconType}
+            afterMessage={`${iconType} copied`}>
+            {(copy) => (
+              <EuiPanel
+                hasShadow={false}
+                hasBorder={false}
+                onClick={copy}
+                paddingSize="s">
+                <EuiIcon className="eui-alignMiddle" type={iconType} /> &emsp;{' '}
+                <small>{iconType}</small>
+              </EuiPanel>
+            )}
+          </EuiCopy>
+        </EuiFlexItem>
+      ))}
+    </EuiFlexGrid>
+  </>
 );

--- a/src-docs/src/views/icon/logos.js
+++ b/src-docs/src/views/icon/logos.js
@@ -1,14 +1,3 @@
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-
-// This example JS is overly complex for simple icon usage
-// and is set up this way for ease of use in our docs.
-//
-// Check the snippet tab for a more common usage.
-
 import React from 'react';
 
 import {
@@ -16,7 +5,8 @@ import {
   EuiFlexItem,
   EuiIcon,
   EuiPanel,
-  EuiText,
+  EuiCodeBlock,
+  EuiSpacer,
   EuiCopy,
 } from '../../../../src/components';
 
@@ -44,23 +34,35 @@ export const iconTypes = [
 ].sort();
 
 export default () => (
-  <EuiFlexGrid columns={4}>
-    {iconTypes.map((iconType) => (
-      <EuiFlexItem
-        className="guideDemo__icon"
-        key={iconType}
-        style={{ width: '200px' }}>
-        <EuiCopy textToCopy={iconType} afterMessage={`${iconType} copied`}>
-          {(copy) => (
-            <EuiPanel onClick={copy} className="eui-textCenter">
-              <EuiIcon type={iconType} size="xl" />
-              <EuiText size="s">
-                <p>{iconType}</p>
-              </EuiText>
-            </EuiPanel>
-          )}
-        </EuiCopy>
-      </EuiFlexItem>
-    ))}
-  </EuiFlexGrid>
+  <>
+    <EuiCodeBlock language="html" isCopyable paddingSize="m">
+      {'<EuiIcon type="logoElasticsearch" size="xl" />'}
+    </EuiCodeBlock>
+    <EuiSpacer />
+    <EuiFlexGrid direction="column" columns={3}>
+      {iconTypes.map((iconType) => (
+        <EuiFlexItem key={iconType}>
+          <EuiCopy
+            display="block"
+            textToCopy={iconType}
+            afterMessage={`${iconType} copied`}>
+            {(copy) => (
+              <EuiPanel
+                hasShadow={false}
+                hasBorder={false}
+                onClick={copy}
+                paddingSize="s">
+                <EuiIcon
+                  className="eui-alignMiddle"
+                  type={iconType}
+                  size="xl"
+                />{' '}
+                &emsp; <small>{iconType}</small>
+              </EuiPanel>
+            )}
+          </EuiCopy>
+        </EuiFlexItem>
+      ))}
+    </EuiFlexGrid>
+  </>
 );

--- a/src-docs/src/views/icon/logos_third.js
+++ b/src-docs/src/views/icon/logos_third.js
@@ -1,14 +1,3 @@
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-
-// This example JS is overly complex for simple icon usage
-// and is set up this way for ease of use in our docs.
-//
-// Check the snippet tab for a more common usage.
-
 import React from 'react';
 
 import {

--- a/src-docs/src/views/icon/ml.js
+++ b/src-docs/src/views/icon/ml.js
@@ -1,14 +1,3 @@
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-
-// This example JS is overly complex for simple icon usage
-// and is set up this way for ease of use in our docs.
-//
-// Check the snippet tab for a more common usage.
-
 import React from 'react';
 
 import {
@@ -16,8 +5,9 @@ import {
   EuiFlexItem,
   EuiIcon,
   EuiPanel,
-  EuiText,
+  EuiCodeBlock,
   EuiCopy,
+  EuiSpacer,
 } from '../../../../src/components';
 
 const iconTypes = [
@@ -32,23 +22,35 @@ const iconTypes = [
 ];
 
 export default () => (
-  <EuiFlexGrid columns={4}>
-    {iconTypes.map((iconType) => (
-      <EuiFlexItem
-        className="guideDemo__icon"
-        key={iconType}
-        style={{ width: '200px' }}>
-        <EuiCopy textToCopy={iconType} afterMessage={`${iconType} copied`}>
-          {(copy) => (
-            <EuiPanel onClick={copy} className="eui-textCenter">
-              <EuiIcon type={iconType} size="xl" />
-              <EuiText size="s">
-                <p>{iconType}</p>
-              </EuiText>
-            </EuiPanel>
-          )}
-        </EuiCopy>
-      </EuiFlexItem>
-    ))}
-  </EuiFlexGrid>
+  <>
+    <EuiCodeBlock language="html" isCopyable paddingSize="m">
+      {'<EuiIcon type="dataVisualizer" size="xl" />'}
+    </EuiCodeBlock>
+    <EuiSpacer />
+    <EuiFlexGrid direction="column" columns={3}>
+      {iconTypes.map((iconType) => (
+        <EuiFlexItem key={iconType}>
+          <EuiCopy
+            display="block"
+            textToCopy={iconType}
+            afterMessage={`${iconType} copied`}>
+            {(copy) => (
+              <EuiPanel
+                hasShadow={false}
+                hasBorder={false}
+                onClick={copy}
+                paddingSize="s">
+                <EuiIcon
+                  className="eui-alignMiddle"
+                  type={iconType}
+                  size="xl"
+                />{' '}
+                &emsp; <small>{iconType}</small>
+              </EuiPanel>
+            )}
+          </EuiCopy>
+        </EuiFlexItem>
+      ))}
+    </EuiFlexGrid>
+  </>
 );

--- a/src-docs/src/views/icon/playground.js
+++ b/src-docs/src/views/icon/playground.js
@@ -2,8 +2,6 @@ import {
   propUtilityForPlayground,
   dummyFunction,
   iconValidator,
-  createOptionalEnum,
-  simulateFunction,
 } from '../../services/playground';
 import { EuiIcon } from '../../../../src/components/';
 
@@ -13,11 +11,12 @@ export default () => {
     : EuiIcon.__docgenInfo;
   const propsToUse = propUtilityForPlayground(docgenInfo.props);
 
-  propsToUse.type = iconValidator(propsToUse.type);
+  propsToUse.type = iconValidator({ ...propsToUse.type }, 'grid');
 
-  propsToUse.size = createOptionalEnum(propsToUse.size);
-
-  propsToUse.onIconLoad = simulateFunction(propsToUse.onIconLoad);
+  propsToUse.size = {
+    ...propsToUse.size,
+    defaultValue: 'm',
+  };
 
   return {
     config: {

--- a/src-docs/src/views/icon/tokens.js
+++ b/src-docs/src/views/icon/tokens.js
@@ -1,25 +1,13 @@
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-// DON'T USE THIS
-
-// This example JS is overly complex for simple icon usage
-// and is set up this way for ease of use in our docs.
-//
-// Check the snippet tab for a more common usage.
-
-import React, { Fragment } from 'react';
+import React from 'react';
 
 import {
   EuiFlexGrid,
   EuiFlexItem,
   EuiPanel,
-  EuiText,
   EuiToken,
-  EuiSpacer,
   EuiCopy,
-  EuiCode,
+  EuiCodeBlock,
+  EuiSpacer,
 } from '../../../../src/components';
 
 const tokens = [
@@ -76,121 +64,31 @@ const tokens = [
 ];
 
 export default () => (
-  <Fragment>
-    <EuiFlexGrid columns={4}>
+  <>
+    <EuiCodeBlock language="html" isCopyable paddingSize="m">
+      {'<EuiToken iconType="tokenAnnotation" />'}
+    </EuiCodeBlock>
+    <EuiSpacer />
+    <EuiFlexGrid direction="column" columns={3}>
       {tokens.map((token) => (
-        <EuiFlexItem
-          className="guideDemo__icon"
-          key={token}
-          style={{ width: '200px' }}>
-          <EuiCopy textToCopy={token} afterMessage={`${token} copied`}>
+        <EuiFlexItem key={token}>
+          <EuiCopy
+            display="block"
+            textToCopy={token}
+            afterMessage={`${token} copied`}>
             {(copy) => (
-              <EuiPanel className="eui-textCenter" onClick={copy}>
-                <div
-                  style={{
-                    display: 'flex',
-                    justifyContent: 'center',
-                    marginBottom: '8px',
-                  }}>
-                  <EuiToken iconType={token} />
-                </div>
-                <EuiText size="s">
-                  <p>{token}</p>
-                </EuiText>
+              <EuiPanel
+                hasShadow={false}
+                hasBorder={false}
+                onClick={copy}
+                paddingSize="s">
+                <EuiToken className="eui-alignMiddle" iconType={token} /> &emsp;{' '}
+                <small>{token}</small>
               </EuiPanel>
             )}
           </EuiCopy>
         </EuiFlexItem>
       ))}
     </EuiFlexGrid>
-
-    <EuiSpacer />
-
-    <EuiText size="s">
-      <h3>Custom tokens</h3>
-      <p>
-        By default, an <EuiCode>iconType</EuiCode> with the token prefix (i.e.
-        those listed above) will have predefined styles. However, any valid{' '}
-        <EuiCode>iconType</EuiCode> can be passed and, in either case, the{' '}
-        <EuiCode>shape</EuiCode>, <EuiCode>size</EuiCode>,{' '}
-        <EuiCode>color</EuiCode>, and <EuiCode>fill</EuiCode> can be customized.
-      </p>
-    </EuiText>
-
-    <EuiSpacer />
-
-    <EuiFlexGrid columns={4}>
-      <EuiFlexItem className="guideDemo__icon">
-        <EuiPanel>
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'center',
-              marginBottom: '8px',
-            }}>
-            <EuiToken iconType="tokenStruct" size="xs" color="gray" />
-          </div>
-          <EuiText size="s">
-            <p>An xs, gray tokenStruct</p>
-          </EuiText>
-        </EuiPanel>
-      </EuiFlexItem>
-      <EuiFlexItem className="guideDemo__icon">
-        <EuiPanel>
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'center',
-              marginBottom: '8px',
-            }}>
-            <EuiToken iconType="tokenStruct" fill="none" />
-          </div>
-          <EuiText size="s">
-            <p>A none fill tokenStruct</p>
-          </EuiText>
-        </EuiPanel>
-      </EuiFlexItem>
-      <EuiFlexItem className="guideDemo__icon">
-        <EuiPanel>
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'center',
-              marginBottom: '8px',
-            }}>
-            <EuiToken
-              iconType="tokenStruct"
-              size="m"
-              shape="circle"
-              color="#FF0000"
-            />
-          </div>
-          <EuiText size="s">
-            <p>A size m, circle, #FF0000 tokenStruct</p>
-          </EuiText>
-        </EuiPanel>
-      </EuiFlexItem>
-      <EuiFlexItem className="guideDemo__icon">
-        <EuiPanel>
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'center',
-              marginBottom: '8px',
-            }}>
-            <EuiToken
-              iconType="faceNeutral"
-              size="l"
-              color="euiColorVis7"
-              shape="rectangle"
-              fill="dark"
-            />
-          </div>
-          <EuiText size="s">
-            <p>A completely custom token</p>
-          </EuiText>
-        </EuiPanel>
-      </EuiFlexItem>
-    </EuiFlexGrid>
-  </Fragment>
+  </>
 );


### PR DESCRIPTION
This PR fixes up the Icons documentation page mainly to reduce the panels. It also removes the third-party logos example without breaking actual usages by keeping the logos in the repo.


<img width="1003" alt="Screen Shot 2021-04-12 at 18 36 09 PM" src="https://user-images.githubusercontent.com/549577/114471059-f9fa8080-9bbd-11eb-8356-2016545675eb.png">


It also defaults first time users to the Amsterdam (light) theme now 😜 

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
