### PR TITLE
[Platform] Force prune local tags on release

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -66,7 +66,7 @@ if (args.dry_run) {
     updateChangelog(changelog, versionTarget);
 
     // Clear any local tags
-    execSync('git fetch upstream --tags --prune --prune-tags');
+    execSync('git fetch upstream --tags --prune --prune-tags --force');
 
     // update package.json & package-lock.json version, git commit, git tag
     execSync(`npm version ${versionTarget}`, execOptions);


### PR DESCRIPTION
### Summary

Caught in the latest release, I still had a local version of the _v52.0.0_ tag from prior testing which the newly added tag fetch & prune tripped on because it was being very nice and cautious. This PR throws that caution to the wind, screams YOLO, and force prunes.

~### Checklist~
