### PR TITLE
[Misc] Fix typo in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ Provide a detailed summary of your PR. Explain how you arrived at your solution.
 - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
 - [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
 - [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
-- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for the any docs examples
+- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
 - [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
 - [ ] Checked for **breaking changes** and labeled appropriately
 - [ ] Checked for **accessibility** including keyboard-only and screenreader modes


### PR DESCRIPTION
### Summary

Removed an extra `the` from `the any`. Copy should now be:

> Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples