### PR TITLE
Fix clearing heights cache behavior in datagrid

### DIFF
--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -667,7 +667,10 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
   const rowHeightUtils = useMemo(() => new RowHeightUtils(), []);
 
   // we should check that colums actually changes
-  const orderedVisibleColumnsIds = orderedVisibleColumns.map(column => column.id).sort().join();
+  const orderedVisibleColumnsIds = orderedVisibleColumns
+    .map((column) => column.id)
+    .sort()
+    .join();
 
   useEffect(() => {
     rowHeightUtils.clearHeightsCache();


### PR DESCRIPTION
### Summary

For clearing heights cache we should check actual data changes, not just ref.

