### PR TITLE
[Docs only] Fix EuiFilePicker example file list on Firefox

### DIFF
--- a/src-docs/src/views/form_controls/file_picker.js
+++ b/src-docs/src/views/form_controls/file_picker.js
@@ -15,16 +15,16 @@ export default () => {
   const [large, setLarge] = useState(true);
 
   const onChange = (files) => {
-    setFiles(files.length > 0 ? files : {});
+    setFiles(files.length > 0 ? Array.from(files) : []);
   };
 
   const renderFiles = () => {
     if (files.length > 0) {
       return (
         <ul>
-          {Object.keys(files).map((item, i) => (
+          {files.map((file, i) => (
             <li key={i}>
-              <strong>{files[item].name}</strong> ({files[item].size} bytes)
+              <strong>{file.name}</strong> ({file.size} bytes)
             </li>
           ))}
         </ul>
@@ -57,9 +57,7 @@ export default () => {
               id="asdf2"
               multiple
               initialPromptText="Select or drag and drop multiple files"
-              onChange={(files) => {
-                onChange(files);
-              }}
+              onChange={onChange}
               display={large ? 'large' : 'default'}
               aria-label="Use aria labels when no actual label is in use"
             />


### PR DESCRIPTION
### Summary

I noticed this while QA testing https://github.com/elastic/eui/pull/5063 locally - my file list in the file picker doc example wasn't updating when I added/updated existing files, only on new file add:

![before](https://user-images.githubusercontent.com/549407/130293812-8659fd5b-421a-4d68-9f3c-42f0add78d38.gif)

(note how `trial` does not update to match `gold`, and 3 files are listed in the picker but not on the right)

After some digging, this appears to be because I'm a Firefox user, and Firefox for some reason is mutating the existing FileList in place, which fails to trigger a React state change 🤦‍♀️ (https://github.com/facebook/react/issues/18104)

There's a relatively simple `Array.from(FileList)` workaround you can use to correctly trigger state changes, which I thought was worth implementing both to fix this behavior and as an example to other dev users who may run into the same issue at some point in the future 🤷 

Fixed behavior on FF:

![after](https://user-images.githubusercontent.com/549407/130293244-caeb3f25-679d-40fa-a9f3-89dc36845dac.gif)

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~

- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**

~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
