### PR TITLE
Force bump known-css-properties package to 0.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "**/prismjs": "1.27.0",
     "**/trim": "0.0.3",
     "**/node-sass": "^6.0.1",
-    "**/react": "^17.0.0"
+    "**/react": "^17.0.0",
+    "**/known-css-properties": "0.24.0"
   },
   "pre-commit": [
     "test-staged"

--- a/src/components/date_picker/super_date_picker/date_popover/_absolute_tab.scss
+++ b/src/components/date_picker/super_date_picker/date_popover/_absolute_tab.scss
@@ -1,3 +1,4 @@
 .euiSuperDatePicker__absoluteDateFormRow {
   padding: 0 $euiSizeS $euiSizeS;
+  gap: 1em;
 }

--- a/src/components/date_picker/super_date_picker/date_popover/_absolute_tab.scss
+++ b/src/components/date_picker/super_date_picker/date_popover/_absolute_tab.scss
@@ -1,4 +1,3 @@
 .euiSuperDatePicker__absoluteDateFormRow {
   padding: 0 $euiSizeS $euiSizeS;
-  gap: 1em;
 }

--- a/src/themes/amsterdam/global_styling/react_date_picker/_date_picker_times.scss
+++ b/src/themes/amsterdam/global_styling/react_date_picker/_date_picker_times.scss
@@ -48,7 +48,7 @@
   flex-direction: column;
   flex-grow: 1;
   align-items: center;
-  gap: $euiSizeXS; // sass-lint:disable-line no-misspelled-properties
+  gap: $euiSizeXS;
 }
 
 // Mainly a copy/paste of .euiEmptyButton

--- a/yarn.lock
+++ b/yarn.lock
@@ -12528,15 +12528,10 @@ klona@^2.0.4:
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.5.tgz#d166574d90076395d9963aa7a928fabb8d76afbc"
   integrity sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==
 
-known-css-properties@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.3.0.tgz#a3d135bbfc60ee8c6eacf2f7e7e6f2d4755e49a4"
-  integrity sha512-QMQcnKAiQccfQTqtBh/qwquGZ2XK/DXND1jrcN9M8gMMy99Gwla7GQjndVUsEqIaRyP6bsFRuhwRj5poafBGJQ==
-
-known-css-properties@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.5.0.tgz#6ff66943ed4a5b55657ee095779a91f4536f8084"
-  integrity sha512-LOS0CoS8zcZnB1EjLw4LLqDXw8nvt3AGH5dXLQP3D9O1nLLA+9GC5GnPl5mmF+JiQAtSX4VyZC7KvEtcA4kUtA==
+known-css-properties@0.24.0, known-css-properties@^0.3.0, known-css-properties@^0.5.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.24.0.tgz#19aefd85003ae5698a5560d2b55135bf5432155c"
+  integrity sha512-RTSoaUAfLvpR357vWzAz/50Q/BmHfmE6ETSWfutT0AJiw10e6CmcdYRQJlLRd95B53D0Y2aD1jSxD3V3ySF+PA==
 
 labeled-stream-splicer@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
### Summary

Brings the `known-css-properties` package used by `sass-lint` and `style-lint` (via `prettier-stylelint`) from 0.3.0 and 0.5.0 respectively to the latest 0.24.0.

Compatibility check:

* entry file between the two versions retain the same API [0.3.0](https://github.com/known-css/known-css-properties/blob/v0.3.0/index.js) / [0.24.0](https://github.com/known-css/known-css-properties/blob/v0.24.0/index.js)
* the shape of exported data is the same [0.3.0](https://github.com/known-css/known-css-properties/blob/v0.3.0/data/all.json) / [0.24.0](https://github.com/known-css/known-css-properties/blob/v0.24.0/data/all.json)
* added a `gap: 1em;` to one of the SCSS files
  * 0.3.0 flags as an unknown prop
  * 0.24.0 has no problems
  * typo'd `gap` -> `gbp` and 0.24.0 flags as incorrect

~### Checklist~
