### PR TITLE
Update documentation for service imports

### DIFF
--- a/src-docs/src/components/guide_section/_utils.js
+++ b/src-docs/src/components/guide_section/_utils.js
@@ -1,11 +1,7 @@
 import { cleanEuiImports } from '../../services';
 
 export const renderJsSourceCode = (code) => {
-  let renderedCode = code.default.replace(
-    /(from )'(..\/)+src\/.*?';/g,
-    "from '@elastic/eui';"
-  );
-  renderedCode = renderedCode.split('\n');
+  let renderedCode = cleanEuiImports(code.default).split('\n');
   const linesWithImport = [];
   // eslint-disable-next-line guard-for-in
   for (const idx in renderedCode) {
@@ -38,5 +34,5 @@ export const renderJsSourceCode = (code) => {
     len = renderedCode.replace('\n\n\n', '\n\n').length;
   }
 
-  return cleanEuiImports(renderedCode);
+  return renderedCode;
 };

--- a/src-docs/src/components/guide_section/_utils.js
+++ b/src-docs/src/components/guide_section/_utils.js
@@ -1,12 +1,10 @@
 import { cleanEuiImports } from '../../services';
 
 export const renderJsSourceCode = (code) => {
-  let renderedCode = code.default
-    .replace(
-      /(from )'(..\/)+src\/services(\/?';)/g,
-      "from '@elastic/eui/lib/services';"
-    )
-    .replace(/(from )'(..\/)+src\/components\/.*?';/g, "from '@elastic/eui';");
+  let renderedCode = code.default.replace(
+    /(from )'(..\/)+src\/.*?';/g,
+    "from '@elastic/eui';"
+  );
   renderedCode = renderedCode.split('\n');
   const linesWithImport = [];
   // eslint-disable-next-line guard-for-in

--- a/src-docs/src/services/string/clean_imports.js
+++ b/src-docs/src/services/string/clean_imports.js
@@ -3,12 +3,7 @@ export const hasDisplayToggles = (code) => {
 };
 
 export const cleanEuiImports = (code) => {
-  return code
-    .replace(/(from )'(..\/)+src\/components(\/?';)/, "from '@elastic/eui';")
-    .replace(
-      /(from )'(..\/)+src\/services(\/?';)/,
-      "from '@elastic/eui/lib/services';"
-    );
+  return code.replace(/(from )'(..\/)+src(\/.*)?';/g, "from '@elastic/eui';");
 };
 
 export const listExtraDeps = (code) => {

--- a/wiki/consuming.md
+++ b/wiki/consuming.md
@@ -26,15 +26,6 @@ import {
 } from '@elastic/eui';
 ```
 
-### Services
-
-Most services are published from the `lib/services` directory. Some are published from their module directories in this directory.
-
-```js
-import { keys } from '@elastic/eui/lib/services';
-import { Timer } from '@elastic/eui/lib/services/time';
-```
-
 ### Test
 
 Test utilities are published from the `lib/test` directory.


### PR DESCRIPTION
### Summary

Updates the _consuming_ wiki & _Demo JS_ code rendering to not import from locations other than `@elastic/eui`. Noticed this while looking at some accordion examples with @breehall.

### Before

<img width="476" alt="Screen Shot 2021-08-26 at 1 41 41 PM" src="https://user-images.githubusercontent.com/313125/131025681-c3869f11-2955-4b33-bca8-6f38bc72640e.png">

### After

<img width="488" alt="Screen Shot 2021-08-26 at 1 43 22 PM" src="https://user-images.githubusercontent.com/313125/131025868-9ec86f12-13da-4f7c-8c1b-353ce4e8bcd6.png">


### ~Checklist~
