### PR TITLE
[EuiFlyout] Fix `outsideClickCloses` logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug fixes**
 
 - Fixed content in `EuiFilterButton` when `numFilters` is not passed ([#5012](https://github.com/elastic/eui/pull/5012))
+- Fixed default value of `outsideClickCloses` prop of `EuiFlyout` ([#5027](https://github.com/elastic/eui/pull/5027))
 
 ## [`37.2.0`](https://github.com/elastic/eui/tree/v37.2.0)
 

--- a/src-docs/src/views/flyout/flyout_small.js
+++ b/src-docs/src/views/flyout/flyout_small.js
@@ -24,6 +24,7 @@ export default () => {
     flyout = (
       <EuiFlyout
         ownFocus={false}
+        outsideClickCloses={true}
         onClose={closeFlyout}
         aria-labelledby={flyoutTitleId}>
         <EuiFlyoutHeader hasBorder>

--- a/src-docs/src/views/flyout/flyout_small.js
+++ b/src-docs/src/views/flyout/flyout_small.js
@@ -24,7 +24,6 @@ export default () => {
     flyout = (
       <EuiFlyout
         ownFocus={false}
-        outsideClickCloses={true}
         onClose={closeFlyout}
         aria-labelledby={flyoutTitleId}>
         <EuiFlyoutHeader hasBorder>

--- a/src/components/flyout/flyout.tsx
+++ b/src/components/flyout/flyout.tsx
@@ -361,15 +361,24 @@ const EuiFlyout = forwardRef(
      */
     let flyout = (
       <EuiFocusTrap disabled={isPushed} clickOutsideDisables={!ownFocus}>
-        {/* Outside click detector is needed if theres no overlay mask to auto-close when clicking on elements outside */}
-        <EuiOutsideClickDetector
-          isDisabled={isPushed || outsideClickCloses === false}
-          onOutsideClick={() => onClose()}>
-          {flyoutContent}
-        </EuiOutsideClickDetector>
+        {flyoutContent}
       </EuiFocusTrap>
     );
-
+    /**
+     * Unless outsideClickCloses = true, then add the outside click detector
+     */
+    if (ownFocus === false && outsideClickCloses === true) {
+      flyout = (
+        <EuiFocusTrap disabled={isPushed} clickOutsideDisables={!ownFocus}>
+          {/* Outside click detector is needed if theres no overlay mask to auto-close when clicking on elements outside */}
+          <EuiOutsideClickDetector
+            isDisabled={isPushed}
+            onOutsideClick={() => onClose()}>
+            {flyoutContent}
+          </EuiOutsideClickDetector>
+        </EuiFocusTrap>
+      );
+    }
     // If ownFocus is set, wrap with an overlay and allow the user to click it to close it.
     if (ownFocus && !isPushed) {
       flyout = (


### PR DESCRIPTION
### Summary

#4986 unintentionally changed the default value of `outsideClickCloses` to `true` when `ownFocus={false}`. This resets the default behavior while respecting `outsideClickCloses={true}` when `ownFocus={false}`.

See to-be-reverted docs change "Without ownFocus"

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
- [x] Revert `revert me` commit
