### PR TITLE
[EuiGlobalStyles] Omit global and reset styles when using legacy theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed `EUiDataGrid`'s cell popover overlapping with modals and flyouts ([#5461](https://github.com/elastic/eui/pull/5461))
 - Fixed an accessibility issue where `EuiDatePicker` time options did not have unique IDs ([#5466](https://github.com/elastic/eui/pull/5466))
+- Removed CSS-in-JS global and reset styles from `EuiProvider` when using the legacy theme ([#5473](https://github.com/elastic/eui/pull/5473))
 
 ## [`43.1.0`](https://github.com/elastic/eui/tree/v43.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fixed `EUiDataGrid`'s cell popover overlapping with modals and flyouts ([#5461](https://github.com/elastic/eui/pull/5461))
 - Fixed an accessibility issue where `EuiDatePicker` time options did not have unique IDs ([#5466](https://github.com/elastic/eui/pull/5466))
-- Removed CSS-in-JS global and reset styles when using the legacy theme ([#5473](https://github.com/elastic/eui/pull/5473))
+- Fixed global and reset styles when using the legacy theme ([#5473](https://github.com/elastic/eui/pull/5473))
 
 ## [`43.1.0`](https://github.com/elastic/eui/tree/v43.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fixed `EUiDataGrid`'s cell popover overlapping with modals and flyouts ([#5461](https://github.com/elastic/eui/pull/5461))
 - Fixed an accessibility issue where `EuiDatePicker` time options did not have unique IDs ([#5466](https://github.com/elastic/eui/pull/5466))
-- Removed CSS-in-JS global and reset styles from `EuiProvider` when using the legacy theme ([#5473](https://github.com/elastic/eui/pull/5473))
+- Removed CSS-in-JS global and reset styles when using the legacy theme ([#5473](https://github.com/elastic/eui/pull/5473))
 
 ## [`43.1.0`](https://github.com/elastic/eui/tree/v43.1.0)
 

--- a/src/components/provider/__snapshots__/provider.test.tsx.snap
+++ b/src/components/provider/__snapshots__/provider.test.tsx.snap
@@ -894,9 +894,7 @@ exports[`EuiProvider changing themes propagates \`theme\` 1`] = `
       },
     }
   }
->
-  <EuiGlobalStyles />
-</EuiThemeProvider>
+/>
 `;
 
 exports[`EuiProvider is rendered 1`] = `

--- a/src/components/provider/__snapshots__/provider.test.tsx.snap
+++ b/src/components/provider/__snapshots__/provider.test.tsx.snap
@@ -894,7 +894,9 @@ exports[`EuiProvider changing themes propagates \`theme\` 1`] = `
       },
     }
   }
-/>
+>
+  <EuiGlobalStyles />
+</EuiThemeProvider>
 `;
 
 exports[`EuiProvider is rendered 1`] = `

--- a/src/components/provider/provider.tsx
+++ b/src/components/provider/provider.tsx
@@ -18,7 +18,7 @@ import {
   EuiThemeProviderProps,
   EuiThemeSystem,
 } from '../../services';
-import { EuiThemeAmsterdam } from '../../themes/amsterdam/theme';
+import { EuiThemeAmsterdam, isLegacyTheme } from '../../themes';
 
 export interface EuiProviderProps<T>
   extends Omit<EuiThemeProviderProps<T>, 'children' | 'theme'>,
@@ -38,18 +38,19 @@ export const EuiProvider = <T extends {} = {}>({
   modify,
   children,
 }: PropsWithChildren<EuiProviderProps<T>>) => {
-  return theme !== null ? (
+  return theme === null ? (
+    <EuiThemeProvider colorMode={colorMode}>{children}</EuiThemeProvider>
+  ) : (
     <EuiThemeProvider theme={theme} colorMode={colorMode} modify={modify}>
-      {cache ? (
-        <CacheProvider value={cache}>
+      {!isLegacyTheme(theme.key) &&
+        (cache ? (
+          <CacheProvider value={cache}>
+            <EuiGlobalStyles />
+          </CacheProvider>
+        ) : (
           <EuiGlobalStyles />
-        </CacheProvider>
-      ) : (
-        <EuiGlobalStyles />
-      )}
+        ))}
       {children}
     </EuiThemeProvider>
-  ) : (
-    <EuiThemeProvider colorMode={colorMode}>{children}</EuiThemeProvider>
   );
 };

--- a/src/components/provider/provider.tsx
+++ b/src/components/provider/provider.tsx
@@ -18,7 +18,7 @@ import {
   EuiThemeProviderProps,
   EuiThemeSystem,
 } from '../../services';
-import { EuiThemeAmsterdam, isLegacyTheme } from '../../themes';
+import { EuiThemeAmsterdam } from '../../themes';
 
 export interface EuiProviderProps<T>
   extends Omit<EuiThemeProviderProps<T>, 'children' | 'theme'>,
@@ -38,19 +38,18 @@ export const EuiProvider = <T extends {} = {}>({
   modify,
   children,
 }: PropsWithChildren<EuiProviderProps<T>>) => {
-  return theme === null ? (
-    <EuiThemeProvider colorMode={colorMode}>{children}</EuiThemeProvider>
-  ) : (
+  return theme !== null ? (
     <EuiThemeProvider theme={theme} colorMode={colorMode} modify={modify}>
-      {!isLegacyTheme(theme.key) &&
-        (cache ? (
-          <CacheProvider value={cache}>
-            <EuiGlobalStyles />
-          </CacheProvider>
-        ) : (
+      {cache ? (
+        <CacheProvider value={cache}>
           <EuiGlobalStyles />
-        ))}
+        </CacheProvider>
+      ) : (
+        <EuiGlobalStyles />
+      )}
       {children}
     </EuiThemeProvider>
+  ) : (
+    <EuiThemeProvider colorMode={colorMode}>{children}</EuiThemeProvider>
   );
 };

--- a/src/global_styling/reset/global_styles.tsx
+++ b/src/global_styling/reset/global_styles.tsx
@@ -12,12 +12,13 @@ import { useScrollBar } from '../mixins/_helpers';
 import { shade, tint, transparentize } from '../../services/color';
 import { useEuiTheme } from '../../services/theme';
 import { resetStyles as reset } from './reset';
+import { isLegacyTheme } from '../../themes';
 
 export interface EuiGlobalStylesProps {}
 
 export const EuiGlobalStyles = ({}: EuiGlobalStylesProps) => {
   const {
-    euiTheme: { base, border, colors, font },
+    euiTheme: { base, border, colors, font, themeName },
     colorMode,
   } = useEuiTheme();
 
@@ -32,6 +33,15 @@ export const EuiGlobalStyles = ({}: EuiGlobalStylesProps) => {
         : tint(colors.body, 0.07),
     width: 'auto',
   });
+
+  /**
+   * Early return with no styles if using the legacy theme,
+   * which has reset and global styles included in the compiled CSS.
+   * Comes after `scrollbarStyles` because of hook rules.
+   */
+  if (isLegacyTheme(themeName)) {
+    return null;
+  }
 
   /**
    * This font reset sets all our base font/typography related properties


### PR DESCRIPTION
### Summary

Makes `EuiGlobalStyles` theme-aware so that global and reset styles are not added when using the legacy theme.
Decided to do this in the component rather than in the docs because as we move forward, we'll need to account for future and custom themes potentially having different global styles. For now, we can simply use `isLegacyTheme` as the flag.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Checked for **breaking changes** and labeled appropriately
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
