### PR TITLE
[EuiDataGrid] Change data grid body background to light gray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [`main`](https://github.com/elastic/eui/tree/main)
 
-No public interface changes since `46.1.0`.
+- Updated `EuiDataGrid`'s body to a light gray background, which primarily shows when scrolling through virtualized content ([#5562](https://github.com/elastic/eui/pull/5562))
 
 ## [`46.1.0`](https://github.com/elastic/eui/tree/v46.1.0)
 

--- a/src/components/datagrid/_data_grid.scss
+++ b/src/components/datagrid/_data_grid.scss
@@ -30,7 +30,7 @@
   width: 100%;
   overflow: hidden;
   z-index: 2; // Sits above the pagination below it, but below the controls above it
-  background: $euiColorEmptyShade;
+  background: $euiPageBackgroundColor;
   font-feature-settings: 'tnum' 1; // Tabular numbers
 }
 

--- a/src/components/datagrid/_data_grid.scss
+++ b/src/components/datagrid/_data_grid.scss
@@ -49,14 +49,6 @@
   }
 }
 
-
-.euiDataGrid__controlScroll {
-  @include euiYScrollWithShadows;
-  max-height: $euiDataGridPopoverMaxHeight;
-  padding: $euiSizeS;
-  margin: -$euiSizeS; // Offset against the panel to make the scrollbar flush scrollbars
-}
-
 .euiDataGrid__focusWrap {
   height: 100%;
 }

--- a/src/components/datagrid/controls/_data_grid_toolbar.scss
+++ b/src/components/datagrid/controls/_data_grid_toolbar.scss
@@ -59,3 +59,10 @@
   transition: none !important;
   margin-top: -$euiSizeS;
 }
+
+.euiDataGrid__controlScroll {
+  @include euiYScrollWithShadows;
+  max-height: $euiDataGridPopoverMaxHeight;
+  padding: $euiSizeS;
+  margin: -$euiSizeS; // Offset against the panel to make the scrollbar flush scrollbars
+}


### PR DESCRIPTION
## Summary

This attempts to address item 4 in #4458:

> 4. It would be great if while scrolling with virtualization which shows a white background while the cells load, we could have either add in some light gray like `$euiPageBackgroundColor`, or even some sort of pattern indication "loading".

I tried to take some screencaps but the GIFs didn't end up capturing the very subtle color change sufficiently in terms of either FPS or color swatching. It's probably easier just to compare staging vs. prod directly:

- Prod: https://elastic.github.io/eui/#/tabular-content/data-grid-virtualization
- Staging: https://eui.elastic.co/pr_5562/#/tabular-content/data-grid-virtualization

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
