### PR TITLE
[Docs] Enable `css` prop in codesandbox

### DIFF
--- a/src-docs/src/components/codesandbox/link.js
+++ b/src-docs/src/components/codesandbox/link.js
@@ -78,7 +78,9 @@ export const CodeSandboxLinkComponent = ({
     /* 2 */
     demoContent = `import React from 'react';
 
-export const Demo = () => (<div css={{ color: 'coral' }}>Hello world!</div>);
+import { EuiButton } from '@elastic/eui';
+
+export const Demo = () => (<EuiButton>Hello world!</EuiButton>);
 `;
   } else {
     /** This cleans the Demo JS example for Code Sanbox.

--- a/src-docs/src/views/accordion/accordion.tsx
+++ b/src-docs/src/views/accordion/accordion.tsx
@@ -7,7 +7,7 @@ export default () => {
   const simpleAccordionId = useGeneratedHtmlId({ prefix: 'simpleAccordion' });
 
   return (
-    <div css={{ color: 'coral' }}>
+    <div>
       <EuiAccordion id={simpleAccordionId} buttonContent="Click me to toggle">
         <EuiPanel color="subdued">
           Any content inside of <strong>EuiAccordion</strong> will appear here.


### PR DESCRIPTION
### Summary

Closes #5614

Prepends the [`@emotion/react` JSX pragma](https://emotion.sh/docs/css-prop#jsx-pragma) to demo content, enabling use of the `css` prop on non-EUI comonents (e.g., HTML elements)

### Checklist

- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Revert [755de9f](https://github.com/elastic/eui/pull/5750/commits/755de9f25886d9991022e7f699c20f673636ffd2)
