### PR TITLE
Highlight relevant toolbar button when in a matching text node

### DIFF
--- a/src/components/markdown_editor/__snapshots__/markdown_editor.test.tsx.snap
+++ b/src/components/markdown_editor/__snapshots__/markdown_editor.test.tsx.snap
@@ -89,19 +89,31 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
         MarkdownActions {
           "editorID": "editorId",
           "styles": Object {
-            "mdBold": Object {
+            "blockquote": Object {
               "button": Object {
                 "iconType": "",
                 "label": "",
               },
               "formatting": Object {
-                "prefix": "**",
-                "suffix": "**",
+                "multiline": true,
+                "prefix": "> ",
+                "surroundWithNewlines": true,
+              },
+              "name": "quote",
+            },
+            "emphasis": Object {
+              "button": Object {
+                "iconType": "",
+                "label": "",
+              },
+              "formatting": Object {
+                "prefix": "_",
+                "suffix": "_",
                 "trimFirst": true,
               },
-              "name": "mdBold",
+              "name": "emphasis",
             },
-            "mdCode": Object {
+            "inlineCode": Object {
               "button": Object {
                 "iconType": "",
                 "label": "",
@@ -112,19 +124,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
                 "prefix": "\`",
                 "suffix": "\`",
               },
-              "name": "mdCode",
-            },
-            "mdItalic": Object {
-              "button": Object {
-                "iconType": "",
-                "label": "",
-              },
-              "formatting": Object {
-                "prefix": "_",
-                "suffix": "_",
-                "trimFirst": true,
-              },
-              "name": "mdItalic",
+              "name": "inlineCode",
             },
             "mdLink": Object {
               "button": Object {
@@ -151,18 +151,6 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
               },
               "name": "mdOl",
             },
-            "mdQuote": Object {
-              "button": Object {
-                "iconType": "",
-                "label": "",
-              },
-              "formatting": Object {
-                "multiline": true,
-                "prefix": "> ",
-                "surroundWithNewlines": true,
-              },
-              "name": "mdQuote",
-            },
             "mdTl": Object {
               "button": Object {
                 "iconType": "",
@@ -187,15 +175,46 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
               },
               "name": "mdUl",
             },
+            "strong": Object {
+              "button": Object {
+                "iconType": "",
+                "label": "",
+              },
+              "formatting": Object {
+                "prefix": "**",
+                "suffix": "**",
+                "trimFirst": true,
+              },
+              "name": "strong",
+            },
           },
         }
       }
       onClickPreview={[Function]}
+      selectedNode={
+        Object {
+          "children": Array [],
+          "position": Object {
+            "end": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "root",
+        }
+      }
       uiPlugins={Array []}
       viewMode="editing"
     >
       <div
         className="euiMarkdownEditorToolbar"
+        data-test-subj="euiMarkdownEditorToolbar"
       >
         <div
           className="euiMarkdownEditorToolbar__buttons"
@@ -204,7 +223,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
             content="Bold"
             delay="long"
             display="inlineBlock"
-            key="mdBold"
+            key="strong"
             position="top"
           >
             <span
@@ -214,6 +233,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
             >
               <EuiButtonIcon
                 aria-label="Bold"
+                aria-pressed={false}
                 color="text"
                 iconType="editorBold"
                 isDisabled={false}
@@ -223,6 +243,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
               >
                 <button
                   aria-label="Bold"
+                  aria-pressed={false}
                   className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -252,7 +273,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
             content="Italic"
             delay="long"
             display="inlineBlock"
-            key="mdItalic"
+            key="emphasis"
             position="top"
           >
             <span
@@ -262,6 +283,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
             >
               <EuiButtonIcon
                 aria-label="Italic"
+                aria-pressed={false}
                 color="text"
                 iconType="editorItalic"
                 isDisabled={false}
@@ -271,6 +293,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
               >
                 <button
                   aria-label="Italic"
+                  aria-pressed={false}
                   className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -313,6 +336,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
             >
               <EuiButtonIcon
                 aria-label="Unordered list"
+                aria-pressed={false}
                 color="text"
                 iconType="editorUnorderedList"
                 isDisabled={false}
@@ -322,6 +346,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
               >
                 <button
                   aria-label="Unordered list"
+                  aria-pressed={false}
                   className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -361,6 +386,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
             >
               <EuiButtonIcon
                 aria-label="Ordered list"
+                aria-pressed={false}
                 color="text"
                 iconType="editorOrderedList"
                 isDisabled={false}
@@ -370,6 +396,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
               >
                 <button
                   aria-label="Ordered list"
+                  aria-pressed={false}
                   className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -409,6 +436,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
             >
               <EuiButtonIcon
                 aria-label="Task list"
+                aria-pressed={false}
                 color="text"
                 iconType="editorChecklist"
                 isDisabled={false}
@@ -418,6 +446,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
               >
                 <button
                   aria-label="Task list"
+                  aria-pressed={false}
                   className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -450,7 +479,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
             content="Quote"
             delay="long"
             display="inlineBlock"
-            key="mdQuote"
+            key="blockquote"
             position="top"
           >
             <span
@@ -460,6 +489,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
             >
               <EuiButtonIcon
                 aria-label="Quote"
+                aria-pressed={false}
                 color="text"
                 iconType="quote"
                 isDisabled={false}
@@ -469,6 +499,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
               >
                 <button
                   aria-label="Quote"
+                  aria-pressed={false}
                   className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -498,7 +529,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
             content="Code"
             delay="long"
             display="inlineBlock"
-            key="mdCode"
+            key="inlineCode"
             position="top"
           >
             <span
@@ -508,6 +539,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
             >
               <EuiButtonIcon
                 aria-label="Code"
+                aria-pressed={false}
                 color="text"
                 iconType="editorCodeBlock"
                 isDisabled={false}
@@ -517,6 +549,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
               >
                 <button
                   aria-label="Code"
+                  aria-pressed={false}
                   className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -546,7 +579,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
             content="Link"
             delay="long"
             display="inlineBlock"
-            key="mdLink"
+            key="link"
             position="top"
           >
             <span
@@ -556,6 +589,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
             >
               <EuiButtonIcon
                 aria-label="Link"
+                aria-pressed={false}
                 color="text"
                 iconType="editorLink"
                 isDisabled={false}
@@ -565,6 +599,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
               >
                 <button
                   aria-label="Link"
+                  aria-pressed={false}
                   className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -690,6 +725,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
               <textarea
                 aria-label="aria-label"
                 className="euiMarkdownEditorTextArea"
+                data-test-subj="euiMarkdownEditorTextArea"
                 id="editorId"
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -1153,6 +1189,7 @@ exports[`EuiMarkdownEditor is rendered 1`] = `
 >
   <div
     class="euiMarkdownEditorToolbar"
+    data-test-subj="euiMarkdownEditorToolbar"
   >
     <div
       class="euiMarkdownEditorToolbar__buttons"
@@ -1341,6 +1378,7 @@ exports[`EuiMarkdownEditor is rendered 1`] = `
       <textarea
         aria-label="aria-label"
         class="euiMarkdownEditorTextArea"
+        data-test-subj="euiMarkdownEditorTextArea"
         id="editorId"
         placeholder="placeholder"
         rows="6"
@@ -1399,19 +1437,31 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
         MarkdownActions {
           "editorID": "editorId",
           "styles": Object {
-            "mdBold": Object {
+            "blockquote": Object {
               "button": Object {
                 "iconType": "",
                 "label": "",
               },
               "formatting": Object {
-                "prefix": "**",
-                "suffix": "**",
+                "multiline": true,
+                "prefix": "> ",
+                "surroundWithNewlines": true,
+              },
+              "name": "quote",
+            },
+            "emphasis": Object {
+              "button": Object {
+                "iconType": "",
+                "label": "",
+              },
+              "formatting": Object {
+                "prefix": "_",
+                "suffix": "_",
                 "trimFirst": true,
               },
-              "name": "mdBold",
+              "name": "emphasis",
             },
-            "mdCode": Object {
+            "inlineCode": Object {
               "button": Object {
                 "iconType": "",
                 "label": "",
@@ -1422,19 +1472,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
                 "prefix": "\`",
                 "suffix": "\`",
               },
-              "name": "mdCode",
-            },
-            "mdItalic": Object {
-              "button": Object {
-                "iconType": "",
-                "label": "",
-              },
-              "formatting": Object {
-                "prefix": "_",
-                "suffix": "_",
-                "trimFirst": true,
-              },
-              "name": "mdItalic",
+              "name": "inlineCode",
             },
             "mdLink": Object {
               "button": Object {
@@ -1461,18 +1499,6 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
               },
               "name": "mdOl",
             },
-            "mdQuote": Object {
-              "button": Object {
-                "iconType": "",
-                "label": "",
-              },
-              "formatting": Object {
-                "multiline": true,
-                "prefix": "> ",
-                "surroundWithNewlines": true,
-              },
-              "name": "mdQuote",
-            },
             "mdTl": Object {
               "button": Object {
                 "iconType": "",
@@ -1497,6 +1523,18 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
               },
               "name": "mdUl",
             },
+            "strong": Object {
+              "button": Object {
+                "iconType": "",
+                "label": "",
+              },
+              "formatting": Object {
+                "prefix": "**",
+                "suffix": "**",
+                "trimFirst": true,
+              },
+              "name": "strong",
+            },
             "tooltipPlugin": Object {
               "button": Object {
                 "iconType": "editorComment",
@@ -1520,6 +1558,24 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
         }
       }
       onClickPreview={[Function]}
+      selectedNode={
+        Object {
+          "children": Array [],
+          "position": Object {
+            "end": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "root",
+        }
+      }
       uiPlugins={
         Array [
           Object {
@@ -1547,6 +1603,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
     >
       <div
         className="euiMarkdownEditorToolbar"
+        data-test-subj="euiMarkdownEditorToolbar"
       >
         <div
           className="euiMarkdownEditorToolbar__buttons"
@@ -1555,7 +1612,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
             content="Bold"
             delay="long"
             display="inlineBlock"
-            key="mdBold"
+            key="strong"
             position="top"
           >
             <span
@@ -1565,6 +1622,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
             >
               <EuiButtonIcon
                 aria-label="Bold"
+                aria-pressed={false}
                 color="text"
                 iconType="editorBold"
                 isDisabled={false}
@@ -1574,6 +1632,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
               >
                 <button
                   aria-label="Bold"
+                  aria-pressed={false}
                   className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -1603,7 +1662,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
             content="Italic"
             delay="long"
             display="inlineBlock"
-            key="mdItalic"
+            key="emphasis"
             position="top"
           >
             <span
@@ -1613,6 +1672,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
             >
               <EuiButtonIcon
                 aria-label="Italic"
+                aria-pressed={false}
                 color="text"
                 iconType="editorItalic"
                 isDisabled={false}
@@ -1622,6 +1682,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
               >
                 <button
                   aria-label="Italic"
+                  aria-pressed={false}
                   className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -1664,6 +1725,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
             >
               <EuiButtonIcon
                 aria-label="Unordered list"
+                aria-pressed={false}
                 color="text"
                 iconType="editorUnorderedList"
                 isDisabled={false}
@@ -1673,6 +1735,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
               >
                 <button
                   aria-label="Unordered list"
+                  aria-pressed={false}
                   className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -1712,6 +1775,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
             >
               <EuiButtonIcon
                 aria-label="Ordered list"
+                aria-pressed={false}
                 color="text"
                 iconType="editorOrderedList"
                 isDisabled={false}
@@ -1721,6 +1785,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
               >
                 <button
                   aria-label="Ordered list"
+                  aria-pressed={false}
                   className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -1760,6 +1825,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
             >
               <EuiButtonIcon
                 aria-label="Task list"
+                aria-pressed={false}
                 color="text"
                 iconType="editorChecklist"
                 isDisabled={false}
@@ -1769,6 +1835,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
               >
                 <button
                   aria-label="Task list"
+                  aria-pressed={false}
                   className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -1801,7 +1868,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
             content="Quote"
             delay="long"
             display="inlineBlock"
-            key="mdQuote"
+            key="blockquote"
             position="top"
           >
             <span
@@ -1811,6 +1878,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
             >
               <EuiButtonIcon
                 aria-label="Quote"
+                aria-pressed={false}
                 color="text"
                 iconType="quote"
                 isDisabled={false}
@@ -1820,6 +1888,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
               >
                 <button
                   aria-label="Quote"
+                  aria-pressed={false}
                   className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -1849,7 +1918,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
             content="Code"
             delay="long"
             display="inlineBlock"
-            key="mdCode"
+            key="inlineCode"
             position="top"
           >
             <span
@@ -1859,6 +1928,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
             >
               <EuiButtonIcon
                 aria-label="Code"
+                aria-pressed={false}
                 color="text"
                 iconType="editorCodeBlock"
                 isDisabled={false}
@@ -1868,6 +1938,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
               >
                 <button
                   aria-label="Code"
+                  aria-pressed={false}
                   className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -1897,7 +1968,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
             content="Link"
             delay="long"
             display="inlineBlock"
-            key="mdLink"
+            key="link"
             position="top"
           >
             <span
@@ -1907,6 +1978,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
             >
               <EuiButtonIcon
                 aria-label="Link"
+                aria-pressed={false}
                 color="text"
                 iconType="editorLink"
                 isDisabled={false}
@@ -1916,6 +1988,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
               >
                 <button
                   aria-label="Link"
+                  aria-pressed={false}
                   className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -1958,6 +2031,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
             >
               <EuiButtonIcon
                 aria-label="Tooltip"
+                aria-pressed={false}
                 color="text"
                 iconType="editorComment"
                 isDisabled={false}
@@ -1967,6 +2041,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
               >
                 <button
                   aria-label="Tooltip"
+                  aria-pressed={false}
                   className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -2114,6 +2189,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
               <textarea
                 aria-label="aria-label"
                 className="euiMarkdownEditorTextArea"
+                data-test-subj="euiMarkdownEditorTextArea"
                 id="editorId"
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -3445,6 +3521,7 @@ exports[`EuiMarkdownEditor props autoExpandPreview is rendered with false 1`] = 
 >
   <div
     class="euiMarkdownEditorToolbar"
+    data-test-subj="euiMarkdownEditorToolbar"
   >
     <div
       class="euiMarkdownEditorToolbar__buttons"
@@ -3633,6 +3710,7 @@ exports[`EuiMarkdownEditor props autoExpandPreview is rendered with false 1`] = 
       <textarea
         aria-label="aria-label"
         class="euiMarkdownEditorTextArea"
+        data-test-subj="euiMarkdownEditorTextArea"
         id="editorId"
         rows="6"
         style="height:calc(250px);max-height:500px"
@@ -3679,6 +3757,7 @@ exports[`EuiMarkdownEditor props height is rendered in full mode 1`] = `
 >
   <div
     class="euiMarkdownEditorToolbar"
+    data-test-subj="euiMarkdownEditorToolbar"
   >
     <div
       class="euiMarkdownEditorToolbar__buttons"
@@ -3867,6 +3946,7 @@ exports[`EuiMarkdownEditor props height is rendered in full mode 1`] = `
       <textarea
         aria-label="aria-label"
         class="euiMarkdownEditorTextArea"
+        data-test-subj="euiMarkdownEditorTextArea"
         id="editorId"
         rows="6"
         style="height:100%;max-height:"
@@ -3913,6 +3993,7 @@ exports[`EuiMarkdownEditor props height is rendered with a custom size 1`] = `
 >
   <div
     class="euiMarkdownEditorToolbar"
+    data-test-subj="euiMarkdownEditorToolbar"
   >
     <div
       class="euiMarkdownEditorToolbar__buttons"
@@ -4101,6 +4182,7 @@ exports[`EuiMarkdownEditor props height is rendered with a custom size 1`] = `
       <textarea
         aria-label="aria-label"
         class="euiMarkdownEditorTextArea"
+        data-test-subj="euiMarkdownEditorTextArea"
         id="editorId"
         rows="6"
         style="height:calc(400px);max-height:500px"
@@ -4147,6 +4229,7 @@ exports[`EuiMarkdownEditor props maxHeight is rendered with a custom size 1`] = 
 >
   <div
     class="euiMarkdownEditorToolbar"
+    data-test-subj="euiMarkdownEditorToolbar"
   >
     <div
       class="euiMarkdownEditorToolbar__buttons"
@@ -4335,6 +4418,7 @@ exports[`EuiMarkdownEditor props maxHeight is rendered with a custom size 1`] = 
       <textarea
         aria-label="aria-label"
         class="euiMarkdownEditorTextArea"
+        data-test-subj="euiMarkdownEditorTextArea"
         id="editorId"
         rows="6"
         style="height:calc(250px);max-height:600px"
@@ -4381,6 +4465,7 @@ exports[`EuiMarkdownEditor props readOnly is set to true 1`] = `
 >
   <div
     class="euiMarkdownEditorToolbar"
+    data-test-subj="euiMarkdownEditorToolbar"
   >
     <div
       class="euiMarkdownEditorToolbar__buttons"
@@ -4579,6 +4664,7 @@ exports[`EuiMarkdownEditor props readOnly is set to true 1`] = `
       <textarea
         aria-label="aria-label"
         class="euiMarkdownEditorTextArea euiMarkdownEditorTextArea-isReadOnly"
+        data-test-subj="euiMarkdownEditorTextArea"
         id="editorId"
         readonly=""
         rows="6"

--- a/src/components/markdown_editor/__snapshots__/markdown_editor.test.tsx.snap
+++ b/src/components/markdown_editor/__snapshots__/markdown_editor.test.tsx.snap
@@ -89,31 +89,19 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
         MarkdownActions {
           "editorID": "editorId",
           "styles": Object {
-            "blockquote": Object {
+            "mdBold": Object {
               "button": Object {
                 "iconType": "",
                 "label": "",
               },
               "formatting": Object {
-                "multiline": true,
-                "prefix": "> ",
-                "surroundWithNewlines": true,
-              },
-              "name": "quote",
-            },
-            "emphasis": Object {
-              "button": Object {
-                "iconType": "",
-                "label": "",
-              },
-              "formatting": Object {
-                "prefix": "_",
-                "suffix": "_",
+                "prefix": "**",
+                "suffix": "**",
                 "trimFirst": true,
               },
-              "name": "emphasis",
+              "name": "mdBold",
             },
-            "inlineCode": Object {
+            "mdCode": Object {
               "button": Object {
                 "iconType": "",
                 "label": "",
@@ -124,7 +112,19 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
                 "prefix": "\`",
                 "suffix": "\`",
               },
-              "name": "inlineCode",
+              "name": "mdCode",
+            },
+            "mdItalic": Object {
+              "button": Object {
+                "iconType": "",
+                "label": "",
+              },
+              "formatting": Object {
+                "prefix": "_",
+                "suffix": "_",
+                "trimFirst": true,
+              },
+              "name": "mdItalic",
             },
             "mdLink": Object {
               "button": Object {
@@ -151,6 +151,18 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
               },
               "name": "mdOl",
             },
+            "mdQuote": Object {
+              "button": Object {
+                "iconType": "",
+                "label": "",
+              },
+              "formatting": Object {
+                "multiline": true,
+                "prefix": "> ",
+                "surroundWithNewlines": true,
+              },
+              "name": "mdQuote",
+            },
             "mdTl": Object {
               "button": Object {
                 "iconType": "",
@@ -174,18 +186,6 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
                 "surroundWithNewlines": true,
               },
               "name": "mdUl",
-            },
-            "strong": Object {
-              "button": Object {
-                "iconType": "",
-                "label": "",
-              },
-              "formatting": Object {
-                "prefix": "**",
-                "suffix": "**",
-                "trimFirst": true,
-              },
-              "name": "strong",
             },
           },
         }
@@ -223,7 +223,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
             content="Bold"
             delay="long"
             display="inlineBlock"
-            key="strong"
+            key="mdBold"
             position="top"
           >
             <span
@@ -273,7 +273,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
             content="Italic"
             delay="long"
             display="inlineBlock"
-            key="emphasis"
+            key="mdItalic"
             position="top"
           >
             <span
@@ -479,7 +479,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
             content="Quote"
             delay="long"
             display="inlineBlock"
-            key="blockquote"
+            key="mdQuote"
             position="top"
           >
             <span
@@ -529,7 +529,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
             content="Code"
             delay="long"
             display="inlineBlock"
-            key="inlineCode"
+            key="mdCode"
             position="top"
           >
             <span
@@ -579,7 +579,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
             content="Link"
             delay="long"
             display="inlineBlock"
-            key="link"
+            key="mdLink"
             position="top"
           >
             <span
@@ -1437,31 +1437,19 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
         MarkdownActions {
           "editorID": "editorId",
           "styles": Object {
-            "blockquote": Object {
+            "mdBold": Object {
               "button": Object {
                 "iconType": "",
                 "label": "",
               },
               "formatting": Object {
-                "multiline": true,
-                "prefix": "> ",
-                "surroundWithNewlines": true,
-              },
-              "name": "quote",
-            },
-            "emphasis": Object {
-              "button": Object {
-                "iconType": "",
-                "label": "",
-              },
-              "formatting": Object {
-                "prefix": "_",
-                "suffix": "_",
+                "prefix": "**",
+                "suffix": "**",
                 "trimFirst": true,
               },
-              "name": "emphasis",
+              "name": "mdBold",
             },
-            "inlineCode": Object {
+            "mdCode": Object {
               "button": Object {
                 "iconType": "",
                 "label": "",
@@ -1472,7 +1460,19 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
                 "prefix": "\`",
                 "suffix": "\`",
               },
-              "name": "inlineCode",
+              "name": "mdCode",
+            },
+            "mdItalic": Object {
+              "button": Object {
+                "iconType": "",
+                "label": "",
+              },
+              "formatting": Object {
+                "prefix": "_",
+                "suffix": "_",
+                "trimFirst": true,
+              },
+              "name": "mdItalic",
             },
             "mdLink": Object {
               "button": Object {
@@ -1499,6 +1499,18 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
               },
               "name": "mdOl",
             },
+            "mdQuote": Object {
+              "button": Object {
+                "iconType": "",
+                "label": "",
+              },
+              "formatting": Object {
+                "multiline": true,
+                "prefix": "> ",
+                "surroundWithNewlines": true,
+              },
+              "name": "mdQuote",
+            },
             "mdTl": Object {
               "button": Object {
                 "iconType": "",
@@ -1522,18 +1534,6 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
                 "surroundWithNewlines": true,
               },
               "name": "mdUl",
-            },
-            "strong": Object {
-              "button": Object {
-                "iconType": "",
-                "label": "",
-              },
-              "formatting": Object {
-                "prefix": "**",
-                "suffix": "**",
-                "trimFirst": true,
-              },
-              "name": "strong",
             },
             "tooltipPlugin": Object {
               "button": Object {
@@ -1612,7 +1612,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
             content="Bold"
             delay="long"
             display="inlineBlock"
-            key="strong"
+            key="mdBold"
             position="top"
           >
             <span
@@ -1662,7 +1662,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
             content="Italic"
             delay="long"
             display="inlineBlock"
-            key="emphasis"
+            key="mdItalic"
             position="top"
           >
             <span
@@ -1868,7 +1868,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
             content="Quote"
             delay="long"
             display="inlineBlock"
-            key="blockquote"
+            key="mdQuote"
             position="top"
           >
             <span
@@ -1918,7 +1918,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
             content="Code"
             delay="long"
             display="inlineBlock"
-            key="inlineCode"
+            key="mdCode"
             position="top"
           >
             <span
@@ -1968,7 +1968,7 @@ exports[`EuiMarkdownEditor modal with help syntax is rendered 1`] = `
             content="Link"
             delay="long"
             display="inlineBlock"
-            key="link"
+            key="mdLink"
             position="top"
           >
             <span

--- a/src/components/markdown_editor/markdown_actions.ts
+++ b/src/components/markdown_editor/markdown_actions.ts
@@ -60,8 +60,8 @@ class MarkdownActions {
         },
         {}
       ),
-      strong: {
-        name: 'strong',
+      mdBold: {
+        name: 'mdBold',
         button: { label: '', iconType: '' },
         formatting: {
           prefix: '**',
@@ -69,8 +69,8 @@ class MarkdownActions {
           trimFirst: true,
         },
       },
-      emphasis: {
-        name: 'emphasis',
+      mdItalic: {
+        name: 'mdItalic',
         button: { label: '', iconType: '' },
         formatting: {
           prefix: '_',
@@ -78,8 +78,8 @@ class MarkdownActions {
           trimFirst: true,
         },
       },
-      blockquote: {
-        name: 'quote',
+      mdQuote: {
+        name: 'mdQuote',
         button: { label: '', iconType: '' },
         formatting: {
           prefix: '> ',
@@ -87,8 +87,8 @@ class MarkdownActions {
           surroundWithNewlines: true,
         },
       },
-      inlineCode: {
-        name: 'inlineCode',
+      mdCode: {
+        name: 'mdCode',
         button: { label: '', iconType: '' },
         formatting: {
           prefix: '`',

--- a/src/components/markdown_editor/markdown_actions.ts
+++ b/src/components/markdown_editor/markdown_actions.ts
@@ -60,8 +60,8 @@ class MarkdownActions {
         },
         {}
       ),
-      mdBold: {
-        name: 'mdBold',
+      strong: {
+        name: 'strong',
         button: { label: '', iconType: '' },
         formatting: {
           prefix: '**',
@@ -69,8 +69,8 @@ class MarkdownActions {
           trimFirst: true,
         },
       },
-      mdItalic: {
-        name: 'mdItalic',
+      emphasis: {
+        name: 'emphasis',
         button: { label: '', iconType: '' },
         formatting: {
           prefix: '_',
@@ -78,8 +78,8 @@ class MarkdownActions {
           trimFirst: true,
         },
       },
-      mdQuote: {
-        name: 'mdQuote',
+      blockquote: {
+        name: 'quote',
         button: { label: '', iconType: '' },
         formatting: {
           prefix: '> ',
@@ -87,8 +87,8 @@ class MarkdownActions {
           surroundWithNewlines: true,
         },
       },
-      mdCode: {
-        name: 'mdCode',
+      inlineCode: {
+        name: 'inlineCode',
         button: { label: '', iconType: '' },
         formatting: {
           prefix: '`',

--- a/src/components/markdown_editor/markdown_editor.spec.tsx
+++ b/src/components/markdown_editor/markdown_editor.spec.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React from 'react';
+import { EuiMarkdownEditor } from './index';
+
+describe('EuiMarkdownEditor', () => {
+  describe('toolbar interactions', () => {
+    it('keeps focus on the input box when clicking a disabled item', () => {
+      const value = `**bold**
+
+_italic_
+
+> quote
+
+\`inline codeblock\`
+
+[link](https://elastic.co)
+
+!{tooltip[text](help)}`;
+      cy.realMount(
+        <EuiMarkdownEditor
+          data-test-subj="test-editor"
+          aria-label="editor for cypress test"
+          value={value}
+          onChange={() => {}}
+        />
+      );
+
+      // verify all of the toolbar buttons are not selected
+      cy.get(
+        '[data-test-subj=test-editor] [data-test-subj=euiMarkdownEditorToolbar] button[aria-pressed=true]'
+      ).should('not.exist');
+
+      // Focus the editor text area for key events
+      cy.get(
+        '[data-test-subj=test-editor] [data-test-subj=euiMarkdownEditorTextArea]'
+      ).focus();
+
+      // Enter the bold node & verify
+      cy.realPress('ArrowRight');
+      cy.get(
+        '[data-test-subj=test-editor] [data-test-subj=euiMarkdownEditorToolbar] button[aria-label=Bold][aria-pressed=true]'
+      ).should('exist');
+
+      // Enter the italic node & verify
+      cy.repeatRealPress('ArrowDown', 2);
+      cy.get(
+        '[data-test-subj=test-editor] [data-test-subj=euiMarkdownEditorToolbar] button[aria-label=Italic][aria-pressed=true]'
+      ).should('exist');
+
+      // Enter the quote node & verify
+      cy.repeatRealPress('ArrowDown', 2);
+      cy.get(
+        '[data-test-subj=test-editor] [data-test-subj=euiMarkdownEditorToolbar] button[aria-label=Quote][aria-pressed=true]'
+      ).should('exist');
+
+      // Enter the inline code node & verify
+      cy.repeatRealPress('ArrowDown', 2);
+      cy.get(
+        '[data-test-subj=test-editor] [data-test-subj=euiMarkdownEditorToolbar] button[aria-label=Code][aria-pressed=true]'
+      ).should('exist');
+
+      // Enter the link node & verify
+      cy.repeatRealPress('ArrowDown', 2);
+      cy.get(
+        '[data-test-subj=test-editor] [data-test-subj=euiMarkdownEditorToolbar] button[aria-label=Link][aria-pressed=true]'
+      ).should('exist');
+
+      // Enter the tooltip node & verify
+      cy.repeatRealPress('ArrowDown', 2);
+      cy.get(
+        '[data-test-subj=test-editor] [data-test-subj=euiMarkdownEditorToolbar] button[aria-label=Tooltip][aria-pressed=true]'
+      ).should('exist');
+    });
+  });
+});

--- a/src/components/markdown_editor/markdown_editor.tsx
+++ b/src/components/markdown_editor/markdown_editor.tsx
@@ -320,6 +320,9 @@ export const EuiMarkdownEditor = forwardRef<
 
         setSelectedNode(node);
       };
+      // `parsed` changed, which means the node at the cursor may be different
+      // e.g. from clicking a toolbar button
+      getCursorNode();
 
       const textarea = textareaRef.current!;
 

--- a/src/components/markdown_editor/markdown_editor_text_area.tsx
+++ b/src/components/markdown_editor/markdown_editor_text_area.tsx
@@ -49,6 +49,7 @@ export const EuiMarkdownEditorTextArea = forwardRef<
     return (
       <textarea
         ref={ref}
+        data-test-subj="euiMarkdownEditorTextArea"
         style={{ height, maxHeight }}
         className={classes}
         {...rest}

--- a/src/components/markdown_editor/markdown_editor_toolbar.tsx
+++ b/src/components/markdown_editor/markdown_editor_toolbar.tsx
@@ -21,6 +21,7 @@ import { MARKDOWN_MODE, MODE_VIEWING } from './markdown_modes';
 import { EuiMarkdownEditorUiPlugin } from './markdown_types';
 import { EuiMarkdownContext } from './markdown_context';
 import MarkdownActions from './markdown_actions';
+import { IconType } from '../icon';
 
 export type EuiMarkdownEditorToolbarProps = HTMLAttributes<HTMLDivElement> &
   CommonProps & {
@@ -33,13 +34,13 @@ export type EuiMarkdownEditorToolbarProps = HTMLAttributes<HTMLDivElement> &
 
 const boldItalicButtons = [
   {
-    id: 'mdBold',
+    id: 'strong',
     label: 'Bold',
     name: 'bold',
     iconType: 'editorBold',
   },
   {
-    id: 'mdItalic',
+    id: 'emphasis',
     label: 'Italic',
     name: 'italic',
     iconType: 'editorItalic',
@@ -69,24 +70,54 @@ const listButtons = [
 
 const quoteCodeLinkButtons = [
   {
-    id: 'mdQuote',
+    id: 'blockquote',
     label: 'Quote',
     name: 'quote',
     iconType: 'quote',
   },
   {
-    id: 'mdCode',
+    id: 'inlineCode',
     label: 'Code',
     name: 'code',
     iconType: 'editorCodeBlock',
   },
   {
-    id: 'mdLink',
+    id: 'link',
     label: 'Link',
     name: 'link',
     iconType: 'editorLink',
   },
 ];
+
+interface FormatSelectableButtonArgs {
+  selectedNode: null | any;
+  handleMdButtonClick: (mdButtonId: string) => void;
+  isEditable: boolean;
+  id: string;
+  label: string;
+  icon: IconType;
+}
+export const formatSelectableButton = ({
+  selectedNode,
+  handleMdButtonClick,
+  isEditable,
+  id,
+  label,
+  icon,
+}: FormatSelectableButtonArgs) => (
+  <EuiButtonIcon
+    color="text"
+    {...(selectedNode && selectedNode.type === id
+      ? {
+          style: { background: 'rgba(0, 0, 0, 0.15)' },
+        }
+      : null)}
+    onClick={() => handleMdButtonClick(id)}
+    iconType={icon}
+    aria-label={label}
+    isDisabled={!isEditable}
+  />
+);
 
 export const EuiMarkdownEditorToolbar = forwardRef<
   HTMLDivElement,
@@ -112,37 +143,40 @@ export const EuiMarkdownEditorToolbar = forwardRef<
         <div className="euiMarkdownEditorToolbar__buttons">
           {boldItalicButtons.map((item) => (
             <EuiToolTip key={item.id} content={item.label} delay="long">
-              <EuiButtonIcon
-                color="text"
-                onClick={() => handleMdButtonClick(item.id)}
-                iconType={item.iconType}
-                aria-label={item.label}
-                isDisabled={!isEditable}
-              />
+              {formatSelectableButton({
+                selectedNode,
+                handleMdButtonClick,
+                isEditable,
+                id: item.id,
+                label: item.label,
+                icon: item.iconType,
+              })}
             </EuiToolTip>
           ))}
           <span className="euiMarkdownEditorToolbar__divider" />
           {listButtons.map((item) => (
             <EuiToolTip key={item.id} content={item.label} delay="long">
-              <EuiButtonIcon
-                color="text"
-                onClick={() => handleMdButtonClick(item.id)}
-                iconType={item.iconType}
-                aria-label={item.label}
-                isDisabled={!isEditable}
-              />
+              {formatSelectableButton({
+                selectedNode,
+                handleMdButtonClick,
+                isEditable,
+                id: item.id,
+                label: item.label,
+                icon: item.iconType,
+              })}
             </EuiToolTip>
           ))}
           <span className="euiMarkdownEditorToolbar__divider" />
           {quoteCodeLinkButtons.map((item) => (
             <EuiToolTip key={item.id} content={item.label} delay="long">
-              <EuiButtonIcon
-                color="text"
-                onClick={() => handleMdButtonClick(item.id)}
-                iconType={item.iconType}
-                aria-label={item.label}
-                isDisabled={!isEditable}
-              />
+              {formatSelectableButton({
+                selectedNode,
+                handleMdButtonClick,
+                isEditable,
+                id: item.id,
+                label: item.label,
+                icon: item.iconType,
+              })}
             </EuiToolTip>
           ))}
 
@@ -150,22 +184,16 @@ export const EuiMarkdownEditorToolbar = forwardRef<
             <>
               <span className="euiMarkdownEditorToolbar__divider" />
               {uiPlugins.map(({ name, button }) => {
-                const isSelectedNodeType =
-                  selectedNode && selectedNode.type === name;
                 return (
                   <EuiToolTip key={name} content={button.label} delay="long">
-                    <EuiButtonIcon
-                      color="text"
-                      {...(isSelectedNodeType
-                        ? {
-                            style: { background: 'rgba(0, 0, 0, 0.15)' },
-                          }
-                        : null)}
-                      onClick={() => handleMdButtonClick(name)}
-                      iconType={button.iconType}
-                      aria-label={button.label}
-                      isDisabled={!isEditable}
-                    />
+                    {formatSelectableButton({
+                      selectedNode,
+                      handleMdButtonClick,
+                      isEditable,
+                      id: name,
+                      label: button.label,
+                      icon: button.iconType,
+                    })}
                   </EuiToolTip>
                 );
               })}

--- a/src/components/markdown_editor/markdown_editor_toolbar.tsx
+++ b/src/components/markdown_editor/markdown_editor_toolbar.tsx
@@ -34,15 +34,15 @@ export type EuiMarkdownEditorToolbarProps = HTMLAttributes<HTMLDivElement> &
 
 const boldItalicButtons = [
   {
-    id: 'strong',
+    id: 'mdBold',
     label: 'Bold',
-    name: 'bold',
+    name: 'strong',
     iconType: 'editorBold',
   },
   {
-    id: 'emphasis',
+    id: 'mdItalic',
     label: 'Italic',
-    name: 'italic',
+    name: 'emphasis',
     iconType: 'editorItalic',
   },
 ];
@@ -70,19 +70,19 @@ const listButtons = [
 
 const quoteCodeLinkButtons = [
   {
-    id: 'blockquote',
+    id: 'mdQuote',
     label: 'Quote',
-    name: 'quote',
+    name: 'blockquote',
     iconType: 'quote',
   },
   {
-    id: 'inlineCode',
+    id: 'mdCode',
     label: 'Code',
-    name: 'code',
+    name: 'inlineCode',
     iconType: 'editorCodeBlock',
   },
   {
-    id: 'link',
+    id: 'mdLink',
     label: 'Link',
     name: 'link',
     iconType: 'editorLink',
@@ -94,6 +94,7 @@ interface FormatSelectableButtonArgs {
   handleMdButtonClick: (mdButtonId: string) => void;
   isEditable: boolean;
   id: string;
+  nodeId: string;
   label: string;
   icon: IconType;
 }
@@ -102,10 +103,11 @@ export const formatSelectableButton = ({
   handleMdButtonClick,
   isEditable,
   id,
+  nodeId,
   label,
   icon,
 }: FormatSelectableButtonArgs) => {
-  const isSelected = selectedNode && selectedNode.type === id;
+  const isSelected = selectedNode && selectedNode.type === nodeId;
   return (
     <EuiButtonIcon
       color="text"
@@ -156,6 +158,7 @@ export const EuiMarkdownEditorToolbar = forwardRef<
                 handleMdButtonClick,
                 isEditable,
                 id: item.id,
+                nodeId: item.name,
                 label: item.label,
                 icon: item.iconType,
               })}
@@ -169,6 +172,7 @@ export const EuiMarkdownEditorToolbar = forwardRef<
                 handleMdButtonClick,
                 isEditable,
                 id: item.id,
+                nodeId: item.name,
                 label: item.label,
                 icon: item.iconType,
               })}
@@ -182,6 +186,7 @@ export const EuiMarkdownEditorToolbar = forwardRef<
                 handleMdButtonClick,
                 isEditable,
                 id: item.id,
+                nodeId: item.name,
                 label: item.label,
                 icon: item.iconType,
               })}
@@ -199,6 +204,7 @@ export const EuiMarkdownEditorToolbar = forwardRef<
                       handleMdButtonClick,
                       isEditable,
                       id: name,
+                      nodeId: name,
                       label: button.label,
                       icon: button.iconType,
                     })}

--- a/src/components/markdown_editor/markdown_editor_toolbar.tsx
+++ b/src/components/markdown_editor/markdown_editor_toolbar.tsx
@@ -104,20 +104,24 @@ export const formatSelectableButton = ({
   id,
   label,
   icon,
-}: FormatSelectableButtonArgs) => (
-  <EuiButtonIcon
-    color="text"
-    {...(selectedNode && selectedNode.type === id
-      ? {
-          style: { background: 'rgba(0, 0, 0, 0.15)' },
-        }
-      : null)}
-    onClick={() => handleMdButtonClick(id)}
-    iconType={icon}
-    aria-label={label}
-    isDisabled={!isEditable}
-  />
-);
+}: FormatSelectableButtonArgs) => {
+  const isSelected = selectedNode && selectedNode.type === id;
+  return (
+    <EuiButtonIcon
+      color="text"
+      {...(isSelected
+        ? {
+            style: { background: 'rgba(0, 0, 0, 0.15)' },
+          }
+        : null)}
+      onClick={() => handleMdButtonClick(id)}
+      iconType={icon}
+      aria-label={label}
+      aria-pressed={isSelected}
+      isDisabled={!isEditable}
+    />
+  );
+};
 
 export const EuiMarkdownEditorToolbar = forwardRef<
   HTMLDivElement,
@@ -139,7 +143,11 @@ export const EuiMarkdownEditorToolbar = forwardRef<
     const isEditable = !isPreviewing && !readOnly;
 
     return (
-      <div ref={ref} className="euiMarkdownEditorToolbar">
+      <div
+        ref={ref}
+        data-test-subj="euiMarkdownEditorToolbar"
+        className="euiMarkdownEditorToolbar"
+      >
         <div className="euiMarkdownEditorToolbar__buttons">
           {boldItalicButtons.map((item) => (
             <EuiToolTip key={item.id} content={item.label} delay="long">


### PR DESCRIPTION
### Summary

Opening as a draft to ensure CI is happy before reviews

* properly linked the toolbar buttons with their markdown AST nodes so the buttons will highlight as the user navigates the markdown
* added `aria-pressed` to the toolbar buttons
* created an initial markdown cypress spec, added test cases for the button<->node linkage

I wanted to take this further and make the buttons highlight for nested nodes (e.g. italic in bold), but the button actions don't function in that environment so I think it's better to avoid handling element nesting when determining the button state.

#### Before

![markdown](https://user-images.githubusercontent.com/313125/165146115-2f1f11f0-41fb-4a88-946c-5ac9e28eeb65.gif)

#### After

![markdown-after](https://user-images.githubusercontent.com/313125/165146155-fa97456b-f6ae-45d5-b81c-35dac88c7abc.gif)

### Checklist

~- [ ] Checked in both **light and dark** modes~
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
