### PR TITLE
[EuiDataGrid] bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 **Bug fixes**
 
 - Fixed a bug where on hovering an expandable row cell in `EuiDataGrid` a vertical line would show ([#4689](https://github.com/elastic/eui/pull/4689))
+- Fixed a bug in `EuiDataGrid` where key presses in portalled content were being handled by the grid ([#4706](https://github.com/elastic/eui/pull/4706))
+- Fixed `EuiDataGrid`'s header content arrangement prevented closing a header cell's popover ([#4706](https://github.com/elastic/eui/pull/4706))
+- Fixed a performance issue in `EuiDataGrid` when its `rowCount` changes  ([#4706](https://github.com/elastic/eui/pull/4706))
 
 ## [`32.0.4`](https://github.com/elastic/eui/tree/v32.0.4)
 

--- a/src-docs/src/views/datagrid/column_actions.js
+++ b/src-docs/src/views/datagrid/column_actions.js
@@ -69,7 +69,7 @@ for (let i = 1; i < 5; i++) {
 }
 
 export default () => {
-  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
+  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 5 });
 
   const [visibleColumns, setVisibleColumns] = useState(() =>
     columns.map(({ id }) => id)

--- a/src-docs/src/views/datagrid/column_widths.js
+++ b/src-docs/src/views/datagrid/column_widths.js
@@ -46,7 +46,7 @@ for (let i = 1; i < 5; i++) {
 }
 
 export default () => {
-  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
+  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 5 });
 
   const [visibleColumns, setVisibleColumns] = useState(() =>
     columns.map(({ id }) => id)

--- a/src-docs/src/views/datagrid/styling.js
+++ b/src-docs/src/views/datagrid/styling.js
@@ -263,7 +263,7 @@ const DataGrid = () => {
   );
   const [pagination, setPagination] = useState({
     pageIndex: 0,
-    pageSize: 50,
+    pageSize: 5,
   });
   const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -1035,6 +1035,7 @@ Array [
                       />
                       <div
                         class="euiPopover euiPopover--anchorDownCenter"
+                        offset="7"
                       >
                         <div
                           class="euiPopover__anchor euiDataGridHeaderCell__anchor"
@@ -1072,6 +1073,7 @@ Array [
                       />
                       <div
                         class="euiPopover euiPopover--anchorDownCenter"
+                        offset="7"
                       >
                         <div
                           class="euiPopover__anchor euiDataGridHeaderCell__anchor"
@@ -1387,6 +1389,7 @@ Array [
                       />
                       <div
                         class="euiPopover euiPopover--anchorDownCenter"
+                        offset="7"
                       >
                         <div
                           class="euiPopover__anchor euiDataGridHeaderCell__anchor"
@@ -1424,6 +1427,7 @@ Array [
                       />
                       <div
                         class="euiPopover euiPopover--anchorDownCenter"
+                        offset="7"
                       >
                         <div
                           class="euiPopover__anchor euiDataGridHeaderCell__anchor"
@@ -2006,6 +2010,7 @@ Array [
                       />
                       <div
                         class="euiPopover euiPopover--anchorDownCenter"
+                        offset="7"
                       >
                         <div
                           class="euiPopover__anchor euiDataGridHeaderCell__anchor"
@@ -2043,6 +2048,7 @@ Array [
                       />
                       <div
                         class="euiPopover euiPopover--anchorDownCenter"
+                        offset="7"
                       >
                         <div
                           class="euiPopover__anchor euiDataGridHeaderCell__anchor"
@@ -2342,6 +2348,7 @@ Array [
                       />
                       <div
                         class="euiPopover euiPopover--anchorDownCenter"
+                        offset="7"
                       >
                         <div
                           class="euiPopover__anchor euiDataGridHeaderCell__anchor"
@@ -2379,6 +2386,7 @@ Array [
                       />
                       <div
                         class="euiPopover euiPopover--anchorDownCenter"
+                        offset="7"
                       >
                         <div
                           class="euiPopover__anchor euiDataGridHeaderCell__anchor"

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -1033,29 +1033,30 @@ Array [
                         data-test-subj="dataGridColumnResizer"
                         style="margin-right:0px"
                       />
-                      <button
-                        class="euiDataGridHeaderCell__button"
+                      <div
+                        class="euiPopover euiPopover--anchorDownCenter"
                       >
                         <div
-                          class="euiDataGridHeaderCell__content"
+                          class="euiPopover__anchor euiDataGridHeaderCell__anchor"
                         >
-                          A
-                        </div>
-                        <div
-                          class="euiPopover euiPopover--anchorDownRight euiDataGridHeaderCell__popover"
-                        >
-                          <div
-                            class="euiPopover__anchor"
+                          <button
+                            class="euiDataGridHeaderCell__button"
                           >
+                            <div
+                              class="euiDataGridHeaderCell__content"
+                            >
+                              A
+                            </div>
                             <span
                               aria-label="Header actions"
+                              class="euiDataGridHeaderCell__icon"
                               color="text"
                               data-euiicon-type="arrowDown"
                               data-test-subj="dataGridHeaderCellActionButton-A"
                             />
-                          </div>
+                          </button>
                         </div>
-                      </button>
+                      </div>
                     </div>
                     <div
                       class="euiDataGridHeaderCell"
@@ -1069,29 +1070,30 @@ Array [
                         data-test-subj="dataGridColumnResizer"
                         style="margin-right:0px"
                       />
-                      <button
-                        class="euiDataGridHeaderCell__button"
+                      <div
+                        class="euiPopover euiPopover--anchorDownCenter"
                       >
                         <div
-                          class="euiDataGridHeaderCell__content"
+                          class="euiPopover__anchor euiDataGridHeaderCell__anchor"
                         >
-                          B
-                        </div>
-                        <div
-                          class="euiPopover euiPopover--anchorDownRight euiDataGridHeaderCell__popover"
-                        >
-                          <div
-                            class="euiPopover__anchor"
+                          <button
+                            class="euiDataGridHeaderCell__button"
                           >
+                            <div
+                              class="euiDataGridHeaderCell__content"
+                            >
+                              B
+                            </div>
                             <span
                               aria-label="Header actions"
+                              class="euiDataGridHeaderCell__icon"
                               color="text"
                               data-euiicon-type="arrowDown"
                               data-test-subj="dataGridHeaderCellActionButton-B"
                             />
-                          </div>
+                          </button>
                         </div>
-                      </button>
+                      </div>
                     </div>
                   </div>
                   <div
@@ -1383,29 +1385,30 @@ Array [
                         data-test-subj="dataGridColumnResizer"
                         style="margin-right:0px"
                       />
-                      <button
-                        class="euiDataGridHeaderCell__button"
+                      <div
+                        class="euiPopover euiPopover--anchorDownCenter"
                       >
                         <div
-                          class="euiDataGridHeaderCell__content"
+                          class="euiPopover__anchor euiDataGridHeaderCell__anchor"
                         >
-                          A
-                        </div>
-                        <div
-                          class="euiPopover euiPopover--anchorDownRight euiDataGridHeaderCell__popover"
-                        >
-                          <div
-                            class="euiPopover__anchor"
+                          <button
+                            class="euiDataGridHeaderCell__button"
                           >
+                            <div
+                              class="euiDataGridHeaderCell__content"
+                            >
+                              A
+                            </div>
                             <span
                               aria-label="Header actions"
+                              class="euiDataGridHeaderCell__icon"
                               color="text"
                               data-euiicon-type="arrowDown"
                               data-test-subj="dataGridHeaderCellActionButton-A"
                             />
-                          </div>
+                          </button>
                         </div>
-                      </button>
+                      </div>
                     </div>
                     <div
                       class="euiDataGridHeaderCell"
@@ -1419,29 +1422,30 @@ Array [
                         data-test-subj="dataGridColumnResizer"
                         style="margin-right:0px"
                       />
-                      <button
-                        class="euiDataGridHeaderCell__button"
+                      <div
+                        class="euiPopover euiPopover--anchorDownCenter"
                       >
                         <div
-                          class="euiDataGridHeaderCell__content"
+                          class="euiPopover__anchor euiDataGridHeaderCell__anchor"
                         >
-                          B
-                        </div>
-                        <div
-                          class="euiPopover euiPopover--anchorDownRight euiDataGridHeaderCell__popover"
-                        >
-                          <div
-                            class="euiPopover__anchor"
+                          <button
+                            class="euiDataGridHeaderCell__button"
                           >
+                            <div
+                              class="euiDataGridHeaderCell__content"
+                            >
+                              B
+                            </div>
                             <span
                               aria-label="Header actions"
+                              class="euiDataGridHeaderCell__icon"
                               color="text"
                               data-euiicon-type="arrowDown"
                               data-test-subj="dataGridHeaderCellActionButton-B"
                             />
-                          </div>
+                          </button>
                         </div>
-                      </button>
+                      </div>
                     </div>
                     <div
                       class="euiDataGridHeaderCell euiDataGridHeaderCell--controlColumn"
@@ -2000,29 +2004,30 @@ Array [
                         data-test-subj="dataGridColumnResizer"
                         style="margin-right:0px"
                       />
-                      <button
-                        class="euiDataGridHeaderCell__button"
+                      <div
+                        class="euiPopover euiPopover--anchorDownCenter"
                       >
                         <div
-                          class="euiDataGridHeaderCell__content"
+                          class="euiPopover__anchor euiDataGridHeaderCell__anchor"
                         >
-                          Column A
-                        </div>
-                        <div
-                          class="euiPopover euiPopover--anchorDownRight euiDataGridHeaderCell__popover"
-                        >
-                          <div
-                            class="euiPopover__anchor"
+                          <button
+                            class="euiDataGridHeaderCell__button"
                           >
+                            <div
+                              class="euiDataGridHeaderCell__content"
+                            >
+                              Column A
+                            </div>
                             <span
                               aria-label="Header actions"
+                              class="euiDataGridHeaderCell__icon"
                               color="text"
                               data-euiicon-type="arrowDown"
                               data-test-subj="dataGridHeaderCellActionButton-A"
                             />
-                          </div>
+                          </button>
                         </div>
-                      </button>
+                      </div>
                     </div>
                     <div
                       class="euiDataGridHeaderCell"
@@ -2036,31 +2041,32 @@ Array [
                         data-test-subj="dataGridColumnResizer"
                         style="margin-right:0px"
                       />
-                      <button
-                        class="euiDataGridHeaderCell__button"
+                      <div
+                        class="euiPopover euiPopover--anchorDownCenter"
                       >
                         <div
-                          class="euiDataGridHeaderCell__content"
+                          class="euiPopover__anchor euiDataGridHeaderCell__anchor"
                         >
-                          <div>
-                            More Elements
-                          </div>
-                        </div>
-                        <div
-                          class="euiPopover euiPopover--anchorDownRight euiDataGridHeaderCell__popover"
-                        >
-                          <div
-                            class="euiPopover__anchor"
+                          <button
+                            class="euiDataGridHeaderCell__button"
                           >
+                            <div
+                              class="euiDataGridHeaderCell__content"
+                            >
+                              <div>
+                                More Elements
+                              </div>
+                            </div>
                             <span
                               aria-label="Header actions"
+                              class="euiDataGridHeaderCell__icon"
                               color="text"
                               data-euiicon-type="arrowDown"
                               data-test-subj="dataGridHeaderCellActionButton-B"
                             />
-                          </div>
+                          </button>
                         </div>
-                      </button>
+                      </div>
                     </div>
                   </div>
                   <div
@@ -2334,29 +2340,30 @@ Array [
                         data-test-subj="dataGridColumnResizer"
                         style="margin-right:0px"
                       />
-                      <button
-                        class="euiDataGridHeaderCell__button"
+                      <div
+                        class="euiPopover euiPopover--anchorDownCenter"
                       >
                         <div
-                          class="euiDataGridHeaderCell__content"
+                          class="euiPopover__anchor euiDataGridHeaderCell__anchor"
                         >
-                          A
-                        </div>
-                        <div
-                          class="euiPopover euiPopover--anchorDownRight euiDataGridHeaderCell__popover"
-                        >
-                          <div
-                            class="euiPopover__anchor"
+                          <button
+                            class="euiDataGridHeaderCell__button"
                           >
+                            <div
+                              class="euiDataGridHeaderCell__content"
+                            >
+                              A
+                            </div>
                             <span
                               aria-label="Header actions"
+                              class="euiDataGridHeaderCell__icon"
                               color="text"
                               data-euiicon-type="arrowDown"
                               data-test-subj="dataGridHeaderCellActionButton-A"
                             />
-                          </div>
+                          </button>
                         </div>
-                      </button>
+                      </div>
                     </div>
                     <div
                       class="euiDataGridHeaderCell"
@@ -2370,29 +2377,30 @@ Array [
                         data-test-subj="dataGridColumnResizer"
                         style="margin-right:0px"
                       />
-                      <button
-                        class="euiDataGridHeaderCell__button"
+                      <div
+                        class="euiPopover euiPopover--anchorDownCenter"
                       >
                         <div
-                          class="euiDataGridHeaderCell__content"
+                          class="euiPopover__anchor euiDataGridHeaderCell__anchor"
                         >
-                          B
-                        </div>
-                        <div
-                          class="euiPopover euiPopover--anchorDownRight euiDataGridHeaderCell__popover"
-                        >
-                          <div
-                            class="euiPopover__anchor"
+                          <button
+                            class="euiDataGridHeaderCell__button"
                           >
+                            <div
+                              class="euiDataGridHeaderCell__content"
+                            >
+                              B
+                            </div>
                             <span
                               aria-label="Header actions"
+                              class="euiDataGridHeaderCell__icon"
                               color="text"
                               data-euiicon-type="arrowDown"
                               data-test-subj="dataGridHeaderCellActionButton-B"
                             />
-                          </div>
+                          </button>
                         </div>
-                      </button>
+                      </div>
                     </div>
                   </div>
                   <div

--- a/src/components/datagrid/_data_grid_header_row.scss
+++ b/src/components/datagrid/_data_grid_header_row.scss
@@ -43,28 +43,38 @@
       border-top: none;
     }
 
+    .euiDataGridHeaderCell__sortingArrow {
+      margin-right: $euiSizeXS;
+    }
+
+    .euiDataGridHeaderCell__anchor {
+      width: 100%;
+    }
+
     .euiDataGridHeaderCell__button {
       flex: 0 0 auto;
       position: relative;
       align-items: center;
       display: flex;
-      text-align: left;
+      width: 100%;
       font-weight: $euiFontWeightBold;
       outline: none;
-    }
 
-    .euiDataGridHeaderCell__sortingArrow {
-      margin-right: $euiSizeXS;
+      .euiDataGridHeaderCell__sortingArrow {
+        flex-grow: 0;
+      }
     }
 
     .euiDataGridHeaderCell__content {
       @include euiTextTruncate;
       overflow: hidden;
       white-space: nowrap;
+      text-align: left;
       flex-grow: 1;
+      align-self: baseline;
     }
 
-    .euiDataGridHeaderCell__popover {
+    .euiDataGridHeaderCell__icon {
       flex-grow: 0;
       flex-basis: auto;
       width: auto;

--- a/src/components/datagrid/data_grid_body.tsx
+++ b/src/components/datagrid/data_grid_body.tsx
@@ -528,21 +528,21 @@ export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const wrapperDimensions = useResizeObserver(wrapperRef.current);
 
-  // reset height constraint when rowCount or fullscreen setting changes
+  // reset height constraint when rowCount changes
   useEffect(() => {
     setHeight(wrapperRef.current!.getBoundingClientRect().height);
-  }, [rowCount, isFullScreen]);
+  }, [rowCount]);
 
   useEffect(() => {
     const boundingRect = wrapperRef.current!.getBoundingClientRect();
 
-    if (boundingRect.height !== unconstrainedHeight) {
+    if (boundingRect.height !== unconstrainedHeight && !isFullScreen) {
       setHeight(boundingRect.height);
     }
     if (boundingRect.width !== unconstrainedWidth) {
       setWidth(boundingRect.width);
     }
-  }, [unconstrainedHeight, wrapperDimensions]);
+  }, [unconstrainedHeight, wrapperDimensions, isFullScreen]);
 
   const preventTabbing = useCallback(() => {
     if (wrapperRef.current) {

--- a/src/components/datagrid/data_grid_body.tsx
+++ b/src/components/datagrid/data_grid_body.tsx
@@ -525,13 +525,13 @@ export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
   const [height, setHeight] = useState<number | undefined>(undefined);
   const [width, setWidth] = useState<number | undefined>(undefined);
 
-  // reset height constraint when rowCount or fullscreen setting changes
-  useEffect(() => {
-    setHeight(undefined);
-  }, [rowCount, isFullScreen]);
-
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const wrapperDimensions = useResizeObserver(wrapperRef.current);
+
+  // reset height constraint when rowCount or fullscreen setting changes
+  useEffect(() => {
+    setHeight(wrapperRef.current!.getBoundingClientRect().height);
+  }, [rowCount, isFullScreen]);
 
   useEffect(() => {
     const boundingRect = wrapperRef.current!.getBoundingClientRect();

--- a/src/components/datagrid/data_grid_header_cell.tsx
+++ b/src/components/datagrid/data_grid_header_cell.tsx
@@ -332,6 +332,7 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
         <EuiPopover
           anchorClassName="euiDataGridHeaderCell__anchor"
           panelPaddingSize="none"
+          offset={7}
           button={
             <button
               className="euiDataGridHeaderCell__button"

--- a/src/components/datagrid/data_grid_header_cell.tsx
+++ b/src/components/datagrid/data_grid_header_cell.tsx
@@ -134,8 +134,6 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
   const [isCellEntered, setIsCellEntered] = useState(false);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
-  const [buttonRef, setButtonRef] = useState<HTMLButtonElement | null>(null);
-
   const enableInteractives = useCallback(() => {
     if (headerRef.current) {
       const interactiveElements = headerRef.current.querySelectorAll(
@@ -333,7 +331,6 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
       ) : (
         <button
           className="euiDataGridHeaderCell__button"
-          ref={setButtonRef}
           onClick={() => setIsPopoverOpen((isPopoverOpen) => !isPopoverOpen)}>
           {sortingArrow}
           <div className="euiDataGridHeaderCell__content">
@@ -353,8 +350,7 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
               />
             }
             isOpen={isPopoverOpen}
-            closePopover={() => setIsPopoverOpen(false)}
-            elementsNotOutside={buttonRef ? [buttonRef] : undefined}>
+            closePopover={() => setIsPopoverOpen(false)}>
             <div>
               <EuiListGroup
                 listItems={columnActions}

--- a/src/components/datagrid/data_grid_header_cell.tsx
+++ b/src/components/datagrid/data_grid_header_cell.tsx
@@ -134,6 +134,8 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
   const [isCellEntered, setIsCellEntered] = useState(false);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
+  const [buttonRef, setButtonRef] = useState<HTMLButtonElement | null>(null);
+
   const enableInteractives = useCallback(() => {
     if (headerRef.current) {
       const interactiveElements = headerRef.current.querySelectorAll(
@@ -331,6 +333,7 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
       ) : (
         <button
           className="euiDataGridHeaderCell__button"
+          ref={setButtonRef}
           onClick={() => setIsPopoverOpen((isPopoverOpen) => !isPopoverOpen)}>
           {sortingArrow}
           <div className="euiDataGridHeaderCell__content">
@@ -350,7 +353,8 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
               />
             }
             isOpen={isPopoverOpen}
-            closePopover={() => setIsPopoverOpen(false)}>
+            closePopover={() => setIsPopoverOpen(false)}
+            elementsNotOutside={buttonRef ? [buttonRef] : undefined}>
             <div>
               <EuiListGroup
                 listItems={columnActions}

--- a/src/components/datagrid/data_grid_header_cell.tsx
+++ b/src/components/datagrid/data_grid_header_cell.tsx
@@ -329,37 +329,39 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
           </div>
         </>
       ) : (
-        <button
-          className="euiDataGridHeaderCell__button"
-          onClick={() => setIsPopoverOpen((isPopoverOpen) => !isPopoverOpen)}>
-          {sortingArrow}
-          <div className="euiDataGridHeaderCell__content">
-            {display || displayAsText || id}
-          </div>
-          <EuiPopover
-            className="euiDataGridHeaderCell__popover"
-            panelPaddingSize="none"
-            anchorPosition="downRight"
-            button={
+        <EuiPopover
+          anchorClassName="euiDataGridHeaderCell__anchor"
+          panelPaddingSize="none"
+          button={
+            <button
+              className="euiDataGridHeaderCell__button"
+              onClick={() =>
+                setIsPopoverOpen((isPopoverOpen) => !isPopoverOpen)
+              }>
+              {sortingArrow}
+              <div className="euiDataGridHeaderCell__content">
+                {display || displayAsText || id}
+              </div>
               <EuiIcon
+                className="euiDataGridHeaderCell__icon"
                 type="arrowDown"
                 size="s"
                 color="text"
                 aria-label={actionButtonAriaLabel}
                 data-test-subj={`dataGridHeaderCellActionButton-${id}`}
               />
-            }
-            isOpen={isPopoverOpen}
-            closePopover={() => setIsPopoverOpen(false)}>
-            <div>
-              <EuiListGroup
-                listItems={columnActions}
-                gutterSize="none"
-                data-test-subj={`dataGridHeaderCellActionGroup-${id}`}
-              />
-            </div>
-          </EuiPopover>
-        </button>
+            </button>
+          }
+          isOpen={isPopoverOpen}
+          closePopover={() => setIsPopoverOpen(false)}>
+          <div>
+            <EuiListGroup
+              listItems={columnActions}
+              gutterSize="none"
+              data-test-subj={`dataGridHeaderCellActionGroup-${id}`}
+            />
+          </div>
+        </EuiPopover>
       )}
     </div>
   );

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -196,6 +196,11 @@ export interface EuiPopoverProps {
    * Usually takes the `id` of the popover title
    */
   'aria-labelledby'?: string;
+  /**
+   * An array of elements considered inside the anchor, click events on these
+   * elements will not close the popover
+   */
+  elementsNotOutside?: HTMLElement[];
 }
 
 type AnchorPosition = 'up' | 'right' | 'down' | 'left';
@@ -399,9 +404,27 @@ export class EuiPopover extends Component<Props, State> {
 
   onClickOutside = (event: Event) => {
     // only close the popover if the event source isn't the anchor button
-    // otherwise, it is up to the anchor to toggle the popover's open status
-    if (this.button && this.button.contains(event.target as Node) === false) {
-      this.closePopover();
+    // or in the elementsNotOutside array otherwise, it is up to the
+    // anchor to toggle the popover's open status
+    if (this.button) {
+      const { elementsNotOutside = [] } = this.props;
+      const insideElements = [this.button, ...elementsNotOutside];
+      let isOutside = true;
+
+      for (let i = 0; i < insideElements.length; i++) {
+        const insideElement = insideElements[i];
+        if (
+          insideElement === event.target ||
+          insideElement.contains(event.target as Node)
+        ) {
+          isOutside = false;
+          break;
+        }
+      }
+
+      if (isOutside) {
+        this.closePopover();
+      }
     }
   };
 
@@ -689,6 +712,7 @@ export class EuiPopover extends Component<Props, State> {
       'aria-labelledby': ariaLabelledBy,
       container,
       focusTrapProps,
+      elementsNotOutside,
       ...rest
     } = this.props;
 

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -196,11 +196,6 @@ export interface EuiPopoverProps {
    * Usually takes the `id` of the popover title
    */
   'aria-labelledby'?: string;
-  /**
-   * An array of elements considered inside the anchor, click events on these
-   * elements will not close the popover
-   */
-  elementsNotOutside?: HTMLElement[];
 }
 
 type AnchorPosition = 'up' | 'right' | 'down' | 'left';
@@ -404,27 +399,9 @@ export class EuiPopover extends Component<Props, State> {
 
   onClickOutside = (event: Event) => {
     // only close the popover if the event source isn't the anchor button
-    // or in the elementsNotOutside array otherwise, it is up to the
-    // anchor to toggle the popover's open status
-    if (this.button) {
-      const { elementsNotOutside = [] } = this.props;
-      const insideElements = [this.button, ...elementsNotOutside];
-      let isOutside = true;
-
-      for (let i = 0; i < insideElements.length; i++) {
-        const insideElement = insideElements[i];
-        if (
-          insideElement === event.target ||
-          insideElement.contains(event.target as Node)
-        ) {
-          isOutside = false;
-          break;
-        }
-      }
-
-      if (isOutside) {
-        this.closePopover();
-      }
+    // otherwise, it is up to the anchor to toggle the popover's open status
+    if (this.button && this.button.contains(event.target as Node) === false) {
+      this.closePopover();
     }
   };
 
@@ -712,7 +689,6 @@ export class EuiPopover extends Component<Props, State> {
       'aria-labelledby': ariaLabelledBy,
       container,
       focusTrapProps,
-      elementsNotOutside,
       ...rest
     } = this.props;
 


### PR DESCRIPTION
### Summary

#### [EuiDataGrid] Column action menu can freeze Chrome browser

Fixes #4641 by only responding to key events when they are triggered on an element in the grid's DOM, ignoring events React bubbles through portals.

#### [EuiDataGrid] Clicking a column header twice makes it impossible to close it via outside click

Fixes #4588 by moving all datagrid header cell contents into the popover's anchor button

#### [EuiDataGrid] Performance issue when row count changes while pagination is enabled

Fixes #4532 (and another bug) by resetting the grid's height to its container size instead of unsetting+rerender+recalculate the container size. The second bug was in that recalculate step, or more correctly that it wasn't triggered at all.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
