### PR TITLE
[EuiResizableContainer] Fix z-index ui bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Removed Sass variables for `EuiTabs` font size (`$euiTabFontSize, $euiTabFontSizeS, $euiTabFontSizeL`) ([#5135](https://github.com/elastic/eui/pull/5135))
 - Extended all `EuiTabProps` for each `EuiTabbedContentTab` ([#5135](https://github.com/elastic/eui/pull/5135))
 - Added `useGeneratedHtmlId` utility, which memoizes the randomly generated ID on mount and prevents regenerated IDs on component rerender ([#5133](https://github.com/elastic/eui/pull/5133))
+- Fixed `z-index` styles that were causing parts of `EuiResizableContainer` to overlap `EuiHeader` ([#5164](https://github.com/elastic/eui/pull/5164))
 
 **Theme: Amsterdam**
 

--- a/src/components/resizable_container/_resizable_button.scss
+++ b/src/components/resizable_container/_resizable_button.scss
@@ -3,7 +3,7 @@
 .euiResizableButton {
   position: relative;
   flex-shrink: 0;
-  z-index: $euiZLevel1;
+  z-index: 1;
 
   &:before,
   &:after {

--- a/src/components/resizable_container/_resizable_collapse_button.scss
+++ b/src/components/resizable_container/_resizable_collapse_button.scss
@@ -11,7 +11,7 @@
 .euiResizableToggleButton {
   @include euiSlightShadow;
   position: absolute;
-  z-index: $euiZLevel1 + 1;
+  z-index: 2;
   // Remove animations from EuiButtonIcon because of the custom transforms
   animation: none !important; // sass-lint:disable-line no-important
   // Remove transition from EuiButtonIcon because of the custom transforms


### PR DESCRIPTION
### Summary
Fixes #5003

This PR changes: 
- `.euiResizableButton` to use `z-index: 1` instead of `z-index: $euiZLevel1`
- `.euiResizableToggleButton` to `z-index: 2`  instead of  `z-index: $euiZLevel1 + 1`

Both of these changes fix the UI bug which caused the button's separating line and the button itself to overlap the header when the page is scrolled.

Here is a before and after:

#### Before:
<img width="905" alt="Screen Shot 2021-09-09 at 4 17 59 PM" src="https://user-images.githubusercontent.com/63428137/132770376-8911bbac-6616-4c12-93d4-729a2feab5e4.png">

![Screen Shot 2021-09-09 at 6 37 08 PM](https://user-images.githubusercontent.com/63428137/132772554-18543cf1-2ae9-4da8-aca3-34f5c99d5f12.png)

#### After:
<img width="897" alt="Screen Shot 2021-09-09 at 4 15 52 PM" src="https://user-images.githubusercontent.com/63428137/132770366-02bf8313-1a35-40f3-b49f-a53577fa376c.png">

![Screen Shot 2021-09-09 at 6 36 05 PM](https://user-images.githubusercontent.com/63428137/132772592-df9f15d4-25c3-4a76-92ff-6f2f713598e3.png)


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
