### PR TITLE
Fix screenreader text in DG sort dropdown

### DIFF
--- a/src/components/datagrid/column_sorting_draggable.tsx
+++ b/src/components/datagrid/column_sorting_draggable.tsx
@@ -70,13 +70,15 @@ export const EuiDataGridColumnSortingDraggable: FunctionComponent<EuiDataGridCol
           }`}
         >
           <EuiScreenReaderOnly>
-            <EuiI18n
-              token="euiColumnSortingDraggable.activeSortLabel"
-              default="{display} is sorting this data grid"
-              values={{ display }}
-            >
-              {(activeSortLabel: string) => <p>{activeSortLabel}</p>}
-            </EuiI18n>
+            <p>
+              <EuiI18n
+                token="euiColumnSortingDraggable.activeSortLabel"
+                default="{display} is sorting this data grid"
+                values={{ display }}
+              >
+                {(activeSortLabel: string) => <>{activeSortLabel}</>}
+              </EuiI18n>
+            </p>
           </EuiScreenReaderOnly>
           <EuiFlexGroup
             gutterSize="xs"


### PR DESCRIPTION
### Summary

Fixes https://github.com/elastic/eui/issues/5081

`EuiScreenReader` uses clones to apply classnames. If wrapped around an `i18n` block along, it can not pass the CSS class to the inner item.

![image](https://user-images.githubusercontent.com/324519/130814680-5be13b16-e7b8-44e1-ba82-41dc53a0b03a.png)
![image](https://user-images.githubusercontent.com/324519/130814833-26bdf6c8-0442-454b-a773-791e612ff0f2.png)


### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- ~[ ] Checked in **mobile**~
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles]~(https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
