### PR TITLE
[EuiDataGrid] Actually fix calls to tabbable instead of moving the issue to a different part of the code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Extended all `EuiTabProps` for each `EuiTabbedContentTab` ([#5135](https://github.com/elastic/eui/pull/5135))
 - Added `useGeneratedHtmlId` utility, which memoizes the randomly generated ID on mount and prevents regenerated IDs on component rerender ([#5133](https://github.com/elastic/eui/pull/5133))
 
+**Bug fixes**
+
+- Fixed [de]optimization bug in `EuiDataGrid` when cells are removed from the DOM via virtualization ([#5163](https://github.com/elastic/eui/pull/5163))
+
 **Theme: Amsterdam**
 
 - Deprecated `display` prop of `EuiTabs` in favor of unified styles and `bottomBorder` ([#5135](https://github.com/elastic/eui/pull/5135))

--- a/src/components/datagrid/body/data_grid_body.test.tsx
+++ b/src/components/datagrid/body/data_grid_body.test.tsx
@@ -13,7 +13,7 @@ import { DataGridSortingContext } from '../data_grid_context';
 import { schemaDetectors } from '../data_grid_schema';
 import { RowHeightUtils } from '../row_height_utils';
 
-import { EuiDataGridBody } from './data_grid_body';
+import { EuiDataGridBody, getParentCellContent } from './data_grid_body';
 
 describe('EuiDataGridBody', () => {
   const requiredProps = {
@@ -118,4 +118,31 @@ describe('EuiDataGridBody', () => {
   });
 
   // TODO: Test tabbing in Cypress
+
+  // TODO: Test column resizing in Cypress
+});
+
+describe('getParentCellContent', () => {
+  it("locates the provided element's cell", () => {
+    const doc = document.createDocumentFragment();
+
+    const body = document.createElement('body');
+    doc.appendChild(body);
+
+    const cell = document.createElement('div');
+    cell.setAttribute('data-datagrid-cellcontent', 'true');
+    body.appendChild(cell);
+
+    const span = document.createElement('span');
+    span.textContent = 'Here comes the text';
+    cell.appendChild(span);
+
+    const text = span.childNodes[0];
+
+    expect(getParentCellContent(cell)).toBe(cell);
+    expect(getParentCellContent(span!)).toBe(cell);
+    expect(getParentCellContent(text)).toBe(cell);
+    expect(getParentCellContent(text)).toBe(cell);
+    expect(getParentCellContent(body)).toBeNull();
+  });
 });

--- a/src/components/datagrid/body/data_grid_body.test.tsx
+++ b/src/components/datagrid/body/data_grid_body.test.tsx
@@ -123,26 +123,34 @@ describe('EuiDataGridBody', () => {
 });
 
 describe('getParentCellContent', () => {
-  it("locates the provided element's cell", () => {
-    const doc = document.createDocumentFragment();
+  const doc = document.createDocumentFragment();
 
-    const body = document.createElement('body');
-    doc.appendChild(body);
+  const body = document.createElement('body');
+  doc.appendChild(body);
 
-    const cell = document.createElement('div');
-    cell.setAttribute('data-datagrid-cellcontent', 'true');
-    body.appendChild(cell);
+  const cell = document.createElement('div');
+  cell.setAttribute('data-datagrid-cellcontent', 'true');
+  body.appendChild(cell);
 
-    const span = document.createElement('span');
-    span.textContent = 'Here comes the text';
-    cell.appendChild(span);
+  const span = document.createElement('span');
+  span.textContent = 'Here comes the text';
+  cell.appendChild(span);
 
-    const text = span.childNodes[0];
+  const text = span.childNodes[0];
 
+  it('locates the cell element when starting with the cell itself', () => {
     expect(getParentCellContent(cell)).toBe(cell);
+  });
+
+  it('locates the cell element when starting with an element inside the cell', () => {
     expect(getParentCellContent(span!)).toBe(cell);
-    expect(getParentCellContent(text)).toBe(cell);
-    expect(getParentCellContent(text)).toBe(cell);
+  });
+
+  it('locates the cell element when starting with a text node inside the cell', () => {
+    expect(getParentCellContent(text!)).toBe(cell);
+  });
+
+  it('does not locate the cell element when starting outside the cell', () => {
     expect(getParentCellContent(body)).toBeNull();
   });
 });

--- a/src/components/datagrid/body/data_grid_body.tsx
+++ b/src/components/datagrid/body/data_grid_body.tsx
@@ -248,7 +248,7 @@ const IS_JEST_ENVIRONMENT = global.hasOwnProperty('_isJest');
  * and search its ancestors for a div[data-datagrid-cellcontent], if any,
  * which is a valid target for disabling tabbing within
  */
-function getParentCellContent(_element: Node | HTMLElement) {
+export function getParentCellContent(_element: Node | HTMLElement) {
   let element: HTMLElement | null =
     _element.nodeType === document.ELEMENT_NODE
       ? (_element as HTMLElement)

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -18,7 +18,6 @@ import { EuiDataGridColumnResizer } from './body/header/data_grid_column_resizer
 import { EuiDataGridRowHeightOption } from './data_grid_types';
 import { keys } from '../../services';
 import { act } from 'react-dom/test-utils';
-import { getParentCellContent } from './body/data_grid_body';
 
 jest.mock('./row_height_utils', () => {
   return {
@@ -2748,41 +2747,5 @@ describe('EuiDataGrid', () => {
       expect(focusableCell.text()).toEqual('0, B'); // grid navigation is enabled again, check that we can move
       expect(takeMountedSnapshot(component)).toMatchSnapshot();
     });
-  });
-});
-
-describe('getParentCellContent', () => {
-  it("locates the provided element's cell", () => {
-    const component = mount(
-      <EuiDataGrid
-        {...requiredProps}
-        columns={[{ id: 'A' }, { id: 'B' }, { id: 'C' }]}
-        columnVisibility={{
-          visibleColumns: ['A', 'B', 'C'],
-          setVisibleColumns: () => {},
-        }}
-        rowCount={10}
-        renderCellValue={() => (
-          <div>
-            <span>This is in a cell</span>
-          </div>
-        )}
-      />
-    );
-    const cell = component
-      .find('[data-datagrid-cellcontent]')
-      .first()
-      .getDOMNode();
-    expect(cell).not.toBeNull();
-
-    const span = cell.querySelector('span');
-    expect(span).not.toBeNull();
-
-    const text = span!.childNodes[0];
-    expect(text).not.toBeNull();
-
-    expect(getParentCellContent(cell)).toBe(cell);
-    expect(getParentCellContent(span!)).toBe(cell);
-    expect(getParentCellContent(text)).toBe(cell);
   });
 });

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -18,6 +18,7 @@ import { EuiDataGridColumnResizer } from './body/header/data_grid_column_resizer
 import { EuiDataGridRowHeightOption } from './data_grid_types';
 import { keys } from '../../services';
 import { act } from 'react-dom/test-utils';
+import { getParentCellContent } from './body/data_grid_body';
 
 jest.mock('./row_height_utils', () => {
   return {
@@ -2747,5 +2748,41 @@ describe('EuiDataGrid', () => {
       expect(focusableCell.text()).toEqual('0, B'); // grid navigation is enabled again, check that we can move
       expect(takeMountedSnapshot(component)).toMatchSnapshot();
     });
+  });
+});
+
+describe('getParentCellContent', () => {
+  it("locates the provided element's cell", () => {
+    const component = mount(
+      <EuiDataGrid
+        {...requiredProps}
+        columns={[{ id: 'A' }, { id: 'B' }, { id: 'C' }]}
+        columnVisibility={{
+          visibleColumns: ['A', 'B', 'C'],
+          setVisibleColumns: () => {},
+        }}
+        rowCount={10}
+        renderCellValue={() => (
+          <div>
+            <span>This is in a cell</span>
+          </div>
+        )}
+      />
+    );
+    const cell = component
+      .find('[data-datagrid-cellcontent]')
+      .first()
+      .getDOMNode();
+    expect(cell).not.toBeNull();
+
+    const span = cell.querySelector('span');
+    expect(span).not.toBeNull();
+
+    const text = span!.childNodes[0];
+    expect(text).not.toBeNull();
+
+    expect(getParentCellContent(cell)).toBe(cell);
+    expect(getParentCellContent(span!)).toBe(cell);
+    expect(getParentCellContent(text)).toBe(cell);
   });
 });


### PR DESCRIPTION
### Summary

Fixes #5162

Um, so. I omitted a `!` in an if statement in #5136 which interacted with itself in an extreme way when a column resize causes a column to drop off into the virtualization void.

This PR:

* adds an optimization to only process a cell once even if there were multiple mutations (not the crux of the issue, but one flame graph implicated this)
* actually finds the cell's div to pass to tabbable, instead of flagging the entire grid

Testing:

Set the main grid demo's page size to 100, then resize a column to drop one or more off the end.

/cc @kqualters-elastic if you'd like to test this within your grid

## Before
![flame graph showing really bad performance](https://user-images.githubusercontent.com/56408403/132755046-e8c83a07-5400-4ef1-ad61-0f9282310148.png)

## After
<img width="1277" alt="flame graph showing significantly better performance" src="https://user-images.githubusercontent.com/313125/132766825-80ef824e-b4b4-40e5-8698-d437554018d2.png">


### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
