### PR TITLE
[EuiMarkdowEditor] export intermediary type

### DIFF
--- a/src/components/markdown_editor/plugins/markdown_default_plugins.tsx
+++ b/src/components/markdown_editor/plugins/markdown_default_plugins.tsx
@@ -64,7 +64,7 @@ const unknownHandler: Handler = (h, node) => {
   return h(node, node.type, node, all(h, node));
 };
 
-interface Rehype2ReactOptions {
+export interface Rehype2ReactOptions {
   components: { [key: string]: React.ComponentType<any> };
   [key: string]: any;
 }


### PR DESCRIPTION
### Summary

Fixes #4688 by exporting `Rehype2ReactOptions`

This is needed because of the same underlying problem noted in https://github.com/elastic/eui/pull/4672

~### Checklist~
