### PR TITLE
[Cypress] Fix missing reset styles

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,8 @@
+import { mount as cypressMount } from '@cypress/react';
+import { EuiProvider } from '../../src';
+
+// Provide global cy.mount() shortcut that includes required providers
+// @see https://github.com/cypress-io/cypress/blob/develop/npm/react/docs/providers-and-composition.md
+Cypress.Commands.add('mount', (children) => {
+  return cypressMount(<EuiProvider>{children}</EuiProvider>);
+});

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -1,0 +1,7 @@
+declare namespace Cypress {
+  type MountReturn = import('@cypress/react').MountReturn;
+
+  interface Chainable<Subject> {
+    mount(children: React.ReactNode): Cypress.Chainable<MountReturn>;
+  }
+}

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -14,4 +14,5 @@
 // ***********************************************************
 
 import '@cypress/code-coverage/support';
+import './commands.js';
 require(THEME_IMPORT); // defined by DefinePlugin in the cypress webpack config

--- a/src/components/context_menu/context_menu_panel.spec.tsx
+++ b/src/components/context_menu/context_menu_panel.spec.tsx
@@ -7,7 +7,6 @@
  */
 
 import React from 'react';
-import { mount } from '@cypress/react';
 
 import { EuiContextMenuItem } from './context_menu_item';
 import { EuiContextMenuPanel } from './context_menu_panel';
@@ -15,7 +14,7 @@ import { EuiContextMenuPanel } from './context_menu_panel';
 describe('EuiContextMenuPanel', () => {
   describe('focus behavior', () => {
     it('is set on the first focusable element by default if there are no items and hasFocus is true', () => {
-      mount(
+      cy.mount(
         <EuiContextMenuPanel>
           <button data-test-subj="button">Hello world</button>
         </EuiContextMenuPanel>
@@ -25,7 +24,7 @@ describe('EuiContextMenuPanel', () => {
     });
 
     it('is not set on anything if hasFocus is false', () => {
-      mount(
+      cy.mount(
         <EuiContextMenuPanel hasFocus={false}>
           <button data-test-subj="button">Hello world</button>
         </EuiContextMenuPanel>
@@ -53,7 +52,7 @@ describe('EuiContextMenuPanel', () => {
 
     describe('up/down keys', () => {
       beforeEach(() => {
-        mount(<EuiContextMenuPanel items={items} />);
+        cy.mount(<EuiContextMenuPanel items={items} />);
         cy.wait(FLAKE_WAIT);
       });
 
@@ -98,7 +97,7 @@ describe('EuiContextMenuPanel', () => {
     describe('left/right arrow keys', () => {
       it("right arrow key shows next panel with focused item's index", () => {
         const showNextPanelHandler = cy.stub();
-        mount(
+        cy.mount(
           <EuiContextMenuPanel
             items={items}
             showNextPanel={showNextPanelHandler}
@@ -116,7 +115,7 @@ describe('EuiContextMenuPanel', () => {
 
       it('left arrow key shows previous panel', () => {
         const showPreviousPanelHandler = cy.stub();
-        mount(
+        cy.mount(
           <EuiContextMenuPanel
             items={items}
             showPreviousPanel={showPreviousPanelHandler}

--- a/src/components/datagrid/data_grid.spec.tsx
+++ b/src/components/datagrid/data_grid.spec.tsx
@@ -7,7 +7,6 @@
  */
 
 import React from 'react';
-import { mount } from '@cypress/react';
 import { EuiDataGrid, EuiDataGridProps } from './index';
 
 const baseProps: EuiDataGridProps = {
@@ -28,7 +27,7 @@ const baseProps: EuiDataGridProps = {
 describe('EuiDataGrid', () => {
   describe('row creation', () => {
     it('creates rows', () => {
-      mount(<EuiDataGrid {...baseProps} />);
+      cy.mount(<EuiDataGrid {...baseProps} />);
 
       getGridData().then((data) => {
         expect(data).to.deep.equal({

--- a/src/components/focus_trap/focus_trap.spec.tsx
+++ b/src/components/focus_trap/focus_trap.spec.tsx
@@ -7,14 +7,13 @@
  */
 
 import React from 'react';
-import { mount } from '@cypress/react';
 import { EuiFocusTrap } from './focus_trap';
 import { EuiPortal } from '../portal';
 
 describe('EuiFocusTrap', () => {
   describe('focus', () => {
     it('is set on the first focusable element by default', () => {
-      mount(
+      cy.mount(
         <div>
           <input data-test-subj="outside" />
           <EuiFocusTrap>
@@ -36,7 +35,7 @@ describe('EuiFocusTrap', () => {
     });
 
     it('will not take focus when `autoFocus` is disabled', () => {
-      mount(
+      cy.mount(
         <div>
           <input data-test-subj="outside" />
           <EuiFocusTrap autoFocus={false}>
@@ -52,7 +51,7 @@ describe('EuiFocusTrap', () => {
     });
 
     it('is set on the element identified by `data-autofocus`', () => {
-      mount(
+      cy.mount(
         <div>
           <input data-test-subj="outside" />
           <EuiFocusTrap>
@@ -70,7 +69,7 @@ describe('EuiFocusTrap', () => {
 
   describe('clickOutsideDisables', () => {
     it('trap remains enabled when false', () => {
-      mount(
+      cy.mount(
         <div>
           <EuiFocusTrap>
             <div data-test-subj="container">
@@ -94,7 +93,7 @@ describe('EuiFocusTrap', () => {
     });
 
     it('trap remains enabled after internal clicks', () => {
-      mount(
+      cy.mount(
         <div>
           <EuiFocusTrap clickOutsideDisables>
             <div data-test-subj="container">
@@ -114,7 +113,7 @@ describe('EuiFocusTrap', () => {
     });
 
     it('trap remains enabled after internal portal clicks', () => {
-      mount(
+      cy.mount(
         <div>
           <EuiFocusTrap clickOutsideDisables>
             <div data-test-subj="container">
@@ -137,7 +136,7 @@ describe('EuiFocusTrap', () => {
     });
 
     it('trap becomes disabled on outside clicks', () => {
-      mount(
+      cy.mount(
         <div>
           <EuiFocusTrap clickOutsideDisables>
             <div data-test-subj="container">


### PR DESCRIPTION
### Summary

Replaces `@cypress/react`'s `mount()` API with our own custom `cy.mount()` which automatically wraps children in `<EuiProvider>`. This DRY's out each component/file having to remember to wrap a provider in order to correctly get EUI's reset styles.

Reference links:

- https://github.com/cypress-io/cypress/issues/14672#issuecomment-900825353
- https://github.com/cypress-io/cypress/blob/develop/npm/react/docs/providers-and-composition.md

### Before

![image](https://user-images.githubusercontent.com/549407/144922415-cee25cb8-f641-4d71-bc59-e7e3f3e94163.png)

### After

<img width="1428" alt="" src="https://user-images.githubusercontent.com/549407/144922384-14c47dbe-27cf-49ca-801b-1f5a736395b0.png">

### Checklist

N/A, dev/test-only change