### PR TITLE
[EuiComboBox] keep focus on the combobox input when clicking disabled options

### DIFF
--- a/src/components/combo_box/combo_box.spec.tsx
+++ b/src/components/combo_box/combo_box.spec.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React from 'react';
+import { EuiComboBox } from './index';
+
+describe('EuiComboBox', () => {
+  describe('Focus management', () => {
+    it('keeps focus on the input box when clicking a disabled item', () => {
+      cy.realMount(
+        <EuiComboBox
+          data-test-subj="combobox"
+          options={[
+            { label: 'Item 1' },
+            { label: 'Item 2', disabled: true },
+            { label: 'Item 3' },
+          ]}
+        />
+      );
+
+      cy.get(
+        '[data-test-subj=combobox] [data-test-subj=comboBoxSearchInput]'
+      ).realClick();
+
+      cy.get('span').contains('Item 2').realClick();
+
+      cy.focused().should('have.attr', 'data-test-subj', 'comboBoxSearchInput');
+    });
+  });
+});

--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -550,7 +550,7 @@ export class EuiComboBox<T> extends Component<
   };
 
   onContainerBlur: EventListener = (event) => {
-    // close the options list, unless the use clicked on an option
+    // close the options list, unless the user clicked on an option
 
     /**
      * FireFox returns `relatedTarget` as `null` for security reasons, but provides a proprietary `explicitOriginalTarget`.
@@ -586,6 +586,10 @@ export class EuiComboBox<T> extends Component<
       if (!this.hasActiveOption()) {
         this.setCustomOptions(true);
       }
+    } else if (focusedInOptionsList) {
+      // https://github.com/elastic/eui/issues/5179
+      // need to restore focus to the input box when clicking non-interactive elements
+      this.searchInputRefInstance?.focus();
     }
   };
 

--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -589,7 +589,12 @@ export class EuiComboBox<T> extends Component<
     } else if (focusedInOptionsList) {
       // https://github.com/elastic/eui/issues/5179
       // need to restore focus to the input box when clicking non-interactive elements
-      this.searchInputRefInstance?.focus();
+
+      // firefox doesn't support calling .focus() during a blur event
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=53579
+      requestAnimationFrame(() => {
+        this.searchInputRefInstance?.focus();
+      });
     }
   };
 

--- a/upcoming_changelogs/5795.md
+++ b/upcoming_changelogs/5795.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiComboBox` losing focus when a disabled option is clicked


### PR DESCRIPTION
### Summary

Fixes #5179 , addressing https://github.com/elastic/kibana/issues/111335

**EuiComboBox** has a custom `blur` handler to know when it should close the options popover and assumes various callbacks or other method invocations will restore focus to the input box. This change removes that assumption and explicitly restores focus.

### Checklist

~- [ ] Checked in both **light and dark** modes~
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
