### PR TITLE
[Misc] Type fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [`main`](https://github.com/elastic/eui/tree/main)
 
-No public interface changes since `51.0.0`.
+**Bug fixes**
+
+- Fixed type of `SharedRenderCellElementProps.schema` to be optional ([#5704](https://github.com/elastic/eui/pull/5704))
+- Fixed generated type definition file referencing non-existant Jest util ([#5704](https://github.com/elastic/eui/pull/5704))
 
 ## [`51.0.0`](https://github.com/elastic/eui/tree/v51.0.0)
 

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -407,7 +407,7 @@ interface SharedRenderCellElementProps {
   /**
    * The schema type of the column being rendered
    */
-  schema: string | undefined | null;
+  schema?: string | null;
 }
 
 export type EuiDataGridSetCellProps = CommonProps &

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -14,4 +14,3 @@ export {
   stopThrowingReactWarnings,
 } from './react_warnings';
 export { sleep } from './sleep';
-export { IS_JEST_ENVIRONMENT } from '../utils/is_jest';


### PR DESCRIPTION
### Summary

Type fixes related to https://github.com/elastic/kibana/pull/126926

* Ensure `SharedRenderCellElementProps.schema` is optional
  * `: undefined | null | string` is not the same as `?: null | string`
  * https://buildkite.com/elastic/kibana-pull-request/builds/28576#62eba969-0a7f-4793-9a93-574d7641c42f
* Remove `IS_JEST_ENVIRONMENT` from `test/index.d.ts`
  * It now exists in `eui.d.ts` because it's now in `utils/`
  * The path was incorrect in `test/index.d.ts` (https://buildkite.com/elastic/kibana-pull-request/builds/28847#b58e4b0c-372f-4630-aba1-96c5cd67d313)

### Checklist

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
