### PR TITLE
[Jest] Remove `_isJest` polyfill

### DIFF
--- a/scripts/jest/setup/polyfills.js
+++ b/scripts/jest/setup/polyfills.js
@@ -1,10 +1,5 @@
 import { MutationObserver, MutationNotifier } from '../polyfills/mutation_observer';
 
-// used by data_grid.tsx to return a column size for the jest environment
-// long term, we need to find an in-browser test environment for these
-// e.g. cypress
-global._isJest = true;
-
 // polyfill window.MutationObserver and intersect jsdom's relevant methods
 // from https://github.com/aurelia/pal-nodejs
 // https://github.com/aurelia/pal-nodejs/blob/56396ff7c7693669dbafc8e9e49ee6bc29472f12/src/nodejs-pal-builder.ts#L63

--- a/src/utils/is_jest.ts
+++ b/src/utils/is_jest.ts
@@ -6,4 +6,4 @@
  * Side Public License, v 1.
  */
 
-export const IS_JEST_ENVIRONMENT = global.hasOwnProperty('_isJest');
+export const IS_JEST_ENVIRONMENT = typeof jest !== 'undefined';


### PR DESCRIPTION
### Summary

_Taking a page from Caroline's book and using an "on" Friday to go through the backlog_

Closes #3713 

Uses the check against the global `jest` namespace [mentioned therein](https://github.com/elastic/eui/issues/3713#issuecomment-771785574) rather than adding to `global`. Note that we should remove polyfill from Kibana, also, after this is released: https://github.com/elastic/kibana/blob/cf844371e4ceeae5471b8d26d073f27776545433/packages/kbn-test/src/jest/setup/polyfills.jsdom.js#L18-L20

~### Checklist~
