### PR TITLE
[EuiDataGrid] Add `onChange` callbacks for display selector changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Updated `EuiDataGrid`'s full screen mode to use the `fullScreenExit` icon ([#5415](https://github.com/elastic/eui/pull/5415))
 - Added `left.append` and `left.prepend` to `EuiDataGrid`'s `toolbarVisibility.additionalControls` prop [#5394](https://github.com/elastic/eui/pull/5394))
 - Added a row height control to `EuiDataGrid`'s toolbar ([#5372](https://github.com/elastic/eui/pull/5372))
+- Added `onChange` callbacks to `EuiDataGrid`'s `gridStyle` and `rowHeightOptions` settings ([#5424](https://github.com/elastic/eui/pull/5424))
 
 **Bug fixes**
 

--- a/src-docs/src/views/datagrid/datagrid_height_options_example.js
+++ b/src-docs/src/views/datagrid/datagrid_height_options_example.js
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react';
+import { Link } from 'react-router-dom';
 
 import { GuideSectionTypes } from '../../components';
 import {
@@ -136,8 +137,8 @@ export const DataGridRowHeightOptionsExample = {
           By default, all rows get a height of <strong>34 pixels</strong>, but
           there are scenarios where you might want to adjust the height to fit
           more content. To do that, you can pass an object to the{' '}
-          <EuiCode>rowHeightsOptions</EuiCode> prop. This object accepts three
-          properties:
+          <EuiCode>rowHeightsOptions</EuiCode> prop. This object accepts the
+          following properties:
         </p>
         <ul>
           <li>
@@ -170,6 +171,24 @@ export const DataGridRowHeightOptionsExample = {
               <li>
                 Accepts any value that the <EuiCode>line-height</EuiCode> CSS
                 property normally takes (e.g. px, ems, rems, or unitless)
+              </li>
+            </ul>
+          </li>
+          <li>
+            <EuiCode>onChange</EuiCode>
+            <ul>
+              <li>
+                Optional callback when the user changes the data grid&apos;s
+                internal <EuiCode>rowHeightsOptions</EuiCode> (e.g., via the
+                toolbar display selector).
+              </li>
+              <li>
+                Can be used to store and preserve user display preferences on
+                page refresh - see this{' '}
+                <Link to="/tabular-content/data-grid-styling-and-control#adjusting-your-grid-to-usertoolbar-changes">
+                  data grid styling and control example
+                </Link>
+                .
               </li>
             </ul>
           </li>

--- a/src-docs/src/views/datagrid/datagrid_styling_example.js
+++ b/src-docs/src/views/datagrid/datagrid_styling_example.js
@@ -11,6 +11,9 @@ import {
   EuiListGroupItem,
 } from '../../../../src/components';
 
+import DataGridDisplayCallbacks from './display_callbacks';
+const dataGridDisplayCallbacksSource = require('!!raw-loader!./display_callbacks');
+
 import DataGridContainer from './container';
 const dataGridContainerSource = require('!!raw-loader!./container');
 const dataGridContainerHtml = renderToHtml(DataGridContainer);
@@ -219,6 +222,32 @@ export const DataGridStylingExample = {
         EuiDataGridToolBarVisibilityOptions,
       },
       demo: <DataGridStyling />,
+    },
+    {
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: dataGridDisplayCallbacksSource,
+        },
+      ],
+      title: 'Adjusting your grid to user/toolbar changes',
+      text: (
+        <>
+          <p>
+            You can use the optional <EuiCode>gridStyle.onChange</EuiCode> and{' '}
+            <EuiCode>rowHeightsOptions.onChange</EuiCode> callbacks to adjust
+            your data grid based on user density or row height changes.
+          </p>
+          <p>
+            For example, if the user changes the grid density to compressed, you
+            may want to adjust a cell&apos;s content sizing in response. Or you
+            could store user settings in localStorage or other database to
+            preserve display settings on page refresh, like the below example
+            does.
+          </p>
+        </>
+      ),
+      demo: <DataGridDisplayCallbacks />,
     },
     {
       source: [

--- a/src-docs/src/views/datagrid/display_callbacks.js
+++ b/src-docs/src/views/datagrid/display_callbacks.js
@@ -1,0 +1,92 @@
+import React, { useState, useCallback, useMemo } from 'react';
+import { fake } from 'faker';
+
+import { EuiDataGrid, EuiIcon } from '../../../../src/components/';
+
+const columns = [
+  { id: 'name' },
+  { id: 'email' },
+  { id: 'city' },
+  { id: 'country' },
+  { id: 'account' },
+];
+const data = [];
+for (let i = 1; i <= 5; i++) {
+  data.push({
+    name: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
+    email: fake('{{internet.email}}'),
+    city: fake('{{address.city}}'),
+    country: fake('{{address.country}}'),
+    account: fake('{{finance.account}}'),
+  });
+}
+
+const GRID_STYLES_KEY = 'euiDataGridStyles';
+const INITIAL_STYLES = JSON.stringify({ stripes: true });
+const storedGridStyles = JSON.parse(
+  localStorage.getItem(GRID_STYLES_KEY) || INITIAL_STYLES
+);
+
+const ROW_HEIGHTS_KEY = 'euiDataGridRowHeightsOptions';
+const INITIAL_ROW_HEIGHTS = JSON.stringify({});
+const storedRowHeightsOptions = JSON.parse(
+  localStorage.getItem(ROW_HEIGHTS_KEY) || INITIAL_ROW_HEIGHTS
+);
+
+export default () => {
+  const [densitySize, setDensitySize] = useState('');
+  const responsiveIcon = useCallback(
+    () => <EuiIcon type="user" size={densitySize} />,
+    [densitySize]
+  );
+  const responsiveIconWidth = useMemo(() => {
+    if (densitySize === 'l') return 44;
+    if (densitySize === 's') return 24;
+    return 32;
+  }, [densitySize]);
+  const leadingControlColumns = useMemo(
+    () => [
+      {
+        id: 'icon',
+        width: responsiveIconWidth,
+        headerCellRender: responsiveIcon,
+        rowCellRender: responsiveIcon,
+      },
+    ],
+    [responsiveIcon, responsiveIconWidth]
+  );
+
+  const saveRowHeightsOptions = useCallback((updatedRowHeights) => {
+    console.log(updatedRowHeights);
+    localStorage.setItem(ROW_HEIGHTS_KEY, JSON.stringify(updatedRowHeights));
+  }, []);
+
+  const saveGridStyles = useCallback((updatedStyles) => {
+    console.log(updatedStyles);
+    localStorage.setItem(GRID_STYLES_KEY, JSON.stringify(updatedStyles));
+    setDensitySize(updatedStyles.fontSize);
+  }, []);
+
+  const [visibleColumns, setVisibleColumns] = useState(() =>
+    columns.map(({ id }) => id)
+  );
+
+  return (
+    <EuiDataGrid
+      aria-label="DataGrid demonstrating display selector callbacks"
+      leadingControlColumns={leadingControlColumns}
+      rowHeightsOptions={{
+        ...storedRowHeightsOptions,
+        onChange: saveRowHeightsOptions,
+      }}
+      gridStyle={{
+        ...storedGridStyles,
+        onChange: saveGridStyles,
+      }}
+      columns={columns}
+      columnVisibility={{ visibleColumns, setVisibleColumns }}
+      rowCount={data.length}
+      renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
+    />
+  );
+};

--- a/src-docs/src/views/datagrid/display_callbacks.js
+++ b/src-docs/src/views/datagrid/display_callbacks.js
@@ -23,15 +23,9 @@ for (let i = 1; i <= 5; i++) {
 
 const GRID_STYLES_KEY = 'euiDataGridStyles';
 const INITIAL_STYLES = JSON.stringify({ stripes: true });
-const storedGridStyles = JSON.parse(
-  localStorage.getItem(GRID_STYLES_KEY) || INITIAL_STYLES
-);
 
 const ROW_HEIGHTS_KEY = 'euiDataGridRowHeightsOptions';
 const INITIAL_ROW_HEIGHTS = JSON.stringify({});
-const storedRowHeightsOptions = JSON.parse(
-  localStorage.getItem(ROW_HEIGHTS_KEY) || INITIAL_ROW_HEIGHTS
-);
 
 export default () => {
   const [densitySize, setDensitySize] = useState('');
@@ -56,12 +50,21 @@ export default () => {
     [responsiveIcon, responsiveIconWidth]
   );
 
-  const saveRowHeightsOptions = useCallback((updatedRowHeights) => {
+  const storedRowHeightsOptions = useMemo(
+    () =>
+      JSON.parse(localStorage.getItem(ROW_HEIGHTS_KEY) || INITIAL_ROW_HEIGHTS),
+    []
+  );
+  const storeRowHeightsOptions = useCallback((updatedRowHeights) => {
     console.log(updatedRowHeights);
     localStorage.setItem(ROW_HEIGHTS_KEY, JSON.stringify(updatedRowHeights));
   }, []);
 
-  const saveGridStyles = useCallback((updatedStyles) => {
+  const storedGridStyles = useMemo(
+    () => JSON.parse(localStorage.getItem(GRID_STYLES_KEY) || INITIAL_STYLES),
+    []
+  );
+  const storeGridStyles = useCallback((updatedStyles) => {
     console.log(updatedStyles);
     localStorage.setItem(GRID_STYLES_KEY, JSON.stringify(updatedStyles));
     setDensitySize(updatedStyles.fontSize);
@@ -77,11 +80,11 @@ export default () => {
       leadingControlColumns={leadingControlColumns}
       rowHeightsOptions={{
         ...storedRowHeightsOptions,
-        onChange: saveRowHeightsOptions,
+        onChange: storeRowHeightsOptions,
       }}
       gridStyle={{
         ...storedGridStyles,
-        onChange: saveGridStyles,
+        onChange: storeGridStyles,
       }}
       columns={columns}
       columnVisibility={{ visibleColumns, setVisibleColumns }}

--- a/src/components/datagrid/controls/display_selector.test.tsx
+++ b/src/components/datagrid/controls/display_selector.test.tsx
@@ -92,6 +92,24 @@ describe('useDataGridDisplaySelector', () => {
         ).toEqual('tableDensityCompact');
       });
 
+      it('calls the gridStyles.onDensityChange callback on user change', () => {
+        const onDensityChange = jest.fn();
+        const component = mount(
+          <MockComponent
+            gridStyles={{ stripes: true, onChange: onDensityChange }}
+          />
+        );
+
+        openPopover(component);
+        component.find('[data-test-subj="expanded"]').simulate('change');
+
+        expect(onDensityChange).toHaveBeenCalledWith({
+          stripes: true,
+          fontSize: 'l',
+          cellPadding: 'l',
+        });
+      });
+
       it('hides the density buttongroup if allowDensity is set to false', () => {
         const component = mount(
           <MockComponent showDisplaySelector={{ allowDensity: false }} />
@@ -151,6 +169,23 @@ describe('useDataGridDisplaySelector', () => {
 
         component.find('[data-test-subj="auto"]').simulate('change');
         expect(getSelection(component)).toEqual('auto');
+      });
+
+      it('calls the rowHeightsOptions.onChange callback on user change', () => {
+        const onRowHeightChange = jest.fn();
+        const component = mount(
+          <MockComponent
+            rowHeightsOptions={{ lineHeight: '3', onChange: onRowHeightChange }}
+          />
+        );
+
+        openPopover(component);
+        component.find('[data-test-subj="auto"]').simulate('change');
+
+        expect(onRowHeightChange).toHaveBeenCalledWith({
+          defaultHeight: 'auto',
+          lineHeight: '3',
+        });
       });
 
       it('hides the row height buttongroup if allowRowHeight is set to false', () => {
@@ -286,7 +321,7 @@ describe('useDataGridDisplaySelector', () => {
     it('returns an object of grid styles with user overrides', () => {
       const initialStyles = { ...startingStyles, stripes: true };
       const MockComponent = () => {
-        const [, gridStyles] = useDataGridDisplaySelector(
+        const [, { onChange, ...gridStyles }] = useDataGridDisplaySelector(
           true,
           initialStyles,
           {}

--- a/src/components/datagrid/controls/display_selector.tsx
+++ b/src/components/datagrid/controls/display_selector.tsx
@@ -8,6 +8,7 @@
 
 import React, { ReactNode, useState, useMemo, useCallback } from 'react';
 
+import { useUpdateEffect } from '../../../services';
 import { EuiI18n, useEuiI18n } from '../../i18n';
 import { EuiPopover } from '../../popover';
 import { EuiButtonIcon, EuiButtonGroup } from '../../button';
@@ -162,6 +163,17 @@ export const useDataGridDisplaySelector = (
       ...userRowHeightsOptions,
     };
   }, [initialRowHeightsOptions, userRowHeightsOptions]);
+
+  // Invoke onChange callbacks on user input (removing the callback value itself, so that only configuration values are returned)
+  useUpdateEffect(() => {
+    const { onChange, ...currentGridStyles } = gridStyles;
+    initialStyles?.onChange?.(currentGridStyles);
+  }, [userGridStyles]);
+
+  useUpdateEffect(() => {
+    const { onChange, ...currentRowHeightsOptions } = rowHeightsOptions;
+    initialRowHeightsOptions?.onChange?.(currentRowHeightsOptions);
+  }, [userRowHeightsOptions]);
 
   const buttonLabel = useEuiI18n(
     'euiDisplaySelector.buttonText',

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -576,6 +576,11 @@ export interface EuiDataGridStyle {
    * If set to true, the footer row will be sticky
    */
   stickyFooter?: boolean;
+  /**
+   * Optional callback returning the current `gridStyle` config when changes occur from user input (e.g. toolbar display controls).
+   * Can be used for, e.g. storing user `gridStyle` in a local storage object.
+   */
+  onChange?: (gridStyle: EuiDataGridStyle) => void;
 }
 
 export interface EuiDataGridToolBarVisibilityColumnSelectorOptions {
@@ -767,6 +772,11 @@ export interface EuiDataGridRowHeightsOptions {
    * Defines a global lineHeight style to apply to all cells
    */
   lineHeight?: string;
+  /**
+   * Optional callback returning the current `rowHeightsOptions` when changes occur from user input (e.g. toolbar display controls).
+   * Can be used for, e.g. storing user `rowHeightsOptions` in a local storage object.
+   */
+  onChange?: (rowHeightsOptions: EuiDataGridRowHeightsOptions) => void;
 }
 
 export interface EuiDataGridRowManager {

--- a/src/services/hooks/index.ts
+++ b/src/services/hooks/index.ts
@@ -7,6 +7,7 @@
  */
 
 export * from './useCombinedRefs';
+export * from './useUpdateEffect';
 export * from './useDependentState';
 export * from './useIsWithinBreakpoints';
 export * from './useMouseMove';

--- a/src/services/hooks/useDependentState.ts
+++ b/src/services/hooks/useDependentState.ts
@@ -6,7 +6,8 @@
  * Side Public License, v 1.
  */
 
-import { useEffect, useState, useRef } from 'react';
+import { useState } from 'react';
+import { useUpdateEffect } from './useUpdateEffect';
 
 export function useDependentState<T>(
   valueFn: (previousState: undefined | T) => T,
@@ -14,20 +15,9 @@ export function useDependentState<T>(
 ) {
   const [state, setState] = useState<T>(valueFn as () => T);
 
-  // use ref instead of a state to avoid causing an unnecessary re-render
-  const hasMounted = useRef<boolean>(false);
-
-  useEffect(() => {
-    // don't call setState on initial mount
-    if (hasMounted.current === true) {
-      setState(valueFn);
-    } else {
-      hasMounted.current = true;
-    }
-
-    // purposefully omitting `updateCount.current` and `valueFn`
-    // this means updating only the valueFn has no effect, but allows for more natural feeling hook use
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+  // don't call setState on initial mount
+  useUpdateEffect(() => {
+    setState(valueFn);
   }, deps);
 
   return [state, setState] as const;

--- a/src/services/hooks/useUpdateEffect.test.tsx
+++ b/src/services/hooks/useUpdateEffect.test.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { mount } from 'enzyme';
+import { useUpdateEffect } from './useUpdateEffect';
+
+describe('useUpdateEffect', () => {
+  const mockEffect = jest.fn();
+  const mockCleanup = jest.fn();
+
+  const MockComponent = ({ test }: { test?: boolean }) => {
+    useUpdateEffect(() => {
+      mockEffect();
+      return () => mockCleanup();
+    }, [test]);
+
+    return null;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not invoke the passed effect on initial mount', () => {
+    mount(<MockComponent />);
+
+    expect(mockEffect).not.toHaveBeenCalled();
+  });
+
+  it('invokes the passed effect on each component update/rerender', () => {
+    const component = mount(<MockComponent />);
+
+    component.setProps({ test: true });
+    expect(mockEffect).toHaveBeenCalledTimes(1);
+
+    component.setProps({ test: false });
+    expect(mockEffect).toHaveBeenCalledTimes(2);
+
+    component.setProps({ test: true });
+    expect(mockEffect).toHaveBeenCalledTimes(3);
+  });
+
+  it('invokes returned cleanup, same as useEffect', () => {
+    const component = mount(<MockComponent />);
+
+    component.setProps({ test: true }); // Trigger first update/call
+    expect(mockCleanup).not.toHaveBeenCalled();
+
+    component.unmount(); // Trigger cleanup
+    expect(mockCleanup).toHaveBeenCalled();
+  });
+});

--- a/src/services/hooks/useUpdateEffect.ts
+++ b/src/services/hooks/useUpdateEffect.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { useEffect, useRef } from 'react';
+
+export const useUpdateEffect = (effect: Function, deps: unknown[]) => {
+  // use ref instead of a state to avoid causing an unnecessary re-render
+  const hasMounted = useRef<boolean>(false);
+
+  useEffect(() => {
+    // don't invoke the effect on initial mount
+    if (hasMounted.current === true) {
+      return effect();
+    } else {
+      hasMounted.current = true;
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+};

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -125,6 +125,7 @@ export { EuiWindowEvent } from './window_event';
 
 export {
   useCombinedRefs,
+  useUpdateEffect,
   useDependentState,
   useIsWithinBreakpoints,
   useMouseMove,


### PR DESCRIPTION
### Summary

Per feedback from Caroline and Vlad, we should expose internal `gridStyle` and `rowHeightsOptions` state in an `onChange` callback:

> In the future, we should provide a grid example that manually adjusts its content based on the selected display size. Does that display selector have a callback function that consumers can use?
(From Caroline)

> I had some thought about height switcher, what we can do if devs will need current state of rowHeightsOptions to store it in something like saved object.
(From Vlad)

After discussion with @chandlerprall, the API we settled on was adding these callbacks in `gridStyle.onChange` and `rowHeightsOptions.onChange`.

### Screencaps

<img width="1103" alt="" src="https://user-images.githubusercontent.com/549407/144127770-0cbea5b0-d264-40e6-aa51-75a87e47dbb8.png">

https://user-images.githubusercontent.com/549407/144127724-c0dba6d8-6329-4a9a-b36b-15e67b931e4e.mp4

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~

- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**

~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**

~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
