### PR TITLE
Fix filenames and paths for components and routes

### DIFF
--- a/wiki/creating-components-manually.md
+++ b/wiki/creating-components-manually.md
@@ -14,7 +14,7 @@ This makes your styles available to your project and to the [EUI documentation][
 
 1. Create the React component(s) (preferably as TypeScript) in the same directory as the related SCSS file(s).
 2. Export these components from an `index.ts` file.
-3. Re-export these components from `src/components/index.js`.
+3. Re-export these components from `src/components/index.ts`.
 
 This makes your React component available for import into your project.
 
@@ -22,7 +22,7 @@ This makes your React component available for import into your project.
 
 1. Create a directory for your example in `src-docs/src/views`. Name it the name of the component.
 2. Create a `{component name}_example.js` file inside the directory. You'll use this file to define the different examples for your component.
-3. Add the route to this file in `src-docs/src/services/routes/routes.js`.
+3. Add the route to this file in `src-docs/src/routes.js`.
 4. In the `{component name}_example.js` file you created, define examples which demonstrate the component and describe its role from a UI perspective.
 
 ### 👉 Refer to the [Documentation Guidelines](documentation-guidelines.md) for more instruction on writing docs.

--- a/wiki/creating-components-yeoman.md
+++ b/wiki/creating-components-yeoman.md
@@ -55,6 +55,6 @@ First, you'll be prompted for what kind of documentation to create:
 
 Follow the prompts and your documentation files will be created. You can use the snippets that are printed to the terminal to integrate these files into the EUI documentation site.
 
-The script will ask you for the name of the component you'd like to document, then create some files in `src-docs/src/views/`. If the name you provide isn't the exact name of a component, you might need to adjust the `import` in the generated files. Otherwise simply add the document to the `src-docs/src/services/routes/routes.js` file to make it available in the browser.
+The script will ask you for the name of the component you'd like to document, then create some files in `src-docs/src/views/`. If the name you provide isn't the exact name of a component, you might need to adjust the `import` in the generated files. Otherwise simply add the document to the `src-docs/src/routes.js` file to make it available in the browser.
 
 ### 👉 Refer to the [Documentation Guidelines](documentation-guidelines.md) for more instruction on writing docs.

--- a/wiki/react-router.md
+++ b/wiki/react-router.md
@@ -104,7 +104,7 @@ Note that if using HMR, you'll need to re-register the router after a hot reload
 ### `routing.js` service
 
 You can create a `routing.js` service to surface the `registerRouter` method as well as your
-conversion function (called `getRouterLinkProps` here). The EUI documentation site [uses this approach](../src-docs/src/services/routing/routing.js).
+conversion function (called `getRouterLinkProps` here). The EUI documentation site [uses this approach](../src-docs/src/services/routing/routing.ts).
 
 ```js
 // routing.js

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -4,8 +4,8 @@
 
 ## Naming your test files
 
-Create test files with the name pattern of `{component name}.test.js` in the same directory which
-contains `{component name}.js`.
+Create test files with the name pattern of `{component name}.test.tsx` in the same directory which
+contains `{component name}.tsx`.
 
 ## Updating snapshots
 


### PR DESCRIPTION
### Summary
Fix filenames and paths for components and routes on the wiki.

Fix files that still have `.js` extension
Fix references to `src-docs/src/routes.js`

Closes https://github.com/elastic/eui/issues/5347
