### PR TITLE
[Docs] Fix Colors guidelines

### DIFF
--- a/src-docs/src/views/guidelines/colors/vis_palette.js
+++ b/src-docs/src/views/guidelines/colors/vis_palette.js
@@ -14,7 +14,7 @@ import {
 export const VisPalette = ({ variant }) => {
   const vars = useJsonVars();
   const visColors = vars.euiPaletteColorBlind;
-  const visColorKeys = Object.keys(vars.euiPaletteColorBlind);
+  const visColorKeys = Object.keys(visColors);
 
   function renderPaletteColor(palette, color, index, key) {
     const hex = key ? palette[color][key] : palette[color];


### PR DESCRIPTION
### Summary

Fixes #5314 by using the `useJsonVars` util instead of `useSassVars`, which does not contain all variables for dark mode(s).

The other approach would be to alter the return value of `useSassVars` by first spreading the light mode colors object onto the dark mode object, but now that a [static JSON representation is available](https://github.com/elastic/eui/tree/master/src-docs/src/views/theme/_json) it seems like we should switch to use those values.

_Break first [introduced in v37.7.0](https://github.com/elastic/eui/pull/5078/files#diff-e6efc1aa2547f780ee0d5a98f3315695275f914c898c3be3706ff3c30d7b9656)_

~### Checklist~
