### PR TITLE
[EuiRange] Remove tick label scrollbars in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`main`](https://github.com/elastic/eui/tree/main)
 
-No public interface changes since `42.0.0`.
+**Bug fixes**
+
+- Fixed scrollbars in `EuiRange` tick labels in Safari ([#5427](https://github.com/elastic/eui/pull/5427))
 
 ## [`42.0.0`](https://github.com/elastic/eui/tree/v42.0.0)
 

--- a/src/components/form/range/_range_ticks.scss
+++ b/src/components/form/range/_range_ticks.scss
@@ -21,8 +21,8 @@
 }
 
 .euiRangeTick {
-  overflow-x: hidden;
-  overflow-y: hidden;
+  overflow-x: hidden; // Overridden if labels overflow horizontally
+  overflow-y: hidden; // Should never scroll vertically
   text-overflow: ellipsis;
   font-size: $euiFontSizeXS;
   position: absolute;

--- a/src/components/form/range/_range_ticks.scss
+++ b/src/components/form/range/_range_ticks.scss
@@ -22,6 +22,7 @@
 
 .euiRangeTick {
   overflow-x: hidden;
+  overflow-y: hidden;
   text-overflow: ellipsis;
   font-size: $euiFontSizeXS;
   position: absolute;


### PR DESCRIPTION
### Summary

Fixes #5425 by adding `overflow-y: hidden;` to the tick label elements.

Note that this bug only affects Safari, and is really only noticeable when system scrollbars are configured to show "Always" (System Preferences > General > Show scrollbars)


`overflow: hidden;` was not used because we override `overflow-x` in the case of custom labels.
Pink: Desired label truncation
Orange: Desired label overflow
<img width="332" alt="Screen Shot 2021-12-01 at 10 06 20 AM" src="https://user-images.githubusercontent.com/2728212/144270351-19be30d6-258a-48f3-bea5-0e83a2026e21.png">


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~

- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
