### PR TITLE
[EuiDatePicker] Fixed `Time` component not showing pre-selected item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed `EUiDataGrid`'s cell popover overlapping with modals and flyouts ([#5461](https://github.com/elastic/eui/pull/5461))
 - Fixed an accessibility issue where `EuiDatePicker` time options did not have unique IDs ([#5466](https://github.com/elastic/eui/pull/5466))
+- Fixed an issue where `EuiDatePicker` pre-selected time was not appearing in the viewport consistently ([#5474](https://github.com/elastic/eui/pull/5474))
 
 ## [`43.1.0`](https://github.com/elastic/eui/tree/v43.1.0)
 

--- a/src/components/date_picker/react-datepicker/src/time.js
+++ b/src/components/date_picker/react-datepicker/src/time.js
@@ -78,7 +78,7 @@ export default class Time extends React.Component {
 
   static calcCenterPosition = (listHeight, centerLiRef) => {
     return (
-      centerLiRef.offsetTop - (listHeight / 2 - centerLiRef.clientHeight / 2)
+      centerLiRef.offsetTop - (listHeight / 2.5 - centerLiRef.clientHeight / 2)
     );
   };
 
@@ -126,6 +126,9 @@ export default class Time extends React.Component {
   componentDidMount() {
     // code to ensure selected time will always be in focus within time window when it first appears
     const scrollParent = this.list;
+    // console.log(`${this.props.monthRef.clientHeight - this.header.clientHeight}`);
+    // console.log(`${this.props.monthRef.clientHeight}`);
+    // console.log(`${this.header.clientHeight}`);
 
     scrollParent.scrollTop = Time.calcCenterPosition(
       this.props.monthRef

--- a/src/components/date_picker/react-datepicker/src/time.js
+++ b/src/components/date_picker/react-datepicker/src/time.js
@@ -126,9 +126,6 @@ export default class Time extends React.Component {
   componentDidMount() {
     // code to ensure selected time will always be in focus within time window when it first appears
     const scrollParent = this.list;
-    // console.log(`${this.props.monthRef.clientHeight - this.header.clientHeight}`);
-    // console.log(`${this.props.monthRef.clientHeight}`);
-    // console.log(`${this.header.clientHeight}`);
 
     scrollParent.scrollTop = Time.calcCenterPosition(
       this.props.monthRef

--- a/src/global_styling/react_date_picker/_date_picker.scss
+++ b/src/global_styling/react_date_picker/_date_picker.scss
@@ -326,7 +326,7 @@
         flex-grow: 1;
         overflow-y: auto;
         align-items: center;
-        min-width: 90px; // Safari bug where list width collapses
+        min-width: $euiSize * 5.625; // Safari bug where list width collapses. 90px min-width.
 
         li.react-datepicker__time-list-item {
           padding: $euiSizeXS $euiSizeS;

--- a/src/global_styling/react_date_picker/_date_picker.scss
+++ b/src/global_styling/react_date_picker/_date_picker.scss
@@ -326,6 +326,7 @@
         flex-grow: 1;
         overflow-y: auto;
         align-items: center;
+        min-width: 90px; // Safari bug where list width collapses
 
         li.react-datepicker__time-list-item {
           padding: $euiSizeXS $euiSizeS;

--- a/src/themes/amsterdam/global_styling/react_date_picker/_date_picker_times.scss
+++ b/src/themes/amsterdam/global_styling/react_date_picker/_date_picker_times.scss
@@ -20,6 +20,8 @@
   flex-grow: 1;
   background-color: $euiPageBackgroundColor;
   border-radius: $euiBorderRadius;
+  flex-direction: column;
+  position: relative;
 
   &--focus {
     .react-datepicker__time-list-item--preselected {
@@ -43,12 +45,13 @@
   @include euiYScroll;
   padding: $euiSizeXS $euiSizeM;
   // Set the min-height with the following, but it should stretch to fit if the container is larger
-  height: 100px !important; // sass-lint:disable-line no-important
+  height: 120px !important; // sass-lint:disable-line no-important
   display: flex;
   flex-direction: column;
   flex-grow: 1;
   align-items: center;
   gap: $euiSizeXS; // sass-lint:disable-line no-misspelled-properties
+  min-width: 115px; // Safari bug where list width collapses
 }
 
 // Mainly a copy/paste of .euiEmptyButton

--- a/src/themes/amsterdam/global_styling/react_date_picker/_date_picker_times.scss
+++ b/src/themes/amsterdam/global_styling/react_date_picker/_date_picker_times.scss
@@ -21,7 +21,7 @@
   background-color: $euiPageBackgroundColor;
   border-radius: $euiBorderRadius;
   flex-direction: column;
-  position: relative;
+  position: relative; /* Needed when we switch to mobile in Amsterdam. Container height is different, offset value must be calculated on this element. */
 
   &--focus {
     .react-datepicker__time-list-item--preselected {

--- a/src/themes/amsterdam/global_styling/react_date_picker/_date_picker_times.scss
+++ b/src/themes/amsterdam/global_styling/react_date_picker/_date_picker_times.scss
@@ -45,13 +45,14 @@
   @include euiYScroll;
   padding: $euiSizeXS $euiSizeM;
   // Set the min-height with the following, but it should stretch to fit if the container is larger
-  height: 120px !important; // sass-lint:disable-line no-important
+  // Default height is 120px;
+  height: $euiSize * 7.5 !important; // sass-lint:disable-line no-important
   display: flex;
   flex-direction: column;
   flex-grow: 1;
   align-items: center;
   gap: $euiSizeXS; // sass-lint:disable-line no-misspelled-properties
-  min-width: 115px; // Safari bug where list width collapses
+  min-width: $euiSize * 7.1875; // Safari bug where list width collapses. 115px min-width.
 }
 
 // Mainly a copy/paste of .euiEmptyButton


### PR DESCRIPTION
### Summary

The `Time` component of EuiDatePicker wasn't showing the pre-selected item consistently in Amsterdam theme. I updated the CSS and the JS offset calculation to work more consistently in Amsterdam and fixed a bug in Safari for list width. Closes #5471.

The Code Sandbox examples didn't pick up my CSS changes, but I'm guessing they will after the change is merged and published.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] ~~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~~
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] ~~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~~
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

---
<img width="469" alt="Screen Shot 2021-12-15 at 11 25 29 AM" src="https://user-images.githubusercontent.com/934879/146241136-77d1206c-0f2d-403f-90d8-286f8c114744.png">

---
<img width="435" alt="Screen Shot 2021-12-15 at 11 25 42 AM" src="https://user-images.githubusercontent.com/934879/146241164-0e9359dc-8a3c-48c4-970a-53896c3c6637.png">

