### PR TITLE
[EuiDataGrid] Account for horizontal scrollbar when determining height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`main`](https://github.com/elastic/eui/tree/main)
 
-No public interface changes since `43.1.1`.
+**Bug fixes**
+
+- Fixed a `EuiDataGrid` sizing bug which didn't account for a horizontal scrollbar ([#5478](https://github.com/elastic/eui/pull/5478))
 
 ## [`43.1.1`](https://github.com/elastic/eui/tree/v43.1.1)
 

--- a/src/components/datagrid/data_grid.spec.tsx
+++ b/src/components/datagrid/data_grid.spec.tsx
@@ -117,9 +117,7 @@ describe('EuiDataGrid', () => {
 
       // make sure the vertical scrollbar is gone
       virtualizedContainer.then(([outerContainer]: [HTMLDivElement]) => {
-        expect(outerContainer.offsetWidth).to.equal(
-          outerContainer.clientWidth
-        );
+        expect(outerContainer.offsetWidth).to.equal(outerContainer.clientWidth);
       });
     });
   });

--- a/src/components/datagrid/data_grid.spec.tsx
+++ b/src/components/datagrid/data_grid.spec.tsx
@@ -82,6 +82,40 @@ describe('EuiDataGrid', () => {
             .should('be.greaterThan', firstHeight);
         });
     });
+
+    it('accounts for a horizontal scrollbar', () => {
+      const columns: EuiDataGridColumn[] = [
+        { id: 'one' },
+        { id: 'two' },
+        { id: 'three' },
+        { id: 'four' },
+        { id: 'five' },
+        { id: 'six' },
+      ];
+      const columnVisibility = {
+        visibleColumns: columns.map(({ id }) => id),
+        setVisibleColumns: () => {},
+      };
+      cy.mount(
+        <EuiDataGrid
+          {...baseProps}
+          columns={columns}
+          columnVisibility={columnVisibility}
+          renderFooterCellValue={undefined}
+        />
+      );
+
+      getGridData();
+
+      cy.get('[data-test-subj=euiDataGridBody]')
+        .children()
+        .first()
+        .then(([outerContainer]: [HTMLDivElement]) => {
+          expect(outerContainer.offsetWidth).not.to.be.greaterThan(
+            outerContainer.clientWidth
+          );
+        });
+    });
   });
 
   describe('focus management', () => {

--- a/src/components/datagrid/data_grid.spec.tsx
+++ b/src/components/datagrid/data_grid.spec.tsx
@@ -83,15 +83,11 @@ describe('EuiDataGrid', () => {
         });
     });
 
-    it('accounts for a horizontal scrollbar', () => {
-      const columns: EuiDataGridColumn[] = [
-        { id: 'one' },
-        { id: 'two' },
-        { id: 'three' },
-        { id: 'four' },
-        { id: 'five' },
-        { id: 'six' },
-      ];
+    it.only('accounts for a horizontal scrollbar', () => {
+      const columns: EuiDataGridColumn[] = [];
+      for (let i = 0; i < 100; i++) {
+        columns.push({ id: `column ${i}` });
+      }
       const columnVisibility = {
         visibleColumns: columns.map(({ id }) => id),
         setVisibleColumns: () => {},
@@ -107,14 +103,24 @@ describe('EuiDataGrid', () => {
 
       getGridData();
 
-      cy.get('[data-test-subj=euiDataGridBody]')
+      const virtualizedContainer = cy
+        .get('[data-test-subj=euiDataGridBody]')
         .children()
-        .first()
-        .then(([outerContainer]: [HTMLDivElement]) => {
-          expect(outerContainer.offsetWidth).not.to.be.greaterThan(
-            outerContainer.clientWidth
-          );
-        });
+        .first();
+
+      // make sure the horizontal scrollbar is present
+      virtualizedContainer.then(([outerContainer]: [HTMLDivElement]) => {
+        expect(outerContainer.offsetHeight).to.be.greaterThan(
+          outerContainer.clientHeight
+        );
+      });
+
+      // make sure the vertical scrollbar is gone
+      virtualizedContainer.then(([outerContainer]: [HTMLDivElement]) => {
+        expect(outerContainer.offsetWidth).to.equal(
+          outerContainer.clientWidth
+        );
+      });
     });
   });
 

--- a/src/components/datagrid/data_grid.spec.tsx
+++ b/src/components/datagrid/data_grid.spec.tsx
@@ -83,7 +83,7 @@ describe('EuiDataGrid', () => {
         });
     });
 
-    it.only('accounts for a horizontal scrollbar', () => {
+    it('accounts for a horizontal scrollbar', () => {
       const columns: EuiDataGridColumn[] = [];
       for (let i = 0; i < 100; i++) {
         columns.push({ id: `column ${i}` });


### PR DESCRIPTION
### Summary

When computing the unconstrained height, now determine if a horizontal scroll is present & find its height, adding that to the datagrid contents' height. This helps address (and may close) some open issues like #4848 , but there's been a lot of movement and re-validating these issues will be necessary before closing them.

To test: in the primary data grid example, resize any of the columns so you get a horizontal scrollbar. Previously, the vertical scrollbar would be present to scroll the extra 13 pixels. Now, all the cells + horizontal scroll are rendered and no vertical scrolling is needed.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
