### PR TITLE
fix: replace slash div with math.div

### DIFF
--- a/src/global_styling/functions/_colors.scss
+++ b/src/global_styling/functions/_colors.scss
@@ -51,9 +51,9 @@
 
   @for $i from 1 through 3 {
     $rgb: nth($rgba, $i);
-    $rgb: $rgb / 255;
+    $rgb: math.div($rgb, 255);
 
-    $rgb: if($rgb < .03928, $rgb / 12.92, pow(($rgb + .055) / 1.055, 2.4));
+    $rgb: if($rgb < .03928, math.div($rgb, 12.92), pow(math.div(($rgb + .055) / 1.055), 2.4));
 
     $rgba2: append($rgba2, $rgb);
   }
@@ -66,7 +66,7 @@
   $backgroundLum: luminance($background) + .05;
   $foregroundLum: luminance($foreground) + .05;
 
-  @return max($backgroundLum, $foregroundLum) / min($backgroundLum, $foregroundLum);
+  @return math.div(max($backgroundLum, $foregroundLum), min($backgroundLum, $foregroundLum));
 }
 
 // Given $color, decide whether $lightText or $darkText should be used as the text color

--- a/src/global_styling/functions/_math.scss
+++ b/src/global_styling/functions/_math.scss
@@ -35,7 +35,7 @@
     @if ($hasTrailingOne) {
       $power: $power - 1;
     }
-    $halfPower: pow($number, floor($power / 2));
+    $halfPower: pow($number, floor(math.div($power, 2)));
     $fullPower: $halfPower * $halfPower;
     @if ($hasTrailingOne) {
       $fullPower: $fullPower * $number;


### PR DESCRIPTION
### Summary
Was getting these errors:
```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($rgb, 255) or calc($rgb / 255)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
54 │     $rgb: $rgb / 255;
   │           ^^^^^^^^^^
   ╵
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 54:11  luminance()
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 66:19  contrastRatio()
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 94:14  makeHighContrastColor()
    node_modules/@elastic/eui/src/themes/amsterdam/_colors_light.scss 37:23    @import
    node_modules/@elastic/eui/src/themes/amsterdam/theme_light.scss 2:9        @import
    src/styles/elastic.scss 3:9                                                root stylesheet

Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($rgb, 12.92) or calc($rgb / 12.92)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
56 │     $rgb: if($rgb < .03928, $rgb / 12.92, pow(($rgb + .055) / 1.055, 2.4));
   │                             ^^^^^^^^^^^^
   ╵
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 56:29  luminance()
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 66:19  contrastRatio()
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 94:14  makeHighContrastColor()
    node_modules/@elastic/eui/src/themes/amsterdam/_colors_light.scss 37:23    @import
    node_modules/@elastic/eui/src/themes/amsterdam/theme_light.scss 2:9        @import
    src/styles/elastic.scss 3:9                                                root stylesheet

Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($rgb + 0.055, 1.055) or calc(($rgb + 0.055) / 1.055)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
56 │     $rgb: if($rgb < .03928, $rgb / 12.92, pow(($rgb + .055) / 1.055, 2.4));
   │                                               ^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 56:47  luminance()
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 66:19  contrastRatio()
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 94:14  makeHighContrastColor()
    node_modules/@elastic/eui/src/themes/amsterdam/_colors_light.scss 37:23    @import
    node_modules/@elastic/eui/src/themes/amsterdam/theme_light.scss 2:9        @import
    src/styles/elastic.scss 3:9                                                root stylesheet

Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($power, 2) or calc($power / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

  ╷
3 │   @if ($power != $power or ($power != 0 and $power == $power / 2)) {
  │                                                       ^^^^^^^^^^
  ╵
    node_modules/@elastic/eui/src/global_styling/functions/_math.scss 3:55     pow()
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 56:43  luminance()
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 66:19  contrastRatio()
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 94:14  makeHighContrastColor()
    node_modules/@elastic/eui/src/themes/amsterdam/_colors_light.scss 37:23    @import
    node_modules/@elastic/eui/src/themes/amsterdam/theme_light.scss 2:9        @import
    src/styles/elastic.scss 3:9                                                root stylesheet

Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($power, 2) or calc($power / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
38 │     $halfPower: pow($number, floor($power / 2));
   │                                    ^^^^^^^^^^
   ╵
    node_modules/@elastic/eui/src/global_styling/functions/_math.scss 38:36    pow()
    node_modules/@elastic/eui/src/global_styling/functions/_math.scss 32:13    pow()
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 56:43  luminance()
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 66:19  contrastRatio()
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 94:14  makeHighContrastColor()
    node_modules/@elastic/eui/src/themes/amsterdam/_colors_light.scss 37:23    @import
    node_modules/@elastic/eui/src/themes/amsterdam/theme_light.scss 2:9        @import
    src/styles/elastic.scss 3:9                                                root stylesheet

Deprecation Warning: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(1.0141020291, 0.2255328499)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
69 │   @return max($backgroundLum, $foregroundLum) / min($backgroundLum, $foregroundLum);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 69:11  contrastRatio()
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 94:14  makeHighContrastColor()
    node_modules/@elastic/eui/src/themes/amsterdam/_colors_light.scss 37:23    @import
    node_modules/@elastic/eui/src/themes/amsterdam/theme_light.scss 2:9        @import
    src/styles/elastic.scss 3:9                                                root stylesheet

Deprecation Warning: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(1.0141020291, 0.2070529646)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
69 │   @return max($backgroundLum, $foregroundLum) / min($backgroundLum, $foregroundLum);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 69:11   contrastRatio()
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 109:16  makeHighContrastColor()
    node_modules/@elastic/eui/src/themes/amsterdam/_colors_light.scss 37:23     @import
    node_modules/@elastic/eui/src/themes/amsterdam/theme_light.scss 2:9         @import
    src/styles/elastic.scss 3:9                                                 root stylesheet

Deprecation Warning: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(1.0141020291, 0.4551627675)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
69 │   @return max($backgroundLum, $foregroundLum) / min($backgroundLum, $foregroundLum);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 69:11  contrastRatio()
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 94:14  makeHighContrastColor()
    node_modules/@elastic/eui/src/themes/amsterdam/_colors_light.scss 38:23    @import
    node_modules/@elastic/eui/src/themes/amsterdam/theme_light.scss 2:9        @import
    src/styles/elastic.scss 3:9                                                root stylesheet

Deprecation Warning: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(1.0141020291, 0.4095002659)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
69 │   @return max($backgroundLum, $foregroundLum) / min($backgroundLum, $foregroundLum);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 69:11   contrastRatio()
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 109:16  makeHighContrastColor()
    node_modules/@elastic/eui/src/themes/amsterdam/_colors_light.scss 38:23     @import
    node_modules/@elastic/eui/src/themes/amsterdam/theme_light.scss 2:9         @import
    src/styles/elastic.scss 3:9                                                 root stylesheet

Deprecation Warning: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(1.0141020291, 0.3711368267)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
69 │   @return max($backgroundLum, $foregroundLum) / min($backgroundLum, $foregroundLum);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 69:11   contrastRatio()
    node_modules/@elastic/eui/src/global_styling/functions/_colors.scss 109:16  makeHighContrastColor()
    node_modules/@elastic/eui/src/themes/amsterdam/_colors_light.scss 38:23     @import
    node_modules/@elastic/eui/src/themes/amsterdam/theme_light.scss 2:9         @import
    src/styles/elastic.scss 3:9                                                 root stylesheet




```

Due to: https://sass-lang.com/documentation/breaking-changes/slash-div

This PR fixes it.

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
