### PR TITLE
Fixes typo in EuiPageHeader docs

### DIFF
--- a/src/components/page/page_header/page_header_content.tsx
+++ b/src/components/page/page_header/page_header_content.tsx
@@ -81,7 +81,7 @@ export type EuiPageHeaderContentProps = CommonProps &
   EuiPageHeaderContentLeft & {
     /**
      * Set to false if you don't want the children to stack at small screen sizes.
-     * Set to `reverse` to display the right side content first for the sack of hierarchy (like global time)
+     * Set to `reverse` to display the right side content first for the sake of hierarchy (like global time)
      */
     responsive?: boolean | 'reverse';
     /**


### PR DESCRIPTION
### Summary

This PR fixes a small typo in the autodocs of `EuiPageHeader`.

### Checklist

- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**