### PR TITLE
Update elastic-charts to v41.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,7 @@
 **Bug fixes**
 
 - Fixed a `EuiDataGrid` sizing bug which didn't account for a horizontal scrollbar ([#5478](https://github.com/elastic/eui/pull/5478))
-
-**Breaking changes**
-
-- Upgraded to `@elastic/charts@^41.0.0` which removed partition config in favor of inclusion in Charts theme config ([#5492](https://github.com/elastic/eui/pull/5492))
+- Upgraded to `@elastic/charts@^41.0.1` which deprecated `PartitionConfig` in favor of inclusion in Charts theme config ([#5492](https://github.com/elastic/eui/pull/5492))
 
 ## [`43.1.1`](https://github.com/elastic/eui/tree/v43.1.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 **Bug fixes**
 
 - Fixed a `EuiDataGrid` sizing bug which didn't account for a horizontal scrollbar ([#5478](https://github.com/elastic/eui/pull/5478))
-- Upgraded to `@elastic/charts@^41.0.1` which deprecated `PartitionConfig` in favor of inclusion in Charts theme config ([#5492](https://github.com/elastic/eui/pull/5492))
+
+**Deprecations**
+
+- Deprecated `PartitionConfig` in favor of inclusion in Charts `theme.partition` ([#5492](https://github.com/elastic/eui/pull/5492))
 
 ## [`43.1.1`](https://github.com/elastic/eui/tree/v43.1.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 **Bug fixes**
 
 - Fixed a `EuiDataGrid` sizing bug which didn't account for a horizontal scrollbar ([#5478](https://github.com/elastic/eui/pull/5478))
+- Upgraded to `@elastic/charts@^41.0.0` which removed partition config in favor of theming.
+
+**Breaking changes**
+
+- Requires `@elastic/charts@^41.0.0` for refactored partition chart theming. No more partition config on eui charts theme.
 
 ## [`43.1.1`](https://github.com/elastic/eui/tree/v43.1.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,10 @@
 **Bug fixes**
 
 - Fixed a `EuiDataGrid` sizing bug which didn't account for a horizontal scrollbar ([#5478](https://github.com/elastic/eui/pull/5478))
-- Upgraded to `@elastic/charts@^41.0.0` which removed partition config in favor of theming.
 
 **Breaking changes**
 
-- Requires `@elastic/charts@^41.0.0` for refactored partition chart theming. No more partition config on eui charts theme.
+- Upgraded to `@elastic/charts@^41.0.0` which removed partition config in favor of inclusion in Charts theme config ([#5492](https://github.com/elastic/eui/pull/5492))
 
 ## [`43.1.1`](https://github.com/elastic/eui/tree/v43.1.1)
 

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@cypress/code-coverage": "^3.9.12",
     "@cypress/react": "^5.10.3",
     "@cypress/webpack-dev-server": "^1.7.0",
-    "@elastic/charts": "^41.0.0",
+    "@elastic/charts": "^41.0.1",
     "@elastic/datemath": "^5.0.3",
     "@elastic/eslint-config-kibana": "^0.15.0",
     "@emotion/babel-preset-css-prop": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@cypress/code-coverage": "^3.9.12",
     "@cypress/react": "^5.10.3",
     "@cypress/webpack-dev-server": "^1.7.0",
-    "@elastic/charts": "^38.1.1",
+    "@elastic/charts": "^41.0.0",
     "@elastic/datemath": "^5.0.3",
     "@elastic/eslint-config-kibana": "^0.15.0",
     "@emotion/babel-preset-css-prop": "^11.0.0",

--- a/src-docs/src/views/elastic_charts/accessibility_sunburst.js
+++ b/src-docs/src/views/elastic_charts/accessibility_sunburst.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { ThemeContext } from '../../components';
-import { Chart, Partition, Settings } from '@elastic/charts';
+import { Chart, Partition, Settings, PartitionLayout } from '@elastic/charts';
 
 import {
   EUI_CHARTS_THEME_DARK,
@@ -20,7 +20,6 @@ export const AccessibilitySunburst = () => {
   const euiChartTheme = isDarkTheme
     ? EUI_CHARTS_THEME_DARK
     : EUI_CHARTS_THEME_LIGHT;
-  const euiPartitionConfig = euiChartTheme.partition;
   const { vizColors } = euiChartTheme.theme.colors;
 
   const data = [
@@ -50,12 +49,14 @@ export const AccessibilitySunburst = () => {
       <EuiSpacer />
       <Chart size={{ height: 200 }}>
         <Settings
+          theme={euiChartTheme.theme}
           ariaLabelledBy={id}
           ariaDescription="There is a great variety of reported favorite fruit"
           ariaTableCaption="For the chart representation, after Clementine (22) individual results are not labelled as the segments become too small"
         />
         <Partition
           data={data}
+          layout={PartitionLayout.sunburst}
           valueAccessor={({ count }) => count}
           layers={[
             {
@@ -66,11 +67,7 @@ export const AccessibilitySunburst = () => {
               },
             },
           ]}
-          config={{
-            ...euiPartitionConfig,
-            clockwiseSectors: false,
-            partitionLayout: 'sunburst',
-          }}
+          clockwiseSectors={false}
         />
       </Chart>
     </>
@@ -82,6 +79,7 @@ export const AccessibilitySunburst = () => {
       <EuiSpacer />
       <Chart size={{ height: 200 }}>
         <Settings
+          theme={euiChartTheme.theme}
           ariaLabelledBy={id}
           ariaDescription="There is a great variety of reported favorite fruit"
           ariaTableCaption="For the chart representation, after Clementine (22) individual results are not labelled as the segments become too small"
@@ -89,6 +87,7 @@ export const AccessibilitySunburst = () => {
         <Partition
           data={data}
           valueAccessor={({ count }) => count}
+          layout={PartitionLayout.sunburst}
           layers={[
             {
               groupByRollup: ({ fruit }) => fruit,
@@ -98,14 +97,7 @@ export const AccessibilitySunburst = () => {
               },
             },
           ]}
-          config={{
-            ...euiPartitionConfig,
-            ...(isDarkTheme
-              ? EUI_CHARTS_THEME_DARK.partition
-              : EUI_CHARTS_THEME_LIGHT.partition),
-            clockwiseSectors: false,
-            partitionLayout: 'sunburst',
-          }}
+          clockwiseSectors={false}
         />
       </Chart>
     </>

--- a/src-docs/src/views/elastic_charts/pie.js
+++ b/src-docs/src/views/elastic_charts/pie.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { ThemeContext } from '../../components';
-import { Chart, Partition, Settings } from '@elastic/charts';
+import { Chart, Partition, Settings, PartitionLayout } from '@elastic/charts';
 
 import {
   EUI_CHARTS_THEME_DARK,
@@ -27,7 +27,6 @@ export default () => {
   const euiChartTheme = isDarkTheme
     ? EUI_CHARTS_THEME_DARK
     : EUI_CHARTS_THEME_LIGHT;
-  const euiPartitionConfig = euiChartTheme.partition;
 
   return (
     <div>
@@ -38,7 +37,7 @@ export default () => {
           </EuiTitle>
           <EuiSpacer />
           <Chart size={{ height: 200 }}>
-            <Settings ariaLabelledBy={exampleOne} />
+            <Settings theme={euiChartTheme.theme} ariaLabelledBy={exampleOne} />
             <Partition
               id="pieByPR"
               data={[
@@ -51,20 +50,18 @@ export default () => {
                   count: 319,
                 },
               ]}
+              layout={PartitionLayout.sunburst}
               valueAccessor={(d) => d.count}
               layers={[
                 {
                   groupByRollup: (d) => d.status,
                   shape: {
                     fillColor: (d) =>
-                      euiChartTheme.theme.colors.vizColors[d.sortIndex],
+                      euiChartTheme.colors.vizColors[d.sortIndex],
                   },
                 },
               ]}
-              config={{
-                ...euiPartitionConfig,
-                clockwiseSectors: false,
-              }}
+              clockwiseSectors={false}
             />
           </Chart>
         </EuiFlexItem>
@@ -74,7 +71,7 @@ export default () => {
           </EuiTitle>
           <EuiSpacer />
           <Chart size={{ height: 200 }}>
-            <Settings ariaLabelledBy={exampleTwo} />
+            <Settings theme={euiChartTheme.theme} ariaLabelledBy={exampleTwo} />
             <Partition
               id="donutByLanguage"
               data={[
@@ -91,6 +88,7 @@ export default () => {
                   percent: 8.7,
                 },
               ]}
+              layout={PartitionLayout.sunburst}
               valueAccessor={(d) => Number(d.percent)}
               valueFormatter={() => ''}
               layers={[
@@ -98,15 +96,12 @@ export default () => {
                   groupByRollup: (d) => d.language,
                   shape: {
                     fillColor: (d) =>
-                      euiChartTheme.theme.colors.vizColors[d.sortIndex],
+                      euiChartTheme.colors.vizColors[d.sortIndex],
                   },
                 },
               ]}
-              config={{
-                ...euiPartitionConfig,
-                emptySizeRatio: 0.4,
-                clockwiseSectors: false,
-              }}
+              emptySizeRatio={0.4}
+              clockwiseSectors={false}
             />
           </Chart>
         </EuiFlexItem>

--- a/src-docs/src/views/elastic_charts/pie.js
+++ b/src-docs/src/views/elastic_charts/pie.js
@@ -57,7 +57,7 @@ export default () => {
                   groupByRollup: (d) => d.status,
                   shape: {
                     fillColor: (d) =>
-                      euiChartTheme.colors.vizColors[d.sortIndex],
+                      euiChartTheme.theme.colors.vizColors[d.sortIndex],
                   },
                 },
               ]}
@@ -96,7 +96,7 @@ export default () => {
                   groupByRollup: (d) => d.language,
                   shape: {
                     fillColor: (d) =>
-                      euiChartTheme.colors.vizColors[d.sortIndex],
+                      euiChartTheme.theme.colors.vizColors[d.sortIndex],
                   },
                 },
               ]}

--- a/src-docs/src/views/elastic_charts/pie_example.js
+++ b/src-docs/src/views/elastic_charts/pie_example.js
@@ -13,8 +13,6 @@ import {
   EuiLink,
   EuiIconTip,
   EuiToolTip,
-  EuiCallOut,
-  EuiCode,
   EuiImage,
 } from '../../../../src/components';
 
@@ -197,40 +195,15 @@ export const ElasticChartsPieExample = {
             />
             .
           </p>
-          <EuiCallOut
-            color="warning"
-            title={
-              <>
-                Elastic Charts&apos;{' '}
-                <EuiLink href="https://github.com/elastic/elastic-charts/issues/518">
-                  partition charts do not currently support theming
-                </EuiLink>{' '}
-                through the <EuiCode>{'<Settings />'}</EuiCode> component.
-              </>
-            }
-          >
-            <p>
-              {' '}
-              EUI provides a separate key for use with
-              <EuiCode language="ts">
-                {'Partition.config={{...EUI_CHARTS_THEME_LIGHT.partition}}'}
-              </EuiCode>
-              . The chart colors also need to be passed a different way via{' '}
-              <EuiCode language="ts">
-                {'Partition.layers.shape.fillColor'}
-              </EuiCode>
-              . See the snippet for full details.
-            </p>
-          </EuiCallOut>
         </>
       ),
       demo: <PieChart />,
       snippet: `import { EUI_CHARTS_THEME_DARK, EUI_CHARTS_THEME_LIGHT } from '@elastic/eui/dist/eui_charts_theme';
 
 const euiChartTheme = isDarkTheme ? EUI_CHARTS_THEME_DARK : EUI_CHARTS_THEME_LIGHT;
-const euiPartitionConfig = euiChartTheme.partition;
 
-<Chart size={{height: 200}}>
+<Chart size={{ height: 200 }}>
+  <Settings theme={euiChartTheme.theme} />
   <Partition
     data={[
       {
@@ -248,11 +221,8 @@ const euiPartitionConfig = euiChartTheme.partition;
         },
       },
     ]}
-    config={{
-      ...euiPartitionConfig,
-      emptySizeRatio: 0.4, // To create a donut chart
-      clockwiseSectors: false, // For correct slice order
-    }}
+    emptySizeRatio={0.4} // To create a donut chart
+    clockwiseSectors={false} // For correct slice order
   />
 </Chart>`,
     },

--- a/src-docs/src/views/elastic_charts/pie_slices.js
+++ b/src-docs/src/views/elastic_charts/pie_slices.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-nested-ternary */
 import React, { Fragment, useState, useContext } from 'react';
-import { Chart, Partition, Settings } from '@elastic/charts';
+import { Chart, Partition, Settings, PartitionLayout } from '@elastic/charts';
 import { ThemeContext } from '../../components';
 
 import {
@@ -34,7 +34,6 @@ export default () => {
   const euiChartTheme = isDarkTheme
     ? EUI_CHARTS_THEME_DARK
     : EUI_CHARTS_THEME_LIGHT;
-  const euiPartitionConfig = euiChartTheme.partition;
 
   const sliceOrderRadiosIdPrefix = 'colorType';
   const sliceOrderRadios = [
@@ -140,15 +139,26 @@ export default () => {
     }
   };
 
+  const themeOverrides = {
+    partition: {
+      emptySizeRatio: pieTypeIdSelected.includes('Donut') && 0.4,
+    },
+  };
+
   return (
     <Fragment>
       {customTitle}
       <div style={{ position: 'relative' }}>
         <Chart size={{ height: 200 }}>
-          <Settings showLegend={showLegend} showLegendExtra />
+          <Settings
+            theme={[themeOverrides, euiChartTheme.theme]}
+            showLegend={showLegend}
+            showLegendExtra
+          />
           <Partition
             id="donutByLanguage"
             data={pieData()}
+            layout={PartitionLayout.sunburst}
             valueAccessor={(d) => Number(d.percent)}
             valueFormatter={showValues ? undefined : () => ''}
             valueGetter={showValues ? 'percent' : undefined}
@@ -161,11 +171,7 @@ export default () => {
                 },
               },
             ]}
-            config={{
-              ...euiPartitionConfig,
-              emptySizeRatio: pieTypeIdSelected.includes('Donut') && 0.4,
-              ...sliceOrderConfig,
-            }}
+            {...sliceOrderConfig}
           />
         </Chart>
       </div>
@@ -273,8 +279,10 @@ export default () => {
           textToCopy={`<EuiTitle size="xxs">
   <h4>Distribution of the top ${numSlices} browsers from 2019</h4>
 </EuiTitle>
-<Chart size={{height: 200}}>
-  ${showLegend ? '<Settings showLegend />' : ''}
+<Chart size={{ height: 200 }}>
+  <Settings${showLegend ? '\nshowLegend' : ''}
+    theme={[themeOverrides, euiChartTheme.theme]}
+  />
   <Partition
     id={chartID}
     data={[
@@ -303,9 +311,8 @@ export default () => {
         },
       },
     ]}
-    config={{
-      ...euiPartitionConfig,
-      ${pieTypeIdSelected.includes('Donut') ? 'emptySizeRatio: 0.4,' : ''}
+    ${pieTypeIdSelected.includes('Donut') ? 'emptySizeRatio={0.4}' : ''}
+    {...{
       ${sliceOrderConfigText}
     }}
   />

--- a/src-docs/src/views/elastic_charts/pie_slices.js
+++ b/src-docs/src/views/elastic_charts/pie_slices.js
@@ -70,7 +70,7 @@ export default () => {
     clockwiseSectors: false,
   });
   const [sliceOrderConfigText, setSliceOrderConfigText] = useState(
-    'clockwiseSectors: false,'
+    'clockwiseSectors={false}'
   );
 
   const [pieTypeIdSelected, setPieTypeIdSelected] = useState(
@@ -92,10 +92,10 @@ export default () => {
       .label;
     if (sliceOrderLabel.includes('Counter')) {
       setSliceOrderConfig({ clockwiseSectors: false });
-      setSliceOrderConfigText('clockwiseSectors: false,');
+      setSliceOrderConfigText('clockwiseSectors={false}');
     } else if (sliceOrderLabel.includes('Clockwise')) {
       setSliceOrderConfig({ specialFirstInnermostSector: false });
-      setSliceOrderConfigText('specialFirstInnermostSector: false,');
+      setSliceOrderConfigText('specialFirstInnermostSector={false}');
     } else if (sliceOrderLabel.includes('natural')) {
       setSliceOrderConfig({});
       setSliceOrderConfigText('');
@@ -312,9 +312,7 @@ export default () => {
       },
     ]}
     ${pieTypeIdSelected.includes('Donut') ? 'emptySizeRatio={0.4}' : ''}
-    {...{
-      ${sliceOrderConfigText}
-    }}
+    ${sliceOrderConfigText}
   />
 </Chart>`}
         >

--- a/src-docs/src/views/elastic_charts/treemap.js
+++ b/src-docs/src/views/elastic_charts/treemap.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useMemo } from 'react';
 import { ThemeContext } from '../../components';
 import { Chart, Partition, Settings, PartitionLayout } from '@elastic/charts';
 import { GITHUB_DATASET_MOD } from './data';
@@ -32,6 +32,11 @@ export default () => {
     sortBy: 'natural',
   });
 
+  const euiChartTheme = useMemo(
+    () => (isDarkTheme ? EUI_CHARTS_THEME_DARK : EUI_CHARTS_THEME_LIGHT),
+    [isDarkTheme]
+  );
+
   return (
     <div>
       <EuiTitle className="eui-textCenter" size="xs">
@@ -41,18 +46,21 @@ export default () => {
       <EuiFlexGrid columns={2}>
         <EuiFlexItem>
           <Chart size={{ height: 240 }}>
-            <Settings showLegend legendMaxDepth={2} />
+            <Settings
+              theme={euiChartTheme.theme}
+              showLegend
+              legendMaxDepth={2}
+            />
             <Partition
               id="sunburst"
               data={GITHUB_DATASET_MOD}
+              layout={PartitionLayout.sunburst}
               valueAccessor={(d) => d.count}
               layers={[
                 {
                   groupByRollup: (d) => d.total,
                   shape: {
-                    fillColor: isDarkTheme
-                      ? EUI_CHARTS_THEME_DARK.partition.sectorLineStroke
-                      : EUI_CHARTS_THEME_LIGHT.partition.sectorLineStroke,
+                    fillColor: euiChartTheme.theme.partition.sectorLineStroke,
                   },
                   hideInLegend: true,
                 },
@@ -70,27 +78,21 @@ export default () => {
                   },
                 },
               ]}
-              config={{
-                ...(isDarkTheme
-                  ? EUI_CHARTS_THEME_DARK.partition
-                  : EUI_CHARTS_THEME_LIGHT.partition),
-                clockwiseSectors: false,
-                fillLabel: {
-                  ...(isDarkTheme
-                    ? EUI_CHARTS_THEME_DARK.partition.fillLabel
-                    : EUI_CHARTS_THEME_LIGHT.partition.fillLabel),
-                  textInvertible: true,
-                },
-              }}
+              clockwiseSectors={false}
             />
           </Chart>
         </EuiFlexItem>
         <EuiFlexItem>
           <Chart size={{ height: 240 }}>
-            <Settings showLegend legendMaxDepth={1} />
+            <Settings
+              theme={euiChartTheme.theme}
+              showLegend
+              legendMaxDepth={1}
+            />
             <Partition
               id="treemap"
               data={GITHUB_DATASET_MOD}
+              layout={PartitionLayout.treemap}
               valueAccessor={(d) => d.count}
               valueGetter="percent"
               topGroove={0}
@@ -113,12 +115,6 @@ export default () => {
                   },
                 },
               ]}
-              config={{
-                partitionLayout: PartitionLayout.treemap,
-                ...(isDarkTheme
-                  ? EUI_CHARTS_THEME_DARK.partition
-                  : EUI_CHARTS_THEME_LIGHT.partition),
-              }}
             />
           </Chart>
         </EuiFlexItem>

--- a/src/themes/charts/themes.ts
+++ b/src/themes/charts/themes.ts
@@ -6,7 +6,12 @@
  * Side Public License, v 1.
  */
 
-import { PartialTheme, LineAnnotationStyle } from '@elastic/charts';
+import {
+  PartialTheme,
+  LineAnnotationStyle,
+  RecursivePartial,
+  PartitionConfig,
+} from '@elastic/charts';
 
 import { euiPaletteColorBlind } from '../../services/color/eui_palettes';
 import { DEFAULT_VISUALIZATION_COLOR } from '../../services/color/visualization_colors';
@@ -22,7 +27,7 @@ const fontFamily = `'Inter', 'Inter UI', -apple-system, BlinkMacSystemFont,
 export interface EuiChartThemeType {
   lineAnnotation: LineAnnotationStyle;
   theme: PartialTheme;
-  partition: PartialTheme['partition'];
+  partition: RecursivePartial<PartitionConfig>;
 }
 
 function createTheme(colors: any): EuiChartThemeType {

--- a/src/themes/charts/themes.ts
+++ b/src/themes/charts/themes.ts
@@ -27,6 +27,7 @@ const fontFamily = `'Inter', 'Inter UI', -apple-system, BlinkMacSystemFont,
 export interface EuiChartThemeType {
   lineAnnotation: LineAnnotationStyle;
   theme: PartialTheme;
+  /** DEPRECATED: Use `theme.partition` config instead */
   partition: RecursivePartial<PartitionConfig>;
 }
 

--- a/src/themes/charts/themes.ts
+++ b/src/themes/charts/themes.ts
@@ -22,6 +22,7 @@ const fontFamily = `'Inter', 'Inter UI', -apple-system, BlinkMacSystemFont,
 export interface EuiChartThemeType {
   lineAnnotation: LineAnnotationStyle;
   theme: PartialTheme;
+  partition: PartialTheme['partition'];
 }
 
 function createTheme(colors: any): EuiChartThemeType {
@@ -38,6 +39,25 @@ function createTheme(colors: any): EuiChartThemeType {
         fill: colors.euiTextColor.rgba,
         padding: 0,
       },
+    },
+    partition: {
+      fontFamily: fontFamily,
+      minFontSize: 8,
+      maxFontSize: 16,
+      fillLabel: {
+        valueFont: {
+          fontWeight: 700,
+        },
+      },
+      linkLabel: {
+        maxCount: 5,
+        fontSize: 11,
+        textColor: colors.euiTextColor.rgba,
+      },
+      outerSizeRatio: 1,
+      circlePadding: 4,
+      sectorLineStroke: colors.euiColorEmptyShade.rgba,
+      sectorLineWidth: 1.5,
     },
     theme: {
       background: {

--- a/src/themes/charts/themes.ts
+++ b/src/themes/charts/themes.ts
@@ -6,14 +6,10 @@
  * Side Public License, v 1.
  */
 
+import { PartialTheme, LineAnnotationStyle } from '@elastic/charts';
+
 import { euiPaletteColorBlind } from '../../services/color/eui_palettes';
 import { DEFAULT_VISUALIZATION_COLOR } from '../../services/color/visualization_colors';
-import {
-  PartialTheme,
-  LineAnnotationStyle,
-  PartitionConfig,
-} from '@elastic/charts';
-import { RecursivePartial } from '../../components/common';
 
 // @ts-ignore typescript doesn't understand the webpack loader
 import lightColors from '!!sass-vars-to-js-loader!../../themes/amsterdam/_colors_light.scss';
@@ -26,7 +22,6 @@ const fontFamily = `'Inter', 'Inter UI', -apple-system, BlinkMacSystemFont,
 export interface EuiChartThemeType {
   lineAnnotation: LineAnnotationStyle;
   theme: PartialTheme;
-  partition: RecursivePartial<PartitionConfig>;
 }
 
 function createTheme(colors: any): EuiChartThemeType {
@@ -43,25 +38,6 @@ function createTheme(colors: any): EuiChartThemeType {
         fill: colors.euiTextColor.rgba,
         padding: 0,
       },
-    },
-    partition: {
-      fontFamily: fontFamily,
-      minFontSize: 8,
-      maxFontSize: 16,
-      fillLabel: {
-        valueFont: {
-          fontWeight: 700,
-        },
-      },
-      linkLabel: {
-        maxCount: 5,
-        fontSize: 11,
-        textColor: colors.euiTextColor.rgba,
-      },
-      outerSizeRatio: 1,
-      circlePadding: 4,
-      sectorLineStroke: colors.euiColorEmptyShade.rgba,
-      sectorLineWidth: 1.5,
     },
     theme: {
       background: {
@@ -207,6 +183,25 @@ function createTheme(colors: any): EuiChartThemeType {
         progressLine: {
           stroke: colors.euiColorDarkestShade.rgba,
         },
+      },
+      partition: {
+        fontFamily: fontFamily,
+        minFontSize: 8,
+        maxFontSize: 16,
+        fillLabel: {
+          valueFont: {
+            fontWeight: 700,
+          },
+        },
+        linkLabel: {
+          maxCount: 5,
+          fontSize: 11,
+          textColor: colors.euiTextColor.rgba,
+        },
+        outerSizeRatio: 1,
+        circlePadding: 4,
+        sectorLineStroke: colors.euiColorEmptyShade.rgba,
+        sectorLineWidth: 1.5,
       },
     },
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1189,10 +1189,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@elastic/charts@^41.0.0":
-  version "41.0.0"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-41.0.0.tgz#fcc83b86d72aa3f2787b2652e5d72076ad756cec"
-  integrity sha512-8MhmoYfoBGrQWDxF+XW/QCfrJv0Oyd0HekYFW7I6Q/C9KdtAyhHloQ4u4NC2NSCOz6yQgoFwCml0hI+shrPSCA==
+"@elastic/charts@^41.0.1":
+  version "41.0.1"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-41.0.1.tgz#28bd722d86366f799668e1e79c36b3977c1a9710"
+  integrity sha512-oqNcWG6qkJCsSk+DcXWIOgvz7SpfY4AsOG6moTD/i5LnON9mteVsMdRm1Tw4PZV6JWDgGQnSH3gmQhQrb0wONQ==
   dependencies:
     "@popperjs/core" "^2.4.0"
     chroma-js "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1189,10 +1189,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@elastic/charts@^38.1.1":
-  version "38.1.1"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-38.1.1.tgz#ca12e9a9e3dbcd28f151e8858326ea722ec7065a"
-  integrity sha512-c6/pFVTrrY3210rHbEjcKwJGqUCowhW0sm+wZhBzGEMIfcLdzeE8BqhDYmdE2glslN/EWMKCNCZjC7g+yOmZ0g==
+"@elastic/charts@^41.0.0":
+  version "41.0.0"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-41.0.0.tgz#fcc83b86d72aa3f2787b2652e5d72076ad756cec"
+  integrity sha512-8MhmoYfoBGrQWDxF+XW/QCfrJv0Oyd0HekYFW7I6Q/C9KdtAyhHloQ4u4NC2NSCOz6yQgoFwCml0hI+shrPSCA==
   dependencies:
     "@popperjs/core" "^2.4.0"
     chroma-js "^2.1.0"
@@ -1202,7 +1202,7 @@
     d3-collection "^1.0.7"
     d3-interpolate "^1.4.0"
     d3-scale "^1.0.7"
-    d3-shape "^1.3.4"
+    d3-shape "^2.0.0"
     luxon "^1.25.0"
     prop-types "^15.7.2"
     re-reselect "^3.4.0"
@@ -5619,10 +5619,10 @@ d3-interpolate@1, d3-interpolate@^1.4.0:
   dependencies:
     d3-color "1"
 
-d3-path@1:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
-  integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
+"d3-path@1 - 2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-2.0.0.tgz#55d86ac131a0548adae241eebfb56b4582dd09d8"
+  integrity sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA==
 
 d3-scale@^1.0.7:
   version "1.0.7"
@@ -5637,12 +5637,12 @@ d3-scale@^1.0.7:
     d3-time "1"
     d3-time-format "2"
 
-d3-shape@^1.3.4:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
-  integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
+d3-shape@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-2.1.0.tgz#3b6a82ccafbc45de55b57fcf956c584ded3b666f"
+  integrity sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==
   dependencies:
-    d3-path "1"
+    d3-path "1 - 2"
 
 d3-time-format@2:
   version "2.3.0"


### PR DESCRIPTION
### Summary

This PR upgrades `@elastic/charts` to `v41.0.1` which included some breaking changes. Namely, the removal of `config` from `PartitionSpec`. EUI uses this config to set default properties on the shared eui charts theme, thus throws and errors with `PartitionConfig` being removed.

The changes move all the old config overrides into the `theme.partition` sections which is a 1:1 match for all defined properties.

> Note: I'm not sure if y'all are able to backport or plan to use your latest version in `7.17` but this would be ideal for us as we plan to upgrade charts to the breaking version in `7.17`.