### PR TITLE
Remove missing Sass file import

### DIFF
--- a/src/themes/amsterdam/_globals.scss
+++ b/src/themes/amsterdam/_globals.scss
@@ -1,6 +1,9 @@
 // Helper file for supplying EUI Amsterdam globals (invisibles only)
 // Must be imported AFTER a colors modifier file
 
+// Functions need to be first, since we use them in our variables and mixin definitions
+@import '../../global_styling/functions/index';
+
 // Variables come next, and are used in some mixins
 @import 'global_styling/variables/index';
 

--- a/src/themes/amsterdam/_globals.scss
+++ b/src/themes/amsterdam/_globals.scss
@@ -1,9 +1,6 @@
 // Helper file for supplying EUI Amsterdam globals (invisibles only)
 // Must be imported AFTER a colors modifier file
 
-// Functions need to be first, since we use them in our variables and mixin definitions
-@import 'global_styling/functions/index';
-
 // Variables come next, and are used in some mixins
 @import 'global_styling/variables/index';
 

--- a/upcoming_changelogs/5820.md
+++ b/upcoming_changelogs/5820.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed missing Sass variable file import
+


### PR DESCRIPTION
### Summary

The [file was removed in #5754](https://github.com/elastic/eui/pull/5754/files#diff-3f78e1899db035e3ec701f288f86d85d2b877ec1ede9f977df824f657b21c3f8) but the import statement was not. Unsure why EUI was able to compile but Kibana fails.

### Checklist

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
