### PR TITLE
[EuiDataGrid] Add new `gridStyle.rowClasses` API

### DIFF
--- a/src-docs/src/views/datagrid/_datagrid.scss
+++ b/src-docs/src/views/datagrid/_datagrid.scss
@@ -5,3 +5,21 @@
 .euiDataGridHeaderCell--favoriteFranchise {
   background: transparentize($color: #800080, $amount: .9) !important; // sass-lint:disable-line no-important
 }
+
+.euiDataGridRow--rowClassesDemo {
+  $stripeColor: transparentize($euiColorPrimary, .9);
+  background-image: linear-gradient(135deg,
+    $euiColorEmptyShade 41.67%,
+    $stripeColor 41.67%,
+    $stripeColor 50%,
+    $euiColorEmptyShade 50%,
+    $euiColorEmptyShade 91.67%,
+    $stripeColor 91.67%,
+    $stripeColor 100%
+  );
+  background-size: 8.49px 8.49px;
+}
+
+.euiDataGridRow--rowClassesDemoSelected {
+  background: $euiColorHighlight;
+}

--- a/src-docs/src/views/datagrid/styling/datagrid_styling_example.js
+++ b/src-docs/src/views/datagrid/styling/datagrid_styling_example.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 
 import { GuideSectionTypes } from '../../../components';
 import { EuiDataGrid, EuiCode } from '../../../../../src/components';
@@ -7,6 +7,9 @@ import { EuiDataGridStyle } from '!!prop-loader!../../../../../src/components/da
 
 import DataGridStyling from './styling';
 const dataGridStylingSource = require('!!raw-loader!./styling_grid');
+
+import DataGridRowClasses from './row_classes';
+const dataGridRowClassesSource = require('!!raw-loader!./row_classes');
 
 import DataGridDisplayCallbacks from './display_callbacks';
 const dataGridDisplayCallbacksSource = require('!!raw-loader!./display_callbacks');
@@ -28,6 +31,23 @@ const ${gridSnippets.gridStyle};
 />
 `;
 
+const dataGridRowClassesSnippet = `
+<EuiDataGrid
+  aria-label="Data grid with gridStyle.rowClasses set"
+  columns={columns}
+  columnVisibility={{ visibleColumns, setVisibleColumns }}
+  rowCount={rowCount}
+  renderCellValue={renderCellValue}
+  gridStyle={{
+    rowClasses: {
+      0: 'someClass', // the first row will receive the 'someClass' class
+      1: 'anotherClass',
+      5: 'etc',
+    }
+  }}
+/>
+`;
+
 export const DataGridStylingExample = {
   title: 'Data grid style & display',
   sections: [
@@ -40,7 +60,7 @@ export const DataGridStylingExample = {
         },
       ],
       text: (
-        <Fragment>
+        <>
           <p>
             Styling can be passed down to the grid through the{' '}
             <EuiCode>gridStyle</EuiCode> prop. It accepts an object that allows
@@ -56,7 +76,7 @@ export const DataGridStylingExample = {
             parent font size or elements that use units relative to the parent
             container.
           </p>
-        </Fragment>
+        </>
       ),
       props: {
         EuiDataGrid,
@@ -64,6 +84,35 @@ export const DataGridStylingExample = {
       },
       snippet: gridStyleSnippet,
       demo: <DataGridStyling />,
+    },
+    {
+      title: 'Grid row classes',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: dataGridRowClassesSource,
+        },
+      ],
+      text: (
+        <>
+          <p>
+            Specific rows can be highlighted or otherwise have custom styling
+            passed to them via the
+            <EuiCode>gridStyle.rowClasses</EuiCode> prop. It accepts an object
+            associating the row&apos;s index with a class name string.
+          </p>
+          <p>
+            The example below sets a custom striped class on the 3rd row and
+            dynamically updates the <EuiCode>rowClasses</EuiCode> map when rows
+            are selected.
+          </p>
+        </>
+      ),
+      props: {
+        EuiDataGridStyle,
+      },
+      snippet: dataGridRowClassesSnippet,
+      demo: <DataGridRowClasses />,
     },
     ...dataGridRowHeightOptionsExample.sections,
     {

--- a/src-docs/src/views/datagrid/styling/row_classes.js
+++ b/src-docs/src/views/datagrid/styling/row_classes.js
@@ -1,0 +1,172 @@
+import React, {
+  createContext,
+  useContext,
+  useReducer,
+  useState,
+  useMemo,
+} from 'react';
+import { fake } from 'faker';
+
+import {
+  EuiDataGrid,
+  EuiCheckbox,
+  EuiButtonEmpty,
+} from '../../../../../src/components';
+
+/**
+ * Data
+ */
+const columns = [
+  { id: 'name' },
+  { id: 'email' },
+  { id: 'city' },
+  { id: 'country' },
+  { id: 'account' },
+];
+
+const DEMO_ROW = 2;
+
+const data = [];
+for (let i = 1; i <= 10; i++) {
+  data.push({
+    name: fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}'),
+    email: fake('{{internet.email}}'),
+    city: fake('{{address.city}}'),
+    country: fake('{{address.country}}'),
+    account: fake('{{finance.account}}'),
+  });
+}
+data[DEMO_ROW].account = 'OVERDUE';
+
+/**
+ * Selection
+ */
+const SelectionContext = createContext();
+
+const SelectionButton = () => {
+  const [selectedRows] = useContext(SelectionContext);
+  const hasSelection = selectedRows.size > 0;
+  return hasSelection ? (
+    <EuiButtonEmpty
+      size="xs"
+      iconType="arrowDown"
+      iconSide="right"
+      onClick={() => window.alert('This is not a real control.')}
+    >
+      {selectedRows.size} {selectedRows.size > 1 ? 'items' : 'item'} selected
+    </EuiButtonEmpty>
+  ) : null;
+};
+
+const SelectionHeaderCell = () => {
+  const [selectedRows, updateSelectedRows] = useContext(SelectionContext);
+  const isIndeterminate =
+    selectedRows.size > 0 && selectedRows.size < data.length;
+  return (
+    <EuiCheckbox
+      id="selection-toggle"
+      aria-label="Select all rows"
+      indeterminate={isIndeterminate}
+      checked={selectedRows.size > 0}
+      onChange={(e) => {
+        if (isIndeterminate) {
+          // clear selection
+          updateSelectedRows({ action: 'clear' });
+        } else {
+          if (e.target.checked) {
+            // select everything
+            updateSelectedRows({ action: 'selectAll' });
+          } else {
+            // clear selection
+            updateSelectedRows({ action: 'clear' });
+          }
+        }
+      }}
+    />
+  );
+};
+
+const SelectionRowCell = ({ rowIndex }) => {
+  const [selectedRows, updateSelectedRows] = useContext(SelectionContext);
+  const isChecked = selectedRows.has(rowIndex);
+  return (
+    <div>
+      <EuiCheckbox
+        id={`${rowIndex}`}
+        aria-label={`Select row ${rowIndex}, ${data[rowIndex].name}`}
+        checked={isChecked}
+        onChange={(e) => {
+          if (e.target.checked) {
+            updateSelectedRows({ action: 'add', rowIndex });
+          } else {
+            updateSelectedRows({ action: 'delete', rowIndex });
+          }
+        }}
+      />
+    </div>
+  );
+};
+
+const leadingControlColumns = [
+  {
+    id: 'selection',
+    width: 32,
+    headerCellRender: SelectionHeaderCell,
+    rowCellRender: SelectionRowCell,
+  },
+];
+
+/**
+ * Data grid
+ */
+export default () => {
+  const [visibleColumns, setVisibleColumns] = useState(
+    columns.map(({ id }) => id)
+  );
+
+  const rowSelection = useReducer((rowSelection, { action, rowIndex }) => {
+    if (action === 'add') {
+      const nextRowSelection = new Set(rowSelection);
+      nextRowSelection.add(rowIndex);
+      return nextRowSelection;
+    } else if (action === 'delete') {
+      const nextRowSelection = new Set(rowSelection);
+      nextRowSelection.delete(rowIndex);
+      return nextRowSelection;
+    } else if (action === 'clear') {
+      return new Set();
+    } else if (action === 'selectAll') {
+      return new Set(data.map((_, index) => index));
+    }
+    return rowSelection;
+  }, new Set());
+
+  const rowClasses = useMemo(() => {
+    const rowClasses = {
+      [DEMO_ROW]: 'euiDataGridRow--rowClassesDemo',
+    };
+    rowSelection[0].forEach((rowIndex) => {
+      rowClasses[rowIndex] = 'euiDataGridRow--rowClassesDemoSelected';
+    });
+    return rowClasses;
+  }, [rowSelection]);
+
+  return (
+    <SelectionContext.Provider value={rowSelection}>
+      <div>
+        <EuiDataGrid
+          aria-label="Top EUI contributors"
+          columns={columns}
+          columnVisibility={{ visibleColumns, setVisibleColumns }}
+          rowCount={data.length}
+          renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
+          leadingControlColumns={leadingControlColumns}
+          toolbarVisibility={{
+            additionalControls: <SelectionButton />,
+          }}
+          gridStyle={{ rowClasses, rowHover: 'none' }}
+        />
+      </div>
+    </SelectionContext.Provider>
+  );
+};

--- a/src/components/datagrid/body/data_grid_body.tsx
+++ b/src/components/datagrid/body/data_grid_body.tsx
@@ -30,11 +30,10 @@ import { EuiDataGridHeaderRow } from './header';
 import { DataGridCellPopoverContext } from './data_grid_cell_popover';
 import {
   EuiDataGridBodyProps,
-  EuiDataGridRowManager,
   DataGridWrapperRowsContentsShape,
   EuiDataGridSchemaDetector,
 } from '../data_grid_types';
-import { makeRowManager } from './data_grid_row_manager';
+import { useRowManager } from './data_grid_row_manager';
 import {
   useFinalGridDimensions,
   useUnconstrainedHeight,
@@ -378,11 +377,9 @@ export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
   /**
    * Row manager
    */
-  // useState instead of useMemo as React reserves the right to drop memoized
-  // values in the future, and that would be very bad here
-  const [rowManager] = useState<EuiDataGridRowManager>(() =>
-    makeRowManager(innerGridRef)
-  );
+  const rowManager = useRowManager({
+    innerGridRef,
+  });
 
   /**
    * Heights

--- a/src/components/datagrid/body/data_grid_body.tsx
+++ b/src/components/datagrid/body/data_grid_body.tsx
@@ -379,6 +379,7 @@ export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
    */
   const rowManager = useRowManager({
     innerGridRef,
+    rowClasses: gridStyles.rowClasses,
   });
 
   /**

--- a/src/components/datagrid/body/data_grid_row_manager.test.ts
+++ b/src/components/datagrid/body/data_grid_row_manager.test.ts
@@ -107,4 +107,41 @@ describe('row manager', () => {
       });
     });
   });
+
+  describe('rowClasses', () => {
+    const rowClasses = {
+      0: 'hello',
+    };
+    let row0: HTMLDivElement;
+    let row1: HTMLDivElement;
+    const mockRowArgs = { visibleRowIndex: 99, top: '15px', height: 30 };
+
+    const { return: rowManager, updateHookArgs } = testCustomHook<
+      EuiDataGridRowManager
+    >(useRowManager, { innerGridRef: mockGridRef, rowClasses });
+
+    beforeAll(() => {
+      row0 = rowManager.getRow({ ...mockRowArgs, rowIndex: 0 });
+      row1 = rowManager.getRow({ ...mockRowArgs, rowIndex: 1 });
+    });
+
+    it('creates rows with the passed gridStyle.rowClasses', () => {
+      expect(row0.classList.contains('hello')).toBe(true);
+    });
+
+    it('updates row classes dynamically when gridStyle.rowClasses updates', () => {
+      updateHookArgs({ rowClasses: { 0: 'world' } });
+
+      expect(row0.classList.contains('hello')).toBe(false);
+      expect(row0.classList.contains('world')).toBe(true);
+    });
+
+    it('adds/removes row classes correctly when gridStyle.rowClasses updates', () => {
+      updateHookArgs({ rowClasses: { 1: 'test' } });
+
+      expect(row0.classList.contains('hello')).toBe(false);
+      expect(row0.classList.contains('world')).toBe(false);
+      expect(row1.classList.contains('test')).toBe(true);
+    });
+  });
 });

--- a/src/components/datagrid/body/data_grid_row_manager.test.ts
+++ b/src/components/datagrid/body/data_grid_row_manager.test.ts
@@ -6,18 +6,22 @@
  * Side Public License, v 1.
  */
 
-import { makeRowManager } from './data_grid_row_manager';
+import { testCustomHook } from '../../../test/test_custom_hook.test_helper';
+
+import { EuiDataGridRowManager } from '../data_grid_types';
+import { useRowManager } from './data_grid_row_manager';
 
 describe('row manager', () => {
-  const mockContainerRef = { current: document.createElement('div') } as any;
-  const rowManager = makeRowManager(mockContainerRef);
-
-  beforeEach(() => jest.clearAllMocks());
+  const mockGridRef = { current: document.createElement('div') } as any;
 
   describe('getRow', () => {
+    const { return: rowManager } = testCustomHook<EuiDataGridRowManager>(() =>
+      useRowManager({ innerGridRef: mockGridRef })
+    );
+
     describe('when the row DOM element does not already exist', () => {
       beforeAll(() => {
-        expect(mockContainerRef.current.children).toHaveLength(0);
+        expect(mockGridRef.current.children).toHaveLength(0);
       });
 
       it('creates a row DOM element', () => {
@@ -54,15 +58,15 @@ describe('row manager', () => {
             style="position: absolute; left: 0px; right: 0px; top: 15px; height: 30px;"
           />
         `);
-        mockContainerRef.current.removeChild(row);
+        mockGridRef.current.removeChild(row);
       });
 
       it('sets the parent innerGrid container to position relative', () => {
-        expect(mockContainerRef.current.style.position).toEqual('relative');
+        expect(mockGridRef.current.style.position).toEqual('relative');
       });
 
       it('appends the row DOM element to the grid body container', () => {
-        expect(mockContainerRef.current.children).toHaveLength(1);
+        expect(mockGridRef.current.children).toHaveLength(1);
       });
     });
 
@@ -74,7 +78,7 @@ describe('row manager', () => {
           top: '15px',
           height: 30,
         });
-        expect(mockContainerRef.current.children).toHaveLength(1);
+        expect(mockGridRef.current.children).toHaveLength(1);
       });
 
       it("updates the row's top and height values", () => {

--- a/src/components/datagrid/body/data_grid_row_manager.ts
+++ b/src/components/datagrid/body/data_grid_row_manager.ts
@@ -6,17 +6,19 @@
  * Side Public License, v 1.
  */
 
-import { RefObject } from 'react';
+import { useRef, useCallback, RefObject } from 'react';
 import { EuiDataGridRowManager } from '../data_grid_types';
 
-export const makeRowManager = (
-  containerRef: RefObject<HTMLDivElement>
-): EuiDataGridRowManager => {
-  const rowIdToElements = new Map<number, HTMLDivElement>();
+export const useRowManager = ({
+  innerGridRef,
+}: {
+  innerGridRef: RefObject<HTMLDivElement>;
+}): EuiDataGridRowManager => {
+  const rowIdToElements = useRef(new Map<number, HTMLDivElement>());
 
-  return {
-    getRow({ rowIndex, visibleRowIndex, top, height }) {
-      let rowElement = rowIdToElements.get(rowIndex);
+  const getRow = useCallback(
+    ({ rowIndex, visibleRowIndex, top, height }) => {
+      let rowElement = rowIdToElements.current.get(rowIndex);
 
       if (rowElement == null) {
         rowElement = document.createElement('div');
@@ -32,20 +34,20 @@ export const makeRowManager = (
 
         // In order for the rowElement's left and right position to correctly inherit
         // from the innerGrid width, we need to make its position relative
-        containerRef.current!.style.position = 'relative';
+        innerGridRef.current!.style.position = 'relative';
 
-        // add the element to the wrapping container
-        containerRef.current!.appendChild(rowElement);
+        // add the element to the grid
+        innerGridRef.current!.appendChild(rowElement);
 
         // add the element to the row map
-        rowIdToElements.set(rowIndex, rowElement);
+        rowIdToElements.current.set(rowIndex, rowElement);
 
         // watch the row's children, if they all disappear then remove this row
         const observer = new MutationObserver((records) => {
           if ((records[0].target as HTMLElement).childElementCount === 0) {
             observer.disconnect();
             rowElement?.remove();
-            rowIdToElements.delete(rowIndex);
+            rowIdToElements.current.delete(rowIndex);
           }
         });
         observer.observe(rowElement, { childList: true });
@@ -57,5 +59,8 @@ export const makeRowManager = (
 
       return rowElement;
     },
-  };
+    [innerGridRef]
+  );
+
+  return { getRow };
 };

--- a/src/components/datagrid/body/data_grid_row_manager.ts
+++ b/src/components/datagrid/body/data_grid_row_manager.ts
@@ -6,13 +6,15 @@
  * Side Public License, v 1.
  */
 
-import { useRef, useCallback, RefObject } from 'react';
-import { EuiDataGridRowManager } from '../data_grid_types';
+import { useRef, useCallback, useEffect, RefObject } from 'react';
+import { EuiDataGridRowManager, EuiDataGridStyle } from '../data_grid_types';
 
 export const useRowManager = ({
   innerGridRef,
+  rowClasses,
 }: {
   innerGridRef: RefObject<HTMLDivElement>;
+  rowClasses?: EuiDataGridStyle['rowClasses'];
 }): EuiDataGridRowManager => {
   const rowIdToElements = useRef(new Map<number, HTMLDivElement>());
 
@@ -26,6 +28,9 @@ export const useRowManager = ({
         rowElement.dataset.gridRowIndex = String(rowIndex); // Row index from data, affected by sorting/pagination
         rowElement.dataset.gridVisibleRowIndex = String(visibleRowIndex); // Affected by sorting/pagination
         rowElement.classList.add('euiDataGridRow');
+        if (rowClasses?.[rowIndex]) {
+          rowElement.classList.add(rowClasses[rowIndex]);
+        }
         const isOddRow = visibleRowIndex % 2 !== 0;
         if (isOddRow) rowElement.classList.add('euiDataGridRow--striped');
         rowElement.style.position = 'absolute';
@@ -59,8 +64,21 @@ export const useRowManager = ({
 
       return rowElement;
     },
-    [innerGridRef]
+    [rowClasses, innerGridRef]
   );
+
+  // Update row classes dynamically whenever a new prop is passed in
+  useEffect(() => {
+    if (rowClasses) {
+      rowIdToElements.current.forEach((rowElement, rowIndex) => {
+        if (rowClasses[rowIndex]) {
+          rowElement.classList.value = `euiDataGridRow ${rowClasses[rowIndex]}`;
+        } else {
+          rowElement.classList.value = 'euiDataGridRow'; // Clear any added classes
+        }
+      });
+    }
+  }, [rowClasses]);
 
   return { getRow };
 };

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -666,6 +666,10 @@ export interface EuiDataGridStyle {
    */
   fontSize?: EuiDataGridStyleFontSizes;
   /**
+   * Defines the padding with the row and column cells
+   */
+  cellPadding?: EuiDataGridStyleCellPaddings;
+  /**
    * Border uses for the row and column cells
    */
   border?: EuiDataGridStyleBorders;
@@ -682,17 +686,13 @@ export interface EuiDataGridStyle {
    */
   footer?: EuiDataGridStyleFooter;
   /**
-   * Will define what visual style to show on row hover
-   */
-  rowHover?: EuiDataGridStyleRowHover;
-  /**
-   * Defines the padding with the row and column cells
-   */
-  cellPadding?: EuiDataGridStyleCellPaddings;
-  /**
    * If set to true, the footer row will be sticky
    */
   stickyFooter?: boolean;
+  /**
+   * Will define what visual style to show on row hover
+   */
+  rowHover?: EuiDataGridStyleRowHover;
   /**
    * Optionally pass custom classes to highlight or customize certain rows
    */

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -694,6 +694,10 @@ export interface EuiDataGridStyle {
    */
   stickyFooter?: boolean;
   /**
+   * Optionally pass custom classes to highlight or customize certain rows
+   */
+  rowClasses?: { [rowIndex: number]: string };
+  /**
    * Optional callback returning the current `gridStyle` config when changes occur from user input (e.g. toolbar display controls).
    * Can be used for, e.g. storing user `gridStyle` in a local storage object.
    */

--- a/upcoming_changelogs/5732.md
+++ b/upcoming_changelogs/5732.md
@@ -1,0 +1,1 @@
+- Added a new `gridStyle.rowClasses` API to `EuiDataGrid`, which allows adding custom classes/styling to specific row indices, primarily for the purpose of highlighting rows


### PR DESCRIPTION
### Summary

closes #4401

This PR adds the ability to add specific classes/styling to certain rows, primarily for the purpose of highlighting (e.g. selections, or important row data, etc.), via a new `gridStyle.rowClasses` prop. The API of this is intentionally meant to be similar to `rowHeightsOptions.rowHeights`.

### Screencaps

![screencap](https://user-images.githubusercontent.com/549407/159061207-eff7ac5a-5691-420b-b729-2e156eb79636.gif)

Added a gradient/striped example to show how styling differs from styling each individual cell:

<img src="https://user-images.githubusercontent.com/1490444/128142156-2b7db8b2-212f-4b1c-853e-56e1e00f5ffd.png" alt="cell stripes" width="250">
<img width="1006" alt="row stripes" src="https://user-images.githubusercontent.com/549407/159061258-2dffb96d-695c-4bf2-b075-035c364fd2ea.png">

### Checklist

- [x] Checked in both **light and dark** modes
- [x] Props have proper **autodocs** ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~