### PR TITLE
[Docs] Add writing guidelines to selection controls

### DIFF
--- a/src-docs/src/views/selection_controls/guidelines.js
+++ b/src-docs/src/views/selection_controls/guidelines.js
@@ -89,6 +89,80 @@ export default () => {
     },
   ];
 
+  const positiveDo = [
+    {
+      id: 'positive_do_one',
+      label: 'Use logs',
+    },
+    {
+      id: 'positive_do_two',
+      label: 'Use metrics',
+    },
+  ];
+
+  const positiveDont = [
+    {
+      id: 'positive_dont_one',
+      label: 'Do not include logs',
+    },
+    {
+      id: 'positive_dont_two',
+      label: 'Do not include metrics',
+    },
+  ];
+
+  const groupTitleDo = [
+    {
+      id: 'group_title_do_one',
+      label: 'Logs',
+    },
+    {
+      id: 'group_title_do_two',
+      label: 'Metrics',
+    },
+  ];
+
+  const groupTitleDont = [
+    {
+      id: 'group_title_dont_one',
+      label: 'Use Logs',
+    },
+    {
+      id: 'group_title_dont_two',
+      label: 'Metrics',
+    },
+  ];
+
+  const consistentDo = [
+    {
+      id: 'consistent_do_one',
+      label: '1 zone',
+    },
+    {
+      id: 'consistent_do_two',
+      label: '2 zones',
+    },
+    {
+      id: 'consistent_do_three',
+      label: '3 zones',
+    },
+  ];
+
+  const consistentDont = [
+    {
+      id: 'consistent_dont_one',
+      label: 'One zone',
+    },
+    {
+      id: 'consistent_dont_two',
+      label: '2 zones.',
+    },
+    {
+      id: 'consistent_dont_three',
+      label: '3 zones',
+    },
+  ];
+
   const items = [
     {
       id: '1',
@@ -150,7 +224,7 @@ export default () => {
       </EuiTitle>
 
       <GuideRule
-        heading="Make it easy to scan the options"
+        heading="Checkbox and radio button labels"
         description={
           <p>
             A label should be succinct, short, and descriptive with one to two
@@ -177,6 +251,125 @@ export default () => {
             options={easyScanDont}
             onChange={() => {}}
             name="radio group"
+          />
+        </GuideRuleExample>
+      </GuideRule>
+
+      <GuideRule description={<p>Use positive and active wording.</p>}>
+        <GuideRuleExample
+          type="do"
+          text="Let users know what happens when the selection control is on."
+        >
+          <EuiCheckboxGroup
+            options={positiveDo}
+            onChange={() => {}}
+            idToSelectedMap={
+              ({ positive_do_one: true }, { positive_do_two: true })
+            }
+          />
+        </GuideRuleExample>
+        <GuideRuleExample
+          type="dont"
+          text="Use negatives. They're unnatural and confusing."
+        >
+          <EuiCheckboxGroup
+            options={positiveDont}
+            onChange={() => {}}
+            idToSelectedMap={{ positive_dont_one: true }}
+          />
+        </GuideRuleExample>
+      </GuideRule>
+
+      <GuideRule
+        description={
+          <p>For groups of options, be consistent with wording and title.</p>
+        }
+      >
+        <GuideRuleExample
+          type="do"
+          text="Use nouns that describe the choices to make as group title."
+        >
+          <EuiCheckboxGroup
+            options={groupTitleDo}
+            onChange={() => {}}
+            idToSelectedMap={{ group_title_do_one: true }}
+            legend={{
+              children: <span>Data to ship</span>,
+            }}
+          />
+        </GuideRuleExample>
+        <GuideRuleExample
+          type="dont"
+          text="Repeat choices or use the title as instructions."
+        >
+          <EuiCheckboxGroup
+            options={groupTitleDo}
+            onChange={() => {}}
+            idToSelectedMap={{ group_title_do_one: true }}
+            legend={{
+              children: <span>Choose to ship logs and/or metrics</span>,
+            }}
+          />
+        </GuideRuleExample>
+      </GuideRule>
+
+      <GuideRule>
+        <GuideRuleExample
+          type="do"
+          text="Use sentences only or fragments only."
+        >
+          <EuiCheckboxGroup
+            options={groupTitleDo}
+            onChange={() => {}}
+            idToSelectedMap={{ group_title_do_one: true }}
+            legend={{
+              children: <span>Data to ship</span>,
+            }}
+          />
+        </GuideRuleExample>
+        <GuideRuleExample
+          type="dont"
+          text="Mix label structure within the same group of options."
+        >
+          <EuiCheckboxGroup
+            options={groupTitleDont}
+            onChange={() => {}}
+            idToSelectedMap={{ group_title_dont_one: true }}
+            legend={{
+              children: <span>Data to ship</span>,
+            }}
+          />
+        </GuideRuleExample>
+      </GuideRule>
+
+      <GuideRule>
+        <GuideRuleExample
+          type="do"
+          text="Start all with a verb, all with a noun, or all with a number."
+        >
+          <EuiRadioGroup
+            options={consistentDo}
+            idSelected={{ consistent_do_one: true }}
+            onChange={() => {}}
+            name="radio group"
+            legend={{
+              children: <span>Availability zones</span>,
+            }}
+          />
+        </GuideRuleExample>
+        <GuideRuleExample
+          type="dont"
+          text="Use ending punctuation. 
+          Exception: Question marks can be used if they add clarity."
+        >
+          <EuiRadioGroup
+            options={consistentDont}
+            idSelected={{ consistent_dont_one: true }}
+            onChange={() => {}}
+            name="radio group"
+            legend={{
+              children: <span>Availability zones</span>,
+            }}
           />
         </GuideRuleExample>
       </GuideRule>

--- a/src-docs/src/views/selection_controls/guidelines.js
+++ b/src-docs/src/views/selection_controls/guidelines.js
@@ -386,7 +386,7 @@ export default () => {
       >
         <GuideRuleExample
           type="do"
-          text="Use nouns that describe the choices to make as group title."
+          text="Use nouns that describe the choices to make."
         >
           <EuiCheckboxGroup
             options={groupTitleDo}

--- a/src-docs/src/views/selection_controls/guidelines.js
+++ b/src-docs/src/views/selection_controls/guidelines.js
@@ -412,7 +412,7 @@ export default () => {
         description={
           <p>
             The label should be static, action-oriented, and describe the
-            feature. Avoid verbs that are less conversational such as `enable`
+            feature. Avoid verbs that are less conversational such as "enable"
             unless they are your only option.
           </p>
         }

--- a/src-docs/src/views/selection_controls/guidelines.js
+++ b/src-docs/src/views/selection_controls/guidelines.js
@@ -258,7 +258,7 @@ export default () => {
       <GuideRule description={<p>Use positive and active wording.</p>}>
         <GuideRuleExample
           type="do"
-          text="Let users know what happens when the selection control is on."
+          text="Tell users what happens when the selection control is on."
         >
           <EuiCheckboxGroup
             options={positiveDo}

--- a/src-docs/src/views/selection_controls/guidelines.js
+++ b/src-docs/src/views/selection_controls/guidelines.js
@@ -232,10 +232,7 @@ export default () => {
           </p>
         }
       >
-        <GuideRuleExample
-          type="do"
-          text="A label should be succinct, short, and descriptive with one to two words."
-        >
+        <GuideRuleExample type="do" text="Use one to two descriptive words.">
           <EuiRadioGroup
             options={easyScanDo}
             onChange={() => {}}
@@ -245,7 +242,7 @@ export default () => {
 
         <GuideRuleExample
           type="dont"
-          text="Long labels makes it difficult to scan."
+          text="Repeat the same words. They make labels difficult to scan."
         >
           <EuiRadioGroup
             options={easyScanDont}
@@ -281,9 +278,7 @@ export default () => {
       </GuideRule>
 
       <GuideRule
-        description={
-          <p>Use sentence case (capitalize the first word).</p>
-        }
+        description={<p>Use sentence case (capitalize the first word).</p>}
       >
         <GuideRuleExample
           type="do"
@@ -416,8 +411,9 @@ export default () => {
         heading="Switch labels"
         description={
           <p>
-            The label should be static, action-oriented and describe the
-            feature.
+            The label should be static, action-oriented, and describe the
+            feature. Avoid verbs that are less conversational such as `enable`
+            unless they are your only option.
           </p>
         }
       >
@@ -462,7 +458,7 @@ export default () => {
         </GuideRuleExample>
         <GuideRuleExample
           type="dont"
-          text='Use only a verb, such as "Enable".'
+          text="Use only a verb. Generic verbs alone make options unclear."
           minHeight={80}
         >
           <EuiSwitch checked={false} onChange={() => {}} label="Enable" />

--- a/src-docs/src/views/selection_controls/guidelines.js
+++ b/src-docs/src/views/selection_controls/guidelines.js
@@ -311,7 +311,8 @@ export default () => {
         heading="Checkbox and radio button labels"
         description={
           <p>
-            For groups of options, add a legend that gives meaning to the options.
+            For groups of options, add a legend that gives meaning to the
+            options.
           </p>
         }
       >

--- a/src-docs/src/views/selection_controls/guidelines.js
+++ b/src-docs/src/views/selection_controls/guidelines.js
@@ -224,7 +224,6 @@ export default () => {
       </EuiTitle>
 
       <GuideRule
-        heading="Checkbox and radio button labels"
         description={
           <p>
             A label should be succinct, short, and descriptive with one to two
@@ -282,7 +281,38 @@ export default () => {
 
       <GuideRule
         description={
-          <p>For groups of options, be consistent with wording and title.</p>
+          <p>Always prefer sentence cases (capitalize the first word).</p>
+        }
+      >
+        <GuideRuleExample
+          type="do"
+          text="Sentence case makes titles easier to read."
+        >
+          <EuiCheckboxGroup
+            options={accessDo}
+            onChange={() => {}}
+            idToSelectedMap={{ access_do_one: true }}
+          />
+        </GuideRuleExample>
+
+        <GuideRuleExample
+          type="dont"
+          text="Title case can feel more cluttered."
+        >
+          <EuiCheckboxGroup
+            options={accessDont}
+            onChange={() => {}}
+            idToSelectedMap={{ access_dont_one: true }}
+          />
+        </GuideRuleExample>
+      </GuideRule>
+
+      <GuideRule
+        heading="Checkbox and radio button labels"
+        description={
+          <p>
+            For groups of options, add titles that give meaning to the options.
+          </p>
         }
       >
         <GuideRuleExample
@@ -313,7 +343,13 @@ export default () => {
         </GuideRuleExample>
       </GuideRule>
 
-      <GuideRule>
+      <GuideRule
+        description={
+          <p>
+            Use consistent label structures for options within the same group.
+          </p>
+        }
+      >
         <GuideRuleExample
           type="do"
           text="Use sentences only or fragments only."
@@ -370,34 +406,6 @@ export default () => {
             legend={{
               children: <span>Availability zones</span>,
             }}
-          />
-        </GuideRuleExample>
-      </GuideRule>
-
-      <GuideRule
-        description={
-          <p>Always prefer sentence cases (capitalize the first word).</p>
-        }
-      >
-        <GuideRuleExample
-          type="do"
-          text="Sentence case makes titles easier to read."
-        >
-          <EuiCheckboxGroup
-            options={accessDo}
-            onChange={() => {}}
-            idToSelectedMap={{ access_do_one: true }}
-          />
-        </GuideRuleExample>
-
-        <GuideRuleExample
-          type="dont"
-          text="Title case can feel more cluttered."
-        >
-          <EuiCheckboxGroup
-            options={accessDont}
-            onChange={() => {}}
-            idToSelectedMap={{ access_dont_one: true }}
           />
         </GuideRuleExample>
       </GuideRule>

--- a/src-docs/src/views/selection_controls/guidelines.js
+++ b/src-docs/src/views/selection_controls/guidelines.js
@@ -282,7 +282,7 @@ export default () => {
 
       <GuideRule
         description={
-          <p>Always prefer sentence cases (capitalize the first word).</p>
+          <p>Use sentence case (capitalize the first word).</p>
         }
       >
         <GuideRuleExample

--- a/src-docs/src/views/selection_controls/guidelines.js
+++ b/src-docs/src/views/selection_controls/guidelines.js
@@ -224,6 +224,7 @@ export default () => {
       </EuiTitle>
 
       <GuideRule
+        heading="Checkbox and radio button labels"
         description={
           <p>
             A label should be succinct, short, and descriptive with one to two
@@ -308,43 +309,6 @@ export default () => {
       </GuideRule>
 
       <GuideRule
-        heading="Checkbox and radio button labels"
-        description={
-          <p>
-            For groups of options, add a legend that gives meaning to the
-            options.
-          </p>
-        }
-      >
-        <GuideRuleExample
-          type="do"
-          text="Use nouns that describe the choices to make as group title."
-        >
-          <EuiCheckboxGroup
-            options={groupTitleDo}
-            onChange={() => {}}
-            idToSelectedMap={{ group_title_do_one: true }}
-            legend={{
-              children: <span>Data to ship</span>,
-            }}
-          />
-        </GuideRuleExample>
-        <GuideRuleExample
-          type="dont"
-          text="Repeat choices or use the title as instructions."
-        >
-          <EuiCheckboxGroup
-            options={groupTitleDo}
-            onChange={() => {}}
-            idToSelectedMap={{ group_title_do_one: true }}
-            legend={{
-              children: <span>Choose to ship logs and/or metrics</span>,
-            }}
-          />
-        </GuideRuleExample>
-      </GuideRule>
-
-      <GuideRule
         description={
           <p>
             Use consistent label structures for options within the same group.
@@ -406,6 +370,43 @@ export default () => {
             name="radio group"
             legend={{
               children: <span>Availability zones</span>,
+            }}
+          />
+        </GuideRuleExample>
+      </GuideRule>
+
+      <GuideRule
+        heading="Legends"
+        description={
+          <p>
+            For groups of options, add a legend that gives meaning to the
+            options. Legends appear like a title.
+          </p>
+        }
+      >
+        <GuideRuleExample
+          type="do"
+          text="Use nouns that describe the choices to make as group title."
+        >
+          <EuiCheckboxGroup
+            options={groupTitleDo}
+            onChange={() => {}}
+            idToSelectedMap={{ group_title_do_one: true }}
+            legend={{
+              children: <span>Data to ship</span>,
+            }}
+          />
+        </GuideRuleExample>
+        <GuideRuleExample
+          type="dont"
+          text="Repeat choices or use the title as instructions."
+        >
+          <EuiCheckboxGroup
+            options={groupTitleDo}
+            onChange={() => {}}
+            idToSelectedMap={{ group_title_do_one: true }}
+            legend={{
+              children: <span>Choose to ship logs and/or metrics</span>,
             }}
           />
         </GuideRuleExample>

--- a/src-docs/src/views/selection_controls/guidelines.js
+++ b/src-docs/src/views/selection_controls/guidelines.js
@@ -412,8 +412,8 @@ export default () => {
         description={
           <p>
             The label should be static, action-oriented, and describe the
-            feature. Avoid verbs that are less conversational such as "enable"
-            unless they are your only option.
+            feature. Avoid verbs that are less conversational such as
+            &quot;enable&quot; unless they are your only option.
           </p>
         }
       >

--- a/src-docs/src/views/selection_controls/guidelines.js
+++ b/src-docs/src/views/selection_controls/guidelines.js
@@ -311,7 +311,7 @@ export default () => {
         heading="Checkbox and radio button labels"
         description={
           <p>
-            For groups of options, add titles that give meaning to the options.
+            For groups of options, add a legend that gives meaning to the options.
           </p>
         }
       >

--- a/src-docs/src/views/selection_controls/selection_controls_example.js
+++ b/src-docs/src/views/selection_controls/selection_controls_example.js
@@ -372,7 +372,11 @@ export const SelectionControlsExample = {
             <strong>EuiFormFieldset</strong> simply wraps its children in a{' '}
             <EuiCode language="html">&lt;fieldset&gt;</EuiCode> with the option
             to add a <EuiCode language="html">&lt;legend&gt;</EuiCode> via the{' '}
-            <EuiCode>legend</EuiCode> object prop.
+            <EuiCode>legend</EuiCode> object prop. Find more examples in the{' '}
+            <Link to="/forms/selection-controls/guidelines">
+              guidelines tab
+            </Link>
+            .
           </p>
         </Fragment>
       ),


### PR DESCRIPTION
### Summary

This PR adds guidelines and Do/Don't examples for writing checkbox and radio button labels as well as some generic guidelines. 

<img width="1725" alt="image" src="https://user-images.githubusercontent.com/10208282/157643287-fabdbf97-06aa-4d55-b30f-03cb55261955.png">


### Checklist

- ~[ ] Check against **all themes** for compatibility in both light and dark modes~
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
