### PR TITLE
Enabled `EuiCodeBlock` copy button  in `EuiMarkdownFormat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Updated `copyClipboard` glyph in `EuiIcon` to be centered ([#5023](https://github.com/elastic/eui/pull/5023))
 - Updated `EuiFilePicker` `removeFiles` method to enable programmatic selection clearing  ([#5017](https://github.com/elastic/eui/pull/5017))
 - Updated `EuiFlyout` testenv mock to pass-through `onKeyDown` prop ([#5029](https://github.com/elastic/eui/pull/5029))
+- Enabled `EuiCodeBlock` copy button  in `EuiMarkdownFormat` ([#5032](https://github.com/elastic/eui/pull/5032))
 
 **Bug fixes**
 

--- a/src/components/markdown_editor/plugins/markdown_default_plugins/processing_plugins.tsx
+++ b/src/components/markdown_editor/plugins/markdown_default_plugins/processing_plugins.tsx
@@ -67,7 +67,7 @@ export const getDefaultEuiMarkdownProcessingPlugins = (): [
           // If there are linebreaks use codeblock, otherwise code
           /\r|\n/.exec(props.children) ||
           (props.className && props.className.indexOf(FENCED_CLASS) > -1) ? (
-            <EuiCodeBlock fontSize="m" paddingSize="s" {...props} />
+            <EuiCodeBlock fontSize="m" paddingSize="s" isCopyable {...props} />
           ) : (
             <EuiCode {...props} />
           ),


### PR DESCRIPTION
### Summary

This PR enables the `EuiCodeBlock` copy button in `EuiMarkdownFormat`. 

<img width="1811" alt="codeblock-copy@2x" src="https://user-images.githubusercontent.com/2750668/129583356-f58e3ac0-1ca8-47fa-b2fa-3706d9273968.png">


### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- ~[ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
