### PR TITLE
[Docs only] Fix type error in EuiDataGrid props table

### DIFF
--- a/src-docs/src/views/datagrid/datagrid_example.js
+++ b/src-docs/src/views/datagrid/datagrid_example.js
@@ -32,10 +32,9 @@ import {
   EuiDataGridControlColumn,
   EuiDataGridToolBarVisibilityColumnSelectorOptions,
   EuiDataGridRowHeightsOptions,
+  EuiDataGridCellValueElementProps,
+  EuiDataGridSchemaDetector,
 } from '!!prop-loader!../../../../src/components/datagrid/data_grid_types';
-
-import { EuiDataGridCellValueElementProps } from '!!prop-loader!../../../../src/components/datagrid/body/data_grid_cell';
-import { EuiDataGridSchemaDetector } from '!!prop-loader!../../../../src/components/datagrid/data_grid_schema';
 
 const gridSnippet = `
   <EuiDataGrid


### PR DESCRIPTION
### Summary

This PR should fix the type errors in the DataGrid props tab/table.

Before:

<img width="557" alt="" src="https://user-images.githubusercontent.com/549407/129964675-7901af03-d838-4569-b767-51b352d7224d.png">

After:

<img width="534" alt="" src="https://user-images.githubusercontent.com/549407/129964665-59771476-74fa-48a6-bd0e-0c2dc2498705.png">

The issue was that all types were moved to `data_grid_types.ts` in https://github.com/elastic/eui/pull/5008, and the 2 imports in the diff needed to be updated accordingly.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~

- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**

~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~