### PR TITLE
[EuiDataGrid] Fix focus on pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed an accessibility issue where `EuiComboBoxPill` close button had a nested interactive element ([#5560](https://github.com/elastic/eui/pull/5560))
 - Fixed EuiDataGrid height issue when in full-screen mode and with scrolling content ([#5557](https://github.com/elastic/eui/pull/5557))
 - Fixed a focus bug in `EuiDataGrid` when clicking another cell header with an already-open cell header popover ([#5556](https://github.com/elastic/eui/pull/5556))
+- Fixed `EuiDataGrid` to always focus back into the grid on pagination ([#5587](https://github.com/elastic/eui/pull/5587))
 
 ## [`46.1.0`](https://github.com/elastic/eui/tree/v46.1.0)
 

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -459,7 +459,6 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
                 rowCount={rowCount}
                 controls={gridId}
                 aria-label={props['aria-label']}
-                gridRef={gridRef}
               />
             )}
             <p id={interactiveCellId} hidden>

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -49,7 +49,6 @@ export interface EuiDataGridPaginationRendererProps
   controls: string;
   'aria-label'?: AriaAttributes['aria-label'];
   'aria-labelledby'?: AriaAttributes['aria-labelledby'];
-  gridRef: EuiDataGridBodyProps['gridRef'];
 }
 
 export interface EuiDataGridInMemoryRendererProps {

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -48,7 +48,6 @@ export interface EuiDataGridPaginationRendererProps
   rowCount: number;
   controls: string;
   'aria-label'?: AriaAttributes['aria-label'];
-  'aria-labelledby'?: AriaAttributes['aria-labelledby'];
 }
 
 export interface EuiDataGridInMemoryRendererProps {

--- a/src/components/datagrid/utils/data_grid_pagination.test.tsx
+++ b/src/components/datagrid/utils/data_grid_pagination.test.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+
+import { DataGridFocusContext } from './focus';
+import { mockFocusContext } from './__mocks__/focus_context';
+import { EuiDataGridPaginationRenderer } from './data_grid_pagination';
+
+describe('EuiDataGridPaginationRenderer', () => {
+  const props = {
+    pageIndex: 0,
+    pageSize: 25,
+    pageSizeOptions: [25],
+    onChangePage: jest.fn(),
+    onChangeItemsPerPage: jest.fn(),
+    rowCount: 100,
+    controls: 'data-grid-id',
+  };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders', () => {
+    const component = shallow(<EuiDataGridPaginationRenderer {...props} />);
+    expect(component).toMatchInlineSnapshot(`
+      <div
+        className="euiDataGrid__pagination"
+      >
+        <EuiTablePagination
+          activePage={0}
+          aria-controls="data-grid-id"
+          aria-label="Pagination for preceding grid"
+          hidePerPageOptions={false}
+          itemsPerPage={25}
+          itemsPerPageOptions={
+            Array [
+              25,
+            ]
+          }
+          onChangeItemsPerPage={[MockFunction]}
+          onChangePage={[Function]}
+          pageCount={4}
+        />
+      </div>
+    `);
+  });
+
+  it('renders a detailed aria-label', () => {
+    const component = shallow(
+      <EuiDataGridPaginationRenderer {...props} aria-label="Test Grid" />
+    );
+    expect(component).toMatchInlineSnapshot(`
+      <div
+        className="euiDataGrid__pagination"
+      >
+        <EuiTablePagination
+          activePage={0}
+          aria-controls="data-grid-id"
+          aria-label="Pagination for preceding grid: Test Grid"
+          hidePerPageOptions={false}
+          itemsPerPage={25}
+          itemsPerPageOptions={
+            Array [
+              25,
+            ]
+          }
+          onChangeItemsPerPage={[MockFunction]}
+          onChangePage={[Function]}
+          pageCount={4}
+        />
+      </div>
+    `);
+  });
+
+  it('hides the page size selection if pageSizeOptions is empty', () => {
+    const component = shallow(
+      <EuiDataGridPaginationRenderer {...props} pageSizeOptions={[]} />
+    );
+    expect(component).toMatchInlineSnapshot(`
+      <div
+        className="euiDataGrid__pagination"
+      >
+        <EuiTablePagination
+          activePage={0}
+          aria-controls="data-grid-id"
+          aria-label="Pagination for preceding grid"
+          hidePerPageOptions={true}
+          itemsPerPage={25}
+          itemsPerPageOptions={Array []}
+          onChangeItemsPerPage={[MockFunction]}
+          onChangePage={[Function]}
+          pageCount={4}
+        />
+      </div>
+    `);
+  });
+
+  it('does not render if there are fewer rows than the smallest page size option', () => {
+    const component = shallow(
+      <EuiDataGridPaginationRenderer
+        {...props}
+        rowCount={1}
+        pageSizeOptions={[10, 25]}
+      />
+    );
+    expect(component.isEmptyRender()).toBe(true);
+  });
+
+  it('focuses the first data cell on page change', () => {
+    const component = mount(
+      <DataGridFocusContext.Provider value={mockFocusContext}>
+        <EuiDataGridPaginationRenderer {...props} />
+      </DataGridFocusContext.Provider>
+    );
+    const onChangePage: Function = component
+      .find('EuiTablePagination')
+      .prop('onChangePage');
+    onChangePage(3);
+    expect(mockFocusContext.setFocusedCell).toHaveBeenCalledWith([0, 0]);
+  });
+});

--- a/src/components/datagrid/utils/data_grid_pagination.tsx
+++ b/src/components/datagrid/utils/data_grid_pagination.tsx
@@ -21,7 +21,6 @@ export const EuiDataGridPaginationRenderer = ({
   rowCount,
   controls,
   'aria-label': ariaLabel,
-  gridRef,
 }: EuiDataGridPaginationRendererProps) => {
   const detailedPaginationLabel = useEuiI18n(
     'euiDataGridPagination.detailedPaginationLabel',
@@ -39,9 +38,8 @@ export const EuiDataGridPaginationRenderer = ({
     (pageIndex) => {
       _onChangePage(pageIndex);
       setFocusedCell([0, 0]);
-      gridRef.current?.scrollToItem?.({ rowIndex: 0 });
     },
-    [gridRef, setFocusedCell, _onChangePage]
+    [setFocusedCell, _onChangePage]
   );
 
   const pageCount = Math.ceil(rowCount / pageSize);

--- a/src/components/datagrid/utils/data_grid_pagination.tsx
+++ b/src/components/datagrid/utils/data_grid_pagination.tsx
@@ -6,10 +6,11 @@
  * Side Public License, v 1.
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useContext } from 'react';
 import { useEuiI18n } from '../../i18n'; // Note: this file must be named data_grid_pagination to match i18n tokens
 import { EuiTablePagination } from '../../table/table_pagination';
 import { EuiDataGridPaginationRendererProps } from '../data_grid_types';
+import { DataGridFocusContext } from './focus';
 
 export const EuiDataGridPaginationRenderer = ({
   pageIndex,
@@ -32,13 +33,15 @@ export const EuiDataGridPaginationRenderer = ({
     'Pagination for preceding grid'
   );
 
-  // Scroll back to the top of the grid whenever paginating to a new page
+  // Focus the first data cell & scroll back to the top of the grid whenever paginating to a new page
+  const { setFocusedCell } = useContext(DataGridFocusContext);
   const onChangePage = useCallback(
     (pageIndex) => {
       _onChangePage(pageIndex);
+      setFocusedCell([0, 0]);
       gridRef.current?.scrollToItem?.({ rowIndex: 0 });
     },
-    [gridRef, _onChangePage]
+    [gridRef, setFocusedCell, _onChangePage]
   );
 
   const pageCount = Math.ceil(rowCount / pageSize);


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/5577 - please see the linked issue for a description of why the bug is happening.

### Before

Notice the black outline (in Safari) that indicates the grid wrapper is getting focused instead of into a grid cell.

![before](https://user-images.githubusercontent.com/549407/151618723-0c492614-519a-42b2-9a2c-cf69b079e0cf.gif)

### After

Notice that the first grid data cell is now focused on every new page.

![after](https://user-images.githubusercontent.com/549407/151618735-9bfe45a3-6c14-4472-ab58-42b088a20477.gif)

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**

~- [ ] Checked for **breaking changes** and labeled appropriately~

- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately