### PR TITLE
[EuiCodeBlock] Fix HTML attributes not being accepted as props

### DIFF
--- a/src/components/code/code.tsx
+++ b/src/components/code/code.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { useMemo, FunctionComponent, HTMLAttributes } from 'react';
+import React, { useMemo, FunctionComponent } from 'react';
 import { highlight, RefractorNode } from 'refractor';
 import classNames from 'classnames';
 import {
@@ -16,7 +16,7 @@ import {
   getHtmlContent,
 } from './utils';
 
-export type EuiCodeProps = EuiCodeSharedProps & HTMLAttributes<HTMLElement>;
+export type EuiCodeProps = EuiCodeSharedProps;
 
 export const EuiCode: FunctionComponent<EuiCodeProps> = ({
   transparentBackground = false,

--- a/src/components/code/code_block.tsx
+++ b/src/components/code/code_block.tsx
@@ -125,8 +125,7 @@ export type EuiCodeBlockProps = EuiCodeSharedProps & {
    * `whiteSpace` can only be `pre`.
    */
   isVirtualized?: boolean;
-} & VirtualizedOptionProps &
-  HTMLAttributes<HTMLElement>;
+} & VirtualizedOptionProps;
 
 export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
   language: _language = DEFAULT_LANGUAGE,

--- a/src/components/code/code_block.tsx
+++ b/src/components/code/code_block.tsx
@@ -125,7 +125,8 @@ export type EuiCodeBlockProps = EuiCodeSharedProps & {
    * `whiteSpace` can only be `pre`.
    */
   isVirtualized?: boolean;
-} & VirtualizedOptionProps;
+} & VirtualizedOptionProps &
+  HTMLAttributes<HTMLElement>;
 
 export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
   language: _language = DEFAULT_LANGUAGE,

--- a/src/components/code/utils.tsx
+++ b/src/components/code/utils.tsx
@@ -6,7 +6,12 @@
  * Side Public License, v 1.
  */
 
-import React, { createElement, ReactElement, ReactNode } from 'react';
+import React, {
+  createElement,
+  ReactElement,
+  ReactNode,
+  HTMLAttributes,
+} from 'react';
 import { listLanguages, highlight, AST, RefractorNode } from 'refractor';
 import classNames from 'classnames';
 import { CommonProps } from '../common';
@@ -15,14 +20,15 @@ import { CommonProps } from '../common';
  * Utils shared between EuiCode and EuiCodeBlock
  */
 
-export type EuiCodeSharedProps = CommonProps & {
-  /**
-   * Sets the syntax highlighting for a specific language
-   * @see [https://prismjs.com/#supported-languages](https://prismjs.com/#supported-languages) for options
-   */
-  language?: string;
-  transparentBackground?: boolean;
-};
+export type EuiCodeSharedProps = CommonProps &
+  HTMLAttributes<HTMLElement> & {
+    /**
+     * Sets the syntax highlighting for a specific language
+     * @see [https://prismjs.com/#supported-languages](https://prismjs.com/#supported-languages) for options
+     */
+    language?: string;
+    transparentBackground?: boolean;
+  };
 
 export const SUPPORTED_LANGUAGES = listLanguages();
 export const DEFAULT_LANGUAGE = 'text';


### PR DESCRIPTION
### Summary

In #5379, I refactored `code_block.tsx` to essentially be `_code_block.tsx` but forgot to check/update the types accordingly:

https://github.com/elastic/eui/blob/c85913bef931f2eb7df754c48eca7fdf6481ebc4/src/components/code/code_block.tsx#L14-L16

(specifically the last line is what I missed)

CommonProps was DRY'd out to `EuiSharedProps`. (Theoretically `& HTMLAttributes<HTMLElement>` could go there as well since EuiCode uses it as well - would be open to making that change, let me know)

Without this fix, a bunch of Kibana type checks end up failing because folks are using (e.g.) `style` and other props on EuiCodeBlock:

```
      x-pack/plugins/enterprise_search/public/applications/workplace_search/components/shared/status_item/status_item.tsx:47:9 - error TS2322: Type '{ children: string; language: string; fontSize: "m"; paddingSize: "m"; style: { maxWidth: number; }; isCopyable: true; }' is not assignable to type '(IntrinsicAttributes & CommonProps & { language?: string | undefined; transparentBackground?: boolean | undefined; } & { paddingSize?: "none" | "s" | "m" | "l" | undefined; ... 5 more ...; isVirtualized?: boolean | undefined; } & DisambiguateSet<...> & { ...; } & { ...; }) | (IntrinsicAttributes & ... 5 more ... & {...'.
        Property 'style' does not exist on type '(IntrinsicAttributes & CommonProps & { language?: string | undefined; transparentBackground?: boolean | undefined; } & { paddingSize?: "none" | "s" | "m" | "l" | undefined; ... 5 more ...; isVirtualized?: boolean | undefined; } & DisambiguateSet<...> & { ...; } & { ...; }) | (IntrinsicAttributes & ... 5 more ... & {...'.

      47         style={{ maxWidth: 300 }}
```

### Checklist

- [x] Props table is same as before
- [x] Paste `eui.d.ts` from this branch into Kibana and run `node scripts/type_check` - all tests should pass

~- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~

No changelog since EuiCodeBlock changes are still in main and have yet to be released