### PR TITLE
Update yeoman docs generator

### DIFF
--- a/generator-eui/documentation/index.js
+++ b/generator-eui/documentation/index.js
@@ -128,6 +128,7 @@ module.exports = class extends Generator {
       const {
         componentExampleName,
         componentExamplePrefix,
+        componentName,
         fileName,
       } = this.config.documentationVars;
 
@@ -140,30 +141,23 @@ module.exports = class extends Generator {
             'const'
           )} ${componentExamplePrefix}Source = require(${chalk.cyan(
             `'!!raw-loader!./${fileName}'`
-          )});\n` +
-          `${chalk.magenta(
-            'const'
-          )} ${componentExamplePrefix}Html = renderToHtml(${componentExampleName});`
+          )});`
       );
 
-      this.log(chalk.white('\n// Render demo.'));
+      this.log(chalk.white('\n// Append to existing example sections.'));
       this.log(
-        '<GuideSection\n' +
-          `  title="${componentExampleName}"\n` +
-          '  source={[{\n' +
+        '{\n' +
+          `  title: '${componentExampleName}',\n` +
+          '  source: [{\n' +
           '    type: GuideSectionTypes.JS,\n' +
           `    code: ${componentExamplePrefix}Source,\n` +
-          '  }, {\n' +
-          '    type: GuideSectionTypes.HTML,\n' +
-          `    code: ${componentExamplePrefix}Html,\n` +
-          '  }]}\n' +
-          '  text={\n' +
-          `    <p>Description needed: how to use the ${componentExampleName} component.</p>\n` +
-          ' }\n' +
-          '  demo={\n' +
-          `    <${componentExampleName} />\n` +
-          ' }\n' +
-          '/>\n'
+          '  }],\n' +
+          '  text: (\n' +
+          `    <><p>Description needed: how to use the <strong>${componentExampleName}</strong> component.</p></>\n` +
+          '  ),\n' +
+          `  demo: <${componentExampleName} />,\n` +
+          `  props: { ${componentName} },\n` +
+        ' }\n'
       );
     };
 

--- a/generator-eui/documentation/index.js
+++ b/generator-eui/documentation/index.js
@@ -148,13 +148,13 @@ module.exports = class extends Generator {
       this.log(
         '{\n' +
           `  title: '${componentExampleName}',\n` +
+          '  text: (\n' +
+          `    <><p>Description needed: how to use the <strong>${componentExampleName}</strong> component.</p></>\n` +
+          '  ),\n' +
           '  source: [{\n' +
           '    type: GuideSectionTypes.JS,\n' +
           `    code: ${componentExamplePrefix}Source,\n` +
           '  }],\n' +
-          '  text: (\n' +
-          `    <><p>Description needed: how to use the <strong>${componentExampleName}</strong> component.</p></>\n` +
-          '  ),\n' +
           `  demo: <${componentExampleName} />,\n` +
           `  props: { ${componentName} },\n` +
         ' }\n'

--- a/generator-eui/documentation/templates/documentation_page.js
+++ b/generator-eui/documentation/templates/documentation_page.js
@@ -15,10 +15,6 @@ export const <%= componentExampleName %>Example = {
   title: '<%= componentExampleName %>',
   sections: [{
     title: '<%= componentExampleName %>',
-    source: [{
-      type: GuideSectionTypes.JS,
-      code: <%= componentExamplePrefix %>Source,
-    }],
     text: (
       <>
         <p>
@@ -26,6 +22,10 @@ export const <%= componentExampleName %>Example = {
         </p>
       </>
     ),
+    source: [{
+      type: GuideSectionTypes.JS,
+      code: <%= componentExamplePrefix %>Source,
+    }],
     demo: <<%= componentExampleName %> />,
     props: { <%= componentName %> },
   }],

--- a/generator-eui/documentation/templates/documentation_page.js
+++ b/generator-eui/documentation/templates/documentation_page.js
@@ -5,6 +5,7 @@ import {
 } from '../../components';
 
 import {
+  EuiText,
   <%= componentName %>,
 } from '../../../../src';
 
@@ -13,6 +14,9 @@ const <%= componentExamplePrefix %>Source = require('!!raw-loader!./<%= fileName
 
 export const <%= componentExampleName %>Example = {
   title: '<%= componentExampleName %>',
+  intro: (
+    <><EuiText></EuiText></>
+  ),
   sections: [{
     title: '<%= componentExampleName %>',
     text: (

--- a/generator-eui/documentation/templates/documentation_page.js
+++ b/generator-eui/documentation/templates/documentation_page.js
@@ -1,18 +1,15 @@
 import React from 'react';
 
-import { renderToHtml } from '../../services';
-
 import {
   GuideSectionTypes,
 } from '../../components';
 
 import {
   <%= componentName %>,
-} from '../../../../src/components';
+} from '../../../../src';
 
 import <%= componentExampleName %> from './<%= fileName %>';
 const <%= componentExamplePrefix %>Source = require('!!raw-loader!./<%= fileName %>');
-const <%= componentExamplePrefix %>Html = renderToHtml(<%= componentExampleName %>);
 
 export const <%= componentExampleName %>Example = {
   title: '<%= componentExampleName %>',
@@ -21,16 +18,15 @@ export const <%= componentExampleName %>Example = {
     source: [{
       type: GuideSectionTypes.JS,
       code: <%= componentExamplePrefix %>Source,
-    }, {
-      type: GuideSectionTypes.HTML,
-      code: <%= componentExamplePrefix %>Html,
     }],
     text: (
-      <p>
-        Description needed: how to use the <strong>Eui<%= componentExampleName %></strong> component.
-      </p>
+      <>
+        <p>
+          Description needed: how to use the <strong>Eui<%= componentExampleName %></strong> component.
+        </p>
+      </>
     ),
-    props: { <%= componentName %> },
     demo: <<%= componentExampleName %> />,
+    props: { <%= componentName %> },
   }],
 };

--- a/generator-eui/documentation/templates/documentation_page_demo.tsx
+++ b/generator-eui/documentation/templates/documentation_page_demo.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {
   <%= componentName %>,
-} from '../../../../src/components/<%= folderName %>';
+} from '../../../../src';
 
 export default () => (
   <<%= componentName %>>


### PR DESCRIPTION
- Removes `HTML` source tab
- Aligns both sets to spit out the same content
- Wraps text in fragment (we do this manually a lot)
- Changes the `existing` doc output to be the **object** method not component
- Reduces import path to just `/src` since further folders are no longer necessary
- Moved order of `text` to just after `title` since `source` it's more related to the `demo`
- Added `intro` section to the new page with required `<EuiText>`

---


Running the following commands: 

1. `yarn run yo-doc` option 1 for component called `test`
```bash
? What do you want to do? Create a new component documentation page
? What's the name of the component you're documenting? Use snake_case, please. test
```

2. `yarn run yo-doc` option 2 for the same named component `test`
```bash
? What do you want to do? Add an example to an existing component documentation page
? What's the name of the component you're documenting? Use snake_case, please. test
? What's the name of the directory this demo should go in? (Within src-docs/src/views). Use snake_case, please. test
? What would you like to name this demo? Use snake_case, please. test_existing
```

Results in:

**test/test_example.tsx**

```tsx
import React from 'react';

import { GuideSectionTypes } from '../../components';

import { EuiTest } from '../../../../src';

import Test from './test';
const testSource = require('!!raw-loader!./test');

import TestExisting from './test_existing';
const testExistingSource = require('!!raw-loader!./test_existing');

export const TestExample = {
  title: 'Test',
  intro: (
    <>
      <EuiText />
    </>
  ),
  sections: [
    {
      title: 'Test',
      text: (
        <>
          <p>
            Description needed: how to use the <strong>EuiTest</strong>{' '}
            component.
          </p>
        </>
      ),
      source: [
        {
          type: GuideSectionTypes.JS,
          code: testSource,
        },
      ],
      demo: <Test />,
      props: { EuiTest },
    },
    {
      title: 'TestExisting',
      text: (
        <>
          <p>
            Description needed: how to use the <strong>TestExisting</strong>{' '}
            component.
          </p>
        </>
      ),
      source: [
        {
          type: GuideSectionTypes.JS,
          code: testExistingSource,
        },
      ],
      demo: <TestExisting />,
      props: { EuiTest },
    },
  ],
};
```