### PR TITLE
Prevent datagrid cells from queuing up focus ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 **Bug fixes**
 
 - Fixed filter count of 0 in `EuiSearchBar` ([#4977](https://github.com/elastic/eui/pull/4977))
+- Fixed edge case where EuiDataGrid cells could create an infinite loop of focus changes ([#4983](https://github.com/elastic/eui/pull/4983))
 
 ## [`36.0.0`](https://github.com/elastic/eui/tree/v36.0.0)
 


### PR DESCRIPTION
### Summary

Fixes #4975 

A few things came together to create this bug:

* **EuiDataGrid** owns which cell is focused
* **EuiDataGridCell** subscribes to notifications about its focus state and responds accordingly by accepting focus
* **EuiDataGridCell** also reacts to it receiving focus by e.g. a user clicking on it, it tells the parent grid about the updated focus state in a setTimeout which is meant to allow any focus traps to deactivate before the cell re-claims focus
* If multiple cells receive focus within that same setTimeout delay, they each queued up the focus claim
* As the focus queue was processed, each cell noticed it was no longer focused and would re-queue its claim

This fix avoids any queuing by merging the timeouts into one.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
