### PR TITLE
[EuiSuperDatePicker] Now Supports onFocus

### DIFF
--- a/src/components/date_picker/super_date_picker/super_date_picker.test.tsx
+++ b/src/components/date_picker/super_date_picker/super_date_picker.test.tsx
@@ -145,4 +145,17 @@ describe('EuiSuperDatePicker', () => {
     );
     expect(component.find(EuiButton).props()).toMatchObject(updateButtonProps);
   });
+
+  test('onFocus prop-callback should be fired once', () => {
+    const focusMock = jest.fn();
+
+    const componentFocus = mount<EuiSuperDatePicker>(
+      <EuiSuperDatePicker onTimeChange={noop} onFocus={focusMock} />
+    );
+
+    componentFocus.find('EuiSuperDatePicker').simulate('focus');
+    componentFocus.find('EuiDatePickerRange').simulate('focus');
+
+    expect(focusMock).toBeCalledTimes(1);
+  });
 });

--- a/src/components/date_picker/super_date_picker/super_date_picker.tsx
+++ b/src/components/date_picker/super_date_picker/super_date_picker.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { Component } from 'react';
+import React, { Component, FocusEvent } from 'react';
 import classNames from 'classnames';
 import {
   prettyDuration,
@@ -86,6 +86,12 @@ export type EuiSuperDatePickerProps = CommonProps & {
    * Used to localize e.g. month names, passed to `moment`
    */
   locale?: LocaleSpecifier;
+
+  /**
+   * Callback for when the super date picker gets focus
+   * Only triggered once on the parent Element
+   */
+  onFocus?: (event: FocusEvent<HTMLInputElement>) => void;
 
   /**
    * Callback for when the refresh interval is fired.
@@ -516,6 +522,7 @@ export class EuiSuperDatePicker extends Component<
       isDisabled,
       isPaused,
       onRefreshChange,
+      onFocus,
       recentlyUsedRanges,
       refreshInterval,
       showUpdateButton,
@@ -555,7 +562,8 @@ export class EuiSuperDatePicker extends Component<
           <EuiFormControlLayout
             className="euiSuperDatePicker"
             isDisabled={isDisabled}
-            prepend={quickSelect}>
+            prepend={quickSelect}
+            onFocus={onFocus}>
             {this.renderDatePickerRange()}
           </EuiFormControlLayout>
         </EuiFlexItem>


### PR DESCRIPTION
Added onFocus-prop to superdatepicker and added a test
The test will make an unrelated test fail though so this is just a draft

### Summary

Provide a detailed summary of your PR. Explain how you arrived at your solution. If it includes changes to UI elements include a screenshot or gif.

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
