### PR TITLE
Bump typescript version to ~4.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 - Fixed `EuiDataGrid` stripes not alternating as expected on sort/pagination ([#5070](https://github.com/elastic/eui/pull/5070))
 
+**Breaking changes**
+
+- Upgraded TypeScript version to ~4.1.3 ([#5182](https://github.com/elastic/eui/pull/5182))
+
 ## [`37.7.0`](https://github.com/elastic/eui/tree/v37.7.0)
 
 - Added `placeholder` prop to `EuiMarkdownEditor` ([#5151](https://github.com/elastic/eui/pull/5151))

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "start-server-and-test": "^1.11.3",
     "style-loader": "^1.2.1",
     "terser-webpack-plugin": "^4.1.0",
-    "typescript": "4.0.5",
+    "typescript": "4.1.3",
     "uglifyjs-webpack-plugin": "^2.2.0",
     "url-loader": "^4.1.0",
     "webpack": "^4.44.1",
@@ -229,6 +229,6 @@
     "prop-types": "^15.5.0",
     "react": "^16.12",
     "react-dom": "^16.12",
-    "typescript": "^4.0.5"
+    "typescript": "~4.1.3"
   }
 }

--- a/src/components/icon/icon.test.tsx
+++ b/src/components/icon/icon.test.tsx
@@ -34,7 +34,7 @@ const prettyHtml = cheerio.load('');
 function testIcon(props: PropsOf<EuiIcon>) {
   return () => {
     expect.assertions(1);
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
       const onIconLoad = () => {
         component.update();
         expect(prettyHtml(component.html())).toMatchSnapshot();

--- a/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
@@ -230,7 +230,8 @@ export const EuiSelectableTemplateSitewide: FunctionComponent<EuiSelectableTempl
       searchProps={{
         placeholder: searchPlaceholder,
         isClearable: true,
-        ...searchProps,
+        // TS is mad that searchProps.className may be `undefined`, but we overwrite it below
+        ...(searchProps as Omit<typeof searchProps, 'className'>),
         onFocus: searchOnFocus,
         onBlur: searchOnBlur,
         onInput: onSearchInput,

--- a/yarn.lock
+++ b/yarn.lock
@@ -16116,10 +16116,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
-  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
+typescript@4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 uglify-js@^3.6.0:
   version "3.10.2"


### PR DESCRIPTION
### Summary

#### Breaking change

Closes #5146 by upgrading our typescript dependency to match Kibana's pinned version.

* updated TS version in `dependencies` & `peerDependencies`
* gave a Promise in _icon.test.txt_ an explicit return type
* convinced TS spreading `searchProps` in **EuiSelectableSitewideTemplate* is okay
* tested resulting _eui.d.ts_ in Kibana

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
