### PR TITLE
[euiScreenReaderOnly] Revert #5130 - clip property addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `37.6.1`.
+**Reverts**
+
+- Reverted `EuiScreenReaderOnly` clip property ([#5150](https://github.com/elastic/eui/pull/5150))
 
 ## [`37.6.1`](https://github.com/elastic/eui/tree/v37.6.1)
 
 **Bug fixes**
 
-- Fixed `EuiScreenReaderOnly` positioning issues within scrolling containers ([#5130](https://github.com/elastic/eui/pull/5130))
+- **[REVERTED in 37.6.2]** Fixed `EuiScreenReaderOnly` positioning issues within scrolling containers ([#5130](https://github.com/elastic/eui/pull/5130))
 - Fixed `EuiDataGrid` cell actions not unmounting from the DOM after mouse interaction ([#5120](https://github.com/elastic/eui/pull/5120))
 - Optimized `EuiDataGrid` cell interactions' performance  ([#5136](https://github.com/elastic/eui/pull/5136))
 

--- a/src/global_styling/mixins/_helpers.scss
+++ b/src/global_styling/mixins/_helpers.scss
@@ -106,15 +106,10 @@
 }
 
 // Hiding elements offscreen to only be read by screen reader
-// NOTE: Hidden absolute positioning can cause issues with scrolling/overflow.
-// `clip` and `left` (for Chromium browsers) are needed to prevent these issues -
-// @see https://github.com/elastic/eui/pull/5130 for more info
 @mixin euiScreenReaderOnly {
   position: absolute;
   left: -10000px;
   top: auto;
-  clip: rect(0 0 0 0);
-  clip-path: inset(50%);
   width: 1px;
   height: 1px;
   overflow: hidden;


### PR DESCRIPTION
### Summary

closes #5145

Per @cchaos, we should consider the addition of the `clip` property to be a breaking change since it may impact other devs who were targeting or overriding `.euiScreenReaderOnly` (which is what we were doing in #5149).

This PR thus reverts #5130, and after it lands, I'll open a new PR that includes both #5130 and #5149 that will be labeled as a breaking change and target `38.0`.

### Checklist

Mostly skipped as this is a straightforward git revert

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
