### PR TITLE
Add interface from react-beautiful-dnd

### DIFF
--- a/src/components/drag_and_drop/index.ts
+++ b/src/components/drag_and_drop/index.ts
@@ -34,6 +34,7 @@ export {
 export {
   DraggableLocation,
   DraggableProps,
+  DraggableProvidedDragHandleProps,
   DragDropContextProps,
   DragStart,
   DroppableProps,


### PR DESCRIPTION
### Summary

This PR adds an interface to the list of exports from 'react-beautiful-dnd' for use by consumers, without the need to export them from 'react-beautiful-dnd’.

See https://github.com/elastic/kibana/issues/102689
### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
