### PR TITLE
[Docs] Add `euiBorderRadius` to sass guidelines

### DIFF
--- a/src-docs/src/views/guidelines/index.scss
+++ b/src-docs/src/views/guidelines/index.scss
@@ -198,6 +198,11 @@
   border-radius: $euiBorderRadius;
 }
 
+.guideSass__border--radius--small {
+  border: $euiBorderThin;
+  border-radius: $euiBorderRadiusSmall;
+}
+
 .guideSass__border--euiBorderThin {
   border: $euiBorderThin;
 }

--- a/src-docs/src/views/guidelines/index.scss
+++ b/src-docs/src/views/guidelines/index.scss
@@ -198,7 +198,7 @@
   border-radius: $euiBorderRadius;
 }
 
-.guideSass__border--radius--small {
+.guideSass__border--radiusSmall {
   border: $euiBorderThin;
   border-radius: $euiBorderRadiusSmall;
 }

--- a/src-docs/src/views/guidelines/sass.js
+++ b/src-docs/src/views/guidelines/sass.js
@@ -722,7 +722,7 @@ export const SassGuidelines = ({ selectedTheme }) => {
             {borderRadiusExample}
           </EuiCodeBlock>
         </EuiFlexItem>
-        <EuiFlexItem className="guideSass__border guideSass__border--radius--small">
+        <EuiFlexItem className="guideSass__border guideSass__border--radiusSmall">
           <EuiCodeBlock
             language="scss"
             transparentBackground

--- a/src-docs/src/views/guidelines/sass.js
+++ b/src-docs/src/views/guidelines/sass.js
@@ -706,7 +706,7 @@ export const SassGuidelines = ({ selectedTheme }) => {
 
       <EuiText grow={false}>
         <p>
-          In addition, you can utilize <EuiCode>$euiBorderRadius</EuiCode> or
+          In addition, you can utilize <EuiCode>$euiBorderRadius</EuiCode> or{' '}
           <EuiCode>$euiBorderRadiusSmall</EuiCode> to round the corners.
         </p>
       </EuiText>

--- a/src-docs/src/views/guidelines/sass.js
+++ b/src-docs/src/views/guidelines/sass.js
@@ -306,6 +306,10 @@ const borderRadiusExample = `border: $euiBorderThin;
 border-radius: $euiBorderRadius;
 `;
 
+const borderRadiusSmallExample = `border: $euiBorderThin;
+border-radius: $euiBorderRadiusSmall;
+`;
+
 const importKibanaExample = `// In Kibana you can add this to the top of your Sass file
 @import 'ui/public/styles/styling_constants';
 `;
@@ -702,8 +706,8 @@ export const SassGuidelines = ({ selectedTheme }) => {
 
       <EuiText grow={false}>
         <p>
-          In addition, you can utilize <EuiCode>$euiBorderRadius</EuiCode> to
-          round the corners.
+          In addition, you can utilize <EuiCode>$euiBorderRadius</EuiCode> or
+          <EuiCode>$euiBorderRadiusSmall</EuiCode> to round the corners.
         </p>
       </EuiText>
 
@@ -716,6 +720,14 @@ export const SassGuidelines = ({ selectedTheme }) => {
             transparentBackground
             paddingSize="none">
             {borderRadiusExample}
+          </EuiCodeBlock>
+        </EuiFlexItem>
+        <EuiFlexItem className="guideSass__border guideSass__border--radius--small">
+          <EuiCodeBlock
+            language="scss"
+            transparentBackground
+            paddingSize="none">
+            {borderRadiusSmallExample}
           </EuiCodeBlock>
         </EuiFlexItem>
       </EuiFlexGrid>


### PR DESCRIPTION
### Summary

Fixed issue #4715 by adding `euiBorderRadiusSmall` to Sass section.

### Checklist

- [ ] ~Check against **all themes** for compatibility in both light and dark modes~
- [ ] ~Checked in **mobile**~
- [ ] ~Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- [ ] ~Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] ~A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
