### PR TITLE
[EuiDataGrid] Fix cell popover close on cell click unintentionally affecting complex cell popovers

### DIFF
--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -397,14 +397,13 @@ export class EuiDataGridCell extends Component<
             interactables[0].focus();
             this.setState({ disableCellTabIndex: true });
           }
-
-          // Close the cell popover if the popover was open and the user clicked the cell
-          if (this.props.popoverContext.popoverIsOpen) {
-            this.props.popoverContext.closeCellPopover();
-          }
         },
         0
       );
+      // Close the cell popover if the popover was open and the user clicked the cell
+      if (this.props.popoverContext.popoverIsOpen) {
+        this.props.popoverContext.closeCellPopover();
+      }
     }
   };
 

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -397,6 +397,11 @@ export class EuiDataGridCell extends Component<
             interactables[0].focus();
             this.setState({ disableCellTabIndex: true });
           }
+
+          // Close the cell popover if the popover was open and the user clicked the cell
+          if (this.props.popoverContext.popoverIsOpen) {
+            this.props.popoverContext.closeCellPopover();
+          }
         },
         0
       );

--- a/src/components/datagrid/body/data_grid_cell_popover.spec.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.spec.tsx
@@ -83,4 +83,21 @@ describe('EuiDataGridCellPopover', () => {
         .should('have.attr', 'data-gridcell-row-index', '1');
     });
   });
+
+  it('closes the cell popover when the originating cell is clicked', () => {
+    cy.realMount(<EuiDataGrid {...baseProps} />);
+    cy.get(
+      '[data-gridcell-row-index="0"][data-gridcell-column-index="0"]'
+    ).realClick();
+
+    cy.get('[data-test-subj="euiDataGridCellExpandButton"]').realClick();
+    cy.get('[data-test-subj="euiDataGridExpansionPopover"]').should('exist');
+
+    cy.get(
+      '[data-gridcell-row-index="0"][data-gridcell-column-index="0"]'
+    ).realClick();
+    cy.get('[data-test-subj="euiDataGridExpansionPopover"]').should(
+      'not.exist'
+    );
+  });
 });

--- a/src/components/datagrid/body/data_grid_cell_popover.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.test.tsx
@@ -101,7 +101,6 @@ describe('useCellPopover', () => {
           hasArrow={false}
           isOpen={true}
           onKeyDown={[Function]}
-          onTrapDeactivation={[Function]}
           panelClassName="euiDataGridRowCell__popover"
           panelPaddingSize="s"
           panelProps={

--- a/src/components/datagrid/body/data_grid_cell_popover.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.tsx
@@ -83,7 +83,6 @@ export const useCellPopover = (): {
         'data-test-subj': 'euiDataGridExpansionPopover',
       }}
       closePopover={closeCellPopover}
-      onTrapDeactivation={closeCellPopover}
       onKeyDown={(event) => {
         if (event.key === keys.F2 || event.key === keys.ESCAPE) {
           event.preventDefault();

--- a/upcoming_changelogs/5797.md
+++ b/upcoming_changelogs/5797.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed an `EuiDataGrid` bug occurring when closing cell popovers on clicking the originating cell. The original fix was unintentionally affecting cell popovers with nested modals, popovers, etc.


### PR DESCRIPTION
### Summary

This PR essentially reverts the approach used in https://github.com/elastic/eui/pull/5681 as it is causing the Security team unintentional headaches/bugs, detailed in https://github.com/elastic/kibana/issues/128626#issuecomment-1099554165.

This PR will need to be backported to v53.0.2 and then further backported to Kibana's 8.2 branch before the next BC.

### Checklist

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~ `onFocus` should work for tap events as well
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~ Applies to mouse clicks only, not possible to focus originating cell without popover already having been closed otherwise

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately