### PR TITLE
[EuiSuperDatePicker] Small unit test clean up

### DIFF
--- a/src/components/date_picker/super_date_picker/async_interval.test.ts
+++ b/src/components/date_picker/super_date_picker/async_interval.test.ts
@@ -36,7 +36,7 @@ describe('AsyncInterval', () => {
     await instance.__pendingFn;
   }
 
-  describe('when creating a 1000ms interval', async () => {
+  describe('when creating a 1000ms interval', () => {
     let instance: AsyncInterval;
     let spy: jest.Mock;
     beforeEach(() => {
@@ -73,7 +73,7 @@ describe('AsyncInterval', () => {
     });
   });
 
-  describe('when creating a 1000ms interval that calls a fn that takes 2000ms to complete', async () => {
+  describe('when creating a 1000ms interval that calls a fn that takes 2000ms to complete', () => {
     let instance: AsyncInterval;
     let spy: jest.Mock;
     beforeEach(() => {


### PR DESCRIPTION
### Summary

Noticed the jest output for the _async_interval.test.ts_ complained about the `async` describe blocks. Verified that the tests themselves have been running (& passing), this is just maintenance cleaning up noise.

~### Checklist~
