### PR TITLE
Use SelectableTemplateSitewide for nav search

### DIFF
--- a/src-docs/src/components/guide_components.scss
+++ b/src-docs/src/components/guide_components.scss
@@ -27,7 +27,7 @@ $guideZLevelHighest: $euiZLevel9 + 1000;
 
 .guideSideNav__content {
   @include euiYScroll;
-  padding: 0 $euiSizeL $euiSizeL;
+  padding: $euiSizeL;
 }
 
 .guideSideNav__search {

--- a/src-docs/src/components/guide_page/guide_page_header.tsx
+++ b/src-docs/src/components/guide_page/guide_page_header.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, ReactNode } from 'react';
 
 import {
   EuiHeaderLogo,
@@ -11,6 +11,7 @@ import { EuiToolTip } from '../../../../src/components/tool_tip';
 import { EuiPopover } from '../../../../src/components/popover';
 import { useIsWithinBreakpoints } from '../../../../src/services/hooks';
 import { EuiButtonEmpty } from '../../../../src/components/button';
+import { GuidePageSearch } from './guide_page_search';
 
 // @ts-ignore Not TS
 import { CodeSandboxLink } from '../../components/codesandbox/link';
@@ -25,11 +26,30 @@ const pkg = require('../../../../package.json');
 export type GuidePageHeaderProps = {
   onToggleLocale: () => {};
   selectedLocale: string;
+  historyPush: (path: string) => void;
+  navigation: Array<{
+    name: string;
+    type: string;
+    items: Array<{
+      isNew?: boolean;
+      name: string;
+      path: string;
+      component: ReactNode;
+      sections?: Array<{
+        id: string;
+        text: any;
+        title?: string;
+        wrapText: boolean;
+      }>;
+    }>;
+  }>;
 };
 
 export const GuidePageHeader: React.FunctionComponent<GuidePageHeaderProps> = ({
   onToggleLocale,
   selectedLocale,
+  navigation,
+  historyPush,
 }) => {
   const isMobileSize = useIsWithinBreakpoints(['xs', 's']);
 
@@ -146,6 +166,14 @@ export const GuidePageHeader: React.FunctionComponent<GuidePageHeaderProps> = ({
         {
           items: [renderLogo(), renderVersion()],
           borders: 'none',
+        },
+        {
+          items: [
+            <GuidePageSearch
+              historyPush={historyPush}
+              navigation={navigation}
+            />,
+          ],
         },
         {
           items: rightSideItems,

--- a/src-docs/src/components/guide_page/guide_page_search.tsx
+++ b/src-docs/src/components/guide_page/guide_page_search.tsx
@@ -1,0 +1,136 @@
+import React, { KeyboardEvent, useEffect, useState } from 'react';
+import { EuiButton } from '../../../../src/components/button';
+import { EuiCode } from '../../../../src/components/code';
+import { EuiFlexGroup, EuiFlexItem } from '../../../../src/components/flex';
+import {
+  EuiSelectableTemplateSitewide,
+  EuiSelectableTemplateSitewideOption,
+} from '../../../../src/components/selectable/selectable_templates';
+import { EuiText } from '../../../../src/components/text';
+import { GuidePageHeaderProps } from './guide_page_header';
+
+export function GuidePageSearch({
+  navigation,
+  historyPush,
+}: {
+  navigation: GuidePageHeaderProps['navigation'];
+  historyPush: GuidePageHeaderProps['historyPush'];
+}) {
+  const [searchRef, setSearchRef] = useState<HTMLInputElement | null>(null);
+  const [buttonRef, setButtonRef] = useState<HTMLDivElement | null>(null);
+  const [searchValue, setSearchValue] = useState('');
+  const searchValueExists = !searchValue.length;
+
+  /**
+   * Hook up the keyboard shortcut for command+k to initiate focus into search input
+   */
+  useEffect(() => {
+    window.addEventListener('keydown', onWindowKeyDown);
+
+    return function cleanup() {
+      window.removeEventListener('resize', onWindowKeyDown);
+    };
+  });
+
+  const onWindowKeyDown = (e: any) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === '/') {
+      if (searchRef) {
+        searchRef.focus();
+      } else if (buttonRef) {
+        (buttonRef.children[0] as HTMLButtonElement).click();
+      }
+    }
+  };
+
+  const onKeyUpCapture = (e: KeyboardEvent<HTMLInputElement>) => {
+    setSearchValue(e.currentTarget.value);
+  };
+
+  const pages: EuiSelectableTemplateSitewideOption[] = [];
+  navigation.forEach(({ name: text, items }) => {
+    pages.push(
+      ...items.map(({ name: label, path }) => ({
+        label,
+        path,
+        meta: [
+          {
+            text,
+            type: 'application',
+          },
+        ],
+      }))
+    );
+  });
+
+  const pagesAndSections: EuiSelectableTemplateSitewideOption[] = [...pages];
+  navigation.forEach(({ name: categoryName, items }) => {
+    items.forEach(({ name: routeName, sections, path }) => {
+      if (!sections) return;
+
+      pagesAndSections.push(
+        ...sections
+          .filter((section) => section.title)
+          .map(({ title, id }) => {
+            return {
+              label: title!,
+              path: `${path}/#${id}`,
+              meta: [
+                {
+                  text: categoryName,
+                  type: 'application',
+                },
+                {
+                  text: routeName,
+                  type: 'article',
+                },
+              ],
+            };
+          })
+      );
+    });
+  });
+
+  const onChange = (updatedOptions: EuiSelectableTemplateSitewideOption[]) => {
+    const clickedItem = updatedOptions.find(({ checked }) => checked === 'on');
+    if (!clickedItem) return;
+    historyPush(`/${clickedItem.path}`);
+  };
+
+  return (
+    <EuiSelectableTemplateSitewide
+      options={searchValueExists ? pages : pagesAndSections}
+      onChange={onChange}
+      singleSelection={true}
+      searchProps={{
+        'aria-label': 'Search docs pages and sections',
+        placeholder: 'Search docs pages and sections',
+        compressed: true,
+        onKeyUpCapture: onKeyUpCapture,
+        inputRef: setSearchRef,
+      }}
+      popoverProps={{
+        repositionOnScroll: true,
+        buttonRef: setButtonRef,
+      }}
+      popoverButton={<EuiButton>Mobile toggle</EuiButton>}
+      popoverButtonBreakpoints={['xs', 's']}
+      popoverFooter={
+        <EuiFlexGroup
+          alignItems="center"
+          justifyContent="flexEnd"
+          gutterSize="s"
+          responsive={false}
+          wrap>
+          <EuiFlexItem grow={false}>
+            <EuiText color="subdued" size="xs">
+              <p>
+                Shortcut: <EuiCode>Ctrl + /</EuiCode> or{' '}
+                <EuiCode>Cmd + /</EuiCode>
+              </p>
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      }
+    />
+  );
+}

--- a/src-docs/src/views/app_view.js
+++ b/src-docs/src/views/app_view.js
@@ -57,14 +57,14 @@ export class AppView extends Component {
         <GuidePageHeader
           onToggleLocale={toggleLocale}
           selectedLocale={locale}
+          navigation={navigation}
+          historyPush={routes.history.push}
         />
         <EuiPage paddingSize="none">
           <EuiErrorBoundary>
             <GuidePageChrome
               currentRoute={currentRoute}
               navigation={navigation}
-              onToggleLocale={toggleLocale}
-              selectedLocale={locale}
             />
           </EuiErrorBoundary>
 


### PR DESCRIPTION
### Summary

I thought it'd be nice for EUI to use the same search UI that Kibana uses so I gave it a go.

<table>
<tr>
	<td>
<img width="1597" alt="Screen Shot 2021-04-22 at 11 33 15" src="https://user-images.githubusercontent.com/4188087/115742375-9b23cc80-a35e-11eb-9ba8-51ff70715654.png">
</td>
	<td>
<img width="1597" alt="Screen Shot 2021-04-22 at 11 33 27" src="https://user-images.githubusercontent.com/4188087/115742392-9eb75380-a35e-11eb-86f6-7af6c29df3f1.png">
</td>
</tr>
</table>

#### TODO
- Mobile

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
