### PR TITLE
[Docs] Fix Sass `border-radius` snippet in theming borders

### DIFF
--- a/src-docs/src/views/theme/borders/_border_sass.tsx
+++ b/src-docs/src/views/theme/borders/_border_sass.tsx
@@ -142,7 +142,7 @@ export const RadiusSass: FunctionComponent<ThemeRowType> = ({
             <strong>{`border-radius: ${values.euiBorderRadius};`}</strong>
           </div>
         }
-        snippet={'border-width: $euiBorderRadius;'}
+        snippet={'border-radius: $euiBorderRadius;'}
         snippetLanguage="scss"
       />
 


### PR DESCRIPTION
### Summary

This PR fixes the Sass `border-radius` snippet in theming borders that was incorrect.

<img width="1135" alt="theming-border-radius-code-snippet@2x" src="https://user-images.githubusercontent.com/2750668/143919790-14f74b70-c889-41a1-a4e6-922ab36d04ac.png">

### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- ~[ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
