### PR TITLE
[EuiSearchBar] Allow phrases with leading and trailing spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## [`main`](https://github.com/elastic/eui/tree/main)
 
-**Bug fixes**
+**Breaking changes**
 
-- Fixed `EuiSearchBar` to allow phrases with leading and trailing spaces ([#5514](https://github.com/elastic/eui/pull/5514))
+- Changed `EuiSearchBar` to preserve phrases with leading and trailing spaces, instead of dropping surrounding whitespace ([#5514](https://github.com/elastic/eui/pull/5514))
 
 **Breaking changes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [`main`](https://github.com/elastic/eui/tree/main)
 
+**Bug fixes**
+
+- Fixed `EuiSearchBar` to allow phrases with leading and trailing spaces ([#5514](https://github.com/elastic/eui/pull/5514))
+
 **Breaking changes**
 
 - Removed `data-test-subj="dataGridWrapper"`  from `EuiDataGrid` in favor of `data-test-subj="euiDataGridBody"` ([#5506](https://github.com/elastic/eui/pull/5506))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,6 @@
 **Breaking changes**
 
 - Changed `EuiSearchBar` to preserve phrases with leading and trailing spaces, instead of dropping surrounding whitespace ([#5514](https://github.com/elastic/eui/pull/5514))
-
-**Breaking changes**
-
 - Removed `data-test-subj="dataGridWrapper"`  from `EuiDataGrid` in favor of `data-test-subj="euiDataGridBody"` ([#5506](https://github.com/elastic/eui/pull/5506))
 
 ## [`44.0.0`](https://github.com/elastic/eui/tree/v44.0.0)

--- a/src-docs/src/views/search_bar/search_bar.js
+++ b/src-docs/src/views/search_bar/search_bar.js
@@ -17,10 +17,10 @@ import {
 const random = new Random();
 
 const tags = [
-  { name: 'marketing', color: 'danger' },
-  { name: 'finance', color: 'success' },
-  { name: 'eng', color: 'success' },
-  { name: 'sales', color: 'warning' },
+  { name: ' marketing', color: 'danger' },
+  { name: '	finance', color: 'success' }, // NB: this is a tab character
+  { name: ' eng ', color: 'success' },
+  { name: 'sa les', color: 'warning' },
   { name: 'ga', color: 'success' },
 ];
 
@@ -85,11 +85,11 @@ export const SearchBar = () => {
         field: 'status',
         items: [
           {
-            value: 'open',
+            value: ' open',
             name: 'Open',
           },
           {
-            value: 'closed',
+            value: 'closed ',
             name: 'Closed',
           },
         ],
@@ -104,7 +104,7 @@ export const SearchBar = () => {
         type: 'field_value_toggle',
         name: 'Mine',
         field: 'owner',
-        value: 'dewey',
+        value: ' dewey',
       },
       {
         type: 'field_value_toggle',

--- a/src-docs/src/views/search_bar/search_bar.js
+++ b/src-docs/src/views/search_bar/search_bar.js
@@ -17,10 +17,10 @@ import {
 const random = new Random();
 
 const tags = [
-  { name: ' marketing', color: 'danger' },
-  { name: '	finance', color: 'success' }, // NB: this is a tab character
-  { name: ' eng ', color: 'success' },
-  { name: 'sa les', color: 'warning' },
+  { name: 'marketing', color: 'danger' },
+  { name: 'finance', color: 'success' },
+  { name: 'eng', color: 'success' },
+  { name: 'sales', color: 'warning' },
   { name: 'ga', color: 'success' },
 ];
 
@@ -85,11 +85,11 @@ export const SearchBar = () => {
         field: 'status',
         items: [
           {
-            value: ' open',
+            value: 'open',
             name: 'Open',
           },
           {
-            value: 'closed ',
+            value: 'closed',
             name: 'Closed',
           },
         ],
@@ -104,7 +104,7 @@ export const SearchBar = () => {
         type: 'field_value_toggle',
         name: 'Mine',
         field: 'owner',
-        value: ' dewey',
+        value: 'dewey',
       },
       {
         type: 'field_value_toggle',

--- a/src/components/search_bar/query/default_syntax.test.ts
+++ b/src/components/search_bar/query/default_syntax.test.ts
@@ -562,8 +562,8 @@ describe('defaultSyntax', () => {
     expect(printedQuery).toBe(query);
   });
 
-  test('relaxed phrases with spaces', () => {
-    const query = 'f:" this is a relaxed phrase \t"';
+  test('phrases with spaces', () => {
+    const query = 'f:" this is a phrase that preserves spaces\t"';
     const ast = defaultSyntax.parse(query);
 
     expect(ast).toBeDefined();
@@ -574,10 +574,10 @@ describe('defaultSyntax', () => {
     expect(AST.Field.isInstance(clause)).toBe(true);
     expect(AST.Match.isMustClause(clause)).toBe(true);
     expect(clause.field).toBe('f');
-    expect(clause.value).toBe('this is a relaxed phrase');
+    expect(clause.value).toBe(' this is a phrase that preserves spaces	');
 
     const printedQuery = defaultSyntax.print(ast);
-    expect(printedQuery).toBe('f:"this is a relaxed phrase"');
+    expect(printedQuery).toBe('f:" this is a phrase that preserves spaces	"');
   });
 
   test('phrases with extra characters', () => {

--- a/src/components/search_bar/query/default_syntax.ts
+++ b/src/components/search_bar/query/default_syntax.ts
@@ -146,9 +146,9 @@ containsValue
   / word
 
 phrase
-  = '"' space? phrase:(
-  	(phraseWord+)? (space phraseWord+)* { return unescapePhraseValue(text()); }
-  ) space? '"' { return Exp.string(phrase, location()); }
+  = '"' phrase:(
+  	space? (phraseWord+)? (space phraseWord+)* space? { return unescapePhraseValue(text()); }
+  ) '"' { return Exp.string(phrase, location()); }
 
 phraseWord
   // not a backslash, quote, or space


### PR DESCRIPTION
## Summary

See https://github.com/elastic/kibana/issues/122237 - filter values with leading or trailing spaces were resulting in buggy behavior within EuiSearchBar. The search bar should now correctly preserve leading and trailing spaces within phrases.

⚠️ I'm not sure if this is considered a breaking change, since based on the previous unit test, it's an intentional change in functionality from how it was before. Any thoughts?

### Before

![before](https://user-images.githubusercontent.com/549407/148288975-ca83c47c-5861-4e8d-b882-541f448249dd.gif)

Notice in particular that `owner:" dewey"` is not removing the correct filter

### After

![after](https://user-images.githubusercontent.com/549407/148289691-bd69abfe-0ed6-48f3-9c15-18eac198869d.gif)

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately

~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately