### PR TITLE
[Breaking] Remove Sass vars `$euiColorSecondary` and `$euiColorSecondaryText`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Removed `panelPaddingSize` from `EuiPageContent` ([#5323](https://github.com/elastic/eui/pull/5323))
 - Removed `makeId` ([#5323](https://github.com/elastic/eui/pull/5323))
 - Removed mobile-only props from `EuiTableRowCell` ([#5323](https://github.com/elastic/eui/pull/5323))
+- Removed Sass vars `$euiColorSecondary` and `$euiColorSuccess` ([#5345](https://github.com/elastic/eui/pull/5345))
 
 **Bug fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Removed `panelPaddingSize` from `EuiPageContent` ([#5323](https://github.com/elastic/eui/pull/5323))
 - Removed `makeId` ([#5323](https://github.com/elastic/eui/pull/5323))
 - Removed mobile-only props from `EuiTableRowCell` ([#5323](https://github.com/elastic/eui/pull/5323))
-- Removed Sass vars `$euiColorSecondary` and `$euiColorSuccess` ([#5345](https://github.com/elastic/eui/pull/5345))
+- Removed Sass vars `$euiColorSecondary` and `$euiColorSecondaryText` ([#5345](https://github.com/elastic/eui/pull/5345))
 
 **Bug fixes**
 

--- a/src/components/button/button_empty/_button_empty.scss
+++ b/src/components/button/button_empty/_button_empty.scss
@@ -74,7 +74,7 @@ $euiButtonEmptyTypes: (
   disabled: $euiButtonColorDisabledText,
   ghost: $euiColorGhost,
   text: $euiTextColor,
-  success: $euiColorSecondaryText,
+  success: $euiColorSuccessText,
   warning: $euiColorWarningText,
 );
 

--- a/src/components/call_out/_variables.scss
+++ b/src/components/call_out/_variables.scss
@@ -1,7 +1,7 @@
 // Modifier naming and colors.
 $euiCallOutTypes: (
   primary: $euiColorPrimary,
-  success: $euiColorSecondary,
+  success: $euiColorSuccess,
   warning: $euiColorWarning,
   danger: $euiColorDanger,
 );

--- a/src/components/drag_and_drop/_droppable.scss
+++ b/src/components/drag_and_drop/_droppable.scss
@@ -1,5 +1,5 @@
 .euiDroppable {
-  $euiDroppableColor: $euiColorSecondary;
+  $euiDroppableColor: $euiColorSuccess;
   transition: background-color $euiAnimSpeedExtraSlow ease;
 
   &.euiDroppable--isDraggingType:not(.euiDroppable--isDisabled) {

--- a/src/components/toast/_toast.scss
+++ b/src/components/toast/_toast.scss
@@ -50,7 +50,7 @@
 // Modifier naming and colors.
 $euiToastTypes: (
   primary: makeGraphicContrastColor($euiColorPrimary, $euiColorEmptyShade),
-  success: makeGraphicContrastColor($euiColorSecondary, $euiColorEmptyShade),
+  success: makeGraphicContrastColor($euiColorSuccess, $euiColorEmptyShade),
   warning: makeGraphicContrastColor($euiColorWarning, $euiColorEmptyShade),
   danger: makeGraphicContrastColor($euiColorDanger, $euiColorEmptyShade),
 );

--- a/src/global_styling/react_date_picker/_date_picker.scss
+++ b/src/global_styling/react_date_picker/_date_picker.scss
@@ -422,11 +422,11 @@
 
   &--highlighted {
     border-radius: $euiBorderRadius;
-    background-color: $euiColorSecondary;
+    background-color: $euiColorSuccess;
     color: $euiColorGhost;
 
     &:hover {
-      background-color: darken($euiColorSecondary, 5%);
+      background-color: darken($euiColorSuccess, 5%);
     }
   }
 

--- a/src/global_styling/variables/_colors.scss
+++ b/src/global_styling/variables/_colors.scss
@@ -7,11 +7,10 @@ $euiColorInk: #000 !default;
 
 // Core
 $euiColorPrimary: #006BB4 !default;
-$euiColorSecondary: #017D73 !default;
 $euiColorAccent: #DD0A73 !default;
 
 // Status
-$euiColorSuccess: $euiColorSecondary !default;
+$euiColorSuccess: #017D73 !default;
 $euiColorWarning: #F5A700 !default;
 $euiColorDanger: #BD271E !default;
 
@@ -36,12 +35,11 @@ $euiColorDisabled: tint($euiTextColor, 70%) !default;
 
 // Contrasty text variants
 $euiColorPrimaryText: makeHighContrastColor($euiColorPrimary) !default;
-$euiColorSecondaryText: makeHighContrastColor($euiColorSecondary) !default;
 $euiColorAccentText: makeHighContrastColor($euiColorAccent) !default;
+$euiColorSuccessText: makeHighContrastColor($euiColorSuccess) !default;
 $euiColorWarningText: makeHighContrastColor($euiColorWarning) !default;
 $euiColorDangerText: makeHighContrastColor($euiColorDanger) !default;
 $euiColorDisabledText: makeDisabledContrastColor($euiColorDisabled) !default;
-$euiColorSuccessText: $euiColorSecondaryText !default;
 $euiLinkColor: $euiColorPrimaryText !default;
 
 // Visualization colors

--- a/src/themes/eui-amsterdam/eui_amsterdam_colors_dark.scss
+++ b/src/themes/eui-amsterdam/eui_amsterdam_colors_dark.scss
@@ -2,11 +2,10 @@
 
 // Core
 $euiColorPrimary: #36A2EF;
-$euiColorSecondary: #7DDED8;
 $euiColorAccent: #F68FBE;
 
 // Status
-$euiColorSuccess: $euiColorSecondary;
+$euiColorSuccess: #7DDED8;
 $euiColorWarning: #F3D371;
 $euiColorDanger: #F86B63;
 $euiColorDisabled: #515761;
@@ -18,10 +17,9 @@ $euiColorHighlight: #2E2D25;
 
 // Contrasty text variants
 $euiColorPrimaryText: makeHighContrastColor($euiColorPrimary);
-$euiColorSecondaryText: makeHighContrastColor($euiColorSecondary);
 $euiColorAccentText: makeHighContrastColor($euiColorAccent);
+$euiColorSuccessText: makeHighContrastColor($euiColorSuccess);
 $euiColorWarningText: makeHighContrastColor($euiColorWarning);
 $euiColorDangerText: makeHighContrastColor($euiColorDanger);
 $euiColorDisabledText: makeDisabledContrastColor($euiColorDisabled);
-$euiColorSuccessText: $euiColorSecondaryText;
 $euiLinkColor: $euiColorPrimaryText;

--- a/src/themes/eui-amsterdam/eui_amsterdam_colors_light.scss
+++ b/src/themes/eui-amsterdam/eui_amsterdam_colors_light.scss
@@ -3,11 +3,10 @@
 
 // Core
 $euiColorPrimary: #07C;
-$euiColorSecondary: #00BFB3;
 $euiColorAccent: #F04E98;
 
 // Status
-$euiColorSuccess: $euiColorSecondary;
+$euiColorSuccess: #00BFB3;
 $euiColorWarning: #FEC514;
 $euiColorDisabled: #ABB4C4;
 
@@ -20,9 +19,8 @@ $euiColorHighlight: tint($euiColorWarning, 90%);
 // Contrasty text variants
 $euiTextSubduedColor: $euiColorDarkShade;
 $euiColorPrimaryText: makeHighContrastColor($euiColorPrimary);
-$euiColorSecondaryText: makeHighContrastColor($euiColorSecondary);
 $euiColorAccentText: makeHighContrastColor($euiColorAccent);
+$euiColorSuccessText: makeHighContrastColor($euiColorSuccess);
 $euiColorWarningText: makeHighContrastColor($euiColorWarning);
 $euiColorDisabledText: makeDisabledContrastColor($euiColorDisabled);
-$euiColorSuccessText: $euiColorSecondaryText;
 $euiLinkColor: $euiColorPrimaryText;

--- a/src/themes/eui/eui_colors_dark.scss
+++ b/src/themes/eui/eui_colors_dark.scss
@@ -6,11 +6,10 @@ $euiColorInk: #000;
 
 // Core
 $euiColorPrimary: #1BA9F5;
-$euiColorSecondary: #7DE2D1;
 $euiColorAccent: #F990C0;
 
 // Status
-$euiColorSuccess: $euiColorSecondary;
+$euiColorSuccess: #7DE2D1;
 $euiColorWarning: #FFCE7A;
 $euiColorDanger: #F66;
 
@@ -35,12 +34,11 @@ $euiColorDisabled: shade($euiTextColor, 70%);
 
 // Contrasty text variants
 $euiColorPrimaryText: makeHighContrastColor($euiColorPrimary);
-$euiColorSecondaryText: makeHighContrastColor($euiColorSecondary);
 $euiColorAccentText: makeHighContrastColor($euiColorAccent);
+$euiColorSuccessText: makeHighContrastColor($euiColorSuccess);
 $euiColorWarningText: makeHighContrastColor($euiColorWarning);
 $euiColorDangerText: makeHighContrastColor($euiColorDanger);
 $euiColorDisabledText: makeDisabledContrastColor($euiColorDisabled);
-$euiColorSuccessText: $euiColorSecondaryText;
 $euiLinkColor: $euiColorPrimaryText;
 
 // Charts


### PR DESCRIPTION
As a follow up to https://github.com/elastic/eui/pull/5323#pullrequestreview-791097097 and #4874, this PR removes the Sass vars with `secondary` in the name.

https://gist.github.com/thompsongl/506f6f86201c83d61cc850170fd49467#remove-secondary-color-prop-options

### Checklist

- [x] Checked for **breaking changes** and labeled appropriately
- [x] A **[changelog](https://github.com/elastic/eui/blob/master/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
