### PR TITLE
[EuiColorStops] Fixed outline flashing when clicking or adding a stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed `EuiRange` container expansion due to negative margin value ([#4815](https://github.com/elastic/eui/pull/4815))
 - Fixed `EuiRange` ticks position to better align with thumbs ([#4815](https://github.com/elastic/eui/pull/4815))
 - Fixed DataGrid footer and header rows jumps in Firefox ([#4869](https://github.com/elastic/eui/issues/4869))
+- Fixed bug in `EuiColorStops` where the outline was flashing when clicking or adding stops ([#0000](https://github.com/elastic/eui/issues/0000))
 
 **Theme: Amsterdam**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Fixed `EuiRange` container expansion due to negative margin value ([#4815](https://github.com/elastic/eui/pull/4815))
 - Fixed `EuiRange` ticks position to better align with thumbs ([#4815](https://github.com/elastic/eui/pull/4815))
 - Fixed DataGrid footer and header rows jumps in Firefox ([#4869](https://github.com/elastic/eui/issues/4869))
-- Fixed bug in `EuiColorStops` where the outline was flashing when clicking or adding stops ([#0000](https://github.com/elastic/eui/issues/0000))
+- Fixed bug in `EuiColorStops` where the outline was flashing when clicking or adding stops in Safari ([#4900](https://github.com/elastic/eui/issues/4900))
 
 **Theme: Amsterdam**
 

--- a/src/themes/eui-amsterdam/global_styling/mixins/_range.scss
+++ b/src/themes/eui-amsterdam/global_styling/mixins/_range.scss
@@ -3,7 +3,6 @@
 
 @mixin euiRangeTrackSize($compressed: false) {
   height: $euiRangeTrackHeight;
-  transition: all $euiAnimSpeedNormal ease-in;
   width: $euiRangeTrackWidth;
 
   @if ($compressed) {

--- a/src/themes/eui-amsterdam/overrides/_color_stops.scss
+++ b/src/themes/eui-amsterdam/overrides/_color_stops.scss
@@ -26,43 +26,26 @@
 }
 
 .euiColorStops:not(.euiColorStops-isDisabled) {
-  // pseudo-element that creates a shadow (focus ring) 
-  // initially we set the opacity to 0 
-  // on focus the .euiColorStops we transition the opacity to 1
-  // this is a higher-performance method. Better than transitioning the box-shadow.
-  // https://alligator.io/css/transition-box-shadows/
-  .euiRangeTrack::before {
-    @include euiRangeTrackSize;
-    content: '';
-    display: block;
-    position: absolute;
-    top: calc(50% - #{($euiRangeTrackHeight/2)});
-    left: 0;
-    background: transparent;
-    border-radius: $euiRangeTrackRadius;
-    box-shadow: 0 0 0 1px $euiColorEmptyShade,
-    0 0 0 3px $euiFocusRingColor;
-    opacity: 0;
-    transition-property: opacity;
+  .euiRangeTrack::after {
+    transition-property: box-shadow;
+    // this `transition-delay` prevents Safari of adding the focus ring (box-shadow) every time we click the `EuiColorStops`
+    // the focus still appear when we drag a color stop in Safari
     transition-delay: $euiAnimSpeedExtraFast;
-  }
-
-  .euiRangeTrack--compressed::before {
-    @include euiRangeTrackSize($compressed: true);
-    top: calc(50% - #{($euiRangeTrackCompressedHeight/2)});
   }
 
   &:focus {
     outline: none;
 
-    .euiRangeTrack::before {
-      opacity: 1;
+    .euiRangeTrack::after {
+      // sass-lint:disable-block no-color-literals
+      box-shadow: 0 0 0 1px rgba($euiColorEmptyShade, .8),
+      0 0 0 3px $euiFocusRingColor;
     }
   }
 
   &:focus:not(:focus-visible) {
-    .euiRangeTrack::before {
-      opacity: 0;
+    .euiRangeTrack::after {
+      box-shadow: none;
     }
   }
 }

--- a/src/themes/eui-amsterdam/overrides/_color_stops.scss
+++ b/src/themes/eui-amsterdam/overrides/_color_stops.scss
@@ -26,21 +26,43 @@
 }
 
 .euiColorStops:not(.euiColorStops-isDisabled) {
+  // pseudo-element that creates a shadow (focus ring) 
+  // initially we set the opacity to 0 
+  // on focus the .euiColorStops we transition the opacity to 1
+  // this is a higher-performance method. Better than transitioning the box-shadow.
+  // https://alligator.io/css/transition-box-shadows/
+  .euiRangeTrack::before {
+    @include euiRangeTrackSize;
+    content: '';
+    display: block;
+    position: absolute;
+    top: calc(50% - #{($euiRangeTrackHeight/2)});
+    left: 0;
+    background: transparent;
+    border-radius: $euiRangeTrackRadius;
+    box-shadow: 0 0 0 1px $euiColorEmptyShade,
+    0 0 0 3px $euiFocusRingColor;
+    opacity: 0;
+    transition-property: opacity;
+    transition-delay: $euiAnimSpeedExtraFast;
+  }
+
+  .euiRangeTrack--compressed::before {
+    @include euiRangeTrackSize($compressed: true);
+    top: calc(50% - #{($euiRangeTrackCompressedHeight/2)});
+  }
+
   &:focus {
     outline: none;
-    transition-property: box-shadow;
 
-    .euiRangeTrack::after {
-      box-shadow: 0 0 0 1px $euiColorEmptyShade,
-      0 0 0 3px $euiFocusRingColor;
-      // prevents a flash of the outline in Safari
-      transition-delay: $euiAnimSpeedExtraFast;
+    .euiRangeTrack::before {
+      opacity: 1;
     }
   }
 
   &:focus:not(:focus-visible) {
-    .euiRangeTrack::after {
-      box-shadow: none;
+    .euiRangeTrack::before {
+      opacity: 0;
     }
   }
 }

--- a/src/themes/eui-amsterdam/overrides/_color_stops.scss
+++ b/src/themes/eui-amsterdam/overrides/_color_stops.scss
@@ -27,12 +27,21 @@
 
 .euiColorStops:not(.euiColorStops-isDisabled) {
   &:focus {
-    // prevents a flash of the outline in Safari
-    transition-delay: $euiAnimSpeedExtraFast;
+    outline: none;
+    transition-property: box-shadow;
+
+    .euiRangeTrack::after {
+      box-shadow: 0 0 0 1px $euiColorEmptyShade,
+      0 0 0 3px $euiFocusRingColor;
+      // prevents a flash of the outline in Safari
+      transition-delay: $euiAnimSpeedExtraFast;
+    }
   }
 
   &:focus:not(:focus-visible) {
-    outline: none;
+    .euiRangeTrack::after {
+      box-shadow: none;
+    }
   }
 }
 


### PR DESCRIPTION
### Summary

This PR **almost** fixes the **EuiColorStops** outline flashing in Safari when clicking or adding a stop.

### Design improvement

The focus state is now more consistent with the stop focus state.

<img width="1013" alt="ColorStops - focus@2x" src="https://user-images.githubusercontent.com/2750668/122589848-ac384380-d058-11eb-94ca-e7368249a805.png">


### Behavior in Safari

It seems that the issue is fixed but if we press the mouse until we're **dragging** the outline appears. This behavior doesn't happen in other browsers.

https://user-images.githubusercontent.com/2750668/123241815-60165480-d4d9-11eb-9b03-204b69abaefa.mov


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
