### PR TITLE
[EuiPageHeader] Added truncation in title 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## [`34.2.0`](https://github.com/elastic/eui/tree/v34.2.0)
 
+- Added truncation in `EuiPageTitle` ([#4854](https://github.com/elastic/eui/pull/4854))
 - Removed `text-transform: capitalize` from the `EuiTourSteps` title to better fit with Elastic title guidelines ([#4839](https://github.com/elastic/eui/pull/4839))
 - Added `color` and `size` props and added support for click event to `EuiBetaBadge` ([#4798](https://github.com/elastic/eui/pull/4798))
 - Added `documentation` and `layers` glyphs to `EuiIcon` ([#4833](https://github.com/elastic/eui/pull/4833))

--- a/src/components/title/_title.scss
+++ b/src/components/title/_title.scss
@@ -1,7 +1,7 @@
-.euiTitle { 
+.euiTitle {
   + .euiTitle {
     margin-top: $euiSizeL;
-   }
+  }
 }
 
 .euiTitle--uppercase {

--- a/src/components/title/_title.scss
+++ b/src/components/title/_title.scss
@@ -1,7 +1,7 @@
-.euiTitle {
+.euiTitle { 
   + .euiTitle {
     margin-top: $euiSizeL;
-  }
+   }
 }
 
 .euiTitle--uppercase {
@@ -29,5 +29,9 @@
 }
 
 .euiTitle--large {
+  width: 300px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   @include euiTitle('l');
 }


### PR DESCRIPTION
### Summary
Added truncation in EuiPageHeader. Fixed #4856 

Before: 

![WhatsApp Image 2021-06-07 at 11 09 37 PM (1)](https://user-images.githubusercontent.com/74231481/121066144-31b12d80-c7e7-11eb-8d6e-e4412c2c06a8.jpeg)

After : 

![WhatsApp Image 2021-06-07 at 11 09 37 PM](https://user-images.githubusercontent.com/74231481/121066026-13e3c880-c7e7-11eb-93f1-f2df2407ebfc.jpeg)

### Checklist
- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] ~Props have proper **autodocs** and **[playground toggles]~(https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [ ] ~Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
