### PR TITLE
[EuiComboBox] Fixed disabled pills and text contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,14 @@
 - Fixed `EuiRange` container expansion due to negative margin value ([#4815](https://github.com/elastic/eui/pull/4815))
 - Fixed `EuiRange` ticks position to better align with thumbs ([#4815](https://github.com/elastic/eui/pull/4815))
 - Fixed DataGrid footer and header rows jumps in Firefox ([#4869](https://github.com/elastic/eui/issues/4869))
+- Fixed `EuiComboBox` disabled pills and text contrast ([#0000](https://github.com/elastic/eui/issues/0000))
 
 **Theme: Amsterdam**
 
 - Updated styles for `EuiRange` ([#4815](https://github.com/elastic/eui/pull/4815)
 - Fixed more unique focus states using `outline` ([#4876](https://github.com/elastic/eui/pull/4876))
 - Fixed `border-radius` value of `EuiPanel` ([#4876](https://github.com/elastic/eui/pull/4876))
-- Fixed `disabled` background color of `EuiCard` for better visiblity on subdued backgrounds ([#4876](https://github.com/elastic/eui/pull/4876))
+- Fixed `disabled` background color of `EuiCard` for better visibility on subdued backgrounds ([#4876](https://github.com/elastic/eui/pull/4876))
 
 ## [`34.4.0`](https://github.com/elastic/eui/tree/v34.4.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - Fixed `EuiRange` container expansion due to negative margin value ([#4815](https://github.com/elastic/eui/pull/4815))
 - Fixed `EuiRange` ticks position to better align with thumbs ([#4815](https://github.com/elastic/eui/pull/4815))
-- Fixed `EuiComboBox` disabled pills and text contrast ([#0000](https://github.com/elastic/eui/issues/0000))
+- Fixed `EuiComboBox` disabled pills and text contrast ([#4901](https://github.com/elastic/eui/issues/4901))
 - Fixed `EuiDataGrid` footer and header rows jumps in Firefox ([#4869](https://github.com/elastic/eui/issues/4869))
 - Fixed shaded colors of `EuiButtonIcon` ([#4874](https://github.com/elastic/eui/pull/4874))
 - Fixed `pageHeader` display in `EuiPageTemplate` when template is `empty` or `default` ([#4905](https://github.com/elastic/eui/pull/4905))

--- a/src-docs/src/views/combo_box/colors.js
+++ b/src-docs/src/views/combo_box/colors.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 
 import { EuiComboBox } from '../../../../src/components';
 import { euiPaletteColorBlindBehindText } from '../../../../src/services';
+import { DisplayToggles } from '../form_controls/display_toggles';
 
 const visColorsBehindText = euiPaletteColorBlindBehindText();
 const optionsStatic = [
@@ -86,12 +87,16 @@ export default () => {
   };
 
   return (
-    <EuiComboBox
-      placeholder="Select or create options"
-      options={options}
-      selectedOptions={selectedOptions}
-      onChange={onChange}
-      onCreateOption={onCreateOption}
-    />
+    /* DisplayToggles wrapper for Docs only */
+    <DisplayToggles canDisabled={false} canReadOnly={false} canIsDisabled>
+      <EuiComboBox
+        placeholder="Select or create options"
+        options={options}
+        selectedOptions={selectedOptions}
+        onChange={onChange}
+        onCreateOption={onCreateOption}
+        isDisabled
+      />
+    </DisplayToggles>
   );
 };

--- a/src-docs/src/views/combo_box/combo_box.js
+++ b/src-docs/src/views/combo_box/combo_box.js
@@ -72,7 +72,7 @@ export default () => {
 
   return (
     /* DisplayToggles wrapper for Docs only */
-    <DisplayToggles canDisabled={false} canReadOnly={false}>
+    <DisplayToggles canDisabled={false} canReadOnly={false} canIsDisabled>
       <EuiComboBox
         placeholder="Select or create options"
         options={options}

--- a/src-docs/src/views/combo_box/single_selection.js
+++ b/src-docs/src/views/combo_box/single_selection.js
@@ -51,7 +51,8 @@ export default () => {
       canDisabled={false}
       canReadOnly={false}
       canLoading={false}
-      canPrepend
+      canPrepend={false}
+      canIsDisabled
       canAppend>
       <EuiComboBox
         placeholder="Select a single option"
@@ -59,6 +60,7 @@ export default () => {
         options={options}
         selectedOptions={selectedOptions}
         onChange={onChange}
+        isDisabled
       />
     </DisplayToggles>
   );

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -112,14 +112,8 @@
       -webkit-text-fill-color: unset; // overrides $euiFormControlDisabledColor because the color doesn't work with multiple background colors 
     }
 
-    .euiComboBoxPill:not(.euiComboBoxPill--plainText) {
-      opacity: .25;
-    }
-
     .euiComboBoxPill--plainText {
-      // sass-lint:disable-block no-vendor-prefixes
-      color: $euiFormControlDisabledColor;
-      -webkit-text-fill-color: $euiFormControlDisabledColor; // Required for Safari
+      @include euiFormControlDisabledTextStyle;
     }
   }
 

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -115,6 +115,11 @@
     .euiComboBoxPill--plainText {
       @include euiFormControlDisabledTextStyle;
     }
+
+    // overrides the `cursor: text;` that displays on hover for combo boxes that allow multiple pills
+    .euiComboBox__inputWrap:not(.euiComboBox__inputWrap--noWrap):hover {
+      cursor: not-allowed;
+    }
   }
 
   &.euiComboBox--compressed {

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -112,6 +112,7 @@
       -webkit-text-fill-color: unset; // overrides $euiFormControlDisabledColor because the color doesn't work with multiple background colors 
     }
 
+    .euiComboBoxPlaceholder,
     .euiComboBoxPill--plainText {
       @include euiFormControlDisabledTextStyle;
     }

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -107,7 +107,19 @@
 
   &.euiComboBox-isDisabled {
     .euiComboBox__inputWrap {
+      // sass-lint:disable-block no-vendor-prefixes
       @include euiFormControlDisabledStyle;
+      -webkit-text-fill-color: unset; // overrides $euiFormControlDisabledColor because the color doesn't work with multiple background colors 
+    }
+
+    .euiComboBoxPill:not(.euiComboBoxPill--plainText) {
+      opacity: .25;
+    }
+
+    .euiComboBoxPill--plainText {
+      // sass-lint:disable-block no-vendor-prefixes
+      color: $euiFormControlDisabledColor;
+      -webkit-text-fill-color: $euiFormControlDisabledColor; // Required for Safari
     }
   }
 

--- a/src/global_styling/mixins/_form.scss
+++ b/src/global_styling/mixins/_form.scss
@@ -194,11 +194,15 @@
   background-size: 100%;
 }
 
-@mixin euiFormControlDisabledStyle {
+@mixin euiFormControlDisabledTextStyle {
   // sass-lint:disable-block no-vendor-prefixes
-  cursor: not-allowed;
   color: $euiFormControlDisabledColor;
   -webkit-text-fill-color: $euiFormControlDisabledColor; // Required for Safari
+}
+
+@mixin euiFormControlDisabledStyle {
+  @include euiFormControlDisabledTextStyle;
+  cursor: not-allowed;
   background: $euiFormBackgroundDisabledColor;
   box-shadow: inset 0 0 0 1px $euiFormBorderDisabledColor;
 


### PR DESCRIPTION
### Summary

This PR fixes the **EuiComboBox** disabled pills and text color contrast.

This issue was originated by:
https://github.com/elastic/eui/blob/fb286cbe1b67f451cf33a984d2a1ead1832149df/src/global_styling/mixins/_form.scss#L201

The text and pills were inheriting this `-webkit-text-fill-color` in webkit browsers. And in no webkit browsers, there were no disabled styles for the pills and texts. They were getting their default colors.

So I added some styles and also added more `DisplayToggles` with `isDisabled` states in a few **EuiComboBox** examples.

<img width="1223" alt="combobox disabled@2x" src="https://user-images.githubusercontent.com/2750668/122917268-c2464c80-d355-11eb-877c-1142ad2370ec.png">


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
