### PR TITLE
[EuiCheckbox][EuiRadio] Fix checkboxes/radios without labels not being clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `37.6.1`.
+**Bug fixes**
+
+- Fixed `EuiCheckbox`s and `EuiRadio`s without labels not being clickable ([#5149](https://github.com/elastic/eui/pull/5149))
 
 ## [`37.6.1`](https://github.com/elastic/eui/tree/v37.6.1)
 

--- a/src/components/form/checkbox/_checkbox.scss
+++ b/src/components/form/checkbox/_checkbox.scss
@@ -92,7 +92,6 @@
       opacity: 0; /* 1 */
       z-index: 1; /* 1 */
       margin: 0; /* 1 */
-      left: 0; /* 1 */
       cursor: pointer;
     }
   }

--- a/src/components/form/checkbox/_checkbox.scss
+++ b/src/components/form/checkbox/_checkbox.scss
@@ -1,9 +1,11 @@
 .euiCheckbox {
   position: relative;
 
-  .euiCheckbox__input {
+  &:not(.euiCheckbox--noLabel) .euiCheckbox__input {
     @include euiScreenReaderOnly;
+  }
 
+  .euiCheckbox__input {
     ~ .euiCheckbox__label {
       display: inline-block;
       padding-left: ($euiCheckBoxSize * 1.5);

--- a/src/components/form/radio/_radio.scss
+++ b/src/components/form/radio/_radio.scss
@@ -80,7 +80,6 @@
       opacity: 0; /* 1 */
       z-index: 1; /* 1 */
       margin: 0; /* 1 */
-      left: 0; /* 1 */
       cursor: pointer;
     }
   }

--- a/src/components/form/radio/_radio.scss
+++ b/src/components/form/radio/_radio.scss
@@ -1,9 +1,11 @@
 .euiRadio {
   position: relative;
 
-  .euiRadio__input {
+  &:not(.euiRadio--noLabel) .euiRadio__input {
     @include euiScreenReaderOnly;
+  }
 
+  .euiRadio__input {
     ~ .euiRadio__label {
       display: inline-block;
       padding-left: ($euiRadioSize * 1.5);


### PR DESCRIPTION
### Summary

closes #5145 (_NB: This bug only exists in 37.6.1, and should be fixed in 37.6.2_)

#5130 updated the `euiScreenReaderOnly` mixin (which `EuiCheckbox` and `EuiRadio` both use) to include `clip(0 0 0 0)` CSS (to prevent scrolling issues caused by absolute positioning). Per the QA section of that PR, I tested the change against the normal checkbox/radio examples in our docs, but did not test them against checkbox/radios with no labels (which I hadn't realized functioned slightly differently than their counterparts with labels).

Checkboxes and radios **without** labels actually **do not** want the standard `euiScreenReaderOnly` behavior. The visually hidden input actually overlays the visually displayed element with a set height/width, unlike SR behavior which moves the hidden element totally offscreen.

As such, I decided the cleanest solution would be to only apply the `euiScreenReaderOnly` CSS to checkboxes/radios with labels (using `:not()`), thus negating the need for checkbox/radios to override any parts `euiScreenReaderOnly` CSS.

### Before

<img width="400" alt="" src="https://user-images.githubusercontent.com/549407/132383820-7557e652-14ed-4086-bcab-faa4446bff93.png">

### After

<img width="400" alt="" src="https://user-images.githubusercontent.com/549407/132383841-ff70309c-ca2c-4fa4-8ff6-6aa2bad90e0c.png">

Checkboxes/radios with labels remain the same:

<img width="400" alt="" src="https://user-images.githubusercontent.com/549407/132383866-cf905537-b0b3-4f5b-a663-339b2c616e32.png">

## QA

- [x] Go to https://eui.elastic.co/pr_5149/#/tabular-content/tables#adding-selection-to-a-table and confirm the table row selection is now clickable
- [x] (Regression testing) Go to https://eui.elastic.co/pr_5149/#/forms/form-controls#checkbox and confirm that checkbox and radio inputs still look and function correctly/as before
- [x] Open the playgrounds for the EuiCheckbox and EuiRadio elements, and clear the `Label` input. Confirm the inputs are still interactable (NB: the checkbox playground doesn't change state, but the radio playground does)

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~

- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
