### PR TITLE
[Dev-only] Release script improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "start-test-server": "BABEL_MODULES=false NODE_ENV=puppeteer NODE_OPTIONS=--max-old-space-size=4096 webpack-dev-server --config src-docs/webpack.config.js --port 9999",
     "yo-component": "yo ./generator-eui/app/component.js",
     "update-token-changelog": "node ./scripts/update-token-changelog.js",
+    "update-changelog-manual": "node -e \"require('./scripts/update-changelog').manualChangelog('${npm_config_release}')\"",
     "start-test-server-and-a11y-test": "cross-env WAIT_ON_TIMEOUT=600000 start-server-and-test start-test-server http-get://localhost:9999 test-a11y",
     "yo-doc": "yo ./generator-eui/app/documentation.js",
     "yo-changelog": "yo ./generator-eui/changelog/index.js",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -62,14 +62,14 @@ if (args.dry_run) {
     // to i18ntokens_changelog.json, comitting both to the workspace before running `npm version`
     execSync(`npm run update-token-changelog -- ${versionTarget}`, execOptions);
 
+    // Update CHANGELOG.md
+    updateChangelog(changelog, versionTarget);
+
     // Clear any local tags
     execSync('git fetch upstream --tags --prune --prune-tags');
 
     // update package.json & package-lock.json version, git commit, git tag
     execSync(`npm version ${versionTarget}`, execOptions);
-
-    // Update CHANGELOG.md
-    updateChangelog(changelog);
   }
 
   if (args.steps.indexOf('tag') > -1) {

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -62,6 +62,9 @@ if (args.dry_run) {
     // to i18ntokens_changelog.json, comitting both to the workspace before running `npm version`
     execSync(`npm run update-token-changelog -- ${versionTarget}`, execOptions);
 
+    // Clear any local tags
+    execSync('git fetch upstream --tags --prune --prune-tags');
+
     // update package.json & package-lock.json version, git commit, git tag
     execSync(`npm version ${versionTarget}`, execOptions);
 

--- a/scripts/tests/update-changelog.test.js
+++ b/scripts/tests/update-changelog.test.js
@@ -120,7 +120,7 @@ describe('getUpcomingVersion', () => {
   test('patch', () => {
     expect(getUpcomingVersion('patch')).toEqual('1.2.4');
   });
-  test('major', () => {
+  test('minor', () => {
     expect(getUpcomingVersion('minor')).toEqual('1.3.0');
   });
   test('major', () => {

--- a/scripts/tests/update-changelog.test.js
+++ b/scripts/tests/update-changelog.test.js
@@ -1,4 +1,7 @@
-const { collateChangelogFiles } = require('../update-changelog');
+const {
+  collateChangelogFiles,
+  getUpcomingVersion,
+} = require('../update-changelog');
 
 // Mock files
 jest.mock('fs', () => ({
@@ -106,5 +109,21 @@ describe('collateChangelogFiles', () => {
     expect(() => collateChangelogFiles()).toThrowError(
       /No upcoming changelog files/
     );
+  });
+});
+
+describe('getUpcomingVersion', () => {
+  jest.mock('../../package.json', () => ({
+    version: '1.2.3',
+  }));
+
+  test('patch', () => {
+    expect(getUpcomingVersion('patch')).toEqual('1.2.4');
+  });
+  test('major', () => {
+    expect(getUpcomingVersion('minor')).toEqual('1.3.0');
+  });
+  test('major', () => {
+    expect(getUpcomingVersion('major')).toEqual('2.0.0');
   });
 });

--- a/scripts/update-changelog.js
+++ b/scripts/update-changelog.js
@@ -159,8 +159,28 @@ const getUpcomingVersion = (versionTarget) => {
   return [major, minor, patch].join('.');
 };
 
+/**
+ * Command to manually update the changelog (standalone from release.js).
+ * Primarily used for backports. Usage from project root:
+ *
+ * npm run update-changelog-manual --release=patch|minor|major (must be `npm` and not `yarn` to specify the release arg)
+ * OR
+ * node -e "require('./scripts/update-changelog').manualChangelog('patch|minor|major')"
+ */
+const manualChangelog = (release) => {
+  versionTarget = release || 'patch'; // Unfortunately can't be a = fallback, because the package.json script passes an empty string
+  console.log(
+    chalk.magenta(
+      `Manually updating CHANGELOG.md to next ${versionTarget} version.`
+    )
+  );
+  const { changelog } = collateChangelogFiles();
+  updateChangelog(changelog, versionTarget);
+};
+
 module.exports = {
   collateChangelogFiles,
   updateChangelog,
   getUpcomingVersion,
+  manualChangelog,
 };

--- a/scripts/update-changelog.js
+++ b/scripts/update-changelog.js
@@ -109,7 +109,7 @@ const collateChangelogFiles = () => {
 /**
  * Write to CHANGELOG.md, delete individual upcoming changelog files, & stage changes
  */
-const updateChangelog = (upcomingChangelog) => {
+const updateChangelog = (upcomingChangelog, versionTarget) => {
   if (!upcomingChangelog) {
     throwError('Cannot update CHANGELOG.md - no changes found');
   }
@@ -117,8 +117,7 @@ const updateChangelog = (upcomingChangelog) => {
   const pathToChangelog = path.resolve(rootDir, 'CHANGELOG.md');
   const changelogArchive = fs.readFileSync(pathToChangelog).toString();
 
-  const pathToPackage = path.resolve(rootDir, 'package.json');
-  const { version } = require(pathToPackage);
+  const version = getUpcomingVersion(versionTarget);
   const latestVersionHeading = `## [\`${version}\`](https://github.com/elastic/eui/tree/v${version})`;
 
   if (changelogArchive.startsWith(latestVersionHeading)) {
@@ -133,7 +132,35 @@ const updateChangelog = (upcomingChangelog) => {
 
   execSync('git add CHANGELOG.md upcoming_changelogs/');
   execSync('git commit -m "Updated changelog." -n');
-  execSync('git push upstream');
 };
 
-module.exports = { collateChangelogFiles, updateChangelog };
+/**
+ * Get the current EUI version and increment it based on the
+ * user-input versionTarget (major/minor/patch)
+ */
+const getUpcomingVersion = (versionTarget) => {
+  const pathToPackage = path.resolve(rootDir, 'package.json');
+  const { version } = require(pathToPackage);
+  let [major, minor, patch] = version.split('.').map(Number);
+  switch (versionTarget) {
+    case 'major':
+      major += 1;
+      minor = 0;
+      patch = 0;
+      break;
+    case 'minor':
+      minor += 1;
+      patch = 0;
+      break;
+    case 'patch':
+      patch += 1;
+      break;
+  }
+  return [major, minor, patch].join('.');
+};
+
+module.exports = {
+  collateChangelogFiles,
+  updateChangelog,
+  getUpcomingVersion,
+};

--- a/wiki/releasing-versions.md
+++ b/wiki/releasing-versions.md
@@ -84,6 +84,7 @@ This provides a walkthrough of the patching & backport release process; examples
   * Run the unit tests again - `npm test`
   * Create the release builds - `npm run build`
   * Update the I18n tokens - `npm run update-token-changelog -- patch`
+  * Update the changelog - `npm run update-changelog-manual --release=patch`
   * Use npm to update package.json & package-lock.json version, git commit, and git tag - `npm version patch`
   * Push the version commit & tag to upstream - `git push upstream --tags`
   * Publish the new version to npm


### PR DESCRIPTION
## Summary

I noticed some improvements to be made while doing the latest manual cherry-pick v53.0.2 backport!

1. Our changelog commits are happening **after** `npm version`, which means they're not getting included correctly in the appropriate release tag 🤦‍♀️ (fixed by 66358de31a08910b92aaa21bbcf222ffa269f0ea)

2. There's no way to manually run the changelog script outside of the release.js script, which we can't do for backport releases (fixed by 659de548e1b64092c34dbd141f2b9c5af5014e1c)

Also since I was here I added the git command to prune tags that may have been created locally as part of testing this script, since it's bitten 3 separate devs in the past, and is fairly risk-free to add (05425d5e6fc7bbd68f419dbfb9a32b3a8b887655).

## QA

yarn command
- Run `yarn update-changelog-manual`
- [x] Look at `CHANGELOG.md` and confirm the version heading matches a patch release
- Run `git reset && git checkout CHANGELOG.md upcoming_changelogs/`

npm script with options
- Run `npm run update-changelog-manual --release=patch`
- [x] Look at `CHANGELOG.md` and confirm the version heading matches a patch release
- `git reset && git checkout CHANGELOG.md upcoming_changelogs/`
- Run `npm run update-changelog-manual --release=minor`
- [x] Look at `CHANGELOG.md` and confirm the version heading matches a minor release
- Run `git reset && git checkout CHANGELOG.md upcoming_changelogs/`
- Run `npm run update-changelog-manual --release=major`
- [x] Look at `CHANGELOG.md` and confirm the version heading matches a major release
- Run `git reset && git checkout CHANGELOG.md upcoming_changelogs/`

release script

- Open release.js and comment out `await ensureMainBranch();` so it runs at all, `test`/`run build` steps for expedience, and `git push upstream --tags` to not mess up main
- You'll have to temporarily commit these changes to not have a dirty staging
- Run `npm run release`, select any version target
- [x] Cancel out of OTP prompt and confirm that a changelog commit was made before the latest tag
- [x] Run `npm run release` again and confirm you see the local tag created by the previous run being deleted