### PR TITLE
[EuiDataGrid] Enforce `visibleCellActions` shown (overflowing extra actions to the cell popover)

### DIFF
--- a/src-docs/src/views/datagrid/cells_popovers/datagrid_cells_example.js
+++ b/src-docs/src/views/datagrid/cells_popovers/datagrid_cells_example.js
@@ -66,20 +66,26 @@ export const DataGridCellsExample = {
       text: (
         <Fragment>
           <p>
-            On top of making a cell expandable, you can add more custom actions
-            by setting <EuiCode>cellActions</EuiCode>. This contains functions
-            called to render additional buttons in the cell and in the popover
-            when expanded. Behind the scenes those are treated as a React
-            components allowing hooks, context, and other React concepts to be
-            used. The functions receives an argument of type
-            <code>EuiDataGridColumnCellActionProps</code>. The icons of these
-            actions are displayed on mouse over, and also appear in the popover
-            when the cell is expanded. Note that once you&apos;ve defined the{' '}
-            <EuiCode>cellAction</EuiCode> property, the cell&apos;s
-            automatically expandable.
+            In addition to making a cell expandable, you can add more custom
+            actions by setting <EuiCode>columns.cellActions</EuiCode>. These
+            actions will render as icon buttons in the cell on hover/focus, and
+            render as full buttons in the cell expansion popover. Note that once
+            any <EuiCode>cellActions</EuiCode> are passed, the cell becomes
+            automatically expandable - this ensures keyboard and screen reader
+            users have access to all cell actions.
           </p>
           <p>
-            Below, the email and city columns provide 1{' '}
+            <EuiCode>columns.cellActions</EuiCode> accepts an array of render
+            functions. Behind the scenes, the functions are treated as a React
+            components allowing hooks, context, and other React concepts to be
+            used. Because different button types are used between the cell and
+            the cell popover, we pass your render function a{' '}
+            <EuiCode>Component</EuiCode> prop which you must render in order for
+            your cell actions to switch correctly between button icons and
+            buttons.
+          </p>
+          <p>
+            In the below example, the email and city columns provide 1{' '}
             <EuiCode>cellAction</EuiCode> each, while the country column
             provides 2 <EuiCode>cellAction</EuiCode>s.
             <br />

--- a/src-docs/src/views/datagrid/cells_popovers/datagrid_cells_example.js
+++ b/src-docs/src/views/datagrid/cells_popovers/datagrid_cells_example.js
@@ -15,6 +15,9 @@ import {
 import DataGridColumnCellActions from './column_cell_actions';
 const dataGridColumnCellActionsSource = require('!!raw-loader!./column_cell_actions');
 
+import VisibleCellActions from './visible_cell_actions';
+const visibleCellActionsSource = require('!!raw-loader!./visible_cell_actions');
+
 import { DataGridCellPopoverExample } from './datagrid_cell_popover_example';
 
 import DataGridFocus from './focus';
@@ -94,6 +97,42 @@ export const DataGridCellsExample = {
         EuiListGroupItem,
       },
       demo: <DataGridColumnCellActions />,
+    },
+    {
+      title: 'Visible cell actions and cell popovers',
+      text: (
+        <>
+          <p>
+            By default, only the first 2 cell actions of a cell will be
+            displayed to the left of the expand action button, and remaining
+            actions will be displayed in the footer of the cell expansion
+            popover.
+          </p>
+          <p>
+            This number is configurable by setting{' '}
+            <EuiCode>columns.visibleCellActions</EuiCode>, should you need to
+            display more cell actions immediately. However, we advise caution
+            when increasing this limit - the default is set to ensure cell
+            action buttons do not crowd out content.
+          </p>
+          <p>
+            The below example shows an increasing number of{' '}
+            <EuiCode>cellActions</EuiCode> in each column. The third column
+            shows <EuiCode>visibleCellActions</EuiCode> set to 3, and the fourth
+            column shows excess actions overflowing into the popover.
+          </p>
+        </>
+      ),
+      demo: <VisibleCellActions />,
+      source: [
+        {
+          type: GuideSectionTypes.TSX,
+          code: visibleCellActionsSource,
+        },
+      ],
+      props: {
+        EuiDataGridColumn,
+      },
     },
 
     ...DataGridCellPopoverExample.sections,

--- a/src-docs/src/views/datagrid/cells_popovers/visible_cell_actions.tsx
+++ b/src-docs/src/views/datagrid/cells_popovers/visible_cell_actions.tsx
@@ -1,0 +1,97 @@
+import React, { useState, ReactNode } from 'react';
+// @ts-ignore - faker does not have type declarations
+import { fake } from 'faker';
+
+import {
+  EuiDataGrid,
+  EuiDataGridColumnCellAction,
+  EuiDataGridColumn,
+} from '../../../../../src/components';
+
+const cellActions1: EuiDataGridColumnCellAction[] = [
+  ({ Component }) => (
+    <Component onClick={() => {}} iconType="timeline">
+      Add to timeline
+    </Component>
+  ),
+];
+const cellActions2: EuiDataGridColumnCellAction[] = [
+  ({ Component }) => (
+    <Component iconType="plusInCircle" aria-label="Filter in">
+      Filter in
+    </Component>
+  ),
+  ({ Component }) => (
+    <Component iconType="minusInCircle" aria-label="Filter out">
+      Filter out
+    </Component>
+  ),
+];
+const cellActions3 = [...cellActions2, ...cellActions1];
+const cellActions5: EuiDataGridColumnCellAction[] = [
+  ...cellActions3,
+  ({ Component }) => (
+    <Component onClick={() => {}} iconType="starEmpty">
+      Custom action 1
+    </Component>
+  ),
+  ({ Component }) => (
+    <Component onClick={() => {}} iconType="starEmpty">
+      Custom action 2
+    </Component>
+  ),
+];
+
+const columns: EuiDataGridColumn[] = [
+  {
+    id: 'default',
+    cellActions: cellActions1,
+  },
+  {
+    id: 'datetime',
+    cellActions: cellActions2,
+  },
+  {
+    id: 'json',
+    schema: 'json',
+    cellActions: cellActions3,
+    visibleCellActions: 3,
+  },
+  {
+    id: 'custom',
+    schema: 'favoriteFranchise',
+    cellActions: cellActions5,
+  },
+];
+
+const data: Array<{ [key: string]: ReactNode }> = [];
+for (let i = 1; i < 5; i++) {
+  data.push({
+    default: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
+    datetime: fake('{{date.past}}'),
+    json: JSON.stringify([
+      {
+        numeric: fake('{{finance.account}}'),
+        currency: fake('${{finance.amount}}'),
+        date: fake('{{date.past}}'),
+      },
+    ]),
+    custom: i % 2 === 0 ? 'Star Wars' : 'Star Trek',
+  });
+}
+
+export default () => {
+  const [visibleColumns, setVisibleColumns] = useState(
+    columns.map(({ id }) => id)
+  );
+
+  return (
+    <EuiDataGrid
+      aria-label="Data grid example of cellActions within popovers"
+      columns={columns}
+      columnVisibility={{ visibleColumns, setVisibleColumns }}
+      rowCount={data.length}
+      renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
+    />
+  );
+};

--- a/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
@@ -1,5 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiDataGridCell componentDidUpdate handles the cell popover by forwarding the cell's DOM node and contents to the parent popover context 1`] = `
+Array [
+  <div
+    class="euiText euiText--medium"
+  >
+    <div>
+      <button
+        data-datagrid-interactable="true"
+      >
+        hello
+      </button>
+      <button
+        data-datagrid-interactable="true"
+      >
+        world
+      </button>
+    </div>
+  </div>,
+  <div
+    class="euiPopoverFooter"
+  >
+    <div
+      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--wrap"
+    >
+      <div
+        class="euiFlexItem"
+      >
+        <div>
+          <button />
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
 exports[`EuiDataGridCell renders 1`] = `
 <EuiDataGridCell
   colIndex={0}
@@ -167,38 +203,4 @@ exports[`EuiDataGridCell renders 1`] = `
     </div>
   </div>
 </EuiDataGridCell>
-`;
-
-exports[`EuiDataGridCell componentDidUpdate handles the cell popover by forwarding the cell's DOM node and contents to the parent popover context 1`] = `
-Array [
-  <div
-    class="euiText euiText--medium"
-  >
-    <div>
-      <button
-        data-datagrid-interactable="true"
-      >
-        hello
-      </button>
-      <button
-        data-datagrid-interactable="true"
-      >
-        world
-      </button>
-    </div>
-  </div>,
-  <div
-    class="euiPopoverFooter"
-  >
-    <div
-      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--wrap"
-    >
-      <div
-        class="euiFlexItem"
-      >
-        <button />
-      </div>
-    </div>
-  </div>,
-]
 `;

--- a/src/components/datagrid/body/data_grid_cell_actions.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_actions.test.tsx
@@ -110,6 +110,21 @@ describe('EuiDataGridCellActions', () => {
       </div>
     `);
   });
+
+  it('does not render more than the first two primary cell actions', () => {
+    const component = shallow(
+      <EuiDataGridCellActions
+        {...requiredProps}
+        isExpandable={true}
+        column={{
+          id: 'someId',
+          cellActions: [MockAction, MockAction, MockAction],
+        }}
+      />
+    );
+
+    expect(component.find('MockAction')).toHaveLength(2);
+  });
 });
 
 describe('EuiDataGridCellPopoverActions', () => {
@@ -123,25 +138,27 @@ describe('EuiDataGridCellPopoverActions', () => {
     );
 
     expect(component).toMatchInlineSnapshot(`
-      <EuiPopoverFooter>
-        <EuiFlexGroup
-          gutterSize="s"
-          responsive={false}
-          wrap={true}
-        >
-          <EuiFlexItem
-            key="0"
+      <Fragment>
+        <EuiPopoverFooter>
+          <EuiFlexGroup
+            gutterSize="s"
+            responsive={false}
+            wrap={true}
           >
-            <MockAction
-              Component={[Function]}
-              colIndex={0}
-              columnId="someId"
-              isExpanded={true}
-              rowIndex={0}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiPopoverFooter>
+            <EuiFlexItem
+              key="0"
+            >
+              <MockAction
+                Component={[Function]}
+                colIndex={0}
+                columnId="someId"
+                isExpanded={true}
+                rowIndex={0}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiPopoverFooter>
+      </Fragment>
     `);
 
     const action = component.find('MockAction') as any;
@@ -154,6 +171,72 @@ describe('EuiDataGridCellPopoverActions', () => {
     `);
   });
 
+  it('renders the first two primary actions in their own footer, and all remaining secondary actions in a column footer', () => {
+    const component = shallow(
+      <EuiDataGridCellPopoverActions
+        colIndex={0}
+        rowIndex={0}
+        column={{
+          id: 'someId',
+          cellActions: [MockAction, MockAction, MockAction],
+        }}
+      />
+    );
+
+    expect(component).toMatchInlineSnapshot(`
+      <Fragment>
+        <EuiPopoverFooter>
+          <EuiFlexGroup
+            gutterSize="s"
+            responsive={false}
+            wrap={true}
+          >
+            <EuiFlexItem
+              key="0"
+            >
+              <MockAction
+                Component={[Function]}
+                colIndex={0}
+                columnId="someId"
+                isExpanded={true}
+                rowIndex={0}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem
+              key="1"
+            >
+              <MockAction
+                Component={[Function]}
+                colIndex={0}
+                columnId="someId"
+                isExpanded={true}
+                rowIndex={0}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiPopoverFooter>
+        <EuiPopoverFooter>
+          <EuiFlexGroup
+            direction="column"
+            gutterSize="s"
+          >
+            <EuiFlexItem
+              key="0"
+            >
+              <MockAction
+                Component={[Function]}
+                colIndex={0}
+                columnId="someId"
+                isExpanded={true}
+                rowIndex={0}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiPopoverFooter>
+      </Fragment>
+    `);
+  });
+
   it('does not render anything if the column has no cell actions', () => {
     const component = shallow(
       <EuiDataGridCellPopoverActions
@@ -163,6 +246,6 @@ describe('EuiDataGridCellPopoverActions', () => {
       />
     );
 
-    expect(component.isEmptyRender()).toBe(true);
+    expect(component).toMatchInlineSnapshot('<Fragment />');
   });
 });

--- a/src/components/datagrid/body/data_grid_cell_actions.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_actions.test.tsx
@@ -148,13 +148,15 @@ describe('EuiDataGridCellPopoverActions', () => {
             <EuiFlexItem
               key="0"
             >
-              <MockAction
-                Component={[Function]}
-                colIndex={0}
-                columnId="someId"
-                isExpanded={true}
-                rowIndex={0}
-              />
+              <div>
+                <MockAction
+                  Component={[Function]}
+                  colIndex={0}
+                  columnId="someId"
+                  isExpanded={true}
+                  rowIndex={0}
+                />
+              </div>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiPopoverFooter>
@@ -194,42 +196,49 @@ describe('EuiDataGridCellPopoverActions', () => {
             <EuiFlexItem
               key="0"
             >
-              <MockAction
-                Component={[Function]}
-                colIndex={0}
-                columnId="someId"
-                isExpanded={true}
-                rowIndex={0}
-              />
+              <div>
+                <MockAction
+                  Component={[Function]}
+                  colIndex={0}
+                  columnId="someId"
+                  isExpanded={true}
+                  rowIndex={0}
+                />
+              </div>
             </EuiFlexItem>
             <EuiFlexItem
               key="1"
             >
-              <MockAction
-                Component={[Function]}
-                colIndex={0}
-                columnId="someId"
-                isExpanded={true}
-                rowIndex={0}
-              />
+              <div>
+                <MockAction
+                  Component={[Function]}
+                  colIndex={0}
+                  columnId="someId"
+                  isExpanded={true}
+                  rowIndex={0}
+                />
+              </div>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiPopoverFooter>
         <EuiPopoverFooter>
           <EuiFlexGroup
+            alignItems="flexStart"
             direction="column"
             gutterSize="s"
           >
             <EuiFlexItem
               key="0"
             >
-              <MockAction
-                Component={[Function]}
-                colIndex={0}
-                columnId="someId"
-                isExpanded={true}
-                rowIndex={0}
-              />
+              <div>
+                <MockAction
+                  Component={[Function]}
+                  colIndex={0}
+                  columnId="someId"
+                  isExpanded={true}
+                  rowIndex={0}
+                />
+              </div>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiPopoverFooter>

--- a/src/components/datagrid/body/data_grid_cell_actions.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_actions.test.tsx
@@ -111,19 +111,35 @@ describe('EuiDataGridCellActions', () => {
     `);
   });
 
-  it('does not render more than the first two primary cell actions', () => {
-    const component = shallow(
-      <EuiDataGridCellActions
-        {...requiredProps}
-        isExpandable={true}
-        column={{
-          id: 'someId',
-          cellActions: [MockAction, MockAction, MockAction],
-        }}
-      />
-    );
+  describe('visible cell actions limit', () => {
+    it('by default, does not render more than the first two primary cell actions', () => {
+      const component = shallow(
+        <EuiDataGridCellActions
+          {...requiredProps}
+          column={{
+            id: 'someId',
+            cellActions: [MockAction, MockAction, MockAction],
+          }}
+        />
+      );
 
-    expect(component.find('MockAction')).toHaveLength(2);
+      expect(component.find('MockAction')).toHaveLength(2);
+    });
+
+    it('allows configuring the default number of visible cell actions', () => {
+      const component = shallow(
+        <EuiDataGridCellActions
+          {...requiredProps}
+          column={{
+            id: 'someId',
+            cellActions: [MockAction, MockAction, MockAction, MockAction],
+            visibleCellActions: 3,
+          }}
+        />
+      );
+
+      expect(component.find('MockAction')).toHaveLength(3);
+    });
   });
 });
 
@@ -173,7 +189,7 @@ describe('EuiDataGridCellPopoverActions', () => {
     `);
   });
 
-  it('renders the first two primary actions in their own footer, and all remaining secondary actions in a column footer', () => {
+  it('renders primary actions in their own footer, and all remaining secondary actions in a column footer', () => {
     const component = shallow(
       <EuiDataGridCellPopoverActions
         colIndex={0}
@@ -244,6 +260,27 @@ describe('EuiDataGridCellPopoverActions', () => {
         </EuiPopoverFooter>
       </Fragment>
     `);
+  });
+
+  it('uses visibleCellActions to configure the number of primary vs. secondary actions', () => {
+    const component = shallow(
+      <EuiDataGridCellPopoverActions
+        colIndex={0}
+        rowIndex={0}
+        column={{
+          id: 'someId',
+          cellActions: [MockAction, MockAction, MockAction, MockAction],
+          visibleCellActions: 3,
+        }}
+      />
+    );
+
+    expect(
+      component.find('EuiPopoverFooter').first().find('MockAction')
+    ).toHaveLength(3);
+    expect(
+      component.find('EuiPopoverFooter').last().find('MockAction')
+    ).toHaveLength(1);
   });
 
   it('does not render anything if the column has no cell actions', () => {

--- a/src/components/datagrid/body/data_grid_cell_actions.tsx
+++ b/src/components/datagrid/body/data_grid_cell_actions.tsx
@@ -119,15 +119,17 @@ export const EuiDataGridCellPopoverActions = ({
       >;
       return (
         <EuiFlexItem key={idx}>
-          <ActionButtonElement
-            rowIndex={rowIndex}
-            colIndex={colIndex}
-            columnId={column!.id}
-            Component={(props: EuiButtonEmptyProps) => (
-              <EuiButtonEmpty {...props} size="s" />
-            )}
-            isExpanded={true}
-          />
+          <div>
+            <ActionButtonElement
+              rowIndex={rowIndex}
+              colIndex={colIndex}
+              columnId={column!.id}
+              Component={(props: EuiButtonEmptyProps) => (
+                <EuiButtonEmpty {...props} size="s" />
+              )}
+              isExpanded={true}
+            />
+          </div>
         </EuiFlexItem>
       );
     },
@@ -145,7 +147,11 @@ export const EuiDataGridCellPopoverActions = ({
       )}
       {secondaryActions.length > 0 && (
         <EuiPopoverFooter>
-          <EuiFlexGroup gutterSize="s" direction="column">
+          <EuiFlexGroup
+            gutterSize="s"
+            direction="column"
+            alignItems="flexStart"
+          >
             {secondaryActions.map(renderActions)}
           </EuiFlexGroup>
         </EuiPopoverFooter>

--- a/src/components/datagrid/body/data_grid_cell_actions.tsx
+++ b/src/components/datagrid/body/data_grid_cell_actions.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { JSXElementConstructor, useMemo } from 'react';
+import React, { JSXElementConstructor, useMemo, useCallback } from 'react';
 import {
   EuiDataGridColumn,
   EuiDataGridColumnCellAction,
@@ -59,6 +59,8 @@ export const EuiDataGridCellActions = ({
   );
 
   const additionalButtons = useMemo(() => {
+    if (!column || !Array.isArray(column?.cellActions)) return [];
+
     const ButtonComponent = (props: EuiButtonIconProps) => (
       <EuiButtonIcon
         {...props}
@@ -67,27 +69,27 @@ export const EuiDataGridCellActions = ({
         iconSize="s"
       />
     );
-    return column && Array.isArray(column.cellActions)
-      ? column.cellActions.map(
-          (Action: EuiDataGridColumnCellAction, idx: number) => {
-            // React is more permissible than the TS types indicate
-            const ActionButtonElement = Action as JSXElementConstructor<
-              EuiDataGridColumnCellActionProps
-            >;
-            return (
-              <ActionButtonElement
-                key={idx}
-                rowIndex={rowIndex}
-                colIndex={colIndex}
-                columnId={column.id}
-                Component={ButtonComponent}
-                isExpanded={false}
-                closePopover={closePopover}
-              />
-            );
-          }
-        )
-      : [];
+
+    const [primaryCellActions] = getPrimaryActions(column?.cellActions);
+    return primaryCellActions.map(
+      (Action: EuiDataGridColumnCellAction, idx: number) => {
+        // React is more permissible than the TS types indicate
+        const ActionButtonElement = Action as JSXElementConstructor<
+          EuiDataGridColumnCellActionProps
+        >;
+        return (
+          <ActionButtonElement
+            key={idx}
+            rowIndex={rowIndex}
+            colIndex={colIndex}
+            columnId={column.id}
+            Component={ButtonComponent}
+            isExpanded={false}
+            closePopover={closePopover}
+          />
+        );
+      }
+    );
   }, [column, colIndex, rowIndex, closePopover]);
 
   return (
@@ -106,32 +108,62 @@ export const EuiDataGridCellPopoverActions = ({
   colIndex: number;
   rowIndex: number;
 }) => {
-  if (!column?.cellActions?.length) return null;
+  const [primaryActions, secondaryActions] = getPrimaryActions(
+    column?.cellActions
+  );
+
+  const renderActions = useCallback(
+    (Action: EuiDataGridColumnCellAction, idx: number) => {
+      const ActionButtonElement = Action as JSXElementConstructor<
+        EuiDataGridColumnCellActionProps
+      >;
+      return (
+        <EuiFlexItem key={idx}>
+          <ActionButtonElement
+            rowIndex={rowIndex}
+            colIndex={colIndex}
+            columnId={column!.id}
+            Component={(props: EuiButtonEmptyProps) => (
+              <EuiButtonEmpty {...props} size="s" />
+            )}
+            isExpanded={true}
+          />
+        </EuiFlexItem>
+      );
+    },
+    [column, colIndex, rowIndex]
+  );
 
   return (
-    <EuiPopoverFooter>
-      <EuiFlexGroup gutterSize="s" responsive={false} wrap>
-        {column.cellActions.map(
-          (Action: EuiDataGridColumnCellAction, idx: number) => {
-            const ActionButtonElement = Action as JSXElementConstructor<
-              EuiDataGridColumnCellActionProps
-            >;
-            return (
-              <EuiFlexItem key={idx}>
-                <ActionButtonElement
-                  rowIndex={rowIndex}
-                  colIndex={colIndex}
-                  columnId={column.id}
-                  Component={(props: EuiButtonEmptyProps) => (
-                    <EuiButtonEmpty {...props} size="s" />
-                  )}
-                  isExpanded={true}
-                />
-              </EuiFlexItem>
-            );
-          }
-        )}
-      </EuiFlexGroup>
-    </EuiPopoverFooter>
+    <>
+      {primaryActions.length > 0 && (
+        <EuiPopoverFooter>
+          <EuiFlexGroup gutterSize="s" responsive={false} wrap>
+            {primaryActions.map(renderActions)}
+          </EuiFlexGroup>
+        </EuiPopoverFooter>
+      )}
+      {secondaryActions.length > 0 && (
+        <EuiPopoverFooter>
+          <EuiFlexGroup gutterSize="s" direction="column">
+            {secondaryActions.map(renderActions)}
+          </EuiFlexGroup>
+        </EuiPopoverFooter>
+      )}
+    </>
   );
+};
+
+// Util helper to separate primary actions (the first two cell actions)
+// and secondary actions (all other actions after the first two)
+const getPrimaryActions = (
+  cellActions?: EuiDataGridColumnCellAction[]
+): [EuiDataGridColumnCellAction[], EuiDataGridColumnCellAction[]] => {
+  if (!cellActions) return [[], []];
+  if (cellActions.length <= 2) return [cellActions, []];
+
+  const primaryCellActions = cellActions.slice(0, 2);
+  const remainingCellActions = cellActions.slice(2);
+
+  return [primaryCellActions, remainingCellActions];
 };

--- a/src/components/datagrid/body/data_grid_cell_actions.tsx
+++ b/src/components/datagrid/body/data_grid_cell_actions.tsx
@@ -70,8 +70,11 @@ export const EuiDataGridCellActions = ({
       />
     );
 
-    const [primaryCellActions] = getPrimaryActions(column?.cellActions);
-    return primaryCellActions.map(
+    const [visibleCellActions] = getVisibleCellActions(
+      column?.cellActions,
+      column?.visibleCellActions
+    );
+    return visibleCellActions.map(
       (Action: EuiDataGridColumnCellAction, idx: number) => {
         // React is more permissible than the TS types indicate
         const ActionButtonElement = Action as JSXElementConstructor<
@@ -108,8 +111,9 @@ export const EuiDataGridCellPopoverActions = ({
   colIndex: number;
   rowIndex: number;
 }) => {
-  const [primaryActions, secondaryActions] = getPrimaryActions(
-    column?.cellActions
+  const [primaryActions, secondaryActions] = getVisibleCellActions(
+    column?.cellActions,
+    column?.visibleCellActions
   );
 
   const renderActions = useCallback(
@@ -160,16 +164,17 @@ export const EuiDataGridCellPopoverActions = ({
   );
 };
 
-// Util helper to separate primary actions (the first two cell actions)
-// and secondary actions (all other actions after the first two)
-const getPrimaryActions = (
-  cellActions?: EuiDataGridColumnCellAction[]
+// Util helper to separate primary actions (columns.visibleCellActions, defaults to 2)
+// and secondary actions (all remaning actions)
+const getVisibleCellActions = (
+  cellActions?: EuiDataGridColumnCellAction[],
+  visibleCellActions = 2
 ): [EuiDataGridColumnCellAction[], EuiDataGridColumnCellAction[]] => {
   if (!cellActions) return [[], []];
-  if (cellActions.length <= 2) return [cellActions, []];
+  if (cellActions.length <= visibleCellActions) return [cellActions, []];
 
-  const primaryCellActions = cellActions.slice(0, 2);
-  const remainingCellActions = cellActions.slice(2);
+  const primaryCellActions = cellActions.slice(0, visibleCellActions);
+  const remainingCellActions = cellActions.slice(visibleCellActions);
 
   return [primaryCellActions, remainingCellActions];
 };

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -576,6 +576,12 @@ export interface EuiDataGridColumn {
    * Additional actions displayed as icon on hover / focus, and in the expanded view of the cell containing the value
    */
   cellActions?: EuiDataGridColumnCellAction[];
+  /**
+   * Configures the amount of cell action buttons immediately visible on a cell.
+   * Any cell actions above this number will only display in the cell expansion popover.
+   * Defaults to 2.
+   */
+  visibleCellActions?: number;
 }
 
 export type EuiDataGridColumnCellAction =

--- a/upcoming_changelogs/5675.md
+++ b/upcoming_changelogs/5675.md
@@ -1,0 +1,1 @@
+- `EuiDataGrid` now allows limiting the number of visible cell actions with a new `columns.visibleCellActions` prop (defaults to 2). All additional actions will be shown in the cell expansion popover.


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/5132

Cell action buttons on the cell will only show a maximum number of actions on the cell (default limit is 2, but this is configurable via `columns.visibleCellActions`). The remaining items in the `columns.cellActions` array will only be displayed on the cell expansion popover, in a second column-style footer.

### Screencap

![screencap](https://user-images.githubusercontent.com/549407/159059706-fc37b430-af8d-4cf1-ae15-981200006f40.gif)

## QA

https://eui.elastic.co/pr_5675/#/tabular-content/data-grid-cell-popovers#cell-actions-and-cell-popovers

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~

- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**

~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately