### PR TITLE
Remove Sketch references from Creating icons wiki

### DIFF
--- a/wiki/creating-icons.md
+++ b/wiki/creating-icons.md
@@ -91,4 +91,3 @@ _\** Run `yarn && yarn start` to view the EUI docs site locally._
 [icons]: https://elastic.github.io/eui/#/display/icons
 [docs]: https://elastic.github.io/eui/
 [svg-plugin]: https://www.figma.com/community/plugin/814345141907543603/SVG-Export
-[sketch-symbol-organizer-plugin]: [https://github.com/sonburn/symbol-organizer]

--- a/wiki/creating-icons.md
+++ b/wiki/creating-icons.md
@@ -53,7 +53,7 @@ EUI provides SVG icon formats only. After exporting your icon as an SVG from you
 - `fill: <value>`
 - `fill-rule: <value>` or `fillRule: <value>`
 
-_**Note**: Sketch users can use the [SVGO plugin][sketch-SVGO-plugin] to remove any extraneous code added by Sketch. Once installed, this plugin will run automatically any time an SVG is exported from Sketch._
+_**Note**: Figma users can use the [SVG Export plugin][svg-plugin] to optimize SVG sizes and code._
 
 ### Prepare the pull request
 
@@ -90,5 +90,5 @@ _\** Run `yarn && yarn start` to view the EUI docs site locally._
 
 [icons]: https://elastic.github.io/eui/#/display/icons
 [docs]: https://elastic.github.io/eui/
-[sketch-SVGO-plugin]: [https://www.sketch.com/extensions/plugins/svgo-compressor/]
+[svg-plugin]: https://www.figma.com/community/plugin/814345141907543603/SVG-Export
 [sketch-symbol-organizer-plugin]: [https://github.com/sonburn/symbol-organizer]

--- a/wiki/creating-icons.md
+++ b/wiki/creating-icons.md
@@ -35,7 +35,7 @@ This is where things get more opinionated. To maintain a cohesive, high quality 
 ![Guides](https://user-images.githubusercontent.com/446285/63458958-5624f580-c419-11e9-89cf-45fa1b596329.png)
 
 #### _For Figma users_
-_As a reference, you can view and duplicate our Figma library files via the **Figma icon** link atop the [EUI documentation site][docs] site. The "Icon" page within this file contains artboards for the vast majority of EUI glyphs._
+_As a reference, you can view and duplicate our [Figma Icon Template](https://www.figma.com/file/Alv38VIPHGd2cNZYKgtVEe/EUI-Utilities-Icon-Template?node-id=1%3A165). The "template" page within this project contains frames with helper grids, margins, and an example._
 
 #### _For non-Figma users_
 _While we use Figma to maintain our internal design library, you can use any design tool to produce the SVG file._

--- a/wiki/creating-icons.md
+++ b/wiki/creating-icons.md
@@ -34,11 +34,11 @@ This is where things get more opinionated. To maintain a cohesive, high quality 
 
 ![Guides](https://user-images.githubusercontent.com/446285/63458958-5624f580-c419-11e9-89cf-45fa1b596329.png)
 
-#### _For Sketch users_
-_As a reference, you can download and view the `icons.sketch` file via the **Sketch libraries** link atop the [EUI documentation site][docs] site. The Symbols page within this file contains artboards for the vast majority of EUI glyphs._
+#### _For Figma users_
+_As a reference, you can view and duplicate our Figma library files via the **Figma icon** link atop the [EUI documentation site][docs] site. The "Icon" page within this file contains artboards for the vast majority of EUI glyphs._
 
-#### _For non-Sketch users_
-_While we use Sketch to maintain our internal design library, you can use any design tool to produce the SVG file._
+#### _For non-Figma users_
+_While we use Figma to maintain our internal design library, you can use any design tool to produce the SVG file._
 
 ## Add the icon to the EUI repo
 


### PR DESCRIPTION
### Summary

The current Creating Icons wiki docs have a lot of references to Sketch (and says a Sketch library can be downloaded from EUI's docs, which no longer appears to be true). I translated them all as closely as I could to Figma equivalents (which we now appear to be using), although I'm far from a Figma expert and would totally appreciate a pair of eyes from someone with more knowledge than me.

### Checklist

N/A, documentation changes only