### PR TITLE
[EuiPageHeader] Fix margin/padding when `bottomBorder` exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Fixed `EuiRange` ticks position to better align with thumbs ([#4815](https://github.com/elastic/eui/pull/4815))
 - Fixed DataGrid footer and header rows jumps in Firefox ([#4869](https://github.com/elastic/eui/issues/4869))
 - Fixed shaded colors of `EuiButtonIcon` ([#4874](https://github.com/elastic/eui/pull/4874))
+- Fixed `pageHeader` display in `EuiPageTemplate` when template is `empty` or `default` ([#4905](https://github.com/elastic/eui/pull/4905))
+- Fixed `EuiPageHeader` bottom padding when `borderBottom = true` ([#4905](https://github.com/elastic/eui/pull/4905))
 
 **Theme: Amsterdam**
 

--- a/src-docs/src/views/page/page_custom_content.js
+++ b/src-docs/src/views/page/page_custom_content.js
@@ -18,10 +18,9 @@ export default ({ button = <></> }) => (
         iconType="logoElastic"
         pageTitle="Page title"
         rightSideItems={[button, <EuiButton>Do something</EuiButton>]}
-        paddingSize="none"
         bottomBorder
       />
-      <EuiPageContentBody paddingSize="none">
+      <EuiPageContentBody>
         <EuiFlexGrid columns={2}>
           <EuiFlexItem>
             <EuiPanel style={{ height: 200 }} />

--- a/src-docs/src/views/page/page_custom_content.js
+++ b/src-docs/src/views/page/page_custom_content.js
@@ -12,15 +12,16 @@ import {
 } from '../../../../src/components';
 
 export default ({ button = <></> }) => (
-  <EuiPage paddingSize="none">
+  <EuiPage paddingSize="l">
     <EuiPageBody>
       <EuiPageHeader
         iconType="logoElastic"
         pageTitle="Page title"
         rightSideItems={[button, <EuiButton>Do something</EuiButton>]}
-        paddingSize="l"
+        paddingSize="none"
+        bottomBorder
       />
-      <EuiPageContentBody paddingSize="l" style={{ paddingTop: 0 }}>
+      <EuiPageContentBody paddingSize="none">
         <EuiFlexGrid columns={2}>
           <EuiFlexItem>
             <EuiPanel style={{ height: 200 }} />

--- a/src-docs/src/views/page/page_simple.js
+++ b/src-docs/src/views/page/page_simple.js
@@ -14,6 +14,7 @@ export default ({ button = <></>, content }) => (
       <EuiPageHeader
         restrictWidth
         paddingSize="l"
+        pageTitle="Page title"
         rightSideItems={[button]}
         tabs={[{ label: 'Tab 1', isSelected: true }, { label: 'Tab 2' }]}
       />

--- a/src-docs/src/views/page/page_simple_template.js
+++ b/src-docs/src/views/page/page_simple_template.js
@@ -5,6 +5,7 @@ import { EuiPageTemplate } from '../../../../src/components';
 export default ({ button = <></>, content }) => (
   <EuiPageTemplate
     pageHeader={{
+      pageTitle: 'Page title',
       rightSideItems: [button],
       tabs: [{ label: 'Tab 1', isSelected: true }, { label: 'Tab 2' }],
     }}>

--- a/src/components/page/__snapshots__/page_template.test.tsx.snap
+++ b/src/components/page/__snapshots__/page_template.test.tsx.snap
@@ -105,14 +105,14 @@ exports[`EuiPageTemplate restrict width can be turned off 1`] = `
 
 exports[`EuiPageTemplate template centeredBody is rendered 1`] = `
 <div
-  class="euiPage euiPage--grow euiPageTemplate"
+  class="euiPage euiPage--paddingLarge euiPage--grow euiPageTemplate"
   style="min-height:460px"
 >
   <div
-    class="euiPageBody euiPageBody--borderRadiusNone"
+    class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--restrictWidth-default"
   >
     <div
-      class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--paddingLarge"
+      class="euiPageBody euiPageBody--borderRadiusNone"
     >
       <div
         class="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPageContent euiPageContent--verticalCenter euiPageContent--horizontalCenter"
@@ -129,16 +129,16 @@ exports[`EuiPageTemplate template centeredBody is rendered 1`] = `
 
 exports[`EuiPageTemplate template centeredBody is rendered with pageBodyProps 1`] = `
 <div
-  class="euiPage euiPage--grow euiPageTemplate"
+  class="euiPage euiPage--paddingLarge euiPage--grow euiPageTemplate"
   style="min-height:460px"
 >
   <div
     aria-label="aria-label"
-    class="euiPageBody euiPageBody--borderRadiusNone testClass1 testClass2"
+    class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--restrictWidth-default testClass1 testClass2"
     data-test-subj="test subject string"
   >
     <div
-      class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--paddingLarge"
+      class="euiPageBody euiPageBody--borderRadiusNone"
     >
       <div
         class="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPageContent euiPageContent--verticalCenter euiPageContent--horizontalCenter"
@@ -155,14 +155,14 @@ exports[`EuiPageTemplate template centeredBody is rendered with pageBodyProps 1`
 
 exports[`EuiPageTemplate template centeredBody is rendered with pageContentBodyProps 1`] = `
 <div
-  class="euiPage euiPage--grow euiPageTemplate"
+  class="euiPage euiPage--paddingLarge euiPage--grow euiPageTemplate"
   style="min-height:460px"
 >
   <div
-    class="euiPageBody euiPageBody--borderRadiusNone"
+    class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--restrictWidth-default"
   >
     <div
-      class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--paddingLarge"
+      class="euiPageBody euiPageBody--borderRadiusNone"
     >
       <div
         class="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPageContent euiPageContent--verticalCenter euiPageContent--horizontalCenter"
@@ -181,14 +181,14 @@ exports[`EuiPageTemplate template centeredBody is rendered with pageContentBodyP
 
 exports[`EuiPageTemplate template centeredBody is rendered with pageContentProps 1`] = `
 <div
-  class="euiPage euiPage--grow euiPageTemplate"
+  class="euiPage euiPage--paddingLarge euiPage--grow euiPageTemplate"
   style="min-height:460px"
 >
   <div
-    class="euiPageBody euiPageBody--borderRadiusNone"
+    class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--restrictWidth-default"
   >
     <div
-      class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--paddingLarge"
+      class="euiPageBody euiPageBody--borderRadiusNone"
     >
       <div
         aria-label="aria-label"
@@ -207,20 +207,20 @@ exports[`EuiPageTemplate template centeredBody is rendered with pageContentProps
 
 exports[`EuiPageTemplate template centeredBody is rendered with pageHeader 1`] = `
 <div
-  class="euiPage euiPage--grow euiPageTemplate"
+  class="euiPage euiPage--paddingLarge euiPage--grow euiPageTemplate"
   style="min-height:460px"
 >
   <div
-    class="euiPageBody euiPageBody--borderRadiusNone"
+    class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--restrictWidth-default"
   >
     <header
       aria-label="aria-label"
-      class="euiPageHeader euiPageHeader--paddingLarge euiPageHeader--responsive euiPage--restrictWidth-default euiPageHeader--center testClass1 testClass2"
+      class="euiPageHeader euiPageHeader--bottomBorder euiPageHeader--responsive euiPageHeader--center testClass1 testClass2"
       data-test-subj="test subject string"
       title="Page title"
     />
     <div
-      class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--paddingLarge"
+      class="euiPageBody euiPageBody--borderRadiusNone"
     >
       <div
         class="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPageContent euiPageContent--verticalCenter euiPageContent--horizontalCenter"
@@ -237,14 +237,14 @@ exports[`EuiPageTemplate template centeredBody is rendered with pageHeader 1`] =
 
 exports[`EuiPageTemplate template centeredBody minHeight is rendered 1`] = `
 <div
-  class="euiPage euiPage--grow euiPageTemplate"
+  class="euiPage euiPage--paddingLarge euiPage--grow euiPageTemplate"
   style="min-height:40vh"
 >
   <div
-    class="euiPageBody euiPageBody--borderRadiusNone"
+    class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--restrictWidth-default"
   >
     <div
-      class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--paddingLarge"
+      class="euiPageBody euiPageBody--borderRadiusNone"
     >
       <div
         class="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPageContent euiPageContent--verticalCenter euiPageContent--horizontalCenter"
@@ -265,7 +265,7 @@ exports[`EuiPageTemplate template centeredBody paddingSize is rendered 1`] = `
   style="min-height:460px"
 >
   <div
-    class="euiPageBody euiPageBody--borderRadiusNone"
+    class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--restrictWidth-default"
   >
     <div
       class="euiPageBody euiPageBody--borderRadiusNone"
@@ -285,14 +285,14 @@ exports[`EuiPageTemplate template centeredBody paddingSize is rendered 1`] = `
 
 exports[`EuiPageTemplate template centeredBody style is rendered 1`] = `
 <div
-  class="euiPage euiPage--grow euiPageTemplate"
+  class="euiPage euiPage--paddingLarge euiPage--grow euiPageTemplate"
   style="min-height:460px;max-height:100vh"
 >
   <div
-    class="euiPageBody euiPageBody--borderRadiusNone"
+    class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--restrictWidth-default"
   >
     <div
-      class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--paddingLarge"
+      class="euiPageBody euiPageBody--borderRadiusNone"
     >
       <div
         class="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPageContent euiPageContent--verticalCenter euiPageContent--horizontalCenter"
@@ -857,18 +857,18 @@ exports[`EuiPageTemplate template default with pageSideBar is rendered with page
 
 exports[`EuiPageTemplate template empty is rendered 1`] = `
 <div
-  class="euiPage euiPage--grow euiPageTemplate"
+  class="euiPage euiPage--paddingLarge euiPage--grow euiPageTemplate"
   style="min-height:460px"
 >
   <div
-    class="euiPageBody euiPageBody--borderRadiusNone"
+    class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--restrictWidth-default"
   >
     <div
       class="euiPanel euiPanel--borderRadiusNone euiPanel--transparent euiPanel--noShadow euiPanel--noBorder euiPageContent euiPageContent--borderRadiusNone"
       role="main"
     >
       <div
-        class="euiPageContentBody euiPage--paddingLarge euiPage--restrictWidth-default"
+        class="euiPageContentBody"
       />
     </div>
   </div>
@@ -877,12 +877,12 @@ exports[`EuiPageTemplate template empty is rendered 1`] = `
 
 exports[`EuiPageTemplate template empty is rendered with pageBodyProps 1`] = `
 <div
-  class="euiPage euiPage--grow euiPageTemplate"
+  class="euiPage euiPage--paddingLarge euiPage--grow euiPageTemplate"
   style="min-height:460px"
 >
   <div
     aria-label="aria-label"
-    class="euiPageBody euiPageBody--borderRadiusNone testClass1 testClass2"
+    class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--restrictWidth-default testClass1 testClass2"
     data-test-subj="test subject string"
   >
     <div
@@ -890,7 +890,7 @@ exports[`EuiPageTemplate template empty is rendered with pageBodyProps 1`] = `
       role="main"
     >
       <div
-        class="euiPageContentBody euiPage--paddingLarge euiPage--restrictWidth-default"
+        class="euiPageContentBody"
       />
     </div>
   </div>
@@ -899,11 +899,11 @@ exports[`EuiPageTemplate template empty is rendered with pageBodyProps 1`] = `
 
 exports[`EuiPageTemplate template empty is rendered with pageContentBodyProps 1`] = `
 <div
-  class="euiPage euiPage--grow euiPageTemplate"
+  class="euiPage euiPage--paddingLarge euiPage--grow euiPageTemplate"
   style="min-height:460px"
 >
   <div
-    class="euiPageBody euiPageBody--borderRadiusNone"
+    class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--restrictWidth-default"
   >
     <div
       class="euiPanel euiPanel--borderRadiusNone euiPanel--transparent euiPanel--noShadow euiPanel--noBorder euiPageContent euiPageContent--borderRadiusNone"
@@ -911,7 +911,7 @@ exports[`EuiPageTemplate template empty is rendered with pageContentBodyProps 1`
     >
       <div
         aria-label="aria-label"
-        class="euiPageContentBody euiPage--paddingLarge euiPage--restrictWidth-default testClass1 testClass2"
+        class="euiPageContentBody testClass1 testClass2"
         data-test-subj="test subject string"
       />
     </div>
@@ -921,11 +921,11 @@ exports[`EuiPageTemplate template empty is rendered with pageContentBodyProps 1`
 
 exports[`EuiPageTemplate template empty is rendered with pageContentProps 1`] = `
 <div
-  class="euiPage euiPage--grow euiPageTemplate"
+  class="euiPage euiPage--paddingLarge euiPage--grow euiPageTemplate"
   style="min-height:460px"
 >
   <div
-    class="euiPageBody euiPageBody--borderRadiusNone"
+    class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--restrictWidth-default"
   >
     <div
       aria-label="aria-label"
@@ -934,7 +934,7 @@ exports[`EuiPageTemplate template empty is rendered with pageContentProps 1`] = 
       role="main"
     >
       <div
-        class="euiPageContentBody euiPage--paddingLarge euiPage--restrictWidth-default"
+        class="euiPageContentBody"
       />
     </div>
   </div>
@@ -943,17 +943,16 @@ exports[`EuiPageTemplate template empty is rendered with pageContentProps 1`] = 
 
 exports[`EuiPageTemplate template empty is rendered with pageHeader 1`] = `
 <div
-  class="euiPage euiPage--grow euiPageTemplate"
+  class="euiPage euiPage--paddingLarge euiPage--grow euiPageTemplate"
   style="min-height:460px"
 >
   <div
-    class="euiPageBody euiPageBody--borderRadiusNone"
+    class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--restrictWidth-default"
   >
     <header
       aria-label="aria-label"
-      class="euiPageHeader euiPageHeader--paddingLarge euiPageHeader--responsive euiPage--restrictWidth-default euiPageHeader--center testClass1 testClass2"
+      class="euiPageHeader euiPageHeader--bottomBorder euiPageHeader--responsive euiPageHeader--center testClass1 testClass2"
       data-test-subj="test subject string"
-      style="padding-bottom:0"
       title="Page title"
     />
     <div
@@ -961,7 +960,7 @@ exports[`EuiPageTemplate template empty is rendered with pageHeader 1`] = `
       role="main"
     >
       <div
-        class="euiPageContentBody euiPage--paddingLarge euiPage--restrictWidth-default"
+        class="euiPageContentBody"
       />
     </div>
   </div>
@@ -970,18 +969,18 @@ exports[`EuiPageTemplate template empty is rendered with pageHeader 1`] = `
 
 exports[`EuiPageTemplate template empty minHeight is rendered 1`] = `
 <div
-  class="euiPage euiPage--grow euiPageTemplate"
+  class="euiPage euiPage--paddingLarge euiPage--grow euiPageTemplate"
   style="min-height:40vh"
 >
   <div
-    class="euiPageBody euiPageBody--borderRadiusNone"
+    class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--restrictWidth-default"
   >
     <div
       class="euiPanel euiPanel--borderRadiusNone euiPanel--transparent euiPanel--noShadow euiPanel--noBorder euiPageContent euiPageContent--borderRadiusNone"
       role="main"
     >
       <div
-        class="euiPageContentBody euiPage--paddingLarge euiPage--restrictWidth-default"
+        class="euiPageContentBody"
       />
     </div>
   </div>
@@ -994,14 +993,14 @@ exports[`EuiPageTemplate template empty paddingSize is rendered 1`] = `
   style="min-height:460px"
 >
   <div
-    class="euiPageBody euiPageBody--borderRadiusNone"
+    class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--restrictWidth-default"
   >
     <div
       class="euiPanel euiPanel--borderRadiusNone euiPanel--transparent euiPanel--noShadow euiPanel--noBorder euiPageContent euiPageContent--borderRadiusNone"
       role="main"
     >
       <div
-        class="euiPageContentBody euiPage--restrictWidth-default"
+        class="euiPageContentBody"
       />
     </div>
   </div>
@@ -1010,18 +1009,18 @@ exports[`EuiPageTemplate template empty paddingSize is rendered 1`] = `
 
 exports[`EuiPageTemplate template empty style is rendered 1`] = `
 <div
-  class="euiPage euiPage--grow euiPageTemplate"
+  class="euiPage euiPage--paddingLarge euiPage--grow euiPageTemplate"
   style="min-height:460px;max-height:100vh"
 >
   <div
-    class="euiPageBody euiPageBody--borderRadiusNone"
+    class="euiPageBody euiPageBody--borderRadiusNone euiPageBody--restrictWidth-default"
   >
     <div
       class="euiPanel euiPanel--borderRadiusNone euiPanel--transparent euiPanel--noShadow euiPanel--noBorder euiPageContent euiPageContent--borderRadiusNone"
       role="main"
     >
       <div
-        class="euiPageContentBody euiPage--paddingLarge euiPage--restrictWidth-default"
+        class="euiPageContentBody"
       />
     </div>
   </div>

--- a/src/components/page/_mixins.scss
+++ b/src/components/page/_mixins.scss
@@ -3,6 +3,7 @@
   &--restrictWidth-custom {
     margin-left: auto;
     margin-right: auto;
+    width: 100%;
   }
 
   &--restrictWidth-default {

--- a/src/components/page/_page.scss
+++ b/src/components/page/_page.scss
@@ -34,7 +34,7 @@
       }
     }
 
-    .euiPageHeader {
+    .euiPageBody > .euiPageHeader {
       margin-bottom: $amount;
     }
   }

--- a/src/components/page/page_header/_page_header.scss
+++ b/src/components/page/page_header/_page_header.scss
@@ -15,6 +15,11 @@
 
 .euiPageHeader--bottomBorder {
   border-bottom: $euiBorderThin;
+
+  &:not(.euiPageHeader--tabsAtBottom) {
+    // Default padding to separate contents (unless there's tabs)
+    padding-bottom: map-get($euiPanelPaddingModifiers, 'paddingLarge');
+  }
 }
 
 // Uses the same values as EuiPanel
@@ -22,9 +27,12 @@
   .euiPageHeader--#{$modifier} {
     padding: $amount;
 
+    // Use margin if there are tabs to keep border close to tabs
     &.euiPageHeader--tabsAtBottom {
-      // Use margin if there are tabs to keep border close to tabs
       padding-bottom: 0;
+    }
+
+    &.euiPageHeader--tabsAtBottom.euiPageHeader--bottomBorder {
       margin-bottom: $amount;
     }
   }

--- a/src/components/page/page_template.tsx
+++ b/src/components/page/page_template.tsx
@@ -209,26 +209,28 @@ export const EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
       ) : (
         <EuiPage
           className={classes}
-          paddingSize="none"
+          paddingSize={paddingSize}
           grow={grow}
           {...rest}
           style={pageStyle}>
-          <EuiPageBody paddingSize="none" {...pageBodyProps}>
+          <EuiPageBody restrictWidth={restrictWidth} {...pageBodyProps}>
             {pageHeader && (
               <EuiPageHeader
-                paddingSize={paddingSize}
-                restrictWidth={restrictWidth}
+                paddingSize="none"
+                restrictWidth={false}
+                bottomBorder
                 {...pageHeader}
               />
             )}
             {/* Extra page body to get the correct alignment and padding of the centered EuiPageContent */}
-            <EuiPageBody paddingSize={paddingSize}>
+            <EuiPageBody>
               <EuiPageContent
                 verticalPosition="center"
                 horizontalPosition="center"
                 paddingSize={paddingSize}
                 {...pageContentProps}>
                 <EuiPageContentBody
+                  paddingSize="none"
                   restrictWidth={restrictWidth}
                   {...pageContentBodyProps}>
                   {children}
@@ -318,8 +320,8 @@ export const EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
       );
 
     /**
-     * DEFAULT
-     * Typical layout with nothing "centered"
+     * EMPTY
+     * No panelling at all
      */
     case 'empty':
       return pageSideBar ? (
@@ -358,17 +360,17 @@ export const EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
       ) : (
         <EuiPage
           className={classes}
-          paddingSize="none"
+          paddingSize={paddingSize}
           grow={grow}
           {...rest}
           style={pageStyle}>
-          <EuiPageBody {...pageBodyProps}>
+          <EuiPageBody restrictWidth={restrictWidth} {...pageBodyProps}>
             {pageHeader && (
               <EuiPageHeader
-                restrictWidth={restrictWidth}
-                paddingSize={paddingSize}
+                paddingSize="none"
+                restrictWidth={false}
+                bottomBorder
                 {...pageHeader}
-                style={{ paddingBottom: 0, ...pageHeader?.style }}
               />
             )}
             <EuiPageContent
@@ -378,10 +380,7 @@ export const EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
               color={'transparent'}
               borderRadius={'none'}
               {...pageContentProps}>
-              <EuiPageContentBody
-                restrictWidth={restrictWidth}
-                paddingSize={paddingSize}
-                {...pageContentBodyProps}>
+              <EuiPageContentBody paddingSize="none" {...pageContentBodyProps}>
                 {children}
               </EuiPageContentBody>
             </EuiPageContent>


### PR DESCRIPTION
...and fix [EuiPageTemplate] props of EuiPageHeader in `empty` template type

## Fixing `bottomBorder` + `tabs`

Before, if you just added `bottomBorder = true` to EuiPageHeader, but there was no padding, there would also be no space between the header content and the border.

**Before**

<img width="1189" alt="Screen Shot 2021-06-21 at 15 19 30 PM" src="https://user-images.githubusercontent.com/549577/122816087-493aec80-d2a4-11eb-9d6e-1df644d609ab.png">

**After**

Now it will always add a large padding. So it's not currently configurable, but it matches the default `paddingSize` of the typical page layout.

<img width="1190" alt="Screen Shot 2021-06-21 at 15 21 49 PM" src="https://user-images.githubusercontent.com/549577/122816368-a20a8500-d2a4-11eb-9bcf-2ed8c8fd69fb.png">


**Unless there's tabs**

Which still removes the bottom padding.

<img width="1192" alt="Screen Shot 2021-06-21 at 15 27 51 PM" src="https://user-images.githubusercontent.com/549577/122816939-50162f00-d2a5-11eb-8c71-1dbef8f0e3da.png">


## Updated the EuiPageTemplate to properly display page header in certain template types

### Default template

**Before **
<img width="1195" alt="Screen Shot 2021-06-21 at 15 29 47 PM" src="https://user-images.githubusercontent.com/549577/122817240-ab482180-d2a5-11eb-8262-3e61225b6409.png">

**After**
<img width="1189" alt="Screen Shot 2021-06-21 at 15 30 42 PM" src="https://user-images.githubusercontent.com/549577/122817256-b00cd580-d2a5-11eb-8403-af601c49e8e8.png">


### Empty template

**Before**
<img width="1194" alt="Screen Shot 2021-06-21 at 15 31 31 PM" src="https://user-images.githubusercontent.com/549577/122817411-dc285680-d2a5-11eb-8367-1e81453e4e41.png">


**After**
<img width="1192" alt="Screen Shot 2021-06-21 at 15 31 41 PM" src="https://user-images.githubusercontent.com/549577/122817430-e185a100-d2a5-11eb-961f-684cd9f60a7c.png">


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
