### PR TITLE
[EuiAccordion] Replace `translateZ` with `will-change`

### DIFF
--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -40,11 +40,11 @@
 }
 
 .euiAccordion__childWrapper {
+  will-change: opacity, visibility, height;
   visibility: hidden;
   height: 0;
   opacity: 0;
   overflow: hidden;
-  transform: translatez(0);
   // sass-lint:disable-block indentation
   transition:
     height $euiAnimSpeedNormal $euiAnimSlightResistance,


### PR DESCRIPTION
### Summary

Closes #3548 

Using `translateZ` causes any `position: fixed;` content to render in the wrong location.
My guess is that `transform: translatez(0);` was used to either 1) force hardware acceleration of transition effects or 2) resolve rendering a bug in an old/unsupported browser.
If the latter, we're no longer affected. If the former, we can achieve [hardware acceleration with `will-change: opacity;`](https://dev.opera.com/articles/css-will-change-property/); the other values are nice-to-haves in this case.

It's also very possible that we don't need to engage the GPU at all and even `transform: translatez(0);` was a preoptimization. In that case, we can remove [`will-change`](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change), too, but the current method will render _more similarly_ to using `translateZ`.


https://user-images.githubusercontent.com/2728212/163624600-66cc6453-7620-4189-a96b-91f267e2deec.mov



### Checklist

- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
