### PR TITLE
Removing text transform from EuiTour.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Removed `text-transform: capitalize` from the `EuiTourSteps` title to better fit with Elastic title guidelines ([#4839](https://github.com/elastic/eui/pull/4839))
 - Added `color` and `size` props and added support for click event to `EuiBetaBadge` ([#4798](https://github.com/elastic/eui/pull/4798))
 
 **Bug fixes**
@@ -17,7 +18,7 @@
 
 **Bug fixes**
 
-- Fixed `EuiText` color of `EuiCallout` to `default` ([#4816](https://github.com/elastic/eui/pull/4816)) 
+- Fixed `EuiText` color of `EuiCallout` to `default` ([#4816](https://github.com/elastic/eui/pull/4816))
 - Fixed inconsistent width of `EuiRange` and `EuiDualRange` with custom tick values ([#4781](https://github.com/elastic/eui/pull/4781))
 - Fixes browser freezing when `EuiDataGrid` is used together with `EuiFlyout` and the user clicks a cell ([4813](https://github.com/elastic/eui/pull/4813))
 - Added `flex-shrink: 0` to `EuiTabs`, `EuiSpacer`, and `EuiImage` to fix possible shrunken heights ([#4793](https://github.com/elastic/eui/pull/4793))

--- a/src/components/tour/_tour.scss
+++ b/src/components/tour/_tour.scss
@@ -10,7 +10,6 @@
 
   .euiTourHeader__title { // nested for additional specificity to override EuiTitle styles
     margin-top: 0;
-    text-transform: capitalize;
   }
 }
 


### PR DESCRIPTION
### Summary

Removing the `text-transform: capitalize` from the `EuiTourStep` header title as per [Elastic writing guidelines](https://eui.elastic.co/#/guidelines/writing). 

### Checklist

- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

### Screenshots

#### Before
<img width="397" alt="Screenshot 2021-05-28 at 13 19 04" src="https://user-images.githubusercontent.com/305167/120020165-5d4a4180-bfb7-11eb-87d6-cb41e1cb73eb.png">

#### After
<img width="376" alt="Screenshot 2021-05-28 at 13 19 26" src="https://user-images.githubusercontent.com/305167/120020178-60453200-bfb7-11eb-8beb-8aff599d19a9.png">
