### PR TITLE
[A11y] Added `aria-label` to the flyout testenv file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 ## [`main`](https://github.com/elastic/eui/tree/main)
 - Updated `testenv` mock for `EuiFlyout` to include default `aria-label` on the close button ([#5702](https://github.com/elastic/eui/pull/5702))
 
-No public interface changes since `51.0.0`.
-
 ## [`51.0.0`](https://github.com/elastic/eui/tree/v51.0.0)
 
 - Enhanced `EuiSuggest` to fire the `onItemClick` callback on Enter key press as well as clicks ([#5693](https://github.com/elastic/eui/pull/5693))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [`main`](https://github.com/elastic/eui/tree/main)
+- Updated `testenv` mock for `EuiFlyout` to include default `aria-label` on the close button ([#5702](https://github.com/elastic/eui/pull/5702))
 
 No public interface changes since `51.0.0`.
 

--- a/src/components/flyout/flyout.testenv.tsx
+++ b/src/components/flyout/flyout.testenv.tsx
@@ -29,6 +29,7 @@ export const EuiFlyout = ({
         <button
           type="button"
           data-test-subj="euiFlyoutCloseButton"
+          aria-label="Close this dialog"
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             onClose();
             closeButtonProps?.onClick && closeButtonProps.onClick(e);


### PR DESCRIPTION
### Summary

This PR only changes `testenv` file of EuiFlyout that produces a mocked version of EuiFlyout. The current mock doesn't have an `aria-label` on the close flyout button and causes "critical" a11y violations when an jest-axe test is run against any consuming components in Kibana (see https://github.com/elastic/kibana/pull/127185).

### Checklist
I don't think any of the items in the checklist are applicable because this PR only touches the mock file. 

- [ ] Check against **all themes** for compatibility in both light and dark modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
