### PR TITLE
[Docs] Use `<meta>` tag for global style insertion point

### DIFF
--- a/src-docs/src/index.html
+++ b/src-docs/src/index.html
@@ -14,7 +14,7 @@
     <meta property="og:image" content="https://repository-images.githubusercontent.com/107422373/b6180480-a1d7-11eb-8a3c-902086232aa7">
     <meta property="og:url" content="hhttps://elastic.github.io/eui">
     <meta name="twitter:card" content="summary_large_image">
-    <style id="emotion-global-insert"></style>
+    <meta name="emotion-global">
   </head>
   <body class="guideBody">
     <div id="guide"></div>

--- a/src-docs/src/views/app_context.js
+++ b/src-docs/src/views/app_context.js
@@ -19,7 +19,7 @@ import favicon96Dev from '../images/favicon/dev/favicon-96x96.png';
 
 const emotionCache = createCache({
   key: 'eui-docs',
-  container: document.querySelector('#emotion-global-insert'),
+  container: document.querySelector('meta[name="emotion-global"]'),
 });
 
 export const AppContext = ({ children }) => {


### PR DESCRIPTION
### Summary

Seeing a difference between [eui.elastic.co](https://eui.elastic.co/#/) and all other documentation site deployments (including the [preview](https://eui.elastic.co/pr_5121/) and [versioned](https://eui.elastic.co/v42.0.0) deployments of the exact same site 🤔) with regards to global styles.
I can't really test this until it gets released, as even the preview deployment will appear fine, but my theory is that the empty `<style>` tag is being removed before bundle can reference it. Also, the `<meta>` tag is just better, as I've learned that `@emotion` will not insert styles above `<meta>` tags unless instructed.

~### Checklist~