### PR TITLE
SONK-592: imperva theme  elevation corner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `29.3.1`.
+- Upgraded `highlight.js` to 9.18.5 ([#4313](https://github.com/elastic/eui/pull/4313))
 
 ## [`29.3.1`](https://github.com/elastic/eui/tree/v29.3.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+No public interface changes since `29.3.2`.
+
+## [`29.3.2`](https://github.com/elastic/eui/tree/v29.3.2)
+
 **Note: this release is a backport containing changes originally made in `30.6.0`**
 
 **Bug fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+No public interface changes since `29.3.1`.
+
+## [`29.3.1`](https://github.com/elastic/eui/tree/v29.3.1)
+
 **Note: this release is a backport containing changes originally made in `30.0.0`**
 
 **Bug fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `29.3.0`.
+**Note: this release is a backport containing changes originally made in `30.0.0`**
+
+**Bug fixes**
+
+- Fixed focus management bug in `EuiSelectable` ([4152](https://github.com/elastic/eui/pull/4152))
 
 ## [`29.3.0`](https://github.com/elastic/eui/tree/v29.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+**Note: this release is a backport containing changes originally made in `30.6.0`**
+
+**Bug fixes**
+
 - Upgraded `highlight.js` to 9.18.5 ([#4313](https://github.com/elastic/eui/pull/4313))
+- Limited the links allowed in `EuiMarkdownEditor` to http, https, or starting with a forward slash ([#4362](https://github.com/elastic/eui/pull/4362))
+- Aligned components with an `href` prop to React's practice of disallowing `javascript:` protocols ([#4362](https://github.com/elastic/eui/pull/4362))
 
 ## [`29.3.1`](https://github.com/elastic/eui/tree/v29.3.1)
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@types/vfile-message": "^2.0.0",
     "chroma-js": "^2.1.0",
     "classnames": "^2.2.6",
-    "highlight.js": "^9.12.0",
+    "highlight.js": "^9.18.5",
     "lodash": "^4.17.20",
     "numeral": "^2.0.6",
     "prop-types": "^15.6.0",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "tabbable": "^3.0.0",
     "text-diff": "^1.0.1",
     "unified": "^8.4.2",
+    "url-parse": "^1.4.7",
     "uuid": "^8.3.0",
     "vfile": "^4.2.0"
   },
@@ -111,6 +112,7 @@
     "@types/react-router-dom": "^5.1.5",
     "@types/resize-observer-browser": "^0.1.3",
     "@types/tabbable": "^3.1.0",
+    "@types/url-parse": "^1.4.3",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^3.10.1",
     "@typescript-eslint/parser": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elastic/eui",
   "description": "Elastic UI Component Library",
-  "version": "29.3.0",
+  "version": "29.3.1",
   "license": "Apache-2.0",
   "main": "lib",
   "module": "es",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elastic/eui",
   "description": "Elastic UI Component Library",
-  "version": "29.3.1",
+  "version": "29.3.2",
   "license": "Apache-2.0",
   "main": "lib",
   "module": "es",

--- a/src-docs/src/i18ntokens.json
+++ b/src-docs/src/i18ntokens.json
@@ -1829,11 +1829,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 106,
+        "line": 110,
         "column": 6
       },
       "end": {
-        "line": 106,
+        "line": 110,
         "column": 74
       }
     },

--- a/src-docs/src/i18ntokens.json
+++ b/src-docs/src/i18ntokens.json
@@ -2309,11 +2309,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 427,
+        "line": 430,
         "column": 16
       },
       "end": {
-        "line": 430,
+        "line": 433,
         "column": 18
       }
     },
@@ -2325,11 +2325,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 449,
+        "line": 452,
         "column": 14
       },
       "end": {
-        "line": 453,
+        "line": 456,
         "column": 16
       }
     },
@@ -2341,11 +2341,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 468,
+        "line": 471,
         "column": 14
       },
       "end": {
-        "line": 471,
+        "line": 474,
         "column": 16
       }
     },
@@ -2357,11 +2357,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 535,
+        "line": 538,
         "column": 6
       },
       "end": {
-        "line": 535,
+        "line": 538,
         "column": 78
       }
     },
@@ -2373,11 +2373,11 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 566,
+        "line": 569,
         "column": 6
       },
       "end": {
-        "line": 566,
+        "line": 569,
         "column": 78
       }
     },

--- a/src-docs/src/index.js
+++ b/src-docs/src/index.js
@@ -19,6 +19,7 @@ import themeLight from './theme_light.scss';
 import themeDark from './theme_dark.scss';
 import themeAmsterdamLight from './theme_amsterdam_light.scss';
 import themeAmsterdamDark from './theme_amsterdam_dark.scss';
+import themeImperva from './theme_imperva.scss';
 import { ThemeProvider } from './components/with_theme/theme_context';
 import ScrollToHash from './components/scroll_to_hash';
 
@@ -26,6 +27,7 @@ registerTheme('light', [themeLight]);
 registerTheme('dark', [themeDark]);
 registerTheme('amsterdam-light', [themeAmsterdamLight]);
 registerTheme('amsterdam-dark', [themeAmsterdamDark]);
+registerTheme('imperva', [themeImperva]);
 
 // Set up app
 

--- a/src-docs/src/theme_imperva.scss
+++ b/src-docs/src/theme_imperva.scss
@@ -1,0 +1,11 @@
+// sass-lint:disable no-url-domains, no-url-protocols
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap');
+
+@import '../../src/theme_imperva';
+@import './components/guide_components';
+@import './services/playground/index';
+@import './views/suggest/global_filter_group';
+
+// Elastic charts
+@import '~@elastic/charts/dist/theme';
+@import '../../src/themes/charts/theme';

--- a/src-docs/src/views/guidelines/_get_sass_vars.js
+++ b/src-docs/src/views/guidelines/_get_sass_vars.js
@@ -2,6 +2,7 @@ import lightColors from '!!sass-vars-to-js-loader!../../../../src/global_styling
 import darkColors from '!!sass-vars-to-js-loader!../../../../src/themes/eui/eui_colors_dark.scss';
 import lightAmsterdamColors from '!!sass-vars-to-js-loader!../../../../src/themes/eui-amsterdam/eui_amsterdam_colors_light.scss';
 import darkAmsterdamColors from '!!sass-vars-to-js-loader!../../../../src/themes/eui-amsterdam/eui_amsterdam_colors_dark.scss';
+import impervaColors from '!!sass-vars-to-js-loader!../../../../src/themes/imperva/imperva_colors.scss';
 
 export const getSassVars = theme => {
   let palette;
@@ -14,6 +15,9 @@ export const getSassVars = theme => {
       break;
     case 'dark':
       palette = darkColors;
+      break;
+    case 'imperva':
+      palette = { ...lightColors, ...impervaColors };
       break;
     default:
       palette = lightColors;

--- a/src-docs/src/views/guidelines/_get_sass_vars.js
+++ b/src-docs/src/views/guidelines/_get_sass_vars.js
@@ -16,11 +16,10 @@ export const getSassVars = theme => {
     case 'dark':
       palette = darkColors;
       break;
+    case 'light':
     case 'imperva':
-      palette = { ...lightColors, ...impervaColors };
-      break;
     default:
-      palette = lightColors;
+      palette = { ...lightColors, ...impervaColors };
       break;
   }
 

--- a/src-docs/src/views/link/link_example.js
+++ b/src-docs/src/views/link/link_example.js
@@ -10,12 +10,16 @@ import linkConfig from './playground';
 
 import Link from './link';
 import { LinkDisable } from './link_disable';
+import { LinkValidation } from './link_validation';
 
 const linkSource = require('!!raw-loader!./link');
 const linkHtml = renderToHtml(Link);
 
 const linkDisableSource = require('!!raw-loader!./link_disable');
 const linkDisableHtml = renderToHtml(LinkDisable);
+
+const linkValidationSource = require('!!raw-loader!./link_validation');
+const linkValidationHtml = renderToHtml(LinkValidation);
 
 const linkSnippet = [
   `<EuiLink href="#"><!-- Link text --></EuiLink>
@@ -76,6 +80,36 @@ export const LinkExample = {
       ),
       props: { EuiLink },
       demo: <LinkDisable />,
+    },
+    {
+      title: 'Link validation',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: linkValidationSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: linkValidationHtml,
+        },
+      ],
+      text: (
+        <p>
+          To make links more secure for users, <strong>EuiLink</strong> and
+          other components that accept an <EuiCode>href</EuiCode> prop become
+          disabled if that <EuiCode>href</EuiCode> uses the{' '}
+          <EuiCode>javascript:</EuiCode> protocol. This helps protect consuming
+          applications from cross-site scripting (XSS) attacks and mirrors
+          React&apos;s{' '}
+          <EuiLink
+            href="https://github.com/facebook/react/blob/940f48b999a3131e77b2545bd7ae252ef27ae6d1/packages/react-dom/src/shared/sanitizeURL.js#L37"
+            target="_blank">
+            planned behavior
+          </EuiLink>{' '}
+          to prevent rendering of <EuiCode>javascript:</EuiCode> links.
+        </p>
+      ),
+      demo: <LinkValidation />,
     },
   ],
   playground: linkConfig,

--- a/src-docs/src/views/link/link_validation.js
+++ b/src-docs/src/views/link/link_validation.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { EuiLink } from '../../../../src/components';
+
+const urls = [
+  'https://elastic.co',
+  '//elastic.co',
+  'relative/url/somewhere',
+  'http://username:password@example.com/',
+  // eslint-disable-next-line no-script-url
+  'javascript:alert()',
+];
+
+export const LinkValidation = () => {
+  return (
+    <>
+      {urls.map(url => (
+        <div key={url}>
+          <EuiLink color="secondary" href={url}>
+            {url}
+          </EuiLink>
+        </div>
+      ))}
+    </>
+  );
+};

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -36,6 +36,7 @@ import {
 import { EuiInnerText } from '../inner_text';
 import { EuiIcon, IconColor, IconType } from '../icon';
 import { chromaValid, parseColor } from '../color_picker/utils';
+import { validateHref } from '../../services/security/href_validator';
 
 type IconSide = 'left' | 'right';
 
@@ -136,7 +137,7 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
   iconType,
   iconSide = 'left',
   className,
-  isDisabled,
+  isDisabled: _isDisabled,
   onClick,
   iconOnClick,
   onClickAriaLabel,
@@ -149,6 +150,9 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
   ...rest
 }) => {
   checkValidColor(color);
+
+  const isHrefValid = !href || validateHref(href);
+  const isDisabled = _isDisabled || !isHrefValid;
 
   let optionalCustomStyles: object | undefined = style;
   let textColor = null;
@@ -215,6 +219,7 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
     'euiBadge__icon',
     closeButtonProps && closeButtonProps.className
   );
+
   const Element = href && !isDisabled ? 'a' : 'button';
   const relObj: {
     href?: string;

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -385,6 +385,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
                               <button
                                 className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
                                 data-test-subj="tablePaginationPopoverButton"
+                                disabled={false}
                                 onClick={[Function]}
                                 type="button"
                               >

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -35,6 +35,7 @@ import {
   EuiButtonContentType,
   EuiButtonContent,
 } from './button_content';
+import { validateHref } from '../../services/security/href_validator';
 
 export type ButtonColor =
   | 'primary'
@@ -203,8 +204,8 @@ export type Props = ExclusiveUnion<
 >;
 
 export const EuiButton: FunctionComponent<Props> = ({
-  isDisabled,
-  disabled,
+  isDisabled: _isDisabled,
+  disabled: _disabled,
   href,
   target,
   rel,
@@ -212,6 +213,10 @@ export const EuiButton: FunctionComponent<Props> = ({
   buttonRef,
   ...rest
 }) => {
+  const isHrefValid = !href || validateHref(href);
+  const disabled = _disabled || !isHrefValid;
+  const isDisabled = _isDisabled || !isHrefValid;
+
   const buttonIsDisabled = rest.isLoading || isDisabled || disabled;
   const element = href && !isDisabled ? 'a' : 'button';
 

--- a/src/components/button/button_empty/button_empty.tsx
+++ b/src/components/button/button_empty/button_empty.tsx
@@ -33,6 +33,7 @@ import {
   EuiButtonContentProps,
   EuiButtonContentType,
 } from '../button_content';
+import { validateHref } from '../../../services/security/href_validator';
 
 export type EuiButtonEmptyColor =
   | 'primary'
@@ -119,8 +120,8 @@ export const EuiButtonEmpty: FunctionComponent<EuiButtonEmptyProps> = ({
   color = 'primary',
   size,
   flush,
-  isDisabled,
-  disabled,
+  isDisabled: _isDisabled,
+  disabled: _disabled,
   isLoading,
   href,
   target,
@@ -131,6 +132,10 @@ export const EuiButtonEmpty: FunctionComponent<EuiButtonEmptyProps> = ({
   textProps,
   ...rest
 }) => {
+  const isHrefValid = !href || validateHref(href);
+  const disabled = _disabled || !isHrefValid;
+  const isDisabled = _isDisabled || !isHrefValid;
+
   // If in the loading state, force disabled to true
   const buttonIsDisabled = isLoading || isDisabled || disabled;
 

--- a/src/components/button/button_icon/button_icon.tsx
+++ b/src/components/button/button_icon/button_icon.tsx
@@ -37,6 +37,7 @@ import {
 import { IconType, IconSize, EuiIcon } from '../../icon';
 
 import { ButtonSize } from '../button';
+import { validateHref } from '../../../services/security/href_validator';
 
 export type EuiButtonIconColor =
   | 'accent'
@@ -101,7 +102,7 @@ export const EuiButtonIcon: FunctionComponent<Props> = ({
   iconType,
   iconSize = 'm',
   color = 'primary',
-  isDisabled,
+  isDisabled: _isDisabled,
   href,
   type = 'button',
   target,
@@ -109,6 +110,9 @@ export const EuiButtonIcon: FunctionComponent<Props> = ({
   buttonRef,
   ...rest
 }) => {
+  const isHrefValid = !href || validateHref(href);
+  const isDisabled = _isDisabled || !isHrefValid;
+
   const ariaHidden = rest['aria-hidden'];
   const isAriaHidden = ariaHidden === 'true' || ariaHidden === true;
 

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -37,6 +37,7 @@ import {
   euiCardSelectableColor,
 } from './card_select';
 import { htmlIdGenerator } from '../../services/accessibility';
+import { validateHref } from '../../services/security/href_validator';
 
 type CardAlignment = 'left' | 'center' | 'right';
 
@@ -176,7 +177,7 @@ export const SIZES = keysOf(paddingSizeToClassNameMap);
 export const EuiCard: FunctionComponent<EuiCardProps> = ({
   className,
   description,
-  isDisabled,
+  isDisabled: _isDisabled,
   title,
   titleElement = 'span',
   titleSize = 's',
@@ -198,6 +199,9 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
   paddingSize = 'm',
   ...rest
 }) => {
+  const isHrefValid = !href || validateHref(href);
+  const isDisabled = _isDisabled || !isHrefValid;
+
   /**
    * For a11y, we simulate the same click that's provided on the title when clicking the whole card
    * without having to make the whole card a button or anchor tag.

--- a/src/components/context_menu/__snapshots__/context_menu_panel.test.tsx.snap
+++ b/src/components/context_menu/__snapshots__/context_menu_panel.test.tsx.snap
@@ -449,7 +449,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
       <EuiResizeObserver onResize={[Function: onResize]}>
         <div>
           <EuiContextMenuItem data-counter={0} buttonRef={[Function: bound ]}>
-            <button disabled={[undefined]} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={0}>
+            <button disabled={false} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={0}>
               <span className=\\"euiContextMenu__itemLayout\\">
                 <span className=\\"euiContextMenuItem__text\\">
                   Option A
@@ -458,7 +458,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
             </button>
           </EuiContextMenuItem>
           <EuiContextMenuItem data-counter={1} buttonRef={[Function: bound ]}>
-            <button disabled={[undefined]} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={1}>
+            <button disabled={false} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={1}>
               <span className=\\"euiContextMenu__itemLayout\\">
                 <span className=\\"euiContextMenuItem__text\\">
                   Option B
@@ -480,7 +480,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
       <EuiResizeObserver onResize={[Function: onResize]}>
         <div>
           <EuiContextMenuItem data-counter={0} buttonRef={[Function: bound ]}>
-            <button disabled={[undefined]} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={0}>
+            <button disabled={false} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={0}>
               <span className=\\"euiContextMenu__itemLayout\\">
                 <span className=\\"euiContextMenuItem__text\\">
                   Option A
@@ -489,7 +489,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
             </button>
           </EuiContextMenuItem>
           <EuiContextMenuItem data-counter={1} buttonRef={[Function: bound ]}>
-            <button disabled={[undefined]} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={1}>
+            <button disabled={false} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={1}>
               <span className=\\"euiContextMenu__itemLayout\\">
                 <span className=\\"euiContextMenuItem__text\\">
                   Option B
@@ -539,7 +539,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
       <EuiResizeObserver onResize={[Function: onResize]}>
         <div>
           <EuiContextMenuItem data-counter={0} buttonRef={[Function: bound ]}>
-            <button disabled={[undefined]} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={0}>
+            <button disabled={false} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={0}>
               <span className=\\"euiContextMenu__itemLayout\\">
                 <span className=\\"euiContextMenuItem__text\\">
                   Option A
@@ -548,7 +548,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
             </button>
           </EuiContextMenuItem>
           <EuiContextMenuItem data-counter={1} buttonRef={[Function: bound ]}>
-            <button disabled={[undefined]} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={1}>
+            <button disabled={false} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={1}>
               <span className=\\"euiContextMenu__itemLayout\\">
                 <span className=\\"euiContextMenuItem__text\\">
                   Option B
@@ -570,7 +570,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
       <EuiResizeObserver onResize={[Function: onResize]}>
         <div>
           <EuiContextMenuItem data-counter={2} buttonRef={[Function: bound ]}>
-            <button disabled={[undefined]} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={2}>
+            <button disabled={false} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={2}>
               <span className=\\"euiContextMenu__itemLayout\\">
                 <span className=\\"euiContextMenuItem__text\\">
                   Option A
@@ -579,7 +579,7 @@ exports[`EuiContextMenuPanel updating items and content updates to items should 
             </button>
           </EuiContextMenuItem>
           <EuiContextMenuItem data-counter={3} buttonRef={[Function: bound ]}>
-            <button disabled={[undefined]} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={3}>
+            <button disabled={false} className=\\"euiContextMenuItem\\" type=\\"button\\" data-counter={3}>
               <span className=\\"euiContextMenu__itemLayout\\">
                 <span className=\\"euiContextMenuItem__text\\">
                   Option B

--- a/src/components/context_menu/context_menu_item.tsx
+++ b/src/components/context_menu/context_menu_item.tsx
@@ -33,6 +33,7 @@ import { EuiIcon } from '../icon';
 import { EuiToolTip, ToolTipPositions } from '../tool_tip';
 
 import { getSecureRelForTarget } from '../../services';
+import { validateHref } from '../../services/security/href_validator';
 
 export type EuiContextMenuItemIcon = ReactElement<any> | string | HTMLElement;
 
@@ -90,7 +91,7 @@ export class EuiContextMenuItem extends Component<Props> {
       hasPanel,
       icon,
       buttonRef,
-      disabled,
+      disabled: _disabled,
       layoutAlign = 'center',
       toolTipTitle,
       toolTipContent,
@@ -101,6 +102,9 @@ export class EuiContextMenuItem extends Component<Props> {
       ...rest
     } = this.props;
     let iconInstance;
+
+    const isHrefValid = !href || validateHref(href);
+    const disabled = _disabled || !isHrefValid;
 
     if (icon) {
       switch (typeof icon) {

--- a/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
+++ b/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
@@ -303,7 +303,9 @@ exports[`EuiControlBar props leftOffset is rendered 1`] = `
                 className="euiControlBar__button"
                 color="ghost"
                 data-test-subj="dts"
+                disabled={false}
                 element="button"
+                isDisabled={false}
                 onClick={[Function]}
                 size="s"
                 type="button"
@@ -311,6 +313,7 @@ exports[`EuiControlBar props leftOffset is rendered 1`] = `
                 <button
                   className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
                   data-test-subj="dts"
+                  disabled={false}
                   onClick={[Function]}
                   type="button"
                 >
@@ -618,7 +621,9 @@ exports[`EuiControlBar props maxHeight is rendered 1`] = `
                 className="euiControlBar__button"
                 color="ghost"
                 data-test-subj="dts"
+                disabled={false}
                 element="button"
+                isDisabled={false}
                 onClick={[Function]}
                 size="s"
                 type="button"
@@ -626,6 +631,7 @@ exports[`EuiControlBar props maxHeight is rendered 1`] = `
                 <button
                   className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
                   data-test-subj="dts"
+                  disabled={false}
                   onClick={[Function]}
                   type="button"
                 >
@@ -932,7 +938,9 @@ exports[`EuiControlBar props mobile is rendered 1`] = `
                 className="euiControlBar__button"
                 color="ghost"
                 data-test-subj="dts"
+                disabled={false}
                 element="button"
+                isDisabled={false}
                 onClick={[Function]}
                 size="s"
                 type="button"
@@ -940,6 +948,7 @@ exports[`EuiControlBar props mobile is rendered 1`] = `
                 <button
                   className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
                   data-test-subj="dts"
+                  disabled={false}
                   onClick={[Function]}
                   type="button"
                 >
@@ -1159,7 +1168,9 @@ exports[`EuiControlBar props position is rendered 1`] = `
             className="euiControlBar__button"
             color="ghost"
             data-test-subj="dts"
+            disabled={false}
             element="button"
+            isDisabled={false}
             onClick={[Function]}
             size="s"
             type="button"
@@ -1167,6 +1178,7 @@ exports[`EuiControlBar props position is rendered 1`] = `
             <button
               className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
               data-test-subj="dts"
+              disabled={false}
               onClick={[Function]}
               type="button"
             >
@@ -1458,7 +1470,9 @@ exports[`EuiControlBar props rightOffset is rendered 1`] = `
                 className="euiControlBar__button"
                 color="ghost"
                 data-test-subj="dts"
+                disabled={false}
                 element="button"
+                isDisabled={false}
                 onClick={[Function]}
                 size="s"
                 type="button"
@@ -1466,6 +1480,7 @@ exports[`EuiControlBar props rightOffset is rendered 1`] = `
                 <button
                   className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
                   data-test-subj="dts"
+                  disabled={false}
                   onClick={[Function]}
                   type="button"
                 >
@@ -1777,7 +1792,9 @@ exports[`EuiControlBar props showContent is rendered 1`] = `
                 className="euiControlBar__button"
                 color="ghost"
                 data-test-subj="dts"
+                disabled={false}
                 element="button"
+                isDisabled={false}
                 onClick={[Function]}
                 size="s"
                 type="button"
@@ -1785,6 +1802,7 @@ exports[`EuiControlBar props showContent is rendered 1`] = `
                 <button
                   className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
                   data-test-subj="dts"
+                  disabled={false}
                   onClick={[Function]}
                   type="button"
                 >
@@ -2096,7 +2114,9 @@ exports[`EuiControlBar props size is rendered 1`] = `
                 className="euiControlBar__button"
                 color="ghost"
                 data-test-subj="dts"
+                disabled={false}
                 element="button"
+                isDisabled={false}
                 onClick={[Function]}
                 size="s"
                 type="button"
@@ -2104,6 +2124,7 @@ exports[`EuiControlBar props size is rendered 1`] = `
                 <button
                   className="euiButton euiButton--ghost euiButton--small euiControlBar__button"
                   data-test-subj="dts"
+                  disabled={false}
                   onClick={[Function]}
                   type="button"
                 >

--- a/src/components/header/header_logo.tsx
+++ b/src/components/header/header_logo.tsx
@@ -27,6 +27,7 @@ import classNames from 'classnames';
 import { EuiIcon, IconType } from '../icon';
 import { CommonProps } from '../common';
 import { getSecureRelForTarget } from '../../services';
+import { validateHref } from '../../services/security/href_validator';
 
 export type EuiHeaderLogoProps = CommonProps &
   AnchorHTMLAttributes<HTMLAnchorElement> & {
@@ -53,9 +54,10 @@ export const EuiHeaderLogo: FunctionComponent<EuiHeaderLogoProps> = ({
 }) => {
   const classes = classNames('euiHeaderLogo', className);
   const secureRel = getSecureRelForTarget({ href, rel, target });
+  const isHrefValid = !href || validateHref(href);
   return (
     <a
-      href={href}
+      href={isHrefValid ? href : ''}
       rel={secureRel}
       target={target}
       className={classes}

--- a/src/components/key_pad_menu/key_pad_menu_item.tsx
+++ b/src/components/key_pad_menu/key_pad_menu_item.tsx
@@ -33,6 +33,7 @@ import { EuiBetaBadge } from '../badge/beta_badge';
 import { getSecureRelForTarget } from '../../services';
 
 import { IconType } from '../icon';
+import { validateHref } from '../../services/security/href_validator';
 
 const renderContent = (
   children: ReactNode,
@@ -94,7 +95,7 @@ export type EuiKeyPadMenuItemProps = CommonProps &
   EuiKeyPadMenuItemCommonProps;
 
 export const EuiKeyPadMenuItem: FunctionComponent<EuiKeyPadMenuItemProps> = ({
-  isDisabled,
+  isDisabled: _isDisabled,
   label,
   children,
   className,
@@ -106,6 +107,9 @@ export const EuiKeyPadMenuItem: FunctionComponent<EuiKeyPadMenuItemProps> = ({
   target,
   ...rest
 }) => {
+  const isHrefValid = !href || validateHref(href);
+  const isDisabled = _isDisabled || !isHrefValid;
+
   const classes = classNames(
     'euiKeyPadMenuItem',
     {

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -28,6 +28,7 @@ import { EuiIcon } from '../icon';
 import { EuiI18n } from '../i18n';
 import { CommonProps, ExclusiveUnion, keysOf } from '../common';
 import { getSecureRelForTarget } from '../../services';
+import { validateHref } from '../../services/security/href_validator';
 
 export type EuiLinkType = 'button' | 'reset' | 'submit';
 export type EuiLinkColor =
@@ -97,11 +98,14 @@ const EuiLink = forwardRef<HTMLAnchorElement | HTMLButtonElement, EuiLinkProps>(
       rel,
       type = 'button',
       onClick,
-      disabled,
+      disabled: _disabled,
       ...rest
     },
     ref
   ) => {
+    const isHrefValid = !href || validateHref(href);
+    const disabled = _disabled || !isHrefValid;
+
     const externalLinkIcon = external ? (
       <EuiI18n token="euiLink.external.ariaLabel" default="External link">
         {(ariaLabel: string) => (
@@ -117,7 +121,7 @@ const EuiLink = forwardRef<HTMLAnchorElement | HTMLButtonElement, EuiLinkProps>(
       undefined
     );
 
-    if (href === undefined) {
+    if (href === undefined || !isHrefValid) {
       const buttonProps = {
         className: classNames(
           'euiLink',

--- a/src/components/list_group/list_group_item.tsx
+++ b/src/components/list_group/list_group_item.tsx
@@ -36,6 +36,7 @@ import { useInnerText } from '../inner_text';
 import { ExclusiveUnion, CommonProps } from '../common';
 
 import { getSecureRelForTarget } from '../../services';
+import { validateHref } from '../../services/security/href_validator';
 
 type ItemSize = 'xs' | 's' | 'm' | 'l';
 const sizeToClassNameMap: { [size in ItemSize]: string } = {
@@ -147,7 +148,7 @@ export type EuiListGroupItemProps = CommonProps &
 export const EuiListGroupItem: FunctionComponent<EuiListGroupItemProps> = ({
   label,
   isActive = false,
-  isDisabled = false,
+  isDisabled: _isDisabled = false,
   href,
   target,
   rel,
@@ -163,6 +164,9 @@ export const EuiListGroupItem: FunctionComponent<EuiListGroupItemProps> = ({
   buttonRef,
   ...rest
 }) => {
+  const isHrefValid = !href || validateHref(href);
+  const isDisabled = _isDisabled || !isHrefValid;
+
   const classes = classNames(
     'euiListGroupItem',
     sizeToClassNameMap[size],

--- a/src/components/markdown_editor/plugins/markdown_default_plugins.tsx
+++ b/src/components/markdown_editor/plugins/markdown_default_plugins.tsx
@@ -22,6 +22,7 @@ import remark2rehype from 'remark-rehype';
 import rehype2react from 'rehype-react';
 import * as MarkdownTooltip from './markdown_tooltip';
 import * as MarkdownCheckbox from './markdown_checkbox';
+import { markdownLinkValidator } from './markdown_link_validator';
 import React, { createElement } from 'react';
 import { EuiLink } from '../../link';
 import { EuiCodeBlock, EuiCode } from '../../code';
@@ -37,6 +38,7 @@ export const getDefaultEuiMarkdownParsingPlugins = (): PluggableList => [
   [emoji, { emoticon: true }],
   [MarkdownTooltip.parser, {}],
   [MarkdownCheckbox.parser, {}],
+  [markdownLinkValidator, {}],
 ];
 
 export const defaultParsingPlugins = getDefaultEuiMarkdownParsingPlugins();

--- a/src/components/markdown_editor/plugins/markdown_link_validator.test.tsx
+++ b/src/components/markdown_editor/plugins/markdown_link_validator.test.tsx
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { validateUrl, mutateLinkToText } from './markdown_link_validator';
+import { validateHref } from '../../../services/security/href_validator';
+
+describe('validateURL', () => {
+  it('approves of https:', () => {
+    expect(validateUrl('https:')).toBeTruthy();
+  });
+  it('approves of http:', () => {
+    expect(validateUrl('http:')).toBeTruthy();
+  });
+  it('approves of absolute relative links', () => {
+    expect(validateUrl('/')).toBeTruthy();
+  });
+  it('approves of relative protocols', () => {
+    expect(validateUrl('//')).toBeTruthy();
+  });
+  it('rejects a url starting with http with not an s following', () => {
+    expect(validateUrl('httpm:')).toBeFalsy();
+  });
+  it('rejects a directory relative link', () => {
+    expect(validateUrl('./')).toBeFalsy();
+    expect(validateUrl('../')).toBeFalsy();
+  });
+  it('rejects a word', () => {
+    expect(validateUrl('word')).toBeFalsy();
+  });
+  it('rejects gopher', () => {
+    expect(validateUrl('gopher:')).toBeFalsy();
+  });
+  it('rejects javascript', () => {
+    // eslint-disable-next-line no-script-url
+    expect(validateUrl('javascript:')).toBeFalsy();
+    // eslint-disable-next-line no-script-url
+    expect(validateHref('javascript:alert()')).toBeFalsy();
+  });
+});
+
+describe('mutateLinkToText', () => {
+  it('mutates', () => {
+    expect(
+      mutateLinkToText({
+        type: 'link',
+        url: 'https://cats.com',
+        title: null,
+        children: [{ value: 'Cats' }],
+      })
+    ).toMatchInlineSnapshot(`
+Object {
+  "type": "text",
+  "value": "[Cats](https://cats.com)",
+}
+`);
+    expect(
+      mutateLinkToText({
+        type: 'link',
+        url: 'https://cats.com',
+        title: null,
+        children: [],
+      })
+    ).toMatchInlineSnapshot(`
+Object {
+  "type": "text",
+  "value": "[](https://cats.com)",
+}
+`);
+  });
+});

--- a/src/components/markdown_editor/plugins/markdown_link_validator.tsx
+++ b/src/components/markdown_editor/plugins/markdown_link_validator.tsx
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// @ts-ignore fixed in future versions, this is a backport
+import visit from 'unist-util-visit';
+
+interface LinkOrTextNode {
+  type: string;
+  url?: string;
+  title?: string | null;
+  value?: string;
+  children?: Array<{ value: string }>;
+}
+
+export function markdownLinkValidator() {
+  return (ast: any) => {
+    visit(ast, 'link', (_node: unknown) => {
+      const node = _node as LinkOrTextNode;
+
+      if (!validateUrl(node.url!)) {
+        mutateLinkToText(node);
+      }
+    });
+  };
+}
+
+export function mutateLinkToText(node: LinkOrTextNode) {
+  node.type = 'text';
+  node.value = `[${node.children![0]?.value || ''}](${node.url})`;
+  delete node.children;
+  delete node.title;
+  delete node.url;
+  return node;
+}
+
+export function validateUrl(url: string) {
+  // A link is valid if it starts with http:, https:, or /
+  return /^(https?:|\/)/.test(url);
+}

--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -154,7 +154,7 @@ export class EuiSelectable<T = {}> extends Component<
     singleSelection: false,
     searchable: false,
   };
-
+  private containerRef = createRef<HTMLDivElement>();
   private optionsListRef = createRef<EuiSelectableList<T>>();
   rootId = htmlIdGenerator();
   constructor(props: EuiSelectableProps<T>) {
@@ -335,7 +335,10 @@ export class EuiSelectable<T = {}> extends Component<
     );
   };
 
-  onContainerBlur = () => {
+  onContainerBlur = (e: React.FocusEvent) => {
+    // Ignore blur events when moving from search to option to avoid activeOptionIndex conflicts
+    if (this.containerRef.current!.contains(e.relatedTarget as Node)) return;
+
     this.setState({
       activeOptionIndex: undefined,
       isFocused: false,
@@ -594,6 +597,7 @@ export class EuiSelectable<T = {}> extends Component<
 
     return (
       <div
+        ref={this.containerRef}
         className={classes}
         onKeyDown={this.onKeyDown}
         onBlur={this.onContainerBlur}

--- a/src/components/side_nav/side_nav_item.tsx
+++ b/src/components/side_nav/side_nav_item.tsx
@@ -30,6 +30,7 @@ import { CommonProps } from '../common';
 import { EuiIcon } from '../icon';
 
 import { getSecureRelForTarget } from '../../services';
+import { validateHref } from '../../services/security/href_validator';
 
 type ItemProps = CommonProps & {
   href?: string;
@@ -124,7 +125,7 @@ export function EuiSideNavItem<
   isParent,
   icon,
   onClick,
-  href,
+  href: _href,
   rel,
   target,
   items,
@@ -134,6 +135,8 @@ export function EuiSideNavItem<
   className,
   ...rest
 }: EuiSideNavItemProps<T>) {
+  const isHrefValid = !_href || validateHref(_href);
+  const href = isHrefValid ? _href : '';
   let childItems;
 
   if (items && isOpen) {

--- a/src/components/tabs/tab.tsx
+++ b/src/components/tabs/tab.tsx
@@ -26,6 +26,7 @@ import React, {
 import classNames from 'classnames';
 import { CommonProps, ExclusiveUnion } from '../common';
 import { getSecureRelForTarget } from '../../services';
+import { validateHref } from '../../services/security/href_validator';
 
 export interface EuiTabProps extends CommonProps {
   isSelected?: boolean;
@@ -49,12 +50,15 @@ export const EuiTab: FunctionComponent<Props> = ({
   isSelected,
   children,
   className,
-  disabled,
+  disabled: _disabled,
   href,
   target,
   rel,
   ...rest
 }) => {
+  const isHrefValid = !href || validateHref(href);
+  const disabled = _disabled || !isHrefValid;
+
   const classes = classNames('euiTab', className, {
     'euiTab-isSelected': isSelected,
     'euiTab-isDisabled': disabled,

--- a/src/components/tabs/tabbed_content/__snapshots__/tabbed_content.test.tsx.snap
+++ b/src/components/tabs/tabbed_content/__snapshots__/tabbed_content.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`EuiTabbedContent behavior when uncontrolled, the selected tab should up
             aria-controls="42"
             aria-selected={false}
             className="euiTab"
+            disabled={false}
             id="es"
             onClick={[Function]}
             role="tab"
@@ -120,6 +121,7 @@ exports[`EuiTabbedContent behavior when uncontrolled, the selected tab should up
             aria-selected={true}
             className="euiTab euiTab-isSelected"
             data-test-subj="kibanaTab"
+            disabled={false}
             id="kibana"
             onClick={[Function]}
             role="tab"

--- a/src/services/security/href_validator.test.tsx
+++ b/src/services/security/href_validator.test.tsx
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { validateHref } from './href_validator';
+
+describe('validateHref', () => {
+  it('approves of https:', () => {
+    expect(validateHref('https:')).toBeTruthy();
+  });
+  it('approves of http:', () => {
+    expect(validateHref('http:')).toBeTruthy();
+  });
+  it('approves of absolute relative hrefs', () => {
+    expect(validateHref('/')).toBeTruthy();
+  });
+  it('approves of relative protocols', () => {
+    expect(validateHref('//')).toBeTruthy();
+  });
+  it('approves of url starting with http with not an s following', () => {
+    expect(validateHref('httpm:')).toBeTruthy();
+  });
+  it('approves of directory relative href', () => {
+    expect(validateHref('./')).toBeTruthy();
+    expect(validateHref('../')).toBeTruthy();
+  });
+  it('approves of word', () => {
+    expect(validateHref('word')).toBeTruthy();
+  });
+  it('approves of gopher', () => {
+    expect(validateHref('gopher:')).toBeTruthy();
+  });
+  it('approves of authenticated hrefs', () => {
+    expect(validateHref('http://username:password@example.com/')).toBeTruthy();
+  });
+  it('rejects javascript', () => {
+    // eslint-disable-next-line no-script-url
+    expect(validateHref('javascript:')).toBeFalsy();
+    // eslint-disable-next-line no-script-url
+    expect(validateHref('javascript:alert()')).toBeFalsy();
+  });
+});

--- a/src/services/security/href_validator.tsx
+++ b/src/services/security/href_validator.tsx
@@ -1,0 +1,27 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import URL from 'url-parse';
+
+export function validateHref(href: string) {
+  // check href and treat it as invalid if it uses the javascript: protocol
+  const parts = new URL(href);
+  // eslint-disable-next-line no-script-url
+  return parts.protocol !== 'javascript:';
+}

--- a/src/theme_imperva.scss
+++ b/src/theme_imperva.scss
@@ -1,0 +1,15 @@
+// This is the default theme.
+@import 'themes/imperva/imperva_colors';
+
+// Global styling
+@import 'themes/imperva/global_styling/index';
+
+// Components
+@import 'components/index';
+
+// Packages
+@import '../packages/index';
+
+// Component overrides
+// Comes after the component import and overrides via cascade
+@import 'themes/imperva/overrides/index';

--- a/src/theme_imperva.scss
+++ b/src/theme_imperva.scss
@@ -1,4 +1,4 @@
-// This is the default theme.
+// Imperva default theme.
 @import 'themes/imperva/imperva_colors';
 
 // Global styling

--- a/src/theme_light.scss
+++ b/src/theme_light.scss
@@ -1,11 +1,15 @@
 // This is the default theme.
-@import 'themes/eui/eui_colors_light';
+@import 'themes/imperva/imperva_colors';
 
 // Global styling
-@import 'global_styling/index';
+@import 'themes/imperva/global_styling/index';
 
 // Components
 @import 'components/index';
 
 // Packages
 @import '../packages/index';
+
+// Component overrides
+// Comes after the component import and overrides via cascade
+@import 'themes/imperva/overrides/index';

--- a/src/themes/imperva/global_styling/functions/_index.scss
+++ b/src/themes/imperva/global_styling/functions/_index.scss
@@ -1,0 +1,2 @@
+// Import base theme first, then override
+@import '../../../../global_styling/functions/index';

--- a/src/themes/imperva/global_styling/index.scss
+++ b/src/themes/imperva/global_styling/index.scss
@@ -1,0 +1,16 @@
+// Core
+
+// Functions need to be first, since we use them in our variables and mixin definitions
+@import 'functions/index';
+
+// Variables come next, and are used in some mixins
+@import 'variables/index';
+
+// Mixins provide generic code expansion through helpers
+@import 'mixins/index';
+
+// Utility classes provide one-off selectors for common css problems
+@import '../../../global_styling/utility/index';
+
+// The reset file makes use of variables and mixins
+@import '../../../global_styling/reset/index';

--- a/src/themes/imperva/global_styling/mixins/_index.scss
+++ b/src/themes/imperva/global_styling/mixins/_index.scss
@@ -1,2 +1,4 @@
 // Import base theme first, then override
 @import '../../../../global_styling/mixins/index';
+
+@import 'shadow';

--- a/src/themes/imperva/global_styling/mixins/_index.scss
+++ b/src/themes/imperva/global_styling/mixins/_index.scss
@@ -1,0 +1,2 @@
+// Import base theme first, then override
+@import '../../../../global_styling/mixins/index';

--- a/src/themes/imperva/global_styling/mixins/_shadow.scss
+++ b/src/themes/imperva/global_styling/mixins/_shadow.scss
@@ -1,0 +1,56 @@
+// This file uses RGBA literal values responsibly
+// This file uses off-pattern indentation to be more readable
+
+// sass-lint:disable no-color-literals, no-color-keywords, indentation, quotes
+
+// Depth 4: tiles
+@mixin euiSlightShadow($color: $euiShadowColor, $opacity: .1) {
+  box-shadow:
+    0 2px 6px -2px rgba($color, .13),
+    0 1px 1px rgba($color, .1);
+}
+
+// Depth 8: hover, dropdown, panel, toggle
+@mixin euiBottomShadowSmall($color: $euiShadowColor, $opacity: .1) {
+  box-shadow:
+    0 4px 8px -1px rgba($color, .13),
+    0 1px 1px rgba($color, .1);
+}
+
+// Depth 16: tooltips
+@mixin euiBottomShadowMedium($color: $euiShadowColor, $opacity: .1) {
+  box-shadow:
+    0 1px 1px rgba($color, .1),
+    0 6px 7px -1px rgba($color, .15),
+}
+
+// Depth 32: pop up dialogs
+@mixin euiBottomShadow($color: $euiShadowColorLarge, $opacity: .1, $adjustBorders: false) {
+  box-shadow:
+    0 8px 24px rgba($color, .13),
+    0 4px 14px rgba($color, .1),
+}
+
+// Depth 64
+@mixin euiBottomShadowLarge(
+  $color: $euiShadowColorLarge,
+  $opacity: .1,
+  $adjustBorders: false,
+  $reverse: false
+) {
+  @if ($reverse) {
+    box-shadow:
+      0 -24px 60px rgba($color, .18),
+      0 -4px 14px rgba($color, $opacity),
+  } @else {
+    box-shadow:
+      0 24px 60px rgba($color, .18),
+      0 4px 14px rgba($color, .1),
+  }
+}
+
+@mixin euiSlightShadowHover($color: $euiShadowColor, $opacity: .3) {
+  box-shadow:
+    0 4px 8px 0 rgba($color, $opacity/2),
+    0 2px 2px -1px rgba($color, $opacity);
+}

--- a/src/themes/imperva/global_styling/variables/_borders.scss
+++ b/src/themes/imperva/global_styling/variables/_borders.scss
@@ -1,0 +1,5 @@
+// Borders
+
+$euiBorderRadius: 4px;
+$euiBorderRadiusSmall: $euiBorderRadius / 2;
+$euiBorderRadiusLarge: $euiBorderRadius * 2;

--- a/src/themes/imperva/global_styling/variables/_index.scss
+++ b/src/themes/imperva/global_styling/variables/_index.scss
@@ -1,2 +1,4 @@
 // Import base theme first, then override
 @import '../../../../global_styling/variables/index';
+
+@import 'typography';

--- a/src/themes/imperva/global_styling/variables/_index.scss
+++ b/src/themes/imperva/global_styling/variables/_index.scss
@@ -1,0 +1,2 @@
+// Import base theme first, then override
+@import '../../../../global_styling/variables/index';

--- a/src/themes/imperva/global_styling/variables/_index.scss
+++ b/src/themes/imperva/global_styling/variables/_index.scss
@@ -2,3 +2,4 @@
 @import '../../../../global_styling/variables/index';
 
 @import 'typography';
+@import 'shadows';

--- a/src/themes/imperva/global_styling/variables/_index.scss
+++ b/src/themes/imperva/global_styling/variables/_index.scss
@@ -3,3 +3,4 @@
 
 @import 'typography';
 @import 'shadows';
+@import 'borders';

--- a/src/themes/imperva/global_styling/variables/_shadows.scss
+++ b/src/themes/imperva/global_styling/variables/_shadows.scss
@@ -1,0 +1,4 @@
+// Shadows
+// Transparency only affects the use of variable this outside of the shadow mixins (borders)
+$euiShadowColor: $euiColorInk;
+$euiShadowColorLarge: $euiColorInk;

--- a/src/themes/imperva/global_styling/variables/_typography.scss
+++ b/src/themes/imperva/global_styling/variables/_typography.scss
@@ -1,0 +1,63 @@
+// Families
+$euiFontFamily: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+$euiCodeFontFamily: 'Roboto Mono', Consolas, Menlo, Courier, monospace;
+
+// Font sizes -- scale is loosely based on Major Third (1.250)
+$euiTextScale:      2, 1.5, 1.25, 1.125, 1, .875, .75;
+
+$euiFontSize:       $euiSize; // 5th position in scale
+$euiFontSizeXS:     $euiFontSize * nth($euiTextScale, 7); // 12px
+$euiFontSizeS:      $euiFontSize * nth($euiTextScale, 6); // 14px
+$euiFontSizeM:      $euiFontSize * nth($euiTextScale, 4); // 18px
+$euiFontSizeL:      $euiFontSize * nth($euiTextScale, 3); // 20px
+$euiFontSizeXL:     $euiFontSize * nth($euiTextScale, 2); // 24px
+$euiFontSizeXXL:    $euiFontSize * nth($euiTextScale, 1); // 32px
+
+// Font weights
+$euiFontWeightLight:    300;
+$euiFontWeightRegular:  400;
+$euiFontWeightMedium:   500;
+$euiFontWeightSemiBold: 600;
+$euiFontWeightBold:     700;
+
+// Titles map
+// Lists all the properties per EuiTitle size that then gets looped through to create the selectors.
+// The map allows for tokenization and easier customization per theme, otherwise you'd have to override the selectors themselves
+$euiTitles: (
+  'xxxs': (
+    'font-size': $euiFontSizeXS,
+    'line-height': lineHeightFromBaseline(2),
+    'font-weight': $euiFontWeightBold,
+    'letter-spacing': .5px,
+  ),
+  'xxs': (
+    'font-size': $euiFontSizeS,
+    'line-height': lineHeightFromBaseline(2.5),
+    'font-weight': $euiFontWeightBold,
+    'letter-spacing': .25px,
+  ),
+  'xs': (
+    'font-size': $euiFontSize,
+    'line-height': lineHeightFromBaseline(3),
+    'font-weight': $euiFontWeightSemiBold,
+    'letter-spacing': .5px,
+  ),
+  's': (
+    'font-size': $euiFontSizeL,
+    'line-height': lineHeightFromBaseline(4),
+    'font-weight': $euiFontWeightMedium,
+    'letter-spacing': 0,
+  ),
+  'm': (
+    'font-size': $euiFontSizeXL,
+    'line-height': lineHeightFromBaseline(4),
+    'font-weight': $euiFontWeightLight,
+    'letter-spacing': 0,
+  ),
+  'l': (
+    'font-size': $euiFontSizeXXL,
+    'line-height': lineHeightFromBaseline(5),
+    'font-weight': $euiFontWeightLight,
+    'letter-spacing': 0,
+  ),
+);

--- a/src/themes/imperva/imperva_colors.scss
+++ b/src/themes/imperva/imperva_colors.scss
@@ -1,0 +1,39 @@
+// This extra import allows any variables that are created via functions to work when loaded into JS
+@import '../../global_styling/variables/colors';
+
+// Core
+$euiColorPrimary: #285AE6;    // primary blue
+$euiColorSecondary: #2DB07F;  // primary success
+$euiColorAccent: #E561AF;     // primary magenta
+$euiColorHighlight: #F0F6FF;  // blue 50
+
+// These colors stay the same no matter the theme
+$euiColorGhost: #FFF;
+$euiColorInk: #000;
+
+// Status
+$euiColorSuccess: $euiColorSecondary;
+$euiColorWarning: #FAC73A;    // warning primary
+$euiColorDanger: #DF2427;     // alert primary
+
+// Grays
+$euiColorEmptyShade: #FEFEFE;     // gray 50
+$euiColorLightestShade: #E5EBF2;  // gray 200
+$euiColorLightShade: #ACB9C5;     // gray 400
+$euiColorMediumShade: #808B95;    // gray 500
+$euiColorDarkShade: #606A73;      // gray 600
+$euiColorDarkestShade: #212121;   // gray 800
+$euiColorFullShade: #000;         // gray 900
+
+// Every color below must be based mathematically on the set above and in a particular order.
+$euiTextColor: $euiColorDarkestShade;
+$euiPageBackgroundColor: tintOrShade($euiColorLightestShade, 50%, 30%);
+$euiTextSubduedColor: makeHighContrastColor($euiColorMediumShade);
+$euiTitleColor: shadeOrTint($euiTextColor, 0%, 0%);
+$euiLinkColor: $euiColorPrimary;
+$euiFocusBackgroundColor: tintOrShade($euiColorPrimary, 90%, 50%);
+
+// Contrasty text variants
+$euiColorPrimaryText: makeHighContrastColor($euiColorPrimary);
+$euiColorSecondaryText: makeHighContrastColor($euiColorSecondary);
+$euiColorAccentText: makeHighContrastColor($euiColorAccent);

--- a/src/themes/imperva/imperva_globals.scss
+++ b/src/themes/imperva/imperva_globals.scss
@@ -1,0 +1,11 @@
+// Helper file for supplying EUI Amsterdam globals (invisibles only)
+// Must be imported AFTER a colors modifier file
+
+// Functions need to be first, since we use them in our variables and mixin definitions
+@import 'global_styling/functions/index';
+
+// Variables come next, and are used in some mixins
+@import 'global_styling/variables/index';
+
+// Mixins provide generic code expansion through helpers
+@import 'global_styling/mixins/index';

--- a/src/themes/imperva/overrides/_index.scss
+++ b/src/themes/imperva/overrides/_index.scss
@@ -1,0 +1,6 @@
+// Component overrides: scss files in src/components/<component>
+// Eg: to override src/components/button/_button.scss
+// create ./_button.scss
+// then @import 'button'
+
+// To be imported from src/imperva.scss

--- a/src/themes/themes.ts
+++ b/src/themes/themes.ts
@@ -39,4 +39,8 @@ export const EUI_THEMES: EUI_THEME[] = [
     text: 'Amsterdam: Dark',
     value: 'amsterdam-dark',
   },
+  {
+    text: 'Imperva',
+    value: 'imperva',
+  },
 ];

--- a/src/themes/themes.ts
+++ b/src/themes/themes.ts
@@ -24,11 +24,11 @@ export interface EUI_THEME {
 
 export const EUI_THEMES: EUI_THEME[] = [
   {
-    text: 'Light',
+    text: 'Imperva: light ',
     value: 'light',
   },
   {
-    text: 'Dark',
+    text: 'Elastic: Dark',
     value: 'dark',
   },
   {
@@ -38,9 +38,5 @@ export const EUI_THEMES: EUI_THEME[] = [
   {
     text: 'Amsterdam: Dark',
     value: 'amsterdam-dark',
-  },
-  {
-    text: 'Imperva',
-    value: 'imperva',
   },
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1620,6 +1620,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
+"@types/url-parse@^1.4.3":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@types/url-parse/-/url-parse-1.4.3.tgz#fba49d90f834951cb000a674efee3d6f20968329"
+  integrity sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw==
+
 "@types/uuid@^8.3.0":
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
@@ -13217,10 +13222,10 @@ querystring@0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
-querystringify@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.0.tgz#7ded8dfbf7879dcc60d0a644ac6754b283ad17ef"
-  integrity sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 quick-lru@^1.0.0:
   version "1.1.0"
@@ -16677,12 +16682,12 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-parse@^1.4.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.3.tgz#bfaee455c889023219d757e045fa6a684ec36c15"
-  integrity sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==
+url-parse@^1.4.3, url-parse@^1.4.7:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
+  integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
   dependencies:
-    querystringify "^2.0.0"
+    querystringify "^2.1.1"
     requires-port "^1.0.0"
 
 url-regex@^3.0.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7823,10 +7823,10 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-highlight.js@^9.12.0:
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
-  integrity sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=
+highlight.js@^9.18.5:
+  version "9.18.5"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.5.tgz#d18a359867f378c138d6819edfc2a8acd5f29825"
+  integrity sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==
 
 highlight.js@~10.1.0:
   version "10.1.2"


### PR DESCRIPTION
### Summary

Override global stylings of shadow and border variables.

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
