### PR TITLE
[EuiDataGrid] Update display selector UI when `gridStyle` and `rowHeightsOptions` props change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [`main`](https://github.com/elastic/eui/tree/main)
 
+**Bug fixes**
+
+- Fixed `EuiDataGrid`'s display toolbar control to update initial UI state when developer `gridStyle` or `rowHeightsOptions` props are updated ([#5525](https://github.com/elastic/eui/pull/5525))
+
 **Breaking changes**
 
 - Changed `EuiSearchBar` to preserve phrases with leading and trailing spaces, instead of dropping surrounding whitespace ([#5514](https://github.com/elastic/eui/pull/5514))

--- a/src-docs/src/views/datagrid/styling.js
+++ b/src-docs/src/views/datagrid/styling.js
@@ -455,6 +455,9 @@ const DataGrid = () => {
     toolbarConfig = toolbarVisibilityOptions;
   }
 
+  const [rowHeight, setRowHeight] = useState();
+  const setRowHeightAuto = () => setRowHeight('auto');
+
   return (
     <div>
       <EuiFlexGroup gutterSize="s">
@@ -705,6 +708,11 @@ const DataGrid = () => {
             </div>
           </EuiPopover>
         </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButton size="s" onClick={setRowHeightAuto}>
+            [TEST] Set row height to auto
+          </EuiButton>
+        </EuiFlexItem>
       </EuiFlexGroup>
 
       {footerSelected === 'striped' ? (
@@ -738,6 +746,7 @@ const DataGrid = () => {
           header: headerSelected,
           footer: footerSelected,
         }}
+        rowHeightsOptions={{ defaultHeight: rowHeight }}
         toolbarVisibility={toolbarConfig}
         renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
         renderFooterCellValue={renderFooterCellValue}

--- a/src-docs/src/views/datagrid/styling.js
+++ b/src-docs/src/views/datagrid/styling.js
@@ -455,9 +455,6 @@ const DataGrid = () => {
     toolbarConfig = toolbarVisibilityOptions;
   }
 
-  const [rowHeight, setRowHeight] = useState();
-  const setRowHeightAuto = () => setRowHeight('auto');
-
   return (
     <div>
       <EuiFlexGroup gutterSize="s">
@@ -708,11 +705,6 @@ const DataGrid = () => {
             </div>
           </EuiPopover>
         </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiButton size="s" onClick={setRowHeightAuto}>
-            [TEST] Set row height to auto
-          </EuiButton>
-        </EuiFlexItem>
       </EuiFlexGroup>
 
       {footerSelected === 'striped' ? (
@@ -746,7 +738,6 @@ const DataGrid = () => {
           header: headerSelected,
           footer: footerSelected,
         }}
-        rowHeightsOptions={{ defaultHeight: rowHeight }}
         toolbarVisibility={toolbarConfig}
         renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
         renderFooterCellValue={renderFooterCellValue}

--- a/src/components/datagrid/controls/display_selector.test.tsx
+++ b/src/components/datagrid/controls/display_selector.test.tsx
@@ -474,11 +474,6 @@ describe('useDataGridDisplaySelector', () => {
         .find('[data-test-subj="rowHeightButtonGroup"]')
         .simulate('change', selection);
     };
-    const setLineCount = (component: ShallowWrapper, lineCount = 1) => {
-      diveIntoEuiI18n(component)
-        .find('[data-test-subj="lineCountNumber"]')
-        .simulate('change', { target: { value: lineCount } });
-    };
     const getOutput = (component: ShallowWrapper) => {
       return JSON.parse(component.find('[data-test-subj="output"]').text());
     };
@@ -508,11 +503,10 @@ describe('useDataGridDisplaySelector', () => {
         );
 
         setRowHeight(component, 'lineCount');
-        setLineCount(component, 5);
 
         expect(getOutput(component)).toEqual({
           lineHeight: '2em',
-          defaultHeight: { lineCount: 5 },
+          defaultHeight: { lineCount: 2 },
           rowHeights: {},
         });
       });

--- a/src/components/datagrid/controls/display_selector.test.tsx
+++ b/src/components/datagrid/controls/display_selector.test.tsx
@@ -121,7 +121,7 @@ describe('useDataGridDisplaySelector', () => {
         ).toHaveLength(0);
       });
 
-      describe('convertGridStylesToSelection (loading initial state from passed gridStyles', () => {
+      describe('convertGridStylesToSelection', () => {
         it('should set compact state if both fontSize and cellPadding are s', () => {
           const component = mount(
             <MockComponent gridStyles={{ fontSize: 's', cellPadding: 's' }} />
@@ -153,6 +153,18 @@ describe('useDataGridDisplaySelector', () => {
           openPopover(component);
           expect(getSelection(component)).toEqual('');
         });
+      });
+
+      it('updates grid density whenever new developer styles are passed in', () => {
+        const component = mount(
+          <MockComponent gridStyles={{ fontSize: 'l', cellPadding: 'l' }} />
+        );
+        openPopover(component);
+        expect(getSelection(component)).toEqual('expanded');
+
+        component.setProps({ gridStyles: { fontSize: 's', cellPadding: 's' } });
+        component.update();
+        expect(getSelection(component)).toEqual('compact');
       });
 
       it('correctly resets density to initial developer-passed state', () => {
@@ -216,7 +228,7 @@ describe('useDataGridDisplaySelector', () => {
         ).toHaveLength(0);
       });
 
-      describe('convertRowHeightsOptionsToSelection (loading initial state from passed rowHeightsOptions)', () => {
+      describe('convertRowHeightsOptionsToSelection', () => {
         test('auto', () => {
           const component = mount(
             <MockComponent rowHeightsOptions={{ defaultHeight: 'auto' }} />
@@ -258,6 +270,20 @@ describe('useDataGridDisplaySelector', () => {
           openPopover(component2);
           expect(getSelection(component2)).toEqual('');
         });
+      });
+
+      it('updates row height whenever new developer settings are passed in', () => {
+        const component = mount(
+          <MockComponent rowHeightsOptions={{ defaultHeight: 'auto' }} />
+        );
+        openPopover(component);
+        expect(getSelection(component)).toEqual('auto');
+
+        component.setProps({
+          rowHeightsOptions: { defaultHeight: { lineCount: 3 } },
+        });
+        component.update();
+        expect(getSelection(component)).toEqual('lineCount');
       });
 
       it('correctly resets row height to initial developer-passed state', () => {

--- a/src/components/datagrid/controls/display_selector.test.tsx
+++ b/src/components/datagrid/controls/display_selector.test.tsx
@@ -406,9 +406,10 @@ describe('useDataGridDisplaySelector', () => {
         component.find('[data-test-subj="resetDisplaySelector"]').exists()
       ).toBe(true);
 
-      // Should hide the reset button again when changing back to the initial configuration
-      component.find('[data-test-subj="normal"]').simulate('change');
-      component.find('[data-test-subj="undefined"]').simulate('change');
+      // Should hide the reset button again after it's been clicked
+      component
+        .find('button[data-test-subj="resetDisplaySelector"]')
+        .simulate('click');
       expect(
         component.find('[data-test-subj="resetDisplaySelector"]').exists()
       ).toBe(false);

--- a/src/components/datagrid/controls/display_selector.tsx
+++ b/src/components/datagrid/controls/display_selector.tsx
@@ -184,13 +184,22 @@ export const useDataGridDisplaySelector = (
     // @ts-ignore - same as above
   }, [rowHeightsOptions?.defaultHeight?.lineCount]);
 
-  // Invoke onChange callbacks on user input (removing the callback value itself, so that only configuration values are returned)
+  // Show a reset button whenever users manually change settings, and
+  // invoke onChange callbacks (removing the callback value itself, so that only configuration values are returned)
+  const [showResetButton, setShowResetButton] = useState(false);
+
   useUpdateEffect(() => {
+    const hasUserChanges = Object.keys(userGridStyles).length > 0;
+    if (hasUserChanges) setShowResetButton(true);
+
     const { onChange, ...currentGridStyles } = gridStyles;
     initialStyles?.onChange?.(currentGridStyles);
   }, [userGridStyles]);
 
   useUpdateEffect(() => {
+    const hasUserChanges = Object.keys(userRowHeightsOptions).length > 0;
+    if (hasUserChanges) setShowResetButton(true);
+
     const { onChange, ...currentRowHeightsOptions } = rowHeightsOptions;
     initialRowHeightsOptions?.onChange?.(currentRowHeightsOptions);
   }, [userRowHeightsOptions]);
@@ -199,21 +208,8 @@ export const useDataGridDisplaySelector = (
   const resetToInitialState = useCallback(() => {
     setUserGridStyles({});
     setUserRowHeightsOptions({});
+    setShowResetButton(false);
   }, []);
-
-  const showResetButton = useMemo(() => {
-    if (initialDensity !== gridDensity) return true;
-    if (initialRowHeight !== rowHeightSelection) return true;
-    if (initialLineCount !== lineCount) return true;
-    return false;
-  }, [
-    initialDensity,
-    gridDensity,
-    initialRowHeight,
-    rowHeightSelection,
-    initialLineCount,
-    lineCount,
-  ]);
 
   const buttonLabel = useEuiI18n(
     'euiDisplaySelector.buttonText',

--- a/src/components/datagrid/controls/display_selector.tsx
+++ b/src/components/datagrid/controls/display_selector.tsx
@@ -112,15 +112,13 @@ export const useDataGridDisplaySelector = (
   const [userGridStyles, setUserGridStyles] = useState({});
   const [userRowHeightsOptions, setUserRowHeightsOptions] = useState({});
 
-  // Density state
-  const [gridDensity, setGridDensity] = useState('');
-  const setGridStyles = (density: string) => {
+  // Density logic
+  const setGridStyles = useCallback((density: string) => {
     setUserGridStyles(densityStyles[density]);
-  };
+  }, []);
 
-  // Row height state
+  // Row height logic
   const [lineCount, setLineCount] = useState(2);
-  const [rowHeightSelection, setRowHeightSelection] = useState('');
   const setRowHeight = useCallback(
     (option: string) => {
       const rowHeightsOptions: EuiDataGridRowHeightsOptions = {
@@ -165,15 +163,13 @@ export const useDataGridDisplaySelector = (
     };
   }, [initialRowHeightsOptions, userRowHeightsOptions]);
 
-  // Update UI controls based on current settings, on init & when either developer or user settings change
-  useEffect(() => {
-    setGridDensity(convertGridStylesToSelection(gridStyles));
+  // Set UI controls based on current configurations, on init & when either developer or user settings change
+  const gridDensity = useMemo(() => {
+    return convertGridStylesToSelection(gridStyles);
   }, [gridStyles]);
 
-  useEffect(() => {
-    setRowHeightSelection(
-      convertRowHeightsOptionsToSelection(rowHeightsOptions)
-    );
+  const rowHeightSelection = useMemo(() => {
+    return convertRowHeightsOptionsToSelection(rowHeightsOptions);
   }, [rowHeightsOptions]);
 
   useEffect(() => {

--- a/src/components/datagrid/controls/display_selector.tsx
+++ b/src/components/datagrid/controls/display_selector.tsx
@@ -57,11 +57,11 @@ const densityStyles: { [key: string]: Partial<EuiDataGridStyle> } = {
   },
 };
 const convertGridStylesToSelection = (gridStyles: EuiDataGridStyle) => {
-  if (gridStyles?.fontSize === 's' && gridStyles?.cellPadding === 's')
+  if (gridStyles.fontSize === 's' && gridStyles.cellPadding === 's')
     return 'compact';
-  if (gridStyles?.fontSize === 'm' && gridStyles?.cellPadding === 'm')
+  if (gridStyles.fontSize === 'm' && gridStyles.cellPadding === 'm')
     return 'normal';
-  if (gridStyles?.fontSize === 'l' && gridStyles?.cellPadding === 'l')
+  if (gridStyles.fontSize === 'l' && gridStyles.cellPadding === 'l')
     return 'expanded';
   return '';
 };
@@ -72,23 +72,21 @@ const capitalizeDensityString = (s: string) => s[0].toUpperCase() + s.slice(1);
 // Row height options and utilities
 const rowHeightButtonOptions: string[] = ['undefined', 'auto', 'lineCount'];
 const convertRowHeightsOptionsToSelection = (
-  rowHeightsOptions?: EuiDataGridRowHeightsOptions
+  rowHeightsOptions: EuiDataGridRowHeightsOptions
 ) => {
-  if (rowHeightsOptions) {
-    const { defaultHeight } = rowHeightsOptions;
+  const { defaultHeight } = rowHeightsOptions;
 
-    if (defaultHeight === 'auto') {
-      return rowHeightButtonOptions[1];
-    }
-    if (typeof defaultHeight === 'object' && defaultHeight?.lineCount) {
-      return rowHeightButtonOptions[2];
-    }
-    if (
-      typeof defaultHeight === 'number' ||
-      (typeof defaultHeight === 'object' && defaultHeight.height)
-    ) {
-      return '';
-    }
+  if (defaultHeight === 'auto') {
+    return rowHeightButtonOptions[1];
+  }
+  if (typeof defaultHeight === 'object' && defaultHeight?.lineCount) {
+    return rowHeightButtonOptions[2];
+  }
+  if (
+    typeof defaultHeight === 'number' ||
+    (typeof defaultHeight === 'object' && defaultHeight.height)
+  ) {
+    return '';
   }
   return rowHeightButtonOptions[0];
 };

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -127,7 +127,10 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
   /**
    * Merge consumer settings with defaults
    */
-  const gridStyleWithDefaults = { ...startingStyles, ...gridStyle };
+  const gridStyleWithDefaults = useMemo(
+    () => ({ ...startingStyles, ...gridStyle }),
+    [gridStyle]
+  );
 
   const mergedPopoverContents = useMemo(
     () => ({


### PR DESCRIPTION
## Summary

- closes #5524 (⚠️ see below `Caveat` heading)
- I recommend following along by commit, as there is some tangential cleanup in this PR.

### Before

https://user-images.githubusercontent.com/549407/148836777-79b70e9b-ec9a-46dc-b3ae-b0777a3795f6.mp4

### After

https://user-images.githubusercontent.com/549407/148836555-9c7af405-faaa-4433-a18e-6fd203ab26b1.mp4

### Caveat

Note that this fix only applies to prop changes that occur **before** the user interacts with the display selector. Once the user has chosen their own settings, those user settings will always override any passed props, regardless of whether the props update later. See the below example:

![caveat](https://user-images.githubusercontent.com/549407/148837576-4a90e21d-7aa5-4fcb-a19c-3d5054fdbcce.gif)

## QA

- Go to https://eui.elastic.co/pr_5526/#/tabular-content/data-grid-styling-and-control (first demo)
- Open the display selector, confirm it's set to Compact and Single
- Click the `gridStyle` button and set `fontSize` and `cellPadding` both to large
- [x] Open the display selector again and confirm density is now set to Expanded
- Click the `Set row height to auto` test button
- [x] Open the display selector again and confirm row height is now set to Auto

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**

~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
- [x] Revert docs commit