### PR TITLE
[EuiDataGrid] Fixed focus ring to be contained in cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `38.0.0`.
+**Bug fixes**
+
+- Fixed `EuiDataGrid` focus ring to be contained in cell ([#5194](https://github.com/elastic/eui/pull/5194))
+- Fixed `EuiDataGrid` cell when focused getting a higher `z-index` which was causing long content to overlap surrounding cells ([#5194](https://github.com/elastic/eui/pull/5194))
+
 
 ## [`38.0.0`](https://github.com/elastic/eui/tree/v38.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 **Bug fixes**
 
-- Fixed `EuiDataGrid` focus ring to be contained in cell ([#5194](https://github.com/elastic/eui/pull/5194))
-- Fixed `EuiDataGrid` cell when focused getting a higher `z-index` which was causing long content to overlap surrounding cells ([#5194](https://github.com/elastic/eui/pull/5194))
+- Fixed `EuiDataGrid` focus ring to be contained in the cell ([#5194](https://github.com/elastic/eui/pull/5194))
+- Fixed `EuiDataGrid` cells when focused getting a higher `z-index` which was causing long content to overlap surrounding cells ([#5194](https://github.com/elastic/eui/pull/5194))
 
 
 ## [`38.0.0`](https://github.com/elastic/eui/tree/v38.0.0)

--- a/src-docs/src/views/datagrid/datagrid_focus_example.js
+++ b/src-docs/src/views/datagrid/datagrid_focus_example.js
@@ -56,12 +56,12 @@ export const DataGridFocusExample = {
               element unless a subsequent user action changes it.
             </li>
             <li>
-              Enter or F2 can be used interchangibly to enter inner cell focus
+              Enter or F2 can be used interchangeably to enter inner cell focus
               if the logic below allows it.
             </li>
           </ul>
           <h2>
-            The content and expandability of the cells dicate the focus target
+            The content and expandability of the cells dictate the focus target
             of the cell
           </h2>
           <p>
@@ -70,14 +70,14 @@ export const DataGridFocusExample = {
             a grid with your keyboard.
           </p>
           <h3>
-            Cell alone recieves the focus, with no possible inner focus action
+            Cell alone receives the focus, with no possible inner focus action
             when:
           </h3>
           <ul>
             <li>The cell is not expandable.</li>
             <li>The cell has no interactive elements</li>
           </ul>
-          <h3>A single inner element within the cell recieves focus when:</h3>
+          <h3>A single inner element within the cell receives focus when:</h3>
           <ul>
             <li>The cell is not expandable.</li>
             <li>The cell has a single interaction element.</li>

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -30,7 +30,6 @@
 
   &:focus {
     @include euiDataGridCellFocus;
-    margin-top: -1px;
   }
 
   // Only add the transition effect on hover, so that it is instantaneous on focus
@@ -82,11 +81,6 @@
     .euiDataGridRowCell__actionButtonIcon {
       display: none;
     }
-  }
-
-  &:focus:not(:first-of-type) {
-    // Needed because the focus state adds a border, which needs to be subtracted from padding
-    padding-left: $euiDataGridCellPaddingM - 1px;
   }
 
   &.euiDataGridRowCell--numeric {

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -13,6 +13,7 @@
   position: relative;
   align-items: center;
   display: flex;
+  overflow: hidden;
 
   // Hack to allow for all the focus guard stuff
   > * {
@@ -247,11 +248,6 @@
 @include euiDataGridStyles(paddingSmall) {
   @include euiDataGridRowCell {
     padding: $euiDataGridCellPaddingS;
-
-    &:focus:not(:first-of-type) {
-      // Needed because the focus state adds a border, which needs to be subtracted from padding
-      padding-left: $euiDataGridCellPaddingS - 1px;
-    }
   }
 }
 
@@ -266,11 +262,6 @@
 @include euiDataGridStyles(paddingLarge) {
   @include euiDataGridRowCell {
     padding: $euiDataGridCellPaddingL;
-
-    &:focus:not(:first-of-type) {
-      // Needed because the focus state adds a border, which needs to be subtracted from padding
-      padding-left: $euiDataGridCellPaddingL - 1px;
-    }
   }
 }
 

--- a/src/components/datagrid/_mixins.scss
+++ b/src/components/datagrid/_mixins.scss
@@ -51,11 +51,25 @@ $euiDataGridStyles: (
 }
 
 @mixin euiDataGridCellFocus {
-  border: 1px solid transparent;
-  box-shadow: 0 0 0 2px $euiFocusRingColor;
-  border-radius: 1px;
-  z-index: 2; // Needed so it sits above potential striping in the next row
   outline: none; // Remove outline as we're handling it manually
+  overflow: hidden;
+
+  // We don't want to use a border on the focused cell directly because we want to maintain the light gray borders
+  // We can't use a box shadow or outline because it would be contained outside the cell and it would be cut by other surrounding cells
+  // So the solution is to use use a pseudo-element. It allows us to use a border, and it can be contained inside the cell by positioning it with an absolute position.
+  &::after {
+    content: '';
+    display: block;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    border: 2px solid $euiFocusRingColor;
+    border-radius: $euiBorderRadiusSmall;
+    z-index: 2; // We want this to be on top of all the content
+    pointer-events: none; // Because we put it with a higher z-index we don't want to make it clickable this way we allow selecting the content behind 
+  }
 }
 
 @mixin euiDataGridRowCell {

--- a/src/components/datagrid/_mixins.scss
+++ b/src/components/datagrid/_mixins.scss
@@ -52,7 +52,6 @@ $euiDataGridStyles: (
 
 @mixin euiDataGridCellFocus {
   outline: none; // Remove outline as we're handling it manually
-  overflow: hidden;
 
   // We don't want to use a border on the focused cell directly because we want to maintain the light gray borders
   // We can't use a box shadow or outline because it would be contained outside the cell and it would be cut by other surrounding cells

--- a/src/components/datagrid/_mixins.scss
+++ b/src/components/datagrid/_mixins.scss
@@ -64,7 +64,7 @@ $euiDataGridStyles: (
     position: absolute;
     top: 0;
     left: 0;
-    border: 2px solid $euiFocusRingColor;
+    border: $euiBorderWidthThick solid $euiFocusRingColor;
     border-radius: $euiBorderRadiusSmall;
     z-index: 2; // We want this to be on top of all the content
     pointer-events: none; // Because we put it with a higher z-index we don't want to make it clickable this way we allow selecting the content behind 


### PR DESCRIPTION
### Summary

This PR fixes the **EuiDataGrid** focus ring to be contained in the cell. It also fixes cells when focused getting a higher `z-index` which was causing long content to overlap surrounding cells.

The issue with the focus states was found on #4958. 

### Why contained focus rings?

As we can see having the focus rings outside of the cells was making them getting cut by other surrounding cells. IMO it was not looking good. 

<img width="2027" alt="data-grid-focus-ring@2x" src="https://user-images.githubusercontent.com/2750668/133603031-42d039d1-8f61-4de7-9dc8-3af32640e677.png">


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
