### PR TITLE
[EuiCode] Fixed display to be `inline-block`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Improved `EuiSelectable` keypress scenarios ([#5613](https://github.com/elastic/eui/pull/5613))
 
+**Bug fixes**
+
+- Fixed `EuiCode` display to be `inline-block` so it can have padding ([#0000](https://github.com/elastic/eui/pull/0000))
+
 ## [`48.0.0`](https://github.com/elastic/eui/tree/v48.0.0)
 
 - Refactored `EuiSuggest` to use `EuiSelectable` ([#5157](https://github.com/elastic/eui/pull/5157))

--- a/src/components/code/_code.scss
+++ b/src/components/code/_code.scss
@@ -3,6 +3,7 @@
 */
 .euiCode {
   @include euiCodeFont;
+  display: inline-block;
   font-size: .9em; /* 1 */
   padding: .2em .5em; /* 1 */
   background: $euiCodeBlockBackgroundColor;


### PR DESCRIPTION
### Summary

The padding for the **EuiCode** component was not being taken into consideration because it uses a `<code />` element that is inline by default.

This PR fixes the display to be `inline-block` so it can have padding.

<img width="679" alt="EuiCode-inline-issue@2x" src="https://user-images.githubusercontent.com/2750668/153607382-56952690-f9f0-4caf-bcbe-1b5520e1185a.png">


### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
