### PR TITLE
[Deps] Add `unist-util-visit`

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "tabbable": "^3.0.0",
     "text-diff": "^1.0.1",
     "unified": "^9.2.0",
+    "unist-util-visit": "^2.0.3",
     "url-parse": "^1.5.0",
     "uuid": "^8.3.0",
     "vfile": "^4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16221,7 +16221,7 @@ unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
   dependencies:
     unist-util-visit-parents "^2.0.0"
 
-unist-util-visit@^2.0.0, unist-util-visit@^2.0.2:
+unist-util-visit@^2.0.0, unist-util-visit@^2.0.2, unist-util-visit@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-2.0.3.tgz#c3703893146df47203bb8a9795af47d7b971208c"
   integrity sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==


### PR DESCRIPTION
### Summary

Closes #4894, which highlighted that EUI has an undeclared dependency: `unist-util-visit`. It is available via some remark plugins, but it is imported directly.

~### Checklist~
