### PR TITLE
[EuiPageBody] Revert `z-index: 1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `34.4.0`.
-
+- Reverted `z-index: 1` on `EuiPageBody` ([#4892](https://github.com/elastic/eui/pull/4892))
 ## [`34.4.0`](https://github.com/elastic/eui/tree/v34.4.0)
 
 - Added draggable highlight area to `EuiDualRange` ([#4776](https://github.com/elastic/eui/pull/4776))

--- a/src/components/page/page_body/_page_body.scss
+++ b/src/components/page/page_body/_page_body.scss
@@ -7,7 +7,9 @@
   // Make sure that inner flex layouts don't get larger than this container
   max-width: 100%;
   min-width: 0;
-  z-index: 1; // Ensures any side nav emphasis gets rendered under shadow
+  // Commenting out for posterity
+  // Adding z-index disallows fullscreens like EuiDataGrid to get above the headers
+  // z-index: 1; // Ensures any side nav emphasis gets rendered under shadow
 
   // Assumes that in the default theme, the borders are touching the edge of the EuiPage so remove them.
   &.euiPageBody--borderRadiusNone { // Nested for specificity


### PR DESCRIPTION
This had broke full screen data grids by scoping the grid to that component, so no matter how high the z-index was on full screen data grids, that since it wasn't in a portal, it would always be constrained to the position of the page body.

**Before**
<img width="1280" alt="Screen Shot 2021-06-16 at 15 55 18 PM" src="https://user-images.githubusercontent.com/549577/122284402-888bc680-cebb-11eb-9e0d-f770901df8a5.png">


**After**
<img width="1278" alt="Screen Shot 2021-06-16 at 15 57 33 PM" src="https://user-images.githubusercontent.com/549577/122284449-97727900-cebb-11eb-9ecf-c331fb4d9826.png">


### ~Checklist~ Just a revert
