### PR TITLE
[EuiIcon] Moved isNamedColor out of a testenv-targeted file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`main`](https://github.com/elastic/eui/tree/main)
 
-No public interface changes since `41.2.0`.
+**Bug fixes**
+
+- Refactored definition of `isNamedColor` function so it isn't mocked away by the testenv configuration ([#5397](https://github.com/elastic/eui/pull/5397))
 
 ## [`41.2.0`](https://github.com/elastic/eui/tree/v41.2.0)
 

--- a/src/components/empty_prompt/empty_prompt.tsx
+++ b/src/components/empty_prompt/empty_prompt.tsx
@@ -14,7 +14,7 @@ import { EuiTitle, EuiTitleSize } from '../title';
 import { EuiFlexGroup, EuiFlexItem } from '../flex';
 import { EuiSpacer } from '../spacer';
 import { EuiIcon, IconColor, IconType } from '../icon';
-import { isNamedColor } from '../icon/icon';
+import { isNamedColor } from '../icon/named_colors';
 import { EuiText, EuiTextColor } from '../text';
 import { EuiPanel, _EuiPanelDivlike } from '../panel/panel';
 

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -20,6 +20,7 @@ import { icon as empty } from './assets/empty';
 import { enqueueStateChange } from '../../services/react';
 
 import { htmlIdGenerator } from '../../services';
+import { colorToClassMap, isNamedColor, NamedColor } from './named_colors';
 
 const typeToPathMap = {
   accessibility: 'accessibility',
@@ -457,26 +458,7 @@ export type EuiIconType = keyof typeof typeToPathMap;
 
 export type IconType = EuiIconType | string | ComponentType;
 
-const colorToClassMap = {
-  default: null,
-  primary: 'euiIcon--primary',
-  success: 'euiIcon--success',
-  accent: 'euiIcon--accent',
-  warning: 'euiIcon--warning',
-  danger: 'euiIcon--danger',
-  text: 'euiIcon--text',
-  subdued: 'euiIcon--subdued',
-  ghost: 'euiIcon--ghost',
-  inherit: 'euiIcon--inherit',
-};
-
 export const COLORS: NamedColor[] = keysOf(colorToClassMap);
-
-type NamedColor = keyof typeof colorToClassMap;
-
-export function isNamedColor(name: string): name is NamedColor {
-  return colorToClassMap.hasOwnProperty(name);
-}
 
 // We accept arbitrary color strings, which are impossible to type.
 export type IconColor = string | NamedColor;

--- a/src/components/icon/named_colors.tsx
+++ b/src/components/icon/named_colors.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export const colorToClassMap = {
+  default: null,
+  primary: 'euiIcon--primary',
+  success: 'euiIcon--success',
+  accent: 'euiIcon--accent',
+  warning: 'euiIcon--warning',
+  danger: 'euiIcon--danger',
+  text: 'euiIcon--text',
+  subdued: 'euiIcon--subdued',
+  ghost: 'euiIcon--ghost',
+  inherit: 'euiIcon--inherit',
+};
+
+export type NamedColor = keyof typeof colorToClassMap;
+
+export function isNamedColor(name: string): name is NamedColor {
+  return colorToClassMap.hasOwnProperty(name);
+}


### PR DESCRIPTION
### Summary

**EuiEmptyPrompt** uses the `isNamedColor` function from icon.tsx, but wasn't included in the icon.testenv.tsx mock. I don't think there's a good way to mock the function, so instead I moved it & its dependencies into a new file that isn't bypassed in test environments.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- [x] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
