### PR TITLE
[EuiDataGrid] Add unit tests for body/ components + minor refactors

### DIFF
--- a/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
@@ -990,6 +990,7 @@ exports[`EuiDataGridBody renders 1`] = `
                     onFocus={[Function]}
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                     role="gridcell"
                     style={
                       Object {
@@ -1222,6 +1223,7 @@ exports[`EuiDataGridBody renders 1`] = `
                     onFocus={[Function]}
                     onKeyDown={[Function]}
                     onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                     role="gridcell"
                     style={
                       Object {

--- a/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
@@ -1,0 +1,1304 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiDataGridBody renders 1`] = `
+<EuiDataGridBody
+  columnWidths={
+    Object {
+      "columnA": 20,
+    }
+  }
+  columns={
+    Array [
+      Object {
+        "id": "columnA",
+        "schema": "boolean",
+      },
+      Object {
+        "id": "columnB",
+        "isExpandable": true,
+      },
+    ]
+  }
+  handleHeaderMutation={[MockFunction]}
+  headerIsInteractive={true}
+  inMemory={
+    Object {
+      "level": "enhancements",
+    }
+  }
+  inMemoryValues={Object {}}
+  interactiveCellId="someId"
+  isFullScreen={false}
+  renderCellValue={[Function]}
+  rowCount={1}
+  rowHeightUtils={
+    RowHeightUtils {
+      "fakeCell": <div />,
+      "styles": Object {},
+    }
+  }
+  schema={
+    Object {
+      "columnA": Object {
+        "columnType": "boolean",
+      },
+      "columnB": Object {
+        "columnType": "string",
+      },
+    }
+  }
+  schemaDetectors={
+    Array [
+      Object {
+        "comparator": [Function],
+        "detector": [Function],
+        "icon": "tokenBoolean",
+        "sortTextAsc": <EuiI18n
+          default="False-True"
+          token="euiDataGridSchema.booleanSortTextAsc"
+        />,
+        "sortTextDesc": <EuiI18n
+          default="True-False"
+          token="euiDataGridSchema.booleanSortTextDesc"
+        />,
+        "type": "boolean",
+      },
+      Object {
+        "color": "euiColorVis0",
+        "comparator": [Function],
+        "detector": [Function],
+        "icon": "currency",
+        "sortTextAsc": <EuiI18n
+          default="Low-High"
+          token="euiDataGridSchema.currencySortTextAsc"
+        />,
+        "sortTextDesc": <EuiI18n
+          default="High-Low"
+          token="euiDataGridSchema.currencySortTextDesc"
+        />,
+        "type": "currency",
+      },
+      Object {
+        "detector": [Function],
+        "icon": "tokenDate",
+        "sortTextAsc": <EuiI18n
+          default="Old-New"
+          token="euiDataGridSchema.dateSortTextAsc"
+        />,
+        "sortTextDesc": <EuiI18n
+          default="New-Old"
+          token="euiDataGridSchema.dateSortTextDesc"
+        />,
+        "type": "datetime",
+      },
+      Object {
+        "comparator": [Function],
+        "detector": [Function],
+        "icon": "tokenNumber",
+        "sortTextAsc": <EuiI18n
+          default="Low-High"
+          token="euiDataGridSchema.numberSortTextAsc"
+        />,
+        "sortTextDesc": <EuiI18n
+          default="High-Low"
+          token="euiDataGridSchema.numberSortTextDesc"
+        />,
+        "type": "numeric",
+      },
+      Object {
+        "comparator": [Function],
+        "detector": [Function],
+        "icon": "tokenObject",
+        "sortTextAsc": <EuiI18n
+          default="Small-Large"
+          token="euiDataGridSchema.jsonSortTextAsc"
+        />,
+        "sortTextDesc": <EuiI18n
+          default="Large-Small"
+          token="euiDataGridSchema.jsonSortTextDesc"
+        />,
+        "type": "json",
+      },
+    ]
+  }
+  setColumnWidth={[MockFunction]}
+  setVisibleColumns={[MockFunction]}
+  switchColumnPos={[MockFunction]}
+  toolbarHeight={10}
+>
+  <EuiMutationObserver
+    observerOptions={
+      Object {
+        "childList": true,
+        "subtree": true,
+      }
+    }
+    onMutation={[Function]}
+  >
+    <div
+      style={
+        Object {
+          "height": "100%",
+          "overflow": "hidden",
+          "width": "100%",
+        }
+      }
+    >
+      <Grid
+        className="euiDataGrid__virtualized"
+        columnCount={2}
+        columnWidth={[Function]}
+        direction="ltr"
+        height={9007199254740991}
+        innerElementType={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "displayName": "EuiDataGridInnerElement",
+            "propTypes": Object {
+              "style": [Function],
+            },
+            "render": [Function],
+          }
+        }
+        itemData={
+          Object {
+            "columnWidths": Object {
+              "columnA": 20,
+            },
+            "columns": Array [
+              Object {
+                "id": "columnA",
+                "schema": "boolean",
+              },
+              Object {
+                "id": "columnB",
+                "isExpandable": true,
+              },
+            ],
+            "defaultColumnWidth": undefined,
+            "getCorrectRowIndex": [Function],
+            "getRowHeight": [Function],
+            "interactiveCellId": "someId",
+            "leadingControlColumns": Array [],
+            "popoverContents": Object {
+              "json": [Function],
+            },
+            "renderCellValue": [Function],
+            "rowHeightsOptions": undefined,
+            "rowMap": Object {},
+            "rowOffset": 0,
+            "schema": Object {
+              "columnA": Object {
+                "columnType": "boolean",
+              },
+              "columnB": Object {
+                "columnType": "string",
+              },
+            },
+            "schemaDetectors": Array [
+              Object {
+                "comparator": [Function],
+                "detector": [Function],
+                "icon": "tokenBoolean",
+                "sortTextAsc": <EuiI18n
+                  default="False-True"
+                  token="euiDataGridSchema.booleanSortTextAsc"
+                />,
+                "sortTextDesc": <EuiI18n
+                  default="True-False"
+                  token="euiDataGridSchema.booleanSortTextDesc"
+                />,
+                "type": "boolean",
+              },
+              Object {
+                "color": "euiColorVis0",
+                "comparator": [Function],
+                "detector": [Function],
+                "icon": "currency",
+                "sortTextAsc": <EuiI18n
+                  default="Low-High"
+                  token="euiDataGridSchema.currencySortTextAsc"
+                />,
+                "sortTextDesc": <EuiI18n
+                  default="High-Low"
+                  token="euiDataGridSchema.currencySortTextDesc"
+                />,
+                "type": "currency",
+              },
+              Object {
+                "detector": [Function],
+                "icon": "tokenDate",
+                "sortTextAsc": <EuiI18n
+                  default="Old-New"
+                  token="euiDataGridSchema.dateSortTextAsc"
+                />,
+                "sortTextDesc": <EuiI18n
+                  default="New-Old"
+                  token="euiDataGridSchema.dateSortTextDesc"
+                />,
+                "type": "datetime",
+              },
+              Object {
+                "comparator": [Function],
+                "detector": [Function],
+                "icon": "tokenNumber",
+                "sortTextAsc": <EuiI18n
+                  default="Low-High"
+                  token="euiDataGridSchema.numberSortTextAsc"
+                />,
+                "sortTextDesc": <EuiI18n
+                  default="High-Low"
+                  token="euiDataGridSchema.numberSortTextDesc"
+                />,
+                "type": "numeric",
+              },
+              Object {
+                "comparator": [Function],
+                "detector": [Function],
+                "icon": "tokenObject",
+                "sortTextAsc": <EuiI18n
+                  default="Small-Large"
+                  token="euiDataGridSchema.jsonSortTextAsc"
+                />,
+                "sortTextDesc": <EuiI18n
+                  default="Large-Small"
+                  token="euiDataGridSchema.jsonSortTextDesc"
+                />,
+                "type": "json",
+              },
+            ],
+            "setRowHeight": [Function],
+            "trailingControlColumns": Array [],
+          }
+        }
+        rowCount={1}
+        rowHeight={[Function]}
+        useIsScrolling={false}
+        width={9007199254740991}
+      >
+        <div
+          className="euiDataGrid__virtualized"
+          onScroll={[Function]}
+          style={
+            Object {
+              "WebkitOverflowScrolling": "touch",
+              "direction": "ltr",
+              "height": 9007199254740991,
+              "overflow": "auto",
+              "position": "relative",
+              "width": 9007199254740991,
+              "willChange": "transform",
+            }
+          }
+        >
+          <EuiDataGridInnerElement
+            style={
+              Object {
+                "height": 34,
+                "pointerEvents": undefined,
+                "width": 120,
+              }
+            }
+          >
+            <div
+              style={
+                Object {
+                  "height": 34,
+                  "pointerEvents": undefined,
+                  "width": 120,
+                }
+              }
+            >
+              <EuiDataGridHeaderRow
+                columnWidths={
+                  Object {
+                    "columnA": 20,
+                  }
+                }
+                columns={
+                  Array [
+                    Object {
+                      "id": "columnA",
+                      "schema": "boolean",
+                    },
+                    Object {
+                      "id": "columnB",
+                      "isExpandable": true,
+                    },
+                  ]
+                }
+                headerIsInteractive={true}
+                leadingControlColumns={Array []}
+                schema={
+                  Object {
+                    "columnA": Object {
+                      "columnType": "boolean",
+                    },
+                    "columnB": Object {
+                      "columnType": "string",
+                    },
+                  }
+                }
+                schemaDetectors={
+                  Array [
+                    Object {
+                      "comparator": [Function],
+                      "detector": [Function],
+                      "icon": "tokenBoolean",
+                      "sortTextAsc": <EuiI18n
+                        default="False-True"
+                        token="euiDataGridSchema.booleanSortTextAsc"
+                      />,
+                      "sortTextDesc": <EuiI18n
+                        default="True-False"
+                        token="euiDataGridSchema.booleanSortTextDesc"
+                      />,
+                      "type": "boolean",
+                    },
+                    Object {
+                      "color": "euiColorVis0",
+                      "comparator": [Function],
+                      "detector": [Function],
+                      "icon": "currency",
+                      "sortTextAsc": <EuiI18n
+                        default="Low-High"
+                        token="euiDataGridSchema.currencySortTextAsc"
+                      />,
+                      "sortTextDesc": <EuiI18n
+                        default="High-Low"
+                        token="euiDataGridSchema.currencySortTextDesc"
+                      />,
+                      "type": "currency",
+                    },
+                    Object {
+                      "detector": [Function],
+                      "icon": "tokenDate",
+                      "sortTextAsc": <EuiI18n
+                        default="Old-New"
+                        token="euiDataGridSchema.dateSortTextAsc"
+                      />,
+                      "sortTextDesc": <EuiI18n
+                        default="New-Old"
+                        token="euiDataGridSchema.dateSortTextDesc"
+                      />,
+                      "type": "datetime",
+                    },
+                    Object {
+                      "comparator": [Function],
+                      "detector": [Function],
+                      "icon": "tokenNumber",
+                      "sortTextAsc": <EuiI18n
+                        default="Low-High"
+                        token="euiDataGridSchema.numberSortTextAsc"
+                      />,
+                      "sortTextDesc": <EuiI18n
+                        default="High-Low"
+                        token="euiDataGridSchema.numberSortTextDesc"
+                      />,
+                      "type": "numeric",
+                    },
+                    Object {
+                      "comparator": [Function],
+                      "detector": [Function],
+                      "icon": "tokenObject",
+                      "sortTextAsc": <EuiI18n
+                        default="Small-Large"
+                        token="euiDataGridSchema.jsonSortTextAsc"
+                      />,
+                      "sortTextDesc": <EuiI18n
+                        default="Large-Small"
+                        token="euiDataGridSchema.jsonSortTextDesc"
+                      />,
+                      "type": "json",
+                    },
+                  ]
+                }
+                setColumnWidth={[MockFunction]}
+                setVisibleColumns={[MockFunction]}
+                switchColumnPos={[MockFunction]}
+                trailingControlColumns={Array []}
+              >
+                <div
+                  className="euiDataGridHeader"
+                  data-test-subj="dataGridHeader"
+                  role="row"
+                >
+                  <EuiDataGridHeaderCell
+                    column={
+                      Object {
+                        "id": "columnA",
+                        "schema": "boolean",
+                      }
+                    }
+                    columnWidths={
+                      Object {
+                        "columnA": 20,
+                      }
+                    }
+                    columns={
+                      Array [
+                        Object {
+                          "id": "columnA",
+                          "schema": "boolean",
+                        },
+                        Object {
+                          "id": "columnB",
+                          "isExpandable": true,
+                        },
+                      ]
+                    }
+                    headerIsInteractive={true}
+                    index={0}
+                    key="columnA"
+                    schema={
+                      Object {
+                        "columnA": Object {
+                          "columnType": "boolean",
+                        },
+                        "columnB": Object {
+                          "columnType": "string",
+                        },
+                      }
+                    }
+                    schemaDetectors={
+                      Array [
+                        Object {
+                          "comparator": [Function],
+                          "detector": [Function],
+                          "icon": "tokenBoolean",
+                          "sortTextAsc": <EuiI18n
+                            default="False-True"
+                            token="euiDataGridSchema.booleanSortTextAsc"
+                          />,
+                          "sortTextDesc": <EuiI18n
+                            default="True-False"
+                            token="euiDataGridSchema.booleanSortTextDesc"
+                          />,
+                          "type": "boolean",
+                        },
+                        Object {
+                          "color": "euiColorVis0",
+                          "comparator": [Function],
+                          "detector": [Function],
+                          "icon": "currency",
+                          "sortTextAsc": <EuiI18n
+                            default="Low-High"
+                            token="euiDataGridSchema.currencySortTextAsc"
+                          />,
+                          "sortTextDesc": <EuiI18n
+                            default="High-Low"
+                            token="euiDataGridSchema.currencySortTextDesc"
+                          />,
+                          "type": "currency",
+                        },
+                        Object {
+                          "detector": [Function],
+                          "icon": "tokenDate",
+                          "sortTextAsc": <EuiI18n
+                            default="Old-New"
+                            token="euiDataGridSchema.dateSortTextAsc"
+                          />,
+                          "sortTextDesc": <EuiI18n
+                            default="New-Old"
+                            token="euiDataGridSchema.dateSortTextDesc"
+                          />,
+                          "type": "datetime",
+                        },
+                        Object {
+                          "comparator": [Function],
+                          "detector": [Function],
+                          "icon": "tokenNumber",
+                          "sortTextAsc": <EuiI18n
+                            default="Low-High"
+                            token="euiDataGridSchema.numberSortTextAsc"
+                          />,
+                          "sortTextDesc": <EuiI18n
+                            default="High-Low"
+                            token="euiDataGridSchema.numberSortTextDesc"
+                          />,
+                          "type": "numeric",
+                        },
+                        Object {
+                          "comparator": [Function],
+                          "detector": [Function],
+                          "icon": "tokenObject",
+                          "sortTextAsc": <EuiI18n
+                            default="Small-Large"
+                            token="euiDataGridSchema.jsonSortTextAsc"
+                          />,
+                          "sortTextDesc": <EuiI18n
+                            default="Large-Small"
+                            token="euiDataGridSchema.jsonSortTextDesc"
+                          />,
+                          "type": "json",
+                        },
+                      ]
+                    }
+                    setColumnWidth={[MockFunction]}
+                    setVisibleColumns={[MockFunction]}
+                    switchColumnPos={[MockFunction]}
+                  >
+                    <div
+                      className="euiDataGridHeaderCell euiDataGridHeaderCell--boolean"
+                      data-test-subj="dataGridHeaderCell-columnA"
+                      role="columnheader"
+                      style={
+                        Object {
+                          "width": "20px",
+                        }
+                      }
+                      tabIndex={-1}
+                    >
+                      <EuiDataGridColumnResizer
+                        columnId="columnA"
+                        columnWidth={20}
+                        setColumnWidth={[MockFunction]}
+                      >
+                        <div
+                          className="euiDataGridColumnResizer"
+                          data-test-subj="dataGridColumnResizer"
+                          onMouseDown={[Function]}
+                          style={
+                            Object {
+                              "marginRight": "0px",
+                            }
+                          }
+                        />
+                      </EuiDataGridColumnResizer>
+                      <EuiPopover
+                        anchorClassName="euiDataGridHeaderCell__anchor"
+                        anchorPosition="downCenter"
+                        button={
+                          <button
+                            className="euiDataGridHeaderCell__button"
+                            onClick={[Function]}
+                          >
+                            <div
+                              className="euiDataGridHeaderCell__content"
+                            >
+                              columnA
+                            </div>
+                            <EuiIcon
+                              aria-label="Header actions"
+                              className="euiDataGridHeaderCell__icon"
+                              color="text"
+                              data-test-subj="dataGridHeaderCellActionButton-columnA"
+                              size="s"
+                              type="arrowDown"
+                            />
+                          </button>
+                        }
+                        closePopover={[Function]}
+                        display="inlineBlock"
+                        hasArrow={true}
+                        isOpen={false}
+                        offset={7}
+                        ownFocus={true}
+                        panelPaddingSize="none"
+                      >
+                        <div
+                          className="euiPopover euiPopover--anchorDownCenter"
+                          offset={7}
+                        >
+                          <div
+                            className="euiPopover__anchor euiDataGridHeaderCell__anchor"
+                          >
+                            <button
+                              className="euiDataGridHeaderCell__button"
+                              onClick={[Function]}
+                            >
+                              <div
+                                className="euiDataGridHeaderCell__content"
+                              >
+                                columnA
+                              </div>
+                              <EuiIcon
+                                aria-label="Header actions"
+                                className="euiDataGridHeaderCell__icon"
+                                color="text"
+                                data-test-subj="dataGridHeaderCellActionButton-columnA"
+                                size="s"
+                                type="arrowDown"
+                              >
+                                <span
+                                  aria-label="Header actions"
+                                  className="euiDataGridHeaderCell__icon"
+                                  color="text"
+                                  data-euiicon-type="arrowDown"
+                                  data-test-subj="dataGridHeaderCellActionButton-columnA"
+                                  size="s"
+                                />
+                              </EuiIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </EuiPopover>
+                    </div>
+                  </EuiDataGridHeaderCell>
+                  <EuiDataGridHeaderCell
+                    column={
+                      Object {
+                        "id": "columnB",
+                        "isExpandable": true,
+                      }
+                    }
+                    columnWidths={
+                      Object {
+                        "columnA": 20,
+                      }
+                    }
+                    columns={
+                      Array [
+                        Object {
+                          "id": "columnA",
+                          "schema": "boolean",
+                        },
+                        Object {
+                          "id": "columnB",
+                          "isExpandable": true,
+                        },
+                      ]
+                    }
+                    headerIsInteractive={true}
+                    index={1}
+                    key="columnB"
+                    schema={
+                      Object {
+                        "columnA": Object {
+                          "columnType": "boolean",
+                        },
+                        "columnB": Object {
+                          "columnType": "string",
+                        },
+                      }
+                    }
+                    schemaDetectors={
+                      Array [
+                        Object {
+                          "comparator": [Function],
+                          "detector": [Function],
+                          "icon": "tokenBoolean",
+                          "sortTextAsc": <EuiI18n
+                            default="False-True"
+                            token="euiDataGridSchema.booleanSortTextAsc"
+                          />,
+                          "sortTextDesc": <EuiI18n
+                            default="True-False"
+                            token="euiDataGridSchema.booleanSortTextDesc"
+                          />,
+                          "type": "boolean",
+                        },
+                        Object {
+                          "color": "euiColorVis0",
+                          "comparator": [Function],
+                          "detector": [Function],
+                          "icon": "currency",
+                          "sortTextAsc": <EuiI18n
+                            default="Low-High"
+                            token="euiDataGridSchema.currencySortTextAsc"
+                          />,
+                          "sortTextDesc": <EuiI18n
+                            default="High-Low"
+                            token="euiDataGridSchema.currencySortTextDesc"
+                          />,
+                          "type": "currency",
+                        },
+                        Object {
+                          "detector": [Function],
+                          "icon": "tokenDate",
+                          "sortTextAsc": <EuiI18n
+                            default="Old-New"
+                            token="euiDataGridSchema.dateSortTextAsc"
+                          />,
+                          "sortTextDesc": <EuiI18n
+                            default="New-Old"
+                            token="euiDataGridSchema.dateSortTextDesc"
+                          />,
+                          "type": "datetime",
+                        },
+                        Object {
+                          "comparator": [Function],
+                          "detector": [Function],
+                          "icon": "tokenNumber",
+                          "sortTextAsc": <EuiI18n
+                            default="Low-High"
+                            token="euiDataGridSchema.numberSortTextAsc"
+                          />,
+                          "sortTextDesc": <EuiI18n
+                            default="High-Low"
+                            token="euiDataGridSchema.numberSortTextDesc"
+                          />,
+                          "type": "numeric",
+                        },
+                        Object {
+                          "comparator": [Function],
+                          "detector": [Function],
+                          "icon": "tokenObject",
+                          "sortTextAsc": <EuiI18n
+                            default="Small-Large"
+                            token="euiDataGridSchema.jsonSortTextAsc"
+                          />,
+                          "sortTextDesc": <EuiI18n
+                            default="Large-Small"
+                            token="euiDataGridSchema.jsonSortTextDesc"
+                          />,
+                          "type": "json",
+                        },
+                      ]
+                    }
+                    setColumnWidth={[MockFunction]}
+                    setVisibleColumns={[MockFunction]}
+                    switchColumnPos={[MockFunction]}
+                  >
+                    <div
+                      className="euiDataGridHeaderCell euiDataGridHeaderCell--string"
+                      data-test-subj="dataGridHeaderCell-columnB"
+                      role="columnheader"
+                      style={Object {}}
+                      tabIndex={-1}
+                    >
+                      <EuiPopover
+                        anchorClassName="euiDataGridHeaderCell__anchor"
+                        anchorPosition="downCenter"
+                        button={
+                          <button
+                            className="euiDataGridHeaderCell__button"
+                            onClick={[Function]}
+                          >
+                            <div
+                              className="euiDataGridHeaderCell__content"
+                            >
+                              columnB
+                            </div>
+                            <EuiIcon
+                              aria-label="Header actions"
+                              className="euiDataGridHeaderCell__icon"
+                              color="text"
+                              data-test-subj="dataGridHeaderCellActionButton-columnB"
+                              size="s"
+                              type="arrowDown"
+                            />
+                          </button>
+                        }
+                        closePopover={[Function]}
+                        display="inlineBlock"
+                        hasArrow={true}
+                        isOpen={false}
+                        offset={7}
+                        ownFocus={true}
+                        panelPaddingSize="none"
+                      >
+                        <div
+                          className="euiPopover euiPopover--anchorDownCenter"
+                          offset={7}
+                        >
+                          <div
+                            className="euiPopover__anchor euiDataGridHeaderCell__anchor"
+                          >
+                            <button
+                              className="euiDataGridHeaderCell__button"
+                              onClick={[Function]}
+                            >
+                              <div
+                                className="euiDataGridHeaderCell__content"
+                              >
+                                columnB
+                              </div>
+                              <EuiIcon
+                                aria-label="Header actions"
+                                className="euiDataGridHeaderCell__icon"
+                                color="text"
+                                data-test-subj="dataGridHeaderCellActionButton-columnB"
+                                size="s"
+                                type="arrowDown"
+                              >
+                                <span
+                                  aria-label="Header actions"
+                                  className="euiDataGridHeaderCell__icon"
+                                  color="text"
+                                  data-euiicon-type="arrowDown"
+                                  data-test-subj="dataGridHeaderCellActionButton-columnB"
+                                  size="s"
+                                />
+                              </EuiIcon>
+                            </button>
+                          </div>
+                        </div>
+                      </EuiPopover>
+                    </div>
+                  </EuiDataGridHeaderCell>
+                </div>
+              </EuiDataGridHeaderRow>
+              <Cell
+                columnIndex={0}
+                data={
+                  Object {
+                    "columnWidths": Object {
+                      "columnA": 20,
+                    },
+                    "columns": Array [
+                      Object {
+                        "id": "columnA",
+                        "schema": "boolean",
+                      },
+                      Object {
+                        "id": "columnB",
+                        "isExpandable": true,
+                      },
+                    ],
+                    "defaultColumnWidth": undefined,
+                    "getCorrectRowIndex": [Function],
+                    "getRowHeight": [Function],
+                    "interactiveCellId": "someId",
+                    "leadingControlColumns": Array [],
+                    "popoverContents": Object {
+                      "json": [Function],
+                    },
+                    "renderCellValue": [Function],
+                    "rowHeightsOptions": undefined,
+                    "rowMap": Object {},
+                    "rowOffset": 0,
+                    "schema": Object {
+                      "columnA": Object {
+                        "columnType": "boolean",
+                      },
+                      "columnB": Object {
+                        "columnType": "string",
+                      },
+                    },
+                    "schemaDetectors": Array [
+                      Object {
+                        "comparator": [Function],
+                        "detector": [Function],
+                        "icon": "tokenBoolean",
+                        "sortTextAsc": <EuiI18n
+                          default="False-True"
+                          token="euiDataGridSchema.booleanSortTextAsc"
+                        />,
+                        "sortTextDesc": <EuiI18n
+                          default="True-False"
+                          token="euiDataGridSchema.booleanSortTextDesc"
+                        />,
+                        "type": "boolean",
+                      },
+                      Object {
+                        "color": "euiColorVis0",
+                        "comparator": [Function],
+                        "detector": [Function],
+                        "icon": "currency",
+                        "sortTextAsc": <EuiI18n
+                          default="Low-High"
+                          token="euiDataGridSchema.currencySortTextAsc"
+                        />,
+                        "sortTextDesc": <EuiI18n
+                          default="High-Low"
+                          token="euiDataGridSchema.currencySortTextDesc"
+                        />,
+                        "type": "currency",
+                      },
+                      Object {
+                        "detector": [Function],
+                        "icon": "tokenDate",
+                        "sortTextAsc": <EuiI18n
+                          default="Old-New"
+                          token="euiDataGridSchema.dateSortTextAsc"
+                        />,
+                        "sortTextDesc": <EuiI18n
+                          default="New-Old"
+                          token="euiDataGridSchema.dateSortTextDesc"
+                        />,
+                        "type": "datetime",
+                      },
+                      Object {
+                        "comparator": [Function],
+                        "detector": [Function],
+                        "icon": "tokenNumber",
+                        "sortTextAsc": <EuiI18n
+                          default="Low-High"
+                          token="euiDataGridSchema.numberSortTextAsc"
+                        />,
+                        "sortTextDesc": <EuiI18n
+                          default="High-Low"
+                          token="euiDataGridSchema.numberSortTextDesc"
+                        />,
+                        "type": "numeric",
+                      },
+                      Object {
+                        "comparator": [Function],
+                        "detector": [Function],
+                        "icon": "tokenObject",
+                        "sortTextAsc": <EuiI18n
+                          default="Small-Large"
+                          token="euiDataGridSchema.jsonSortTextAsc"
+                        />,
+                        "sortTextDesc": <EuiI18n
+                          default="Large-Small"
+                          token="euiDataGridSchema.jsonSortTextDesc"
+                        />,
+                        "type": "json",
+                      },
+                    ],
+                    "setRowHeight": [Function],
+                    "trailingControlColumns": Array [],
+                  }
+                }
+                key="0:0"
+                rowIndex={0}
+                style={
+                  Object {
+                    "height": 34,
+                    "left": 0,
+                    "position": "absolute",
+                    "top": 0,
+                    "width": 20,
+                  }
+                }
+              >
+                <EuiDataGridCell
+                  className="euiDataGridRowCell--firstColumn"
+                  colIndex={0}
+                  column={
+                    Object {
+                      "id": "columnA",
+                      "schema": "boolean",
+                    }
+                  }
+                  columnId="columnA"
+                  columnType="boolean"
+                  getRowHeight={[Function]}
+                  interactiveCellId="someId"
+                  isExpandable={true}
+                  popoverContent={[Function]}
+                  renderCellValue={[Function]}
+                  rowIndex={0}
+                  style={
+                    Object {
+                      "height": 34,
+                      "left": 0,
+                      "position": "absolute",
+                      "top": "0px",
+                      "width": 20,
+                    }
+                  }
+                  visibleRowIndex={0}
+                  width={20}
+                >
+                  <div
+                    className="euiDataGridRowCell euiDataGridRowCell--boolean euiDataGridRowCell--firstColumn"
+                    data-test-subj="dataGridRowCell"
+                    onBlur={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    role="gridcell"
+                    style={
+                      Object {
+                        "height": 34,
+                        "left": 0,
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": 20,
+                      }
+                    }
+                    tabIndex={-1}
+                  >
+                    <div
+                      className="euiDataGridRowCell__expandFlex"
+                    >
+                      <div
+                        className="euiDataGridRowCell__expandContent"
+                      >
+                        <Memo()
+                          colIndex={0}
+                          column={
+                            Object {
+                              "id": "columnA",
+                              "schema": "boolean",
+                            }
+                          }
+                          columnId="columnA"
+                          columnType="boolean"
+                          getRowHeight={[Function]}
+                          isDetails={false}
+                          isExpandable={true}
+                          isExpanded={false}
+                          renderCellValue={[Function]}
+                          rowIndex={0}
+                          setCellContentsRef={[Function]}
+                          setCellProps={[Function]}
+                          visibleRowIndex={0}
+                        >
+                          <div
+                            className="euiDataGridRowCell__truncate"
+                            style={Object {}}
+                          >
+                            <renderCellValue
+                              columnId="columnA"
+                              columnType="boolean"
+                              data-test-subj="cell-content"
+                              getRowHeight={[Function]}
+                              isDetails={false}
+                              isExpandable={true}
+                              isExpanded={false}
+                              rowIndex={0}
+                              setCellProps={[Function]}
+                              visibleRowIndex={0}
+                            >
+                              <span>
+                                cell content
+                              </span>
+                            </renderCellValue>
+                          </div>
+                          <EuiScreenReaderOnly>
+                            <p
+                              className="euiScreenReaderOnly"
+                            >
+                              Row: 1; Column: 1
+                            </p>
+                          </EuiScreenReaderOnly>
+                        </Memo()>
+                      </div>
+                    </div>
+                  </div>
+                </EuiDataGridCell>
+              </Cell>
+              <Cell
+                columnIndex={1}
+                data={
+                  Object {
+                    "columnWidths": Object {
+                      "columnA": 20,
+                    },
+                    "columns": Array [
+                      Object {
+                        "id": "columnA",
+                        "schema": "boolean",
+                      },
+                      Object {
+                        "id": "columnB",
+                        "isExpandable": true,
+                      },
+                    ],
+                    "defaultColumnWidth": undefined,
+                    "getCorrectRowIndex": [Function],
+                    "getRowHeight": [Function],
+                    "interactiveCellId": "someId",
+                    "leadingControlColumns": Array [],
+                    "popoverContents": Object {
+                      "json": [Function],
+                    },
+                    "renderCellValue": [Function],
+                    "rowHeightsOptions": undefined,
+                    "rowMap": Object {},
+                    "rowOffset": 0,
+                    "schema": Object {
+                      "columnA": Object {
+                        "columnType": "boolean",
+                      },
+                      "columnB": Object {
+                        "columnType": "string",
+                      },
+                    },
+                    "schemaDetectors": Array [
+                      Object {
+                        "comparator": [Function],
+                        "detector": [Function],
+                        "icon": "tokenBoolean",
+                        "sortTextAsc": <EuiI18n
+                          default="False-True"
+                          token="euiDataGridSchema.booleanSortTextAsc"
+                        />,
+                        "sortTextDesc": <EuiI18n
+                          default="True-False"
+                          token="euiDataGridSchema.booleanSortTextDesc"
+                        />,
+                        "type": "boolean",
+                      },
+                      Object {
+                        "color": "euiColorVis0",
+                        "comparator": [Function],
+                        "detector": [Function],
+                        "icon": "currency",
+                        "sortTextAsc": <EuiI18n
+                          default="Low-High"
+                          token="euiDataGridSchema.currencySortTextAsc"
+                        />,
+                        "sortTextDesc": <EuiI18n
+                          default="High-Low"
+                          token="euiDataGridSchema.currencySortTextDesc"
+                        />,
+                        "type": "currency",
+                      },
+                      Object {
+                        "detector": [Function],
+                        "icon": "tokenDate",
+                        "sortTextAsc": <EuiI18n
+                          default="Old-New"
+                          token="euiDataGridSchema.dateSortTextAsc"
+                        />,
+                        "sortTextDesc": <EuiI18n
+                          default="New-Old"
+                          token="euiDataGridSchema.dateSortTextDesc"
+                        />,
+                        "type": "datetime",
+                      },
+                      Object {
+                        "comparator": [Function],
+                        "detector": [Function],
+                        "icon": "tokenNumber",
+                        "sortTextAsc": <EuiI18n
+                          default="Low-High"
+                          token="euiDataGridSchema.numberSortTextAsc"
+                        />,
+                        "sortTextDesc": <EuiI18n
+                          default="High-Low"
+                          token="euiDataGridSchema.numberSortTextDesc"
+                        />,
+                        "type": "numeric",
+                      },
+                      Object {
+                        "comparator": [Function],
+                        "detector": [Function],
+                        "icon": "tokenObject",
+                        "sortTextAsc": <EuiI18n
+                          default="Small-Large"
+                          token="euiDataGridSchema.jsonSortTextAsc"
+                        />,
+                        "sortTextDesc": <EuiI18n
+                          default="Large-Small"
+                          token="euiDataGridSchema.jsonSortTextDesc"
+                        />,
+                        "type": "json",
+                      },
+                    ],
+                    "setRowHeight": [Function],
+                    "trailingControlColumns": Array [],
+                  }
+                }
+                key="0:1"
+                rowIndex={0}
+                style={
+                  Object {
+                    "height": 34,
+                    "left": 20,
+                    "position": "absolute",
+                    "top": 0,
+                    "width": 100,
+                  }
+                }
+              >
+                <EuiDataGridCell
+                  className="euiDataGridRowCell--lastColumn"
+                  colIndex={1}
+                  column={
+                    Object {
+                      "id": "columnB",
+                      "isExpandable": true,
+                    }
+                  }
+                  columnId="columnB"
+                  columnType="string"
+                  getRowHeight={[Function]}
+                  interactiveCellId="someId"
+                  isExpandable={true}
+                  popoverContent={[Function]}
+                  renderCellValue={[Function]}
+                  rowIndex={0}
+                  style={
+                    Object {
+                      "height": 34,
+                      "left": 20,
+                      "position": "absolute",
+                      "top": "0px",
+                      "width": 100,
+                    }
+                  }
+                  visibleRowIndex={0}
+                >
+                  <div
+                    className="euiDataGridRowCell euiDataGridRowCell--string euiDataGridRowCell--lastColumn"
+                    data-test-subj="dataGridRowCell"
+                    onBlur={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    role="gridcell"
+                    style={
+                      Object {
+                        "height": 34,
+                        "left": 20,
+                        "position": "absolute",
+                        "top": "0px",
+                        "width": undefined,
+                      }
+                    }
+                    tabIndex={-1}
+                  >
+                    <div
+                      className="euiDataGridRowCell__expandFlex"
+                    >
+                      <div
+                        className="euiDataGridRowCell__expandContent"
+                      >
+                        <Memo()
+                          colIndex={1}
+                          column={
+                            Object {
+                              "id": "columnB",
+                              "isExpandable": true,
+                            }
+                          }
+                          columnId="columnB"
+                          columnType="string"
+                          getRowHeight={[Function]}
+                          isDetails={false}
+                          isExpandable={true}
+                          isExpanded={false}
+                          renderCellValue={[Function]}
+                          rowIndex={0}
+                          setCellContentsRef={[Function]}
+                          setCellProps={[Function]}
+                          visibleRowIndex={0}
+                        >
+                          <div
+                            className="euiDataGridRowCell__truncate"
+                            style={Object {}}
+                          >
+                            <renderCellValue
+                              columnId="columnB"
+                              columnType="string"
+                              data-test-subj="cell-content"
+                              getRowHeight={[Function]}
+                              isDetails={false}
+                              isExpandable={true}
+                              isExpanded={false}
+                              rowIndex={0}
+                              setCellProps={[Function]}
+                              visibleRowIndex={0}
+                            >
+                              <span>
+                                cell content
+                              </span>
+                            </renderCellValue>
+                          </div>
+                          <EuiScreenReaderOnly>
+                            <p
+                              className="euiScreenReaderOnly"
+                            >
+                              Row: 1; Column: 2
+                            </p>
+                          </EuiScreenReaderOnly>
+                        </Memo()>
+                      </div>
+                    </div>
+                  </div>
+                </EuiDataGridCell>
+              </Cell>
+            </div>
+          </EuiDataGridInnerElement>
+        </div>
+      </Grid>
+    </div>
+  </EuiMutationObserver>
+</EuiDataGridBody>
+`;

--- a/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiDataGridCell renders 1`] = `
+<EuiDataGridCell
+  colIndex={0}
+  columnId="someColumn"
+  interactiveCellId="someId"
+  isExpandable={true}
+  popoverContent={[Function]}
+  renderCellValue={[Function]}
+  rowIndex={0}
+  visibleRowIndex={0}
+>
+  <div
+    className="euiDataGridRowCell"
+    data-test-subj="dataGridRowCell"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseEnter={[Function]}
+    role="gridcell"
+    style={
+      Object {
+        "width": undefined,
+      }
+    }
+    tabIndex={-1}
+  >
+    <div
+      className="euiDataGridRowCell__expandFlex"
+    >
+      <div
+        className="euiDataGridRowCell__expandContent"
+      >
+        <Memo()
+          colIndex={0}
+          columnId="someColumn"
+          isDetails={false}
+          isExpandable={true}
+          isExpanded={false}
+          renderCellValue={[Function]}
+          rowIndex={0}
+          setCellContentsRef={[Function]}
+          setCellProps={[Function]}
+          visibleRowIndex={0}
+        >
+          <div
+            className="euiDataGridRowCell__truncate"
+            style={Object {}}
+          >
+            <renderCellValue
+              columnId="someColumn"
+              data-test-subj="cell-content"
+              isDetails={false}
+              isExpandable={true}
+              isExpanded={false}
+              rowIndex={0}
+              setCellProps={[Function]}
+              visibleRowIndex={0}
+            >
+              <div>
+                <button
+                  data-datagrid-interactable="true"
+                >
+                  hello
+                </button>
+                <button
+                  data-datagrid-interactable="true"
+                >
+                  world
+                </button>
+              </div>
+            </renderCellValue>
+          </div>
+          <EuiScreenReaderOnly>
+            <p
+              className="euiScreenReaderOnly"
+            >
+              Row: 1; Column: 1
+            </p>
+          </EuiScreenReaderOnly>
+        </Memo()>
+      </div>
+    </div>
+  </div>
+</EuiDataGridCell>
+`;

--- a/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`EuiDataGridCell renders 1`] = `
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
     role="gridcell"
     style={
       Object {

--- a/src/components/datagrid/body/data_grid_body.test.tsx
+++ b/src/components/datagrid/body/data_grid_body.test.tsx
@@ -76,7 +76,7 @@ describe('EuiDataGridBody', () => {
   });
 
   // TODO: This is likely better handled/asserted by Cypress.
-  // I'm leaving it in for now to provide example of props/inMemoryValues
+  // I'm leaving it in for now to provide an example of props/inMemoryValues
   it('handles in-memory sorting and pagination', () => {
     mount(
       <DataGridSortingContext.Provider

--- a/src/components/datagrid/body/data_grid_body.test.tsx
+++ b/src/components/datagrid/body/data_grid_body.test.tsx
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { DataGridSortingContext } from '../data_grid_context';
+import { schemaDetectors } from '../data_grid_schema';
+import { RowHeightUtils } from '../row_height_utils';
+
+import { EuiDataGridBody } from './data_grid_body';
+
+describe('EuiDataGridBody', () => {
+  const requiredProps = {
+    isFullScreen: false,
+    headerIsInteractive: true,
+    rowCount: 1,
+    toolbarHeight: 10,
+    columnWidths: { columnA: 20 },
+    columns: [
+      { id: 'columnA', schema: 'boolean' },
+      { id: 'columnB', isExpandable: true },
+    ],
+    schema: {
+      columnA: { columnType: 'boolean' },
+      columnB: { columnType: 'string' },
+    },
+    renderCellValue: () => <span>cell content</span>,
+    interactiveCellId: 'someId',
+    inMemory: { level: 'enhancements' as any },
+    inMemoryValues: {},
+    setColumnWidth: jest.fn(),
+    handleHeaderMutation: jest.fn(),
+    setVisibleColumns: jest.fn(),
+    switchColumnPos: jest.fn(),
+    schemaDetectors,
+    rowHeightUtils: new RowHeightUtils(),
+  };
+
+  it('renders', () => {
+    const component = mount(<EuiDataGridBody {...requiredProps} />);
+    expect(component).toMatchSnapshot();
+    expect(component.find('Cell')).toHaveLength(2);
+  });
+
+  it('renders leading columns, trailing columns, and footer rows', () => {
+    const component = mount(
+      <EuiDataGridBody
+        {...requiredProps}
+        leadingControlColumns={[
+          {
+            id: 'someLeadingColumn',
+            headerCellRender: () => <div />,
+            rowCellRender: () => <div />,
+            width: 30,
+          },
+        ]}
+        trailingControlColumns={[
+          {
+            id: 'someTrailingColumn',
+            headerCellRender: () => <div />,
+            rowCellRender: () => <div />,
+            width: 40,
+          },
+        ]}
+        renderFooterCellValue={() => <footer data-test-subj="footer" />}
+      />
+    );
+    expect(component.find('Cell')).toHaveLength(4);
+    expect(component.find('[data-test-subj="footer"]')).toHaveLength(2);
+  });
+
+  // TODO: This is likely better handled/asserted by Cypress.
+  // I'm leaving it in for now to provide example of props/inMemoryValues
+  it('handles in-memory sorting and pagination', () => {
+    mount(
+      <DataGridSortingContext.Provider
+        value={{
+          onSort: jest.fn(),
+          columns: [
+            { id: 'columnA', direction: 'desc' },
+            { id: 'columnB', direction: 'asc' },
+          ],
+        }}
+      >
+        <EuiDataGridBody
+          {...requiredProps}
+          inMemory={{ level: 'sorting' }}
+          inMemoryValues={{
+            '0': { columnA: 'true', columnB: 'sdff' },
+            '1': { columnA: 'false', columnB: 'asdfsdf' },
+          }}
+          pagination={{
+            pageIndex: 0,
+            pageSize: 1,
+            onChangeItemsPerPage: jest.fn(),
+            onChangePage: jest.fn(),
+          }}
+        />
+      </DataGridSortingContext.Provider>
+    );
+  });
+
+  // TODO: Test final height/weights in Cypress
+  it('calculates height and widths', () => {
+    mount(
+      <EuiDataGridBody
+        {...requiredProps}
+        rowHeightsOptions={{ defaultHeight: 10, rowHeights: { 0: 20 } }}
+        defaultColumnWidth={50}
+      />
+    );
+  });
+
+  // TODO: Test tabbing in Cypress
+});

--- a/src/components/datagrid/body/data_grid_body.tsx
+++ b/src/components/datagrid/body/data_grid_body.tsx
@@ -33,6 +33,7 @@ import {
   DataGridSortingContext,
   DataGridWrapperRowsContext,
 } from '../data_grid_context';
+import { defaultComparator } from '../data_grid_schema';
 import { EuiDataGridFooterRow } from './data_grid_footer_row';
 import { EuiDataGridHeaderRow } from './header';
 import {
@@ -46,14 +47,6 @@ import {
 } from '../data_grid_types';
 
 export const VIRTUALIZED_CONTAINER_CLASS = 'euiDataGrid__virtualized';
-
-const defaultComparator: NonNullable<
-  EuiDataGridSchemaDetector['comparator']
-> = (a, b, direction) => {
-  if (a < b) return direction === 'asc' ? -1 : 1;
-  if (a > b) return direction === 'asc' ? 1 : -1;
-  return 0;
-};
 
 const Cell: FunctionComponent<GridChildComponentProps> = ({
   columnIndex,

--- a/src/components/datagrid/body/data_grid_body.tsx
+++ b/src/components/datagrid/body/data_grid_body.tsx
@@ -23,13 +23,11 @@ import {
   VariableSizeGridProps,
 } from 'react-window';
 import tabbable from 'tabbable';
-import { EuiCodeBlock } from '../../code';
 import {
   EuiMutationObserver,
   useMutationObserver,
 } from '../../observer/mutation_observer';
 import { useResizeObserver } from '../../observer/resize_observer';
-import { EuiText } from '../../text';
 import { EuiDataGridCell } from './data_grid_cell';
 import {
   DataGridSortingContext,
@@ -38,10 +36,12 @@ import {
 import { EuiDataGridFooterRow } from './data_grid_footer_row';
 import { EuiDataGridHeaderRow } from './header';
 import {
+  DefaultColumnFormatter,
+  providedPopoverContents,
+} from './popover_utils';
+import {
   EuiDataGridBodyProps,
   EuiDataGridInMemoryValues,
-  EuiDataGridPopoverContent,
-  EuiDataGridPopoverContents,
   EuiDataGridSchemaDetector,
 } from '../data_grid_types';
 
@@ -53,32 +53,6 @@ const defaultComparator: NonNullable<
   if (a < b) return direction === 'asc' ? -1 : 1;
   if (a > b) return direction === 'asc' ? 1 : -1;
   return 0;
-};
-
-const providedPopoverContents: EuiDataGridPopoverContents = {
-  json: ({ cellContentsElement }) => {
-    let formattedText = cellContentsElement.innerText;
-
-    // attempt to pretty-print the json
-    try {
-      formattedText = JSON.stringify(JSON.parse(formattedText), null, 2);
-    } catch (e) {} // eslint-disable-line no-empty
-
-    return (
-      <EuiCodeBlock
-        isCopyable
-        transparentBackground
-        paddingSize="none"
-        language="json"
-      >
-        {formattedText}
-      </EuiCodeBlock>
-    );
-  },
-};
-
-const DefaultColumnFormatter: EuiDataGridPopoverContent = ({ children }) => {
-  return <EuiText>{children}</EuiText>;
 };
 
 const Cell: FunctionComponent<GridChildComponentProps> = ({

--- a/src/components/datagrid/body/data_grid_cell.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell.test.tsx
@@ -1,0 +1,244 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { mount, ReactWrapper } from 'enzyme';
+import { keys } from '../../../services';
+
+import { EuiDataGridCell } from './data_grid_cell';
+
+describe('EuiDataGridCell', () => {
+  const requiredProps = {
+    rowIndex: 0,
+    visibleRowIndex: 0,
+    colIndex: 0,
+    columnId: 'someColumn',
+    interactiveCellId: 'someId',
+    isExpandable: true,
+    renderCellValue: () => (
+      <div>
+        <button data-datagrid-interactable="true">hello</button>
+        <button data-datagrid-interactable="true">world</button>
+      </div>
+    ),
+    popoverContent: () => <div>popover</div>,
+  };
+
+  const mountEuiDataGridCellWithContext = ({ ...props } = {}) => {
+    const focusContext = {
+      setFocusedCell: jest.fn(),
+      onFocusUpdate: jest.fn(),
+    };
+    return mount(<EuiDataGridCell {...requiredProps} {...props} />, {
+      context: focusContext,
+    });
+  };
+
+  it('renders', () => {
+    const component = mountEuiDataGridCellWithContext();
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders cell buttons', () => {
+    const component = mountEuiDataGridCellWithContext({
+      isExpandable: false,
+      column: {
+        id: 'someColumn',
+        cellActions: [() => <button />],
+      },
+    });
+    component.setState({ popoverIsOpen: true });
+
+    const cellButtons = component.find('EuiDataGridCellButtons');
+    expect(component.find('EuiDataGridCellButtons')).toHaveLength(1);
+
+    // Should handle re-closing the popover correctly
+
+    (cellButtons.prop('onExpandClick') as Function)();
+    expect(component.state('popoverIsOpen')).toEqual(false);
+
+    component.setState({ popoverIsOpen: true });
+    (cellButtons.prop('closePopover') as Function)();
+    expect(component.state('popoverIsOpen')).toEqual(false);
+  });
+
+  describe('shouldComponentUpdate', () => {
+    let shouldComponentUpdate: jest.SpyInstance;
+    let component: ReactWrapper;
+
+    beforeEach(() => {
+      shouldComponentUpdate = jest.spyOn(
+        EuiDataGridCell.prototype,
+        'shouldComponentUpdate'
+      );
+      component = mountEuiDataGridCellWithContext();
+    });
+    afterEach(() => {
+      shouldComponentUpdate.mockRestore();
+    });
+
+    describe('should return true', () => {
+      afterEach(() => {
+        expect(shouldComponentUpdate).toHaveReturnedWith(true);
+      });
+
+      describe('when props change:', () => {
+        it('rowIndex', () => {
+          component.setProps({ rowIndex: 1 });
+        });
+        it('visibleRowIndex', () => {
+          component.setProps({ visibleRowIndex: 1 });
+        });
+        it('colIndex', () => {
+          component.setProps({ colIndex: 1 });
+        });
+        it('columnId', () => {
+          component.setProps({ columnId: 'test' });
+        });
+        it('columnType', () => {
+          component.setProps({ columnType: 'string' });
+        });
+        it('width', () => {
+          component.setProps({ width: 30 });
+        });
+        it('renderCellValue', () => {
+          component.setProps({ renderCellValue: () => <div>test</div> });
+        });
+        it('interactiveCellId', () => {
+          component.setProps({ interactiveCellId: 'test' });
+        });
+        it('popoverContent', () => {
+          component.setProps({ popoverContent: () => <div>test</div> });
+        });
+        it('style', () => {
+          component.setProps({ style: {} });
+          component.setProps({ style: { top: 0 } });
+          component.setProps({ style: { top: 0, left: 0 } });
+          component.setProps({ style: { top: 0, left: 0, width: 50 } });
+          component.setProps({
+            style: { top: 0, left: 0, width: 50, height: 10 },
+          });
+        });
+      });
+
+      describe('when state changes:', () => {
+        it('cellProps', () => {
+          component.setState({ cellProps: {} });
+        });
+        it('popoverIsOpen', () => {
+          component.setState({ popoverIsOpen: true });
+        });
+        it('isEntered', () => {
+          component.setState({ isEntered: true });
+        });
+        it('isFocused', () => {
+          component.setState({ isFocused: true });
+        });
+        it('enableInteractions', () => {
+          component.setState({ enableInteractions: true });
+        });
+        it('disableCellTabIndex', () => {
+          component.setState({ disableCellTabIndex: true });
+        });
+      });
+
+      it('when cell height changes', () => {
+        Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+          configurable: true,
+          value: 10,
+        });
+        const getRowHeight = jest.fn(() => 20);
+
+        component.setProps({ getRowHeight });
+      });
+    });
+
+    it('should not update for prop/state changes not specified above', () => {
+      component.setProps({ className: 'test' });
+      expect(shouldComponentUpdate).toHaveReturnedWith(false);
+    });
+  });
+
+  describe('componentDidUpdate', () => {
+    it('resets cell props when the cell columnId changes', () => {
+      const setState = jest.spyOn(EuiDataGridCell.prototype, 'setState');
+      const component = mountEuiDataGridCellWithContext();
+
+      component.setProps({ columnId: 'newColumnId' });
+      expect(setState).toHaveBeenCalledWith({ cellProps: {} });
+    });
+  });
+
+  // TODO: Test ResizeObserver logic in Cypress
+
+  // TODO: Test interacting/focus/tabbing in Cypress instead of Jest
+  describe('interactions', () => {
+    describe('keyboard events', () => {
+      it('when cell is expandable', () => {
+        const component = mountEuiDataGridCellWithContext();
+        const preventDefault = jest.fn();
+
+        component.simulate('keyDown', { preventDefault, key: keys.ENTER });
+        component.simulate('keyDown', { preventDefault, key: keys.F2 });
+
+        expect(component.state('popoverIsOpen')).toEqual(true);
+      });
+
+      it('when cell is not expandable', () => {
+        const component = mountEuiDataGridCellWithContext({
+          isExpandable: false,
+        });
+        const preventDefault = jest.fn();
+
+        component.simulate('keyDown', { preventDefault, key: keys.ENTER });
+        // TODO: Assert that tabbing should be enabled
+        expect(component.state('isEntered')).toEqual(true);
+
+        component.simulate('keyDown', { preventDefault, key: keys.F2 });
+        // TODO: Assert that tabbing should be prevented
+        expect(component.state('isEntered')).toEqual(false);
+
+        component.simulate('keyDown', { preventDefault, key: keys.F2 });
+        // TODO: Assert that tabbing should be enabled
+        expect(component.state('isEntered')).toEqual(true);
+
+        component.simulate('keyDown', { preventDefault, key: keys.ENTER });
+        component.simulate('keyDown', { preventDefault, key: keys.ESCAPE });
+        // TODO: Assert that tabbing should be prevented
+        expect(component.state('isEntered')).toEqual(false);
+      });
+    });
+
+    it('mouse event', () => {
+      const component = mountEuiDataGridCellWithContext();
+      component.simulate('mouseEnter');
+      expect(component.state('enableInteractions')).toEqual(true);
+    });
+
+    it('focus/blur events', () => {
+      const component = mountEuiDataGridCellWithContext();
+      component.simulate('focus');
+      component.simulate('blur');
+      expect(component.state('disableCellTabIndex')).toEqual(false);
+    });
+  });
+
+  it('renders certain classes/styles if rowHeightOptions is passed', () => {
+    const component = mountEuiDataGridCellWithContext({
+      rowHeightsOptions: {
+        defaultHeight: 20,
+        rowHeights: { 0: 10 },
+      },
+    });
+    component.setState({ popoverIsOpen: true });
+
+    expect(
+      component.find('.euiDataGridRowCell__contentByHeight').exists()
+    ).toBe(true);
+  });
+});

--- a/src/components/datagrid/body/data_grid_cell.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell.test.tsx
@@ -214,10 +214,12 @@ describe('EuiDataGridCell', () => {
       });
     });
 
-    it('mouse event', () => {
+    it('mouse events', () => {
       const component = mountEuiDataGridCellWithContext();
       component.simulate('mouseEnter');
       expect(component.state('enableInteractions')).toEqual(true);
+      component.simulate('mouseLeave');
+      expect(component.state('enableInteractions')).toEqual(false);
     });
 
     it('focus/blur events', () => {

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -23,6 +23,7 @@ import { keys } from '../../../services';
 import { EuiScreenReaderOnly } from '../../accessibility';
 import { EuiFocusTrap } from '../../focus_trap';
 import { useEuiI18n } from '../../i18n';
+import { hasResizeObserver } from '../../observer/resize_observer/resize_observer';
 import { DataGridFocusContext } from '../data_grid_context';
 import {
   EuiDataGridCellProps,
@@ -86,15 +87,6 @@ const EuiDataGridCellContent: FunctionComponent<
     );
   }
 );
-
-// TODO: TypeScript has added types for ResizeObserver but not yet released
-// https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/948
-// for now, marking ResizeObserver usage as `any`
-// and when EUI upgrades to a version of TS with ResizeObserver
-// the anys can be removed
-const hasResizeObserver =
-  typeof window !== 'undefined' &&
-  typeof (window as any).ResizeObserver !== 'undefined';
 
 export class EuiDataGridCell extends Component<
   EuiDataGridCellProps,

--- a/src/components/datagrid/body/data_grid_cell_buttons.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_buttons.test.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { EuiDataGridCellButtons } from './data_grid_cell_buttons';
+
+describe('EuiDataGridCellButtons', () => {
+  const requiredProps = {
+    popoverIsOpen: false,
+    closePopover: jest.fn(),
+    onExpandClick: jest.fn(),
+    rowIndex: 0,
+  };
+
+  it('renders an expand button', () => {
+    const component = shallow(<EuiDataGridCellButtons {...requiredProps} />);
+
+    expect(component).toMatchInlineSnapshot(`
+      <div
+        className="euiDataGridRowCell__expandButton"
+      >
+        <EuiI18n
+          default="Click or hit enter to interact with cell content"
+          key="expand"
+          token="euiDataGridCellButtons.expandButtonTitle"
+        >
+          <Component />
+        </EuiI18n>
+      </div>
+    `);
+
+    const button: Function = component.find('EuiI18n').renderProp('children');
+    expect(button('expandButtonTitle')).toMatchInlineSnapshot(`
+      <EuiButtonIcon
+        aria-hidden={true}
+        className="euiDataGridRowCell__expandButtonIcon"
+        color="primary"
+        display="fill"
+        iconSize="s"
+        iconType="expandMini"
+        onClick={[MockFunction]}
+        title="expandButtonTitle"
+      />
+    `);
+  });
+
+  it('renders column cell actions', () => {
+    const component = shallow(
+      <EuiDataGridCellButtons
+        {...requiredProps}
+        column={{ id: 'someId', cellActions: [() => <button />] }}
+      />
+    );
+
+    expect(component).toMatchInlineSnapshot(`
+      <div
+        className="euiDataGridRowCell__expandButton"
+      >
+        <Component
+          Component={[Function]}
+          closePopover={[MockFunction]}
+          columnId="someId"
+          isExpanded={false}
+          key="0"
+          rowIndex={0}
+        />
+        <EuiI18n
+          default="Click or hit enter to interact with cell content"
+          key="expand"
+          token="euiDataGridCellButtons.expandButtonTitle"
+        >
+          <Component />
+        </EuiI18n>
+      </div>
+    `);
+
+    const button = component.childAt(0).renderProp('Component');
+    expect(button({ iconType: 'eye' })).toMatchInlineSnapshot(`
+      <EuiButtonIcon
+        aria-hidden={true}
+        className="euiDataGridRowCell__actionButtonIcon"
+        iconSize="s"
+        iconType="eye"
+      />
+    `);
+  });
+});

--- a/src/components/datagrid/body/data_grid_cell_popover.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.test.tsx
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { keys } from '../../../services';
+
+import { EuiDataGridCellPopover } from './data_grid_cell_popover';
+
+describe('EuiDataGridCellPopover', () => {
+  const requiredProps = {
+    // column,
+    rowIndex: 0,
+    cellContentProps: {
+      rowIndex: 0,
+      columnId: 'someId',
+      setCellProps: () => {},
+      isExpandable: false,
+      isExpanded: false,
+      isDetails: false,
+    },
+    anchorContent: <button />,
+    cellContentsRef: ((<div />) as unknown) as HTMLDivElement,
+    panelRefFn: () => <div />,
+    renderCellValue: () => <div />,
+    popoverContent: () => <div />,
+    popoverIsOpen: true,
+    closePopover: jest.fn(),
+  };
+
+  it('renders', () => {
+    const component = shallow(<EuiDataGridCellPopover {...requiredProps} />);
+
+    expect(component).toMatchInlineSnapshot(`
+      <EuiPopover
+        anchorClassName="euiDataGridRowCell__expand"
+        anchorPosition="downCenter"
+        button={<button />}
+        closePopover={[MockFunction]}
+        display="block"
+        hasArrow={false}
+        isOpen={true}
+        onKeyDown={[Function]}
+        ownFocus={true}
+        panelClassName="euiDataGridRowCell__popover"
+        panelPaddingSize="s"
+        panelRef={[Function]}
+        zIndex={8001}
+      >
+        <popoverContent
+          cellContentsElement={<div />}
+        >
+          <renderCellValue
+            columnId="someId"
+            isDetails={true}
+            isExpandable={false}
+            isExpanded={false}
+            rowIndex={0}
+            setCellProps={[Function]}
+          />
+        </popoverContent>
+      </EuiPopover>
+    `);
+  });
+
+  it('renders popover content', () => {
+    const component = shallow(
+      <EuiDataGridCellPopover
+        {...requiredProps}
+        popoverIsOpen={true}
+        column={{ id: 'someId', cellActions: [() => <button />] }}
+      />
+    );
+
+    expect(component).toMatchInlineSnapshot(`
+      <EuiPopover
+        anchorClassName="euiDataGridRowCell__expand"
+        anchorPosition="downCenter"
+        button={<button />}
+        closePopover={[MockFunction]}
+        display="block"
+        hasArrow={false}
+        isOpen={true}
+        onKeyDown={[Function]}
+        ownFocus={true}
+        panelClassName="euiDataGridRowCell__popover"
+        panelPaddingSize="s"
+        panelRef={[Function]}
+        zIndex={8001}
+      >
+        <popoverContent
+          cellContentsElement={<div />}
+        >
+          <renderCellValue
+            columnId="someId"
+            isDetails={true}
+            isExpandable={false}
+            isExpanded={false}
+            rowIndex={0}
+            setCellProps={[Function]}
+          />
+        </popoverContent>
+        <EuiPopoverFooter>
+          <EuiFlexGroup
+            gutterSize="s"
+          >
+            <EuiFlexItem
+              key="0"
+            >
+              <Component
+                Component={[Function]}
+                closePopover={[MockFunction]}
+                columnId="someId"
+                isExpanded={true}
+                rowIndex={0}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiPopoverFooter>
+      </EuiPopover>
+    `);
+
+    const button = component
+      .find('EuiFlexItem')
+      .children()
+      .renderProp('Component');
+    expect(button()).toMatchInlineSnapshot(`
+      <EuiButtonEmpty
+        size="s"
+      />
+    `);
+  });
+
+  it('handles closing the popover', () => {
+    const component = shallow(<EuiDataGridCellPopover {...requiredProps} />);
+    requiredProps.closePopover.mockImplementation(() => {
+      component.setProps({ popoverIsOpen: false });
+    });
+
+    const event = {
+      key: keys.ESCAPE,
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+    };
+    component.find('EuiPopover').simulate('keyDown', event);
+
+    expect(requiredProps.closePopover).toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.stopPropagation).toHaveBeenCalled();
+
+    requiredProps.closePopover.mockReset();
+  });
+});

--- a/src/components/datagrid/body/data_grid_footer_row.test.tsx
+++ b/src/components/datagrid/body/data_grid_footer_row.test.tsx
@@ -151,20 +151,4 @@ describe('EuiDataGridFooterRow', () => {
       .prop('renderCellValue');
     expect(renderCellValue()).toEqual(null);
   });
-
-  describe('DefaultColumnFormatter', () => {
-    it('wraps content with EuiText', () => {
-      const component = shallow(<EuiDataGridFooterRow {...requiredProps} />);
-      const popoverContent: Function = component
-        .find('EuiDataGridCell')
-        .first()
-        .prop('popoverContent');
-
-      expect(popoverContent({ children: 'test' })).toMatchInlineSnapshot(`
-        <EuiText>
-          test
-        </EuiText>
-      `);
-    });
-  });
 });

--- a/src/components/datagrid/body/data_grid_footer_row.test.tsx
+++ b/src/components/datagrid/body/data_grid_footer_row.test.tsx
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { EuiDataGridFooterRow } from './data_grid_footer_row';
+
+describe('EuiDataGridFooterRow', () => {
+  const requiredProps = {
+    rowIndex: 10,
+    leadingControlColumns: [],
+    trailingControlColumns: [],
+    columns: [{ id: 'someColumn' }, { id: 'someColumnWithoutSchema' }],
+    schema: { someColumn: { columnType: 'string' } },
+    popoverContents: {},
+    columnWidths: { someColumn: 30 },
+    renderCellValue: () => <div />,
+    interactiveCellId: 'someId',
+  };
+
+  it('renders columns', () => {
+    const component = shallow(<EuiDataGridFooterRow {...requiredProps} />);
+
+    expect(component).toMatchInlineSnapshot(`
+      <div
+        className="euiDataGridRow euiDataGridFooter"
+        data-test-subj="dataGridRow"
+        role="row"
+      >
+        <EuiDataGridCell
+          className="euiDataGridFooterCell"
+          colIndex={0}
+          columnId="someColumn"
+          columnType="string"
+          interactiveCellId="someId"
+          isExpandable={true}
+          key="someColumn-10"
+          popoverContent={[Function]}
+          renderCellValue={[Function]}
+          rowIndex={10}
+          visibleRowIndex={10}
+          width={30}
+        />
+        <EuiDataGridCell
+          className="euiDataGridFooterCell"
+          colIndex={1}
+          columnId="someColumnWithoutSchema"
+          columnType={null}
+          interactiveCellId="someId"
+          isExpandable={true}
+          key="someColumnWithoutSchema-10"
+          popoverContent={[Function]}
+          renderCellValue={[Function]}
+          rowIndex={10}
+          visibleRowIndex={10}
+        />
+      </div>
+    `);
+  });
+
+  it('renders leading control columns', () => {
+    const component = shallow(
+      <EuiDataGridFooterRow
+        {...requiredProps}
+        columns={[]}
+        leadingControlColumns={[
+          {
+            id: 'someLeadingColumn',
+            headerCellRender: () => <div />,
+            rowCellRender: () => <div />,
+            width: 25,
+          },
+        ]}
+      />
+    );
+
+    expect(component).toMatchInlineSnapshot(`
+      <div
+        className="euiDataGridRow euiDataGridFooter"
+        data-test-subj="dataGridRow"
+        role="row"
+      >
+        <EuiDataGridCell
+          className="euiDataGridFooterCell euiDataGridRowCell--controlColumn"
+          colIndex={0}
+          columnId="someLeadingColumn"
+          interactiveCellId="someId"
+          isExpandable={true}
+          key="someLeadingColumn-10"
+          popoverContent={[Function]}
+          renderCellValue={[Function]}
+          rowIndex={10}
+          visibleRowIndex={10}
+          width={25}
+        />
+      </div>
+    `);
+
+    const renderCellValue: Function = component
+      .find('EuiDataGridCell')
+      .prop('renderCellValue');
+    expect(renderCellValue()).toEqual(null);
+  });
+
+  it('renders trailing control columns', () => {
+    const component = shallow(
+      <EuiDataGridFooterRow
+        {...requiredProps}
+        columns={[]}
+        trailingControlColumns={[
+          {
+            id: 'someTrailingColumn',
+            headerCellRender: () => <div />,
+            rowCellRender: () => <div />,
+            width: 50,
+          },
+        ]}
+      />
+    );
+
+    expect(component).toMatchInlineSnapshot(`
+      <div
+        className="euiDataGridRow euiDataGridFooter"
+        data-test-subj="dataGridRow"
+        role="row"
+      >
+        <EuiDataGridCell
+          className="euiDataGridFooterCell euiDataGridRowCell--controlColumn"
+          colIndex={0}
+          columnId="someTrailingColumn"
+          interactiveCellId="someId"
+          isExpandable={true}
+          key="someTrailingColumn-10"
+          popoverContent={[Function]}
+          renderCellValue={[Function]}
+          rowIndex={10}
+          visibleRowIndex={10}
+          width={50}
+        />
+      </div>
+    `);
+
+    const renderCellValue: Function = component
+      .find('EuiDataGridCell')
+      .prop('renderCellValue');
+    expect(renderCellValue()).toEqual(null);
+  });
+
+  describe('DefaultColumnFormatter', () => {
+    it('wraps content with EuiText', () => {
+      const component = shallow(<EuiDataGridFooterRow {...requiredProps} />);
+      const popoverContent: Function = component
+        .find('EuiDataGridCell')
+        .first()
+        .prop('popoverContent');
+
+      expect(popoverContent({ children: 'test' })).toMatchInlineSnapshot(`
+        <EuiText>
+          test
+        </EuiText>
+      `);
+    });
+  });
+});

--- a/src/components/datagrid/body/data_grid_footer_row.tsx
+++ b/src/components/datagrid/body/data_grid_footer_row.tsx
@@ -8,16 +8,9 @@
 
 import classnames from 'classnames';
 import React, { forwardRef, memo } from 'react';
-import { EuiText } from '../../text';
 import { EuiDataGridCell } from './data_grid_cell';
-import {
-  EuiDataGridFooterRowProps,
-  EuiDataGridPopoverContent,
-} from '../data_grid_types';
-
-const DefaultColumnFormatter: EuiDataGridPopoverContent = ({ children }) => {
-  return <EuiText>{children}</EuiText>;
-};
+import { DefaultColumnFormatter } from './popover_utils';
+import { EuiDataGridFooterRowProps } from '../data_grid_types';
 
 const EuiDataGridFooterRow = memo(
   forwardRef<HTMLDivElement, EuiDataGridFooterRowProps>(

--- a/src/components/datagrid/body/popover_utils.test.tsx
+++ b/src/components/datagrid/body/popover_utils.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import {
+  DefaultColumnFormatter,
+  providedPopoverContents,
+} from './popover_utils';
+
+describe('popover utils', () => {
+  const cellContentsElement = document.createElement('div');
+  cellContentsElement.innerText = '{ "hello": "world" }';
+
+  test('DefaultColumnFormatter', () => {
+    const component = shallow(
+      <DefaultColumnFormatter cellContentsElement={cellContentsElement}>
+        Test
+      </DefaultColumnFormatter>
+    );
+
+    expect(component).toMatchInlineSnapshot(`
+      <EuiText>
+        Test
+      </EuiText>
+    `);
+  });
+
+  test('providedPopoverContents.json', () => {
+    const Component = providedPopoverContents.json;
+    const component = shallow(
+      <Component cellContentsElement={cellContentsElement}>Test</Component>
+    );
+
+    expect(component).toMatchInlineSnapshot(`
+      <EuiCodeBlock
+        isCopyable={true}
+        language="json"
+        paddingSize="none"
+        transparentBackground={true}
+      >
+        {
+        "hello": "world"
+      }
+      </EuiCodeBlock>
+    `);
+  });
+});

--- a/src/components/datagrid/body/popover_utils.tsx
+++ b/src/components/datagrid/body/popover_utils.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { EuiText } from '../../text';
+import { EuiCodeBlock } from '../../code';
+import {
+  EuiDataGridPopoverContents,
+  EuiDataGridPopoverContent,
+} from '../data_grid_types';
+
+export const DefaultColumnFormatter: EuiDataGridPopoverContent = ({
+  children,
+}) => {
+  return <EuiText>{children}</EuiText>;
+};
+
+export const providedPopoverContents: EuiDataGridPopoverContents = {
+  json: ({ cellContentsElement }) => {
+    let formattedText = cellContentsElement.innerText;
+
+    // attempt to pretty-print the json
+    try {
+      formattedText = JSON.stringify(JSON.parse(formattedText), null, 2);
+    } catch (e) {} // eslint-disable-line no-empty
+
+    return (
+      <EuiCodeBlock
+        isCopyable
+        transparentBackground
+        paddingSize="none"
+        language="json"
+      >
+        {formattedText}
+      </EuiCodeBlock>
+    );
+  },
+};

--- a/src/components/datagrid/data_grid_schema.tsx
+++ b/src/components/datagrid/data_grid_schema.tsx
@@ -210,6 +210,14 @@ export const schemaDetectors: EuiDataGridSchemaDetector[] = [
   },
 ];
 
+export const defaultComparator: NonNullable<
+  EuiDataGridSchemaDetector['comparator']
+> = (a, b, direction) => {
+  if (a < b) return direction === 'asc' ? -1 : 1;
+  if (a > b) return direction === 'asc' ? 1 : -1;
+  return 0;
+};
+
 function scoreValueBySchemaType(
   value: string,
   schemaDetectors: EuiDataGridSchemaDetector[] = []

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -663,7 +663,7 @@ export interface EuiDataGridInMemory {
 export type EuiDataGridFocusedCell = [number, number];
 
 export interface EuiDataGridInMemoryValues {
-  [key: string]: { [key: string]: string };
+  [rowIndex: string]: { [columnId: string]: string };
 }
 
 export interface EuiDataGridPopoverContentProps {

--- a/src/components/observer/resize_observer/resize_observer.tsx
+++ b/src/components/observer/resize_observer/resize_observer.tsx
@@ -17,8 +17,9 @@ export interface EuiResizeObserverProps {
   onResize: (dimensions: { height: number; width: number }) => void;
 }
 
-const hasResizeObserver =
+export const hasResizeObserver =
   typeof window !== 'undefined' && typeof window.ResizeObserver !== 'undefined';
+
 export class EuiResizeObserver extends EuiObserver<EuiResizeObserverProps> {
   name = 'EuiResizeObserver';
 


### PR DESCRIPTION
### Summary

I originally started writing unit tests on the top-level files and realized those were some of the most complex 😅 I ended up going from small files to large for my own sanity.

Code coverage of new tests:

<img width="1435" alt="" src="https://user-images.githubusercontent.com/549407/131727078-060e9028-9729-4e06-abac-232f2a228697.png">

I **strongly** recommend following along by-commit. Here's a tl;dr breakdown of changes:

- Straightforward tests
  - b46fcf4: EuiDataGridFooterRow
  - 5cc3274: EuiDataGridCellButtons
  - c092407: EuiDataGridCellPopover
- Non-straightforward tests:
  - 56c8215: EuiDataGridCell contains a high amount of native DOM behaviors (resize observer, mouse/keyboard events, focus/tab state, etc.) that are difficult to mimic in JSDom. I left general TODO blocks in here for sections of code I thought would be better served by writing in Cypress than Jest
  - cc8777c: EuiDataGridBody has the same difficulties (element height/width, focus/tabbing, complex UX interactions) that would be better tested in Cypress, which I've left TODOs for
  - I am planning on revisiting once the Cypress is merged in, but I am honestly wondering for these 2 tests if it might not be better to skip Jest testing them almost entirely and only use Cypress 🤔 the component lifecycle tests in EuiDataGridCell are likely worth keeping in Jest however.
- Suggested refactors:
  -  After parsing the source code while writing unit tests, I had some suggested cleanups for `EuiDataGridCell` and `EuiDataGridBody` that (IMO) makes the files a little simpler to read through and easier to unit test. I've laid out my reasoning for each change in the commit messages - would definitely appreciate folks' 2c on them!
  -  b60fd93, b1f86d6, b89f80c, 041eeb2 

### Checklist

N/A - added tests are internal/dev-only changes, and code refactors did not change functionality, but file locations only