### PR TITLE
[EuiTour] Style and a11y fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
-No public interface changes since `38.2.0`.
+- Added `maxWidth` prop to `EuiTour`, made `subtitle` optional, and fixed heading levels and footer background ([#5225](https://github.com/elastic/eui/pull/5225))
+
+**Breaking changes**
+
+- Removed `boolean` from `EuiTour`'s `minWidth` type ([#5225](https://github.com/elastic/eui/pull/5225))
 
 ## [`38.2.0`](https://github.com/elastic/eui/tree/v38.2.0)
 

--- a/src-docs/src/views/tour/step.js
+++ b/src-docs/src/views/tour/step.js
@@ -23,7 +23,7 @@ export default () => {
         step={1}
         stepsTotal={1}
         title="Title of the current step"
-        subtitle="Title of the full tour"
+        subtitle="Title of the full tour (optional)"
         anchorPosition="rightUp"
       >
         <EuiText>

--- a/src/components/tour/__snapshots__/tour_step.test.tsx.snap
+++ b/src/components/tour/__snapshots__/tour_step.test.tsx.snap
@@ -16,9 +16,9 @@ exports[`EuiTourStep can be closed 1`] = `
 </div>
 `;
 
-exports[`EuiTourStep can have subtitle 1`] = `
+exports[`EuiTourStep can change the minWidth and maxWidth 1`] = `
 <div
-  class="euiPopover euiPopover--anchorLeftUp"
+  class="euiPopover euiPopover--anchorLeftUp euiPopover-isOpen"
   data-test-subj="test subject string"
   offset="10"
 >
@@ -29,12 +29,195 @@ exports[`EuiTourStep can have subtitle 1`] = `
       Test
     </span>
   </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="-1"
+  />
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="-1"
+  />
+  <div
+    data-focus-lock-disabled="disabled"
+  >
+    <div
+      aria-label="aria-label"
+      aria-labelledby="generated-id"
+      aria-live="assertive"
+      aria-modal="true"
+      class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--left euiPopover__panel-isOpen euiTour testClass1 testClass2"
+      role="dialog"
+      style="top: -22px; left: -26px; will-change: transform, opacity; max-width: 420px; min-width: 240px; z-index: 2000;"
+    >
+      <div
+        class="euiPopover__panelArrow euiPopover__panelArrow--left"
+        style="left: 0px; top: 10px;"
+      >
+        <div
+          class="euiBeacon euiTour__beacon"
+          style="height: 12px; width: 12px;"
+        />
+      </div>
+      <div>
+        <div
+          class="euiPopoverTitle euiTourHeader"
+          id="generated-id"
+        >
+          <h2
+            class="euiTitle euiTitle--xxsmall euiTourHeader__title"
+          >
+            A demo
+          </h2>
+        </div>
+        <div
+          class="euiTour__content"
+        >
+          You are here
+        </div>
+        <div
+          class="euiPopoverFooter euiTourFooter"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow"
+          >
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <button
+                class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                type="button"
+              >
+                <span
+                  class="euiButtonContent euiButtonEmpty__content"
+                >
+                  <span
+                    class="euiButtonEmpty__text"
+                  >
+                    Close tour
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="-1"
+  />
+</div>
+`;
+
+exports[`EuiTourStep can have subtitle 1`] = `
+<div
+  class="euiPopover euiPopover--anchorLeftUp euiPopover-isOpen"
+  data-test-subj="test subject string"
+  offset="10"
+>
+  <div
+    class="euiPopover__anchor"
+  >
+    <span>
+      Test
+    </span>
+  </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="-1"
+  />
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="-1"
+  />
+  <div
+    data-focus-lock-disabled="disabled"
+  >
+    <div
+      aria-label="aria-label"
+      aria-labelledby="generated-id"
+      aria-live="assertive"
+      aria-modal="true"
+      class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--left euiPopover__panel-isOpen euiTour testClass1 testClass2"
+      role="dialog"
+      style="top: -22px; left: -26px; will-change: transform, opacity; max-width: 600px; min-width: 300px; z-index: 2000;"
+    >
+      <div
+        class="euiPopover__panelArrow euiPopover__panelArrow--left"
+        style="left: 0px; top: 10px;"
+      >
+        <div
+          class="euiBeacon euiTour__beacon"
+          style="height: 12px; width: 12px;"
+        />
+      </div>
+      <div>
+        <div
+          class="euiPopoverTitle euiTourHeader"
+          id="generated-id"
+        >
+          <h2
+            class="euiTitle euiTitle--xxxsmall euiTourHeader__subtitle"
+          >
+            Subtitle
+          </h2>
+          <h3
+            class="euiTitle euiTitle--xxsmall euiTourHeader__title"
+          >
+            A demo
+          </h3>
+        </div>
+        <div
+          class="euiTour__content"
+        >
+          You are here
+        </div>
+        <div
+          class="euiPopoverFooter euiTourFooter"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow"
+          >
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <button
+                class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                type="button"
+              >
+                <span
+                  class="euiButtonContent euiButtonEmpty__content"
+                >
+                  <span
+                    class="euiButtonEmpty__text"
+                  >
+                    Close tour
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="-1"
+  />
 </div>
 `;
 
 exports[`EuiTourStep can override the footer action 1`] = `
 <div
-  class="euiPopover euiPopover--anchorLeftUp"
+  class="euiPopover euiPopover--anchorLeftUp euiPopover-isOpen"
   data-test-subj="test subject string"
   offset="10"
 >
@@ -45,28 +228,82 @@ exports[`EuiTourStep can override the footer action 1`] = `
       Test
     </span>
   </div>
-</div>
-`;
-
-exports[`EuiTourStep can set a minWidth and maxWidth 1`] = `
-<div
-  class="euiPopover euiPopover--anchorLeftUp"
-  data-test-subj="test subject string"
-  offset="10"
->
   <div
-    class="euiPopover__anchor"
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="-1"
+  />
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="-1"
+  />
+  <div
+    data-focus-lock-disabled="disabled"
   >
-    <span>
-      Test
-    </span>
+    <div
+      aria-label="aria-label"
+      aria-labelledby="generated-id"
+      aria-live="assertive"
+      aria-modal="true"
+      class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--left euiPopover__panel-isOpen euiTour testClass1 testClass2"
+      role="dialog"
+      style="top: -22px; left: -26px; will-change: transform, opacity; max-width: 600px; min-width: 300px; z-index: 2000;"
+    >
+      <div
+        class="euiPopover__panelArrow euiPopover__panelArrow--left"
+        style="left: 0px; top: 10px;"
+      >
+        <div
+          class="euiBeacon euiTour__beacon"
+          style="height: 12px; width: 12px;"
+        />
+      </div>
+      <div>
+        <div
+          class="euiPopoverTitle euiTourHeader"
+          id="generated-id"
+        >
+          <h2
+            class="euiTitle euiTitle--xxsmall euiTourHeader__title"
+          >
+            A demo
+          </h2>
+        </div>
+        <div
+          class="euiTour__content"
+        >
+          You are here
+        </div>
+        <div
+          class="euiPopoverFooter euiTourFooter"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow"
+          >
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <button>
+                Test
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="-1"
+  />
 </div>
 `;
 
 exports[`EuiTourStep can turn off the beacon 1`] = `
 <div
-  class="euiPopover euiPopover--anchorLeftUp"
+  class="euiPopover euiPopover--anchorLeftUp euiPopover-isOpen"
   data-test-subj="test subject string"
   offset="0"
 >
@@ -77,12 +314,88 @@ exports[`EuiTourStep can turn off the beacon 1`] = `
       Test
     </span>
   </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="-1"
+  />
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="-1"
+  />
+  <div
+    data-focus-lock-disabled="disabled"
+  >
+    <div
+      aria-label="aria-label"
+      aria-labelledby="generated-id"
+      aria-live="assertive"
+      aria-modal="true"
+      class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--left euiPopover__panel-isOpen euiTour testClass1 testClass2"
+      role="dialog"
+      style="top: -22px; left: -16px; will-change: transform, opacity; max-width: 600px; min-width: 300px; z-index: 2000;"
+    >
+      <div
+        class="euiPopover__panelArrow euiPopover__panelArrow--left"
+        style="left: 0px; top: 10px;"
+      />
+      <div>
+        <div
+          class="euiPopoverTitle euiTourHeader"
+          id="generated-id"
+        >
+          <h2
+            class="euiTitle euiTitle--xxsmall euiTourHeader__title"
+          >
+            A demo
+          </h2>
+        </div>
+        <div
+          class="euiTour__content"
+        >
+          You are here
+        </div>
+        <div
+          class="euiPopoverFooter euiTourFooter"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow"
+          >
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <button
+                class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                type="button"
+              >
+                <span
+                  class="euiButtonContent euiButtonEmpty__content"
+                >
+                  <span
+                    class="euiButtonEmpty__text"
+                  >
+                    Close tour
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="-1"
+  />
 </div>
 `;
 
 exports[`EuiTourStep is rendered 1`] = `
 <div
-  class="euiPopover euiPopover--anchorLeftUp"
+  class="euiPopover euiPopover--anchorLeftUp euiPopover-isOpen"
   data-test-subj="test subject string"
   offset="10"
 >
@@ -93,5 +406,86 @@ exports[`EuiTourStep is rendered 1`] = `
       Test
     </span>
   </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="-1"
+  />
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="-1"
+  />
+  <div
+    data-focus-lock-disabled="disabled"
+  >
+    <div
+      aria-label="aria-label"
+      aria-labelledby="generated-id"
+      aria-live="assertive"
+      aria-modal="true"
+      class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--left euiPopover__panel-isOpen euiTour testClass1 testClass2"
+      role="dialog"
+      style="top: -22px; left: -26px; will-change: transform, opacity; max-width: 600px; min-width: 300px; z-index: 2000;"
+    >
+      <div
+        class="euiPopover__panelArrow euiPopover__panelArrow--left"
+        style="left: 0px; top: 10px;"
+      >
+        <div
+          class="euiBeacon euiTour__beacon"
+          style="height: 12px; width: 12px;"
+        />
+      </div>
+      <div>
+        <div
+          class="euiPopoverTitle euiTourHeader"
+          id="generated-id"
+        >
+          <h2
+            class="euiTitle euiTitle--xxsmall euiTourHeader__title"
+          >
+            A demo
+          </h2>
+        </div>
+        <div
+          class="euiTour__content"
+        >
+          You are here
+        </div>
+        <div
+          class="euiPopoverFooter euiTourFooter"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow"
+          >
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <button
+                class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                type="button"
+              >
+                <span
+                  class="euiButtonContent euiButtonEmpty__content"
+                >
+                  <span
+                    class="euiButtonEmpty__text"
+                  >
+                    Close tour
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="-1"
+  />
 </div>
 `;

--- a/src/components/tour/__snapshots__/tour_step.test.tsx.snap
+++ b/src/components/tour/__snapshots__/tour_step.test.tsx.snap
@@ -16,6 +16,22 @@ exports[`EuiTourStep can be closed 1`] = `
 </div>
 `;
 
+exports[`EuiTourStep can have subtitle 1`] = `
+<div
+  class="euiPopover euiPopover--anchorLeftUp"
+  data-test-subj="test subject string"
+  offset="10"
+>
+  <div
+    class="euiPopover__anchor"
+  >
+    <span>
+      Test
+    </span>
+  </div>
+</div>
+`;
+
 exports[`EuiTourStep can override the footer action 1`] = `
 <div
   class="euiPopover euiPopover--anchorLeftUp"

--- a/src/components/tour/__snapshots__/tour_step.test.tsx.snap
+++ b/src/components/tour/__snapshots__/tour_step.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`EuiTourStep can override the footer action 1`] = `
 </div>
 `;
 
-exports[`EuiTourStep can set a minWidth 1`] = `
+exports[`EuiTourStep can set a minWidth and maxWidth 1`] = `
 <div
   class="euiPopover euiPopover--anchorLeftUp"
   data-test-subj="test subject string"

--- a/src/components/tour/_tour.scss
+++ b/src/components/tour/_tour.scss
@@ -6,21 +6,15 @@
   border-bottom: none;
   // Overriding default `EuiPopoverTitle` styles
   margin-bottom: $euiSizeS !important; // sass-lint:disable-line no-important
-
-
-  .euiTourHeader__title { // nested for additional specificity to override EuiTitle styles
-    margin-top: 0;
-  }
 }
 
 .euiTourHeader__subtitle {
-  color: $euiColorDarkShade;
+  color: $euiTextSubduedColor;
 }
 
 .euiTourFooter {
-  background-color: $euiColorLightestShade;
-  // Overriding default `EuiPopoverFooter` styles
-  margin-top: $euiSizeL !important; // sass-lint:disable-line no-important
+  background-color: $euiPageBackgroundColor;
+  border-radius: 0 0 $euiBorderRadius $euiBorderRadius;
 }
 
 .euiTour {

--- a/src/components/tour/_tour.scss
+++ b/src/components/tour/_tour.scss
@@ -1,11 +1,12 @@
-.euiTour--minWidth-default {
-  min-width: $euiSizeL * 10;
-}
-
 .euiTourHeader {
   border-bottom: none;
   // Overriding default `EuiPopoverTitle` styles
   margin-bottom: $euiSizeS !important; // sass-lint:disable-line no-important
+
+  .euiTourHeader__title { // nested for additional specificity to override EuiTitle styles
+    // Removes extra margin applied to siblint EuiTitle's
+    margin-top: 0;
+  }
 }
 
 .euiTourHeader__subtitle {

--- a/src/components/tour/tour_step.test.tsx
+++ b/src/components/tour/tour_step.test.tsx
@@ -67,9 +67,15 @@ describe('EuiTourStep', () => {
     expect(component).toMatchSnapshot();
   });
 
-  test('can set a minWidth', () => {
+  test('can set a minWidth and maxWidth', () => {
     const component = render(
-      <EuiTourStep {...config} {...steps[0]} minWidth={240} {...requiredProps}>
+      <EuiTourStep
+        {...config}
+        {...steps[0]}
+        minWidth={240}
+        maxWidth={420}
+        {...requiredProps}
+      >
         <span>Test</span>
       </EuiTourStep>
     );

--- a/src/components/tour/tour_step.test.tsx
+++ b/src/components/tour/tour_step.test.tsx
@@ -15,7 +15,6 @@ import { EuiTourStep } from './tour_step';
 const steps = [
   {
     step: 1,
-    subtitle: 'Step 1',
     content: 'You are here',
   },
 ];
@@ -30,6 +29,22 @@ describe('EuiTourStep', () => {
   test('is rendered', () => {
     const component = render(
       <EuiTourStep {...config} {...steps[0]} {...requiredProps}>
+        <span>Test</span>
+      </EuiTourStep>
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
+  test('can have subtitle', () => {
+    const component = render(
+      <EuiTourStep
+        {...config}
+        {...steps[0]}
+        subtitle="Subtitle"
+        isStepOpen={false}
+        {...requiredProps}
+      >
         <span>Test</span>
       </EuiTourStep>
     );

--- a/src/components/tour/tour_step.test.tsx
+++ b/src/components/tour/tour_step.test.tsx
@@ -7,10 +7,14 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { mount } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
 
 import { EuiTourStep } from './tour_step';
+
+jest.mock('../portal', () => ({
+  EuiPortal: ({ children }: any) => children,
+}));
 
 const steps = [
   {
@@ -27,33 +31,33 @@ const config = {
 
 describe('EuiTourStep', () => {
   test('is rendered', () => {
-    const component = render(
-      <EuiTourStep {...config} {...steps[0]} {...requiredProps}>
+    const component = mount(
+      <EuiTourStep {...config} {...steps[0]} isStepOpen {...requiredProps}>
         <span>Test</span>
       </EuiTourStep>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(component.render()).toMatchSnapshot();
   });
 
   test('can have subtitle', () => {
-    const component = render(
+    const component = mount(
       <EuiTourStep
         {...config}
         {...steps[0]}
+        isStepOpen
         subtitle="Subtitle"
-        isStepOpen={false}
         {...requiredProps}
       >
         <span>Test</span>
       </EuiTourStep>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(component.render()).toMatchSnapshot();
   });
 
   test('can be closed', () => {
-    const component = render(
+    const component = mount(
       <EuiTourStep
         {...config}
         {...steps[0]}
@@ -64,30 +68,32 @@ describe('EuiTourStep', () => {
       </EuiTourStep>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(component.render()).toMatchSnapshot();
   });
 
-  test('can set a minWidth and maxWidth', () => {
-    const component = render(
+  test('can change the minWidth and maxWidth', () => {
+    const component = mount(
       <EuiTourStep
         {...config}
         {...steps[0]}
         minWidth={240}
         maxWidth={420}
+        isStepOpen
         {...requiredProps}
       >
         <span>Test</span>
       </EuiTourStep>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(component.render()).toMatchSnapshot();
   });
 
   test('can override the footer action', () => {
-    const component = render(
+    const component = mount(
       <EuiTourStep
         {...config}
         {...steps[0]}
+        isStepOpen
         footerAction={<button onClick={() => {}}>Test</button>}
         {...requiredProps}
       >
@@ -95,14 +101,15 @@ describe('EuiTourStep', () => {
       </EuiTourStep>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(component.render()).toMatchSnapshot();
   });
 
   test('can turn off the beacon', () => {
-    const component = render(
+    const component = mount(
       <EuiTourStep
         {...config}
         {...steps[0]}
+        isStepOpen
         decoration="none"
         {...requiredProps}
       >
@@ -110,6 +117,6 @@ describe('EuiTourStep', () => {
       </EuiTourStep>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(component.render()).toMatchSnapshot();
   });
 });

--- a/src/components/tour/tour_step.tsx
+++ b/src/components/tour/tour_step.tsx
@@ -55,7 +55,7 @@ export interface EuiTourStepProps
   isStepOpen?: boolean;
 
   /**
-   * Change the default max width of the popover panel
+   * Change the default min width of the popover panel
    */
   minWidth?: CSSProperties['maxWidth'];
 

--- a/src/components/tour/tour_step.tsx
+++ b/src/components/tour/tour_step.tsx
@@ -86,7 +86,7 @@ export interface EuiTourStepProps
   /**
    * Smaller title text that appears atop each step in the tour. The subtitle gets wrapped in the appropriate heading level.
    */
-  subtitle: ReactNode;
+  subtitle?: ReactNode;
 
   /**
    * Larger title text specific to this step. The title gets wrapped in the appropriate heading level.
@@ -215,9 +215,11 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
       {...rest}
     >
       <EuiPopoverTitle className="euiTourHeader" id={titleId}>
-        <EuiTitle size="xxxs" className="euiTourHeader__subtitle">
-          <h1>{subtitle}</h1>
-        </EuiTitle>
+        {subtitle && (
+          <EuiTitle size="xxxs" className="euiTourHeader__subtitle">
+            <h1>{subtitle}</h1>
+          </EuiTitle>
+        )}
         <EuiTitle size="xxs" className="euiTourHeader__title">
           <h2>{title}</h2>
         </EuiTitle>

--- a/src/components/tour/tour_step.tsx
+++ b/src/components/tour/tour_step.tsx
@@ -212,11 +212,11 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
       <EuiPopoverTitle className="euiTourHeader" id={titleId}>
         {subtitle && (
           <EuiTitle size="xxxs" className="euiTourHeader__subtitle">
-            <h1>{subtitle}</h1>
+            <h2>{subtitle}</h2>
           </EuiTitle>
         )}
         <EuiTitle size="xxs" className="euiTourHeader__title">
-          <h2>{title}</h2>
+          <h3>{title}</h3>
         </EuiTitle>
       </EuiPopoverTitle>
       <div className="euiTour__content">{content}</div>

--- a/src/components/tour/tour_step.tsx
+++ b/src/components/tour/tour_step.tsx
@@ -57,7 +57,7 @@ export interface EuiTourStepProps
   /**
    * Change the default min width of the popover panel
    */
-  minWidth?: CSSProperties['maxWidth'];
+  minWidth?: CSSProperties['minWidth'];
 
   /**
    * Change the default max width of the popover panel
@@ -216,7 +216,7 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
           </EuiTitle>
         )}
         <EuiTitle size="xxs" className="euiTourHeader__title">
-          <h3>{title}</h3>
+          {subtitle ? <h3>{title}</h3> : <h2>{title}</h2>}
         </EuiTitle>
       </EuiPopoverTitle>
       <div className="euiTour__content">{content}</div>

--- a/src/components/tour/tour_step.tsx
+++ b/src/components/tour/tour_step.tsx
@@ -55,13 +55,14 @@ export interface EuiTourStepProps
   isStepOpen?: boolean;
 
   /**
-   * Sets the min-width of the tour popover,
-   * set to `true` to use the default size,
-   * set to `false` to not restrict the width,
-   * set to a number for a custom width in px,
-   * set to a string for a custom width in custom measurement.
+   * Change the default max width of the popover panel
    */
-  minWidth?: boolean | number | string;
+  minWidth?: CSSProperties['maxWidth'];
+
+  /**
+   * Change the default max width of the popover panel
+   */
+  maxWidth?: CSSProperties['maxWidth'];
 
   /**
    * Function to call for 'Skip tour' and 'End tour' actions
@@ -111,7 +112,8 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
   closePopover = () => {},
   content,
   isStepOpen = false,
-  minWidth = true,
+  minWidth = 300,
+  maxWidth = 600,
   onFinish,
   step = 1,
   stepsTotal,
@@ -128,17 +130,10 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
       'EuiTourStep `step` should 1-based indexing. Please update to eliminate 0 indexes.'
     );
   }
-  let newStyle;
 
-  let widthClassName;
-  if (minWidth === true) {
-    widthClassName = 'euiTour--minWidth-default';
-  } else if (minWidth !== false) {
-    const value = typeof minWidth === 'number' ? `${minWidth}px` : minWidth;
-    newStyle = { ...style, minWidth: value };
-  }
+  const newStyle: CSSProperties = { ...style, maxWidth, minWidth };
 
-  const classes = classNames('euiTour', widthClassName, className);
+  const classes = classNames('euiTour', className);
 
   const finishButtonProps: EuiButtonEmptyProps = {
     color: 'text',
@@ -208,7 +203,7 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
       isOpen={isStepOpen}
       ownFocus={false}
       panelClassName={classes}
-      panelStyle={newStyle || style}
+      panelStyle={newStyle}
       offset={hasBeacon ? 10 : 0}
       aria-labelledby={titleId}
       arrowChildren={hasBeacon && <EuiBeacon className="euiTour__beacon" />}


### PR DESCRIPTION
### Closes #5112 and closes #4843

## Made `subtitle` optional

I ran into this where I wanted to use the EuiTour component more to indicate to users changes in the UI, so it wasn't more than a single step. Requiring **two** titles and body content was quite excessive. So I just made `subtitle` optional.

## Fixed the `footer` background from extending beyond the popover bounds

**Before**
<img width="396" alt="Screen Shot 2021-09-29 at 17 10 35 PM" src="https://user-images.githubusercontent.com/549577/135349409-ed8d1491-64ae-4417-a922-26b52a6b0b18.png">

**After**
<img width="394" alt="Screen Shot 2021-09-29 at 17 10 26 PM" src="https://user-images.githubusercontent.com/549577/135349425-e2bf42d6-607f-4d75-9f8b-50bbba0cd65c.png">

## 🔔 [Breaking] Changed how `minWidth` was applied and added `maxWidth`

Before, it was accepting a boolean, number or string and doing some className workarounds for the default of `true`. I noticed that this wasn't actually working (the default minWidth class was never getting applied) and so I just changed the type to `CSSProperties['minWidth']` set the default to `300` and passed it along to `panelStyle`.

I also then added a similar thing for `maxWidth`.

## Lowered the heading levels

They started at `<h1>`, but as per the guidance in #4843 , they should start at `h2`.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
