### PR TITLE
[EuiDataGrid] Allow `isExpandable` to be set via `setCellProps`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Updated `EuiComboBox` to WAI-ARIA 1.2 pattern and improved keyboard navigation ([#5636](https://github.com/elastic/eui/pull/5636))
 - Added `readOnly` prop to `EuiMarkdownEditor` ([#5627](https://github.com/elastic/eui/pull/5627))
+- Updated `EuiDataGrid` to allow setting individual cell `isExpandable` state via `setCellProps` ([#5667](https://github.com/elastic/eui/pull/5667))
 
 ## [`49.0.0`](https://github.com/elastic/eui/tree/v49.0.0)
 

--- a/src-docs/src/views/datagrid/cell_popover_is_expandable.tsx
+++ b/src-docs/src/views/datagrid/cell_popover_is_expandable.tsx
@@ -37,7 +37,7 @@ const columns: EuiDataGridColumn[] = [
   },
   {
     id: 'boolean',
-    isExpandable: false,
+    isExpandable: true, // Overridden by setCellProps for specific cells
   },
 ];
 
@@ -58,11 +58,21 @@ export default () => {
 
   return (
     <EuiDataGrid
-      aria-label="Data grid example of columns.isExpandable"
+      aria-label="Data grid example of isExpandable false"
       columns={columns}
       columnVisibility={{ visibleColumns, setVisibleColumns }}
       rowCount={data.length}
-      renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
+      renderCellValue={({ rowIndex, columnId, setCellProps }) => {
+        const value = data[rowIndex][columnId];
+
+        useEffect(() => {
+          if (columnId === 'boolean' && value === 'false') {
+            setCellProps({ isExpandable: false });
+          }
+        }, [columnId, value, setCellProps]);
+
+        return value;
+      }}
     />
   );
 };

--- a/src-docs/src/views/datagrid/cell_popover_is_expandable.tsx
+++ b/src-docs/src/views/datagrid/cell_popover_is_expandable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ReactNode } from 'react';
+import React, { useEffect, useState, ReactNode } from 'react';
 // @ts-ignore - faker does not have type declarations
 import { fake } from 'faker';
 

--- a/src-docs/src/views/datagrid/datagrid.js
+++ b/src-docs/src/views/datagrid/datagrid.js
@@ -84,9 +84,6 @@ const RenderCellValue = ({ rowIndex, columnId, setCellProps }) => {
         });
       }
     }
-    if (rowIndex === 2) {
-      setCellProps({ isExpandable: false });
-    }
   }, [rowIndex, columnId, setCellProps, data]);
 
   function getFormatted() {

--- a/src-docs/src/views/datagrid/datagrid.js
+++ b/src-docs/src/views/datagrid/datagrid.js
@@ -84,6 +84,9 @@ const RenderCellValue = ({ rowIndex, columnId, setCellProps }) => {
         });
       }
     }
+    if (rowIndex === 2) {
+      setCellProps({ isExpandable: false });
+    }
   }, [rowIndex, columnId, setCellProps, data]);
 
   function getFormatted() {

--- a/src-docs/src/views/datagrid/datagrid_cell_popover_example.js
+++ b/src-docs/src/views/datagrid/datagrid_cell_popover_example.js
@@ -135,12 +135,21 @@ export const DataGridCellPopoverExample = {
     {
       title: 'Disabling cell expansion popovers',
       text: (
-        <p>
-          Popovers can sometimes be unnecessary for short form content. In the
-          example below we&apos;ve turned them off by setting{' '}
-          <EuiCode>isExpandable=false</EuiCode> on specific{' '}
-          <EuiCode>columns</EuiCode>.
-        </p>
+        <>
+          <p>
+            Popovers can sometimes be unnecessary for short form content. In the
+            example below we&apos;ve turned them off by setting{' '}
+            <EuiCode>isExpandable=false</EuiCode> on specific{' '}
+            <EuiCode>columns</EuiCode>.
+          </p>
+          <p>
+            To set <EuiCode>isExpandable</EuiCode> at a per-cell level instead
+            of per-column, you can use the <EuiCode>setCellProps</EuiCode>{' '}
+            callback passed by <EuiCode>renderCellValue</EuiCode>. The below
+            example conditionally disables the expansion popover for boolean
+            cells that are &apos;false&apos;.
+          </p>
+        </>
       ),
       demo: <IsExpandablePopover />,
       components: { IsExpandablePopover },
@@ -152,6 +161,7 @@ export const DataGridCellPopoverExample = {
       ],
       props: {
         EuiDataGridColumn,
+        EuiDataGridCellValueElementProps,
       },
     },
   ],

--- a/src/components/datagrid/body/data_grid_cell.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell.test.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { mount, render, ReactWrapper } from 'enzyme';
 import { keys } from '../../../services';
 import { mockRowHeightUtils } from '../utils/__mocks__/row_heights';
@@ -382,6 +382,36 @@ describe('EuiDataGridCell', () => {
         <EuiDataGridCell {...props} isExpandable={false} />
       );
       expect((component.instance() as any).isPopoverOpen()).toEqual(false);
+    });
+  });
+
+  describe('isExpandable', () => {
+    it('falls back to props.isExpandable which is derived from the column config', () => {
+      const component = mount(
+        <EuiDataGridCell {...requiredProps} isExpandable={true} />
+      );
+
+      expect(component.find('renderCellValue').prop('isExpandable')).toBe(true);
+    });
+
+    it('allows overriding column.isExpandable with setCellProps({ isExpandable })', () => {
+      const RenderCellValue = ({ setCellProps }: any) => {
+        useEffect(() => {
+          setCellProps({ isExpandable: false });
+        }, [setCellProps]);
+        return 'cell render';
+      };
+      const component = mount(
+        <EuiDataGridCell
+          {...requiredProps}
+          isExpandable={true}
+          renderCellValue={RenderCellValue}
+        />
+      );
+
+      expect(component.find('RenderCellValue').prop('isExpandable')).toBe(
+        false
+      );
     });
   });
 

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -529,13 +529,18 @@ export class EuiDataGridCell extends Component<
       className
     );
 
-    const cellProps = {
-      ...this.state.cellProps,
-      'data-test-subj': classNames(
-        'dataGridRowCell',
-        this.state.cellProps['data-test-subj']
-      ),
-      className: classNames(cellClasses, this.state.cellProps.className),
+    const {
+      isExpandable: _, // Not a valid DOM property, so needs to be destructured out
+      style: cellPropsStyle,
+      className: cellPropsClassName,
+      'data-test-subj': cellPropsDataTestSubj,
+      ...setCellProps
+    } = this.state.cellProps;
+
+    const cellProps: EuiDataGridSetCellProps = {
+      ...setCellProps,
+      'data-test-subj': classNames('dataGridRowCell', cellPropsDataTestSubj),
+      className: classNames(cellClasses, cellPropsClassName),
     };
 
     cellProps.style = {
@@ -543,7 +548,7 @@ export class EuiDataGridCell extends Component<
       top: 0, // The cell's row will handle top positioning
       width, // column width, can be undefined
       lineHeight: rowHeightsOptions?.lineHeight ?? undefined, // lineHeight configuration
-      ...cellProps.style, // apply anything from setCellProps({style})
+      ...cellPropsStyle, // apply anything from setCellProps({ style })
     };
 
     const handleCellKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -160,7 +160,7 @@ export class EuiDataGridCell extends Component<
 
       if (doFocusUpdate) {
         const interactables = this.getInteractables();
-        if (this.props.isExpandable === false && interactables.length === 1) {
+        if (this.isExpandable() === false && interactables.length === 1) {
           // Only one element can be interacted with
           interactables[0].focus({ preventScroll });
         } else {
@@ -379,7 +379,7 @@ export class EuiDataGridCell extends Component<
     //  * if the cell children include portalled content React will bubble the focus
     //      event up, which can trigger the focus() call below, causing focus lock fighting
     if (this.cellRef.current === e.target) {
-      const { colIndex, visibleRowIndex, isExpandable } = this.props;
+      const { colIndex, visibleRowIndex } = this.props;
       // focus in next tick to give potential focus capturing mechanisms time to release their traps
       // also clear any previous focus timeout that may still be queued
       if (EuiDataGridCell.activeFocusTimeoutId) {
@@ -390,7 +390,7 @@ export class EuiDataGridCell extends Component<
           this.context.setFocusedCell([colIndex, visibleRowIndex]);
 
           const interactables = this.getInteractables();
-          if (interactables.length === 1 && isExpandable === false) {
+          if (interactables.length === 1 && this.isExpandable() === false) {
             interactables[0].focus();
             this.setState({ disableCellTabIndex: true });
           }
@@ -425,12 +425,17 @@ export class EuiDataGridCell extends Component<
     }
   };
 
+  isExpandable = () => {
+    // props.isExpandable inherits from column.isExpandable
+    // state.cellProps allows consuming applications to override isExpandable on a per-cell basis
+    return this.state.cellProps.isExpandable ?? this.props.isExpandable;
+  };
+
   isPopoverOpen = () => {
-    const { isExpandable, popoverContext } = this.props;
-    const { popoverIsOpen, cellLocation } = popoverContext;
+    const { popoverIsOpen, cellLocation } = this.props.popoverContext;
 
     return (
-      isExpandable &&
+      this.isExpandable() &&
       popoverIsOpen &&
       cellLocation.colIndex === this.props.colIndex &&
       cellLocation.rowIndex === this.props.visibleRowIndex
@@ -493,7 +498,6 @@ export class EuiDataGridCell extends Component<
   render() {
     const {
       width,
-      isExpandable,
       popoverContext: { closeCellPopover, openCellPopover },
       interactiveCellId,
       columnType,
@@ -507,6 +511,7 @@ export class EuiDataGridCell extends Component<
     } = this.props;
     const { rowIndex, visibleRowIndex, colIndex } = rest;
 
+    const isExpandable = this.isExpandable();
     const popoverIsOpen = this.isPopoverOpen();
     const hasCellActions = isExpandable || column?.cellActions;
     const showCellActions =

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -12,7 +12,6 @@ import React, {
   createRef,
   FocusEvent,
   FunctionComponent,
-  HTMLAttributes,
   JSXElementConstructor,
   KeyboardEvent,
   memo,
@@ -29,6 +28,7 @@ import { DataGridFocusContext } from '../utils/focus';
 import {
   EuiDataGridCellProps,
   EuiDataGridCellState,
+  EuiDataGridSetCellProps,
   EuiDataGridCellValueElementProps,
   EuiDataGridCellValueProps,
   EuiDataGridCellPopoverElementProps,
@@ -353,7 +353,7 @@ export class EuiDataGridCell extends Component<
     return false;
   }
 
-  setCellProps = (cellProps: HTMLAttributes<HTMLDivElement>) => {
+  setCellProps = (cellProps: EuiDataGridSetCellProps) => {
     this.setState({ cellProps });
   };
 

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -410,13 +410,18 @@ interface SharedRenderCellElementProps {
   schema: string | undefined | null;
 }
 
+export type EuiDataGridSetCellProps = CommonProps &
+  HTMLAttributes<HTMLDivElement> & {
+    isExpandable?: boolean;
+  };
+
 export interface EuiDataGridCellValueElementProps
   extends SharedRenderCellElementProps {
   /**
    * Callback function to set custom props & attributes on the cell's wrapping `div` element;
    * it's best to wrap calls to `setCellProps` in a `useEffect` hook
    */
-  setCellProps: (props: CommonProps & HTMLAttributes<HTMLDivElement>) => void;
+  setCellProps: (props: EuiDataGridSetCellProps) => void;
   /**
    * Whether or not the cell is expandable, comes from the #EuiDataGridColumn `isExpandable` which defaults to `true`
    */
@@ -482,7 +487,7 @@ export interface EuiDataGridCellProps {
 }
 
 export interface EuiDataGridCellState {
-  cellProps: CommonProps & HTMLAttributes<HTMLDivElement>;
+  cellProps: EuiDataGridSetCellProps;
   isFocused: boolean; // tracks if this cell has focus or not, used to enable tabIndex on the cell
   isEntered: boolean; // enables focus trap for non-expandable cells with multiple interactive elements
   enableInteractions: boolean; // cell got hovered at least once, so cell button and popover interactions are rendered


### PR DESCRIPTION
### Summary

closes https://github.com/elastic/eui/issues/2793

This PR allows `isExpandable` to be set at the `cellProps` level, which lets consumers override/more granularly set `column.isExpandable`. Consumers can key off of any of the props passed to `renderCellValue`, such as rowIndex, colIndex, columnId, schema, etc.

## QA

http://localhost:8030/#/tabular-content/data-grid - note how none of the cells in the 3rd row have an expansion button, but all other cells do

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~

- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**

~- [ ] Checked for **breaking changes** and labeled appropriately~

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately