### PR TITLE
[EuiDataGrid] Fix cell props not clearing state on column reorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed untranslated i18n strings for `EuiFilterButton` - adds 2 new tokens and removes old `euiFilterButton.filterBadge` token ([#4750](https://github.com/elastic/eui/pull/5061))
 - Fixed missing i18n token `EuiFilePicker`'s default prompt, and improved i18n string for `euiFilePicker.filesSelected` ([#5063](https://github.com/elastic/eui/pull/5063))
 - Fixed `EuiDataGrid` sort button text pluralization ([#5043](https://github.com/elastic/eui/pull/5043))
+- Fixed `EuiDataGrid` not clearing cell styles when column position changes ([#5068](https://github.com/elastic/eui/issues/5068))
 
 **Theme: Amsterdam**
 

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -251,6 +251,12 @@ export class EuiDataGridCell extends Component<
     return false;
   }
 
+  componentDidUpdate(prevProps: EuiDataGridCellProps) {
+    if (this.props.columnId !== prevProps.columnId) {
+      this.setCellProps({});
+    }
+  }
+
   setCellProps = (cellProps: HTMLAttributes<HTMLDivElement>) => {
     this.setState({ cellProps });
   };

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -1467,6 +1467,48 @@ describe('EuiDataGrid', () => {
         ['1-ColumnB', '1-ColumnA'],
       ]);
     });
+
+    it('resets cell props on column reorder', () => {
+      const columnVisibility = {
+        visibleColumns: ['ColumnA', 'ColumnB'],
+        setVisibleColumns: (visibleColumns: string[]) => {
+          columnVisibility.visibleColumns = visibleColumns;
+          component.setProps({ columnVisibility });
+        },
+      };
+
+      const component = mount(
+        <EuiDataGrid
+          aria-labelledby="#test"
+          columns={[{ id: 'ColumnA' }, { id: 'ColumnB' }]}
+          columnVisibility={columnVisibility}
+          rowCount={1}
+          renderCellValue={({ rowIndex, columnId, setCellProps }) => {
+            useEffect(() => {
+              if (columnId === 'ColumnB') {
+                setCellProps({ style: { color: 'blue' } });
+              }
+            }, [columnId, rowIndex, setCellProps]);
+
+            return `${rowIndex}-${columnId}`;
+          }}
+        />
+      );
+
+      const getCellColorAt = (index: number) =>
+        component
+          .find('[data-test-subj="dataGridRowCell"]')
+          .at(index)
+          .prop('style')?.color;
+
+      expect(getCellColorAt(0)).toEqual(undefined);
+      expect(getCellColorAt(1)).toEqual('blue');
+
+      moveColumnToIndex(component, 'B', 0);
+
+      expect(getCellColorAt(0)).toEqual('blue');
+      expect(getCellColorAt(1)).toEqual(undefined);
+    });
   });
 
   describe('column sorting', () => {

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -2213,7 +2213,7 @@ describe('EuiDataGrid', () => {
     });
   });
 
-  describe('rowHeighsOptions', () => {
+  describe('rowHeightsOptions', () => {
     it('all row heights options applied correctly', async () => {
       const component = mount(
         <EuiDataGrid


### PR DESCRIPTION
### Summary

closes #4599, and I _believe_ should also close #4665

The before/after screenshots depict the issue quite clearly, so I'll let a picture speak a thousand words for me 😄 

#### Before

![before](https://snid.es/2021MAR/gWVJAxc68IajWZl8.gif)

#### After

![after](https://user-images.githubusercontent.com/549407/130514411-be6532bc-7fe3-489b-8df8-dc841e260b61.gif)

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~

- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**

~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
