### PR TITLE
[EuiCodeBlock] Fix empty code blocks with children returning `[Object object]`, use `fullScreenExit` icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## [`main`](https://github.com/elastic/eui/tree/main)
 
 - Added `payment` glyph to `EuiIcon` ([#5414](https://github.com/elastic/eui/pull/5414))
+- Updated `EuiCodeBlock`'s full screen mode to use the `fullScreenExit` icon ([#5421](https://github.com/elastic/eui/pull/5421))
+
+**Bug fixes**
+
+- Fixed an `EuiCodeBlock` bug where empty code blocks could be copyable ([#5421](https://github.com/elastic/eui/pull/5421))
 
 ## [`41.3.0`](https://github.com/elastic/eui/tree/v41.3.0)
 

--- a/src-docs/src/views/code/code_block_copy.tsx
+++ b/src-docs/src/views/code/code_block_copy.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 import { EuiCodeBlock } from '../../../../src/components';
 
-const htmlCode = `<!-- I'm an example of HTML -->
-<h1>Hello world!</h1>
-<p>Lorem ipsum dolor sit amet.</p>`;
+// const htmlCode = `<!-- I'm an example of HTML -->
+// <h1>Hello world!</h1>
+// <p>Lorem ipsum dolor sit amet.</p>`;
 
 export default () => (
-  <EuiCodeBlock language="html" isCopyable>
-    {htmlCode}
+  <EuiCodeBlock isCopyable>
+    <div />
   </EuiCodeBlock>
 );

--- a/src-docs/src/views/code/code_block_copy.tsx
+++ b/src-docs/src/views/code/code_block_copy.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 import { EuiCodeBlock } from '../../../../src/components';
 
-// const htmlCode = `<!-- I'm an example of HTML -->
-// <h1>Hello world!</h1>
-// <p>Lorem ipsum dolor sit amet.</p>`;
+const htmlCode = `<!-- I'm an example of HTML -->
+<h1>Hello world!</h1>
+<p>Lorem ipsum dolor sit amet.</p>`;
 
 export default () => (
-  <EuiCodeBlock isCopyable>
-    <div />
+  <EuiCodeBlock language="html" isCopyable>
+    {htmlCode}
   </EuiCodeBlock>
 );

--- a/src/components/code/__snapshots__/code_block.test.tsx.snap
+++ b/src/components/code/__snapshots__/code_block.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`EuiCodeBlock full screen displays content in fullscreen mode 1`] = `
           aria-label="Collapse"
           className="euiCodeBlock__fullScreenButton"
           color="text"
-          iconType="cross"
+          iconType="fullScreenExit"
           onClick={[Function]}
         >
           <button
@@ -119,13 +119,13 @@ exports[`EuiCodeBlock full screen displays content in fullscreen mode 1`] = `
               className="euiButtonIcon__icon"
               color="inherit"
               size="m"
-              type="cross"
+              type="fullScreenExit"
             >
               <span
                 aria-hidden="true"
                 className="euiButtonIcon__icon"
                 color="inherit"
-                data-euiicon-type="cross"
+                data-euiicon-type="fullScreenExit"
                 size="m"
               />
             </EuiIcon>

--- a/src/components/code/code_block.test.tsx
+++ b/src/components/code/code_block.test.tsx
@@ -200,6 +200,20 @@ describe('EuiCodeBlock', () => {
       expect(component).toMatchSnapshot();
     });
 
+    it('correctly copies virtualized text', () => {
+      const component = render(
+        <EuiCodeBlock
+          isCopyable
+          isVirtualized={true}
+          overflowHeight="50%"
+          {...requiredProps}
+        >
+          {code}
+        </EuiCodeBlock>
+      );
+      expect(component.find('.euiCodeBlock__copyButton')).toHaveLength(1);
+    });
+
     describe('type checks', () => {
       it('requires overflowHeight', () => {
         // @ts-expect-error should expect overflowHeight

--- a/src/components/code/code_block.tsx
+++ b/src/components/code/code_block.tsx
@@ -166,13 +166,14 @@ export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
     children,
   ]);
 
-  const isVirtualized = useMemo(() => _isVirtualized && Array.isArray(data), [
-    _isVirtualized,
-    data,
-  ]);
+  const isVirtualized = useMemo(
+    () => !!(_isVirtualized && Array.isArray(data)),
+    [_isVirtualized, data]
+  );
 
   const { innerTextRef, showCopyButton, CopyButton } = useCopy({
     isCopyable,
+    isVirtualized,
     children,
   });
 
@@ -334,18 +335,19 @@ const useOverflowDetection = () => {
 
 const useCopy = ({
   isCopyable,
+  isVirtualized,
   children,
 }: {
   isCopyable: boolean;
+  isVirtualized: boolean;
   children: ReactNode;
 }) => {
   const [innerTextRef, _innerText] = useInnerText('');
   const innerText = useMemo(
-    () => _innerText?.replace(/[\r\n?]{2}|\n\n/g, '\n'),
+    () => _innerText?.replace(/[\r\n?]{2}|\n\n/g, '\n') || '',
     [_innerText]
   );
-  // Fallback to `children` for virtualized blocks
-  const textToCopy = innerText || `${children}`;
+  const textToCopy = isVirtualized ? `${children}` : innerText; // Virtualized code blocks do not have inner text
 
   const showCopyButton = isCopyable && textToCopy;
 

--- a/src/components/code/code_block.tsx
+++ b/src/components/code/code_block.tsx
@@ -416,7 +416,7 @@ const useFullScreen = ({
           <EuiButtonIcon
             className="euiCodeBlock__fullScreenButton"
             onClick={toggleFullScreen}
-            iconType={isFullScreen ? 'cross' : 'fullScreen'}
+            iconType={isFullScreen ? 'fullScreenExit' : 'fullScreen'}
             color="text"
             aria-label={isFullScreen ? fullscreenCollapse : fullscreenExpand}
           />


### PR DESCRIPTION
## Summary

Fixes a copy bug and incidentally closes #5416 while I'm here

### Before

When using empty HTML nodes/React components inside an `EuiCodeBlock`, e.g.:

```
<EuiCodeBlock>
  <div />
</EuiCodeBlock>
```

It was possible for the copy button to incorrectly output `[Object object]` due to the ``` innerText || `${children}` ``` fallback.

![before](https://user-images.githubusercontent.com/549407/143926188-e3acada3-579a-4dc5-893a-8a0c1354585a.gif)

### After

<img width="1157" alt="" src="https://user-images.githubusercontent.com/549407/143926716-a8b93a8e-a2a7-4e45-af92-3a7c546dd811.png">

This PR amends the `${children}` fallback to _only_ be used for its intended edge case (virtualized code blocks), and correctly hides the copy buttons for EuiCodeBlocks with empty text and child nodes.

## QA

- [x] Confirm that the (temporary) empty doc example no longer has a copy button
- [x] Confirm that virtualization example still has correctly working copy-able text

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**

~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
- [x] Revert "REVERT ME" commit