### PR TITLE
[EuiButtonGroup] Add `title` when in `iconOnly` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Moved `title` prop out of `textprops` to `EuiButtonDisplay` ([#5199](https://github.com/elastic/eui/pull/5199))
+- Fixed the `title` prop `EuiButtonGroup` to automatically display the `label` provided ([#5199](https://github.com/elastic/eui/pull/5199))
 - Updated `barSeriesStyle.displayValue` of the elastic-charts `Theme` for better default styles ([#4845](https://github.com/elastic/eui/pull/4845))
 - Updated `titleProps` and `descriptionProps` on `EuiDescriptionList` to extend `CommonProps` ([#5166](https://github.com/elastic/eui/pull/5166))
 - Added the ability to return `visibleOptions` from `EuiSelectable` by using `onSearch` ([#5178](https://github.com/elastic/eui/pull/5178))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Added `title` in `EuiButtonGroup` when in `iconOnly` mode ([#5199](https://github.com/elastic/eui/pull/5199))
+- Moved `title` prop out of `textprops` to `EuiButtonDisplay` ([#5199](https://github.com/elastic/eui/pull/5199))
 - Updated `barSeriesStyle.displayValue` of the elastic-charts `Theme` for better default styles ([#4845](https://github.com/elastic/eui/pull/4845))
 
 **Bug fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Added `title` in `EuiButtonGroup` when in `iconOnly` mode ([#5199](https://github.com/elastic/eui/pull/5199))
 - Updated `barSeriesStyle.displayValue` of the elastic-charts `Theme` for better default styles ([#4845](https://github.com/elastic/eui/pull/4845))
 
 **Bug fixes**

--- a/src/components/button/button_group/__snapshots__/button_group.test.tsx.snap
+++ b/src/components/button/button_group/__snapshots__/button_group.test.tsx.snap
@@ -2316,6 +2316,7 @@ exports[`EuiButtonGroup button props isIconOnly is rendered for multi 1`] = `
       class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton-isIconOnly testClass1 testClass2"
       data-test-subj="test subject string"
       id="generated-id"
+      title="Option one"
       type="button"
     >
       <span
@@ -2338,6 +2339,7 @@ exports[`EuiButtonGroup button props isIconOnly is rendered for multi 1`] = `
       class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton-isIconOnly"
       data-test-subj="button01"
       id="generated-id"
+      title="Option two"
       type="button"
     >
       <span
@@ -2361,6 +2363,7 @@ exports[`EuiButtonGroup button props isIconOnly is rendered for multi 1`] = `
       data-test-subj="button02"
       disabled=""
       id="generated-id"
+      title="Option three"
       type="submit"
     >
       <span
@@ -2399,6 +2402,7 @@ exports[`EuiButtonGroup button props isIconOnly is rendered for single 1`] = `
       class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton-isIconOnly testClass1 testClass2"
       data-test-subj="test subject string"
       for="generated-id"
+      title="Option one"
     >
       <span
         class="euiButtonContent euiButton__content"
@@ -2425,6 +2429,7 @@ exports[`EuiButtonGroup button props isIconOnly is rendered for single 1`] = `
     <label
       class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton-isIconOnly"
       for="generated-id"
+      title="Option two"
     >
       <span
         class="euiButtonContent euiButton__content"
@@ -2454,6 +2459,7 @@ exports[`EuiButtonGroup button props isIconOnly is rendered for single 1`] = `
       data-test-subj="button02"
       disabled=""
       id="generated-id"
+      title="Option three"
       type="submit"
     >
       <span

--- a/src/components/button/button_group/__snapshots__/button_group.test.tsx.snap
+++ b/src/components/button/button_group/__snapshots__/button_group.test.tsx.snap
@@ -2316,7 +2316,6 @@ exports[`EuiButtonGroup button props isIconOnly is rendered for multi 1`] = `
       class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton-isIconOnly testClass1 testClass2"
       data-test-subj="test subject string"
       id="generated-id"
-      title="Option one"
       type="button"
     >
       <span
@@ -2339,7 +2338,6 @@ exports[`EuiButtonGroup button props isIconOnly is rendered for multi 1`] = `
       class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton-isIconOnly"
       data-test-subj="button01"
       id="generated-id"
-      title="Option two"
       type="button"
     >
       <span
@@ -2363,7 +2361,6 @@ exports[`EuiButtonGroup button props isIconOnly is rendered for multi 1`] = `
       data-test-subj="button02"
       disabled=""
       id="generated-id"
-      title="Option three"
       type="submit"
     >
       <span
@@ -2402,7 +2399,6 @@ exports[`EuiButtonGroup button props isIconOnly is rendered for single 1`] = `
       class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton-isIconOnly testClass1 testClass2"
       data-test-subj="test subject string"
       for="generated-id"
-      title="Option one"
     >
       <span
         class="euiButtonContent euiButton__content"
@@ -2429,7 +2425,6 @@ exports[`EuiButtonGroup button props isIconOnly is rendered for single 1`] = `
     <label
       class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton-isIconOnly"
       for="generated-id"
-      title="Option two"
     >
       <span
         class="euiButtonContent euiButton__content"
@@ -2459,7 +2454,6 @@ exports[`EuiButtonGroup button props isIconOnly is rendered for single 1`] = `
       data-test-subj="button02"
       disabled=""
       id="generated-id"
-      title="Option three"
       type="submit"
     >
       <span

--- a/src/components/button/button_group/button_group_button.tsx
+++ b/src/components/button/button_group/button_group_button.tsx
@@ -129,6 +129,7 @@ export const EuiButtonGroupButton: FunctionComponent<Props> = ({
         'data-text': innerText,
         title: innerText,
       }}
+      title={isIconOnly ? label?.toString() : undefined}
       {...elementProps}
       {...rest}
     >

--- a/src/components/button/button_group/button_group_button.tsx
+++ b/src/components/button/button_group/button_group_button.tsx
@@ -127,9 +127,8 @@ export const EuiButtonGroupButton: FunctionComponent<Props> = ({
           : 'euiButtonGroupButton__textShift',
         ref: buttonTextRef,
         'data-text': innerText,
-        title: innerText,
       }}
-      title={isIconOnly ? label?.toString() : undefined}
+      title={innerText}
       {...elementProps}
       {...rest}
     >


### PR DESCRIPTION
### Summary

Fixes (#5180)

![CHANGE](https://user-images.githubusercontent.com/16671822/133827918-e8741852-3a69-43d5-ace7-f6488e0ca7bc.png)

### Checklist

- ~~[ ] Check against **all themes** for compatibility in both light and dark modes~~
- ~~[ ] Checked in **mobile**~~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~~
- ~~[ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~~
- ~~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~~
- ~~[] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~~
- ~~[ ] Checked for **breaking changes** and labeled appropriately~~
- ~~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
