### PR TITLE
[EuiDataGrid] Fix initial alignment of cells and expand button on multi-line cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Refactored `EuiFlyout` types ([#4940](https://github.com/elastic/eui/pull/4940))
 - Updated `pause` icon ([#4947](https://github.com/elastic/eui/pull/4947))
+- Changed multi-line `EuiDataGrid` cells to `break-word` instead of `break-all` ([#4955](https://github.com/elastic/eui/pull/4955))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 **Bug fixes**
 
 - Fixed render-blocking error when `EuiCodeBlock` is configured with an unsupported language ([#4943](https://github.com/elastic/eui/pull/4943))
+- Fixed initial alignment of `EuiDataGrid` cells and the expand button on multi-line cells ([#4955](https://github.com/elastic/eui/pull/4955))
 
 ## [`35.1.0`](https://github.com/elastic/eui/tree/v35.1.0)
 

--- a/src-docs/src/views/datagrid/datagrid_height_options_example.js
+++ b/src-docs/src/views/datagrid/datagrid_height_options_example.js
@@ -14,7 +14,7 @@ const dataGridRowHeightOptionsSource = require('!!raw-loader!./row_height_option
 const dataGridRowHeightOptionsHtml = renderToHtml(DataGridRowHeightOptions);
 
 const rowHeightsSnippet = `
-  {
+  rowHeightsOptions = {
     defaultHeight: {
       lineCount: 2, // default every row to 2 lines of text. Also we can provide height in pixels
     },

--- a/src-docs/src/views/datagrid/datagrid_height_options_example.js
+++ b/src-docs/src/views/datagrid/datagrid_height_options_example.js
@@ -13,20 +13,18 @@ import DataGridRowHeightOptions from './row_height_options';
 const dataGridRowHeightOptionsSource = require('!!raw-loader!./row_height_options');
 const dataGridRowHeightOptionsHtml = renderToHtml(DataGridRowHeightOptions);
 
-const rowHeightsSnippet = `
-  rowHeightsOptions = {
-    defaultHeight: {
-      lineCount: 2, // default every row to 2 lines of text. Also we can provide height in pixels
+const rowHeightsSnippet = `rowHeightsOptions = {
+  defaultHeight: {
+    lineCount: 2, // default every row to 2 lines of text. Also we can provide height in pixels
+  },
+  rowHeights: {
+    1: {
+      lineCount: 5, // for row which have index 1 we allow to show 5 lines after that we truncate
     },
-    rowHeights: {
-      1: {
-        lineCount: 5, // for row which have index 1 we allow to show 5 lines after that we truncate
-      },
-      4: 140, // for row which have index 4 we set 140 pixel
-      5: 80,
-    },
-  }
-`;
+    4: 140, // for row which have index 4 we set 140 pixel
+    5: 80,
+  },
+}`;
 
 export const DataGridRowHeightOptionsExample = {
   title: 'Data grid row height options',

--- a/src-docs/src/views/datagrid/row_height_options.js
+++ b/src-docs/src/views/datagrid/row_height_options.js
@@ -8,7 +8,7 @@ import React, {
 } from 'react';
 import { fake } from 'faker';
 
-import { EuiDataGrid, EuiText } from '../../../../src/components/';
+import { EuiDataGrid, EuiTitle, EuiSpacer } from '../../../../src/components/';
 
 const DataContext = createContext();
 
@@ -20,6 +20,15 @@ const columns = [
   },
   {
     id: 'text',
+    cellActions: [
+      ({ Component }) => {
+        return (
+          <Component iconType="heart" aria-label={'Heart'}>
+            Heart
+          </Component>
+        );
+      },
+    ],
   },
 ];
 
@@ -119,9 +128,10 @@ export default () => {
 
   return (
     <DataContext.Provider value={dataContext}>
-      <EuiText>
-        <p>There are {mountedCellCount} rendered cells</p>
-      </EuiText>
+      <EuiTitle size="xxs">
+        <h2>There are {mountedCellCount} rendered cells</h2>
+      </EuiTitle>
+      <EuiSpacer />
       {grid}
     </DataContext.Provider>
   );

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -1136,17 +1136,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        0, A
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 1, Column: 1:
-                        </p>
+                          0, A
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 1, Column: 1:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1158,17 +1162,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        0, B
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 1, Column: 2:
-                        </p>
+                          0, B
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 1, Column: 2:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1180,17 +1188,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        1, A
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 2, Column: 1:
-                        </p>
+                          1, A
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 2, Column: 1:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1202,17 +1214,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        1, B
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 2, Column: 2:
-                        </p>
+                          1, B
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 2, Column: 2:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1224,17 +1240,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        2, A
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 3, Column: 1:
-                        </p>
+                          2, A
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 3, Column: 1:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1246,17 +1266,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        2, B
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 3, Column: 2:
-                        </p>
+                          2, B
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 3, Column: 2:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1545,7 +1569,7 @@ Array [
                       data-focus-lock-disabled="disabled"
                     >
                       <div
-                        class="euiDataGridRowCell__expandFlex "
+                        class="euiDataGridRowCell__expandFlex"
                       >
                         <div
                           class="euiDataGridRowCell__expandContent"
@@ -1577,17 +1601,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        0, A
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 1, Column: 2:
-                        </p>
+                          0, A
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 1, Column: 2:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1599,17 +1627,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        0, B
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 1, Column: 3:
-                        </p>
+                          0, B
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 1, Column: 3:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1634,7 +1666,7 @@ Array [
                       data-focus-lock-disabled="disabled"
                     >
                       <div
-                        class="euiDataGridRowCell__expandFlex "
+                        class="euiDataGridRowCell__expandFlex"
                       >
                         <div
                           class="euiDataGridRowCell__expandContent"
@@ -1679,7 +1711,7 @@ Array [
                       data-focus-lock-disabled="disabled"
                     >
                       <div
-                        class="euiDataGridRowCell__expandFlex "
+                        class="euiDataGridRowCell__expandFlex"
                       >
                         <div
                           class="euiDataGridRowCell__expandContent"
@@ -1711,17 +1743,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        1, A
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 2, Column: 2:
-                        </p>
+                          1, A
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 2, Column: 2:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1733,17 +1769,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        1, B
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 2, Column: 3:
-                        </p>
+                          1, B
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 2, Column: 3:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1768,7 +1808,7 @@ Array [
                       data-focus-lock-disabled="disabled"
                     >
                       <div
-                        class="euiDataGridRowCell__expandFlex "
+                        class="euiDataGridRowCell__expandFlex"
                       >
                         <div
                           class="euiDataGridRowCell__expandContent"
@@ -1813,7 +1853,7 @@ Array [
                       data-focus-lock-disabled="disabled"
                     >
                       <div
-                        class="euiDataGridRowCell__expandFlex "
+                        class="euiDataGridRowCell__expandFlex"
                       >
                         <div
                           class="euiDataGridRowCell__expandContent"
@@ -1845,17 +1885,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        2, A
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 3, Column: 2:
-                        </p>
+                          2, A
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 3, Column: 2:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1867,17 +1911,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        2, B
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 3, Column: 3:
-                        </p>
+                          2, B
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 3, Column: 3:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1902,7 +1950,7 @@ Array [
                       data-focus-lock-disabled="disabled"
                     >
                       <div
-                        class="euiDataGridRowCell__expandFlex "
+                        class="euiDataGridRowCell__expandFlex"
                       >
                         <div
                           class="euiDataGridRowCell__expandContent"
@@ -2167,17 +2215,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        0, A
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 1, Column: 1:
-                        </p>
+                          0, A
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 1, Column: 1:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -2189,17 +2241,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        0, B
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 1, Column: 2:
-                        </p>
+                          0, B
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 1, Column: 2:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -2211,17 +2267,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        1, A
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 2, Column: 1:
-                        </p>
+                          1, A
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 2, Column: 1:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -2233,17 +2293,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        1, B
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 2, Column: 2:
-                        </p>
+                          1, B
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 2, Column: 2:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -2255,17 +2319,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        2, A
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 3, Column: 1:
-                        </p>
+                          2, A
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 3, Column: 1:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -2277,17 +2345,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        2, B
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 3, Column: 2:
-                        </p>
+                          2, B
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 3, Column: 2:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -2530,17 +2602,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        0, A
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 1, Column: 1:
-                        </p>
+                          0, A
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 1, Column: 1:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -2552,17 +2628,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        0, B
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 1, Column: 2:
-                        </p>
+                          0, B
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 1, Column: 2:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -2574,17 +2654,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        1, A
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 2, Column: 1:
-                        </p>
+                          1, A
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 2, Column: 1:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -2596,17 +2680,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        1, B
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 2, Column: 2:
-                        </p>
+                          1, B
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 2, Column: 2:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -2618,17 +2706,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        2, A
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 3, Column: 1:
-                        </p>
+                          2, A
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 3, Column: 1:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -2640,17 +2732,21 @@ Array [
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridRowCell__expandFlex "
+                      class="euiDataGridRowCell__expandFlex"
                     >
                       <div
-                        class="euiDataGridRowCell__truncate"
+                        class="euiDataGridRowCell__expandContent"
                       >
-                        2, B
-                        <p
-                          class="euiScreenReaderOnly"
+                        <div
+                          class="euiDataGridRowCell__truncate"
                         >
-                          Row: 3, Column: 2:
-                        </p>
+                          2, B
+                          <p
+                            class="euiScreenReaderOnly"
+                          >
+                            Row: 3, Column: 2:
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -136,6 +136,7 @@
 }
 
 .euiDataGridRowCell__expandFlex {
+  position: relative; // for positioning expand button
   display: flex;
   align-items: center;
   height: 100%;
@@ -157,6 +158,14 @@
 .euiDataGridRowCell__expandButton {
   display: flex;
   flex-grow: 0;
+
+  .euiDataGridRowCell__contentByHeight + & {
+    background-color: $euiColorEmptyShade;
+    position: absolute;
+    right: 0;
+    top: 0;
+    padding: $euiDataGridCellPaddingM 0;
+  }
 }
 
 .euiDataGridRowCell__expandButtonIcon {
@@ -254,6 +263,10 @@
 
 .euiDataGridRowCell--paddingSmall {
   padding: $euiDataGridCellPaddingS;
+
+  .euiDataGridRowCell__contentByHeight + .euiDataGridRowCell__expandButton {
+    padding: 0;
+  }
 }
 
 @include euiDataGridStyles(paddingLarge) {
@@ -269,6 +282,10 @@
 
 .euiDataGridRowCell--paddingLarge {
   padding: $euiDataGridCellPaddingL;
+
+  .euiDataGridRowCell__contentByHeight + .euiDataGridRowCell__expandButton {
+    padding: $euiDataGridCellPaddingL 0;
+  }
 }
 
 @keyframes euiDataGridCellButtonSlideIn {

--- a/src/components/datagrid/data_grid_cell.tsx
+++ b/src/components/datagrid/data_grid_cell.tsx
@@ -483,6 +483,13 @@ export class EuiDataGridCell extends Component<
       rowHeightsOptions: this.props.rowHeightsOptions,
     };
 
+    const anchorClass = classNames('euiDataGridRowCell__expandFlex', {
+      euiDataGridRowCell__alignBaseLine: this.props.rowHeightsOptions,
+    });
+    const expandClass = this.props.rowHeightsOptions
+      ? 'euiDataGridRowCell__contentByHeight'
+      : 'euiDataGridRowCell__expandContent';
+
     let anchorContent = (
       <EuiFocusTrap
         disabled={!this.state.isEntered}
@@ -492,18 +499,8 @@ export class EuiDataGridCell extends Component<
         }}
         style={this.props.rowHeightsOptions ? { height: '100%' } : {}}
         clickOutsideDisables={true}>
-        <div
-          className={`euiDataGridRowCell__expandFlex ${
-            this.props.rowHeightsOptions
-              ? 'euiDataGridRowCell__alignBaseLine'
-              : ''
-          }`}>
-          <div
-            className={
-              !this.props.rowHeightsOptions
-                ? 'euiDataGridRowCell__expandContent'
-                : 'euiDataGridRowCell__contentByHeight'
-            }>
+        <div className={anchorClass}>
+          <div className={expandClass}>
             <EuiDataGridCellContent {...cellContentProps} />
           </div>
         </div>
@@ -513,44 +510,29 @@ export class EuiDataGridCell extends Component<
     if (isExpandable || (column && column.cellActions)) {
       if (showCellButtons) {
         anchorContent = (
-          <div
-            className={`euiDataGridRowCell__expandFlex ${
-              this.props.rowHeightsOptions
-                ? 'euiDataGridRowCell__alignBaseLine'
-                : ''
-            }`}>
-            <div
-              className={
-                !this.props.rowHeightsOptions
-                  ? 'euiDataGridRowCell__expandContent'
-                  : 'euiDataGridRowCell__contentByHeight'
-              }>
+          <div className={anchorClass}>
+            <div className={expandClass}>
               <EuiDataGridCellContent {...cellContentProps} />
             </div>
-            {showCellButtons && (
-              <EuiDataGridCellButtons
-                rowIndex={rowIndex}
-                column={column}
-                popoverIsOpen={this.state.popoverIsOpen}
-                closePopover={this.closePopover}
-                onExpandClick={() => {
-                  this.setState(({ popoverIsOpen }) => ({
-                    popoverIsOpen: !popoverIsOpen,
-                  }));
-                }}
-              />
-            )}
+            <EuiDataGridCellButtons
+              rowIndex={rowIndex}
+              column={column}
+              popoverIsOpen={this.state.popoverIsOpen}
+              closePopover={this.closePopover}
+              onExpandClick={() => {
+                this.setState(({ popoverIsOpen }) => ({
+                  popoverIsOpen: !popoverIsOpen,
+                }));
+              }}
+            />
           </div>
         );
       } else {
         anchorContent = (
-          <div
-            className={`euiDataGridRowCell__expandFlex ${
-              this.props.rowHeightsOptions
-                ? 'euiDataGridRowCell__alignBaseLine'
-                : ''
-            }`}>
-            <EuiDataGridCellContent {...cellContentProps} />
+          <div className={anchorClass}>
+            <div className={expandClass}>
+              <EuiDataGridCellContent {...cellContentProps} />
+            </div>
           </div>
         );
       }
@@ -562,9 +544,9 @@ export class EuiDataGridCell extends Component<
         innerContent = (
           <div
             className={
-              !this.props.rowHeightsOptions
-                ? 'euiDataGridRowCell__content'
-                : 'euiDataGridRowCell__contentByHeight'
+              this.props.rowHeightsOptions
+                ? 'euiDataGridRowCell__contentByHeight'
+                : 'euiDataGridRowCell__content'
             }>
             <EuiDataGridCellPopover
               anchorContent={anchorContent}

--- a/src/components/datagrid/row_height_utils.ts
+++ b/src/components/datagrid/row_height_utils.ts
@@ -106,7 +106,8 @@ export const getStylesForCell = (
       height: '100%',
       overflow: 'hidden',
       flexGrow: 1,
-      wordBreak: 'break-all',
+      wordWrap: 'break-word',
+      wordBreak: 'break-word',
     };
   }
 
@@ -114,6 +115,7 @@ export const getStylesForCell = (
     height: '100%',
     overflow: 'hidden',
     flexGrow: 1,
-    wordBreak: 'break-all',
+    wordWrap: 'break-word',
+    wordBreak: 'break-word',
   };
 };


### PR DESCRIPTION
### Fixes #4953

Adds a missing wrapping div to match the other cell instances in when the expand buttons are not showing yet. Basically it needed the same DOM structure as the other permutations, but it was just missing the  `.euiDataGridRowCell__expandContent` element.

**AFTER:**


https://user-images.githubusercontent.com/549577/125856032-06611905-029f-4bdb-b445-b86434dfce8c.mp4

## Also fixed the shifting of text wrap when heights are declared

By absolute positioning the buttons instead, they overlap instead of shift content. This behavior only affects multi-line cells. I also changed `break-all` to simply `break-word` for better line break positions. Eventually, this should become a customizable prop.

**Before**
![Screen Recording 2021-07-15 at 03 51 43 PM](https://user-images.githubusercontent.com/549577/125856354-ea7f1243-78e2-48d8-898f-41918d6fdd9a.gif)


**After**
![Screen Recording 2021-07-15 at 04 47 45 PM](https://user-images.githubusercontent.com/549577/125856244-39da6918-d8bd-41e7-93f6-449b0d19440b.gif)


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [x] Added to **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
