### PR TITLE
[EuiCode][EuiCodeBlock] Reinstate `testenv` mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Added `magnifyWithExclamation` icon ([#5455](https://github.com/elastic/eui/pull/5455))
 
+**Bug fixes**
+
+- Reinstated `EuiCode` and `EuiCodeBlock` `testenv` mocking ([#5464](https://github.com/elastic/eui/pull/5464))
+
 ## [`43.0.0`](https://github.com/elastic/eui/tree/v43.0.0)
 
 - Updated the organization of `EuiDataGrid`'s toolbar/grid controls ([#5334](https://github.com/elastic/eui/pull/5334))

--- a/src/components/code/code.testenv.tsx
+++ b/src/components/code/code.testenv.tsx
@@ -7,6 +7,14 @@
  */
 
 import React from 'react';
-export const EuiCode = ({ children, 'data-test-subj': dataTestSubj }: any) => {
-  return <code data-test-subj={dataTestSubj}>{children}</code>;
+export const EuiCode = ({
+  children,
+  'data-test-subj': dataTestSubj,
+  language,
+}: any) => {
+  return (
+    <code data-test-subj={dataTestSubj} data-code-language={language}>
+      {children}
+    </code>
+  );
 };

--- a/src/components/code/code.testenv.tsx
+++ b/src/components/code/code.testenv.tsx
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+export const EuiCode = ({ children, 'data-test-subj': dataTestSubj }: any) => {
+  return <code data-test-subj={dataTestSubj}>{children}</code>;
+};

--- a/src/components/code/code_block.testenv.tsx
+++ b/src/components/code/code_block.testenv.tsx
@@ -10,11 +10,14 @@ import React from 'react';
 export const EuiCodeBlock = ({
   children,
   'data-test-subj': dataTestSubj,
+  language,
 }: any) => {
   return (
     <div>
       <pre>
-        <code data-test-subj={dataTestSubj}>{children}</code>
+        <code data-test-subj={dataTestSubj} data-code-language={language}>
+          {children}
+        </code>
       </pre>
     </div>
   );

--- a/src/components/code/code_block.testenv.tsx
+++ b/src/components/code/code_block.testenv.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+export const EuiCodeBlock = ({
+  children,
+  'data-test-subj': dataTestSubj,
+}: any) => {
+  return (
+    <div>
+      <pre>
+        <code data-test-subj={dataTestSubj}>{children}</code>
+      </pre>
+    </div>
+  );
+};
+
+export const FONT_SIZES: Array<'s' | 'm' | 'l'> = ['s', 'm', 'l'];
+export const PADDING_SIZES: Array<'s' | 'm' | 'l' | 'none'> = [
+  'none',
+  's',
+  'm',
+  'l',
+];


### PR DESCRIPTION
### Summary

`testenv` mocking was mistakenly removed when moving away from the shared `EuiCodeBlockImpl` component.
Previous mock file for reference: [_code_block.testenv.tsx](https://github.com/elastic/eui/pull/5379/files#diff-d54be217b09ff7e4968e0f8fb637b97ba29f16d31dfe5755d78908f24297149f)
Adds a new file for each component and adds a `data-code-language` attribute for debugging.

### Checklist

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
