### PR TITLE
[EuiSelectableTemplateSitewide] Increase contrast of text when in dark header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added `compressed` prop to `EuiFilterGroup` and reduced the size of the `EuiFilterButton` notification badge ([#5717](https://github.com/elastic/eui/pull/5717))
 - Updated `testenv` mock for `EuiIcon` to render `aria-label` as text ([#5709](https://github.com/elastic/eui/pull/5709))
 - Added `editorChecklist` glyph to `EuiIcon` ([#5705](https://github.com/elastic/eui/pull/5705))
+- Increased contrast of `EuiSelectableTemplateSitewide` input text when in dark header ([#5724](https://github.com/elastic/eui/pull/5724))
 
 **Breaking changes**
 
@@ -49,7 +50,7 @@
 - Added `textWrap` to `EuiSelectableListItem`, `EuiSelectableList`, and `EuiSelectable.listOptions` ([#5679](https://github.com/elastic/eui/issues/5679))
 - Forced `truncation` on `EuiSuggest` items when `isVirtualize` ([#5679](https://github.com/elastic/eui/issues/5679))
 - Changed proportion handling between content and image in `horizontal` `EuiEmptyPrompt` and added spacing between ([#5663](https://github.com/elastic/eui/pull/5663))
-- Reduced SASS compilation time using a different math `pow` implementation ([#5674](https://github.com/elastic/eui/pull/5674)) 
+- Reduced SASS compilation time using a different math `pow` implementation ([#5674](https://github.com/elastic/eui/pull/5674))
 
 **Bug fixes**
 

--- a/src/components/selectable/selectable_templates/_selectable_template_sitewide.scss
+++ b/src/components/selectable/selectable_templates/_selectable_template_sitewide.scss
@@ -9,12 +9,13 @@
   }
 
   &:not(:focus-within) {
-    color: transparentize($euiColorGhost, .3);
+    // Increase contrast of filled text to be more than placeholder text
+    color: $euiColorGhost;
 
     input {
       // Increase contrast of placeholder text
       @include euiPlaceholderPerBrowser {
-        color: transparentize($euiColorGhost, .6);
+        color: makeHighContrastColor($euiFormControlPlaceholderText, $euiHeaderDarkBackgroundColor, 8);
       }
 
       // Inherit color from form control layout


### PR DESCRIPTION


We received feedback that the global navigational search in Kibana is hard to find. So we're opting to increase the contrast of the text as it is in the dark header and then in Kibana we'll change the placeholder text to be more specific.

![image](https://user-images.githubusercontent.com/549577/158641578-a1754a1d-cac5-4ead-b6e9-1ed19b5a1b1d.png)


### Checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [x] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
