### PR TITLE
[Docs] Fixing up some more pages under Navigation

### DIFF
--- a/src-docs/src/components/guide_section/guide_section_parts/guide_section_snippets.tsx
+++ b/src-docs/src/components/guide_section/guide_section_parts/guide_section_snippets.tsx
@@ -12,14 +12,14 @@ export const GuideSectionSnippets: FunctionComponent<GuideSectionSnippets> = ({
   let snippetCode;
   if (typeof snippets === 'string') {
     snippetCode = (
-      <EuiCodeBlock language="html" fontSize="m" paddingSize="m" isCopyable>
+      <EuiCodeBlock language="jsx" fontSize="m" paddingSize="m" isCopyable>
         {snippets}
       </EuiCodeBlock>
     );
   } else {
     snippetCode = snippets.map((snip, index) => (
       <React.Fragment key={`snippet${index}`}>
-        <EuiCodeBlock language="html" fontSize="m" paddingSize="m" isCopyable>
+        <EuiCodeBlock language="jsx" fontSize="m" paddingSize="m" isCopyable>
           {snip}
         </EuiCodeBlock>
         {index < snippets.length - 1 && <EuiSpacer size="xs" />}

--- a/src-docs/src/routes.js
+++ b/src-docs/src/routes.js
@@ -364,10 +364,10 @@ const navigation = [
       KeyPadMenuExample,
       LinkExample,
       PaginationExample,
-      TreeViewExample,
       SideNavExample,
       StepsExample,
       TabsExample,
+      TreeViewExample,
     ].map((example) => createExample(example)),
   },
   {

--- a/src-docs/src/services/playground/playground.js
+++ b/src-docs/src/services/playground/playground.js
@@ -42,7 +42,7 @@ export default ({
     // TODO: Replace `html-format` with something better.
     // Notably, something more jsx-friendly
     try {
-      formatted = format(newCode.trim(), ' '.repeat(4));
+      formatted = format(newCode.trim(), '  '.repeat(1));
     } catch {
       formatted = newCode.trim();
     }

--- a/src-docs/src/views/breadcrumbs/breadcrumbs.js
+++ b/src-docs/src/views/breadcrumbs/breadcrumbs.js
@@ -4,9 +4,7 @@ import {
   EuiBreadcrumbs,
   EuiButton,
   EuiPageContent,
-  EuiPageContentHeader,
-  EuiPageContentHeaderSection,
-  EuiTitle,
+  EuiPageHeader,
   EuiSpacer,
 } from '../../../../src/components';
 
@@ -15,6 +13,7 @@ export default () => {
     {
       text: 'Animals',
       href: '#',
+      color: 'primary',
       onClick: (e) => {
         e.preventDefault();
       },
@@ -47,17 +46,10 @@ export default () => {
         aria-label="An example of EuiBreadcrumbs"
       />
       <EuiSpacer size="xs" />
-      <EuiPageContentHeader>
-        <EuiPageContentHeaderSection>
-          <EuiTitle size="l">
-            <h1>Boa constrictor</h1>
-          </EuiTitle>
-        </EuiPageContentHeaderSection>
-
-        <EuiPageContentHeaderSection>
-          <EuiButton>Cancel</EuiButton>
-        </EuiPageContentHeaderSection>
-      </EuiPageContentHeader>
+      <EuiPageHeader
+        pageTitle="Boa constrictor"
+        rightSideItems={[<EuiButton>Cancel</EuiButton>]}
+      />
     </EuiPageContent>
   );
 };

--- a/src-docs/src/views/breadcrumbs/breadcrumbs_example.js
+++ b/src-docs/src/views/breadcrumbs/breadcrumbs_example.js
@@ -34,7 +34,7 @@ const breadcrumpProps = {
 export const BreadcrumbsExample = {
   title: 'Breadcrumbs',
   intro: (
-    <EuiText grow={false}>
+    <EuiText>
       <p>
         <strong>EuiBreadcrumbs</strong> let the user track their progress within
         and back out of a UX flow and work well when used in combination with{' '}

--- a/src-docs/src/views/breadcrumbs/breadcrumbs_example.js
+++ b/src-docs/src/views/breadcrumbs/breadcrumbs_example.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 
 import { GuideSectionTypes } from '../../components';
 
-import { EuiCode, EuiBreadcrumbs } from '../../../../src/components';
+import { EuiCode, EuiBreadcrumbs, EuiText } from '../../../../src/components';
 import { BreadcrumbResponsiveMaxCount, BreadcrumbProps } from './props';
 
 import { breadcrumbsConfig } from './playground';
@@ -22,6 +22,7 @@ import TruncateSingle from './truncate_single';
 const truncateSingleSource = require('!!raw-loader!./truncate_single');
 
 import Max from './max';
+import { EuiCallOut } from '../../../../src/components/call_out';
 const maxSource = require('!!raw-loader!./max');
 
 const breadcrumpProps = {
@@ -32,6 +33,22 @@ const breadcrumpProps = {
 
 export const BreadcrumbsExample = {
   title: 'Breadcrumbs',
+  intro: (
+    <EuiText grow={false}>
+      <p>
+        <strong>EuiBreadcrumbs</strong> let the user track their progress within
+        and back out of a UX flow and work well when used in combination with{' '}
+        <Link to="/layout/page-header">
+          <strong>EuiPageHeader</strong>
+        </Link>
+        . They are meant to be used at lower page level flows, while{' '}
+        <Link to="/layout/header">
+          <strong>EuiHeaderBreadcrumbs</strong>
+        </Link>{' '}
+        should be used for application-wide navigation.
+      </p>
+    </EuiText>
+  ),
   sections: [
     {
       source: [
@@ -41,22 +58,28 @@ export const BreadcrumbsExample = {
         },
       ],
       text: (
-        <p>
-          <strong>EuiBreadcrumbs</strong> let the user track their progress
-          within and back out of a UX flow. You can provide an{' '}
-          <EuiCode>href</EuiCode> prop on any breadcrumb item that you wish to
-          make clickable, including the last item, though we recommend the last
-          item represent the current page and therefore the link is unnecessary.
-          They work well within{' '}
-          <Link to="/layout/page">
-            <strong>EuiPageContentHeader</strong>
-          </Link>{' '}
-          but be careful not to use them within an app that also uses{' '}
-          <Link to="/layout/header">
-            <strong>EuiHeaderBreadcrumbs</strong>
-          </Link>
-          .
-        </p>
+        <>
+          <p>
+            <strong>EuiBreadcrumbs</strong> requires an array of{' '}
+            <strong>EuiBreadcrumb</strong> objects as{' '}
+            <EuiCode>breadcrumbs</EuiCode> and handles truncation, including
+            middle-truncation in the case of many items, and mobile
+            responsiveness. Each item accepts an <EuiCode>href</EuiCode> prop,
+            though we recommend the last item represent the current page and
+            therefore the link is unnecessary.
+          </p>
+          <EuiCallOut
+            color="warning"
+            iconType="accessibility"
+            title={
+              <>
+                For accessibility, it is highly recommended to provide a
+                descriptive <EuiCode>aria-label</EuiCode> for each set of
+                breadcrumbs.
+              </>
+            }
+          />
+        </>
       ),
       props: breadcrumpProps,
       playground: breadcrumbsConfig,
@@ -70,11 +93,15 @@ export const BreadcrumbsExample = {
       text: 'Breadcrumb 2',
       href: '#',
     },
+    {
+      text: 'Current',
+      href: '#',
+    },
   ]}
-  aria-label=""
 />
 `,
       demo: <Breadcrumbs />,
+      demoPanelProps: { color: 'subdued' },
     },
     {
       title: 'Limit the number of breadcrumbs',
@@ -98,7 +125,6 @@ export const BreadcrumbsExample = {
       snippet: `<EuiBreadcrumbs
   max={4}
   breadcrumbs={breadcrumbs}
-  aria-label=""
 />`,
       demo: <Max />,
     },
@@ -126,7 +152,6 @@ export const BreadcrumbsExample = {
         `<EuiBreadcrumbs
   truncate={true}
   breadcrumbs={breadcrumbs}
-  aria-label=""
 />`,
       ],
     },
@@ -139,11 +164,10 @@ export const BreadcrumbsExample = {
       ],
       text: (
         <>
-          <h3>Single item only</h3>
           <p>
-            You can also force truncation on single breadcrumb{' '}
+            Alternatively, you can force truncation on single breadcrumb{' '}
             <strong>item</strong> by adding{' '}
-            <EuiCode>{'truncate: true'}</EuiCode>.
+            <EuiCode>{'truncate: true'}</EuiCode> to the object.
           </p>
         </>
       ),
@@ -158,7 +182,6 @@ export const BreadcrumbsExample = {
       truncate: true,
     }
   ]}
-  aria-label=""
 />`,
       ],
     },
@@ -186,7 +209,6 @@ export const BreadcrumbsExample = {
   responsive={false}
   max={null}
   breadcrumbs={breadcrumbs}
-  aria-label=""
 />`,
       ],
       demo: <Responsive />,
@@ -200,7 +222,6 @@ export const BreadcrumbsExample = {
       ],
       text: (
         <>
-          <h3>Customizing number of items to display</h3>
           <p>
             Alternatively, you can change number of breadcrumbs that show per
             breakpoint by passing a custom responsive object.
@@ -216,7 +237,6 @@ export const BreadcrumbsExample = {
   }}
   max={null}
   breadcrumbs={breadcrumbs}
-  aria-label=""
 />`,
       ],
       demo: <ResponsiveCustom />,

--- a/src-docs/src/views/breadcrumbs/breadcrumbs_example.js
+++ b/src-docs/src/views/breadcrumbs/breadcrumbs_example.js
@@ -1,28 +1,28 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-import { renderToHtml } from '../../services';
-
 import { GuideSectionTypes } from '../../components';
 
 import { EuiCode, EuiBreadcrumbs } from '../../../../src/components';
 import { BreadcrumbResponsiveMaxCount, BreadcrumbProps } from './props';
 
+import { breadcrumbsConfig } from './playground';
+
 import Breadcrumbs from './breadcrumbs';
 const breadcrumbsSource = require('!!raw-loader!./breadcrumbs');
-const breadcrumbsHtml = renderToHtml(Breadcrumbs);
 
 import Responsive from './responsive';
 const responsiveSource = require('!!raw-loader!./responsive');
-const responsiveHtml = renderToHtml(Responsive);
+import ResponsiveCustom from './responsive_custom';
+const responsiveCustomSource = require('!!raw-loader!./responsive_custom');
 
 import Truncate from './truncate';
 const truncateSource = require('!!raw-loader!./truncate');
-const truncateHtml = renderToHtml(Truncate);
+import TruncateSingle from './truncate_single';
+const truncateSingleSource = require('!!raw-loader!./truncate_single');
 
 import Max from './max';
 const maxSource = require('!!raw-loader!./max');
-const maxHtml = renderToHtml(Max);
 
 const breadcrumpProps = {
   EuiBreadcrumbs,
@@ -38,10 +38,6 @@ export const BreadcrumbsExample = {
         {
           type: GuideSectionTypes.JS,
           code: breadcrumbsSource,
-        },
-        {
-          type: GuideSectionTypes.HTML,
-          code: breadcrumbsHtml,
         },
       ],
       text: (
@@ -63,6 +59,7 @@ export const BreadcrumbsExample = {
         </p>
       ),
       props: breadcrumpProps,
+      playground: breadcrumbsConfig,
       snippet: `<EuiBreadcrumbs
   breadcrumbs={[
     {
@@ -85,10 +82,6 @@ export const BreadcrumbsExample = {
         {
           type: GuideSectionTypes.JS,
           code: maxSource,
-        },
-        {
-          type: GuideSectionTypes.HTML,
-          code: maxHtml,
         },
       ],
       text: (
@@ -116,10 +109,6 @@ export const BreadcrumbsExample = {
           type: GuideSectionTypes.JS,
           code: truncateSource,
         },
-        {
-          type: GuideSectionTypes.HTML,
-          code: truncateHtml,
-        },
       ],
       text: (
         <>
@@ -127,9 +116,7 @@ export const BreadcrumbsExample = {
             <strong>EuiBreadcrumbs</strong> will truncate the full set by
             default, forcing it to a single line and setting a max width on all
             items except for the last. You can turn this off by setting{' '}
-            <EuiCode language="ts">{'truncate={false}'}</EuiCode>. You can also
-            force truncation on single breadcrumb <strong>item</strong> by
-            adding <EuiCode>{'truncate: true'}</EuiCode>.
+            <EuiCode language="ts">{'truncate={false}'}</EuiCode>.
           </p>
         </>
       ),
@@ -141,6 +128,28 @@ export const BreadcrumbsExample = {
   breadcrumbs={breadcrumbs}
   aria-label=""
 />`,
+      ],
+    },
+    {
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: truncateSingleSource,
+        },
+      ],
+      text: (
+        <>
+          <h3>Single item only</h3>
+          <p>
+            You can also force truncation on single breadcrumb{' '}
+            <strong>item</strong> by adding{' '}
+            <EuiCode>{'truncate: true'}</EuiCode>.
+          </p>
+        </>
+      ),
+      props: breadcrumpProps,
+      demo: <TruncateSingle />,
+      snippet: [
         `<EuiBreadcrumbs
   truncate={false}
   breadcrumbs={[
@@ -160,10 +169,6 @@ export const BreadcrumbsExample = {
           type: GuideSectionTypes.JS,
           code: responsiveSource,
         },
-        {
-          type: GuideSectionTypes.HTML,
-          code: responsiveHtml,
-        },
       ],
       text: (
         <>
@@ -172,10 +177,6 @@ export const BreadcrumbsExample = {
             default and will collapse breadcrumbs on narrower screens. Setting{' '}
             <EuiCode language="ts">{'responsive={false}'}</EuiCode> will keep
             all breadcrumbs visible at all screens sizes.
-          </p>
-          <p>
-            Alternatively, you can change number of breadcrumbs that show per
-            breakpoint by passing a custom responsive object.
           </p>
         </>
       ),
@@ -187,6 +188,27 @@ export const BreadcrumbsExample = {
   breadcrumbs={breadcrumbs}
   aria-label=""
 />`,
+      ],
+      demo: <Responsive />,
+    },
+    {
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: responsiveCustomSource,
+        },
+      ],
+      text: (
+        <>
+          <h3>Customizing number of items to display</h3>
+          <p>
+            Alternatively, you can change number of breadcrumbs that show per
+            breakpoint by passing a custom responsive object.
+          </p>
+        </>
+      ),
+      props: breadcrumpProps,
+      snippet: [
         `<EuiBreadcrumbs
   responsive={{
     xs: 2,
@@ -197,7 +219,7 @@ export const BreadcrumbsExample = {
   aria-label=""
 />`,
       ],
-      demo: <Responsive />,
+      demo: <ResponsiveCustom />,
     },
   ],
 };

--- a/src-docs/src/views/breadcrumbs/playground.js
+++ b/src-docs/src/views/breadcrumbs/playground.js
@@ -1,0 +1,76 @@
+import {
+  EuiBreadcrumbs,
+  EuiBreadcrumb,
+} from '../../../../src/components/breadcrumbs';
+import {
+  propUtilityForPlayground,
+  generateCustomProps,
+} from '../../services/playground';
+
+export const breadcrumbsConfig = () => {
+  const docgenInfo = Array.isArray(EuiBreadcrumbs.__docgenInfo)
+    ? EuiBreadcrumbs.__docgenInfo[0]
+    : EuiBreadcrumbs.__docgenInfo;
+  const propsToUse = propUtilityForPlayground(docgenInfo.props);
+
+  const breadcrumbs = `[
+  {
+    text: 'Animals',
+    href: '#',
+  },
+  {
+    text: 'Metazoans',
+    href: '#',
+  },
+  {
+    text: 'Chordates',
+    href: '#',
+  },
+  {
+    text: 'Vertebrates',
+    href: '#',
+  },
+  {
+    text: 'Tetrapods',
+    href: '#',
+  },
+  {
+    text: 'Reptiles',
+    href: '#',
+  },
+  {
+    text: 'Boa constrictor',
+    href: '#',
+  },
+  {
+    text: 'Nebulosa subspecies',
+  },
+]`;
+
+  propsToUse.breadcrumbs = {
+    ...propsToUse.breadcrumbs,
+    value: breadcrumbs,
+  };
+
+  propsToUse.max = {
+    ...propsToUse.max,
+    value: 5,
+  };
+
+  return {
+    config: {
+      componentName: 'EuiBreadcrumbs',
+      props: propsToUse,
+      scope: {
+        EuiBreadcrumbs,
+        EuiBreadcrumb,
+      },
+      imports: {
+        '@elastic/eui': {
+          named: ['EuiBreadcrumbs', 'EuiBreadcrumb'],
+        },
+      },
+      customProps: generateCustomProps(['breadcrumbs']),
+    },
+  };
+};

--- a/src-docs/src/views/breadcrumbs/playground.js
+++ b/src-docs/src/views/breadcrumbs/playground.js
@@ -1,7 +1,4 @@
-import {
-  EuiBreadcrumbs,
-  EuiBreadcrumb,
-} from '../../../../src/components/breadcrumbs';
+import { EuiBreadcrumbs } from '../../../../src/components/breadcrumbs';
 import {
   propUtilityForPlayground,
   generateCustomProps,
@@ -63,11 +60,10 @@ export const breadcrumbsConfig = () => {
       props: propsToUse,
       scope: {
         EuiBreadcrumbs,
-        EuiBreadcrumb,
       },
       imports: {
         '@elastic/eui': {
-          named: ['EuiBreadcrumbs', 'EuiBreadcrumb'],
+          named: ['EuiBreadcrumbs'],
         },
       },
       customProps: generateCustomProps(['breadcrumbs']),

--- a/src-docs/src/views/breadcrumbs/responsive.js
+++ b/src-docs/src/views/breadcrumbs/responsive.js
@@ -1,10 +1,6 @@
 import React from 'react';
 
-import {
-  EuiBreadcrumbs,
-  EuiTitle,
-  EuiSpacer,
-} from '../../../../src/components';
+import { EuiBreadcrumbs } from '../../../../src/components';
 
 export default () => {
   const breadcrumbs = [
@@ -42,33 +38,11 @@ export default () => {
   ];
 
   return (
-    <>
-      <EuiTitle size="xs">
-        <span>Turning responsive completely off</span>
-      </EuiTitle>
-      <EuiSpacer size="s" />
-      <EuiBreadcrumbs
-        responsive={false}
-        breadcrumbs={breadcrumbs}
-        max={null}
-        aria-label="An example of non-responsive EuiBreadcrumbs"
-      />
-      <EuiSpacer />
-      <EuiTitle size="xs">
-        <span>Customizing number of items to display</span>
-      </EuiTitle>
-      <EuiSpacer size="s" />
-      <EuiBreadcrumbs
-        responsive={{
-          xs: 1,
-          s: 3,
-          m: 5,
-          xl: 6,
-        }}
-        breadcrumbs={breadcrumbs}
-        max={null}
-        aria-label="An example of custom responsive EuiBreadcrumbs"
-      />
-    </>
+    <EuiBreadcrumbs
+      responsive={false}
+      breadcrumbs={breadcrumbs}
+      max={null}
+      aria-label="An example of non-responsive EuiBreadcrumbs"
+    />
   );
 };

--- a/src-docs/src/views/breadcrumbs/responsive_custom.js
+++ b/src-docs/src/views/breadcrumbs/responsive_custom.js
@@ -9,10 +9,8 @@ export default () => {
       href: '#',
     },
     {
-      text:
-        'Metazoans is a real mouthful, especially for creatures without mouths',
+      text: 'Metazoans',
       href: '#',
-      truncate: true,
     },
     {
       text: 'Chordates',
@@ -35,16 +33,21 @@ export default () => {
       href: '#',
     },
     {
-      text:
-        'Nebulosa subspecies is also a real mouthful, especially for creatures without mouths',
+      text: 'Nebulosa subspecies',
     },
   ];
 
   return (
     <EuiBreadcrumbs
-      truncate={true}
+      responsive={{
+        xs: 1,
+        s: 3,
+        m: 5,
+        xl: 6,
+      }}
       breadcrumbs={breadcrumbs}
-      aria-label="An example of EuiBreadcrumbs with truncate prop"
+      max={null}
+      aria-label="An example of custom responsive EuiBreadcrumbs"
     />
   );
 };

--- a/src-docs/src/views/breadcrumbs/truncate_single.js
+++ b/src-docs/src/views/breadcrumbs/truncate_single.js
@@ -42,9 +42,9 @@ export default () => {
 
   return (
     <EuiBreadcrumbs
-      truncate={true}
+      truncate={false}
       breadcrumbs={breadcrumbs}
-      aria-label="An example of EuiBreadcrumbs with truncate prop"
+      aria-label="An example of EuiBreadcrumbs without truncate prop"
     />
   );
 };

--- a/src-docs/src/views/facet/facet_example.js
+++ b/src-docs/src/views/facet/facet_example.js
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { renderToHtml } from '../../services';
-
 import { GuideSectionTypes } from '../../components';
 
 import {
@@ -14,7 +12,6 @@ import { facetButtonConfig, facetLayoutConfig } from './playground';
 
 import Facet from './facet';
 const facetSource = require('!!raw-loader!./facet');
-const facetHtml = renderToHtml(Facet);
 const facetSnippet = `<EuiFacetButton
   quantity={6}
   icon={<EuiIcon type="dot" color="success" />}
@@ -25,7 +22,8 @@ const facetSnippet = `<EuiFacetButton
 
 import FacetLayout from './facet_layout';
 const facetLayoutSource = require('!!raw-loader!./facet_layout');
-const facetLayoutHtml = renderToHtml(FacetLayout);
+import FacetLayoutHorizontal from './facet_layout_horizontal';
+const facetLayoutHorizontalSource = require('!!raw-loader!./facet_layout_horizontal');
 
 export const FacetExample = {
   title: 'Facet',
@@ -35,10 +33,6 @@ export const FacetExample = {
         {
           type: GuideSectionTypes.JS,
           code: facetSource,
-        },
-        {
-          type: GuideSectionTypes.HTML,
-          code: facetHtml,
         },
       ],
       text: (
@@ -67,10 +61,6 @@ export const FacetExample = {
           type: GuideSectionTypes.JS,
           code: facetLayoutSource,
         },
-        {
-          type: GuideSectionTypes.HTML,
-          code: facetLayoutHtml,
-        },
       ],
       text: (
         <>
@@ -94,12 +84,28 @@ export const FacetExample = {
       props: { EuiFacetGroup },
       demo: <FacetLayout />,
       snippet: [
-        `// Restrict the width of default (vertical) if not restricted by parent
+        `// Restrict the width of the default (vertical) layout only if not restricted by parent
 <EuiFacetGroup style={{ maxWidth: 200 }}>{facets}</EuiFacetGroup>`,
-        `// Horizontal
-<EuiFacetGroup layout="horizontal" gutterSize="l">{facets}</EuiFacetGroup>`,
       ],
       playground: facetLayoutConfig,
+    },
+    {
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: facetLayoutHorizontalSource,
+        },
+      ],
+      text: (
+        <>
+          <h3>Horizontal and large gutter</h3>
+        </>
+      ),
+      props: { EuiFacetGroup },
+      demo: <FacetLayoutHorizontal />,
+      snippet: [
+        '<EuiFacetGroup layout="horizontal" gutterSize="l">{facets}</EuiFacetGroup>',
+      ],
     },
   ],
 };

--- a/src-docs/src/views/facet/facet_layout_horizontal.js
+++ b/src-docs/src/views/facet/facet_layout_horizontal.js
@@ -1,0 +1,150 @@
+import React, { useState } from 'react';
+
+import {
+  EuiFacetButton,
+  EuiFacetGroup,
+  EuiIcon,
+  EuiAvatar,
+} from '../../../../src/components';
+
+import { euiPaletteColorBlind } from '../../../../src/services';
+
+export default () => {
+  const [icon, setIcon] = useState(false);
+  const [disabled, setDisabled] = useState(false);
+  const [avatars, setAvatars] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [selectedOptionId, setSelectedOptionId] = useState(undefined);
+
+  const facet0Clicked = (id) => {
+    setIcon(false);
+    setDisabled(false);
+    setAvatars(false);
+    setLoading(false);
+    setSelectedOptionId((selectedOptionId) =>
+      selectedOptionId === id ? undefined : id
+    );
+  };
+
+  const facet1Clicked = (id) => {
+    setIcon(true);
+    setDisabled(false);
+    setAvatars(false);
+    setLoading(false);
+    setSelectedOptionId((selectedOptionId) =>
+      selectedOptionId === id ? undefined : id
+    );
+  };
+
+  const facet2Clicked = (id) => {
+    setDisabled((disabled) => !disabled);
+    setSelectedOptionId((selectedOptionId) =>
+      selectedOptionId === id ? undefined : id
+    );
+  };
+
+  const facet3Clicked = (id) => {
+    setIcon(false);
+    setDisabled(false);
+    setAvatars(true);
+    setLoading(false);
+    setSelectedOptionId((selectedOptionId) =>
+      selectedOptionId === id ? undefined : id
+    );
+  };
+
+  const facet4Clicked = (id) => {
+    setLoading(true);
+    setSelectedOptionId((selectedOptionId) =>
+      selectedOptionId === id ? undefined : id
+    );
+  };
+
+  const list = [
+    {
+      id: 'facetHorizontal0',
+      label: 'Simple, no icon',
+      quantity: 6,
+      iconColor: euiPaletteColorBlind()[0],
+      onClick: facet0Clicked,
+    },
+    {
+      id: 'facetHorizontal1',
+      label: 'Label or color indicator',
+      quantity: 60,
+      iconColor: euiPaletteColorBlind()[1],
+      onClick: facet1Clicked,
+    },
+    {
+      id: 'facetHorizontal2',
+      label: 'Disable all others',
+      quantity: 600,
+      iconColor: euiPaletteColorBlind()[2],
+      onClick: facet2Clicked,
+    },
+    {
+      id: 'facetHorizontal3',
+      label: 'Avatars instead of icons',
+      quantity: 60,
+      iconColor: euiPaletteColorBlind()[3],
+      onClick: facet3Clicked,
+    },
+    {
+      id: 'facetHorizontal4',
+      label: 'Show all as loading',
+      quantity: 6,
+      iconColor: euiPaletteColorBlind()[4],
+      onClick: facet4Clicked,
+    },
+    {
+      id: 'facetHorizontal5',
+      label: 'Just here to show truncation of really long labels',
+      quantity: 0,
+      iconColor: euiPaletteColorBlind()[5],
+    },
+  ];
+
+  clearTimeout(searchTimeout);
+
+  const searchTimeout = setTimeout(() => {
+    // Simulate a remotely-executed search.
+    setLoading(false);
+  }, 1200);
+
+  const facets = (align) => {
+    return (
+      <>
+        {list.map((facet) => {
+          let iconNode;
+          if (icon) {
+            iconNode = <EuiIcon type="dot" color={facet.iconColor} />;
+          } else if (avatars) {
+            iconNode = <EuiAvatar size="s" name={facet.label} />;
+          }
+
+          return (
+            <EuiFacetButton
+              key={facet.id}
+              id={`${facet.id}_${align}`}
+              quantity={facet.quantity}
+              icon={iconNode}
+              isSelected={selectedOptionId === facet.id}
+              isDisabled={disabled && facet.id !== 'facetHorizontal2'}
+              isLoading={loading}
+              onClick={
+                facet.onClick ? () => facet.onClick(facet.id) : undefined
+              }>
+              {facet.label}
+            </EuiFacetButton>
+          );
+        })}
+      </>
+    );
+  };
+
+  return (
+    <EuiFacetGroup layout="horizontal" gutterSize="l">
+      {facets('Horizontal')}
+    </EuiFacetGroup>
+  );
+};

--- a/src-docs/src/views/pagination/pagination_example.js
+++ b/src-docs/src/views/pagination/pagination_example.js
@@ -1,58 +1,51 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-import { renderToHtml } from '../../services';
-
 import { GuideSectionTypes } from '../../components';
 
 import {
   EuiCode,
   EuiPagination,
   EuiPaginationButton,
+  EuiText,
+  EuiCallOut,
 } from '../../../../src/components';
 
 import { paginationConfig } from './playground';
 
 import ManyPages from './many_pages';
 const manyPagesSource = require('!!raw-loader!./many_pages');
-const manyPagesHtml = renderToHtml(ManyPages);
 const manyPagesSnippet = `<EuiPagination
-  aria-label="my pagination"
+  aria-label={paginationLabel}
   pageCount={higherThan5Number}
   activePage={activePage}
-  onPageClick={goToPage}
-/>
-`;
+  onPageClick={(activePage) => goToPage(activePage)}
+/>`;
 
 import FewPages from './few_pages';
 const fewPagesSource = require('!!raw-loader!./few_pages');
-const fewPagesHtml = renderToHtml(FewPages);
 const fewPagesSnippet = `<EuiPagination
-  aria-label="my pagination"
+  aria-label={paginationLabel}
   pageCount={lowerThan5Number}
   activePage={activePage}
-  onPageClick={goToPage}
-/>
-`;
+  onPageClick={(activePage) => goToPage(activePage)}
+/>`;
 
 import CenteredPagination from './centered_pagination';
 const centeredPaginationSource = require('!!raw-loader!./centered_pagination');
-const centeredPaginationHtml = renderToHtml(CenteredPagination);
 const centeredPaginationSnippet = `<EuiFlexGroup justifyContent="spaceAround">
   <EuiFlexItem grow={false}>
     <EuiPagination
-      aria-label="my pagination"
+      aria-label={paginationLabel}
       pageCount={pageCount}
       activePage={activePage}
-      onPageClick={goToPage}
+      onPageClick={(activePage) => goToPage(activePage)}
     />
   </EuiFlexItem>
-</EuiFlexGroup>
-`;
+</EuiFlexGroup>`;
 
 import CustomizablePagination from './customizable_pagination';
 const customizablePaginationSource = require('!!raw-loader!./customizable_pagination');
-const customizablePaginationHtml = renderToHtml(CustomizablePagination);
 const customizablePaginationSnippet = `<EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
   <EuiFlexItem grow={false}>
     <EuiPopover
@@ -65,51 +58,74 @@ const customizablePaginationSnippet = `<EuiFlexGroup justifyContent="spaceBetwee
 
   <EuiFlexItem grow={false}>
     <EuiPagination
-      aria-label="my pagination"
+      aria-label={paginationLabel}
       pageCount={pageCount}
       activePage={activePage}
-      onPageClick={goToPage}
+      onPageClick={(activePage) => goToPage(activePage)}
     />
   </EuiFlexItem>
-</EuiFlexGroup>
-`;
+</EuiFlexGroup>`;
 
 import Compressed from './compressed';
 const compressedSource = require('!!raw-loader!./compressed');
-const compressedHtml = renderToHtml(Compressed);
 const compressedSnippet = `<EuiPagination
-  aria-label="my pagination"
+  aria-label={paginationLabel}
   pageCount={pageCount}
   activePage={activePage}
-  onPageClick={goToPage}
+  onPageClick={(activePage) => goToPage(activePage)}
   compressed
-/>
-`;
+/>`;
 
 export const PaginationExample = {
   title: 'Pagination',
+  intro: (
+    <EuiText>
+      <p>
+        Some EUI components have pagination built-in, like{' '}
+        <Link to="/tabular-content/tables">
+          <strong>EuiBasicTable</strong>
+        </Link>
+        , but for custom built paginated interfaces you can use{' '}
+        <strong>EuiPagination</strong> manually.
+      </p>
+    </EuiText>
+  ),
   sections: [
     {
-      title: 'Many pages',
+      title: 'Basic usage with many pages',
       source: [
         {
           type: GuideSectionTypes.JS,
           code: manyPagesSource,
         },
-        {
-          type: GuideSectionTypes.HTML,
-          code: manyPagesHtml,
-        },
       ],
       text: (
-        <p>
-          We only show at most 5 consecutive pages, with shortcuts to the first
-          and/or last page.
-        </p>
+        <>
+          <p>
+            <strong>EuiPagination</strong> accepts a total{' '}
+            <EuiCode>pageCount</EuiCode> and only shows up to 5 consecutive
+            pages, with shortcuts to the first and/or last page. It also
+            requires the parent component to maintain the current{' '}
+            <EuiCode>activePage</EuiCode> and handle the{' '}
+            <EuiCode>onPageClick</EuiCode>.
+          </p>
+          <EuiCallOut
+            color="warning"
+            iconType="accessibility"
+            title={
+              <>
+                For accessibility, it is highly recommended to provide a
+                descriptive <EuiCode>aria-label</EuiCode> for each pagination
+                set.
+              </>
+            }
+          />
+        </>
       ),
       props: { EuiPagination, EuiPaginationButton },
       snippet: manyPagesSnippet,
       demo: <ManyPages />,
+      playground: paginationConfig,
     },
     {
       title: 'Few pages',
@@ -117,10 +133,6 @@ export const PaginationExample = {
         {
           type: GuideSectionTypes.JS,
           code: fewPagesSource,
-        },
-        {
-          type: GuideSectionTypes.HTML,
-          code: fewPagesHtml,
         },
       ],
       text: (
@@ -138,10 +150,6 @@ export const PaginationExample = {
         {
           type: GuideSectionTypes.JS,
           code: centeredPaginationSource,
-        },
-        {
-          type: GuideSectionTypes.HTML,
-          code: centeredPaginationHtml,
         },
       ],
       text: (
@@ -163,10 +171,6 @@ export const PaginationExample = {
           type: GuideSectionTypes.JS,
           code: compressedSource,
         },
-        {
-          type: GuideSectionTypes.HTML,
-          code: compressedHtml,
-        },
       ],
       text: (
         <p>
@@ -184,16 +188,16 @@ export const PaginationExample = {
           type: GuideSectionTypes.JS,
           code: customizablePaginationSource,
         },
-        {
-          type: GuideSectionTypes.HTML,
-          code: customizablePaginationHtml,
-        },
       ],
       text: (
         <p>
           You can use{' '}
           <Link to="/layout/flex">
             <strong>EuiFlexGroup</strong>
+          </Link>{' '}
+          and{' '}
+          <Link to="/navigation/context-menu#with-single-panel">
+            <strong>EuiContextMenu</strong>
           </Link>{' '}
           to set up this pagination layout, commonly used with{' '}
           <Link to="/tabular-content/tables">tables</Link>.
@@ -203,5 +207,4 @@ export const PaginationExample = {
       demo: <CustomizablePagination />,
     },
   ],
-  playground: paginationConfig,
 };

--- a/src-docs/src/views/pagination/playground.js
+++ b/src-docs/src/views/pagination/playground.js
@@ -1,4 +1,4 @@
-import { EuiPagination, EuiText } from '../../../../src/components/';
+import { EuiPagination } from '../../../../src/components/';
 import {
   propUtilityForPlayground,
   dummyFunction,
@@ -12,17 +12,22 @@ export const paginationConfig = () => {
   const propsToUse = propUtilityForPlayground(docgenInfo.props);
 
   propsToUse.onPageClick = simulateFunction(propsToUse.onPageClick);
+
+  propsToUse.pageCount = {
+    ...propsToUse.pageCount,
+    value: 22,
+  };
+
   return {
     config: {
       componentName: 'EuiPagination',
       props: propsToUse,
       scope: {
         EuiPagination,
-        EuiText,
       },
       imports: {
         '@elastic/eui': {
-          named: ['EuiPagination', 'EuiText'],
+          named: ['EuiPagination'],
         },
       },
       customProps: {

--- a/src-docs/src/views/tree_view/playground.js
+++ b/src-docs/src/views/tree_view/playground.js
@@ -1,0 +1,60 @@
+import { EuiTreeView, EuiIcon } from '../../../../src/components';
+import {
+  propUtilityForPlayground,
+  generateCustomProps,
+} from '../../services/playground';
+
+export const TreeViewConfig = () => {
+  const docgenInfo = Array.isArray(EuiTreeView.__docgenInfo)
+    ? EuiTreeView.__docgenInfo[0]
+    : EuiTreeView.__docgenInfo;
+  const propsToUse = propUtilityForPlayground(docgenInfo.props);
+
+  propsToUse.display = {
+    ...propsToUse.display,
+    defaultValue: 'default',
+  };
+
+  propsToUse['aria-label'] = {
+    ...propsToUse['aria-label'],
+    value: 'Descriptive aria-label',
+  };
+
+  const items = `[
+    {
+      label: 'Item One',
+      id: 'item_one',
+      icon: <EuiIcon type="folderClosed" />,
+      iconWhenExpanded: <EuiIcon type="folderOpen" />,
+      children: [
+        {
+          label: 'Item A',
+          id: 'item_a',
+          icon: <EuiIcon type="document" />,
+        },
+      ],
+    }
+  ]`;
+
+  propsToUse.items = {
+    ...propsToUse.items,
+    value: items,
+  };
+
+  return {
+    config: {
+      componentName: 'EuiTreeView',
+      props: propsToUse,
+      scope: {
+        EuiTreeView,
+        EuiIcon,
+      },
+      imports: {
+        '@elastic/eui': {
+          named: ['EuiTreeView', 'EuiIcon'],
+        },
+      },
+      customProps: generateCustomProps(['items']),
+    },
+  };
+};

--- a/src-docs/src/views/tree_view/tree_view_example.js
+++ b/src-docs/src/views/tree_view/tree_view_example.js
@@ -1,20 +1,22 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-import { renderToHtml } from '../../services';
-
 import { GuideSectionTypes } from '../../components';
 
-import { EuiCode, EuiTreeView } from '../../../../src/components';
+import {
+  EuiCode,
+  EuiTreeView,
+  EuiText,
+  EuiCallOut,
+} from '../../../../src/components';
 import { EuiTreeViewNode } from './tree_view_props';
 import TreeView from './tree_view';
 import TreeViewCompressed from './compressed';
+import { TreeViewConfig } from './playground';
 
 const treeViewSource = require('!!raw-loader!./tree_view');
-const treeViewHtml = renderToHtml(TreeView);
 
 const treeViewCompressedSource = require('!!raw-loader!./compressed');
-const treeViewCompressedHtml = renderToHtml(TreeViewCompressed);
 
 const treeViewSnippet = [
   `<EuiTreeView
@@ -49,6 +51,19 @@ const treeViewSnippet = [
 
 export const TreeViewExample = {
   title: 'Tree view',
+  intro: (
+    <EuiText>
+      <p>
+        <strong>EuiTreeView</strong> allows you to render recursive objects,
+        such as a file directory. It is not meant to be used as primary
+        navigation, for that we recommend using{' '}
+        <Link to="/navigation/side-nav">
+          <strong>EuiSideNav</strong>
+        </Link>
+        .
+      </p>
+    </EuiText>
+  ),
   sections: [
     {
       source: [
@@ -56,34 +71,41 @@ export const TreeViewExample = {
           type: GuideSectionTypes.JS,
           code: treeViewSource,
         },
-        {
-          type: GuideSectionTypes.HTML,
-          code: treeViewHtml,
-        },
       ],
       text: (
         <div>
           <p>
-            <strong>EuiTreeView</strong> allows you to render recursive objects,
-            such as a file directory. The <EuiCode>children</EuiCode> prop takes
-            an array of <EuiCode>nodes</EuiCode>.
+            <strong>EuiTreeView</strong> does not accept{' '}
+            <EuiCode>children</EuiCode> directly but requires an array of{' '}
+            <EuiCode>EuiTreeViewNode</EuiCode>s through its{' '}
+            <EuiCode>items</EuiCode> prop.
           </p>
           <p>
-            Keyboard navigation allows users to navigate and interact with the
-            tree using the arrow keys, spacebar, and return.
+            Each node requires a <EuiCode>label</EuiCode> and a unique{' '}
+            <EuiCode>id</EuiCode>. The <EuiCode>icon</EuiCode> prop accepts any{' '}
+            <Link to="/display/icons">icon or token</Link>. You can also specify
+            a different icon for the open state with the{' '}
+            <EuiCode>iconWhenExpanded</EuiCode> prop. Use the nodes&apos;{' '}
+            <EuiCode>children</EuiCode> prop to nest more nodes.
           </p>
-          <p>
-            The <EuiCode>icon</EuiCode> prop accepts any{' '}
-            <Link to="/display/icons">icon or token</Link>. You can also
-            specifiy a different icon for the open state with the{' '}
-            <EuiCode>iconWhenExpanded</EuiCode> prop.
-          </p>
+          <EuiCallOut
+            color="warning"
+            iconType="accessibility"
+            title={
+              <>
+                For accessibility, it is required to provide a descriptive{' '}
+                <EuiCode>aria-label</EuiCode> for each tree view. This component
+                also builds in keyboard navigation allowing users to traverse
+                the tree using the arrow keys, spacebar, and return.
+              </>
+            }
+          />
         </div>
       ),
-      components: { EuiTreeView },
       demo: <TreeView />,
       snippet: treeViewSnippet,
       props: { EuiTreeView, EuiTreeViewNode },
+      playground: TreeViewConfig,
     },
     {
       title: 'Optional styling',
@@ -91,10 +113,6 @@ export const TreeViewExample = {
         {
           type: GuideSectionTypes.JS,
           code: treeViewCompressedSource,
-        },
-        {
-          type: GuideSectionTypes.HTML,
-          code: treeViewCompressedHtml,
         },
       ],
       text: (

--- a/src-docs/src/views/utility_classes/utility_classes_example.js
+++ b/src-docs/src/views/utility_classes/utility_classes_example.js
@@ -54,11 +54,14 @@ export const UtilityClassesExample = {
           <EuiCallOut
             color="warning"
             iconType="accessibility"
-            title="Scrollable regions must be focusable">
+            title="Scrollable regions must be focusable, promoted to region and with the right aria-label">
             <p>
               To ensure keyboard-only users have access to the scrollable
               regions, the optimal solution is to apply{' '}
-              <EuiCode>{'tabIndex="0"'}</EuiCode> to the region.{' '}
+              <EuiCode>{'tabIndex="0"'}</EuiCode> to the region. Add{' '}
+              <EuiCode language="html">{'role="region"'}</EuiCode> and supply an
+              accessible name by using{' '}
+              <EuiCode language="html">aria-label</EuiCode> or another method.
               <EuiLink href="https://dequeuniversity.com/rules/axe/4.1/scrollable-region-focusable">
                 Learn more about the{' '}
                 <EuiCode>scrollable-region-focusable</EuiCode> rule at Deque.

--- a/src-docs/src/views/utility_classes/utility_classes_overflow.js
+++ b/src-docs/src/views/utility_classes/utility_classes_overflow.js
@@ -46,6 +46,8 @@ export default () => (
           }}>
           <EuiText
             tabIndex={0}
+            role="region"
+            aria-label="Example of eui-yScroll region"
             className="eui-yScrollWithShadows"
             size="s"
             style={{ padding: 16 }}>
@@ -73,8 +75,10 @@ export default () => (
       snippet={`<BodyContent
   style={{ height: 200, overflowY: 'hidden' }}>
   <BodyScroll
-    className="eui-yScrollWithShadows"
     tabIndex={0}
+    role="region"
+    aria-label=""
+    className="eui-yScrollWithShadows"
   />
 </BodyContent>`}
     />
@@ -103,7 +107,11 @@ export default () => (
       }
       example={
         <EuiPanel color="warning" paddingSize="none">
-          <div tabIndex={0} className="eui-xScrollWithShadows">
+          <div
+            tabIndex={0}
+            role="region"
+            aria-label="Example of eui-xScroll region"
+            className="eui-xScrollWithShadows">
             <EuiText size="s" style={{ width: '150%', padding: 16 }}>
               <p>
                 Orbiting this at a distance of roughly ninety-two million miles
@@ -116,8 +124,10 @@ export default () => (
         </EuiPanel>
       }
       snippet={`<BodyScroll
-  className="eui-xScrollWithShadows"
-  tabIndex={0}>
+  tabIndex={0}
+  role="region"
+  aria-label=""
+  className="eui-xScrollWithShadows">
   <BodyContent style={{ width: '150%', padding: 16 }} />
 </BodyScroll>`}
     />
@@ -152,7 +162,12 @@ export default () => (
             gutterSize="s"
             responsive={false}>
             <EuiFlexItem>
-              <EuiPanel className="eui-yScroll" color="warning" tabIndex="0">
+              <EuiPanel
+                className="eui-yScroll"
+                color="warning"
+                tabIndex="0"
+                role="region"
+                aria-label="Example 1 for full height region">
                 <EuiText size="s">
                   <p>
                     Orbiting this at a distance of roughly ninety-two million
@@ -165,7 +180,12 @@ export default () => (
               </EuiPanel>
             </EuiFlexItem>
             <EuiFlexItem>
-              <EuiPanel className="eui-yScroll" color="warning" tabIndex="0">
+              <EuiPanel
+                className="eui-yScroll"
+                color="warning"
+                tabIndex="0"
+                role="region"
+                aria-label="Example 2 for full height region">
                 <EuiText size="s">
                   <p>
                     Orbiting this at a distance of roughly ninety-two million
@@ -185,11 +205,11 @@ export default () => (
     className="eui-fullHeight" responsive={false}>
     <EuiFlexItem>
       <BodyScroll
-        className="eui-yScroll" tabIndex="0"/>
+        className="eui-yScroll" tabIndex="0" role="region" aria-label=""/>
     </EuiFlexItem>
     <EuiFlexItem>
       <BodyScroll
-        className="eui-yScroll" tabIndex="0"/>
+        className="eui-yScroll" tabIndex="0" role="region" aria-label=""/>
     </EuiFlexItem>
   </EuiFlexGroup>
 </BodyContent>`}

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -56,7 +56,6 @@ export type EuiBreadcrumbsProps = CommonProps & {
   /**
    * Hides extra (above the max) breadcrumbs under a collapsed item as the window gets smaller.
    * Pass a custom #EuiBreadcrumbResponsiveMaxCount object to change the number of breadcrumbs to show at the particular breakpoints.
-   * Omitting or passing a `0` value will show all breadcrumbs.
    *
    * Pass `false` to turn this behavior off.
    *
@@ -73,7 +72,8 @@ export type EuiBreadcrumbsProps = CommonProps & {
 
   /**
    * Collapses the inner items past the maximum set here
-   * into a single ellipses item
+   * into a single ellipses item.
+   * Omitting or passing a `0` value will show all breadcrumbs.
    */
   max?: number | null;
 

--- a/src/components/flyout/flyout.tsx
+++ b/src/components/flyout/flyout.tsx
@@ -361,14 +361,25 @@ const EuiFlyout = forwardRef(
      */
     let flyout = (
       <EuiFocusTrap disabled={isPushed} clickOutsideDisables={!ownFocus}>
-        {/* Outside click detector is needed if theres no overlay mask to auto-close when clicking on elements outside */}
-        <EuiOutsideClickDetector
-          isDisabled={isPushed || outsideClickCloses === false}
-          onOutsideClick={() => onClose()}>
-          {flyoutContent}
-        </EuiOutsideClickDetector>
+        {flyoutContent}
       </EuiFocusTrap>
     );
+
+    /**
+     * Unless outsideClickCloses = true, then add the outside click detector
+     */
+    if (ownFocus === false && outsideClickCloses === true) {
+      flyout = (
+        <EuiFocusTrap disabled={isPushed} clickOutsideDisables={!ownFocus}>
+          {/* Outside click detector is needed if theres no overlay mask to auto-close when clicking on elements outside */}
+          <EuiOutsideClickDetector
+            isDisabled={isPushed}
+            onOutsideClick={() => onClose()}>
+            {flyoutContent}
+          </EuiOutsideClickDetector>
+        </EuiFocusTrap>
+      );
+    }
 
     // If ownFocus is set, wrap with an overlay and allow the user to click it to close it.
     if (ownFocus && !isPushed) {

--- a/src/components/pagination/__snapshots__/pagination.test.tsx.snap
+++ b/src/components/pagination/__snapshots__/pagination.test.tsx.snap
@@ -7,9 +7,10 @@ exports[`EuiPagination is rendered 1`] = `
   data-test-subj="test subject string"
 >
   <button
-    aria-label="Previous page, 1"
+    aria-label="Previous page"
     class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
     data-test-subj="pagination-button-previous"
+    disabled=""
     type="button"
   >
     <span
@@ -27,9 +28,11 @@ exports[`EuiPagination is rendered 1`] = `
       class="euiPagination__item"
     >
       <button
+        aria-current="true"
         aria-label="Page 1 of 1"
-        class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiPaginationButton euiPaginationButton--hideOnMobile"
+        class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
         data-test-subj="pagination-button-0"
+        disabled=""
         type="button"
       >
         <span
@@ -45,9 +48,10 @@ exports[`EuiPagination is rendered 1`] = `
     </li>
   </ul>
   <button
-    aria-label="Next page, 3"
+    aria-label="Next page"
     class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
     data-test-subj="pagination-button-next"
+    disabled=""
     type="button"
   >
     <span

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -51,7 +51,7 @@ type Props = CommonProps & HTMLAttributes<HTMLDivElement> & EuiPaginationProps;
 export const EuiPagination: FunctionComponent<Props> = ({
   className,
   pageCount = 1,
-  activePage = 1,
+  activePage = 0,
   onPageClick = () => {},
   compressed,
   'aria-controls': ariaControls,

--- a/src/components/tree_view/tree_view.tsx
+++ b/src/components/tree_view/tree_view.tsx
@@ -83,6 +83,10 @@ interface EuiTreeViewState {
 
 export type CommonTreeProps = CommonProps &
   HTMLAttributes<HTMLUListElement> & {
+    /**
+     * Never accepts children directly, only through the `items` prop
+     */
+    children?: never;
     /** An array of EuiTreeViewNodes
      */
     items: Node[];

--- a/src/themes/eui-amsterdam/global_styling/mixins/_link.scss
+++ b/src/themes/eui-amsterdam/global_styling/mixins/_link.scss
@@ -2,14 +2,22 @@
   text-align: left;
   font-weight: $euiButtonFontWeight;
 
-  &:hover,
-  &:focus {
-    text-decoration: underline;
+  &:hover {
+    @include euiLinkHover;
   }
 
   &:focus {
     @include euiFocusRing(null, 'outer');
-    // sass-lint:disable-block no-misspelled-properties no-important
-    text-decoration-thickness: $euiBorderWidthThick !important;
+    @include euiLinkFocus;
   }
+}
+
+@mixin euiLinkHover {
+  text-decoration: underline;
+}
+
+@mixin euiLinkFocus {
+  text-decoration: underline;
+  // sass-lint:disable-block no-misspelled-properties no-important
+  text-decoration-thickness: $euiBorderWidthThick !important;
 }

--- a/src/themes/eui-amsterdam/overrides/_facet.scss
+++ b/src/themes/eui-amsterdam/overrides/_facet.scss
@@ -1,0 +1,10 @@
+.euiFacetButton {
+  &:focus {
+    background-color: transparent;
+    box-shadow: none;
+
+    &:not(:disabled) .euiFacetButton__text {
+      @include euiLinkFocus;
+    }
+  }
+}

--- a/src/themes/eui-amsterdam/overrides/_index.scss
+++ b/src/themes/eui-amsterdam/overrides/_index.scss
@@ -9,6 +9,7 @@
 @import 'color_stops';
 @import 'comment';
 @import 'date_picker';
+@import 'facet';
 @import 'filter_group';
 @import 'form_control_layout';
 @import 'form_control_layout_delimited';
@@ -22,6 +23,7 @@
 @import 'mark';
 @import 'markdown_editor';
 @import 'modal';
+@import 'notification_badge';
 @import 'overlay_mask';
 @import 'popover';
 @import 'progress';

--- a/src/themes/eui-amsterdam/overrides/_notification_badge.scss
+++ b/src/themes/eui-amsterdam/overrides/_notification_badge.scss
@@ -1,0 +1,3 @@
+.euiNotificationBadge {
+  border-radius: $euiBorderRadiusSmall;
+}


### PR DESCRIPTION
### A. The main docs pages that were touched were:

1. Breadcrumbs
2. Facets
3. Pagination
4. Tree view
5. Overflow scroll utility classes (added more a11y guidance)

## B. Other related changes

### 1. EuiNotificationBadge

Closes #4992 by reducing the border-radius in Amsterdam theme
![image](https://user-images.githubusercontent.com/549577/130089789-f5439e6e-1956-40ed-962e-eebbfa6e6d1f.png)

### 2. EuiPagination

Fixed the default active page to the actual first page. The `activePage` is actually `0` based index, but the default was set to `1` making it default to selecting page 2. 🤣

### 3. EuiTreeView

This is a component that controls the render of it's items through an object passed as a prop. While `children` was actually allowed via TS, it would error if you tried to pass any. So I set it to never allow children with `children?: never;`

### 4. EuiFacet

Updated the focus states in Amsterdam to match our established patter.
![image](https://user-images.githubusercontent.com/549577/130092798-5d7ab8d2-7408-447b-9ca9-462d6484c388.png)


### 5. Changed doc's snippet code language from `html` to `jsx`

Mainly because nested objects made it very confused. 
![image](https://user-images.githubusercontent.com/549577/130090526-ce388e68-7683-4aef-8cc8-e44a7978fc8f.png)

## 6. Reduced Playground code from 4 space indents to 2 spaces

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
