### PR TITLE
[EuiTableFieldDataColumnType] improve autocomplete suggestions for `field` property

### DIFF
--- a/src/components/basic_table/table_types.ts
+++ b/src/components/basic_table/table_types.ts
@@ -34,7 +34,9 @@ export interface EuiTableFieldDataColumnType<T>
   /**
    * A field of the item (may be a nested field)
    */
-  field: keyof T | string; // supports outer.inner key paths
+  // type hack used for better autocomplete support
+  // https://github.com/microsoft/TypeScript/issues/29729
+  field: keyof T | (string & {}); // supports outer.inner key paths
   /**
    * The display name of the column
    */


### PR DESCRIPTION
### Summary

https://github.com/elastic/eui/blob/4a67fdc66ea7f9139824c7d000ec4f5d4402b7f1/src/components/basic_table/table_types.ts#L37

currently there's no suggestions from `keyof T` on `field` when the type is `EuiTableFieldDataColumnType` 

turns out this happens because `keyof T | string` ends up being just `string` 

[workaround](https://github.com/microsoft/TypeScript/issues/29729#issuecomment-460346421) is applied in this PR

and suggestions now include the keys from `T` :

![Screen Shot 2021-11-22 at 22 26 32](https://user-images.githubusercontent.com/20814186/142931167-5e1cfeef-ec5a-4a06-98b5-d0d5ec533f98.png)


also -

- we could get support for all nested keys with [Paths<T>](https://stackoverflow.com/a/58436959) but that's probably too much
- we could enforce root keys or dotted keys with root key as prefix, not sure it's worth it though

### Checklist

i think it's not relevant here. types didn't really change, just how TS displays them. 