### PR TITLE
[EuiTourStep] title and subtitle should accept ReactNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Removed `text-transform: capitalize` from the `EuiTourSteps` title to better fit with Elastic title guidelines ([#4839](https://github.com/elastic/eui/pull/4839))
 - Added `color` and `size` props and added support for click event to `EuiBetaBadge` ([#4798](https://github.com/elastic/eui/pull/4798))
 - Added `documentation` and `layers` glyphs to `EuiIcon` ([#4833](https://github.com/elastic/eui/pull/4833))
+- Updated `EuiTourStep`'s `title` and `subtitle` prop type from `string` to `ReactNode` ([#4841](https://github.com/elastic/eui/pull/4841))
 
 **Bug fixes**
 

--- a/src/components/tour/tour_step.tsx
+++ b/src/components/tour/tour_step.tsx
@@ -97,12 +97,12 @@ export interface EuiTourStepProps
   /**
    * Smaller title text that appears atop each step in the tour
    */
-  subtitle: string;
+  subtitle: ReactNode;
 
   /**
    * Larger title text specific to this step
    */
-  title: string;
+  title: ReactNode;
 
   /**
    * Extra visual indication of step location

--- a/src/components/tour/tour_step.tsx
+++ b/src/components/tour/tour_step.tsx
@@ -95,12 +95,12 @@ export interface EuiTourStepProps
   style?: CSSProperties;
 
   /**
-   * Smaller title text that appears atop each step in the tour
+   * Smaller title text that appears atop each step in the tour. The subtitle gets wrapped in the appropriate heading level.
    */
   subtitle: ReactNode;
 
   /**
-   * Larger title text specific to this step
+   * Larger title text specific to this step. The title gets wrapped in the appropriate heading level.
    */
   title: ReactNode;
 


### PR DESCRIPTION
Fixes #4840.

Updated `EuiTourStep`'s `title` and `subtitle` prop type from `string` to `ReactNode`

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes (#4814 has ideas to address a11y, should be a follow-up)~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately