### PR TITLE
[EuiBasicTable & EuiInMemoryTable] Fix missing i18n token for default noItemsMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Fixed tick and level alignment in `Eui[Dual]Range` ([#5181](https://github.com/elastic/eui/pull/5181))
 - Fixed duplicate IDs on mobile/desktop select all checkboxes in `EuiBasicTable` ([#5237](https://github.com/elastic/eui/pull/5237))
+- Fixed missing i18n token in `EuiBasicTable`'s no items message ([#5242](https://github.com/elastic/eui/pull/5242))
 
 **Breaking changes**
 

--- a/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -312,7 +312,10 @@ exports[`EuiBasicTable empty is rendered 1`] = `
             colSpan={1}
             isMobileFullWidth={true}
           >
-            No items found
+            <EuiI18n
+              default="No items found"
+              token="euiBasicTable.noItemsMessage"
+            />
           </EuiTableRowCell>
         </EuiTableRow>
       </EuiTableBody>
@@ -1417,7 +1420,12 @@ exports[`EuiBasicTable with initial selection 1`] = `
       },
     ]
   }
-  noItemsMessage="No items found"
+  noItemsMessage={
+    <EuiI18n
+      default="No items found"
+      token="euiBasicTable.noItemsMessage"
+    />
+  }
   responsive={true}
   selection={
     Object {

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -71,7 +71,12 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
         },
       ]
     }
-    noItemsMessage="No items found"
+    noItemsMessage={
+      <EuiI18n
+        default="No items found"
+        token="euiBasicTable.noItemsMessage"
+      />
+    }
     onChange={[Function]}
     pagination={
       Object {
@@ -770,7 +775,12 @@ exports[`EuiInMemoryTable empty array 1`] = `
   }
   data-test-subj="test subject string"
   items={Array []}
-  noItemsMessage="No items found"
+  noItemsMessage={
+    <EuiI18n
+      default="No items found"
+      token="euiBasicTable.noItemsMessage"
+    />
+  }
   onChange={[Function]}
   responsive={true}
   tableLayout="fixed"
@@ -792,7 +802,12 @@ exports[`EuiInMemoryTable with executeQueryOptions 1`] = `
   }
   data-test-subj="test subject string"
   items={Array []}
-  noItemsMessage="No items found"
+  noItemsMessage={
+    <EuiI18n
+      default="No items found"
+      token="euiBasicTable.noItemsMessage"
+    />
+  }
   onChange={[Function]}
   responsive={true}
   tableLayout="fixed"
@@ -874,7 +889,12 @@ exports[`EuiInMemoryTable with initial selection 1`] = `
         },
       ]
     }
-    noItemsMessage="No items found"
+    noItemsMessage={
+      <EuiI18n
+        default="No items found"
+        token="euiBasicTable.noItemsMessage"
+      />
+    }
     onChange={[Function]}
     responsive={true}
     selection={
@@ -1422,7 +1442,12 @@ exports[`EuiInMemoryTable with initial sorting 1`] = `
       },
     ]
   }
-  noItemsMessage="No items found"
+  noItemsMessage={
+    <EuiI18n
+      default="No items found"
+      token="euiBasicTable.noItemsMessage"
+    />
+  }
   onChange={[Function]}
   responsive={true}
   sorting={
@@ -1468,7 +1493,12 @@ exports[`EuiInMemoryTable with items 1`] = `
       },
     ]
   }
-  noItemsMessage="No items found"
+  noItemsMessage={
+    <EuiI18n
+      default="No items found"
+      token="euiBasicTable.noItemsMessage"
+    />
+  }
   onChange={[Function]}
   responsive={true}
   tableLayout="fixed"
@@ -1513,7 +1543,12 @@ exports[`EuiInMemoryTable with items and expanded item 1`] = `
       },
     ]
   }
-  noItemsMessage="No items found"
+  noItemsMessage={
+    <EuiI18n
+      default="No items found"
+      token="euiBasicTable.noItemsMessage"
+    />
+  }
   onChange={[Function]}
   responsive={true}
   tableLayout="fixed"
@@ -1628,7 +1663,12 @@ exports[`EuiInMemoryTable with pagination 1`] = `
       },
     ]
   }
-  noItemsMessage="No items found"
+  noItemsMessage={
+    <EuiI18n
+      default="No items found"
+      token="euiBasicTable.noItemsMessage"
+    />
+  }
   onChange={[Function]}
   pagination={
     Object {
@@ -1670,7 +1710,12 @@ exports[`EuiInMemoryTable with pagination and default page size and index 1`] = 
       },
     ]
   }
-  noItemsMessage="No items found"
+  noItemsMessage={
+    <EuiI18n
+      default="No items found"
+      token="euiBasicTable.noItemsMessage"
+    />
+  }
   onChange={[Function]}
   pagination={
     Object {
@@ -1721,7 +1766,12 @@ exports[`EuiInMemoryTable with pagination and selection 1`] = `
       },
     ]
   }
-  noItemsMessage="No items found"
+  noItemsMessage={
+    <EuiI18n
+      default="No items found"
+      token="euiBasicTable.noItemsMessage"
+    />
+  }
   onChange={[Function]}
   pagination={
     Object {
@@ -1769,7 +1819,12 @@ exports[`EuiInMemoryTable with pagination, default page size and error 1`] = `
       },
     ]
   }
-  noItemsMessage="No items found"
+  noItemsMessage={
+    <EuiI18n
+      default="No items found"
+      token="euiBasicTable.noItemsMessage"
+    />
+  }
   onChange={[Function]}
   pagination={
     Object {
@@ -1819,7 +1874,12 @@ exports[`EuiInMemoryTable with pagination, hiding the per page options 1`] = `
       },
     ]
   }
-  noItemsMessage="No items found"
+  noItemsMessage={
+    <EuiI18n
+      default="No items found"
+      token="euiBasicTable.noItemsMessage"
+    />
+  }
   onChange={[Function]}
   pagination={
     Object {
@@ -1871,7 +1931,12 @@ exports[`EuiInMemoryTable with pagination, selection and sorting 1`] = `
       },
     ]
   }
-  noItemsMessage="No items found"
+  noItemsMessage={
+    <EuiI18n
+      default="No items found"
+      token="euiBasicTable.noItemsMessage"
+    />
+  }
   onChange={[Function]}
   pagination={
     Object {
@@ -1951,7 +2016,12 @@ exports[`EuiInMemoryTable with pagination, selection, sorting  and simple search
         },
       ]
     }
-    noItemsMessage="No items found"
+    noItemsMessage={
+      <EuiI18n
+        default="No items found"
+        token="euiBasicTable.noItemsMessage"
+      />
+    }
     onChange={[Function]}
     pagination={
       Object {
@@ -2025,7 +2095,12 @@ exports[`EuiInMemoryTable with pagination, selection, sorting and a single recor
       },
     ]
   }
-  noItemsMessage="No items found"
+  noItemsMessage={
+    <EuiI18n
+      default="No items found"
+      token="euiBasicTable.noItemsMessage"
+    />
+  }
   onChange={[Function]}
   pagination={
     Object {
@@ -2085,7 +2160,12 @@ exports[`EuiInMemoryTable with pagination, selection, sorting and column rendere
       },
     ]
   }
-  noItemsMessage="No items found"
+  noItemsMessage={
+    <EuiI18n
+      default="No items found"
+      token="euiBasicTable.noItemsMessage"
+    />
+  }
   onChange={[Function]}
   pagination={
     Object {
@@ -2174,7 +2254,12 @@ exports[`EuiInMemoryTable with pagination, selection, sorting and configured sea
         },
       ]
     }
-    noItemsMessage="No items found"
+    noItemsMessage={
+      <EuiI18n
+        default="No items found"
+        token="euiBasicTable.noItemsMessage"
+      />
+    }
     onChange={[Function]}
     pagination={
       Object {
@@ -2258,7 +2343,12 @@ exports[`EuiInMemoryTable with search and component between search and table 1`]
         },
       ]
     }
-    noItemsMessage="No items found"
+    noItemsMessage={
+      <EuiI18n
+        default="No items found"
+        token="euiBasicTable.noItemsMessage"
+      />
+    }
     onChange={[Function]}
     responsive={true}
     tableLayout="fixed"

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -311,7 +311,9 @@ export class EuiBasicTable<T = any> extends Component<
   static defaultProps = {
     responsive: true,
     tableLayout: 'fixed',
-    noItemsMessage: 'No items found',
+    noItemsMessage: (
+      <EuiI18n token="euiBasicTable.noItemsMessage" default="No items found" />
+    ),
   };
 
   static getDerivedStateFromProps<T>(


### PR DESCRIPTION
### Summary

I was messing around EuiBasicTable fixing accessibility issues and noticed this small missing i18n token 👀 

## QA

- [x] Go to http://localhost:8030/#/tabular-content/in-memory-tables#in-memory-table-with-search and type in `asdfasdf` and confirm you still see "No items found"

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
