### PR TITLE
[Docs] Fix `EuiLink` CodeSandbox demos

### DIFF
--- a/src-docs/src/views/link/link_disable.js
+++ b/src-docs/src/views/link/link_disable.js
@@ -7,7 +7,7 @@ import {
   EuiText,
 } from '../../../../src/components';
 
-export const LinkDisable = () => {
+export default () => {
   const [disableLink, setDisableLink] = useState(true);
 
   return (

--- a/src-docs/src/views/link/link_example.js
+++ b/src-docs/src/views/link/link_example.js
@@ -16,10 +16,10 @@ const linkExternalSource = require('!!raw-loader!./link_external');
 import LinkColor from './link_color';
 const linkColorSource = require('!!raw-loader!./link_color');
 
-import { LinkDisable } from './link_disable';
+import LinkDisable from './link_disable';
 const linkDisableSource = require('!!raw-loader!./link_disable');
 
-import { LinkValidation } from './link_validation';
+import LinkValidation from './link_validation';
 const linkValidationSource = require('!!raw-loader!./link_validation');
 
 export const LinkExample = {

--- a/src-docs/src/views/link/link_validation.js
+++ b/src-docs/src/views/link/link_validation.js
@@ -10,16 +10,14 @@ const urls = [
   'javascript:alert()',
 ];
 
-export const LinkValidation = () => {
-  return (
-    <EuiText>
-      {urls.map((url) => (
-        <p key={url}>
-          <EuiLink color="success" href={url}>
-            {url}
-          </EuiLink>
-        </p>
-      ))}
-    </EuiText>
-  );
-};
+export default () => (
+  <EuiText>
+    {urls.map((url) => (
+      <p key={url}>
+        <EuiLink color="success" href={url}>
+          {url}
+        </EuiLink>
+      </p>
+    ))}
+  </EuiText>
+);


### PR DESCRIPTION
### Summary

Fix #5659. 

This PR fixes the following EuiLink CodeSandbox demos:

- https://eui.elastic.co/#/navigation/link#disabled-links
- https://eui.elastic.co/#/navigation/link#link-validation


### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
