### PR TITLE
[Docs] Fix broken TSX demos/CodeSandbox links

### DIFF
--- a/src-docs/src/components/guide_section/guide_section_parts/guide_section_code.tsx
+++ b/src-docs/src/components/guide_section/guide_section_parts/guide_section_code.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState, useEffect } from 'react';
+import React, { FunctionComponent, useState, useEffect, useMemo } from 'react';
 import { EuiCodeBlock } from '../../../../../src/components/code';
 import { EuiButtonEmpty } from '../../../../../src/components/button';
 // @ts-ignore Not TS
@@ -16,10 +16,15 @@ export const GuideSectionExampleCode: FunctionComponent<GuideSectionExampleCode>
   code,
   type = GuideSectionTypes.JS,
 }) => {
+  const isJavascript = useMemo(
+    () => [GuideSectionTypes.JS, GuideSectionTypes.TSX].includes(type),
+    [type]
+  );
+
   const [codeToRender, setCodeToRender] = useState();
 
   useEffect(() => {
-    if (type === GuideSectionTypes.JS) {
+    if (isJavascript) {
       setCodeToRender(renderJsSourceCode(code));
     } else {
       setCodeToRender(code);
@@ -28,20 +33,19 @@ export const GuideSectionExampleCode: FunctionComponent<GuideSectionExampleCode>
     return () => {
       setCodeToRender(undefined);
     };
-  }, [code, type]);
+  }, [code, isJavascript]);
 
-  const codeSandboxLink =
-    type === GuideSectionTypes.JS ? (
-      <CodeSandboxLink
-        className="guideSectionExampleCode__link"
-        content={code.default}
-        type={type.toLowerCase()}
-      >
-        <EuiButtonEmpty size="xs" iconType="logoCodesandbox">
-          Try out this demo on Code Sandbox
-        </EuiButtonEmpty>
-      </CodeSandboxLink>
-    ) : undefined;
+  const codeSandboxLink = isJavascript ? (
+    <CodeSandboxLink
+      className="guideSectionExampleCode__link"
+      content={code.default}
+      type={type.toLowerCase()}
+    >
+      <EuiButtonEmpty size="xs" iconType="logoCodesandbox">
+        Try out this demo on Code Sandbox
+      </EuiButtonEmpty>
+    </CodeSandboxLink>
+  ) : undefined;
 
   return (
     <>


### PR DESCRIPTION
## Summary

Broken in https://github.com/elastic/eui/pull/5378 - the code there was only checking for `.JS` types and needed `.TSX` as well

### Before

<img width="1153" alt="" src="https://user-images.githubusercontent.com/549407/144668960-128e24a3-829b-4c22-8ef8-7f2c8717e839.png">

### After

<img width="1158" alt="" src="https://user-images.githubusercontent.com/549407/144668970-78298150-dc6e-4a2c-af84-1cdc57ea637b.png">

## QA

- [x] Confirm https://eui.elastic.co/pr_5443/#/navigation/tabs#controlled-tabbed-content works - `Demo TS` tab and CodeSandbox link
- [x] Confirm https://eui.elastic.co/pr_5443/#/forms/combo-box#accessible-label-with-aria-labelledby works - `Demo TS` tab and CodeSandbox link

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~

- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples

~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
