### PR TITLE
[EuiDataGrid] Fix sorting console errors + header cell focus cleanup/refactors

### DIFF
--- a/src/components/datagrid/body/header/data_grid_header_cell_wrapper.test.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell_wrapper.test.tsx
@@ -20,7 +20,7 @@ describe('EuiDataGridHeaderCellWrapper', () => {
     id: 'someColumn',
     index: 0,
     headerIsInteractive: true,
-    children: <button data-euigrid-tab-managed="true" />,
+    children: <button />,
   };
 
   const focusContext = {
@@ -57,9 +57,7 @@ describe('EuiDataGridHeaderCellWrapper', () => {
           style={Object {}}
           tabIndex={-1}
         >
-          <button
-            data-euigrid-tab-managed="true"
-          />
+          <button />
         </div>
       </EuiDataGridHeaderCellWrapper>
     `);
@@ -85,34 +83,12 @@ describe('EuiDataGridHeaderCellWrapper', () => {
         }
         tabIndex={-1}
       >
-        <button
-          data-euigrid-tab-managed="true"
-        />
+        <button />
       </div>
     `);
   });
 
   describe('focus behavior', () => {
-    it('warns when a header cell contains multiple interactive children', () => {
-      const consoleWarnSpy = jest
-        .spyOn(console, 'warn')
-        .mockImplementationOnce(() => {}); // Silence expected warning
-
-      mountWithContext({
-        children: (
-          <div>
-            <button data-euigrid-tab-managed="true" />
-            <button data-euigrid-tab-managed="true" />
-            <button data-euigrid-tab-managed="true" />
-          </div>
-        ),
-      });
-
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        'EuiDataGridHeaderCell expects at most 1 tabbable element, 3 found instead'
-      );
-    });
-
     // Reusable assertions for DRYness
     const expectCellFocused = (headerCell: Element) => {
       expect(document.activeElement).toEqual(headerCell);
@@ -268,6 +244,44 @@ describe('EuiDataGridHeaderCellWrapper', () => {
             expect(headerCell.querySelector('[tabIndex="0"]')).toBeNull();
           });
         });
+      });
+    });
+
+    describe('multiple interactive children', () => {
+      const children = (
+        <div>
+          <button />
+          <button />
+          <button />
+        </div>
+      );
+
+      let consoleWarnSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        consoleWarnSpy = jest
+          .spyOn(console, 'warn')
+          .mockImplementation(() => {}); // Silence expected warning
+      });
+      afterEach(() => {
+        consoleWarnSpy.mockRestore();
+      });
+
+      it('emits a console warning', () => {
+        mountWithContext({ children });
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          'EuiDataGridHeaderCell expects at most 1 tabbable element, 3 found instead'
+        );
+      });
+
+      it('will still focus in to the first interactable element on cell enter', () => {
+        const headerCell = mountWithContext({ children }).getDOMNode();
+        act(() => {
+          headerCell.dispatchEvent(
+            new KeyboardEvent('keyup', { key: keys.ENTER })
+          );
+        });
+        expectCellChildrenFocused(headerCell);
       });
     });
   });

--- a/src/components/datagrid/body/header/data_grid_header_cell_wrapper.test.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell_wrapper.test.tsx
@@ -153,22 +153,6 @@ describe('EuiDataGridHeaderCellWrapper', () => {
           });
           expectCellFocused(headerCell);
         });
-
-        test('F2 key toggles between cell child focus and cell focus', () => {
-          const headerCell = mountWithContext().getDOMNode();
-          act(() => {
-            headerCell.dispatchEvent(
-              new KeyboardEvent('keyup', { key: keys.F2 })
-            );
-          });
-          expectCellFocused(headerCell);
-          act(() => {
-            headerCell.dispatchEvent(
-              new KeyboardEvent('keyup', { key: keys.F2 })
-            );
-          });
-          expectCellChildrenFocused(headerCell);
-        });
       });
 
       describe('focus', () => {

--- a/src/components/datagrid/body/header/data_grid_header_cell_wrapper.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell_wrapper.tsx
@@ -13,7 +13,6 @@ import React, {
   useEffect,
   useRef,
   useState,
-  useCallback,
 } from 'react';
 import tabbable from 'tabbable';
 import { keys } from '../../../../services';
@@ -47,37 +46,6 @@ export const EuiDataGridHeaderCellWrapper: FunctionComponent<EuiDataGridHeaderCe
   const headerRef = useRef<HTMLDivElement>(null);
   const [isCellEntered, setIsCellEntered] = useState(false);
 
-  const focusInteractives = useCallback((headerNode: Element) => {
-    const tabbables = tabbable(headerNode);
-    if (tabbables.length === 1) {
-      tabbables[0].focus();
-      setIsCellEntered(true);
-    }
-  }, []);
-
-  const enableInteractives = useCallback((headerNode: Element) => {
-    const interactiveElements = headerNode.querySelectorAll(
-      '[data-euigrid-tab-managed]'
-    );
-    for (let i = 0; i < interactiveElements.length; i++) {
-      interactiveElements[i].setAttribute('tabIndex', '0');
-    }
-  }, []);
-
-  const disableInteractives = useCallback((headerNode: Element) => {
-    const tababbles = tabbable(headerNode);
-    if (tababbles.length > 1) {
-      console.warn(
-        `EuiDataGridHeaderCell expects at most 1 tabbable element, ${tababbles.length} found instead`
-      );
-    }
-    for (let i = 0; i < tababbles.length; i++) {
-      const element = tababbles[i];
-      element.setAttribute('data-euigrid-tab-managed', 'true');
-      element.setAttribute('tabIndex', '-1');
-    }
-  }, []);
-
   useEffect(() => {
     const headerNode = headerRef.current!;
 
@@ -87,12 +55,7 @@ export const EuiDataGridHeaderCellWrapper: FunctionComponent<EuiDataGridHeaderCe
     } else {
       disableInteractives(headerNode);
     }
-  }, [
-    disableInteractives,
-    enableInteractives,
-    focusInteractives,
-    isCellEntered,
-  ]);
+  }, [isCellEntered]);
 
   useEffect(() => {
     const headerNode = headerRef.current!;
@@ -190,4 +153,38 @@ export const EuiDataGridHeaderCellWrapper: FunctionComponent<EuiDataGridHeaderCe
       {children}
     </div>
   );
+};
+
+/**
+ * Utility fns for managing child interactive tabIndex state
+ */
+
+const disableInteractives = (headerNode: Element) => {
+  const tabbables = tabbable(headerNode);
+  if (tabbables.length > 1) {
+    console.warn(
+      `EuiDataGridHeaderCell expects at most 1 tabbable element, ${tabbables.length} found instead`
+    );
+  }
+  tabbables.forEach((element) => {
+    element.setAttribute('data-euigrid-tab-managed', 'true');
+    element.setAttribute('tabIndex', '-1');
+  });
+};
+
+const enableInteractives = (headerNode: Element) => {
+  const interactiveElements = headerNode.querySelectorAll(
+    '[data-euigrid-tab-managed]'
+  );
+  interactiveElements.forEach((element) => {
+    element.setAttribute('tabIndex', '0');
+  });
+};
+
+const focusInteractives = (headerNode: Element) => {
+  const tabbables = tabbable(headerNode);
+
+  if (tabbables.length === 1) {
+    tabbables[0].focus();
+  }
 };

--- a/src/components/datagrid/body/header/data_grid_header_cell_wrapper.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell_wrapper.tsx
@@ -114,18 +114,6 @@ export const EuiDataGridHeaderCellWrapper: FunctionComponent<EuiDataGridHeaderCe
           headerNode.focus();
           break;
         }
-        case keys.F2: {
-          event.preventDefault();
-          if (document.activeElement === headerNode) {
-            // move focus into cell's interactives
-            setIsCellEntered(true);
-          } else {
-            // move focus to cell
-            setIsCellEntered(false);
-            headerNode.focus();
-          }
-          break;
-        }
       }
     };
 

--- a/src/components/datagrid/body/header/data_grid_header_cell_wrapper.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell_wrapper.tsx
@@ -50,8 +50,7 @@ export const EuiDataGridHeaderCellWrapper: FunctionComponent<EuiDataGridHeaderCe
     const headerNode = headerRef.current!;
 
     if (isCellEntered) {
-      enableInteractives(headerNode);
-      focusInteractives(headerNode);
+      enableAndFocusInteractives(headerNode);
     } else {
       disableInteractives(headerNode);
     }
@@ -172,19 +171,14 @@ const disableInteractives = (headerNode: Element) => {
   });
 };
 
-const enableInteractives = (headerNode: Element) => {
+const enableAndFocusInteractives = (headerNode: Element) => {
   const interactiveElements = headerNode.querySelectorAll(
     '[data-euigrid-tab-managed]'
   );
-  interactiveElements.forEach((element) => {
+  interactiveElements.forEach((element, i) => {
     element.setAttribute('tabIndex', '0');
+    if (i === 0) {
+      (element as HTMLElement).focus();
+    }
   });
-};
-
-const focusInteractives = (headerNode: Element) => {
-  const tabbables = tabbable(headerNode);
-
-  if (tabbables.length === 1) {
-    tabbables[0].focus();
-  }
 };

--- a/src/components/datagrid/body/header/data_grid_header_cell_wrapper.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell_wrapper.tsx
@@ -122,10 +122,8 @@ export const EuiDataGridHeaderCellWrapper: FunctionComponent<EuiDataGridHeaderCe
         if (isFocused === false) {
           setFocusedCell([index, -1]);
         } else {
-          // this cell already had the grid's focus, so re-enable interactives
-          enableInteractives(headerNode);
-          // shift focus to the interactive element
-          focusInteractives(headerNode);
+          // this cell already had the grid's focus, so re-enable and focus interactives
+          setIsCellEntered(true);
         }
       }
     }

--- a/src/components/datagrid/body/header/data_grid_header_cell_wrapper.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell_wrapper.tsx
@@ -73,7 +73,7 @@ export const EuiDataGridHeaderCellWrapper: FunctionComponent<EuiDataGridHeaderCe
     }
 
     // focusin bubbles while focus does not, and this needs to react to children gaining focus
-    function onFocusIn(e: FocusEvent) {
+    const onFocusIn = (e: FocusEvent) => {
       if (!headerIsInteractive) {
         // header is not interactive, avoid focusing
         requestAnimationFrame(() => headerNode.blur());
@@ -88,19 +88,19 @@ export const EuiDataGridHeaderCellWrapper: FunctionComponent<EuiDataGridHeaderCe
           setIsCellEntered(true);
         }
       }
-    }
+    };
 
     // focusout bubbles while blur does not, and this needs to react to the children losing focus
-    function onFocusOut() {
+    const onFocusOut = () => {
       // wait for the next element to receive focus, then update interactives' state
       requestAnimationFrame(() => {
         if (!headerNode.contains(document.activeElement)) {
           setIsCellEntered(false);
         }
       });
-    }
+    };
 
-    function onKeyUp(event: KeyboardEvent) {
+    const onKeyUp = (event: KeyboardEvent) => {
       switch (event.key) {
         case keys.ENTER: {
           event.preventDefault();
@@ -116,7 +116,7 @@ export const EuiDataGridHeaderCellWrapper: FunctionComponent<EuiDataGridHeaderCe
         }
         case keys.F2: {
           event.preventDefault();
-          if (document.activeElement === headerRef.current) {
+          if (document.activeElement === headerNode) {
             // move focus into cell's interactives
             setIsCellEntered(true);
           } else {
@@ -127,7 +127,7 @@ export const EuiDataGridHeaderCellWrapper: FunctionComponent<EuiDataGridHeaderCe
           break;
         }
       }
-    }
+    };
 
     headerNode.addEventListener('focusin', onFocusIn);
     headerNode.addEventListener('focusout', onFocusOut);

--- a/src/components/datagrid/body/header/data_grid_header_cell_wrapper.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell_wrapper.tsx
@@ -175,15 +175,7 @@ export const EuiDataGridHeaderCellWrapper: FunctionComponent<EuiDataGridHeaderCe
       headerNode.removeEventListener('focusout', onFocusOut);
       headerNode.removeEventListener('keyup', onKeyUp);
     };
-  }, [
-    enableInteractives,
-    focusInteractives,
-    headerIsInteractive,
-    isFocused,
-    setIsCellEntered,
-    index,
-    setFocusedCell,
-  ]);
+  }, [headerIsInteractive, isFocused, index, setFocusedCell]);
 
   return (
     <div

--- a/src/components/datagrid/column_selector.tsx
+++ b/src/components/datagrid/column_selector.tsx
@@ -94,13 +94,15 @@ export const useDataGridColumnSelector = (
     source: { index: sourceIndex },
     destination,
   }: DropResult) {
-    const destinationIndex = destination!.index;
-    const nextSortedColumns = euiDragDropReorder(
-      sortedColumns,
-      sourceIndex,
-      destinationIndex
-    );
-    setColumns(nextSortedColumns);
+    if (destination) {
+      const destinationIndex = destination.index;
+      const nextSortedColumns = euiDragDropReorder(
+        sortedColumns,
+        sourceIndex,
+        destinationIndex
+      );
+      setColumns(nextSortedColumns);
+    }
   }
 
   const numberOfHiddenFields = availableColumns.length - visibleColumns.length;


### PR DESCRIPTION
### Summary

This PR contains 2 console error fixes, a functionality removal that was already not working on master, several cleanup/refactors of the EuiHeaderGridCellWrapper focus code (that I noticed and wanted to work on while debugging/fixing the above bugs), and several unit test improvements. I strongly recommend following along by commit.

- Console error fixes
  - 6be8f53
    - I noticed that when dragging a column outside the popover, a `destination is null` error appears in the console:
    - ![destinationnull](https://user-images.githubusercontent.com/549407/134387881-c113b837-6e20-4523-8c15-42be1e17f2c4.gif)
    - This commit adds a simple object existence check to ensure it's not null.
  - ac5e058
    - closes #4384
    - Currently in Safari, clicking on a header cell and then opening the Columns popover and attemping to drag/drop reorder the clicked header cell causes a focus lock:
    - <img width="1416" alt="" src="https://user-images.githubusercontent.com/549407/134386859-68a6bf3c-064e-46a2-8833-907b307413f1.png">
    - This happens because the focusin/focusout events are firing repeatedly on the moved headercell, triggering focus events on the header cell and causing a fight between the cell and the reorder popover.
    - Removing the manual `focusInteractives()` call and instead relying on `setIsCellEntered(true)` removes this lock/fight, because the state change does not repeatedly call itself
    - TBH, It's possible that this `isFocused` conditional branch isn't even needed with current header cell behavior, but this is a pretty simple fix, so Im leaving it as is
- Functionality removal
  - 405b1c0
    - I chatted with @chandlerprall earlier to confirm that F2 keyboard event behavior is not working on master, and it makes sense that it isn't. We agreed that the logic for it can be removed, since we treat the header cell itself as the widget, which means there isn't a discernible focus state between cell focus or widget focus.
    - We also console warn when header control cells (which can contain any children) contain more than one interactable element.
- Refactors
  - The remaining commits deal with several cleanups (mostly moving and combining code / unit tests) and is easier to follow along by commit.

## QA

- [ ] In the Columns popover, confirm that dragging and dropping a column outside the popover does not generate a console error
- [ ] In the Safari browser, confirm that clicking a header cell and then opening the Columns popover and trying to drag/drop the clicked header cell does not create a stack call console error

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~ (toolbar doesn't appear on mobile)

- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~

- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**

~- [ ] Checked for **breaking changes** and labeled appropriately~

- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
