### PR TITLE
[EuiDataGrid] Fix open cell popovers causing auto height rows to bug out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed `EuiDataGrid` to correctly remove the cell expansion action button when a column sets both `cellActions` and `isExpandable` to false ([#5592](https://github.com/elastic/eui/pull/5592))
 - Fixed `EuiDataGrid` re-playing the cell actions animation when hovering over an already-focused cell ([#5592](https://github.com/elastic/eui/pull/5592))
+- Fixed `EuiDataGrid` auto row heights bugging out when cell popovers are opened ([#5618](https://github.com/elastic/eui/pull/5618))
 
 **Breaking changes**
 

--- a/src/components/datagrid/body/data_grid_cell.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell.test.tsx
@@ -213,6 +213,20 @@ describe('EuiDataGridCell', () => {
       );
       expect(popoverContent).toMatchSnapshot();
     });
+
+    it('does not recalculate row auto height when the cell popover opens', () => {
+      const component = mount(
+        <EuiDataGridCell
+          {...requiredProps}
+          rowHeightsOptions={{ defaultHeight: 'auto' }}
+        />
+      );
+      component.setProps({
+        popoverContext: { ...mockPopoverContext, popoverIsOpen: true },
+      });
+      expect(mockRowHeightUtils.isAutoHeight).not.toHaveBeenCalled();
+      expect(mockRowHeightUtils.setRowHeight).not.toHaveBeenCalled();
+    });
   });
 
   describe('componentDidMount', () => {

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -631,12 +631,12 @@ export class EuiDataGridCell extends Component<
     );
 
     if (hasCellActions) {
-      if (showCellActions) {
-        innerContent = (
-          <div className={anchorClass} ref={this.popoverAnchorRef}>
-            <div className={expandClass}>
-              <EuiDataGridCellContent {...cellContentProps} />
-            </div>
+      innerContent = (
+        <div className={anchorClass} ref={this.popoverAnchorRef}>
+          <div className={expandClass}>
+            <EuiDataGridCellContent {...cellContentProps} />
+          </div>
+          {showCellActions && (
             <EuiDataGridCellActions
               rowIndex={rowIndex}
               colIndex={colIndex}
@@ -651,17 +651,9 @@ export class EuiDataGridCell extends Component<
                 }
               }}
             />
-          </div>
-        );
-      } else {
-        innerContent = (
-          <div className={anchorClass} ref={this.popoverAnchorRef}>
-            <div className={expandClass}>
-              <EuiDataGridCellContent {...cellContentProps} />
-            </div>
-          </div>
-        );
-      }
+          )}
+        </div>
+      );
     }
 
     const content = (

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -279,7 +279,11 @@ export class EuiDataGridCell extends Component<
   }
 
   componentDidUpdate(prevProps: EuiDataGridCellProps) {
-    this.recalculateAutoHeight();
+    // Avoid recalculating auto height when the popover opens -
+    // the inserted EuiWrappingPopover DOM creates false miscalculations
+    if (!this.props.popoverContext.popoverIsOpen) {
+      this.recalculateAutoHeight();
+    }
 
     if (
       this.props.rowHeightsOptions?.defaultHeight !==


### PR DESCRIPTION
## Summary

This was introduced in #5550 by our conversion to `EuiWrappingPopover`, which now dynamically inserts 2 extra DOM nodes around the cell popover anchor wrapper only when the popover is open:

<img width="911" alt="" src="https://user-images.githubusercontent.com/549407/153326930-a561a2ee-a52d-474f-98db-6eb7111f8c71.png">

For some bizarre reason, this triggers the cell content's `offsetHeight` to briefly be larger than it should be, which immediately updates the row height cache even though the cell content height returns to normal almost immediately after.

The easiest solution I could think of was to avoid setting the row height cache when the popover is opening, but I'm not sure if this will have unintentional side effects on consumer updates when the user has the popover open - those are likely very edge case, fingers crossed. I think the absolute best long-term solution might be to try and make `EuiWrappingPopover`/`EuiPopover` optionally not add DOM wrappers, but this might be the best fix in the interim, unless you can think of something else.

Really hoping we can get this merged in / backported along with the type fixes for the next Kibana upgrade! 🙏 

### Before

![before](https://user-images.githubusercontent.com/549407/153326422-5931f5c2-3c78-40af-9ab2-5097298af82f.gif)

### After

![after](https://user-images.githubusercontent.com/549407/153326431-2948ca3f-e836-493c-9330-1996b94f2b74.gif)

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**

~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately