### PR TITLE
[CSS-in-JS] Theme exports

### DIFF
--- a/src/services/theme/hooks.tsx
+++ b/src/services/theme/hooks.tsx
@@ -19,11 +19,13 @@ import {
   EuiThemeComputed,
 } from './types';
 
-export const useEuiTheme = <T extends {} = {}>(): {
+export interface UseEuiTheme<T extends {} = {}> {
   euiTheme: EuiThemeComputed<T>;
   colorMode: EuiThemeColorMode;
   modifications: EuiThemeModifications<T>;
-} => {
+}
+
+export const useEuiTheme = <T extends {} = {}>(): UseEuiTheme<T> => {
   const theme = useContext(EuiThemeContext);
   const colorMode = useContext(EuiColorModeContext);
   const modifications = useContext(EuiModificationsContext);
@@ -36,10 +38,7 @@ export const useEuiTheme = <T extends {} = {}>(): {
 };
 
 export interface WithEuiThemeProps<P = {}> {
-  theme: {
-    euiTheme: EuiThemeComputed<P>;
-    colorMode: EuiThemeColorMode;
-  };
+  theme: UseEuiTheme<P>;
 }
 export const withEuiTheme = <T extends {} = {}, U extends {} = {}>(
   Component: React.ComponentType<T & WithEuiThemeProps<U>>
@@ -49,12 +48,13 @@ export const withEuiTheme = <T extends {} = {}, U extends {} = {}>(
     props: Omit<T, keyof WithEuiThemeProps<U>>,
     ref: React.Ref<Omit<T, keyof WithEuiThemeProps<U>>>
   ) => {
-    const { euiTheme, colorMode } = useEuiTheme<U>();
+    const { euiTheme, colorMode, modifications } = useEuiTheme<U>();
     return (
       <Component
         theme={{
           euiTheme,
           colorMode,
+          modifications,
         }}
         ref={ref}
         {...(props as T)}

--- a/src/services/theme/index.ts
+++ b/src/services/theme/index.ts
@@ -12,7 +12,12 @@ export {
   EuiModificationsContext,
   EuiColorModeContext,
 } from './context';
-export { useEuiTheme, withEuiTheme, WithEuiThemeProps } from './hooks';
+export {
+  useEuiTheme,
+  UseEuiTheme,
+  withEuiTheme,
+  WithEuiThemeProps,
+} from './hooks';
 export { EuiThemeProvider } from './provider';
 export {
   buildTheme,
@@ -28,10 +33,12 @@ export {
 export {
   ComputedThemeShape,
   EuiThemeColorMode,
+  EuiThemeColorModeStandard,
   EuiThemeComputed,
   EuiThemeModifications,
   EuiThemeShape,
   EuiThemeSystem,
+  COLOR_MODES_STANDARD,
 } from './types';
 export { lineHeightFromBaseline } from './typography';
 export { sizeToPixel } from './size';

--- a/src/services/theme/types.ts
+++ b/src/services/theme/types.ts
@@ -25,7 +25,7 @@ export const COLOR_MODES_STANDARD = {
 export const COLOR_MODES_INVERSE = 'INVERSE' as const;
 
 type EuiThemeColorModeInverse = typeof COLOR_MODES_INVERSE;
-type EuiThemeColorModeStandard = ValueOf<typeof COLOR_MODES_STANDARD>;
+export type EuiThemeColorModeStandard = ValueOf<typeof COLOR_MODES_STANDARD>;
 export type EuiThemeColorMode =
   | string
   | EuiThemeColorModeStandard

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -7,3 +7,6 @@
  */
 
 export { EUI_THEMES, EUI_THEME } from './themes';
+
+export { EuiThemeAmsterdam } from './eui-amsterdam/theme';
+export { EuiThemeDefault } from './eui/theme';


### PR DESCRIPTION
### Summary

https://github.com/elastic/kibana/pull/117368 highlights some missing exports from the original `EuiThemeProvider`/`useEuiTheme` PR:

* The actual themes (`EuiThemeDefault`, `EuiThemeAmsterdam`)
  * 🙈 
  * Required for switching to Amsterdam
* `COLOR_MODES_STANDARD` constant, for convenience
* Newly defined, comprehensive `UseEuiTheme` interface
  * Simple wrapper around its 3 component parts 
  * Reused in `WithEuiTheme`

~### Checklist~
