### PR TITLE
Added `euiTextBreakWord` mixin to the `euiTitle` mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Added `euiTextBreakWord()` mixin to the `euiTitle()` mixin to ensure all titles break long words ([#5107](https://github.com/elastic/eui/pull/5107))
+- Added `euiTextBreakWord()` to `EuiFormLabels` ([#5107](https://github.com/elastic/eui/pull/5107))
+
 **Bug fixes**
 
 - Fixed `EuiSuperSelect`'s focus keyboard behavior when no initial value is passed, and focus label behavior ([#5097](https://github.com/elastic/eui/pull/5097))

--- a/src/components/form/form_row/_form_row.scss
+++ b/src/components/form/form_row/_form_row.scss
@@ -38,7 +38,6 @@
   align-items: stretch;
 
   .euiFormRow__label {
-    @include euiTextBreakWord;
     hyphens: auto;
     max-width: 100%; // Fixes IE
   }

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -145,7 +145,6 @@
  * 1. Vertically align all children.
  * 2. The padding on this div allows the ellipsis to show if the content is truncated. If
  *    the padding was on the cell, the ellipsis would be cropped.
- * 3. Support wrapping.
  * 4. Prevent very long single words (e.g. the name of a field in a document) from overflowing
  *    the cell.
  */
@@ -175,7 +174,7 @@
 .euiTableHeaderCell,
 .euiTableFooterCell,
 .euiTableCellContent--truncateText {
-  white-space: nowrap; /* 3 */
+  @include euiTextTruncate;
 
   .euiTableCellContent__text {
     overflow: hidden;

--- a/src/components/toast/_toast.scss
+++ b/src/components/toast/_toast.scss
@@ -88,7 +88,6 @@ $euiToastTypes: (
 
 .euiToastHeader__title {
   @include euiTitle('xs');
-  @include euiTextBreakWord;
   font-weight: $euiFontWeightLight;
 }
 

--- a/src/global_styling/mixins/_form.scss
+++ b/src/global_styling/mixins/_form.scss
@@ -1,6 +1,7 @@
 // Labels
 @mixin euiFormLabel {
   @include euiFontSizeXS;
+  @include euiTextBreakWord;
   color: $euiTitleColor;
   font-weight: $euiFontWeightSemiBold;
 }

--- a/src/global_styling/mixins/_typography.scss
+++ b/src/global_styling/mixins/_typography.scss
@@ -58,6 +58,7 @@
 }
 
 @mixin euiTitle($size: 'm') {
+  @include euiTextBreakWord;
   color: $euiTitleColor;
 
   @if (map-has-key($euiTitles, $size)) {

--- a/src/global_styling/mixins/_typography.scss
+++ b/src/global_styling/mixins/_typography.scss
@@ -61,6 +61,12 @@
   @include euiTextBreakWord;
   color: $euiTitleColor;
 
+  // REMOVE ME
+  &::after {
+    content: 'This_is_a_really_long_word_to_test_what_happens_to_every_use_of_euiTitle()_mixin_that_exists_in_any_component';
+  }
+  // FOR TESTING ONLY
+
   @if (map-has-key($euiTitles, $size)) {
     @each $property, $value in map-get($euiTitles, $size) {
       @if ($property == 'font-size') {

--- a/src/global_styling/mixins/_typography.scss
+++ b/src/global_styling/mixins/_typography.scss
@@ -61,12 +61,6 @@
   @include euiTextBreakWord;
   color: $euiTitleColor;
 
-  // REMOVE ME
-  &::after {
-    content: 'This_is_a_really_long_word_to_test_what_happens_to_every_use_of_euiTitle()_mixin_that_exists_in_any_component';
-  }
-  // FOR TESTING ONLY
-
   @if (map-has-key($euiTitles, $size)) {
     @each $property, $value in map-get($euiTitles, $size) {
       @if ($property == 'font-size') {


### PR DESCRIPTION
### Closes #5105

Ensures that anywhere we use the title mixin to create titles, it will break on really long words if need be. This doesn’t affect those that use it with truncation.

<img width="1003" alt="Screen Shot 2021-08-28 at 18 21 14 PM" src="https://user-images.githubusercontent.com/549577/131232399-7701b2dc-5cf9-446f-a9b4-b086b2dfc45d.png">


## Testing 

I've also pushed a `REVERT ME` commit that adds a really long string to the end of content that uses the mixin to test all the usages.

## Found breaks with fixes

<details>
<summary> EuiTable header cell wasn't using the full `euiTextTruncate` mixin </summary>

---

This was a really old style, before we had the mixin, where there title mixin was used at more parent element than the truncation mixin. But there was a style that was applying `nowrap` at the same level, which I just changed to the whole `euiTextTruncate` mixin.

**Before**
<img width="1018" alt="Screen Shot 2021-08-28 at 18 15 27 PM" src="https://user-images.githubusercontent.com/549577/131232368-cae209d8-3ef0-42fa-ba7f-dd555710a563.png">

**After**
<img width="1014" alt="Screen Shot 2021-08-28 at 18 16 16 PM" src="https://user-images.githubusercontent.com/549577/131232372-7aa25b35-6bd5-4e9f-b8d6-dba723bfd084.png">

---
</details>

<details>
<summary> Added `euiTextTruncate` mixin to EuiFormLabel</summary>

---

It doesn't actually use the `euiText` mixin, but I saw it was only getting the word-wrap when used in a horizontal form row. I've moved it to apply to ALL form row labels.

**Before**
<img width="603" alt="Screen Shot 2021-08-28 at 18 08 13 PM" src="https://user-images.githubusercontent.com/549577/131232656-c773dd87-4f0d-44ab-b502-1630077fcdb7.png">

**After**
<img width="607" alt="Screen Shot 2021-08-28 at 18 08 59 PM" src="https://user-images.githubusercontent.com/549577/131232658-87508dfd-6a9f-44a3-82a7-1322b5b88aee.png">

---
</details>


## Known breaks that need a follow up

<details>
<summary> EuiHeader has general truncation/max-width control issues. #5110</summary>
<img width="1010" alt="Screen Shot 2021-08-28 at 17 58 30 PM" src="https://user-images.githubusercontent.com/549577/131232131-ce518529-a8ac-4cc5-8ec3-ba7405168056.png">
</details>

<details>
<summary> EuiCallOut and EuiToast's left alignment isn't great #5111</summary>
<img width="1009" alt="Screen Shot 2021-08-28 at 18 21 41 PM" src="https://user-images.githubusercontent.com/549577/131232414-c54d1878-08a8-4afb-ba0c-903fbcf1eb8b.png">
<img width="346" alt="Screen Shot 2021-08-28 at 18 25 16 PM" src="https://user-images.githubusercontent.com/549577/131232447-07a61533-442a-4667-bece-19bf05a6e8d4.png">
</details>

<details>
<summary>Should EuiTour max it's width? #5112</summary>
<img width="1051" alt="Screen Shot 2021-08-28 at 18 26 22 PM" src="https://user-images.githubusercontent.com/549577/131232467-a7c21be1-59fb-4599-85a5-a004b4495af3.png">
</details>

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
- [ ] Revert test commit