### PR TITLE
[EuiDataGrid] Fix multiple grid focus restoration issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [`main`](https://github.com/elastic/eui/tree/main)
 
+**Bug fixes**
+
+- Fixed multiple bugs with `EuiDataGrid` keyboard focus restoration ([#5530](https://github.com/elastic/eui/pull/5530))
+
 **Breaking changes**
 
 - Changed `EuiSearchBar` to preserve phrases with leading and trailing spaces, instead of dropping surrounding whitespace ([#5514](https://github.com/elastic/eui/pull/5514))

--- a/src-docs/src/views/datagrid/focus.js
+++ b/src-docs/src/views/datagrid/focus.js
@@ -17,7 +17,7 @@ import {
 
 const data = [];
 
-for (let i = 0; i < 10; i++) {
+for (let i = 0; i < 25; i++) {
   data.push([
     <span>{fake('{{name.firstName}}')}</span>,
     <span>{fake('{{name.firstName}}')}</span>,
@@ -214,7 +214,7 @@ export default () => {
   );
 
   const [pagination, setPagination] = useState({
-    pageSize: 4,
+    pageSize: 20,
     pageIndex: 0,
     pageSizeOptions: [4],
   });
@@ -250,6 +250,7 @@ export default () => {
           onChangeItemsPerPage,
           onChangePage,
         }}
+        height={300}
       />
     </>
   );

--- a/src-docs/src/views/datagrid/focus.js
+++ b/src-docs/src/views/datagrid/focus.js
@@ -17,7 +17,7 @@ import {
 
 const data = [];
 
-for (let i = 0; i < 25; i++) {
+for (let i = 0; i < 10; i++) {
   data.push([
     <span>{fake('{{name.firstName}}')}</span>,
     <span>{fake('{{name.firstName}}')}</span>,
@@ -214,7 +214,7 @@ export default () => {
   );
 
   const [pagination, setPagination] = useState({
-    pageSize: 20,
+    pageSize: 4,
     pageIndex: 0,
     pageSizeOptions: [4],
   });
@@ -250,7 +250,6 @@ export default () => {
           onChangeItemsPerPage,
           onChangePage,
         }}
-        height={300}
       />
     </>
   );

--- a/src/components/datagrid/body/data_grid_body.test.tsx
+++ b/src/components/datagrid/body/data_grid_body.test.tsx
@@ -52,6 +52,7 @@ describe('EuiDataGridBody', () => {
         resetAfterRowIndex: jest.fn(),
       } as any,
     },
+    gridItemsRendered: {} as any,
     wrapperRef: { current: document.createElement('div') },
   };
 

--- a/src/components/datagrid/body/data_grid_body.tsx
+++ b/src/components/datagrid/body/data_grid_body.tsx
@@ -243,6 +243,7 @@ export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
     gridStyles,
     gridWidth,
     gridRef,
+    gridItemsRendered,
     wrapperRef,
   } = props;
 
@@ -442,6 +443,9 @@ export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
       <Grid
         {...(virtualizationOptions ? virtualizationOptions : {})}
         ref={gridRef}
+        onItemsRendered={(itemsRendered) => {
+          gridItemsRendered.current = itemsRendered;
+        }}
         innerElementType={InnerElement}
         outerRef={outerGridRef}
         innerRef={innerGridRef}

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -124,7 +124,7 @@ export class EuiDataGridCell extends Component<
     enableInteractions: false,
     disableCellTabIndex: false,
   };
-  unsubscribeCell?: Function = () => {};
+  unsubscribeCell?: Function;
   focusTimeout: number | undefined;
   style = null;
 
@@ -234,15 +234,20 @@ export class EuiDataGridCell extends Component<
 
     // Account for virtualization - when a cell unmounts when scrolled out of view
     // and then remounts when scrolled back into view, it should retain focus state
-    if (
-      this.context.focusedCell?.[0] === colIndex &&
-      this.context.focusedCell?.[1] === visibleRowIndex
-    ) {
+    if (this.isFocusedCell()) {
       // The second flag sets preventScroll: true as a focus option, which prevents
       // hijacking the user's scroll behavior when the cell re-mounts on scroll
       this.onFocusUpdate(true, true);
+      this.context.setIsFocusedCellInView(true);
     }
   }
+
+  isFocusedCell = () => {
+    return (
+      this.context.focusedCell?.[0] === this.props.colIndex &&
+      this.context.focusedCell?.[1] === this.props.visibleRowIndex
+    );
+  };
 
   onFocusUpdate = (isFocused: boolean, preventScroll = false) => {
     this.setState({ isFocused }, () => {
@@ -256,6 +261,10 @@ export class EuiDataGridCell extends Component<
     window.clearTimeout(this.focusTimeout);
     if (this.unsubscribeCell) {
       this.unsubscribeCell();
+    }
+
+    if (this.isFocusedCell()) {
+      this.context.setIsFocusedCellInView(false);
     }
   }
 

--- a/src/components/datagrid/body/header/column_actions.test.tsx
+++ b/src/components/datagrid/body/header/column_actions.test.tsx
@@ -195,6 +195,10 @@ describe('getColumnActions', () => {
         callActionOnClick(moveRight);
         expect(switchColumnPos).toHaveBeenCalledWith('B', 'C');
         expect(setFocusedCell).toHaveBeenLastCalledWith([2, -1]);
+
+        // Quick note about the -1 row index above: `-1` is the index we set for our
+        // sticky header row, and these column actions can only ever be called by an
+        // interactive header cell, so we can safely and statically set the -1 index
       });
     });
 

--- a/src/components/datagrid/body/header/column_actions.test.tsx
+++ b/src/components/datagrid/body/header/column_actions.test.tsx
@@ -19,6 +19,7 @@ import {
 
 describe('getColumnActions', () => {
   const setVisibleColumns = jest.fn();
+  const focusFirstVisibleInteractiveCell = jest.fn();
   const setIsPopoverOpen = jest.fn();
   const switchColumnPos = jest.fn();
 
@@ -28,6 +29,7 @@ describe('getColumnActions', () => {
     schema: {},
     schemaDetectors,
     setVisibleColumns,
+    focusFirstVisibleInteractiveCell,
     setIsPopoverOpen,
     sorting: undefined,
     switchColumnPos,
@@ -104,9 +106,10 @@ describe('getColumnActions', () => {
           `);
       });
 
-      it('sets column visibility on click', () => {
+      it('hides the current column on click and refocuses into the grid', () => {
         callActionOnClick(hideColumn);
         expect(setVisibleColumns).toHaveBeenCalledWith(['A', 'C']);
+        expect(focusFirstVisibleInteractiveCell).toHaveBeenCalled();
       });
     });
 

--- a/src/components/datagrid/body/header/column_actions.test.tsx
+++ b/src/components/datagrid/body/header/column_actions.test.tsx
@@ -22,6 +22,7 @@ describe('getColumnActions', () => {
   const focusFirstVisibleInteractiveCell = jest.fn();
   const setIsPopoverOpen = jest.fn();
   const switchColumnPos = jest.fn();
+  const setFocusedCell = jest.fn();
 
   const testArgs = {
     column: { id: 'B' },
@@ -33,6 +34,7 @@ describe('getColumnActions', () => {
     setIsPopoverOpen,
     sorting: undefined,
     switchColumnPos,
+    setFocusedCell,
   };
 
   // DRY test helper
@@ -185,12 +187,14 @@ describe('getColumnActions', () => {
           `);
       });
 
-      it('calls switchColumnPos on click', () => {
+      it('calls switchColumnPos and updates the focused cell column index on click', () => {
         callActionOnClick(moveLeft);
         expect(switchColumnPos).toHaveBeenCalledWith('B', 'A');
+        expect(setFocusedCell).toHaveBeenLastCalledWith([0, -1]);
 
         callActionOnClick(moveRight);
         expect(switchColumnPos).toHaveBeenCalledWith('B', 'C');
+        expect(setFocusedCell).toHaveBeenLastCalledWith([2, -1]);
       });
     });
 

--- a/src/components/datagrid/body/header/column_actions.tsx
+++ b/src/components/datagrid/body/header/column_actions.tsx
@@ -13,6 +13,7 @@ import {
   EuiDataGridSchema,
   EuiDataGridSchemaDetector,
   EuiDataGridSorting,
+  DataGridFocusContextShape,
 } from '../../data_grid_types';
 import { EuiI18n } from '../../../i18n';
 import { EuiListGroupItemProps } from '../../../list_group';
@@ -28,6 +29,7 @@ interface GetColumnActions {
   schema: EuiDataGridSchema;
   schemaDetectors: EuiDataGridSchemaDetector[];
   setVisibleColumns: (columnId: string[]) => void;
+  focusFirstVisibleInteractiveCell: DataGridFocusContextShape['focusFirstVisibleInteractiveCell'];
   setIsPopoverOpen: (value: boolean) => void;
   sorting: EuiDataGridSorting | undefined;
   switchColumnPos: (colFromId: string, colToId: string) => void;
@@ -39,6 +41,7 @@ export const getColumnActions = ({
   schema,
   schemaDetectors,
   setVisibleColumns,
+  focusFirstVisibleInteractiveCell,
   setIsPopoverOpen,
   sorting,
   switchColumnPos,
@@ -52,6 +55,7 @@ export const getColumnActions = ({
       column,
       columns,
       setVisibleColumns,
+      focusFirstVisibleInteractiveCell,
     }),
     ...getSortColumnActions({
       column,
@@ -85,20 +89,27 @@ export const getColumnActions = ({
  */
 type HideColumnAction = Pick<
   GetColumnActions,
-  'column' | 'columns' | 'setVisibleColumns'
+  | 'column'
+  | 'columns'
+  | 'setVisibleColumns'
+  | 'focusFirstVisibleInteractiveCell'
 >;
 
 export const getHideColumnAction = ({
   column,
   columns,
   setVisibleColumns,
+  focusFirstVisibleInteractiveCell,
 }: HideColumnAction): EuiListGroupItemProps[] => {
   const items = [];
 
-  const onClickHideColumn = () =>
+  const onClickHideColumn = () => {
     setVisibleColumns(
       columns.filter((col) => col.id !== column.id).map((col) => col.id)
     );
+    // Since we hid the current column, we need to manually set focus back onto the grid
+    focusFirstVisibleInteractiveCell();
+  };
 
   const action = {
     label: (

--- a/src/components/datagrid/body/header/column_actions.tsx
+++ b/src/components/datagrid/body/header/column_actions.tsx
@@ -33,6 +33,7 @@ interface GetColumnActions {
   setIsPopoverOpen: (value: boolean) => void;
   sorting: EuiDataGridSorting | undefined;
   switchColumnPos: (colFromId: string, colToId: string) => void;
+  setFocusedCell: DataGridFocusContextShape['setFocusedCell'];
 }
 
 export const getColumnActions = ({
@@ -45,6 +46,7 @@ export const getColumnActions = ({
   setIsPopoverOpen,
   sorting,
   switchColumnPos,
+  setFocusedCell,
 }: GetColumnActions): EuiListGroupItemProps[] => {
   if (column.actions === false) {
     return [];
@@ -67,6 +69,7 @@ export const getColumnActions = ({
       column,
       columns,
       switchColumnPos,
+      setFocusedCell,
     }),
     ...(column.actions?.additional || []),
   ];
@@ -133,13 +136,14 @@ export const getHideColumnAction = ({
  */
 type MoveColumnActions = Pick<
   GetColumnActions,
-  'column' | 'columns' | 'switchColumnPos'
+  'column' | 'columns' | 'switchColumnPos' | 'setFocusedCell'
 >;
 
 const getMoveColumnActions = ({
   column,
   columns,
   switchColumnPos,
+  setFocusedCell,
 }: MoveColumnActions): EuiListGroupItemProps[] => {
   const items = [];
 
@@ -150,6 +154,7 @@ const getMoveColumnActions = ({
       const targetCol = columns[colIdx - 1];
       if (targetCol) {
         switchColumnPos(column.id, targetCol.id);
+        setFocusedCell([colIdx - 1, -1]);
       }
     };
     const action = {
@@ -169,6 +174,7 @@ const getMoveColumnActions = ({
       const targetCol = columns[colIdx + 1];
       if (targetCol) {
         switchColumnPos(column.id, targetCol.id);
+        setFocusedCell([colIdx + 1, -1]);
       }
     };
     const action = {

--- a/src/components/datagrid/body/header/data_grid_header_cell.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.tsx
@@ -21,6 +21,7 @@ import { EuiIcon } from '../../../icon';
 import { EuiListGroup } from '../../../list_group';
 import { EuiPopover } from '../../../popover';
 import { DataGridSortingContext } from '../../utils/sorting';
+import { DataGridFocusContext } from '../../utils/focus';
 import { EuiDataGridHeaderCellProps } from '../../data_grid_types';
 
 import { getColumnActions } from './column_actions';
@@ -58,6 +59,8 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
   } = {};
   const screenReaderId = useGeneratedHtmlId();
 
+  const { focusFirstVisibleInteractiveCell } = useContext(DataGridFocusContext);
+
   const { sorting } = useContext(DataGridSortingContext);
   let sortString;
   if (sorting) {
@@ -92,6 +95,7 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
     schema,
     schemaDetectors,
     setVisibleColumns,
+    focusFirstVisibleInteractiveCell,
     setIsPopoverOpen,
     sorting,
     switchColumnPos,

--- a/src/components/datagrid/body/header/data_grid_header_cell.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.tsx
@@ -59,7 +59,9 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
   } = {};
   const screenReaderId = useGeneratedHtmlId();
 
-  const { focusFirstVisibleInteractiveCell } = useContext(DataGridFocusContext);
+  const { setFocusedCell, focusFirstVisibleInteractiveCell } = useContext(
+    DataGridFocusContext
+  );
 
   const { sorting } = useContext(DataGridSortingContext);
   let sortString;
@@ -99,6 +101,7 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
     setIsPopoverOpen,
     sorting,
     switchColumnPos,
+    setFocusedCell,
   });
 
   const showColumnActions = columnActions && columnActions.length > 0;

--- a/src/components/datagrid/body/header/data_grid_header_cell_wrapper.test.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell_wrapper.test.tsx
@@ -12,6 +12,7 @@ import { mount } from 'enzyme';
 
 import { keys } from '../../../../services';
 import { DataGridFocusContext } from '../../utils/focus';
+import { mockFocusContext } from '../../utils/__mocks__/focus_context';
 
 import { EuiDataGridHeaderCellWrapper } from './data_grid_header_cell_wrapper';
 
@@ -23,16 +24,12 @@ describe('EuiDataGridHeaderCellWrapper', () => {
     children: <button />,
   };
 
-  const focusContext = {
-    setFocusedCell: jest.fn(),
-    onFocusUpdate: jest.fn(),
-  };
   const mountWithContext = (props = {}, isFocused = true) => {
-    (focusContext.onFocusUpdate as jest.Mock).mockImplementation(
+    (mockFocusContext.onFocusUpdate as jest.Mock).mockImplementation(
       (_, callback) => callback(isFocused) // allows us to mock isFocused state
     );
     return mount(
-      <DataGridFocusContext.Provider value={focusContext}>
+      <DataGridFocusContext.Provider value={mockFocusContext}>
         <EuiDataGridHeaderCellWrapper {...requiredProps} {...props} />
       </DataGridFocusContext.Provider>
     );
@@ -186,7 +183,7 @@ describe('EuiDataGridHeaderCellWrapper', () => {
               act(() => {
                 headerCell.dispatchEvent(new FocusEvent('focusin'));
               });
-              expect(focusContext.setFocusedCell).toHaveBeenCalled();
+              expect(mockFocusContext.setFocusedCell).toHaveBeenCalled();
             });
 
             it('re-enables and focuses cell interactives when already focused', () => {

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -14,7 +14,10 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { VariableSizeGrid as Grid } from 'react-window';
+import {
+  VariableSizeGrid as Grid,
+  GridOnItemsRenderedProps,
+} from 'react-window';
 import { useGeneratedHtmlId, keys } from '../../services';
 import { EuiFocusTrap } from '../focus_trap';
 import { EuiI18n, useEuiI18n } from '../i18n';
@@ -169,6 +172,7 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
   // Imperative handler passed back by react-window - we're setting this at
   // the top datagrid level to make passing it to other children & utils easier
   const gridRef = useRef<Grid | null>(null);
+  const gridItemsRendered = useRef<GridOnItemsRenderedProps | null>(null);
 
   /**
    * Display
@@ -254,9 +258,10 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
   const { headerIsInteractive, handleHeaderMutation } = useHeaderIsInteractive(
     contentRef.current
   );
-  const { focusProps: wrappingDivFocusProps, ...focusContext } = useFocus(
-    headerIsInteractive
-  );
+  const { focusProps: wrappingDivFocusProps, ...focusContext } = useFocus({
+    headerIsInteractive,
+    gridItemsRendered,
+  });
 
   /**
    * Toolbar & full-screen
@@ -437,6 +442,7 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
                 gridStyles={gridStyles}
                 gridWidth={gridWidth}
                 gridRef={gridRef}
+                gridItemsRendered={gridItemsRendered}
                 wrapperRef={contentRef}
               />
             </div>

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -403,6 +403,8 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
                 gridElement: contentRef.current,
                 visibleColCount,
                 visibleRowCount,
+                visibleRowStartIndex:
+                  gridItemsRendered.current?.visibleRowStartIndex || 0,
                 rowCount,
                 pagination,
                 hasFooter: !!renderFooterCellValue,

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -183,6 +183,7 @@ export interface DataGridSortingContextShape {
 export interface DataGridFocusContextShape {
   focusedCell?: EuiDataGridFocusedCell;
   setFocusedCell: (cell: EuiDataGridFocusedCell) => void;
+  setIsFocusedCellInView: (isFocusedCellInView: boolean) => void;
   onFocusUpdate: (
     cell: EuiDataGridFocusedCell,
     updateFocus: Function

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -192,6 +192,7 @@ export interface DataGridFocusContextShape {
     cell: EuiDataGridFocusedCell,
     updateFocus: Function
   ) => () => void;
+  focusFirstVisibleInteractiveCell: () => void;
 }
 
 export type CommonGridProps = CommonProps &

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -19,7 +19,11 @@ import {
   SetStateAction,
   MutableRefObject,
 } from 'react';
-import { VariableSizeGridProps, VariableSizeGrid as Grid } from 'react-window';
+import {
+  VariableSizeGridProps,
+  VariableSizeGrid as Grid,
+  GridOnItemsRenderedProps,
+} from 'react-window';
 import { EuiListGroupItemProps } from '../list_group';
 import { EuiButtonEmpty, EuiButtonIcon } from '../button';
 import { ExclusiveUnion, CommonProps, OneOf } from '../common';
@@ -347,6 +351,7 @@ export interface EuiDataGridBodyProps {
   gridStyles: EuiDataGridStyle;
   gridWidth: number;
   gridRef: MutableRefObject<Grid | null>;
+  gridItemsRendered: MutableRefObject<GridOnItemsRenderedProps | null>;
   wrapperRef: MutableRefObject<HTMLDivElement | null>;
 }
 export interface EuiDataGridCellValueElementProps {

--- a/src/components/datagrid/utils/__mocks__/focus_context.ts
+++ b/src/components/datagrid/utils/__mocks__/focus_context.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export const mockFocusContext = {
+  focusedCell: undefined,
+  onFocusUpdate: jest.fn(),
+  setFocusedCell: jest.fn(),
+  setIsFocusedCellInView: jest.fn(),
+};

--- a/src/components/datagrid/utils/__mocks__/focus_context.ts
+++ b/src/components/datagrid/utils/__mocks__/focus_context.ts
@@ -11,4 +11,5 @@ export const mockFocusContext = {
   onFocusUpdate: jest.fn(),
   setFocusedCell: jest.fn(),
   setIsFocusedCellInView: jest.fn(),
+  focusFirstVisibleInteractiveCell: jest.fn(),
 };

--- a/src/components/datagrid/utils/focus.ts
+++ b/src/components/datagrid/utils/focus.ts
@@ -28,6 +28,7 @@ import {
 export const DataGridFocusContext = createContext<DataGridFocusContextShape>({
   focusedCell: undefined,
   setFocusedCell: () => {},
+  setIsFocusedCellInView: () => {},
   onFocusUpdate: () => () => {},
 });
 
@@ -54,9 +55,15 @@ export const useFocus = (
   );
 
   // Current focused cell
-  const [focusedCell, setFocusedCell] = useState<
+  const [isFocusedCellInView, setIsFocusedCellInView] = useState(false);
+  const [focusedCell, _setFocusedCell] = useState<
     EuiDataGridFocusedCell | undefined
   >(undefined);
+
+  const setFocusedCell = useCallback((focusedCell: EuiDataGridFocusedCell) => {
+    _setFocusedCell(focusedCell);
+    setIsFocusedCellInView(true); // The cell must be in view to focus it
+  }, []);
 
   const previousCell = useRef<EuiDataGridFocusedCell | undefined>(undefined);
   useEffect(() => {
@@ -74,11 +81,9 @@ export const useFocus = (
     }
   }, [cellsUpdateFocus, focusedCell]);
 
-  const hasHadFocus = useMemo(() => focusedCell != null, [focusedCell]);
-
   const focusProps = useMemo<FocusProps>(
     () =>
-      hasHadFocus
+      isFocusedCellInView
         ? {
             // FireFox allows tabbing to a div that is scrollable, while Chrome does not
             tabIndex: -1,
@@ -95,13 +100,14 @@ export const useFocus = (
               }
             },
           },
-    [hasHadFocus, setFocusedCell, headerIsInteractive]
+    [isFocusedCellInView, setFocusedCell, headerIsInteractive]
   );
 
   return {
     onFocusUpdate,
     focusedCell,
     setFocusedCell,
+    setIsFocusedCellInView,
     focusProps,
   };
 };

--- a/src/components/datagrid/utils/focus.ts
+++ b/src/components/datagrid/utils/focus.ts
@@ -89,16 +89,20 @@ export const useFocus = ({
   }, [cellsUpdateFocus, focusedCell]);
 
   const focusFirstVisibleInteractiveCell = useCallback(() => {
-    const {
-      visibleColumnStartIndex,
-      visibleRowStartIndex,
-    } = gridItemsRendered.current!;
+    if (headerIsInteractive) {
+      // The header (rowIndex -1) is sticky and will always be in view
+      setFocusedCell([0, -1]);
+    } else if (gridItemsRendered.current) {
+      const {
+        visibleColumnStartIndex,
+        visibleRowStartIndex,
+      } = gridItemsRendered.current;
 
-    setFocusedCell(
-      headerIsInteractive
-        ? [0, -1]
-        : [visibleColumnStartIndex, visibleRowStartIndex]
-    );
+      setFocusedCell([visibleColumnStartIndex, visibleRowStartIndex]);
+    } else {
+      // If the header is non-interactive and there are no rendered cells,
+      // there's nothing to do - we might as well leave focus on the grid body wrapper
+    }
   }, [setFocusedCell, headerIsInteractive, gridItemsRendered]);
 
   const focusProps = useMemo<FocusProps>(

--- a/src/components/datagrid/utils/focus.ts
+++ b/src/components/datagrid/utils/focus.ts
@@ -32,6 +32,7 @@ export const DataGridFocusContext = createContext<DataGridFocusContextShape>({
   setFocusedCell: () => {},
   setIsFocusedCellInView: () => {},
   onFocusUpdate: () => () => {},
+  focusFirstVisibleInteractiveCell: () => {},
 });
 
 type FocusProps = Pick<HTMLAttributes<HTMLDivElement>, 'tabIndex' | 'onFocus'>;
@@ -127,6 +128,7 @@ export const useFocus = ({
     focusedCell,
     setFocusedCell,
     setIsFocusedCellInView,
+    focusFirstVisibleInteractiveCell,
     focusProps,
   };
 };

--- a/src/components/datagrid/utils/focus.ts
+++ b/src/components/datagrid/utils/focus.ts
@@ -156,6 +156,7 @@ export const createKeyDownHandler = ({
   gridElement,
   visibleColCount,
   visibleRowCount,
+  visibleRowStartIndex,
   rowCount,
   pagination,
   hasFooter,
@@ -165,6 +166,7 @@ export const createKeyDownHandler = ({
   gridElement: HTMLDivElement | null;
   visibleColCount: number;
   visibleRowCount: number;
+  visibleRowStartIndex: number;
   rowCount: EuiDataGridProps['rowCount'];
   pagination: EuiDataGridProps['pagination'];
   hasFooter: boolean;
@@ -187,7 +189,14 @@ export const createKeyDownHandler = ({
     if (key === keys.ARROW_DOWN) {
       event.preventDefault();
       if (hasFooter ? y < visibleRowCount : y < visibleRowCount - 1) {
-        setFocusedCell([x, y + 1]);
+        if (y === -1) {
+          // The header is sticky, so on scrolling virtualized grids, row 0 will not
+          // always be rendered to navigate down to. We need to account for this by
+          // sending the down arrow to the first visible/virtualized row instead
+          setFocusedCell([x, visibleRowStartIndex]);
+        } else {
+          setFocusedCell([x, y + 1]);
+        }
       }
     } else if (key === keys.ARROW_LEFT) {
       event.preventDefault();


### PR DESCRIPTION
## Summary

This PR fixes 3 bugs with EuiDataGrid around restoring correct focus/keyboard navigation to the grid:

### c06db86 and 7f031ac closes https://github.com/elastic/eui/issues/5517

If the user scrolls the currently focused cell out of view (via mouse) and then attempts to tab back into the grid (via keyboard), the grid should intelligently focus into the first visible and interactive cell (instead of the entire grid becoming unfocusable).

https://user-images.githubusercontent.com/549407/149015670-fce2ae61-d8e6-42fe-87e1-1bc72a71cf38.mp4

### d29d938 closes https://github.com/elastic/eui/issues/4923

Problem: If the user hides the current column via the column header's actions popover, the popover cannot focus back into the now-removed cell, and sets the current focus back to the top of the document 
Fix: Focus should be manually set to the grid by targeting its first visible and interactive cell (which is not perfect, but at least does not strand the user and require them tab all the way back to the grid)

https://user-images.githubusercontent.com/549407/149016289-bdc13778-ccc4-4b4c-b97f-31ce4488ee23.mp4

### 8a035de closes https://github.com/elastic/eui/issues/5476

Fixes keyboard focus index being incorrect after moving a column left or right via the header's actions popover.

https://user-images.githubusercontent.com/549407/149016200-732c3e4d-90a7-4e3d-b7ec-3c712ac8c013.mp4

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**

~- [ ] Checked for **breaking changes** and labeled appropriately~

- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
- [x] Revert [REVERT] commit