### PR TITLE
Define set of i18n tokens via TypeScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `34.5.2`.
+- Added `EuiTokensObject` type definition to allow enforcing i18n token coverage in consuming applications ([#4927](https://github.com/elastic/eui/issues/4927))
 
 ## [`34.5.2`](https://github.com/elastic/eui/tree/v34.5.2)
 

--- a/scripts/dtsgenerator.js
+++ b/scripts/dtsgenerator.js
@@ -154,15 +154,15 @@ generator.then(() => {
 function buildEuiTokensObject() {
   // reduce over the tokens list as a few of the tokens are used multiple times and must be
   // filtered down to a list
-  const i18ndefs = require('../i18ntokens.json').reduce(
-    ({ definitions, tokens }, def) => {
-      if (tokens.has(def.token)) {
+  const { i18ndefs } = require('../i18ntokens.json').reduce(
+    ({ i18ndefs, tokens }, def) => {
+      if (!tokens.has(def.token)) {
         tokens.add(def.token);
-        definitions.push(def);
+        i18ndefs.push(def);
       }
-      return definitions;
+      return { i18ndefs, tokens };
     },
-    { definitions: [], tokens: new Set() }
+    { i18ndefs: [], tokens: new Set() }
   );
   return `
 declare module '@elastic/eui' {

--- a/scripts/dtsgenerator.js
+++ b/scripts/dtsgenerator.js
@@ -96,6 +96,7 @@ const generator = dtsGenerator({
 // 1. strip any `/// <reference` lines from the generated eui.d.ts
 // 2. replace any import("src/...") declarations to import("@elastic/eui/src/...")
 // 3. replace any import("./...") declarations to import("@elastic/eui/src/...)
+// 4. generate & add EuiTokenObject
 generator.then(() => {
   const defsFilePath = path.resolve(baseDir, 'eui.d.ts');
 
@@ -144,5 +145,30 @@ generator.then(() => {
           );
         }
       ) // end 3.
+      .replace(/$/, `\n\n${buildEuiTokensObject()}`) // 4.
   );
 });
+
+/** For step 4 **/
+// i18ntokens.json is generated as the first step in the build and can be relied upon here
+function buildEuiTokensObject() {
+  // reduce over the tokens list as a few of the tokens are used multiple times and must be
+  // filtered down to a list
+  const i18ndefs = require('../i18ntokens.json').reduce(
+    ({ definitions, tokens }, def) => {
+      if (tokens.has(def.token)) {
+        tokens.add(def.token);
+        definitions.push(def);
+      }
+      return definitions;
+    },
+    { definitions: [], tokens: new Set() }
+  );
+  return `
+declare module '@elastic/eui' {
+  export type EuiTokensObject = {
+    ${i18ndefs.map(({ token }) => `"${token}": any;`).join('\n')}
+  }
+}
+  `;
+}


### PR DESCRIPTION
### Summary

To allow applications to confirm they define the whole set of our i18n tokens - and are updated when tokens are added or removed - this creates an `EuiTokensObject` definition in _eui.d.ts_ that can be used to type the context mapping object.

Relevant change in Kibana to opt-in to this typing: https://github.com/elastic/kibana/blob/master/src/core/public/i18n/i18n_eui_mapping.tsx#L18

`const euiContextMapping = {`
becomes
`const euiContextMapping: EuiTokensObject = {`

Tested this by dropping the generated eui.d.ts into Kibana & making the above change. TypeScript then identified 9 tokens that are no longer in use and 15 that are missing from that mapping.

### ~Checklist~
