### PR TITLE
[EuiSuperSelect] Add popoverProps prop 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Updated `EuiRangeLevel` `color` property to accept CSS color values ([#5171](https://github.com/elastic/eui/pull/5171))
-- Deprecated  `EuiSuperSelect`'s `popoverClassName` & `repositionOnScroll` props in favor of a single `popoverProps` configuration object ([#5214](https://github.com/elastic/eui/pull/5214))
+- Added `popoverProps` to `EuiSuperSelect` and deprecated `popoverClassName` & `repositionOnScroll` ([#5214](https://github.com/elastic/eui/pull/5214))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Updated `EuiRangeLevel` `color` property to accept CSS color values ([#5171](https://github.com/elastic/eui/pull/5171))
-- Deprecated  `EuiSuperSelect`'s `popoverClassName`, `isOpen`, & `repositionOnScroll` props in favor of a single `popoverProps` configuration object ([#5214](https://github.com/elastic/eui/pull/5214))
+- Deprecated  `EuiSuperSelect`'s `popoverClassName` & `repositionOnScroll` props in favor of a single `popoverProps` configuration object ([#5214](https://github.com/elastic/eui/pull/5214))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
+- Added `popoverPanelClassName` prop to `EuiSuperSelect` ([#5214](https://github.com/elastic/eui/pull/5214))
+
 **Bug fixes**
 
 - Fixed logo icons with static SVG IDs causing accessibility errors when multiples of the same logo were present ([#5204](https://github.com/elastic/eui/pull/5204))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-- Added `popoverPanelClassName` prop to `EuiSuperSelect` ([#5214](https://github.com/elastic/eui/pull/5214))
+- Deprecated  `EuiSuperSelect`'s `popoverClassName`, `isOpen`, & `repositionOnScroll` props in favor of a single `popoverProps` configuration object ([#5214](https://github.com/elastic/eui/pull/5214))
 
 **Bug fixes**
 

--- a/src-docs/src/views/super_select/super_select_complex.js
+++ b/src-docs/src/views/super_select/super_select_complex.js
@@ -55,12 +55,24 @@ export default () => {
   };
 
   return (
-    <EuiSuperSelect
-      options={options}
-      valueOfSelected={value}
-      onChange={(value) => onChange(value)}
-      itemLayoutAlign="top"
-      hasDividers
-    />
+    <>
+      <style>
+        {`.wrapper {
+          width: 150px;
+        }
+        .dropdown {
+          width: 450px !important;
+        }`}
+      </style>
+      <EuiSuperSelect
+        options={options}
+        valueOfSelected={value}
+        onChange={(value) => onChange(value)}
+        itemLayoutAlign="top"
+        hasDividers
+        popoverClassName="wrapper"
+        popoverPanelClassName="dropdown"
+      />
+    </>
   );
 };

--- a/src-docs/src/views/super_select/super_select_complex.js
+++ b/src-docs/src/views/super_select/super_select_complex.js
@@ -55,26 +55,12 @@ export default () => {
   };
 
   return (
-    <>
-      <style>
-        {`.wrapper {
-          width: 150px;
-        }
-        .dropdown {
-          width: 450px !important;
-        }`}
-      </style>
-      <EuiSuperSelect
-        options={options}
-        valueOfSelected={value}
-        onChange={(value) => onChange(value)}
-        itemLayoutAlign="top"
-        hasDividers
-        popoverProps={{
-          className: 'wrapper',
-          panelClassName: 'dropdown',
-        }}
-      />
-    </>
+    <EuiSuperSelect
+      options={options}
+      valueOfSelected={value}
+      onChange={(value) => onChange(value)}
+      itemLayoutAlign="top"
+      hasDividers
+    />
   );
 };

--- a/src-docs/src/views/super_select/super_select_complex.js
+++ b/src-docs/src/views/super_select/super_select_complex.js
@@ -70,8 +70,10 @@ export default () => {
         onChange={(value) => onChange(value)}
         itemLayoutAlign="top"
         hasDividers
-        popoverClassName="wrapper"
-        popoverPanelClassName="dropdown"
+        popoverProps={{
+          className: 'wrapper',
+          panelClassName: 'dropdown',
+        }}
       />
     </>
   );

--- a/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
@@ -736,7 +736,7 @@ exports[`EuiSuperSelect props renders popoverProps on the underlying EuiPopover 
   <EuiInputPopover
     anchorPosition="downLeft"
     attachToAnchor={true}
-    className="euiSuperSelect goes-on-popover-panel"
+    className="euiSuperSelect goes-on-outermost-wrapper"
     closePopover={[Function]}
     display="block"
     fullWidth={false}
@@ -780,7 +780,7 @@ exports[`EuiSuperSelect props renders popoverProps on the underlying EuiPopover 
         </EuiResizeObserver>
       }
       buttonRef={[Function]}
-      className="euiInputPopover euiSuperSelect goes-on-popover-panel"
+      className="euiInputPopover euiSuperSelect goes-on-outermost-wrapper"
       closePopover={[Function]}
       display="block"
       hasArrow={true}
@@ -795,7 +795,7 @@ exports[`EuiSuperSelect props renders popoverProps on the underlying EuiPopover 
         onOutsideClick={[Function]}
       >
         <div
-          className="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiSuperSelect goes-on-popover-panel"
+          className="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiSuperSelect goes-on-outermost-wrapper"
           onKeyDown={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}

--- a/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
@@ -703,7 +703,7 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
 </div>
 `;
 
-exports[`EuiSuperSelect props popoverClassName and popoverPanelClassName render 1`] = `
+exports[`EuiSuperSelect props renders popoverProps on the underlying EuiPopover 1`] = `
 <EuiSuperSelect
   compressed={false}
   fullWidth={false}
@@ -723,14 +723,20 @@ exports[`EuiSuperSelect props popoverClassName and popoverPanelClassName render 
       },
     ]
   }
-  popoverClassName="goes-on-outermost-wrapper"
-  popoverPanelClassName="goes-on-popover-panel"
+  popoverProps={
+    Object {
+      "className": "goes-on-outermost-wrapper",
+      "isOpen": false,
+      "panelClassName": "goes-on-popover-panel",
+      "repositionOnScroll": true,
+    }
+  }
   valueOfSelected="2"
 >
   <EuiInputPopover
     anchorPosition="downLeft"
     attachToAnchor={true}
-    className="euiSuperSelect goes-on-outermost-wrapper"
+    className="euiSuperSelect goes-on-popover-panel"
     closePopover={[Function]}
     display="block"
     fullWidth={false}
@@ -761,6 +767,7 @@ exports[`EuiSuperSelect props popoverClassName and popoverPanelClassName render 
     isOpen={false}
     panelClassName="goes-on-popover-panel"
     panelPaddingSize="none"
+    repositionOnScroll={true}
   >
     <EuiPopover
       anchorPosition="downLeft"
@@ -773,7 +780,7 @@ exports[`EuiSuperSelect props popoverClassName and popoverPanelClassName render 
         </EuiResizeObserver>
       }
       buttonRef={[Function]}
-      className="euiInputPopover euiSuperSelect goes-on-outermost-wrapper"
+      className="euiInputPopover euiSuperSelect goes-on-popover-panel"
       closePopover={[Function]}
       display="block"
       hasArrow={true}
@@ -782,12 +789,13 @@ exports[`EuiSuperSelect props popoverClassName and popoverPanelClassName render 
       panelClassName="goes-on-popover-panel"
       panelPaddingSize="none"
       panelRef={[Function]}
+      repositionOnScroll={true}
     >
       <EuiOutsideClickDetector
         onOutsideClick={[Function]}
       >
         <div
-          className="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiSuperSelect goes-on-outermost-wrapper"
+          className="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiSuperSelect goes-on-popover-panel"
           onKeyDown={[Function]}
           onMouseDown={[Function]}
           onMouseUp={[Function]}

--- a/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
@@ -726,7 +726,6 @@ exports[`EuiSuperSelect props renders popoverProps on the underlying EuiPopover 
   popoverProps={
     Object {
       "className": "goes-on-outermost-wrapper",
-      "isOpen": false,
       "panelClassName": "goes-on-popover-panel",
       "repositionOnScroll": true,
     }

--- a/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
@@ -703,6 +703,226 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
 </div>
 `;
 
+exports[`EuiSuperSelect props popoverClassName and popoverPanelClassName render 1`] = `
+<EuiSuperSelect
+  compressed={false}
+  fullWidth={false}
+  hasDividers={false}
+  isInvalid={false}
+  isLoading={false}
+  onChange={[Function]}
+  options={
+    Array [
+      Object {
+        "inputDisplay": "Option #1",
+        "value": "1",
+      },
+      Object {
+        "inputDisplay": "Option #2",
+        "value": "2",
+      },
+    ]
+  }
+  popoverClassName="goes-on-outermost-wrapper"
+  popoverPanelClassName="goes-on-popover-panel"
+  valueOfSelected="2"
+>
+  <EuiInputPopover
+    anchorPosition="downLeft"
+    attachToAnchor={true}
+    className="euiSuperSelect goes-on-outermost-wrapper"
+    closePopover={[Function]}
+    display="block"
+    fullWidth={false}
+    input={
+      <EuiSuperSelectControl
+        className=""
+        compressed={false}
+        fullWidth={false}
+        isInvalid={false}
+        isLoading={false}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        options={
+          Array [
+            Object {
+              "inputDisplay": "Option #1",
+              "value": "1",
+            },
+            Object {
+              "inputDisplay": "Option #2",
+              "value": "2",
+            },
+          ]
+        }
+        value="2"
+      />
+    }
+    isOpen={false}
+    panelClassName="goes-on-popover-panel"
+    panelPaddingSize="none"
+  >
+    <EuiPopover
+      anchorPosition="downLeft"
+      attachToAnchor={true}
+      button={
+        <EuiResizeObserver
+          onResize={[Function]}
+        >
+          [Function]
+        </EuiResizeObserver>
+      }
+      buttonRef={[Function]}
+      className="euiInputPopover euiSuperSelect goes-on-outermost-wrapper"
+      closePopover={[Function]}
+      display="block"
+      hasArrow={true}
+      isOpen={false}
+      ownFocus={false}
+      panelClassName="goes-on-popover-panel"
+      panelPaddingSize="none"
+      panelRef={[Function]}
+    >
+      <EuiOutsideClickDetector
+        onOutsideClick={[Function]}
+      >
+        <div
+          className="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiSuperSelect goes-on-outermost-wrapper"
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchStart={[Function]}
+        >
+          <div
+            className="euiPopover__anchor"
+          >
+            <EuiResizeObserver
+              onResize={[Function]}
+            >
+              <div>
+                <EuiSuperSelectControl
+                  className=""
+                  compressed={false}
+                  fullWidth={false}
+                  isInvalid={false}
+                  isLoading={false}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  options={
+                    Array [
+                      Object {
+                        "inputDisplay": "Option #1",
+                        "value": "1",
+                      },
+                      Object {
+                        "inputDisplay": "Option #2",
+                        "value": "2",
+                      },
+                    ]
+                  }
+                  value="2"
+                >
+                  <input
+                    type="hidden"
+                    value="2"
+                  />
+                  <EuiFormControlLayout
+                    compressed={false}
+                    fullWidth={false}
+                    icon={
+                      Object {
+                        "side": "right",
+                        "type": "arrowDown",
+                      }
+                    }
+                    isLoading={false}
+                  >
+                    <div
+                      className="euiFormControlLayout"
+                    >
+                      <div
+                        className="euiFormControlLayout__childrenWrapper"
+                      >
+                        <EuiScreenReaderOnly>
+                          <span
+                            className="euiScreenReaderOnly"
+                            id="generated-id"
+                          >
+                            <EuiI18n
+                              default="Select an option: {selectedValue}, is selected"
+                              token="euiSuperSelectControl.selectAnOption"
+                              values={
+                                Object {
+                                  "selectedValue": "Option #2",
+                                }
+                              }
+                            >
+                              Select an option: Option #2, is selected
+                            </EuiI18n>
+                          </span>
+                        </EuiScreenReaderOnly>
+                        <button
+                          aria-haspopup="true"
+                          aria-labelledby="generated-id"
+                          className="euiSuperSelectControl"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          type="button"
+                        >
+                          Option #2
+                        </button>
+                        <EuiFormControlLayoutIcons
+                          compressed={false}
+                          icon={
+                            Object {
+                              "side": "right",
+                              "type": "arrowDown",
+                            }
+                          }
+                          isLoading={false}
+                        >
+                          <div
+                            className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                          >
+                            <EuiFormControlLayoutCustomIcon
+                              size="m"
+                              type="arrowDown"
+                            >
+                              <span
+                                className="euiFormControlLayoutCustomIcon"
+                              >
+                                <EuiIcon
+                                  aria-hidden="true"
+                                  className="euiFormControlLayoutCustomIcon__icon"
+                                  size="m"
+                                  type="arrowDown"
+                                >
+                                  <span
+                                    aria-hidden="true"
+                                    className="euiFormControlLayoutCustomIcon__icon"
+                                    data-euiicon-type="arrowDown"
+                                    size="m"
+                                  />
+                                </EuiIcon>
+                              </span>
+                            </EuiFormControlLayoutCustomIcon>
+                          </div>
+                        </EuiFormControlLayoutIcons>
+                      </div>
+                    </div>
+                  </EuiFormControlLayout>
+                </EuiSuperSelectControl>
+              </div>
+            </EuiResizeObserver>
+          </div>
+        </div>
+      </EuiOutsideClickDetector>
+    </EuiPopover>
+  </EuiInputPopover>
+</EuiSuperSelect>
+`;
+
 exports[`EuiSuperSelect props select component is rendered 1`] = `
 <div
   class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiSuperSelect"

--- a/src/components/form/super_select/super_select.test.tsx
+++ b/src/components/form/super_select/super_select.test.tsx
@@ -161,5 +161,19 @@ describe('EuiSuperSelect', () => {
 
       expect(takeMountedSnapshot(component)).toMatchSnapshot();
     });
+
+    test('popoverClassName and popoverPanelClassName render', () => {
+      const component = mount(
+        <EuiSuperSelect
+          options={options}
+          valueOfSelected="2"
+          onChange={() => {}}
+          popoverClassName="goes-on-outermost-wrapper"
+          popoverPanelClassName="goes-on-popover-panel"
+        />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
   });
 });

--- a/src/components/form/super_select/super_select.test.tsx
+++ b/src/components/form/super_select/super_select.test.tsx
@@ -172,7 +172,6 @@ describe('EuiSuperSelect', () => {
             className: 'goes-on-outermost-wrapper',
             panelClassName: 'goes-on-popover-panel',
             repositionOnScroll: true,
-            isOpen: false,
           }}
         />
       );

--- a/src/components/form/super_select/super_select.test.tsx
+++ b/src/components/form/super_select/super_select.test.tsx
@@ -162,14 +162,18 @@ describe('EuiSuperSelect', () => {
       expect(takeMountedSnapshot(component)).toMatchSnapshot();
     });
 
-    test('popoverClassName and popoverPanelClassName render', () => {
+    test('renders popoverProps on the underlying EuiPopover', () => {
       const component = mount(
         <EuiSuperSelect
           options={options}
           valueOfSelected="2"
           onChange={() => {}}
-          popoverClassName="goes-on-outermost-wrapper"
-          popoverPanelClassName="goes-on-popover-panel"
+          popoverProps={{
+            className: 'goes-on-outermost-wrapper',
+            panelClassName: 'goes-on-popover-panel',
+            repositionOnScroll: true,
+            isOpen: false,
+          }}
         />
       );
 

--- a/src/components/form/super_select/super_select.tsx
+++ b/src/components/form/super_select/super_select.tsx
@@ -277,7 +277,7 @@ export class EuiSuperSelect<T extends string> extends Component<
 
     const popoverClasses = classNames(
       'euiSuperSelect',
-      popoverProps?.panelClassName ?? popoverClassName
+      popoverProps?.className ?? popoverClassName
     );
 
     const buttonClasses = classNames(

--- a/src/components/form/super_select/super_select.tsx
+++ b/src/components/form/super_select/super_select.tsx
@@ -17,7 +17,7 @@ import {
   EuiSuperSelectControlProps,
   EuiSuperSelectOption,
 } from './super_select_control';
-import { EuiInputPopover } from '../../popover';
+import { EuiInputPopover, EuiPopoverProps } from '../../popover';
 import {
   EuiContextMenuItem,
   EuiContextMenuItemLayoutAlignment,
@@ -64,30 +64,35 @@ export type EuiSuperSelectProps<T extends string> = CommonProps &
     hasDividers?: boolean;
 
     /**
+     * Props to pass to the underlying EuiPopover. Allows fine-grained control
+     * of the popover dropdown menu, including `isOpen` state, `repositionOnScroll`
+     * for EuiSuperSelects used within scrollable containers, and customizing
+     * popover panel styling.
+     */
+    popoverProps?: Partial<CommonProps & EuiPopoverProps>;
+
+    /**
      * Change `EuiContextMenuItem` layout position of icon
      */
     itemLayoutAlign?: EuiContextMenuItemLayoutAlignment;
 
     /**
      * Applied to the outermost wrapper (popover)
+     * **DEPRECATED: Use `popoverProps.className` instead. `popoverProps.className` will take precedence over `popoverClassName` if set.**
      */
     popoverClassName?: string;
 
     /**
-     * Applied to the popover panel
-     */
-    popoverPanelClassName?: string;
-
-    /**
      * Controls whether the options are shown. Default: false
+     * **DEPRECATED: Use `popoverProps.isOpen` instead. `popoverProps.isOpen` will take precedence over `isOpen` if set.**
      */
     isOpen?: boolean;
 
     /**
      * When `true`, the popover's position is re-calculated when the user
-     * scrolls, this supports having fixed-position popover anchors. This value is passed
-     * to the EuiInputPopover component. When nesting an `EuiSuperSelect` in a scrollable container,
+     * scrolls. When nesting an `EuiSuperSelect` in a scrollable container,
      * `repositionOnScroll` should be `true`
+     * **DEPRECATED: Use `popoverProps.repositionOnScroll` instead. `popoverProps.repositionOnScroll` will take precedence over `repositionOnScroll` if set.**
      */
     repositionOnScroll?: boolean;
   };
@@ -264,13 +269,16 @@ export class EuiSuperSelect<T extends string> extends Component<
       itemLayoutAlign,
       fullWidth,
       popoverClassName,
-      popoverPanelClassName,
+      popoverProps,
       compressed,
       repositionOnScroll,
       ...rest
     } = this.props;
 
-    const popoverClasses = classNames('euiSuperSelect', popoverClassName);
+    const popoverClasses = classNames(
+      'euiSuperSelect',
+      popoverProps?.panelClassName ?? popoverClassName
+    );
 
     const buttonClasses = classNames(
       {
@@ -327,14 +335,14 @@ export class EuiSuperSelect<T extends string> extends Component<
 
     return (
       <EuiInputPopover
-        className={popoverClasses}
-        panelClassName={popoverPanelClassName}
-        input={button}
         isOpen={isOpen || this.state.isPopoverOpen}
         closePopover={this.closePopover}
         panelPaddingSize="none"
-        fullWidth={fullWidth}
         repositionOnScroll={repositionOnScroll}
+        {...popoverProps}
+        className={popoverClasses}
+        input={button}
+        fullWidth={fullWidth}
       >
         <EuiScreenReaderOnly>
           <p role="alert">

--- a/src/components/form/super_select/super_select.tsx
+++ b/src/components/form/super_select/super_select.tsx
@@ -74,6 +74,11 @@ export type EuiSuperSelectProps<T extends string> = CommonProps &
     popoverClassName?: string;
 
     /**
+     * Applied to the popover panel
+     */
+    popoverPanelClassName?: string;
+
+    /**
      * Controls whether the options are shown. Default: false
      */
     isOpen?: boolean;
@@ -259,6 +264,7 @@ export class EuiSuperSelect<T extends string> extends Component<
       itemLayoutAlign,
       fullWidth,
       popoverClassName,
+      popoverPanelClassName,
       compressed,
       repositionOnScroll,
       ...rest
@@ -322,6 +328,7 @@ export class EuiSuperSelect<T extends string> extends Component<
     return (
       <EuiInputPopover
         className={popoverClasses}
+        panelClassName={popoverPanelClassName}
         input={button}
         isOpen={isOpen || this.state.isPopoverOpen}
         closePopover={this.closePopover}

--- a/src/components/form/super_select/super_select.tsx
+++ b/src/components/form/super_select/super_select.tsx
@@ -64,27 +64,29 @@ export type EuiSuperSelectProps<T extends string> = CommonProps &
     hasDividers?: boolean;
 
     /**
-     * Props to pass to the underlying EuiPopover. Allows fine-grained control
-     * of the popover dropdown menu, including `isOpen` state, `repositionOnScroll`
-     * for EuiSuperSelects used within scrollable containers, and customizing
-     * popover panel styling.
-     */
-    popoverProps?: Partial<CommonProps & EuiPopoverProps>;
-
-    /**
      * Change `EuiContextMenuItem` layout position of icon
      */
     itemLayoutAlign?: EuiContextMenuItemLayoutAlignment;
 
     /**
+     * Props to pass to the underlying [EuiPopover](/#/layout/popover). Allows
+     * fine-grained control of the popover dropdown menu, including `isOpen` state,
+     * `repositionOnScroll` for EuiSuperSelects used within scrollable containers,
+     * and customizing popover panel styling.
+     */
+    popoverProps?: Partial<CommonProps & EuiPopoverProps>;
+
+    /**
      * Applied to the outermost wrapper (popover)
-     * **DEPRECATED: Use `popoverProps.className` instead. `popoverProps.className` will take precedence over `popoverClassName` if set.**
+     *
+     * **DEPRECATED: Use `popoverProps.className` instead (will take precedence over this prop if set).**
      */
     popoverClassName?: string;
 
     /**
      * Controls whether the options are shown. Default: false
-     * **DEPRECATED: Use `popoverProps.isOpen` instead. `popoverProps.isOpen` will take precedence over `isOpen` if set.**
+     *
+     * **DEPRECATED: Use `popoverProps.isOpen` instead (will take precedence over this prop if set).**
      */
     isOpen?: boolean;
 
@@ -92,7 +94,8 @@ export type EuiSuperSelectProps<T extends string> = CommonProps &
      * When `true`, the popover's position is re-calculated when the user
      * scrolls. When nesting an `EuiSuperSelect` in a scrollable container,
      * `repositionOnScroll` should be `true`
-     * **DEPRECATED: Use `popoverProps.repositionOnScroll` instead. `popoverProps.repositionOnScroll` will take precedence over `repositionOnScroll` if set.**
+     *
+     * **DEPRECATED: Use `popoverProps.repositionOnScroll` instead (will take precedence over this prop if set).**
      */
     repositionOnScroll?: boolean;
   };

--- a/src/components/form/super_select/super_select.tsx
+++ b/src/components/form/super_select/super_select.tsx
@@ -69,12 +69,20 @@ export type EuiSuperSelectProps<T extends string> = CommonProps &
     itemLayoutAlign?: EuiContextMenuItemLayoutAlignment;
 
     /**
-     * Props to pass to the underlying [EuiPopover](/#/layout/popover). Allows
-     * fine-grained control of the popover dropdown menu, including `isOpen` state,
+     * Controls whether the options are shown. Default: false
+     */
+    isOpen?: boolean;
+
+    /**
+     * Optional props to pass to the underlying [EuiPopover](/#/layout/popover).
+     *  Allows fine-grained control of the popover dropdown menu, including
      * `repositionOnScroll` for EuiSuperSelects used within scrollable containers,
      * and customizing popover panel styling.
+     *
+     * Does not accept a nested `popoverProps.isOpen` property - use the top level
+     * `isOpen` API instead.
      */
-    popoverProps?: Partial<CommonProps & EuiPopoverProps>;
+    popoverProps?: Partial<CommonProps & Omit<EuiPopoverProps, 'isOpen'>>;
 
     /**
      * Applied to the outermost wrapper (popover)
@@ -82,13 +90,6 @@ export type EuiSuperSelectProps<T extends string> = CommonProps &
      * **DEPRECATED: Use `popoverProps.className` instead (will take precedence over this prop if set).**
      */
     popoverClassName?: string;
-
-    /**
-     * Controls whether the options are shown. Default: false
-     *
-     * **DEPRECATED: Use `popoverProps.isOpen` instead (will take precedence over this prop if set).**
-     */
-    isOpen?: boolean;
 
     /**
      * When `true`, the popover's position is re-calculated when the user
@@ -338,12 +339,12 @@ export class EuiSuperSelect<T extends string> extends Component<
 
     return (
       <EuiInputPopover
-        isOpen={isOpen || this.state.isPopoverOpen}
         closePopover={this.closePopover}
         panelPaddingSize="none"
         repositionOnScroll={repositionOnScroll}
         {...popoverProps}
         className={popoverClasses}
+        isOpen={isOpen || this.state.isPopoverOpen}
         input={button}
         fullWidth={fullWidth}
       >


### PR DESCRIPTION
### Summary

While discussing EuiSuperSelect with @scottybollinger, we realized that there isn't a className prop that developers can pass to the actual portalled EuiPopover panel generated by EuiSuperSelect. `popoverClassName` feels like it should, but actually passes it to the un-portalled wrapping class (instead of to `.euiPopover__panel`).

This PR solves that by adding a new `popoverProps` config object to EuiSuperSelect, which passes down almost every prop that EuiPopover would normally take (except for `isOpen`, which we still want to remain as a top-level API). Users can now simply pass `popoverProps={{ className: 'wrapper', panelClassName: 'foo' }}` (plus any other popover styling props desired).

<img width="933" alt="" src="https://user-images.githubusercontent.com/549407/134979226-93293dfc-aa9b-457f-8d10-bfce0fe959cb.png">

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~

- [x] Props have proper **autodocs** ~and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~ (no existing playground for EuiSuperSelect)

~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~ I didn't add extra documentation since there wasn't any for `popoverClassName`

- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**

~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
- [x] Revert eb406ac 