### PR TITLE
[Docs] Add `copyToClipboard` utility function docs

### DIFF
--- a/src-docs/src/views/copy/copy_example.js
+++ b/src-docs/src/views/copy/copy_example.js
@@ -7,6 +7,9 @@ import { EuiCopy, EuiCode } from '../../../../src/components';
 import Copy from './copy';
 const copySource = require('!!raw-loader!./copy');
 
+import CopyToClipboard from './copy_to_clipboard';
+const copyToClipboardSource = require('!!raw-loader!./copy_to_clipboard');
+
 export const CopyExample = {
   title: 'Copy',
   sections: [
@@ -32,6 +35,22 @@ export const CopyExample = {
     <EuiButton onClick={copy}>Click to copy</EuiButton>
   )}
 </EuiCopy>`,
+    },
+    {
+      title: 'Copy to clipboard function',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: copyToClipboardSource,
+        },
+      ],
+      text: (
+        <p>
+          The function <EuiCode>copyToClipboard</EuiCode> allows you to copy
+          text in a string format to the clipboard.
+        </p>
+      ),
+      demo: <CopyToClipboard />,
     },
   ],
 };

--- a/src-docs/src/views/copy/copy_example.js
+++ b/src-docs/src/views/copy/copy_example.js
@@ -47,7 +47,8 @@ export const CopyExample = {
       text: (
         <p>
           The function <EuiCode>copyToClipboard</EuiCode> allows you to copy
-          text in a string format to the clipboard.
+          text to the clipboard. It receives an argument of type{' '}
+          <EuiCode>string</EuiCode>.
         </p>
       ),
       demo: <CopyToClipboard />,

--- a/src-docs/src/views/copy/copy_to_clipboard.js
+++ b/src-docs/src/views/copy/copy_to_clipboard.js
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+
+import { copyToClipboard, formatDate } from '../../../../src/services';
+import {
+  EuiComment,
+  EuiText,
+  EuiButtonIcon,
+  EuiToolTip,
+} from '../../../../src/components';
+
+export default () => {
+  const [isTextCopied, setTextCopied] = useState(false);
+
+  const text =
+    'You must be imaginative, strong-hearted. You must try things that may not work, and you must not let anyone define your limits because of where you come from. Your only limit is your soul. What I say is true—anyone can cook… but only the fearless can be great.';
+
+  const onClick = () => {
+    copyToClipboard(text);
+    setTextCopied(true);
+  };
+
+  // we want to make sure that after clicking on the comment copy button the tooltip is reset to the initial msg "Copy text"
+  // after that, users can copy to clipboard other texts on a page
+  // so showing in the tooltip that the text from the comment is copied to clipboard could be misleading
+  const onBlur = () => {
+    setTextCopied(false);
+  };
+
+  const date = formatDate(Date.now(), 'dobLong');
+
+  return (
+    <div>
+      <EuiComment
+        username="Gusteau"
+        event="added a comment"
+        actions={
+          <EuiToolTip
+            content={isTextCopied ? 'Text copied to clipboard' : 'Copy text'}
+          >
+            <EuiButtonIcon
+              aria-label="Copy text clipboard"
+              color="text"
+              iconType="copy"
+              onClick={onClick}
+              onBlur={onBlur}
+            />
+          </EuiToolTip>
+        }
+        timestamp={`on ${date}`}
+      >
+        <EuiText size="s">
+          <p>{text}</p>
+        </EuiText>
+      </EuiComment>
+    </div>
+  );
+};

--- a/src-docs/src/views/copy/copy_to_clipboard.js
+++ b/src-docs/src/views/copy/copy_to_clipboard.js
@@ -19,8 +19,8 @@ export default () => {
     setTextCopied(true);
   };
 
-  // we want to make sure that after clicking on the comment copy button the tooltip is reset to the initial msg "Copy text"
-  // after that, users can copy to clipboard other texts on a page
+  // we want to make sure that after clicking on the comment copy button the tooltip is reset to the initial msg "copy text"
+  // after clicking on the button, users can copy to clipboard other texts on a page
   // so showing in the tooltip that the text from the comment is copied to clipboard could be misleading
   const onBlur = () => {
     setTextCopied(false);
@@ -29,29 +29,27 @@ export default () => {
   const date = formatDate(Date.now(), 'dobLong');
 
   return (
-    <div>
-      <EuiComment
-        username="Gusteau"
-        event="added a comment"
-        actions={
-          <EuiToolTip
-            content={isTextCopied ? 'Text copied to clipboard' : 'Copy text'}
-          >
-            <EuiButtonIcon
-              aria-label="Copy text to clipboard"
-              color="text"
-              iconType="copy"
-              onClick={onClick}
-              onBlur={onBlur}
-            />
-          </EuiToolTip>
-        }
-        timestamp={`on ${date}`}
-      >
-        <EuiText size="s">
-          <p>{text}</p>
-        </EuiText>
-      </EuiComment>
-    </div>
+    <EuiComment
+      username="Gusteau"
+      event="added a comment"
+      actions={
+        <EuiToolTip
+          content={isTextCopied ? 'Text copied to clipboard' : 'Copy text'}
+        >
+          <EuiButtonIcon
+            aria-label="Copy text to clipboard"
+            color="text"
+            iconType="copy"
+            onClick={onClick}
+            onBlur={onBlur}
+          />
+        </EuiToolTip>
+      }
+      timestamp={`on ${date}`}
+    >
+      <EuiText size="s">
+        <p>{text}</p>
+      </EuiText>
+    </EuiComment>
   );
 };

--- a/src-docs/src/views/copy/copy_to_clipboard.js
+++ b/src-docs/src/views/copy/copy_to_clipboard.js
@@ -38,7 +38,7 @@ export default () => {
             content={isTextCopied ? 'Text copied to clipboard' : 'Copy text'}
           >
             <EuiButtonIcon
-              aria-label="Copy text clipboard"
+              aria-label="Copy text to clipboard"
               color="text"
               iconType="copy"
               onClick={onClick}

--- a/src-docs/src/views/copy/copy_to_clipboard.js
+++ b/src-docs/src/views/copy/copy_to_clipboard.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import { copyToClipboard, formatDate } from '../../../../src/services';
 import {
@@ -9,12 +9,14 @@ import {
 } from '../../../../src/components';
 
 export default () => {
+  const buttonRef = useRef();
   const [isTextCopied, setTextCopied] = useState(false);
 
   const text =
     'You must be imaginative, strong-hearted. You must try things that may not work, and you must not let anyone define your limits because of where you come from. Your only limit is your soul. What I say is true—anyone can cook… but only the fearless can be great.';
 
   const onClick = () => {
+    buttonRef.current.focus(); // sets focus for safari
     copyToClipboard(text);
     setTextCopied(true);
   };
@@ -37,6 +39,7 @@ export default () => {
           content={isTextCopied ? 'Text copied to clipboard' : 'Copy text'}
         >
           <EuiButtonIcon
+            buttonRef={buttonRef}
             aria-label="Copy text to clipboard"
             color="text"
             iconType="copy"


### PR DESCRIPTION
### Summary

Closes ##5573. 

This PR adds a new section in `/#/utilities/copy` called **Copy to clipboard function**.

<img width="1184" alt="Screenshot 2022-03-03 at 16 09 40" src="https://user-images.githubusercontent.com/2750668/156604310-177222cd-1fc8-4ab8-88e3-0778b207f8ae.png">


### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- ~[ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
