### PR TITLE
[EuiSwitch] Add guidelines around labelling

### DIFF
--- a/src-docs/src/views/form_controls/form_controls_example.js
+++ b/src-docs/src/views/form_controls/form_controls_example.js
@@ -504,11 +504,19 @@ export const FormControlsExample = {
     {
       title: 'Switch',
       text: (
-        <p>
-          A switch can be substituted for a checkbox when the semantics of the
-          label dictate a true on/off state. The label should be{' '}
-          <strong>static</strong> and describe the feature or question.
-        </p>
+        <>
+          <p>
+            A switch can be substituted for a checkbox when the semantics of the
+            label dictate a true on/off state. The label should be{' '}
+            <strong>static</strong>, action-oriented, and describe the feature
+            or present a question. Use past tense only when labelling a list of
+            previously created items, like in a{' '}
+            <EuiLink href="https://github.com/elastic/eui/pull/5119#discussion_r699717319">
+              table header
+            </EuiLink>
+            .
+          </p>
+        </>
       ),
       source: [
         {

--- a/src-docs/src/views/form_controls/form_controls_example.js
+++ b/src-docs/src/views/form_controls/form_controls_example.js
@@ -177,12 +177,26 @@ const radioGroupHtml = renderToHtml(RadioGroup);
 
 import Switch from './switch';
 const switchSource = require('!!raw-loader!./switch');
-const switchHtml = renderToHtml(Switch);
-const switchSnippet = [
-  `<EuiSwitch
-  label="I am a switch"
+const switchSnippet = `<EuiSwitch
+  label="Enable"
   checked={checked}
   onChange={onChange}
+/>`;
+import SwitchLabel from './switch_label';
+const switchLabelSource = require('!!raw-loader!./switch_label');
+const switchLabelSnippet = [
+  `<EuiSwitch
+  showLabel={false}
+  label="Enable"
+  checked={checked}
+  onChange={onChange}
+  compressed
+/>`,
+  `<EuiSwitch
+  label={checked ? 'on' : 'off'}
+  checked={checked}
+  onChange={onChange}
+  compressed
 />`,
 ];
 
@@ -488,14 +502,17 @@ export const FormControlsExample = {
     },
     {
       title: 'Switch',
+      text: (
+        <p>
+          A switch can be substituted for a checkbox when the semantics of the
+          label dictate a true on/off state. The label should be{' '}
+          <strong>static</strong> and describe the feature or question.
+        </p>
+      ),
       source: [
         {
           type: GuideSectionTypes.JS,
           code: switchSource,
-        },
-        {
-          type: GuideSectionTypes.HTML,
-          code: switchHtml,
         },
       ],
       snippet: switchSnippet,
@@ -504,6 +521,30 @@ export const FormControlsExample = {
       },
       demo: <Switch />,
       playground: SwitchConfig,
+    },
+    {
+      text: (
+        <p>
+          If the switch is described in some other manner, like when using an{' '}
+          <Link to="/forms/form-layouts#form-and-form-rows">
+            <strong>EuiFormRow</strong>
+          </Link>
+          , you can eliminate the visible label with{' '}
+          <EuiCode language="tsx">{'showLabel={false}'}</EuiCode> or use it to
+          further describe the state.
+        </p>
+      ),
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: switchLabelSource,
+        },
+      ],
+      snippet: switchLabelSnippet,
+      props: {
+        EuiSwitch,
+      },
+      demo: <SwitchLabel />,
     },
     {
       title: 'Fieldset and legend',
@@ -522,7 +563,6 @@ export const FormControlsExample = {
           <EuiCallOut
             color="warning"
             iconType="accessibility"
-            size="s"
             title={
               <span>
                 &quot;[Use a fieldset and legend] for groups of related controls

--- a/src-docs/src/views/form_controls/form_controls_example.js
+++ b/src-docs/src/views/form_controls/form_controls_example.js
@@ -194,6 +194,7 @@ const switchLabelSnippet = [
 />`,
   `<EuiSwitch
   label={checked ? 'on' : 'off'}
+  aria-describedby={labelId}
   checked={checked}
   onChange={onChange}
   compressed
@@ -524,15 +525,22 @@ export const FormControlsExample = {
     },
     {
       text: (
-        <p>
-          If the switch is described in some other manner, like when using an{' '}
-          <Link to="/forms/form-layouts#form-and-form-rows">
-            <strong>EuiFormRow</strong>
-          </Link>
-          , you can eliminate the visible label with{' '}
-          <EuiCode language="tsx">{'showLabel={false}'}</EuiCode> or use it to
-          further describe the state.
-        </p>
+        <>
+          <p>
+            If the switch is described in some other manner, like when using an{' '}
+            <Link to="/forms/form-layouts#form-and-form-rows">
+              <strong>EuiFormRow</strong>
+            </Link>
+            , you can eliminate the visible label with{' '}
+            <EuiCode language="tsx">{'showLabel={false}'}</EuiCode> or use it to
+            further describe the state.
+          </p>
+          <EuiCallOut
+            color="warning"
+            iconType="accessibility"
+            title="When providing the state as the label, you'll need to provide an aria-describedby with the label's id to associate it with the swtich."
+          />
+        </>
       ),
       source: [
         {

--- a/src-docs/src/views/form_controls/switch.js
+++ b/src-docs/src/views/form_controls/switch.js
@@ -1,6 +1,7 @@
-import React, { useState, Fragment } from 'react';
+import React, { useState } from 'react';
 
-import { EuiSwitch, EuiSpacer } from '../../../../src/components';
+import { EuiSwitch } from '../../../../src/components';
+import { DisplayToggles } from './display_toggles';
 
 export default () => {
   const [checked, setChecked] = useState(false);
@@ -10,59 +11,18 @@ export default () => {
   };
 
   return (
-    <Fragment>
+    /* DisplayToggles wrapper for Docs only */
+    <DisplayToggles
+      canReadOnly={false}
+      canLoading={false}
+      canInvalid={false}
+      canFullWidth={false}
+    >
       <EuiSwitch
-        label="I am a switch"
+        label="Enable"
         checked={checked}
         onChange={(e) => onChange(e)}
       />
-
-      <EuiSpacer size="m" />
-
-      <EuiSwitch
-        label="I am a disabled switch"
-        checked={checked}
-        onChange={(e) => onChange(e)}
-        disabled
-      />
-
-      <EuiSpacer size="m" />
-
-      <EuiSwitch
-        showLabel={false}
-        label="I am a switch without a visible label"
-        checked={checked}
-        onChange={(e) => onChange(e)}
-      />
-
-      <EuiSpacer size="m" />
-
-      <EuiSwitch
-        label="I am a compressed switch"
-        checked={checked}
-        onChange={(e) => onChange(e)}
-        compressed
-      />
-
-      <EuiSpacer size="m" />
-
-      <EuiSwitch
-        label="I am a compressed, disabled switch"
-        checked={checked}
-        onChange={(e) => onChange(e)}
-        compressed
-        disabled
-      />
-
-      <EuiSpacer size="m" />
-
-      <EuiSwitch
-        showLabel={false}
-        label="I am a compressed switch without a visible label"
-        checked={checked}
-        onChange={(e) => onChange(e)}
-        compressed
-      />
-    </Fragment>
+    </DisplayToggles>
   );
 };

--- a/src-docs/src/views/form_controls/switch_label.tsx
+++ b/src-docs/src/views/form_controls/switch_label.tsx
@@ -1,0 +1,42 @@
+import React, { useState, Fragment } from 'react';
+
+import { EuiSwitch, EuiFormRow } from '../../../../src/components';
+
+export default () => {
+  const [checked1, setChecked1] = useState(false);
+  const [checked2, setChecked2] = useState(false);
+
+  const onChange1 = (e: {
+    target: { checked: React.SetStateAction<boolean> };
+  }) => {
+    setChecked1(e.target.checked);
+  };
+
+  const onChange2 = (e: {
+    target: { checked: React.SetStateAction<boolean> };
+  }) => {
+    setChecked2(e.target.checked);
+  };
+
+  return (
+    <Fragment>
+      <EuiFormRow display="columnCompressedSwitch" label="Enable">
+        <EuiSwitch
+          showLabel={false}
+          label="Enable"
+          checked={checked1}
+          onChange={onChange1}
+          compressed
+        />
+      </EuiFormRow>
+      <EuiFormRow display="columnCompressedSwitch" label="Show something">
+        <EuiSwitch
+          label={checked2 ? 'on' : 'off'}
+          checked={checked2}
+          onChange={onChange2}
+          compressed
+        />
+      </EuiFormRow>
+    </Fragment>
+  );
+};

--- a/src-docs/src/views/form_controls/switch_label.tsx
+++ b/src-docs/src/views/form_controls/switch_label.tsx
@@ -1,10 +1,12 @@
 import React, { useState, Fragment } from 'react';
 
 import { EuiSwitch, EuiFormRow } from '../../../../src/components';
+import { htmlIdGenerator } from '../../../../src/services';
 
 export default () => {
   const [checked1, setChecked1] = useState(false);
   const [checked2, setChecked2] = useState(false);
+  const switch2RowId = htmlIdGenerator('switch2row')();
 
   const onChange1 = (e: {
     target: { checked: React.SetStateAction<boolean> };
@@ -29,11 +31,15 @@ export default () => {
           compressed
         />
       </EuiFormRow>
-      <EuiFormRow display="columnCompressedSwitch" label="Show something">
+      <EuiFormRow
+        display="columnCompressedSwitch"
+        label={<span id={switch2RowId}>Show something</span>}
+      >
         <EuiSwitch
           label={checked2 ? 'on' : 'off'}
           checked={checked2}
           onChange={onChange2}
+          aria-describedby={switch2RowId}
           compressed
         />
       </EuiFormRow>


### PR DESCRIPTION
### Docs only

In the Security design meeting there was a discussion around how to label switches. The age old question of if it should be detailing the current state or not. We came to a consensus that if it is the **sole** label for the switch, it should be static and describe the feature or state the question.

But if there is a label elsewhere in the UI that gives meaning to the switch, then the label can either be completely eliminated or used to describe the state like "on/off".

This PR, updates our Switch section to detail these ideas as well as cleans up the original example to display a single switch and use the `DisplayToggles` to see the different states (which is 🤷 up for debate since we have the playground now, but at least its consistent).

<img width="952" alt="Screen Shot 2021-08-31 at 17 43 14 PM" src="https://user-images.githubusercontent.com/549577/131579789-0310c672-487e-4cf9-b9f5-10dd509dcadd.png">




### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
