### PR TITLE
[EuiErrorBoundary] Use EuiCodeBlock to render error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed an `EuiDataGrid` race condition where grid rows had incorrect heights if loaded in before CSS ([#5284](https://github.com/elastic/eui/pull/5284))
 - Fixed an accessibility issue where `EuiDataGrid` cells weren't owned by `role=row` elements ([#5285](https://github.com/elastic/eui/pull/5285))
+- Wrapped content of `EuiErrorBoundary` with `EuiCodeBlock` which fixed the overflow scrolling ([#5359](https://github.com/elastic/eui/pull/5359))
 
 ## [`41.0.0`](https://github.com/elastic/eui/tree/v41.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fixed an `EuiDataGrid` race condition where grid rows had incorrect heights if loaded in before CSS ([#5284](https://github.com/elastic/eui/pull/5284))
 - Fixed an accessibility issue where `EuiDataGrid` cells weren't owned by `role=row` elements ([#5285](https://github.com/elastic/eui/pull/5285))
-- Wrapped content of `EuiErrorBoundary` with `EuiCodeBlock` which fixed the overflow scrolling ([#5359](https://github.com/elastic/eui/pull/5359))
+- Fixed `EuiErrorBoundary` overflow scrolling by wrapping contents in `EuiCodeBlock` ([#5359](https://github.com/elastic/eui/pull/5359))
 
 ## [`41.0.0`](https://github.com/elastic/eui/tree/v41.0.0)
 

--- a/src/components/error_boundary/_error_boundary.scss
+++ b/src/components/error_boundary/_error_boundary.scss
@@ -9,15 +9,5 @@
     $color2 1px,
     $color2 20px
   );
-  overflow: auto;
   padding: $euiSize;
-}
-
-.euiErrorBoundary__text {
-  background-color: $euiColorEmptyShade;
-  padding: $euiSizeS;
-}
-
-.euiErrorBoundary__stack {
-  white-space: pre-wrap;
 }

--- a/src/components/error_boundary/error_boundary.tsx
+++ b/src/components/error_boundary/error_boundary.tsx
@@ -10,7 +10,8 @@ import React, { Component, HTMLAttributes, ReactNode } from 'react';
 import { CommonProps } from '../common';
 import classNames from 'classnames';
 
-import { EuiText } from '../text';
+import { EuiTitle } from '../title';
+import { EuiCodeBlock } from '../code';
 
 interface EuiErrorBoundaryState {
   hasError: boolean;
@@ -66,14 +67,12 @@ ${stackStr}`;
           data-test-subj={dataTestSubj}
           {...rest}
         >
-          <div className="euiErrorBoundary__text">
-            <EuiText size="xs">
-              <h1>Error</h1>
-              <pre className="euiErrorBoundary__stack">
-                <p>{this.state.error}</p>
-              </pre>
-            </EuiText>
-          </div>
+          <EuiCodeBlock>
+            <EuiTitle size="xs">
+              <p>Error</p>
+            </EuiTitle>
+            {this.state.error}
+          </EuiCodeBlock>
         </div>
       );
     }

--- a/src/components/error_boundary/error_boundary.tsx
+++ b/src/components/error_boundary/error_boundary.tsx
@@ -12,6 +12,7 @@ import classNames from 'classnames';
 
 import { EuiTitle } from '../title';
 import { EuiCodeBlock } from '../code';
+import { EuiI18n } from '../i18n';
 
 interface EuiErrorBoundaryState {
   hasError: boolean;
@@ -69,7 +70,9 @@ ${stackStr}`;
         >
           <EuiCodeBlock>
             <EuiTitle size="xs">
-              <p>Error</p>
+              <p>
+                <EuiI18n token="euiErrorBoundary.error" default="Error" />
+              </p>
             </EuiTitle>
             {this.state.error}
           </EuiCodeBlock>


### PR DESCRIPTION
### Fixes #5358

Before the component was just rendering a bare `<pre>` element, but now the error gets wrapped in our EuiCodeBlock which handles the overflow scrolling and gets rid of some unnecessary custom styles and selectors.

**Before**
<img width="400" alt="Screen Shot 2021-11-08 at 14 18 27 PM" src="https://user-images.githubusercontent.com/549577/140804932-8d2aff71-f0aa-4ad0-876b-2687f098255a.png">



**After**
<img width="406" alt="Screen Shot 2021-11-08 at 14 18 07 PM" src="https://user-images.githubusercontent.com/549577/140804950-1e12904a-5437-4864-8e4d-55e0ba3b25a3.png">


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
