### PR TITLE
[EuiDataGrid] Add `openCellPopover` and `closeCellPopover` to ref APIs

### DIFF
--- a/src-docs/src/views/datagrid/datagrid_ref_example.js
+++ b/src-docs/src/views/datagrid/datagrid_ref_example.js
@@ -1,12 +1,7 @@
 import React from 'react';
 
 import { GuideSectionTypes } from '../../components';
-import {
-  EuiCode,
-  EuiCodeBlock,
-  EuiSpacer,
-  EuiCallOut,
-} from '../../../../src/components';
+import { EuiCode, EuiSpacer, EuiCallOut } from '../../../../src/components';
 
 import { EuiDataGridRefProps } from '!!prop-loader!../../../../src/components/datagrid/data_grid_types';
 import DataGridRef from './ref';
@@ -19,6 +14,12 @@ dataGridRef.current.setIsFullScreen(true);
 
 // Mnaually focus a specific cell within the data grid
 dataGridRef.current.setFocusedCell({ rowIndex, colIndex });
+
+// Manually opens the popover of a specified cell within the data grid
+dataGridRef.current.openCellPopover({ rowIndex, colIndex });
+
+// Close any open cell popover
+dataGridRef.current.closeCellPopover();
 `;
 
 export const DataGridRefExample = {
@@ -59,9 +60,21 @@ export const DataGridRefExample = {
                 Your modal or flyout should restore focus into the grid on close
                 to prevent keyboard or screen reader users from being stranded.
               </EuiCallOut>
+              <EuiSpacer size="m" />
+            </li>
+            <li>
+              <p>
+                <EuiCode>openCellPopover({'{ rowIndex, colIndex }'})</EuiCode> -
+                opens the specified cell&apos;s popover contents.
+              </p>
+            </li>
+            <li>
+              <p>
+                <EuiCode>closeCellPopover()</EuiCode> - closes any currently
+                open cell popover.
+              </p>
             </li>
           </ul>
-          <EuiCodeBlock language="jsx">{dataGridRefSnippet}</EuiCodeBlock>
           <p>
             The below example shows how to use the internal APIs for a data grid
             that opens a modal via cell actions.

--- a/src-docs/src/views/datagrid/ref.js
+++ b/src-docs/src/views/datagrid/ref.js
@@ -42,6 +42,7 @@ export default () => {
 
   const showModal = useCallback(({ rowIndex, colIndex }) => {
     setIsModalVisible(true);
+    dataGridRef.current.closeCellPopover(); // Close any open cell popovers
     setLastFocusedCell({ rowIndex, colIndex }); // Store the cell that opened this modal
   }, []);
 
@@ -112,8 +113,8 @@ export default () => {
 
   return (
     <>
-      <EuiFlexGroup alignItems="flexEnd" gutterSize="s" style={{ width: 500 }}>
-        <EuiFlexItem>
+      <EuiFlexGroup alignItems="flexEnd" gutterSize="s">
+        <EuiFlexItem grow={false} style={{ width: '80px' }}>
           <EuiFormRow label="Row index">
             <EuiFieldNumber
               min={0}
@@ -124,7 +125,7 @@ export default () => {
             />
           </EuiFormRow>
         </EuiFlexItem>
-        <EuiFlexItem>
+        <EuiFlexItem grow={false} style={{ width: '80px' }}>
           <EuiFormRow label="Column index">
             <EuiFieldNumber
               min={0}
@@ -135,7 +136,7 @@ export default () => {
             />
           </EuiFormRow>
         </EuiFlexItem>
-        <EuiFlexItem>
+        <EuiFlexItem grow={false}>
           <EuiButton
             size="s"
             onClick={() =>
@@ -148,7 +149,20 @@ export default () => {
             Set cell focus
           </EuiButton>
         </EuiFlexItem>
-        <EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            size="s"
+            onClick={() =>
+              dataGridRef.current.openCellPopover({
+                rowIndex: rowIndexAction,
+                colIndex: colIndexAction,
+              })
+            }
+          >
+            Open cell popover
+          </EuiButton>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
           <EuiButton
             size="s"
             onClick={() => dataGridRef.current.setIsFullScreen(true)}

--- a/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
@@ -16,6 +16,8 @@ exports[`EuiDataGridCell renders 1`] = `
       },
       "openCellPopover": [MockFunction],
       "popoverIsOpen": false,
+      "setPopoverAnchor": [MockFunction],
+      "setPopoverContent": [MockFunction],
     }
   }
   renderCellValue={[Function]}

--- a/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
@@ -7,6 +7,17 @@ exports[`EuiDataGridCell renders 1`] = `
   interactiveCellId="someId"
   isExpandable={true}
   popoverContent={[Function]}
+  popoverContext={
+    Object {
+      "closeCellPopover": [MockFunction],
+      "openCellLocation": Object {
+        "colIndex": 0,
+        "rowIndex": 0,
+      },
+      "openCellPopover": [MockFunction],
+      "popoverIsOpen": false,
+    }
+  }
   renderCellValue={[Function]}
   rowHeightUtils={
     Object {

--- a/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
@@ -9,11 +9,11 @@ exports[`EuiDataGridCell renders 1`] = `
   popoverContent={[Function]}
   popoverContext={
     Object {
-      "closeCellPopover": [MockFunction],
-      "openCellLocation": Object {
+      "cellLocation": Object {
         "colIndex": 0,
         "rowIndex": 0,
       },
+      "closeCellPopover": [MockFunction],
       "openCellPopover": [MockFunction],
       "popoverIsOpen": false,
       "setPopoverAnchor": [MockFunction],

--- a/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
@@ -167,3 +167,37 @@ exports[`EuiDataGridCell renders 1`] = `
   </div>
 </EuiDataGridCell>
 `;
+
+exports[`EuiDataGridCell componentDidUpdate handles the cell popover by forwarding the cell's DOM node and contents to the parent popover context 1`] = `
+Array [
+  <div
+    data-test-subj="popover-test"
+  >
+    <div>
+      <button
+        data-datagrid-interactable="true"
+      >
+        hello
+      </button>
+      <button
+        data-datagrid-interactable="true"
+      >
+        world
+      </button>
+    </div>
+  </div>,
+  <div
+    class="euiPopoverFooter"
+  >
+    <div
+      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
+    >
+      <div
+        class="euiFlexItem"
+      >
+        <button />
+      </div>
+    </div>
+  </div>,
+]
+`;

--- a/src/components/datagrid/body/data_grid_body.tsx
+++ b/src/components/datagrid/body/data_grid_body.tsx
@@ -28,6 +28,7 @@ import { EuiDataGridCell } from './data_grid_cell';
 import { EuiDataGridFooterRow } from './data_grid_footer_row';
 import { EuiDataGridHeaderRow } from './header';
 import { DefaultColumnFormatter } from './popover_utils';
+import { DataGridCellPopoverContext } from './data_grid_cell_popover';
 import {
   EuiDataGridBodyProps,
   EuiDataGridRowManager,
@@ -70,6 +71,7 @@ export const Cell: FunctionComponent<GridChildComponentProps> = ({
     rowHeightUtils,
     rowManager,
   } = data;
+  const popoverContext = useContext(DataGridCellPopoverContext);
   const { headerRowHeight } = useContext(DataGridWrapperRowsContext);
   const { getCorrectRowIndex } = useContext(DataGridSortingContext);
 
@@ -118,7 +120,8 @@ export const Cell: FunctionComponent<GridChildComponentProps> = ({
     rowHeightsOptions,
     rowHeightUtils,
     setRowHeight: isFirstColumn ? setRowHeight : undefined,
-    rowManager: rowManager,
+    rowManager,
+    popoverContext,
   };
 
   if (isLeadingControlColumn) {

--- a/src/components/datagrid/body/data_grid_cell.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell.test.tsx
@@ -293,6 +293,21 @@ describe('EuiDataGridCell', () => {
         false
       );
     });
+
+    it('closes the popover if open and the user scrolls out of view', () => {
+      const component = mount(
+        <EuiDataGridCell
+          {...requiredProps}
+          popoverContext={{
+            ...mockPopoverContext,
+            popoverIsOpen: true,
+          }}
+        />
+      );
+      component.unmount();
+
+      expect(mockPopoverContext.closeCellPopover).toHaveBeenCalled();
+    });
   });
 
   describe('isFocusedCell', () => {

--- a/src/components/datagrid/body/data_grid_cell.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { mount, ReactWrapper } from 'enzyme';
+import { mount, render, ReactWrapper } from 'enzyme';
 import { keys } from '../../../services';
 import { mockRowHeightUtils } from '../utils/__mocks__/row_heights';
 import { mockFocusContext } from '../utils/__mocks__/focus_context';
@@ -37,7 +37,9 @@ describe('EuiDataGridCell', () => {
         <button data-datagrid-interactable="true">world</button>
       </div>
     ),
-    popoverContent: () => <div>popover</div>,
+    popoverContent: ({ children }: { children: React.ReactNode }) => (
+      <div data-test-subj="popover-test">{children}</div>
+    ),
     popoverContext: mockPopoverContext,
     rowHeightUtils: mockRowHeightUtils,
   };
@@ -190,7 +192,12 @@ describe('EuiDataGridCell', () => {
     });
 
     it("handles the cell popover by forwarding the cell's DOM node and contents to the parent popover context", () => {
-      const component = mount(<EuiDataGridCell {...requiredProps} />);
+      const component = mount(
+        <EuiDataGridCell
+          {...requiredProps}
+          column={{ id: 'someColumn', cellActions: [() => <button />] }}
+        />
+      );
       expect(mockPopoverContext.setPopoverAnchor).not.toHaveBeenCalled();
       expect(mockPopoverContext.setPopoverContent).not.toHaveBeenCalled();
 
@@ -199,6 +206,12 @@ describe('EuiDataGridCell', () => {
       });
       expect(mockPopoverContext.setPopoverAnchor).toHaveBeenCalled();
       expect(mockPopoverContext.setPopoverContent).toHaveBeenCalled();
+
+      // Examine popover content which should contain popoverContent, renderCellValue, and cellActions
+      const popoverContent = render(
+        <>{mockPopoverContext.setPopoverContent.mock.calls[0][0]}</>
+      );
+      expect(popoverContent).toMatchSnapshot();
     });
   });
 

--- a/src/components/datagrid/body/data_grid_cell.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell.test.tsx
@@ -21,6 +21,8 @@ describe('EuiDataGridCell', () => {
     openCellLocation: { rowIndex: 0, colIndex: 0 },
     closeCellPopover: jest.fn(),
     openCellPopover: jest.fn(),
+    setPopoverAnchor: jest.fn(),
+    setPopoverContent: jest.fn(),
   };
   const requiredProps = {
     rowIndex: 0,
@@ -129,6 +131,19 @@ describe('EuiDataGridCell', () => {
         it('popoverContent', () => {
           component.setProps({ popoverContent: () => <div>test</div> });
         });
+        it('popoverContext.popoverIsOpen', () => {
+          component.setProps({
+            popoverContext: { ...mockPopoverContext, popoverIsOpen: true },
+          });
+        });
+        it('popoverContext.openCellLocation', () => {
+          component.setProps({
+            popoverContext: {
+              ...mockPopoverContext,
+              openCellLocation: { rowIndex: 5, colIndex: 5 },
+            },
+          });
+        });
         it('style', () => {
           component.setProps({ style: {} });
           component.setProps({ style: { top: 0 } });
@@ -173,6 +188,18 @@ describe('EuiDataGridCell', () => {
       component.setProps({ columnId: 'newColumnId' });
       expect(setState).toHaveBeenCalledWith({ cellProps: {} });
     });
+
+    it("handles the cell popover by forwarding the cell's DOM node and contents to the parent popover context", () => {
+      const component = mount(<EuiDataGridCell {...requiredProps} />);
+      expect(mockPopoverContext.setPopoverAnchor).not.toHaveBeenCalled();
+      expect(mockPopoverContext.setPopoverContent).not.toHaveBeenCalled();
+
+      component.setProps({
+        popoverContext: { ...mockPopoverContext, popoverIsOpen: true },
+      });
+      expect(mockPopoverContext.setPopoverAnchor).toHaveBeenCalled();
+      expect(mockPopoverContext.setPopoverContent).toHaveBeenCalled();
+    });
   });
 
   describe('componentDidMount', () => {
@@ -205,6 +232,18 @@ describe('EuiDataGridCell', () => {
       expect(mockFocusContext.setIsFocusedCellInView).toHaveBeenCalledWith(
         true
       );
+    });
+
+    it('handles the cell popover if the current cell should have an open popover', () => {
+      mount(
+        <EuiDataGridCell
+          {...requiredProps}
+          popoverContext={{ ...mockPopoverContext, popoverIsOpen: true }}
+        />
+      );
+
+      expect(mockPopoverContext.setPopoverAnchor).toHaveBeenCalled();
+      expect(mockPopoverContext.setPopoverContent).toHaveBeenCalled();
     });
   });
 

--- a/src/components/datagrid/body/data_grid_cell.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell.test.tsx
@@ -16,6 +16,12 @@ import { DataGridFocusContext } from '../utils/focus';
 import { EuiDataGridCell } from './data_grid_cell';
 
 describe('EuiDataGridCell', () => {
+  const mockPopoverContext = {
+    popoverIsOpen: false,
+    openCellLocation: { rowIndex: 0, colIndex: 0 },
+    closeCellPopover: jest.fn(),
+    openCellPopover: jest.fn(),
+  };
   const requiredProps = {
     rowIndex: 0,
     visibleRowIndex: 0,
@@ -30,6 +36,7 @@ describe('EuiDataGridCell', () => {
       </div>
     ),
     popoverContent: () => <div>popover</div>,
+    popoverContext: mockPopoverContext,
     rowHeightUtils: mockRowHeightUtils,
   };
 

--- a/src/components/datagrid/body/data_grid_cell.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell.test.tsx
@@ -380,12 +380,11 @@ describe('EuiDataGridCell', () => {
       expect((component.instance() as any).isPopoverOpen()).toEqual(false);
     });
 
-    it('returns false if the cell is not expandable, and sets popover state to closed', () => {
+    it('returns false if the cell is not expandable', () => {
       const component = mount(
         <EuiDataGridCell {...props} isExpandable={false} />
       );
       expect((component.instance() as any).isPopoverOpen()).toEqual(false);
-      expect(mockPopoverContext.closeCellPopover).toHaveBeenCalled();
     });
   });
 

--- a/src/components/datagrid/body/data_grid_cell.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell.test.tsx
@@ -18,7 +18,7 @@ import { EuiDataGridCell } from './data_grid_cell';
 describe('EuiDataGridCell', () => {
   const mockPopoverContext = {
     popoverIsOpen: false,
-    openCellLocation: { rowIndex: 0, colIndex: 0 },
+    cellLocation: { rowIndex: 0, colIndex: 0 },
     closeCellPopover: jest.fn(),
     openCellPopover: jest.fn(),
     setPopoverAnchor: jest.fn(),
@@ -138,11 +138,11 @@ describe('EuiDataGridCell', () => {
             popoverContext: { ...mockPopoverContext, popoverIsOpen: true },
           });
         });
-        it('popoverContext.openCellLocation', () => {
+        it('popoverContext.cellLocation', () => {
           component.setProps({
             popoverContext: {
               ...mockPopoverContext,
-              openCellLocation: { rowIndex: 5, colIndex: 5 },
+              cellLocation: { rowIndex: 5, colIndex: 5 },
             },
           });
         });
@@ -350,7 +350,7 @@ describe('EuiDataGridCell', () => {
       popoverContext: {
         ...mockPopoverContext,
         popoverIsOpen: true,
-        openCellLocation: { colIndex: 1, rowIndex: 2 },
+        cellLocation: { colIndex: 1, rowIndex: 2 },
       },
       colIndex: 1,
       visibleRowIndex: 2,
@@ -373,7 +373,7 @@ describe('EuiDataGridCell', () => {
       expect((component.instance() as any).isPopoverOpen()).toEqual(false);
     });
 
-    it("returns false if popoverContext.openCellLocation does not match the cell's colIndex and visibleRowIndex", () => {
+    it("returns false if popoverContext.cellLocation does not match the cell's colIndex and visibleRowIndex", () => {
       const component = mount(
         <EuiDataGridCell {...props} colIndex={3} visibleRowIndex={4} />
       );

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -271,6 +271,10 @@ export class EuiDataGridCell extends Component<
     if (this.isFocusedCell()) {
       this.context.setIsFocusedCellInView(false);
     }
+
+    if (this.isPopoverOpen()) {
+      this.props.popoverContext.closeCellPopover();
+    }
   }
 
   componentDidUpdate(prevProps: EuiDataGridCellProps) {

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -290,8 +290,8 @@ export class EuiDataGridCell extends Component<
     if (
       this.props.popoverContext.popoverIsOpen !==
         prevProps.popoverContext.popoverIsOpen ||
-      this.props.popoverContext.openCellLocation !==
-        prevProps.popoverContext.openCellLocation
+      this.props.popoverContext.cellLocation !==
+        prevProps.popoverContext.cellLocation
     ) {
       this.handleCellPopover();
     }
@@ -320,8 +320,8 @@ export class EuiDataGridCell extends Component<
     if (
       nextProps.popoverContext.popoverIsOpen !==
         this.props.popoverContext.popoverIsOpen ||
-      nextProps.popoverContext.openCellLocation !==
-        this.props.popoverContext.openCellLocation
+      nextProps.popoverContext.cellLocation !==
+        this.props.popoverContext.cellLocation
     )
       return true;
 
@@ -421,12 +421,12 @@ export class EuiDataGridCell extends Component<
 
   isPopoverOpen = () => {
     const { isExpandable, popoverContext } = this.props;
-    const { popoverIsOpen, openCellLocation } = popoverContext;
+    const { popoverIsOpen, cellLocation } = popoverContext;
 
     if (
       popoverIsOpen &&
-      openCellLocation.colIndex === this.props.colIndex &&
-      openCellLocation.rowIndex === this.props.visibleRowIndex
+      cellLocation.colIndex === this.props.colIndex &&
+      cellLocation.rowIndex === this.props.visibleRowIndex
     ) {
       if (isExpandable) {
         return true;

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -423,21 +423,12 @@ export class EuiDataGridCell extends Component<
     const { isExpandable, popoverContext } = this.props;
     const { popoverIsOpen, cellLocation } = popoverContext;
 
-    if (
+    return (
+      isExpandable &&
       popoverIsOpen &&
       cellLocation.colIndex === this.props.colIndex &&
       cellLocation.rowIndex === this.props.visibleRowIndex
-    ) {
-      if (isExpandable) {
-        return true;
-      } else {
-        // If `openCellPopover` was somehow called on this cell but it's not
-        // supposed to be expandable, we should do nothing and set popoverIsOpen
-        // state back to false
-        popoverContext.closeCellPopover();
-      }
-    }
-    return false;
+    );
   };
 
   handleCellPopover = () => {

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -239,6 +239,10 @@ export class EuiDataGridCell extends Component<
       this.onFocusUpdate(true, true);
       this.context.setIsFocusedCellInView(true);
     }
+
+    // Check if popover should be open on mount (typically only occurs if
+    // openCellPopover() is manually called on a location that's out of view)
+    this.handleCellPopover();
   }
 
   isFocusedCell = () => {
@@ -277,6 +281,15 @@ export class EuiDataGridCell extends Component<
       this.recalculateLineHeight();
     }
 
+    if (
+      this.props.popoverContext.popoverIsOpen !==
+        prevProps.popoverContext.popoverIsOpen ||
+      this.props.popoverContext.openCellLocation !==
+        prevProps.popoverContext.openCellLocation
+    ) {
+      this.handleCellPopover();
+    }
+
     if (this.props.columnId !== prevProps.columnId) {
       this.setCellProps({});
     }
@@ -298,6 +311,13 @@ export class EuiDataGridCell extends Component<
     if (nextProps.interactiveCellId !== this.props.interactiveCellId)
       return true;
     if (nextProps.popoverContent !== this.props.popoverContent) return true;
+    if (
+      nextProps.popoverContext.popoverIsOpen !==
+        this.props.popoverContext.popoverIsOpen ||
+      nextProps.popoverContext.openCellLocation !==
+        this.props.popoverContext.openCellLocation
+    )
+      return true;
 
     // respond to adjusted position & dimensions
     if (nextProps.style) {
@@ -412,6 +432,22 @@ export class EuiDataGridCell extends Component<
       }
     }
     return false;
+  };
+
+  handleCellPopover = () => {
+    if (this.isPopoverOpen()) {
+      const { setPopoverAnchor, setPopoverContent } = this.props.popoverContext;
+
+      // Set popover anchor
+      const cellAnchorEl = this.cellRef.current!.querySelector<HTMLDivElement>(
+        '.euiDataGridRowCell__expandFlex' // Anchor class
+      )!;
+      setPopoverAnchor(cellAnchorEl);
+
+      // Set popover contents with cell content
+      const popoverContent = <>TODO, testing</>;
+      setPopoverContent(popoverContent);
+    }
   };
 
   render() {

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -404,6 +404,7 @@ export class EuiDataGridCell extends Component<
       width,
       isExpandable,
       popoverContent: PopoverContent,
+      popoverContext,
       interactiveCellId,
       columnType,
       className,

--- a/src/components/datagrid/body/data_grid_cell_buttons.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_buttons.test.tsx
@@ -9,7 +9,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { EuiDataGridCellButtons } from './data_grid_cell_buttons';
+import {
+  EuiDataGridCellButtons,
+  EuiDataGridCellPopoverButtons,
+} from './data_grid_cell_buttons';
 
 describe('EuiDataGridCellButtons', () => {
   const requiredProps = {
@@ -52,7 +55,7 @@ describe('EuiDataGridCellButtons', () => {
     `);
   });
 
-  it('renders column cell actions', () => {
+  it('renders column cell actions as `EuiButtonIcon`s', () => {
     const component = shallow(
       <EuiDataGridCellButtons
         {...requiredProps}
@@ -92,5 +95,61 @@ describe('EuiDataGridCellButtons', () => {
         iconType="eye"
       />
     `);
+  });
+});
+
+describe('EuiDataGridCellPopoverButtons', () => {
+  it('renders column cell actions as `EuiButtonEmpty`s', () => {
+    const component = shallow(
+      <EuiDataGridCellPopoverButtons
+        colIndex={0}
+        rowIndex={0}
+        column={{ id: 'someId', cellActions: [() => <button />] }}
+      />
+    );
+
+    expect(component).toMatchInlineSnapshot(`
+      <EuiPopoverFooter>
+        <EuiFlexGroup
+          gutterSize="s"
+        >
+          <EuiFlexItem
+            key="0"
+          >
+            <Component
+              Component={[Function]}
+              colIndex={0}
+              columnId="someId"
+              isExpanded={true}
+              rowIndex={0}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPopoverFooter>
+    `);
+
+    const button = component
+      .childAt(0)
+      .childAt(0)
+      .childAt(0) // .find('Component') doesn't work, for whatever reason
+      .renderProp('Component');
+    expect(button({ iconType: 'function' })).toMatchInlineSnapshot(`
+      <EuiButtonEmpty
+        iconType="function"
+        size="s"
+      />
+    `);
+  });
+
+  it('does not render anything if the column has no cell actions', () => {
+    const component = shallow(
+      <EuiDataGridCellPopoverButtons
+        colIndex={0}
+        rowIndex={0}
+        column={{ id: 'noActions' }}
+      />
+    );
+
+    expect(component.isEmptyRender()).toBe(true);
   });
 });

--- a/src/components/datagrid/body/data_grid_cell_buttons.tsx
+++ b/src/components/datagrid/body/data_grid_cell_buttons.tsx
@@ -5,6 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+
 import React, { JSXElementConstructor, useMemo } from 'react';
 import {
   EuiDataGridColumn,
@@ -12,8 +13,12 @@ import {
   EuiDataGridColumnCellActionProps,
 } from '../data_grid_types';
 import classNames from 'classnames';
+
 import { EuiI18n } from '../../i18n';
 import { EuiButtonIcon, EuiButtonIconProps } from '../../button/button_icon';
+import { EuiButtonEmpty, EuiButtonEmptyProps } from '../../button/button_empty';
+import { EuiFlexGroup, EuiFlexItem } from '../../flex';
+import { EuiPopoverFooter } from '../../popover';
 
 export const EuiDataGridCellButtons = ({
   popoverIsOpen,
@@ -90,5 +95,44 @@ export const EuiDataGridCellButtons = ({
 
   return (
     <div className={buttonClasses}>{[...additionalButtons, expandButton]}</div>
+  );
+};
+
+export const EuiDataGridCellPopoverButtons = ({
+  rowIndex,
+  colIndex,
+  column,
+}: {
+  column?: EuiDataGridColumn;
+  colIndex: number;
+  rowIndex: number;
+}) => {
+  if (!column?.cellActions?.length) return null;
+
+  return (
+    <EuiPopoverFooter>
+      <EuiFlexGroup gutterSize="s">
+        {column.cellActions.map(
+          (Action: EuiDataGridColumnCellAction, idx: number) => {
+            const CellButtonElement = Action as JSXElementConstructor<
+              EuiDataGridColumnCellActionProps
+            >;
+            return (
+              <EuiFlexItem key={idx}>
+                <CellButtonElement
+                  rowIndex={rowIndex}
+                  colIndex={colIndex}
+                  columnId={column.id}
+                  Component={(props: EuiButtonEmptyProps) => (
+                    <EuiButtonEmpty {...props} size="s" />
+                  )}
+                  isExpanded={true}
+                />
+              </EuiFlexItem>
+            );
+          }
+        )}
+      </EuiFlexGroup>
+    </EuiPopoverFooter>
   );
 };

--- a/src/components/datagrid/body/data_grid_cell_popover.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.test.tsx
@@ -7,10 +7,49 @@
  */
 
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import { shallow } from 'enzyme';
 import { keys } from '../../../services';
+import { testCustomHook } from '../../../test';
 
-import { EuiDataGridCellPopover } from './data_grid_cell_popover';
+import {
+  useCellPopover,
+  EuiDataGridCellPopover,
+} from './data_grid_cell_popover';
+
+describe('useCellPopover', () => {
+  describe('openCellPopover', () => {
+    it('sets popoverIsOpen state to true', () => {
+      const {
+        return: { cellPopoverContext },
+        getUpdatedState,
+      } = testCustomHook(() => useCellPopover());
+      expect(cellPopoverContext.popoverIsOpen).toEqual(false);
+
+      act(() =>
+        cellPopoverContext.openCellPopover({ rowIndex: 0, colIndex: 0 })
+      );
+      expect(getUpdatedState().cellPopoverContext.popoverIsOpen).toEqual(true);
+    });
+  });
+
+  describe('closeCellPopover', () => {
+    it('sets popoverIsOpen state to false', () => {
+      const {
+        return: { cellPopoverContext },
+        getUpdatedState,
+      } = testCustomHook(() => useCellPopover());
+
+      act(() =>
+        cellPopoverContext.openCellPopover({ rowIndex: 0, colIndex: 0 })
+      );
+      expect(getUpdatedState().cellPopoverContext.popoverIsOpen).toEqual(true);
+
+      act(() => cellPopoverContext.closeCellPopover());
+      expect(getUpdatedState().cellPopoverContext.popoverIsOpen).toEqual(false);
+    });
+  });
+});
 
 describe('EuiDataGridCellPopover', () => {
   const requiredProps = {

--- a/src/components/datagrid/body/data_grid_cell_popover.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.test.tsx
@@ -29,6 +29,28 @@ describe('useCellPopover', () => {
       );
       expect(getUpdatedState().cellPopoverContext.popoverIsOpen).toEqual(true);
     });
+
+    it('does nothing if called again on a popover that is already open', () => {
+      const {
+        return: { cellPopoverContext, cellPopover },
+        getUpdatedState,
+      } = testCustomHook(() => useCellPopover());
+      expect(cellPopover).toBeFalsy();
+
+      act(() => {
+        cellPopoverContext.openCellPopover({ rowIndex: 0, colIndex: 0 });
+        cellPopoverContext.setPopoverAnchor(document.createElement('div'));
+      });
+      expect(getUpdatedState().cellPopover).not.toBeFalsy();
+
+      act(() => {
+        getUpdatedState().cellPopoverContext.openCellPopover({
+          rowIndex: 0,
+          colIndex: 0,
+        });
+      });
+      expect(getUpdatedState().cellPopover).not.toBeFalsy();
+    });
   });
 
   describe('closeCellPopover', () => {

--- a/src/components/datagrid/body/data_grid_cell_popover.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.tsx
@@ -5,17 +5,61 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import React, { JSXElementConstructor } from 'react';
+
+import React, {
+  createContext,
+  useState,
+  useCallback,
+  JSXElementConstructor,
+} from 'react';
 import { keys } from '../../../services';
 import { EuiButtonEmpty, EuiButtonEmptyProps } from '../../button/button_empty';
 import { EuiFlexGroup, EuiFlexItem } from '../../flex';
 import { EuiPopover, EuiPopoverFooter } from '../../popover';
 import {
+  DataGridCellPopoverContextShape,
   EuiDataGridCellPopoverProps,
   EuiDataGridCellValueElementProps,
   EuiDataGridColumnCellAction,
   EuiDataGridColumnCellActionProps,
 } from '../data_grid_types';
+
+export const DataGridCellPopoverContext = createContext<
+  DataGridCellPopoverContextShape
+>({
+  popoverIsOpen: false,
+  openCellLocation: { rowIndex: 0, colIndex: 0 },
+  openCellPopover: () => {},
+  closeCellPopover: () => {},
+});
+
+export const useCellPopover = (): {
+  cellPopoverContext: DataGridCellPopoverContextShape;
+} => {
+  // Current open state & cell location are handled here
+  const [popoverIsOpen, setPopoverIsOpen] = useState(false);
+  const [openCellLocation, setOpenCellLocation] = useState({
+    rowIndex: 0,
+    colIndex: 0,
+  });
+
+  const closeCellPopover = useCallback(() => setPopoverIsOpen(false), []);
+  const openCellPopover = useCallback(({ rowIndex, colIndex }) => {
+    // TODO: Popover anchor & content
+
+    setOpenCellLocation({ rowIndex, colIndex });
+    setPopoverIsOpen(true);
+  }, []);
+
+  const cellPopoverContext = {
+    popoverIsOpen,
+    closeCellPopover,
+    openCellPopover,
+    openCellLocation,
+  };
+
+  return { cellPopoverContext };
+};
 
 export function EuiDataGridCellPopover({
   anchorContent,

--- a/src/components/datagrid/body/data_grid_cell_popover.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.tsx
@@ -31,6 +31,8 @@ export const DataGridCellPopoverContext = createContext<
   openCellLocation: { rowIndex: 0, colIndex: 0 },
   openCellPopover: () => {},
   closeCellPopover: () => {},
+  setPopoverAnchor: () => {},
+  setPopoverContent: () => {},
 });
 
 export const useCellPopover = (): {
@@ -42,11 +44,14 @@ export const useCellPopover = (): {
     rowIndex: 0,
     colIndex: 0,
   });
+  // Popover anchor & content are passed by individual `EuiDataGridCell`s
+  const [popoverAnchor, setPopoverAnchor] = useState<HTMLElement | null>(null);
+  const [popoverContent, setPopoverContent] = useState<ReactNode>();
 
   const closeCellPopover = useCallback(() => setPopoverIsOpen(false), []);
   const openCellPopover = useCallback(({ rowIndex, colIndex }) => {
-    // TODO: Popover anchor & content
-
+    // Toggle our open cell state, which causes EuiDataGridCells to react/check
+    // if they should be the open popover and send their anchor+content if so
     setOpenCellLocation({ rowIndex, colIndex });
     setPopoverIsOpen(true);
   }, []);
@@ -56,6 +61,8 @@ export const useCellPopover = (): {
     closeCellPopover,
     openCellPopover,
     openCellLocation,
+    setPopoverAnchor,
+    setPopoverContent,
   };
 
   return { cellPopoverContext };

--- a/src/components/datagrid/body/data_grid_cell_popover.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.tsx
@@ -16,7 +16,7 @@ export const DataGridCellPopoverContext = createContext<
   DataGridCellPopoverContextShape
 >({
   popoverIsOpen: false,
-  openCellLocation: { rowIndex: 0, colIndex: 0 },
+  cellLocation: { rowIndex: 0, colIndex: 0 },
   openCellPopover: () => {},
   closeCellPopover: () => {},
   setPopoverAnchor: () => {},
@@ -29,7 +29,7 @@ export const useCellPopover = (): {
 } => {
   // Current open state & cell location are handled here
   const [popoverIsOpen, setPopoverIsOpen] = useState(false);
-  const [openCellLocation, setOpenCellLocation] = useState({
+  const [cellLocation, setCellLocation] = useState({
     rowIndex: 0,
     colIndex: 0,
   });
@@ -43,8 +43,8 @@ export const useCellPopover = (): {
       // Prevent popover DOM issues when re-opening the same popover
       if (
         popoverIsOpen &&
-        rowIndex === openCellLocation.rowIndex &&
-        colIndex === openCellLocation.colIndex
+        rowIndex === cellLocation.rowIndex &&
+        colIndex === cellLocation.colIndex
       ) {
         return;
       }
@@ -52,17 +52,17 @@ export const useCellPopover = (): {
       // Toggle our open cell state, which causes EuiDataGridCells to react/check
       // if they should be the open popover and send their anchor+content if so
       setPopoverAnchor(null); // Resetting the anchor node is required for rerendering to work correctly
-      setOpenCellLocation({ rowIndex, colIndex });
+      setCellLocation({ rowIndex, colIndex });
       setPopoverIsOpen(true);
     },
-    [popoverIsOpen, openCellLocation]
+    [popoverIsOpen, cellLocation]
   );
 
   const cellPopoverContext = {
     popoverIsOpen,
     closeCellPopover,
     openCellPopover,
-    openCellLocation,
+    cellLocation,
     setPopoverAnchor,
     setPopoverContent,
   };

--- a/src/components/datagrid/body/data_grid_cell_popover.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.tsx
@@ -38,12 +38,25 @@ export const useCellPopover = (): {
   const [popoverContent, setPopoverContent] = useState<ReactNode>();
 
   const closeCellPopover = useCallback(() => setPopoverIsOpen(false), []);
-  const openCellPopover = useCallback(({ rowIndex, colIndex }) => {
-    // Toggle our open cell state, which causes EuiDataGridCells to react/check
-    // if they should be the open popover and send their anchor+content if so
-    setOpenCellLocation({ rowIndex, colIndex });
-    setPopoverIsOpen(true);
-  }, []);
+  const openCellPopover = useCallback(
+    ({ rowIndex, colIndex }) => {
+      // Prevent popover DOM issues when re-opening the same popover
+      if (
+        popoverIsOpen &&
+        rowIndex === openCellLocation.rowIndex &&
+        colIndex === openCellLocation.colIndex
+      ) {
+        return;
+      }
+
+      // Toggle our open cell state, which causes EuiDataGridCells to react/check
+      // if they should be the open popover and send their anchor+content if so
+      setPopoverAnchor(null); // Resetting the anchor node is required for rerendering to work correctly
+      setOpenCellLocation({ rowIndex, colIndex });
+      setPopoverIsOpen(true);
+    },
+    [popoverIsOpen, openCellLocation]
+  );
 
   const cellPopoverContext = {
     popoverIsOpen,

--- a/src/components/datagrid/body/data_grid_footer_row.test.tsx
+++ b/src/components/datagrid/body/data_grid_footer_row.test.tsx
@@ -44,11 +44,11 @@ describe('EuiDataGridFooterRow', () => {
           popoverContent={[Function]}
           popoverContext={
             Object {
-              "closeCellPopover": [Function],
-              "openCellLocation": Object {
+              "cellLocation": Object {
                 "colIndex": 0,
                 "rowIndex": 0,
               },
+              "closeCellPopover": [Function],
               "openCellPopover": [Function],
               "popoverIsOpen": false,
               "setPopoverAnchor": [Function],
@@ -71,11 +71,11 @@ describe('EuiDataGridFooterRow', () => {
           popoverContent={[Function]}
           popoverContext={
             Object {
-              "closeCellPopover": [Function],
-              "openCellLocation": Object {
+              "cellLocation": Object {
                 "colIndex": 0,
                 "rowIndex": 0,
               },
+              "closeCellPopover": [Function],
               "openCellPopover": [Function],
               "popoverIsOpen": false,
               "setPopoverAnchor": [Function],
@@ -122,11 +122,11 @@ describe('EuiDataGridFooterRow', () => {
           popoverContent={[Function]}
           popoverContext={
             Object {
-              "closeCellPopover": [Function],
-              "openCellLocation": Object {
+              "cellLocation": Object {
                 "colIndex": 0,
                 "rowIndex": 0,
               },
+              "closeCellPopover": [Function],
               "openCellPopover": [Function],
               "popoverIsOpen": false,
               "setPopoverAnchor": [Function],
@@ -179,11 +179,11 @@ describe('EuiDataGridFooterRow', () => {
           popoverContent={[Function]}
           popoverContext={
             Object {
-              "closeCellPopover": [Function],
-              "openCellLocation": Object {
+              "cellLocation": Object {
                 "colIndex": 0,
                 "rowIndex": 0,
               },
+              "closeCellPopover": [Function],
               "openCellPopover": [Function],
               "popoverIsOpen": false,
               "setPopoverAnchor": [Function],

--- a/src/components/datagrid/body/data_grid_footer_row.test.tsx
+++ b/src/components/datagrid/body/data_grid_footer_row.test.tsx
@@ -42,6 +42,17 @@ describe('EuiDataGridFooterRow', () => {
           isExpandable={true}
           key="someColumn-10"
           popoverContent={[Function]}
+          popoverContext={
+            Object {
+              "closeCellPopover": [Function],
+              "openCellLocation": Object {
+                "colIndex": 0,
+                "rowIndex": 0,
+              },
+              "openCellPopover": [Function],
+              "popoverIsOpen": false,
+            }
+          }
           renderCellValue={[Function]}
           rowIndex={10}
           visibleRowIndex={10}
@@ -56,6 +67,17 @@ describe('EuiDataGridFooterRow', () => {
           isExpandable={true}
           key="someColumnWithoutSchema-10"
           popoverContent={[Function]}
+          popoverContext={
+            Object {
+              "closeCellPopover": [Function],
+              "openCellLocation": Object {
+                "colIndex": 0,
+                "rowIndex": 0,
+              },
+              "openCellPopover": [Function],
+              "popoverIsOpen": false,
+            }
+          }
           renderCellValue={[Function]}
           rowIndex={10}
           visibleRowIndex={10}
@@ -94,6 +116,17 @@ describe('EuiDataGridFooterRow', () => {
           isExpandable={true}
           key="someLeadingColumn-10"
           popoverContent={[Function]}
+          popoverContext={
+            Object {
+              "closeCellPopover": [Function],
+              "openCellLocation": Object {
+                "colIndex": 0,
+                "rowIndex": 0,
+              },
+              "openCellPopover": [Function],
+              "popoverIsOpen": false,
+            }
+          }
           renderCellValue={[Function]}
           rowIndex={10}
           visibleRowIndex={10}
@@ -138,6 +171,17 @@ describe('EuiDataGridFooterRow', () => {
           isExpandable={true}
           key="someTrailingColumn-10"
           popoverContent={[Function]}
+          popoverContext={
+            Object {
+              "closeCellPopover": [Function],
+              "openCellLocation": Object {
+                "colIndex": 0,
+                "rowIndex": 0,
+              },
+              "openCellPopover": [Function],
+              "popoverIsOpen": false,
+            }
+          }
           renderCellValue={[Function]}
           rowIndex={10}
           visibleRowIndex={10}

--- a/src/components/datagrid/body/data_grid_footer_row.test.tsx
+++ b/src/components/datagrid/body/data_grid_footer_row.test.tsx
@@ -51,6 +51,8 @@ describe('EuiDataGridFooterRow', () => {
               },
               "openCellPopover": [Function],
               "popoverIsOpen": false,
+              "setPopoverAnchor": [Function],
+              "setPopoverContent": [Function],
             }
           }
           renderCellValue={[Function]}
@@ -76,6 +78,8 @@ describe('EuiDataGridFooterRow', () => {
               },
               "openCellPopover": [Function],
               "popoverIsOpen": false,
+              "setPopoverAnchor": [Function],
+              "setPopoverContent": [Function],
             }
           }
           renderCellValue={[Function]}
@@ -125,6 +129,8 @@ describe('EuiDataGridFooterRow', () => {
               },
               "openCellPopover": [Function],
               "popoverIsOpen": false,
+              "setPopoverAnchor": [Function],
+              "setPopoverContent": [Function],
             }
           }
           renderCellValue={[Function]}
@@ -180,6 +186,8 @@ describe('EuiDataGridFooterRow', () => {
               },
               "openCellPopover": [Function],
               "popoverIsOpen": false,
+              "setPopoverAnchor": [Function],
+              "setPopoverContent": [Function],
             }
           }
           renderCellValue={[Function]}

--- a/src/components/datagrid/body/data_grid_footer_row.tsx
+++ b/src/components/datagrid/body/data_grid_footer_row.tsx
@@ -7,8 +7,9 @@
  */
 
 import classnames from 'classnames';
-import React, { forwardRef, memo } from 'react';
+import React, { forwardRef, memo, useContext } from 'react';
 import { EuiDataGridCell } from './data_grid_cell';
+import { DataGridCellPopoverContext } from './data_grid_cell_popover';
 import { DefaultColumnFormatter } from './popover_utils';
 import { EuiDataGridFooterRowProps } from '../data_grid_types';
 
@@ -44,11 +45,13 @@ const EuiDataGridFooterRow = memo(
         _dataTestSubj
       );
 
+      const popoverContext = useContext(DataGridCellPopoverContext);
       const sharedCellProps = {
         rowIndex,
         visibleRowIndex,
         interactiveCellId,
         isExpandable: true,
+        popoverContext,
       };
 
       return (

--- a/src/components/datagrid/controls/display_selector.test.tsx
+++ b/src/components/datagrid/controls/display_selector.test.tsx
@@ -420,7 +420,9 @@ describe('useDataGridDisplaySelector', () => {
   describe('gridStyles', () => {
     it('returns an object of grid styles with user overrides', () => {
       const initialStyles = { ...startingStyles, stripes: true };
-      const [, gridStyles] = testCustomHook(() =>
+      const {
+        return: [, gridStyles],
+      } = testCustomHook(() =>
         useDataGridDisplaySelector(true, initialStyles, {})
       );
 

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -2762,6 +2762,8 @@ describe('EuiDataGrid', () => {
     expect(gridRef.current).toEqual({
       setIsFullScreen: expect.any(Function),
       setFocusedCell: expect.any(Function),
+      openCellPopover: expect.any(Function),
+      closeCellPopover: expect.any(Function),
     });
   });
 });

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -19,6 +19,14 @@ import { EuiDataGridColumnResizer } from './body/header/data_grid_column_resizer
 import { keys } from '../../services';
 import { act } from 'react-dom/test-utils';
 
+// Mock the cell popover (TODO: Move failing tests to Cypress and remove need for mock?)
+jest.mock('../popover', () => ({
+  ...jest.requireActual('../popover'),
+  EuiWrappingPopover: ({ children }: { children: React.ReactNode }) => (
+    <div data-test-subj="euiDataGridExpansionPopover">{children}</div>
+  ),
+}));
+
 function getFocusableCell(component: ReactWrapper) {
   return findTestSubject(component, 'dataGridRowCell').find('[tabIndex=0]');
 }

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -304,17 +304,20 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
     /**
      * Expose internal APIs as ref to consumer
      */
+    const { setFocusedCell } = focusContext; // eslint complains about the dependency array otherwise
+    const { openCellPopover, closeCellPopover } = cellPopoverContext;
+
     useImperativeHandle(
       ref,
       () => ({
         setIsFullScreen,
         setFocusedCell: ({ rowIndex, colIndex }) => {
-          focusContext.setFocusedCell([colIndex, rowIndex]);
+          setFocusedCell([colIndex, rowIndex]); // Transmog args from obj to array
         },
-        openCellPopover: cellPopoverContext.openCellPopover,
-        closeCellPopover: cellPopoverContext.closeCellPopover,
+        openCellPopover,
+        closeCellPopover,
       }),
-      [focusContext, cellPopoverContext]
+      [setFocusedCell, openCellPopover, closeCellPopover]
     );
 
     /**

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -280,7 +280,7 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
     /**
      * Cell popover
      */
-    const { cellPopoverContext } = useCellPopover();
+    const { cellPopoverContext, cellPopover } = useCellPopover();
 
     /**
      * Toolbar & full-screen
@@ -509,6 +509,7 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
               </div>
             </EuiFocusTrap>
           </DataGridSortingContext.Provider>
+          {cellPopover}
         </DataGridCellPopoverContext.Provider>
       </DataGridFocusContext.Provider>
     );

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -45,6 +45,10 @@ import {
   EuiDataGridInMemoryRenderer,
 } from './utils/in_memory';
 import { useHeaderIsInteractive } from './body/header/header_is_interactive';
+import {
+  DataGridCellPopoverContext,
+  useCellPopover,
+} from './body/data_grid_cell_popover';
 import { providedPopoverContents } from './body/popover_utils';
 import { computeVisibleRows } from './utils/row_count';
 import { EuiDataGridPaginationRenderer } from './utils/data_grid_pagination';
@@ -274,6 +278,11 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
     });
 
     /**
+     * Cell popover
+     */
+    const { cellPopoverContext } = useCellPopover();
+
+    /**
      * Toolbar & full-screen
      */
     const showToolbar = !!toolbarVisibility;
@@ -302,8 +311,10 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
         setFocusedCell: ({ rowIndex, colIndex }) => {
           focusContext.setFocusedCell([colIndex, rowIndex]);
         },
+        openCellPopover: cellPopoverContext.openCellPopover,
+        closeCellPopover: cellPopoverContext.closeCellPopover,
       }),
-      [focusContext]
+      [focusContext, cellPopoverContext]
     );
 
     /**
@@ -381,122 +392,124 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
 
     return (
       <DataGridFocusContext.Provider value={focusContext}>
-        <DataGridSortingContext.Provider value={sortingContext}>
-          <EuiFocusTrap
-            disabled={!isFullScreen}
-            className="euiDataGrid__focusWrap"
-          >
-            <div
-              className={classes}
-              onKeyDown={handleGridKeyDown}
-              style={isFullScreen ? undefined : { width, height }}
-              ref={resizeRef}
-              {...rest}
+        <DataGridCellPopoverContext.Provider value={cellPopoverContext}>
+          <DataGridSortingContext.Provider value={sortingContext}>
+            <EuiFocusTrap
+              disabled={!isFullScreen}
+              className="euiDataGrid__focusWrap"
             >
-              {showToolbar && (
-                <EuiDataGridToolbar
-                  setRef={setToolbarRef}
-                  gridWidth={gridWidth}
-                  minSizeForControls={minSizeForControls}
-                  toolbarVisibility={toolbarVisibility}
-                  displaySelector={displaySelector}
-                  isFullScreen={isFullScreen}
-                  setIsFullScreen={setIsFullScreen}
-                  controlBtnClasses={controlBtnClasses}
-                  columnSelector={columnSelector}
-                  columnSorting={columnSorting}
-                />
-              )}
-              {inMemory ? (
-                <EuiDataGridInMemoryRenderer
-                  inMemory={inMemory}
-                  renderCellValue={renderCellValue}
-                  columns={columns}
-                  rowCount={
-                    inMemory.level === 'enhancements'
-                      ? // if `inMemory.level === enhancements` then we can only be sure the pagination's pageSize is available in memory
-                        pagination?.pageSize || rowCount
-                      : // otherwise, all of the data is present and usable
-                        rowCount
-                  }
-                  onCellRender={onCellRender}
-                />
-              ) : null}
-              <div // eslint-disable-line jsx-a11y/interactive-supports-focus
-                ref={contentRef}
-                onKeyDown={createKeyDownHandler({
-                  gridElement: contentRef.current,
-                  visibleColCount,
-                  visibleRowCount,
-                  visibleRowStartIndex:
-                    gridItemsRendered.current?.visibleRowStartIndex || 0,
-                  rowCount,
-                  pagination,
-                  hasFooter: !!renderFooterCellValue,
-                  headerIsInteractive,
-                  focusContext,
-                })}
-                data-test-subj="euiDataGridBody"
-                className="euiDataGrid__content"
-                role="grid"
-                id={gridId}
-                {...wrappingDivFocusProps} // re: above jsx-a11y - tabIndex is handled by these props, but the linter isn't smart enough to know that
-                {...gridAriaProps}
+              <div
+                className={classes}
+                onKeyDown={handleGridKeyDown}
+                style={isFullScreen ? undefined : { width, height }}
+                ref={resizeRef}
+                {...rest}
               >
-                <EuiDataGridBody
-                  isFullScreen={isFullScreen}
-                  columns={orderedVisibleColumns}
-                  visibleColCount={visibleColCount}
-                  toolbarHeight={toolbarHeight}
-                  leadingControlColumns={leadingControlColumns}
-                  schema={mergedSchema}
-                  trailingControlColumns={trailingControlColumns}
-                  setVisibleColumns={setVisibleColumns}
-                  switchColumnPos={switchColumnPos}
-                  onColumnResize={onColumnResize}
-                  headerIsInteractive={headerIsInteractive}
-                  handleHeaderMutation={handleHeaderMutation}
-                  schemaDetectors={allSchemaDetectors}
-                  popoverContents={mergedPopoverContents}
-                  pagination={pagination}
-                  renderCellValue={renderCellValue}
-                  renderFooterCellValue={renderFooterCellValue}
-                  rowCount={rowCount}
-                  visibleRows={visibleRows}
-                  interactiveCellId={interactiveCellId}
-                  rowHeightsOptions={rowHeightsOptions}
-                  virtualizationOptions={virtualizationOptions || {}}
-                  gridStyles={gridStyles}
-                  gridWidth={gridWidth}
-                  gridRef={gridRef}
-                  gridItemsRendered={gridItemsRendered}
-                  wrapperRef={contentRef}
-                />
-              </div>
-              {pagination && props['aria-labelledby'] && (
-                <p id={ariaLabelledById} hidden>
-                  {ariaLabelledBy}
+                {showToolbar && (
+                  <EuiDataGridToolbar
+                    setRef={setToolbarRef}
+                    gridWidth={gridWidth}
+                    minSizeForControls={minSizeForControls}
+                    toolbarVisibility={toolbarVisibility}
+                    displaySelector={displaySelector}
+                    isFullScreen={isFullScreen}
+                    setIsFullScreen={setIsFullScreen}
+                    controlBtnClasses={controlBtnClasses}
+                    columnSelector={columnSelector}
+                    columnSorting={columnSorting}
+                  />
+                )}
+                {inMemory ? (
+                  <EuiDataGridInMemoryRenderer
+                    inMemory={inMemory}
+                    renderCellValue={renderCellValue}
+                    columns={columns}
+                    rowCount={
+                      inMemory.level === 'enhancements'
+                        ? // if `inMemory.level === enhancements` then we can only be sure the pagination's pageSize is available in memory
+                          pagination?.pageSize || rowCount
+                        : // otherwise, all of the data is present and usable
+                          rowCount
+                    }
+                    onCellRender={onCellRender}
+                  />
+                ) : null}
+                <div // eslint-disable-line jsx-a11y/interactive-supports-focus
+                  ref={contentRef}
+                  onKeyDown={createKeyDownHandler({
+                    gridElement: contentRef.current,
+                    visibleColCount,
+                    visibleRowCount,
+                    visibleRowStartIndex:
+                      gridItemsRendered.current?.visibleRowStartIndex || 0,
+                    rowCount,
+                    pagination,
+                    hasFooter: !!renderFooterCellValue,
+                    headerIsInteractive,
+                    focusContext,
+                  })}
+                  data-test-subj="euiDataGridBody"
+                  className="euiDataGrid__content"
+                  role="grid"
+                  id={gridId}
+                  {...wrappingDivFocusProps} // re: above jsx-a11y - tabIndex is handled by these props, but the linter isn't smart enough to know that
+                  {...gridAriaProps}
+                >
+                  <EuiDataGridBody
+                    isFullScreen={isFullScreen}
+                    columns={orderedVisibleColumns}
+                    visibleColCount={visibleColCount}
+                    toolbarHeight={toolbarHeight}
+                    leadingControlColumns={leadingControlColumns}
+                    schema={mergedSchema}
+                    trailingControlColumns={trailingControlColumns}
+                    setVisibleColumns={setVisibleColumns}
+                    switchColumnPos={switchColumnPos}
+                    onColumnResize={onColumnResize}
+                    headerIsInteractive={headerIsInteractive}
+                    handleHeaderMutation={handleHeaderMutation}
+                    schemaDetectors={allSchemaDetectors}
+                    popoverContents={mergedPopoverContents}
+                    pagination={pagination}
+                    renderCellValue={renderCellValue}
+                    renderFooterCellValue={renderFooterCellValue}
+                    rowCount={rowCount}
+                    visibleRows={visibleRows}
+                    interactiveCellId={interactiveCellId}
+                    rowHeightsOptions={rowHeightsOptions}
+                    virtualizationOptions={virtualizationOptions || {}}
+                    gridStyles={gridStyles}
+                    gridWidth={gridWidth}
+                    gridRef={gridRef}
+                    gridItemsRendered={gridItemsRendered}
+                    wrapperRef={contentRef}
+                  />
+                </div>
+                {pagination && props['aria-labelledby'] && (
+                  <p id={ariaLabelledById} hidden>
+                    {ariaLabelledBy}
+                  </p>
+                )}
+                {pagination && (
+                  <EuiDataGridPaginationRenderer
+                    {...pagination}
+                    rowCount={rowCount}
+                    controls={gridId}
+                    aria-label={props['aria-label']}
+                    gridRef={gridRef}
+                  />
+                )}
+                <p id={interactiveCellId} hidden>
+                  <EuiI18n
+                    token="euiDataGrid.screenReaderNotice"
+                    default="Cell contains interactive content."
+                  />
+                  {/* TODO: if no keyboard shortcuts panel gets built, add keyboard shortcut info here */}
                 </p>
-              )}
-              {pagination && (
-                <EuiDataGridPaginationRenderer
-                  {...pagination}
-                  rowCount={rowCount}
-                  controls={gridId}
-                  aria-label={props['aria-label']}
-                  gridRef={gridRef}
-                />
-              )}
-              <p id={interactiveCellId} hidden>
-                <EuiI18n
-                  token="euiDataGrid.screenReaderNotice"
-                  default="Cell contains interactive content."
-                />
-                {/* TODO: if no keyboard shortcuts panel gets built, add keyboard shortcut info here */}
-              </p>
-            </div>
-          </EuiFocusTrap>
-        </DataGridSortingContext.Provider>
+              </div>
+            </EuiFocusTrap>
+          </DataGridSortingContext.Provider>
+        </DataGridCellPopoverContext.Provider>
       </DataGridFocusContext.Provider>
     );
   }

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -195,6 +195,13 @@ export interface DataGridFocusContextShape {
   focusFirstVisibleInteractiveCell: () => void;
 }
 
+export interface DataGridCellPopoverContextShape {
+  popoverIsOpen: boolean;
+  closeCellPopover(): void;
+  openCellPopover(args: { rowIndex: number; colIndex: number }): void;
+  openCellLocation: { rowIndex: number; colIndex: number };
+}
+
 export type CommonGridProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {
     /**
@@ -301,10 +308,16 @@ export interface EuiDataGridRefProps {
    * toggles a modal or flyout - focus must be restored to the grid on close
    * to prevent keyboard or screen reader users from being stranded.
    */
-  setFocusedCell(targetCell: EuiDataGridCellLocation): void;
+  setFocusedCell: (cell: { rowIndex: number; colIndex: number }) => void;
+  /**
+   * Allows manually opening the popover of the specified cell in the grid.
+   */
+  openCellPopover: (cell: { rowIndex: number; colIndex: number }) => void;
+  /**
+   * Closes any currently open popovers in the data grid.
+   */
+  closeCellPopover: () => void;
 }
-
-export type EuiDataGridCellLocation = { rowIndex: number; colIndex: number };
 
 export interface EuiDataGridColumnResizerProps {
   columnId: string;

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -200,6 +200,8 @@ export interface DataGridCellPopoverContextShape {
   closeCellPopover(): void;
   openCellPopover(args: { rowIndex: number; colIndex: number }): void;
   openCellLocation: { rowIndex: number; colIndex: number };
+  setPopoverAnchor(anchor: HTMLElement): void;
+  setPopoverContent(content: ReactNode): void;
 }
 
 export type CommonGridProps = CommonProps &

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -442,7 +442,6 @@ export interface EuiDataGridCellProps {
 
 export interface EuiDataGridCellState {
   cellProps: CommonProps & HTMLAttributes<HTMLDivElement>;
-  popoverIsOpen: boolean; // is expansion popover open
   isFocused: boolean; // tracks if this cell has focus or not, used to enable tabIndex on the cell
   isEntered: boolean; // enables focus trap for non-expandable cells with multiple interactive elements
   enableInteractions: boolean; // cell got hovered at least once, so cell button and popover interactions are rendered

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -197,9 +197,9 @@ export interface DataGridFocusContextShape {
 
 export interface DataGridCellPopoverContextShape {
   popoverIsOpen: boolean;
-  closeCellPopover(): void;
+  cellLocation: { rowIndex: number; colIndex: number };
   openCellPopover(args: { rowIndex: number; colIndex: number }): void;
-  openCellLocation: { rowIndex: number; colIndex: number };
+  closeCellPopover(): void;
   setPopoverAnchor(anchor: HTMLElement): void;
   setPopoverContent(content: ReactNode): void;
 }

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -332,21 +332,6 @@ export interface EuiDataGridColumnResizerState {
   offset: number;
 }
 
-export interface EuiDataGridCellPopoverProps {
-  anchorContent: NonNullable<ReactNode>;
-  cellContentProps: EuiDataGridCellValueElementProps;
-  cellContentsRef: HTMLDivElement | null;
-  closePopover: () => void;
-  column?: EuiDataGridColumn;
-  panelRefFn: RefCallback<HTMLElement | null>;
-  popoverIsOpen: boolean;
-  popoverContent: EuiDataGridPopoverContent;
-  renderCellValue:
-    | JSXElementConstructor<EuiDataGridCellValueElementProps>
-    | ((props: EuiDataGridCellValueElementProps) => ReactNode);
-  rowIndex: number;
-  colIndex: number;
-}
 export interface EuiDataGridColumnSortingDraggableProps {
   id: string;
   direction: string;
@@ -581,7 +566,7 @@ export interface EuiDataGridColumnCellActionProps {
    * Closes the popover if a cell is expanded.
    * The prop is provided for an expanded cell only.
    */
-  closePopover: () => void;
+  closePopover?: () => void;
 }
 
 export interface EuiDataGridColumnVisibility {

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -428,6 +428,7 @@ export interface EuiDataGridCellProps {
   isExpandable: boolean;
   className?: string;
   popoverContent: EuiDataGridPopoverContent;
+  popoverContext: DataGridCellPopoverContextShape;
   renderCellValue:
     | JSXElementConstructor<EuiDataGridCellValueElementProps>
     | ((props: EuiDataGridCellValueElementProps) => ReactNode);
@@ -450,7 +451,11 @@ export interface EuiDataGridCellState {
 
 export type EuiDataGridCellValueProps = Omit<
   EuiDataGridCellProps,
-  'width' | 'interactiveCellId' | 'popoverContent' | 'rowManager'
+  | 'width'
+  | 'interactiveCellId'
+  | 'popoverContent'
+  | 'popoverContext'
+  | 'rowManager'
 >;
 export interface EuiDataGridControlColumn {
   /**

--- a/src/components/datagrid/utils/scrolling.spec.tsx
+++ b/src/components/datagrid/utils/scrolling.spec.tsx
@@ -6,8 +6,9 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
+import React, { createRef } from 'react';
 import { EuiDataGrid, EuiDataGridProps } from '../';
+import { EuiDataGridRefProps } from '../data_grid_types';
 
 const baseProps: EuiDataGridProps = {
   'aria-label': 'useScroll test',
@@ -31,7 +32,7 @@ const baseProps: EuiDataGridProps = {
 };
 
 describe('useScroll', () => {
-  describe('on cell focus', () => {
+  describe('cell focus', () => {
     it('fully scrolls cells into view (accounting for sticky headers, rows, and scrollbars)', () => {
       cy.realMount(<EuiDataGrid {...baseProps} />);
       cy.repeatRealPress('Tab', 3);
@@ -56,6 +57,36 @@ describe('useScroll', () => {
       cy.focused()
         .should('have.attr', 'data-gridcell-column-index', '0')
         .should('have.attr', 'data-gridcell-visible-row-index', '0');
+    });
+
+    it('handles setFocusedCell being called manually on cells out of view', () => {
+      const ref = createRef<EuiDataGridRefProps>();
+      cy.mount(<EuiDataGrid {...baseProps} ref={ref} />);
+
+      // Wait for the grid to finish rendering and pass back the ref
+      cy.get('[data-test-subj="euiDataGridBody"]').then(() => {
+        ref.current.setFocusedCell({ rowIndex: 14, colIndex: 5 });
+        cy.focused()
+          .should('have.attr', 'data-gridcell-visible-row-index', '14')
+          .should('have.attr', 'data-gridcell-column-index', '5');
+      });
+    });
+  });
+
+  describe('cell popover', () => {
+    it('handles openCellPopover being called manually on cells out of view', () => {
+      const ref = createRef<EuiDataGridRefProps>();
+      cy.mount(<EuiDataGrid {...baseProps} ref={ref} />);
+
+      // Wait for the grid to finish rendering and pass back the ref
+      cy.get('[data-test-subj="euiDataGridBody"]').then(() => {
+        ref.current.openCellPopover({ rowIndex: 14, colIndex: 5 });
+        cy.focused().should(
+          'have.attr',
+          'data-test-subj',
+          'euiDataGridExpansionPopover'
+        );
+      });
     });
   });
 });

--- a/src/components/datagrid/utils/scrolling.test.ts
+++ b/src/components/datagrid/utils/scrolling.test.ts
@@ -56,7 +56,9 @@ describe('useScrollCellIntoView', () => {
   });
 
   it('does nothing if the grid references are unavailable', () => {
-    const { scrollCellIntoView } = testCustomHook(() =>
+    const {
+      return: { scrollCellIntoView },
+    } = testCustomHook(() =>
       useScrollCellIntoView({
         ...args,
         gridRef: { current: null },
@@ -78,7 +80,9 @@ describe('useScrollCellIntoView', () => {
       offsetWidth: 500,
     };
 
-    const { scrollCellIntoView } = testCustomHook(() =>
+    const {
+      return: { scrollCellIntoView },
+    } = testCustomHook(() =>
       useScrollCellIntoView({
         ...args,
         outerGridRef: {
@@ -95,9 +99,9 @@ describe('useScrollCellIntoView', () => {
 
   it('calls scrollToItem if the specified cell is not virtualized', async () => {
     getCell.mockReturnValue(null);
-    const { scrollCellIntoView } = testCustomHook(() =>
-      useScrollCellIntoView(args)
-    );
+    const {
+      return: { scrollCellIntoView },
+    } = testCustomHook(() => useScrollCellIntoView(args));
     await scrollCellIntoView({ rowIndex: 20, colIndex: 5 });
     expect(scrollToItem).toHaveBeenCalledWith({ columnIndex: 5, rowIndex: 20 });
   });
@@ -108,9 +112,9 @@ describe('useScrollCellIntoView', () => {
       offsetTop: 50,
       offsetLeft: 50,
     });
-    const { scrollCellIntoView } = testCustomHook(() =>
-      useScrollCellIntoView(args)
-    );
+    const {
+      return: { scrollCellIntoView },
+    } = testCustomHook(() => useScrollCellIntoView(args));
     scrollCellIntoView({ rowIndex: 1, colIndex: 1 });
 
     expect(scrollToItem).not.toHaveBeenCalled();
@@ -130,7 +134,9 @@ describe('useScrollCellIntoView', () => {
       };
 
       getCell.mockReturnValue(cell);
-      const { scrollCellIntoView } = testCustomHook(() =>
+      const {
+        return: { scrollCellIntoView },
+      } = testCustomHook(() =>
         useScrollCellIntoView({
           ...args,
           outerGridRef: { current: { ...args.outerGridRef.current, ...grid } },
@@ -154,7 +160,9 @@ describe('useScrollCellIntoView', () => {
       };
 
       getCell.mockReturnValue(cell);
-      const { scrollCellIntoView } = testCustomHook(() =>
+      const {
+        return: { scrollCellIntoView },
+      } = testCustomHook(() =>
         useScrollCellIntoView({
           ...args,
           outerGridRef: { current: { ...args.outerGridRef.current, ...grid } },
@@ -177,7 +185,9 @@ describe('useScrollCellIntoView', () => {
       };
 
       getCell.mockReturnValue(cell);
-      const { scrollCellIntoView } = testCustomHook(() =>
+      const {
+        return: { scrollCellIntoView },
+      } = testCustomHook(() =>
         useScrollCellIntoView({
           ...args,
           outerGridRef: { current: { ...args.outerGridRef.current, ...grid } },
@@ -202,7 +212,9 @@ describe('useScrollCellIntoView', () => {
 
     it('scrolls the grid down if the bottom side of the cell is out of view', () => {
       getCell.mockReturnValue(cell);
-      const { scrollCellIntoView } = testCustomHook(() =>
+      const {
+        return: { scrollCellIntoView },
+      } = testCustomHook(() =>
         useScrollCellIntoView({
           ...args,
           outerGridRef: { current: { ...args.outerGridRef.current, ...grid } },
@@ -214,7 +226,9 @@ describe('useScrollCellIntoView', () => {
 
     it('accounts for the sticky bottom footer if present', () => {
       getCell.mockReturnValue(cell);
-      const { scrollCellIntoView } = testCustomHook(() =>
+      const {
+        return: { scrollCellIntoView },
+      } = testCustomHook(() =>
         useScrollCellIntoView({
           ...args,
           outerGridRef: { current: { ...args.outerGridRef.current, ...grid } },
@@ -228,7 +242,9 @@ describe('useScrollCellIntoView', () => {
 
     it('makes no vertical adjustments if the cell is a sticky header cell', () => {
       getCell.mockReturnValue(cell);
-      const { scrollCellIntoView } = testCustomHook(() =>
+      const {
+        return: { scrollCellIntoView },
+      } = testCustomHook(() =>
         useScrollCellIntoView({
           ...args,
           outerGridRef: { current: { ...args.outerGridRef.current, ...grid } },
@@ -240,7 +256,9 @@ describe('useScrollCellIntoView', () => {
 
     it('makes no vertical adjustments if the cell is a sticky footer cell', () => {
       getCell.mockReturnValue(cell);
-      const { scrollCellIntoView } = testCustomHook(() =>
+      const {
+        return: { scrollCellIntoView },
+      } = testCustomHook(() =>
         useScrollCellIntoView({
           ...args,
           outerGridRef: { current: { ...args.outerGridRef.current, ...grid } },
@@ -265,7 +283,9 @@ describe('useScrollCellIntoView', () => {
 
     it('scrolls the grid up if the top side of the cell is out of view', () => {
       getCell.mockReturnValue(cell);
-      const { scrollCellIntoView } = testCustomHook(() =>
+      const {
+        return: { scrollCellIntoView },
+      } = testCustomHook(() =>
         useScrollCellIntoView({
           ...args,
           outerGridRef: { current: { ...args.outerGridRef.current, ...grid } },
@@ -277,7 +297,9 @@ describe('useScrollCellIntoView', () => {
 
     it('accounts for the sticky header', () => {
       getCell.mockReturnValue(cell);
-      const { scrollCellIntoView } = testCustomHook(() =>
+      const {
+        return: { scrollCellIntoView },
+      } = testCustomHook(() =>
         useScrollCellIntoView({
           ...args,
           outerGridRef: { current: { ...args.outerGridRef.current, ...grid } },
@@ -300,7 +322,9 @@ describe('useScrollCellIntoView', () => {
       };
 
       getCell.mockReturnValue(cell);
-      const { scrollCellIntoView } = testCustomHook(() =>
+      const {
+        return: { scrollCellIntoView },
+      } = testCustomHook(() =>
         useScrollCellIntoView({
           ...args,
           outerGridRef: { current: { ...args.outerGridRef.current, ...grid } },
@@ -314,7 +338,9 @@ describe('useScrollCellIntoView', () => {
 
     it('makes no vertical adjustments if the cell is a sticky header cell', () => {
       getCell.mockReturnValue(cell);
-      const { scrollCellIntoView } = testCustomHook(() =>
+      const {
+        return: { scrollCellIntoView },
+      } = testCustomHook(() =>
         useScrollCellIntoView({
           ...args,
           outerGridRef: { current: { ...args.outerGridRef.current, ...grid } },
@@ -326,7 +352,9 @@ describe('useScrollCellIntoView', () => {
 
     it('makes no vertical adjustments if the cell is a sticky footer cell', () => {
       getCell.mockReturnValue(cell);
-      const { scrollCellIntoView } = testCustomHook(() =>
+      const {
+        return: { scrollCellIntoView },
+      } = testCustomHook(() =>
         useScrollCellIntoView({
           ...args,
           outerGridRef: { current: { ...args.outerGridRef.current, ...grid } },

--- a/src/components/datagrid/utils/scrolling.ts
+++ b/src/components/datagrid/utils/scrolling.ts
@@ -45,17 +45,17 @@ export const useScroll = (args: Dependencies) => {
     }
   }, [focusedCell, scrollCellIntoView]);
 
-  const { popoverIsOpen, openCellLocation } = useContext(
+  const { popoverIsOpen, cellLocation } = useContext(
     DataGridCellPopoverContext
   );
   useEffect(() => {
     if (popoverIsOpen) {
       scrollCellIntoView({
-        rowIndex: openCellLocation.rowIndex,
-        colIndex: openCellLocation.colIndex,
+        rowIndex: cellLocation.rowIndex,
+        colIndex: cellLocation.colIndex,
       });
     }
-  }, [popoverIsOpen, openCellLocation, scrollCellIntoView]);
+  }, [popoverIsOpen, cellLocation, scrollCellIntoView]);
 
   return { scrollCellIntoView };
 };

--- a/src/components/datagrid/utils/scrolling.ts
+++ b/src/components/datagrid/utils/scrolling.ts
@@ -8,6 +8,8 @@
 
 import { useContext, useEffect, useCallback, MutableRefObject } from 'react';
 import { VariableSizeGrid as Grid } from 'react-window';
+
+import { DataGridCellPopoverContext } from '../body/data_grid_cell_popover';
 import { DataGridFocusContext } from './focus';
 
 interface ScrollCellIntoView {
@@ -42,6 +44,18 @@ export const useScroll = (args: Dependencies) => {
       });
     }
   }, [focusedCell, scrollCellIntoView]);
+
+  const { popoverIsOpen, openCellLocation } = useContext(
+    DataGridCellPopoverContext
+  );
+  useEffect(() => {
+    if (popoverIsOpen) {
+      scrollCellIntoView({
+        rowIndex: openCellLocation.rowIndex,
+        colIndex: openCellLocation.colIndex,
+      });
+    }
+  }, [popoverIsOpen, openCellLocation, scrollCellIntoView]);
 
   return { scrollCellIntoView };
 };

--- a/src/test/test_custom_hook.tsx
+++ b/src/test/test_custom_hook.tsx
@@ -15,9 +15,18 @@ export const HookWrapper = (props: { hook?: Function }) => {
   return <div hook={hook} />;
 };
 
-export const testCustomHook = <T,>(hook?: Function): T => {
+export const testCustomHook = <T,>(
+  hook?: Function
+): { return: T; getUpdatedState: () => T } => {
   const wrapper = mount(<HookWrapper hook={hook} />);
-  const hookValues: T = wrapper.find('div').prop('hook');
 
-  return hookValues;
+  const getHookReturn = (): T => {
+    wrapper.update();
+    return wrapper.find('div').prop('hook');
+  };
+
+  return {
+    return: getHookReturn(),
+    getUpdatedState: getHookReturn, // Allows consuming tests to get most recent values
+  };
 };


### PR DESCRIPTION
## Summary

The main goal of this PR is to expose APIs that allow consumers to manually control cell popovers (#5310)

However, because each cell contained its own individual popover and popover state, this required a refactor of how our cell popover architecture works:
-  Each data grid now only creates a single popover for the entire grid (instead of a popover per cell) which changes location/anchor depending on the cell that triggered it
- A top-level cell popover context now exists and which manages open/closed popover state and the popover cell location
- Each cell responds to changes in open/closed and location state to determine whether its popover should be open, and if so, it updates the top level context with its anchor (wrapping div element) and popover content (rendered cell values).

I strongly recommend:
- [Following along by commit](https://github.com/elastic/eui/pull/5550/commits) (which I tried to make as atomic as possible and include specific details and reasons in commit messages)
- Turning off whitespace changes, in particular for https://github.com/elastic/eui/commit/100e3146ea08e42d1e29c007bc0527f76af5e1c8 which is mostly just indentation changes due to the new context wrapper

### Screencaps

![popover](https://user-images.githubusercontent.com/549407/150391745-c37a2c43-5e59-4122-abe9-3f777ef844d7.gif)

### Coverage

<img width="1432" alt="" src="https://user-images.githubusercontent.com/549407/150391920-74f1b51d-527e-400c-9648-94e018057cff.png">

## QA

- Regression testing - https://eui.elastic.co/pr_5550/#/tabular-content/data-grid-schemas-and-popovers
  - [x] The previous cell expansion button still works as before with no bugs
  - [x] Pressing Enter and F2 to open a cell expansion popover still works
  - [x] Cells render as before including action buttons with no regressions
  - [x] Closing a popover with Esc and F2 still works
  - [x] Closing a popover by clicking away from it still works
- Feature testing - https://eui.elastic.co/pr_5550/#/tabular-content/data-grid-ref-methods
  - [x] The new `openCellPopover` and `closeCellPopover` APIs work as expected
  - [x] Opening a cell popover on a virtualized row that is not rendered works as expected (e.g., set rowIndex to 24 while at the top of the grid and press the 

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**

~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**

~- [ ] Checked for **breaking changes** and labeled appropriately~

- [x] Checked for **accessibility** including keyboard-only and screenreader modes

~- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~ (Will add a finished changelog in final feature branch PR)
