### PR TITLE
[EuiIcon] Early setState yields a console error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `34.5.2`.
+**Bug fixes**
+
+- Fixed `EuiIcon` from producing console warning in React.StrictMode ([#4910](https://github.com/elastic/eui/pull/4910))
 
 ## [`34.5.2`](https://github.com/elastic/eui/tree/v34.5.2)
 
@@ -39,6 +41,7 @@ No public interface changes since `34.5.2`.
 - Fixed `pageHeader` display in `EuiPageTemplate` when template is `empty` or `default` ([#4905](https://github.com/elastic/eui/pull/4905))
 - Fixed `EuiPageHeader` bottom padding when `borderBottom = true` ([#4905](https://github.com/elastic/eui/pull/4905))
 - Fixed incomplete `height` and `width` information in `EuiResizeObserver` ([#4909](https://github.com/elastic/eui/pull/4909))
+
 
 **Theme: Amsterdam**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@
 - Fixed `EuiPageHeader` bottom padding when `borderBottom = true` ([#4905](https://github.com/elastic/eui/pull/4905))
 - Fixed incomplete `height` and `width` information in `EuiResizeObserver` ([#4909](https://github.com/elastic/eui/pull/4909))
 
-
 **Theme: Amsterdam**
 
 - Updated styles for `EuiRange` ([#4815](https://github.com/elastic/eui/pull/4815)

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -595,21 +595,30 @@ export class EuiIcon extends PureComponent<EuiIconProps, State> {
 
     const { type } = props;
     const initialIcon = getInitialIcon(type);
-    let isLoading = false;
-
-    if (isEuiIconType(type) && initialIcon == null) {
-      isLoading = true;
-      this.loadIconComponent(type);
-    } else {
-      this.onIconLoad();
-    }
 
     this.state = {
       icon: initialIcon,
       iconTitle: undefined,
-      isLoading,
-      neededLoading: isLoading,
+      isLoading: false,
+      neededLoading: false,
     };
+  }
+
+  componentDidMount() {
+    const { type } = this.props;
+    const initialIcon = getInitialIcon(type);
+
+    if (isEuiIconType(type) && initialIcon == null) {
+      //eslint-disable-next-line react/no-did-mount-set-state
+      this.setState({
+        neededLoading: true,
+        isLoading: true,
+      });
+
+      this.loadIconComponent(type);
+    } else {
+      this.onIconLoad();
+    }
   }
 
   componentDidUpdate(prevProps: EuiIconProps) {

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -606,9 +606,8 @@ export class EuiIcon extends PureComponent<EuiIconProps, State> {
 
   componentDidMount() {
     const { type } = this.props;
-    const initialIcon = getInitialIcon(type);
 
-    if (isEuiIconType(type) && initialIcon == null) {
+    if (isEuiIconType(type) && this.state.icon == null) {
       //eslint-disable-next-line react/no-did-mount-set-state
       this.setState({
         neededLoading: true,


### PR DESCRIPTION
### Summary

Fixes #4783 

Using ```<EuiIcon />``` with React.StrictMode would yield the following react warning ```Warning: Can't call setState on a component that is not yet mounted. This is a no-op, but it might indicate a bug in your application. Instead, assign to 'this.state' directly or define a 'state = {};' class property with the desired state in the EuiIcon component.```

This would happen because the ```loadIconComponent()``` function calls ```this.setState()``` and is used in the constructor.

Moving the the ```loadIconComponent()``` and logic around it in the constructor to ```componentDidMount()``` resolves this warning.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~~
~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
~~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
