### PR TITLE
[EuiFlexGroup] Switch gutter CSS from negative margins to gap

### DIFF
--- a/src/components/flex/_flex_group.scss
+++ b/src/components/flex/_flex_group.scss
@@ -29,7 +29,7 @@ $gutterTypes: (
 // Gutter Sizes
 @each $gutterName, $gutterSize in $gutterTypes {
   .euiFlexGroup--#{$gutterName} {
-    gap: $gutterSize;
+    gap: $gutterSize; // sass-lint:disable-line no-misspelled-properties - gap is a valid property, sass-lint is out of date
   }
 }
 

--- a/src/components/flex/_flex_group.scss
+++ b/src/components/flex/_flex_group.scss
@@ -28,14 +28,8 @@ $gutterTypes: (
 
 // Gutter Sizes
 @each $gutterName, $gutterSize in $gutterTypes {
-  $halfGutterSize: $gutterSize * .5;
-
   .euiFlexGroup--#{$gutterName} {
-    margin: -$halfGutterSize;
-
-    & > .euiFlexItem {
-      margin: $halfGutterSize;
-    }
+    gap: $gutterSize;
   }
 }
 


### PR DESCRIPTION
## Summary

<img src="https://user-images.githubusercontent.com/549407/151592040-c7f023ff-0064-477b-891b-536cc570c506.png" alt="Life is good, but it can be better." width="500">

The `gap` property in flexbox has been supported by all major browsers (and all supported Elastic browsers) as of April 2021. We should move away from it instead of making use of negative margins, both for simplicity and because negative margins can occasionally cause unexpected DOM or cross-browser side effects (For example: the [2nd Safari issue in this comment](https://github.com/elastic/eui/pull/5561/#pullrequestreview-866109379) that occurs when using negative margins and horizontal scrolling, which is solved by switching to `gap`).

Links:

- https://caniuse.com/flexbox-gap
- https://developer.mozilla.org/en-US/docs/Web/CSS/gap#browser_compatibility
- https://coryrylan.com/blog/css-gap-space-with-flexbox

## QA

- [ ] Check https://eui.elastic.co/pr_5575/#/layout/flex against https://elastic.github.io/eui/#/layout/flex and confirm no visual regressions

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~

- [ ] Checked for **breaking changes** and labeled appropriately

~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
