### PR TITLE
[TypeScript] Return type for `euiSelectableTemplateSitewideFormatOptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Refactored `EuiSuggest` to use `EuiSelectable` ([#5157](https://github.com/elastic/eui/pull/5157))
 - Added a return type to `EuiTable` `resolveWidthAsStyle` util ([#5615](https://github.com/elastic/eui/pull/5615))
+- Added a return type to `euiSelectableTemplateSitewideFormatOptions` util ([#5620](https://github.com/elastic/eui/pull/5620))
 
 **Bug fixes**
 

--- a/src/components/selectable/selectable_templates/selectable_template_sitewide_option.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide_option.tsx
@@ -61,7 +61,7 @@ export type EuiSelectableTemplateSitewideOption<T = { [key: string]: any }> = {
 
 export const euiSelectableTemplateSitewideFormatOptions = (
   options: EuiSelectableTemplateSitewideOption[]
-) => {
+): EuiSelectableTemplateSitewideOption[] => {
   return options.map((item: EuiSelectableTemplateSitewideOption) => {
     let title = item.label;
     if (item.meta && item.meta.length) {


### PR DESCRIPTION
### Summary

Closes #5616

Adds an explicit return type of `EuiSelectableTemplateSitewideOption[]` to `euiSelectableTemplateSitewideFormatOptions` to avoid a verbose inferred type resulting in hundreds of `<div>` and `<li>` DOM attributes and event handlers being added to the definition.

This change will eliminate ~600 lines from `eui.d.ts`

### Checklist

- [x] Checked for **breaking changes** and labeled appropriately
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
