### PR TITLE
[Docs] Fix demo export types

### DIFF
--- a/src-docs/src/views/highlight_and_mark/highlight.js
+++ b/src-docs/src/views/highlight_and_mark/highlight.js
@@ -8,7 +8,7 @@ import {
   EuiSwitch,
 } from '../../../../src/components';
 
-export function Highlight() {
+export default () => {
   const [searchValue, setSearchValue] = useState('jumped over');
   const [isHighlightAll, setHighlightAll] = useState(false);
 
@@ -42,4 +42,4 @@ export function Highlight() {
       </EuiHighlight>
     </Fragment>
   );
-}
+};

--- a/src-docs/src/views/highlight_and_mark/highlight_and_mark_example.js
+++ b/src-docs/src/views/highlight_and_mark/highlight_and_mark_example.js
@@ -6,8 +6,8 @@ import { EuiCode, EuiHighlight, EuiMark } from '../../../../src/components';
 
 import { highlightConfig, markConfig } from './playground';
 
-import { Highlight } from './highlight';
-import { Mark } from './mark';
+import Highlight from './highlight';
+import Mark from './mark';
 
 const highlightSource = require('!!raw-loader!./highlight');
 const highlightSnippet = `<EuiHighlight search={searchValue} highlightAll={isHighlightAll}>

--- a/src-docs/src/views/highlight_and_mark/mark.js
+++ b/src-docs/src/views/highlight_and_mark/mark.js
@@ -2,10 +2,10 @@ import React, { Fragment } from 'react';
 
 import { EuiMark } from '../../../../src/components';
 
-export function Mark() {
+export default () => {
   return (
     <Fragment>
       The quick brown fox <EuiMark>jumped over</EuiMark> the lazy dog
     </Fragment>
   );
-}
+};


### PR DESCRIPTION
### Summary

Changes named demo exports (which our codesandbox regex doesn't understand) to `export default () =>`

~### Checklist~
