### PR TITLE
[EuiOverlayMask] Fixed click event subscription bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Fixed render-blocking error when `EuiCodeBlock` is configured with an unsupported language ([#4943](https://github.com/elastic/eui/pull/4943))
 - Fixed initial alignment of `EuiDataGrid` cells and the expand button on multi-line cells ([#4955](https://github.com/elastic/eui/pull/4955))
+- Fixed click event subscription bug in `EuiOverlayMask` ([#4967](https://github.com/elastic/eui/pull/4967))
 
 ## [`35.1.0`](https://github.com/elastic/eui/tree/v35.1.0)
 

--- a/src/components/overlay_mask/overlay_mask.tsx
+++ b/src/components/overlay_mask/overlay_mask.tsx
@@ -99,15 +99,16 @@ export const EuiOverlayMask: FunctionComponent<EuiOverlayMaskProps> = ({
   useEffect(() => {
     if (!overlayMaskNode.current || !onClick) return;
     const portalTarget = overlayMaskNode.current;
-    overlayMaskNode.current.addEventListener('click', (e) => {
+    const listener = (e: Event) => {
       if (e.target === overlayMaskNode.current) {
         onClick();
       }
-    });
+    };
+    overlayMaskNode.current.addEventListener('click', listener);
 
     return () => {
       if (portalTarget && onClick) {
-        portalTarget.removeEventListener('click', onClick);
+        portalTarget.removeEventListener('click', listener);
       }
     };
   }, [onClick]);


### PR DESCRIPTION
### Summary

PR fixes an issue with the "click" event for EuiOverlayMask. Otherwise, it keeps adding listeners to the "click" event without removing them.