### PR TITLE
Update renovate configuration to include @elastic/charts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,8 @@
       "enabled": true
     },
     {
-      "matchPackagePatterns": [".*"],
+      "matchPackagePatterns": ["*"],
+      "excludePackagePatterns": ["^@elastic/charts$"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
### Summary

This updates the renovate configuration to re-enable updates to `@elastic/charts`. I initially tried some negative lookaheads but the `re2` package used by renovate [doesn't support lookaheads](https://github.com/renovatebot/config-help/issues/540) and then came across a [discussion](https://github.com/renovatebot/renovate/discussions/14713#discussioncomment-2380555) with an approach that worked.

I tested this by creating a [new repo](https://github.com/chandlerprall/renovate-testing) and configured renovate there by copying EUI's _renovate.json_ configuration into the [PR to enable renovate](https://github.com/chandlerprall/renovate-testing/pull/1), which provides a **What to Expect** section now listing only the `@elastic/charts` package. Prior to the proposed configuration, all 3 packages in that repo were listed for upgrades.

Output from renovate running against that repo/pr, showing the two disabled deps + the detected upgrade for charts:

```
DEBUG: baseBranch: main
DEBUG: Dependency is disabled (react)(dependency="react")
DEBUG: Dependency is disabled (@cypress/react)(dependency="@cypress/react")
DEBUG: Package releases lookups complete
{
  "baseBranch": "main"
}
DEBUG: branchifyUpgrades
DEBUG: Using group branchName template
DEBUG: Dependency @elastic/charts is part of group @elastic/charts
DEBUG: 1 flattened updates found: @elastic/charts
DEBUG: Returning 1 branch(es)
DEBUG: Fetching changelog: https://github.com/elastic/elastic-charts (41.0.1 -> 45.1.1)
```