### PR TITLE
[Docs] Fixing the logic for shadow and border combinations of EuiPanel

### DIFF
--- a/src-docs/src/views/panel/panel_example.js
+++ b/src-docs/src/views/panel/panel_example.js
@@ -134,8 +134,9 @@ export const PanelExample = {
           <p>
             <strong>EuiPanel</strong> can give depth to your container with{' '}
             <EuiCode>hasShadow</EuiCode> while <EuiCode>hasBorder</EuiCode> can
-            add containment. Just be sure not to include too many nested panels
-            with these settings.
+            add containment. Just be sure not to include too many{' '}
+            <Link to="/layout/panel/guidelines">nested panels</Link> with these
+            settings.
           </p>
           <EuiCallOut
             color="warning"
@@ -143,11 +144,9 @@ export const PanelExample = {
           >
             <p>
               For instance, only plain or transparent panels can have a border
-              and/or shadow. The Amsterdam theme doesn&apos;t allow combining
-              the <EuiCode>hasBorder</EuiCode> option with{' '}
-              <EuiCode>hasShadow</EuiCode>. The default theme only allows
-              removing the border if both <EuiCode>hasShadow</EuiCode> and{' '}
-              <EuiCode>hasBorder</EuiCode> are set to <EuiCode>false</EuiCode>.
+              and/or shadow. The default theme doesn&apos;t allow combining the{' '}
+              <EuiCode>hasBorder</EuiCode> option with{' '}
+              <EuiCode>hasShadow</EuiCode>.
             </p>
           </EuiCallOut>
         </>

--- a/src-docs/src/views/panel/panel_shadow.js
+++ b/src-docs/src/views/panel/panel_shadow.js
@@ -1,11 +1,15 @@
-import React, { useContext } from 'react';
-
-import { EuiPanel, EuiCode, EuiSpacer } from '../../../../src/components';
-import { ThemeContext } from '../../components';
+import React from 'react';
+import {
+  EuiPanel,
+  EuiCode,
+  EuiSpacer,
+  LEGACY_NAME_KEY,
+  useEuiTheme,
+} from '../../../../src';
 
 export default () => {
-  const themeContext = useContext(ThemeContext);
-  const isAmsterdamTheme = !themeContext.theme.includes('legacy');
+  const { euiTheme } = useEuiTheme();
+  const isLegacyTheme = euiTheme.themeName.includes(LEGACY_NAME_KEY);
 
   return (
     <div>
@@ -15,19 +19,19 @@ export default () => {
 
       <EuiSpacer />
 
-      {/* This example only works for the Amsterdam theme. The default theme has `hasBorder={true}` by default. */}
-      {isAmsterdamTheme && (
-        <>
-          <EuiPanel hasBorder={true}>
-            <EuiCode>{'hasBorder={true}'}</EuiCode>
-          </EuiPanel>
-          <EuiSpacer />
-        </>
+      {/* This example only works for the default theme. The legacy theme has `hasBorder={true}` by default. */}
+      {!isLegacyTheme && (
+        <EuiPanel hasBorder={true}>
+          <EuiCode>{'hasBorder={true}'}</EuiCode>
+        </EuiPanel>
       )}
 
-      <EuiPanel hasShadow={false} hasBorder={false}>
-        <EuiCode>{'hasShadow={false} hasBorder={false}'}</EuiCode>
-      </EuiPanel>
+      {/* This example only matters for the legacy theme. The default theme has `hasBorder={false}` by default. */}
+      {isLegacyTheme && (
+        <EuiPanel hasShadow={false} hasBorder={false}>
+          <EuiCode>{'hasShadow={false} hasBorder={false}'}</EuiCode>
+        </EuiPanel>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
### Follow up from #5617

The original logic showcasing the right combination of `hasShadow` and `hasBorder` props no longer worked with the addition of EuiProvider. So I've updated this example to use `useEuiTheme` instead.

### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
