### PR TITLE
[EuiContextMenuPanelDescriptor] title should accept ReactNode rather than string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `34.5.2`.
+- Updated `EuiContextMenuPanelDescriptor`'s `title` prop type from `string` to `ReactNode` ([#4933](https://github.com/elastic/eui/pull/4933))
 
 ## [`34.5.2`](https://github.com/elastic/eui/tree/v34.5.2)
 

--- a/src/components/context_menu/context_menu.tsx
+++ b/src/components/context_menu/context_menu.tsx
@@ -61,7 +61,7 @@ export type EuiContextMenuPanelItemDescriptor = ExclusiveUnion<
 
 export interface EuiContextMenuPanelDescriptor {
   id: EuiContextMenuPanelId;
-  title?: string;
+  title?: ReactNode;
   items?: EuiContextMenuPanelItemDescriptor[];
   content?: ReactNode;
   width?: number;

--- a/src/components/context_menu/context_menu.tsx
+++ b/src/components/context_menu/context_menu.tsx
@@ -61,6 +61,9 @@ export type EuiContextMenuPanelItemDescriptor = ExclusiveUnion<
 
 export interface EuiContextMenuPanelDescriptor {
   id: EuiContextMenuPanelId;
+  /**
+   * Wrapped in a `span`
+   */
   title?: ReactNode;
   items?: EuiContextMenuPanelItemDescriptor[];
   content?: ReactNode;

--- a/src/components/context_menu/context_menu.tsx
+++ b/src/components/context_menu/context_menu.tsx
@@ -61,9 +61,6 @@ export type EuiContextMenuPanelItemDescriptor = ExclusiveUnion<
 
 export interface EuiContextMenuPanelDescriptor {
   id: EuiContextMenuPanelId;
-  /**
-   * Wrapped in a `span`
-   */
   title?: ReactNode;
   items?: EuiContextMenuPanelItemDescriptor[];
   content?: ReactNode;


### PR DESCRIPTION
### Summary

Updated EuiContextMenuPanelDescriptor's title prop type from string to ReactNode

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
