### PR TITLE
Added euiBorderRadiusSmall to Sass guidlines 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Added `readOnly` as a `sorting` option of `EuiBasicTable` and its columns ([#4626](https://github.com/elastic/eui/pull/4626))
 
+- Fixed `pagination` prop in EuiInMemoryTable to properly render the table content ([#4714](https://github.com/elastic/eui/pull/4714))
+
+
 **Bug fixes**
 
 - Fixed a bug where on hovering an expandable row cell in `EuiDataGrid` a vertical line would show ([#4689](https://github.com/elastic/eui/pull/4689))

--- a/src-docs/src/views/guidelines/index.scss
+++ b/src-docs/src/views/guidelines/index.scss
@@ -198,6 +198,11 @@
   border-radius: $euiBorderRadius;
 }
 
+.guideSass__border--radius--small {
+  border: $euiBorderThin;
+  border-radius: $euiBorderRadiusSmall;
+}
+
 .guideSass__border--euiBorderThin {
   border: $euiBorderThin;
 }

--- a/src-docs/src/views/guidelines/sass.js
+++ b/src-docs/src/views/guidelines/sass.js
@@ -306,6 +306,10 @@ const borderRadiusExample = `border: $euiBorderThin;
 border-radius: $euiBorderRadius;
 `;
 
+const borderRadiusSmallExample = `border: $euiBorderThin;
+border-radius: $euiBorderRadiusSmall;
+`;
+
 const importKibanaExample = `// In Kibana you can add this to the top of your Sass file
 @import 'ui/public/styles/styling_constants';
 `;
@@ -702,8 +706,8 @@ export const SassGuidelines = ({ selectedTheme }) => {
 
       <EuiText grow={false}>
         <p>
-          In addition, you can utilize <EuiCode>$euiBorderRadius</EuiCode> to
-          round the corners.
+          In addition, you can utilize <EuiCode>$euiBorderRadius</EuiCode> or
+          <EuiCode>$euiBorderRadiusSmall</EuiCode> to round the corners.
         </p>
       </EuiText>
 
@@ -716,6 +720,14 @@ export const SassGuidelines = ({ selectedTheme }) => {
             transparentBackground
             paddingSize="none">
             {borderRadiusExample}
+          </EuiCodeBlock>
+        </EuiFlexItem>
+        <EuiFlexItem className="guideSass__border guideSass__border--radius--small">
+          <EuiCodeBlock
+            language="scss"
+            transparentBackground
+            paddingSize="none">
+            {borderRadiusSmallExample}
           </EuiCodeBlock>
         </EuiFlexItem>
       </EuiFlexGrid>

--- a/src/components/basic_table/in_memory_table.tsx
+++ b/src/components/basic_table/in_memory_table.tsx
@@ -584,15 +584,16 @@ export class EuiInMemoryTable<T> extends Component<
           .sort(this.getItemSorter()) // sort, causes mutation
       : matchingItems;
 
-    const visibleItems = pageSize
-      ? (() => {
-          const startIndex = pageIndex * pageSize;
-          return sortedItems.slice(
-            startIndex,
-            Math.min(startIndex + pageSize, sortedItems.length)
-          );
-        })()
-      : sortedItems;
+    const visibleItems =
+      pageSize && this.props.pagination
+        ? (() => {
+            const startIndex = pageIndex * pageSize;
+            return sortedItems.slice(
+              startIndex,
+              Math.min(startIndex + pageSize, sortedItems.length)
+            );
+          })()
+        : sortedItems;
 
     return {
       items: visibleItems,


### PR DESCRIPTION
### Summary

Fixed issue #4715 by adding euiBorderRadiusSmall to Sass section.

### Checklist

- [ ] ~Check against **all themes** for compatibility in both light and dark modes~
- [ ] ~Checked in **mobile**~
- [ ] ~Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- [ ] ~Props have proper **autodocs** and **[playground toggles]~(https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] ~A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
