### PR TITLE
[EuiDataGrid] Fix stripes incorrectly alternating on sort/pagination 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `37.7.0`.
+**Bug fixes**
+
+- Fixed `EuiDataGrid` stripes not alternating as expected on sort/pagination ([#5070](https://github.com/elastic/eui/pull/5070))
 
 ## [`37.7.0`](https://github.com/elastic/eui/tree/v37.7.0)
 

--- a/src/components/datagrid/body/data_grid_body.test.tsx
+++ b/src/components/datagrid/body/data_grid_body.test.tsx
@@ -7,13 +7,13 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
 import { DataGridSortingContext } from '../data_grid_context';
 import { schemaDetectors } from '../data_grid_schema';
 import { RowHeightUtils } from '../row_height_utils';
 
-import { EuiDataGridBody, getParentCellContent } from './data_grid_body';
+import { EuiDataGridBody, Cell, getParentCellContent } from './data_grid_body';
 
 describe('EuiDataGridBody', () => {
   const requiredProps = {
@@ -120,6 +120,56 @@ describe('EuiDataGridBody', () => {
   // TODO: Test tabbing in Cypress
 
   // TODO: Test column resizing in Cypress
+});
+
+describe('Cell', () => {
+  const requiredProps = {
+    columnIndex: 0,
+    rowIndex: 0,
+    style: {},
+    data: {
+      rowMap: {},
+      rowOffset: 0,
+      leadingControlColumns: [],
+      trailingControlColumns: [],
+      columns: [{ id: 'C' }],
+      columnWidths: {},
+      defaultColumnWidth: 30,
+      schema: {},
+      schemaDetectors,
+      popoverContents: {},
+      interactiveCellId: '',
+      renderCellValue: jest.fn(),
+    },
+  };
+
+  it('is a light wrapper around EuiDataGridCell', () => {
+    const component = shallow(<Cell {...requiredProps} />);
+    expect(component.find('EuiDataGridCell').exists()).toBe(true);
+  });
+
+  describe('stripes', () => {
+    it('renders odd rows with .euiDataGridRowCell--stripe', () => {
+      const component = shallow(<Cell {...requiredProps} rowIndex={3} />);
+      expect(component.hasClass('euiDataGridRowCell--stripe')).toBe(true);
+
+      component.setProps({ rowIndex: 4 });
+      expect(component.hasClass('euiDataGridRowCell--stripe')).toBe(false);
+    });
+
+    it('renders striping based on the visible rowIndex, and not from the row offset that accounts for pagination', () => {
+      const component = shallow(
+        <Cell
+          {...requiredProps}
+          rowIndex={3}
+          data={{ ...requiredProps.data, rowOffset: 15 }}
+        />
+      );
+      expect(component.prop('rowIndex')).toBe(18);
+      expect(component.prop('visibleRowIndex')).toBe(3);
+      expect(component.hasClass('euiDataGridRowCell--stripe')).toBe(true);
+    });
+  });
 });
 
 describe('getParentCellContent', () => {

--- a/src/components/datagrid/body/data_grid_body.tsx
+++ b/src/components/datagrid/body/data_grid_body.tsx
@@ -89,7 +89,7 @@ const Cell: FunctionComponent<GridChildComponentProps> = ({
       leadingControlColumns.length +
       trailingControlColumns.length -
       1;
-  const isStripableRow = rowIndex % 2 !== 0;
+  const isStripableRow = visibleRowIndex % 2 !== 0;
 
   const isLeadingControlColumn = columnIndex < leadingControlColumns.length;
   const isTrailingControlColumn =

--- a/src/components/datagrid/body/data_grid_body.tsx
+++ b/src/components/datagrid/body/data_grid_body.tsx
@@ -48,7 +48,7 @@ import {
 
 export const VIRTUALIZED_CONTAINER_CLASS = 'euiDataGrid__virtualized';
 
-const Cell: FunctionComponent<GridChildComponentProps> = ({
+export const Cell: FunctionComponent<GridChildComponentProps> = ({
   columnIndex,
   rowIndex: visibleRowIndex,
   style,


### PR DESCRIPTION
### Summary

closes #4705

Apologies if the striping is hard to see on my recorded gif settings! 🙈 

#### Before

![before](https://user-images.githubusercontent.com/549407/130526483-9631c860-7931-4d91-9df0-a24981a1bd6f.gif)

#### After
![after](https://user-images.githubusercontent.com/549407/130526334-cbf45769-ebfa-42a1-adb6-564a4e09c4a4.gif)

### Checklist

This is a fairly straightforward JS fix, so I opted not to thoroughly frontend test it. I'm also 50/50 on adding unit tests for this fix; if we didn't have unit tests already written for striping I'm not a massive fan of adding ones now for a primarily visual bugfix, but I can do so if folks feel strongly about it!

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~

- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**

~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
