### PR TITLE
[CSS-in-JS] Add provider to generated codesandbox examples

### DIFF
--- a/src-docs/src/components/codesandbox/link.js
+++ b/src-docs/src/components/codesandbox/link.js
@@ -65,13 +65,12 @@ export const CodeSandboxLinkComponent = ({
       break;
   }
 
+  const isLegacyTheme = context.theme.includes(LEGACY_NAME_KEY);
+
   const providerPropsObject = {};
   // Only add configuration if it isn't the default
   if (context.theme.includes('dark')) {
     providerPropsObject.colorMode = 'dark';
-  }
-  if (context.theme.includes(LEGACY_NAME_KEY)) {
-    providerPropsObject.theme = null;
   }
   // Can't spread an object inside of a string literal
   const providerProps = Object.keys(providerPropsObject)
@@ -83,9 +82,13 @@ export const CodeSandboxLinkComponent = ({
 
   // Renders the new Demo component generically into the code sandbox page
   const exampleClose = `ReactDOM.render(
-  <EuiProvider ${providerProps}>
+  ${
+    isLegacyTheme
+      ? '<Demo />'
+      : `<EuiProvider ${providerProps}>
     <Demo />
-  </EuiProvider>,
+  </EuiProvider>`
+  },
   document.getElementById('root')
 );`;
 
@@ -98,8 +101,12 @@ import '${cssFile}';
 import React from 'react';
 
 import {
-  EuiButton,
-  EuiProvider,
+  ${
+    isLegacyTheme
+      ? 'EuiButton,'
+      : `EuiButton,
+  EuiProvider,`
+  }
 } from '@elastic/eui';
 
 const Demo = () => (<EuiButton>Hello world!</EuiButton>);
@@ -119,7 +126,7 @@ ${exampleClose}
         "from './display_toggles';"
       );
 
-    if (!exampleCleaned.includes('EuiProvider')) {
+    if (!isLegacyTheme && !exampleCleaned.includes('EuiProvider')) {
       if (exampleCleaned.includes(" } from '@elastic/eui';")) {
         // Single line import statement
         exampleCleaned = exampleCleaned.replace(


### PR DESCRIPTION
### Summary

Adds a global provider to generated codesandbox examples.

~Note that `EuiThemeProvider` is currently used because `EuiProvider` is not yet in a public release. Once we confirm the output is correct, I will replace all instances with `EuiProvider`.~ ✅ 
Also note that we cannot guarantee that static and global style source order is correct. Will need to wait until `EuiProvider` is in a public release and adjust as necessary.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes

~- [ ] Checked in **mobile**~~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~

- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples

~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/master/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/master/wiki/cypress-testing.md) tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~

- [x] Replaced `EuiThemeProvider` with `EuiProvider`
