### PR TITLE
[EuiCodeBlock] Account for empty children in edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `34.5.1`.
+**Bug fixes**
+
+- Fixed a render-blocking error in `EuiCodeBlock` when certain HTML tags are childless ([#4929](https://github.com/elastic/eui/issues/4929))
 
 ## [`34.5.1`](https://github.com/elastic/eui/tree/v34.5.1)
 

--- a/src-docs/src/views/code/code_block.js
+++ b/src-docs/src/views/code/code_block.js
@@ -4,7 +4,7 @@ import { EuiCodeBlock, EuiSpacer } from '../../../../src/components';
 
 const htmlCode = require('!!raw-loader!./code_examples/example.html').default;
 
-const jsCode = require('!!raw-loader!./code_examples/example.js').default;
+// const jsCode = require('!!raw-loader!./code_examples/example.js').default;
 
 const sqlCode = require('!!raw-loader!./code_examples/example.sql').default;
 
@@ -15,12 +15,12 @@ export default () => (
     <EuiSpacer />
 
     <EuiCodeBlock
-      language="jsx"
+      language="html"
       fontSize="m"
       paddingSize="m"
       overflowHeight={300}
       isCopyable>
-      {jsCode}
+      {'<script data-src="kbn_canvas.js"></script>'}
     </EuiCodeBlock>
 
     <EuiSpacer />

--- a/src-docs/src/views/code/code_block.js
+++ b/src-docs/src/views/code/code_block.js
@@ -4,7 +4,7 @@ import { EuiCodeBlock, EuiSpacer } from '../../../../src/components';
 
 const htmlCode = require('!!raw-loader!./code_examples/example.html').default;
 
-// const jsCode = require('!!raw-loader!./code_examples/example.js').default;
+const jsCode = require('!!raw-loader!./code_examples/example.js').default;
 
 const sqlCode = require('!!raw-loader!./code_examples/example.sql').default;
 
@@ -15,12 +15,12 @@ export default () => (
     <EuiSpacer />
 
     <EuiCodeBlock
-      language="html"
+      language="jsx"
       fontSize="m"
       paddingSize="m"
       overflowHeight={300}
       isCopyable>
-      {'<script data-src="kbn_canvas.js"></script>'}
+      {jsCode}
     </EuiCodeBlock>
 
     <EuiSpacer />

--- a/src/components/code/_code_block.tsx
+++ b/src/components/code/_code_block.tsx
@@ -96,7 +96,7 @@ const addLineData = (
       return result;
     }
 
-    if (node.children) {
+    if (node.children && node.children.length) {
       const children = addLineData(node.children, data);
       const first = children[0];
       const last = children[children.length - 1];


### PR DESCRIPTION
### Summary

Typically prism.js sets an empty `children` node as `undefined`, but in certain edge cases, like a childless `script` tag in a `language=html` block, `children` is set to `[]`.
This updates the logic to bypass parsing line data for `children: []`

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
