### PR TITLE
[EuiDataGrid] Reverse asc and desc labels for `datetime` schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 **Bug fixes**
 
-- Fixed `EuiInMemoryTable` `pagination` prop to update visible items when changed  ([#4714](https://github.com/elastic/eui/pull/4714))
+- Fixed `EuiInMemoryTable` `pagination` prop to update visible items when changed ([#4714](https://github.com/elastic/eui/pull/4714))
+- Fixed inverted asc and desc labels for `EuiDataGrid` `datetime` schema ([#4733](https://github.com/elastic/eui/pull/4733))
 
 ## [`32.1.0`](https://github.com/elastic/eui/tree/v32.1.0)
 

--- a/src/components/datagrid/data_grid_schema.tsx
+++ b/src/components/datagrid/data_grid_schema.tsx
@@ -178,10 +178,10 @@ export const schemaDetectors: EuiDataGridSchemaDetector[] = [
     },
     icon: 'tokenDate',
     sortTextAsc: (
-      <EuiI18n token="euiDataGridSchema.dateSortTextDesc" default="Old-New" />
+      <EuiI18n token="euiDataGridSchema.dateSortTextAsc" default="Old-New" />
     ),
     sortTextDesc: (
-      <EuiI18n token="euiDataGridSchema.dateSortTextAsc" default="New-Old" />
+      <EuiI18n token="euiDataGridSchema.dateSortTextDesc" default="New-Old" />
     ),
   },
   {

--- a/src/components/datagrid/data_grid_schema.tsx
+++ b/src/components/datagrid/data_grid_schema.tsx
@@ -178,10 +178,10 @@ export const schemaDetectors: EuiDataGridSchemaDetector[] = [
     },
     icon: 'tokenDate',
     sortTextAsc: (
-      <EuiI18n token="euiDataGridSchema.dateSortTextAsc" default="New-Old" />
+      <EuiI18n token="euiDataGridSchema.dateSortTextDesc" default="Old-New" />
     ),
     sortTextDesc: (
-      <EuiI18n token="euiDataGridSchema.dateSortTextDesc" default="Old-New" />
+      <EuiI18n token="euiDataGridSchema.dateSortTextAsc" default="New-Old" />
     ),
   },
   {


### PR DESCRIPTION
### Summary

Closes #4712, in which it was discovered that the sort labels for `datetime` schema were inverted.

For dates, ascending means that earlier values precede later ones (e.g., 1/1/2020 will sort ahead of 1/1/2021)

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~

- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples

~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~

- [x] Checked for **breaking changes** and labeled appropriately

~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
