### PR TITLE
[EuiScreenReaderOnly] Revert left positioning change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Fixed logo icons with static SVG IDs causing accessibility errors when multiples of the same logo were present ([#5204](https://github.com/elastic/eui/pull/5204))
 
+**Reverts**
+
+- Reverted `EuiScreenReaderOnly` left positioning change due to Selenium issues ([#5215](https://github.com/elastic/eui/pull/5215))
+
 ## [`38.1.0`](https://github.com/elastic/eui/tree/v38.1.0)
 
 - Fixed the `title` prop `EuiButtonGroup` to automatically display the `label` provided ([#5199](https://github.com/elastic/eui/pull/5199))

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -4,6 +4,10 @@
   &[target='_blank'] {
     // Make the screen reader only text positioned relatively against the link itself
     position: relative;
+
+    .euiScreenReaderOnly {
+      left: 0;
+    }
   }
 
   .euiLink__externalIcon {

--- a/src/global_styling/mixins/_helpers.scss
+++ b/src/global_styling/mixins/_helpers.scss
@@ -112,8 +112,8 @@
   position: absolute;
   // Keep it vertically inline
   top: auto;
-  // Chrome requires a left value
-  left: 0;
+  // Chrome requires a left value, and Selenium (used by Kibana's FTR) requires an off-screen position for its .getVisibleText() to not register SR-only text
+  left: -10000px;
   // The element must have a size (for some screen readers)
   width: 1px;
   height: 1px;


### PR DESCRIPTION
## Summary

We changed `.euiScreenReaderOnly` to `left: 0` in #5152, specifically [here](https://github.com/elastic/eui/commit/5833109a7129f65185ecb7cc238e4320da51d9d5#diff-21df3b63568ade74e435fc702dc637d3e7cb68431f01f24456d496fdc48fa201L114-R116).

Unfortunately, this change caused Kibana's FTR Selenium `.getVisibleText()` to include screen reader text when it previously did not:

<img width="355" alt="" src="https://user-images.githubusercontent.com/549407/134608626-0aa17260-3e3c-4950-bf3e-0628fc8a99ec.png">

<img width="600" alt="" src="https://user-images.githubusercontent.com/549407/134608544-9ebc8f5d-165d-4aac-8367-173f66c976b0.png">

These functional test failures can be viewed in our Kibana upgrade PR: https://github.com/elastic/kibana/pull/112462

### Why revert?

1. I strongly think it will be significantly faster and less dev time/effort to backport this reversion to a new `38.0.1` release and update our Kibana upgrade to point at that release.
2. It's extremely confusing from a Kibana dev POV to assert on/expect visually hidden text.
3. I don't think the change to `left: 0` is important. It only affects Safari on VO visually and it has no impact on actual screen reader functionality. I don't think that small visual nice-to-have is worth the developer time being spent right now on fixing Kibana tests/delaying the upgrade.

## QA

- Check out this branch
- `yarn build-pack`
- Follow the [wiki instructions for pointing local Kibana at the built tgz](https://github.com/elastic/eui/blob/master/wiki/component-development.md#in-kibana)
- Once your Kibana has been bootstrapped with the built tgz, run from Kibana root:
```sh
node scripts/functional_tests --config x-pack/test/functional/config.js --grep='Elasticsearch overview mb'
```
- Confirm this test passes (it's currently failing on Kibana CI)

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~

- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
