### PR TITLE
[EuiButtonEmpty] Reduce icon in xs size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Reduced icon size in `EuiButtonEmpty` of `size` xs. ([#4759](https://github.com/elastic/eui/pull/4759))
+
 **Bug fixes**
 
 - Fixed missing i18n tokens for `EuiFilePicker` ([#4750](https://github.com/elastic/eui/pull/4750))

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -382,8 +382,8 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                               <EuiButtonContent
                                 className="euiButtonEmpty__content"
                                 iconSide="right"
+                                iconSize="s"
                                 iconType="arrowDown"
-                                size="xs"
                                 textProps={
                                   Object {
                                     "className": "euiButtonEmpty__text",
@@ -548,7 +548,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
                                           iconSide="left"
-                                          size="s"
+                                          iconSize="m"
                                           textProps={
                                             Object {
                                               "className": "euiButtonEmpty__text",
@@ -631,7 +631,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
                                           iconSide="left"
-                                          size="s"
+                                          iconSize="m"
                                           textProps={
                                             Object {
                                               "className": "euiButtonEmpty__text",

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -383,6 +383,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                 className="euiButtonEmpty__content"
                                 iconSide="right"
                                 iconType="arrowDown"
+                                size="xs"
                                 textProps={
                                   Object {
                                     "className": "euiButtonEmpty__text",
@@ -394,13 +395,13 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                 >
                                   <EuiIcon
                                     className="euiButtonContent__icon"
-                                    size="m"
+                                    size="s"
                                     type="arrowDown"
                                   >
                                     <span
                                       className="euiButtonContent__icon"
                                       data-euiicon-type="arrowDown"
-                                      size="m"
+                                      size="s"
                                     />
                                   </EuiIcon>
                                   <span
@@ -547,6 +548,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
                                           iconSide="left"
+                                          size="s"
                                           textProps={
                                             Object {
                                               "className": "euiButtonEmpty__text",
@@ -629,6 +631,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
                                           iconSide="left"
+                                          size="s"
                                           textProps={
                                             Object {
                                               "className": "euiButtonEmpty__text",

--- a/src/components/button/button_content.tsx
+++ b/src/components/button/button_content.tsx
@@ -58,6 +58,7 @@ export interface EuiButtonContentProps extends CommonProps {
       ref?: Ref<HTMLSpanElement>;
       'data-text'?: string;
     };
+  size?: 'xs' | 's' | 'm' | 'l' | 'compressed' | undefined;
 }
 
 export const EuiButtonContent: FunctionComponent<
@@ -67,6 +68,7 @@ export const EuiButtonContent: FunctionComponent<
   textProps,
   isLoading = false,
   iconType,
+  size,
   iconSide = 'left',
   ...contentProps
 }) => {
@@ -79,7 +81,11 @@ export const EuiButtonContent: FunctionComponent<
     );
   } else if (iconType) {
     buttonIcon = (
-      <EuiIcon className="euiButtonContent__icon" type={iconType} size="m" />
+      <EuiIcon
+        className="euiButtonContent__icon"
+        type={iconType}
+        size={size === 'xs' ? 's' : 'm'}
+      />
     );
   }
 

--- a/src/components/button/button_content.tsx
+++ b/src/components/button/button_content.tsx
@@ -58,7 +58,7 @@ export interface EuiButtonContentProps extends CommonProps {
       ref?: Ref<HTMLSpanElement>;
       'data-text'?: string;
     };
-  size?: 'xs' | 's' | 'm' | 'l' | 'compressed' | undefined;
+  iconSize?: 's' | 'm';
 }
 
 export const EuiButtonContent: FunctionComponent<
@@ -68,7 +68,7 @@ export const EuiButtonContent: FunctionComponent<
   textProps,
   isLoading = false,
   iconType,
-  size,
+  iconSize = 'm',
   iconSide = 'left',
   ...contentProps
 }) => {
@@ -84,7 +84,7 @@ export const EuiButtonContent: FunctionComponent<
       <EuiIcon
         className="euiButtonContent__icon"
         type={iconType}
-        size={size === 'xs' ? 's' : 'm'}
+        size={iconSize}
       />
     );
   }

--- a/src/components/button/button_empty/button_empty.tsx
+++ b/src/components/button/button_empty/button_empty.tsx
@@ -175,6 +175,7 @@ export const EuiButtonEmpty: FunctionComponent<EuiButtonEmptyProps> = ({
       isLoading={isLoading}
       iconType={iconType}
       iconSide={iconSide}
+      size={size}
       textProps={{ ...textProps, className: textClassNames }}
       {...contentProps}
       // className has to come last to override contentProps.className

--- a/src/components/button/button_empty/button_empty.tsx
+++ b/src/components/button/button_empty/button_empty.tsx
@@ -170,12 +170,14 @@ export const EuiButtonEmpty: FunctionComponent<EuiButtonEmptyProps> = ({
     textProps && textProps.className
   );
 
+  const iconSize = size === 'xs' ? 's' : 'm';
+
   const innerNode = (
     <EuiButtonContent
       isLoading={isLoading}
       iconType={iconType}
       iconSide={iconSide}
-      size={size}
+      iconSize={iconSize}
       textProps={{ ...textProps, className: textClassNames }}
       {...contentProps}
       // className has to come last to override contentProps.className


### PR DESCRIPTION
### Summary

Reduce size of the icon in `EuiButtonEmpty` so that when the size is `xs` the icon's size is `s`.

<img width="302" alt="Frame 12" src="https://user-images.githubusercontent.com/4016496/116199414-f271c600-a6eb-11eb-97a0-d528ade6c83b.png">

This is one of the issues we're tracking on the Amsterdam Airtable.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~- [ ] Props have proper **autodocs** and **[playground toggles]~(https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
