### PR TITLE
[EuiSuperDatePicker] Button `title` formatting and i18n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added `fleetApp` and `agentApp` icons ([#4989](https://github.com/elastic/eui/pull/4989))
+- Added i18n tokens for `EuiSuperDatePicker` button `title` ([#4998](https://github.com/elastic/eui/pull/4998))
+
+**Bug fixes**
+
+- Fixed incorrect date formatting on `EuiSuperDatePicker` button `title` ([#4998](https://github.com/elastic/eui/pull/4998))
 
 ## [`36.1.0`](https://github.com/elastic/eui/tree/v36.1.0)
 

--- a/src/components/date_picker/super_date_picker/date_popover/date_popover_button.tsx
+++ b/src/components/date_picker/super_date_picker/date_popover/date_popover_button.tsx
@@ -12,7 +12,9 @@ import React, {
   MouseEventHandler,
 } from 'react';
 import classNames from 'classnames';
+import { LocaleSpecifier } from 'moment'; // eslint-disable-line import/named
 
+import { useEuiI18n } from '../../../i18n';
 import { EuiPopover, EuiPopoverProps } from '../../../popover';
 
 import { formatTimeString } from '../pretty_duration';
@@ -20,7 +22,6 @@ import {
   EuiDatePopoverContent,
   EuiDatePopoverContentProps,
 } from './date_popover_content';
-import { LocaleSpecifier } from 'moment'; // eslint-disable-line import/named
 
 export interface EuiDatePopoverButtonProps {
   className?: string;
@@ -74,11 +75,24 @@ export const EuiDatePopoverButton: FunctionComponent<EuiDatePopoverButtonProps> 
     },
   ]);
 
-  let title = value;
+  const formattedValue = formatTimeString(value, dateFormat, roundUp, locale);
+  let title = formattedValue;
+
+  const invalidTitle = useEuiI18n(
+    'euiDatePopoverButton.invalidTitle',
+    'Invalid date: {title}',
+    { title }
+  );
+  const outdatedTitle = useEuiI18n(
+    'euiDatePopoverButton.outdatedTitle',
+    'Update needed: {title}',
+    { title }
+  );
+
   if (isInvalid) {
-    title = `Invalid date: ${title}`;
+    title = invalidTitle;
   } else if (needsUpdating) {
-    title = `Update needed: ${title}`;
+    title = outdatedTitle;
   }
 
   const button = (
@@ -89,7 +103,7 @@ export const EuiDatePopoverButton: FunctionComponent<EuiDatePopoverButtonProps> 
       disabled={isDisabled}
       data-test-subj={`superDatePicker${position}DatePopoverButton`}
       {...buttonProps}>
-      {formatTimeString(value, dateFormat, roundUp, locale)}
+      {formattedValue}
     </button>
   );
 


### PR DESCRIPTION
### Summary

Fixes #4995 by formatting the date value passed to `title` and adds i18n tokens.

<img width="483" alt="image" src="https://user-images.githubusercontent.com/2728212/127679021-e0a39a47-dc5c-43d1-b5c6-4fe01930a8f7.png">

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
