### PR TITLE
[EuiComboBox][KEYBOARD]: Removing `tabindex -1` from `EuiComboboxPill` SVG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`main`](https://github.com/elastic/eui/tree/main)
 
 **Bug fixes**
+
 - Fixed an accessibility issue where `EuiComboBoxPill` close button had a nested interactive element ([#5560](https://github.com/elastic/eui/pull/5560))
 - Fixed EuiDataGrid height issue when in full-screen mode and with scrolling content ([#5557](https://github.com/elastic/eui/pull/5557))
 - Fixed a focus bug in `EuiDataGrid` when clicking another cell header with an already-open cell header popover ([#5556](https://github.com/elastic/eui/pull/5556))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`main`](https://github.com/elastic/eui/tree/main)
 
-No public interface changes since `46.1.0`.
+**Bug fixes**
+- Fixed an accessibility issue where `EuiComboBoxPill` close button had a nested interactive element ([#5560](https://github.com/elastic/eui/pull/5560))
 
 ## [`46.1.0`](https://github.com/elastic/eui/tree/v46.1.0)
 

--- a/src/components/combo_box/combo_box_input/combo_box_pill.tsx
+++ b/src/components/combo_box/combo_box_input/combo_box_pill.tsx
@@ -74,7 +74,6 @@ export class EuiComboBoxPill<T> extends Component<EuiComboBoxPillProps<T>> {
           {(removeSelection: string) => (
             <EuiBadge
               className={classes}
-              closeButtonProps={{ tabIndex: -1 }}
               color={color}
               iconOnClick={this.onCloseButtonClick}
               iconOnClickAriaLabel={removeSelection}

--- a/src/components/provider/__snapshots__/provider.test.tsx.snap
+++ b/src/components/provider/__snapshots__/provider.test.tsx.snap
@@ -1496,7 +1496,6 @@ exports[`EuiProvider providing an @emotion cache config applies the cache to glo
           "before": null,
           "container": <head />,
           "ctr": 0,
-          "insertionPoint": undefined,
           "isSpeedy": false,
           "key": "testing",
           "nonce": undefined,

--- a/src/components/provider/__snapshots__/provider.test.tsx.snap
+++ b/src/components/provider/__snapshots__/provider.test.tsx.snap
@@ -1496,6 +1496,7 @@ exports[`EuiProvider providing an @emotion cache config applies the cache to glo
           "before": null,
           "container": <head />,
           "ctr": 0,
+          "insertionPoint": undefined,
           "isSpeedy": false,
           "key": "testing",
           "nonce": undefined,


### PR DESCRIPTION
### Summary

Our `EuiComboBox` component had a nested SVG with a tabindex -1 passed into `...closeButtonProps` that was causing axe to throw a violation. We removed the negative tabindex because the SVG is nested inside a standard button.

Closes #5545 

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] ~~Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~~
- [ ] ~~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~~
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
