### PR TITLE
[TypeScript] Return type for `resolveWidthAsStyle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [`main`](https://github.com/elastic/eui/tree/main)
 
 - Refactored `EuiSuggest` to use `EuiSelectable` ([#5157](https://github.com/elastic/eui/pull/5157))
+- Added a return type to `EuiTable` `resolveWidthAsStyle` util ([#5615](https://github.com/elastic/eui/pull/5615))
 
 **Bug fixes**
 

--- a/src/components/table/utils.ts
+++ b/src/components/table/utils.ts
@@ -14,7 +14,7 @@ export const WARNING_MESSAGE =
 export const resolveWidthAsStyle = (
   style: CSSProperties = {},
   width?: string | number
-) => {
+): CSSProperties => {
   const { width: styleWidth, ...styleRest } = style;
   let attrWidth = width;
   if (


### PR DESCRIPTION
### Summary

Adds an explicit return type of `CSSProperties` to `resolveWidthAsStyle` (table util) to avoid a verbose inferred type resulting in hundreds of `cssType` imports in the shape of:

```
WebkitTransform?: import("csstype").Property.Transform | undefined;
```

Previously, the verbosity was present, but did not use an import:

```
WebkitTransform?: string | undefined;
```

This change will eliminate ~700s line from `eui.d.ts`

### Checklist

- [x] Checked for **breaking changes** and labeled appropriately
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
