### PR TITLE
[EuiSuperSelect] Remove popoverClassName and repositionOnScroll props 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - Deprecated `PartitionConfig` in favor of inclusion in Charts `theme.partition` ([#5492](https://github.com/elastic/eui/pull/5492))
 
+**Breaking changes**
+
+- Removed `popoverClassName` and `repositionOnScroll` props from `EuiSuperSelect` (use `popoverProps` instead) ([#5512](https://github.com/elastic/eui/pull/5512))
+
 ## [`43.1.1`](https://github.com/elastic/eui/tree/v43.1.1)
 
 **Bug fixes**

--- a/src-docs/src/views/flyout/flyout_complicated.js
+++ b/src-docs/src/views/flyout/flyout_complicated.js
@@ -232,7 +232,7 @@ export default () => {
                 valueOfSelected={superSelectvalue}
                 onChange={(value) => onSuperSelectChange(value)}
                 itemLayoutAlign="top"
-                repositionOnScroll={true}
+                popoverProps={{ repositionOnScroll: true }}
                 hasDividers
               />
             </EuiFormRow>

--- a/src/components/form/super_select/super_select.tsx
+++ b/src/components/form/super_select/super_select.tsx
@@ -76,7 +76,7 @@ export type EuiSuperSelectProps<T extends string> = CommonProps &
 
     /**
      * Optional props to pass to the underlying [EuiPopover](/#/layout/popover).
-     *  Allows fine-grained control of the popover dropdown menu, including
+     * Allows fine-grained control of the popover dropdown menu, including
      * `repositionOnScroll` for EuiSuperSelects used within scrollable containers,
      * and customizing popover panel styling.
      *
@@ -84,22 +84,6 @@ export type EuiSuperSelectProps<T extends string> = CommonProps &
      * `isOpen` API instead.
      */
     popoverProps?: Partial<CommonProps & Omit<EuiPopoverProps, 'isOpen'>>;
-
-    /**
-     * Applied to the outermost wrapper (popover)
-     *
-     * **DEPRECATED: Use `popoverProps.className` instead (will take precedence over this prop if set).**
-     */
-    popoverClassName?: string;
-
-    /**
-     * When `true`, the popover's position is re-calculated when the user
-     * scrolls. When nesting an `EuiSuperSelect` in a scrollable container,
-     * `repositionOnScroll` should be `true`
-     *
-     * **DEPRECATED: Use `popoverProps.repositionOnScroll` instead (will take precedence over this prop if set).**
-     */
-    repositionOnScroll?: boolean;
   };
 
 export class EuiSuperSelect<T extends string> extends Component<
@@ -276,16 +260,14 @@ export class EuiSuperSelect<T extends string> extends Component<
       itemClassName,
       itemLayoutAlign,
       fullWidth,
-      popoverClassName,
       popoverProps,
       compressed,
-      repositionOnScroll,
       ...rest
     } = this.props;
 
     const popoverClasses = classNames(
       'euiSuperSelect',
-      popoverProps?.className ?? popoverClassName
+      popoverProps?.className
     );
 
     const buttonClasses = classNames(
@@ -346,7 +328,6 @@ export class EuiSuperSelect<T extends string> extends Component<
       <EuiInputPopover
         closePopover={this.closePopover}
         panelPaddingSize="none"
-        repositionOnScroll={repositionOnScroll}
         {...popoverProps}
         className={popoverClasses}
         isOpen={isOpen || this.state.isPopoverOpen}


### PR DESCRIPTION
### Summary

Follow up to our [January 2022 deprecations](https://github.com/elastic/eui/issues/1469) and https://github.com/elastic/eui/pull/5214

## QA

- [x] Confirm that the complicated flyout modal's EuiSuperSelect correctly scrolls with the flyout body:

![superselect](https://user-images.githubusercontent.com/549407/148103762-8816b520-2faa-46f4-9f44-84674d900a51.gif)

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~

- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**

~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~

- [x] Checked for **breaking changes** and labeled appropriately

~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
