### PR TITLE
[EuiDatePicker] Update ARIA and role attributes for better screen reader accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Fixed a `EuiDataGrid` sizing bug which didn't account for a horizontal scrollbar ([#5478](https://github.com/elastic/eui/pull/5478))
+- Fixed a `EuiDatePicker` a11y bug where axe-core reported missing ARIA and role attributes ([#5501](https://github.com/elastic/eui/pull/5501))
 
 **Deprecations**
 

--- a/src/components/date_picker/__snapshots__/date_picker.test.tsx.snap
+++ b/src/components/date_picker/__snapshots__/date_picker.test.tsx.snap
@@ -197,42 +197,49 @@ exports[`EuiDatePicker localization accepts the locale prop 1`] = `
               <div
                 aria-label="day-30"
                 class="react-datepicker__day react-datepicker__day--sun react-datepicker__day--weekend react-datepicker__day--outside-month"
+                role="option"
               >
                 30
               </div>
               <div
                 aria-label="day-1"
                 class="react-datepicker__day react-datepicker__day--mon react-datepicker__day--selected"
+                role="option"
               >
                 1
               </div>
               <div
                 aria-label="day-2"
                 class="react-datepicker__day react-datepicker__day--tue"
+                role="option"
               >
                 2
               </div>
               <div
                 aria-label="day-3"
                 class="react-datepicker__day react-datepicker__day--wed"
+                role="option"
               >
                 3
               </div>
               <div
                 aria-label="day-4"
                 class="react-datepicker__day react-datepicker__day--thu"
+                role="option"
               >
                 4
               </div>
               <div
                 aria-label="day-5"
                 class="react-datepicker__day react-datepicker__day--fri"
+                role="option"
               >
                 5
               </div>
               <div
                 aria-label="day-6"
                 class="react-datepicker__day react-datepicker__day--sat react-datepicker__day--weekend"
+                role="option"
               >
                 6
               </div>
@@ -243,42 +250,49 @@ exports[`EuiDatePicker localization accepts the locale prop 1`] = `
               <div
                 aria-label="day-7"
                 class="react-datepicker__day react-datepicker__day--sun react-datepicker__day--weekend"
+                role="option"
               >
                 7
               </div>
               <div
                 aria-label="day-8"
                 class="react-datepicker__day react-datepicker__day--mon"
+                role="option"
               >
                 8
               </div>
               <div
                 aria-label="day-9"
                 class="react-datepicker__day react-datepicker__day--tue"
+                role="option"
               >
                 9
               </div>
               <div
                 aria-label="day-10"
                 class="react-datepicker__day react-datepicker__day--wed"
+                role="option"
               >
                 10
               </div>
               <div
                 aria-label="day-11"
                 class="react-datepicker__day react-datepicker__day--thu"
+                role="option"
               >
                 11
               </div>
               <div
                 aria-label="day-12"
                 class="react-datepicker__day react-datepicker__day--fri"
+                role="option"
               >
                 12
               </div>
               <div
                 aria-label="day-13"
                 class="react-datepicker__day react-datepicker__day--sat react-datepicker__day--weekend"
+                role="option"
               >
                 13
               </div>
@@ -289,42 +303,49 @@ exports[`EuiDatePicker localization accepts the locale prop 1`] = `
               <div
                 aria-label="day-14"
                 class="react-datepicker__day react-datepicker__day--sun react-datepicker__day--weekend"
+                role="option"
               >
                 14
               </div>
               <div
                 aria-label="day-15"
                 class="react-datepicker__day react-datepicker__day--mon"
+                role="option"
               >
                 15
               </div>
               <div
                 aria-label="day-16"
                 class="react-datepicker__day react-datepicker__day--tue"
+                role="option"
               >
                 16
               </div>
               <div
                 aria-label="day-17"
                 class="react-datepicker__day react-datepicker__day--wed"
+                role="option"
               >
                 17
               </div>
               <div
                 aria-label="day-18"
                 class="react-datepicker__day react-datepicker__day--thu"
+                role="option"
               >
                 18
               </div>
               <div
                 aria-label="day-19"
                 class="react-datepicker__day react-datepicker__day--fri"
+                role="option"
               >
                 19
               </div>
               <div
                 aria-label="day-20"
                 class="react-datepicker__day react-datepicker__day--sat react-datepicker__day--weekend"
+                role="option"
               >
                 20
               </div>
@@ -335,42 +356,49 @@ exports[`EuiDatePicker localization accepts the locale prop 1`] = `
               <div
                 aria-label="day-21"
                 class="react-datepicker__day react-datepicker__day--sun react-datepicker__day--weekend"
+                role="option"
               >
                 21
               </div>
               <div
                 aria-label="day-22"
                 class="react-datepicker__day react-datepicker__day--mon"
+                role="option"
               >
                 22
               </div>
               <div
                 aria-label="day-23"
                 class="react-datepicker__day react-datepicker__day--tue"
+                role="option"
               >
                 23
               </div>
               <div
                 aria-label="day-24"
                 class="react-datepicker__day react-datepicker__day--wed"
+                role="option"
               >
                 24
               </div>
               <div
                 aria-label="day-25"
                 class="react-datepicker__day react-datepicker__day--thu"
+                role="option"
               >
                 25
               </div>
               <div
                 aria-label="day-26"
                 class="react-datepicker__day react-datepicker__day--fri"
+                role="option"
               >
                 26
               </div>
               <div
                 aria-label="day-27"
                 class="react-datepicker__day react-datepicker__day--sat react-datepicker__day--weekend"
+                role="option"
               >
                 27
               </div>
@@ -381,42 +409,49 @@ exports[`EuiDatePicker localization accepts the locale prop 1`] = `
               <div
                 aria-label="day-28"
                 class="react-datepicker__day react-datepicker__day--sun react-datepicker__day--weekend"
+                role="option"
               >
                 28
               </div>
               <div
                 aria-label="day-29"
                 class="react-datepicker__day react-datepicker__day--mon"
+                role="option"
               >
                 29
               </div>
               <div
                 aria-label="day-30"
                 class="react-datepicker__day react-datepicker__day--tue"
+                role="option"
               >
                 30
               </div>
               <div
                 aria-label="day-31"
                 class="react-datepicker__day react-datepicker__day--wed"
+                role="option"
               >
                 31
               </div>
               <div
                 aria-label="day-1"
                 class="react-datepicker__day react-datepicker__day--thu react-datepicker__day--outside-month"
+                role="option"
               >
                 1
               </div>
               <div
                 aria-label="day-2"
                 class="react-datepicker__day react-datepicker__day--fri react-datepicker__day--outside-month"
+                role="option"
               >
                 2
               </div>
               <div
                 aria-label="day-3"
                 class="react-datepicker__day react-datepicker__day--sat react-datepicker__day--weekend react-datepicker__day--outside-month"
+                role="option"
               >
                 3
               </div>
@@ -565,42 +600,49 @@ exports[`EuiDatePicker localization inherits locale from context 1`] = `
               <div
                 aria-label="day-1"
                 class="react-datepicker__day react-datepicker__day--mon react-datepicker__day--selected"
+                role="option"
               >
                 1
               </div>
               <div
                 aria-label="day-2"
                 class="react-datepicker__day react-datepicker__day--tue"
+                role="option"
               >
                 2
               </div>
               <div
                 aria-label="day-3"
                 class="react-datepicker__day react-datepicker__day--wed"
+                role="option"
               >
                 3
               </div>
               <div
                 aria-label="day-4"
                 class="react-datepicker__day react-datepicker__day--thu"
+                role="option"
               >
                 4
               </div>
               <div
                 aria-label="day-5"
                 class="react-datepicker__day react-datepicker__day--fri"
+                role="option"
               >
                 5
               </div>
               <div
                 aria-label="day-6"
                 class="react-datepicker__day react-datepicker__day--sat react-datepicker__day--weekend"
+                role="option"
               >
                 6
               </div>
               <div
                 aria-label="day-7"
                 class="react-datepicker__day react-datepicker__day--sun react-datepicker__day--weekend"
+                role="option"
               >
                 7
               </div>
@@ -611,42 +653,49 @@ exports[`EuiDatePicker localization inherits locale from context 1`] = `
               <div
                 aria-label="day-8"
                 class="react-datepicker__day react-datepicker__day--mon"
+                role="option"
               >
                 8
               </div>
               <div
                 aria-label="day-9"
                 class="react-datepicker__day react-datepicker__day--tue"
+                role="option"
               >
                 9
               </div>
               <div
                 aria-label="day-10"
                 class="react-datepicker__day react-datepicker__day--wed"
+                role="option"
               >
                 10
               </div>
               <div
                 aria-label="day-11"
                 class="react-datepicker__day react-datepicker__day--thu"
+                role="option"
               >
                 11
               </div>
               <div
                 aria-label="day-12"
                 class="react-datepicker__day react-datepicker__day--fri"
+                role="option"
               >
                 12
               </div>
               <div
                 aria-label="day-13"
                 class="react-datepicker__day react-datepicker__day--sat react-datepicker__day--weekend"
+                role="option"
               >
                 13
               </div>
               <div
                 aria-label="day-14"
                 class="react-datepicker__day react-datepicker__day--sun react-datepicker__day--weekend"
+                role="option"
               >
                 14
               </div>
@@ -657,42 +706,49 @@ exports[`EuiDatePicker localization inherits locale from context 1`] = `
               <div
                 aria-label="day-15"
                 class="react-datepicker__day react-datepicker__day--mon"
+                role="option"
               >
                 15
               </div>
               <div
                 aria-label="day-16"
                 class="react-datepicker__day react-datepicker__day--tue"
+                role="option"
               >
                 16
               </div>
               <div
                 aria-label="day-17"
                 class="react-datepicker__day react-datepicker__day--wed"
+                role="option"
               >
                 17
               </div>
               <div
                 aria-label="day-18"
                 class="react-datepicker__day react-datepicker__day--thu"
+                role="option"
               >
                 18
               </div>
               <div
                 aria-label="day-19"
                 class="react-datepicker__day react-datepicker__day--fri"
+                role="option"
               >
                 19
               </div>
               <div
                 aria-label="day-20"
                 class="react-datepicker__day react-datepicker__day--sat react-datepicker__day--weekend"
+                role="option"
               >
                 20
               </div>
               <div
                 aria-label="day-21"
                 class="react-datepicker__day react-datepicker__day--sun react-datepicker__day--weekend"
+                role="option"
               >
                 21
               </div>
@@ -703,42 +759,49 @@ exports[`EuiDatePicker localization inherits locale from context 1`] = `
               <div
                 aria-label="day-22"
                 class="react-datepicker__day react-datepicker__day--mon"
+                role="option"
               >
                 22
               </div>
               <div
                 aria-label="day-23"
                 class="react-datepicker__day react-datepicker__day--tue"
+                role="option"
               >
                 23
               </div>
               <div
                 aria-label="day-24"
                 class="react-datepicker__day react-datepicker__day--wed"
+                role="option"
               >
                 24
               </div>
               <div
                 aria-label="day-25"
                 class="react-datepicker__day react-datepicker__day--thu"
+                role="option"
               >
                 25
               </div>
               <div
                 aria-label="day-26"
                 class="react-datepicker__day react-datepicker__day--fri"
+                role="option"
               >
                 26
               </div>
               <div
                 aria-label="day-27"
                 class="react-datepicker__day react-datepicker__day--sat react-datepicker__day--weekend"
+                role="option"
               >
                 27
               </div>
               <div
                 aria-label="day-28"
                 class="react-datepicker__day react-datepicker__day--sun react-datepicker__day--weekend"
+                role="option"
               >
                 28
               </div>
@@ -749,42 +812,49 @@ exports[`EuiDatePicker localization inherits locale from context 1`] = `
               <div
                 aria-label="day-29"
                 class="react-datepicker__day react-datepicker__day--mon"
+                role="option"
               >
                 29
               </div>
               <div
                 aria-label="day-30"
                 class="react-datepicker__day react-datepicker__day--tue"
+                role="option"
               >
                 30
               </div>
               <div
                 aria-label="day-31"
                 class="react-datepicker__day react-datepicker__day--wed"
+                role="option"
               >
                 31
               </div>
               <div
                 aria-label="day-1"
                 class="react-datepicker__day react-datepicker__day--thu react-datepicker__day--outside-month"
+                role="option"
               >
                 1
               </div>
               <div
                 aria-label="day-2"
                 class="react-datepicker__day react-datepicker__day--fri react-datepicker__day--outside-month"
+                role="option"
               >
                 2
               </div>
               <div
                 aria-label="day-3"
                 class="react-datepicker__day react-datepicker__day--sat react-datepicker__day--weekend react-datepicker__day--outside-month"
+                role="option"
               >
                 3
               </div>
               <div
                 aria-label="day-4"
                 class="react-datepicker__day react-datepicker__day--sun react-datepicker__day--weekend react-datepicker__day--outside-month"
+                role="option"
               >
                 4
               </div>

--- a/src/components/date_picker/__snapshots__/date_picker.test.tsx.snap
+++ b/src/components/date_picker/__snapshots__/date_picker.test.tsx.snap
@@ -183,7 +183,7 @@ exports[`EuiDatePicker localization accepts the locale prop 1`] = `
             </div>
           </div>
           <div
-            aria-label="month-2019-07"
+            aria-label="7월, 2019"
             class="react-datepicker__month react-datepicker__month--accessible"
             role="listbox"
             tabindex="0"
@@ -586,7 +586,7 @@ exports[`EuiDatePicker localization inherits locale from context 1`] = `
             </div>
           </div>
           <div
-            aria-label="month-2019-07"
+            aria-label="juillet, 2019"
             class="react-datepicker__month react-datepicker__month--accessible"
             role="listbox"
             tabindex="0"

--- a/src/components/date_picker/react-datepicker/src/day.js
+++ b/src/components/date_picker/react-datepicker/src/day.js
@@ -217,6 +217,7 @@ export default class Day extends React.Component {
         onClick={this.handleClick}
         onMouseEnter={this.handleMouseEnter}
         aria-label={`day-${getDate(this.props.day)}`}
+        role="option"
       >
         {this.props.renderDayContents
           ? this.props.renderDayContents(getDate(this.props.day))

--- a/src/components/date_picker/react-datepicker/src/month.js
+++ b/src/components/date_picker/react-datepicker/src/month.js
@@ -253,7 +253,7 @@ export default class Month extends React.Component {
         className={this.getClassNames()}
         onMouseLeave={this.handleMouseLeave}
         role="listbox"
-        aria-label={"month-" + this.props.day.format("YYYY-MM")}
+        aria-label={this.props.day.format("MMMM, YYYY")}
         tabIndex={this.props.accessibleMode ? 0 : -1}
         onKeyDown={this.onInputKeyDown}
         onFocus={this.onFocus}

--- a/src/components/date_picker/react-datepicker/src/time.js
+++ b/src/components/date_picker/react-datepicker/src/time.js
@@ -72,7 +72,7 @@ export default class Time extends React.Component {
       intervals: 30,
       onTimeChange: () => {},
       todayButton: null,
-      timeCaption: "Time"
+      timeCaption: "Timing"
     };
   }
 

--- a/src/components/date_picker/react-datepicker/src/time.js
+++ b/src/components/date_picker/react-datepicker/src/time.js
@@ -374,6 +374,7 @@ export default class Time extends React.Component {
             onBlur={this.onBlur}
           >
             <ul
+              aria-label={this.props.timeCaption}
               className="react-datepicker__time-list"
               ref={list => {
                 this.list = list;

--- a/src/components/date_picker/react-datepicker/src/time.js
+++ b/src/components/date_picker/react-datepicker/src/time.js
@@ -72,7 +72,7 @@ export default class Time extends React.Component {
       intervals: 30,
       onTimeChange: () => {},
       todayButton: null,
-      timeCaption: "Timing"
+      timeCaption: "Time"
     };
   }
 


### PR DESCRIPTION
### Summary
The calendar datepicker needed `role="option"` added to the individual date choices and the time picker needed an accessible label. Also revised the accessible label for the calendar to closer match the time picker. Closes #5303.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] ~~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~~
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
