### PR TITLE
[EuiFormControlLayout] Fixed style of `compressed`, `prepend/append`, `readOnly` input backgrounds

### DIFF
--- a/src/themes/eui-amsterdam/overrides/_form_control_layout.scss
+++ b/src/themes/eui-amsterdam/overrides/_form_control_layout.scss
@@ -56,6 +56,10 @@
     border-radius: $euiFormControlCompressedBorderRadius;
     background-color: $euiFormInputGroupLabelBackground;
 
+    &.euiFormControlLayout--readOnly input {
+      background-color: $euiFormBackgroundReadOnlyColor;
+    }
+
     .euiFormControlLayout__prepend:first-child {
       @include euiFormControlSideBorderRadius($euiFormControlCompressedBorderRadius, $side: 'left', $internal: true);
 


### PR DESCRIPTION
### BEFORE

When working on the date picker styles, I noticed that the `readOnly` text input in the "Relative" tab didn't seem to be displaying correctly.

<img width="674" alt="Screen Shot 2021-08-23 at 17 12 19 PM" src="https://user-images.githubusercontent.com/549577/130659999-7aa1bc3e-bab4-495b-9754-896d652796a8.png">

So I compared the different state/toggles and themes and there's definitely a discrepancy between uncompressed and the compressed/default theme versions.

![image](https://user-images.githubusercontent.com/549577/130660091-f78c14fc-d759-4c81-8bfc-ab9d09212c7a.png)


### AFTER

This PR just fixes the background color for inputs when in the state of having a prepend/append, compressed, and readOnly.

![image](https://user-images.githubusercontent.com/549577/130660164-0aaa1463-5362-4d47-99bc-067ee7e902b7.png)
 


### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
