### PR TITLE
[EuiFormRow] Allow isDisabled to remove interaction from label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added `isDisabled` prop to `EuiFormRow` that disables the child field element ([#4908](https://github.com/elastic/eui/pull/4908))
+- Pass `isDisabled` prop from `EuiFormRow` to `EuiFormLabel` which removes the interaction from the `EuiFormLabel`  ([#5009](https://github.com/elastic/eui/pull/#5009))
 
 ## [`37.0.0`](https://github.com/elastic/eui/tree/v37.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added `isDisabled` prop to `EuiFormRow` that disables the child field element ([#4908](https://github.com/elastic/eui/pull/4908))
-- Pass `isDisabled` prop from `EuiFormRow` to `EuiFormLabel` which removes the interaction from the `EuiFormLabel`  ([#5009](https://github.com/elastic/eui/pull/#5009))
+- Added `isDisabled` prop to `EuiFormLabel` and passed it down from `EuiFormRow` ([#5009](https://github.com/elastic/eui/pull/#5009))
 
 ## [`37.0.0`](https://github.com/elastic/eui/tree/v37.0.0)
 

--- a/src/components/form/form_label/__snapshots__/form_label.test.tsx.snap
+++ b/src/components/form/form_label/__snapshots__/form_label.test.tsx.snap
@@ -8,6 +8,19 @@ exports[`EuiFormLabel is rendered 1`] = `
 />
 `;
 
+exports[`EuiFormLabel props isDisabled is rendered 1`] = `
+<label
+  class="euiFormLabel euiFormLabel-isDisabled"
+/>
+`;
+
+exports[`EuiFormLabel props isDisabled is still disabled with for attribute 1`] = `
+<label
+  class="euiFormLabel euiFormLabel-isDisabled"
+  for=""
+/>
+`;
+
 exports[`EuiFormLabel props isFocused is rendered 1`] = `
 <label
   class="euiFormLabel euiFormLabel-isFocused"

--- a/src/components/form/form_label/_form_label.scss
+++ b/src/components/form/form_label/_form_label.scss
@@ -1,5 +1,6 @@
 /**
  * 1. Focused state overrides invalid state.
+ * 2. Disabled state overrides pointer.
  */
 .euiFormLabel {
   @include euiFormLabel;
@@ -13,8 +14,12 @@
   &.euiFormLabel-isFocused {
     color: $euiColorPrimary; /* 1 */
   }
-}
 
-.euiFormLabel[for] {
-  cursor: pointer;
+  &[for] {
+    cursor: pointer; /* 2 */
+  }
+
+  &[for].euiFormLabel-isDisabled {
+    cursor: default; /* 2 */
+  }
 }

--- a/src/components/form/form_label/form_label.test.tsx
+++ b/src/components/form/form_label/form_label.test.tsx
@@ -32,6 +32,20 @@ describe('EuiFormLabel', () => {
       expect(component).toMatchSnapshot();
     });
 
+    describe('isDisabled', () => {
+      test('is rendered', () => {
+        const component = render(<EuiFormLabel isDisabled />);
+
+        expect(component).toMatchSnapshot();
+      });
+
+      test('is still disabled with for attribute', () => {
+        const component = render(<EuiFormLabel isDisabled htmlFor="" />);
+
+        expect(component).toMatchSnapshot();
+      });
+    });
+
     test('type can be changed to legend', () => {
       const component = render(<EuiFormLabel type="legend" />);
 

--- a/src/components/form/form_label/form_label.tsx
+++ b/src/components/form/form_label/form_label.tsx
@@ -18,6 +18,10 @@ interface EuiFormLabelCommonProps {
   isFocused?: boolean;
   isInvalid?: boolean;
   /**
+   * Changes `cursor` to `default`.
+   */
+  isDisabled?: boolean;
+  /**
    * Default type is a `label` but can be changed to a `legend`
    * if using inside a `fieldset`.
    */
@@ -45,6 +49,7 @@ export const EuiFormLabel: FunctionComponent<EuiFormLabelProps> = ({
   type = 'label',
   isFocused,
   isInvalid,
+  isDisabled,
   children,
   className,
   ...rest
@@ -52,6 +57,7 @@ export const EuiFormLabel: FunctionComponent<EuiFormLabelProps> = ({
   const classes = classNames('euiFormLabel', className, {
     'euiFormLabel-isFocused': isFocused,
     'euiFormLabel-isInvalid': isInvalid,
+    'euiFormLabel-isDisabled': isDisabled,
   });
 
   if (type === 'legend') {

--- a/src/components/form/form_row/form_row.tsx
+++ b/src/components/form/form_row/form_row.tsx
@@ -84,7 +84,7 @@ type EuiFormRowCommonProps = CommonProps & {
    */
   helpText?: ReactNode | ReactNode[];
   /**
-   *  Passed along to the label element and the child field element when `disabled` doesn't already exist on the child field element.
+   *  Passed along to the label element; and to the child field element when `disabled` doesn't already exist on the child field element.
    */
   isDisabled?: boolean;
 };

--- a/src/components/form/form_row/form_row.tsx
+++ b/src/components/form/form_row/form_row.tsx
@@ -84,7 +84,7 @@ type EuiFormRowCommonProps = CommonProps & {
    */
   helpText?: ReactNode | ReactNode[];
   /**
-   *  Passed along to the child field element if `disabled` doesn't already exist on the child
+   *  Passed along to the label element and the child field element when `disabled` doesn't already exist on the child field element.
    */
   isDisabled?: boolean;
 };
@@ -237,6 +237,7 @@ export class EuiFormRow extends Component<EuiFormRowProps, EuiFormRowState> {
           <EuiFormLabel
             className="euiFormRow__label"
             isInvalid={isInvalid}
+            isDisabled={isDisabled}
             aria-invalid={isInvalid}
             {...labelProps}>
             {label}

--- a/src/components/form/form_row/form_row.tsx
+++ b/src/components/form/form_row/form_row.tsx
@@ -228,7 +228,7 @@ export class EuiFormRow extends Component<EuiFormRowProps, EuiFormRowState> {
       } else {
         labelProps = {
           htmlFor: hasChildLabel ? id : undefined,
-          isFocused: this.state.isFocused,
+          ...(!isDisabled && { isFocused: this.state.isFocused }), // If the row is disabled, don't pass the isFocused state.
           type: labelType,
         };
       }


### PR DESCRIPTION
### Summary
Fixes #4987 

This PR passes the `isDisabled` prop from `EuiFormRow` to `EuiFormLabel`. When `isDisabled = true` the `EuiFormLabel` applies a class that changes its appearance to be `cursor: default`, which overrides the default behavior of `cursor: pointer` when there is a `for` attribute on the label.

#### Before:
https://user-images.githubusercontent.com/63428137/128564497-ab7882e2-cc29-44d0-94da-8b748d728a1e.mov

#### After:
https://user-images.githubusercontent.com/63428137/128563993-f458c293-a7e5-4009-b555-dd0e5699a489.mov


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
