### PR TITLE
Remove lodash times

### DIFF
--- a/src/services/utils.test.ts
+++ b/src/services/utils.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { times } from './utils';
+import { isArray } from './predicate';
+
+describe('times', () => {
+  it('should invoke iteratee n times', () => {
+    let count = 0;
+    times(3, () => {
+      count++;
+    });
+
+    expect(count).toEqual(3);
+  });
+
+  it('should return an array of results', () => {
+    const results = times(3, (index) => ({
+      index,
+      foo: 'bar',
+    }));
+    const expected = [
+      { index: 0, foo: 'bar' },
+      { index: 1, foo: 'bar' },
+    ];
+
+    expect(isArray).toBeTruthy();
+    expect(results.length).toEqual(3);
+    expect(results[0]).toEqual(expected[0]);
+    expect(results[1]).toEqual(expected[1]);
+  });
+
+  it('should return an array of indexes', () => {
+    const results = times(3);
+
+    expect(results).toEqual([0, 1, 2]);
+  });
+});

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -17,20 +17,19 @@
  * under the License.
  */
 
-import _times from 'lodash/times';
 import _memoize from 'lodash/memoize';
-
-// wrap the lodash functions to avoid having lodash's TS type definition from being
-// exported, which can conflict with the lodash namespace if other versions are used
 
 export function times(count: number): number[];
 export function times<T>(count: number, iteratee: (index: number) => T): T[];
 export function times<T>(count: number, iteratee?: (index: number) => T) {
-  if (iteratee === undefined) {
-    return _times(count);
-  }
-  return _times(count, iteratee);
+  return Array.from({ length: count }).map((_, index) =>
+    iteratee === undefined ? index : iteratee(index)
+  );
 }
+
+
+// wrap the lodash functions to avoid having lodash's TS type definition from being
+// exported, which can conflict with the lodash namespace if other versions are used
 
 export function memoize<T extends (...args: any[]) => any>(
   func: T,


### PR DESCRIPTION
### Summary

As my first PR I try to remove Lodash `times` according to #360 and implemented a function that works almost like `times`. for example, Lodash `times` checks if the number of times to invoke `iteratee` is less than `MAX_SAFE_INTEGER` but I ignored this validation since there is no heavy usage of the `times` in the project. let me know if I should handle these kinds of validations.


### Checklist

- [ ] ~~Check against **all themes** for compatibility in both light and dark modes~~
- [ ] ~~Checked in **mobile**~~
- [ ] ~~Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~~
- [ ] ~~Props have proper **autodocs** and **[playground toggles]~~(https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~~
- [ ] ~~Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
- [ ] ~~Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] ~~Checked for **accessibility** including keyboard-only and screenreader modes~~
- [ ] ~~A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~~
