### PR TITLE
[EuiDataGrid] Fix documentation examples with invalid React hook usage

### DIFF
--- a/src-docs/src/views/datagrid/additional_controls.tsx
+++ b/src-docs/src/views/datagrid/additional_controls.tsx
@@ -94,7 +94,7 @@ export default () => {
     );
   };
 
-  const [visibleColumns, setVisibleColumns] = useState(() =>
+  const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
   );
 

--- a/src-docs/src/views/datagrid/column_actions.js
+++ b/src-docs/src/views/datagrid/column_actions.js
@@ -71,7 +71,7 @@ for (let i = 1; i < 5; i++) {
 export default () => {
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 5 });
 
-  const [visibleColumns, setVisibleColumns] = useState(() =>
+  const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
   );
 

--- a/src-docs/src/views/datagrid/column_cell_actions.js
+++ b/src-docs/src/views/datagrid/column_cell_actions.js
@@ -122,7 +122,7 @@ for (let i = 1; i < 5; i++) {
 export default () => {
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
 
-  const [visibleColumns, setVisibleColumns] = useState(() =>
+  const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
   );
 

--- a/src-docs/src/views/datagrid/column_widths.js
+++ b/src-docs/src/views/datagrid/column_widths.js
@@ -48,7 +48,7 @@ for (let i = 1; i < 5; i++) {
 export default () => {
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 5 });
 
-  const [visibleColumns, setVisibleColumns] = useState(() =>
+  const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
   );
 

--- a/src-docs/src/views/datagrid/container.js
+++ b/src-docs/src/views/datagrid/container.js
@@ -38,7 +38,7 @@ for (let i = 1; i < 20; i++) {
 export default () => {
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
 
-  const [visibleColumns, setVisibleColumns] = useState(() =>
+  const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
   );
 

--- a/src-docs/src/views/datagrid/control_columns.js
+++ b/src-docs/src/views/datagrid/control_columns.js
@@ -322,7 +322,7 @@ export default function DataGrid() {
     [pagination, setPagination]
   );
 
-  const [visibleColumns, setVisibleColumns] = useState(() =>
+  const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
   );
 

--- a/src-docs/src/views/datagrid/datagrid.js
+++ b/src-docs/src/views/datagrid/datagrid.js
@@ -2,7 +2,6 @@ import React, {
   Fragment,
   useCallback,
   useEffect,
-  useMemo,
   useState,
   createContext,
   useContext,
@@ -65,6 +64,35 @@ for (let i = 1; i < 100; i++) {
     version: fake('{{system.semver}}'),
   });
 }
+
+const RenderCellValue = ({ rowIndex, columnId, setCellProps }) => {
+  const data = useContext(DataContext);
+  useEffect(() => {
+    if (columnId === 'amount') {
+      if (data.hasOwnProperty(rowIndex)) {
+        const numeric = parseFloat(
+          data[rowIndex][columnId].match(/\d+\.\d+/)[0],
+          10
+        );
+        setCellProps({
+          style: {
+            backgroundColor: `rgba(0, 255, 0, ${numeric * 0.0002})`,
+          },
+        });
+      }
+    }
+  }, [rowIndex, columnId, setCellProps, data]);
+
+  function getFormatted() {
+    return data[rowIndex][columnId].formatted
+      ? data[rowIndex][columnId].formatted
+      : data[rowIndex][columnId];
+  }
+
+  return data.hasOwnProperty(rowIndex)
+    ? getFormatted(rowIndex, columnId)
+    : null;
+};
 
 const columns = [
   {
@@ -365,37 +393,6 @@ export default () => {
     columns.map(({ id }) => id)
   ); // initialize to the full set of columns
 
-  const renderCellValue = useMemo(() => {
-    return ({ rowIndex, columnId, setCellProps }) => {
-      const data = useContext(DataContext);
-      useEffect(() => {
-        if (columnId === 'amount') {
-          if (data.hasOwnProperty(rowIndex)) {
-            const numeric = parseFloat(
-              data[rowIndex][columnId].match(/\d+\.\d+/)[0],
-              10
-            );
-            setCellProps({
-              style: {
-                backgroundColor: `rgba(0, 255, 0, ${numeric * 0.0002})`,
-              },
-            });
-          }
-        }
-      }, [rowIndex, columnId, setCellProps, data]);
-
-      function getFormatted() {
-        return data[rowIndex][columnId].formatted
-          ? data[rowIndex][columnId].formatted
-          : data[rowIndex][columnId];
-      }
-
-      return data.hasOwnProperty(rowIndex)
-        ? getFormatted(rowIndex, columnId)
-        : null;
-    };
-  }, []);
-
   const onColumnResize = useRef((eventData) => {
     console.log(eventData);
   });
@@ -408,7 +405,7 @@ export default () => {
         columnVisibility={{ visibleColumns, setVisibleColumns }}
         trailingControlColumns={trailingControlColumns}
         rowCount={raw_data.length}
-        renderCellValue={renderCellValue}
+        renderCellValue={RenderCellValue}
         inMemory={{ level: 'sorting' }}
         sorting={{ columns: sortingColumns, onSort }}
         pagination={{

--- a/src-docs/src/views/datagrid/datagrid.js
+++ b/src-docs/src/views/datagrid/datagrid.js
@@ -362,7 +362,7 @@ const trailingControlColumns = [
 ];
 
 export default () => {
-  // ** Pagination config
+  // Pagination
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
   const onChangeItemsPerPage = useCallback(
     (pageSize) =>
@@ -379,7 +379,7 @@ export default () => {
     [setPagination]
   );
 
-  // ** Sorting config
+  // Sorting
   const [sortingColumns, setSortingColumns] = useState([]);
   const onSort = useCallback(
     (sortingColumns) => {
@@ -389,9 +389,9 @@ export default () => {
   );
 
   // Column visibility
-  const [visibleColumns, setVisibleColumns] = useState(() =>
-    columns.map(({ id }) => id)
-  ); // initialize to the full set of columns
+  const [visibleColumns, setVisibleColumns] = useState(
+    columns.map(({ id }) => id) // initialize to the full set of columns
+  );
 
   const onColumnResize = useRef((eventData) => {
     console.log(eventData);

--- a/src-docs/src/views/datagrid/display_callbacks.js
+++ b/src-docs/src/views/datagrid/display_callbacks.js
@@ -70,7 +70,7 @@ export default () => {
     setDensitySize(updatedStyles.fontSize);
   }, []);
 
-  const [visibleColumns, setVisibleColumns] = useState(() =>
+  const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
   );
 

--- a/src-docs/src/views/datagrid/flex.js
+++ b/src-docs/src/views/datagrid/flex.js
@@ -44,7 +44,7 @@ for (let i = 1; i < 20; i++) {
 export default () => {
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
 
-  const [visibleColumns, setVisibleColumns] = useState(() =>
+  const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
   );
 

--- a/src-docs/src/views/datagrid/footer_row.js
+++ b/src-docs/src/views/datagrid/footer_row.js
@@ -79,7 +79,7 @@ const renderFooterCellValue = ({ columnId }) =>
   footerCellValues[columnId] || null;
 
 export default () => {
-  // ** Pagination config
+  // Pagination
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
   const onChangeItemsPerPage = useCallback(
     (pageSize) =>
@@ -97,9 +97,9 @@ export default () => {
   );
 
   // Column visibility
-  const [visibleColumns, setVisibleColumns] = useState(() =>
+  const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
-  ); // initialize to the full set of columns
+  );
 
   // Footer row
   const [showFooterRow, setShowFooterRow] = useState(true);

--- a/src-docs/src/views/datagrid/footer_row.js
+++ b/src-docs/src/views/datagrid/footer_row.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { fake } from 'faker';
 
 import {
@@ -19,6 +19,28 @@ for (let i = 1; i < 20; i++) {
     version: fake('{{system.semver}}'),
   });
 }
+
+const RenderCellValue = ({ rowIndex, columnId, setCellProps }) => {
+  useEffect(() => {
+    if (columnId === 'amount') {
+      if (raw_data.hasOwnProperty(rowIndex)) {
+        const numeric = parseFloat(
+          raw_data[rowIndex][columnId].match(/\d+\.\d+/)[0],
+          10
+        );
+        setCellProps({
+          style: {
+            backgroundColor: `rgba(0, 255, 0, ${numeric * 0.0002})`,
+          },
+        });
+      }
+    }
+  }, [rowIndex, columnId, setCellProps]);
+
+  return raw_data.hasOwnProperty(rowIndex)
+    ? raw_data[rowIndex][columnId]
+    : null;
+};
 
 const columns = [
   {
@@ -53,6 +75,9 @@ const footerCellValues = {
   }`,
 };
 
+const renderFooterCellValue = ({ columnId }) =>
+  footerCellValues[columnId] || null;
+
 export default () => {
   // ** Pagination config
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
@@ -76,35 +101,6 @@ export default () => {
     columns.map(({ id }) => id)
   ); // initialize to the full set of columns
 
-  const renderCellValue = useMemo(() => {
-    return ({ rowIndex, columnId, setCellProps }) => {
-      useEffect(() => {
-        if (columnId === 'amount') {
-          if (raw_data.hasOwnProperty(rowIndex)) {
-            const numeric = parseFloat(
-              raw_data[rowIndex][columnId].match(/\d+\.\d+/)[0],
-              10
-            );
-            setCellProps({
-              style: {
-                backgroundColor: `rgba(0, 255, 0, ${numeric * 0.0002})`,
-              },
-            });
-          }
-        }
-      }, [rowIndex, columnId, setCellProps]);
-
-      return raw_data.hasOwnProperty(rowIndex)
-        ? raw_data[rowIndex][columnId]
-        : null;
-    };
-  }, []);
-
-  const renderFooterCellValue = useCallback(
-    ({ columnId }) => footerCellValues[columnId] || null,
-    []
-  );
-
   // Footer row
   const [showFooterRow, setShowFooterRow] = useState(true);
 
@@ -123,7 +119,7 @@ export default () => {
           columns={columns}
           columnVisibility={{ visibleColumns, setVisibleColumns }}
           rowCount={raw_data.length}
-          renderCellValue={renderCellValue}
+          renderCellValue={RenderCellValue}
           renderFooterCellValue={
             showFooterRow ? renderFooterCellValue : undefined
           }

--- a/src-docs/src/views/datagrid/in_memory.js
+++ b/src-docs/src/views/datagrid/in_memory.js
@@ -54,7 +54,7 @@ for (let i = 1; i < 100; i++) {
 }
 
 export default () => {
-  // ** Pagination config
+  // Pagination
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
   const onChangeItemsPerPage = useCallback(
     (pageSize) =>
@@ -71,7 +71,7 @@ export default () => {
     [setPagination]
   );
 
-  // ** Sorting config
+  // Sorting
   const [sortingColumns, setSortingColumns] = useState([]);
   const onSort = useCallback(
     (sortingColumns) => {
@@ -104,9 +104,9 @@ export default () => {
   }, [data, pagination]);
 
   // Column visibility
-  const [visibleColumns, setVisibleColumns] = useState(() =>
+  const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
-  ); // initialize to the full set of columns
+  );
 
   const renderCellValue = useMemo(() => {
     return ({ rowIndex, columnId }) => {

--- a/src-docs/src/views/datagrid/in_memory_enhancements.js
+++ b/src-docs/src/views/datagrid/in_memory_enhancements.js
@@ -53,7 +53,7 @@ for (let i = 1; i < 100; i++) {
 }
 
 export default () => {
-  // ** Pagination config
+  // Pagination
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
   const onChangeItemsPerPage = useCallback(
     (pageSize) =>
@@ -70,7 +70,7 @@ export default () => {
     [setPagination]
   );
 
-  // ** Sorting config
+  // Sorting
   const [sortingColumns, setSortingColumns] = useState([]);
   const onSort = useCallback(
     (sortingColumns) => {
@@ -105,9 +105,9 @@ export default () => {
   }, [data, pagination]);
 
   // Column visibility
-  const [visibleColumns, setVisibleColumns] = useState(() =>
+  const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
-  ); // initialize to the full set of columns
+  );
 
   const renderCellValue = useMemo(() => {
     return ({ rowIndex, columnId }) => {

--- a/src-docs/src/views/datagrid/in_memory_pagination.js
+++ b/src-docs/src/views/datagrid/in_memory_pagination.js
@@ -53,7 +53,7 @@ for (let i = 1; i < 100; i++) {
 }
 
 export default () => {
-  // ** Pagination config
+  // Pagination
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
   const onChangeItemsPerPage = useCallback(
     (pageSize) =>
@@ -70,7 +70,7 @@ export default () => {
     [setPagination]
   );
 
-  // ** Sorting config
+  // Sorting
   const [sortingColumns, setSortingColumns] = useState([]);
   const onSort = useCallback(
     (sortingColumns) => {
@@ -96,9 +96,9 @@ export default () => {
   }, [sortingColumns]);
 
   // Column visibility
-  const [visibleColumns, setVisibleColumns] = useState(() =>
+  const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
-  ); // initialize to the full set of columns
+  );
 
   const renderCellValue = useMemo(() => {
     return ({ rowIndex, columnId }) => {

--- a/src-docs/src/views/datagrid/in_memory_sorting.js
+++ b/src-docs/src/views/datagrid/in_memory_sorting.js
@@ -53,7 +53,7 @@ for (let i = 1; i < 100; i++) {
 }
 
 export default () => {
-  // ** Pagination config
+  // Pagination
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
   const onChangeItemsPerPage = useCallback(
     (pageSize) =>
@@ -70,7 +70,7 @@ export default () => {
     [setPagination]
   );
 
-  // ** Sorting config
+  // Sorting
   const [sortingColumns, setSortingColumns] = useState([]);
   const onSort = useCallback(
     (sortingColumns) => {
@@ -80,9 +80,9 @@ export default () => {
   );
 
   // Column visibility
-  const [visibleColumns, setVisibleColumns] = useState(() =>
+  const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
-  ); // initialize to the full set of columns
+  );
 
   const renderCellValue = useMemo(() => {
     return ({ rowIndex, columnId }) => {

--- a/src-docs/src/views/datagrid/row_height_auto.tsx
+++ b/src-docs/src/views/datagrid/row_height_auto.tsx
@@ -148,10 +148,10 @@ const RenderCellValue: EuiDataGridProps['renderCellValue'] = ({
 };
 
 export default () => {
-  // ** Pagination config
+  // Pagination
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 50 });
 
-  // ** Sorting config
+  // Sorting
   const [sortingColumns, setSortingColumns] = useState([]);
   const onSort = useCallback(
     (sortingColumns) => {
@@ -177,9 +177,9 @@ export default () => {
   );
 
   // Column visibility
-  const [visibleColumns, setVisibleColumns] = useState(() =>
+  const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
-  ); // initialize to the full set of columns
+  );
 
   // matches the snippet example
   const rowHeightsOptions = useMemo(

--- a/src-docs/src/views/datagrid/row_height_fixed.tsx
+++ b/src-docs/src/views/datagrid/row_height_fixed.tsx
@@ -148,10 +148,10 @@ const RenderCellValue: EuiDataGridProps['renderCellValue'] = ({
 };
 
 export default () => {
-  // ** Pagination config
+  // Pagination
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 50 });
 
-  // ** Sorting config
+  // Sorting
   const [sortingColumns, setSortingColumns] = useState([]);
   const onSort = useCallback(
     (sortingColumns) => {
@@ -177,9 +177,9 @@ export default () => {
   );
 
   // Column visibility
-  const [visibleColumns, setVisibleColumns] = useState(() =>
+  const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
-  ); // initialize to the full set of columns
+  );
 
   // matches the snippet example
   const rowHeightsOptions = useMemo(

--- a/src-docs/src/views/datagrid/row_line_height.tsx
+++ b/src-docs/src/views/datagrid/row_line_height.tsx
@@ -102,10 +102,10 @@ const RenderCellValue: EuiDataGridProps['renderCellValue'] = ({
 };
 
 export default () => {
-  // ** Pagination config
+  // Pagination
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 50 });
 
-  // ** Sorting config
+  // Sorting
   const [sortingColumns, setSortingColumns] = useState([]);
   const onSort = useCallback(
     (sortingColumns) => {
@@ -131,9 +131,9 @@ export default () => {
   );
 
   // Column visibility
-  const [visibleColumns, setVisibleColumns] = useState(() =>
+  const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
-  ); // initialize to the full set of columns
+  );
 
   // matches the snippet example
   const rowHeightsOptions = useMemo(

--- a/src-docs/src/views/datagrid/virtualization.js
+++ b/src-docs/src/views/datagrid/virtualization.js
@@ -101,7 +101,7 @@ const dimensionSizes = {
 };
 
 export default () => {
-  // ** Pagination config
+  // Pagination
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 50 });
   const onChangeItemsPerPage = useCallback(
     (pageSize) =>
@@ -119,9 +119,9 @@ export default () => {
   );
 
   // Column visibility
-  const [visibleColumns, setVisibleColumns] = useState(() =>
+  const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
-  ); // initialize to the full set of columns
+  );
 
   const [mountedCellCount, setMountedCellCount] = useState(0);
 

--- a/src-docs/src/views/datagrid/virtualization_constrained.js
+++ b/src-docs/src/views/datagrid/virtualization_constrained.js
@@ -90,7 +90,7 @@ function RenderCellValue({ rowIndex, columnId }) {
 }
 
 export default () => {
-  // ** Pagination config
+  // Pagination
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 50 });
   const onChangeItemsPerPage = useCallback(
     (pageSize) =>
@@ -108,9 +108,9 @@ export default () => {
   );
 
   // Column visibility
-  const [visibleColumns, setVisibleColumns] = useState(() =>
+  const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
-  ); // initialize to the full set of columns
+  );
 
   const [mountedCellCount, setMountedCellCount] = useState(0);
 


### PR DESCRIPTION
### Summary

closes https://github.com/elastic/eui/issues/5235

As the linked issue points out, we have invalid React hook usage in 2 of our datagrid demos - the main one and our footer row example - where we're nesting `useContext` and `useEffect` within a `useMemo`, which is invalid (hooks cannot be nested within a hook).

The solution I used for this is copied from one we're using in a few other places, notably our [virtualization](https://github.com/elastic/eui/blob/f67acef220f569bef1ee6e33f73f01ae1b785ef4/src-docs/src/views/datagrid/virtualization.js#L60) and row height examples where we declare `renderCellValue` outside the main component as its own React component, essentially. All other usages of `renderCellValue` in other examples do not use React hooks within their fn's and do not need to be fixed.

While here I also cleaned up some comments and other things that I noted were getting copied and pasted from the main demo (last commit).

## QA

- [x] All datagrid documentation examples still work as before with no regressions

### Checklist

N/A, documentation changes only