### PR TITLE
Fix links to playgrounds and guidelines

### DIFF
--- a/src-docs/src/index.js
+++ b/src-docs/src/index.js
@@ -55,7 +55,6 @@ ReactDOM.render(
               const mainComponent = (
                 <Route
                   key={path}
-                  exact
                   path={`/${path}`}
                   render={(props) => {
                     const { location } = props;
@@ -96,15 +95,17 @@ ReactDOM.render(
                 })
                 .filter((x) => !!x);
 
+              // place standaloneSections before mainComponent so their routes take precedent
+              const routes = [...standaloneSections, mainComponent];
+
               if (from)
                 return [
-                  mainComponent,
-                  ...standaloneSections,
+                  ...routes,
                   <Route exact path={`/${from}`}>
                     <Redirect to={`/${to}`} />
                   </Route>,
                 ];
-              else if (component) return [mainComponent, ...standaloneSections];
+              else if (component) return routes;
               return null;
             }
           )}

--- a/src-docs/src/routes.js
+++ b/src-docs/src/routes.js
@@ -240,13 +240,6 @@ const createExample = (example, customTitle) => {
     );
   }
 
-  const isPlaygroundUnsupported =
-    // Check for IE11
-    typeof window !== 'undefined' &&
-    typeof document !== 'undefined' &&
-    !!window.MSInputMethodContext &&
-    !!document.documentMode;
-
   const {
     title,
     intro,
@@ -269,9 +262,7 @@ const createExample = (example, customTitle) => {
   );
 
   let playgroundComponent;
-  if (isPlaygroundUnsupported) {
-    playgroundComponent = null;
-  } else if (playground) {
+  if (playground) {
     if (Array.isArray(playground)) {
       playgroundComponent = playground.map((elm, idx) => {
         return <Fragment key={idx}>{playgroundCreator(elm())}</Fragment>;


### PR DESCRIPTION
### Summary

Fixes #4870, the broken **playground** and **guidelines** links&tabs.

**Bug source:** the changes to enable stand-alone routes for **EuiPage** included marking component routes as `exact`, but these component routes are the only way playground/guideline routes are provided, and when navigating off those exact-matches the target routes were unmounted.

**Fix:** avoided specifying `exact` by re-ordered the main component & its full-screen section routes so sections can be matched first, allowing the component route to exist with its playground/guidelines.

**Tested:**
In Chrome, FF, Safari, Edge, and Mobile Chrome:
* full-screen, linked examples for **EuiPage**
* **EuiButton**'s guidelines
* _Key pad menu_'s playground

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
