### PR TITLE
[EuiOverlayMask] fix SSR bug in overlay mask creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`main`](https://github.com/elastic/eui/tree/main)
 
-No public interface changes since `42.0.0`.
+**Bug fixes**
+
+- Fixed `EuiOverlayMask` so it works in server-side rendering ([#5430](https://github.com/elastic/eui/pull/5430))
 
 ## [`42.0.0`](https://github.com/elastic/eui/tree/v42.0.0)
 

--- a/src-docs/src/views/overlay_mask/overlay_mask.js
+++ b/src-docs/src/views/overlay_mask/overlay_mask.js
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import {
   EuiOverlayMask,
   EuiButton,
+  EuiPanel,
   EuiSpacer,
   EuiTitle,
 } from '../../../../src/components';
@@ -18,22 +19,26 @@ export default () => {
           changeMask(false);
         }}
       >
-        <EuiTitle>
-          <h2> Click anywhere to close overlay. </h2>
-        </EuiTitle>
+        <EuiPanel grow={false}>
+          <EuiTitle>
+            <h2> Click anywhere to close overlay. </h2>
+          </EuiTitle>
+        </EuiPanel>
       </EuiOverlayMask>
     </React.Fragment>
   );
 
   const maskWithClick = (
     <EuiOverlayMask>
-      <EuiButton
-        onClick={() => {
-          changeMaskWithClick(false);
-        }}
-      >
-        Click this button to close
-      </EuiButton>
+      <EuiPanel grow={false}>
+        <EuiButton
+          onClick={() => {
+            changeMaskWithClick(false);
+          }}
+        >
+          Click this button to close
+        </EuiButton>
+      </EuiPanel>
     </EuiOverlayMask>
   );
 

--- a/src/components/overlay_mask/overlay_mask.tsx
+++ b/src/components/overlay_mask/overlay_mask.tsx
@@ -52,7 +52,9 @@ export const EuiOverlayMask: FunctionComponent<EuiOverlayMaskProps> = ({
   headerZindexLocation = 'above',
   ...rest
 }) => {
-  const overlayMaskNode = useRef<HTMLDivElement>(document.createElement('div'));
+  const overlayMaskNode = useRef<HTMLDivElement | undefined>(
+    typeof document !== 'undefined' ? document.createElement('div') : undefined
+  );
   const [isPortalTargetReady, setIsPortalTargetReady] = useState(false);
 
   useEffect(() => {
@@ -65,7 +67,8 @@ export const EuiOverlayMask: FunctionComponent<EuiOverlayMaskProps> = ({
 
   useEffect(() => {
     const portalTarget = overlayMaskNode.current;
-    document.body.appendChild(overlayMaskNode.current);
+    overlayMaskNode.current &&
+      document.body.appendChild(overlayMaskNode.current);
     setIsPortalTargetReady(true);
 
     return () => {
@@ -83,7 +86,8 @@ export const EuiOverlayMask: FunctionComponent<EuiOverlayMaskProps> = ({
           `Unhandled property type. EuiOverlayMask property ${key} is not a string.`
         );
       }
-      overlayMaskNode.current.setAttribute(key, rest[key]!);
+      overlayMaskNode.current &&
+        overlayMaskNode.current.setAttribute(key, rest[key]!);
     });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -113,7 +117,7 @@ export const EuiOverlayMask: FunctionComponent<EuiOverlayMaskProps> = ({
     };
   }, [onClick]);
 
-  return isPortalTargetReady ? (
-    <>{createPortal(children, overlayMaskNode.current!)}</>
+  return isPortalTargetReady && overlayMaskNode.current ? (
+    <>{createPortal(children, overlayMaskNode.current)}</>
   ) : null;
 };


### PR DESCRIPTION
### Summary

Fixes #4807 by making **EuiOverlayMask** aware of the potential for `document` to not be declared.

I tested with a custom build and:

```
import { createElement } from 'react';
import { renderToString } from 'react-dom/server';
import { EuiOverlayMask } from '@elastic/eui';

console.log(
  renderToString(
    createElement(
      'div', null, createElement(
        EuiOverlayMask, null, createElement(
          'span', null, 'Hello!'
        )
      )
    )
  )
)
```

confirmed it errored, applied the custom build, no more error

### Example update

The overlay mask utility example wasn't a great experience, so I made it a little better.

#### Before

<img width="1007" alt="Screen Shot 2021-12-01 at 11 16 06 AM" src="https://user-images.githubusercontent.com/313125/144297163-e05d8a42-e1fe-4db2-be21-f43eba959d86.png">

#### After

<img width="1003" alt="Screen Shot 2021-12-01 at 11 16 15 AM" src="https://user-images.githubusercontent.com/313125/144297176-6b73822f-0482-4830-8bb8-3936fe744f11.png">

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
