### PR TITLE
[Docs] Add `@emotion/react` to codesandbox `dependecies`

### DIFF
--- a/src-docs/src/components/codesandbox/link.js
+++ b/src-docs/src/components/codesandbox/link.js
@@ -187,6 +187,7 @@ ${exampleClose}
             '@elastic/eui': pkg.version,
             ...[
               '@elastic/datemath',
+              '@emotion/react',
               'moment',
               'react',
               'react-dom',


### PR DESCRIPTION
### Summary

Closes #5433 
Correctly handles the `@emotion/react` `peerDependencies` setup for codesandbox links

~### Checklist~
