### PR TITLE
Update component-development.md

### DIFF
--- a/wiki/component-development.md
+++ b/wiki/component-development.md
@@ -67,12 +67,12 @@ This will create a `.tgz` file with the changes in your EUI directory. At this p
 Point the `package.json` file in Kibana to that file: `"@elastic/eui": "/path/to/elastic-eui-xx.x.x.tgz"`. Then run the following commands at Kibana's root folder:
 
 ```bash
-yarn kbn bootstrap --no-validate && FORCE_DLL_CREATION=true node scripts/kibana --dev
+yarn kbn bootstrap --no-validate && node scripts/kibana --dev
 ```
 
 * The `--no-validate` flag is required when bootstrapping with a `.tgz`.
   * Change the name of the `.tgz` after subsequent `yarn build` and `npm pack` steps (e.g., `elastic-eui-xx.x.x-1.tgz`, `elastic-eui-xx.x.x-2.tgz`). This is required for `yarn` to recognize new changes to the package.
-* Running Kibana with `FORCE_DLL_CREATION=true node scripts/kibana --dev` ensures it doesn't use a previously cached version of EUI.
+* Running Kibana with `node scripts/kibana --dev` ensures it doesn't use a previously cached version of EUI.
 
 
 ## Principles


### PR DESCRIPTION
### Summary

Remove FORCE_DLL_CREATION=true of the component development documentation, since it's no longer needed. When combining Kibana and a EUI branch, dlls are no longer created since https://github.com/elastic/kibana/pull/72096

Tested it in a cloud deployment, works.

