### PR TITLE
Refactoring `EuiKeypadMenuItem` beta badge for improved accessibility

### DIFF
--- a/src/components/badge/beta_badge/beta_badge.tsx
+++ b/src/components/badge/beta_badge/beta_badge.tsx
@@ -224,7 +224,7 @@ export const EuiBetaBadge: FunctionComponent<EuiBetaBadgeProps> = ({
           content={tooltipContent}
           title={title || label}
         >
-          <span tabIndex={0} className={classes} {...rest}>
+          <span tabIndex={0} className={classes} role="button" {...rest}>
             {icon || label}
           </span>
         </EuiToolTip>

--- a/src/components/key_pad_menu/__snapshots__/key_pad_menu_item.test.tsx.snap
+++ b/src/components/key_pad_menu/__snapshots__/key_pad_menu_item.test.tsx.snap
@@ -94,96 +94,106 @@ exports[`EuiKeyPadMenuItem is rendered 1`] = `
 `;
 
 exports[`EuiKeyPadMenuItem props betaBadge renders 1`] = `
-<button
-  class="euiKeyPadMenuItem euiKeyPadMenuItem--hasBetaBadge"
-  type="button"
->
-  <span
-    class="euiKeyPadMenuItem__inner"
+Array [
+  <button
+    class="euiKeyPadMenuItem euiKeyPadMenuItem--hasBetaBadge"
+    type="button"
   >
     <span
-      class="euiBetaBadge euiBetaBadge--singleLetter euiBetaBadge--subdued euiBetaBadge--small euiKeyPadMenuItem__betaBadge"
-      title="Beta"
+      class="euiKeyPadMenuItem__inner"
     >
-      B
+      <span
+        class="euiKeyPadMenuItem__icon"
+      >
+        Icon
+      </span>
+      <span
+        class="euiKeyPadMenuItem__label"
+      >
+        Label
+      </span>
     </span>
-    <span
-      class="euiKeyPadMenuItem__icon"
-    >
-      Icon
-    </span>
-    <span
-      class="euiKeyPadMenuItem__label"
-    >
-      Label
-    </span>
-  </span>
-</button>
+  </button>,
+  <span
+    aria-label="Label. Beta item."
+    class="euiBetaBadge euiBetaBadge--singleLetter euiBetaBadge--subdued euiBetaBadge--small euiKeyPadMenuItem__betaBadge"
+    title="Beta"
+  >
+    B
+  </span>,
+]
 `;
 
 exports[`EuiKeyPadMenuItem props betaBadge renders with betaBadgeIconType 1`] = `
-<button
-  class="euiKeyPadMenuItem euiKeyPadMenuItem--hasBetaBadge"
-  type="button"
->
-  <span
-    class="euiKeyPadMenuItem__inner"
+Array [
+  <button
+    class="euiKeyPadMenuItem euiKeyPadMenuItem--hasBetaBadge"
+    type="button"
   >
     <span
-      class="euiBetaBadge euiBetaBadge--iconOnly euiBetaBadge--singleLetter euiBetaBadge--subdued euiBetaBadge--small euiKeyPadMenuItem__betaBadge"
-      title="Beta"
+      class="euiKeyPadMenuItem__inner"
     >
       <span
-        aria-hidden="true"
-        class="euiBetaBadge__icon"
-        color="inherit"
-        data-euiicon-type="bolt"
-      />
+        class="euiKeyPadMenuItem__icon"
+      >
+        Icon
+      </span>
+      <span
+        class="euiKeyPadMenuItem__label"
+      >
+        Label
+      </span>
     </span>
+  </button>,
+  <span
+    aria-label="Label. Beta item."
+    class="euiBetaBadge euiBetaBadge--iconOnly euiBetaBadge--singleLetter euiBetaBadge--subdued euiBetaBadge--small euiKeyPadMenuItem__betaBadge"
+    title="Beta"
+  >
     <span
-      class="euiKeyPadMenuItem__icon"
-    >
-      Icon
-    </span>
-    <span
-      class="euiKeyPadMenuItem__label"
-    >
-      Label
-    </span>
-  </span>
-</button>
+      aria-hidden="true"
+      class="euiBetaBadge__icon"
+      color="inherit"
+      data-euiicon-type="bolt"
+    />
+  </span>,
+]
 `;
 
 exports[`EuiKeyPadMenuItem props betaBadge renders with betaBadgeTooltipContent 1`] = `
-<button
-  class="euiKeyPadMenuItem euiKeyPadMenuItem--hasBetaBadge"
-  type="button"
->
-  <span
-    class="euiKeyPadMenuItem__inner"
+Array [
+  <button
+    class="euiKeyPadMenuItem euiKeyPadMenuItem--hasBetaBadge"
+    type="button"
   >
     <span
-      class="euiToolTipAnchor"
+      class="euiKeyPadMenuItem__inner"
     >
       <span
-        class="euiBetaBadge euiBetaBadge--singleLetter euiBetaBadge--subdued euiBetaBadge--small euiKeyPadMenuItem__betaBadge"
-        tabindex="0"
+        class="euiKeyPadMenuItem__icon"
       >
-        B
+        Icon
+      </span>
+      <span
+        class="euiKeyPadMenuItem__label"
+      >
+        Label
       </span>
     </span>
+  </button>,
+  <span
+    class="euiToolTipAnchor"
+  >
     <span
-      class="euiKeyPadMenuItem__icon"
+      aria-label="Label. Beta item."
+      class="euiBetaBadge euiBetaBadge--singleLetter euiBetaBadge--subdued euiBetaBadge--small euiKeyPadMenuItem__betaBadge"
+      role="button"
+      tabindex="0"
     >
-      Icon
+      B
     </span>
-    <span
-      class="euiKeyPadMenuItem__label"
-    >
-      Label
-    </span>
-  </span>
-</button>
+  </span>,
+]
 `;
 
 exports[`EuiKeyPadMenuItem props isDisabled renders with href 1`] = `

--- a/src/components/key_pad_menu/_key_pad_menu.scss
+++ b/src/components/key_pad_menu/_key_pad_menu.scss
@@ -18,5 +18,6 @@
   > *:not(legend) {
     margin-bottom: $euiKeyPadMenuMarginSize;
     margin-right: $euiKeyPadMenuMarginSize;
+    position: relative;
   }
 }

--- a/src/components/key_pad_menu/_key_pad_menu_item.scss
+++ b/src/components/key_pad_menu/_key_pad_menu_item.scss
@@ -92,10 +92,6 @@
   .euiKeyPadMenuItem__checkableInput {
     transform: scale(.75);
     transform-origin: top right;
-  }
-
-  .euiKeyPadMenuItem__checkableInput,
-  .euiKeyPadMenuItem__betaBadge {
     position: absolute;
     top: $euiSizeXS;
     right: $euiSizeXS;
@@ -124,5 +120,14 @@
     @include euiFocusBackground;
     color: $euiColorPrimaryText;
     border-color: $euiColorPrimaryText;
+  }
+}
+
+.euiKeyPadMenuListItem {
+  .euiToolTipAnchor {
+    position: absolute;
+    top: $euiSizeS;
+    right: $euiSizeS;
+    z-index: 3;
   }
 }

--- a/src/components/key_pad_menu/key_pad_menu.tsx
+++ b/src/components/key_pad_menu/key_pad_menu.tsx
@@ -74,7 +74,7 @@ export const EuiKeyPadMenu: FunctionComponent<EuiKeyPadMenuProps> = ({
   ) : (
     <ul className={classes} {...rest}>
       {React.Children.map(children, (child) => (
-        <li>{child}</li>
+        <li className="euiKeyPadMenuListItem">{child}</li>
       ))}
     </ul>
   );

--- a/src/components/key_pad_menu/key_pad_menu_item.test.tsx
+++ b/src/components/key_pad_menu/key_pad_menu_item.test.tsx
@@ -166,7 +166,7 @@ describe('EuiKeyPadMenuItem', () => {
       </EuiKeyPadMenuItem>
     );
 
-    $button.simulate('click');
+    $button.find('button').simulate('click');
 
     expect(onClickHandler).toBeCalledTimes(1);
   });

--- a/src/components/key_pad_menu/key_pad_menu_item.tsx
+++ b/src/components/key_pad_menu/key_pad_menu_item.tsx
@@ -225,6 +225,7 @@ export const EuiKeyPadMenuItem: FunctionComponent<EuiKeyPadMenuItemProps> = ({
 
     return (
       <EuiBetaBadge
+        aria-label={`${label}. Beta item.`}
         size="s"
         color="subdued"
         className="euiKeyPadMenuItem__betaBadge"
@@ -238,7 +239,7 @@ export const EuiKeyPadMenuItem: FunctionComponent<EuiKeyPadMenuItemProps> = ({
 
   const renderContent = () => (
     <span className="euiKeyPadMenuItem__inner">
-      {checkable ? renderCheckableElement() : renderBetaBadge()}
+      {checkable && renderCheckableElement()}
       <span className="euiKeyPadMenuItem__icon">{children}</span>
       <span className="euiKeyPadMenuItem__label">{label}</span>
     </span>
@@ -269,14 +270,17 @@ export const EuiKeyPadMenuItem: FunctionComponent<EuiKeyPadMenuItemProps> = ({
   }
 
   return (
-    <Element
-      className={classes}
-      {...(relObj as ElementType)}
-      {...(rest as ElementType)}
-      // Unable to get past `LegacyRef` conflicts
-      ref={buttonRef as Ref<any>}
-    >
-      {renderContent()}
-    </Element>
+    <React.Fragment>
+      <Element
+        className={classes}
+        {...(relObj as ElementType)}
+        {...(rest as ElementType)}
+        // Unable to get past `LegacyRef` conflicts
+        ref={buttonRef as Ref<any>}
+      >
+        {renderContent()}
+      </Element>
+      {betaBadgeLabel && renderBetaBadge()}
+    </React.Fragment>
   );
 };


### PR DESCRIPTION
### Summary
The `EuiKeypadMenuItem` had a focusable span inside the focusable button, used to trigger the tooltips. Axe-core was complaining about this nested focusable element, so I refactored it to move it outside the button as a sibling element. Closes #5290.

* Moved the EuiBetaBadge outside the parent button
* Updated the absolute positioning of the beta badge to match current
* Added role="button" to beta badge span for more consistent SR read out

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
