### PR TITLE
[Emotion] Add internal service for cloning elements with the `css` property

### DIFF
--- a/src/services/theme/clone_element.test.tsx
+++ b/src/services/theme/clone_element.test.tsx
@@ -52,7 +52,7 @@ describe('cloneElementWithCss', () => {
 
     expect(component).toMatchInlineSnapshot(`
       <div
-        class="css-1pj53ay-component-component-component"
+        class="css-88aly5-component-component-component"
       >
         hello world
       </div>

--- a/src/services/theme/clone_element.test.tsx
+++ b/src/services/theme/clone_element.test.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/** @jsx jsx */
+import React from 'react';
+import { css, jsx } from '@emotion/react';
+import { render } from 'enzyme';
+
+import { cloneElementWithCss } from './clone_element';
+
+describe('cloneElementWithCss', () => {
+  const CloningParent: React.FC<any> = ({ children, ...props }) => {
+    return cloneElementWithCss(children, props);
+  };
+
+  it('correctly renders css on elements that do not already have a `css` property', () => {
+    const component = render(
+      <CloningParent css={{ color: 'red' }}>
+        <div>hello world</div>
+      </CloningParent>
+    );
+
+    expect(component).toMatchInlineSnapshot(`
+      <div
+        class="css-1h3ogp1-component"
+      >
+        hello world
+      </div>
+    `);
+    expect(component).toHaveStyleRule('color', 'red');
+  });
+
+  it('combines css properties on cloned elements that already have a `css` property', () => {
+    const component = render(
+      <CloningParent css={{ color: 'red' }}>
+        <div
+          css={[
+            css`
+              background-color: blue;
+            `,
+          ]}
+        >
+          hello world
+        </div>
+      </CloningParent>
+    );
+
+    expect(component).toMatchInlineSnapshot(`
+      <div
+        class="css-1pj53ay-component-component-component"
+      >
+        hello world
+      </div>
+    `);
+    expect(component).toHaveStyleRule('color', 'red');
+    expect(component).toHaveStyleRule('background-color', 'blue');
+  });
+
+  it('does nothing if no css property is set', () => {
+    const component = render(
+      <CloningParent className="test">
+        <div>hello world</div>
+      </CloningParent>
+    );
+
+    expect(component).toMatchInlineSnapshot(`
+      <div
+        class="test"
+      >
+        hello world
+      </div>
+    `);
+    expect(component).not.toHaveStyleRule('color', 'red');
+  });
+});

--- a/src/services/theme/clone_element.test.tsx
+++ b/src/services/theme/clone_element.test.tsx
@@ -61,6 +61,31 @@ describe('cloneElementWithCss', () => {
     expect(component).toHaveStyleRule('background-color', 'blue');
   });
 
+  it('handles components', () => {
+    const TestComponent: React.FC = (props) => (
+      <div {...props} css={{ backgroundColor: 'blue' }}>
+        hello world
+      </div>
+    );
+
+    const component = render(
+      <CloningParent css={{ color: 'red' }}>
+        <TestComponent css={{ border: '1px solid black' }} />
+      </CloningParent>
+    );
+
+    expect(component).toMatchInlineSnapshot(`
+      <div
+        class="css-1fcrfq4-TestComponent-component-component"
+      >
+        hello world
+      </div>
+    `);
+    expect(component).toHaveStyleRule('color', 'red');
+    expect(component).toHaveStyleRule('background-color', 'blue');
+    expect(component).toHaveStyleRule('border', '1px solid black');
+  });
+
   it('does nothing if no css property is set', () => {
     const component = render(
       <CloningParent className="test">

--- a/src/services/theme/clone_element.tsx
+++ b/src/services/theme/clone_element.tsx
@@ -13,6 +13,8 @@ import { jsx } from '@emotion/react';
  * React.cloneElement does not work if the cloned element does not already have the
  * `css` prop - as a result, we need to use `jsx()` to manually clone the element
  * See https://github.com/emotion-js/emotion/issues/1404
+ *
+ * NOTE: We're still using/testing this utility internally, so this is not yet a public API
  */
 export const cloneElementWithCss = (
   element: any,

--- a/src/services/theme/clone_element.tsx
+++ b/src/services/theme/clone_element.tsx
@@ -20,13 +20,19 @@ export const cloneElementWithCss = (
   element: any,
   props: any
 ): React.ReactElement => {
-  const elementType =
+  const clonedElement =
     element.props.__EMOTION_TYPE_PLEASE_DO_NOT_USE__ || element.type; // EMOTION_TYPE handles non-React elements (native JSX/HTML nodes)
 
-  return jsx(elementType, {
+  const clonedProps = {
     key: element.key,
     ref: element.ref,
     ...element.props,
     ...props,
-  });
+  };
+
+  if (props.css || element.props.css) {
+    clonedProps.css = [element.props.css, props.css];
+  }
+
+  return jsx(clonedElement, clonedProps);
 };

--- a/src/services/theme/clone_element.tsx
+++ b/src/services/theme/clone_element.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { jsx } from '@emotion/react';
+
+/**
+ * React.cloneElement does not work if the cloned element does not already have the
+ * `css` prop - as a result, we need to use `jsx()` to manually clone the element
+ * See https://github.com/emotion-js/emotion/issues/1404
+ */
+export const cloneElementWithCss = (
+  element: any,
+  props: any
+): React.ReactElement => {
+  const elementType =
+    element.props.__EMOTION_TYPE_PLEASE_DO_NOT_USE__ || element.type; // EMOTION_TYPE handles non-React elements (native JSX/HTML nodes)
+
+  return jsx(elementType, {
+    key: element.key,
+    ref: element.ref,
+    ...element.props,
+    ...props,
+  });
+};

--- a/src/services/theme/index.ts
+++ b/src/services/theme/index.ts
@@ -38,4 +38,3 @@ export type {
 } from './types';
 export { COLOR_MODES_STANDARD } from './types';
 export { sizeToPixel } from './size';
-export { cloneElementWithCss } from './clone_element';

--- a/src/services/theme/index.ts
+++ b/src/services/theme/index.ts
@@ -38,3 +38,4 @@ export type {
 } from './types';
 export { COLOR_MODES_STANDARD } from './types';
 export { sizeToPixel } from './size';
+export { cloneElementWithCss } from './clone_element';


### PR DESCRIPTION
### Summary

`React.cloneElement` does not work when setting `css` if the cloned element does not already have the `css` prop. To support cloning `css`, we need to create an internal helper that uses `jsx()` when cloning elements in the above scenario.

See:
- https://github.com/emotion-js/emotion/issues/1404
- https://github.com/emotion-js/emotion/issues/1102
- https://emotion.sh/docs/css-prop#gotchas

Per note from @thompsongl, we're holding off on exporting this as a public API until we've tested it more thoroughly internally.

### Checklist

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~

Only needed if public export:

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**