### PR TITLE
[EuiDatePicker] Moved `Time` component tabindex to UL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed a `EuiDataGrid` sizing bug which didn't account for a horizontal scrollbar ([#5478](https://github.com/elastic/eui/pull/5478))
 - Fixed a `EuiDatePicker` a11y bug where axe-core reported missing ARIA and role attributes ([#5501](https://github.com/elastic/eui/pull/5501))
 - Fixed `EuiModalHeaderTitle` to conditionally wrap title strings in an H1 ([#5494](https://github.com/elastic/eui/pull/5494))
+- Fixed an `EuiDatePicker` accessibility issue where `tabindex` was not applied to a listbox element ([#5509](https://github.com/elastic/eui/pull/5509))
 
 **Deprecations**
 

--- a/src/components/date_picker/react-datepicker/src/time.js
+++ b/src/components/date_picker/react-datepicker/src/time.js
@@ -368,7 +368,6 @@ export default class Time extends React.Component {
         <div className="react-datepicker__time">
           <div
             className={timeBoxClassNames}
-            tabIndex={this.props.accessibleMode ? 0 : -1}
             onKeyDown={this.onInputKeyDown}
             onFocus={this.onFocus}
             onBlur={this.onBlur}
@@ -381,6 +380,7 @@ export default class Time extends React.Component {
               }}
               style={height ? { height } : {}}
               role="listbox"
+              tabIndex={this.props.accessibleMode ? 0 : -1}
             >
               {this.renderTimes.bind(this)()}
             </ul>


### PR DESCRIPTION
### Summary
Axe-core was reporting a violation for the `Time` component `ul[role="listbox"]` being contained in a DIV with a tab index. I moved the tab index to the UL and retested for keyboard navigation and screen reader usability. Closes #5296.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] ~~Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~~
- [ ] ~~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~~
- [ ] ~~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~~
- [ ] ~~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~~
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
