### PR TITLE
[EuiSearchBar] Handle 0 count after manual query manipulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Added `markdownFormatProps` prop to `EuiMarkdownEditor` to extend the props passed to the rendered `EuiMarkdownFormat` ([#4663](https://github.com/elastic/eui/pull/4663))
 - Added optional virtualized line rendering to `EuiCodeBlock` ([#4952](https://github.com/elastic/eui/pull/4952))
 
+**Bug fixes**
+
+- Fixed filter count of 0 in `EuiSearchBar` ([#4977](https://github.com/elastic/eui/pull/4977))
+
 ## [`36.0.0`](https://github.com/elastic/eui/tree/v36.0.0)
 
 - Refactored `EuiFlyout` types ([#4940](https://github.com/elastic/eui/pull/4940))

--- a/src/components/search_bar/filters/__snapshots__/field_value_selection_filter.test.tsx.snap
+++ b/src/components/search_bar/filters/__snapshots__/field_value_selection_filter.test.tsx.snap
@@ -6,10 +6,9 @@ exports[`FieldValueSelectionFilter active - field is global 1`] = `
   button={
     <EuiFilterButton
       grow={true}
-      hasActiveFilters={true}
+      hasActiveFilters={false}
       iconSide="right"
       iconType="arrowDown"
-      numActiveFilters={0}
       onClick={[Function]}
     >
       Tag

--- a/src/components/search_bar/filters/field_value_selection_filter.tsx
+++ b/src/components/search_bar/filters/field_value_selection_filter.tsx
@@ -342,7 +342,8 @@ export class FieldValueSelectionFilter extends Component<
       ? this.state.options.all.some((item) => this.isActiveField(item.field))
       : false;
 
-    const active = activeTop || activeItem;
+    const activeItemsCount = this.state.activeItems.length;
+    const active = (activeTop || activeItem) && activeItemsCount > 0;
 
     const button = (
       <EuiFilterButton
@@ -350,7 +351,7 @@ export class FieldValueSelectionFilter extends Component<
         iconSide="right"
         onClick={this.onButtonClick.bind(this)}
         hasActiveFilters={active}
-        numActiveFilters={active ? this.state.activeItems.length : undefined}
+        numActiveFilters={active ? activeItemsCount : undefined}
         grow>
         {config.name}
       </EuiFilterButton>


### PR DESCRIPTION
### Summary

Closes #4976 by marking a filter as inactive when the number of active filters drops to 0.
See repro steps in the[ issue](https://github.com/elastic/eui/issues/4976).

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
