### PR TITLE
[EuiDataGrid] When a cell expansion popover is closed, ensure focus is always returned to the originating cell for keyboard users

### DIFF
--- a/src/components/datagrid/body/data_grid_cell_popover.spec.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.spec.tsx
@@ -30,7 +30,7 @@ describe('EuiDataGridCellPopover', () => {
       cy.realMount(<EuiDataGrid {...baseProps} />);
       cy.get(
         '[data-gridcell-row-index="0"][data-gridcell-column-index="0"]'
-      ).click();
+      ).realClick();
 
       cy.realPress('Enter');
       cy.focused().should(
@@ -49,11 +49,9 @@ describe('EuiDataGridCellPopover', () => {
       cy.realMount(<EuiDataGrid {...baseProps} />);
       cy.get(
         '[data-gridcell-row-index="0"][data-gridcell-column-index="0"]'
-      ).click();
+      ).realClick();
 
-      cy.get('[data-test-subj="euiDataGridCellExpandButton"]').click({
-        force: true,
-      });
+      cy.get('[data-test-subj="euiDataGridCellExpandButton"]').realClick();
       cy.focused().should(
         'have.attr',
         'data-test-subj',
@@ -70,11 +68,9 @@ describe('EuiDataGridCellPopover', () => {
       cy.realMount(<EuiDataGrid {...baseProps} />);
       cy.get(
         '[data-gridcell-row-index="1"][data-gridcell-column-index="1"]'
-      ).click();
+      ).realClick();
 
-      cy.get('[data-test-subj="euiDataGridCellExpandButton"]').click({
-        force: true,
-      });
+      cy.get('[data-test-subj="euiDataGridCellExpandButton"]').realClick();
       cy.focused().should(
         'have.attr',
         'data-test-subj',

--- a/src/components/datagrid/body/data_grid_cell_popover.spec.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.spec.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../../cypress/support"/>
+
+import React from 'react';
+import { EuiDataGrid, EuiDataGridProps } from '../';
+
+const baseProps: EuiDataGridProps = {
+  'aria-label': 'Grid cell popover test',
+  height: 300,
+  width: 300,
+  columns: [{ id: 'A' }, { id: 'B' }],
+  rowCount: 2,
+  renderCellValue: ({ rowIndex, columnId }) => `${columnId}, ${rowIndex}`,
+  columnVisibility: {
+    visibleColumns: ['A', 'B'],
+    setVisibleColumns: () => {},
+  },
+};
+
+describe('EuiDataGridCellPopover', () => {
+  describe('manually restores focus to the originating cell when the cell popover is closed', () => {
+    it('when Enter key and then Escape key is pressed', () => {
+      cy.realMount(<EuiDataGrid {...baseProps} />);
+      cy.get(
+        '[data-gridcell-row-index="0"][data-gridcell-column-index="0"]'
+      ).click();
+
+      cy.realPress('Enter');
+      cy.focused().should(
+        'have.attr',
+        'data-test-subj',
+        'euiDataGridExpansionPopover'
+      );
+
+      cy.realPress('Escape');
+      cy.focused()
+        .should('have.attr', 'data-gridcell-column-index', '0')
+        .should('have.attr', 'data-gridcell-row-index', '0');
+    });
+
+    it('when the expand button is clicked and then Escape key is pressed', () => {
+      cy.realMount(<EuiDataGrid {...baseProps} />);
+      cy.get(
+        '[data-gridcell-row-index="0"][data-gridcell-column-index="0"]'
+      ).click();
+
+      cy.get('[data-test-subj="euiDataGridCellExpandButton"]').click({
+        force: true,
+      });
+      cy.focused().should(
+        'have.attr',
+        'data-test-subj',
+        'euiDataGridExpansionPopover'
+      );
+
+      cy.realPress('Escape');
+      cy.focused()
+        .should('have.attr', 'data-gridcell-column-index', '0')
+        .should('have.attr', 'data-gridcell-row-index', '0');
+    });
+
+    it('when the expand button is clicked and then F2 key is pressed', () => {
+      cy.realMount(<EuiDataGrid {...baseProps} />);
+      cy.get(
+        '[data-gridcell-row-index="1"][data-gridcell-column-index="1"]'
+      ).click();
+
+      cy.get('[data-test-subj="euiDataGridCellExpandButton"]').click({
+        force: true,
+      });
+      cy.focused().should(
+        'have.attr',
+        'data-test-subj',
+        'euiDataGridExpansionPopover'
+      );
+
+      cy.realPress('F2');
+      cy.focused()
+        .should('have.attr', 'data-gridcell-column-index', '1')
+        .should('have.attr', 'data-gridcell-row-index', '1');
+    });
+  });
+});

--- a/src/components/datagrid/body/data_grid_cell_popover.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.test.tsx
@@ -70,7 +70,7 @@ describe('useCellPopover', () => {
     });
   });
 
-  describe('cellPopver', () => {
+  describe('cellPopover', () => {
     const mockPopoverAnchor = document.createElement('div');
     const mockPopoverContent = (
       <div data-test-subj="mockPopover">Hello world</div>
@@ -120,6 +120,20 @@ describe('useCellPopover', () => {
     });
 
     describe('onKeyDown', () => {
+      let rafSpy: jest.SpyInstance;
+      beforeAll(() => {
+        rafSpy = jest
+          .spyOn(window, 'requestAnimationFrame')
+          .mockImplementation((cb: Function) => cb());
+      });
+      beforeEach(() => jest.clearAllMocks());
+      afterAll(() => rafSpy.mockRestore());
+
+      // Mock a focusable cell parent
+      const mockCell = document.createElement('div');
+      mockCell.tabIndex = 0;
+      mockCell.appendChild(mockPopoverAnchor);
+
       const renderCellPopover = () => {
         const {
           return: { cellPopoverContext },
@@ -135,7 +149,7 @@ describe('useCellPopover', () => {
         return { component, getUpdatedState };
       };
 
-      it('closes the popover when the Escape key is pressed', () => {
+      it('closes the popover and refocuses the cell when the Escape key is pressed', () => {
         const { component, getUpdatedState } = renderCellPopover();
         expect(getUpdatedState().cellPopoverContext.popoverIsOpen).toEqual(
           true
@@ -149,12 +163,13 @@ describe('useCellPopover', () => {
         act(() => {
           component.find('EuiWrappingPopover').simulate('keyDown', event);
         });
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(event.stopPropagation).toHaveBeenCalled();
 
         expect(getUpdatedState().cellPopoverContext.popoverIsOpen).toEqual(
           false
         );
-        expect(event.preventDefault).toHaveBeenCalled();
-        expect(event.stopPropagation).toHaveBeenCalled();
+        expect(document.activeElement).toEqual(mockCell);
       });
 
       it('closes the popover when the F2 key is pressed', () => {
@@ -171,12 +186,13 @@ describe('useCellPopover', () => {
         act(() => {
           component.find('EuiWrappingPopover').simulate('keyDown', event);
         });
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(event.stopPropagation).toHaveBeenCalled();
 
         expect(getUpdatedState().cellPopoverContext.popoverIsOpen).toEqual(
           false
         );
-        expect(event.preventDefault).toHaveBeenCalled();
-        expect(event.stopPropagation).toHaveBeenCalled();
+        expect(document.activeElement).toEqual(mockCell);
       });
 
       it('does nothing when other keys are pressed', () => {
@@ -193,12 +209,13 @@ describe('useCellPopover', () => {
         act(() => {
           component.find('EuiWrappingPopover').simulate('keyDown', event);
         });
+        expect(event.preventDefault).not.toHaveBeenCalled();
+        expect(event.stopPropagation).not.toHaveBeenCalled();
+        expect(rafSpy).not.toHaveBeenCalled();
 
         expect(getUpdatedState().cellPopoverContext.popoverIsOpen).toEqual(
           true
         );
-        expect(event.preventDefault).not.toHaveBeenCalled();
-        expect(event.stopPropagation).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/components/datagrid/body/data_grid_cell_popover.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.tsx
@@ -89,6 +89,8 @@ export const useCellPopover = (): {
           event.preventDefault();
           event.stopPropagation();
           closeCellPopover();
+          // Ensure focus is returned to the parent cell
+          requestAnimationFrame(() => popoverAnchor.parentElement!.focus());
         }
       }}
     >

--- a/upcoming_changelogs/5761.md
+++ b/upcoming_changelogs/5761.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiDataGrid` cell focus sometimes not being restored for keyboard users when cell expansion popovers were closed


### PR DESCRIPTION
### Summary

This PR closes https://github.com/elastic/eui/issues/5646 by manually returning `.focus()` to the originating cell when a popover is closed by keyboard users (the escape key or the F2 key). This applies to two separate buggy use cases:

1. When VoiceOver is open (see detailed convo in #5646, this appears to be a very strange Mac/VO quirk)
2. When the user uses a **mouse** button on the expand icon to open the popover, but uses the **Escape key** to close the popover

### Before
![before](https://user-images.githubusercontent.com/549407/161836669-fb797524-db14-4084-854b-70eab5b88877.gif)

### After
![after](https://user-images.githubusercontent.com/549407/161836021-327eec3e-75f4-4d4e-aac1-278b2e78b1a7.gif)

### Checklist

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
