### PR TITLE
[EuiDataGrid] Add remaining unit tests for focus logic

### DIFF
--- a/scripts/jest/setup/unmount_enzyme.js
+++ b/scripts/jest/setup/unmount_enzyme.js
@@ -11,7 +11,7 @@ jest.mock('enzyme', () => {
   };
 });
 
-afterEach(() => {
+afterAll(() => {
   while (mockMountedComponents.length) {
     const component = mockMountedComponents.pop();
     if (component.length === 1) {

--- a/src/components/datagrid/utils/focus.test.tsx
+++ b/src/components/datagrid/utils/focus.test.tsx
@@ -8,13 +8,338 @@
 
 import React from 'react';
 import { mount } from 'enzyme';
-
+import { keys } from '../../../services';
 import {
   DataGridFocusContext,
+  createKeyDownHandler,
   preventTabbing,
   getParentCellContent,
   useHeaderFocusWorkaround,
 } from './focus';
+
+describe('createKeyDownHandler', () => {
+  const focusContext = {
+    focusedCell: [0, 0],
+    setFocusedCell: jest.fn(),
+  } as any;
+  const mockArgs = {
+    gridElement: document.createElement('div'),
+    visibleColCount: 5,
+    visibleRowCount: 10,
+    visibleRowStartIndex: 0,
+    rowCount: 10,
+    pagination: undefined,
+    hasFooter: false,
+    headerIsInteractive: true,
+    focusContext,
+  };
+  const mockKeyDown = {
+    preventDefault: jest.fn(),
+    key: keys.ARROW_UP,
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Ensure document.activeElement is inside the grid pass the early return
+    const mockFocus = mockArgs.gridElement.appendChild(
+      document.createElement('button')
+    );
+    mockFocus.focus();
+  });
+
+  describe('left arrow key', () => {
+    it('moves the focusedCell x position left by 1', () => {
+      const keyDownHandler = createKeyDownHandler({
+        ...mockArgs,
+        focusContext: { ...focusContext, focusedCell: [1, 1] },
+      });
+      keyDownHandler({ ...mockKeyDown, key: keys.ARROW_LEFT });
+      expect(focusContext.setFocusedCell).toHaveBeenCalledWith([0, 1]);
+    });
+
+    describe('when focus is on the left-most column', () => {
+      it('does nothing', () => {
+        const keyDownHandler = createKeyDownHandler({
+          ...mockArgs,
+          focusContext: { ...focusContext, focusedCell: [0, 1] },
+        });
+        keyDownHandler({ ...mockKeyDown, key: keys.ARROW_LEFT });
+        expect(focusContext.setFocusedCell).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('right arrow key', () => {
+    it('moves the focusedCell x position right by 1', () => {
+      const keyDownHandler = createKeyDownHandler({
+        ...mockArgs,
+        focusContext: { ...focusContext, focusedCell: [1, 1] },
+      });
+      keyDownHandler({ ...mockKeyDown, key: keys.ARROW_RIGHT });
+      expect(focusContext.setFocusedCell).toHaveBeenCalledWith([2, 1]);
+    });
+
+    describe('when focus is on the right-most column', () => {
+      it('does nothing', () => {
+        const keyDownHandler = createKeyDownHandler({
+          ...mockArgs,
+          focusContext: { ...focusContext, focusedCell: [4, 1] },
+        });
+        keyDownHandler({ ...mockKeyDown, key: keys.ARROW_RIGHT });
+        expect(focusContext.setFocusedCell).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('down arrow key', () => {
+    it('moves the focusedCell y position down by 1', () => {
+      const keyDownHandler = createKeyDownHandler({
+        ...mockArgs,
+        focusContext: { ...focusContext, focusedCell: [1, 1] },
+      });
+      keyDownHandler({ ...mockKeyDown, key: keys.ARROW_DOWN });
+      expect(focusContext.setFocusedCell).toHaveBeenCalledWith([1, 2]);
+    });
+
+    describe('when focus is on the bottom-most row', () => {
+      it('does nothing', () => {
+        const keyDownHandler = createKeyDownHandler({
+          ...mockArgs,
+          focusContext: { ...focusContext, focusedCell: [1, 9] },
+        });
+        keyDownHandler({ ...mockKeyDown, key: keys.ARROW_DOWN });
+        expect(focusContext.setFocusedCell).not.toHaveBeenCalled();
+      });
+
+      it('accounts for the footer row', () => {
+        const keyDownHandler = createKeyDownHandler({
+          ...mockArgs,
+          hasFooter: true,
+          focusContext: { ...focusContext, focusedCell: [1, 10] },
+        });
+        keyDownHandler({ ...mockKeyDown, key: keys.ARROW_DOWN });
+        expect(focusContext.setFocusedCell).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when moving focus down from the sticky header', () => {
+      it('moves focus down to the visibleRowStartIndex, since rowIndex 0 may not be virtualized', () => {
+        const keyDownHandler = createKeyDownHandler({
+          ...mockArgs,
+          visibleRowStartIndex: 5,
+          focusContext: { ...focusContext, focusedCell: [1, -1] },
+        });
+        keyDownHandler({ ...mockKeyDown, key: keys.ARROW_DOWN });
+        expect(focusContext.setFocusedCell).toHaveBeenCalledWith([1, 5]);
+      });
+    });
+  });
+
+  describe('up arrow key', () => {
+    it('moves the focusedCell y position up by 1', () => {
+      const keyDownHandler = createKeyDownHandler({
+        ...mockArgs,
+        focusContext: { ...focusContext, focusedCell: [1, 1] },
+      });
+      keyDownHandler({ ...mockKeyDown, key: keys.ARROW_UP });
+      expect(focusContext.setFocusedCell).toHaveBeenCalledWith([1, 0]);
+    });
+
+    describe('when focus is on the top-most row', () => {
+      it('does nothing', () => {
+        const keyDownHandler = createKeyDownHandler({
+          ...mockArgs,
+          headerIsInteractive: false,
+          focusContext: { ...focusContext, focusedCell: [1, 0] },
+        });
+        keyDownHandler({ ...mockKeyDown, key: keys.ARROW_UP });
+        expect(focusContext.setFocusedCell).not.toHaveBeenCalled();
+      });
+
+      it('accounts for an interactive header row', () => {
+        const keyDownHandler = createKeyDownHandler({
+          ...mockArgs,
+          headerIsInteractive: true,
+          focusContext: { ...focusContext, focusedCell: [1, -1] },
+        });
+        keyDownHandler({ ...mockKeyDown, key: keys.ARROW_UP });
+        expect(focusContext.setFocusedCell).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('page down key', () => {
+    describe('when grid pagination is set', () => {
+      const pagination = {
+        pageIndex: 0,
+        pageSize: 5,
+        onChangePage: jest.fn(),
+        onChangeItemsPerPage: () => {},
+      };
+
+      it('paginates to the next page and sets the focus to the first data row on that page', () => {
+        const keyDownHandler = createKeyDownHandler({
+          ...mockArgs,
+          pagination,
+          focusContext: { ...focusContext, focusedCell: [2, 5] },
+        });
+        keyDownHandler({ ...mockKeyDown, key: keys.PAGE_DOWN });
+
+        expect(pagination.onChangePage).toHaveBeenCalledWith(1);
+        expect(focusContext.setFocusedCell).toHaveBeenCalledWith([2, 0]);
+      });
+
+      it('does not paginate if already on the last page, but still moves focus to the last row', () => {
+        const keyDownHandler = createKeyDownHandler({
+          ...mockArgs,
+          pagination: { ...pagination, pageIndex: 1 },
+          focusContext: { ...focusContext, focusedCell: [2, 5] },
+        });
+        keyDownHandler({ ...mockKeyDown, key: keys.PAGE_DOWN });
+
+        expect(pagination.onChangePage).not.toHaveBeenCalled();
+        expect(focusContext.setFocusedCell).toHaveBeenCalledWith([2, 0]);
+      });
+    });
+
+    describe('when grid pagination is not set', () => {
+      it('does nothing', () => {
+        const keyDownHandler = createKeyDownHandler({
+          ...mockArgs,
+          pagination: undefined,
+        });
+        keyDownHandler({ ...mockKeyDown, key: keys.PAGE_DOWN });
+        expect(focusContext.setFocusedCell).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('page up key', () => {
+    describe('when grid pagination is set', () => {
+      const pagination = {
+        pageIndex: 1,
+        pageSize: 5,
+        onChangePage: jest.fn(),
+        onChangeItemsPerPage: () => {},
+      };
+
+      it('paginates to the previous page and sets the focus to the last data row on that page', () => {
+        const keyDownHandler = createKeyDownHandler({
+          ...mockArgs,
+          pagination,
+          focusContext: { ...focusContext, focusedCell: [2, 1] },
+        });
+        keyDownHandler({ ...mockKeyDown, key: keys.PAGE_UP });
+
+        expect(pagination.onChangePage).toHaveBeenCalled();
+        expect(focusContext.setFocusedCell).toHaveBeenCalledWith([2, 4]);
+      });
+
+      it('does not paginate if already on the first page, but still moves focus to the last row', () => {
+        const keyDownHandler = createKeyDownHandler({
+          ...mockArgs,
+          pagination: { ...pagination, pageIndex: 0 },
+          focusContext: { ...focusContext, focusedCell: [2, 1] },
+        });
+        keyDownHandler({ ...mockKeyDown, key: keys.PAGE_UP });
+
+        expect(pagination.onChangePage).not.toHaveBeenCalledWith(0);
+        expect(focusContext.setFocusedCell).toHaveBeenCalledWith([2, 4]);
+      });
+    });
+
+    describe('when grid pagination is not set', () => {
+      it('does nothing', () => {
+        const keyDownHandler = createKeyDownHandler({
+          ...mockArgs,
+          pagination: undefined,
+        });
+        keyDownHandler({ ...mockKeyDown, key: keys.PAGE_UP });
+        expect(focusContext.setFocusedCell).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('home key', () => {
+    it('moves the focusedCell to the leftmost column in the current row', () => {
+      const keyDownHandler = createKeyDownHandler({
+        ...mockArgs,
+        focusContext: { ...focusContext, focusedCell: [2, 2] },
+      });
+      keyDownHandler({ ...mockKeyDown, key: keys.HOME });
+      expect(focusContext.setFocusedCell).toHaveBeenCalledWith([0, 2]);
+    });
+
+    describe('ctrl+home key', () => {
+      it('moves the focusedCell to the topmost and leftmost cell on the current page', () => {
+        const keyDownHandler = createKeyDownHandler({
+          ...mockArgs,
+          focusContext: { ...focusContext, focusedCell: [2, 2] },
+        });
+        keyDownHandler({ ...mockKeyDown, key: keys.HOME, ctrlKey: true });
+        expect(focusContext.setFocusedCell).toHaveBeenCalledWith([0, 0]);
+      });
+    });
+  });
+
+  describe('end key', () => {
+    it('moves the focusedCell to the rightmost column in the current row', () => {
+      const keyDownHandler = createKeyDownHandler({
+        ...mockArgs,
+        focusContext: { ...focusContext, focusedCell: [2, 2] },
+      });
+      keyDownHandler({ ...mockKeyDown, key: keys.END });
+      expect(focusContext.setFocusedCell).toHaveBeenCalledWith([4, 2]);
+    });
+
+    describe('ctrl+end key', () => {
+      it('moves the focusedCell to the rightmost and bottommost cell on the current page', () => {
+        const keyDownHandler = createKeyDownHandler({
+          ...mockArgs,
+          focusContext: { ...focusContext, focusedCell: [2, 2] },
+        });
+        keyDownHandler({ ...mockKeyDown, key: keys.END, ctrlKey: true });
+        expect(focusContext.setFocusedCell).toHaveBeenCalledWith([4, 9]);
+      });
+    });
+  });
+
+  it('does nothing for other non-navigation keys', () => {
+    const keyDownHandler = createKeyDownHandler(mockArgs);
+    keyDownHandler({ ...mockKeyDown, key: keys.SPACE });
+    expect(focusContext.setFocusedCell).not.toHaveBeenCalled();
+  });
+
+  // mostly here for branch/code coverage
+  describe('early returns', () => {
+    test('unintialized focusedCell', () => {
+      const keyDownHandler = createKeyDownHandler({
+        ...mockArgs,
+        focusContext: { ...focusContext, focusedCell: undefined },
+      });
+      keyDownHandler(mockKeyDown);
+      expect(mockKeyDown.preventDefault).not.toHaveBeenCalled();
+    });
+
+    test('unintialized grids', () => {
+      const keyDownHandler = createKeyDownHandler({
+        ...mockArgs,
+        gridElement: null,
+      });
+      keyDownHandler(mockKeyDown);
+      expect(mockKeyDown.preventDefault).not.toHaveBeenCalled();
+    });
+
+    test('document.activeElement is not inside the grid', () => {
+      const keyDownHandler = createKeyDownHandler({
+        ...mockArgs,
+        gridElement: document.createElement('div'),
+      });
+      keyDownHandler(mockKeyDown);
+      expect(mockKeyDown.preventDefault).not.toHaveBeenCalled();
+    });
+  });
+});
 
 describe('preventTabbing', () => {
   const mockCellWithInteractiveChildren = () => {

--- a/src/components/datagrid/utils/focus.test.tsx
+++ b/src/components/datagrid/utils/focus.test.tsx
@@ -11,11 +11,30 @@ import { mount } from 'enzyme';
 import { keys } from '../../../services';
 import {
   DataGridFocusContext,
+  notifyCellOfFocusState,
   createKeyDownHandler,
   preventTabbing,
   getParentCellContent,
   useHeaderFocusWorkaround,
 } from './focus';
+
+describe('notifyCellOfFocusState', () => {
+  const onFocus = jest.fn();
+  const cellsUpdateFocus = new Map();
+  cellsUpdateFocus.set('0-0', onFocus);
+
+  it("looks through the cellsUpdateFocus map and calls the focused cell's onFocus callback", () => {
+    notifyCellOfFocusState(cellsUpdateFocus, [0, 0], true);
+    expect(onFocus).toHaveBeenLastCalledWith(true);
+
+    notifyCellOfFocusState(cellsUpdateFocus, [0, 0], false);
+    expect(onFocus).toHaveBeenLastCalledWith(false);
+  });
+
+  it('does not error if the cell does not exist in the map', () => {
+    notifyCellOfFocusState(cellsUpdateFocus, [1, 1], true);
+  });
+});
 
 describe('createKeyDownHandler', () => {
   const focusContext = {

--- a/src/components/datagrid/utils/focus.test.tsx
+++ b/src/components/datagrid/utils/focus.test.tsx
@@ -6,7 +6,14 @@
  * Side Public License, v 1.
  */
 
-import { getParentCellContent } from './focus';
+import React from 'react';
+import { mount } from 'enzyme';
+
+import {
+  DataGridFocusContext,
+  getParentCellContent,
+  useHeaderFocusWorkaround,
+} from './focus';
 
 describe('getParentCellContent', () => {
   const doc = document.createDocumentFragment();
@@ -38,5 +45,38 @@ describe('getParentCellContent', () => {
 
   it('does not locate the cell element when starting outside the cell', () => {
     expect(getParentCellContent(body)).toBeNull();
+  });
+});
+
+describe('useHeaderFocusWorkaround', () => {
+  const MockComponent = () => {
+    useHeaderFocusWorkaround(false);
+    return <div />;
+  };
+
+  it('moves focus down from the header to the first data row if the header becomes uninteractive', () => {
+    const focusedCell = [2, -1];
+    const setFocusedCell = jest.fn();
+    mount(
+      <DataGridFocusContext.Provider
+        value={{ focusedCell, setFocusedCell } as any}
+      >
+        <MockComponent />
+      </DataGridFocusContext.Provider>
+    );
+    expect(setFocusedCell).toHaveBeenCalledWith([2, 0]);
+  });
+
+  it('does nothing if the focus was not on the header when the header became uninteractive', () => {
+    const focusedCell = [2, 0];
+    const setFocusedCell = jest.fn();
+    mount(
+      <DataGridFocusContext.Provider
+        value={{ focusedCell, setFocusedCell } as any}
+      >
+        <MockComponent />
+      </DataGridFocusContext.Provider>
+    );
+    expect(setFocusedCell).not.toHaveBeenCalled();
   });
 });

--- a/src/components/datagrid/utils/focus.ts
+++ b/src/components/datagrid/utils/focus.ts
@@ -271,10 +271,7 @@ export const preventTabbing = (records: MutationRecord[]) => {
       const tabbables = tabbable(cell);
       for (let i = 0; i < tabbables.length; i++) {
         const element = tabbables[i];
-        if (
-          element.getAttribute('role') !== 'gridcell' &&
-          !element.dataset['euigrid-tab-managed']
-        ) {
+        if (!element.hasAttribute('data-euigrid-tab-managed')) {
           element.setAttribute('tabIndex', '-1');
           element.setAttribute('data-datagrid-interactable', 'true');
         }


### PR DESCRIPTION
### Summary

We had a `utils/focus.test.ts` file, but it only had tests for `getParentCellContent`. This PR writes unit tests for all the remaining exported utilities in the file.

### Checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**

No changelog; should be dev-only changes