### PR TITLE
[EuiDataGrid] Set up `ref` that exposes focus/popover internal APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [`main`](https://github.com/elastic/eui/tree/main)
 
+- Added the ability to access certain `EuiDataGrid` internal methods via the `ref` prop ([#5499](https://github.com/elastic/eui/pull/5499))
+
 **Breaking changes**
 
 - Removed `data-test-subj="dataGridWrapper"`  from `EuiDataGrid` in favor of `data-test-subj="euiDataGridBody"` ([#5506](https://github.com/elastic/eui/pull/5506))

--- a/src-docs/src/routes.js
+++ b/src-docs/src/routes.js
@@ -89,6 +89,7 @@ import { DataGridControlColumnsExample } from './views/datagrid/datagrid_control
 import { DataGridFooterRowExample } from './views/datagrid/datagrid_footer_row_example';
 import { DataGridVirtualizationExample } from './views/datagrid/datagrid_virtualization_example';
 import { DataGridRowHeightOptionsExample } from './views/datagrid/datagrid_height_options_example';
+import { DataGridRefExample } from './views/datagrid/datagrid_ref_example';
 
 import { DatePickerExample } from './views/date_picker/date_picker_example';
 
@@ -489,6 +490,7 @@ const navigation = [
       DataGridFooterRowExample,
       DataGridVirtualizationExample,
       DataGridRowHeightOptionsExample,
+      DataGridRefExample,
       TableExample,
       TableInMemoryExample,
     ].map((example) => createExample(example)),

--- a/src-docs/src/views/datagrid/datagrid_example.js
+++ b/src-docs/src/views/datagrid/datagrid_example.js
@@ -33,6 +33,7 @@ import {
   EuiDataGridRowHeightsOptions,
   EuiDataGridCellValueElementProps,
   EuiDataGridSchemaDetector,
+  EuiDataGridRefProps,
 } from '!!prop-loader!../../../../src/components/datagrid/data_grid_types';
 
 const gridSnippet = `
@@ -164,6 +165,8 @@ const gridSnippet = `
         );
       },
     }}
+    // Optional. For advanced control of internal data grid popover/focus state, passes back an object of API methods
+    ref={dataGridRef}
   />
 `;
 
@@ -323,6 +326,19 @@ const gridConcepts = [
       </span>
     ),
   },
+  {
+    title: 'ref',
+    description: (
+      <span>
+        Passes back an object of internal <strong>EuiDataGridRefProps</strong>{' '}
+        methods for advanced control of data grid popover/focus state. See{' '}
+        <Link to="/tabular-content/data-grid-ref-methods">
+          Data grid ref methods
+        </Link>{' '}
+        for more details and examples.
+      </span>
+    ),
+  },
 ];
 
 export const DataGridExample = {
@@ -414,6 +430,7 @@ export const DataGridExample = {
         EuiDataGridToolBarAdditionalControlsLeftOptions,
         EuiDataGridPopoverContentProps,
         EuiDataGridRowHeightsOptions,
+        EuiDataGridRefProps,
       },
       demo: (
         <Fragment>

--- a/src-docs/src/views/datagrid/datagrid_ref_example.js
+++ b/src-docs/src/views/datagrid/datagrid_ref_example.js
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import { GuideSectionTypes } from '../../components';
+import {
+  EuiCode,
+  EuiCodeBlock,
+  EuiSpacer,
+  EuiCallOut,
+} from '../../../../src/components';
+
+import { EuiDataGridRefProps } from '!!prop-loader!../../../../src/components/datagrid/data_grid_types';
+import DataGridRef from './ref';
+const dataGridRefSource = require('!!raw-loader!./ref');
+const dataGridRefSnippet = `const dataGridRef = useRef();
+<EuiDataGrid ref={dataGridRef} {...props} />
+
+// Mnaually focus a specific cell within the data grid
+dataGridRef.current.setFocusedCell({ rowIndex, colIndex });
+`;
+
+export const DataGridRefExample = {
+  title: 'Data grid ref methods',
+  sections: [
+    {
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: dataGridRefSource,
+        },
+      ],
+      text: (
+        <>
+          <p>
+            For advanced use cases, and particularly for data grids that manage
+            associated modals/flyouts and need to manually control their grid
+            cell popovers & focus states, we expose certain internal methods via
+            the <EuiCode>ref</EuiCode> prop of EuiDataGrid. These methods are:
+          </p>
+          <ul>
+            <li>
+              <EuiCode>setFocusedCell({'{ rowIndex, colIndex }'})</EuiCode> -
+              focuses the specified cell in the grid.
+              <EuiSpacer size="s" />
+              <EuiCallOut
+                iconType="accessibility"
+                title="Using this method is an accessibility requirement if your data
+                grid toggles a modal or flyout."
+              >
+                Your modal or flyout should restore focus into the grid on close
+                to prevent keyboard or screen reader users from being stranded.
+              </EuiCallOut>
+            </li>
+          </ul>
+          <EuiCodeBlock language="jsx">{dataGridRefSnippet}</EuiCodeBlock>
+          <p>
+            The below example shows how to use the internal APIs for a data grid
+            that opens a modal via cell actions.
+          </p>
+        </>
+      ),
+      components: { DataGridRef },
+      demo: <DataGridRef />,
+      snippet: dataGridRefSnippet,
+      props: { EuiDataGridRefProps },
+    },
+  ],
+};

--- a/src-docs/src/views/datagrid/ref.js
+++ b/src-docs/src/views/datagrid/ref.js
@@ -1,0 +1,196 @@
+import React, { useCallback, useMemo, useState, useRef } from 'react';
+import { fake } from 'faker';
+
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiFormRow,
+  EuiFieldNumber,
+  EuiButton,
+  EuiDataGrid,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiText,
+} from '../../../../src/components/';
+
+const raw_data = [];
+for (let i = 1; i < 100; i++) {
+  raw_data.push({
+    name: fake('{{name.lastName}}, {{name.firstName}}'),
+    email: fake('{{internet.email}}'),
+    location: fake('{{address.city}}, {{address.country}}'),
+    account: fake('{{finance.account}}'),
+    date: fake('{{date.past}}'),
+  });
+}
+
+export default () => {
+  const dataGridRef = useRef();
+
+  // Modal
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const [lastFocusedCell, setLastFocusedCell] = useState({});
+
+  const closeModal = useCallback(() => {
+    setIsModalVisible(false);
+    dataGridRef.current.setFocusedCell(lastFocusedCell); // Set the data grid focus back to the cell that opened the modal
+  }, [lastFocusedCell]);
+
+  const showModal = useCallback(({ rowIndex, colIndex }) => {
+    setIsModalVisible(true);
+    setLastFocusedCell({ rowIndex, colIndex }); // Store the cell that opened this modal
+  }, []);
+
+  const openModalAction = useCallback(
+    ({ Component, rowIndex, colIndex }) => {
+      return (
+        <Component
+          onClick={() => showModal({ rowIndex, colIndex })}
+          iconType="faceHappy"
+          aria-label="Open modal"
+        >
+          Open modal
+        </Component>
+      );
+    },
+    [showModal]
+  );
+
+  // Columns
+  const columns = useMemo(
+    () => [
+      {
+        id: 'name',
+        displayAsText: 'Name',
+        cellActions: [openModalAction],
+      },
+      {
+        id: 'email',
+        displayAsText: 'Email address',
+        initialWidth: 130,
+        cellActions: [openModalAction],
+      },
+      {
+        id: 'location',
+        displayAsText: 'Location',
+        cellActions: [openModalAction],
+      },
+      {
+        id: 'account',
+        displayAsText: 'Account',
+        cellActions: [openModalAction],
+      },
+      {
+        id: 'date',
+        displayAsText: 'Date',
+        cellActions: [openModalAction],
+      },
+    ],
+    [openModalAction]
+  );
+
+  // Column visibility
+  const [visibleColumns, setVisibleColumns] = useState(() =>
+    columns.map(({ id }) => id)
+  );
+
+  // Pagination
+  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 25 });
+  const onChangePage = useCallback(
+    (pageIndex) =>
+      setPagination((pagination) => ({ ...pagination, pageIndex })),
+    []
+  );
+
+  // Manual cell focus
+  const [rowIndexAction, setRowIndexAction] = useState(0);
+  const [colIndexAction, setColIndexAction] = useState(0);
+
+  return (
+    <>
+      <EuiFlexGroup alignItems="flexEnd" gutterSize="s" style={{ width: 500 }}>
+        <EuiFlexItem>
+          <EuiFormRow label="Row index">
+            <EuiFieldNumber
+              min={0}
+              max={24}
+              value={rowIndexAction}
+              onChange={(e) => setRowIndexAction(Number(e.target.value))}
+              compressed
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiFormRow label="Column index">
+            <EuiFieldNumber
+              min={0}
+              max={4}
+              value={colIndexAction}
+              onChange={(e) => setColIndexAction(Number(e.target.value))}
+              compressed
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiButton
+            size="s"
+            onClick={() =>
+              dataGridRef.current.setFocusedCell({
+                rowIndex: rowIndexAction,
+                colIndex: colIndexAction,
+              })
+            }
+          >
+            Set cell focus
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer />
+
+      <EuiDataGrid
+        aria-label="Data grid demo"
+        columns={columns}
+        columnVisibility={{ visibleColumns, setVisibleColumns }}
+        rowCount={raw_data.length}
+        renderCellValue={({ rowIndex, columnId }) =>
+          raw_data[rowIndex][columnId]
+        }
+        pagination={{
+          ...pagination,
+          pageSizeOptions: [25],
+          onChangePage: onChangePage,
+        }}
+        height={400}
+        ref={dataGridRef}
+      />
+      {isModalVisible && (
+        <EuiModal onClose={closeModal} style={{ width: 500 }}>
+          <EuiModalHeader>
+            <EuiModalHeaderTitle>
+              <h2>Example modal</h2>
+            </EuiModalHeaderTitle>
+          </EuiModalHeader>
+
+          <EuiModalBody>
+            <EuiText>
+              <p>
+                When closed, this modal should re-focus into the cell that
+                toggled it.
+              </p>
+            </EuiText>
+          </EuiModalBody>
+
+          <EuiModalFooter>
+            <EuiButton onClick={closeModal} fill>
+              Close
+            </EuiButton>
+          </EuiModalFooter>
+        </EuiModal>
+      )}
+    </>
+  );
+};

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -405,7 +405,7 @@ export class EuiDataGridCell extends Component<
       rowManager,
       ...rest
     } = this.props;
-    const { rowIndex } = rest;
+    const { rowIndex, colIndex } = rest;
 
     const showCellButtons =
       this.state.isFocused ||
@@ -546,6 +546,7 @@ export class EuiDataGridCell extends Component<
             </div>
             <EuiDataGridCellButtons
               rowIndex={rowIndex}
+              colIndex={colIndex}
               column={column}
               popoverIsOpen={this.state.popoverIsOpen}
               closePopover={this.closePopover}
@@ -588,6 +589,7 @@ export class EuiDataGridCell extends Component<
               panelRefFn={(ref) => (this.popoverPanelRef.current = ref)}
               popoverIsOpen={this.state.popoverIsOpen}
               rowIndex={rowIndex}
+              colIndex={colIndex}
               renderCellValue={rest.renderCellValue}
               popoverContent={PopoverContent}
             />

--- a/src/components/datagrid/body/data_grid_cell_buttons.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_buttons.test.tsx
@@ -17,6 +17,7 @@ describe('EuiDataGridCellButtons', () => {
     closePopover: jest.fn(),
     onExpandClick: jest.fn(),
     rowIndex: 0,
+    colIndex: 0,
   };
 
   it('renders an expand button', () => {
@@ -66,6 +67,7 @@ describe('EuiDataGridCellButtons', () => {
         <Component
           Component={[Function]}
           closePopover={[MockFunction]}
+          colIndex={0}
           columnId="someId"
           isExpanded={false}
           key="0"

--- a/src/components/datagrid/body/data_grid_cell_buttons.tsx
+++ b/src/components/datagrid/body/data_grid_cell_buttons.tsx
@@ -21,12 +21,14 @@ export const EuiDataGridCellButtons = ({
   onExpandClick,
   column,
   rowIndex,
+  colIndex,
 }: {
   popoverIsOpen: boolean;
   closePopover: () => void;
   onExpandClick: () => void;
   column?: EuiDataGridColumn;
   rowIndex: number;
+  colIndex: number;
 }) => {
   const buttonIconClasses = classNames('euiDataGridRowCell__expandButtonIcon', {
     'euiDataGridRowCell__expandButtonIcon-isActive': popoverIsOpen,
@@ -74,6 +76,7 @@ export const EuiDataGridCellButtons = ({
               <CellButtonElement
                 key={idx}
                 rowIndex={rowIndex}
+                colIndex={colIndex}
                 columnId={column.id}
                 Component={ButtonComponent}
                 isExpanded={false}
@@ -83,7 +86,7 @@ export const EuiDataGridCellButtons = ({
           }
         )
       : [];
-  }, [column, rowIndex, closePopover]);
+  }, [column, colIndex, rowIndex, closePopover]);
 
   return (
     <div className={buttonClasses}>{[...additionalButtons, expandButton]}</div>

--- a/src/components/datagrid/body/data_grid_cell_popover.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.test.tsx
@@ -14,8 +14,8 @@ import { EuiDataGridCellPopover } from './data_grid_cell_popover';
 
 describe('EuiDataGridCellPopover', () => {
   const requiredProps = {
-    // column,
     rowIndex: 0,
+    colIndex: 0,
     cellContentProps: {
       rowIndex: 0,
       columnId: 'someId',
@@ -123,6 +123,7 @@ describe('EuiDataGridCellPopover', () => {
               <Component
                 Component={[Function]}
                 closePopover={[MockFunction]}
+                colIndex={0}
                 columnId="someId"
                 isExpanded={true}
                 rowIndex={0}

--- a/src/components/datagrid/body/data_grid_cell_popover.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.tsx
@@ -28,6 +28,7 @@ export function EuiDataGridCellPopover({
   popoverIsOpen,
   renderCellValue,
   rowIndex,
+  colIndex,
 }: EuiDataGridCellPopoverProps) {
   const CellElement = renderCellValue as JSXElementConstructor<
     EuiDataGridCellValueElementProps
@@ -71,6 +72,7 @@ export function EuiDataGridCellPopover({
                       <EuiFlexItem key={idx}>
                         <CellButtonElement
                           rowIndex={rowIndex}
+                          colIndex={colIndex}
                           columnId={column.id}
                           Component={(props: EuiButtonEmptyProps) => (
                             <EuiButtonEmpty {...props} size="s" />

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -6,9 +6,10 @@
  * Side Public License, v 1.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, createRef } from 'react';
 import { mount, ReactWrapper, render } from 'enzyme';
-import { EuiDataGrid, EuiDataGridProps } from './';
+import { EuiDataGrid } from './';
+import { EuiDataGridProps, EuiDataGridRefProps } from './data_grid_types';
 import {
   findTestSubject,
   requiredProps,
@@ -2726,29 +2727,23 @@ describe('EuiDataGrid', () => {
   });
 
   it('returns a ref which exposes internal imperative APIs', () => {
-    // Using a class component for this test so we can inspect the internal gridRef
-    class MockApp extends React.Component {
-      gridRef = React.createRef<any>();
+    const gridRef = createRef<EuiDataGridRefProps>();
 
-      render() {
-        return (
-          <EuiDataGrid
-            {...requiredProps}
-            columns={[{ id: 'A' }, { id: 'B' }]}
-            columnVisibility={{
-              visibleColumns: ['A', 'B'],
-              setVisibleColumns: () => {},
-            }}
-            rowCount={1}
-            renderCellValue={() => 'value'}
-            ref={this.gridRef}
-          />
-        );
-      }
-    }
-    const component = mount(<MockApp />);
+    mount(
+      <EuiDataGrid
+        {...requiredProps}
+        columns={[{ id: 'A' }, { id: 'B' }]}
+        columnVisibility={{
+          visibleColumns: ['A', 'B'],
+          setVisibleColumns: () => {},
+        }}
+        rowCount={1}
+        renderCellValue={() => 'value'}
+        ref={gridRef}
+      />
+    );
 
-    expect((component.instance() as any).gridRef.current).toEqual({
+    expect(gridRef.current).toEqual({
       setFocusedCell: expect.any(Function),
     });
   });

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -2724,4 +2724,32 @@ describe('EuiDataGrid', () => {
       expect(takeMountedSnapshot(component)).toMatchSnapshot();
     });
   });
+
+  it('returns a ref which exposes internal imperative APIs', () => {
+    // Using a class component for this test so we can inspect the internal gridRef
+    class MockApp extends React.Component {
+      gridRef = React.createRef<any>();
+
+      render() {
+        return (
+          <EuiDataGrid
+            {...requiredProps}
+            columns={[{ id: 'A' }, { id: 'B' }]}
+            columnVisibility={{
+              visibleColumns: ['A', 'B'],
+              setVisibleColumns: () => {},
+            }}
+            rowCount={1}
+            renderCellValue={() => 'value'}
+            ref={this.gridRef}
+          />
+        );
+      }
+    }
+    const component = mount(<MockApp />);
+
+    expect((component.instance() as any).gridRef.current).toEqual({
+      setFocusedCell: expect.any(Function),
+    });
+  });
 });

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -8,7 +8,7 @@
 
 import classNames from 'classnames';
 import React, {
-  FunctionComponent,
+  forwardRef,
   KeyboardEvent,
   useMemo,
   useRef,
@@ -51,6 +51,7 @@ import {
 import {
   EuiDataGridColumn,
   EuiDataGridProps,
+  EuiDataGridRefProps,
   EuiDataGridStyleBorders,
   EuiDataGridStyleCellPaddings,
   EuiDataGridStyleFontSizes,
@@ -98,372 +99,381 @@ const cellPaddingsToClassMap: {
   l: 'euiDataGrid--paddingLarge',
 };
 
-export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
-  const {
-    leadingControlColumns = [],
-    trailingControlColumns = [],
-    columns,
-    columnVisibility,
-    schemaDetectors,
-    rowCount,
-    renderCellValue,
-    renderFooterCellValue,
-    className,
-    gridStyle,
-    toolbarVisibility = true,
-    pagination,
-    sorting,
-    inMemory,
-    popoverContents,
-    onColumnResize,
-    minSizeForControls,
-    height,
-    width,
-    rowHeightsOptions: _rowHeightsOptions,
-    virtualizationOptions,
-    ...rest
-  } = props;
+export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
+  (props, ref) => {
+    const {
+      leadingControlColumns = [],
+      trailingControlColumns = [],
+      columns,
+      columnVisibility,
+      schemaDetectors,
+      rowCount,
+      renderCellValue,
+      renderFooterCellValue,
+      className,
+      gridStyle,
+      toolbarVisibility = true,
+      pagination,
+      sorting,
+      inMemory,
+      popoverContents,
+      onColumnResize,
+      minSizeForControls,
+      height,
+      width,
+      rowHeightsOptions: _rowHeightsOptions,
+      virtualizationOptions,
+      ...rest
+    } = props;
 
-  /**
-   * Merge consumer settings with defaults
-   */
-  const gridStyleWithDefaults = { ...startingStyles, ...gridStyle };
+    /**
+     * Merge consumer settings with defaults
+     */
+    const gridStyleWithDefaults = { ...startingStyles, ...gridStyle };
 
-  const mergedPopoverContents = useMemo(
-    () => ({
-      ...providedPopoverContents,
-      ...popoverContents,
-    }),
-    [popoverContents]
-  );
-
-  const [inMemoryValues, onCellRender] = useInMemoryValues(inMemory, rowCount);
-
-  const allSchemaDetectors = useMemo(
-    () => [...providedSchemaDetectors, ...(schemaDetectors || [])],
-    [schemaDetectors]
-  );
-
-  const mergedSchema = useMergedSchema({
-    columns,
-    inMemory,
-    inMemoryValues,
-    schemaDetectors: allSchemaDetectors,
-    autoDetectSchema: inMemory != null,
-  });
-
-  /**
-   * Grid refs & observers
-   */
-  // Outermost wrapper div
-  const resizeRef = useRef<HTMLDivElement | null>(null);
-  const { width: gridWidth } = useResizeObserver(resizeRef.current, 'width');
-
-  // Wrapper div around EuiDataGridBody
-  const contentRef = useRef<HTMLDivElement | null>(null);
-  useMutationObserver(contentRef.current, preventTabbing, {
-    subtree: true,
-    childList: true,
-  });
-
-  // Imperative handler passed back by react-window - we're setting this at
-  // the top datagrid level to make passing it to other children & utils easier
-  const gridRef = useRef<Grid | null>(null);
-
-  /**
-   * Display
-   */
-  const displayValues: { [key: string]: string } = useMemo(() => {
-    return columns.reduce(
-      (acc: { [key: string]: string }, column: EuiDataGridColumn) => ({
-        ...acc,
-        [column.id]: column.displayAsText || column.id,
+    const mergedPopoverContents = useMemo(
+      () => ({
+        ...providedPopoverContents,
+        ...popoverContents,
       }),
-      {}
+      [popoverContents]
     );
-  }, [columns]);
 
-  const [
-    displaySelector,
-    gridStyles,
-    rowHeightsOptions,
-  ] = useDataGridDisplaySelector(
-    checkOrDefaultToolBarDisplayOptions(
-      toolbarVisibility,
-      'showDisplaySelector'
-    ),
-    gridStyleWithDefaults,
-    _rowHeightsOptions
-  );
+    const [inMemoryValues, onCellRender] = useInMemoryValues(
+      inMemory,
+      rowCount
+    );
 
-  /**
-   * Column order & visibility
-   */
-  const [
-    columnSelector,
-    orderedVisibleColumns,
-    setVisibleColumns,
-    switchColumnPos,
-  ] = useDataGridColumnSelector(
-    columns,
-    columnVisibility,
-    checkOrDefaultToolBarDisplayOptions(
-      toolbarVisibility,
-      'showColumnSelector'
-    ),
-    displayValues
-  );
+    const allSchemaDetectors = useMemo(
+      () => [...providedSchemaDetectors, ...(schemaDetectors || [])],
+      [schemaDetectors]
+    );
 
-  const visibleColCount = useMemo(() => {
+    const mergedSchema = useMergedSchema({
+      columns,
+      inMemory,
+      inMemoryValues,
+      schemaDetectors: allSchemaDetectors,
+      autoDetectSchema: inMemory != null,
+    });
+
+    /**
+     * Grid refs & observers
+     */
+    // Outermost wrapper div
+    const resizeRef = useRef<HTMLDivElement | null>(null);
+    const { width: gridWidth } = useResizeObserver(resizeRef.current, 'width');
+
+    // Wrapper div around EuiDataGridBody
+    const contentRef = useRef<HTMLDivElement | null>(null);
+    useMutationObserver(contentRef.current, preventTabbing, {
+      subtree: true,
+      childList: true,
+    });
+
+    // Imperative handler passed back by react-window - we're setting this at
+    // the top datagrid level to make passing it to other children & utils easier
+    const gridRef = useRef<Grid | null>(null);
+
+    /**
+     * Display
+     */
+    const displayValues: { [key: string]: string } = useMemo(() => {
+      return columns.reduce(
+        (acc: { [key: string]: string }, column: EuiDataGridColumn) => ({
+          ...acc,
+          [column.id]: column.displayAsText || column.id,
+        }),
+        {}
+      );
+    }, [columns]);
+
+    const [
+      displaySelector,
+      gridStyles,
+      rowHeightsOptions,
+    ] = useDataGridDisplaySelector(
+      checkOrDefaultToolBarDisplayOptions(
+        toolbarVisibility,
+        'showDisplaySelector'
+      ),
+      gridStyleWithDefaults,
+      _rowHeightsOptions
+    );
+
+    /**
+     * Column order & visibility
+     */
+    const [
+      columnSelector,
+      orderedVisibleColumns,
+      setVisibleColumns,
+      switchColumnPos,
+    ] = useDataGridColumnSelector(
+      columns,
+      columnVisibility,
+      checkOrDefaultToolBarDisplayOptions(
+        toolbarVisibility,
+        'showColumnSelector'
+      ),
+      displayValues
+    );
+
+    const visibleColCount = useMemo(() => {
+      return (
+        orderedVisibleColumns.length +
+        leadingControlColumns.length +
+        trailingControlColumns.length
+      );
+    }, [orderedVisibleColumns, leadingControlColumns, trailingControlColumns]);
+
+    const visibleRows = useMemo(
+      () => computeVisibleRows({ pagination, rowCount }),
+      [pagination, rowCount]
+    );
+    const { visibleRowCount } = visibleRows;
+
+    /**
+     * Sorting
+     */
+    const columnSorting = useDataGridColumnSorting(
+      orderedVisibleColumns,
+      sorting,
+      mergedSchema,
+      allSchemaDetectors,
+      displayValues
+    );
+
+    const sortingContext = useSorting({
+      sorting,
+      inMemory,
+      inMemoryValues,
+      schema: mergedSchema,
+      schemaDetectors: allSchemaDetectors,
+      startRow: visibleRows.startRow,
+    });
+
+    /**
+     * Focus
+     */
+    const {
+      headerIsInteractive,
+      handleHeaderMutation,
+    } = useHeaderIsInteractive(contentRef.current);
+    const { focusProps: wrappingDivFocusProps, ...focusContext } = useFocus(
+      headerIsInteractive
+    );
+
+    /**
+     * Toolbar & full-screen
+     */
+    const showToolbar = !!toolbarVisibility;
+    const [toolbarRef, setToolbarRef] = useState<HTMLDivElement | null>(null);
+    const { height: toolbarHeight } = useResizeObserver(toolbarRef, 'height');
+
+    const [isFullScreen, setIsFullScreen] = useState(false);
+    const handleGridKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+      switch (event.key) {
+        case keys.ESCAPE:
+          if (isFullScreen) {
+            event.preventDefault();
+            setIsFullScreen(false);
+          }
+          break;
+      }
+    };
+
+    /**
+     * Classes
+     */
+    const classes = classNames(
+      'euiDataGrid',
+      fontSizesToClassMap[gridStyles.fontSize!],
+      bordersToClassMap[gridStyles.border!],
+      headerToClassMap[gridStyles.header!],
+      footerToClassMap[gridStyles.footer!],
+      rowHoverToClassMap[gridStyles.rowHover!],
+      cellPaddingsToClassMap[gridStyles.cellPadding!],
+      {
+        'euiDataGrid--stripes': gridStyles.stripes!,
+      },
+      {
+        'euiDataGrid--stickyFooter':
+          gridStyles.footer && gridStyles.stickyFooter,
+      },
+      {
+        'euiDataGrid--fullScreen': isFullScreen,
+      },
+      {
+        'euiDataGrid--noControls': !toolbarVisibility,
+      },
+      className
+    );
+
+    const controlBtnClasses = classNames('euiDataGrid__controlBtn', {
+      'euiDataGrid__controlBtn--active': isFullScreen,
+    });
+
+    /**
+     * Accessibility
+     */
+    const gridId = useGeneratedHtmlId();
+    const interactiveCellId = useGeneratedHtmlId();
+    const ariaLabelledById = useGeneratedHtmlId();
+
+    const ariaLabel = useEuiI18n(
+      'euiDataGrid.ariaLabel',
+      '{label}; Page {page} of {pageCount}.',
+      {
+        label: rest['aria-label'],
+        page: pagination ? pagination.pageIndex + 1 : 0,
+        pageCount: pagination ? Math.ceil(rowCount / pagination.pageSize) : 0,
+      }
+    );
+
+    const ariaLabelledBy = useEuiI18n(
+      'euiDataGrid.ariaLabelledBy',
+      'Page {page} of {pageCount}.',
+      {
+        page: pagination ? pagination.pageIndex + 1 : 0,
+        pageCount: pagination ? Math.ceil(rowCount / pagination.pageSize) : 0,
+      }
+    );
+
+    // extract aria-label and/or aria-labelledby from `rest`
+    const gridAriaProps: {
+      'aria-label'?: string;
+      'aria-labelledby'?: string;
+    } = {};
+    if ('aria-label' in rest) {
+      gridAriaProps['aria-label'] = pagination ? ariaLabel : rest['aria-label'];
+      delete rest['aria-label'];
+    }
+    if ('aria-labelledby' in rest) {
+      gridAriaProps['aria-labelledby'] = `${rest['aria-labelledby']} ${
+        pagination ? ariaLabelledById : ''
+      }`;
+      delete rest['aria-labelledby'];
+    }
+
     return (
-      orderedVisibleColumns.length +
-      leadingControlColumns.length +
-      trailingControlColumns.length
-    );
-  }, [orderedVisibleColumns, leadingControlColumns, trailingControlColumns]);
-
-  const visibleRows = useMemo(
-    () => computeVisibleRows({ pagination, rowCount }),
-    [pagination, rowCount]
-  );
-  const { visibleRowCount } = visibleRows;
-
-  /**
-   * Sorting
-   */
-  const columnSorting = useDataGridColumnSorting(
-    orderedVisibleColumns,
-    sorting,
-    mergedSchema,
-    allSchemaDetectors,
-    displayValues
-  );
-
-  const sortingContext = useSorting({
-    sorting,
-    inMemory,
-    inMemoryValues,
-    schema: mergedSchema,
-    schemaDetectors: allSchemaDetectors,
-    startRow: visibleRows.startRow,
-  });
-
-  /**
-   * Focus
-   */
-  const { headerIsInteractive, handleHeaderMutation } = useHeaderIsInteractive(
-    contentRef.current
-  );
-  const { focusProps: wrappingDivFocusProps, ...focusContext } = useFocus(
-    headerIsInteractive
-  );
-
-  /**
-   * Toolbar & full-screen
-   */
-  const showToolbar = !!toolbarVisibility;
-  const [toolbarRef, setToolbarRef] = useState<HTMLDivElement | null>(null);
-  const { height: toolbarHeight } = useResizeObserver(toolbarRef, 'height');
-
-  const [isFullScreen, setIsFullScreen] = useState(false);
-  const handleGridKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    switch (event.key) {
-      case keys.ESCAPE:
-        if (isFullScreen) {
-          event.preventDefault();
-          setIsFullScreen(false);
-        }
-        break;
-    }
-  };
-
-  /**
-   * Classes
-   */
-  const classes = classNames(
-    'euiDataGrid',
-    fontSizesToClassMap[gridStyles.fontSize!],
-    bordersToClassMap[gridStyles.border!],
-    headerToClassMap[gridStyles.header!],
-    footerToClassMap[gridStyles.footer!],
-    rowHoverToClassMap[gridStyles.rowHover!],
-    cellPaddingsToClassMap[gridStyles.cellPadding!],
-    {
-      'euiDataGrid--stripes': gridStyles.stripes!,
-    },
-    {
-      'euiDataGrid--stickyFooter': gridStyles.footer && gridStyles.stickyFooter,
-    },
-    {
-      'euiDataGrid--fullScreen': isFullScreen,
-    },
-    {
-      'euiDataGrid--noControls': !toolbarVisibility,
-    },
-    className
-  );
-
-  const controlBtnClasses = classNames('euiDataGrid__controlBtn', {
-    'euiDataGrid__controlBtn--active': isFullScreen,
-  });
-
-  /**
-   * Accessibility
-   */
-  const gridId = useGeneratedHtmlId();
-  const interactiveCellId = useGeneratedHtmlId();
-  const ariaLabelledById = useGeneratedHtmlId();
-
-  const ariaLabel = useEuiI18n(
-    'euiDataGrid.ariaLabel',
-    '{label}; Page {page} of {pageCount}.',
-    {
-      label: rest['aria-label'],
-      page: pagination ? pagination.pageIndex + 1 : 0,
-      pageCount: pagination ? Math.ceil(rowCount / pagination.pageSize) : 0,
-    }
-  );
-
-  const ariaLabelledBy = useEuiI18n(
-    'euiDataGrid.ariaLabelledBy',
-    'Page {page} of {pageCount}.',
-    {
-      page: pagination ? pagination.pageIndex + 1 : 0,
-      pageCount: pagination ? Math.ceil(rowCount / pagination.pageSize) : 0,
-    }
-  );
-
-  // extract aria-label and/or aria-labelledby from `rest`
-  const gridAriaProps: {
-    'aria-label'?: string;
-    'aria-labelledby'?: string;
-  } = {};
-  if ('aria-label' in rest) {
-    gridAriaProps['aria-label'] = pagination ? ariaLabel : rest['aria-label'];
-    delete rest['aria-label'];
-  }
-  if ('aria-labelledby' in rest) {
-    gridAriaProps['aria-labelledby'] = `${rest['aria-labelledby']} ${
-      pagination ? ariaLabelledById : ''
-    }`;
-    delete rest['aria-labelledby'];
-  }
-
-  return (
-    <DataGridFocusContext.Provider value={focusContext}>
-      <DataGridSortingContext.Provider value={sortingContext}>
-        <EuiFocusTrap
-          disabled={!isFullScreen}
-          className="euiDataGrid__focusWrap"
-        >
-          <div
-            className={classes}
-            onKeyDown={handleGridKeyDown}
-            style={isFullScreen ? undefined : { width, height }}
-            ref={resizeRef}
-            {...rest}
+      <DataGridFocusContext.Provider value={focusContext}>
+        <DataGridSortingContext.Provider value={sortingContext}>
+          <EuiFocusTrap
+            disabled={!isFullScreen}
+            className="euiDataGrid__focusWrap"
           >
-            {showToolbar && (
-              <EuiDataGridToolbar
-                setRef={setToolbarRef}
-                gridWidth={gridWidth}
-                minSizeForControls={minSizeForControls}
-                toolbarVisibility={toolbarVisibility}
-                displaySelector={displaySelector}
-                isFullScreen={isFullScreen}
-                setIsFullScreen={setIsFullScreen}
-                controlBtnClasses={controlBtnClasses}
-                columnSelector={columnSelector}
-                columnSorting={columnSorting}
-              />
-            )}
-            {inMemory ? (
-              <EuiDataGridInMemoryRenderer
-                inMemory={inMemory}
-                renderCellValue={renderCellValue}
-                columns={columns}
-                rowCount={
-                  inMemory.level === 'enhancements'
-                    ? // if `inMemory.level === enhancements` then we can only be sure the pagination's pageSize is available in memory
-                      pagination?.pageSize || rowCount
-                    : // otherwise, all of the data is present and usable
-                      rowCount
-                }
-                onCellRender={onCellRender}
-              />
-            ) : null}
-            <div // eslint-disable-line jsx-a11y/interactive-supports-focus
-              ref={contentRef}
-              onKeyDown={createKeyDownHandler({
-                gridElement: contentRef.current,
-                visibleColCount,
-                visibleRowCount,
-                rowCount,
-                pagination,
-                hasFooter: !!renderFooterCellValue,
-                headerIsInteractive,
-                focusContext,
-              })}
-              data-test-subj="euiDataGridBody"
-              className="euiDataGrid__content"
-              role="grid"
-              id={gridId}
-              {...wrappingDivFocusProps} // re: above jsx-a11y - tabIndex is handled by these props, but the linter isn't smart enough to know that
-              {...gridAriaProps}
+            <div
+              className={classes}
+              onKeyDown={handleGridKeyDown}
+              style={isFullScreen ? undefined : { width, height }}
+              ref={resizeRef}
+              {...rest}
             >
-              <EuiDataGridBody
-                isFullScreen={isFullScreen}
-                columns={orderedVisibleColumns}
-                visibleColCount={visibleColCount}
-                toolbarHeight={toolbarHeight}
-                leadingControlColumns={leadingControlColumns}
-                schema={mergedSchema}
-                trailingControlColumns={trailingControlColumns}
-                setVisibleColumns={setVisibleColumns}
-                switchColumnPos={switchColumnPos}
-                onColumnResize={onColumnResize}
-                headerIsInteractive={headerIsInteractive}
-                handleHeaderMutation={handleHeaderMutation}
-                schemaDetectors={allSchemaDetectors}
-                popoverContents={mergedPopoverContents}
-                pagination={pagination}
-                renderCellValue={renderCellValue}
-                renderFooterCellValue={renderFooterCellValue}
-                rowCount={rowCount}
-                visibleRows={visibleRows}
-                interactiveCellId={interactiveCellId}
-                rowHeightsOptions={rowHeightsOptions}
-                virtualizationOptions={virtualizationOptions || {}}
-                gridStyles={gridStyles}
-                gridWidth={gridWidth}
-                gridRef={gridRef}
-                wrapperRef={contentRef}
-              />
-            </div>
-            {pagination && props['aria-labelledby'] && (
-              <p id={ariaLabelledById} hidden>
-                {ariaLabelledBy}
+              {showToolbar && (
+                <EuiDataGridToolbar
+                  setRef={setToolbarRef}
+                  gridWidth={gridWidth}
+                  minSizeForControls={minSizeForControls}
+                  toolbarVisibility={toolbarVisibility}
+                  displaySelector={displaySelector}
+                  isFullScreen={isFullScreen}
+                  setIsFullScreen={setIsFullScreen}
+                  controlBtnClasses={controlBtnClasses}
+                  columnSelector={columnSelector}
+                  columnSorting={columnSorting}
+                />
+              )}
+              {inMemory ? (
+                <EuiDataGridInMemoryRenderer
+                  inMemory={inMemory}
+                  renderCellValue={renderCellValue}
+                  columns={columns}
+                  rowCount={
+                    inMemory.level === 'enhancements'
+                      ? // if `inMemory.level === enhancements` then we can only be sure the pagination's pageSize is available in memory
+                        pagination?.pageSize || rowCount
+                      : // otherwise, all of the data is present and usable
+                        rowCount
+                  }
+                  onCellRender={onCellRender}
+                />
+              ) : null}
+              <div // eslint-disable-line jsx-a11y/interactive-supports-focus
+                ref={contentRef}
+                onKeyDown={createKeyDownHandler({
+                  gridElement: contentRef.current,
+                  visibleColCount,
+                  visibleRowCount,
+                  rowCount,
+                  pagination,
+                  hasFooter: !!renderFooterCellValue,
+                  headerIsInteractive,
+                  focusContext,
+                })}
+                data-test-subj="euiDataGridBody"
+                className="euiDataGrid__content"
+                role="grid"
+                id={gridId}
+                {...wrappingDivFocusProps} // re: above jsx-a11y - tabIndex is handled by these props, but the linter isn't smart enough to know that
+                {...gridAriaProps}
+              >
+                <EuiDataGridBody
+                  isFullScreen={isFullScreen}
+                  columns={orderedVisibleColumns}
+                  visibleColCount={visibleColCount}
+                  toolbarHeight={toolbarHeight}
+                  leadingControlColumns={leadingControlColumns}
+                  schema={mergedSchema}
+                  trailingControlColumns={trailingControlColumns}
+                  setVisibleColumns={setVisibleColumns}
+                  switchColumnPos={switchColumnPos}
+                  onColumnResize={onColumnResize}
+                  headerIsInteractive={headerIsInteractive}
+                  handleHeaderMutation={handleHeaderMutation}
+                  schemaDetectors={allSchemaDetectors}
+                  popoverContents={mergedPopoverContents}
+                  pagination={pagination}
+                  renderCellValue={renderCellValue}
+                  renderFooterCellValue={renderFooterCellValue}
+                  rowCount={rowCount}
+                  visibleRows={visibleRows}
+                  interactiveCellId={interactiveCellId}
+                  rowHeightsOptions={rowHeightsOptions}
+                  virtualizationOptions={virtualizationOptions || {}}
+                  gridStyles={gridStyles}
+                  gridWidth={gridWidth}
+                  gridRef={gridRef}
+                  wrapperRef={contentRef}
+                />
+              </div>
+              {pagination && props['aria-labelledby'] && (
+                <p id={ariaLabelledById} hidden>
+                  {ariaLabelledBy}
+                </p>
+              )}
+              {pagination && (
+                <EuiDataGridPaginationRenderer
+                  {...pagination}
+                  rowCount={rowCount}
+                  controls={gridId}
+                  aria-label={props['aria-label']}
+                  gridRef={gridRef}
+                />
+              )}
+              <p id={interactiveCellId} hidden>
+                <EuiI18n
+                  token="euiDataGrid.screenReaderNotice"
+                  default="Cell contains interactive content."
+                />
+                {/* TODO: if no keyboard shortcuts panel gets built, add keyboard shortcut info here */}
               </p>
-            )}
-            {pagination && (
-              <EuiDataGridPaginationRenderer
-                {...pagination}
-                rowCount={rowCount}
-                controls={gridId}
-                aria-label={props['aria-label']}
-                gridRef={gridRef}
-              />
-            )}
-            <p id={interactiveCellId} hidden>
-              <EuiI18n
-                token="euiDataGrid.screenReaderNotice"
-                default="Cell contains interactive content."
-              />
-              {/* TODO: if no keyboard shortcuts panel gets built, add keyboard shortcut info here */}
-            </p>
-          </div>
-        </EuiFocusTrap>
-      </DataGridSortingContext.Provider>
-    </DataGridFocusContext.Provider>
-  );
-};
+            </div>
+          </EuiFocusTrap>
+        </DataGridSortingContext.Provider>
+      </DataGridFocusContext.Provider>
+    );
+  }
+);
+
+EuiDataGrid.displayName = 'EuiDataGrid';

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -13,6 +13,7 @@ import React, {
   useMemo,
   useRef,
   useState,
+  useImperativeHandle,
 } from 'react';
 import { VariableSizeGrid as Grid } from 'react-window';
 import { useGeneratedHtmlId, keys } from '../../services';
@@ -262,6 +263,19 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
     } = useHeaderIsInteractive(contentRef.current);
     const { focusProps: wrappingDivFocusProps, ...focusContext } = useFocus(
       headerIsInteractive
+    );
+
+    /**
+     * Expose internal APIs as ref to consumer
+     */
+    useImperativeHandle(
+      ref,
+      () => ({
+        setFocusedCell: ({ rowIndex, colIndex }) => {
+          focusContext.setFocusedCell([colIndex, rowIndex]);
+        },
+      }),
+      [focusContext]
     );
 
     /**

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -266,19 +266,6 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
     );
 
     /**
-     * Expose internal APIs as ref to consumer
-     */
-    useImperativeHandle(
-      ref,
-      () => ({
-        setFocusedCell: ({ rowIndex, colIndex }) => {
-          focusContext.setFocusedCell([colIndex, rowIndex]);
-        },
-      }),
-      [focusContext]
-    );
-
-    /**
      * Toolbar & full-screen
      */
     const showToolbar = !!toolbarVisibility;
@@ -296,6 +283,19 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
           break;
       }
     };
+
+    /**
+     * Expose internal APIs as ref to consumer
+     */
+    useImperativeHandle(
+      ref,
+      () => ({
+        setFocusedCell: ({ rowIndex, colIndex }) => {
+          focusContext.setFocusedCell([colIndex, rowIndex]);
+        },
+      }),
+      [focusContext]
+    );
 
     /**
      * Classes

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -283,6 +283,13 @@ export type EuiDataGridProps = OneOf<
   'aria-label' | 'aria-labelledby'
 >;
 
+export interface EuiDataGridRefProps {
+  setFocusedCell({ rowIndex, colIndex }: EuiDataGridCellLocation): void;
+  focusIntoGrid(): void;
+}
+
+export type EuiDataGridCellLocation = { rowIndex: number; colIndex: number };
+
 export interface EuiDataGridColumnResizerProps {
   columnId: string;
   columnWidth: number;

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -285,7 +285,6 @@ export type EuiDataGridProps = OneOf<
 
 export interface EuiDataGridRefProps {
   setFocusedCell({ rowIndex, colIndex }: EuiDataGridCellLocation): void;
-  focusIntoGrid(): void;
 }
 
 export type EuiDataGridCellLocation = { rowIndex: number; colIndex: number };
@@ -523,6 +522,10 @@ export interface EuiDataGridColumnCellActionProps {
    * The index of the row that contains cell's data
    */
   rowIndex: number;
+  /**
+   * The index of the column that contains cell's data
+   */
+  colIndex: number;
   /**
    * The id of the column that contains the cell's data
    */

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -291,7 +291,7 @@ export interface EuiDataGridRefProps {
    * toggles a modal or flyout - focus must be restored to the grid on close
    * to prevent keyboard or screen reader users from being stranded.
    */
-  setFocusedCell({ rowIndex, colIndex }: EuiDataGridCellLocation): void;
+  setFocusedCell(targetCell: EuiDataGridCellLocation): void;
 }
 
 export type EuiDataGridCellLocation = { rowIndex: number; colIndex: number };

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -313,6 +313,7 @@ export interface EuiDataGridCellPopoverProps {
     | JSXElementConstructor<EuiDataGridCellValueElementProps>
     | ((props: EuiDataGridCellValueElementProps) => ReactNode);
   rowIndex: number;
+  colIndex: number;
 }
 export interface EuiDataGridColumnSortingDraggableProps {
   id: string;

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -284,6 +284,13 @@ export type EuiDataGridProps = OneOf<
 >;
 
 export interface EuiDataGridRefProps {
+  /**
+   * Allows manually focusing the specified cell in the grid.
+   *
+   * Using this method is an accessibility requirement if your EuiDataGrid
+   * toggles a modal or flyout - focus must be restored to the grid on close
+   * to prevent keyboard or screen reader users from being stranded.
+   */
   setFocusedCell({ rowIndex, colIndex }: EuiDataGridCellLocation): void;
 }
 


### PR DESCRIPTION
### Summary

https://user-images.githubusercontent.com/549407/146981252-3c208b9b-1c8b-4c5c-bade-8176ecc3756e.mp4

https://eui.elastic.co/pr_5499/#/tabular-content/data-grid-ref-methods

What this PR does:

- Adds a `forwardRef` and `useImperativeHandle` to EuiDataGrid
- Exposes the `setFocusedCell` API **only**

What this PR does not do:

- Add a `closeCellPopover` or `openCellPopover` API (that will be the next PR, since it requires a new context for EuiDataGridCells to communicate with EuiDataGrid and a decent amount of refactoring)
- Re-focusing to the cell from the **cell popover actions** does not currently work. This is because the popover is trapping focus within the popover. This will begin working once we add the `closeCellPopover` API.
- Attempting to `setFocusedCell` to a location that is currently outside the virtualization window (i.e. not rendered) **currently** does not work, but I have a fix for this that addresses open focus/scroll bugs that will be PR'ed against main.

⚠️ Notes:
- This PR is against a feature branch for https://github.com/elastic/eui/issues/5310 (since it will likely take multiple PRs to accomplish)
- I recommend turning off whitespace changes while viewing the diff, since the wrapping `forwardRef` created a ton of indentation in `data_grid.tsx`

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~

- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately (This PR is going into a feature branch, and additionally is only adding new APIs)
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
