### PR TITLE
[EuiSuperDatePicker] Pass `isDisabled` to `EuiAutoRefresh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 **Bug fixes**
 
-- Fixed `EUiDataGrid`'s cell popover overlapping with modals and flyouts ([#5461](https://github.com/elastic/eui/pull/5461))
+- Fixed `EuiDataGrid`'s cell popover overlapping with modals and flyouts ([#5461](https://github.com/elastic/eui/pull/5461))
+- Fixed `EuiSuperDatePicker` not passing `isDisabled` to `EuiAutoRefresh` ([#5472](https://github.com/elastic/eui/pull/5472))
 
 ## [`43.1.0`](https://github.com/elastic/eui/tree/v43.1.0)
 

--- a/src/components/date_picker/super_date_picker/__snapshots__/super_date_picker.test.tsx.snap
+++ b/src/components/date_picker/super_date_picker/__snapshots__/super_date_picker.test.tsx.snap
@@ -329,6 +329,43 @@ exports[`EuiSuperDatePicker props compressed is rendered 1`] = `
 </EuiFlexGroup>
 `;
 
+exports[`EuiSuperDatePicker props isAutoRefreshOnly is rendered 1`] = `
+<EuiFlexGroup
+  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--isAutoRefreshOnly"
+  gutterSize="s"
+  responsive={false}
+>
+  <EuiFlexItem>
+    <EuiAutoRefresh
+      fullWidth={false}
+      isDisabled={false}
+      isPaused={true}
+      onRefreshChange={[Function]}
+      refreshInterval={1000}
+    />
+  </EuiFlexItem>
+</EuiFlexGroup>
+`;
+
+exports[`EuiSuperDatePicker props isAutoRefreshOnly passes required props 1`] = `
+<EuiFlexGroup
+  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--isAutoRefreshOnly"
+  gutterSize="s"
+  responsive={false}
+>
+  <EuiFlexItem>
+    <EuiAutoRefresh
+      data-test-subj="autoRefreshOnly"
+      fullWidth={false}
+      isDisabled={true}
+      isPaused={true}
+      onRefreshChange={[Function]}
+      refreshInterval={1000}
+    />
+  </EuiFlexItem>
+</EuiFlexGroup>
+`;
+
 exports[`EuiSuperDatePicker props isQuickSelectOnly is rendered 1`] = `
 <EuiFlexGroup
   className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--isQuickSelectOnly euiSuperDatePicker__flexWrapper--autoWidth"

--- a/src/components/date_picker/super_date_picker/super_date_picker.test.tsx
+++ b/src/components/date_picker/super_date_picker/super_date_picker.test.tsx
@@ -196,5 +196,31 @@ describe('EuiSuperDatePicker', () => {
         expect(component).toMatchSnapshot();
       });
     });
+
+    describe('isAutoRefreshOnly', () => {
+      it('is rendered', () => {
+        const component = shallow(
+          <EuiSuperDatePicker
+            onTimeChange={noop}
+            onRefreshChange={noop}
+            isAutoRefreshOnly
+          />
+        );
+        expect(component).toMatchSnapshot();
+      });
+
+      it('passes required props', () => {
+        const component = shallow(
+          <EuiSuperDatePicker
+            onTimeChange={noop}
+            onRefreshChange={noop}
+            isAutoRefreshOnly
+            isDisabled
+            data-test-subj="autoRefreshOnly"
+          />
+        );
+        expect(component).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/src/components/date_picker/super_date_picker/super_date_picker.tsx
+++ b/src/components/date_picker/super_date_picker/super_date_picker.tsx
@@ -574,6 +574,8 @@ export class EuiSuperDatePicker extends Component<
               onRefreshChange={onRefreshChange}
               fullWidth={width === 'full'}
               compressed={compressed}
+              isDisabled={isDisabled}
+              data-test-subj={dataTestSubj}
             />
           </EuiFlexItem>
         ) : (


### PR DESCRIPTION
### Summary

Fixes a bug where `EuiAutoRefresh` is not disabled when `EuiSuperDatePicker` is configured with `isDisabled`.
Also passes through `data-test-subj` and adds minimal tests for `isAutoRefreshOnly`.

### Checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
