### PR TITLE
[sass] Improve compilation speed using a different pow implementation

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -52,3 +52,29 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE
+
+--
+This product bundles code based on sass-math-pow@0.1.7 which is
+available under a "MIT" license.
+
+MIT License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE

--- a/src/global_styling/functions/_math.scss
+++ b/src/global_styling/functions/_math.scss
@@ -1,63 +1,91 @@
-//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/pow
-@function pow($number, $power) {
-  @if ($power != $power or ($power != 0 and $power == $power / 2)) {
-    @return $power;
+//Forked by @elastic/eui from strarsis/sass-math-pow see https://github.com/strarsis/sass-math-pow
+
+/**
+The MIT License (MIT)
+
+Copyright (c) 2015 strarsis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+// By drtimofey, script based on script by davidkpiano, see these links:
+// https://github.com/thoughtbot/bitters/issues/167
+// https://github.com/thoughtbot/bourbon/issues/717
+// https://gist.github.com/davidkpiano/ad6e6771df050ff3727f
+//
+
+
+@function pow($number, $exp) {
+  $exp1: round($exp);
+  $result: powInt($number, $exp1);
+
+  @if ($exp1 != $exp) {
+    $result: $result * mathExp(($exp - $exp1) * mathLn($number));
   }
-  @if ($power == 1) {
-    @return $number;
-  }
-  @if ($power == 0) {
+
+  @return $result;
+}
+
+@function powInt($number, $exp) {
+  @if $exp == 0 {
     @return 1;
-  }
-  @if ($power < 0) {
-    @return 1 / pow($number, -$power);
-  }
-  @if (0 < $power and $power < 2) {
-    $hasLeadingOne: false;
-    @if (floor($power) == 1) {
-      $power: $power - 1;
-      $hasLeadingOne: true;
-    } @else {
-      $hasLeadingOne: false;
-    }
-    $doublePower: pow($number, $power * 2);
-    $fullPower: nthRoot($doublePower, 2);
-    @if ($hasLeadingOne) {
-      $fullPower: $fullPower * $number;
-    }
-    @return $fullPower;
-  } @else if (getDecimal($power) != 0) {
-    $wholePower: floor($power);
-    $decimalPower: getDecimal($power);
-    @return pow($number, $wholePower) * pow($number, $decimalPower);
+  } @else if $exp < 0 {
+    @return 1 / powInt($number, -$exp);
   } @else {
-    $hasTrailingOne: $power % 2 == 1;
-    @if ($hasTrailingOne) {
-      $power: $power - 1;
+    $e: floor($exp / 2);
+    $pow: pow($number, $e);
+    @if $e * 2 == $exp {
+      @return $pow * $pow;
+    } @else {
+      @return $pow * $pow * $number;
     }
-    $halfPower: pow($number, floor($power / 2));
-    $fullPower: $halfPower * $halfPower;
-    @if ($hasTrailingOne) {
-      $fullPower: $fullPower * $number;
-    }
-    @return $fullPower;
   }
 }
 
-@function getDecimal($number) {
-  @if ($number < 0) {
-    $number: -$number;
+@function mathExp($value) {
+  $item: 1;
+  $result: 1;
+
+  @for $index from 1 to 100 {
+    $item: $item * $value / $index;
+    $result: $result + $item;
   }
-  @return $number % 1;
+
+  @return $result;
 }
 
-// From: http://rosettacode.org/wiki/Nth_root#JavaScript
-@function nthRoot($num, $n: 2, $prec: 12) {
-  $x: 1;
+@function mathLn($value) {
+  $tenExp: 0;
+  $lnTen: 2.30258509;
 
-  @for $i from 0 through $prec {
-    $x: 1 / $n * (($n - 1) * $x + ($num / pow($x, $n - 1)));
+  @while ($value > 1) {
+    $tenExp: $tenExp + 1;
+    $value: $value / 10;
   }
 
-  @return $x;
+  $item: -1;
+  $result: 0;
+
+  @for $index from 1 to 100 {
+    $item: $item * (1 - $value);
+    $result: $result + $item / $index;
+  }
+
+  @return $result + $tenExp * $lnTen;
 }


### PR DESCRIPTION
### Summary

I've noticed that compiling `@elastic/charts` SASS files (that imports some mixins and variables from EUI) takes a very long time.
I've tried to debug the status of the SASS compilation and I've found that the time spent on the `pow` function available in `src/global_styling/functions/_math.scss` is huge and slow down a lot the compilation.

I tried to replace the `pow` operation with the implementation coming from [https://github.com/strarsis/sass-math-pow ](https://github.com/strarsis/sass-math-pow) and the speed gain was significant to consider opening a draft/testing PR here.

In particular I've tested this assumption both with `sass` and with `dart-sass` (the native dart version, not the js port) to compile our sass styles with the following results:

from:
```
sass src/theme_light.scss dist/theme_light.css  5.66s user 0.10s system 98% cpu 5.871 total
```
to:
```
sass src/theme_light.scss dist/theme_light.css  0.54s user 0.06s system 100% cpu 0.591 total
```
a 10x speedup

Locally I've tested the same compiling EUI and these are the results:

from:
<img width="425" alt="Screenshot 2022-03-01 at 23 31 09" src="https://user-images.githubusercontent.com/1421091/156263960-e8d0294c-b273-4dae-b26d-5fc974ed7e4a.png">

to:
<img width="357" alt="Screenshot 2022-03-01 at 23 28 58" src="https://user-images.githubusercontent.com/1421091/156263996-4aff24be-f056-4de5-a3e1-fc17c366eca7.png">

I'd like to run this PR to check the difference in a CI run (I've checked one of the latest PR and the compilation time was around 110seconds).

**Notes**
- this PR is just a draft and for testing purposes: I'd like to discuss the finding with you folks and understand how to proceed (e.g. testing various implementations, improving the current code, adding the dependency instead of copying the code etc)
- I've tested the compilation our our elastic-charts library in `dart-sass` using directly the `math.pow`  https://sass-lang.com/documentation/modules/math#pow built-in. IMHO this should be the way to go, since this is probably way more optimized.
- I've quickly verified that this new pow implementation results in the same CSS as the previous implementation by diffing the outputs of the original vs the new implementation: they look exactly the same.


### Checklist

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
