### PR TITLE
fix: allow overriding radius

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 No public interface changes since `43.1.1`.
 
+- Fixed overriding border radius [#5490](https://github.com/elastic/eui/pull/5490)
+
 ## [`43.1.1`](https://github.com/elastic/eui/tree/v43.1.1)
 
 **Bug fixes**

--- a/src/themes/amsterdam/global_styling/variables/_borders.scss
+++ b/src/themes/amsterdam/global_styling/variables/_borders.scss
@@ -1,2 +1,2 @@
-$euiBorderRadius: $euiSizeS * .75;
-$euiBorderRadiusSmall: $euiSizeS * .5;
+$euiBorderRadius: $euiSizeS * .75 !default;
+$euiBorderRadiusSmall: $euiSizeS * .5 !default;


### PR DESCRIPTION
### Summary
https://github.com/elastic/eui/blob/main/src/global_styling/variables/_borders.scss#L7 allows for overriding the border radius, but it is then overriden without the `!default` syntax. This PR allows for that. 


### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
