### PR TITLE
[EuiMarkdownEditor] Fix react-dropzone taking over all drop events on the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 **Bug fixes**
 
 - Fixed `endDateControl` `className` in `EuiDatePickerRange` ([#5329](https://github.com/elastic/eui/pull/5329))
+- Fixed `EuiMarkdownEditor` intercepting all drop events on the page ([#5340](https://github.com/elastic/eui/pull/5340))
 
 ## [`40.1.0`](https://github.com/elastic/eui/tree/v40.1.0)
 

--- a/src/components/markdown_editor/markdown_editor_drop_zone.tsx
+++ b/src/components/markdown_editor/markdown_editor_drop_zone.tsx
@@ -101,6 +101,7 @@ export const EuiMarkdownEditorDropZone: FunctionComponent<EuiMarkdownEditorDropZ
     // Disable click and keydown behavior
     noClick: true,
     noKeyboard: true,
+    preventDropOnDocument: false,
     // multiple: false,
     onDragOver: (e) => {
       let result: boolean;


### PR DESCRIPTION
### Summary

@brittanyjoiner15 and @i-a-n noticed that `EuiFilePicker`s on the same page as `EuiMarkdownEditor`s did not have functioning drag & drop. This is because [react-dropzone](https://github.com/react-dropzone/react-dropzone) (used by `EuiMarkdownEditor`) intercepts all document drop events, which we have to toggle off via a `preventDropOnDocument` config.

### Before

![before](https://user-images.githubusercontent.com/549407/139736606-fa61ff29-8818-4d9a-a388-6715e66a12d9.gif)

### After

![after](https://user-images.githubusercontent.com/549407/139736308-8a7f9cd9-517d-4b61-aa5b-bbb51624074e.gif)

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/master/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/master/wiki/cypress-testing.md) tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
