### PR TITLE
[EuiDataGrid] Fix open cell popovers causing auto height rows to bug out + misc cleanup

### DIFF
--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -12,11 +12,9 @@
   background: $euiColorEmptyShade;
   overflow: hidden;
 
-  // Hack to allow for all the focus guard stuff
   > * {
-    max-width: 100%;
-    width: 100%;
-    height: 100%;
+    height: 100%; // Hack to allow for focus trap to still stretch to full row height on defined heights
+    overflow: hidden; // Maintain cutting off content past the cell padding when popover is open
   }
 
   &.euiDataGridRowCell--firstColumn {

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -9,11 +9,8 @@
   padding: $euiDataGridCellPaddingM;
   border-right: $euiDataGridVerticalBorder;
   border-bottom: $euiBorderThin;
-  flex: 0 0 auto;
   background: $euiColorEmptyShade;
   position: relative;
-  align-items: center;
-  display: flex;
   overflow: hidden;
 
   // Hack to allow for all the focus guard stuff

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -10,7 +10,6 @@
   border-right: $euiDataGridVerticalBorder;
   border-bottom: $euiBorderThin;
   background: $euiColorEmptyShade;
-  position: relative;
   overflow: hidden;
 
   // Hack to allow for all the focus guard stuff

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -110,11 +110,6 @@
   z-index: $euiZDataGridCellPopover !important;
 }
 
-.euiDataGridRowCell__expand {
-  width: 100%;
-  max-width: 100%;
-}
-
 .euiDataGridRowCell__expandFlex {
   position: relative; // for positioning expand button
   display: flex;

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -626,12 +626,12 @@ export class EuiDataGridCell extends Component<
     );
 
     if (hasCellActions) {
-      if (showCellActions) {
-        innerContent = (
-          <div className={anchorClass} ref={this.popoverAnchorRef}>
-            <div className={expandClass}>
-              <EuiDataGridCellContent {...cellContentProps} />
-            </div>
+      innerContent = (
+        <div className={anchorClass} ref={this.popoverAnchorRef}>
+          <div className={expandClass}>
+            <EuiDataGridCellContent {...cellContentProps} />
+          </div>
+          {showCellActions && (
             <EuiDataGridCellActions
               rowIndex={rowIndex}
               colIndex={colIndex}
@@ -646,17 +646,9 @@ export class EuiDataGridCell extends Component<
                 }
               }}
             />
-          </div>
-        );
-      } else {
-        innerContent = (
-          <div className={anchorClass} ref={this.popoverAnchorRef}>
-            <div className={expandClass}>
-              <EuiDataGridCellContent {...cellContentProps} />
-            </div>
-          </div>
-        );
-      }
+          )}
+        </div>
+      );
     }
 
     const content = (

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -615,7 +615,6 @@ export class EuiDataGridCell extends Component<
         onDeactivation={() => {
           this.setState({ isEntered: false }, this.preventTabbing);
         }}
-        style={isDefinedHeight ? { height: '100%' } : {}}
         clickOutsideDisables={true}
       >
         <div className={anchorClass} ref={this.popoverAnchorRef}>

--- a/src/components/datagrid/body/data_grid_cell_popover.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.test.tsx
@@ -95,7 +95,6 @@ describe('useCellPopover', () => {
       populateCellPopover(cellPopoverContext);
       expect(getUpdatedState().cellPopover).toMatchInlineSnapshot(`
         <EuiWrappingPopover
-          anchorClassName="euiDataGridRowCell__expand"
           button={<div />}
           closePopover={[Function]}
           display="block"

--- a/src/components/datagrid/body/data_grid_cell_popover.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.tsx
@@ -71,7 +71,6 @@ export const useCellPopover = (): {
   const cellPopover = popoverIsOpen && popoverAnchor && (
     <EuiWrappingPopover
       hasArrow={false}
-      anchorClassName="euiDataGridRowCell__expand"
       button={popoverAnchor}
       isOpen={popoverIsOpen}
       panelClassName="euiDataGridRowCell__popover"


### PR DESCRIPTION
## Summary

This is an CSS-only alternative to https://github.com/elastic/eui/pull/5618, and _should_ (in theory) be a better approach with less side effects or edge cases on consuming applications. This also contains a lot more CSS cleanup.

### Why is the removed CSS no longer needed?

The flex CSS and width CSS is likely no longer necessary for the following reasons

- [Virtualization refactor](https://github.com/elastic/eui/pull/4170)
- [Auto row heights work](https://github.com/elastic/eui/pull/4958), which added a good amount of conditional/wrapping CSS around the cell contents
- [Row height switcher work](https://github.com/elastic/eui/pull/5415) further fixed flex items to be aligned baseline instead of center

### Before

![before](https://user-images.githubusercontent.com/549407/153326422-5931f5c2-3c78-40af-9ab2-5097298af82f.gif)

### After

![after](https://user-images.githubusercontent.com/549407/153326431-2948ca3f-e836-493c-9330-1996b94f2b74.gif)

## QA

- [ ] Single line cells should look the same as before, and should not bug out when opening popovers
- [ ] Auto height cells should look the same as before, and should not bug out when opening popovers
- [ ] Line count cells cells should look the same as before, and should not bug out when opening popovers
- [ ] [Focus guarded cells](http://localhost:8030/#/tabular-content/data-grid-focus) should look the same as before
- [ ] [Static pixel height cells](http://localhost:8030/#/tabular-content/data-grid-row-heights-options#overriding-specific-row-heights) should look the same as before

### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~

- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately