### PR TITLE
[Deps] Add `mdast-util-to-hast`

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "chroma-js": "^2.1.0",
     "classnames": "^2.2.6",
     "lodash": "^4.17.21",
+    "mdast-util-to-hast": "^10.0.0",
     "numeral": "^2.0.6",
     "prop-types": "^15.6.0",
     "react-ace": "^7.0.5",


### PR DESCRIPTION
### Summary

`mdast-util-to-hast` is imported directly in EUI but it is not included in `dependencies`. This was never _functionally_ a problem because it is brought in with `remark-rehype`.

https://github.com/elastic/eui/blob/7aeb30f542186c01b94baa3ab7237ab38b4df15f/src/components/markdown_editor/plugins/markdown_default_plugins.tsx#L38

Including in `dependecies` to unblock @mistic and Bazel

~### Checklis~
