### PR TITLE
[EuiDataGrid] Add `setIsFullScreen` to ref API

### DIFF
--- a/src-docs/src/views/datagrid/datagrid_ref_example.js
+++ b/src-docs/src/views/datagrid/datagrid_ref_example.js
@@ -14,6 +14,9 @@ const dataGridRefSource = require('!!raw-loader!./ref');
 const dataGridRefSnippet = `const dataGridRef = useRef();
 <EuiDataGrid ref={dataGridRef} {...props} />
 
+// Mnaually toggle the data grid's full screen state
+dataGridRef.current.setIsFullScreen(true);
+
 // Mnaually focus a specific cell within the data grid
 dataGridRef.current.setFocusedCell({ rowIndex, colIndex });
 `;
@@ -37,6 +40,13 @@ export const DataGridRefExample = {
             the <EuiCode>ref</EuiCode> prop of EuiDataGrid. These methods are:
           </p>
           <ul>
+            <li>
+              <p>
+                <EuiCode>setIsFullScreen(isFullScreen)</EuiCode> - controls the
+                full screen state of the data grid. Accepts a true/false boolean
+                flag.
+              </p>
+            </li>
             <li>
               <EuiCode>setFocusedCell({'{ rowIndex, colIndex }'})</EuiCode> -
               focuses the specified cell in the grid.

--- a/src-docs/src/views/datagrid/ref.js
+++ b/src-docs/src/views/datagrid/ref.js
@@ -148,6 +148,14 @@ export default () => {
             Set cell focus
           </EuiButton>
         </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiButton
+            size="s"
+            onClick={() => dataGridRef.current.setIsFullScreen(true)}
+          >
+            Set grid to full screen
+          </EuiButton>
+        </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer />
 

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -2744,6 +2744,7 @@ describe('EuiDataGrid', () => {
     );
 
     expect(gridRef.current).toEqual({
+      setIsFullScreen: expect.any(Function),
       setFocusedCell: expect.any(Function),
     });
   });

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -290,6 +290,7 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
     useImperativeHandle(
       ref,
       () => ({
+        setIsFullScreen,
         setFocusedCell: ({ rowIndex, colIndex }) => {
           focusContext.setFocusedCell([colIndex, rowIndex]);
         },

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -285,6 +285,10 @@ export type EuiDataGridProps = OneOf<
 
 export interface EuiDataGridRefProps {
   /**
+   * Allows manually controlling the full-screen state of the grid.
+   */
+  setIsFullScreen: (isFullScreen: boolean) => void;
+  /**
    * Allows manually focusing the specified cell in the grid.
    *
    * Using this method is an accessibility requirement if your EuiDataGrid


### PR DESCRIPTION
### Summary

See https://github.com/elastic/eui/issues/5126 (NB: will not close this until the feature branch is merged into main)

This PR exposes our `setIsFullScreen` state to our new forwarded imperative ref API.

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~

- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**

~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**

~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~

NB: Skipping the changelog for now since this will eventually go into a feature branch, will revisit when feature branch is ready to merge to main
