### PR TITLE
[Global reset] Fix reset of `button` styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed dark mode background color of `EuiFormControlLayout` `prepend` and `append` ([#5383](https://github.com/elastic/eui/pull/5383))
 - Fixed background color of `EuiFormControlLayout` when `readOnly` ([#5383](https://github.com/elastic/eui/pull/5383))
 - Fixed the name of `data-test-subj` prop of `EuiFormControlLayout` ([#5383](https://github.com/elastic/eui/pull/5383))
+- Fixed global reset styles for plain `<button>`s ([#5452](https://github.com/elastic/eui/pull/5452))
 
 **Breaking changes**
 

--- a/src/global_styling/reset/global_styles.tsx
+++ b/src/global_styling/reset/global_styles.tsx
@@ -108,9 +108,12 @@ export const EuiGlobalStyles = ({}: EuiGlobalStylesProps) => {
 
     input,
     textarea,
-    select,
-    button {
+    select {
       ${fontReset}
+    }
+
+    button {
+      font-family: ${font.family};
     }
 
     em {

--- a/src/global_styling/reset/reset.ts
+++ b/src/global_styling/reset/reset.ts
@@ -58,6 +58,7 @@ button {
   margin: 0;
   color: inherit;
   border-radius: 0;
+  font-size: inherit;
 }
 
 input {


### PR DESCRIPTION
I noticed that the font-size of the links in our Props docs table were way too big and found that I was originally too heavy-handed with the new global styles for Emotion. Previously, it just set everything to `inherit`, while in the new file I applied our actual font styles. This broke the EuiLink font-size inheritance if the link was actually a `<button>` and rendered inside of a sized EuiText block.

**Before**
<img width="444" alt="Screen Shot 2021-12-07 at 10 58 28 AM" src="https://user-images.githubusercontent.com/549577/145064949-1292c3ec-4e51-4a52-bf0d-2568840866a9.png">


**After**
<img width="394" alt="Screen Shot 2021-12-07 at 10 58 39 AM" src="https://user-images.githubusercontent.com/549577/145064975-2f359903-39f0-4d0b-b65a-4e5a4c942a6b.png">


This PR pulls that `button` selector out of the input-specific font global styles and just applies the necessary `font-family`. It also ensure font-size inheritance by adding it to the `reset` file.

### Checklist

- [X] Check against **all themes** for compatibility in both light and dark modes
- [X] Checked in **mobile**
- [X] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
