### PR TITLE
[EuiKeyPadMenu] Removing `tabIndex` from Beta Badge for axe violation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Fixed an accessibility issue where `EuiDataGrid` cells weren't owned by `role=row` elements ([#5285](https://github.com/elastic/eui/pull/5285))
 - Fixed `EuiErrorBoundary` overflow scrolling by wrapping contents in `EuiCodeBlock` ([#5359](https://github.com/elastic/eui/pull/5359))
 - Fixed `analyzeEvent` icon to be horizontally centered [#5365](https://github.com/elastic/eui/pull/5365))
-- Fixed an accessibility issue where `EuiKeyPadMenu` buttons had focusable child elements ([#5385]https://github.com/elastic/eui/pull/5385)
+- Fixed an accessibility issue where `EuiKeyPadMenu` buttons had focusable child elements ([#5385](https://github.com/elastic/eui/pull/5385))
 
 ## [`41.0.0`](https://github.com/elastic/eui/tree/v41.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed an accessibility issue where `EuiDataGrid` cells weren't owned by `role=row` elements ([#5285](https://github.com/elastic/eui/pull/5285))
 - Fixed `EuiErrorBoundary` overflow scrolling by wrapping contents in `EuiCodeBlock` ([#5359](https://github.com/elastic/eui/pull/5359))
 - Fixed `analyzeEvent` icon to be horizontally centered [#5365](https://github.com/elastic/eui/pull/5365))
+- Fixed an accessibility issue where `EuiKeyPadMenu` buttons had focusable child elements ([#5385]https://github.com/elastic/eui/pull/5385)
 
 ## [`41.0.0`](https://github.com/elastic/eui/tree/v41.0.0)
 

--- a/src/components/badge/beta_badge/beta_badge.tsx
+++ b/src/components/badge/beta_badge/beta_badge.tsx
@@ -224,7 +224,7 @@ export const EuiBetaBadge: FunctionComponent<EuiBetaBadgeProps> = ({
           content={tooltipContent}
           title={title || label}
         >
-          <span tabIndex={0} className={classes} {...rest}>
+          <span className={classes} {...rest}>
             {icon || label}
           </span>
         </EuiToolTip>

--- a/src/components/key_pad_menu/__snapshots__/key_pad_menu_item.test.tsx.snap
+++ b/src/components/key_pad_menu/__snapshots__/key_pad_menu_item.test.tsx.snap
@@ -167,7 +167,6 @@ exports[`EuiKeyPadMenuItem props betaBadge renders with betaBadgeTooltipContent 
     >
       <span
         class="euiBetaBadge euiBetaBadge--singleLetter euiBetaBadge--subdued euiBetaBadge--small euiKeyPadMenuItem__betaBadge"
-        tabindex="0"
       >
         B
       </span>


### PR DESCRIPTION
### Summary

The `EuiKeyPadMenu` beta buttons have a `<span tabindex="0">` that's throwing an axe-core error. I removed the tabIndex attribute on the span tag, because the parent button is natively focusable. Closes #5290.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
