### PR TITLE
[EuiDataGrid] Fix grid height when exiting full screen mode

### DIFF
--- a/src/components/datagrid/body/data_grid_body.test.tsx
+++ b/src/components/datagrid/body/data_grid_body.test.tsx
@@ -42,6 +42,7 @@ describe('EuiDataGridBody', () => {
     schemaDetectors,
     popoverContents: providedPopoverContents,
     rowHeightUtils: mockRowHeightUtils,
+    isFullScreen: false,
     gridStyles: {},
     gridWidth: 300,
     gridRef: {

--- a/src/components/datagrid/body/data_grid_body.tsx
+++ b/src/components/datagrid/body/data_grid_body.tsx
@@ -239,6 +239,7 @@ export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
     onColumnResize,
     rowHeightsOptions,
     virtualizationOptions,
+    isFullScreen,
     gridStyles,
     gridWidth,
     gridRef,
@@ -424,6 +425,7 @@ export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
     unconstrainedWidth: 0, // unable to determine this until the container's size is known
     wrapperDimensions,
     wrapperRef,
+    isFullScreen,
     rowCount,
   });
 

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -441,6 +441,7 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = (props) => {
                 interactiveCellId={interactiveCellId}
                 rowHeightsOptions={rowHeightsOptions}
                 virtualizationOptions={virtualizationOptions || {}}
+                isFullScreen={isFullScreen}
                 gridStyles={gridStyles}
                 gridWidth={gridWidth}
                 gridRef={gridRef}

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -345,6 +345,7 @@ export interface EuiDataGridBodyProps {
   onColumnResize?: EuiDataGridOnColumnResizeHandler;
   virtualizationOptions?: Partial<VariableSizeGridProps>;
   rowHeightsOptions?: EuiDataGridRowHeightsOptions;
+  isFullScreen: boolean;
   gridStyles: EuiDataGridStyle;
   gridWidth: number;
   gridRef: MutableRefObject<Grid | null>;

--- a/src/components/datagrid/utils/grid_height_width.ts
+++ b/src/components/datagrid/utils/grid_height_width.ts
@@ -60,16 +60,17 @@ export const useFinalGridDimensions = ({
     unconstrainedWidth,
   ]);
 
-  const finalHeight = IS_JEST_ENVIRONMENT
-    ? Number.MAX_SAFE_INTEGER
-    : isFullScreen
+  const finalHeight = isFullScreen
     ? fullScreenHeight
     : height || unconstrainedHeight;
-  const finalWidth = IS_JEST_ENVIRONMENT
-    ? Number.MAX_SAFE_INTEGER
-    : width || unconstrainedWidth;
+  const finalWidth = width || unconstrainedWidth;
 
-  return { finalHeight, finalWidth };
+  return IS_JEST_ENVIRONMENT
+    ? {
+        finalHeight: Number.MAX_SAFE_INTEGER,
+        finalWidth: Number.MAX_SAFE_INTEGER,
+      }
+    : { finalHeight, finalWidth };
 };
 
 /**

--- a/src/components/datagrid/utils/grid_height_width.ts
+++ b/src/components/datagrid/utils/grid_height_width.ts
@@ -19,24 +19,32 @@ export const useFinalGridDimensions = ({
   unconstrainedWidth,
   wrapperDimensions,
   wrapperRef,
+  isFullScreen,
   rowCount,
 }: {
   unconstrainedHeight: number;
   unconstrainedWidth: number;
   wrapperDimensions: { width: number; height: number };
   wrapperRef: MutableRefObject<HTMLDivElement | null>;
+  isFullScreen: boolean;
   rowCount: number;
 }) => {
   // Used if the grid needs to scroll
   const [height, setHeight] = useState<number | undefined>(undefined);
   const [width, setWidth] = useState<number | undefined>(undefined);
+  // Tracking full screen height separately is necessary to correctly restore the grid back to non-full-screen height
+  const [fullScreenHeight, setFullScreenHeight] = useState(0);
 
   // Set the wrapper height on load, whenever the grid wrapper resizes, and whenever rowCount changes
   useEffect(() => {
     const boundingRect = wrapperRef.current!.getBoundingClientRect();
 
-    if (boundingRect.height !== unconstrainedHeight) {
-      setHeight(boundingRect.height);
+    if (isFullScreen) {
+      setFullScreenHeight(boundingRect.height);
+    } else {
+      if (boundingRect.height !== unconstrainedHeight) {
+        setHeight(boundingRect.height);
+      }
     }
     if (boundingRect.width !== unconstrainedWidth) {
       setWidth(boundingRect.width);
@@ -44,6 +52,7 @@ export const useFinalGridDimensions = ({
   }, [
     // Effects that should cause recalculations
     rowCount,
+    isFullScreen,
     wrapperDimensions,
     // Dependencies
     wrapperRef,
@@ -53,6 +62,8 @@ export const useFinalGridDimensions = ({
 
   const finalHeight = IS_JEST_ENVIRONMENT
     ? Number.MAX_SAFE_INTEGER
+    : isFullScreen
+    ? fullScreenHeight
     : height || unconstrainedHeight;
   const finalWidth = IS_JEST_ENVIRONMENT
     ? Number.MAX_SAFE_INTEGER


### PR DESCRIPTION
## Summary

Super huge kudos to @miukimiu for catching this bug before it shipped! I introduced it in https://github.com/elastic/eui/pull/5557 🙈

### Repro steps
- Open the data grid's full screen mode
- Exit full screen mode
- Notice the grid still has the full-screen mode height

### Before
![before](https://user-images.githubusercontent.com/549407/151863597-bab20b7d-370d-485d-abbe-41af7f4324d5.gif)

### After
![after](https://user-images.githubusercontent.com/549407/151863378-ef1384a5-7827-4118-9071-c0900a37606a.gif)

### Checklist

~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- No unit tests written, mostly due to lack of existing tests + the `IS_JEST_ENVIRONMENT` conditional

~- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
- No changelog needed as this bug isn't yet in main/production