### PR TITLE
Reducing the snapshot output of EuiMark unit tests.

### DIFF
--- a/scripts/jest/setup/emotion.js
+++ b/scripts/jest/setup/emotion.js
@@ -1,4 +1,6 @@
-import { createSerializer } from "@emotion/jest";
+import { createSerializer, matchers } from "@emotion/jest";
+
+expect.extend(matchers);
 
 module.exports = createSerializer({
   classNameReplacer: (className) => className,

--- a/src/components/mark/__snapshots__/mark.test.tsx.snap
+++ b/src/components/mark/__snapshots__/mark.test.tsx.snap
@@ -43,19 +43,3 @@ exports[`EuiMark is rendered: renders with emotion styles 1`] = `
   Marked
 </mark>
 `;
-
-exports[`No screen reader helper text is rendered without CSS :before and :after text 1`] = `
-.css-dtzpxu-euiMarkStyles-EuiMark {
-  background-color: rgba(0,119,204,0.1);
-  font-weight: 700;
-  color: #343741;
-}
-
-<mark
-  aria-label="aria-label"
-  class="euiMark testClass1 testClass2 css-dtzpxu-euiMarkStyles-EuiMark"
-  data-test-subj="test subject string"
->
-  Marked
-</mark>
-`;

--- a/src/components/mark/__snapshots__/mark.test.tsx.snap
+++ b/src/components/mark/__snapshots__/mark.test.tsx.snap
@@ -9,37 +9,3 @@ exports[`EuiMark is rendered 1`] = `
   Marked
 </mark>
 `;
-
-exports[`EuiMark is rendered: renders with emotion styles 1`] = `
-.css-b9vly9-euiMarkStyles-EuiMark {
-  background-color: rgba(0,119,204,0.1);
-  font-weight: 700;
-  color: #343741;
-}
-
-.css-b9vly9-euiMarkStyles-EuiMark:before,
-.css-b9vly9-euiMarkStyles-EuiMark:after {
-  -webkit-clip-path: inset(100%);
-  clip-path: inset(100%);
-  clip: rect(1px, 1px, 1px, 1px);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.css-b9vly9-euiMarkStyles-EuiMark:before {
-  content: ' [highlight start] ';
-}
-
-.css-b9vly9-euiMarkStyles-EuiMark:after {
-  content: ' [highlight end] ';
-}
-
-<mark
-  class="euiMark css-b9vly9-euiMarkStyles-EuiMark"
->
-  Marked
-</mark>
-`;

--- a/src/components/mark/mark.test.tsx
+++ b/src/components/mark/mark.test.tsx
@@ -8,26 +8,20 @@
 
 import React from 'react';
 import { render } from 'enzyme';
-import { matchers } from '@emotion/jest';
 import { renderWithStyles } from '../../test/internal';
 import { requiredProps } from '../../test/required_props';
 
 import { EuiMark } from './mark';
 
-// Add the custom matchers provided by '@emotion/jest'
-expect.extend(matchers);
-
 describe('EuiMark', () => {
-  renderWithStyles(<EuiMark {...requiredProps}>Marked</EuiMark>);
+  renderWithStyles(<EuiMark>Marked</EuiMark>);
 
   test('is rendered', () => {
     expect(
       render(<EuiMark {...requiredProps}>Marked</EuiMark>)
     ).toMatchSnapshot();
   });
-});
 
-describe('No screen reader helper text', () => {
   test('is rendered without CSS :before', () => {
     expect(
       render(

--- a/src/components/mark/mark.test.tsx
+++ b/src/components/mark/mark.test.tsx
@@ -8,13 +8,17 @@
 
 import React from 'react';
 import { render } from 'enzyme';
+import { matchers } from '@emotion/jest';
 import { renderWithStyles } from '../../test/internal';
 import { requiredProps } from '../../test/required_props';
 
 import { EuiMark } from './mark';
 
+// Add the custom matchers provided by '@emotion/jest'
+expect.extend(matchers);
+
 describe('EuiMark', () => {
-  renderWithStyles(<EuiMark>Marked</EuiMark>);
+  renderWithStyles(<EuiMark {...requiredProps}>Marked</EuiMark>);
 
   test('is rendered', () => {
     expect(
@@ -24,15 +28,23 @@ describe('EuiMark', () => {
 });
 
 describe('No screen reader helper text', () => {
-  renderWithStyles(<EuiMark>Marked</EuiMark>);
-
-  test('is rendered without CSS :before and :after text', () => {
+  test('is rendered without CSS :before', () => {
     expect(
       render(
         <EuiMark hasScreenReaderHelpText={false} {...requiredProps}>
           Marked
         </EuiMark>
       )
-    ).toMatchSnapshot();
+    ).not.toHaveStyleRule('content', "' [highlight start] '");
+  });
+
+  test('is rendered without CSS :after', () => {
+    expect(
+      render(
+        <EuiMark hasScreenReaderHelpText={false} {...requiredProps}>
+          Marked
+        </EuiMark>
+      )
+    ).not.toHaveStyleRule('content', "' [highlight end] '");
   });
 });


### PR DESCRIPTION
### Summary
The PR #5739 called `renderWithStyles()` twice in a unit test, and it started causing an error. We decided to call `renderWithStyles()` once, and use the [Emotion/jest style checkers](https://emotion.sh/docs/@emotion/jest#tohavestylerule) to assert CSS was not present when `hasScreenReaderText` was set to false.

### Checklist

- [ ] ~~Checked in both **light and dark** modes~~
- [ ] ~~Checked in **mobile**~~
- [ ] ~~Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~~
- [ ] ~~Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~~
- [ ] ~~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~~
- [ ] ~~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [ ] ~~Checked for **accessibility** including keyboard-only and screenreader modes~~
- [ ] ~~Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~~
- [ ] ~~A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~~
