### PR TITLE
[Docs] Fix full height page demo for new `fullScreen` capability

### DIFF
--- a/src-docs/src/views/page/page_example.js
+++ b/src-docs/src/views/page/page_example.js
@@ -551,19 +551,23 @@ export const PageExample = {
         </>
       ),
       demo: (
-        <PageDemo>
-          {(Button, Content, SideNav, showTemplate) =>
-            showTemplate ? (
-              <PageFullHeightTemplate
-                button={<Button />}
-                content={<Content />}
-              />
-            ) : (
-              <PageFullHeight button={<Button />} content={<Content />} />
-            )
-          }
-        </PageDemo>
+        <PageDemo
+          slug="full-height"
+          pattern={PageFullHeight}
+          template={PageFullHeightTemplate}
+        />
       ),
+      fullScreen: {
+        slug: 'full-height',
+        demo: (
+          <PageDemo
+            slug="full-height"
+            pattern={PageFullHeight}
+            template={PageFullHeightTemplate}
+            fullscreen
+          />
+        ),
+      },
     },
     {
       title: 'Simple layout with centered body',


### PR DESCRIPTION
There was a bad merge somewhere that didn't update the full height page demo to the new full screen ability so it was erroring out like this:

<img width="1265" alt="Screen Shot 2021-06-15 at 18 31 23 PM" src="https://user-images.githubusercontent.com/549577/122131962-0098b480-ce08-11eb-9d0d-e9f8b04cf5a8.png">


### ~Checklist~ Docs only