### PR TITLE
Updating a const name in the Emotion wiki entry.

### DIFF
--- a/wiki/writing-styles-with-emotion.md
+++ b/wiki/writing-styles-with-emotion.md
@@ -58,7 +58,7 @@ const _componentSize = ({
 The helper function can then be used in the exported style block:
 
 ```ts
-export const euiComponentStyles = ({ euiTheme }: UseEuiTheme) => ({
+export const euiComponentNameStyles = ({ euiTheme }: UseEuiTheme) => ({
   // Sizes
   s: css(
     _componentSize({

--- a/wiki/writing-styles-with-emotion.md
+++ b/wiki/writing-styles-with-emotion.md
@@ -25,7 +25,7 @@ import { euiComponentNameStyles } from './{component name}.styles.ts';
 
 export const EuiComponent = () => {
   const theme = useEuiTheme();
-  const componentStyles = euiComponentStyles(theme);
+  const componentStyles = euiComponentNameStyles(theme);
   const styles = [componentStyles]
 
   return (


### PR DESCRIPTION
### Summary

I noticed a `const` name that needed updated to match an import statement while reviewing a separate PR. This is a one-line change for consistency.