### PR TITLE
[Cypress] Allow theme selection in tests

### DIFF
--- a/cypress/plugins/webpack.config.js
+++ b/cypress/plugins/webpack.config.js
@@ -11,6 +11,8 @@
 const path = require('path');
 const webpack = require('webpack');
 
+const THEME_IMPORT = `'../../dist/eui_theme_amsterdam_${process.env.THEME ?? 'dark'}.css'`;
+
 module.exports = {
   mode: 'development',
 
@@ -45,4 +47,10 @@ module.exports = {
     ],
     strictExportPresence: false,
   },
+
+  plugins: [
+    new webpack.DefinePlugin({
+      THEME_IMPORT, // allow cypress/suport/index.js to require the correct css file
+    }),
+  ]
 };

--- a/cypress/plugins/webpack.config.js
+++ b/cypress/plugins/webpack.config.js
@@ -11,7 +11,7 @@
 const path = require('path');
 const webpack = require('webpack');
 
-const THEME_IMPORT = `'../../dist/eui_theme_amsterdam_${process.env.THEME ?? 'dark'}.css'`;
+const THEME_IMPORT = `'../../dist/eui_theme_amsterdam_${process.env.THEME}.css'`;
 
 module.exports = {
   mode: 'development',

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -14,4 +14,4 @@
 // ***********************************************************
 
 import '@cypress/code-coverage/support';
-import '../../dist/eui_theme_amsterdam_dark.css';
+require(THEME_IMPORT); // defined by DefinePlugin in the cypress webpack config

--- a/package.json
+++ b/package.json
@@ -92,8 +92,7 @@
     "unist-util-visit": "^2.0.3",
     "url-parse": "^1.5.3",
     "uuid": "^8.3.0",
-    "vfile": "^4.2.0",
-    "yargs": "^17.2.1"
+    "vfile": "^4.2.0"
   },
   "devDependencies": {
     "@axe-core/puppeteer": "^4.1.1",
@@ -229,6 +228,7 @@
     "webpack": "^4.44.1",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0",
+    "yargs": "^17.2.1",
     "yeoman-generator": "^4.12.0",
     "yo": "^3.1.1"
   },

--- a/scripts/cypress.js
+++ b/scripts/cypress.js
@@ -11,7 +11,7 @@ const argv = yargs(hideBin(process.argv))
   .options({
     'skip-css': { type: 'boolean' },
     'dev': { type: 'boolean' },
-    'theme': { type: 'string', default: 'dark', choices: ['light', 'dark'] },
+    'theme': { type: 'string', default: 'light', choices: ['light', 'dark'] },
   })
   .argv
 

--- a/scripts/cypress.js
+++ b/scripts/cypress.js
@@ -11,11 +11,13 @@ const argv = yargs(hideBin(process.argv))
   .options({
     'skip-css': { type: 'boolean' },
     'dev': { type: 'boolean' },
+    'theme': { type: 'string', default: 'dark', choices: ['light', 'dark'] },
   })
   .argv
 
 const isDev = argv.hasOwnProperty('dev');
 const skipScss = argv.hasOwnProperty('skip-css');
+const theme = argv.theme;
 
 const info = chalk.white;
 const log = chalk.grey;
@@ -24,7 +26,7 @@ const log = chalk.grey;
 if (!skipScss) {
   console.log(info('Compiling SCSS'));
   execSync(
-    `TARGET_THEME=amsterdam_dark yarn compile-scss`,
+    `TARGET_THEME=amsterdam_${theme} yarn compile-scss`,
     {
       stdio: 'inherit'
     }
@@ -35,6 +37,7 @@ if (!skipScss) {
 
 const cypressCommandParts = [
   'cross-env', // windows support
+  `THEME=${theme}`, // pass the theme
   'BABEL_MODULES=false', // let webpack receive ES Module code
   'NODE_ENV=cypress_test', // enable code coverage checks
   `cypress ${isDev ? 'open-ct' : 'run-ct'}`,

--- a/wiki/cypress-testing.md
+++ b/wiki/cypress-testing.md
@@ -6,6 +6,10 @@
 
 `yarn test-cypress-dev` launches a chrome window controlled by Cypress, which lists out the discovered tests and allows executing/interacting from that window.
 
+### Setting the theme
+
+By default tests are run using the dark theme. Light mode can be enabled by passing the `--theme=light` option.
+
 ### Skipping CSS compilation
 
 To ensure tests use up-to-date styles, the test runner compiles our SCSS to CSS before executing Cypress. This adds some processing time before the tests can run, and often the existing locally-built styles are still accurate. The CSS compilation step can be skipped by passing the `--skip-css` flag to `yarn test-cypress` and `yarn test-cypress-dev`.

--- a/wiki/cypress-testing.md
+++ b/wiki/cypress-testing.md
@@ -8,7 +8,7 @@
 
 ### Setting the theme
 
-By default tests are run using the dark theme. Light mode can be enabled by passing the `--theme=light` option.
+By default tests are run using the light theme. Dark mode can be enabled by passing the `--theme=dark` option.
 
 ### Skipping CSS compilation
 


### PR DESCRIPTION
### Summary

Adds a `--theme` flag to allow switching to light mode when running cypress. Usage is `--theme=light` or [default] `--theme=dark`. This specifies which css file to build (if `--skip-css` is not present) and uses webpack to define a magic variable so the right css file can be `require`d.

### ~Checklist~
