### PR TITLE
[EuiFilePicker] Fix can still be cleared when disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Bug fixes**
 
 - Fixed `EuiInMemoryTable`'s `onTableChange` callback not returning the correct `sort.field` value on pagination ([#5588](https://github.com/elastic/eui/pull/5588))
+- Fixed `EuiFilePicker` allowing files to be removed when `disabled` ([#5603](https://github.com/elastic/eui/pull/5603))
 
 ## [`46.2.0`](https://github.com/elastic/eui/tree/v46.2.0)
 

--- a/src/components/form/file_picker/file_picker.tsx
+++ b/src/components/form/file_picker/file_picker.tsx
@@ -175,7 +175,7 @@ export class EuiFilePicker extends Component<EuiFilePickerProps> {
             clearButton = (
               <EuiLoadingSpinner className="euiFilePicker__loadingSpinner" />
             );
-          } else if (isOverridingInitialPrompt) {
+          } else if (isOverridingInitialPrompt && !disabled) {
             if (normalFormControl) {
               clearButton = (
                 <button
@@ -183,7 +183,6 @@ export class EuiFilePicker extends Component<EuiFilePickerProps> {
                   aria-label={clearSelectedFiles}
                   className="euiFilePicker__clearButton"
                   onClick={this.removeFiles}
-                  disabled={disabled}
                 >
                   <EuiIcon className="euiFilePicker__clearIcon" type="cross" />
                 </button>
@@ -195,7 +194,6 @@ export class EuiFilePicker extends Component<EuiFilePickerProps> {
                   className="euiFilePicker__clearButton"
                   size="xs"
                   onClick={this.removeFiles}
-                  disabled={disabled}
                 >
                   <EuiI18n
                     token="euiFilePicker.removeSelected"

--- a/src/components/form/file_picker/file_picker.tsx
+++ b/src/components/form/file_picker/file_picker.tsx
@@ -183,6 +183,7 @@ export class EuiFilePicker extends Component<EuiFilePickerProps> {
                   aria-label={clearSelectedFiles}
                   className="euiFilePicker__clearButton"
                   onClick={this.removeFiles}
+                  disabled={disabled}
                 >
                   <EuiIcon className="euiFilePicker__clearIcon" type="cross" />
                 </button>
@@ -194,6 +195,7 @@ export class EuiFilePicker extends Component<EuiFilePickerProps> {
                   className="euiFilePicker__clearButton"
                   size="xs"
                   onClick={this.removeFiles}
+                  disabled={disabled}
                 >
                   <EuiI18n
                     token="euiFilePicker.removeSelected"


### PR DESCRIPTION
### Summary

~~I simply passed down the disabled prop in EuiFilePicker into it's child button components to disallow removing the files when disabled. This doesn't fix the use case of programmatically removing the file but that shouldn't matter at all since that's the expected behavior where users should be implementing that themselves.~~

Above approach introduced some inconsistent UI behavior so instead the clearButton is actually removed from the UI entirely when `EuiFilePicker` is disabled.

![image](https://user-images.githubusercontent.com/18640252/152565017-dcccc6f5-72e6-4b25-a31b-0c88e3c5cbac.png)

![image](https://user-images.githubusercontent.com/18640252/152565052-6e5ab83e-fc47-4ee1-8726-cb817397fc7b.png)

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] ~~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~~
- [x] ~~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~~
- [x] ~~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~~
- [x] ~~Checked for **breaking changes** and labeled appropriately~~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
