### PR TITLE
[EuiSelectable] Prevent `onFocus` from negating selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Fixed `EuiSuperSelect`'s focus keyboard behavior when no initial value is passed, and focus label behavior ([#5097](https://github.com/elastic/eui/pull/5097))
+- Fixed `EuiSelectable` sometimes requiring two clicks to change selection ([#5117](https://github.com/elastic/eui/pull/5117))
 
 ## [`37.5.0`](https://github.com/elastic/eui/tree/v37.5.0)
 

--- a/src-docs/src/views/selectable/data.ts
+++ b/src-docs/src/views/selectable/data.ts
@@ -11,7 +11,7 @@ export const Options: EuiSelectableOption[] = [
   },
   {
     label: 'Mimas',
-    checked: 'on',
+    // checked: 'on',
   },
   {
     label: 'Dione',

--- a/src-docs/src/views/selectable/selectable_popover.js
+++ b/src-docs/src/views/selectable/selectable_popover.js
@@ -12,7 +12,7 @@ import {
   EuiSpacer,
   EuiTitle,
 } from '../../../../src/components';
-import { Comparators } from '../../../../src/services/sort';
+// import { Comparators } from '../../../../src/services/sort';
 
 import { Options } from './data';
 import { createDataStore } from '../tables/data_store';
@@ -32,7 +32,7 @@ export default () => {
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
 
   const onButtonClick = () => {
-    setOptions(options.slice().sort(Comparators.property('checked')));
+    // setOptions(options.slice().sort(Comparators.property('checked')));
     setIsPopoverOpen(!isPopoverOpen);
   };
 
@@ -72,11 +72,12 @@ export default () => {
         closePopover={closePopover}
       >
         <EuiSelectable
-          searchable
-          searchProps={{
-            placeholder: 'Filter list',
-            compressed: true,
-          }}
+          // searchable
+          singleSelection={true}
+          // searchProps={{
+          //   placeholder: 'Filter list',
+          //   compressed: true,
+          // }}
           options={options}
           onChange={onChange}
         >

--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -152,6 +152,7 @@ export class EuiSelectable<T = {}> extends Component<
   };
   private containerRef = createRef<HTMLDivElement>();
   private optionsListRef = createRef<EuiSelectableList<T>>();
+  private preventOnFocus = false;
   rootId = htmlIdGenerator();
   constructor(props: EuiSelectableProps<T>) {
     super(props);
@@ -212,7 +213,19 @@ export class EuiSelectable<T = {}> extends Component<
     return this.state.activeOptionIndex != null;
   };
 
+  onMouseDown = () => {
+    // Bypass onFocus when a click event originates from this.containerRef.
+    // Prevents onFocus from scrolling away from a clicked option and negating the selection event.
+    // https://github.com/elastic/eui/issues/4147
+    this.preventOnFocus = true;
+  };
+
   onFocus = () => {
+    if (this.preventOnFocus) {
+      this.preventOnFocus = false;
+      return;
+    }
+
     if (!this.state.visibleOptions.length || this.state.activeOptionIndex) {
       return;
     }
@@ -618,6 +631,7 @@ export class EuiSelectable<T = {}> extends Component<
         onKeyDown={this.onKeyDown}
         onBlur={this.onContainerBlur}
         onFocus={this.onFocus}
+        onMouseDown={this.onMouseDown}
         {...rest}
       >
         {children && children(list, search)}


### PR DESCRIPTION
### Summary

Fixes #4147, in which a click event on an unfocused EuiSelectable would prevent the intended option click and instead scroll to the currently selected option (i.e., two clicks were required because the first was captured by `onFocus`).

The fix is to look for click events on the element that watches for `onFocus` and prevent the handler from running. The subsequent events triggered by the option selection will correctly place focus inside the list and allow for keyboard navigation. Keyboard navigation is otherwise unaffected.

**Repro:**

1) Go the Single Selection example.
2) Check the last item.
3) Click away from the list (outside the component)
4) Click the first item in the list.
5) The first item should be selected.
6) Repeat with the Popover example.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~

- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
- [ ] Revert `2fbc966`
