### PR TITLE
Adding an explicit node check to Data Grid test.

### DIFF
--- a/src/components/datagrid/body/data_grid_footer_row.spec.tsx
+++ b/src/components/datagrid/body/data_grid_footer_row.spec.tsx
@@ -57,7 +57,7 @@ describe('EuiDataGridFooterRow', () => {
 
     cy.get(
       '[data-gridcell-column-index="0"][data-gridcell-row-index="3"]'
-    ).click();
+    ).click('topLeft');
     cy.get('[data-test-subj="euiDataGridCellExpandButton"]').should(
       'not.exist'
     );
@@ -70,23 +70,25 @@ describe('EuiDataGridFooterRow', () => {
     cy.get(
       '[data-gridcell-column-index="1"][data-gridcell-row-index="-1"]'
     ).click();
-    cy.contains('Move left').click();
 
-    cy.get('[data-gridcell-column-index="0"][data-gridcell-row-index="3"]')
+    cy.get('[data-test-subj="dataGridHeaderCellActionGroup-b"]')
+      .contains('Move left')
       .click()
-      .contains('45')
-      .click();
+      .wait(50);
 
     // Note that the wait/timeout and multiple focused assertions are required for
     // for this specific bug which bounces focus rapidly between cells, as otherwise
     // Cypress re-tries until it happens to be on the cell with correct attributes
-    cy.wait(50);
     const checkFocusedCell = () => {
-      cy.wait(1);
-      cy.focused({ timeout: 0 })
+      cy.get('[data-gridcell-column-index="0"][data-gridcell-row-index="3"]')
+        .click()
+        .wait(50)
+        .contains('45')
+        .focused()
         .should('have.attr', 'data-gridcell-column-index', '0')
         .should('not.have.attr', 'data-gridcell-column-index', '1');
     };
+
     checkFocusedCell();
     checkFocusedCell();
     checkFocusedCell();

--- a/src/components/datagrid/data_grid.spec.tsx
+++ b/src/components/datagrid/data_grid.spec.tsx
@@ -371,7 +371,10 @@ describe('EuiDataGrid', () => {
           '[data-gridcell-column-index="3"][data-gridcell-row-index="0"]'
         ).click();
         cy.focused().type('{enter}');
-        cy.focused().should('have.attr', 'data-test-subj', 'focusOnMe'); // focus trap focuses the link
+        // Get the link that should receive focus after Enter key is pressed
+        cy.get('[data-test-subj="focusOnMe"]')
+          .focused()
+          .should('have.attr', 'data-test-subj', 'focusOnMe'); // focus trap focuses the link
         cy.focused().type('{esc}');
         cy.focused()
           .should('have.attr', 'data-gridcell-column-index', '3')


### PR DESCRIPTION
### Summary

Still trying to isolate flaky Cypress tests. Adding an explicit `cy.get()` to ensure the focused link is in the DOM before we make the next assertion. Looped the test 20 times on local machine with Cypress test runner and in headless mode, zero failures.

### Checklist

- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**