### PR TITLE
[EuiDataGrid] Adding a docs section about nesting in a flex item

### DIFF
--- a/src-docs/src/views/datagrid/container.js
+++ b/src-docs/src/views/datagrid/container.js
@@ -52,29 +52,27 @@ export default () => {
   );
 
   return (
-    <EuiPanel style={{ width: 400, paddingBottom: 4 }} paddingSize="none">
-      <div style={{ height: 300 }}>
-        <EuiDataGrid
-          aria-label="Container constrained data grid demo"
-          columns={columns}
-          columnVisibility={{
-            visibleColumns: visibleColumns,
-            setVisibleColumns: setVisibleColumns,
-          }}
-          rowCount={data.length}
-          gridStyle={{
-            border: 'horizontal',
-            header: 'underline',
-          }}
-          renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
-          pagination={{
-            ...pagination,
-            pageSizeOptions: [5, 10, 25],
-            onChangeItemsPerPage: setPageSize,
-            onChangePage: setPageIndex,
-          }}
-        />
-      </div>
+    <EuiPanel style={{ maxWidth: 400, height: 300 }} paddingSize="none">
+      <EuiDataGrid
+        aria-label="Container constrained data grid demo"
+        columns={columns}
+        columnVisibility={{
+          visibleColumns: visibleColumns,
+          setVisibleColumns: setVisibleColumns,
+        }}
+        rowCount={data.length}
+        gridStyle={{
+          border: 'horizontal',
+          header: 'underline',
+        }}
+        renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
+        pagination={{
+          ...pagination,
+          pageSizeOptions: [5, 10, 25],
+          onChangeItemsPerPage: setPageSize,
+          onChangePage: setPageIndex,
+        }}
+      />
     </EuiPanel>
   );
 };

--- a/src-docs/src/views/datagrid/datagrid_styling_example.js
+++ b/src-docs/src/views/datagrid/datagrid_styling_example.js
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react';
+import { Link } from 'react-router-dom';
 
 import { renderToHtml } from '../../services';
 
@@ -13,6 +14,8 @@ import {
 import DataGridContainer from './container';
 const dataGridContainerSource = require('!!raw-loader!./container');
 const dataGridContainerHtml = renderToHtml(DataGridContainer);
+import DataGridFlex from './flex';
+const dataGridFlexSource = require('!!raw-loader!./flex');
 
 import DataGridStyling from './styling';
 const dataGridStylingSource = require('!!raw-loader!./styling');
@@ -203,9 +206,28 @@ export const DataGridStylingExample = {
           enables/disables grid controls based on available width.
         </p>
       ),
-      components: { DataGridContainer },
-
       demo: <DataGridContainer />,
+    },
+    {
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: dataGridFlexSource,
+        },
+      ],
+      text: (
+        <p>
+          When placed within an{' '}
+          <Link to="/layout/flex">
+            <strong>EuiFlexGroup</strong> and <strong>EuiFlexItem</strong>
+          </Link>
+          , the data grid will have trouble shrinking to fit. To fix this, you
+          will need to manually add a style of{' '}
+          <EuiCode language="css">min-width: 0</EuiCode> to the{' '}
+          <strong>EuiFlexItem</strong>.
+        </p>
+      ),
+      demo: <DataGridFlex />,
     },
     {
       source: [

--- a/src-docs/src/views/datagrid/flex.js
+++ b/src-docs/src/views/datagrid/flex.js
@@ -1,0 +1,93 @@
+import React, { useState, useCallback } from 'react';
+import { fake } from 'faker';
+
+import {
+  EuiDataGrid,
+  EuiPanel,
+  EuiLink,
+  EuiFlexItem,
+  EuiFlexGroup,
+} from '../../../../src/components/';
+
+const columns = [
+  {
+    id: 'name',
+  },
+  {
+    id: 'email',
+  },
+  {
+    id: 'city',
+  },
+  {
+    id: 'country',
+  },
+  {
+    id: 'account',
+  },
+];
+
+const data = [];
+
+for (let i = 1; i < 20; i++) {
+  data.push({
+    name: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
+    email: fake('{{internet.email}}'),
+    city: (
+      <EuiLink href="http://google.com">{fake('{{address.city}}')}</EuiLink>
+    ),
+    country: fake('{{address.country}}'),
+    account: fake('{{finance.account}}'),
+  });
+}
+
+export default () => {
+  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
+
+  const [visibleColumns, setVisibleColumns] = useState(() =>
+    columns.map(({ id }) => id)
+  );
+
+  const setPageIndex = useCallback(
+    (pageIndex) => setPagination({ ...pagination, pageIndex }),
+    [pagination, setPagination]
+  );
+  const setPageSize = useCallback(
+    (pageSize) => setPagination({ ...pagination, pageSize, pageIndex: 0 }),
+    [pagination, setPagination]
+  );
+
+  return (
+    <EuiFlexGroup>
+      <EuiFlexItem grow={false}>
+        <EuiPanel color="subdued">Sidebar</EuiPanel>
+      </EuiFlexItem>
+      <EuiFlexItem style={{ minWidth: 0 }}>
+        <EuiPanel style={{ height: 300 }} hasBorder paddingSize="none">
+          <EuiDataGrid
+            aria-label="Container constrained data grid demo"
+            columns={columns}
+            columnVisibility={{
+              visibleColumns: visibleColumns,
+              setVisibleColumns: setVisibleColumns,
+            }}
+            rowCount={data.length}
+            gridStyle={{
+              border: 'horizontal',
+              header: 'underline',
+            }}
+            renderCellValue={({ rowIndex, columnId }) =>
+              data[rowIndex][columnId]
+            }
+            pagination={{
+              ...pagination,
+              pageSizeOptions: [5, 10, 25],
+              onChangeItemsPerPage: setPageSize,
+              onChangePage: setPageIndex,
+            }}
+          />
+        </EuiPanel>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};


### PR DESCRIPTION
### Closes #4941


https://user-images.githubusercontent.com/549577/126009112-b445c3df-0dc0-45a5-8056-e2686039807b.mp4



### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
