### PR TITLE
[EuiDataGrid] Fix incorrect full screen height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [`main`](https://github.com/elastic/eui/tree/main)
 
-No public interface changes since `46.1.0`.
+**Bug fixes**
+
+- Fixed EuiDataGrid height issue when in full-screen mode and with scrolling content ([#5557](https://github.com/elastic/eui/pull/5557))
 
 ## [`46.1.0`](https://github.com/elastic/eui/tree/v46.1.0)
 

--- a/src/components/datagrid/body/data_grid_body.test.tsx
+++ b/src/components/datagrid/body/data_grid_body.test.tsx
@@ -17,7 +17,6 @@ import { EuiDataGridBody, Cell } from './data_grid_body';
 
 describe('EuiDataGridBody', () => {
   const requiredProps = {
-    isFullScreen: false,
     headerIsInteractive: true,
     rowCount: 1,
     visibleRows: { startRow: 0, endRow: 1, visibleRowCount: 1 },

--- a/src/components/datagrid/body/data_grid_body.test.tsx
+++ b/src/components/datagrid/body/data_grid_body.test.tsx
@@ -20,7 +20,6 @@ describe('EuiDataGridBody', () => {
     headerIsInteractive: true,
     rowCount: 1,
     visibleRows: { startRow: 0, endRow: 1, visibleRowCount: 1 },
-    toolbarHeight: 10,
     columnWidths: { columnA: 20 },
     columns: [
       { id: 'columnA', schema: 'boolean' },

--- a/src/components/datagrid/body/data_grid_body.tsx
+++ b/src/components/datagrid/body/data_grid_body.tsx
@@ -219,7 +219,6 @@ export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
   props
 ) => {
   const {
-    isFullScreen,
     leadingControlColumns,
     trailingControlColumns,
     columns,
@@ -238,7 +237,6 @@ export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
     setVisibleColumns,
     switchColumnPos,
     onColumnResize,
-    toolbarHeight,
     rowHeightsOptions,
     virtualizationOptions,
     gridStyles,
@@ -416,11 +414,7 @@ export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
     unconstrainedWidth: 0, // unable to determine this until the container's size is known
     wrapperDimensions,
     wrapperRef,
-    toolbarHeight,
-    headerRowHeight,
-    footerRowHeight,
     rowCount,
-    isFullScreen,
   });
 
   /**

--- a/src/components/datagrid/body/header/header_is_interactive.ts
+++ b/src/components/datagrid/body/header/header_is_interactive.ts
@@ -8,7 +8,6 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import tabbable from 'tabbable';
-import { useForceRender } from '../../../../services';
 
 export const useHeaderIsInteractive = (gridElement: HTMLElement | null) => {
   const [headerIsInteractive, setHeaderIsInteractive] = useState(false);
@@ -58,14 +57,6 @@ export const useHeaderIsInteractive = (gridElement: HTMLElement | null) => {
     },
     [handleHeaderChange]
   );
-
-  // For some bizarre reason, when the header is *not* interactive, we have to
-  // force a rerender, otherwise the resizeRef/gridWidth of the data grid
-  // registers as 0 and EuiDataGridToolbar hides its left side buttons
-  const forceRender = useForceRender();
-  useEffect(() => {
-    if (!headerIsInteractive) forceRender();
-  }, [headerIsInteractive, forceRender]);
 
   return { headerIsInteractive, handleHeaderMutation };
 };

--- a/src/components/datagrid/body/header/header_is_interactive.ts
+++ b/src/components/datagrid/body/header/header_is_interactive.ts
@@ -8,6 +8,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import tabbable from 'tabbable';
+import { useForceRender } from '../../../../services';
 
 export const useHeaderIsInteractive = (gridElement: HTMLElement | null) => {
   const [headerIsInteractive, setHeaderIsInteractive] = useState(false);
@@ -57,6 +58,14 @@ export const useHeaderIsInteractive = (gridElement: HTMLElement | null) => {
     },
     [handleHeaderChange]
   );
+
+  // For some bizarre reason, when the header is *not* interactive, we have to
+  // force a rerender, otherwise the resizeRef/gridWidth of the data grid
+  // registers as 0 and EuiDataGridToolbar hides its left side buttons
+  const forceRender = useForceRender();
+  useEffect(() => {
+    if (!headerIsInteractive) forceRender();
+  }, [headerIsInteractive, forceRender]);
 
   return { headerIsInteractive, handleHeaderMutation };
 };

--- a/src/components/datagrid/controls/data_grid_toolbar.test.tsx
+++ b/src/components/datagrid/controls/data_grid_toolbar.test.tsx
@@ -25,7 +25,6 @@ describe('EuiDataGridToolbar', () => {
     controlBtnClasses: '',
     columnSelector: <div>mock column selector</div>,
     columnSorting: <div>mock column sorting</div>,
-    setRef: jest.fn(),
     setIsFullScreen: jest.fn(),
   };
 

--- a/src/components/datagrid/controls/data_grid_toolbar.tsx
+++ b/src/components/datagrid/controls/data_grid_toolbar.tsx
@@ -34,7 +34,6 @@ export const EuiDataGridToolbar = ({
   displaySelector,
   columnSelector,
   columnSorting,
-  setRef,
   setIsFullScreen,
 }: EuiDataGridToolbarProps) => {
   const [fullScreenButton, fullScreenButtonActive] = useEuiI18n(
@@ -86,11 +85,7 @@ export const EuiDataGridToolbar = ({
   );
 
   return (
-    <div
-      ref={setRef}
-      className="euiDataGrid__controls"
-      data-test-sub="dataGridControls"
-    >
+    <div className="euiDataGrid__controls" data-test-sub="dataGridControls">
       {hasRoomForGridControls && (
         <div className="euiDataGrid__leftControls">
           {renderAdditionalControls(toolbarVisibility, 'left.prepend')}

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -270,8 +270,6 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
    * Toolbar & full-screen
    */
   const showToolbar = !!toolbarVisibility;
-  const [toolbarRef, setToolbarRef] = useState<HTMLDivElement | null>(null);
-  const { height: toolbarHeight } = useResizeObserver(toolbarRef, 'height');
 
   const [isFullScreen, setIsFullScreen] = useState(false);
   const handleGridKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -373,7 +371,6 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
           >
             {showToolbar && (
               <EuiDataGridToolbar
-                setRef={setToolbarRef}
                 gridWidth={gridWidth}
                 minSizeForControls={minSizeForControls}
                 toolbarVisibility={toolbarVisibility}
@@ -424,7 +421,6 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
               <EuiDataGridBody
                 columns={orderedVisibleColumns}
                 visibleColCount={visibleColCount}
-                toolbarHeight={toolbarHeight}
                 leadingControlColumns={leadingControlColumns}
                 schema={mergedSchema}
                 trailingControlColumns={trailingControlColumns}

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -422,7 +422,6 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
               {...gridAriaProps}
             >
               <EuiDataGridBody
-                isFullScreen={isFullScreen}
                 columns={orderedVisibleColumns}
                 visibleColCount={visibleColCount}
                 toolbarHeight={toolbarHeight}

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -162,8 +162,10 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
    * Grid refs & observers
    */
   // Outermost wrapper div
-  const resizeRef = useRef<HTMLDivElement | null>(null);
-  const { width: gridWidth } = useResizeObserver(resizeRef.current, 'width');
+  // this ref needs to be managed by a state, to cause a re-render after mount
+  // and passing the mounted element to the resize observer
+  const [resizeRef, setResizeRef] = useState<HTMLDivElement | null>(null);
+  const { width: gridWidth } = useResizeObserver(resizeRef, 'width');
 
   // Wrapper div around EuiDataGridBody
   const contentRef = useRef<HTMLDivElement | null>(null);
@@ -366,7 +368,7 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
             className={classes}
             onKeyDown={handleGridKeyDown}
             style={isFullScreen ? undefined : { width, height }}
-            ref={resizeRef}
+            ref={setResizeRef}
             {...rest}
           >
             {showToolbar && (

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -40,9 +40,9 @@ export interface EuiDataGridToolbarProps {
   controlBtnClasses: string;
   columnSelector: ReactNode;
   columnSorting: ReactNode;
-  setRef: RefCallback<HTMLDivElement | null>;
   setIsFullScreen: Dispatch<SetStateAction<boolean>>;
 }
+
 export interface EuiDataGridPaginationRendererProps
   extends EuiDataGridPaginationProps {
   rowCount: number;
@@ -345,7 +345,6 @@ export interface EuiDataGridBodyProps {
   setVisibleColumns: EuiDataGridHeaderRowProps['setVisibleColumns'];
   switchColumnPos: EuiDataGridHeaderRowProps['switchColumnPos'];
   onColumnResize?: EuiDataGridOnColumnResizeHandler;
-  toolbarHeight: number;
   virtualizationOptions?: Partial<VariableSizeGridProps>;
   rowHeightsOptions?: EuiDataGridRowHeightsOptions;
   gridStyles: EuiDataGridStyle;

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -327,7 +327,6 @@ export interface EuiDataGridColumnSortingDraggableProps {
   display: string;
 }
 export interface EuiDataGridBodyProps {
-  isFullScreen: boolean;
   leadingControlColumns: EuiDataGridControlColumn[];
   trailingControlColumns: EuiDataGridControlColumn[];
   columns: EuiDataGridColumn[];

--- a/src/components/datagrid/utils/grid_height_width.ts
+++ b/src/components/datagrid/utils/grid_height_width.ts
@@ -43,7 +43,7 @@ export const useFinalGridDimensions = ({
   useEffect(() => {
     const boundingRect = wrapperRef.current!.getBoundingClientRect();
 
-    if (boundingRect.height !== unconstrainedHeight && !isFullScreen) {
+    if (boundingRect.height !== unconstrainedHeight) {
       setHeight(boundingRect.height);
     }
     if (boundingRect.width !== unconstrainedWidth) {
@@ -57,21 +57,14 @@ export const useFinalGridDimensions = ({
     wrapperRef,
     unconstrainedHeight,
     unconstrainedWidth,
-    isFullScreen,
   ]);
 
-  let finalHeight = IS_JEST_ENVIRONMENT
+  const finalHeight = IS_JEST_ENVIRONMENT
     ? Number.MAX_SAFE_INTEGER
     : height || unconstrainedHeight;
-  let finalWidth = IS_JEST_ENVIRONMENT
+  const finalWidth = IS_JEST_ENVIRONMENT
     ? Number.MAX_SAFE_INTEGER
     : width || unconstrainedWidth;
-
-  if (isFullScreen) {
-    finalHeight =
-      window.innerHeight - toolbarHeight - headerRowHeight - footerRowHeight;
-    finalWidth = window.innerWidth;
-  }
 
   return { finalHeight, finalWidth };
 };

--- a/src/components/datagrid/utils/grid_height_width.ts
+++ b/src/components/datagrid/utils/grid_height_width.ts
@@ -19,21 +19,13 @@ export const useFinalGridDimensions = ({
   unconstrainedWidth,
   wrapperDimensions,
   wrapperRef,
-  toolbarHeight,
-  headerRowHeight,
-  footerRowHeight,
   rowCount,
-  isFullScreen,
 }: {
   unconstrainedHeight: number;
   unconstrainedWidth: number;
   wrapperDimensions: { width: number; height: number };
   wrapperRef: MutableRefObject<HTMLDivElement | null>;
-  toolbarHeight: number;
-  headerRowHeight: number;
-  footerRowHeight: number;
   rowCount: number;
-  isFullScreen: boolean;
 }) => {
   // Used if the grid needs to scroll
   const [height, setHeight] = useState<number | undefined>(undefined);


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/5139
closes https://github.com/elastic/eui/issues/5131

You gotta love it when a fix just involves removing logic! 🔥 

Quick summary of changes - the previous `finalHeight = window.innerHeight - toolbarHeight - headerRowHeight - footerRowHeight` calculation likely came from pre-virtualization and is no longer necessary. There's no need for a separate `isFullScreen` logic - EuiDataGridBody's wrapper dimensions update on full screen toggle and resize correctly due to flexbox. `react-window` should simply use that wrapper's height & width, the same way it does in non-full-screen mode.

### Before

Note how bottom row is cut off and how the horizontal scrollbar does not appear after increasing the width of a column

![before](https://user-images.githubusercontent.com/549407/150877265-d0667941-c496-4c6b-92f2-d1c45bf98081.gif)

### After

Note how bottom row is not cut off and how the horizontal scrollbar **does** appear after increasing the width of a column

![after](https://user-images.githubusercontent.com/549407/150877301-7934dbc1-cdab-4c79-89eb-828870434227.gif)

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~

- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~

- [ ] ~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~ NOTE: No jest tests added here due to no unit tests previously existing for this file + the presence of `IS_JEST_ENVIRONMENT`, but it's on my TODO list to add more unit tests for our `utils/` shortly

~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
