### PR TITLE
[EuiPopover] Fix removeEventListener with mismatched capture flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Fixed scrollbars in `EuiRange` tick labels in Safari ([#5427](https://github.com/elastic/eui/pull/5427))
+- Fixed unremoved event listener memory leak in `EuiPopover` ([#5436](https://github.com/elastic/eui/pull/5436))
 
 ## [`42.0.0`](https://github.com/elastic/eui/tree/v42.0.0)
 

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -546,7 +546,7 @@ export class EuiPopover extends Component<Props, State> {
   }
 
   componentWillUnmount() {
-    window.removeEventListener('scroll', this.positionPopoverFixed);
+    window.removeEventListener('scroll', this.positionPopoverFixed, true);
     clearTimeout(this.respositionTimeout);
     clearTimeout(this.closingTransitionTimeout);
     cancelAnimationFrame(this.closingTransitionAnimationFrame!);


### PR DESCRIPTION
### Summary

[Per MDN](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener): 'Removal of a capturing listener does not affect a non-capturing version of the same listener, and vice versa.'

closes #5435

This is causing a memory leak for Kibana (https://github.com/elastic/kibana/issues/120251), so we'll likely need to backport this to 7.16 and 8.0

### Checklist

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
