### PR TITLE
[EuiSuperDatePicker] Added prop to control the update button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `34.4.0`.
+- Added `updateButtonProps` to `EuiSuperDatePicker` to provide more control over the update/refresh button ([#4776](https://github.com/elastic/eui/pull/4776))
 
 ## [`34.4.0`](https://github.com/elastic/eui/tree/v34.4.0)
 

--- a/src/components/date_picker/super_date_picker/super_date_picker.test.tsx
+++ b/src/components/date_picker/super_date_picker/super_date_picker.test.tsx
@@ -20,7 +20,11 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 
-import { EuiSuperDatePicker } from './super_date_picker';
+import {
+  EuiSuperDatePicker,
+  EuiSuperDatePickerProps,
+} from './super_date_picker';
+import { EuiButton } from '../../button';
 
 const noop = () => {};
 
@@ -125,5 +129,20 @@ describe('EuiSuperDatePicker', () => {
     expect(onRefresh).toBeCalledTimes(1);
 
     jest.useRealTimers();
+  });
+
+  test('updateButtonProps', () => {
+    const updateButtonProps: EuiSuperDatePickerProps['updateButtonProps'] = {
+      fill: false,
+      color: 'ghost',
+    };
+
+    const component = mount(
+      <EuiSuperDatePicker
+        onTimeChange={noop}
+        updateButtonProps={updateButtonProps}
+      />
+    );
+    expect(component.find(EuiButton).props()).toMatchObject(updateButtonProps);
   });
 });

--- a/src/components/date_picker/super_date_picker/super_date_picker.tsx
+++ b/src/components/date_picker/super_date_picker/super_date_picker.tsx
@@ -28,7 +28,10 @@ import { prettyInterval } from './pretty_interval';
 
 import dateMath from '@elastic/datemath';
 
-import { EuiSuperUpdateButton } from './super_update_button';
+import {
+  EuiSuperUpdateButton,
+  EuiSuperUpdateButtonProps,
+} from './super_update_button';
 import { EuiQuickSelectPopover } from './quick_select_popover/quick_select_popover';
 import { EuiDatePopoverButton } from './date_popover/date_popover_button';
 
@@ -120,6 +123,16 @@ export type EuiSuperDatePickerProps = CommonProps & {
    */
   timeFormat: string;
   utcOffset?: number;
+
+  /**
+   * Props passed to the update button
+   */
+  updateButtonProps?: Partial<
+    Omit<
+      EuiSuperUpdateButtonProps,
+      'needsUpdate' | 'showTooltip' | 'isLoading' | 'isDisabled' | 'onClick'
+    >
+  >;
 };
 
 interface EuiSuperDatePickerState {
@@ -487,6 +500,7 @@ export class EuiSuperDatePicker extends Component<
           isDisabled={this.props.isDisabled || this.state.isInvalid}
           onClick={this.handleClickUpdateButton}
           data-test-subj="superDatePickerApplyTimeButton"
+          {...this.props.updateButtonProps}
         />
       </EuiFlexItem>
     );
@@ -550,3 +564,17 @@ export class EuiSuperDatePicker extends Component<
     );
   }
 }
+
+export const A = () => (
+  <EuiSuperDatePicker
+    updateButtonProps={{ fill: false }}
+    isLoading={true}
+    start=""
+    end=""
+    onTimeChange={() => {}}
+    onRefresh={() => {}}
+    isPaused={false}
+    refreshInterval={5000}
+    onRefreshChange={() => {}}
+  />
+);

--- a/src/components/date_picker/super_date_picker/super_update_button.test.tsx
+++ b/src/components/date_picker/super_date_picker/super_update_button.test.tsx
@@ -18,9 +18,10 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import { EuiSuperUpdateButton } from './super_update_button';
+import { EuiButton, EuiButtonProps } from '../../button';
 
 const noop = () => {};
 
@@ -61,5 +62,48 @@ describe('EuiSuperUpdateButton', () => {
     );
 
     expect(component).toMatchSnapshot();
+  });
+
+  test('forwards props to EuiButton', () => {
+    const speciallyHandledProps = {
+      className: 'testClass',
+      textProps: {
+        className: 'textPropsTestClass',
+        id: 'test',
+      },
+    };
+    const extraProps: Partial<EuiButtonProps> = {
+      fill: false,
+      size: 's',
+      contentProps: { id: 'contentSpan' },
+    };
+
+    const component = mount(
+      <EuiSuperUpdateButton
+        onClick={() => {}}
+        {...speciallyHandledProps}
+        {...extraProps}
+      />
+    );
+
+    const {
+      // props not passed through
+      isDisabled,
+      isLoading,
+      onClick,
+
+      // props with special handling
+      className,
+      textProps,
+
+      ...forwardedProps
+    } = component.find(EuiButton).props();
+
+    expect(className).toBe('euiSuperUpdateButton testClass');
+    expect(textProps).toEqual({
+      className: 'euiSuperUpdateButton__text textPropsTestClass',
+      id: 'test',
+    });
+    expect(forwardedProps).toMatchObject(extraProps);
   });
 });

--- a/src/components/date_picker/super_date_picker/super_update_button.tsx
+++ b/src/components/date_picker/super_date_picker/super_update_button.tsx
@@ -20,27 +20,29 @@
 import React, { Component, MouseEventHandler, Ref } from 'react';
 import classNames from 'classnames';
 
-import { EuiButton } from '../../button';
+import { EuiButton, EuiButtonProps } from '../../button';
 import { EuiI18n } from '../../i18n';
 import { EuiToolTip, EuiToolTipProps } from '../../tool_tip';
+import { CommonProps } from '../../common';
 
-export interface EuiSuperUpdateButtonProps {
-  className?: string;
-  isDisabled: boolean;
-  isLoading: boolean;
-  needsUpdate: boolean;
-  onClick: MouseEventHandler<HTMLButtonElement>;
+export type EuiSuperUpdateButtonProps = CommonProps &
+  Partial<Omit<EuiButtonProps, 'isDisabled' | 'isLoading' | 'onClick'>> & {
+    className?: string;
+    isDisabled: boolean;
+    isLoading: boolean;
+    needsUpdate: boolean;
+    onClick: MouseEventHandler<HTMLButtonElement>;
 
-  /**
-   * Passes props to `EuiToolTip`
-   */
-  toolTipProps?: EuiToolTipProps;
+    /**
+     * Passes props to `EuiToolTip`
+     */
+    toolTipProps?: EuiToolTipProps;
 
-  /**
-   * Show the "Click to apply" tooltip
-   */
-  showTooltip: boolean;
-}
+    /**
+     * Show the "Click to apply" tooltip
+     */
+    showTooltip: boolean;
+  };
 
 export class EuiSuperUpdateButton extends Component<EuiSuperUpdateButtonProps> {
   static defaultProps = {
@@ -103,6 +105,8 @@ export class EuiSuperUpdateButton extends Component<EuiSuperUpdateButtonProps> {
       onClick,
       toolTipProps,
       showTooltip,
+
+      textProps: restTextProps,
       ...rest
     } = this.props;
 
@@ -156,7 +160,13 @@ export class EuiSuperUpdateButton extends Component<EuiSuperUpdateButtonProps> {
           color={needsUpdate || isLoading ? 'secondary' : 'primary'}
           fill
           iconType={needsUpdate || isLoading ? 'kqlFunction' : 'refresh'}
-          textProps={{ className: 'euiSuperUpdateButton__text' }}
+          textProps={{
+            ...restTextProps,
+            className: classNames(
+              'euiSuperUpdateButton__text',
+              restTextProps?.className
+            ),
+          }}
           isDisabled={isDisabled}
           onClick={onClick}
           isLoading={isLoading}


### PR DESCRIPTION
### Summary

* Closes #4871 by adding an optional `updateButtonProps` to **EuiSuperDatePicker**
* Extended `EuiSuperUpdateButtonProps` with `CommonProps` and a partialized subset of `EuiButtonProps`
* Added two tests around this setup

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
