### PR TITLE
[EuiDualRange] Add `isLoading` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Added new `renderCellPopover` prop to `EuiDataGrid` ([#5640](https://github.com/elastic/eui/pull/5640))
 - Added cell `schema` info to `EuiDataGrid`'s `renderCellValue` props ([#5640](https://github.com/elastic/eui/pull/5640))
-- Added `isLoading` prop to `EuiDualRange` ([#5640](https://github.com/elastic/eui/pull/5640))
+- Added `isLoading` prop to `EuiDualRange` ([#5648](https://github.com/elastic/eui/pull/5648))
 
 **Breaking changes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added new `renderCellPopover` prop to `EuiDataGrid` ([#5640](https://github.com/elastic/eui/pull/5640))
 - Added cell `schema` info to `EuiDataGrid`'s `renderCellValue` props ([#5640](https://github.com/elastic/eui/pull/5640))
+- Added `isLoading` prop to `EuiDualRange` ([#5640](https://github.com/elastic/eui/pull/5640))
 
 **Breaking changes**
 

--- a/src-docs/src/views/range/input_only.js
+++ b/src-docs/src/views/range/input_only.js
@@ -50,7 +50,7 @@ export default () => {
 
       <EuiSpacer size="xl" />
 
-      <DisplayToggles canAppend canPrepend canLoading={false}>
+      <DisplayToggles canAppend canPrepend>
         <EuiDualRange
           id={dualInputRangeSliderId}
           value={dualValue}

--- a/src/components/form/range/__snapshots__/dual_range.test.tsx.snap
+++ b/src/components/form/range/__snapshots__/dual_range.test.tsx.snap
@@ -499,6 +499,63 @@ exports[`EuiDualRange props levels should render 1`] = `
 </div>
 `;
 
+exports[`EuiDualRange props loading should display when showInput="inputWithPopover" 1`] = `
+<div
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiRange__popover"
+>
+  <div
+    class="euiPopover__anchor"
+  >
+    <div>
+      <div
+        class="euiFormControlLayout euiFormControlLayoutDelimited"
+      >
+        <div
+          class="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-label="aria-label"
+            class="euiFieldNumber euiFormControlLayoutDelimited__input"
+            max="8"
+            min="0"
+            name="name-minValue"
+            step="1"
+            type="number"
+            value="1"
+          />
+          <div
+            class="euiText euiText--small euiFormControlLayoutDelimited__delimeter"
+          >
+            <div
+              class="euiTextColor euiTextColor--subdued"
+            >
+              →
+            </div>
+          </div>
+          <input
+            aria-label="aria-label"
+            class="euiFieldNumber euiFormControlLayoutDelimited__input"
+            max="100"
+            min="1"
+            name="name-maxValue"
+            step="1"
+            type="number"
+            value="8"
+          />
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          >
+            <span
+              class="euiLoadingSpinner euiLoadingSpinner--medium"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EuiDualRange props range should render 1`] = `
 <div
   class="euiRangeWrapper euiDualRange"

--- a/src/components/form/range/__snapshots__/range.test.tsx.snap
+++ b/src/components/form/range/__snapshots__/range.test.tsx.snap
@@ -312,6 +312,46 @@ exports[`EuiRange props levels should render 1`] = `
 </div>
 `;
 
+exports[`EuiRange props loading should display when showInput="inputWithPopover" 1`] = `
+<div
+  class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiRange__popover"
+>
+  <div
+    class="euiPopover__anchor"
+  >
+    <div>
+      <div
+        class="euiFormControlLayout"
+      >
+        <div
+          class="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-label="aria-label"
+            class="euiFieldNumber euiRangeInput euiRangeInput--max euiFieldNumber-isLoading"
+            data-test-subj="test subject string"
+            id="id"
+            max="100"
+            min="0"
+            name="name"
+            step="1"
+            type="number"
+            value="8"
+          />
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          >
+            <span
+              class="euiLoadingSpinner euiLoadingSpinner--medium"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EuiRange props range should render 1`] = `
 <div
   class="euiRangeWrapper euiRange"

--- a/src/components/form/range/dual_range.test.tsx
+++ b/src/components/form/range/dual_range.test.tsx
@@ -131,6 +131,22 @@ describe('EuiDualRange', () => {
       expect(component).toMatchSnapshot();
     });
 
+    test('loading should display when showInput="inputWithPopover"', () => {
+      const component = render(
+        <EuiDualRange
+          name="name"
+          id="id"
+          value={['1', '8']}
+          showInput="inputWithPopover"
+          isLoading
+          {...props}
+          {...requiredProps}
+        />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
     test('levels should render', () => {
       const component = render(
         <EuiDualRange

--- a/src/components/form/range/dual_range.tsx
+++ b/src/components/form/range/dual_range.tsx
@@ -37,7 +37,7 @@ type ValueMember = number | string;
 export interface EuiDualRangeProps
   extends Omit<
     EuiRangeSliderProps,
-    'onChange' | 'onBlur' | 'onFocus' | 'value'
+    'onChange' | 'onBlur' | 'onFocus' | 'value' | 'isLoading'
   > {
   value: [ValueMember, ValueMember];
   onBlur?: (
@@ -101,6 +101,10 @@ export interface EuiDualRangeProps
    *  Creates a draggble highlighted range area
    */
   isDraggable?: boolean;
+  /**
+   * Will only show if `showInput = inputWithPopover`
+   */
+  isLoading?: boolean;
 }
 
 export class EuiDualRange extends Component<EuiDualRangeProps> {

--- a/src/components/form/range/dual_range.tsx
+++ b/src/components/form/range/dual_range.tsx
@@ -110,6 +110,7 @@ export class EuiDualRange extends Component<EuiDualRangeProps> {
     step: 1,
     fullWidth: false,
     compressed: false,
+    isLoading: false,
     showLabels: false,
     showInput: false,
     showRange: true,
@@ -499,6 +500,7 @@ export class EuiDualRange extends Component<EuiDualRangeProps> {
       compressed,
       disabled,
       fullWidth,
+      isLoading,
       readOnly,
       id: propsId,
       max,
@@ -760,6 +762,7 @@ export class EuiDualRange extends Component<EuiDualRangeProps> {
             readOnly={readOnly}
             append={append}
             prepend={prepend}
+            isLoading={isLoading}
           />
         }
         fullWidth={fullWidth}

--- a/src/components/form/range/range.test.tsx
+++ b/src/components/form/range/range.test.tsx
@@ -130,6 +130,22 @@ describe('EuiRange', () => {
       expect(component).toMatchSnapshot();
     });
 
+    test('loading should display when showInput="inputWithPopover"', () => {
+      const component = render(
+        <EuiRange
+          name="name"
+          id="id"
+          onChange={() => {}}
+          showInput="inputWithPopover"
+          isLoading
+          {...props}
+          {...requiredProps}
+        />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
     test('levels should render', () => {
       const component = render(
         <EuiRange

--- a/src/components/form/range/range.tsx
+++ b/src/components/form/range/range.tsx
@@ -26,7 +26,7 @@ import { EuiRangeWrapper } from './range_wrapper';
 
 export interface EuiRangeProps
   extends CommonProps,
-    Omit<EuiRangeInputProps, 'onChange' | 'digitTolerance'> {
+    Omit<EuiRangeInputProps, 'onChange' | 'digitTolerance' | 'isLoading'> {
   compressed?: boolean;
   readOnly?: boolean;
   fullWidth?: boolean;
@@ -73,6 +73,10 @@ export interface EuiRangeProps
    * Prepends to the tooltip
    */
   valuePrepend?: ReactNode;
+  /**
+   * Will only show if `showInput = inputWithPopover`
+   */
+  isLoading?: boolean;
 
   onChange?: (
     event:

--- a/src/components/form/range/range_slider.tsx
+++ b/src/components/form/range/range_slider.tsx
@@ -23,9 +23,6 @@ export type EuiRangeSliderProps = InputHTMLAttributes<HTMLInputElement> &
     max: number;
     step?: number;
     compressed?: boolean;
-    /**
-     * Will only show if `showInput = inputWithPopover`
-     */
     isLoading?: boolean;
     hasFocus?: boolean;
     showRange?: boolean;

--- a/src/components/form/range/range_slider.tsx
+++ b/src/components/form/range/range_slider.tsx
@@ -23,7 +23,7 @@ export type EuiRangeSliderProps = InputHTMLAttributes<HTMLInputElement> &
     max: number;
     step?: number;
     compressed?: boolean;
-    /*
+    /**
      * Will only show if `showInput = inputWithPopover`
      */
     isLoading?: boolean;

--- a/src/components/form/range/range_slider.tsx
+++ b/src/components/form/range/range_slider.tsx
@@ -23,6 +23,10 @@ export type EuiRangeSliderProps = InputHTMLAttributes<HTMLInputElement> &
     max: number;
     step?: number;
     compressed?: boolean;
+    /*
+     * Will only show if `showInput = inputWithPopover`
+     */
+    isLoading?: boolean;
     hasFocus?: boolean;
     showRange?: boolean;
     showTicks?: boolean;


### PR DESCRIPTION
### Summary

This PR adds an `isLoading` prop to **EuiDualRange**. Similar to **EuiRange** the  loading only shows if `showInput = inputWithPopover`.

Closes #5645.

<img width="931" alt="dualrange-isloading@2x" src="https://user-images.githubusercontent.com/2750668/154551088-a49b7236-f3e7-4f35-8d65-554e7dec3473.png">



### Checklist

- [x] Check against **all themes** for compatibility in both light and dark modes
- ~[ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
