### PR TITLE
[EuiDataGrid] Add unit tests for `col_widths` util + minor code cleanup

### DIFF
--- a/src/components/datagrid/utils/col_widths.test.ts
+++ b/src/components/datagrid/utils/col_widths.test.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { act } from 'react-dom/test-utils';
 import { testCustomHook } from '../../../test/test_custom_hook.test_helper';
 import {
   useDefaultColumnWidth,
@@ -71,17 +72,41 @@ describe('doesColumnHaveAnInitialWidth', () => {
 });
 
 describe('useColumnWidths', () => {
-  // TODO: Remaining useColumnWidths values
+  const args = {
+    leadingControlColumns: [{ id: 'a', width: 50 }] as any,
+    columns: [{ id: 'b', initialWidth: 75 }, { id: 'c ' }],
+    trailingControlColumns: [{ id: 'd', width: 25 }] as any,
+    defaultColumnWidth: 150,
+    onColumnResize: jest.fn(),
+  };
+  type ReturnedValues = ReturnType<typeof useColumnWidths>;
+
+  describe('columnWidths', () => {
+    it('returns a map of column `id`s to `initialWidth`s', () => {
+      const {
+        return: { columnWidths },
+      } = testCustomHook(() => useColumnWidths(args));
+      expect(columnWidths).toEqual({ b: 75 });
+    });
+  });
+
+  describe('setColumnWidth', () => {
+    it("sets a single column's width in the columnWidths map", () => {
+      const {
+        return: { setColumnWidth },
+        getUpdatedState,
+      } = testCustomHook<ReturnedValues>(() => useColumnWidths(args));
+
+      act(() => setColumnWidth('c', 125));
+      expect(getUpdatedState().columnWidths).toEqual({ b: 75, c: 125 });
+      expect(args.onColumnResize).toHaveBeenCalledWith({
+        columnId: 'c',
+        width: 125,
+      });
+    });
+  });
 
   describe('getColumnWidth', () => {
-    const args = {
-      leadingControlColumns: [{ id: 'a', width: 50 }] as any,
-      columns: [{ id: 'b', initialWidth: 75 }, { id: 'c ' }],
-      trailingControlColumns: [{ id: 'd', width: 25 }] as any,
-      defaultColumnWidth: 150,
-      onColumnResize: jest.fn(),
-    };
-
     describe('leading control columns', () => {
       it('returns the width property of the column', () => {
         const {

--- a/src/components/datagrid/utils/col_widths.test.ts
+++ b/src/components/datagrid/utils/col_widths.test.ts
@@ -7,9 +7,21 @@
  */
 
 import { testCustomHook } from '../../../test/test_custom_hook.test_helper';
-import { useColumnWidths } from './col_widths';
+import { doesColumnHaveAnInitialWidth, useColumnWidths } from './col_widths';
 
 // TODO: Remaining col_widths utils
+
+describe('doesColumnHaveAnInitialWidth', () => {
+  it('returns true if the column object has an initialWidth property', () => {
+    expect(
+      doesColumnHaveAnInitialWidth({ id: 'someColumn', initialWidth: 100 })
+    ).toEqual(true);
+  });
+
+  it('returns false if not', () => {
+    expect(doesColumnHaveAnInitialWidth({ id: 'someColumn' })).toEqual(false);
+  });
+});
 
 describe('useColumnWidths', () => {
   // TODO: Remaining useColumnWidths values

--- a/src/components/datagrid/utils/col_widths.test.ts
+++ b/src/components/datagrid/utils/col_widths.test.ts
@@ -7,9 +7,56 @@
  */
 
 import { testCustomHook } from '../../../test/test_custom_hook.test_helper';
-import { doesColumnHaveAnInitialWidth, useColumnWidths } from './col_widths';
+import {
+  useDefaultColumnWidth,
+  doesColumnHaveAnInitialWidth,
+  useColumnWidths,
+} from './col_widths';
 
-// TODO: Remaining col_widths utils
+// Allows us to unit test useDefaultColumnWidth without running into the IS_JEST_ENVIRONMENT early return
+jest.mock('../../../utils', () => ({ IS_JEST_ENVIRONMENT: false }));
+
+describe('useDefaultColumnWidth', () => {
+  it('returns null if grid has not yet been initialized (gridWidth = 0)', () => {
+    expect(
+      testCustomHook(() => useDefaultColumnWidth(0, [], [], [])).return
+    ).toEqual(null);
+  });
+
+  it('returns a static default column width of 100px if all columns have initialWidths', () => {
+    const columns = [
+      { id: 'A', initialWidth: 200 },
+      { id: 'B', initialWidth: 150 },
+    ];
+    expect(
+      testCustomHook(() => useDefaultColumnWidth(500, [], [], columns)).return
+    ).toEqual(100);
+  });
+
+  it('returns the grid width divided by the number of columns without initialWidths', () => {
+    const columns = [{ id: 'A' }, { id: 'B' }, { id: 'C' }, { id: 'D' }];
+    expect(
+      testCustomHook(() => useDefaultColumnWidth(500, [], [], columns)).return
+    ).toEqual(125); // 500 / 4
+  });
+
+  it('accounts for leading/trailing control columns affecting the available grid width', () => {
+    const controlColumns = [{ id: 'controlColumn', width: 50 }] as any;
+    const columns = [{ id: 'A' }, { id: 'B' }, { id: 'C' }, { id: 'D' }];
+    expect(
+      testCustomHook(() =>
+        useDefaultColumnWidth(1000, controlColumns, controlColumns, columns)
+      ).return
+    ).toEqual(225); // 1000 - (50 * 2) / 4
+  });
+
+  it('returns a minimum column width of 100px regardless of grid width / number of columns', () => {
+    const columns = [{ id: 'A' }, { id: 'B' }, { id: 'C' }, { id: 'D' }];
+    expect(
+      testCustomHook(() => useDefaultColumnWidth(200, [], [], columns)).return
+    ).toEqual(100); // Would be 200 / 4 = 50 without a minumum
+  });
+});
 
 describe('doesColumnHaveAnInitialWidth', () => {
   it('returns true if the column object has an initialWidth property', () => {

--- a/src/components/datagrid/utils/col_widths.test.ts
+++ b/src/components/datagrid/utils/col_widths.test.ts
@@ -88,6 +88,17 @@ describe('useColumnWidths', () => {
       } = testCustomHook(() => useColumnWidths(args));
       expect(columnWidths).toEqual({ b: 75 });
     });
+
+    it('recomputes column widths on columns change', () => {
+      const { updateHookArgs, getUpdatedState } = testCustomHook<
+        ReturnedValues
+      >(useColumnWidths, args);
+
+      updateHookArgs({
+        columns: [{ id: 'c', initialWidth: 125 }],
+      });
+      expect(getUpdatedState().columnWidths).toEqual({ c: 125 });
+    });
   });
 
   describe('setColumnWidth', () => {

--- a/src/components/datagrid/utils/col_widths.ts
+++ b/src/components/datagrid/utils/col_widths.ts
@@ -6,7 +6,8 @@
  * Side Public License, v 1.
  */
 
-import { useMemo, useCallback, useEffect, useRef, useState } from 'react';
+import { useMemo, useCallback, useState } from 'react';
+import { useUpdateEffect } from '../../../services';
 import { IS_JEST_ENVIRONMENT } from '../../../utils';
 import {
   EuiDataGridColumn,
@@ -78,8 +79,6 @@ export const useColumnWidths = ({
   setColumnWidth: (columnId: string, width: number) => void;
   getColumnWidth: (index: number) => number;
 } => {
-  const hasMounted = useRef(false);
-
   const computeColumnWidths = useCallback(() => {
     return columns
       .filter(doesColumnHaveAnInitialWidth)
@@ -93,12 +92,7 @@ export const useColumnWidths = ({
     computeColumnWidths
   );
 
-  useEffect(() => {
-    if (!hasMounted.current) {
-      hasMounted.current = true;
-      return;
-    }
-
+  useUpdateEffect(() => {
     setColumnWidths(computeColumnWidths());
   }, [computeColumnWidths]);
 

--- a/src/components/datagrid/utils/col_widths.ts
+++ b/src/components/datagrid/utils/col_widths.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useMemo, useCallback, useEffect, useRef, useState } from 'react';
 import { IS_JEST_ENVIRONMENT } from '../../../utils';
 import {
   EuiDataGridColumn,
@@ -24,7 +24,7 @@ export const useDefaultColumnWidth = (
   trailingControlColumns: EuiDataGridControlColumn[],
   columns: EuiDataGridProps['columns']
 ): number | null => {
-  const computeDefaultWidth = useCallback((): number | null => {
+  const defaultColumnWidth = useMemo(() => {
     if (IS_JEST_ENVIRONMENT) return DEFAULT_COLUMN_WIDTH;
     if (gridWidth === 0) return null; // we can't tell what size to compute yet
 
@@ -51,15 +51,6 @@ export const useDefaultColumnWidth = (
     }
     return Math.max(widthToFill / unsizedColumnCount, DEFAULT_COLUMN_WIDTH);
   }, [gridWidth, columns, leadingControlColumns, trailingControlColumns]);
-
-  const [defaultColumnWidth, setDefaultColumnWidth] = useState<number | null>(
-    computeDefaultWidth
-  );
-
-  useEffect(() => {
-    const columnWidth = computeDefaultWidth();
-    setDefaultColumnWidth(columnWidth);
-  }, [computeDefaultWidth]);
 
   return defaultColumnWidth;
 };

--- a/src/components/datagrid/utils/col_widths.ts
+++ b/src/components/datagrid/utils/col_widths.ts
@@ -37,17 +37,13 @@ export const useDefaultColumnWidth = (
       0
     );
 
-    const columnsWithWidths = columns.filter<
-      EuiDataGridColumn & { initialWidth: number }
-    >(doesColumnHaveAnInitialWidth);
-
+    const columnsWithWidths = columns.filter(doesColumnHaveAnInitialWidth);
     const definedColumnsWidth = columnsWithWidths.reduce(
-      (claimedWidth, column) => claimedWidth + column.initialWidth,
+      (claimedWidth, column) => claimedWidth + column.initialWidth!,
       0
     );
 
     const claimedWidth = controlColumnWidths + definedColumnsWidth;
-
     const widthToFill = gridWidth - claimedWidth;
     const unsizedColumnCount = columns.length - columnsWithWidths.length;
     if (unsizedColumnCount === 0) {
@@ -70,7 +66,7 @@ export const useDefaultColumnWidth = (
 
 export const doesColumnHaveAnInitialWidth = (
   column: EuiDataGridColumn
-): column is EuiDataGridColumn & { initialWidth: number } => {
+): boolean => {
   return column.hasOwnProperty('initialWidth');
 };
 
@@ -95,11 +91,9 @@ export const useColumnWidths = ({
 
   const computeColumnWidths = useCallback(() => {
     return columns
-      .filter<EuiDataGridColumn & { initialWidth: number }>(
-        doesColumnHaveAnInitialWidth
-      )
+      .filter(doesColumnHaveAnInitialWidth)
       .reduce<EuiDataGridColumnWidths>((initialWidths, column) => {
-        initialWidths[column.id] = column.initialWidth;
+        initialWidths[column.id] = column.initialWidth!;
         return initialWidths;
       }, {});
   }, [columns]);

--- a/src/test/test_custom_hook.test_helper.tsx
+++ b/src/test/test_custom_hook.test_helper.tsx
@@ -10,15 +10,23 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 export const HookWrapper = (props: { hook?: Function }) => {
-  const hook = props.hook ? props.hook() : undefined;
+  const { hook: _, ...args } = props;
+  const hook = props.hook ? props.hook(args) : undefined;
   // @ts-ignore the actual div is irrelevant, we just need to inspect the prop for return values
   return <div hook={hook} />;
 };
 
 export const testCustomHook = <T,>(
-  hook?: Function
-): { return: T; getUpdatedState: () => T } => {
-  const wrapper = mount(<HookWrapper hook={hook} />);
+  hook?: Function,
+  args?: unknown
+): {
+  return: T;
+  getUpdatedState: () => T;
+  updateHookArgs: (args: unknown) => void;
+} => {
+  const wrapper = mount(<HookWrapper hook={hook} {...args} />);
+
+  const updateHookArgs = (args: any) => wrapper.setProps(args);
 
   const getHookReturn = (): T => {
     wrapper.update();
@@ -28,5 +36,6 @@ export const testCustomHook = <T,>(
   return {
     return: getHookReturn(),
     getUpdatedState: getHookReturn, // Allows consuming tests to get most recent values
+    updateHookArgs, // Allows consuming tests to pass updated hook arguments (objects only, no tuples)
   };
 };


### PR DESCRIPTION
### Summary

Before:

<img width="1108" alt="" src="https://user-images.githubusercontent.com/549407/156657183-320d0883-c914-461b-8969-c9beda46ccc1.png">

After:

<img width="1108" alt="" src="https://user-images.githubusercontent.com/549407/156657191-36b55159-d5c2-49c2-ba60-82a70a4f0163.png">

I recommend following along by commit, as I did end up touching different source code as incidental code cleanup.

### Checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**

No changelog, as unit tests are internal dev-only, and the cleaned up source code should not have affected production code (from my columns QA/testing)