### PR TITLE
[EuiErrorBoundary] Add default `data-test-subj`

### DIFF
--- a/src/components/error_boundary/__snapshots__/error_boundary.test.tsx.snap
+++ b/src/components/error_boundary/__snapshots__/error_boundary.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiErrorBoundary is rendered without an error 1`] = `
+exports[`EuiErrorBoundary without an error thrown UI is not rendered 1`] = `
 <div>
   No error
 </div>

--- a/src/components/error_boundary/error_boundary.test.tsx
+++ b/src/components/error_boundary/error_boundary.test.tsx
@@ -22,30 +22,48 @@ const BadComponent = () => {
 };
 
 describe('EuiErrorBoundary', () => {
-  test('is rendered without an error', () => {
-    const component = takeMountedSnapshot(
-      mount(
-        <EuiErrorBoundary {...requiredProps}>
-          <GoodComponent />
-        </EuiErrorBoundary>
-      )
-    );
+  describe('without an error thrown', () => {
+    it('UI is not rendered', () => {
+      const component = takeMountedSnapshot(
+        mount(
+          <EuiErrorBoundary {...requiredProps}>
+            <GoodComponent />
+          </EuiErrorBoundary>
+        )
+      );
 
-    expect(component).toMatchSnapshot();
+      expect(component).toMatchSnapshot();
+    });
   });
 
-  test('is rendered with an error', () => {
-    // Prevent the React boundary error from appearing in the terminal.
-    spyOn(console, 'error'); // eslint-disable-line no-undef
+  describe('with an error thrown', () => {
+    it('UI is rendered', () => {
+      // Prevent the React boundary error from appearing in the terminal.
+      spyOn(console, 'error');
 
-    // Because the error contains the stack trace, it's non-deterministic. So we'll just check that
-    // it contains our error message.
-    const errorText = mount(
-      <EuiErrorBoundary {...requiredProps}>
-        <BadComponent />
-      </EuiErrorBoundary>
-    ).text();
+      // Because the error contains the stack trace, it's non-deterministic. So we'll just check that
+      // it contains our error message.
+      const errorText = mount(
+        <EuiErrorBoundary {...requiredProps}>
+          <BadComponent />
+        </EuiErrorBoundary>
+      ).text();
 
-    expect(errorText).toContain(errorMessage);
+      expect(errorText).toContain(errorMessage);
+    });
+
+    it('data-test-subj is rendered', () => {
+      // Prevent the React boundary error from appearing in the terminal.
+      spyOn(console, 'error');
+
+      const errorHtml = mount(
+        <EuiErrorBoundary {...requiredProps}>
+          <BadComponent />
+        </EuiErrorBoundary>
+      ).html();
+
+      expect(errorHtml).toContain('euiErrorBoundary');
+      expect(errorHtml).toContain('test subject string');
+    });
   });
 });

--- a/src/components/error_boundary/error_boundary.tsx
+++ b/src/components/error_boundary/error_boundary.tsx
@@ -8,7 +8,7 @@
 
 import React, { Component, HTMLAttributes, ReactNode } from 'react';
 import { CommonProps } from '../common';
-import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 import { EuiText } from '../text';
 
@@ -29,10 +29,6 @@ export class EuiErrorBoundary extends Component<
   EuiErrorBoundaryProps,
   EuiErrorBoundaryState
 > {
-  static propTypes = {
-    children: PropTypes.node,
-  };
-
   constructor(props: EuiErrorBoundaryProps) {
     super(props);
 
@@ -59,12 +55,17 @@ ${stackStr}`;
   }
 
   render() {
-    const { children, ...rest } = this.props;
+    const { children, 'data-test-subj': _dataTestSubj, ...rest } = this.props;
+    const dataTestSubj = classNames('euiErrorBoundary', _dataTestSubj);
 
     if (this.state.hasError) {
       // You can render any custom fallback UI
       return (
-        <div className="euiErrorBoundary" {...rest}>
+        <div
+          className="euiErrorBoundary"
+          data-test-subj={dataTestSubj}
+          {...rest}
+        >
           <div className="euiErrorBoundary__text">
             <EuiText size="xs">
               <h1>Error</h1>


### PR DESCRIPTION
### Summary

Adds a default `data-test-subj` and still accepts any from consumers.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~

- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately

~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
