### PR TITLE
[EuiPanel] Added more customization options to `hasBorder`

### DIFF
--- a/src-docs/src/views/panel/panel_example.js
+++ b/src-docs/src/views/panel/panel_example.js
@@ -134,8 +134,9 @@ export const PanelExample = {
           <p>
             <strong>EuiPanel</strong> can give depth to your container with{' '}
             <EuiCode>hasShadow</EuiCode> while <EuiCode>hasBorder</EuiCode> can
-            add containment. Just be sure not to include too many nested panels
-            with these settings.
+            add containment. Just be sure not to include too many{' '}
+            <Link to="/layout/panel/guidelines">nested panels</Link> with these
+            settings.
           </p>
           <EuiCallOut
             color="warning"
@@ -143,11 +144,9 @@ export const PanelExample = {
           >
             <p>
               For instance, only plain or transparent panels can have a border
-              and/or shadow. The Amsterdam theme doesn&apos;t allow combining
-              the <EuiCode>hasBorder</EuiCode> option with{' '}
-              <EuiCode>hasShadow</EuiCode>. The default theme only allows
-              removing the border if both <EuiCode>hasShadow</EuiCode> and{' '}
-              <EuiCode>hasBorder</EuiCode> are set to <EuiCode>false</EuiCode>.
+              and/or shadow. The default theme doesn&apos;t allow combining the{' '}
+              <EuiCode>hasBorder</EuiCode> option with{' '}
+              <EuiCode>hasShadow</EuiCode>.
             </p>
           </EuiCallOut>
         </>

--- a/src-docs/src/views/panel/panel_shadow.js
+++ b/src-docs/src/views/panel/panel_shadow.js
@@ -1,11 +1,11 @@
 import React, { useContext } from 'react';
+import { EuiPanel, EuiCode, EuiSpacer, LEGACY_NAME_KEY } from '../../../../src';
 
-import { EuiPanel, EuiCode, EuiSpacer } from '../../../../src/components';
 import { ThemeContext } from '../../components';
 
 export default () => {
   const themeContext = useContext(ThemeContext);
-  const isAmsterdamTheme = !themeContext.theme.includes('legacy');
+  const isLegacyTheme = themeContext.theme.includes(LEGACY_NAME_KEY);
 
   return (
     <div>
@@ -15,8 +15,8 @@ export default () => {
 
       <EuiSpacer />
 
-      {/* This example only works for the Amsterdam theme. The default theme has `hasBorder={true}` by default. */}
-      {isAmsterdamTheme && (
+      {/* This example only works for the default theme. The legacy theme has `hasBorder={true}` by default. */}
+      {!isLegacyTheme && (
         <>
           <EuiPanel hasBorder={true}>
             <EuiCode>{'hasBorder={true}'}</EuiCode>
@@ -25,9 +25,20 @@ export default () => {
         </>
       )}
 
-      <EuiPanel hasShadow={false} hasBorder={false}>
-        <EuiCode>{'hasShadow={false} hasBorder={false}'}</EuiCode>
+      <EuiPanel hasBorder={3}>
+        <EuiCode>{'hasBorder={3}'}</EuiCode>
       </EuiPanel>
+
+      {/* This example only matters for the legacy theme. The default theme has `hasBorder={false}` by default. */}
+      {isLegacyTheme && (
+        <>
+          <EuiSpacer />
+
+          <EuiPanel hasShadow={false} hasBorder={false}>
+            <EuiCode>{'hasShadow={false} hasBorder={false}'}</EuiCode>
+          </EuiPanel>
+        </>
+      )}
     </div>
   );
 };

--- a/src-docs/src/views/panel/playground.js
+++ b/src-docs/src/views/panel/playground.js
@@ -29,6 +29,11 @@ export const panelConfig = () => {
     },
   };
 
+  propsToUse.hasBorder = {
+    ...propsToUse.hasBorder,
+    type: PropTypes.Number,
+  };
+
   return {
     config: {
       componentName: 'EuiPanel',

--- a/src/components/card/__snapshots__/card.test.tsx.snap
+++ b/src/components/card/__snapshots__/card.test.tsx.snap
@@ -507,6 +507,7 @@ exports[`EuiCard props href supports href as a link 1`] = `
     <div
       className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPanel--isClickable euiCard euiCard--centerAligned euiCard--isClickable"
       onClick={[Function]}
+      style={Object {}}
     >
       <div
         className="euiCard__content"

--- a/src/components/panel/__snapshots__/panel.test.tsx.snap
+++ b/src/components/panel/__snapshots__/panel.test.tsx.snap
@@ -74,6 +74,13 @@ exports[`EuiPanel props grow can be false 1`] = `
 />
 `;
 
+exports[`EuiPanel props hasBorder can be a string value 1`] = `
+<div
+  class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPanel--hasBorder"
+  style="border-width:1px 0 0 0"
+/>
+`;
+
 exports[`EuiPanel props hasBorder can be false 1`] = `
 <div
   class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPanel--noBorder"

--- a/src/components/panel/panel.test.tsx
+++ b/src/components/panel/panel.test.tsx
@@ -47,6 +47,11 @@ describe('EuiPanel', () => {
 
         expect(component).toMatchSnapshot();
       });
+      test('can be a string value', () => {
+        const component = render(<EuiPanel hasBorder="1px 0 0 0" />);
+
+        expect(component).toMatchSnapshot();
+      });
     });
 
     describe('paddingSize', () => {

--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -8,6 +8,7 @@
 
 import React, {
   ButtonHTMLAttributes,
+  CSSProperties,
   FunctionComponent,
   HTMLAttributes,
   Ref,
@@ -60,11 +61,11 @@ export interface _EuiPanelProps extends CommonProps {
    */
   hasShadow?: boolean;
   /**
-   * Adds a slight 1px border on all edges.
-   * Only works when `color="plain | transparent"`
-   * Default is `undefined` and will default to that theme's panel style
+   * Adds a slight 1px border on all edges when `true` or pass a valid `border-width` value.
+   * Only works when `color="plain | transparent"`.
+   * Default is `undefined` and will default to that theme's panel style.
    */
-  hasBorder?: boolean;
+  hasBorder?: boolean | CSSProperties['borderWidth'];
   /**
    * Padding for all four sides
    */
@@ -113,6 +114,7 @@ export const EuiPanel: FunctionComponent<EuiPanelProps> = ({
   grow = true,
   panelRef,
   element,
+  style,
   ...rest
 }) => {
   // Shadows are only allowed when there's a white background (plain)
@@ -129,7 +131,7 @@ export const EuiPanel: FunctionComponent<EuiPanelProps> = ({
       // While the `has` classes turn it on for Amsterdam
       'euiPanel--hasShadow': canHaveShadow && hasShadow === true,
       'euiPanel--noShadow': !canHaveShadow || hasShadow === false,
-      'euiPanel--hasBorder': canHaveBorder && hasBorder === true,
+      'euiPanel--hasBorder': canHaveBorder && Boolean(hasBorder) === true,
       'euiPanel--noBorder': !canHaveBorder || hasBorder === false,
       'euiPanel--flexGrowZero': !grow,
       'euiPanel--isClickable': rest.onClick,
@@ -137,11 +139,18 @@ export const EuiPanel: FunctionComponent<EuiPanelProps> = ({
     className
   );
 
+  // If `hasBorder` is a string instead of a boolean, add it as the `borderWidth` style property
+  const newStyle = style || {};
+  if (hasBorder !== true && Boolean(hasBorder)) {
+    newStyle.borderWidth = hasBorder as CSSProperties['borderWidth'];
+  }
+
   if (rest.onClick && element !== 'div') {
     return (
       <button
         ref={panelRef as Ref<HTMLButtonElement>}
         className={classes}
+        style={newStyle}
         {...(rest as ButtonHTMLAttributes<HTMLButtonElement>)}
       >
         {children}
@@ -153,6 +162,7 @@ export const EuiPanel: FunctionComponent<EuiPanelProps> = ({
     <div
       ref={panelRef as Ref<HTMLDivElement>}
       className={classes}
+      style={newStyle}
       {...(rest as HTMLAttributes<HTMLDivElement>)}
     >
       {children}


### PR DESCRIPTION
### In support of #5454

EuiPanel is growing to be a more all-encompassing 'box' that consumers can use to contain their content, including EuiPage. However, there are some more customizations that we can (and EuiPageTemplate needs) to allow, like altering the `border-width`.

So now the `hasBorder` prop has been expanded to allow any `CSSProperties['borderWidth']`. This means a `number` that is converted to pixel units or any string shorthand or longhand `2px` or `0 0 2px`. Even though we allow this level of customization, we do still control the combination of its use with other props like `color`. Basically, that it only works if color is `transparent` or `plain`.

An example of just passing the old `boolean` or a `number`:


![Screen Shot 2022-02-09 at 17 11 16 PM](https://user-images.githubusercontent.com/549577/153299877-242e819c-6562-4f98-b518-45e0febd1dba.png)


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
