### PR TITLE
[Pagination Guidelines] Fixed auto-focus on context menu panel by removing the panel

### DIFF
--- a/src-docs/src/views/pagination/guidelines.js
+++ b/src-docs/src/views/pagination/guidelines.js
@@ -17,7 +17,6 @@ import {
   EuiLink,
   EuiCode,
   EuiButtonEmpty,
-  EuiContextMenuPanel,
   EuiContextMenuItem,
 } from '../../../../src/components';
 
@@ -45,13 +44,13 @@ const tooManyItems = [
   <EuiContextMenuItem key="10 rows" icon={'check'}>
     10 rows
   </EuiContextMenuItem>,
-  <EuiContextMenuItem key="20 rows" icon={'empty'}>
+  <EuiContextMenuItem key="15 rows" icon={'empty'}>
     15 rows
   </EuiContextMenuItem>,
   <EuiContextMenuItem key="20 rows" icon={'empty'}>
     20 rows
   </EuiContextMenuItem>,
-  <EuiContextMenuItem key="20 rows" icon={'empty'}>
+  <EuiContextMenuItem key="30 rows" icon={'empty'}>
     30 rows
   </EuiContextMenuItem>,
   <EuiContextMenuItem key="50 rows" icon={'empty'}>
@@ -162,7 +161,7 @@ export default () => (
           </EuiButtonEmpty>
           <EuiSpacer size="s" />
           <EuiPanel paddingSize="none" hasShadow>
-            <EuiContextMenuPanel items={items} />
+            {items}
           </EuiPanel>
         </div>
       </GuideRuleExample>
@@ -184,7 +183,7 @@ export default () => (
           </EuiButtonEmpty>
           <EuiSpacer size="s" />
           <EuiPanel paddingSize="none" hasShadow>
-            <EuiContextMenuPanel items={tooManyItems} />
+            {tooManyItems}
           </EuiPanel>
         </div>
       </GuideRuleExample>


### PR DESCRIPTION
The context menu style examples in the new Pagination Guidelines page was causing the page to auto-scroll to these examples on load because of EuiContextMenuPanel's auto-focusing behavior which is more required for when in real-use.


https://user-images.githubusercontent.com/549577/155583991-fdabff80-2fc6-424d-bdb4-bf7ab6e45501.mp4



I was able to just render the items themselves instead of passing through this component.

### To test:

Go to the pagination guidelines page: https://eui.elastic.co/pr_5661/#/navigation/pagination/guidelines and ensure the page stays at the top.


### ~Checklist~ Docs only