### PR TITLE
Added a Figma specific PR checklist item

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ Provide a detailed summary of your PR. Explain how you arrived at your solution.
 
 ### Checklist
 
-- [ ] Check against **all themes** for compatibility in both light and dark modes
+- [ ] Check in both **light and dark** modes
 - [ ] Checked in **mobile**
 - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
 - [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
@@ -13,4 +13,5 @@ Provide a detailed summary of your PR. Explain how you arrived at your solution.
 - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
 - [ ] Checked for **breaking changes** and labeled appropriately
 - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
+- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
 - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ Provide a detailed summary of your PR. Explain how you arrived at your solution.
 
 ### Checklist
 
-- [ ] Check in both **light and dark** modes
+- [ ] Checked in both **light and dark** modes
 - [ ] Checked in **mobile**
 - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
 - [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**


### PR DESCRIPTION
The UX org leads have been brainstorming ideas to try to keep the Figma library from falling out of relevance. We know that the EUI members can't be **everywhere** (and honestly we hardly use the Figma library ourselves), but one thing we can be more proactive on is ensuring that we consider the Figma side when we make visual updates to the components.

As per usual checklist tasks, you can just cross this one off if it doesn't apply to your PR.

We also know that this will more than likely fall on our designer team members so please be mindful of the extra workload/communication of design changes. 

If it's not likely something to be tackled within the timeframe of the PR, there is now a Figma specific repo where we can add issues: https://github.com/elastic/eui-figma/issues