### PR TITLE
[Docs] Replace Static HTML Element IDs with `htmlIdGenerator()()`

### DIFF
--- a/src-docs/src/views/accordion/accordion.js
+++ b/src-docs/src/views/accordion/accordion.js
@@ -1,13 +1,18 @@
 import React from 'react';
 
 import { EuiAccordion, EuiPanel } from '../../../../src/components';
+import { htmlIdGenerator } from '../../../../src/services';
 
-export default () => (
-  <div>
-    <EuiAccordion id="accordion1" buttonContent="Click me to toggle">
-      <EuiPanel color="subdued">
-        Any content inside of <strong>EuiAccordion</strong> will appear here.
-      </EuiPanel>
-    </EuiAccordion>
-  </div>
-);
+export default () => {
+  const accordionID = htmlIdGenerator('accordion')();
+
+  return (
+    <div>
+      <EuiAccordion id={accordionID} buttonContent="Click me to toggle">
+        <EuiPanel color="subdued">
+          Any content inside of <strong>EuiAccordion</strong> will appear here.
+        </EuiPanel>
+      </EuiAccordion>
+    </div>
+  );
+};

--- a/src-docs/src/views/accordion/accordion_arrow.js
+++ b/src-docs/src/views/accordion/accordion_arrow.js
@@ -1,14 +1,19 @@
 import React from 'react';
 
 import { EuiAccordion, EuiPanel } from '../../../../src/components';
+import { htmlIdGenerator } from '../../../../src/services';
 
-export default () => (
-  <EuiAccordion
-    id="accordion11"
-    arrowDisplay="none"
-    buttonContent="This one has it removed entirely">
-    <EuiPanel color="subdued">
-      Any content inside of <strong>EuiAccordion</strong> will appear here.
-    </EuiPanel>
-  </EuiAccordion>
-);
+export default () => {
+  const accordionID = htmlIdGenerator('accordion')();
+
+  return (
+    <EuiAccordion
+      id={accordionID}
+      arrowDisplay="none"
+      buttonContent="This one has it removed entirely">
+      <EuiPanel color="subdued">
+        Any content inside of <strong>EuiAccordion</strong> will appear here.
+      </EuiPanel>
+    </EuiAccordion>
+  );
+};

--- a/src-docs/src/views/accordion/accordion_arrow_right.js
+++ b/src-docs/src/views/accordion/accordion_arrow_right.js
@@ -1,14 +1,19 @@
 import React from 'react';
 
 import { EuiAccordion, EuiPanel } from '../../../../src/components';
+import { htmlIdGenerator } from '../../../../src/services';
 
-export default () => (
-  <EuiAccordion
-    id="accordion10"
-    arrowDisplay="right"
-    buttonContent="This accordion has the arrow on the right">
-    <EuiPanel color="subdued">
-      Any content inside of <strong>EuiAccordion</strong> will appear here.
-    </EuiPanel>
-  </EuiAccordion>
-);
+export default () => {
+  const accordionID = htmlIdGenerator('accordion')();
+
+  return (
+    <EuiAccordion
+      id={accordionID}
+      arrowDisplay="right"
+      buttonContent="This accordion has the arrow on the right">
+      <EuiPanel color="subdued">
+        Any content inside of <strong>EuiAccordion</strong> will appear here.
+      </EuiPanel>
+    </EuiAccordion>
+  );
+};

--- a/src-docs/src/views/accordion/accordion_extra.js
+++ b/src-docs/src/views/accordion/accordion_extra.js
@@ -1,13 +1,18 @@
 import React from 'react';
 
 import { EuiAccordion, EuiButton } from '../../../../src/components';
+import { htmlIdGenerator } from '../../../../src/services';
 
-export default () => (
-  <EuiAccordion
-    id="accordionExtraWithLeftArrow"
-    buttonContent="Click to open"
-    extraAction={<EuiButton size="s">Extra action!</EuiButton>}
-    paddingSize="l">
-    <strong>Opened content.</strong>
-  </EuiAccordion>
-);
+export default () => {
+  const accordionID = htmlIdGenerator('accordion')();
+
+  return (
+    <EuiAccordion
+      id={accordionID}
+      buttonContent="Click to open"
+      extraAction={<EuiButton size="s">Extra action!</EuiButton>}
+      paddingSize="l">
+      <strong>Opened content.</strong>
+    </EuiAccordion>
+  );
+};

--- a/src-docs/src/views/accordion/accordion_forceState.js
+++ b/src-docs/src/views/accordion/accordion_forceState.js
@@ -35,6 +35,8 @@ export default () => {
     setID(`${idPrefix}--${newState}`);
   };
 
+  const accordionID = htmlIdGenerator('accordion')();
+
   return (
     <div>
       <EuiButtonGroup
@@ -45,7 +47,7 @@ export default () => {
       />
       <EuiSpacer />
       <EuiAccordion
-        id={htmlIdGenerator()()}
+        id={accordionID}
         forceState={trigger}
         onToggle={onToggle}
         buttonContent="I am a controlled accordion"

--- a/src-docs/src/views/accordion/accordion_form.js
+++ b/src-docs/src/views/accordion/accordion_form.js
@@ -16,6 +16,7 @@ import {
   EuiTitle,
   EuiButtonIcon,
 } from '../../../../src/components';
+import { htmlIdGenerator } from '../../../../src/services';
 
 const repeatableForm = (
   <EuiForm component="form">
@@ -76,26 +77,31 @@ const extraAction = (
   />
 );
 
-export default () => (
-  <div>
-    <EuiAccordion
-      id="accordionForm1"
-      className="euiAccordionForm"
-      buttonClassName="euiAccordionForm__button"
-      buttonContent={buttonContent}
-      extraAction={extraAction}
-      paddingSize="l">
-      {repeatableForm}
-    </EuiAccordion>
+export default () => {
+  const accordionID__1 = htmlIdGenerator('accordion')();
+  const accordionID__2 = htmlIdGenerator('accordion')();
 
-    <EuiAccordion
-      id="accordionForm2"
-      className="euiAccordionForm"
-      buttonClassName="euiAccordionForm__button"
-      buttonContent={buttonContent}
-      extraAction={extraAction}
-      paddingSize="l">
-      {repeatableForm}
-    </EuiAccordion>
-  </div>
-);
+  return (
+    <div>
+      <EuiAccordion
+        id={accordionID__1}
+        className="euiAccordionForm"
+        buttonClassName="euiAccordionForm__button"
+        buttonContent={buttonContent}
+        extraAction={extraAction}
+        paddingSize="l">
+        {repeatableForm}
+      </EuiAccordion>
+
+      <EuiAccordion
+        id={accordionID__2}
+        className="euiAccordionForm"
+        buttonClassName="euiAccordionForm__button"
+        buttonContent={buttonContent}
+        extraAction={extraAction}
+        paddingSize="l">
+        {repeatableForm}
+      </EuiAccordion>
+    </div>
+  );
+};

--- a/src-docs/src/views/accordion/accordion_grow.js
+++ b/src-docs/src/views/accordion/accordion_grow.js
@@ -18,6 +18,7 @@ const Rows = () => {
   }
   const growingAccordianDescriptionId = htmlIdGenerator()();
   const listId = htmlIdGenerator()();
+
   return (
     <EuiText size="s">
       <EuiScreenReaderOnly>
@@ -50,14 +51,18 @@ const Rows = () => {
   );
 };
 
-export default () => (
-  <EuiAccordion
-    id={htmlIdGenerator()()}
-    buttonContent="Click me to toggle close / open"
-    initialIsOpen={true}
-    paddingSize="s">
-    <EuiPanel color="subdued">
-      <Rows />
-    </EuiPanel>
-  </EuiAccordion>
-);
+export default () => {
+  const accordionID = htmlIdGenerator('accordion')();
+
+  return (
+    <EuiAccordion
+      id={accordionID}
+      buttonContent="Click me to toggle close / open"
+      initialIsOpen={true}
+      paddingSize="s">
+      <EuiPanel color="subdued">
+        <Rows />
+      </EuiPanel>
+    </EuiAccordion>
+  );
+};

--- a/src-docs/src/views/accordion/accordion_multiple.js
+++ b/src-docs/src/views/accordion/accordion_multiple.js
@@ -6,55 +6,63 @@ import {
   EuiSpacer,
   EuiPanel,
 } from '../../../../src/components';
+import { htmlIdGenerator } from '../../../../src/services';
 
-export default () => (
-  <div>
-    <EuiAccordion
-      id="accordion3"
-      buttonContent="An accordion with padding applied through props"
-      paddingSize="l">
-      <EuiText size="s">
-        <p>The content inside can be of any height.</p>
-        <p>The content inside can be of any height.</p>
-        <p>The content inside can be of any height.</p>
-      </EuiText>
-    </EuiAccordion>
+export default () => {
+  const accordionID__1 = htmlIdGenerator('accordion')();
+  const accordionID__2 = htmlIdGenerator('accordion')();
+  const accordionID__3 = htmlIdGenerator('accordion')();
 
-    <EuiSpacer />
-
-    <EuiAccordion
-      id="accordion4"
-      buttonContent="A second accordion with padding and a very long title that should truncate because of eui-textTruncate"
-      buttonContentClassName="eui-textTruncate"
-      paddingSize="l">
-      <EuiText size="s">
-        <p>The content inside can be of any height.</p>
-        <p>The content inside can be of any height.</p>
-        <p>The content inside can be of any height.</p>
-        <p>The content inside can be of any height.</p>
-        <p>The content inside can be of any height.</p>
-        <p>The content inside can be of any height.</p>
-      </EuiText>
-    </EuiAccordion>
-
-    <EuiSpacer />
-
-    <EuiAccordion
-      id="accordion5"
-      buttonContent="A third accordion with a nested accordion"
-      paddingSize="m">
-      <EuiText size="s">
-        <p>
-          This content area will grow to accommodate when the accordion below
-          opens
-        </p>
-      </EuiText>
-      <EuiSpacer />
-      <EuiAccordion id="accordion6" buttonContent="A fourth nested accordion">
-        <EuiPanel color="subdued">
-          Any content inside of <strong>EuiAccordion</strong> will appear here.
-        </EuiPanel>
+  return (
+    <div>
+      <EuiAccordion
+        id={accordionID__1}
+        buttonContent="An accordion with padding applied through props"
+        paddingSize="l">
+        <EuiText size="s">
+          <p>The content inside can be of any height.</p>
+          <p>The content inside can be of any height.</p>
+          <p>The content inside can be of any height.</p>
+        </EuiText>
       </EuiAccordion>
-    </EuiAccordion>
-  </div>
-);
+
+      <EuiSpacer />
+
+      <EuiAccordion
+        id={accordionID__2}
+        buttonContent="A second accordion with padding and a very long title that should truncate because of eui-textTruncate"
+        buttonContentClassName="eui-textTruncate"
+        paddingSize="l">
+        <EuiText size="s">
+          <p>The content inside can be of any height.</p>
+          <p>The content inside can be of any height.</p>
+          <p>The content inside can be of any height.</p>
+          <p>The content inside can be of any height.</p>
+          <p>The content inside can be of any height.</p>
+          <p>The content inside can be of any height.</p>
+        </EuiText>
+      </EuiAccordion>
+
+      <EuiSpacer />
+
+      <EuiAccordion
+        id={accordionID__3}
+        buttonContent="A third accordion with a nested accordion"
+        paddingSize="m">
+        <EuiText size="s">
+          <p>
+            This content area will grow to accommodate when the accordion below
+            opens
+          </p>
+        </EuiText>
+        <EuiSpacer />
+        <EuiAccordion id="accordion6" buttonContent="A fourth nested accordion">
+          <EuiPanel color="subdued">
+            Any content inside of <strong>EuiAccordion</strong> will appear
+            here.
+          </EuiPanel>
+        </EuiAccordion>
+      </EuiAccordion>
+    </div>
+  );
+};

--- a/src-docs/src/views/accordion/accordion_open.js
+++ b/src-docs/src/views/accordion/accordion_open.js
@@ -3,15 +3,19 @@ import React from 'react';
 import { EuiAccordion, EuiPanel } from '../../../../src/components';
 import { htmlIdGenerator } from '../../../../src/services';
 
-export default () => (
-  <div>
-    <EuiAccordion
-      id={htmlIdGenerator()()}
-      buttonContent="I am opened by default. Click me to toggle close / open"
-      initialIsOpen={true}>
-      <EuiPanel color="subdued">
-        Any content inside of <strong>EuiAccordion</strong> will appear here.
-      </EuiPanel>
-    </EuiAccordion>
-  </div>
-);
+export default () => {
+  const accordionID = htmlIdGenerator('accordion')();
+
+  return (
+    <div>
+      <EuiAccordion
+        id={accordionID}
+        buttonContent="I am opened by default. Click me to toggle close / open"
+        initialIsOpen={true}>
+        <EuiPanel color="subdued">
+          Any content inside of <strong>EuiAccordion</strong> will appear here.
+        </EuiPanel>
+      </EuiAccordion>
+    </div>
+  );
+};

--- a/src-docs/src/views/button/split_button.js
+++ b/src-docs/src/views/button/split_button.js
@@ -10,8 +10,11 @@ import {
   EuiPopover,
 } from '../../../../src/components';
 
+import { htmlIdGenerator } from '../../../../src/services';
+
 export default () => {
   const [isPopoverOpen, setPopover] = useState(false);
+  const buttonID = htmlIdGenerator('button')();
 
   const onButtonClick = () => {
     setPopover(!isPopoverOpen);
@@ -43,7 +46,7 @@ export default () => {
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiPopover
-            id="splitButtonExamplePopover"
+            id={buttonID}
             button={
               <EuiButtonIcon
                 display="base"

--- a/src-docs/src/views/expression/columns.js
+++ b/src-docs/src/views/expression/columns.js
@@ -10,6 +10,8 @@ import {
   EuiSpacer,
 } from '../../../../src/components';
 
+import { htmlIdGenerator } from '../../../../src/services';
+
 export default () => {
   const [example1, setExample1] = useState({
     isOpen: false,
@@ -25,6 +27,9 @@ export default () => {
     isOpen: false,
     value: 'count()',
   });
+
+  const popoverID__1 = htmlIdGenerator('popover')();
+  const popoverID__2 = htmlIdGenerator('popover')();
 
   const options = [
     {
@@ -140,7 +145,7 @@ export default () => {
   return (
     <div style={{ maxWidth: 500 }}>
       <EuiPopover
-        id="columnsPopover1"
+        id={popoverID__1}
         button={
           <EuiExpression
             description="indices"
@@ -162,7 +167,7 @@ export default () => {
       </EuiPopover>
 
       <EuiPopover
-        id="columnsPopover2"
+        id={popoverID__2}
         panelPaddingSize="s"
         button={
           <EuiExpression

--- a/src-docs/src/views/expression/expression.js
+++ b/src-docs/src/views/expression/expression.js
@@ -10,6 +10,8 @@ import {
   EuiExpression,
 } from '../../../../src/components';
 
+import { htmlIdGenerator } from '../../../../src/services';
+
 // Rise the popovers above GuidePageSideNav
 const POPOVER_STYLE = { zIndex: '200' };
 
@@ -23,6 +25,9 @@ export default () => {
     value: 100,
     description: 'Is above',
   });
+
+  const popoverID__1 = htmlIdGenerator('popover')();
+  const popoverID__2 = htmlIdGenerator('popover')();
 
   const openExample1 = () => {
     setExample1({
@@ -132,7 +137,7 @@ export default () => {
     <EuiFlexGroup gutterSize="s">
       <EuiFlexItem grow={false}>
         <EuiPopover
-          id="popover1"
+          id={popoverID__1}
           button={
             <EuiExpression
               description="when"
@@ -151,7 +156,7 @@ export default () => {
 
       <EuiFlexItem grow={false}>
         <EuiPopover
-          id="popover2"
+          id={popoverID__2}
           panelPaddingSize="s"
           button={
             <EuiExpression

--- a/src-docs/src/views/flyout/flyout.js
+++ b/src-docs/src/views/flyout/flyout.js
@@ -10,8 +10,11 @@ import {
   EuiCodeBlock,
 } from '../../../../src/components';
 
+import { htmlIdGenerator } from '../../../../src/services';
+
 export default () => {
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
+  const flyoutID__title = htmlIdGenerator('flyout')();
 
   let flyout;
 
@@ -32,10 +35,10 @@ export default () => {
       <EuiFlyout
         ownFocus
         onClose={() => setIsFlyoutVisible(false)}
-        aria-labelledby="flyoutTitle">
+        aria-labelledby={flyoutID__title}>
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="m">
-            <h2 id="flyoutTitle">A typical flyout</h2>
+            <h2 id={flyoutID__title}>A typical flyout</h2>
           </EuiTitle>
         </EuiFlyoutHeader>
         <EuiFlyoutBody>

--- a/src-docs/src/views/flyout/flyout_banner.js
+++ b/src-docs/src/views/flyout/flyout_banner.js
@@ -11,8 +11,11 @@ import {
   EuiTitle,
 } from '../../../../src/components';
 
+import { htmlIdGenerator } from '../../../../src/services';
+
 export default () => {
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
+  const flyoutID__title = htmlIdGenerator('flyout')();
 
   const closeFlyout = () => setIsFlyoutVisible(false);
 
@@ -34,10 +37,10 @@ export default () => {
       <EuiFlyout
         ownFocus
         onClose={closeFlyout}
-        aria-labelledby="flyoutWithBannerTitle">
+        aria-labelledby={flyoutID__title}>
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="m">
-            <h2 id="flyoutWithBannerTitle">A flyout with a banner</h2>
+            <h2 id={flyoutID__title}>A flyout with a banner</h2>
           </EuiTitle>
         </EuiFlyoutHeader>
         <EuiFlyoutBody banner={callOut}>

--- a/src-docs/src/views/flyout/flyout_complicated.js
+++ b/src-docs/src/views/flyout/flyout_complicated.js
@@ -23,12 +23,15 @@ import {
   EuiSuperSelect,
 } from '../../../../src/components';
 
+import { htmlIdGenerator } from '../../../../src/services';
+
 export default () => {
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
   const [selectedTabId, setSelectedTabId] = useState('1');
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [superSelectvalue, setSuperSelectValue] = useState('option_one');
   const [isExpressionOpen, setIsExpressionOpen] = useState(false);
+  const flyoutID__title = htmlIdGenerator('flyout')();
 
   const tabs = [
     {
@@ -182,10 +185,10 @@ export default () => {
         ownFocus
         onClose={closeFlyout}
         hideCloseButton
-        aria-labelledby="flyoutComplicatedTitle">
+        aria-labelledby={flyoutID__title}>
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="m">
-            <h2 id="flyoutComplicatedTitle">Flyout header</h2>
+            <h2 id={flyoutID__title}>Flyout header</h2>
           </EuiTitle>
           <EuiSpacer size="s" />
           <EuiText color="subdued">

--- a/src-docs/src/views/flyout/flyout_large.js
+++ b/src-docs/src/views/flyout/flyout_large.js
@@ -10,10 +10,13 @@ import {
   EuiButtonGroup,
 } from '../../../../src/components';
 
+import { htmlIdGenerator } from '../../../../src/services';
+
 export default () => {
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
   const [size, setSize] = useState('l');
   const [sizeName, setSizeName] = useState('large');
+  const flyoutID__title = htmlIdGenerator('flyout')();
 
   const sizes = [
     {
@@ -45,10 +48,10 @@ export default () => {
         ownFocus
         onClose={closeFlyout}
         size={size}
-        aria-labelledby="flyoutLargeTitle">
+        aria-labelledby={flyoutID__title}>
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="m">
-            <h2 id="flyoutLargeTitle">A {sizeName.toLowerCase()} flyout</h2>
+            <h2 id={flyoutID__title}>A {sizeName.toLowerCase()} flyout</h2>
           </EuiTitle>
         </EuiFlyoutHeader>
         <EuiFlyoutBody>

--- a/src-docs/src/views/flyout/flyout_max_width.js
+++ b/src-docs/src/views/flyout/flyout_max_width.js
@@ -16,10 +16,13 @@ import {
   EuiSpacer,
 } from '../../../../src/components';
 
+import { htmlIdGenerator } from '../../../../src/services';
+
 export default () => {
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
   const [flyoutSize, setFlyoutSize] = useState('m');
   const [flyoutMaxWidth, setFlyoutMaxWidth] = useState(false);
+  const flyoutID__title = htmlIdGenerator('flyout')();
 
   const closeFlyout = () => setIsFlyoutVisible(false);
 
@@ -49,12 +52,12 @@ export default () => {
       <EuiFlyout
         ownFocus
         onClose={closeFlyout}
-        aria-labelledby="flyoutMaxWidthTitle"
+        aria-labelledby={flyoutID__title}
         size={flyoutSize}
         maxWidth={flyoutMaxWidth}>
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="m">
-            <h2 id="flyoutMaxWidthTitle">{maxWidthTitle} maxWidth</h2>
+            <h2 id={flyoutID__title}>{maxWidthTitle} maxWidth</h2>
           </EuiTitle>
         </EuiFlyoutHeader>
         <EuiFlyoutBody>

--- a/src-docs/src/views/flyout/flyout_padding_medium.js
+++ b/src-docs/src/views/flyout/flyout_padding_medium.js
@@ -15,10 +15,14 @@ import {
   EuiTitle,
 } from '../../../../src/components';
 
+import { htmlIdGenerator } from '../../../../src/services';
+
 export default () => {
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
   const [paddingSize, setPaddingSize] = useState('l');
   const [paddingSizeName, setPaddingSizeName] = useState('large');
+  const flyoutID = htmlIdGenerator('flyout')();
+  const flyoutID__title = htmlIdGenerator('flyout')();
 
   const sizes = [
     {
@@ -56,11 +60,11 @@ export default () => {
         ownFocus
         onClose={closeFlyout}
         paddingSize={paddingSize}
-        id="flyoutMediumPadding"
-        aria-labelledby="flyoutMediumPaddingTitle">
+        id={flyoutID}
+        aria-labelledby={flyoutID__title}>
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="m">
-            <h2 id="flyoutMediumPaddingTitle">
+            <h2 id={flyoutID__title}>
               A flyout with a {paddingSizeName} padding
             </h2>
           </EuiTitle>
@@ -107,7 +111,7 @@ export default () => {
     <>
       <EuiButton
         onClick={showFlyout}
-        aria-controls="flyoutMediumPadding"
+        aria-controls={flyoutID}
         aria-expanded={isFlyoutVisible}
         aria-haspopup="true"
         aria-label="Show padding size flyout">

--- a/src-docs/src/views/flyout/flyout_push.js
+++ b/src-docs/src/views/flyout/flyout_push.js
@@ -10,8 +10,11 @@ import {
   EuiFlyoutFooter,
 } from '../../../../src/components';
 
+import { htmlIdGenerator } from '../../../../src/services';
+
 export default () => {
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
+  const flyoutID__title = htmlIdGenerator('flyout')();
 
   let flyout;
 
@@ -21,10 +24,10 @@ export default () => {
         type="push"
         size="s"
         onClose={() => setIsFlyoutVisible(false)}
-        aria-labelledby="pushedFlyoutTitle">
+        aria-labelledby={flyoutID__title}>
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="m">
-            <h2 id="pushedFlyoutTitle">A pushed flyout</h2>
+            <h2 id={flyoutID__title}>A pushed flyout</h2>
           </EuiTitle>
         </EuiFlyoutHeader>
         <EuiFlyoutBody>

--- a/src-docs/src/views/flyout/flyout_small.js
+++ b/src-docs/src/views/flyout/flyout_small.js
@@ -8,6 +8,7 @@ import {
   EuiText,
   EuiTitle,
 } from '../../../../src/components';
+
 import { htmlIdGenerator } from '../../../../src/services';
 
 export default () => {
@@ -17,7 +18,7 @@ export default () => {
 
   const toggleFlyout = () => setIsFlyoutVisible((isVisible) => !isVisible);
 
-  const flyoutTitleId = htmlIdGenerator('flyout')();
+  const flyoutID__title = htmlIdGenerator('flyout')();
 
   let flyout;
   if (isFlyoutVisible) {
@@ -25,10 +26,10 @@ export default () => {
       <EuiFlyout
         ownFocus={false}
         onClose={closeFlyout}
-        aria-labelledby={flyoutTitleId}>
+        aria-labelledby={flyoutID__title}>
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="s">
-            <h2 id={flyoutTitleId}>A flyout without ownFocus</h2>
+            <h2 id={flyoutID__title}>A flyout without ownFocus</h2>
           </EuiTitle>
         </EuiFlyoutHeader>
         <EuiFlyoutBody>

--- a/src-docs/src/views/form_compressed/complex_example.js
+++ b/src-docs/src/views/form_compressed/complex_example.js
@@ -86,6 +86,12 @@ export default () => {
     setGranularityToggleButtonsIdSelected,
   ] = useState(`${idPrefix}4`);
 
+  const rangeID__1 = htmlIdGenerator('range')();
+  const rangeID__2 = htmlIdGenerator('range')();
+  const selectID__1 = htmlIdGenerator('select')();
+  const selectID__2 = htmlIdGenerator('select')();
+  const selectToolTipID = htmlIdGenerator('select-tooltip')();
+
   const onPopoverSliderValueChange = (e) => {
     setPopoverSliderValues(e.target.value);
   };
@@ -144,7 +150,7 @@ export default () => {
           min={0}
           max={100}
           name="range"
-          id="range"
+          id={rangeID__1}
           showInput
           compressed
           value={opacityValue}
@@ -156,7 +162,7 @@ export default () => {
       <EuiSpacer size="s" />
 
       <EuiScreenReaderOnly>
-        <span id="docsExampleSelectTooltipContent">{selectTooltipContent}</span>
+        <span id={selectToolTipID}>{selectTooltipContent}</span>
       </EuiScreenReaderOnly>
       <EuiFormRow
         label={
@@ -261,7 +267,7 @@ export default () => {
       <EuiFormRow label="Label" display="columnCompressed">
         <div>
           <EuiSelect
-            id="docsExampleLabelFont"
+            id={selectID__1}
             options={[
               { value: 'inter', text: 'Inter UI' },
               { value: 'roboto', text: 'Roboto' },
@@ -312,7 +318,7 @@ export default () => {
       <EuiFlexGroup gutterSize="s" responsive={false} wrap>
         <EuiFlexItem style={{ flexBasis: 72 }}>
           <EuiRange
-            id="docsExampleBorderSize"
+            id={rangeID__2}
             showInput="inputWithPopover"
             min={0}
             max={32}
@@ -324,7 +330,7 @@ export default () => {
         </EuiFlexItem>
         <EuiFlexItem grow={4} style={{ minWidth: 160 }}>
           <EuiSelect
-            id="docsExampleBorderStyle"
+            id={selectID__2}
             options={[
               { value: 'dashed', text: 'Dashed' },
               { value: 'dotted', text: 'Dotted' },

--- a/src-docs/src/views/form_compressed/form_compressed.js
+++ b/src-docs/src/views/form_compressed/form_compressed.js
@@ -17,6 +17,7 @@ import { htmlIdGenerator } from '../../../../src/services';
 
 export default () => {
   const idPrefix = htmlIdGenerator()();
+  const rangeID = htmlIdGenerator('range')();
 
   const [checkboxes] = useState([
     {
@@ -102,7 +103,7 @@ export default () => {
           min={0}
           max={100}
           name="range"
-          id="range"
+          id={rangeID}
           showInput
           compressed
           value={value}

--- a/src-docs/src/views/form_compressed/form_horizontal.js
+++ b/src-docs/src/views/form_compressed/form_horizontal.js
@@ -11,10 +11,13 @@ import {
   EuiPanel,
 } from '../../../../src/components';
 
+import { htmlIdGenerator } from '../../../../src/services';
+
 export default () => {
   const [isSwitchChecked, setIsSwitchChecked] = useState(false);
   const [comboBoxSelectionOptions, setComboBoxSelectionOptions] = useState([]);
   const [value, setValue] = useState('20');
+  const rangeID = htmlIdGenerator('range')();
 
   const onRangeChange = (e) => {
     setValue(e.target.value);
@@ -68,7 +71,7 @@ export default () => {
           min={0}
           max={100}
           name="range"
-          id="range"
+          id={rangeID}
           showInput
           compressed
           value={value}

--- a/src-docs/src/views/form_controls/checkbox.js
+++ b/src-docs/src/views/form_controls/checkbox.js
@@ -8,6 +8,11 @@ export default () => {
   const [checked, setChecked] = useState(false);
   const [indeterminate, setindeterminate] = useState(true);
 
+  const checkboxID__1 = htmlIdGenerator('checkbox')();
+  const checkboxID__2 = htmlIdGenerator('checkbox')();
+  const checkboxID__3 = htmlIdGenerator('checkbox')();
+  const checkboxID__4 = htmlIdGenerator('checkbox')();
+
   const onChange = (e) => {
     setChecked(e.target.checked);
   };
@@ -19,7 +24,7 @@ export default () => {
   return (
     <Fragment>
       <EuiCheckbox
-        id={htmlIdGenerator()()}
+        id={checkboxID__1}
         label="I am a checkbox"
         checked={checked}
         onChange={(e) => onChange(e)}
@@ -28,7 +33,7 @@ export default () => {
       <EuiSpacer size="m" />
 
       <EuiCheckbox
-        id={htmlIdGenerator()()}
+        id={checkboxID__2}
         label="I am an indeterminate checkbox"
         indeterminate={indeterminate}
         onChange={() => onChangeIndeterminate()}
@@ -37,7 +42,7 @@ export default () => {
       <EuiSpacer size="m" />
 
       <EuiCheckbox
-        id={htmlIdGenerator()()}
+        id={checkboxID__3}
         label="I am a disabled checkbox"
         checked={checked}
         onChange={(e) => onChange(e)}
@@ -47,7 +52,7 @@ export default () => {
       <EuiSpacer size="m" />
 
       <EuiCheckbox
-        id={htmlIdGenerator()()}
+        id={checkboxID__4}
         label="I am a compressed checkbox"
         checked={checked}
         onChange={(e) => onChange(e)}

--- a/src-docs/src/views/form_controls/file_picker.js
+++ b/src-docs/src/views/form_controls/file_picker.js
@@ -10,9 +10,13 @@ import {
   EuiSwitch,
 } from '../../../../src/components';
 
+import { htmlIdGenerator } from '../../../../src/services';
+
 export default () => {
   const [files, setFiles] = useState({});
   const [large, setLarge] = useState(true);
+
+  const filePickerID = htmlIdGenerator('filepicker')();
 
   const onChange = (files) => {
     setFiles(files.length > 0 ? files : {});
@@ -54,7 +58,7 @@ export default () => {
               />,
             ]}>
             <EuiFilePicker
-              id="asdf2"
+              id={filePickerID}
               multiple
               initialPromptText="Select or drag and drop multiple files"
               onChange={(files) => {

--- a/src-docs/src/views/form_controls/file_picker_remove.js
+++ b/src-docs/src/views/form_controls/file_picker_remove.js
@@ -7,9 +7,13 @@ import {
   EuiFlexItem,
 } from '../../../../src/components';
 
+import { htmlIdGenerator } from '../../../../src/services';
+
 export default () => {
   const [files, setFiles] = useState({});
   const filePickerRef = useRef();
+
+  const filePickerID = htmlIdGenerator('filepicker')();
 
   const onChange = (files) => {
     setFiles(files.length > 0 ? files : {});
@@ -21,7 +25,7 @@ export default () => {
         <EuiFlexItem>
           <EuiFilePicker
             ref={filePickerRef}
-            id="programmatic"
+            id={filePickerID}
             multiple
             initialPromptText="Select or drag and drop multiple files"
             onChange={onChange}

--- a/src-docs/src/views/form_controls/radio.js
+++ b/src-docs/src/views/form_controls/radio.js
@@ -7,6 +7,10 @@ import { htmlIdGenerator } from '../../../../src/services';
 export default () => {
   const [checked, setChecked] = useState(false);
 
+  const radioID__1 = htmlIdGenerator('radio')();
+  const radioID__2 = htmlIdGenerator('radio')();
+  const radioID__3 = htmlIdGenerator('radio')();
+
   const onChange = (e) => {
     setChecked(e.target.checked);
   };
@@ -14,7 +18,7 @@ export default () => {
   return (
     <Fragment>
       <EuiRadio
-        id={htmlIdGenerator()()}
+        id={radioID__1}
         label="I am a radio"
         checked={checked}
         onChange={(e) => onChange(e)}
@@ -23,7 +27,7 @@ export default () => {
       <EuiSpacer size="m" />
 
       <EuiRadio
-        id={htmlIdGenerator()()}
+        id={radioID__2}
         label="I am a disabled radio"
         checked={checked}
         onChange={(e) => onChange(e)}
@@ -33,7 +37,7 @@ export default () => {
       <EuiSpacer size="m" />
 
       <EuiRadio
-        id={htmlIdGenerator()()}
+        id={radioID__3}
         label="I am a compressed radio"
         checked={checked}
         onChange={(e) => onChange(e)}

--- a/src-docs/src/views/form_controls/select.js
+++ b/src-docs/src/views/form_controls/select.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 
 import { EuiSelect } from '../../../../src/components';
 import { DisplayToggles } from './display_toggles';
+import { htmlIdGenerator } from '../../../../src/services';
 
 export default () => {
   const options = [
@@ -11,6 +12,7 @@ export default () => {
   ];
 
   const [value, setValue] = useState(options[1].value);
+  const selectID = htmlIdGenerator('select')();
 
   const onChange = (e) => {
     setValue(e.target.value);
@@ -20,7 +22,7 @@ export default () => {
     /* DisplayToggles wrapper for Docs only */
     <DisplayToggles canPrepend canAppend canReadOnly={false}>
       <EuiSelect
-        id="selectDocExample"
+        id={selectID}
         options={options}
         value={value}
         onChange={(e) => onChange(e)}

--- a/src-docs/src/views/form_layouts/inline_popover.js
+++ b/src-docs/src/views/form_layouts/inline_popover.js
@@ -21,6 +21,10 @@ export default () => {
   const [isPopover2Open, setIsPopover2Open] = useState(false);
   const [isSwitchChecked, setIsSwitchChecked] = useState(true);
 
+  const switchID = htmlIdGenerator('switch')();
+  const popoverID__1 = htmlIdGenerator('popover')();
+  const popoverID__2 = htmlIdGenerator('popover')();
+
   const onButtonClick = () => {
     setIsPopoverOpen(!isPopoverOpen);
   };
@@ -87,7 +91,7 @@ export default () => {
     <EuiForm component="form">
       <EuiFormRow>
         <EuiSwitch
-          id={htmlIdGenerator()()}
+          id={switchID}
           name="popswitch"
           label="Isn't this popover form cool?"
           checked={isSwitchChecked}
@@ -111,7 +115,7 @@ export default () => {
   return (
     <div>
       <EuiPopover
-        id="inlineFormPopover"
+        id={popoverID__1}
         button={button}
         isOpen={isPopoverOpen}
         closePopover={closePopover}>
@@ -119,7 +123,7 @@ export default () => {
       </EuiPopover>
       &emsp;
       <EuiPopover
-        id="formPopover"
+        id={popoverID__2}
         button={button2}
         isOpen={isPopover2Open}
         closePopover={closePopover2}

--- a/src-docs/src/views/header/header_alert.js
+++ b/src-docs/src/views/header/header_alert.js
@@ -33,6 +33,10 @@ const HeaderUpdates = () => {
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
   const [isPopoverVisible, setIsPopoverVisible] = useState(false);
 
+  const flyoutID = htmlIdGenerator('flyout')();
+  const flyoutID__title = htmlIdGenerator('flyout')();
+  const popoverID = htmlIdGenerator('popoverID')();
+
   const alerts = [
     {
       title: 'Control access to features',
@@ -127,7 +131,7 @@ const HeaderUpdates = () => {
 
   const bellButton = (
     <EuiHeaderSectionItemButton
-      aria-controls="headerFlyoutNewsFeed"
+      aria-controls={flyoutID}
       aria-expanded={isFlyoutVisible}
       aria-haspopup="true"
       aria-label={'Alerts feed: Updates available'}
@@ -139,7 +143,7 @@ const HeaderUpdates = () => {
 
   const cheerButton = (
     <EuiHeaderSectionItemButton
-      aria-controls="headerPopoverNewsFeed"
+      aria-controls={popoverID}
       aria-expanded={isPopoverVisible}
       aria-haspopup="true"
       aria-label={"News feed: Updates available'"}
@@ -154,11 +158,11 @@ const HeaderUpdates = () => {
       <EuiFlyout
         onClose={closeFlyout}
         size="s"
-        id="headerFlyoutNewsFeed"
-        aria-labelledby="flyoutSmallTitle">
+        id={flyoutID}
+        aria-labelledby={flyoutID__title}>
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="s">
-            <h2 id="flyoutSmallTitle">What&apos;s new</h2>
+            <h2 id={flyoutID__title}>What&apos;s new</h2>
           </EuiTitle>
         </EuiFlyoutHeader>
         <EuiFlyoutBody>
@@ -196,7 +200,7 @@ const HeaderUpdates = () => {
 
   const popover = (
     <EuiPopover
-      id="headerPopoverNewsFeed"
+      id={popoverID}
       ownFocus
       repositionOnScroll
       button={cheerButton}

--- a/src-docs/src/views/key_pad_menu/key_pad_menu_checkable.js
+++ b/src-docs/src/views/key_pad_menu/key_pad_menu_checkable.js
@@ -6,40 +6,44 @@ import {
   EuiKeyPadMenuItem,
 } from '../../../../src/components';
 
+import { htmlIdGenerator } from '../../../../src/services';
+
 export default () => {
+  const [keypadButtonID__1] = useState(htmlIdGenerator('keypad-button')());
+  const [keypadButtonID__2] = useState(htmlIdGenerator('keypad-button')());
+  const [keypadButtonID__3] = useState(htmlIdGenerator('keypad-button')());
+
   const radioGroupName = 'singleKeypadSelect';
-  const [singleSelectedID, setSingleSelectedID] = useState(
-    'singleKeypadSelect1'
-  );
+  const [singleSelectedID, setSingleSelectedID] = useState(keypadButtonID__1);
 
   return (
     <EuiKeyPadMenu checkable={{ ariaLegend: 'Single select as radios' }}>
       <EuiKeyPadMenuItem
         checkable="single"
         name={radioGroupName}
-        id="singleKeypadSelect1"
+        id={keypadButtonID__1}
         label="Radio one"
         onChange={(id) => {
           setSingleSelectedID(id);
         }}
-        isSelected={singleSelectedID === 'singleKeypadSelect1'}>
+        isSelected={singleSelectedID === keypadButtonID__1}>
         <EuiIcon type="faceHappy" size="l" />
       </EuiKeyPadMenuItem>
       <EuiKeyPadMenuItem
         checkable="single"
         name={radioGroupName}
-        id="singleKeypadSelect2"
+        id={keypadButtonID__2}
         label="Radio two"
         onChange={(id) => {
           setSingleSelectedID(id);
         }}
-        isSelected={singleSelectedID === 'singleKeypadSelect2'}>
+        isSelected={singleSelectedID === keypadButtonID__2}>
         <EuiIcon type="faceNeutral" size="l" />
       </EuiKeyPadMenuItem>
       <EuiKeyPadMenuItem
         checkable="single"
         name={radioGroupName}
-        id="singleKeypadSelect3"
+        id={keypadButtonID__3}
         label="Disabled"
         isDisabled>
         <EuiIcon type="faceSad" size="l" />

--- a/src-docs/src/views/key_pad_menu/key_pad_menu_checkable_multi.js
+++ b/src-docs/src/views/key_pad_menu/key_pad_menu_checkable_multi.js
@@ -6,14 +6,21 @@ import {
   EuiKeyPadMenuItem,
 } from '../../../../src/components';
 
+import { htmlIdGenerator } from '../../../../src/services';
+
 export default () => {
   const [multiSelect1isSelected, setmultiSelect1isSelected] = useState(true);
   const [multiSelect3isSelected, setmultiSelect2isSelected] = useState(false);
+
+  const keypadButtonID__1 = htmlIdGenerator('keypad-button')();
+  const keypadButtonID__2 = htmlIdGenerator('keypad-button')();
+  const keypadButtonID__3 = htmlIdGenerator('keypad-button')();
 
   return (
     <EuiKeyPadMenu checkable={{ legend: 'Multi select as checkboxes' }}>
       <EuiKeyPadMenuItem
         checkable="multi"
+        id={keypadButtonID__1}
         isSelected={multiSelect1isSelected}
         label="Check one"
         onChange={() => {
@@ -24,7 +31,7 @@ export default () => {
       <EuiKeyPadMenuItem
         checkable="multi"
         isSelected={multiSelect3isSelected}
-        id="multiKeypadSelect2a"
+        id={keypadButtonID__2}
         label="Check two"
         onChange={() => {
           setmultiSelect2isSelected((selected) => !selected);
@@ -33,7 +40,7 @@ export default () => {
       </EuiKeyPadMenuItem>
       <EuiKeyPadMenuItem
         checkable="multi"
-        id="multiKeypadSelect3a"
+        id={keypadButtonID__3}
         label="Disabled"
         isDisabled>
         <EuiIcon type="faceSad" size="l" />

--- a/src-docs/src/views/key_pad_menu/key_pad_menu_item_button.js
+++ b/src-docs/src/views/key_pad_menu/key_pad_menu_item_button.js
@@ -5,50 +5,57 @@ import {
   EuiKeyPadMenu,
   EuiKeyPadMenuItem,
 } from '../../../../src/components';
+import { htmlIdGenerator } from '../../../../src/services';
 
 export default () => {
-  const [selectedID, setSelectedID] = useState('keypadButton6');
+  const keypadButtonID__1 = htmlIdGenerator('keypad-button')();
+  const keypadButtonID__2 = htmlIdGenerator('keypad-button')();
+  const keypadButtonID__3 = htmlIdGenerator('keypad-button')();
+  const keypadButtonID__4 = htmlIdGenerator('keypad-button')();
+  const keypadButtonID__5 = htmlIdGenerator('keypad-button')();
+  const keypadButtonID__6 = htmlIdGenerator('keypad-button')();
+  const [selectedID, setSelectedID] = useState(keypadButtonID__6);
 
   return (
     <EuiKeyPadMenu>
       <EuiKeyPadMenuItem
-        id="keypadButton1"
+        id={keypadButtonID__1}
         label="Button"
-        isSelected={selectedID === 'keypadButton1'}
-        onClick={() => setSelectedID('keypadButton1')}>
+        isSelected={selectedID === keypadButtonID__1}
+        onClick={() => setSelectedID(keypadButtonID__1)}>
         <EuiIcon type="grid" size="l" />
       </EuiKeyPadMenuItem>
       <EuiKeyPadMenuItem
-        id="keypadButton3"
+        id={keypadButtonID__2}
         label="Button"
-        isSelected={selectedID === 'keypadButton3'}
-        onClick={() => setSelectedID('keypadButton3')}>
+        isSelected={selectedID === keypadButtonID__2}
+        onClick={() => setSelectedID(keypadButtonID__2)}>
         <EuiIcon type="grid" size="l" />
       </EuiKeyPadMenuItem>
-      <EuiKeyPadMenuItem id="keypadButton2" label="Disabled" isDisabled>
+      <EuiKeyPadMenuItem id={keypadButtonID__3} label="Disabled" isDisabled>
         <EuiIcon type="grid" size="l" />
       </EuiKeyPadMenuItem>
       <EuiKeyPadMenuItem
-        id="keypadButton4"
+        id={keypadButtonID__4}
         label="Link"
         href="#/navigation/key-pad-menu"
-        isSelected={selectedID === 'keypadButton4'}
-        onClick={() => setSelectedID('keypadButton4')}>
+        isSelected={selectedID === keypadButtonID__4}
+        onClick={() => setSelectedID(keypadButtonID__4)}>
         <EuiIcon type="link" size="l" />
       </EuiKeyPadMenuItem>
       <EuiKeyPadMenuItem
-        id="keypadButton5"
+        id={keypadButtonID__5}
         label="Link"
         href="#/navigation/key-pad-menu"
-        isSelected={selectedID === 'keypadButton5'}
-        onClick={() => setSelectedID('keypadButton5')}>
+        isSelected={selectedID === keypadButtonID__5}
+        onClick={() => setSelectedID(keypadButtonID__5)}>
         <EuiIcon type="link" size="l" />
       </EuiKeyPadMenuItem>
       <EuiKeyPadMenuItem
-        id="keypadButton6"
+        id={keypadButtonID__6}
         label="Disabled"
         isDisabled
-        isSelected={selectedID === 'keypadButton6'}>
+        isSelected={selectedID === keypadButtonID__6}>
         <EuiIcon type="link" size="l" />
       </EuiKeyPadMenuItem>
     </EuiKeyPadMenu>

--- a/src-docs/src/views/list_group/list_group_link_actions.js
+++ b/src-docs/src/views/list_group/list_group_link_actions.js
@@ -2,35 +2,43 @@ import React, { useState } from 'react';
 
 import { EuiListGroup, EuiListGroupItem } from '../../../../src/components';
 
+import { htmlIdGenerator } from '../../../../src/services';
+
 export default () => {
+  const [linkID__1] = useState(htmlIdGenerator('link')());
+  const [linkID__2] = useState(htmlIdGenerator('link')());
+  const [linkID__3] = useState(htmlIdGenerator('link')());
+  const [linkID__4] = useState(htmlIdGenerator('link')());
+  const [linkID__5] = useState(htmlIdGenerator('link')());
+
   const [favorite1, setFavorite1] = useState(undefined);
-  const [favorite2, setFavorite2] = useState('link2');
+  const [favorite2, setFavorite2] = useState(linkID__2);
   const [favorite3, setFavorite3] = useState(undefined);
   const [favorite4, setFavorite4] = useState(undefined);
 
   const link1Clicked = () => {
-    setFavorite1(favorite1 === 'link1' ? undefined : 'link1');
+    setFavorite1(favorite1 === linkID__1 ? undefined : linkID__1);
     if (favorite1 === undefined) {
       document.activeElement.blur();
     }
   };
 
   const link2Clicked = () => {
-    setFavorite2(favorite2 === 'link2' ? undefined : 'link2');
+    setFavorite2(favorite2 === linkID__2 ? undefined : linkID__2);
     if (favorite2 === undefined) {
       document.activeElement.blur();
     }
   };
 
   const link3Clicked = () => {
-    setFavorite3(favorite3 === 'link3' ? undefined : 'link3');
+    setFavorite3(favorite3 === linkID__3 ? undefined : linkID__3);
     if (favorite3 === undefined) {
       document.activeElement.blur();
     }
   };
 
   const link4Clicked = () => {
-    setFavorite4(favorite4 === 'link4' ? undefined : 'link4');
+    setFavorite4(favorite4 === linkID__4 ? undefined : linkID__4);
     if (favorite3 === undefined) {
       document.activeElement.blur();
     }
@@ -39,7 +47,7 @@ export default () => {
   return (
     <EuiListGroup maxWidth={288}>
       <EuiListGroupItem
-        id="link1"
+        id={linkID__1}
         iconType="bullseye"
         label="EUI button link"
         onClick={() => {}}
@@ -47,30 +55,30 @@ export default () => {
         extraAction={{
           color: 'subdued',
           onClick: link1Clicked,
-          iconType: favorite1 === 'link1' ? 'starFilled' : 'starEmpty',
+          iconType: favorite1 === linkID__1 ? 'starFilled' : 'starEmpty',
           iconSize: 's',
           'aria-label': 'Favorite link1',
-          alwaysShow: favorite1 === 'link1',
+          alwaysShow: favorite1 === linkID__1,
         }}
       />
 
       <EuiListGroupItem
-        id="link2"
+        id={linkID__2}
         iconType="visualizeApp"
         onClick={() => {}}
         label="EUI button link"
         extraAction={{
           color: 'subdued',
           onClick: link2Clicked,
-          iconType: favorite2 === 'link2' ? 'starFilled' : 'starEmpty',
+          iconType: favorite2 === linkID__2 ? 'starFilled' : 'starEmpty',
           iconSize: 's',
           'aria-label': 'Favorite link2',
-          alwaysShow: favorite2 === 'link2',
+          alwaysShow: favorite2 === linkID__2,
         }}
       />
 
       <EuiListGroupItem
-        id="link3"
+        id={linkID__3}
         iconType="lensApp"
         iconProps={{ color: 'default' }}
         onClick={() => {}}
@@ -78,31 +86,31 @@ export default () => {
         extraAction={{
           color: 'subdued',
           onClick: link3Clicked,
-          iconType: favorite3 === 'link3' ? 'starFilled' : 'starEmpty',
+          iconType: favorite3 === linkID__3 ? 'starFilled' : 'starEmpty',
           iconSize: 's',
           'aria-label': 'Favorite link3',
-          alwaysShow: favorite3 === 'link3',
+          alwaysShow: favorite3 === linkID__3,
         }}
       />
 
       <EuiListGroupItem
-        id="link4"
+        id={linkID__4}
         onClick={() => {}}
         iconType="broom"
         label="EUI button link"
         extraAction={{
           color: 'subdued',
           onClick: link4Clicked,
-          iconType: favorite4 === 'link4' ? 'starFilled' : 'starEmpty',
+          iconType: favorite4 === linkID__4 ? 'starFilled' : 'starEmpty',
           iconSize: 's',
           'aria-label': 'Favorite link4',
-          alwaysShow: favorite3 === 'link4',
+          alwaysShow: favorite3 === linkID__4,
           isDisabled: true,
         }}
       />
 
       <EuiListGroupItem
-        id="link5"
+        id={linkID__5}
         iconType="brush"
         isDisabled
         label="EUI button link"

--- a/src-docs/src/views/modal/modal_form.js
+++ b/src-docs/src/views/modal/modal_form.js
@@ -24,6 +24,9 @@ export default () => {
   const [isSwitchChecked, setIsSwitchChecked] = useState(true);
   const [superSelectvalue, setSuperSelectValue] = useState('option_one');
 
+  const formID = htmlIdGenerator('form')();
+  const switchID = htmlIdGenerator('switch')();
+
   const onSwitchChange = () =>
     setIsSwitchChecked((isSwitchChecked) => !isSwitchChecked);
 
@@ -77,10 +80,10 @@ export default () => {
   ];
 
   const formSample = (
-    <EuiForm id="modalFormId" component="form">
+    <EuiForm id={formID} component="form">
       <EuiFormRow>
         <EuiSwitch
-          id={htmlIdGenerator()()}
+          id={switchID}
           name="popswitch"
           label="Isn't this modal form cool?"
           checked={isSwitchChecked}
@@ -128,7 +131,7 @@ export default () => {
         <EuiModalFooter>
           <EuiButtonEmpty onClick={closeModal}>Cancel</EuiButtonEmpty>
 
-          <EuiButton type="submit" form="modalFormId" onClick={closeModal} fill>
+          <EuiButton type="submit" form={formID} onClick={closeModal} fill>
             Save
           </EuiButton>
         </EuiModalFooter>

--- a/src-docs/src/views/popover/trap_focus.js
+++ b/src-docs/src/views/popover/trap_focus.js
@@ -8,8 +8,12 @@ import {
   EuiSwitch,
 } from '../../../../src/components';
 
+import { htmlIdGenerator } from '../../../../src/services';
+
 export default () => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const formRowID__1 = htmlIdGenerator('formrow')();
+  const formRowID__2 = htmlIdGenerator('formrow')();
 
   const onButtonClick = () =>
     setIsPopoverOpen((isPopoverOpen) => !isPopoverOpen);
@@ -27,10 +31,10 @@ export default () => {
       button={button}
       isOpen={isPopoverOpen}
       closePopover={closePopover}
-      initialFocus="[id=asdf2]">
+      initalFocus={`[id=${formRowID__2}]`}>
       <EuiFormRow
         label="Generate a public snapshot?"
-        id="asdf"
+        id={formRowID__1}
         hasChildLabel={false}>
         <EuiSwitch
           name="switch"
@@ -40,7 +44,7 @@ export default () => {
         />
       </EuiFormRow>
 
-      <EuiFormRow label="Include the following in the embed" id="asdf2">
+      <EuiFormRow label="Include the following in the embed" id={formRowID__2}>
         <EuiSwitch
           name="switch"
           label="Current time range"

--- a/src-docs/src/views/range/dual_range.js
+++ b/src-docs/src/views/range/dual_range.js
@@ -7,11 +7,13 @@ import { htmlIdGenerator } from '../../../../src/services';
 export default () => {
   const [value, setValue] = useState(['100', '150']);
   const [value2, setValue2] = useState(['40', '60']);
+  const rangeID__1 = htmlIdGenerator('range')();
+  const rangeID__2 = htmlIdGenerator('range')();
 
   return (
     <>
       <EuiDualRange
-        id={htmlIdGenerator()()}
+        id={rangeID__1}
         min={0}
         max={300}
         step={10}
@@ -30,7 +32,7 @@ export default () => {
       <EuiSpacer size="l" />
 
       <EuiDualRange
-        id={htmlIdGenerator()()}
+        id={rangeID__2}
         min={0}
         max={100}
         step={1}

--- a/src-docs/src/views/range/input.js
+++ b/src-docs/src/views/range/input.js
@@ -8,6 +8,9 @@ export default () => {
   const [value, setValue] = useState('20');
   const [dualValue, setDualValue] = useState([20, 100]);
 
+  const rangeID__1 = htmlIdGenerator('range')();
+  const rangeID__2 = htmlIdGenerator('range')();
+
   const onChange = (e) => {
     setValue(e.target.value);
   };
@@ -19,7 +22,7 @@ export default () => {
   return (
     <Fragment>
       <EuiRange
-        id={htmlIdGenerator()()}
+        id={rangeID__1}
         value={value}
         onChange={onChange}
         showInput
@@ -29,7 +32,7 @@ export default () => {
       <EuiSpacer size="xl" />
 
       <EuiDualRange
-        id={htmlIdGenerator()()}
+        id={rangeID__2}
         value={dualValue}
         onChange={onDualChange}
         showInput

--- a/src-docs/src/views/range/input_only.js
+++ b/src-docs/src/views/range/input_only.js
@@ -9,6 +9,9 @@ export default () => {
   const [value, setValue] = useState('20');
   const [dualValue, setDualValue] = useState([20, 100]);
 
+  const rangeID__1 = htmlIdGenerator('range')();
+  const rangeID__2 = htmlIdGenerator('range')();
+
   const onChange = (e) => {
     setValue(e.target.value);
   };
@@ -34,7 +37,7 @@ export default () => {
     <Fragment>
       <DisplayToggles canAppend canPrepend>
         <EuiRange
-          id={htmlIdGenerator()()}
+          id={rangeID__1}
           value={value}
           onChange={onChange}
           showInput="inputWithPopover"
@@ -47,7 +50,7 @@ export default () => {
 
       <DisplayToggles canAppend canPrepend canLoading={false}>
         <EuiDualRange
-          id={htmlIdGenerator()()}
+          id={rangeID__2}
           value={dualValue}
           onChange={onDualChange}
           showInput="inputWithPopover"

--- a/src-docs/src/views/range/levels.js
+++ b/src-docs/src/views/range/levels.js
@@ -13,6 +13,9 @@ export default () => {
   const [value, setvalue] = useState('20');
   const [dualValue, setDualValue] = useState([20, 100]);
 
+  const rangeID__1 = htmlIdGenerator('range')();
+  const rangeID__2 = htmlIdGenerator('range')();
+
   const levels = [
     {
       min: 0,
@@ -37,7 +40,7 @@ export default () => {
   return (
     <Fragment>
       <EuiRange
-        id={htmlIdGenerator()()}
+        id={rangeID__1}
         value={value}
         onChange={(e) => onChange(e)}
         showTicks
@@ -52,7 +55,7 @@ export default () => {
 
       <EuiSpacer size="xl" />
       <EuiDualRange
-        id={htmlIdGenerator()()}
+        id={rangeID__2}
         value={dualValue}
         onChange={(value) => onDualChange(value)}
         showTicks

--- a/src-docs/src/views/range/range.js
+++ b/src-docs/src/views/range/range.js
@@ -6,6 +6,9 @@ import { htmlIdGenerator } from '../../../../src/services';
 
 export default () => {
   const [value, setValue] = useState('120');
+  const rangeID__1 = htmlIdGenerator('range')();
+  const rangeID__2 = htmlIdGenerator('range')();
+  const rangeID__3 = htmlIdGenerator('range')();
 
   const onChange = (e) => {
     setValue(e.target.value);
@@ -14,7 +17,7 @@ export default () => {
   return (
     <Fragment>
       <EuiRange
-        id={htmlIdGenerator()()}
+        id={rangeID__1}
         min={100}
         max={200}
         step={0.05}
@@ -27,7 +30,7 @@ export default () => {
       <EuiSpacer size="xl" />
 
       <EuiRange
-        id={htmlIdGenerator()()}
+        id={rangeID__2}
         min={100}
         max={200}
         value={value}
@@ -40,7 +43,7 @@ export default () => {
       <EuiSpacer size="xl" />
 
       <EuiRange
-        id={htmlIdGenerator()()}
+        id={rangeID__3}
         min={100}
         max={200}
         value={value}

--- a/src-docs/src/views/range/states.js
+++ b/src-docs/src/views/range/states.js
@@ -8,6 +8,10 @@ import { htmlIdGenerator } from '../../../../src/services';
 export default () => {
   const [value, setValue] = useState('20');
   const [dualValue, setDualValue] = useState([20, 100]);
+
+  const rangeID__1 = htmlIdGenerator('range')();
+  const rangeID__2 = htmlIdGenerator('range')();
+
   const levels = [
     {
       min: 0,
@@ -33,7 +37,7 @@ export default () => {
     <Fragment>
       <DisplayToggles canAppend canPrepend canLoading={false}>
         <EuiRange
-          id={htmlIdGenerator()()}
+          id={rangeID__1}
           value={value}
           onChange={onChange}
           showTicks
@@ -51,7 +55,7 @@ export default () => {
 
       <DisplayToggles canLoading={false}>
         <EuiDualRange
-          id={htmlIdGenerator()()}
+          id={rangeID__2}
           value={dualValue}
           onChange={onDualChange}
           showLabels

--- a/src-docs/src/views/range/ticks.js
+++ b/src-docs/src/views/range/ticks.js
@@ -13,6 +13,11 @@ export default () => {
   const [value, setValue] = useState('20');
   const [dualValue, setDualValue] = useState([20, 100]);
 
+  const rangeID__1 = htmlIdGenerator('range')();
+  const rangeID__2 = htmlIdGenerator('range')();
+  const rangeID__3 = htmlIdGenerator('range')();
+  const rangeID__4 = htmlIdGenerator('range')();
+
   const onChange = (e) => {
     setValue(e.target.value);
   };
@@ -24,7 +29,7 @@ export default () => {
   return (
     <Fragment>
       <EuiRange
-        id={htmlIdGenerator()()}
+        id={rangeID__1}
         step={10}
         value={value}
         onChange={onChange}
@@ -41,7 +46,7 @@ export default () => {
       <EuiSpacer size="l" />
 
       <EuiRange
-        id={htmlIdGenerator()()}
+        id={rangeID__2}
         value={value}
         onChange={onChange}
         showInput
@@ -60,7 +65,7 @@ export default () => {
       <EuiSpacer size="l" />
 
       <EuiDualRange
-        id={htmlIdGenerator()()}
+        id={rangeID__3}
         value={dualValue}
         onChange={onDualChange}
         showTicks
@@ -81,7 +86,7 @@ export default () => {
       <EuiSpacer size="l" />
 
       <EuiDualRange
-        id={htmlIdGenerator()()}
+        id={rangeID__4}
         value={dualValue}
         onChange={onDualChange}
         showTicks

--- a/src-docs/src/views/resizable_container/resizable_container_reset_values.js
+++ b/src-docs/src/views/resizable_container/resizable_container_reset_values.js
@@ -9,6 +9,7 @@ import {
   EuiSpacer,
 } from '../../../../src/components';
 import { fake } from 'faker';
+import { htmlIdGenerator } from '../../../../src/services';
 
 const text = (
   <>
@@ -18,13 +19,15 @@ const text = (
   </>
 );
 
-const firstPanelId = 'resizable-panel__1';
-const secondPanelId = 'resizable-panel__2';
+//const firstPanelId = 'resizable-panel__1';
+//const secondPanelId = 'resizable-panel__2';
+const panelID__1 = htmlIdGenerator('panel')();
+const panelID__2 = htmlIdGenerator('panel')();
 const stored = localStorage.getItem('resizableContainer');
 const storedSizes = stored && JSON.parse(stored);
 const defaultSizes = storedSizes || {
-  [firstPanelId]: 50,
-  [secondPanelId]: 50,
+  [panelID__1]: 50,
+  [panelID__2]: 50,
 };
 
 export default () => {
@@ -40,16 +43,16 @@ export default () => {
   const onClick30x70 = useCallback(
     () =>
       setSizes({
-        [firstPanelId]: 30,
-        [secondPanelId]: 70,
+        [panelID__1]: 30,
+        [panelID__2]: 70,
       }),
     []
   );
   const onClick80x20 = useCallback(
     () =>
       setSizes({
-        [firstPanelId]: 80,
-        [secondPanelId]: 20,
+        [panelID__1]: 80,
+        [panelID__2]: 20,
       }),
     []
   );
@@ -88,8 +91,8 @@ export default () => {
         {(EuiResizablePanel, EuiResizableButton) => (
           <>
             <EuiResizablePanel
-              id={firstPanelId}
-              size={sizes[firstPanelId]}
+              id={panelID__1}
+              size={sizes[panelID__1]}
               minSize="30%">
               <EuiText>
                 <div>{text}</div>
@@ -99,8 +102,8 @@ export default () => {
             <EuiResizableButton />
 
             <EuiResizablePanel
-              id={secondPanelId}
-              size={sizes[secondPanelId]}
+              id={panelID__2}
+              size={sizes[panelID__2]}
               minSize="200px">
               <EuiText>
                 <div>{text}</div>

--- a/src-docs/src/views/resizable_container/resizable_panel_collapsible_external.js
+++ b/src-docs/src/views/resizable_container/resizable_panel_collapsible_external.js
@@ -10,6 +10,7 @@ import {
   EuiFlexItem,
   EuiText,
 } from '../../../../src/components';
+import { htmlIdGenerator } from '../../../../src/services';
 
 const toggleButtons = [
   {
@@ -26,6 +27,9 @@ export default () => {
   const collapseFn = useRef(() => {});
 
   const [toggleIdToSelectedMap, setToggleIdToSelectedMap] = useState({});
+  const panelID__1 = htmlIdGenerator('panel')();
+  const panelID__2 = htmlIdGenerator('panel')();
+  const panelID__3 = htmlIdGenerator('panel')();
 
   const onCollapse = (optionId) => {
     const newToggleIdToSelectedMap = {
@@ -61,7 +65,7 @@ export default () => {
             togglePanel(id, { direction });
           return (
             <>
-              <EuiResizablePanel id="panel1" initialSize={30} minSize="10%">
+              <EuiResizablePanel id={panelID__1} initialSize={30} minSize="10%">
                 <EuiPanel paddingSize="l" style={{ height: '100%' }}>
                   <EuiTitle>
                     <p>Panel 1</p>
@@ -71,7 +75,10 @@ export default () => {
 
               <EuiResizableButton />
 
-              <EuiResizablePanel id="panel2" initialSize={35} minSize="50px">
+              <EuiResizablePanel
+                id={panelID__2}
+                initialSize={35}
+                minSize="50px">
                 <EuiPanel paddingSize="l" style={{ height: '100%' }}>
                   <EuiTitle>
                     <p>Panel 2</p>
@@ -83,7 +90,7 @@ export default () => {
 
               <EuiResizablePanel
                 mode={['custom', { position: 'top' }]}
-                id="panel3"
+                id={panelID__3}
                 initialSize={35}
                 minSize="10%">
                 <EuiPanel paddingSize="l" style={{ height: '100%' }}>


### PR DESCRIPTION
### Summary

Updates any static HTML element IDs inside of EUI documentation with IDs generated by the `htmlIdGenerator()()` utility function. This change is based on [Issue #4774 ](https://github.com/elastic/eui/issues/4774) where it was reported that including multiple copies of the same code snippet can cause duplicate ID errors. While static IDs were removed, the existing generated IDs were standardized across relevant files. 
Page-by-page review of the docs revealed that there are about 80 instances of HTML element IDs in the docs. [Here](https://docs.google.com/spreadsheets/d/1qSRsLB_LovEllaIs9VGunBvSazYbwuzlQX9ci7i4rR0/edit?usp=sharing) is a document defining the pages and components affected by this change.

**Before**
![With Static IDs](https://user-images.githubusercontent.com/40739624/131521381-1d8f2939-cf8d-4ef8-8801-5e68f11fdfbe.jpeg)

**After**
![Static IDs Removed](https://user-images.githubusercontent.com/40739624/131521455-e424629c-07f5-46a9-9db3-af2eb8db5edb.jpeg)

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
