### PR TITLE
[EuiDataGrid] Refactor & write unit tests for fullscreen control + Standardize 'fullscreen' copy

### DIFF
--- a/src-docs/src/components/guide_page/_guide_page.scss
+++ b/src-docs/src/components/guide_page/_guide_page.scss
@@ -22,7 +22,7 @@ $guideSideNavWidth: 240px;
   }
 
   .euiHeader:not(.euiHeader--fixed) {
-    // Force headers below the full screen.
+    // Force headers below the fullscreen.
     // This shouldn't be necessary in consuming applications because headers should always be at the top of the page
     z-index: 0;
   }

--- a/src-docs/src/components/guide_section/guide_section.tsx
+++ b/src-docs/src/components/guide_section/guide_section.tsx
@@ -206,7 +206,7 @@ export const GuideSection: FunctionComponent<GuideSection> = ({
                     iconType="fullScreen"
                     href={`#${path}/${fullScreen.slug}`}
                   >
-                    Full screen demo
+                    Fullscreen demo
                   </EuiButton>
                 ) : (
                   demo

--- a/src-docs/src/views/code/code_example.js
+++ b/src-docs/src/views/code/code_example.js
@@ -172,7 +172,7 @@ export const CodeExample = {
         <p>
           For long content, you can set an <EuiCode>overflowHeight</EuiCode>{' '}
           which will scroll if the text exceeds that height, and allows users to
-          view the code in full-screen mode.
+          view the code in fullscreen mode.
         </p>
       ),
       source: [

--- a/src-docs/src/views/collapsible_nav/collapsible_nav_all.tsx
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav_all.tsx
@@ -289,7 +289,7 @@ const CollapsibleNavAll = () => {
           {
             items: [
               <EuiButtonEmpty href={exitPath} iconType="exit">
-                Exit full screen
+                Exit fullscreen
               </EuiButtonEmpty>,
             ],
           },

--- a/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav_example.js
@@ -179,7 +179,7 @@ export const CollapsibleNavExample = {
         <>
           <h3>Putting it all together</h3>
           <p>
-            The button below will launch a full screen example that includes{' '}
+            The button below will launch a fullscreen example that includes{' '}
             <Link to="/layout/header">
               <strong>EuiHeader</strong>
             </Link>{' '}

--- a/src-docs/src/views/context_menu/context_menu_with_content.js
+++ b/src-docs/src/views/context_menu/context_menu_with_content.js
@@ -60,7 +60,7 @@ export default () => {
       title: 'View options',
       items: [
         {
-          name: 'Show full screen',
+          name: 'Show fullscreen',
           icon: <EuiIcon type="search" size="m" />,
           onClick: () => {
             closePopover();

--- a/src-docs/src/views/datagrid/datagrid.js
+++ b/src-docs/src/views/datagrid/datagrid.js
@@ -256,7 +256,7 @@ const trailingControlColumns = [
                     <strong>EuiModal</strong>
                   </Link>{' '}
                   components have a higher <EuiCode>z-index</EuiCode> than{' '}
-                  <strong>EuiDataGrid</strong> components, even in full screen
+                  <strong>EuiDataGrid</strong> components, even in fullscreen
                   mode. This ensures that modals will never appear behind the
                   data grid.
                 </p>
@@ -305,7 +305,7 @@ const trailingControlColumns = [
                     <strong>EuiFlyout</strong>
                   </Link>{' '}
                   components have a higher <EuiCode>z-index</EuiCode> than{' '}
-                  <strong>EuiDataGrid</strong> components, even in full screen
+                  <strong>EuiDataGrid</strong> components, even in fullscreen
                   mode. This ensures that flyouts will never appear behind the
                   data grid.
                 </p>
@@ -313,7 +313,7 @@ const trailingControlColumns = [
                 <p>
                   Flyouts are also styled with a vertical offset that accounts
                   for the presence of fixed headers. However, when the data grid
-                  is in full screen mode, these offset styles are ignored to
+                  is in fullscreen mode, these offset styles are ignored to
                   allow the flyout to correctly appear at the top of the
                   viewport.
                 </p>

--- a/src-docs/src/views/datagrid/datagrid_ref_example.js
+++ b/src-docs/src/views/datagrid/datagrid_ref_example.js
@@ -9,10 +9,10 @@ const dataGridRefSource = require('!!raw-loader!./ref');
 const dataGridRefSnippet = `const dataGridRef = useRef();
 <EuiDataGrid ref={dataGridRef} {...props} />
 
-// Mnaually toggle the data grid's full screen state
+// Manually toggle the data grid's fullscreen state
 dataGridRef.current.setIsFullScreen(true);
 
-// Mnaually focus a specific cell within the data grid
+// Manually focus a specific cell within the data grid
 dataGridRef.current.setFocusedCell({ rowIndex, colIndex });
 
 // Manually opens the popover of a specified cell within the data grid
@@ -45,7 +45,7 @@ export const DataGridRefExample = {
             <li>
               <p>
                 <EuiCode>setIsFullScreen(isFullScreen)</EuiCode> - controls the
-                full screen state of the data grid. Accepts a true/false boolean
+                fullscreen state of the data grid. Accepts a true/false boolean
                 flag.
               </p>
             </li>

--- a/src-docs/src/views/datagrid/ref.tsx
+++ b/src-docs/src/views/datagrid/ref.tsx
@@ -179,7 +179,7 @@ export default () => {
             size="s"
             onClick={() => dataGridRef.current!.setIsFullScreen(true)}
           >
-            Set grid to full screen
+            Set grid to fullscreen
           </EuiButton>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/src-docs/src/views/datagrid/styling.js
+++ b/src-docs/src/views/datagrid/styling.js
@@ -678,12 +678,12 @@ const DataGrid = () => {
 
                   <EuiFormRow
                     display="columnCompressed"
-                    label="Show full screen selector"
+                    label="Show fullscreen selector"
                   >
                     <EuiButtonGroup
                       isFullWidth
                       buttonSize="compressed"
-                      legend="Full screen options"
+                      legend="Fullscreen options"
                       options={showFullScreenSelectorOptions}
                       idSelected={showFullScreenSelector.toString()}
                       onChange={onShowFullScreenSelectorChange}

--- a/src-docs/src/views/header/header_elastic_pattern.js
+++ b/src-docs/src/views/header/header_elastic_pattern.js
@@ -363,7 +363,7 @@ export default () => {
                       color="primary"
                       href={`#${parentPath}`}
                     >
-                      Exit full screen
+                      Exit fullscreen
                     </EuiButton>
                   )}
                 </ExampleContext.Consumer>

--- a/src-docs/src/views/header/header_example.js
+++ b/src-docs/src/views/header/header_example.js
@@ -477,7 +477,7 @@ export const HeaderExample = {
         <>
           <h3>Putting it all together</h3>
           <p>
-            The button below will launch a full screen example that includes two{' '}
+            The button below will launch a fullscreen example that includes two{' '}
             <strong>EuiHeaders</strong> with all the appropriate navigation
             pieces including{' '}
             <Link to="/navigation/collapsible-nav">

--- a/src-docs/src/views/image/image_example.js
+++ b/src-docs/src/views/image/image_example.js
@@ -67,7 +67,7 @@ export const ImageExample = {
       playground: imageConfig,
     },
     {
-      title: 'Click an image for a full screen version',
+      title: 'Click an image for a fullscreen version',
       source: [
         {
           type: GuideSectionTypes.JS,
@@ -77,7 +77,7 @@ export const ImageExample = {
       text: (
         <p>
           Apply the <EuiCode>allowFullScreen</EuiCode> prop to make the image
-          clickable and show a full screen version. Note that the second image
+          clickable and show a fullscreen version. Note that the second image
           also passes{' '}
           <EuiCode language="js">fullScreenIconColor=&quot;dark&quot;</EuiCode>{' '}
           to change icon color to better contrast against the light background

--- a/src-docs/src/views/loading/loading_example.js
+++ b/src-docs/src/views/loading/loading_example.js
@@ -82,7 +82,7 @@ export const LoadingExample = {
           <Link to="/display/icons#elastic-logos">
             <strong>EuiIcon</strong>
           </Link>{' '}
-          logos. It should only be used in very large panels, like full screen
+          logos. It should only be used in very large panels, like fullscreen
           pages.
         </p>
       ),

--- a/src-docs/src/views/page/_page_demo.tsx
+++ b/src-docs/src/views/page/_page_demo.tsx
@@ -22,7 +22,7 @@ const ExitFullscreenDemoButton = () => {
   const exitPath = useExitPath();
   return (
     <EuiButton fill href={exitPath} iconType="exit">
-      Exit full screen
+      Exit fullscreen
     </EuiButton>
   );
 };
@@ -69,7 +69,7 @@ export const PageDemo: FunctionComponent<{
     <ExitFullscreenDemoButton />
   ) : (
     <EuiButton fill href={`#${path}/${slug}`}>
-      Go full screen
+      Go fullscreen
     </EuiButton>
   );
 

--- a/src-docs/src/views/page/page_example.js
+++ b/src-docs/src/views/page/page_example.js
@@ -93,8 +93,8 @@ export const PageExample = {
       >
         <p>
           You&apos;ll find the code for each in their own tab and if you go to
-          full screen, you can see how they would behave in a typical
-          application layout.
+          fullscreen, you can see how they would behave in a typical application
+          layout.
         </p>
       </EuiCallOut>
     </>

--- a/src-docs/src/views/tour/fullscreen.js
+++ b/src-docs/src/views/tour/fullscreen.js
@@ -173,7 +173,7 @@ export default () => {
           <ExampleContext.Consumer>
             {({ parentPath }) => (
               <EuiButton fill href={`#${parentPath}`} iconType="exit">
-                Exit full screen demo
+                Exit fullscreen demo
               </EuiButton>
             )}
           </ExampleContext.Consumer>,

--- a/src-docs/src/views/tour/tour_example.js
+++ b/src-docs/src/views/tour/tour_example.js
@@ -149,7 +149,7 @@ export const TourExample = {
       demo: <Managed />,
     },
     {
-      title: 'Full screen demo',
+      title: 'Fullscreen demo',
       source: [
         {
           type: GuideSectionTypes.JS,
@@ -163,7 +163,7 @@ export const TourExample = {
         </p>
       ),
       fullScreen: {
-        slug: 'full-screen',
+        slug: 'fullscreen',
         demo: <FullScreen />,
       },
     },

--- a/src/components/code/__snapshots__/code_block.test.tsx.snap
+++ b/src/components/code/__snapshots__/code_block.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`EuiCodeBlock dynamic content updates DOM when input changes 2`] = `
 </div>
 `;
 
-exports[`EuiCodeBlock full screen displays content in fullscreen mode 1`] = `
+exports[`EuiCodeBlock fullscreen displays content in fullscreen mode 1`] = `
 <div
   className="testClass1 testClass2 euiCodeBlock euiCodeBlock--hasControl euiCodeBlock--fontLarge euiCodeBlock--paddingLarge euiCodeBlock-isFullScreen"
 >

--- a/src/components/code/code_block.test.tsx
+++ b/src/components/code/code_block.test.tsx
@@ -146,7 +146,7 @@ describe('EuiCodeBlock', () => {
     });
   });
 
-  describe('full screen', () => {
+  describe('fullscreen', () => {
     it('displays content in fullscreen mode', () => {
       const component = mount(
         <EuiCodeBlock

--- a/src/components/code/code_block.tsx
+++ b/src/components/code/code_block.tsx
@@ -191,14 +191,14 @@ export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
     FullScreenDisplay,
   } = useFullScreen({ overflowHeight });
 
-  // Classes used in both full-screen and non-full-screen mode
+  // Classes used in both fullscreen and non-fullscreen mode
   const wrapperClasses = classNames(className, 'euiCodeBlock', {
     'euiCodeBlock--hasControl': showCopyButton || showFullScreenButton,
     'euiCodeBlock--hasBothControls': showCopyButton && showFullScreenButton,
     'euiCodeBlock--hasLineNumbers': lineNumbersConfig.show,
   });
 
-  // Classes used in non-full-screen mode only
+  // Classes used in non-fullscreen mode only
   const classes = classNames(
     wrapperClasses,
     fontSizeToClassNameMap[fontSize],

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -1012,7 +1012,7 @@ Array [
             class="euiToolTipAnchor"
           >
             <button
-              aria-label="Full screen"
+              aria-label="Enter fullscreen"
               class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiDataGrid__controlBtn"
               data-test-subj="dataGridFullScreenButton"
               type="button"
@@ -1436,7 +1436,7 @@ Array [
             class="euiToolTipAnchor"
           >
             <button
-              aria-label="Full screen"
+              aria-label="Enter fullscreen"
               class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiDataGrid__controlBtn"
               data-test-subj="dataGridFullScreenButton"
               type="button"
@@ -2201,7 +2201,7 @@ Array [
             class="euiToolTipAnchor"
           >
             <button
-              aria-label="Full screen"
+              aria-label="Enter fullscreen"
               class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiDataGrid__controlBtn"
               data-test-subj="dataGridFullScreenButton"
               type="button"
@@ -2624,7 +2624,7 @@ Array [
             class="euiToolTipAnchor"
           >
             <button
-              aria-label="Full screen"
+              aria-label="Enter fullscreen"
               class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiDataGrid__controlBtn"
               data-test-subj="dataGridFullScreenButton"
               type="button"

--- a/src/components/datagrid/controls/data_grid_toolbar.test.tsx
+++ b/src/components/datagrid/controls/data_grid_toolbar.test.tsx
@@ -21,11 +21,10 @@ describe('EuiDataGridToolbar', () => {
     gridWidth: 500,
     toolbarVisibility: true,
     isFullScreen: false,
+    fullScreenSelector: <div>mock fullscreen selector</div>,
     displaySelector: <div>mock style selector</div>,
-    controlBtnClasses: '',
     columnSelector: <div>mock column selector</div>,
     columnSorting: <div>mock column sorting</div>,
-    setIsFullScreen: jest.fn(),
   };
 
   it('renders', () => {
@@ -52,21 +51,9 @@ describe('EuiDataGridToolbar', () => {
           <div>
             mock style selector
           </div>
-          <EuiToolTip
-            content="Full screen"
-            delay="long"
-            display="inlineBlock"
-            position="top"
-          >
-            <EuiButtonIcon
-              aria-label="Full screen"
-              color="text"
-              data-test-subj="dataGridFullScreenButton"
-              iconType="fullScreen"
-              onClick={[Function]}
-              size="xs"
-            />
-          </EuiToolTip>
+          <div>
+            mock fullscreen selector
+          </div>
         </div>
       </div>
     `);
@@ -129,29 +116,6 @@ describe('EuiDataGridToolbar', () => {
           </div>
         </div>
       </div>
-    `);
-  });
-
-  it('handles full screen toggling', () => {
-    const component = shallow(<EuiDataGridToolbar {...requiredProps} />);
-    component.setProps({
-      setIsFullScreen: () => component.setProps({ isFullScreen: true }),
-    });
-
-    component
-      .find('[data-test-subj="dataGridFullScreenButton"]')
-      .simulate('click');
-
-    expect(component.find('[data-test-subj="dataGridFullScreenButton"]'))
-      .toMatchInlineSnapshot(`
-      <EuiButtonIcon
-        aria-label="Exit full screen"
-        color="text"
-        data-test-subj="dataGridFullScreenButton"
-        iconType="fullScreenExit"
-        onClick={[Function]}
-        size="xs"
-      />
     `);
   });
 });

--- a/src/components/datagrid/controls/data_grid_toolbar.tsx
+++ b/src/components/datagrid/controls/data_grid_toolbar.tsx
@@ -6,10 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { useEffect } from 'react';
-import { EuiToolTip } from '../../tool_tip';
-import { EuiButtonIcon } from '../../button';
-import { useEuiI18n } from '../../i18n';
+import React from 'react';
 import {
   EuiDataGridProps,
   EuiDataGridToolbarProps,
@@ -19,70 +16,23 @@ import {
 } from '../data_grid_types';
 import { IS_JEST_ENVIRONMENT } from '../../../utils';
 
-// When below this number the grid only shows the full screen button
+// When below this number the grid only shows the right control icon buttons
 const MINIMUM_WIDTH_FOR_GRID_CONTROLS = 479;
-
-// When data grid is full screen, we add a class to the body to remove the extra scrollbar
-const GRID_IS_FULLSCREEN_CLASSNAME = 'euiDataGrid__restrictBody';
 
 export const EuiDataGridToolbar = ({
   gridWidth,
   minSizeForControls = MINIMUM_WIDTH_FOR_GRID_CONTROLS,
   toolbarVisibility,
   isFullScreen,
-  controlBtnClasses,
+  fullScreenSelector,
   displaySelector,
   columnSelector,
   columnSorting,
-  setIsFullScreen,
 }: EuiDataGridToolbarProps) => {
-  const [fullScreenButton, fullScreenButtonActive] = useEuiI18n(
-    [
-      'euiDataGridToolbar.fullScreenButton',
-      'euiDataGridToolbar.fullScreenButtonActive',
-    ],
-    ['Full screen', 'Exit full screen']
-  );
   // Enables/disables grid controls based on available width
   const hasRoomForGridControls = IS_JEST_ENVIRONMENT
     ? true
     : gridWidth > minSizeForControls || isFullScreen;
-
-  useEffect(() => {
-    // When data grid is full screen, we add a class to the body to remove the extra scrollbar and stay above any fixed headers
-    if (isFullScreen) {
-      document.body.classList.add(GRID_IS_FULLSCREEN_CLASSNAME);
-
-      return () => {
-        document.body.classList.remove(GRID_IS_FULLSCREEN_CLASSNAME);
-      };
-    }
-  }, [isFullScreen]);
-
-  const fullScreenSelector = (
-    <EuiToolTip
-      content={
-        isFullScreen ? (
-          <>
-            {fullScreenButtonActive} (<kbd>esc</kbd>)
-          </>
-        ) : (
-          fullScreenButton
-        )
-      }
-      delay="long"
-    >
-      <EuiButtonIcon
-        size="xs"
-        iconType={isFullScreen ? 'fullScreenExit' : 'fullScreen'}
-        color="text"
-        className={controlBtnClasses}
-        data-test-subj="dataGridFullScreenButton"
-        onClick={() => setIsFullScreen(!isFullScreen)}
-        aria-label={isFullScreen ? fullScreenButtonActive : fullScreenButton}
-      />
-    </EuiToolTip>
-  );
 
   return (
     <div className="euiDataGrid__controls" data-test-sub="dataGridControls">

--- a/src/components/datagrid/controls/full_screen_selector.test.tsx
+++ b/src/components/datagrid/controls/full_screen_selector.test.tsx
@@ -1,0 +1,178 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { shallow } from 'enzyme';
+import { keys } from '../../../services';
+import { testCustomHook } from '../../../test/test_custom_hook.test_helper';
+import { useDataGridFullScreenSelector } from './full_screen_selector';
+
+describe('useDataGridFullScreenSelector', () => {
+  type ReturnedValues = ReturnType<typeof useDataGridFullScreenSelector>;
+
+  describe('isFullScreen state', () => {
+    test('setFullScreen toggles isFullScreen', () => {
+      const {
+        return: { isFullScreen, setIsFullScreen },
+        getUpdatedState,
+      } = testCustomHook(() => useDataGridFullScreenSelector());
+
+      expect(isFullScreen).toEqual(false);
+      act(() => setIsFullScreen(true));
+      expect(getUpdatedState().isFullScreen).toEqual(true);
+    });
+  });
+
+  describe('fullScreenSelector', () => {
+    it('renders a button that toggles entering fullscreen', () => {
+      const {
+        return: { fullScreenSelector },
+      } = testCustomHook(() => useDataGridFullScreenSelector());
+      const component = shallow(<div>{fullScreenSelector}</div>);
+
+      expect(component).toMatchInlineSnapshot(`
+        <div>
+          <EuiToolTip
+            content="Full screen"
+            delay="long"
+            display="inlineBlock"
+            position="top"
+          >
+            <EuiButtonIcon
+              aria-label="Full screen"
+              className="euiDataGrid__controlBtn"
+              color="text"
+              data-test-subj="dataGridFullScreenButton"
+              iconType="fullScreen"
+              onClick={[Function]}
+              size="xs"
+            />
+          </EuiToolTip>
+        </div>
+      `);
+    });
+
+    it('renders a button that toggles exiting fullscreen', () => {
+      const {
+        return: { setIsFullScreen },
+        getUpdatedState,
+      } = testCustomHook<ReturnedValues>(() => useDataGridFullScreenSelector());
+      act(() => setIsFullScreen(true));
+
+      const { fullScreenSelector } = getUpdatedState();
+      const component = shallow(<div>{fullScreenSelector}</div>);
+
+      expect(component).toMatchInlineSnapshot(`
+        <div>
+          <EuiToolTip
+            content={
+              <React.Fragment>
+                Exit full screen
+                 (
+                <kbd>
+                  esc
+                </kbd>
+                )
+              </React.Fragment>
+            }
+            delay="long"
+            display="inlineBlock"
+            position="top"
+          >
+            <EuiButtonIcon
+              aria-label="Exit full screen"
+              className="euiDataGrid__controlBtn euiDataGrid__controlBtn--active"
+              color="text"
+              data-test-subj="dataGridFullScreenButton"
+              iconType="fullScreenExit"
+              onClick={[Function]}
+              size="xs"
+            />
+          </EuiToolTip>
+        </div>
+      `);
+    });
+
+    it('toggles fullscreen mode on button click', () => {
+      const {
+        return: { fullScreenSelector, isFullScreen },
+        getUpdatedState,
+      } = testCustomHook(() => useDataGridFullScreenSelector());
+      expect(isFullScreen).toEqual(false);
+      const component = shallow(<div>{fullScreenSelector}</div>);
+
+      act(() => {
+        component
+          .find('[data-test-subj="dataGridFullScreenButton"]')
+          .simulate('click');
+      });
+      expect(getUpdatedState().isFullScreen).toEqual(true);
+    });
+  });
+
+  describe('handleGridKeyDown', () => {
+    it('exits fullscreen mode when the Escape key is pressed', () => {
+      const {
+        return: { setIsFullScreen },
+        getUpdatedState,
+      } = testCustomHook<ReturnedValues>(() => useDataGridFullScreenSelector());
+      act(() => setIsFullScreen(true));
+      const { handleGridKeyDown } = getUpdatedState();
+
+      const preventDefault = jest.fn();
+      act(() => handleGridKeyDown({ key: keys.ESCAPE, preventDefault } as any));
+
+      expect(preventDefault).toHaveBeenCalled();
+      expect(getUpdatedState().isFullScreen).toEqual(false);
+    });
+
+    it('does nothing if fullscreen is not open', () => {
+      const {
+        return: { handleGridKeyDown },
+        getUpdatedState,
+      } = testCustomHook<ReturnedValues>(() => useDataGridFullScreenSelector());
+
+      const preventDefault = jest.fn();
+      act(() => handleGridKeyDown({ key: keys.ESCAPE, preventDefault } as any));
+
+      expect(preventDefault).not.toHaveBeenCalled();
+      expect(getUpdatedState().isFullScreen).toEqual(false);
+    });
+
+    it('does nothing if other keys are pressed or fullscreen is not open', () => {
+      const {
+        return: { handleGridKeyDown },
+        getUpdatedState,
+      } = testCustomHook<ReturnedValues>(() => useDataGridFullScreenSelector());
+
+      const preventDefault = jest.fn();
+      act(() => handleGridKeyDown({ key: keys.ENTER, preventDefault } as any));
+
+      expect(preventDefault).not.toHaveBeenCalled();
+      expect(getUpdatedState().isFullScreen).toEqual(false);
+    });
+  });
+
+  describe('body classes', () => {
+    it('adds and removes a fullscreen class to the document body when fullscreen opens/closes', () => {
+      const {
+        return: { setIsFullScreen },
+      } = testCustomHook(() => useDataGridFullScreenSelector());
+      act(() => setIsFullScreen(true));
+      expect(
+        document.body.classList.contains('euiDataGrid__restrictBody')
+      ).toBe(true);
+
+      act(() => setIsFullScreen(false));
+      expect(
+        document.body.classList.contains('euiDataGrid__restrictBody')
+      ).toBe(false);
+    });
+  });
+});

--- a/src/components/datagrid/controls/full_screen_selector.test.tsx
+++ b/src/components/datagrid/controls/full_screen_selector.test.tsx
@@ -39,13 +39,13 @@ describe('useDataGridFullScreenSelector', () => {
       expect(component).toMatchInlineSnapshot(`
         <div>
           <EuiToolTip
-            content="Full screen"
+            content="Enter fullscreen"
             delay="long"
             display="inlineBlock"
             position="top"
           >
             <EuiButtonIcon
-              aria-label="Full screen"
+              aria-label="Enter fullscreen"
               className="euiDataGrid__controlBtn"
               color="text"
               data-test-subj="dataGridFullScreenButton"
@@ -73,7 +73,7 @@ describe('useDataGridFullScreenSelector', () => {
           <EuiToolTip
             content={
               <React.Fragment>
-                Exit full screen
+                Exit fullscreen
                  (
                 <kbd>
                   esc
@@ -86,7 +86,7 @@ describe('useDataGridFullScreenSelector', () => {
             position="top"
           >
             <EuiButtonIcon
-              aria-label="Exit full screen"
+              aria-label="Exit fullscreen"
               className="euiDataGrid__controlBtn euiDataGrid__controlBtn--active"
               color="text"
               data-test-subj="dataGridFullScreenButton"

--- a/src/components/datagrid/controls/full_screen_selector.tsx
+++ b/src/components/datagrid/controls/full_screen_selector.tsx
@@ -33,10 +33,10 @@ export const useDataGridFullScreenSelector = (): {
 
   const [fullScreenButton, fullScreenButtonActive] = useEuiI18n(
     [
-      'euiDataGridToolbar.fullScreenButton',
-      'euiDataGridToolbar.fullScreenButtonActive',
+      'euiFullScreenSelector.fullScreenButton',
+      'euiFullScreenSelector.fullScreenButtonActive',
     ],
-    ['Full screen', 'Exit full screen']
+    ['Enter fullscreen', 'Exit fullscreen']
   );
   const controlBtnClasses = classNames('euiDataGrid__controlBtn', {
     'euiDataGrid__controlBtn--active': isFullScreen,

--- a/src/components/datagrid/controls/full_screen_selector.tsx
+++ b/src/components/datagrid/controls/full_screen_selector.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, {
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+  ReactNode,
+  KeyboardEvent,
+  KeyboardEventHandler,
+} from 'react';
+import classNames from 'classnames';
+import { keys } from '../../../services';
+import { EuiToolTip } from '../../tool_tip';
+import { EuiButtonIcon } from '../../button';
+import { useEuiI18n } from '../../i18n';
+
+const GRID_IS_FULLSCREEN_CLASSNAME = 'euiDataGrid__restrictBody';
+
+export const useDataGridFullScreenSelector = (): {
+  isFullScreen: boolean;
+  setIsFullScreen: (isFullScreen: boolean) => void;
+  fullScreenSelector: ReactNode;
+  handleGridKeyDown: KeyboardEventHandler<HTMLDivElement>;
+} => {
+  const [isFullScreen, setIsFullScreen] = useState(false);
+
+  const [fullScreenButton, fullScreenButtonActive] = useEuiI18n(
+    [
+      'euiDataGridToolbar.fullScreenButton',
+      'euiDataGridToolbar.fullScreenButtonActive',
+    ],
+    ['Full screen', 'Exit full screen']
+  );
+  const controlBtnClasses = classNames('euiDataGrid__controlBtn', {
+    'euiDataGrid__controlBtn--active': isFullScreen,
+  });
+  const fullScreenSelector = useMemo(
+    () => (
+      <EuiToolTip
+        content={
+          isFullScreen ? (
+            <>
+              {fullScreenButtonActive} (<kbd>esc</kbd>)
+            </>
+          ) : (
+            fullScreenButton
+          )
+        }
+        delay="long"
+      >
+        <EuiButtonIcon
+          size="xs"
+          iconType={isFullScreen ? 'fullScreenExit' : 'fullScreen'}
+          color="text"
+          className={controlBtnClasses}
+          data-test-subj="dataGridFullScreenButton"
+          onClick={() => setIsFullScreen(!isFullScreen)}
+          aria-label={isFullScreen ? fullScreenButtonActive : fullScreenButton}
+        />
+      </EuiToolTip>
+    ),
+    [isFullScreen, controlBtnClasses, fullScreenButton, fullScreenButtonActive]
+  );
+
+  const handleGridKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      switch (event.key) {
+        case keys.ESCAPE:
+          if (isFullScreen) {
+            event.preventDefault();
+            setIsFullScreen(false);
+          }
+          break;
+      }
+    },
+    [isFullScreen]
+  );
+
+  useEffect(() => {
+    // When the data grid is fullscreen, we add a class to the body to remove the extra scrollbar and stay above any fixed headers
+    if (isFullScreen) {
+      document.body.classList.add(GRID_IS_FULLSCREEN_CLASSNAME);
+
+      return () => {
+        document.body.classList.remove(GRID_IS_FULLSCREEN_CLASSNAME);
+      };
+    }
+  }, [isFullScreen]);
+
+  return {
+    isFullScreen,
+    setIsFullScreen,
+    fullScreenSelector,
+    handleGridKeyDown,
+  };
+};

--- a/src/components/datagrid/controls/index.ts
+++ b/src/components/datagrid/controls/index.ts
@@ -9,6 +9,7 @@
 export { useDataGridColumnSelector } from './column_selector';
 export { useDataGridColumnSorting } from './column_sorting';
 export { useDataGridDisplaySelector, startingStyles } from './display_selector';
+export { useDataGridFullScreenSelector } from './full_screen_selector';
 export {
   checkOrDefaultToolBarDisplayOptions,
   EuiDataGridToolbar,

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -786,9 +786,9 @@ describe('EuiDataGrid', () => {
       });
 
       // fullscreen selector
-      expect(findTestSubject(component, 'dataGridFullScrenButton').length).toBe(
-        0
-      );
+      expect(
+        findTestSubject(component, 'dataGridFullScreenButton').length
+      ).toBe(0);
 
       // sort selector
       expect(

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -271,7 +271,7 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
     const { cellPopoverContext, cellPopover } = useCellPopover();
 
     /**
-     * Toolbar & full-screen
+     * Toolbar & fullscreen
      */
     const showToolbar = !!toolbarVisibility;
 

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -7,18 +7,12 @@
  */
 
 import classNames from 'classnames';
-import React, {
-  forwardRef,
-  KeyboardEvent,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { forwardRef, useMemo, useRef, useState } from 'react';
 import {
   VariableSizeGrid as Grid,
   GridOnItemsRenderedProps,
 } from 'react-window';
-import { useGeneratedHtmlId, keys } from '../../services';
+import { useGeneratedHtmlId } from '../../services';
 import { EuiFocusTrap } from '../focus_trap';
 import { EuiI18n, useEuiI18n } from '../i18n';
 import { useMutationObserver } from '../observer/mutation_observer';
@@ -29,6 +23,7 @@ import {
   useDataGridColumnSorting,
   useDataGridDisplaySelector,
   startingStyles,
+  useDataGridFullScreenSelector,
   checkOrDefaultToolBarDisplayOptions,
   EuiDataGridToolbar,
 } from './controls';
@@ -280,17 +275,12 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
      */
     const showToolbar = !!toolbarVisibility;
 
-    const [isFullScreen, setIsFullScreen] = useState(false);
-    const handleGridKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-      switch (event.key) {
-        case keys.ESCAPE:
-          if (isFullScreen) {
-            event.preventDefault();
-            setIsFullScreen(false);
-          }
-          break;
-      }
-    };
+    const {
+      isFullScreen,
+      setIsFullScreen,
+      fullScreenSelector,
+      handleGridKeyDown,
+    } = useDataGridFullScreenSelector();
 
     /**
      * Expose certain internal APIs as ref to consumer
@@ -332,10 +322,6 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
       },
       className
     );
-
-    const controlBtnClasses = classNames('euiDataGrid__controlBtn', {
-      'euiDataGrid__controlBtn--active': isFullScreen,
-    });
 
     /**
      * Accessibility
@@ -396,10 +382,9 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
                     gridWidth={gridWidth}
                     minSizeForControls={minSizeForControls}
                     toolbarVisibility={toolbarVisibility}
-                    displaySelector={displaySelector}
                     isFullScreen={isFullScreen}
-                    setIsFullScreen={setIsFullScreen}
-                    controlBtnClasses={controlBtnClasses}
+                    fullScreenSelector={fullScreenSelector}
+                    displaySelector={displaySelector}
                     columnSelector={columnSelector}
                     columnSorting={columnSorting}
                   />

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -307,7 +307,7 @@ export type EuiDataGridProps = OneOf<
 
 export interface EuiDataGridRefProps {
   /**
-   * Allows manually controlling the full-screen state of the grid.
+   * Allows manually controlling the fullscreen state of the grid.
    */
   setIsFullScreen: (isFullScreen: boolean) => void;
   /**
@@ -724,7 +724,7 @@ export interface EuiDataGridToolBarVisibilityOptions {
    */
   showSortSelector?: boolean;
   /**
-   * Allows user to be able to full screen the data grid. If set to `false` make sure your grid fits within a large enough panel to still show the other controls.
+   * Allows user to be able to fullscreen the data grid. If set to `false` make sure your grid fits within a large enough panel to still show the other controls.
    */
   showFullScreenSelector?: boolean;
   /**
@@ -742,7 +742,7 @@ export interface EuiDataGridToolBarAdditionalControlsOptions {
    */
   left?: ReactNode | EuiDataGridToolBarAdditionalControlsLeftOptions;
   /**
-   * Will prepend the passed node into the right side of the toolbar, **before** the density & full screen controls.
+   * Will prepend the passed node into the right side of the toolbar, **before** the density & fullscreen controls.
    * We recommend using `<EuiButtonIcon size="xs" />` to match the existing controls on the right.
    */
   right?: ReactNode;

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -14,8 +14,6 @@ import {
   CSSProperties,
   ReactElement,
   AriaAttributes,
-  Dispatch,
-  SetStateAction,
   MutableRefObject,
 } from 'react';
 import {
@@ -34,12 +32,11 @@ export interface EuiDataGridToolbarProps {
   gridWidth: number;
   minSizeForControls?: number;
   toolbarVisibility: boolean | EuiDataGridToolBarVisibilityOptions;
-  displaySelector: ReactNode;
   isFullScreen: boolean;
-  controlBtnClasses: string;
+  fullScreenSelector: ReactNode;
+  displaySelector: ReactNode;
   columnSelector: ReactNode;
   columnSorting: ReactNode;
-  setIsFullScreen: Dispatch<SetStateAction<boolean>>;
 }
 
 export interface EuiDataGridPaginationRendererProps

--- a/src/components/datagrid/utils/grid_height_width.ts
+++ b/src/components/datagrid/utils/grid_height_width.ts
@@ -33,7 +33,7 @@ export const useFinalGridDimensions = ({
   // Used if the grid needs to scroll
   const [height, setHeight] = useState<number | undefined>(undefined);
   const [width, setWidth] = useState<number | undefined>(undefined);
-  // Tracking full screen height separately is necessary to correctly restore the grid back to non-full-screen height
+  // Tracking fullscreen height separately is necessary to correctly restore the grid back to non-fullscreen height
   const [fullScreenHeight, setFullScreenHeight] = useState(0);
 
   // Set the wrapper height on load, whenever the grid wrapper resizes, and whenever rowCount changes

--- a/src/components/datagrid/utils/ref.spec.tsx
+++ b/src/components/datagrid/utils/ref.spec.tsx
@@ -65,7 +65,7 @@ describe('useImperativeGridRef', () => {
   });
 
   describe('setIsFullScreen', () => {
-    it('allows the consumer to manually toggle full screen mode', () => {
+    it('allows the consumer to manually toggle fullscreen mode', () => {
       ref.current.setIsFullScreen(true);
       cy.get('[data-test-subj="euiDataGrid"]').should(
         'have.class',

--- a/src/components/image/__snapshots__/image.test.tsx.snap
+++ b/src/components/image/__snapshots__/image.test.tsx.snap
@@ -14,12 +14,12 @@ exports[`EuiImage is rendered 1`] = `
 </figure>
 `;
 
-exports[`EuiImage is rendered and allows full screen 1`] = `
+exports[`EuiImage is rendered and allows fullscreen 1`] = `
 <figure
   class="euiImage euiImage--allowFullScreen testClass1 testClass2 euiImage--large"
 >
   <button
-    aria-label="Open full screen alt image"
+    aria-label="Open fullscreen alt image"
     class="euiImage__button euiImage__button--fullWidth"
     data-test-subj="activateFullScreenButton"
     type="button"

--- a/src/components/image/image.test.tsx
+++ b/src/components/image/image.test.tsx
@@ -23,7 +23,7 @@ describe('EuiImage', () => {
     expect(component).toMatchSnapshot();
   });
 
-  test('is rendered and allows full screen', () => {
+  test('is rendered and allows fullscreen', () => {
     const component = render(
       <EuiImage
         alt="alt"
@@ -73,7 +73,7 @@ describe('EuiImage', () => {
     expect(component).toMatchSnapshot();
   });
 
-  describe('Full screen behaviour', () => {
+  describe('Fullscreen behaviour', () => {
     let component: ReactWrapper;
 
     beforeEach(() => {
@@ -95,7 +95,7 @@ describe('EuiImage', () => {
       findTestSubject(component, 'activateFullScreenButton').simulate('click');
     });
 
-    test('full screen image is rendered', () => {
+    test('fullscreen image is rendered', () => {
       const overlayMask = document.querySelectorAll(
         '[data-test-subj=fullScreenOverlayMask]'
       );

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -212,7 +212,7 @@ export const EuiImage: FunctionComponent<EuiImageProps> = ({
               type="button"
               aria-label={useEuiI18n(
                 'euiImage.closeImage',
-                'Close full screen {alt} image',
+                'Close fullscreen {alt} image',
                 { alt }
               )}
               className="euiImage__button"
@@ -241,7 +241,7 @@ export const EuiImage: FunctionComponent<EuiImageProps> = ({
 
   const fullscreenLabel = useEuiI18n(
     'euiImage.openImage',
-    'Open full screen {alt} image',
+    'Open fullscreen {alt} image',
     { alt }
   );
 


### PR DESCRIPTION
### Summary

This is essentially a 2 part PR, both parts centered around the fullscreen behavior of EuiDataGrid:

1. [Tech debt] Refactors all disparate parts of our fullscreen logic (some previously lived in the main `data_grid` file, others in `data_grid_toolbar`) to a single selector hook/file, and writes missing unit tests for said fullscreen mode logic.

3. [Copy] closes https://github.com/elastic/eui/issues/5653 and addresses all other components as to convert `full(-)screen` -> `fullscreen` per Caroline's comments

⚠️ I recommend following along by commit because the copy changes in particular touch a huge swath of files.

### Test coverage
<img width="1326" alt="" src="https://user-images.githubusercontent.com/549407/156444530-484a15df-9afd-4544-a714-4d1b55b4eda5.png">

Before:
<img width="1327" alt="before" src="https://user-images.githubusercontent.com/549407/156444040-686074d0-37df-416e-b167-c4152016f646.png">

After:
<img width="1330" alt="after" src="https://user-images.githubusercontent.com/549407/156444049-2dd056a3-5d4c-4826-9ca3-c9e14b61cab6.png">

## QA

Other than the 'fullscreen' tooltip text, no fullscreen functionality should have changed as a result of this PR:
- [ ] Fullscreen mode button toggles correctly
- [ ] Escape key to exit fullscreen mode works correctly
- [ ] Ref `setIsFullScreen` demo should still work as before
- [ ] `restrictBody` class should be correctly applied to and removed from the body

### Checklist

~- [ ] Check against **all themes** for compatibility in both light and dark modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**

~- [ ] Checked for **breaking changes** and labeled appropriately~

- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
