### PR TITLE
[POC] Ctrl clicking filters in Basic Table Actions

### DIFF
--- a/src-docs/src/views/tables/actions/actions.js
+++ b/src-docs/src/views/tables/actions/actions.js
@@ -1,4 +1,4 @@
-import React, { useState, Fragment } from 'react';
+import React, { useState, useEffect, Fragment } from 'react';
 import { formatDate } from '../../../../../src/services/format';
 import { createDataStore } from '../data_store';
 
@@ -43,8 +43,30 @@ export const Table = () => {
   const [sortField, setSortField] = useState('firstName');
   const [sortDirection, setSortDirection] = useState('asc');
   const [selectedItems, setSelectedItems] = useState([]);
-  const [multiAction, setMultiAction] = useState(false);
+  const [multiAction, setMultiAction] = useState(true);
   const [customAction, setCustomAction] = useState(false);
+  const [ctrlIsPressed, setCtrlIsPressed] = useState(false);
+
+  const ctrlHandler = (e) => {
+    if (e && e.metaKey) {
+      setCtrlIsPressed(true);
+    } else {
+      setCtrlIsPressed(false);
+    }
+  };
+
+  // Add window resize handlers
+  useEffect(() => {
+    window.addEventListener('keydown', ctrlHandler);
+    window.addEventListener('keypress', ctrlHandler);
+    window.addEventListener('keyup', ctrlHandler);
+
+    return () => {
+      window.removeEventListener('keydown', ctrlHandler);
+      window.removeEventListener('keypress', ctrlHandler);
+      window.removeEventListener('keyup', ctrlHandler);
+    };
+  }, [ctrlHandler]);
 
   const onTableChange = ({ page = {}, sort = {} }) => {
     const { index: pageIndex, size: pageSize } = page;
@@ -89,9 +111,25 @@ export const Table = () => {
     setCustomAction(!customAction);
   };
 
-  const deleteUser = (user) => {
-    store.deleteUsers(user.id);
-    setSelectedItems([]);
+  const primaryAction = (user) => {
+    // store.deleteUsers(user.id);
+    // setSelectedItems([]);
+    window.alert(`Goes somewhere for "${user.firstName}"`);
+  };
+
+  const filter = (user, e) => {
+    if (e && e.metaKey) {
+      filterOut(user);
+      return;
+    }
+
+    window.alert(`Filter IN for "${user.firstName}"`);
+    return;
+  };
+
+  const filterOut = (user) => {
+    window.alert(`Filter OUT for "${user.firstName}"`);
+    return;
   };
 
   const cloneUser = (user) => {
@@ -125,7 +163,7 @@ export const Table = () => {
           {
             render: (item) => {
               return (
-                <EuiLink color="danger" onClick={() => deleteUser(item)}>
+                <EuiLink color="danger" onClick={() => primaryAction(item)}>
                   Delete
                 </EuiLink>
               );
@@ -134,31 +172,28 @@ export const Table = () => {
         ]
       : [
           {
-            name: <span>Clone</span>,
-            description: 'Clone this user',
-            icon: 'copy',
-            onClick: cloneUser,
-            'data-test-subj': 'action-clone',
+            name: 'Primary action',
+            isPrimary: true,
+            description: 'Primary action',
+            icon: 'timeline',
+            type: 'icon',
+            onClick: primaryAction,
           },
           {
-            name: (item) => (item.id ? 'Delete' : 'Remove'),
-            description: 'Delete this user',
-            icon: 'trash',
-            color: 'danger',
-            type: 'icon',
-            onClick: deleteUser,
+            name: (item) => (item.id ? 'Filter in' : 'Filter'),
             isPrimary: true,
-            'data-test-subj': 'action-delete',
+            description: ctrlIsPressed
+              ? 'Filter out, release ctrl to filter in'
+              : 'Filter in, or ctrl+click to filter out',
+            icon: ctrlIsPressed ? 'minusInCircle' : 'plusInCircle',
+            type: 'icon',
+            onClick: filter,
           },
           {
-            name: 'Edit',
-            isPrimary: true,
-            available: ({ online }) => !online,
-            description: 'Edit this user',
-            icon: 'pencil',
-            type: 'icon',
-            onClick: () => {},
-            'data-test-subj': 'action-edit',
+            name: 'Filter out',
+            // description: 'Clone this user',
+            icon: 'minusInCircle',
+            onClick: filterOut,
           },
           {
             name: 'Share',
@@ -185,7 +220,7 @@ export const Table = () => {
           {
             render: (item) => {
               return (
-                <EuiLink onClick={() => deleteUser(item)} color="danger">
+                <EuiLink onClick={() => primaryAction(item)} color="danger">
                   Delete
                 </EuiLink>
               );

--- a/src-docs/src/views/tables/actions/actions.js
+++ b/src-docs/src/views/tables/actions/actions.js
@@ -47,6 +47,7 @@ export const Table = () => {
   const [customAction, setCustomAction] = useState(false);
   const [ctrlIsPressed, setCtrlIsPressed] = useState(false);
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const ctrlHandler = (e) => {
     if (e && e.metaKey) {
       setCtrlIsPressed(true);

--- a/src/components/basic_table/action_types.ts
+++ b/src/components/basic_table/action_types.ts
@@ -28,7 +28,7 @@ export interface DefaultItemActionBase<T> {
   /**
    * A handler function to execute the action
    */
-  onClick?: (item: T, e) => void;
+  onClick?: (item: T, e: any) => void;
   href?: string;
   target?: string;
   /**

--- a/src/components/basic_table/action_types.ts
+++ b/src/components/basic_table/action_types.ts
@@ -28,7 +28,7 @@ export interface DefaultItemActionBase<T> {
   /**
    * A handler function to execute the action
    */
-  onClick?: (item: T) => void;
+  onClick?: (item: T, e) => void;
   href?: string;
   target?: string;
   /**

--- a/src/components/basic_table/collapsed_item_actions.tsx
+++ b/src/components/basic_table/collapsed_item_actions.tsx
@@ -152,9 +152,10 @@ export class CollapsedItemActions<T> extends Component<
               target={target}
               icon={icon}
               data-test-subj={dataTestSubj}
-              onClick={() =>
-                this.onClickItem(onClick ? () => onClick(item) : undefined)
-              }
+              onClick={() => {
+                this.closePopover();
+                onClick ? (e: any) => onClick(item, e) : undefined;
+              }}
             >
               {buttonContent}
             </EuiContextMenuItem>

--- a/src/components/basic_table/default_item_action.tsx
+++ b/src/components/basic_table/default_item_action.tsx
@@ -40,7 +40,9 @@ export const DefaultItemAction = <T extends {}>({
       or 'href' string. If you want to provide a custom action control, make sure to define the 'render' callback`);
   }
 
-  const onClick = action.onClick ? (e) => action.onClick!(item, e) : undefined;
+  const onClick = action.onClick
+    ? (e: any) => action.onClick!(item, e)
+    : undefined;
 
   const buttonColor = action.color;
   let color: EuiButtonIconColor = 'primary';

--- a/src/components/basic_table/default_item_action.tsx
+++ b/src/components/basic_table/default_item_action.tsx
@@ -40,7 +40,7 @@ export const DefaultItemAction = <T extends {}>({
       or 'href' string. If you want to provide a custom action control, make sure to define the 'render' callback`);
   }
 
-  const onClick = action.onClick ? () => action.onClick!(item) : undefined;
+  const onClick = action.onClick ? (e) => action.onClick!(item, e) : undefined;
 
   const buttonColor = action.color;
   let color: EuiButtonIconColor = 'primary';


### PR DESCRIPTION
### POC - Don't merge
_Duplicated description from discussion_

## Filter in/out

I'd like to take a moment to mention the repeated filter actions that we have in most DataGrid usages. 

Applying two distinct filter buttons, one for in, one for out, within the cells themselves takes up a lot of room and adds a lot of noise for what I assume to be is a coupled action that can be simplified to a single experience.

What I mean is that the act of Filtering is a single action. It's whether they want to filter **out** or **in** that is the "choice". I would like to suggest a pattern/component that creates a unified experience around filtering at the data level. Primarily I mean, reducing the act to the primarily use "in" functionality, while prioritizing the "out" functionality.

I've POC'd a quick example of where I think we can optimize for "in" but still allow for quick "out" functionality, and then having both options be explicitly listed in the full format of the popover. The POC (I added to the Basic Table component because it was just easier) basically, creates a single "Filter" action that is shown on hover which when just clicked filters "In". But if the user `ctrl` clicks, will swap to an "out" function. Ten in the popover where we list ALL the options, the filter "in" and "out" are both explicitly listed.

Here's a screenrecording:

https://user-images.githubusercontent.com/549577/131721549-89a69803-98b9-4532-b1ac-679d2892e29e.mp4

