### PR TITLE
[EuiIcon] Improve data URI `type` performance

### DIFF
--- a/src-docs/src/views/icon/icon_types.js
+++ b/src-docs/src/views/icon/icon_types.js
@@ -48,6 +48,33 @@ export default () => (
         grow={false}
         style={{ minWidth: 96 }}
       >
+        <EuiIcon
+          type="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1Ni4zMSA1Ni4zMSI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiNmZmY7c3Ryb2tlOiMwMDc4YTA7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjJweDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlBsYW5lIEljb248L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJMYXllcl8xLTIiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNNDkuNTEsNDguOTMsNDEuMjYsMjIuNTIsNTMuNzYsMTBhNS4yOSw1LjI5LDAsMCwwLTcuNDgtNy40N2wtMTIuNSwxMi41TDcuMzgsNi43OUEuNy43LDAsMCwwLDYuNjksN0wxLjIsMTIuNDVhLjcuNywwLDAsMCwwLDFMMTkuODUsMjlsLTcuMjQsNy4yNC03Ljc0LS42YS43MS43MSwwLDAsMC0uNTMuMkwxLjIxLDM5YS42Ny42NywwLDAsMCwuMDgsMUw5LjQ1LDQ2bC4wNywwYy4xMS4xMy4yMi4yNi4zNC4zOHMuMjUuMjMuMzguMzRhLjM2LjM2LDAsMCwwLDAsLjA3TDE2LjMzLDU1YS42OC42OCwwLDAsMCwxLC4wN0wyMC40OSw1MmEuNjcuNjcsMCwwLDAsLjE5LS41NGwtLjU5LTcuNzQsNy4yNC03LjI0TDQyLjg1LDU1LjA2YS42OC42OCwwLDAsMCwxLDBsNS41LTUuNUEuNjYuNjYsMCwwLDAsNDkuNTEsNDguOTNaIi8+PC9nPjwvZz48L3N2Zz4="
+          size="xl"
+          title="My SVG icon"
+        />
+      </EuiSplitPanel.Inner>
+      <EuiSplitPanel.Inner paddingSize="s" color="subdued">
+        <EuiCodeBlock
+          className="eui-textBreakWord"
+          language="html"
+          isCopyable
+          transparentBackground
+          paddingSize="m"
+        >
+          {
+            '<EuiIcon type="data:image/svg+xml;base64,PHN2...=" size="xl" title="My SVG icon" />'
+          }
+        </EuiCodeBlock>
+      </EuiSplitPanel.Inner>
+    </EuiSplitPanel.Outer>
+    <EuiSpacer />
+    <EuiSplitPanel.Outer hasShadow={false} direction="row">
+      <EuiSplitPanel.Inner
+        className="eui-textCenter"
+        grow={false}
+        style={{ minWidth: 96 }}
+      >
         <EuiIcon type={reactSvg} size="xl" title="Custom SVG icon" />
       </EuiSplitPanel.Inner>
       <EuiSplitPanel.Inner paddingSize="s" color="subdued">
@@ -80,6 +107,14 @@ export default () => (
           title="Another SVG Logo"
         >
           http://some.svg
+        </EuiButton>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          iconType="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1Ni4zMSA1Ni4zMSI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiNmZmY7c3Ryb2tlOiMwMDc4YTA7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjJweDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlBsYW5lIEljb248L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJMYXllcl8xLTIiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNNDkuNTEsNDguOTMsNDEuMjYsMjIuNTIsNTMuNzYsMTBhNS4yOSw1LjI5LDAsMCwwLTcuNDgtNy40N2wtMTIuNSwxMi41TDcuMzgsNi43OUEuNy43LDAsMCwwLDYuNjksN0wxLjIsMTIuNDVhLjcuNywwLDAsMCwwLDFMMTkuODUsMjlsLTcuMjQsNy4yNC03Ljc0LS42YS43MS43MSwwLDAsMC0uNTMuMkwxLjIxLDM5YS42Ny42NywwLDAsMCwuMDgsMUw5LjQ1LDQ2bC4wNywwYy4xMS4xMy4yMi4yNi4zNC4zOHMuMjUuMjMuMzguMzRhLjM2LjM2LDAsMCwwLDAsLjA3TDE2LjMzLDU1YS42OC42OCwwLDAsMCwxLC4wN0wyMC40OSw1MmEuNjcuNjcsMCwwLDAsLjE5LS41NGwtLjU5LTcuNzQsNy4yNC03LjI0TDQyLjg1LDU1LjA2YS42OC42OCwwLDAsMCwxLDBsNS41LTUuNUEuNjYuNjYsMCwwLDAsNDkuNTEsNDguOTNaIi8+PC9nPjwvZz48L3N2Zz4="
+          title="Another SVG icon"
+        >
+          data:uri
         </EuiButton>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -691,8 +691,8 @@ export class EuiIcon extends PureComponent<EuiIconProps, State> {
 
     // These icons are a little special and get some extra CSS flexibility
     const isAppIcon =
-      type &&
       typeof type === 'string' &&
+      !/^data:/.test(type) && // Don't further test data URIs (https://github.com/elastic/eui/issues/5741)
       (/.+App$/.test(type) || /.+Job$/.test(type) || type === 'dataVisualizer');
 
     const appIconHasColor = color && color !== 'default';

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -22,6 +22,12 @@ import { enqueueStateChange } from '../../services/react';
 import { htmlIdGenerator } from '../../services';
 import { colorToClassMap, isNamedColor, NamedColor } from './named_colors';
 
+// String starts with 'data:'
+const isDataUri = (type: string) => type.indexOf('data:') === 0;
+// String is 'dataVisualizer', or ends with with 'App' or 'Job'
+const isSpecialIconType = (type: string) =>
+  type === 'dataVisualizer' || type.endsWith('App') || type.endsWith('Job');
+
 const typeToPathMap = {
   accessibility: 'accessibility',
   addDataApp: 'app_add_data',
@@ -691,9 +697,7 @@ export class EuiIcon extends PureComponent<EuiIconProps, State> {
 
     // These icons are a little special and get some extra CSS flexibility
     const isAppIcon =
-      typeof type === 'string' &&
-      !/^data:/.test(type) && // Don't further test data URIs (https://github.com/elastic/eui/issues/5741)
-      (/.+App$/.test(type) || /.+Job$/.test(type) || type === 'dataVisualizer');
+      typeof type === 'string' && !isDataUri(type) && isSpecialIconType(type);
 
     const appIconHasColor = color && color !== 'default';
 


### PR DESCRIPTION
### Summary

Closes #5741

Running an "ends with" regex on a large string (such as a image data URI) takes a long time

**Before**

<img width="1474" alt="Screen Shot 2022-03-29 at 10 42 01 AM" src="https://user-images.githubusercontent.com/2728212/160673990-0a911315-dcc3-4383-96c4-c4a5b36b369b.png">

<br />
<br />
<br />
So using alternative string search methods help immensely

**After**

<img width="1303" alt="Screen Shot 2022-03-29 at 10 43 13 AM" src="https://user-images.githubusercontent.com/2728212/160674108-1497e4ee-467d-44e4-b8d0-239cc7a434eb.png">


We could use `indexOf` instead of `endsWith`, but there's extra logic involved to prevent `-1` matches. We're using the fastest method to bypass additional parsing of data URIs so I'm less concerned with perf after that point. `endsWith` provides a good bump compared to the regex (.1ms vs 2ms for URL strings).


### Checklist

- [ ] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
