### PR TITLE
[EuiDataGrid] Fix behavior about recalculation heights in auto-height mode

### DIFF
--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -205,12 +205,8 @@ export class EuiDataGridCell extends Component<
         rowIndex,
         rowHeightsOptions
       );
-      const isHeightSame = rowHeightUtils.compareHeights(
-        cellRef.offsetHeight,
-        getRowHeight(rowIndex)
-      );
 
-      if (isAutoHeight && !isHeightSame) {
+      if (isAutoHeight) {
         rowHeightUtils.setRowHeight(
           rowIndex,
           colIndex,


### PR DESCRIPTION
### Summary

Remove conditional about checking  is the height the same so that recalculate height in all cases.