### PR TITLE
[EuiDataGrid] Added focus management cypress tests for data grid

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -16,6 +16,7 @@
 import '@cypress/code-coverage/support';
 import './commands.js';
 require(THEME_IMPORT); // defined by DefinePlugin in the cypress webpack config
+require('cypress-plugin-tab'); // adds the `.tab()` command to cypress chains, see https://docs.cypress.io/api/commands/type#Typing-tab-key-does-not-work
 
 // @see https://github.com/quasarframework/quasar/issues/2233#issuecomment-492975745
 Cypress.on('uncaught:exception', (err) => {

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "css-loader": "^4.2.2",
     "cssnano": "^4.1.10",
     "cypress": "^9.1.1",
+    "cypress-plugin-tab": "^1.0.5",
     "deasync": "^0.1.20",
     "dedent": "^0.7.0",
     "dts-generator": "^3.0.0",

--- a/src/components/datagrid/body/data_grid_cell_popover.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.test.tsx
@@ -49,6 +49,11 @@ describe('EuiDataGridCellPopover', () => {
         ownFocus={true}
         panelClassName="euiDataGridRowCell__popover"
         panelPaddingSize="s"
+        panelProps={
+          Object {
+            "data-test-subj": "euiDataGridExpansionPanel",
+          }
+        }
         panelRef={[Function]}
         zIndex={8001}
       >
@@ -90,6 +95,11 @@ describe('EuiDataGridCellPopover', () => {
         ownFocus={true}
         panelClassName="euiDataGridRowCell__popover"
         panelPaddingSize="s"
+        panelProps={
+          Object {
+            "data-test-subj": "euiDataGridExpansionPanel",
+          }
+        }
         panelRef={[Function]}
         zIndex={8001}
       >

--- a/src/components/datagrid/body/data_grid_cell_popover.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.test.tsx
@@ -51,7 +51,7 @@ describe('EuiDataGridCellPopover', () => {
         panelPaddingSize="s"
         panelProps={
           Object {
-            "data-test-subj": "euiDataGridExpansionPanel",
+            "data-test-subj": "euiDataGridExpansionPopover",
           }
         }
         panelRef={[Function]}
@@ -97,7 +97,7 @@ describe('EuiDataGridCellPopover', () => {
         panelPaddingSize="s"
         panelProps={
           Object {
-            "data-test-subj": "euiDataGridExpansionPanel",
+            "data-test-subj": "euiDataGridExpansionPopover",
           }
         }
         panelRef={[Function]}

--- a/src/components/datagrid/body/data_grid_cell_popover.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.tsx
@@ -45,7 +45,7 @@ export function EuiDataGridCellPopover({
       display="block"
       closePopover={closePopover}
       panelProps={{
-        'data-test-subj': 'euiDataGridExpansionPanel',
+        'data-test-subj': 'euiDataGridExpansionPopover',
       }}
       onKeyDown={(event) => {
         if (event.key === keys.F2 || event.key === keys.ESCAPE) {

--- a/src/components/datagrid/body/data_grid_cell_popover.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.tsx
@@ -44,6 +44,9 @@ export function EuiDataGridCellPopover({
       zIndex={8001}
       display="block"
       closePopover={closePopover}
+      panelProps={{
+        'data-test-subj': 'euiDataGridExpansionPanel',
+      }}
       onKeyDown={(event) => {
         if (event.key === keys.F2 || event.key === keys.ESCAPE) {
           event.preventDefault();

--- a/src/components/datagrid/data_grid.spec.tsx
+++ b/src/components/datagrid/data_grid.spec.tsx
@@ -284,7 +284,7 @@ describe('EuiDataGrid', () => {
         cy.focused().should(
           'have.attr',
           'data-test-subj',
-          'euiDataGridExpansionPanel'
+          'euiDataGridExpansionPopover'
         );
         cy.focused().type('{esc}');
         cy.focused().should('have.attr', 'data-gridcell-id', '0,1');
@@ -320,7 +320,7 @@ describe('EuiDataGrid', () => {
         cy.focused().type('{enter}'); // trigger expansion popover
         cy.focused().should('have.attr', 'data-test-subj', 'btn-yes'); // focus trap should move focus to the first button
         cy.focused().parentsUntil(
-          '[data-test-subj="euiDataGridExpansionPanel"]'
+          '[data-test-subj="euiDataGridExpansionPopover"]'
         ); // ensure focus is in the popover
         cy.focused().tab();
         cy.focused().should('have.attr', 'data-test-subj', 'btn-no');
@@ -328,7 +328,7 @@ describe('EuiDataGrid', () => {
         cy.focused().should(
           'have.attr',
           'data-test-subj',
-          'euiDataGridExpansionPanel'
+          'euiDataGridExpansionPopover'
         );
         cy.focused().type('{esc}');
         cy.focused().should('have.attr', 'data-gridcell-id', '0,5');

--- a/src/components/datagrid/data_grid.spec.tsx
+++ b/src/components/datagrid/data_grid.spec.tsx
@@ -6,8 +6,10 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
-import { EuiDataGrid, EuiDataGridProps } from './index';
+import React, { ReactNode } from 'react';
+import { EuiDataGrid, EuiDataGridColumn, EuiDataGridProps } from './index';
+import { EuiLink } from '../link';
+import { EuiButtonEmpty } from '../button';
 
 const baseProps: EuiDataGridProps = {
   'aria-label': 'grid for testing',
@@ -79,6 +81,258 @@ describe('EuiDataGrid', () => {
             .invoke('outerHeight')
             .should('be.greaterThan', firstHeight);
         });
+    });
+  });
+
+  describe('focus management', () => {
+    const columns: EuiDataGridColumn[] = [
+      {
+        id: 'no_interactive',
+        display: '0 interactive',
+        isExpandable: false,
+        actions: false,
+      },
+      {
+        id: 'no_interactive_expandable',
+        display: '0 interactive',
+        actions: false,
+      },
+      {
+        id: 'one_interactive',
+        display: '1 interactive',
+        isExpandable: false,
+        actions: false,
+      },
+      {
+        id: 'one_interactive_expandable',
+        display: '1 interactive',
+        actions: false,
+      },
+      {
+        id: 'two_interactives',
+        display: '2 interactives',
+        isExpandable: false,
+        actions: false,
+      },
+      {
+        id: 'two_interactives_expandable',
+        display: '2 interactives',
+        actions: false,
+      },
+    ];
+    const columnVisibility = {
+      visibleColumns: columns.map(({ id }) => id),
+      setVisibleColumns: () => {},
+    };
+
+    const columnValueMap: { [key: string]: ReactNode } = {
+      no_interactive: <span>value</span>,
+      no_interactive_expandable: <span>value</span>,
+
+      one_interactive: (
+        <span>
+          <EuiLink href="#" data-test-subj="focusOnMe">
+            value
+          </EuiLink>
+        </span>
+      ),
+      one_interactive_expandable: (
+        <span>
+          <EuiLink href="#" data-test-subj="focusOnMe">
+            value
+          </EuiLink>
+        </span>
+      ),
+
+      two_interactives: (
+        <span>
+          <EuiButtonEmpty size="xs" data-test-subj="btn-yes" onClick={() => {}}>
+            Yes
+          </EuiButtonEmpty>
+          <EuiButtonEmpty
+            size="xs"
+            data-test-subj="btn-no"
+            color="danger"
+            onClick={() => {}}
+          >
+            No
+          </EuiButtonEmpty>
+        </span>
+      ),
+      two_interactives_expandable: (
+        <span>
+          <EuiButtonEmpty size="xs" data-test-subj="btn-yes" onClick={() => {}}>
+            Yes
+          </EuiButtonEmpty>
+          <EuiButtonEmpty
+            size="xs"
+            data-test-subj="btn-no"
+            color="danger"
+            onClick={() => {}}
+          >
+            No
+          </EuiButtonEmpty>
+        </span>
+      ),
+    };
+
+    const renderCellValue: EuiDataGridProps['renderCellValue'] = ({
+      columnId,
+    }) => columnValueMap[columnId];
+
+    const renderFooterCellValue = undefined;
+
+    const focusManagementBaseProps = {
+      ...baseProps,
+      columns,
+      columnVisibility,
+      renderCellValue,
+      renderFooterCellValue,
+    };
+
+    it('focuses a cell when clicked', () => {
+      cy.mount(<EuiDataGrid {...focusManagementBaseProps} />);
+
+      getGridData();
+
+      // starts with body in focus
+      cy.focused().should('not.exist');
+
+      cy.get('[data-gridcell-id="1,1"]').click();
+      cy.focused().should('have.attr', 'data-gridcell-id', '1,1');
+    });
+
+    describe('cell keyboard interactions', () => {
+      it('tabbing to the grid the controls, then the first cell, then off', () => {
+        cy.mount(
+          <>
+            <EuiDataGrid {...focusManagementBaseProps} />
+            <span tabIndex={0} id="final-tabbable" />
+          </>
+        );
+
+        getGridData();
+
+        // starts with body in focus
+        cy.focused().should('not.exist');
+
+        // tab through the control bar
+        cy.get('body')
+          .tab()
+          .should('have.attr', 'data-test-subj', 'dataGridColumnSelectorButton')
+          .tab()
+          .should(
+            'have.attr',
+            'data-test-subj',
+            'dataGridDisplaySelectorButton'
+          )
+          .tab()
+          .should('have.attr', 'data-test-subj', 'dataGridFullScreenButton');
+
+        // tab into the grid, should focus first cell after a short delay
+        cy.focused().tab();
+        cy.focused().should('have.attr', 'data-gridcell-id', '0,0');
+
+        cy.focused().tab().should('have.id', 'final-tabbable');
+      });
+
+      it('arrow-keying focuses another cell, unless it has only one interactive element', () => {
+        cy.mount(<EuiDataGrid {...focusManagementBaseProps} />);
+
+        getGridData();
+
+        cy.get('[data-test-subj=dataGridWrapper]').focus();
+
+        // first cell is non-interactive and non-expandable = focus cell
+        cy.focused().should('have.attr', 'data-gridcell-id', '0,0');
+
+        // already left-most, should be no-op
+        cy.focused().type('{leftarrow}');
+        cy.focused().should('have.attr', 'data-gridcell-id', '0,0');
+
+        // arrow right, expandable cell with no interactive = focus cell
+        cy.focused().type('{rightarrow}');
+        cy.focused().should('have.attr', 'data-gridcell-id', '0,1');
+
+        // arrow right, non-expandable cell with one interactive = focus interactive
+        cy.focused().type('{rightarrow}');
+        cy.focused().should('have.attr', 'data-test-subj', 'focusOnMe');
+
+        // arrow right, non-expandable cell with two interactives = focus cell
+        cy.focused().type('{rightarrow}');
+        cy.focused().should('have.attr', 'data-gridcell-id', '0,3');
+
+        // arrow right, expandable cell with two interactives = focus cell
+        cy.focused().type('{rightarrow}');
+        cy.focused().should('have.attr', 'data-gridcell-id', '0,4');
+      });
+
+      it('cell expansion/interaction', () => {
+        cy.mount(<EuiDataGrid {...focusManagementBaseProps} />);
+
+        getGridData();
+
+        cy.get('[data-test-subj=dataGridWrapper]').focus();
+
+        // first cell is non-interactive and non-expandable, enter should have no effect
+        cy.focused().type('{enter}');
+        cy.focused().should('have.attr', 'data-gridcell-id', '0,0');
+
+        // second cell is expandable
+        cy.get('[data-gridcell-id="0,1"]').click();
+        cy.focused().type('{enter}');
+        cy.focused().should(
+          'have.attr',
+          'data-test-subj',
+          'euiDataGridExpansionPanel'
+        );
+        cy.focused().type('{esc}');
+        cy.focused().should('have.attr', 'data-gridcell-id', '0,1');
+
+        // third cell is non-expandable & interactive, click should focus on the link
+        cy.get('[data-gridcell-id="0,2"]').click();
+        cy.focused().type('{enter}');
+        cy.focused().should('have.attr', 'data-test-subj', 'focusOnMe');
+
+        // fourth cell is non-expandable with multiple interactives, click should focus on the cell
+        cy.get('[data-gridcell-id="0,3"]').click();
+        cy.focused().type('{enter}');
+        cy.focused().should('have.attr', 'data-test-subj', 'focusOnMe'); // focus trap focuses the link
+        cy.focused().type('{esc}');
+        cy.focused().should('have.attr', 'data-gridcell-id', '0,3');
+
+        // fifth cell is non-expandable & no-actions with multiple interactives, click should focus cell
+        cy.get('[data-gridcell-id="0,4"]').click('topLeft'); // top left to avoid clicking a button
+        cy.focused().should('have.attr', 'data-gridcell-id', '0,4');
+        // enable interactives & focus trap
+        cy.focused().type('{enter}');
+        cy.focused().should('have.attr', 'data-test-subj', 'btn-yes');
+        cy.focused().tab();
+        cy.focused().should('have.attr', 'data-test-subj', 'btn-no');
+        cy.focused().tab();
+        cy.focused().should('have.attr', 'data-test-subj', 'btn-yes');
+        cy.focused().type('{esc}');
+        cy.focused().should('have.attr', 'data-gridcell-id', '0,4');
+
+        // sixth cell is expandable cell with two interactives, click should focus on the cell
+        cy.get('[data-gridcell-id="0,5"]').click('topLeft', { force: true }); // top left to avoid clicking a button
+        cy.focused().should('have.attr', 'data-gridcell-id', '0,5');
+        cy.focused().type('{enter}'); // trigger expansion popover
+        cy.focused().should('have.attr', 'data-test-subj', 'btn-yes'); // focus trap should move focus to the first button
+        cy.focused().parentsUntil(
+          '[data-test-subj="euiDataGridExpansionPanel"]'
+        ); // ensure focus is in the popover
+        cy.focused().tab();
+        cy.focused().should('have.attr', 'data-test-subj', 'btn-no');
+        cy.focused().tab();
+        cy.focused().should(
+          'have.attr',
+          'data-test-subj',
+          'euiDataGridExpansionPanel'
+        );
+        cy.focused().type('{esc}');
+        cy.focused().should('have.attr', 'data-gridcell-id', '0,5');
+      });
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2749,6 +2749,14 @@ ajv@^6.12.3, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ally.js@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/ally.js/-/ally.js-1.4.1.tgz#9fb7e6ba58efac4ee9131cb29aa9ee3b540bcf1e"
+  integrity sha1-n7fmuljvrE7pExyymqnuO1QLzx4=
+  dependencies:
+    css.escape "^1.5.0"
+    platform "1.3.3"
+
 alphanum-sort@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
@@ -5354,6 +5362,11 @@ css-what@^3.2.1:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.3.0.tgz#10fec696a9ece2e591ac772d759aacabac38cd39"
   integrity sha512-pv9JPyatiPaQ6pf4OvD/dbfm0o5LviWmwxNWzblYf/1u9QZd0ihV+PMwy5jdQWQ3349kZmKEx9WXuSka2dM4cg==
 
+css.escape@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
@@ -5487,6 +5500,13 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
   integrity sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
+
+cypress-plugin-tab@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/cypress-plugin-tab/-/cypress-plugin-tab-1.0.5.tgz#a40714148104004bb05ed62b1bf46bb544f8eb4a"
+  integrity sha512-QtTJcifOVwwbeMP3hsOzQOKf3EqKsLyjtg9ZAGlYDntrCRXrsQhe4ZQGIthRMRLKpnP6/tTk6G0gJ2sZUfRliQ==
+  dependencies:
+    ally.js "^1.4.1"
 
 cypress@^9.1.1:
   version "9.1.1"
@@ -13586,6 +13606,11 @@ pkginfo@0.x.x:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.1.tgz#b5418ef0439de5425fc4995042dced14fb2a84ff"
   integrity sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=
+
+platform@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.3.tgz#646c77011899870b6a0903e75e997e8e51da7461"
+  integrity sha1-ZGx3ARiZhwtqCQPnXpl+jlHadGE=
 
 pluralize@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
### Summary

Added some cypress tests around **EuiDataGrid**'s focus management, mostly covering the manual testing we've been doing against https://elastic.github.io/eui/#/tabular-content/data-grid-focus to catch regressions.

~### Checklist~
