### PR TITLE
Changed color utility functions to maintain color format supplied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`master`](https://github.com/elastic/eui/tree/master)
 
 - Added `maxWidth` prop to `EuiTour`, made `subtitle` optional, and fixed heading levels and footer background ([#5225](https://github.com/elastic/eui/pull/5225))
+- Updated `tint`, `shade`, `saturate`, `desaturate`, and `makeHighContrastColor` utility functions to maintain color format supplied ([#5230](https://github.com/elastic/eui/pull/5230))
 
 **Breaking changes**
 

--- a/src-docs/src/views/color/color_example.js
+++ b/src-docs/src/views/color/color_example.js
@@ -45,7 +45,8 @@ export const ColorExample = {
         <EuiLink to="https://gka.github.io/chroma.js">chroma.js</EuiLink> for
         calculations. This means that most functions accept most Chroma{' '}
         <EuiLink to="https://gka.github.io/chroma.js/#chroma">Color</EuiLink>{' '}
-        types.
+        types. They will all attempt to maintain the color format that was
+        passed in.
       </p>
     </EuiText>
   ),

--- a/src-docs/src/views/color/contrast_body.js
+++ b/src-docs/src/views/color/contrast_body.js
@@ -28,6 +28,7 @@ export default () => {
                 title={color}
                 css={css`
                   padding: ${euiTheme.size.base};
+                  background: ${euiTheme.colors.body};
                   border-radius: ${euiTheme.border.radius.small};
                   border: ${euiTheme.border.thin};
                   color: ${color};

--- a/src/services/color/contrast.ts
+++ b/src/services/color/contrast.ts
@@ -76,7 +76,7 @@ Background: ${background}`
     }
   }
 
-  return highContrastTextColor;
+  return chroma(highContrastTextColor).hex();
 };
 
 /**

--- a/src/services/color/manipulation.ts
+++ b/src/services/color/manipulation.ts
@@ -22,7 +22,7 @@ export const transparentize = (color: string, alpha: number) =>
  * @param ratio - Mix weight. From 0-1. Larger value indicates more white.
  */
 export const tint = (color: string, ratio: number) =>
-  chroma.mix(color, '#fff', ratio, 'rgb').css();
+  chroma.mix(color, '#fff', ratio, 'rgb').hex();
 
 /**
  * Mixes a provided color with black.
@@ -30,7 +30,7 @@ export const tint = (color: string, ratio: number) =>
  * @param ratio - Mix weight. From 0-1. Larger value indicates more black.
  */
 export const shade = (color: string, ratio: number) =>
-  chroma.mix(color, '#000', ratio, 'rgb').css();
+  chroma.mix(color, '#000', ratio, 'rgb').hex();
 
 /**
  * Increases the saturation of a color by manipulating the hsl saturation.
@@ -38,7 +38,7 @@ export const shade = (color: string, ratio: number) =>
  * @param amount - Amount to change in absolute terms. 0-1.
  */
 export const saturate = (color: string, amount: number) =>
-  chroma(color).set('hsl.s', `+${amount}`).css();
+  chroma(color).set('hsl.s', `+${amount}`).hex();
 
 /**
  * Decreases the saturation of a color by manipulating the hsl saturation.
@@ -46,7 +46,7 @@ export const saturate = (color: string, amount: number) =>
  * @param amount - Amount to change in absolute terms. 0-1.
  */
 export const desaturate = (color: string, amount: number) =>
-  chroma(color).set('hsl.s', `-${amount}`).css();
+  chroma(color).set('hsl.s', `-${amount}`).hex();
 
 /**
  * Returns the lightness value of a color. 0-100

--- a/src/services/color/manipulation.ts
+++ b/src/services/color/manipulation.ts
@@ -7,6 +7,7 @@
  */
 
 import chroma from 'chroma-js';
+import { isValidHex } from './is_valid_hex';
 
 /**
  * Makes a color more transparent.
@@ -21,32 +22,44 @@ export const transparentize = (color: string, alpha: number) =>
  * @param color - Color to mix with white
  * @param ratio - Mix weight. From 0-1. Larger value indicates more white.
  */
-export const tint = (color: string, ratio: number) =>
-  chroma.mix(color, '#fff', ratio, 'rgb').hex();
+export const tint = (color: string, ratio: number) => {
+  const isHex = isValidHex(color);
+  const tint = chroma.mix(color, '#fff', ratio, 'rgb');
+  return isHex ? tint.hex() : tint.css();
+};
 
 /**
  * Mixes a provided color with black.
  * @param color - Color to mix with black
  * @param ratio - Mix weight. From 0-1. Larger value indicates more black.
  */
-export const shade = (color: string, ratio: number) =>
-  chroma.mix(color, '#000', ratio, 'rgb').hex();
+export const shade = (color: string, ratio: number) => {
+  const isHex = isValidHex(color);
+  const shade = chroma.mix(color, '#000', ratio, 'rgb');
+  return isHex ? shade.hex() : shade.css();
+};
 
 /**
  * Increases the saturation of a color by manipulating the hsl saturation.
  * @param color - Color to manipulate
  * @param amount - Amount to change in absolute terms. 0-1.
  */
-export const saturate = (color: string, amount: number) =>
-  chroma(color).set('hsl.s', `+${amount}`).hex();
+export const saturate = (color: string, amount: number) => {
+  const isHex = isValidHex(color);
+  const saturate = chroma(color).set('hsl.s', `+${amount}`);
+  return isHex ? saturate.hex() : saturate.css();
+};
 
 /**
  * Decreases the saturation of a color by manipulating the hsl saturation.
  * @param color - Color to manipulate
  * @param amount - Amount to change in absolute terms. 0-1.
  */
-export const desaturate = (color: string, amount: number) =>
-  chroma(color).set('hsl.s', `-${amount}`).hex();
+export const desaturate = (color: string, amount: number) => {
+  const isHex = isValidHex(color);
+  const desaturate = chroma(color).set('hsl.s', `-${amount}`);
+  return isHex ? desaturate.hex() : desaturate.css();
+};
 
 /**
  * Returns the lightness value of a color. 0-100

--- a/src/services/color/manipulation.ts
+++ b/src/services/color/manipulation.ts
@@ -6,8 +6,12 @@
  * Side Public License, v 1.
  */
 
-import chroma from 'chroma-js';
+import chroma, { Color } from 'chroma-js';
 import { isValidHex } from './is_valid_hex';
+
+const inOriginalFormat = (originalColor: string, newColor: Color) => {
+  return isValidHex(originalColor) ? newColor.hex() : newColor.css();
+};
 
 /**
  * Makes a color more transparent.
@@ -23,9 +27,8 @@ export const transparentize = (color: string, alpha: number) =>
  * @param ratio - Mix weight. From 0-1. Larger value indicates more white.
  */
 export const tint = (color: string, ratio: number) => {
-  const isHex = isValidHex(color);
   const tint = chroma.mix(color, '#fff', ratio, 'rgb');
-  return isHex ? tint.hex() : tint.css();
+  return inOriginalFormat(color, tint);
 };
 
 /**
@@ -34,9 +37,8 @@ export const tint = (color: string, ratio: number) => {
  * @param ratio - Mix weight. From 0-1. Larger value indicates more black.
  */
 export const shade = (color: string, ratio: number) => {
-  const isHex = isValidHex(color);
   const shade = chroma.mix(color, '#000', ratio, 'rgb');
-  return isHex ? shade.hex() : shade.css();
+  return inOriginalFormat(color, shade);
 };
 
 /**
@@ -45,9 +47,8 @@ export const shade = (color: string, ratio: number) => {
  * @param amount - Amount to change in absolute terms. 0-1.
  */
 export const saturate = (color: string, amount: number) => {
-  const isHex = isValidHex(color);
   const saturate = chroma(color).set('hsl.s', `+${amount}`);
-  return isHex ? saturate.hex() : saturate.css();
+  return inOriginalFormat(color, saturate);
 };
 
 /**
@@ -56,9 +57,8 @@ export const saturate = (color: string, amount: number) => {
  * @param amount - Amount to change in absolute terms. 0-1.
  */
 export const desaturate = (color: string, amount: number) => {
-  const isHex = isValidHex(color);
   const desaturate = chroma(color).set('hsl.s', `-${amount}`);
-  return isHex ? desaturate.hex() : desaturate.css();
+  return inOriginalFormat(color, desaturate);
 };
 
 /**


### PR DESCRIPTION
I noticed in our Global Values page any time we were doing color calculations on hex values, the `rgb()` value was output which in turn confused the color picker. So I've updated these functions to attempt to maintain the same format that was passed in except for `makeHighContrast()` since we don't support alpha values anyway.

**Before**

<img width="227" alt="Screen Shot 2021-09-29 at 18 16 58 PM" src="https://user-images.githubusercontent.com/549577/135535380-17a1ef1f-c89d-4bf9-b772-40f0de3696e7.png">

**After**

<img width="241" alt="Screen Shot 2021-09-29 at 18 17 04 PM" src="https://user-images.githubusercontent.com/549577/135535397-7792e4e4-f7a3-4b37-87ae-efe5e1209356.png">

**Color utility page showing input vs output**


<img width="505" alt="Screen Shot 2021-09-30 at 18 17 21 PM" src="https://user-images.githubusercontent.com/549577/135537768-fb450fed-0c90-4a2a-8d28-19758202b62f.png">


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~ Emotion is not working
- ~[ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
