### PR TITLE
[Docs] ThemeExample component - tweak `snippetLanguage` logic

### DIFF
--- a/src-docs/src/views/accessibility/accessibility_example.js
+++ b/src-docs/src/views/accessibility/accessibility_example.js
@@ -212,7 +212,6 @@ export const AccessibilityExample = {
               </EuiText>
             }
             snippet={'<p className="euiScreenReaderOnly" />'}
-            snippetLanguage="html"
           />
           <ThemeExample
             title={<code>euiScreenReaderOnlyStyles()</code>}
@@ -231,7 +230,6 @@ export const AccessibilityExample = {
               </EuiText>
             }
             snippet={'<p css={css(euiScreenReaderOnlyStyles())} />'}
-            snippetLanguage="ts"
           />
         </>
       ),

--- a/src-docs/src/views/scroll/scroll.tsx
+++ b/src-docs/src/views/scroll/scroll.tsx
@@ -45,7 +45,6 @@ export default () => {
             <ScrollContent />
           </div>
         }
-        snippetLanguage="tsx"
         snippet={`<div
   tabIndex={0}
   role="region"
@@ -91,7 +90,8 @@ export default () => {
               <ScrollContent />
             </div>
           }
-          snippet={'useEuiScrollBar()'}
+          snippet={'${useEuiScrollBar()}'}
+          snippetLanguage="emotion"
         />
       )}
 

--- a/src-docs/src/views/scroll/scroll_x.tsx
+++ b/src-docs/src/views/scroll/scroll_x.tsx
@@ -57,7 +57,6 @@ export default () => {
             {scrollingContent}
           </div>
         }
-        snippetLanguage="tsx"
         snippet={
           `<div
   tabIndex={0}
@@ -106,7 +105,6 @@ export default () => {
               {scrollingContent}
             </div>
           }
-          snippetLanguage="tsx"
           snippet={
             `<div
   tabIndex={0}

--- a/src-docs/src/views/scroll/scroll_y.tsx
+++ b/src-docs/src/views/scroll/scroll_y.tsx
@@ -37,7 +37,6 @@ export default () => {
             <ScrollContent />
           </div>
         }
-        snippetLanguage="tsx"
         snippet={`<div
   tabIndex={0}
   role="region"
@@ -82,7 +81,6 @@ export default () => {
               <ScrollContent />
             </div>
           }
-          snippetLanguage="tsx"
           snippet={
             `<div
   tabIndex={0}

--- a/src-docs/src/views/theme/_components/_theme_example.tsx
+++ b/src-docs/src/views/theme/_components/_theme_example.tsx
@@ -42,7 +42,7 @@ export const ThemeExample: FunctionComponent<ThemeExample> = ({
 }) => {
   const { euiTheme } = useEuiTheme();
   const finalSnippet =
-    snippetLanguage === 'jsx'
+    snippetLanguage === 'emotion'
       ? `css\`
   ${snippet}
 \``
@@ -91,7 +91,9 @@ export const ThemeExample: FunctionComponent<ThemeExample> = ({
                     isCopyable={true}
                     paddingSize="none"
                     transparentBackground={true}
-                    language={snippetLanguage || 'jsx'}
+                    language={
+                      snippetLanguage === 'emotion' ? 'jsx' : snippetLanguage
+                    }
                   >
                     {finalSnippet}
                   </EuiCodeBlock>

--- a/src-docs/src/views/theme/borders/_border_js.tsx
+++ b/src-docs/src/views/theme/borders/_border_js.tsx
@@ -44,6 +44,7 @@ export const TypesJS: FunctionComponent<ThemeRowType> = ({ description }) => {
           </div>
         }
         snippet={'border: ${euiTheme.border.thin};'}
+        snippetLanguage="emotion"
       />
 
       <ThemeValuesTable
@@ -101,6 +102,7 @@ export const ColorJS: FunctionComponent<ThemeRowType> = ({ description }) => {
           </div>
         }
         snippet={'border-color: ${euiTheme.border.color};'}
+        snippetLanguage="emotion"
       />
 
       <ThemeValuesTable
@@ -153,6 +155,7 @@ export const WidthJS: FunctionComponent<ThemeRowType> = ({ description }) => {
         snippet={
           'border: ${euiTheme.border.width.thick} dashed ${euiTheme.border.color};'
         }
+        snippetLanguage="emotion"
       />
 
       <ThemeValuesTable
@@ -203,6 +206,7 @@ export const RadiusJS: FunctionComponent<ThemeRowType> = ({ description }) => {
           </div>
         }
         snippet={'border-radius: ${euiTheme.border.radius.medium};'}
+        snippetLanguage="emotion"
       />
 
       <ThemeValuesTable

--- a/src-docs/src/views/theme/color/_color_js.tsx
+++ b/src-docs/src/views/theme/color/_color_js.tsx
@@ -41,6 +41,7 @@ export const BrandJS: FunctionComponent<ThemeRowType> = ({ description }) => {
           </div>
         }
         snippet={'background: ${euiTheme.colors.warning};'}
+        snippetLanguage="emotion"
       />
 
       <ThemeValuesTable
@@ -95,6 +96,7 @@ export const TextJS: FunctionComponent<ThemeRowType> = ({ description }) => {
           </div>
         }
         snippet={'color: ${euiTheme.colors.warningText};'}
+        snippetLanguage="emotion"
       />
 
       <ThemeValuesTable
@@ -149,6 +151,7 @@ export const ShadeJS: FunctionComponent<ThemeRowType> = ({ description }) => {
         snippet={
           'background: ${transparentize(euiTheme.colors.mediumShade, .25)};'
         }
+        snippetLanguage="emotion"
       />
 
       <ThemeValuesTable
@@ -194,6 +197,7 @@ export const SpecialJS: FunctionComponent<ThemeRowType> = ({ description }) => {
         }
         snippet={`color: \${euiTheme.colors.ghost};
   background-color: \${euiTheme.colors.ink};`}
+        snippetLanguage="emotion"
       />
 
       <ThemeValuesTable

--- a/src-docs/src/views/theme/other/_animation_js.tsx
+++ b/src-docs/src/views/theme/other/_animation_js.tsx
@@ -13,13 +13,13 @@ import { getPropsFromComponent } from '../../../services/props/get_props';
 import { ThemeExample } from '../_components/_theme_example';
 import { ThemeValuesTable } from '../_components/_theme_values_table';
 
-const canAnimateString = `\${euiCanAnimate}{
-    transition: background \${euiTheme.animation.slow};
-  }`;
+const canAnimateString = `\${euiCanAnimate} {
+  transition: background \${euiTheme.animation.slow};
+}`;
 
-const animationString = `\${euiCanAnimate}{
-    transition: padding \${euiTheme.animation.slow} \${euiTheme.animation.resistance};
-  }`;
+const animationString = `\${euiCanAnimate} {
+  transition: padding \${euiTheme.animation.slow} \${euiTheme.animation.resistance};
+}`;
 
 export default ({
   speedDescription,
@@ -61,6 +61,7 @@ export default ({
           </div>
         }
         snippet={canAnimateString}
+        snippetLanguage="emotion"
       />
 
       <ThemeValuesTable
@@ -110,6 +111,7 @@ export default ({
           </div>
         }
         snippet={animationString}
+        snippetLanguage="emotion"
       />
 
       <ThemeValuesTable

--- a/src-docs/src/views/theme/other/_animation_js.tsx
+++ b/src-docs/src/views/theme/other/_animation_js.tsx
@@ -14,12 +14,12 @@ import { ThemeExample } from '../_components/_theme_example';
 import { ThemeValuesTable } from '../_components/_theme_values_table';
 
 const canAnimateString = `\${euiCanAnimate} {
-  transition: background \${euiTheme.animation.slow};
-}`;
+    transition: background \${euiTheme.animation.slow};
+  }`;
 
 const animationString = `\${euiCanAnimate} {
-  transition: padding \${euiTheme.animation.slow} \${euiTheme.animation.resistance};
-}`;
+    transition: padding \${euiTheme.animation.slow} \${euiTheme.animation.resistance};
+  }`;
 
 export default ({
   speedDescription,

--- a/src-docs/src/views/theme/other/_shadow_js.tsx
+++ b/src-docs/src/views/theme/other/_shadow_js.tsx
@@ -114,6 +114,7 @@ export default () => {
         snippet={
           'box-shadow: 0 ${euiTheme.size.xs} ${euiTheme.size.xs} ${transparentize(euiTheme.colors.shadow, 0.04)};'
         }
+        snippetLanguage="emotion"
       />
 
       <ThemeExample
@@ -141,8 +142,8 @@ export default () => {
             </strong>
           </div>
         }
-        snippet={'css(useEuiShadow())'}
-        snippetLanguage="tsx"
+        snippet={'${useEuiShadow()}'}
+        snippetLanguage="emotion"
       />
 
       <EuiPanel color="accent">

--- a/src-docs/src/views/theme/sizing/_sizing_js.tsx
+++ b/src-docs/src/views/theme/sizing/_sizing_js.tsx
@@ -39,6 +39,7 @@ export const BaseJS = () => {
         </div>
       }
       snippet={'padding: ${euiTheme.base * 2}px;'}
+      snippetLanguage="emotion"
     />
   );
 };
@@ -69,6 +70,7 @@ export default () => {
           </div>
         }
         snippet={'padding: ${euiTheme.size.xl};'}
+        snippetLanguage="emotion"
       />
 
       <ThemeExample
@@ -95,6 +97,7 @@ export default () => {
           </div>
         }
         snippet={'padding: calc(${euiTheme.size.base} * 2);'}
+        snippetLanguage="emotion"
       />
 
       <ThemeValuesTable

--- a/src-docs/src/views/theme/typography/_typography_js.tsx
+++ b/src-docs/src/views/theme/typography/_typography_js.tsx
@@ -53,6 +53,7 @@ export const FontJS = () => {
           </p>
         }
         snippet={'font-family: ${euiTheme.font.family};'}
+        snippetLanguage="emotion"
       />
 
       <ThemeExample
@@ -68,6 +69,7 @@ export const FontJS = () => {
           </p>
         }
         snippet={'font-family: ${euiTheme.font.familyCode};'}
+        snippetLanguage="emotion"
       />
 
       <ThemeExample
@@ -83,6 +85,7 @@ export const FontJS = () => {
           </p>
         }
         snippet={'font-feature-settings: ${euiTheme.font.featureSettings};'}
+        snippetLanguage="emotion"
       />
     </>
   );
@@ -110,6 +113,7 @@ export const FontWeightJS: FunctionComponent<ThemeRowType> = ({
           </div>
         }
         snippet={'font-weight: ${euiTheme.font.weight.bold};'}
+        snippetLanguage="emotion"
       />
 
       <ThemeValuesTable
@@ -172,6 +176,7 @@ export const FontScaleJS = () => {
           </p>
         }
         snippet="${useEuiFontSize('l')}"
+        snippetLanguage="emotion"
       />
       <ThemeExample
         title={<code>useEuiFontSize().fontSize</code>}
@@ -192,6 +197,7 @@ export const FontScaleJS = () => {
           </p>
         }
         snippet="font-size: ${useEuiFontSize('xs').fontSize};"
+        snippetLanguage="emotion"
       />
       <EuiPanel color="accent">
         <EuiDescribedFormGroup

--- a/src-docs/src/views/theme/typography/typography.tsx
+++ b/src-docs/src/views/theme/typography/typography.tsx
@@ -184,7 +184,7 @@ export default () => {
             ? findSassFontWeight({ fontWeight })
             : findJSFontWeight({ fontWeight, euiTheme })
         }
-        snippetLanguage={showSass ? 'scss' : 'jsx'}
+        snippetLanguage={showSass ? 'scss' : 'emotion'}
       />
 
       <EuiSpacer size="xl" />

--- a/src-docs/src/views/utility_classes/utility_classes_section.tsx
+++ b/src-docs/src/views/utility_classes/utility_classes_section.tsx
@@ -25,7 +25,6 @@ export const UtilityClassesSection: FunctionComponent<UtilityClassesSection> = (
           )}
         </EuiCopy>
       }
-      snippetLanguage="tsx"
       {...rest}
     />
   );


### PR DESCRIPTION
### Summary

We've started to use the `ThemeExample` component for more than just Sass and Emotion and for actual JSX snippets.  As such I'm tweaking the logic that adds a `css` wrapper/ternary around the passed snippet to specify emotion snippets.

### Checklist

- [x] All affected usages of ThemeExample should render the same as before
    - NB: except in one `snippetLanguage="ts"` case which now renders the correct syntax highlighting, and a few hook snippets which I corrected to use expected Emotion syntax