### PR TITLE
[euiScreenReaderOnly] Use `clip` to fix scrolling issues caused by absolute positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `37.6.0`.
+**Bug fixes**
+
+- Fixed `EuiScreenReaderOnly` positioning issues within scrolling containers ([#5130](https://github.com/elastic/eui/pull/5130))
 
 ## [`37.6.0`](https://github.com/elastic/eui/tree/v37.6.0)
 

--- a/src/global_styling/mixins/_helpers.scss
+++ b/src/global_styling/mixins/_helpers.scss
@@ -110,6 +110,8 @@
   position: absolute;
   left: -10000px;
   top: auto;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
   width: 1px;
   height: 1px;
   overflow: hidden;

--- a/src/global_styling/mixins/_helpers.scss
+++ b/src/global_styling/mixins/_helpers.scss
@@ -106,6 +106,9 @@
 }
 
 // Hiding elements offscreen to only be read by screen reader
+// NOTE: Hidden absolute positioning can cause issues with scrolling/overflow.
+// `clip` and `left` (for Chromium browsers) are needed to prevent these issues -
+// @see https://github.com/elastic/eui/pull/5130 for more info
 @mixin euiScreenReaderOnly {
   position: absolute;
   left: -10000px;


### PR DESCRIPTION
## Summary

### Problem

@qn895 reported an issue with their usage of `EuiInMemoryTable` within a scrolling container causing strange scrolling on the rest of their page/body. I was able to reproduce this behavior in our own docs page as well as in a [CodeSandbox](https://codesandbox.io/s/busy-liskov-rlorg?file=/index.js):

![scroll_issue](https://user-images.githubusercontent.com/549407/131779326-9ed4dfb3-a411-435e-bc64-da24576f057d.gif)

Notice the page scrollbar jumping/increasing every time the table rows (and consequently table height) increases.

[CSS-tricks](https://css-tricks.com/findingfixing-unintended-body-overflow/) put me on the right track of thinking it was a hidden absolutely positioned element that was causing the overflow issue. I also noticed when I had a table with plain text and no external link, I didn't have the same scroll issues. Well, I put 2 and 2 together, and it turns out it's the `.euiScreenReaderOnly` part of the table content that's causing the scroll/overflow shenanigans. In above screencap, the external link icon has SR text to indicate the link opens in a new window, and in the table @qn895 had issues with, the actions column icons have SR text to indicate their behavior.

### Reproducing

You can check out [this commit](https://github.com/constancecchen/eui/commit/96982ee884c303b18034a2fbb8a28767729d2419) on my fork to see the issue locally on http://localhost:8030/#/tabular-content/in-memory-tables. You can also cherry-pick that commit to this fixed branch to see the fix.

### Solution

Adding to `clip` prevents the scrolling shenanigans mentioned above, and works on all modern browsers supported by EUI.

This should be fairly safe change in terms of [browser support](https://caniuse.com/mdn-css_properties_clip) - additionally, [WebAIM](https://webaim.org/techniques/css/invisiblecontent/#offscreen), [WordPress](https://make.wordpress.org/accessibility/handbook/markup/the-css-class-screen-reader-text/), [18f](https://accessibility.18f.gov/hidden-content/), and [a11yproject](https://www.a11yproject.com/posts/2013-01-11-how-to-hide-content/) all have snippets using `clip`.

Some fun asides I stumbled upon during testing:
- `clip` is apparently going to be deprecated, which is why I included `clip-path` (per the above links)
- Although interestingly enough on Firefox, `clip-path` didn't solve the above scroll issue by itself - only `clip` did
- On the subject of browser-specific shenanigans: in FF, I was able to remove the `top` and `left` positioning properties totally and the fix worked. However, on Chromium/webkit, just `clip` alone didn't fix the scrolling issue: I needed `left: -10000px` too 😖 The only other place I could find where someone else had this issue was [this filed bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1154640), but they seemed to come to the conclusion the issue was with FontAwesome, not Chromium (which I sorta disagree with, but c'est la vie). Maybe someday someone will google around and come across _this_ issue, and the cycle of the internet will be complete :)

## QA

- [x] Confirm that http://localhost:8030/#/utilities/accessibility links are still visually hidden but appear on keyboard tab/focus
- [x] Confirm that other components that use the `@include euiScreenReaderOnly` mixin still work as expected:
    - Checkbox & radio inputs
    - Key pad menu checkboxes/radios
    - Resizable container
    - Datepicker

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~

- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately