### PR TITLE
Changed EuiText color of EuiCallout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 **Bug fixes**
 
+- Fixed `EuiText` color of `EuiCallout` to `default`([#4816](https://github.com/elastic/eui/pull/4816)) 
 - Fixed inconsistent width of `EuiRange` and `EuiDualRange` with custom tick values ([#4781](https://github.com/elastic/eui/pull/4781))
 - Fixes browser freezing when `EuiDataGrid` is used together with `EuiFlyout` and the user clicks a cell ([4813](https://github.com/elastic/eui/pull/4813))
 - Added `flex-shrink: 0` to `EuiTabs`, `EuiSpacer`, and `EuiImage` to fix possible shrunken heights ([#4793](https://github.com/elastic/eui/pull/4793))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 **Bug fixes**
 
-- Fixed `EuiText` color of `EuiCallout` to `default`([#4816](https://github.com/elastic/eui/pull/4816)) 
+- Fixed `EuiText` color of `EuiCallout` to `default` ([#4816](https://github.com/elastic/eui/pull/4816)) 
 - Fixed inconsistent width of `EuiRange` and `EuiDualRange` with custom tick values ([#4781](https://github.com/elastic/eui/pull/4781))
 - Fixes browser freezing when `EuiDataGrid` is used together with `EuiFlyout` and the user clicks a cell ([4813](https://github.com/elastic/eui/pull/4813))
 - Added `flex-shrink: 0` to `EuiTabs`, `EuiSpacer`, and `EuiImage` to fix possible shrunken heights ([#4793](https://github.com/elastic/eui/pull/4793))

--- a/src/components/call_out/__snapshots__/call_out.test.tsx.snap
+++ b/src/components/call_out/__snapshots__/call_out.test.tsx.snap
@@ -9,7 +9,11 @@ exports[`EuiCallOut is rendered 1`] = `
   <div
     class="euiText euiText--small"
   >
-    Content
+    <div
+      class="euiTextColor euiTextColor--default"
+    >
+      Content
+    </div>
   </div>
 </div>
 `;
@@ -102,7 +106,11 @@ exports[`EuiCallOut props title is rendered 1`] = `
   <div
     class="euiText euiText--small"
   >
-    Content
+    <div
+      class="euiTextColor euiTextColor--default"
+    >
+      Content
+    </div>
   </div>
 </div>
 `;

--- a/src/components/call_out/call_out.tsx
+++ b/src/components/call_out/call_out.tsx
@@ -91,9 +91,17 @@ export const EuiCallOut = forwardRef<HTMLDivElement, EuiCallOutProps>(
 
     let optionalChildren;
     if (children && size === 's') {
-      optionalChildren = <EuiText size="xs">{children}</EuiText>;
+      optionalChildren = (
+        <EuiText size="xs" color="default">
+          {children}
+        </EuiText>
+      );
     } else if (children) {
-      optionalChildren = <EuiText size="s">{children}</EuiText>;
+      optionalChildren = (
+        <EuiText size="s" color="default">
+          {children}
+        </EuiText>
+      );
     }
 
     const H: any = heading ? `${heading}` : 'span';

--- a/src/components/form/__snapshots__/form.test.tsx.snap
+++ b/src/components/form/__snapshots__/form.test.tsx.snap
@@ -65,22 +65,26 @@ exports[`EuiForm renders with error callout when isInvalid is "true" and has mul
     <div
       class="euiText euiText--small"
     >
-      <ul>
-        <li
-          class="euiForm__error"
-        >
-          <span>
-            This is one error
-          </span>
-        </li>
-        <li
-          class="euiForm__error"
-        >
-          <span>
-            This is another error
-          </span>
-        </li>
-      </ul>
+      <div
+        class="euiTextColor euiTextColor--default"
+      >
+        <ul>
+          <li
+            class="euiForm__error"
+          >
+            <span>
+              This is one error
+            </span>
+          </li>
+          <li
+            class="euiForm__error"
+          >
+            <span>
+              This is another error
+            </span>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>
@@ -110,15 +114,19 @@ exports[`EuiForm renders with error callout when isInvalid is "true" and has one
     <div
       class="euiText euiText--small"
     >
-      <ul>
-        <li
-          class="euiForm__error"
-        >
-          <span>
-            This is one error
-          </span>
-        </li>
-      </ul>
+      <div
+        class="euiTextColor euiTextColor--default"
+      >
+        <ul>
+          <li
+            class="euiForm__error"
+          >
+            <span>
+              This is one error
+            </span>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
### Summary

Fixed #4811 by changing EuiText color of EuiCallout to default.


### Before
<img width="1083" alt="Screen Shot 2021-05-25 at 13 16 19 PM" src="https://user-images.githubusercontent.com/549577/119540469-7951a700-bd5b-11eb-8fed-a28d03dc7ccd.png">


### After
<img width="1060" alt="Screen Shot 2021-05-25 at 13 15 56 PM" src="https://user-images.githubusercontent.com/549577/119540485-7d7dc480-bd5b-11eb-97c5-8ac6d5672082.png">


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] ~Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] ~Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
