### PR TITLE
docs: fix a broken link in the EuiMarkdownFormat section

### DIFF
--- a/src-docs/src/views/markdown_editor/mardown_format_example.js
+++ b/src-docs/src/views/markdown_editor/mardown_format_example.js
@@ -4,7 +4,11 @@ import { renderToHtml } from '../../services';
 
 import { GuideSectionTypes } from '../../components';
 
-import { EuiLink, EuiMarkdownFormat, EuiText } from '../../../../src/components';
+import {
+  EuiLink,
+  EuiMarkdownFormat,
+  EuiText,
+} from '../../../../src/components';
 
 import { Link } from 'react-router-dom';
 

--- a/src-docs/src/views/markdown_editor/mardown_format_example.js
+++ b/src-docs/src/views/markdown_editor/mardown_format_example.js
@@ -55,8 +55,10 @@ export const MarkdownFormatExample = {
         <p>
           <strong>EuiMarkdownFormat</strong> is a wrapper that will render
           Markdown provided. EuiMarkdownFormat uses{' '}
-          <EuiLink href="https://github.com/remarkjs/remark">Remark</EuiLink> by
-          default. The translation layer automatically substitutes raw HTML
+          <EuiLink target="_blank" href="https://github.com/remarkjs/remark">
+            Remark
+          </EuiLink>{' '}
+          by default. The translation layer automatically substitutes raw HTML
           output with their EUI equivalent. This means anchor and code blocks
           will become <strong>EuiLink</strong> and <strong>EuiCodeBlock</strong>{' '}
           components respectively.

--- a/src-docs/src/views/markdown_editor/mardown_format_example.js
+++ b/src-docs/src/views/markdown_editor/mardown_format_example.js
@@ -4,7 +4,7 @@ import { renderToHtml } from '../../services';
 
 import { GuideSectionTypes } from '../../components';
 
-import { EuiMarkdownFormat, EuiText } from '../../../../src/components';
+import { EuiLink, EuiMarkdownFormat, EuiText } from '../../../../src/components';
 
 import { Link } from 'react-router-dom';
 
@@ -51,7 +51,7 @@ export const MarkdownFormatExample = {
         <p>
           <strong>EuiMarkdownFormat</strong> is a wrapper that will render
           Markdown provided. EuiMarkdownFormat uses{' '}
-          <Link to="https://github.com/remarkjs/remark)">Remark</Link> by
+          <EuiLink href="https://github.com/remarkjs/remark">Remark</EuiLink> by
           default. The translation layer automatically substitutes raw HTML
           output with their EUI equivalent. This means anchor and code blocks
           will become <strong>EuiLink</strong> and <strong>EuiCodeBlock</strong>{' '}


### PR DESCRIPTION
### Summary

In the documentation of `EuiMarkdownFormat`, the link to the Remark library was broken. It contained a typo and was using a routing component instead of a link. This small PR fixes it. :slightly_smiling_face: 

### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- ~[ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
