### PR TITLE
Revising drag and drop for accessible interactive and complex patterns.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Bug fixes**
 
 - Fixed EuiDataGrid height issue when in full-screen mode and with scrolling content ([#5557](https://github.com/elastic/eui/pull/5557))
+- Fixed an accessibility issue in custom and interactive Drag and Drop patterns ([#5568](https://github.com/elastic/eui/pull/5568))
 
 ## [`46.1.0`](https://github.com/elastic/eui/tree/v46.1.0)
 

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_complex.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_complex.js
@@ -77,7 +77,7 @@ export default () => {
             spacing="l"
             style={{ flex: '1 0 50%' }}
             disableInteractiveElementBlocking // Allows button to be drag handle
-            draggableContainer={true}
+            hasInteractiveChildren={true}
           >
             {(provided) => (
               <EuiPanel color="subdued" paddingSize="s">

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_complex.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_complex.js
@@ -77,6 +77,7 @@ export default () => {
             spacing="l"
             style={{ flex: '1 0 50%' }}
             disableInteractiveElementBlocking // Allows button to be drag handle
+            draggableContainer={true}
           >
             {(provided) => (
               <EuiPanel color="subdued" paddingSize="s">

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_custom_handle.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_custom_handle.js
@@ -47,12 +47,17 @@ export default () => {
             hasInteractiveChildren={true}
           >
             {(provided) => (
-              <EuiPanel className="custom" paddingSize="m">
-                <EuiFlexGroup>
+              <EuiPanel paddingSize="s">
+                <EuiFlexGroup alignItems="center" gutterSize="s">
                   <EuiFlexItem grow={false}>
-                    <div {...provided.dragHandleProps} aria-label="Drag Handle">
+                    <EuiPanel
+                      color="transparent"
+                      paddingSize="s"
+                      {...provided.dragHandleProps}
+                      aria-label="Drag Handle"
+                    >
                       <EuiIcon type="grab" />
-                    </div>
+                    </EuiPanel>
                   </EuiFlexItem>
                   <EuiFlexItem>{content}</EuiFlexItem>
                 </EuiFlexGroup>

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_custom_handle.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_custom_handle.js
@@ -44,7 +44,7 @@ export default () => {
             index={idx}
             draggableId={id}
             customDragHandle={true}
-            draggableContainer={true}
+            hasInteractiveChildren={true}
           >
             {(provided) => (
               <EuiPanel className="custom" paddingSize="m">

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_custom_handle.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_custom_handle.js
@@ -44,6 +44,7 @@ export default () => {
             index={idx}
             draggableId={id}
             customDragHandle={true}
+            draggableContainer={true}
           >
             {(provided) => (
               <EuiPanel className="custom" paddingSize="m">

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_disable_blocking.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_disable_blocking.js
@@ -45,11 +45,11 @@ export default () => {
             index={idx}
             draggableId={id}
             customDragHandle={true}
-            draggableContainer={true}
+            hasInteractiveChildren={true}
           >
             {(provided) => (
-              <EuiPanel className="custom" paddingSize="m">
-                <EuiFlexGroup alignItems="center" gutterSize="l">
+              <EuiPanel className="custom" paddingSize="s">
+                <EuiFlexGroup alignItems="center" gutterSize="m">
                   <EuiFlexItem grow={false}>
                     <div {...provided.dragHandleProps} aria-label="Drag Handle">
                       <EuiIcon type="grab" />

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_disable_blocking.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_disable_blocking.js
@@ -4,6 +4,10 @@ import {
   EuiDragDropContext,
   EuiDraggable,
   EuiDroppable,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiPanel,
   euiDragDropReorder,
 } from '../../../../src/components';
 import { htmlIdGenerator } from '../../../../src/services';
@@ -30,10 +34,9 @@ export default () => {
   return (
     <EuiDragDropContext onDragEnd={onDragEnd}>
       <EuiDroppable
-        droppableId="DROPPABLE_AREA"
+        droppableId="CUSTOM_HANDLE_DROPPABLE_AREA"
         spacing="m"
         withPanel
-        grow={false}
       >
         {list.map(({ content, id }, idx) => (
           <EuiDraggable
@@ -41,11 +44,26 @@ export default () => {
             key={id}
             index={idx}
             draggableId={id}
-            disableInteractiveElementBlocking
+            customDragHandle={true}
+            draggableContainer={true}
+            interactiveElements={true}
           >
-            <EuiButton fullWidth onClick={() => {}}>
-              {content}
-            </EuiButton>
+            {(provided) => (
+              <EuiPanel className="custom" paddingSize="s">
+                <EuiFlexGroup alignItems="center" gutterSize="m">
+                  <EuiFlexItem grow={false}>
+                    <div {...provided.dragHandleProps} aria-label="Drag Handle">
+                      <EuiIcon type="grab" />
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={true}>
+                    <EuiButton fullWidth onClick={() => {}}>
+                      {content}
+                    </EuiButton>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiPanel>
+            )}
           </EuiDraggable>
         ))}
       </EuiDroppable>

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_disable_blocking.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_disable_blocking.js
@@ -46,11 +46,10 @@ export default () => {
             draggableId={id}
             customDragHandle={true}
             draggableContainer={true}
-            interactiveElements={true}
           >
             {(provided) => (
-              <EuiPanel className="custom" paddingSize="s">
-                <EuiFlexGroup alignItems="center" gutterSize="m">
+              <EuiPanel className="custom" paddingSize="m">
+                <EuiFlexGroup alignItems="center" gutterSize="l">
                   <EuiFlexItem grow={false}>
                     <div {...provided.dragHandleProps} aria-label="Drag Handle">
                       <EuiIcon type="grab" />

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_disable_blocking.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_disable_blocking.js
@@ -48,12 +48,17 @@ export default () => {
             hasInteractiveChildren={true}
           >
             {(provided) => (
-              <EuiPanel className="custom" paddingSize="s">
-                <EuiFlexGroup alignItems="center" gutterSize="m">
+              <EuiPanel paddingSize="s">
+                <EuiFlexGroup alignItems="center" gutterSize="s">
                   <EuiFlexItem grow={false}>
-                    <div {...provided.dragHandleProps} aria-label="Drag Handle">
+                    <EuiPanel
+                      color="transparent"
+                      paddingSize="s"
+                      {...provided.dragHandleProps}
+                      aria-label="Drag Handle"
+                    >
                       <EuiIcon type="grab" />
-                    </div>
+                    </EuiPanel>
                   </EuiFlexItem>
                   <EuiFlexItem grow={true}>
                     <EuiButton fullWidth onClick={() => {}}>

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_example.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_example.js
@@ -201,7 +201,7 @@ export const DragAndDropExample = {
             By default the entire element surface can initiate a drag. To
             specify an element within as the handle and create a containing
             group, set <EuiCode>customDragHandle=true</EuiCode> and{' '}
-            <EuiCode>hasInteractiveChildren=true</EuiCode> on the
+            <EuiCode>hasInteractiveChildren=true</EuiCode> on the{' '}
             <strong>EuiDraggable</strong>.
           </p>
           <p>

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_example.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_example.js
@@ -199,15 +199,18 @@ export const DragAndDropExample = {
         <React.Fragment>
           <p>
             By default the entire element surface can initiate a drag. To
-            specify a certain element within as the handle, set
-            <EuiCode>customDragHandle=true</EuiCode> on the{' '}
+            specify an element within as the handle and create a containing
+            group, set
+            <EuiCode>customDragHandle=true</EuiCode> and{' '}
+            <EuiCode>draggableContainer=true</EuiCode> on the{' '}
             <strong>EuiDraggable</strong>.
           </p>
           <p>
             The <EuiCode>provided</EuiCode> parameter on the{' '}
             <strong>EuiDraggable</strong> <EuiCode>children</EuiCode> render
             prop has all data required for functionality. Along with the{' '}
-            <EuiCode>customDragHandle</EuiCode> flag,
+            <EuiCode>customDragHandle</EuiCode> and{' '}
+            <EuiCode>draggableContainer</EuiCode>flags,
             <EuiCode>provided.dragHandleProps</EuiCode> needs to be added to the
             intended handle element.
           </p>
@@ -227,10 +230,12 @@ export const DragAndDropExample = {
         <React.Fragment>
           <p>
             <strong>EuiDraggable</strong> elements can contain interactive
-            elements such as buttons and form fields by adding the
-            <EuiCode>disableInteractiveElementBlocking</EuiCode> prop. This will
-            keep drag functionality while also enabling click, etc., events on
-            the interactive child elements.
+            elements such as buttons and form fields. Interactive elements
+            require <EuiCode>customDragHandle=true</EuiCode> and{' '}
+            <EuiCode>draggableContainer=true</EuiCode> on the{' '}
+            <strong>EuiDraggable</strong>. These props will maintain drag
+            functionality and accessibility, while enabling click, keypress,
+            etc., events on the interactive child elements.
           </p>
         </React.Fragment>
       ),

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_example.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_example.js
@@ -200,7 +200,8 @@ export const DragAndDropExample = {
           <p>
             By default the entire element surface can initiate a drag. To
             specify an element within as the handle and create a containing
-            group, set <EuiCode>customDragHandle=true</EuiCode> on the{' '}
+            group, set <EuiCode>customDragHandle=true</EuiCode> and{' '}
+            <EuiCode>hasInteractiveChildren=true</EuiCode> on the
             <strong>EuiDraggable</strong>.
           </p>
           <p>
@@ -228,7 +229,8 @@ export const DragAndDropExample = {
           <p>
             <strong>EuiDraggable</strong> can contain interactive elements such
             as buttons and form fields. Interactive elements require{' '}
-            <EuiCode>customDragHandle=true</EuiCode> on the{' '}
+            <EuiCode>customDragHandle=true</EuiCode> and{' '}
+            <EuiCode>hasInteractiveChildren=true</EuiCode> on the{' '}
             <strong>EuiDraggable</strong>. These props will maintain drag
             functionality and accessibility, while enabling click, keypress,
             etc., events on the interactive child elements.

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_example.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_example.js
@@ -200,17 +200,14 @@ export const DragAndDropExample = {
           <p>
             By default the entire element surface can initiate a drag. To
             specify an element within as the handle and create a containing
-            group, set
-            <EuiCode>customDragHandle=true</EuiCode> and{' '}
-            <EuiCode>draggableContainer=true</EuiCode> on the{' '}
+            group, set <EuiCode>customDragHandle=true</EuiCode> on the{' '}
             <strong>EuiDraggable</strong>.
           </p>
           <p>
             The <EuiCode>provided</EuiCode> parameter on the{' '}
             <strong>EuiDraggable</strong> <EuiCode>children</EuiCode> render
             prop has all data required for functionality. Along with the{' '}
-            <EuiCode>customDragHandle</EuiCode> and{' '}
-            <EuiCode>draggableContainer</EuiCode>flags,
+            <EuiCode>customDragHandle</EuiCode> flag,
             <EuiCode>provided.dragHandleProps</EuiCode> needs to be added to the
             intended handle element.
           </p>
@@ -229,10 +226,9 @@ export const DragAndDropExample = {
       text: (
         <React.Fragment>
           <p>
-            <strong>EuiDraggable</strong> elements can contain interactive
-            elements such as buttons and form fields. Interactive elements
-            require <EuiCode>customDragHandle=true</EuiCode> and{' '}
-            <EuiCode>draggableContainer=true</EuiCode> on the{' '}
+            <strong>EuiDraggable</strong> can contain interactive elements such
+            as buttons and form fields. Interactive elements require{' '}
+            <EuiCode>customDragHandle=true</EuiCode> on the{' '}
             <strong>EuiDraggable</strong>. These props will maintain drag
             functionality and accessibility, while enabling click, keypress,
             etc., events on the interactive child elements.

--- a/src/components/drag_and_drop/__snapshots__/draggable.test.tsx.snap
+++ b/src/components/drag_and_drop/__snapshots__/draggable.test.tsx.snap
@@ -1,39 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiDraggable can be a draggable container with role group 1`] = `
-<div>
-  <div
-    class="euiDroppable euiDroppable--noGrow"
-    data-rbd-droppable-context-id="0"
-    data-rbd-droppable-id="testDroppable"
-    data-test-subj="droppable"
-  >
-    <div
-      aria-describedby="rbd-hidden-text-0-hidden-text-0"
-      class="euiDraggable"
-      data-rbd-drag-handle-context-id="0"
-      data-rbd-drag-handle-draggable-id="testDraggable"
-      data-rbd-draggable-context-id="0"
-      data-rbd-draggable-id="testDraggable"
-      data-test-subj="draggable"
-      draggable="false"
-      role="group"
-    >
-      <div
-        class="euiDraggable__item"
-      >
-        Hello
-      </div>
-    </div>
-    <div
-      class="euiDroppable__placeholder"
-    />
-  </div>
-</div>
-`;
-
-exports[`EuiDraggable can be a draggable container with role group 2`] = `undefined`;
-
 exports[`EuiDraggable can be given ReactElement children 1`] = `
 <div>
   <div
@@ -68,6 +34,40 @@ exports[`EuiDraggable can be given ReactElement children 1`] = `
 `;
 
 exports[`EuiDraggable can be given ReactElement children 2`] = `undefined`;
+
+exports[`EuiDraggable hasInteractiveChildren renders with role="group" and no tabIndex 1`] = `
+<div>
+  <div
+    class="euiDroppable euiDroppable--noGrow"
+    data-rbd-droppable-context-id="0"
+    data-rbd-droppable-id="testDroppable"
+    data-test-subj="droppable"
+  >
+    <div
+      aria-describedby="rbd-hidden-text-0-hidden-text-0"
+      class="euiDraggable"
+      data-rbd-drag-handle-context-id="0"
+      data-rbd-drag-handle-draggable-id="testDraggable"
+      data-rbd-draggable-context-id="0"
+      data-rbd-draggable-id="testDraggable"
+      data-test-subj="draggable"
+      draggable="false"
+      role="group"
+    >
+      <div
+        class="euiDraggable__item"
+      >
+        Hello
+      </div>
+    </div>
+    <div
+      class="euiDroppable__placeholder"
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiDraggable hasInteractiveChildren renders with role="group" and no tabIndex 2`] = `undefined`;
 
 exports[`EuiDraggable is rendered 1`] = `
 <div>

--- a/src/components/drag_and_drop/__snapshots__/draggable.test.tsx.snap
+++ b/src/components/drag_and_drop/__snapshots__/draggable.test.tsx.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiDraggable can be a draggable container with role group 1`] = `
+<div>
+  <div
+    class="euiDroppable euiDroppable--noGrow"
+    data-rbd-droppable-context-id="0"
+    data-rbd-droppable-id="testDroppable"
+    data-test-subj="droppable"
+  >
+    <div
+      aria-describedby="rbd-hidden-text-0-hidden-text-0"
+      class="euiDraggable"
+      data-rbd-drag-handle-context-id="0"
+      data-rbd-drag-handle-draggable-id="testDraggable"
+      data-rbd-draggable-context-id="0"
+      data-rbd-draggable-id="testDraggable"
+      data-test-subj="draggable"
+      draggable="false"
+      role="group"
+    >
+      <div
+        class="euiDraggable__item"
+      >
+        Hello
+      </div>
+    </div>
+    <div
+      class="euiDroppable__placeholder"
+    />
+  </div>
+</div>
+`;
+
+exports[`EuiDraggable can be a draggable container with role group 2`] = `undefined`;
+
 exports[`EuiDraggable can be given ReactElement children 1`] = `
 <div>
   <div

--- a/src/components/drag_and_drop/_draggable.scss
+++ b/src/components/drag_and_drop/_draggable.scss
@@ -16,6 +16,10 @@
     transition-duration: .001s !important; // sass-lint:disable-line no-important
   }
 
+  &.euiDraggable--hasInteractiveElements .euiFlexItem:first-of-type {
+    margin-left: $euiSize;
+  }
+
   &:focus > .euiDraggable__item,
   &.euiDraggable--hasCustomDragHandle > .euiDraggable__item [data-react-beautiful-dnd-drag-handle]:focus {
     @include euiFocusRing;

--- a/src/components/drag_and_drop/_draggable.scss
+++ b/src/components/drag_and_drop/_draggable.scss
@@ -16,10 +16,6 @@
     transition-duration: .001s !important; // sass-lint:disable-line no-important
   }
 
-  &.euiDraggable--hasInteractiveElements .euiFlexItem:first-of-type {
-    margin-left: $euiSize;
-  }
-
   &:focus > .euiDraggable__item,
   &.euiDraggable--hasCustomDragHandle > .euiDraggable__item [data-react-beautiful-dnd-drag-handle]:focus {
     @include euiFocusRing;

--- a/src/components/drag_and_drop/draggable.test.tsx
+++ b/src/components/drag_and_drop/draggable.test.tsx
@@ -67,4 +67,24 @@ describe('EuiDraggable', () => {
 
     expect(takeSnapshot(appDiv)).toMatchSnapshot();
   });
+
+  test('can be a draggable container with role group', () => {
+    const handler = jest.fn();
+    ReactDOM.render(
+      <EuiDragDropContext onDragEnd={handler} {...requiredProps}>
+        <EuiDroppable droppableId="testDroppable">
+          <EuiDraggable
+            draggableContainer={true}
+            draggableId="testDraggable"
+            index={0}
+          >
+            <div>Hello</div>
+          </EuiDraggable>
+        </EuiDroppable>
+      </EuiDragDropContext>,
+      appDiv
+    );
+
+    expect(takeSnapshot(appDiv)).toMatchSnapshot();
+  });
 });

--- a/src/components/drag_and_drop/draggable.test.tsx
+++ b/src/components/drag_and_drop/draggable.test.tsx
@@ -68,13 +68,13 @@ describe('EuiDraggable', () => {
     expect(takeSnapshot(appDiv)).toMatchSnapshot();
   });
 
-  test('can be a draggable container with role group', () => {
+  test('hasInteractiveChildren renders with role="group" and no tabIndex', () => {
     const handler = jest.fn();
     ReactDOM.render(
       <EuiDragDropContext onDragEnd={handler} {...requiredProps}>
         <EuiDroppable droppableId="testDroppable">
           <EuiDraggable
-            draggableContainer={true}
+            hasInteractiveChildren={true}
             draggableId="testDraggable"
             index={0}
           >

--- a/src/components/drag_and_drop/draggable.tsx
+++ b/src/components/drag_and_drop/draggable.tsx
@@ -41,6 +41,14 @@ export interface EuiDraggableProps
    */
   customDragHandle?: boolean;
   /**
+   * Whether the container is draggable and should have role="group" instead of "button"
+   */
+  draggableContainer?: boolean;
+  /**
+   * Whether the `children` will contain interactive elements
+   */
+  interactiveElements?: boolean;
+  /**
    * Whether the item is currently in a position to be removed
    */
   isRemovable?: boolean;
@@ -54,7 +62,9 @@ export interface EuiDraggableProps
 export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
   customDragHandle = false,
   draggableId,
+  interactiveElements = false,
   isDragDisabled = false,
+  draggableContainer = false,
   isRemovable = false,
   index,
   children,
@@ -79,6 +89,7 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
           {
             'euiDraggable--hasClone': cloneItems,
             'euiDraggable--hasCustomDragHandle': customDragHandle,
+            'euiDraggable--hasInteractiveElements': interactiveElements,
             'euiDraggable--isDragging': snapshot.isDragging,
             'euiDraggable--withoutDropAnimation': isRemovable,
           },
@@ -104,6 +115,14 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
               data-test-subj={dataTestSubj}
               className={classes}
               style={{ ...style, ...provided.draggableProps.style }}
+              role={
+                draggableContainer ? 'group' : provided.dragHandleProps?.role
+              }
+              tabIndex={
+                draggableContainer
+                  ? undefined
+                  : provided.dragHandleProps?.tabIndex
+              }
             >
               {cloneElement(DraggableElement, {
                 className: classNames(

--- a/src/components/drag_and_drop/draggable.tsx
+++ b/src/components/drag_and_drop/draggable.tsx
@@ -41,7 +41,8 @@ export interface EuiDraggableProps
    */
   customDragHandle?: boolean;
   /**
-   * Whether the container is draggable and should have role="group" instead of "button"
+   * Whether the container is draggable and should have `role="group"` instead of `"button"`.
+   * Setting this flag ensures your drag & drop container is keyboard & screen reader accessible.
    */
   draggableContainer?: boolean;
   /**

--- a/src/components/drag_and_drop/draggable.tsx
+++ b/src/components/drag_and_drop/draggable.tsx
@@ -45,10 +45,6 @@ export interface EuiDraggableProps
    */
   draggableContainer?: boolean;
   /**
-   * Whether the `children` will contain interactive elements
-   */
-  interactiveElements?: boolean;
-  /**
    * Whether the item is currently in a position to be removed
    */
   isRemovable?: boolean;
@@ -62,7 +58,6 @@ export interface EuiDraggableProps
 export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
   customDragHandle = false,
   draggableId,
-  interactiveElements = false,
   isDragDisabled = false,
   draggableContainer = false,
   isRemovable = false,
@@ -89,7 +84,6 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
           {
             'euiDraggable--hasClone': cloneItems,
             'euiDraggable--hasCustomDragHandle': customDragHandle,
-            'euiDraggable--hasInteractiveElements': interactiveElements,
             'euiDraggable--isDragging': snapshot.isDragging,
             'euiDraggable--withoutDropAnimation': isRemovable,
           },

--- a/src/components/drag_and_drop/draggable.tsx
+++ b/src/components/drag_and_drop/draggable.tsx
@@ -41,8 +41,8 @@ export interface EuiDraggableProps
    */
   customDragHandle?: boolean;
   /**
-   * Whether the container is draggable and should have `role="group"` instead of `"button"`.
-   * Setting this flag ensures your drag & drop container is keyboard & screen reader accessible.
+   * Whether the container has interactive children and should have `role="group"` instead of `"button"`.
+   * Setting this flag ensures your drag & drop container is keyboard and screen reader accessible.
    */
   hasInteractiveChildren?: boolean;
   /**

--- a/src/components/drag_and_drop/draggable.tsx
+++ b/src/components/drag_and_drop/draggable.tsx
@@ -111,7 +111,8 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
               className={classes}
               style={{ ...style, ...provided.draggableProps.style }}
               // We use [role="group"] instead of [role="button"] when we expect a nested
-              // interactive element. Screen readers will cue users that this is a container // and has one or more elements inside that are part of a related group.
+              // interactive element. Screen readers will cue users that this is a container
+              // and has one or more elements inside that are part of a related group.
               role={
                 hasInteractiveChildren
                   ? 'group'

--- a/src/components/drag_and_drop/draggable.tsx
+++ b/src/components/drag_and_drop/draggable.tsx
@@ -44,7 +44,7 @@ export interface EuiDraggableProps
    * Whether the container is draggable and should have `role="group"` instead of `"button"`.
    * Setting this flag ensures your drag & drop container is keyboard & screen reader accessible.
    */
-  draggableContainer?: boolean;
+  hasInteractiveChildren?: boolean;
   /**
    * Whether the item is currently in a position to be removed
    */
@@ -60,7 +60,7 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
   customDragHandle = false,
   draggableId,
   isDragDisabled = false,
-  draggableContainer = false,
+  hasInteractiveChildren = false,
   isRemovable = false,
   index,
   children,
@@ -110,11 +110,17 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
               data-test-subj={dataTestSubj}
               className={classes}
               style={{ ...style, ...provided.draggableProps.style }}
+              // We use [role="group"] instead of [role="button"] when we expect a nested
+              // interactive element. Screen readers will cue users that this is a container // and has one or more elements inside that are part of a related group.
               role={
-                draggableContainer ? 'group' : provided.dragHandleProps?.role
+                hasInteractiveChildren
+                  ? 'group'
+                  : provided.dragHandleProps?.role
               }
+              // If the container includes an interactive element, we remove the tabindex=0
+              // because [role="group"] does not permit or warrant a tab stop
               tabIndex={
-                draggableContainer
+                hasInteractiveChildren
                   ? undefined
                   : provided.dragHandleProps?.tabIndex
               }


### PR DESCRIPTION
### Summary
Our interactive elements drag and drop pattern had focusable buttons that could not be reached by keyboard, and wouldn't announce to screen readers. We also had a draggable group that was a `div[role="button"]` which was preventing keyboard navigation. I refactored both patterns to retain the existing visual design as much as possible, and add the needed updates to pass an axe check and improve keyboard and screen reader experience.

Closes #5294 

### Design change
I made a visual change to the [interactive elements pattern](https://eui.elastic.co/#/display/drag-and-drop#interactive-elements) by leveraging the custom drag handle. I went this direction to fix a nested focusable element error. If the container will receive keyboard focus, the interactive element(s) will not be usable by keyboard events, and will not be announced to screen readers. I am attaching a screenshot of my proposed change below, and happy to make changes to visual design as needed.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

---
<img width="1307" alt="Screen Shot 2022-01-28 at 8 23 55 AM" src="https://user-images.githubusercontent.com/934879/151563419-7eb4bbcb-1b9e-483a-b02c-8cf256227e52.png">

