### PR TITLE
[EuiFlyout] Add `testenv` mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Added `testenv` mock for `EuiFlyout` ([#4858](https://github.com/elastic/eui/pull/4858))
+
 **Bug fixes**
 
 - Fixed mobile menus styles on `EuiDataGrid` ([#4844](https://github.com/elastic/eui/pull/4844))

--- a/src/components/flyout/flyout.testenv.tsx
+++ b/src/components/flyout/flyout.testenv.tsx
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+export const EuiFlyout = ({
+  as = 'div',
+  children,
+  closeButtonProps,
+  onClose,
+  'data-test-subj': dataTestSubj,
+}: any) => {
+  const Element = as;
+  return (
+    <Element data-eui="EuiFlyout" data-test-subj={dataTestSubj}>
+      <button
+        type="button"
+        data-test-subj="euiFlyoutCloseButton"
+        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+          onClose();
+          closeButtonProps?.onClick && closeButtonProps.onClick(e);
+        }}
+      />
+      {children}
+    </Element>
+  );
+};


### PR DESCRIPTION
### Summary

EuiFlyout is [now wrapped in a React portal by default](https://github.com/elastic/eui/pull/4713), which makes selector querying in Jest environments difficult or impossible.

This adds a `testenv` mock to hide the internal complexities of EuiFlyout in Jest environments.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~

- [x] Checked for **breaking changes** and labeled appropriately

~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
