### PR TITLE
[EuiSideNav] Made `mobileBreakpoints` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Fixed `showIcons` prop in `EuiSelectableListItem` ([#4920](https://github.com/elastic/eui/pull/4920))
+- Changed `mobileBreakpoints` prop to optional `EuiSideNav` ([#4921](https://github.com/elastic/eui/pull/4921))
 
 ## [`34.5.0`](https://github.com/elastic/eui/tree/v34.5.0)
 

--- a/src/components/side_nav/__snapshots__/side_nav.test.tsx.snap
+++ b/src/components/side_nav/__snapshots__/side_nav.test.tsx.snap
@@ -549,3 +549,14 @@ exports[`EuiSideNav props mobileBreakpoints can be adjusted is rendered 1`] = `
   />
 </nav>
 `;
+
+exports[`EuiSideNav props mobileBreakpoints can be adjusted null is rendered 1`] = `
+<nav
+  class="euiSideNav"
+>
+  <div
+    class="euiSideNav__content euiSideNav__contentMobile-xs euiSideNav__contentMobile-s"
+    id="euiSideNavContent_generated-id"
+  />
+</nav>
+`;

--- a/src/components/side_nav/side_nav.test.tsx
+++ b/src/components/side_nav/side_nav.test.tsx
@@ -54,6 +54,12 @@ describe('EuiSideNav', () => {
 
         expect(component).toMatchSnapshot();
       });
+
+      test('null is rendered', () => {
+        const component = render(<EuiSideNav mobileBreakpoints={undefined} />);
+
+        expect(component).toMatchSnapshot();
+      });
     });
 
     describe('heading', () => {

--- a/src/components/side_nav/side_nav.tsx
+++ b/src/components/side_nav/side_nav.tsx
@@ -73,7 +73,8 @@ export type EuiSideNavProps<T = {}> = T &
      */
     mobileTitle?: ReactNode;
     /**
-     * Array of breakpoint names for when to show the mobile version
+     * Array of breakpoint names for when to show the mobile version.
+     * Set to `undefined` to remove responsive behavior
      */
     mobileBreakpoints?: EuiBreakpointSize[];
     /**

--- a/src/components/side_nav/side_nav.tsx
+++ b/src/components/side_nav/side_nav.tsx
@@ -240,9 +240,10 @@ export class EuiSideNav<T> extends Component<EuiSideNavProps<T>> {
     }
 
     let mobileNode;
+    const breakpoints: EuiBreakpointSize[] | undefined = mobileBreakpoints;
     if (hasMobileVersion) {
       mobileNode = (
-        <EuiShowFor sizes={mobileBreakpoints || 'none'}>
+        <EuiShowFor sizes={breakpoints || 'none'}>
           <nav
             aria-labelledby={sharedHeadingProps.id}
             className={classes}
@@ -271,7 +272,7 @@ export class EuiSideNav<T> extends Component<EuiSideNavProps<T>> {
     return (
       <>
         {mobileNode}
-        <EuiHideFor sizes={mobileBreakpoints || 'none'}>
+        <EuiHideFor sizes={breakpoints || 'none'}>
           <nav
             aria-labelledby={headingNode ? sharedHeadingProps.id : undefined}
             className={classes}

--- a/src/components/side_nav/side_nav.tsx
+++ b/src/components/side_nav/side_nav.tsx
@@ -75,7 +75,7 @@ export type EuiSideNavProps<T = {}> = T &
     /**
      * Array of breakpoint names for when to show the mobile version
      */
-    mobileBreakpoints: EuiBreakpointSize[];
+    mobileBreakpoints?: EuiBreakpointSize[];
     /**
      *  An array of #EuiSideNavItem objects. Lists navigation menu items.
      */
@@ -188,7 +188,7 @@ export class EuiSideNav<T> extends Component<EuiSideNavProps<T>> {
     // We add a className for every breakpoint supported
     const contentClasses = classNames(
       'euiSideNav__content',
-      mobileBreakpoints.map(
+      mobileBreakpoints?.map(
         (breakpointName) => `euiSideNav__contentMobile-${breakpointName}`
       )
     );
@@ -205,7 +205,7 @@ export class EuiSideNav<T> extends Component<EuiSideNavProps<T>> {
       ...titleProps
     } = headingProps!;
 
-    const hasMobileVersion = mobileBreakpoints.length > 0;
+    const hasMobileVersion = mobileBreakpoints && mobileBreakpoints.length > 0;
     const hasHeader = !!heading;
     let headingNode;
 
@@ -241,7 +241,7 @@ export class EuiSideNav<T> extends Component<EuiSideNavProps<T>> {
     let mobileNode;
     if (hasMobileVersion) {
       mobileNode = (
-        <EuiShowFor sizes={mobileBreakpoints}>
+        <EuiShowFor sizes={mobileBreakpoints || 'none'}>
           <nav
             aria-labelledby={sharedHeadingProps.id}
             className={classes}
@@ -270,7 +270,7 @@ export class EuiSideNav<T> extends Component<EuiSideNavProps<T>> {
     return (
       <>
         {mobileNode}
-        <EuiHideFor sizes={mobileBreakpoints}>
+        <EuiHideFor sizes={mobileBreakpoints || 'none'}>
           <nav
             aria-labelledby={headingNode ? sharedHeadingProps.id : undefined}
             className={classes}


### PR DESCRIPTION
## Fixes #4919

Also quickly allows for a non-responsive version by setting to `undefined`.

### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
