### PR TITLE
[EuiPopover] Allow content to be accessible during opening animation

### DIFF
--- a/src-docs/src/views/progress/progress_chart.js
+++ b/src-docs/src/views/progress/progress_chart.js
@@ -1,6 +1,12 @@
 import React, { Fragment } from 'react';
 
-import { EuiProgress, EuiSpacer } from '../../../../src/components';
+import {
+  EuiBadge,
+  EuiPopover,
+  EuiButton,
+  EuiProgress,
+  EuiSpacer,
+} from '../../../../src/components';
 
 const data = [
   { label: 'Basic percentage', value: '80' },
@@ -13,36 +19,57 @@ const data = [
   { label: "Women's Accessories", value: '24.0256' },
 ];
 
-export default () => (
-  <Fragment>
-    <div style={{ maxWidth: 160 }}>
-      {data.map((item) => (
-        <>
-          <EuiProgress
-            valueText={true}
-            max={100}
-            color="success"
-            size="s"
-            {...item}
-          />
-          <EuiSpacer size="s" />
-        </>
-      ))}
-    </div>
-    <EuiSpacer size="m" />
-    <div style={{ maxWidth: 200 }}>
-      {data.map((item) => (
-        <>
-          <EuiProgress
-            valueText={true}
-            max={100}
-            color="primary"
-            size="m"
-            {...item}
-          />
-          <EuiSpacer size="s" />
-        </>
-      ))}
-    </div>
-  </Fragment>
-);
+export default () => {
+  const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
+
+  const onButtonClick = () =>
+    setIsPopoverOpen((isPopoverOpen) => !isPopoverOpen);
+  const closePopover = () => setIsPopoverOpen(false);
+
+  const button = (
+    <EuiButton iconType="arrowDown" iconSide="right" onClick={onButtonClick}>
+      Show popover
+    </EuiButton>
+  );
+
+  return (
+    <Fragment>
+      <EuiPopover
+        button={button}
+        isOpen={isPopoverOpen}
+        closePopover={closePopover}
+      >
+        <EuiBadge>Text</EuiBadge>
+        <div style={{ maxWidth: 160 }}>
+          {data.map((item) => (
+            <>
+              <EuiProgress
+                valueText={true}
+                max={100}
+                color="success"
+                size="s"
+                {...item}
+              />
+              <EuiSpacer size="s" />
+            </>
+          ))}
+        </div>
+        <EuiSpacer size="m" />
+        <div style={{ maxWidth: 200 }}>
+          {data.map((item) => (
+            <>
+              <EuiProgress
+                valueText={true}
+                max={100}
+                color="primary"
+                size="m"
+                {...item}
+              />
+              <EuiSpacer size="s" />
+            </>
+          ))}
+        </div>
+      </EuiPopover>
+    </Fragment>
+  );
+};

--- a/src/components/popover/_popover.scss
+++ b/src/components/popover/_popover.scss
@@ -38,7 +38,6 @@
   backface-visibility: hidden;
   pointer-events: none;
   opacity: 0; /* 2 */
-  visibility: hidden; /* 2 */
   transition: /* 2 */
     opacity $euiAnimSlightBounce $euiAnimSpeedSlow,
     visibility $euiAnimSlightBounce $euiAnimSpeedSlow;
@@ -54,7 +53,6 @@
 
   &.euiPopover__panel-isOpen {
     opacity: 1;
-    visibility: visible;
     pointer-events: auto;
   }
 

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -435,8 +435,8 @@ export class EuiPopover extends Component<Props, State> {
         // there isn't a focus target, one of two reasons:
         // #1 is the whole panel hidden? If so, schedule another check
         // #2 panel is visible but no tabbables exist, move focus to the panel
-        const panelVisibility = window.getComputedStyle(this.panel).visibility;
-        if (panelVisibility === 'hidden') {
+        const panelVisibility = window.getComputedStyle(this.panel).opacity;
+        if (panelVisibility === '0') {
           // #1
           this.updateFocus();
         } else {


### PR DESCRIPTION
### Summary

Resolves #5247 by removing `visibility: hidden` from EuiPopover open animation and instead relying on `opacity: 0`.
This allows the contents of EuiPopover to be accessible to the `node.innerText` method  as well as screen readers.

See the EuiProgress "Progress for charts" docs section for resolution. Each label should have a `title` attr that matches the content.

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest tests](https://github.com/elastic/eui/blob/master/wiki/testing.md)**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
- [ ] Revert bf3a363
