### PR TITLE
[EuiDataGrid] Handle exposed ref APIs potentially pointing to invalid, off-page, or out of view cells

### DIFF
--- a/src-docs/src/views/datagrid/datagrid_ref_example.js
+++ b/src-docs/src/views/datagrid/datagrid_ref_example.js
@@ -28,7 +28,7 @@ export const DataGridRefExample = {
     {
       source: [
         {
-          type: GuideSectionTypes.JS,
+          type: GuideSectionTypes.TSX,
           code: dataGridRefSource,
         },
       ],

--- a/src-docs/src/views/datagrid/datagrid_ref_example.js
+++ b/src-docs/src/views/datagrid/datagrid_ref_example.js
@@ -63,10 +63,30 @@ export const DataGridRefExample = {
               <EuiSpacer size="m" />
             </li>
             <li>
-              <p>
-                <EuiCode>openCellPopover({'{ rowIndex, colIndex }'})</EuiCode> -
-                opens the specified cell&apos;s popover contents.
-              </p>
+              <EuiCode>openCellPopover({'{ rowIndex, colIndex }'})</EuiCode> -
+              opens the specified cell&apos;s popover contents.
+              <EuiSpacer size="s" />
+              <EuiCallOut iconType="mapMarker" title="Handling cell location">
+                When using <EuiCode>setFocusedCell</EuiCode> or{' '}
+                <EuiCode>openCellPopover</EuiCode>, keep in mind:
+                <ul>
+                  <li>
+                    colIndex is affected by the user reordering or hiding
+                    columns.
+                  </li>
+                  <li>
+                    If the passed cell indices are outside the data grid&apos;s
+                    total row count or visible column count, an error will be
+                    thrown.
+                  </li>
+                  <li>
+                    If the data grid is paginated or sorted, the grid will
+                    handle automatically finding specified row index&apos;s
+                    correct location for you.
+                  </li>
+                </ul>
+              </EuiCallOut>
+              <EuiSpacer size="m" />
             </li>
             <li>
               <p>

--- a/src-docs/src/views/datagrid/ref.js
+++ b/src-docs/src/views/datagrid/ref.js
@@ -107,6 +107,12 @@ export default () => {
     []
   );
 
+  // Sorting
+  const [sortingColumns, setSortingColumns] = useState([]);
+  const onSort = useCallback((sortingColumns) => {
+    setSortingColumns(sortingColumns);
+  }, []);
+
   // Manual cell focus
   const [rowIndexAction, setRowIndexAction] = useState(0);
   const [colIndexAction, setColIndexAction] = useState(0);
@@ -118,7 +124,7 @@ export default () => {
           <EuiFormRow label="Row index">
             <EuiFieldNumber
               min={0}
-              max={24}
+              max={raw_data.length - 1}
               value={rowIndexAction}
               onChange={(e) => setRowIndexAction(Number(e.target.value))}
               compressed
@@ -129,7 +135,7 @@ export default () => {
           <EuiFormRow label="Column index">
             <EuiFieldNumber
               min={0}
-              max={4}
+              max={visibleColumns.length - 1}
               value={colIndexAction}
               onChange={(e) => setColIndexAction(Number(e.target.value))}
               compressed
@@ -177,6 +183,8 @@ export default () => {
         aria-label="Data grid demo"
         columns={columns}
         columnVisibility={{ visibleColumns, setVisibleColumns }}
+        sorting={{ columns: sortingColumns, onSort }}
+        inMemory={{ level: 'sorting' }}
         rowCount={raw_data.length}
         renderCellValue={({ rowIndex, columnId }) =>
           raw_data[rowIndex][columnId]

--- a/src-docs/src/views/datagrid/ref.tsx
+++ b/src-docs/src/views/datagrid/ref.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useState, useRef } from 'react';
+// @ts-ignore - faker does not have type declarations
 import { fake } from 'faker';
 
 import {
@@ -9,15 +10,16 @@ import {
   EuiFieldNumber,
   EuiButton,
   EuiDataGrid,
+  EuiDataGridRefProps,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiText,
-} from '../../../../src/components/';
+} from '../../../../src/components';
 
-const raw_data = [];
+const raw_data: Array<{ [key: string]: string }> = [];
 for (let i = 1; i < 100; i++) {
   raw_data.push({
     name: fake('{{name.lastName}}, {{name.firstName}}'),
@@ -29,20 +31,23 @@ for (let i = 1; i < 100; i++) {
 }
 
 export default () => {
-  const dataGridRef = useRef();
+  const dataGridRef = useRef<EuiDataGridRefProps>(null);
 
   // Modal
   const [isModalVisible, setIsModalVisible] = useState(false);
-  const [lastFocusedCell, setLastFocusedCell] = useState({});
+  const [lastFocusedCell, setLastFocusedCell] = useState({
+    rowIndex: 0,
+    colIndex: 0,
+  });
 
   const closeModal = useCallback(() => {
     setIsModalVisible(false);
-    dataGridRef.current.setFocusedCell(lastFocusedCell); // Set the data grid focus back to the cell that opened the modal
+    dataGridRef.current!.setFocusedCell(lastFocusedCell); // Set the data grid focus back to the cell that opened the modal
   }, [lastFocusedCell]);
 
   const showModal = useCallback(({ rowIndex, colIndex }) => {
     setIsModalVisible(true);
-    dataGridRef.current.closeCellPopover(); // Close any open cell popovers
+    dataGridRef.current!.closeCellPopover(); // Close any open cell popovers
     setLastFocusedCell({ rowIndex, colIndex }); // Store the cell that opened this modal
   }, []);
 
@@ -101,11 +106,12 @@ export default () => {
 
   // Pagination
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 25 });
-  const onChangePage = useCallback(
-    (pageIndex) =>
-      setPagination((pagination) => ({ ...pagination, pageIndex })),
-    []
-  );
+  const onChangePage = useCallback((pageIndex) => {
+    setPagination((pagination) => ({ ...pagination, pageIndex }));
+  }, []);
+  const onChangePageSize = useCallback((pageSize) => {
+    setPagination((pagination) => ({ ...pagination, pageSize }));
+  }, []);
 
   // Sorting
   const [sortingColumns, setSortingColumns] = useState([]);
@@ -146,7 +152,7 @@ export default () => {
           <EuiButton
             size="s"
             onClick={() =>
-              dataGridRef.current.setFocusedCell({
+              dataGridRef.current!.setFocusedCell({
                 rowIndex: rowIndexAction,
                 colIndex: colIndexAction,
               })
@@ -159,7 +165,7 @@ export default () => {
           <EuiButton
             size="s"
             onClick={() =>
-              dataGridRef.current.openCellPopover({
+              dataGridRef.current!.openCellPopover({
                 rowIndex: rowIndexAction,
                 colIndex: colIndexAction,
               })
@@ -171,7 +177,7 @@ export default () => {
         <EuiFlexItem grow={false}>
           <EuiButton
             size="s"
-            onClick={() => dataGridRef.current.setIsFullScreen(true)}
+            onClick={() => dataGridRef.current!.setIsFullScreen(true)}
           >
             Set grid to full screen
           </EuiButton>
@@ -191,8 +197,9 @@ export default () => {
         }
         pagination={{
           ...pagination,
-          pageSizeOptions: [25],
+          pageSizeOptions: [25, 50],
           onChangePage: onChangePage,
+          onChangeItemsPerPage: onChangePageSize,
         }}
         height={400}
         ref={dataGridRef}

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -490,7 +490,7 @@ export class EuiDataGridCell extends Component<
       rowManager,
       ...rest
     } = this.props;
-    const { rowIndex, colIndex } = rest;
+    const { rowIndex, visibleRowIndex, colIndex } = rest;
 
     const popoverIsOpen = this.isPopoverOpen();
     const hasCellButtons = isExpandable || column?.cellActions;
@@ -534,7 +534,7 @@ export class EuiDataGridCell extends Component<
           case keys.ENTER:
           case keys.F2:
             event.preventDefault();
-            openCellPopover({ rowIndex, colIndex });
+            openCellPopover({ rowIndex: visibleRowIndex, colIndex });
             break;
         }
       } else {
@@ -641,7 +641,7 @@ export class EuiDataGridCell extends Component<
                 if (popoverIsOpen) {
                   closeCellPopover();
                 } else {
-                  openCellPopover({ rowIndex, colIndex });
+                  openCellPopover({ rowIndex: visibleRowIndex, colIndex });
                 }
               }}
             />

--- a/src/components/datagrid/body/header/data_grid_header_cell.test.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.test.tsx
@@ -49,7 +49,7 @@ describe('EuiDataGridHeaderCell', () => {
         <DataGridSortingContext.Provider
           value={{
             sorting: { ...sortingContext, ...sorting },
-            sortedRowMap: {},
+            sortedRowMap: [],
             getCorrectRowIndex: jest.fn(),
           }}
         >

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -6,10 +6,10 @@
  * Side Public License, v 1.
  */
 
-import React, { useEffect, useState, createRef } from 'react';
+import React, { useEffect, useState } from 'react';
 import { mount, ReactWrapper, render } from 'enzyme';
 import { EuiDataGrid } from './';
-import { EuiDataGridProps, EuiDataGridRefProps } from './data_grid_types';
+import { EuiDataGridProps } from './data_grid_types';
 import {
   findTestSubject,
   requiredProps,
@@ -2747,31 +2747,6 @@ describe('EuiDataGrid', () => {
       focusableCell = getFocusableCell(component);
       expect(focusableCell.text()).toEqual('0, B'); // grid navigation is enabled again, check that we can move
       expect(takeMountedSnapshot(component)).toMatchSnapshot();
-    });
-  });
-
-  it('returns a ref which exposes internal imperative APIs', () => {
-    const gridRef = createRef<EuiDataGridRefProps>();
-
-    mount(
-      <EuiDataGrid
-        {...requiredProps}
-        columns={[{ id: 'A' }, { id: 'B' }]}
-        columnVisibility={{
-          visibleColumns: ['A', 'B'],
-          setVisibleColumns: () => {},
-        }}
-        rowCount={1}
-        renderCellValue={() => 'value'}
-        ref={gridRef}
-      />
-    );
-
-    expect(gridRef.current).toEqual({
-      setIsFullScreen: expect.any(Function),
-      setFocusedCell: expect.any(Function),
-      openCellPopover: expect.any(Function),
-      closeCellPopover: expect.any(Function),
     });
   });
 });

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -13,7 +13,6 @@ import React, {
   useMemo,
   useRef,
   useState,
-  useImperativeHandle,
 } from 'react';
 import {
   VariableSizeGrid as Grid,
@@ -56,6 +55,7 @@ import {
   schemaDetectors as providedSchemaDetectors,
   useMergedSchema,
 } from './utils/data_grid_schema';
+import { useImperativeGridRef } from './utils/ref';
 import {
   EuiDataGridColumn,
   EuiDataGridProps,
@@ -302,23 +302,14 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
     };
 
     /**
-     * Expose internal APIs as ref to consumer
+     * Expose certain internal APIs as ref to consumer
      */
-    const { setFocusedCell } = focusContext; // eslint complains about the dependency array otherwise
-    const { openCellPopover, closeCellPopover } = cellPopoverContext;
-
-    useImperativeHandle(
+    useImperativeGridRef({
       ref,
-      () => ({
-        setIsFullScreen,
-        setFocusedCell: ({ rowIndex, colIndex }) => {
-          setFocusedCell([colIndex, rowIndex]); // Transmog args from obj to array
-        },
-        openCellPopover,
-        closeCellPopover,
-      }),
-      [setFocusedCell, openCellPopover, closeCellPopover]
-    );
+      setIsFullScreen,
+      focusContext,
+      cellPopoverContext,
+    });
 
     /**
      * Classes

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -309,6 +309,8 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
       setIsFullScreen,
       focusContext,
       cellPopoverContext,
+      rowCount,
+      visibleColCount,
     });
 
     /**

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -309,6 +309,8 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
       setIsFullScreen,
       focusContext,
       cellPopoverContext,
+      sortingContext,
+      pagination,
       rowCount,
       visibleColCount,
     });

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -180,8 +180,11 @@ export interface EuiDataGridVisibleRows {
 export interface DataGridSortingContextShape {
   sorting?: EuiDataGridSorting;
   sortedRowMap: { [key: number]: number };
-  getCorrectRowIndex: (rowIndex: number) => number;
+  getCorrectRowIndex: (visibleRowIndex: number) => number;
 }
+
+// An array of [x,y] coordinates. Note that the `y` value expected internally is a `visibleRowIndex`
+export type EuiDataGridFocusedCell = [number, number];
 
 export interface DataGridFocusContextShape {
   focusedCell?: EuiDataGridFocusedCell;
@@ -196,6 +199,7 @@ export interface DataGridFocusContextShape {
 
 export interface DataGridCellPopoverContextShape {
   popoverIsOpen: boolean;
+  // Note that the rowIndex used to locate cells internally is a `visibleRowIndex`
   cellLocation: { rowIndex: number; colIndex: number };
   openCellPopover(args: { rowIndex: number; colIndex: number }): void;
   closeCellPopover(): void;
@@ -763,8 +767,6 @@ export interface EuiDataGridInMemory {
    */
   skipColumns?: string[];
 }
-
-export type EuiDataGridFocusedCell = [number, number];
 
 export interface EuiDataGridInMemoryValues {
   [rowIndex: string]: { [columnId: string]: string };

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -179,7 +179,7 @@ export interface EuiDataGridVisibleRows {
 
 export interface DataGridSortingContextShape {
   sorting?: EuiDataGridSorting;
-  sortedRowMap: { [key: number]: number };
+  sortedRowMap: number[];
   getCorrectRowIndex: (visibleRowIndex: number) => number;
 }
 

--- a/src/components/datagrid/utils/ref.spec.tsx
+++ b/src/components/datagrid/utils/ref.spec.tsx
@@ -1,0 +1,198 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { useState, createRef, forwardRef } from 'react';
+import { EuiDataGrid } from '../';
+import { EuiDataGridRefProps } from '../data_grid_types';
+
+// We need to set up a test component here for sorting/pagination state to work
+// The underlying imperative ref should still be forwarded and work as normal
+const GridTest = forwardRef<EuiDataGridRefProps, any>((_, ref) => {
+  // Pagination
+  const [pageIndex, setPageIndex] = useState(0);
+  const onChangePage = (pageIndex) => setPageIndex(pageIndex);
+
+  // Sorting
+  const [sortingColumns, setSortingColumns] = useState([]);
+  const onSort = (sortingColumns) => setSortingColumns(sortingColumns);
+
+  return (
+    <EuiDataGrid
+      aria-label="useImperativeGridRef test"
+      ref={ref}
+      data-test-subj="euiDataGrid"
+      height={400}
+      columns={[
+        { id: 'A' },
+        { id: 'B' },
+        { id: 'C' },
+        { id: 'D' },
+        { id: 'E' },
+        { id: 'F' },
+      ]}
+      columnVisibility={{
+        visibleColumns: ['A', 'B', 'C', 'D', 'E', 'F'],
+        setVisibleColumns: () => {},
+      }}
+      rowCount={100}
+      renderCellValue={({ rowIndex, columnId }) => `${columnId}, ${rowIndex}`}
+      pagination={{
+        pageIndex,
+        pageSize: 25,
+        onChangePage,
+        onChangeItemsPerPage: () => {},
+      }}
+      sorting={{ columns: sortingColumns, onSort }}
+      inMemory={{ level: 'sorting' }}
+    />
+  );
+});
+GridTest.displayName = 'GridTest';
+
+describe('useImperativeGridRef', () => {
+  const ref = createRef<EuiDataGridRefProps>();
+
+  beforeEach(() => {
+    cy.mount(<GridTest ref={ref} />);
+    cy.get('[data-test-subj="euiDataGridBody"]'); // Wait for the grid to finish rendering and pass back the ref
+  });
+
+  describe('setIsFullScreen', () => {
+    it('allows the consumer to manually toggle full screen mode', () => {
+      ref.current.setIsFullScreen(true);
+      cy.get('[data-test-subj="euiDataGrid"]').should(
+        'have.class',
+        'euiDataGrid--fullScreen'
+      );
+      // Has to be a separate .then() block from the above for some Cypress-y reason
+      cy.then(() => {
+        ref.current.setIsFullScreen(false);
+        cy.get('[data-test-subj="euiDataGrid"]').should(
+          'not.have.class',
+          'euiDataGrid--fullScreen'
+        );
+      });
+    });
+  });
+
+  describe('setFocusedCell', () => {
+    it('allows the consumer to manually focus into a specific grid cell', () => {
+      ref.current.setFocusedCell({ rowIndex: 1, colIndex: 1 });
+      cy.focused()
+        .should('have.attr', 'data-gridcell-visible-row-index', '1')
+        .should('have.attr', 'data-gridcell-column-index', '1');
+    });
+
+    it('should scroll to cells that are not in view', () => {
+      ref.current.setFocusedCell({ rowIndex: 24, colIndex: 5 });
+      cy.focused()
+        .should('have.attr', 'data-gridcell-visible-row-index', '24')
+        .should('have.attr', 'data-gridcell-column-index', '5');
+    });
+
+    it('should paginate to cells that are not on the current page', () => {
+      ref.current.setFocusedCell({ rowIndex: 50, colIndex: 0 });
+      cy.get('.euiPagination .euiScreenReaderOnly').should(
+        'have.text',
+        'Page 3 of 4'
+      );
+      cy.focused()
+        .should('have.attr', 'data-gridcell-visible-row-index', '0')
+        .should('have.attr', 'data-gridcell-column-index', '0');
+    });
+
+    it('should correctly find the specified rowIndex when sorted', () => {
+      cy.get('[data-test-subj="dataGridHeaderCell-A"]').click();
+      cy.contains('Sort High-Low').click();
+      cy.then(() => {
+        ref.current.setFocusedCell({ rowIndex: 95, colIndex: 0 });
+        cy.focused()
+          .should('have.attr', 'data-gridcell-visible-row-index', '4')
+          .should('have.attr', 'data-gridcell-column-index', '0');
+      });
+    });
+
+    it('should throw an error if the passed cell indices are invalid', () => {
+      cy.on('fail', (err) => {
+        expect(err.message).to.equal(
+          'Row 150 is not a valid row. The maximum visible row index is 99.'
+        );
+      });
+      ref.current.setFocusedCell({ rowIndex: 150, colIndex: 0 });
+    });
+  });
+
+  describe('openCellPopover', () => {
+    it("allows the consumer to manually open a specific grid cell's popover", () => {
+      ref.current.openCellPopover({ rowIndex: 2, colIndex: 2 });
+      cy.focused()
+        .should('have.attr', 'data-test-subj', 'euiDataGridExpansionPopover')
+        .find('.euiText')
+        .should('have.text', 'C, 2');
+    });
+
+    it('should scroll to cells that are not in view', () => {
+      ref.current.openCellPopover({ rowIndex: 23, colIndex: 0 });
+      cy.focused()
+        .should('have.attr', 'data-test-subj', 'euiDataGridExpansionPopover')
+        .find('.euiText')
+        .should('have.text', 'A, 23');
+    });
+
+    it('should paginate to cells that are not on the current page', () => {
+      ref.current.openCellPopover({ rowIndex: 99, colIndex: 5 });
+      cy.get('.euiPagination .euiScreenReaderOnly').should(
+        'have.text',
+        'Page 4 of 4'
+      );
+      cy.focused()
+        .should('have.attr', 'data-test-subj', 'euiDataGridExpansionPopover')
+        .find('.euiText')
+        .should('have.text', 'F, 99');
+    });
+
+    it('should correctly find the specified rowIndex when sorted', () => {
+      cy.get('[data-test-subj="dataGridHeaderCell-A"]').click();
+      cy.contains('Sort High-Low').click();
+      cy.then(() => {
+        ref.current.openCellPopover({ rowIndex: 98, colIndex: 1 });
+        cy.focused()
+          .should('have.attr', 'data-test-subj', 'euiDataGridExpansionPopover')
+          .find('.euiText')
+          .should('have.text', 'B, 98');
+      });
+    });
+
+    it('should throw an error if the passed cell indices are invalid', () => {
+      cy.on('fail', (err) => {
+        expect(err.message).to.equal(
+          'Column 10 is not a valid column. The maximum visible column index is 5.'
+        );
+      });
+      ref.current.openCellPopover({ rowIndex: 0, colIndex: 10 });
+    });
+  });
+
+  describe('closeCellPopover', () => {
+    it('allows the consumer to manually close any open popovers', () => {
+      ref.current.setFocusedCell({ colIndex: 0, rowIndex: 0 });
+      cy.realPress('Enter');
+      cy.get('[data-test-subj="euiDataGridExpansionPopover"]').should(
+        'have.length',
+        1
+      );
+      cy.then(() => {
+        ref.current.closeCellPopover();
+        cy.get('[data-test-subj="euiDataGridExpansionPopover"]').should(
+          'have.length',
+          0
+        );
+      });
+    });
+  });
+});

--- a/src/components/datagrid/utils/ref.test.ts
+++ b/src/components/datagrid/utils/ref.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { testCustomHook } from '../../../test/test_custom_hook.test_helper';
-import { useCellLocationCheck } from './ref';
+import { useCellLocationCheck, useVisibleRowIndex } from './ref';
 
 // TODO: see ref.spec.tsx for E2E useImperativeGridRef tests
 
@@ -36,5 +36,70 @@ describe('useCellLocationCheck', () => {
     expect(() => {
       checkCellExists({ rowIndex: 0, colIndex: 0 });
     }).not.toThrow();
+  });
+});
+
+describe('useVisibleRowIndex', () => {
+  describe('if the grid is not sorted or paginated', () => {
+    const pagination = undefined;
+    const sortedRowMap: number[] = [];
+
+    it('returns the passed rowIndex as-is', () => {
+      const {
+        return: { getVisibleRowIndex },
+      } = testCustomHook(() => useVisibleRowIndex(pagination, sortedRowMap));
+
+      expect(getVisibleRowIndex(5)).toEqual(5);
+    });
+  });
+
+  describe('if the grid is sorted', () => {
+    const pagination = undefined;
+    const sortedRowMap = [3, 4, 1, 2, 0];
+
+    it('returns the visibleRowIndex of the passed rowIndex (which is the index of the sortedRowMap)', () => {
+      const {
+        return: { getVisibleRowIndex },
+      } = testCustomHook(() => useVisibleRowIndex(pagination, sortedRowMap));
+
+      expect(getVisibleRowIndex(0)).toEqual(4);
+      expect(getVisibleRowIndex(1)).toEqual(2);
+      expect(getVisibleRowIndex(2)).toEqual(3);
+      expect(getVisibleRowIndex(3)).toEqual(0);
+      expect(getVisibleRowIndex(4)).toEqual(1);
+    });
+  });
+
+  describe('if the grid is paginated', () => {
+    const pagination = {
+      pageSize: 20,
+      pageIndex: 0,
+      onChangePage: jest.fn(),
+      onChangeItemsPerPage: jest.fn(),
+    };
+    const sortedRowMap: number[] = [];
+
+    beforeEach(() => jest.clearAllMocks());
+
+    it('calculates what page the row should be on, paginates to that page, and returns the index of the row on that page', () => {
+      const {
+        return: { getVisibleRowIndex },
+      } = testCustomHook(() => useVisibleRowIndex(pagination, sortedRowMap));
+
+      expect(getVisibleRowIndex(20)).toEqual(0); // First item on 2nd page
+      expect(pagination.onChangePage).toHaveBeenLastCalledWith(1);
+
+      expect(getVisibleRowIndex(75)).toEqual(15); // 16th item on 4th page
+      expect(pagination.onChangePage).toHaveBeenLastCalledWith(3);
+    });
+
+    it('does not paginate if the user is already on the correct page', () => {
+      const {
+        return: { getVisibleRowIndex },
+      } = testCustomHook(() => useVisibleRowIndex(pagination, sortedRowMap));
+
+      expect(getVisibleRowIndex(5)).toEqual(5);
+      expect(pagination.onChangePage).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/datagrid/utils/ref.test.ts
+++ b/src/components/datagrid/utils/ref.test.ts
@@ -9,7 +9,7 @@
 import { testCustomHook } from '../../../test/test_custom_hook.test_helper';
 import { useCellLocationCheck, useVisibleRowIndex } from './ref';
 
-// TODO: see ref.spec.tsx for E2E useImperativeGridRef tests
+// see ref.spec.tsx for E2E useImperativeGridRef tests
 
 describe('useCellLocationCheck', () => {
   const {

--- a/src/components/datagrid/utils/ref.test.ts
+++ b/src/components/datagrid/utils/ref.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { testCustomHook } from '../../../test/test_custom_hook.test_helper';
-import { useCellLocationCheck, useVisibleRowIndex } from './ref';
+import { useCellLocationCheck, useSortPageCheck } from './ref';
 
 // see ref.spec.tsx for E2E useImperativeGridRef tests
 
@@ -39,17 +39,17 @@ describe('useCellLocationCheck', () => {
   });
 });
 
-describe('useVisibleRowIndex', () => {
+describe('useSortPageCheck', () => {
   describe('if the grid is not sorted or paginated', () => {
     const pagination = undefined;
     const sortedRowMap: number[] = [];
 
     it('returns the passed rowIndex as-is', () => {
       const {
-        return: { getVisibleRowIndex },
-      } = testCustomHook(() => useVisibleRowIndex(pagination, sortedRowMap));
+        return: { findVisibleRowIndex },
+      } = testCustomHook(() => useSortPageCheck(pagination, sortedRowMap));
 
-      expect(getVisibleRowIndex(5)).toEqual(5);
+      expect(findVisibleRowIndex(5)).toEqual(5);
     });
   });
 
@@ -59,14 +59,14 @@ describe('useVisibleRowIndex', () => {
 
     it('returns the visibleRowIndex of the passed rowIndex (which is the index of the sortedRowMap)', () => {
       const {
-        return: { getVisibleRowIndex },
-      } = testCustomHook(() => useVisibleRowIndex(pagination, sortedRowMap));
+        return: { findVisibleRowIndex },
+      } = testCustomHook(() => useSortPageCheck(pagination, sortedRowMap));
 
-      expect(getVisibleRowIndex(0)).toEqual(4);
-      expect(getVisibleRowIndex(1)).toEqual(2);
-      expect(getVisibleRowIndex(2)).toEqual(3);
-      expect(getVisibleRowIndex(3)).toEqual(0);
-      expect(getVisibleRowIndex(4)).toEqual(1);
+      expect(findVisibleRowIndex(0)).toEqual(4);
+      expect(findVisibleRowIndex(1)).toEqual(2);
+      expect(findVisibleRowIndex(2)).toEqual(3);
+      expect(findVisibleRowIndex(3)).toEqual(0);
+      expect(findVisibleRowIndex(4)).toEqual(1);
     });
   });
 
@@ -83,22 +83,22 @@ describe('useVisibleRowIndex', () => {
 
     it('calculates what page the row should be on, paginates to that page, and returns the index of the row on that page', () => {
       const {
-        return: { getVisibleRowIndex },
-      } = testCustomHook(() => useVisibleRowIndex(pagination, sortedRowMap));
+        return: { findVisibleRowIndex },
+      } = testCustomHook(() => useSortPageCheck(pagination, sortedRowMap));
 
-      expect(getVisibleRowIndex(20)).toEqual(0); // First item on 2nd page
+      expect(findVisibleRowIndex(20)).toEqual(0); // First item on 2nd page
       expect(pagination.onChangePage).toHaveBeenLastCalledWith(1);
 
-      expect(getVisibleRowIndex(75)).toEqual(15); // 16th item on 4th page
+      expect(findVisibleRowIndex(75)).toEqual(15); // 16th item on 4th page
       expect(pagination.onChangePage).toHaveBeenLastCalledWith(3);
     });
 
     it('does not paginate if the user is already on the correct page', () => {
       const {
-        return: { getVisibleRowIndex },
-      } = testCustomHook(() => useVisibleRowIndex(pagination, sortedRowMap));
+        return: { findVisibleRowIndex },
+      } = testCustomHook(() => useSortPageCheck(pagination, sortedRowMap));
 
-      expect(getVisibleRowIndex(5)).toEqual(5);
+      expect(findVisibleRowIndex(5)).toEqual(5);
       expect(pagination.onChangePage).not.toHaveBeenCalled();
     });
   });

--- a/src/components/datagrid/utils/ref.test.ts
+++ b/src/components/datagrid/utils/ref.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { testCustomHook } from '../../../test/test_custom_hook.test_helper';
+import { useCellLocationCheck } from './ref';
+
+// TODO: see ref.spec.tsx for E2E useImperativeGridRef tests
+
+describe('useCellLocationCheck', () => {
+  const {
+    return: { checkCellExists },
+  } = testCustomHook(() => useCellLocationCheck(10, 5));
+
+  it("throws an error if the passed rowIndex is higher than the grid's rowCount", () => {
+    expect(() => {
+      checkCellExists({ rowIndex: 12, colIndex: 0 });
+    }).toThrow(
+      'Row 12 is not a valid row. The maximum visible row index is 9.'
+    );
+  });
+
+  it("throws an error if the passed colIndex is higher than the grid's visibleColCount", () => {
+    expect(() => {
+      checkCellExists({ rowIndex: 1, colIndex: 5 });
+    }).toThrow(
+      'Column 5 is not a valid column. The maximum visible column index is 4.'
+    );
+  });
+
+  it('does not throw if the rowIndex and colIndex are within grid bounds', () => {
+    expect(() => {
+      checkCellExists({ rowIndex: 0, colIndex: 0 });
+    }).not.toThrow();
+  });
+});

--- a/src/components/datagrid/utils/ref.ts
+++ b/src/components/datagrid/utils/ref.ts
@@ -18,6 +18,8 @@ interface Dependencies {
   setIsFullScreen: EuiDataGridRefProps['setIsFullScreen'];
   focusContext: DataGridFocusContextShape;
   cellPopoverContext: DataGridCellPopoverContextShape;
+  rowCount: number;
+  visibleColCount: number;
 }
 
 export const useImperativeGridRef = ({
@@ -25,15 +27,25 @@ export const useImperativeGridRef = ({
   setIsFullScreen,
   focusContext,
   cellPopoverContext,
+  rowCount,
+  visibleColCount,
 }: Dependencies) => {
+  // Cell location helpers
+  const { checkCellExists } = useCellLocationCheck(rowCount, visibleColCount);
+
   // Focus APIs
   const { setFocusedCell: _setFocusedCell } = focusContext; // eslint complains about the dependency array otherwise
 
+  // When we pass this API to the consumer, we can't know for sure that
+  // the targeted cell is valid or in view (unlike our internal state, where
+  // both of those states can be guaranteed), so we need to do some extra
+  // checks here to make sure the grid automatically handles all cells
   const setFocusedCell = useCallback(
     ({ rowIndex, colIndex }) => {
+      checkCellExists({ rowIndex, colIndex });
       _setFocusedCell([colIndex, rowIndex]); // Transmog args from obj to array
     },
-    [_setFocusedCell]
+    [_setFocusedCell, checkCellExists]
   );
 
   // Popover APIs
@@ -42,11 +54,16 @@ export const useImperativeGridRef = ({
     closeCellPopover,
   } = cellPopoverContext;
 
+  // When we pass this API to the consumer, we can't know for sure that
+  // the targeted cell is valid or in view (unlike our internal state, where
+  // both of those states can be guaranteed), so we need to do some extra
+  // checks here to make sure the grid automatically handles all cells
   const openCellPopover = useCallback(
     ({ rowIndex, colIndex }) => {
+      checkCellExists({ rowIndex, colIndex });
       _openCellPopover({ rowIndex, colIndex });
     },
-    [_openCellPopover]
+    [_openCellPopover, checkCellExists]
   );
 
   // Set the ref APIs
@@ -60,4 +77,32 @@ export const useImperativeGridRef = ({
     }),
     [setIsFullScreen, setFocusedCell, openCellPopover, closeCellPopover]
   );
+};
+
+/**
+ * Throw a digestible error if the consumer attempts to focus into an invalid
+ * cell range, which should also stop the APIs from continuing
+ */
+export const useCellLocationCheck = (rowCount: number, colCount: number) => {
+  const checkCellExists = useCallback(
+    ({ rowIndex, colIndex }) => {
+      if (rowIndex >= rowCount || rowIndex < 0) {
+        throw new Error(
+          `Row ${rowIndex} is not a valid row. The maximum visible row index is ${
+            rowCount - 1
+          }.`
+        );
+      }
+      if (colIndex >= colCount) {
+        throw new Error(
+          `Column ${colIndex} is not a valid column. The maximum visible column index is ${
+            colCount - 1
+          }.`
+        );
+      }
+    },
+    [rowCount, colCount]
+  );
+
+  return { checkCellExists };
 };

--- a/src/components/datagrid/utils/ref.ts
+++ b/src/components/datagrid/utils/ref.ts
@@ -38,7 +38,7 @@ export const useImperativeGridRef = ({
 }: Dependencies) => {
   // Cell location helpers
   const { checkCellExists } = useCellLocationCheck(rowCount, visibleColCount);
-  const { getVisibleRowIndex } = useVisibleRowIndex(pagination, sortedRowMap);
+  const { findVisibleRowIndex } = useSortPageCheck(pagination, sortedRowMap);
 
   // Focus APIs
   const { setFocusedCell: _setFocusedCell } = focusContext; // eslint complains about the dependency array otherwise
@@ -50,10 +50,10 @@ export const useImperativeGridRef = ({
   const setFocusedCell = useCallback(
     ({ rowIndex, colIndex }) => {
       checkCellExists({ rowIndex, colIndex });
-      const visibleRowIndex = getVisibleRowIndex(rowIndex);
+      const visibleRowIndex = findVisibleRowIndex(rowIndex);
       _setFocusedCell([colIndex, visibleRowIndex]); // Transmog args from obj to array
     },
-    [_setFocusedCell, checkCellExists, getVisibleRowIndex]
+    [_setFocusedCell, checkCellExists, findVisibleRowIndex]
   );
 
   // Popover APIs
@@ -69,10 +69,10 @@ export const useImperativeGridRef = ({
   const openCellPopover = useCallback(
     ({ rowIndex, colIndex }) => {
       checkCellExists({ rowIndex, colIndex });
-      const visibleRowIndex = getVisibleRowIndex(rowIndex);
+      const visibleRowIndex = findVisibleRowIndex(rowIndex);
       _openCellPopover({ rowIndex: visibleRowIndex, colIndex });
     },
-    [_openCellPopover, checkCellExists, getVisibleRowIndex]
+    [_openCellPopover, checkCellExists, findVisibleRowIndex]
   );
 
   // Set the ref APIs
@@ -123,11 +123,11 @@ export const useCellLocationCheck = (rowCount: number, colCount: number) => {
  * the row is not on the current page, the grid should automatically handle
  * paginating to that row.
  */
-export const useVisibleRowIndex = (
+export const useSortPageCheck = (
   pagination: EuiDataGridProps['pagination'],
   sortedRowMap: DataGridSortingContextShape['sortedRowMap']
 ) => {
-  const getVisibleRowIndex = useCallback(
+  const findVisibleRowIndex = useCallback(
     (rowIndex: number): number => {
       // Account for sorting
       const visibleRowIndex = sortedRowMap.length
@@ -150,5 +150,5 @@ export const useVisibleRowIndex = (
     [pagination, sortedRowMap]
   );
 
-  return { getVisibleRowIndex };
+  return { findVisibleRowIndex };
 };

--- a/src/components/datagrid/utils/ref.ts
+++ b/src/components/datagrid/utils/ref.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { useImperativeHandle, useCallback, Ref } from 'react';
+import {
+  EuiDataGridRefProps,
+  DataGridFocusContextShape,
+  DataGridCellPopoverContextShape,
+} from '../data_grid_types';
+
+interface Dependencies {
+  ref: Ref<unknown>;
+  setIsFullScreen: EuiDataGridRefProps['setIsFullScreen'];
+  focusContext: DataGridFocusContextShape;
+  cellPopoverContext: DataGridCellPopoverContextShape;
+}
+
+export const useImperativeGridRef = ({
+  ref,
+  setIsFullScreen,
+  focusContext,
+  cellPopoverContext,
+}: Dependencies) => {
+  // Focus APIs
+  const { setFocusedCell: _setFocusedCell } = focusContext; // eslint complains about the dependency array otherwise
+
+  const setFocusedCell = useCallback(
+    ({ rowIndex, colIndex }) => {
+      _setFocusedCell([colIndex, rowIndex]); // Transmog args from obj to array
+    },
+    [_setFocusedCell]
+  );
+
+  // Popover APIs
+  const {
+    openCellPopover: _openCellPopover,
+    closeCellPopover,
+  } = cellPopoverContext;
+
+  const openCellPopover = useCallback(
+    ({ rowIndex, colIndex }) => {
+      _openCellPopover({ rowIndex, colIndex });
+    },
+    [_openCellPopover]
+  );
+
+  // Set the ref APIs
+  useImperativeHandle(
+    ref,
+    () => ({
+      setIsFullScreen,
+      setFocusedCell,
+      openCellPopover,
+      closeCellPopover,
+    }),
+    [setIsFullScreen, setFocusedCell, openCellPopover, closeCellPopover]
+  );
+};

--- a/src/components/datagrid/utils/scrolling.ts
+++ b/src/components/datagrid/utils/scrolling.ts
@@ -74,6 +74,9 @@ export const useScrollCellIntoView = ({
   hasStickyFooter,
 }: Dependencies) => {
   const scrollCellIntoView = useCallback(
+    // Note: in order for this UX to work correctly with react-window's APIs,
+    // the `rowIndex` arg expected is actually our internal `visibleRowIndex`,
+    // not the `rowIndex` from the raw unsorted/unpaginated user data
     async ({ rowIndex, colIndex }: ScrollCellIntoView) => {
       if (!gridRef.current || !outerGridRef.current || !innerGridRef.current) {
         return; // Grid isn't rendered yet or is empty

--- a/src/components/datagrid/utils/sorting.ts
+++ b/src/components/datagrid/utils/sorting.ts
@@ -103,19 +103,21 @@ export const useSorting = ({
     schemaDetectors,
   ]);
 
+  // Given a visible row index, obtain the unpaginated & unsorted
+  // row index from the passed cell data
   const getCorrectRowIndex = useCallback(
-    (rowIndex: number) => {
-      let rowIndexWithOffset = rowIndex;
+    (visibleRowIndex: number) => {
+      const isPaginated = visibleRowIndex - startRow < 0;
+      const unpaginatedRowIndex = isPaginated
+        ? visibleRowIndex + startRow
+        : visibleRowIndex;
 
-      if (rowIndex - startRow < 0) {
-        rowIndexWithOffset = rowIndex + startRow;
-      }
+      const unsortedRowIndex =
+        unpaginatedRowIndex in sortedRowMap
+          ? sortedRowMap[unpaginatedRowIndex]
+          : unpaginatedRowIndex;
 
-      const correctRowIndex = sortedRowMap.hasOwnProperty(rowIndexWithOffset)
-        ? sortedRowMap[rowIndexWithOffset]
-        : rowIndexWithOffset;
-
-      return correctRowIndex;
+      return unsortedRowIndex;
     },
     [startRow, sortedRowMap]
   );

--- a/src/components/datagrid/utils/sorting.ts
+++ b/src/components/datagrid/utils/sorting.ts
@@ -21,7 +21,7 @@ export const DataGridSortingContext = createContext<
   DataGridSortingContextShape
 >({
   sorting: undefined,
-  sortedRowMap: {},
+  sortedRowMap: [],
   getCorrectRowIndex: (number) => number,
 });
 
@@ -43,7 +43,7 @@ export const useSorting = ({
   const sortingColumns = sorting?.columns;
 
   const sortedRowMap = useMemo(() => {
-    const rowMap: DataGridSortingContextShape['sortedRowMap'] = {};
+    const rowMap: DataGridSortingContextShape['sortedRowMap'] = [];
 
     if (
       inMemory?.level === 'sorting' &&


### PR DESCRIPTION
### Summary

Follow up to https://github.com/elastic/eui/pull/5550#pullrequestreview-863950503

This should resolve the issue of `setFocusedCell` and  `openCellPopover` being called on sorted or paginated grids. It should also:

- Convert the documentation ref demo to Typescript to better catch potential type issues that our consumers may run into
- Create a full E2E suite of Cypress tests for our ref APIs

I **strongly** recommend following along [by commit](https://github.com/elastic/eui/pull/5572/commits).

### Screencaps

<img width="979" alt="" src="https://user-images.githubusercontent.com/549407/151450462-c57f1f8e-64e9-476a-b435-312bd7568ecd.png">

![ref](https://user-images.githubusercontent.com/549407/151450758-5e63e690-6718-40e0-8c53-1168027a3dc6.gif)

<img src="https://user-images.githubusercontent.com/549407/151454550-6ec41337-3b66-4e14-9bef-3bc9cebeb724.gif" alt="" width="500">

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~

- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**

~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**

~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
 ~- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~ Final changelog will be in final feature branch PR