### PR TITLE
fix combo box auto scrolling on componentDidUpdate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Added draggable highlight area to `EuiDualRange` ([#4776](https://github.com/elastic/eui/pull/4776))
 
+**Bug fixes**
+
+- Fixed auto scrolling on update in `EuiComboBox` ([#4879](https://github.com/elastic/eui/pull/4879))
+
 ## [`34.3.0`](https://github.com/elastic/eui/tree/v34.3.0)
 
 - Added `testenv` mock for `EuiFlyout` ([#4858](https://github.com/elastic/eui/pull/4858))

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
@@ -162,10 +162,6 @@ export class EuiComboBoxOptionsList<T> extends Component<
     ) {
       this.updatePosition();
     }
-
-    if (this.listRef && typeof this.props.activeOptionIndex !== 'undefined') {
-      this.listRef.scrollToItem(this.props.activeOptionIndex, 'auto');
-    }
   }
 
   componentWillUnmount() {
@@ -195,6 +191,10 @@ export class EuiComboBoxOptionsList<T> extends Component<
 
   setListRef = (ref: FixedSizeList | null) => {
     this.listRef = ref;
+
+    if (this.listRef && typeof this.props.activeOptionIndex !== 'undefined') {
+      this.listRef.scrollToItem(this.props.activeOptionIndex, 'auto');
+    }
   };
 
   setListBoxRef = (ref: HTMLUListElement | null) => {

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
@@ -162,6 +162,10 @@ export class EuiComboBoxOptionsList<T> extends Component<
     ) {
       this.updatePosition();
     }
+
+    if (this.listRef && typeof this.props.activeOptionIndex !== 'undefined' && this.props.activeOptionIndex !== prevProps.activeOptionIndex) {
+      this.listRef.scrollToItem(this.props.activeOptionIndex, 'auto');
+    }
   }
 
   componentWillUnmount() {
@@ -191,10 +195,6 @@ export class EuiComboBoxOptionsList<T> extends Component<
 
   setListRef = (ref: FixedSizeList | null) => {
     this.listRef = ref;
-
-    if (this.listRef && typeof this.props.activeOptionIndex !== 'undefined') {
-      this.listRef.scrollToItem(this.props.activeOptionIndex, 'auto');
-    }
   };
 
   setListBoxRef = (ref: HTMLUListElement | null) => {

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
@@ -163,7 +163,11 @@ export class EuiComboBoxOptionsList<T> extends Component<
       this.updatePosition();
     }
 
-    if (this.listRef && typeof this.props.activeOptionIndex !== 'undefined' && this.props.activeOptionIndex !== prevProps.activeOptionIndex) {
+    if (
+      this.listRef &&
+      typeof this.props.activeOptionIndex !== 'undefined' &&
+      this.props.activeOptionIndex !== prevProps.activeOptionIndex
+    ) {
       this.listRef.scrollToItem(this.props.activeOptionIndex, 'auto');
     }
   }


### PR DESCRIPTION
EuiComboBox auto scrolls to the selected item in componentDidUpdate. This makes the combo box unusable, as it auto-scrolls away from where users are looking any time there is an update. This issue is occurring in maps https://github.com/elastic/kibana/issues/78420.

This PR resolves the problem by moving the call to this.listRef.scrollToItem from componentDidUpdate to within setListRef.