### PR TITLE
Added internationalized screen reader helpers to EuiMark.

### DIFF
--- a/src/components/highlight/__snapshots__/highlight.test.tsx.snap
+++ b/src/components/highlight/__snapshots__/highlight.test.tsx.snap
@@ -9,11 +9,21 @@ exports[`EuiHighlight behavior loose matching matches strings with different cas
 
 <span>
   different 
+  <span
+    class="euiScreenReaderOnly"
+  >
+    highlight start
+  </span>
   <mark
     class="euiMark emotion-0"
   >
     case
   </mark>
+  <span
+    class="euiScreenReaderOnly"
+  >
+    highlight end
+  </span>
    match
 </span>
 `;
@@ -26,23 +36,53 @@ exports[`EuiHighlight behavior matching applies to all matches 1`] = `
 }
 
 <span>
+  <span
+    class="euiScreenReaderOnly"
+  >
+    highlight start
+  </span>
   <mark
     class="euiMark emotion-0"
   >
     match
   </mark>
+  <span
+    class="euiScreenReaderOnly"
+  >
+    highlight end
+  </span>
    
+  <span
+    class="euiScreenReaderOnly"
+  >
+    highlight start
+  </span>
   <mark
     class="euiMark emotion-0"
   >
     match
   </mark>
+  <span
+    class="euiScreenReaderOnly"
+  >
+    highlight end
+  </span>
    
+  <span
+    class="euiScreenReaderOnly"
+  >
+    highlight start
+  </span>
   <mark
     class="euiMark emotion-0"
   >
     match
   </mark>
+  <span
+    class="euiScreenReaderOnly"
+  >
+    highlight end
+  </span>
 </span>
 `;
 
@@ -54,11 +94,21 @@ exports[`EuiHighlight behavior matching only applies to first match 1`] = `
 }
 
 <span>
+  <span
+    class="euiScreenReaderOnly"
+  >
+    highlight start
+  </span>
   <mark
     class="euiMark emotion-0"
   >
     match
   </mark>
+  <span
+    class="euiScreenReaderOnly"
+  >
+    highlight end
+  </span>
    match match
 </span>
 `;

--- a/src/components/mark/__snapshots__/mark.test.tsx.snap
+++ b/src/components/mark/__snapshots__/mark.test.tsx.snap
@@ -1,15 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiMark is rendered 1`] = `
-.emotion-0 {
+Array [
+  <span
+    class="euiScreenReaderOnly"
+  >
+    highlight start
+  </span>,
+  .emotion-0 {
   background-color: rgba(0,119,204,0.1);
   font-weight: 700;
   color: #343741;
 }
 
 <mark
-  class="euiMark emotion-0"
->
-  Marked
-</mark>
+    class="euiMark emotion-0"
+  >
+    Marked
+  </mark>,
+  <span
+    class="euiScreenReaderOnly"
+  >
+    highlight end
+  </span>,
+]
 `;

--- a/src/components/mark/mark.tsx
+++ b/src/components/mark/mark.tsx
@@ -6,7 +6,14 @@
  * Side Public License, v 1.
  */
 
-import React, { HTMLAttributes, FunctionComponent, ReactNode } from 'react';
+import React, {
+  HTMLAttributes,
+  Fragment,
+  FunctionComponent,
+  ReactNode,
+} from 'react';
+import { EuiScreenReaderOnly } from '../accessibility';
+import { useEuiI18n } from '../i18n';
 import classNames from 'classnames';
 import { CommonProps } from '../common';
 import { useEuiTheme } from '../../services';
@@ -29,8 +36,16 @@ export const EuiMark: FunctionComponent<EuiMarkProps> = ({
   const classes = classNames('euiMark', className);
 
   return (
-    <mark css={[styles]} className={classes} {...rest}>
-      {children}
-    </mark>
+    <Fragment>
+      <EuiScreenReaderOnly>
+        <span>{useEuiI18n('euiMark.highlightStart', 'highlight start')}</span>
+      </EuiScreenReaderOnly>
+      <mark css={[styles]} className={classes} {...rest}>
+        {children}
+      </mark>
+      <EuiScreenReaderOnly>
+        <span>{useEuiI18n('euiMark.highlightEnd', 'highlight end')}</span>
+      </EuiScreenReaderOnly>
+    </Fragment>
   );
 };

--- a/src/components/selectable/selectable_list/__snapshots__/selectable_list.test.tsx.snap
+++ b/src/components/selectable/selectable_list/__snapshots__/selectable_list.test.tsx.snap
@@ -2227,11 +2227,21 @@ exports[`EuiSelectableListItem props searchValue 1`] = `
               class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
             >
               <span>
+                <span
+                  class="euiScreenReaderOnly"
+                >
+                  highlight start
+                </span>
                 <mark
                   class="euiMark emotion-0"
                 >
                   Mi
                 </mark>
+                <span
+                  class="euiScreenReaderOnly"
+                >
+                  highlight end
+                </span>
                 mas
               </span>
             </span>
@@ -2428,11 +2438,21 @@ exports[`EuiSelectableListItem props searchValue 2`] = `
               class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
             >
               <span>
+                <span
+                  class="euiScreenReaderOnly"
+                >
+                  highlight start
+                </span>
                 <mark
                   class="euiMark emotion-0"
                 >
                   Mi
                 </mark>
+                <span
+                  class="euiScreenReaderOnly"
+                >
+                  highlight end
+                </span>
                 mas
               </span>
             </span>


### PR DESCRIPTION
### Summary

This issue adds screen reader helper text to denote the beginning and end of a highlighted passage of text. The screen reader text uses the `i18n` helper so they are translated properly.

This PR closes #3072. 

### Checklist

- [ ] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] ~~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~~
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] ~~Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~~
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
