### PR TITLE
[Linting] Fix Prettier linting issue in master

### DIFF
--- a/src-docs/src/views/icon/icon_example.js
+++ b/src-docs/src/views/icon/icon_example.js
@@ -80,11 +80,12 @@ export const IconExample = {
             <EuiCode language="js">size=&quot;m&quot;</EuiCode>.
           </p>
           <p>
-            If you would like to contribute to our growing list of glyphs,
-            you can follow{' '}
+            If you would like to contribute to our growing list of glyphs, you
+            can follow{' '}
             <EuiLink to="https://github.com/elastic/eui/blob/master/wiki/creating-icons.md">
               these guidelines
-            </EuiLink>.
+            </EuiLink>
+            .
           </p>
         </>
       ),


### PR DESCRIPTION
### Summary

The [ignore tech debt PR](https://github.com/elastic/eui/pull/5045/files#diff-a0fdacd2ade87c5238dde44378f574f7e123e669acdf8b740878b14b33b20275L11) caused `icon_examples.js` to stopped being lint-ignored and to start being correctly linted by Prettier. Turns out there were some Prettier issues to fix in it that I missed that are now causing issues in master - apologies!

Soapbox aside: Also a good case study in why not to add specific files to ignore files, but instead prefer either fixing the issue or to use single line `// *-ignore` type comments 😅 

### Checklist

N/A, linting fix only