### PR TITLE
Exclude mocks and Cypress specs from eui.d.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed virtualized `EuiCodeBlock`s blanking out when entering & exiting full-screen mode ([#5379](https://github.com/elastic/eui/pull/5379))
 - Fixed `EuiCodeBlock`'s full-screen mode to use a large font and padding size & added several missing wrapper classes ([#5379](https://github.com/elastic/eui/pull/5379))
 - Fixed `EuiCodeBlock` broken line wrapping when using virtualization ([#5379](https://github.com/elastic/eui/pull/5379))
+- Fixed type exports to not include test mocks & specs ([#5412](https://github.com/elastic/eui/pull/5412))
 
 **Theme: Amsterdam**
 

--- a/scripts/dtsgenerator.js
+++ b/scripts/dtsgenerator.js
@@ -31,10 +31,11 @@ const generator = dtsGenerator({
   exclude: [
     'node_modules/**/*.d.ts',
     '*/custom_typings/**/*.d.ts',
-    '**/*.test.ts',
-    '**/*.test.tsx',
-    '**/*.testenv.ts',
-    '**/*.testenv.tsx',
+    '**/*.test.{ts,tsx}',
+    '**/*.testenv.{ts,tsx}',
+    '**/*.spec.{ts,tsx}',
+    '**/*.mock.{ts,tsx}',
+    '**/__mocks__/*',
     'src/themes/charts/*', // A separate d.ts file is generated for the charts theme file
     'src/test/*', // A separate d.ts file is generated for test utils
     'src-docs/**/*', // Don't include src-docs


### PR DESCRIPTION
### Summary

Per @1Copenut's upgrade Kibana PR (https://github.com/elastic/kibana/pull/119205), the checks step is failing with this error:

```
ERROR Type check failed in test/tsconfig.json:
ERROR node_modules/@elastic/eui/eui.d.ts:17870:31 - error TS2503: Cannot find namespace 'jest'.
```

> It looks like there's a TypeScript export issue that I traced back to row_height_utils.ts (datagrid mock) and line 17,864 of the eui.d.ts definitions file.

Mocks should **not** be exported in our `eui.d.ts` file, nor should any other test files. I've updated our `dtsgenerator.js` config to exclude all possible mocks, as well as Cypress spec files just in case.

### Checklist

- [ ] Test against local Kibana somehow before patch release??
