### PR TITLE
[EuiDataGrid] Refactor + write unit tests for body/header/column_actions

### DIFF
--- a/src/components/datagrid/body/header/column_actions.test.tsx
+++ b/src/components/datagrid/body/header/column_actions.test.tsx
@@ -388,7 +388,7 @@ describe('getColumnActions', () => {
         expect(sortAscLabel.props.values.schemaLabel.props.default).toEqual(
           'Low-High'
         );
-        expect(sortDescLabel.props.values.schemaLabel.props.default).toContain(
+        expect(sortDescLabel.props.values.schemaLabel.props.default).toEqual(
           'High-Low'
         );
       });

--- a/src/components/datagrid/body/header/column_actions.test.tsx
+++ b/src/components/datagrid/body/header/column_actions.test.tsx
@@ -14,13 +14,20 @@ import { schemaDetectors } from '../../data_grid_schema';
 import { getColumnActions } from './column_actions';
 
 describe('getColumnActions', () => {
-  const column = { id: 'B' };
-  const columns = [{ id: 'A' }, { id: 'B' }, { id: 'C' }];
-  const schema = {};
   const setVisibleColumns = jest.fn();
   const setIsPopoverOpen = jest.fn();
-  const sorting = undefined;
   const switchColumnPos = jest.fn();
+
+  const testArgs = {
+    column: { id: 'B' },
+    columns: [{ id: 'A' }, { id: 'B' }, { id: 'C' }],
+    schema: {},
+    schemaDetectors,
+    setVisibleColumns,
+    setIsPopoverOpen,
+    sorting: undefined,
+    switchColumnPos,
+  };
 
   // DRY test helper
   const callActionOnClick = (action: EuiListGroupItemProps) => {
@@ -32,50 +39,32 @@ describe('getColumnActions', () => {
   });
 
   it('returns an array of EuiListGroup items', () => {
-    const items = getColumnActions(
-      column,
-      columns,
-      schema,
-      schemaDetectors,
-      setVisibleColumns,
-      setIsPopoverOpen,
-      sorting,
-      switchColumnPos
-    );
+    const items = getColumnActions(testArgs);
     expect(items).toBeInstanceOf(Array); // We'll assert the actual contents below
     expect(items.length).toEqual(3);
   });
 
   it('returns an empty array when column.actions is set to false', () => {
-    const items = getColumnActions(
-      { ...column, actions: false },
-      columns,
-      schema,
-      schemaDetectors,
-      setVisibleColumns,
-      setIsPopoverOpen,
-      sorting,
-      switchColumnPos
-    );
+    const items = getColumnActions({
+      ...testArgs,
+      column: {
+        ...testArgs.column,
+        actions: false,
+      },
+    });
     expect(items.length).toEqual(0);
   });
 
   it('appends additional custom columns to the end of the array', () => {
-    const items = getColumnActions(
-      {
-        ...column,
+    const items = getColumnActions({
+      ...testArgs,
+      column: {
+        ...testArgs.column,
         actions: {
           additional: [{ label: 'Hi world!', iconType: 'alert' }],
         },
       },
-      columns,
-      schema,
-      schemaDetectors,
-      setVisibleColumns,
-      setIsPopoverOpen,
-      sorting,
-      switchColumnPos
-    );
+    });
     expect(items.length).toEqual(4);
 
     const customAction = items[3];
@@ -93,16 +82,7 @@ describe('getColumnActions', () => {
 
   describe('hiding', () => {
     describe('default behavior', () => {
-      const items = getColumnActions(
-        column,
-        columns,
-        schema,
-        schemaDetectors,
-        setVisibleColumns,
-        setIsPopoverOpen,
-        sorting,
-        switchColumnPos
-      );
+      const items = getColumnActions(testArgs);
       const hideColumn = items[0];
 
       it('renders a "Hide column" item first', () => {
@@ -128,44 +108,32 @@ describe('getColumnActions', () => {
 
     describe('custom column behavior', () => {
       it('accepts column action overrides', () => {
-        const items = getColumnActions(
-          {
-            ...column,
+        const items = getColumnActions({
+          ...testArgs,
+          column: {
+            ...testArgs.column,
             actions: {
               showHide: {
                 label: 'hello world',
               },
             },
           },
-          columns,
-          schema,
-          schemaDetectors,
-          setVisibleColumns,
-          setIsPopoverOpen,
-          sorting,
-          switchColumnPos
-        );
+        });
         const hideColumn = items[0];
 
         expect(hideColumn.label).toEqual('hello world');
       });
 
       it('allows disabling the hide action', () => {
-        const items = getColumnActions(
-          {
-            ...column,
+        const items = getColumnActions({
+          ...testArgs,
+          column: {
+            ...testArgs.column,
             actions: {
               showHide: false,
             },
           },
-          columns,
-          schema,
-          schemaDetectors,
-          setVisibleColumns,
-          setIsPopoverOpen,
-          sorting,
-          switchColumnPos
-        );
+        });
 
         expect(items.length).toEqual(2);
       });
@@ -174,16 +142,7 @@ describe('getColumnActions', () => {
 
   describe('column reordering', () => {
     describe('default enabled behavior', () => {
-      const items = getColumnActions(
-        column,
-        columns,
-        schema,
-        schemaDetectors,
-        setVisibleColumns,
-        setIsPopoverOpen,
-        sorting,
-        switchColumnPos
-      );
+      const items = getColumnActions(testArgs);
       const moveLeft = items[1];
       const moveRight = items[2];
 
@@ -230,16 +189,10 @@ describe('getColumnActions', () => {
 
     describe('disabled behavior', () => {
       it('renders "Move left" as disabled if already on the first/left-most column', () => {
-        const items = getColumnActions(
-          { id: 'A' },
-          columns,
-          schema,
-          schemaDetectors,
-          setVisibleColumns,
-          setIsPopoverOpen,
-          sorting,
-          switchColumnPos
-        );
+        const items = getColumnActions({
+          ...testArgs,
+          column: { id: 'A' },
+        });
         const moveLeft = items[1];
         expect(moveLeft.isDisabled).toEqual(true);
 
@@ -249,16 +202,10 @@ describe('getColumnActions', () => {
       });
 
       it('renders "Move left" as disabled if already on the last/right-most column', () => {
-        const items = getColumnActions(
-          { id: 'C' },
-          columns,
-          schema,
-          schemaDetectors,
-          setVisibleColumns,
-          setIsPopoverOpen,
-          sorting,
-          switchColumnPos
-        );
+        const items = getColumnActions({
+          ...testArgs,
+          column: { id: 'C' },
+        });
         const moveRight = items[2];
         expect(moveRight.isDisabled).toEqual(true);
 
@@ -270,9 +217,10 @@ describe('getColumnActions', () => {
 
     describe('custom column behavior', () => {
       it('accepts column action overrides', () => {
-        const items = getColumnActions(
-          {
-            ...column,
+        const items = getColumnActions({
+          ...testArgs,
+          column: {
+            ...testArgs.column,
             actions: {
               showMoveLeft: {
                 label: 'hello',
@@ -282,14 +230,7 @@ describe('getColumnActions', () => {
               },
             },
           },
-          columns,
-          schema,
-          schemaDetectors,
-          setVisibleColumns,
-          setIsPopoverOpen,
-          sorting,
-          switchColumnPos
-        );
+        });
         const moveLeft = items[1];
         const moveRight = items[2];
 
@@ -298,22 +239,16 @@ describe('getColumnActions', () => {
       });
 
       it('allows disabling show actions', () => {
-        const items = getColumnActions(
-          {
-            ...column,
+        const items = getColumnActions({
+          ...testArgs,
+          column: {
+            ...testArgs.column,
             actions: {
               showMoveLeft: false,
               showMoveRight: false,
             },
           },
-          columns,
-          schema,
-          schemaDetectors,
-          setVisibleColumns,
-          setIsPopoverOpen,
-          sorting,
-          switchColumnPos
-        );
+        });
 
         expect(items.length).toEqual(1);
       });
@@ -324,16 +259,10 @@ describe('getColumnActions', () => {
     const onSort = jest.fn();
 
     describe('default behavior (no active sorts present)', () => {
-      const items = getColumnActions(
-        column,
-        columns,
-        schema,
-        schemaDetectors,
-        setVisibleColumns,
-        setIsPopoverOpen,
-        { onSort, columns: [] },
-        switchColumnPos
-      );
+      const items = getColumnActions({
+        ...testArgs,
+        sorting: { onSort, columns: [] },
+      });
       const sortAsc = items[1];
       const sortDesc = items[2];
 
@@ -402,16 +331,10 @@ describe('getColumnActions', () => {
 
     describe('when active sorts are present', () => {
       describe('when current column is sorting by asc', () => {
-        const items = getColumnActions(
-          column,
-          columns,
-          schema,
-          schemaDetectors,
-          setVisibleColumns,
-          setIsPopoverOpen,
-          { onSort, columns: [{ id: 'B', direction: 'asc' }] },
-          switchColumnPos
-        );
+        const items = getColumnActions({
+          ...testArgs,
+          sorting: { onSort, columns: [{ id: 'B', direction: 'asc' }] },
+        });
         const sortAsc = items[1];
 
         it('renders sortAsc as selected', () => {
@@ -427,16 +350,10 @@ describe('getColumnActions', () => {
       });
 
       describe('when current column is sorting by desc', () => {
-        const items = getColumnActions(
-          column,
-          columns,
-          schema,
-          schemaDetectors,
-          setVisibleColumns,
-          setIsPopoverOpen,
-          { onSort, columns: [{ id: 'B', direction: 'desc' }] },
-          switchColumnPos
-        );
+        const items = getColumnActions({
+          ...testArgs,
+          sorting: { onSort, columns: [{ id: 'B', direction: 'desc' }] },
+        });
         const sortAsc = items[1];
         const sortDesc = items[2];
 
@@ -455,16 +372,12 @@ describe('getColumnActions', () => {
 
     describe('modifies the sort label based on schema', () => {
       it('renders low-high instead of A-Z for number schema', () => {
-        const items = getColumnActions(
-          { id: 'A' },
-          columns,
-          { A: { columnType: 'numeric' } },
-          schemaDetectors,
-          setVisibleColumns,
-          setIsPopoverOpen,
-          { onSort, columns: [{ id: 'A', direction: 'desc' }] },
-          switchColumnPos
-        );
+        const items = getColumnActions({
+          ...testArgs,
+          column: { id: 'A' },
+          schema: { A: { columnType: 'numeric' } },
+          sorting: { onSort, columns: [{ id: 'A', direction: 'desc' }] },
+        });
         const sortAscLabel = items[1].label as ReactElement;
         const sortDescLabel = items[2].label as ReactElement;
 
@@ -479,9 +392,10 @@ describe('getColumnActions', () => {
 
     describe('custom column behavior', () => {
       it('accepts column action overrides', () => {
-        const items = getColumnActions(
-          {
-            ...column,
+        const items = getColumnActions({
+          ...testArgs,
+          column: {
+            ...testArgs.column,
             actions: {
               showSortAsc: {
                 label: 'upsies',
@@ -491,14 +405,8 @@ describe('getColumnActions', () => {
               },
             },
           },
-          columns,
-          schema,
-          schemaDetectors,
-          setVisibleColumns,
-          setIsPopoverOpen,
-          { onSort, columns: [] },
-          switchColumnPos
-        );
+          sorting: { onSort, columns: [] },
+        });
         const sortAsc = items[1];
         const sortDesc = items[2];
 
@@ -507,22 +415,17 @@ describe('getColumnActions', () => {
       });
 
       it('allows disabling sort actions', () => {
-        const items = getColumnActions(
-          {
-            ...column,
+        const items = getColumnActions({
+          ...testArgs,
+          column: {
+            ...testArgs.column,
             actions: {
               showSortAsc: false,
               showSortDesc: false,
             },
           },
-          columns,
-          schema,
-          schemaDetectors,
-          setVisibleColumns,
-          setIsPopoverOpen,
-          { onSort, columns: [] },
-          switchColumnPos
-        );
+          sorting: { onSort, columns: [] },
+        });
         expect(items.length).toEqual(3);
       });
     });

--- a/src/components/datagrid/body/header/column_actions.test.tsx
+++ b/src/components/datagrid/body/header/column_actions.test.tsx
@@ -11,7 +11,11 @@ import { ReactElement } from 'react';
 import { EuiListGroupItemProps } from '../../../list_group';
 import { schemaDetectors } from '../../data_grid_schema';
 
-import { getColumnActions } from './column_actions';
+import {
+  getColumnActions,
+  isColumnActionEnabled,
+  getColumnActionConfig,
+} from './column_actions';
 
 describe('getColumnActions', () => {
   const setVisibleColumns = jest.fn();
@@ -427,6 +431,65 @@ describe('getColumnActions', () => {
           sorting: { onSort, columns: [] },
         });
         expect(items.length).toEqual(3);
+      });
+    });
+  });
+});
+
+describe('utility helpers', () => {
+  describe('isColumnActionEnabled', () => {
+    it('returns false if all actions are disabled', () => {
+      expect(isColumnActionEnabled('showHide', false)).toEqual(false);
+    });
+
+    it('returns false if the specified column action is disabled', () => {
+      expect(isColumnActionEnabled('showHide', { showHide: false })).toEqual(
+        false
+      );
+    });
+
+    it('returns true if column actions are not configured', () => {
+      expect(isColumnActionEnabled('showHide', undefined)).toEqual(true);
+    });
+
+    it('returns true if the specified column action is not configured', () => {
+      expect(isColumnActionEnabled('showHide', {})).toEqual(true);
+    });
+
+    it('returns true if the specified column action is configured', () => {
+      expect(
+        isColumnActionEnabled('showHide', { showHide: { label: 'test' } })
+      ).toEqual(true);
+    });
+  });
+
+  describe('getColumnActionConfig', () => {
+    it('appends/overrides custom action configuration to the existing action', () => {
+      expect(
+        getColumnActionConfig({ label: 'hello world' }, 'showHide', {
+          showHide: {
+            label: 'world',
+            isDisabled: true,
+          },
+        })
+      ).toEqual({
+        label: 'world',
+        isDisabled: true,
+      });
+    });
+
+    it('returns the the existing action as-is if no configuration is passed', () => {
+      expect(
+        getColumnActionConfig({ label: 'hello' }, 'showHide', false)
+      ).toEqual({
+        label: 'hello',
+      });
+      expect(
+        getColumnActionConfig({ label: 'world' }, 'showHide', {
+          showHide: false,
+        })
+      ).toEqual({
+        label: 'world',
       });
     });
   });

--- a/src/components/datagrid/body/header/column_actions.test.tsx
+++ b/src/components/datagrid/body/header/column_actions.test.tsx
@@ -1,0 +1,530 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { ReactElement } from 'react';
+
+import { EuiListGroupItemProps } from '../../../list_group';
+import { schemaDetectors } from '../../data_grid_schema';
+
+import { getColumnActions } from './column_actions';
+
+describe('getColumnActions', () => {
+  const column = { id: 'B' };
+  const columns = [{ id: 'A' }, { id: 'B' }, { id: 'C' }];
+  const schema = {};
+  const setVisibleColumns = jest.fn();
+  const setIsPopoverOpen = jest.fn();
+  const sorting = undefined;
+  const switchColumnPos = jest.fn();
+
+  // DRY test helper
+  const callActionOnClick = (action: EuiListGroupItemProps) => {
+    (action.onClick as Function)({ stopPropagation: jest.fn() });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns an array of EuiListGroup items', () => {
+    const items = getColumnActions(
+      column,
+      columns,
+      schema,
+      schemaDetectors,
+      setVisibleColumns,
+      setIsPopoverOpen,
+      sorting,
+      switchColumnPos
+    );
+    expect(items).toBeInstanceOf(Array); // We'll assert the actual contents below
+    expect(items.length).toEqual(3);
+  });
+
+  it('returns an empty array when column.actions is set to false', () => {
+    const items = getColumnActions(
+      { ...column, actions: false },
+      columns,
+      schema,
+      schemaDetectors,
+      setVisibleColumns,
+      setIsPopoverOpen,
+      sorting,
+      switchColumnPos
+    );
+    expect(items.length).toEqual(0);
+  });
+
+  it('appends additional custom columns to the end of the array', () => {
+    const items = getColumnActions(
+      {
+        ...column,
+        actions: {
+          additional: [{ label: 'Hi world!', iconType: 'alert' }],
+        },
+      },
+      columns,
+      schema,
+      schemaDetectors,
+      setVisibleColumns,
+      setIsPopoverOpen,
+      sorting,
+      switchColumnPos
+    );
+    expect(items.length).toEqual(4);
+
+    const customAction = items[3];
+    expect(customAction).toMatchInlineSnapshot(`
+      Object {
+        "iconType": "alert",
+        "label": "Hi world!",
+        "onClick": [Function],
+      }
+    `);
+    callActionOnClick(customAction);
+    // Should still close the popover, even if the custom action has no onClick
+    expect(setIsPopoverOpen).toHaveBeenCalledWith(false);
+  });
+
+  describe('hiding', () => {
+    describe('default behavior', () => {
+      const items = getColumnActions(
+        column,
+        columns,
+        schema,
+        schemaDetectors,
+        setVisibleColumns,
+        setIsPopoverOpen,
+        sorting,
+        switchColumnPos
+      );
+      const hideColumn = items[0];
+
+      it('renders a "Hide column" item first', () => {
+        expect(hideColumn).toMatchInlineSnapshot(`
+            Object {
+              "color": "text",
+              "iconType": "eyeClosed",
+              "label": <EuiI18n
+                default="Hide column"
+                token="euiColumnActions.hideColumn"
+              />,
+              "onClick": [Function],
+              "size": "xs",
+            }
+          `);
+      });
+
+      it('sets column visibility on click', () => {
+        callActionOnClick(hideColumn);
+        expect(setVisibleColumns).toHaveBeenCalledWith(['A', 'C']);
+      });
+    });
+
+    describe('custom column behavior', () => {
+      it('accepts column action overrides', () => {
+        const items = getColumnActions(
+          {
+            ...column,
+            actions: {
+              showHide: {
+                label: 'hello world',
+              },
+            },
+          },
+          columns,
+          schema,
+          schemaDetectors,
+          setVisibleColumns,
+          setIsPopoverOpen,
+          sorting,
+          switchColumnPos
+        );
+        const hideColumn = items[0];
+
+        expect(hideColumn.label).toEqual('hello world');
+      });
+
+      it('allows disabling the hide action', () => {
+        const items = getColumnActions(
+          {
+            ...column,
+            actions: {
+              showHide: false,
+            },
+          },
+          columns,
+          schema,
+          schemaDetectors,
+          setVisibleColumns,
+          setIsPopoverOpen,
+          sorting,
+          switchColumnPos
+        );
+
+        expect(items.length).toEqual(2);
+      });
+    });
+  });
+
+  describe('column reordering', () => {
+    describe('default enabled behavior', () => {
+      const items = getColumnActions(
+        column,
+        columns,
+        schema,
+        schemaDetectors,
+        setVisibleColumns,
+        setIsPopoverOpen,
+        sorting,
+        switchColumnPos
+      );
+      const moveLeft = items[1];
+      const moveRight = items[2];
+
+      it('renders a "Move left" item', () => {
+        expect(moveLeft).toMatchInlineSnapshot(`
+            Object {
+              "color": "text",
+              "iconType": "sortLeft",
+              "isDisabled": false,
+              "label": <EuiI18n
+                default="Move left"
+                token="euiColumnActions.moveLeft"
+              />,
+              "onClick": [Function],
+              "size": "xs",
+            }
+          `);
+      });
+
+      it('renders a "Move right" item', () => {
+        expect(moveRight).toMatchInlineSnapshot(`
+            Object {
+              "color": "text",
+              "iconType": "sortRight",
+              "isDisabled": false,
+              "label": <EuiI18n
+                default="Move right"
+                token="euiColumnActions.moveRight"
+              />,
+              "onClick": [Function],
+              "size": "xs",
+            }
+          `);
+      });
+
+      it('calls switchColumnPos on click', () => {
+        callActionOnClick(moveLeft);
+        expect(switchColumnPos).toHaveBeenCalledWith('B', 'A');
+
+        callActionOnClick(moveRight);
+        expect(switchColumnPos).toHaveBeenCalledWith('B', 'C');
+      });
+    });
+
+    describe('disabled behavior', () => {
+      it('renders "Move left" as disabled if already on the first/left-most column', () => {
+        const items = getColumnActions(
+          { id: 'A' },
+          columns,
+          schema,
+          schemaDetectors,
+          setVisibleColumns,
+          setIsPopoverOpen,
+          sorting,
+          switchColumnPos
+        );
+        const moveLeft = items[1];
+        expect(moveLeft.isDisabled).toEqual(true);
+
+        // Should still not error/do anything if the onClick is somehow invoked
+        callActionOnClick(moveLeft);
+        expect(switchColumnPos).not.toHaveBeenCalled();
+      });
+
+      it('renders "Move left" as disabled if already on the last/right-most column', () => {
+        const items = getColumnActions(
+          { id: 'C' },
+          columns,
+          schema,
+          schemaDetectors,
+          setVisibleColumns,
+          setIsPopoverOpen,
+          sorting,
+          switchColumnPos
+        );
+        const moveRight = items[2];
+        expect(moveRight.isDisabled).toEqual(true);
+
+        // Should still not error/do anything if the onClick is somehow invoked
+        callActionOnClick(moveRight);
+        expect(switchColumnPos).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('custom column behavior', () => {
+      it('accepts column action overrides', () => {
+        const items = getColumnActions(
+          {
+            ...column,
+            actions: {
+              showMoveLeft: {
+                label: 'hello',
+              },
+              showMoveRight: {
+                label: 'world',
+              },
+            },
+          },
+          columns,
+          schema,
+          schemaDetectors,
+          setVisibleColumns,
+          setIsPopoverOpen,
+          sorting,
+          switchColumnPos
+        );
+        const moveLeft = items[1];
+        const moveRight = items[2];
+
+        expect(moveLeft.label).toEqual('hello');
+        expect(moveRight.label).toEqual('world');
+      });
+
+      it('allows disabling show actions', () => {
+        const items = getColumnActions(
+          {
+            ...column,
+            actions: {
+              showMoveLeft: false,
+              showMoveRight: false,
+            },
+          },
+          columns,
+          schema,
+          schemaDetectors,
+          setVisibleColumns,
+          setIsPopoverOpen,
+          sorting,
+          switchColumnPos
+        );
+
+        expect(items.length).toEqual(1);
+      });
+    });
+  });
+
+  describe('sorting', () => {
+    const onSort = jest.fn();
+
+    describe('default behavior (no active sorts present)', () => {
+      const items = getColumnActions(
+        column,
+        columns,
+        schema,
+        schemaDetectors,
+        setVisibleColumns,
+        setIsPopoverOpen,
+        { onSort, columns: [] },
+        switchColumnPos
+      );
+      const sortAsc = items[1];
+      const sortDesc = items[2];
+
+      it('returns 2 more sorting EuiListGroup items when sorting is defined', () => {
+        expect(items.length).toEqual(5);
+      });
+
+      it('renders a "Sort A-Z" item', () => {
+        expect(sortAsc).toMatchInlineSnapshot(`
+          Object {
+            "className": "",
+            "color": "text",
+            "iconType": "sortUp",
+            "isDisabled": false,
+            "label": <EuiI18n
+              default="Sort {schemaLabel}"
+              token="euiColumnActions.sort"
+              values={
+                Object {
+                  "schemaLabel": <EuiI18n
+                    default="A-Z"
+                    token="euiColumnSortingDraggable.defaultSortAsc"
+                  />,
+                }
+              }
+            />,
+            "onClick": [Function],
+            "size": "xs",
+          }
+        `);
+      });
+
+      it('renders a "Sort Z-A" item', () => {
+        expect(sortDesc).toMatchInlineSnapshot(`
+          Object {
+            "className": "",
+            "color": "text",
+            "iconType": "sortDown",
+            "isDisabled": false,
+            "label": <EuiI18n
+              default="Sort {schemaLabel}"
+              token="euiColumnActions.sort"
+              values={
+                Object {
+                  "schemaLabel": <EuiI18n
+                    default="Z-A"
+                    token="euiColumnSortingDraggable.defaultSortDesc"
+                  />,
+                }
+              }
+            />,
+            "onClick": [Function],
+            "size": "xs",
+          }
+        `);
+      });
+
+      it('calls onSort on click', () => {
+        callActionOnClick(sortAsc);
+        expect(onSort).toHaveBeenCalledWith([{ direction: 'asc', id: 'B' }]);
+
+        callActionOnClick(sortDesc);
+        expect(onSort).toHaveBeenCalledWith([{ direction: 'desc', id: 'B' }]);
+      });
+    });
+
+    describe('when active sorts are present', () => {
+      describe('when current column is sorting by asc', () => {
+        const items = getColumnActions(
+          column,
+          columns,
+          schema,
+          schemaDetectors,
+          setVisibleColumns,
+          setIsPopoverOpen,
+          { onSort, columns: [{ id: 'B', direction: 'asc' }] },
+          switchColumnPos
+        );
+        const sortAsc = items[1];
+
+        it('renders sortAsc as selected', () => {
+          expect(sortAsc.className).toEqual(
+            'euiDataGridHeader__action--selected'
+          );
+        });
+
+        it('unsets the current sort if sortAsc is clicked again', () => {
+          callActionOnClick(sortAsc);
+          expect(onSort).toHaveBeenCalledWith([]);
+        });
+      });
+
+      describe('when current column is sorting by desc', () => {
+        const items = getColumnActions(
+          column,
+          columns,
+          schema,
+          schemaDetectors,
+          setVisibleColumns,
+          setIsPopoverOpen,
+          { onSort, columns: [{ id: 'B', direction: 'desc' }] },
+          switchColumnPos
+        );
+        const sortAsc = items[1];
+        const sortDesc = items[2];
+
+        it('renders sortDesc as selected', () => {
+          expect(sortDesc.className).toEqual(
+            'euiDataGridHeader__action--selected'
+          );
+        });
+
+        it('sets a new sort if the direction is changed', () => {
+          callActionOnClick(sortAsc);
+          expect(onSort).toHaveBeenCalledWith([{ id: 'B', direction: 'asc' }]);
+        });
+      });
+    });
+
+    describe('modifies the sort label based on schema', () => {
+      it('renders low-high instead of A-Z for number schema', () => {
+        const items = getColumnActions(
+          { id: 'A' },
+          columns,
+          { A: { columnType: 'numeric' } },
+          schemaDetectors,
+          setVisibleColumns,
+          setIsPopoverOpen,
+          { onSort, columns: [{ id: 'A', direction: 'desc' }] },
+          switchColumnPos
+        );
+        const sortAscLabel = items[1].label as ReactElement;
+        const sortDescLabel = items[2].label as ReactElement;
+
+        expect(sortAscLabel.props.values.schemaLabel.props.default).toEqual(
+          'Low-High'
+        );
+        expect(sortDescLabel.props.values.schemaLabel.props.default).toContain(
+          'High-Low'
+        );
+      });
+    });
+
+    describe('custom column behavior', () => {
+      it('accepts column action overrides', () => {
+        const items = getColumnActions(
+          {
+            ...column,
+            actions: {
+              showSortAsc: {
+                label: 'upsies',
+              },
+              showSortDesc: {
+                label: 'downsies',
+              },
+            },
+          },
+          columns,
+          schema,
+          schemaDetectors,
+          setVisibleColumns,
+          setIsPopoverOpen,
+          { onSort, columns: [] },
+          switchColumnPos
+        );
+        const sortAsc = items[1];
+        const sortDesc = items[2];
+
+        expect(sortAsc.label).toEqual('upsies');
+        expect(sortDesc.label).toEqual('downsies');
+      });
+
+      it('allows disabling sort actions', () => {
+        const items = getColumnActions(
+          {
+            ...column,
+            actions: {
+              showSortAsc: false,
+              showSortDesc: false,
+            },
+          },
+          columns,
+          schema,
+          schemaDetectors,
+          setVisibleColumns,
+          setIsPopoverOpen,
+          { onSort, columns: [] },
+          switchColumnPos
+        );
+        expect(items.length).toEqual(3);
+      });
+    });
+  });
+});

--- a/src/components/datagrid/body/header/column_actions.tsx
+++ b/src/components/datagrid/body/header/column_actions.tsx
@@ -5,6 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
 import React from 'react';
 import {
   EuiDataGridColumn,
@@ -218,20 +219,15 @@ export function getColumnActions(
     ? [...result, ...column.actions?.additional]
     : result;
 
-  //wrap EuiListGroupItem onClick function to close the popover and prevet bubbling up
-
-  return allActions.map((action) => {
-    return {
-      ...action,
-      ...{
-        onClick: (ev: React.MouseEvent<HTMLButtonElement>) => {
-          ev.stopPropagation();
-          setIsPopoverOpen(false);
-          if (action && action.onClick) {
-            action.onClick(ev);
-          }
-        },
-      },
-    };
-  }) as EuiListGroupItemProps[];
+  return allActions.map((action) => ({
+    ...action,
+    // Wrap EuiListGroupItem onClick function to close the popover and prevent bubbling up
+    onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation();
+      setIsPopoverOpen(false);
+      if (action?.onClick) {
+        action.onClick(e);
+      }
+    },
+  })) as EuiListGroupItemProps[];
 }

--- a/src/components/datagrid/body/header/column_actions.tsx
+++ b/src/components/datagrid/body/header/column_actions.tsx
@@ -21,16 +21,27 @@ import {
   defaultSortDescLabel,
 } from '../../column_sorting_draggable';
 
-export function getColumnActions(
-  column: EuiDataGridColumn,
-  columns: EuiDataGridColumn[],
-  schema: EuiDataGridSchema,
-  schemaDetectors: EuiDataGridSchemaDetector[],
-  setVisibleColumns: (columnId: string[]) => void,
-  setIsPopoverOpen: (value: boolean) => void,
-  sorting: EuiDataGridSorting | undefined,
-  switchColumnPos: (colFromId: string, colToId: string) => void
-) {
+interface GetColumnActions {
+  column: EuiDataGridColumn;
+  columns: EuiDataGridColumn[];
+  schema: EuiDataGridSchema;
+  schemaDetectors: EuiDataGridSchemaDetector[];
+  setVisibleColumns: (columnId: string[]) => void;
+  setIsPopoverOpen: (value: boolean) => void;
+  sorting: EuiDataGridSorting | undefined;
+  switchColumnPos: (colFromId: string, colToId: string) => void;
+}
+
+export const getColumnActions = ({
+  column,
+  columns,
+  schema,
+  schemaDetectors,
+  setVisibleColumns,
+  setIsPopoverOpen,
+  sorting,
+  switchColumnPos,
+}: GetColumnActions) => {
   if (column.actions === false) {
     return [];
   }

--- a/src/components/datagrid/body/header/data_grid_header_cell.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.tsx
@@ -255,7 +255,7 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
     setFocusedCell,
   ]);
 
-  const columnActions = getColumnActions(
+  const columnActions = getColumnActions({
     column,
     columns,
     schema,
@@ -263,8 +263,8 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
     setVisibleColumns,
     setIsPopoverOpen,
     sorting,
-    switchColumnPos
-  );
+    switchColumnPos,
+  });
 
   const showColumnActions = columnActions && columnActions.length > 0;
   const sortedColumn = sorting?.columns.find((col) => col.id === id);


### PR DESCRIPTION
### Summary

By-commit walkthrough:

1. ccae0fa - These new unit tests are technically all that's required in terms of test-writing goals. It gets close, but not quite, to 100% coverage:
    <img width="650" alt="" src="https://user-images.githubusercontent.com/549407/133358890-7298275a-b8d8-45c0-930d-39db155dfc87.png">
    The reason why I didn't stop here and ended up refactoring the file further was:

2. 1501bfd - Writing unit tests revealed several code pain points (e.g.: a long series of args vs. an object of options, the object almost always should be used) that I wanted to fix to make reading & writing the unit tests less painful 

3. d67d387 - Parsing the file and writing unit tests was relatively painful in terms of grokking the intended functionality was vs. where the code lived. I wanted the source code to better reflect the end unit test experience (i.e. separating concerns).

4. Separate functions and utilities not only makes code easier to parse (IMO), but it also leads to cleaner code and fewer unnecessary/hard-to-reach branches.
    - The reason why the first unit test could not ever reach 100% was because of this impossible-to-reach return (`sorting` is checked in an early conditional before `sortBy`, but Typescript doesn't know that and throws a bunch of undefined warnings otherwise). 
    - <img width="551" alt="" src="https://user-images.githubusercontent.com/549407/133359552-d26c9ea1-282a-4436-87a7-9c45eb8d5945.png">
    - Rewriting sort logic to its own function allows us to use an early sorting check return which then also allows us to be more deliberate in our subsequent conditional logic.
    - 15ee9ef - Utility functions allow us to unit test those functions individually, reaching other normally hard-to-reach branches and additionally serves as clear developer documentation for our expected use cases.
    - The above utility unit tests and branch cleanups thus allow us to reach 100% coverage with very little extra friction or code gymnastics:

<img width="707" alt="" src="https://user-images.githubusercontent.com/549407/133359850-f596bd97-bb49-49c9-8aac-5845ec38f55b.png">


### Checklist

- [x] Regression testing - all column header popover actions still display & work as before

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~

- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**

~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~

No changelog included as this PR consists of internal-only changes should not have a user-facing impact.