### PR TITLE
[EuiResizeObserver, EuiBottomBar] Account for padding and border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed `EuiRange` ticks position to better align with thumbs ([#4815](https://github.com/elastic/eui/pull/4815))
 - Fixed `EuiDataGrid` footer and header rows jumps in Firefox ([#4869](https://github.com/elastic/eui/issues/4869))
 - Fixed shaded colors of `EuiButtonIcon` ([#4874](https://github.com/elastic/eui/pull/4874))
+- Fixed incomplete `height` and `width` information in `EuiResizeObserver` ([#4909](https://github.com/elastic/eui/pull/4909))
 
 **Theme: Amsterdam**
 

--- a/src/components/observer/resize_observer/resize_observer.tsx
+++ b/src/components/observer/resize_observer/resize_observer.tsx
@@ -20,6 +20,24 @@
 import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { EuiObserver } from '../observer';
 
+const calculateDimensions = ({
+  height,
+  width,
+  top,
+  bottom,
+  left,
+  right,
+}: DOMRectReadOnly) => {
+  // `height` and `width` do not account for padding
+  // https://developer.mozilla.org/en-US/docs/Web/API/DOMRectReadOnly
+  const pBottom = bottom - height;
+  const pRight = right - width;
+  const heightPlus = height + top + pBottom;
+  const widthPlus = width + left + pRight;
+
+  return { height: heightPlus, width: widthPlus };
+};
+
 export interface EuiResizeObserverProps {
   /**
    * ReactNode to render as this component's content
@@ -39,7 +57,7 @@ export class EuiResizeObserver extends EuiObserver<EuiResizeObserverProps> {
   };
 
   onResize: ResizeObserverCallback = ([entry]) => {
-    const { height, width } = entry.contentRect;
+    const { height, width } = calculateDimensions(entry.contentRect);
     // Check for actual resize event
     if (this.state.height === height && this.state.width === width) {
       return;
@@ -109,7 +127,7 @@ export const useResizeObserver = (
       });
 
       const observer = makeResizeObserver(container, ([entry]) => {
-        const { height, width } = entry.contentRect;
+        const { height, width } = calculateDimensions(entry.contentRect);
         setSize({
           width,
           height,


### PR DESCRIPTION
### Summary

Fixes #4907, in which it was discovered that height and width from [`clientRect` do not include padding or border](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) (DOM box model).
This removes reliance on`clientRect` data and uses `getBoundingClientRect` instead.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~

- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples

~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [x] Checked for **breaking changes** and labeled appropriately

~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
