### PR TITLE
[EuiFormRow] Respect child `isDisabled`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug fixes**
 
 - Fixed usage of `outsideClickCloses` prop of `EuiFlyout` ([#4986](https://github.com/elastic/eui/pull/4986))
+- Fixed `EuiFormRow` ignoring `isDisabled` prop on the child element. ([#5022](https://github.com/elastic/eui/pull/5022))
 
 ## [`37.1.0`](https://github.com/elastic/eui/tree/v37.1.0)
 

--- a/src/components/form/form_row/form_row.tsx
+++ b/src/components/form/form_row/form_row.tsx
@@ -271,8 +271,8 @@ export class EuiFormRow extends Component<EuiFormRowProps, EuiFormRowState> {
     const child = Children.only(children);
     const field = cloneElement(child, {
       id,
-      // Allow the child's disabled prop to supercede the `isDisabled`
-      disabled: child.props.disabled ?? isDisabled,
+      // Allow the child's disabled or isDisabled prop to supercede the `isDisabled`
+      disabled: child.props.disabled ?? child.props.isDisabled ?? isDisabled,
       onFocus: this.onFocus,
       onBlur: this.onBlur,
       ...optionalProps,


### PR DESCRIPTION
### Summary

Related to #4908, EuiFormRow also needs to respect the `isDisabled` prop on a child element.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~

- [x] Checked for **breaking changes** and labeled appropriately

~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
