### PR TITLE
[EuiDataGrid] Fix paginated & height-limited datagrids becoming unscrollable on `rowCount` change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`main`](https://github.com/elastic/eui/tree/main)
 
-No public interface changes since `41.2.1`.
+**Bug fixes**
+
+- Fixed an `EuiDataGrid` bug where paginated overflowing data grids could become unscrollable when `rowCount` changed ([#5400](https://github.com/elastic/eui/pull/5400))
 
 ## [`41.2.1`](https://github.com/elastic/eui/tree/v41.2.1)
 

--- a/src-docs/src/views/datagrid/datagrid.js
+++ b/src-docs/src/views/datagrid/datagrid.js
@@ -32,7 +32,6 @@ import {
   EuiPopover,
   EuiText,
   EuiTitle,
-  EuiRange,
 } from '../../../../src/components/';
 const DataContext = createContext();
 
@@ -401,64 +400,23 @@ export default () => {
     console.log(eventData);
   });
 
-  const [data, setData] = useState(raw_data);
-  const [rowCount, setRowCount] = useState(15);
-  const sliceData = useCallback((e) => {
-    const newRowCount = Number(e.target.value);
-    const newData = raw_data.slice(0, newRowCount);
-    setData(newData);
-    setRowCount(newRowCount);
-  }, []);
-  const setRowCountInput = (
-    <EuiRange
-      min={0}
-      max={100}
-      step={5}
-      showLabels
-      showRange
-      showInput
-      onChange={sliceData}
-      value={rowCount}
-    />
-  );
-
   return (
-    <DataContext.Provider value={data}>
-      {setRowCountInput}
-      <div style={{ height: '300px', overflow: 'scroll' }}>
-        <EuiDataGrid
-          aria-label="Data grid demo"
-          columns={columns}
-          columnVisibility={{ visibleColumns, setVisibleColumns }}
-          trailingControlColumns={trailingControlColumns}
-          rowCount={rowCount}
-          renderCellValue={renderCellValue}
-          inMemory={{ level: 'sorting' }}
-          sorting={{ columns: sortingColumns, onSort }}
-          pagination={{
-            ...pagination,
-            pageSizeOptions: [10, 50, 100],
-            onChangeItemsPerPage: onChangeItemsPerPage,
-            onChangePage: onChangePage,
-          }}
-          onColumnResize={onColumnResize.current}
-        />
-      </div>
+    <DataContext.Provider value={raw_data}>
       <EuiDataGrid
         aria-label="Data grid demo"
         columns={columns}
         columnVisibility={{ visibleColumns, setVisibleColumns }}
         trailingControlColumns={trailingControlColumns}
-        rowCount={rowCount}
+        rowCount={raw_data.length}
         renderCellValue={renderCellValue}
-        // inMemory={{ level: 'sorting' }}
-        // sorting={{ columns: sortingColumns, onSort }}
-        // pagination={{
-        //   ...pagination,
-        //   pageSizeOptions: [10, 50, 100],
-        //   onChangeItemsPerPage: onChangeItemsPerPage,
-        //   onChangePage: onChangePage,
-        // }}
+        inMemory={{ level: 'sorting' }}
+        sorting={{ columns: sortingColumns, onSort }}
+        pagination={{
+          ...pagination,
+          pageSizeOptions: [10, 50, 100],
+          onChangeItemsPerPage: onChangeItemsPerPage,
+          onChangePage: onChangePage,
+        }}
         onColumnResize={onColumnResize.current}
       />
     </DataContext.Provider>

--- a/src-docs/src/views/datagrid/datagrid.js
+++ b/src-docs/src/views/datagrid/datagrid.js
@@ -32,6 +32,7 @@ import {
   EuiPopover,
   EuiText,
   EuiTitle,
+  EuiRange,
 } from '../../../../src/components/';
 const DataContext = createContext();
 
@@ -400,23 +401,64 @@ export default () => {
     console.log(eventData);
   });
 
+  const [data, setData] = useState(raw_data);
+  const [rowCount, setRowCount] = useState(15);
+  const sliceData = useCallback((e) => {
+    const newRowCount = Number(e.target.value);
+    const newData = raw_data.slice(0, newRowCount);
+    setData(newData);
+    setRowCount(newRowCount);
+  }, []);
+  const setRowCountInput = (
+    <EuiRange
+      min={0}
+      max={100}
+      step={5}
+      showLabels
+      showRange
+      showInput
+      onChange={sliceData}
+      value={rowCount}
+    />
+  );
+
   return (
-    <DataContext.Provider value={raw_data}>
+    <DataContext.Provider value={data}>
+      {setRowCountInput}
+      <div style={{ height: '300px', overflow: 'scroll' }}>
+        <EuiDataGrid
+          aria-label="Data grid demo"
+          columns={columns}
+          columnVisibility={{ visibleColumns, setVisibleColumns }}
+          trailingControlColumns={trailingControlColumns}
+          rowCount={rowCount}
+          renderCellValue={renderCellValue}
+          inMemory={{ level: 'sorting' }}
+          sorting={{ columns: sortingColumns, onSort }}
+          pagination={{
+            ...pagination,
+            pageSizeOptions: [10, 50, 100],
+            onChangeItemsPerPage: onChangeItemsPerPage,
+            onChangePage: onChangePage,
+          }}
+          onColumnResize={onColumnResize.current}
+        />
+      </div>
       <EuiDataGrid
         aria-label="Data grid demo"
         columns={columns}
         columnVisibility={{ visibleColumns, setVisibleColumns }}
         trailingControlColumns={trailingControlColumns}
-        rowCount={raw_data.length}
+        rowCount={rowCount}
         renderCellValue={renderCellValue}
-        inMemory={{ level: 'sorting' }}
-        sorting={{ columns: sortingColumns, onSort }}
-        pagination={{
-          ...pagination,
-          pageSizeOptions: [10, 50, 100],
-          onChangeItemsPerPage: onChangeItemsPerPage,
-          onChangePage: onChangePage,
-        }}
+        // inMemory={{ level: 'sorting' }}
+        // sorting={{ columns: sortingColumns, onSort }}
+        // pagination={{
+        //   ...pagination,
+        //   pageSizeOptions: [10, 50, 100],
+        //   onChangeItemsPerPage: onChangeItemsPerPage,
+        //   onChangePage: onChangePage,
+        // }}
         onColumnResize={onColumnResize.current}
       />
     </DataContext.Provider>

--- a/src/components/datagrid/body/data_grid_body.tsx
+++ b/src/components/datagrid/body/data_grid_body.tsx
@@ -596,11 +596,6 @@ export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
     makeRowManager(innerGridRef)
   );
 
-  // reset height constraint when rowCount changes
-  useEffect(() => {
-    setHeight(undefined);
-  }, [rowCount]);
-
   useEffect(() => {
     const boundingRect = wrapperRef.current!.getBoundingClientRect();
 
@@ -610,7 +605,7 @@ export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
     if (boundingRect.width !== unconstrainedWidth) {
       setWidth(boundingRect.width);
     }
-  }, [unconstrainedHeight, wrapperDimensions, isFullScreen]);
+  }, [rowCount, unconstrainedHeight, wrapperDimensions, isFullScreen]);
 
   const preventTabbing = useCallback((records: MutationRecord[]) => {
     // multiple mutation records can implicate the same cell


### PR DESCRIPTION
## Summary

- closes #5391
- Bug introduced in https://github.com/elastic/eui/pull/5313

## Problem

https://github.com/elastic/eui/blob/a648149ac0ecb5cb94b655f39187a494344bc9eb/src/components/datagrid/body/data_grid_body.tsx#L601

`height` being set to undefined means that `finalHeight` falls back to `unconstrainedHeight` here on line 641:

https://github.com/elastic/eui/blob/cb9f462a4fc63913019f921bf3fbe5d4c2ba7846/src/components/datagrid/body/data_grid_body.tsx#L639-L641

Which leads to `.euiDataGrid__virtualized` and the inner content being the same `unconstrainedHeight`, resulting in inner content that never scrolls:

<img width="516" alt="" src="https://user-images.githubusercontent.com/549407/142915208-d52806ee-d87b-47b5-805b-3f0b42c21139.png">

### Before

https://user-images.githubusercontent.com/549407/142914297-31dce55a-58b8-46fe-83a5-04d73679a973.mp4

## Solution

Having the main `setHeight()` logic (lines 604-608) respond dynamically to `rowCount` fixes the issue. I did some testing and was also fairly sure that the `setHeight(undefined)` line was unnecessary and that just adding `rowCount` as a dependency/side effect of determining the wrapper height was sufficient to solve the initial issue in #5313, but would appreciate a confirmation of that @chandlerprall!

### After

https://user-images.githubusercontent.com/549407/142914313-8a23f3a4-7d35-4dba-af0f-f135c8257dc0.mp4

### Regression testing

https://user-images.githubusercontent.com/549407/142914429-84303187-d0f9-4440-a963-0c7abded1cc4.mp4

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

NOTE: Heights are still not working quite the same on my local Firefox as on Chrome, but we ascertained this appears to be individual to my Firefox in https://github.com/elastic/eui/pull/5313#issuecomment-951119400

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~

- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**

Not 100% sure about adding tests for this as #5391 did not have any

~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
