### PR TITLE
[Eui(Dual)Range] Clickable labels

### DIFF
--- a/src/components/form/range/__snapshots__/dual_range.test.tsx.snap
+++ b/src/components/form/range/__snapshots__/dual_range.test.tsx.snap
@@ -209,26 +209,22 @@ exports[`EuiDualRange props custom ticks should render 1`] = `
         type="button"
         value="20"
       >
-        <span
-          class="euiRangeTick__label"
-        >
-          20kb
-        </span>
+        20kb
       </button>
       <button
-        class="euiRangeTick euiRangeTick--isCustom euiRangeTick--isMax"
-        style="left:100%"
+        class="euiRangeTick euiRangeTick--isCustom euiRangeTick--isMax euiRangeTick--hasTickMark"
+        style="right:0%;margin-right:-1.25em"
         tabindex="-1"
         title="100kb"
         type="button"
         value="100"
       >
         <span
-          class="euiRangeTick__label"
-          style="margin-right:-1.25em"
-        >
-          100kb
-        </span>
+          aria-hidden="true"
+          class="euiRangeTick__pseudo"
+          style="margin-right:calc(1.25em - 2px)"
+        />
+        100kb
       </button>
     </div>
     <div
@@ -572,11 +568,7 @@ exports[`EuiDualRange props ticks should render 1`] = `
         type="button"
         value="0"
       >
-        <span
-          class="euiRangeTick__label"
-        >
-          0
-        </span>
+        0
       </button>
       <button
         class="euiRangeTick"
@@ -585,11 +577,7 @@ exports[`EuiDualRange props ticks should render 1`] = `
         type="button"
         value="20"
       >
-        <span
-          class="euiRangeTick__label"
-        >
-          20
-        </span>
+        20
       </button>
       <button
         class="euiRangeTick"
@@ -598,11 +586,7 @@ exports[`EuiDualRange props ticks should render 1`] = `
         type="button"
         value="40"
       >
-        <span
-          class="euiRangeTick__label"
-        >
-          40
-        </span>
+        40
       </button>
       <button
         class="euiRangeTick"
@@ -611,11 +595,7 @@ exports[`EuiDualRange props ticks should render 1`] = `
         type="button"
         value="60"
       >
-        <span
-          class="euiRangeTick__label"
-        >
-          60
-        </span>
+        60
       </button>
       <button
         class="euiRangeTick"
@@ -624,11 +604,7 @@ exports[`EuiDualRange props ticks should render 1`] = `
         type="button"
         value="80"
       >
-        <span
-          class="euiRangeTick__label"
-        >
-          80
-        </span>
+        80
       </button>
       <button
         class="euiRangeTick"
@@ -637,11 +613,7 @@ exports[`EuiDualRange props ticks should render 1`] = `
         type="button"
         value="100"
       >
-        <span
-          class="euiRangeTick__label"
-        >
-          100
-        </span>
+        100
       </button>
     </div>
     <div

--- a/src/components/form/range/__snapshots__/range.test.tsx.snap
+++ b/src/components/form/range/__snapshots__/range.test.tsx.snap
@@ -120,26 +120,22 @@ exports[`EuiRange props custom ticks should render 1`] = `
         type="button"
         value="20"
       >
-        <span
-          class="euiRangeTick__label"
-        >
-          20kb
-        </span>
+        20kb
       </button>
       <button
-        class="euiRangeTick euiRangeTick--isCustom euiRangeTick--isMax"
-        style="left:100%"
+        class="euiRangeTick euiRangeTick--isCustom euiRangeTick--isMax euiRangeTick--hasTickMark"
+        style="right:0%;margin-right:-1.25em"
         tabindex="-1"
         title="100kb"
         type="button"
         value="100"
       >
         <span
-          class="euiRangeTick__label"
-          style="margin-right:-1.25em"
-        >
-          100kb
-        </span>
+          aria-hidden="true"
+          class="euiRangeTick__pseudo"
+          style="margin-right:calc(1.25em - 2px)"
+        />
+        100kb
       </button>
     </div>
     <input
@@ -398,11 +394,7 @@ exports[`EuiRange props ticks should render 1`] = `
         type="button"
         value="0"
       >
-        <span
-          class="euiRangeTick__label"
-        >
-          0
-        </span>
+        0
       </button>
       <button
         class="euiRangeTick"
@@ -411,11 +403,7 @@ exports[`EuiRange props ticks should render 1`] = `
         type="button"
         value="20"
       >
-        <span
-          class="euiRangeTick__label"
-        >
-          20
-        </span>
+        20
       </button>
       <button
         class="euiRangeTick"
@@ -424,11 +412,7 @@ exports[`EuiRange props ticks should render 1`] = `
         type="button"
         value="40"
       >
-        <span
-          class="euiRangeTick__label"
-        >
-          40
-        </span>
+        40
       </button>
       <button
         class="euiRangeTick"
@@ -437,11 +421,7 @@ exports[`EuiRange props ticks should render 1`] = `
         type="button"
         value="60"
       >
-        <span
-          class="euiRangeTick__label"
-        >
-          60
-        </span>
+        60
       </button>
       <button
         class="euiRangeTick"
@@ -450,11 +430,7 @@ exports[`EuiRange props ticks should render 1`] = `
         type="button"
         value="80"
       >
-        <span
-          class="euiRangeTick__label"
-        >
-          80
-        </span>
+        80
       </button>
       <button
         class="euiRangeTick"
@@ -463,11 +439,7 @@ exports[`EuiRange props ticks should render 1`] = `
         type="button"
         value="100"
       >
-        <span
-          class="euiRangeTick__label"
-        >
-          100
-        </span>
+        100
       </button>
     </div>
     <input

--- a/src/components/form/range/__snapshots__/range_track.test.tsx.snap
+++ b/src/components/form/range/__snapshots__/range_track.test.tsx.snap
@@ -17,11 +17,7 @@ exports[`EuiRangeTrack is rendered 1`] = `
       type="button"
       value="0"
     >
-      <span
-        class="euiRangeTick__label"
-      >
-        0
-      </span>
+      0
     </button>
     <button
       class="euiRangeTick"
@@ -30,11 +26,7 @@ exports[`EuiRangeTrack is rendered 1`] = `
       type="button"
       value="10"
     >
-      <span
-        class="euiRangeTick__label"
-      >
-        10
-      </span>
+      10
     </button>
     <button
       class="euiRangeTick"
@@ -43,11 +35,7 @@ exports[`EuiRangeTrack is rendered 1`] = `
       type="button"
       value="20"
     >
-      <span
-        class="euiRangeTick__label"
-      >
-        20
-      </span>
+      20
     </button>
     <button
       class="euiRangeTick"
@@ -56,11 +44,7 @@ exports[`EuiRangeTrack is rendered 1`] = `
       type="button"
       value="30"
     >
-      <span
-        class="euiRangeTick__label"
-      >
-        30
-      </span>
+      30
     </button>
     <button
       class="euiRangeTick"
@@ -69,11 +53,7 @@ exports[`EuiRangeTrack is rendered 1`] = `
       type="button"
       value="40"
     >
-      <span
-        class="euiRangeTick__label"
-      >
-        40
-      </span>
+      40
     </button>
     <button
       class="euiRangeTick"
@@ -82,11 +62,7 @@ exports[`EuiRangeTrack is rendered 1`] = `
       type="button"
       value="50"
     >
-      <span
-        class="euiRangeTick__label"
-      >
-        50
-      </span>
+      50
     </button>
     <button
       class="euiRangeTick"
@@ -95,11 +71,7 @@ exports[`EuiRangeTrack is rendered 1`] = `
       type="button"
       value="60"
     >
-      <span
-        class="euiRangeTick__label"
-      >
-        60
-      </span>
+      60
     </button>
     <button
       class="euiRangeTick"
@@ -108,11 +80,7 @@ exports[`EuiRangeTrack is rendered 1`] = `
       type="button"
       value="70"
     >
-      <span
-        class="euiRangeTick__label"
-      >
-        70
-      </span>
+      70
     </button>
     <button
       class="euiRangeTick"
@@ -121,11 +89,7 @@ exports[`EuiRangeTrack is rendered 1`] = `
       type="button"
       value="80"
     >
-      <span
-        class="euiRangeTick__label"
-      >
-        80
-      </span>
+      80
     </button>
     <button
       class="euiRangeTick"
@@ -134,11 +98,7 @@ exports[`EuiRangeTrack is rendered 1`] = `
       type="button"
       value="90"
     >
-      <span
-        class="euiRangeTick__label"
-      >
-        90
-      </span>
+      90
     </button>
     <button
       class="euiRangeTick"
@@ -147,11 +107,7 @@ exports[`EuiRangeTrack is rendered 1`] = `
       type="button"
       value="100"
     >
-      <span
-        class="euiRangeTick__label"
-      >
-        100
-      </span>
+      100
     </button>
   </div>
 </div>

--- a/src/components/form/range/_range_ticks.scss
+++ b/src/components/form/range/_range_ticks.scss
@@ -1,3 +1,12 @@
+@mixin tickStyles {
+  @include size($euiSizeXS);
+
+  background-color: $euiColorDarkShade;
+  border-radius: 100%;
+  position: absolute;
+  top: 0;
+}
+
 .euiRangeTicks {
   position: absolute;
   left: ($euiRangeThumbWidth / 8);
@@ -13,15 +22,15 @@
   position: relative;
   padding-top: $euiSize;
 
-  &::before {
-    @include size($euiSizeXS);
+  &:not(.euiRangeTick--hasTickMark)::before {
+    @include tickStyles;
 
     content: '';
-    background-color: $euiColorDarkShade;
-    border-radius: 100%;
-    position: absolute;
-    top: 0;
     left: calc(50% - #{($euiSizeXS/2)});
+  }
+
+  .euiRangeTick__pseudo {
+    @include tickStyles;
   }
 
   &--isCustom {
@@ -31,22 +40,18 @@
 
   &--isMin,
   &--isMax {
+    transform: translateX(0);
     overflow-x: visible;
-
-    .euiRangeTick__label {
-      position: absolute;
-      white-space: nowrap;
-    }
   }
 
   &--isMin {
-    .euiRangeTick__label {
+    .euiRangeTick__pseudo {
       left: 0;
     }
   }
 
   &--isMax {
-    .euiRangeTick__label {
+    .euiRangeTick__pseudo {
       right: 0;
     }
   }
@@ -72,4 +77,8 @@
   .euiRangeTick {
     padding-top: $euiSize - 2px;
   }
+}
+
+.euiRangeTick__label {
+  pointer-events: none;
 }

--- a/src/components/form/range/range_ticks.tsx
+++ b/src/components/form/range/range_ticks.tsx
@@ -22,6 +22,7 @@ import React, {
   MouseEventHandler,
   FunctionComponent,
   ReactNode,
+  CSSProperties,
 } from 'react';
 import classNames from 'classnames';
 
@@ -62,7 +63,7 @@ const EuiTickValue: FunctionComponent<
   percentageWidth,
   tickValue,
 }) => {
-  const tickStyle: { left?: string; width?: string } = {};
+  const tickStyle: CSSProperties = {};
   let customTick;
   let isMinTick;
   let isMaxTick;
@@ -72,7 +73,11 @@ const EuiTickValue: FunctionComponent<
     isMaxTick = customTick?.value === max;
 
     if (customTick) {
-      tickStyle.left = `${((customTick.value - min) / (max - min)) * 100}%`;
+      if (isMaxTick) {
+        tickStyle.right = '0%';
+      } else {
+        tickStyle.left = `${((customTick.value - min) / (max - min)) * 100}%`;
+      }
     }
   } else {
     tickStyle.width = `${percentageWidth}%`;
@@ -87,18 +92,21 @@ const EuiTickValue: FunctionComponent<
       ? Math.min(label.length * 0.25, 1.25)
       : 0;
 
-  let labelShift;
+  const pseudoShift: CSSProperties = {};
   if (labelShiftVal) {
-    labelShift = isMaxTick
-      ? { marginRight: `-${labelShiftVal}em` }
-      : { marginLeft: `-${labelShiftVal}em` };
+    const labelShift = isMaxTick ? 'marginRight' : 'marginLeft';
+    tickStyle[labelShift] = `-${labelShiftVal}em`;
+    pseudoShift[labelShift] = `calc(${labelShiftVal}em - 2px)`; // 2px derived from .euiRangeTicks left/right offset
   }
+
+  const pseudoTick = customTick && !!labelShiftVal && (isMinTick || isMaxTick);
 
   const tickClasses = classNames('euiRangeTick', {
     'euiRangeTick--selected': value === tickValue,
     'euiRangeTick--isCustom': customTick,
     'euiRangeTick--isMin': labelShiftVal && isMinTick,
     'euiRangeTick--isMax': labelShiftVal && isMaxTick,
+    'euiRangeTick--hasTickMark': pseudoTick,
   });
 
   const [ref, innerText] = useInnerText();
@@ -114,9 +122,14 @@ const EuiTickValue: FunctionComponent<
       tabIndex={-1}
       ref={ref}
       title={typeof label === 'string' ? label : innerText}>
-      <span className="euiRangeTick__label" style={labelShift}>
-        {label}
-      </span>
+      {pseudoTick && (
+        <span
+          className="euiRangeTick__pseudo"
+          aria-hidden
+          style={pseudoShift}
+        />
+      )}
+      {label}
     </button>
   );
 };


### PR DESCRIPTION
### Summary

#4781 introduced some style changes would sometimes result in labels that did not provide the correct click information.
This refactors the way the labels are shifted to ensure solid click target information. In rare cases we need to use an actual DOM element rather than a CSS pseudo for the ticks to that they can be styled via JS.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~

- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~

- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
