### PR TITLE
[EuiDataGrid] Fix cells losing focus state when scrolled out of view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`main`](https://github.com/elastic/eui/tree/main)
 
-No public interface changes since `43.1.1`.
+**Bug fixes**
+
+- Fixed `EuiDataGrid` issue where a focused cell would lose focus when scrolled out of and back into view ([#5488](https://github.com/elastic/eui/pull/5488))
 
 ## [`43.1.1`](https://github.com/elastic/eui/tree/v43.1.1)
 

--- a/src-docs/src/views/datagrid/datagrid_example.js
+++ b/src-docs/src/views/datagrid/datagrid_example.js
@@ -358,8 +358,8 @@ export const DataGridExample = {
                 in memory level
               </Link>{' '}
               to have the grid automatically handle updating your columns.
-              Depending upon the level choosen you may need to manage the
-              content order separate from the grid.
+              Depending upon the level chosen, you may need to manage the
+              content order separately from the grid.
             </li>
             <li>
               <Link to="/tabular-content/data-grid-schemas-and-popovers/">

--- a/src-docs/src/views/datagrid/datagrid_focus_example.js
+++ b/src-docs/src/views/datagrid/datagrid_focus_example.js
@@ -93,7 +93,7 @@ export const DataGridFocusExample = {
             color="warning"
             title="A caution about turning off cell expansion when the width of the column is unknown"
           >
-            In general, you should turn <EuiCode>isExpandible</EuiCode> to false
+            In general, you should turn <EuiCode>isExpandable</EuiCode> to false
             only when you know the exact width and number of items that a cell
             will include. Control columns that contain row actions are a good
             example of when to use them. In certain scenarios, allowing multiple

--- a/src/components/datagrid/body/data_grid_cell.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell.test.tsx
@@ -32,31 +32,24 @@ describe('EuiDataGridCell', () => {
     rowHeightUtils: mockRowHeightUtils,
   };
 
-  const mountEuiDataGridCellWithContext = ({ ...props } = {}) => {
-    const focusContext = {
-      setFocusedCell: jest.fn(),
-      onFocusUpdate: jest.fn(),
-    };
-    return mount(<EuiDataGridCell {...requiredProps} {...props} />, {
-      context: focusContext,
-    });
-  };
-
   beforeEach(() => jest.clearAllMocks());
 
   it('renders', () => {
-    const component = mountEuiDataGridCellWithContext();
+    const component = mount(<EuiDataGridCell {...requiredProps} />);
     expect(component).toMatchSnapshot();
   });
 
   it('renders cell buttons', () => {
-    const component = mountEuiDataGridCellWithContext({
-      isExpandable: false,
-      column: {
-        id: 'someColumn',
-        cellActions: [() => <button />],
-      },
-    });
+    const component = mount(
+      <EuiDataGridCell
+        {...requiredProps}
+        isExpandable={false}
+        column={{
+          id: 'someColumn',
+          cellActions: [() => <button />],
+        }}
+      />
+    );
     component.setState({ popoverIsOpen: true });
 
     const cellButtons = component.find('EuiDataGridCellButtons');
@@ -81,7 +74,7 @@ describe('EuiDataGridCell', () => {
         EuiDataGridCell.prototype,
         'shouldComponentUpdate'
       );
-      component = mountEuiDataGridCellWithContext();
+      component = mount(<EuiDataGridCell {...requiredProps} />);
     });
     afterEach(() => {
       shouldComponentUpdate.mockRestore();
@@ -165,7 +158,7 @@ describe('EuiDataGridCell', () => {
   describe('componentDidUpdate', () => {
     it('resets cell props when the cell columnId changes', () => {
       const setState = jest.spyOn(EuiDataGridCell.prototype, 'setState');
-      const component = mountEuiDataGridCellWithContext();
+      const component = mount(<EuiDataGridCell {...requiredProps} />);
 
       component.setProps({ columnId: 'newColumnId' });
       expect(setState).toHaveBeenCalledWith({ cellProps: {} });
@@ -219,9 +212,12 @@ describe('EuiDataGridCell', () => {
       it('sets the row height cache with cell heights on update', () => {
         (mockRowHeightUtils.isAutoHeight as jest.Mock).mockReturnValue(true);
 
-        const component = mountEuiDataGridCellWithContext({
-          rowHeightsOptions: { defaultHeight: 'auto' },
-        });
+        const component = mount(
+          <EuiDataGridCell
+            {...requiredProps}
+            rowHeightsOptions={{ defaultHeight: 'auto' }}
+          />
+        );
 
         triggerUpdate(component);
         expect(mockRowHeightUtils.setRowHeight).toHaveBeenCalled();
@@ -230,9 +226,12 @@ describe('EuiDataGridCell', () => {
       it('does not update the cache if cell height is not auto', () => {
         (mockRowHeightUtils.isAutoHeight as jest.Mock).mockReturnValue(false);
 
-        const component = mountEuiDataGridCellWithContext({
-          rowHeightsOptions: { defaultHeight: 34 },
-        });
+        const component = mount(
+          <EuiDataGridCell
+            {...requiredProps}
+            rowHeightsOptions={{ defaultHeight: 34 }}
+          />
+        );
 
         triggerUpdate(component);
         expect(mockRowHeightUtils.setRowHeight).not.toHaveBeenCalled();
@@ -247,10 +246,13 @@ describe('EuiDataGridCell', () => {
 
       describe('default height', () => {
         it('observes the first cell for size changes and calls this.props.setRowHeight on change', () => {
-          const component = mountEuiDataGridCellWithContext({
-            rowHeightsOptions: { defaultHeight: { lineCount: 3 } },
-            setRowHeight,
-          });
+          const component = mount(
+            <EuiDataGridCell
+              {...requiredProps}
+              rowHeightsOptions={{ defaultHeight: { lineCount: 3 } }}
+              setRowHeight={setRowHeight}
+            />
+          );
 
           callMethod(component);
           expect(
@@ -262,14 +264,17 @@ describe('EuiDataGridCell', () => {
 
       describe('row height overrides', () => {
         it('uses the rowHeightUtils.setRowHeight cache instead of this.props.setRowHeight', () => {
-          const component = mountEuiDataGridCellWithContext({
-            rowHeightsOptions: {
-              defaultHeight: { lineCount: 3 },
-              rowHeights: { 10: { lineCount: 10 } },
-            },
-            rowIndex: 10,
-            setRowHeight,
-          });
+          const component = mount(
+            <EuiDataGridCell
+              {...requiredProps}
+              rowHeightsOptions={{
+                defaultHeight: { lineCount: 3 },
+                rowHeights: { 10: { lineCount: 10 } },
+              }}
+              rowIndex={10}
+              setRowHeight={setRowHeight}
+            />
+          );
 
           callMethod(component);
           expect(
@@ -281,10 +286,13 @@ describe('EuiDataGridCell', () => {
       });
 
       it('recalculates when rowHeightsOptions.defaultHeight.lineCount changes', () => {
-        const component = mountEuiDataGridCellWithContext({
-          rowHeightsOptions: { defaultHeight: { lineCount: 7 } },
-          setRowHeight,
-        });
+        const component = mount(
+          <EuiDataGridCell
+            {...requiredProps}
+            rowHeightsOptions={{ defaultHeight: { lineCount: 7 } }}
+            setRowHeight={setRowHeight}
+          />
+        );
 
         component.setProps({
           rowHeightsOptions: { defaultHeight: { lineCount: 6 } },
@@ -293,10 +301,13 @@ describe('EuiDataGridCell', () => {
       });
 
       it('calculates undefined heights as single rows with a lineCount of 1', () => {
-        const component = mountEuiDataGridCellWithContext({
-          rowHeightsOptions: { defaultHeight: undefined },
-          setRowHeight,
-        });
+        const component = mount(
+          <EuiDataGridCell
+            {...requiredProps}
+            rowHeightsOptions={{ defaultHeight: undefined }}
+            setRowHeight={setRowHeight}
+          />
+        );
 
         callMethod(component);
         expect(
@@ -306,10 +317,13 @@ describe('EuiDataGridCell', () => {
       });
 
       it('does nothing if cell height is not lineCount or undefined', () => {
-        const component = mountEuiDataGridCellWithContext({
-          rowHeightsOptions: { defaultHeight: 34 },
-          setRowHeight,
-        });
+        const component = mount(
+          <EuiDataGridCell
+            {...requiredProps}
+            rowHeightsOptions={{ defaultHeight: 34 }}
+            setRowHeight={setRowHeight}
+          />
+        );
 
         callMethod(component);
         expect(setRowHeight).not.toHaveBeenCalled();
@@ -321,7 +335,7 @@ describe('EuiDataGridCell', () => {
   describe('interactions', () => {
     describe('keyboard events', () => {
       it('when cell is expandable', () => {
-        const component = mountEuiDataGridCellWithContext();
+        const component = mount(<EuiDataGridCell {...requiredProps} />);
         const preventDefault = jest.fn();
 
         component.simulate('keyDown', { preventDefault, key: keys.ENTER });
@@ -331,9 +345,9 @@ describe('EuiDataGridCell', () => {
       });
 
       it('when cell is not expandable', () => {
-        const component = mountEuiDataGridCellWithContext({
-          isExpandable: false,
-        });
+        const component = mount(
+          <EuiDataGridCell {...requiredProps} isExpandable={false} />
+        );
         const preventDefault = jest.fn();
 
         component.simulate('keyDown', { preventDefault, key: keys.ENTER });
@@ -356,7 +370,7 @@ describe('EuiDataGridCell', () => {
     });
 
     it('mouse events', () => {
-      const component = mountEuiDataGridCellWithContext();
+      const component = mount(<EuiDataGridCell {...requiredProps} />);
       component.simulate('mouseEnter');
       expect(component.state('enableInteractions')).toEqual(true);
       component.simulate('mouseLeave');
@@ -364,7 +378,7 @@ describe('EuiDataGridCell', () => {
     });
 
     it('focus/blur events', () => {
-      const component = mountEuiDataGridCellWithContext();
+      const component = mount(<EuiDataGridCell {...requiredProps} />);
       component.simulate('focus');
       component.simulate('blur');
       expect(component.state('disableCellTabIndex')).toEqual(false);
@@ -372,12 +386,15 @@ describe('EuiDataGridCell', () => {
   });
 
   it('renders certain classes/styles if rowHeightOptions is passed', () => {
-    const component = mountEuiDataGridCellWithContext({
-      rowHeightsOptions: {
-        defaultHeight: 20,
-        rowHeights: { 0: 10 },
-      },
-    });
+    const component = mount(
+      <EuiDataGridCell
+        {...requiredProps}
+        rowHeightsOptions={{
+          defaultHeight: 20,
+          rowHeights: { 0: 10 },
+        }}
+      />
+    );
     component.setState({ popoverIsOpen: true });
 
     expect(

--- a/src/components/datagrid/body/data_grid_cell.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell.test.tsx
@@ -183,6 +183,7 @@ describe('EuiDataGridCell', () => {
     });
 
     it('mounts the cell with focus state if the current cell should be focused', () => {
+      const focusSpy = jest.spyOn(HTMLElement.prototype, 'focus');
       const component = mount(
         <DataGridFocusContext.Provider
           value={{ ...focusContext, focusedCell: [3, 3] }}
@@ -196,6 +197,7 @@ describe('EuiDataGridCell', () => {
       );
 
       expect((component.instance().state as any).isFocused).toEqual(true);
+      expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
     });
   });
 

--- a/src/components/datagrid/body/data_grid_cell.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell.test.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 import { keys } from '../../../services';
 import { mockRowHeightUtils } from '../__mocks__/row_height_utils';
+import { DataGridFocusContext } from '../data_grid_context';
 
 import { EuiDataGridCell } from './data_grid_cell';
 
@@ -168,6 +169,40 @@ describe('EuiDataGridCell', () => {
 
       component.setProps({ columnId: 'newColumnId' });
       expect(setState).toHaveBeenCalledWith({ cellProps: {} });
+    });
+  });
+
+  describe('componentDidMount', () => {
+    const focusContext = {
+      focusedCell: undefined,
+      onFocusUpdate: jest.fn(),
+      setFocusedCell: jest.fn(),
+    };
+
+    it('creates an onFocusUpdate subscription', () => {
+      mount(
+        <DataGridFocusContext.Provider value={focusContext}>
+          <EuiDataGridCell {...requiredProps} />
+        </DataGridFocusContext.Provider>
+      );
+
+      expect(focusContext.onFocusUpdate).toHaveBeenCalled();
+    });
+
+    it('mounts the cell with focus state if the current cell should be focused', () => {
+      const component = mount(
+        <DataGridFocusContext.Provider
+          value={{ ...focusContext, focusedCell: [3, 3] }}
+        >
+          <EuiDataGridCell
+            {...requiredProps}
+            colIndex={3}
+            visibleRowIndex={3}
+          />
+        </DataGridFocusContext.Provider>
+      );
+
+      expect((component.instance().state as any).isFocused).toEqual(true);
     });
   });
 

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -142,7 +142,7 @@ export class EuiDataGridCell extends Component<
     return [];
   };
 
-  takeFocus = () => {
+  takeFocus = (preventScroll: boolean) => {
     const cell = this.cellRef.current;
 
     if (cell) {
@@ -157,9 +157,9 @@ export class EuiDataGridCell extends Component<
         const interactables = this.getInteractables();
         if (this.props.isExpandable === false && interactables.length === 1) {
           // Only one element can be interacted with
-          interactables[0].focus();
+          interactables[0].focus({ preventScroll });
         } else {
-          cell.focus();
+          cell.focus({ preventScroll });
         }
       }
     }
@@ -238,14 +238,16 @@ export class EuiDataGridCell extends Component<
       this.context.focusedCell?.[0] === colIndex &&
       this.context.focusedCell?.[1] === visibleRowIndex
     ) {
-      this.onFocusUpdate(true);
+      // The second flag sets preventScroll: true as a focus option, which prevents
+      // hijacking the user's scroll behavior when the cell re-mounts on scroll
+      this.onFocusUpdate(true, true);
     }
   }
 
-  onFocusUpdate = (isFocused: boolean) => {
+  onFocusUpdate = (isFocused: boolean, preventScroll = false) => {
     this.setState({ isFocused }, () => {
       if (isFocused) {
-        this.takeFocus();
+        this.takeFocus(preventScroll);
       }
     });
   };

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -225,10 +225,21 @@ export class EuiDataGridCell extends Component<
   };
 
   componentDidMount() {
+    const { colIndex, visibleRowIndex } = this.props;
+
     this.unsubscribeCell = this.context.onFocusUpdate(
-      [this.props.colIndex, this.props.visibleRowIndex],
+      [colIndex, visibleRowIndex],
       this.onFocusUpdate
     );
+
+    // Account for virtualization - when a cell unmounts when scrolled out of view
+    // and then remounts when scrolled back into view, it should retain focus state
+    if (
+      this.context.focusedCell?.[0] === colIndex &&
+      this.context.focusedCell?.[1] === visibleRowIndex
+    ) {
+      this.onFocusUpdate(true);
+    }
   }
 
   onFocusUpdate = (isFocused: boolean) => {

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -748,10 +748,11 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
   );
   const datagridFocusContext = useMemo<DataGridFocusContextShape>(() => {
     return {
+      focusedCell,
       setFocusedCell,
       onFocusUpdate,
     };
-  }, [setFocusedCell, onFocusUpdate]);
+  }, [focusedCell, setFocusedCell, onFocusUpdate]);
 
   const gridId = useGeneratedHtmlId();
   const ariaLabelledById = useGeneratedHtmlId();

--- a/src/components/datagrid/data_grid_context.tsx
+++ b/src/components/datagrid/data_grid_context.tsx
@@ -16,6 +16,7 @@ import {
 export const DataGridFocusContext = React.createContext<
   DataGridFocusContextShape
 >({
+  focusedCell: undefined,
   setFocusedCell: () => {},
   onFocusUpdate: () => () => {},
 });

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -167,6 +167,7 @@ export type EuiDataGridFooterRowProps = CommonProps &
   };
 
 export interface DataGridFocusContextShape {
+  focusedCell?: EuiDataGridFocusedCell;
   setFocusedCell: (cell: EuiDataGridFocusedCell) => void;
   onFocusUpdate: (
     cell: EuiDataGridFocusedCell,


### PR DESCRIPTION
### Summary

closes #5047

### Before

![before](https://user-images.githubusercontent.com/549407/146447998-f131e30e-81f8-4a6f-a8fc-fb6bf76a723b.gif)

### After

![after](https://user-images.githubusercontent.com/549407/146448001-67d99c72-4b2f-4e40-ace3-87c3319a710b.gif)

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**

~- [ ] Checked for **breaking changes** and labeled appropriately~

- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
