### PR TITLE
Adding `describe` block to EuiMark unit test that omits screen reader helper text

### DIFF
--- a/src/components/mark/__snapshots__/mark.test.tsx.snap
+++ b/src/components/mark/__snapshots__/mark.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiMark is rendered with screen reader helper text is rendered 1`] = `
+exports[`EuiMark is rendered 1`] = `
 <mark
   aria-label="aria-label"
   class="euiMark testClass1 testClass2 css-b9vly9-euiMarkStyles-EuiMark"

--- a/src/components/mark/__snapshots__/mark.test.tsx.snap
+++ b/src/components/mark/__snapshots__/mark.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiMark is rendered 1`] = `
+exports[`EuiMark is rendered with screen reader helper text is rendered 1`] = `
 <mark
   aria-label="aria-label"
   class="euiMark testClass1 testClass2 css-b9vly9-euiMarkStyles-EuiMark"

--- a/src/components/mark/mark.test.tsx
+++ b/src/components/mark/mark.test.tsx
@@ -16,12 +16,10 @@ import { EuiMark } from './mark';
 describe('EuiMark', () => {
   renderWithStyles(<EuiMark>Marked</EuiMark>);
 
-  describe('is rendered with screen reader helper text', () => {
-    test('is rendered', () => {
-      expect(
-        render(<EuiMark {...requiredProps}>Marked</EuiMark>)
-      ).toMatchSnapshot();
-    });
+  test('is rendered', () => {
+    expect(
+      render(<EuiMark {...requiredProps}>Marked</EuiMark>)
+    ).toMatchSnapshot();
   });
 
   describe('No screen reader helper text', () => {

--- a/src/components/mark/mark.test.tsx
+++ b/src/components/mark/mark.test.tsx
@@ -16,29 +16,33 @@ import { EuiMark } from './mark';
 describe('EuiMark', () => {
   renderWithStyles(<EuiMark>Marked</EuiMark>);
 
-  test('is rendered', () => {
-    expect(
-      render(<EuiMark {...requiredProps}>Marked</EuiMark>)
-    ).toMatchSnapshot();
+  describe('is rendered with screen reader helper text', () => {
+    test('is rendered', () => {
+      expect(
+        render(<EuiMark {...requiredProps}>Marked</EuiMark>)
+      ).toMatchSnapshot();
+    });
   });
 
-  test('is rendered without CSS :before', () => {
-    expect(
-      render(
-        <EuiMark hasScreenReaderHelpText={false} {...requiredProps}>
-          Marked
-        </EuiMark>
-      )
-    ).not.toHaveStyleRule('content', "' [highlight start] '");
-  });
+  describe('No screen reader helper text', () => {
+    test('is rendered without CSS :before', () => {
+      expect(
+        render(
+          <EuiMark hasScreenReaderHelpText={false} {...requiredProps}>
+            Marked
+          </EuiMark>
+        )
+      ).not.toHaveStyleRule('content', "' [highlight start] '");
+    });
 
-  test('is rendered without CSS :after', () => {
-    expect(
-      render(
-        <EuiMark hasScreenReaderHelpText={false} {...requiredProps}>
-          Marked
-        </EuiMark>
-      )
-    ).not.toHaveStyleRule('content', "' [highlight end] '");
+    test('is rendered without CSS :after', () => {
+      expect(
+        render(
+          <EuiMark hasScreenReaderHelpText={false} {...requiredProps}>
+            Marked
+          </EuiMark>
+        )
+      ).not.toHaveStyleRule('content', "' [highlight end] '");
+    });
   });
 });


### PR DESCRIPTION
### Summary
@constancecchen [recommended](https://github.com/elastic/eui/pull/5772#discussion_r845569689) keeping a `describe` block for two new tests that omitted CSS :before and :after helper text as part of PR #5772. This PR adds that block back for readability.

### Checklist

- [ ] ~~Checked in both **light and dark** modes~~
- [ ] ~~Checked in **mobile**~~
- [ ] ~~Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~~
- [ ] ~~Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~~
- [ ] ~~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~~
- [ ] ~~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~~
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] ~~Checked for **breaking changes** and labeled appropriately~~
- [ ] ~~Checked for **accessibility** including keyboard-only and screenreader modes~~
- [ ] ~~Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~~
- [ ] ~~A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~~
