### PR TITLE
[EuiBasicTable] Fix duplicate ID in EuiBasicTable's Select All checkbox(es)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 **Bug fixes**
 
 - Fixed tick and level alignment in `Eui[Dual]Range` ([#5181](https://github.com/elastic/eui/pull/5181))
+- Fixed duplicate IDs on mobile/desktop select all checkboxes in `EuiBasicTable` ([#5237](https://github.com/elastic/eui/pull/5237))
 
 **Breaking changes**
 

--- a/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -1463,7 +1463,7 @@ exports[`EuiBasicTable with initial selection 1`] = `
                       checked={false}
                       compressed={false}
                       disabled={false}
-                      id="_selection_column-checkbox_generated-id"
+                      id="_selection_column-checkbox_generated-id_mobile"
                       indeterminate={false}
                       label="Select all rows"
                       onChange={[Function]}
@@ -1476,7 +1476,7 @@ exports[`EuiBasicTable with initial selection 1`] = `
                           checked={false}
                           className="euiCheckbox__input"
                           disabled={false}
-                          id="_selection_column-checkbox_generated-id"
+                          id="_selection_column-checkbox_generated-id_mobile"
                           onChange={[Function]}
                           type="checkbox"
                         />
@@ -1485,7 +1485,7 @@ exports[`EuiBasicTable with initial selection 1`] = `
                         />
                         <label
                           className="euiCheckbox__label"
-                          htmlFor="_selection_column-checkbox_generated-id"
+                          htmlFor="_selection_column-checkbox_generated-id_mobile"
                         >
                           Select all rows
                         </label>
@@ -1552,7 +1552,7 @@ exports[`EuiBasicTable with initial selection 1`] = `
                           compressed={false}
                           data-test-subj="checkboxSelectAll"
                           disabled={false}
-                          id="_selection_column-checkbox_generated-id"
+                          id="_selection_column-checkbox_generated-id_desktop"
                           indeterminate={false}
                           label={null}
                           onChange={[Function]}
@@ -1567,7 +1567,7 @@ exports[`EuiBasicTable with initial selection 1`] = `
                               className="euiCheckbox__input"
                               data-test-subj="checkboxSelectAll"
                               disabled={false}
-                              id="_selection_column-checkbox_generated-id"
+                              id="_selection_column-checkbox_generated-id_desktop"
                               onChange={[Function]}
                               type="checkbox"
                             />

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -923,7 +923,7 @@ exports[`EuiInMemoryTable with initial selection 1`] = `
                         checked={false}
                         compressed={false}
                         disabled={false}
-                        id="_selection_column-checkbox_generated-id"
+                        id="_selection_column-checkbox_generated-id_mobile"
                         indeterminate={false}
                         label="Select all rows"
                         onChange={[Function]}
@@ -936,7 +936,7 @@ exports[`EuiInMemoryTable with initial selection 1`] = `
                             checked={false}
                             className="euiCheckbox__input"
                             disabled={false}
-                            id="_selection_column-checkbox_generated-id"
+                            id="_selection_column-checkbox_generated-id_mobile"
                             onChange={[Function]}
                             type="checkbox"
                           />
@@ -945,7 +945,7 @@ exports[`EuiInMemoryTable with initial selection 1`] = `
                           />
                           <label
                             className="euiCheckbox__label"
-                            htmlFor="_selection_column-checkbox_generated-id"
+                            htmlFor="_selection_column-checkbox_generated-id_mobile"
                           >
                             Select all rows
                           </label>
@@ -1012,7 +1012,7 @@ exports[`EuiInMemoryTable with initial selection 1`] = `
                             compressed={false}
                             data-test-subj="checkboxSelectAll"
                             disabled={false}
-                            id="_selection_column-checkbox_generated-id"
+                            id="_selection_column-checkbox_generated-id_desktop"
                             indeterminate={false}
                             label={null}
                             onChange={[Function]}
@@ -1027,7 +1027,7 @@ exports[`EuiInMemoryTable with initial selection 1`] = `
                                 className="euiCheckbox__input"
                                 data-test-subj="checkboxSelectAll"
                                 disabled={false}
-                                id="_selection_column-checkbox_generated-id"
+                                id="_selection_column-checkbox_generated-id_desktop"
                                 onChange={[Function]}
                                 type="checkbox"
                               />

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -528,7 +528,6 @@ export class EuiBasicTable<T = any> extends Component<
   }
 
   tableId = htmlIdGenerator('__table')();
-  selectAllCheckboxId = htmlIdGenerator('_selection_column-checkbox')();
 
   render() {
     const {
@@ -733,6 +732,8 @@ export class EuiBasicTable<T = any> extends Component<
     );
   }
 
+  selectAllIdGenerator = htmlIdGenerator('_selection_column-checkbox');
+
   renderSelectAll = (isMobile: boolean) => {
     const { items, selection } = this.props;
 
@@ -763,7 +764,7 @@ export class EuiBasicTable<T = any> extends Component<
       <EuiI18n token="euiBasicTable.selectAllRows" default="Select all rows">
         {(selectAllRows: string) => (
           <EuiCheckbox
-            id={this.selectAllCheckboxId}
+            id={this.selectAllIdGenerator(isMobile ? 'mobile' : 'desktop')}
             type={isMobile ? undefined : 'inList'}
             checked={checked}
             disabled={disabled}


### PR DESCRIPTION
## Summary

Bug fix/follow up to https://github.com/elastic/eui/pull/5196#discussion_r710527022

- I hadn't realized during my initial testing that two `select all` checkboxes are rendered - one in the mobile table header, and one in the regular/desktop table header 🤦‍♀️ 

- In our latest Kibana upgrade (https://github.com/elastic/kibana/pull/113633), its functional accessibility tests are correctly flagging/raising an error due to both checkboxes sharing the same/duplicate ID

- The fix here is to generate a separate suffixed ID depending on whether it's a mobile or desktop checkbox

## QA

- Go to https://eui.elastic.co/pr_5237/#/tabular-content/tables#adding-selection-to-a-table
- [x] Inspect the Select All checkbox in the table header and confirm the ID ends with a `_desktop`
- [x] Confirm that checking it does not cause the ID to rerender
- Make your screen smaller until the table collapses to become mobile
- [x] Inspect the mobile Select All checkbox and confirm the ID ends with a `_mobile`
- [x] Confirm that checking it does not cause the ID to rerender

https://user-images.githubusercontent.com/549407/135918086-59eccf1a-e4e4-42eb-8657-6df78a2b985f.mp4

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~

- [x] Checked in **mobile**

~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~

- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
