### PR TITLE
Enable incremental typescript runs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,9 @@
     // generate declaration files
     "declaration": true,
 
+    // re-use info from previous runs to improve performance
+    "incremental": true,
+
     // don't allow un-used variables
     "noUnusedLocals": true,
 
@@ -47,10 +50,10 @@
 
     // Specifies where to find library definitions. When this is explicitly set,
     // it has to include the default location i.e. node_modules/@types
-    "typeRoots": ["node_modules/@types", "src/custom_typings"]
+    "typeRoots": ["node_modules/@types", "src/custom_typings"],
   },
   "include": [
     "./src/**/*",
-    "./src-docs/**/*",
-  ],
+    "./src-docs/**/*"
+  ]
 }


### PR DESCRIPTION
### Summary

Enabled TypeScript's `incremental` option to increase performance. Locally this decreases the `yarn tsc --noEmit` time from ~30s to ~5s when there are no changes present; changes to more core components approach 30s again, while modifying a TS file in _src-docs_ makes it take ~10s.

eslint & sass-lint, also part of the `test-staged` command, already take only a couple seconds each to run so I did not focus any effort there.

~### Checklist~