### PR TITLE
[EuiModal] Wrapping header in H1 if a string is returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Fixed a `EuiDataGrid` sizing bug which didn't account for a horizontal scrollbar ([#5478](https://github.com/elastic/eui/pull/5478))
+- Fixed `EuiModalHeaderTitle` to conditionally wrap title strings in an H1 ([#5494](https://github.com/elastic/eui/pull/5494))
 
 **Deprecations**
 
@@ -16,7 +17,6 @@
 - Fixed an accessibility issue where `EuiDatePicker` time options did not have unique IDs ([#5466](https://github.com/elastic/eui/pull/5466))
 - Fixed global and reset styles when using the legacy theme ([#5473](https://github.com/elastic/eui/pull/5473))
 - Fixed `EuiSuperDatePicker` not passing `isDisabled` to `EuiAutoRefresh` ([#5472](https://github.com/elastic/eui/pull/5472))
-- Fixed `EuiModalHeaderTitle` to conditionally wrap title strings in an H1 ([#5494](https://github.com/elastic/eui/pull/5494))
 
 ## [`43.1.0`](https://github.com/elastic/eui/tree/v43.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed an accessibility issue where `EuiDatePicker` time options did not have unique IDs ([#5466](https://github.com/elastic/eui/pull/5466))
 - Fixed global and reset styles when using the legacy theme ([#5473](https://github.com/elastic/eui/pull/5473))
 - Fixed `EuiSuperDatePicker` not passing `isDisabled` to `EuiAutoRefresh` ([#5472](https://github.com/elastic/eui/pull/5472))
+- Fixed `EuiModalHeaderTitle` to conditionally wrap title strings in an H1 ([#5494](https://github.com/elastic/eui/pull/5494))
 
 ## [`43.1.0`](https://github.com/elastic/eui/tree/v43.1.0)
 

--- a/src/components/modal/__snapshots__/confirm_modal.test.tsx.snap
+++ b/src/components/modal/__snapshots__/confirm_modal.test.tsx.snap
@@ -47,7 +47,9 @@ Array [
             class="euiModalHeader__title"
             data-test-subj="confirmModalTitleText"
           >
-            A confirmation modal
+            <h1>
+              A confirmation modal
+            </h1>
           </div>
         </div>
         <div
@@ -160,7 +162,9 @@ Array [
             class="euiModalHeader__title"
             data-test-subj="confirmModalTitleText"
           >
-            A confirmation modal
+            <h1>
+              A confirmation modal
+            </h1>
           </div>
         </div>
         <div

--- a/src/components/modal/__snapshots__/modal_header_title.test.tsx.snap
+++ b/src/components/modal/__snapshots__/modal_header_title.test.tsx.snap
@@ -6,6 +6,8 @@ exports[`renders EuiModalHeaderTitle 1`] = `
   class="euiModalHeader__title testClass1 testClass2"
   data-test-subj="test subject string"
 >
-  children
+  <h1>
+    children
+  </h1>
 </div>
 `;

--- a/src/components/modal/modal_header_title.tsx
+++ b/src/components/modal/modal_header_title.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, HTMLAttributes, useMemo } from 'react';
+import React, { FunctionComponent, HTMLAttributes } from 'react';
 import classnames from 'classnames';
 import { CommonProps } from '../common';
 
@@ -20,14 +20,9 @@ export const EuiModalHeaderTitle: EuiModalHeaderTitleProps = ({
   ...rest
 }) => {
   const classes = classnames('euiModalHeader__title', className);
-  const childrenWithHeading = useMemo(() => {
-    if (children && !children.hasOwnProperty('$$typeof'))
-      return <h1>{children}</h1>;
-    return children;
-  }, [children]);
   return (
     <div className={classes} {...rest}>
-      {childrenWithHeading}
+      {React.isValidElement(children) ? children : <h1>{children}</h1>}
     </div>
   );
 };

--- a/src/components/modal/modal_header_title.tsx
+++ b/src/components/modal/modal_header_title.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, HTMLAttributes } from 'react';
+import React, { FunctionComponent, HTMLAttributes, useMemo } from 'react';
 import classnames from 'classnames';
 import { CommonProps } from '../common';
 
@@ -20,14 +20,14 @@ export const EuiModalHeaderTitle: EuiModalHeaderTitleProps = ({
   ...rest
 }) => {
   const classes = classnames('euiModalHeader__title', className);
-  const renderChildren = () =>
-    React.Children.map(children, (child) => {
-      if (typeof child === 'string') return <h1>{child}</h1>;
-      return child;
-    });
+  const childrenWithHeading = useMemo(() => {
+    if (children && !children.hasOwnProperty('$$typeof'))
+      return <h1>{children}</h1>;
+    return children;
+  }, [children]);
   return (
     <div className={classes} {...rest}>
-      {renderChildren()}
+      {childrenWithHeading}
     </div>
   );
 };

--- a/src/components/modal/modal_header_title.tsx
+++ b/src/components/modal/modal_header_title.tsx
@@ -20,9 +20,14 @@ export const EuiModalHeaderTitle: EuiModalHeaderTitleProps = ({
   ...rest
 }) => {
   const classes = classnames('euiModalHeader__title', className);
+  const renderChildren = () =>
+    React.Children.map(children, (child) => {
+      if (typeof child === 'string') return <h1>{child}</h1>;
+      return child;
+    });
   return (
     <div className={classes} {...rest}>
-      {children}
+      {renderChildren()}
     </div>
   );
 };


### PR DESCRIPTION
### Summary
Add a check in the `modal_header_title.tsx` file to wrap `props.children` in an H1 if a string is passed into the component. Anything else (not a string) is ignored by this check. Closes #5276.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] ~~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~~
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
