### PR TITLE
[Emotion] Convert `euiFocusRing()` mixin

### DIFF
--- a/src-docs/src/views/accessibility/accessibility_example.js
+++ b/src-docs/src/views/accessibility/accessibility_example.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { css } from '@emotion/react';
 
 import { GuideSectionTypes } from '../../components';
 
@@ -11,16 +10,13 @@ import {
   EuiScreenReaderLive,
   EuiScreenReaderOnly,
   EuiSpacer,
-  euiScreenReaderOnlyStyles,
-  EuiText,
 } from '../../../../src';
-
-import { ThemeExample } from '../theme/_components/_theme_example';
 
 import ScreenReaderLive from './screen_reader_live';
 import ScreenReaderOnly from './screen_reader';
 import ScreenReaderFocus from './screen_reader_focus';
 import SkipLink from './skip_link';
+import StylesHelpers from './styles_helpers';
 
 const screenReaderLiveSource = require('!!raw-loader!./screen_reader_live');
 const screenReaderOnlySource = require('!!raw-loader!./screen_reader');
@@ -193,46 +189,7 @@ export const AccessibilityExample = {
     {
       title: 'Styles helpers',
       wrapText: false,
-      text: (
-        <>
-          <ThemeExample
-            title={<code>.euiScreenReaderOnly</code>}
-            description={
-              <p>
-                This utility class allows you to apply the screen reader only
-                CSS styles directly to your component.
-              </p>
-            }
-            example={
-              <EuiText size="s">
-                <p>The next paragraph is hidden except for screen readers.</p>
-                <p className="euiScreenReaderOnly">
-                  I am hidden except for screen readers
-                </p>
-              </EuiText>
-            }
-            snippet={'<p className="euiScreenReaderOnly" />'}
-          />
-          <ThemeExample
-            title={<code>euiScreenReaderOnlyStyles()</code>}
-            description={
-              <p>
-                This function allows you to apply the screen reader only CSS
-                styles directly to your component.
-              </p>
-            }
-            example={
-              <EuiText size="s">
-                <p>The next paragraph is hidden except for screen readers.</p>
-                <p css={css(euiScreenReaderOnlyStyles())}>
-                  I am hidden except for screen readers
-                </p>
-              </EuiText>
-            }
-            snippet={'<p css={css(euiScreenReaderOnlyStyles())} />'}
-          />
-        </>
-      ),
+      text: <StylesHelpers />,
     },
   ],
 };

--- a/src-docs/src/views/accessibility/styles_helpers.tsx
+++ b/src-docs/src/views/accessibility/styles_helpers.tsx
@@ -1,0 +1,89 @@
+import { css } from '@emotion/react';
+import React from 'react';
+
+import {
+  EuiCode,
+  euiScreenReaderOnlyStyles,
+  EuiText,
+  useEuiFocusRing,
+} from '../../../../src';
+import { useEuiTheme } from '../../../../src/services';
+import { ThemeExample } from '../theme/_components/_theme_example';
+
+export default () => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <>
+      <ThemeExample
+        title={<code>.euiScreenReaderOnly</code>}
+        description={
+          <p>
+            This utility class allows you to apply the screen reader only CSS
+            styles directly to your component.
+          </p>
+        }
+        example={
+          <EuiText size="s">
+            <p>The next paragraph is hidden except for screen readers.</p>
+            <p className="euiScreenReaderOnly">
+              I am hidden except for screen readers
+            </p>
+          </EuiText>
+        }
+        snippet={'<p className="euiScreenReaderOnly" />'}
+      />
+      <ThemeExample
+        title={<code>euiScreenReaderOnlyStyles()</code>}
+        description={
+          <p>
+            This function allows you to apply the screen reader only CSS styles
+            directly to your component.
+          </p>
+        }
+        example={
+          <EuiText size="s">
+            <p>The next paragraph is hidden except for screen readers.</p>
+            <p css={css(euiScreenReaderOnlyStyles())}>
+              I am hidden except for screen readers
+            </p>
+          </EuiText>
+        }
+        snippet={'<p css={css(euiScreenReaderOnlyStyles())} />'}
+      />
+      <ThemeExample
+        title={<code>useEuiFocusRing(offset, color)</code>}
+        description={
+          <p>
+            By default, all interactable elements will inherit the{' '}
+            <EuiCode>outline</EuiCode> property from the reset file. However,
+            some instances require adjustment to the <EuiCode>offset</EuiCode>{' '}
+            and <EuiCode>color</EuiCode> of this outline. This helper function
+            allows that customization of the focus outline.
+          </p>
+        }
+        example={
+          <EuiText size="s">
+            <p>
+              <button>
+                I am an unstyled <EuiCode>button</EuiCode> with inherited
+                outline
+              </button>
+            </p>
+            <p>
+              <button
+                css={css(useEuiFocusRing('outset', euiTheme.colors.primary))}
+              >
+                I am an unstyled <EuiCode>button</EuiCode> with an{' '}
+                <EuiCode>outset, primary</EuiCode> outline
+              </button>
+            </p>
+          </EuiText>
+        }
+        snippet={
+          "<button css={css(useEuiFocusRing('outset', euiTheme.colors.primary)) />"
+        }
+      />
+    </>
+  );
+};

--- a/src-docs/src/views/accessibility/styles_helpers.tsx
+++ b/src-docs/src/views/accessibility/styles_helpers.tsx
@@ -52,7 +52,7 @@ export default () => {
         snippet={'<p css={css(euiScreenReaderOnlyStyles())} />'}
       />
       <ThemeExample
-        title={<code>useEuiFocusRing(offset, color)</code>}
+        title={<code>useEuiFocusRing(offset?, color?)</code>}
         description={
           <p>
             By default, all interactable elements will inherit the{' '}
@@ -62,6 +62,9 @@ export default () => {
             allows that customization of the focus outline.
           </p>
         }
+        props={`offset: 'inset' | 'outset' | 'center' | CSSProperties['outlineOffset'];
+
+color: CSSProperties['outlineColor'];`}
         example={
           <EuiText size="s">
             <p>

--- a/src-docs/src/views/accessibility/styles_helpers.tsx
+++ b/src-docs/src/views/accessibility/styles_helpers.tsx
@@ -72,7 +72,11 @@ export default () => {
             </p>
             <p>
               <button
-                css={css(useEuiFocusRing('outset', euiTheme.colors.primary))}
+                css={css`
+                  &:focus {
+                    ${useEuiFocusRing('outset', euiTheme.colors.primary)}
+                  }
+                `}
               >
                 I am an unstyled <EuiCode>button</EuiCode> with an{' '}
                 <EuiCode>outset, primary</EuiCode> outline
@@ -80,9 +84,10 @@ export default () => {
             </p>
           </EuiText>
         }
-        snippet={
-          "<button css={css(useEuiFocusRing('outset', euiTheme.colors.primary)) />"
-        }
+        snippetLanguage="emotion"
+        snippet={`&:focus {
+   \${useEuiFocusRing('outset', euiTheme.colors.primary)}
+ }`}
       />
     </>
   );

--- a/src-docs/src/views/theme/_components/_theme_example.tsx
+++ b/src-docs/src/views/theme/_components/_theme_example.tsx
@@ -74,22 +74,23 @@ export const ThemeExample: FunctionComponent<ThemeExample> = ({
         </EuiSplitPanel.Inner>
 
         {(example || snippet) && (
-          <EuiSplitPanel.Inner>
+          <EuiSplitPanel.Inner style={{ overflow: 'hidden' }}>
             <EuiSplitPanel.Outer
+              direction="column"
               hasBorder={true}
               hasShadow={false}
-              style={{ overflow: 'hidden' }}
             >
               {example && (
                 <EuiSplitPanel.Inner {...examplePanel}>
                   {example}
                 </EuiSplitPanel.Inner>
               )}
-              <EuiSplitPanel.Inner color="subdued">
+              <EuiSplitPanel.Inner paddingSize="none" color="subdued">
                 {finalSnippet && (
                   <EuiCodeBlock
+                    whiteSpace="pre"
                     isCopyable={true}
-                    paddingSize="none"
+                    paddingSize="m"
                     transparentBackground={true}
                     language={
                       snippetLanguage === 'emotion' ? 'jsx' : snippetLanguage

--- a/src-docs/src/views/theme/_components/_theme_example.tsx
+++ b/src-docs/src/views/theme/_components/_theme_example.tsx
@@ -25,6 +25,7 @@ export type ThemeExample = {
   examplePanel?: _EuiSplitPanelInnerProps;
   snippet?: GuideSectionExample['tabContent'];
   snippetLanguage?: EuiCodeBlockProps['language'];
+  props?: ReactNode;
   provider?: {
     property?: string;
     type?: string;
@@ -39,6 +40,7 @@ export const ThemeExample: FunctionComponent<ThemeExample> = ({
   examplePanel,
   snippet,
   snippetLanguage = 'jsx',
+  props,
 }) => {
   const { euiTheme } = useEuiTheme();
   const finalSnippet =
@@ -71,6 +73,18 @@ export const ThemeExample: FunctionComponent<ThemeExample> = ({
           <EuiText size="s" grow={false}>
             {description}
           </EuiText>
+          {props && (
+            <>
+              <EuiSpacer />
+              <EuiCodeBlock
+                transparentBackground
+                paddingSize="none"
+                language="ts"
+              >
+                {props}
+              </EuiCodeBlock>
+            </>
+          )}
         </EuiSplitPanel.Inner>
 
         {(example || snippet) && (

--- a/src-docs/src/views/theme/customizing/_focus.js
+++ b/src-docs/src/views/theme/customizing/_focus.js
@@ -1,95 +1,73 @@
 import React from 'react';
-import { css } from '@emotion/react';
 
 import {
   useEuiTheme,
   EuiTitle,
   EuiSpacer,
-  EuiColorPickerSwatch,
-  EuiFlexItem,
-  EuiCodeBlock,
+  EuiText,
+  EuiPanel,
 } from '../../../../../src';
 
-import { ThemeSection } from '../_theme_section';
+import { getPropsFromComponent } from '../../../services/props/get_props';
+import { useDebouncedUpdate } from '../hooks';
+
 import { ThemeValue } from './_values';
 
-import { getPropsFromComponent, EuiThemeFocus } from '../_props';
+import { EuiThemeFocus } from '../_props';
 
 export default ({ onThemeUpdate }) => {
   const { euiTheme } = useEuiTheme();
   const focus = euiTheme.focus;
+
+  const [focusClone, updateFocus] = useDebouncedUpdate({
+    property: 'focus',
+    value: focus,
+    onUpdate: onThemeUpdate,
+  });
+
   const focusProps = getPropsFromComponent(EuiThemeFocus);
-
-  const updateFocus = (property, value) => {
-    onThemeUpdate({
-      focus: {
-        [property]: value,
-      },
-    });
-  };
-
-  const style = css`
-    width: ${euiTheme.size.xl};
-    height: ${euiTheme.size.xl};
-    border-radius: ${euiTheme.border.radius.small};
-  `;
 
   return (
     <div>
-      <EuiTitle>
+      <EuiText>
         <h2>Focus</h2>
-      </EuiTitle>
-
-      <EuiSpacer />
-
-      <ThemeSection
-        code="_EuiThemeFocus"
-        description={
+      </EuiText>
+      <EuiSpacer size="xl" />
+      <EuiPanel color="subdued">
+        <EuiTitle size="xs">
+          <h3>
+            <code>_EuiThemeFocus</code>
+          </h3>
+        </EuiTitle>
+        <EuiSpacer size="s" />
+        <EuiText size="s" grow={false}>
           <p>
             These are general properties that apply to the focus state of
             interactable components. Some components have their own specific
             implementation, but most use these variables.
           </p>
-        }
-        themeValues={Object.keys(focus).map((prop) => {
-          const isColor = prop.toLowerCase().includes('color');
-          if (prop === 'outline') {
-            return (
-              <EuiFlexItem key={prop}>
-                <ThemeValue
-                  property="focus"
-                  type={focusProps[prop]}
-                  name={prop}
-                  buttonStyle={[style, focus[prop]]}
-                />
-                <EuiSpacer size="xs" />
-                <EuiCodeBlock paddingSize="s" language="css">{`${JSON.stringify(
-                  focus[prop]
-                ).replace(/[{}"]/g, '')};`}</EuiCodeBlock>
-              </EuiFlexItem>
-            );
-          }
+        </EuiText>
+
+        <EuiSpacer />
+
+        {Object.keys(focusProps).map((prop) => {
           return (
-            <EuiFlexItem key={prop}>
-              <ThemeValue
-                property="focus"
-                name={prop}
-                type={focusProps[prop]}
-                value={focus[prop]}
-                onUpdate={(value) => updateFocus(prop, value)}
-                example={
-                  isColor ? (
-                    <EuiColorPickerSwatch color={focus[prop]} />
-                  ) : undefined
-                }
-                colorProps={
-                  isColor ? { showAlpha: true, format: 'rgba' } : undefined
-                }
-              />
-            </EuiFlexItem>
+            <ThemeValue
+              key={prop}
+              property="focus"
+              type={focusProps[prop]}
+              name={prop}
+              value={focusClone[prop]}
+              onUpdate={(value) => updateFocus(prop, value)}
+              forceUpdateType="string"
+              example={null}
+              numberProps={{
+                style: { width: 140 },
+              }}
+            />
           );
         })}
-      />
+      </EuiPanel>
     </div>
   );
 };

--- a/src-docs/src/views/theme/customizing/_values.tsx
+++ b/src-docs/src/views/theme/customizing/_values.tsx
@@ -44,6 +44,7 @@ type ThemeValue = {
   numberProps?: EuiFieldNumberProps;
   stringProps?: EuiFieldTextProps;
   colorProps?: Partial<EuiColorPickerProps>;
+  forceUpdateType?: 'string' | 'number' | 'color';
 };
 
 export const ThemeValue: FunctionComponent<ThemeValue> = ({
@@ -58,6 +59,7 @@ export const ThemeValue: FunctionComponent<ThemeValue> = ({
   numberProps,
   stringProps,
   colorProps,
+  forceUpdateType,
 }) => {
   const { euiTheme } = useEuiTheme();
 
@@ -87,7 +89,10 @@ export const ThemeValue: FunctionComponent<ThemeValue> = ({
     debouncedOnUpdate(hex, isValid);
   };
   let exampleRender;
-  if (property === 'colors' || name.toLowerCase().includes('color')) {
+  if (
+    example !== null &&
+    (property === 'colors' || name.toLowerCase().includes('color'))
+  ) {
     exampleRender = (
       <EuiFlexItem grow={false}>
         <EuiColorPickerSwatch color={color} disabled />
@@ -120,57 +125,69 @@ export const ThemeValue: FunctionComponent<ThemeValue> = ({
     descriptionRender = <>{getDescription(type)}</>;
   }
 
-  let valueRender;
-  if (
-    (property === 'colors' || name.toLowerCase().includes('color')) &&
-    onUpdate
-  ) {
-    valueRender = (
-      <EuiFlexItem grow={false}>
-        <EuiColorPicker
-          swatches={[]}
-          onChange={handleColorChange}
-          color={color}
-          isInvalid={!!errors}
+  const valueRender = () => {
+    if (!onUpdate) {
+      return (
+        <EuiText textAlign="right" size="s" color="subdued">
+          <code>{value}</code>
+        </EuiText>
+      );
+    }
+
+    let updateType = forceUpdateType;
+    if (
+      !updateType &&
+      (property === 'colors' || name.toLowerCase().includes('color'))
+    ) {
+      updateType = 'color';
+    } else if (!updateType && typeof value === 'number') {
+      updateType = 'number';
+    } else if (
+      !updateType &&
+      property !== 'colors' &&
+      !name.toLowerCase().includes('color') &&
+      typeof value === 'string'
+    ) {
+      updateType = 'string';
+    }
+
+    if (updateType === 'color') {
+      return (
+        <EuiFlexItem grow={false}>
+          <EuiColorPicker
+            swatches={[]}
+            onChange={handleColorChange}
+            color={color}
+            isInvalid={!!errors}
+            compressed
+            {...colorProps}
+          />
+        </EuiFlexItem>
+      );
+    } else if (updateType === 'number') {
+      return (
+        <EuiFieldNumber
           compressed
-          {...colorProps}
+          aria-label={`Update ${name} value`}
+          value={Number(value)}
+          onChange={(e) => onUpdate(Number(e.target.value))}
+          style={{ width: 64 }}
+          {...numberProps}
         />
-      </EuiFlexItem>
-    );
-  } else if (typeof value === 'number' && onUpdate) {
-    valueRender = (
-      <EuiFieldNumber
-        compressed
-        aria-label={`Update ${name} value`}
-        value={value}
-        onChange={(e) => onUpdate(Number(e.target.value))}
-        style={{ width: 64 }}
-        {...numberProps}
-      />
-    );
-  } else if (
-    property !== 'colors' &&
-    !name.toLowerCase().includes('color') &&
-    typeof value === 'string' &&
-    onUpdate
-  ) {
-    valueRender = (
-      <EuiFieldText
-        compressed
-        aria-label={`Update ${name} value`}
-        value={value}
-        onChange={(e) => onUpdate(e.target.value)}
-        style={{ width: 120 }}
-        {...stringProps}
-      />
-    );
-  } else {
-    valueRender = (
-      <EuiText textAlign="right" size="s" color="subdued">
-        <code>{value}</code>
-      </EuiText>
-    );
-  }
+      );
+    } else if (updateType === 'string') {
+      return (
+        <EuiFieldText
+          compressed
+          aria-label={`Update ${name} value`}
+          value={String(value)}
+          onChange={(e) => onUpdate(e.target.value)}
+          style={{ width: 120 }}
+          {...stringProps}
+        />
+      );
+    }
+  };
 
   name = property ? `${property}.${name}` : name;
 
@@ -193,7 +210,7 @@ export const ThemeValue: FunctionComponent<ThemeValue> = ({
           </EuiToolTip>
         </EuiText>
       </EuiFlexItem>
-      <EuiFlexItem grow={false}>{valueRender}</EuiFlexItem>
+      <EuiFlexItem grow={false}>{valueRender()}</EuiFlexItem>
     </EuiFlexGroup>
   );
 };

--- a/src-docs/src/views/theme/customizing/values.tsx
+++ b/src-docs/src/views/theme/customizing/values.tsx
@@ -39,6 +39,8 @@ import Animation from './_animation';
 import Breakpoints from './_breakpoints';
 // @ts-ignore Importing from JS
 import Levels from './_levels';
+// @ts-ignore Importing from JS
+import Focus from './_focus';
 
 import Sass from './_sass';
 
@@ -114,6 +116,10 @@ export default () => {
             <EuiHorizontalRule margin="xxl" />
 
             <Levels onThemeUpdate={updateTheme} />
+
+            <EuiSpacer />
+
+            <Focus onThemeUpdate={updateTheme} />
 
             <EuiSpacer />
           </>

--- a/src/components/panel/split_panel/_split_panel.scss
+++ b/src/components/panel/split_panel/_split_panel.scss
@@ -11,8 +11,8 @@
   }
 
   @each $modifier, $amount in $euiPanelBorderRadiusModifiers {
-    &.euiSplitPanel-isResponsive.euiPanel--#{$modifier} .euiSplitPanel__inner,
-    &.euiPanel--#{$modifier} .euiSplitPanel__inner {
+    &.euiSplitPanel-isResponsive.euiPanel--#{$modifier} > .euiSplitPanel__inner,
+    &.euiPanel--#{$modifier} > .euiSplitPanel__inner {
       &:first-child {
         border-radius: ($amount - 1) ($amount - 1) 0 0;
       }
@@ -32,7 +32,7 @@
   }
 
   @each $modifier, $amount in $euiPanelBorderRadiusModifiers {
-    &.euiPanel--#{$modifier} .euiSplitPanel__inner {
+    &.euiPanel--#{$modifier} > .euiSplitPanel__inner {
       &:first-child {
         border-radius: ($amount - 1) 0 0 ($amount - 1);
       }

--- a/src/components/provider/__snapshots__/provider.test.tsx.snap
+++ b/src/components/provider/__snapshots__/provider.test.tsx.snap
@@ -224,6 +224,21 @@ exports[`EuiProvider applying modifications propagates \`modify\` 1`] = `
         "ghost": "#FFF",
         "ink": "#000",
       },
+      "focus": Object {
+        "backgroundColor": Computed {
+          "computer": [Function],
+          "dependencies": Array [],
+        },
+        "color": "currentColor",
+        "transparency": Object {
+          "DARK": 0.7,
+          "LIGHT": 0.9,
+        },
+        "width": Computed {
+          "computer": [Function],
+          "dependencies": Array [],
+        },
+      },
       "font": Object {
         "baseline": Computed {
           "computer": [Function],
@@ -533,6 +548,21 @@ exports[`EuiProvider changing color modes propagates \`colorMode\` 1`] = `
         "ghost": "#FFF",
         "ink": "#000",
       },
+      "focus": Object {
+        "backgroundColor": Computed {
+          "computer": [Function],
+          "dependencies": Array [],
+        },
+        "color": "currentColor",
+        "transparency": Object {
+          "DARK": 0.7,
+          "LIGHT": 0.9,
+        },
+        "width": Computed {
+          "computer": [Function],
+          "dependencies": Array [],
+        },
+      },
       "font": Object {
         "baseline": Computed {
           "computer": [Function],
@@ -840,6 +870,21 @@ exports[`EuiProvider is rendered 1`] = `
         },
         "ghost": "#FFF",
         "ink": "#000",
+      },
+      "focus": Object {
+        "backgroundColor": Computed {
+          "computer": [Function],
+          "dependencies": Array [],
+        },
+        "color": "currentColor",
+        "transparency": Object {
+          "DARK": 0.7,
+          "LIGHT": 0.9,
+        },
+        "width": Computed {
+          "computer": [Function],
+          "dependencies": Array [],
+        },
       },
       "font": Object {
         "baseline": Computed {
@@ -1169,6 +1214,21 @@ exports[`EuiProvider providing an @emotion cache config applies the cache to glo
         },
         "ghost": "#FFF",
         "ink": "#000",
+      },
+      "focus": Object {
+        "backgroundColor": Computed {
+          "computer": [Function],
+          "dependencies": Array [],
+        },
+        "color": "currentColor",
+        "transparency": Object {
+          "DARK": 0.7,
+          "LIGHT": 0.9,
+        },
+        "width": Computed {
+          "computer": [Function],
+          "dependencies": Array [],
+        },
       },
       "font": Object {
         "baseline": Computed {

--- a/src/components/provider/__snapshots__/provider.test.tsx.snap
+++ b/src/components/provider/__snapshots__/provider.test.tsx.snap
@@ -225,15 +225,7 @@ exports[`EuiProvider applying modifications propagates \`modify\` 1`] = `
         "ink": "#000",
       },
       "focus": Object {
-        "backgroundColor": Computed {
-          "computer": [Function],
-          "dependencies": Array [],
-        },
         "color": "currentColor",
-        "transparency": Object {
-          "DARK": 0.7,
-          "LIGHT": 0.9,
-        },
         "width": Computed {
           "computer": [Function],
           "dependencies": Array [],
@@ -549,15 +541,7 @@ exports[`EuiProvider changing color modes propagates \`colorMode\` 1`] = `
         "ink": "#000",
       },
       "focus": Object {
-        "backgroundColor": Computed {
-          "computer": [Function],
-          "dependencies": Array [],
-        },
         "color": "currentColor",
-        "transparency": Object {
-          "DARK": 0.7,
-          "LIGHT": 0.9,
-        },
         "width": Computed {
           "computer": [Function],
           "dependencies": Array [],
@@ -872,15 +856,7 @@ exports[`EuiProvider is rendered 1`] = `
         "ink": "#000",
       },
       "focus": Object {
-        "backgroundColor": Computed {
-          "computer": [Function],
-          "dependencies": Array [],
-        },
         "color": "currentColor",
-        "transparency": Object {
-          "DARK": 0.7,
-          "LIGHT": 0.9,
-        },
         "width": Computed {
           "computer": [Function],
           "dependencies": Array [],
@@ -1216,15 +1192,7 @@ exports[`EuiProvider providing an @emotion cache config applies the cache to glo
         "ink": "#000",
       },
       "focus": Object {
-        "backgroundColor": Computed {
-          "computer": [Function],
-          "dependencies": Array [],
-        },
         "color": "currentColor",
-        "transparency": Object {
-          "DARK": 0.7,
-          "LIGHT": 0.9,
-        },
         "width": Computed {
           "computer": [Function],
           "dependencies": Array [],

--- a/src/global_styling/mixins/__snapshots__/_states.test.ts.snap
+++ b/src/global_styling/mixins/__snapshots__/_states.test.ts.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useEuiFocusRing hook returns a string for any color: blue 1`] = `
+"
+    outline: 2px solid blue;
+    outline-offset: 2px;
+
+    // 👀 Chrome respects :focus-visible and allows coloring the \`auto\` style
+    &:focus-visible {
+      outline-style: auto;
+    }
+
+    // 🙅‍♀️ But Chrome also needs to have the outline forcefully removed from regular \`:focus\` state
+    &:not(:focus-visible) {
+      outline: none;
+    }
+  "
+`;
+
+exports[`useEuiFocusRing hook returns a string for each offset: 16px 1`] = `
+"
+    outline: 2px solid currentColor;
+    outline-offset: 16px;
+
+    // 👀 Chrome respects :focus-visible and allows coloring the \`auto\` style
+    &:focus-visible {
+      outline-style: auto;
+    }
+
+    // 🙅‍♀️ But Chrome also needs to have the outline forcefully removed from regular \`:focus\` state
+    &:not(:focus-visible) {
+      outline: none;
+    }
+  "
+`;
+
+exports[`useEuiFocusRing hook returns a string for each offset: inset 1`] = `
+"
+    outline: 2px solid currentColor;
+    outline-offset: -2px;
+
+    // 👀 Chrome respects :focus-visible and allows coloring the \`auto\` style
+    &:focus-visible {
+      outline-style: auto;
+    }
+
+    // 🙅‍♀️ But Chrome also needs to have the outline forcefully removed from regular \`:focus\` state
+    &:not(:focus-visible) {
+      outline: none;
+    }
+  "
+`;
+
+exports[`useEuiFocusRing hook returns a string for each offset: outset 1`] = `
+"
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+
+    // 👀 Chrome respects :focus-visible and allows coloring the \`auto\` style
+    &:focus-visible {
+      outline-style: auto;
+    }
+
+    // 🙅‍♀️ But Chrome also needs to have the outline forcefully removed from regular \`:focus\` state
+    &:not(:focus-visible) {
+      outline: none;
+    }
+  "
+`;

--- a/src/global_styling/mixins/_states.test.ts
+++ b/src/global_styling/mixins/_states.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { testCustomHook } from '../../test/internal';
+import { useEuiFocusRing } from './_states';
+
+describe('useEuiFocusRing hook returns a string', () => {
+  describe('for each offset:', () => {
+    it('inset', () => {
+      expect(
+        testCustomHook(() => useEuiFocusRing('inset')).return
+      ).toMatchSnapshot();
+    });
+
+    it('outset', () => {
+      expect(
+        testCustomHook(() => useEuiFocusRing('outset')).return
+      ).toMatchSnapshot();
+    });
+
+    it('16px', () => {
+      expect(
+        testCustomHook(() => useEuiFocusRing('16px')).return
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('for any color:', () => {
+    it('blue', () => {
+      expect(
+        testCustomHook(() => useEuiFocusRing('outset', 'blue')).return
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/src/global_styling/mixins/_states.ts
+++ b/src/global_styling/mixins/_states.ts
@@ -16,11 +16,11 @@ export type _EuiFocusRingOffset =
   | CSSProperties['outlineOffset'];
 
 /**
- * Focus rings default to the browser's `outline`.
- * However, some components need to be forced to have the same behavior
- * This re-applies the same default outline with a couple parameters
+ * It is best practice to utilize the browser's default `outline` property for handling focus rings.
+ * However, some components need to be forced to have the same behavior, or adjust the display.
+ * This function re-applies the same default outline with a couple parameters
  * @param euiTheme UseEuiTheme.euiTheme
- * @param offset Accepts a specific measurement or 'inset' or 'outset' or 'center' to adjust outline position
+ * @param offset Accepts a specific measurement or 'inset', 'outset' or 'center' to adjust outline position
  * @param color Accepts any CSS color, **Note: only works in -webkit-**
  */
 export const euiFocusRing = (
@@ -41,11 +41,11 @@ export const euiFocusRing = (
     outlineOffset = `calc(${outlineWidth} / -2);`;
   }
 
-  // The latest theme utilizes `focus-visible` to turn on focus outlines.
+  // This function utilizes `focus-visible` to turn on focus outlines.
   // But this is browser-dependend:
   // 👉 Safari and Firefox innately respect only showing the outline with keyboard only
   // 💔 But they don't allow coloring of the 'auto'/default outline, so contrast is no good in dark mode.
-  // 👉 For these browsers we use the solid type in order to match with \`currentColor\`.
+  // 👉 For these browsers we use the solid type in order to match with `currentColor.
   // 😦 Which does means the outline will be square
   return `
     outline: ${outlineWidth} solid ${outlineColor};

--- a/src/global_styling/mixins/_states.ts
+++ b/src/global_styling/mixins/_states.ts
@@ -28,8 +28,8 @@ export const euiFocusRing = (
   offset: _EuiFocusRingOffset = 'center',
   color?: CSSProperties['outlineColor']
 ) => {
-  const outlineWidth = euiTheme.focus?.width;
-  const outlineColor = color || euiTheme.focus?.color;
+  const outlineWidth = euiTheme.focus.width;
+  const outlineColor = color || euiTheme.focus.color;
 
   let outlineOffset = offset;
   if (offset === 'inset') {

--- a/src/global_styling/mixins/_states.ts
+++ b/src/global_styling/mixins/_states.ts
@@ -21,6 +21,7 @@ export type _EuiFocusRingOffset =
  * This re-applies the same default outline with a couple parameters
  * @param euiTheme UseEuiTheme.euiTheme
  * @param offset Accepts a specific measurement or 'inset' or 'outset' or 'center' to adjust outline position
+ * @param color Accepts any CSS color, **Note: only works in -webkit-**
  */
 export const euiFocusRing = (
   euiTheme: UseEuiTheme['euiTheme'],

--- a/src/global_styling/mixins/_states.ts
+++ b/src/global_styling/mixins/_states.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { CSSProperties } from 'react';
+import { useEuiTheme, UseEuiTheme } from '../../services';
+import { css } from '@emotion/react';
+
+export type _EuiFocusRingOffset =
+  | 'inset'
+  | 'outset'
+  | 'center'
+  | CSSProperties['outlineOffset'];
+
+/**
+ * Focus rings default to the browser's `outline`.
+ * However, some components need to be forced to have the same behavior
+ * This re-applies the same default outline with a couple parameters
+ * @param euiTheme UseEuiTheme.euiTheme
+ * @param offset Accepts a specific measurement or 'inset' or 'outset' or 'center' to adjust outline position
+ */
+export const euiFocusRing = (
+  euiTheme: UseEuiTheme['euiTheme'],
+  offset: _EuiFocusRingOffset = 'center'
+) => {
+  const outlineWidth = euiTheme.focus?.width;
+  const outlineColor = euiTheme.focus?.color;
+
+  let outlineOffset = offset;
+  if (offset === 'inset') {
+    outlineOffset = `-${outlineWidth}`;
+  } else if (offset === 'outset') {
+    outlineOffset = `${outlineWidth}`;
+  } else if (offset === 'center') {
+    outlineOffset = `calc(${outlineWidth} / -2);`;
+  }
+
+  // The latest theme utilizes `focus-visible` to turn on focus outlines.
+  // But this is browser-dependend:
+  // 👉 Safari and Firefox innately respect only showing the outline with keyboard only
+  // 💔 But they don't allow coloring of the 'auto'/default outline, so contrast is no good in dark mode.
+  // 👉 For these browsers we use the solid type in order to match with \`currentColor\`.
+  // 😦 Which does means the outline will be square
+  return css`
+    outline: ${outlineWidth} solid ${outlineColor};
+    outline-offset: ${outlineOffset};
+
+    // 👀 Chrome respects :focus-visible and allows coloring the \`auto\` style
+    &:focus-visible {
+      outline-style: auto;
+    }
+
+    // 🙅‍♀️ But Chrome also needs to have the outline forcefully removed from regular \`:focus\` state
+    &:not(:focus-visible) {
+      outline: none;
+    }
+  `;
+};
+
+// Hook version
+export const useEuiFocusRing = (offset?: _EuiFocusRingOffset) => {
+  const { euiTheme } = useEuiTheme();
+  return euiFocusRing(euiTheme, offset);
+};

--- a/src/global_styling/mixins/_states.ts
+++ b/src/global_styling/mixins/_states.ts
@@ -25,10 +25,11 @@ export type _EuiFocusRingOffset =
  */
 export const euiFocusRing = (
   euiTheme: UseEuiTheme['euiTheme'],
-  offset: _EuiFocusRingOffset = 'center'
+  offset: _EuiFocusRingOffset = 'center',
+  color?: CSSProperties['outlineColor']
 ) => {
   const outlineWidth = euiTheme.focus?.width;
-  const outlineColor = euiTheme.focus?.color;
+  const outlineColor = color || euiTheme.focus?.color;
 
   let outlineOffset = offset;
   if (offset === 'inset') {
@@ -62,7 +63,10 @@ export const euiFocusRing = (
 };
 
 // Hook version
-export const useEuiFocusRing = (offset?: _EuiFocusRingOffset) => {
+export const useEuiFocusRing = (
+  offset?: _EuiFocusRingOffset,
+  color?: CSSProperties['outlineColor']
+) => {
   const { euiTheme } = useEuiTheme();
-  return euiFocusRing(euiTheme, offset);
+  return euiFocusRing(euiTheme, offset, color);
 };

--- a/src/global_styling/mixins/_states.ts
+++ b/src/global_styling/mixins/_states.ts
@@ -8,7 +8,6 @@
 
 import { CSSProperties } from 'react';
 import { useEuiTheme, UseEuiTheme } from '../../services';
-import { css } from '@emotion/react';
 
 export type _EuiFocusRingOffset =
   | 'inset'
@@ -28,6 +27,7 @@ export const euiFocusRing = (
   offset: _EuiFocusRingOffset = 'center',
   color?: CSSProperties['outlineColor']
 ) => {
+  // Width is enforced as a constant at the global theme layer
   const outlineWidth = euiTheme.focus.width;
   const outlineColor = color || euiTheme.focus.color;
 
@@ -46,7 +46,7 @@ export const euiFocusRing = (
   // 💔 But they don't allow coloring of the 'auto'/default outline, so contrast is no good in dark mode.
   // 👉 For these browsers we use the solid type in order to match with \`currentColor\`.
   // 😦 Which does means the outline will be square
-  return css`
+  return `
     outline: ${outlineWidth} solid ${outlineColor};
     outline-offset: ${outlineOffset};
 

--- a/src/global_styling/mixins/index.ts
+++ b/src/global_styling/mixins/index.ts
@@ -7,4 +7,5 @@
  */
 
 export * from './_helpers';
+export * from './_states';
 export * from './_typography';

--- a/src/global_styling/reset/global_styles.tsx
+++ b/src/global_styling/reset/global_styles.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import { Global, css } from '@emotion/react';
-import { euiScrollBarStyles } from '../mixins';
+import { euiFocusRing, euiScrollBarStyles } from '../mixins';
 import { shade, tint, transparentize } from '../../services/color';
 import { useEuiTheme } from '../../services/theme';
 import { resetStyles as reset } from './reset';
@@ -17,7 +17,7 @@ export interface EuiGlobalStylesProps {}
 
 export const EuiGlobalStyles = ({}: EuiGlobalStylesProps) => {
   const { euiTheme, colorMode } = useEuiTheme();
-  const { base, border, colors, font } = euiTheme;
+  const { base, colors, font } = euiTheme;
 
   /**
    * Declaring the top level scrollbar colors to match the theme also requires setting the sizes on Chrome
@@ -41,40 +41,6 @@ export const EuiGlobalStyles = ({}: EuiGlobalStylesProps) => {
     line-height: ${base / (font.scale[font.body.scale] * base)};
     font-weight: ${font.weight[font.body.weight]};
   `;
-
-  /**
-   * Outline/Focus state resets
-   */
-  const focusReset = () => {
-    // The latest theme utilizes `focus-visible` to turn on focus outlines.
-    // But this is browser-dependend:
-    // 👉 Safari and Firefox innately respect only showing the outline with keyboard only
-    // 💔 But they don't allow coloring of the 'auto'/default outline, so contrast is no good in dark mode.
-    // 👉 For these browsers we use the solid type in order to match with \`currentColor\`.
-    // 😦 Which does means the outline will be square
-    return `*:focus {
-      outline: currentColor solid ${border.width.thick};
-      outline-offset: calc(-(${border.width.thick} / 2) * -1);
-
-      // 👀 Chrome respects :focus-visible and allows coloring the \`auto\` style
-      &:focus-visible {
-        outline-style: auto;
-      }
-
-      // 🙅‍♀️ But Chrome also needs to have the outline forcefully removed from regular \`:focus\` state
-      &:not(:focus-visible) {
-        outline: none;
-      }
-    }
-
-    // Dark mode's highlighted doesn't work well so lets just set it the same as our focus background
-    ::selection {
-      background: ${transparentize(
-        colors.primary,
-        colorMode === 'LIGHT' ? 0.1 : 0.2
-      )}
-    }`;
-  };
 
   /**
    * Final styles
@@ -117,7 +83,17 @@ export const EuiGlobalStyles = ({}: EuiGlobalStylesProps) => {
       font-weight: ${font.weight.bold};
     }
 
-    ${focusReset()}
+    *:focus {
+      ${euiFocusRing(euiTheme)}
+    }
+
+    // Dark mode's highlighted doesn't work well so lets just set it the same as our focus background
+    ::selection {
+      background: ${transparentize(
+        colors.primary,
+        colorMode === 'LIGHT' ? 0.1 : 0.2
+      )};
+    }
 
     a {
       color: ${colors.primaryText};

--- a/src/global_styling/variables/states.ts
+++ b/src/global_styling/variables/states.ts
@@ -31,7 +31,7 @@ export interface _EuiThemeFocus {
    */
   width: CSSProperties['borderWidth'];
   /**
-   * Used to transprentize any color at certain values
+   * Used to transparentize any color at certain values
    */
   // transparency: ColorModeSwitch<number>;
   /**

--- a/src/global_styling/variables/states.ts
+++ b/src/global_styling/variables/states.ts
@@ -39,11 +39,7 @@ export interface _EuiThemeFocus {
    */
   width: CSSProperties['borderWidth'];
   /**
-   * Larger thickness of the outline for larger components
-   */
-  widthLarge: CSSProperties['borderWidth'];
-  /**
    * Using `outline` is new for Amsterdam but is set to `none` in legacy theme
    */
-  outline: _EuiThemeFocusOutline;
+  // outline: _EuiThemeFocusOutline;
 }

--- a/src/global_styling/variables/states.ts
+++ b/src/global_styling/variables/states.ts
@@ -11,7 +11,7 @@ import { CSSProperties } from 'react';
 
 /**
  * NOTE: These were quick conversions of their Sass counterparts.
- *       They have yet to be used/tested.
+ *       The commented out keys have not been established as necessary yet.
  */
 
 export interface _EuiThemeFocusOutline {
@@ -23,21 +23,21 @@ export interface _EuiThemeFocusOutline {
 
 export interface _EuiThemeFocus {
   /**
-   * Color is used deterministically by the legacy theme, and as fallback for Amsterdam
+   * Default color of the focus ring, some components may override this property
    */
   color: ColorModeSwitch;
   /**
+   * Thickness of the outline
+   */
+  width: CSSProperties['borderWidth'];
+  /**
    * Used to transprentize any color at certain values
    */
-  transparency: ColorModeSwitch<number>;
+  // transparency: ColorModeSwitch<number>;
   /**
    * Default color plus transparency
    */
-  backgroundColor: ColorModeSwitch;
-  /**
-   * Width is the thickness of the outline or faux ring
-   */
-  width: CSSProperties['borderWidth'];
+  // backgroundColor: ColorModeSwitch;
   /**
    * Using `outline` is new for Amsterdam but is set to `none` in legacy theme
    */

--- a/src/services/theme/types.ts
+++ b/src/services/theme/types.ts
@@ -50,7 +50,7 @@ export type EuiThemeShape = {
   size: _EuiThemeSizes;
   font: _EuiThemeFont;
   border: _EuiThemeBorder;
-  focus?: _EuiThemeFocus;
+  focus: _EuiThemeFocus;
   animation: _EuiThemeAnimation;
   breakpoint: _EuiThemeBreakpoints;
   levels: _EuiThemeLevels;

--- a/src/themes/amsterdam/global_styling/variables/_states.ts
+++ b/src/themes/amsterdam/global_styling/variables/_states.ts
@@ -24,11 +24,10 @@ export const focus: _EuiThemeFocus = {
   ),
 
   // Sizing
-  widthLarge: computed(sizeToPixel(0.25)),
   width: computed(sizeToPixel(0.125)),
 
   // Outline
-  outline: {
-    outline: computed(({ focus }) => `${focus!.width} solid ${focus!.color}`),
-  },
+  // outline: {
+  //   outline: computed(({ focus }) => `${focus!.width} solid ${focus!.color}`),
+  // },
 };

--- a/src/themes/amsterdam/global_styling/variables/_states.ts
+++ b/src/themes/amsterdam/global_styling/variables/_states.ts
@@ -6,25 +6,23 @@
  * Side Public License, v 1.
  */
 
+/**
+ * NOTE: These were quick conversions of their Sass counterparts.
+ *       The commented out keys have not been established as necessary yet.
+ */
+
 import { computed } from '../../../../services/theme/utils';
-import { transparentize } from '../../../../services/color';
 import { _EuiThemeFocus } from '../../../../global_styling/variables/states';
 import { sizeToPixel } from '../../../../global_styling/functions/size';
 
-/**
- * NOTE: These were quick conversions of their Sass counterparts.
- *       They have yet to be used/tested.
- */
-
 export const focus: _EuiThemeFocus = {
   color: 'currentColor',
-  transparency: { LIGHT: 0.9, DARK: 0.7 },
-  backgroundColor: computed(({ colors, focus }) =>
-    transparentize(colors.primary, focus!.transparency)
-  ),
-
-  // Sizing
   width: computed(sizeToPixel(0.125)),
+
+  // transparency: { LIGHT: 0.9, DARK: 0.7 },
+  // backgroundColor: computed(({ colors, focus }) =>
+  //   transparentize(colors.primary, focus!.transparency)
+  // ),
 
   // Outline
   // outline: {

--- a/src/themes/amsterdam/theme.ts
+++ b/src/themes/amsterdam/theme.ts
@@ -16,6 +16,7 @@ import { base, size } from './global_styling/variables/_size';
 import { border } from './global_styling/variables/_borders';
 import { levels } from './global_styling/variables/_levels';
 import { font } from './global_styling/variables/_typography';
+import { focus } from './global_styling/variables/_states';
 
 export const AMSTERDAM_NAME_KEY = 'EUI_THEME_AMSTERDAM';
 
@@ -28,6 +29,7 @@ export const euiThemeAmsterdam: EuiThemeShape = {
   animation,
   breakpoint,
   levels,
+  focus,
 };
 
 export const EuiThemeAmsterdam = buildTheme(

--- a/upcoming_changelogs/5855.md
+++ b/upcoming_changelogs/5855.md
@@ -1,0 +1,7 @@
+- Added `focus` token to global `EuiTheme`
+- Added `euiFocusRing()` and `useEuiFocusRing()` function/hook for customizing focus outline
+
+**Bug fixes**
+
+- Fixed border-radius of nested `EuiSplitPanel`s
+- Fixed `offset` of global focus `outline`


### PR DESCRIPTION
My general thought process here is that we want to limit the variances in focus states across components, but we know that there are some places where we at least need to adjust the position (inset/outset) of the outline or better control the `color`. This is mainly a component driven and therefore, will can be adjusted through the new function.

At the global level, however, I can see a consumer (and eventually user) wanting to adjust some of the settings more broadly like making the outline thicker or making them all a specific color. These are the only tokens that can be adjusted.

Since we "pride" ourselves in accessibility, this pattern enforces consumers to use the standard `outline` property for focus rings and standardizes them across all components for consistency.

## Global token

I've re-instated the top-level `focus` token on EuiTheme but reduced the original type to just `color` and `width`. I've left in the comments from the other keys for now as I'll revisit background colors and transparency later.


<img width="1002" alt="Screen Shot 2022-04-29 at 15 20 28 PM" src="https://user-images.githubusercontent.com/549577/166056375-bc95a081-f828-44f3-b2eb-6ef8eb9aa09c.png">

## Mixin -> Function

The new `euiFocusRing()`/`useEuiFocusRing()` function/hook returns a full css`` block of styles necessary to customize focus outlines with the ability to adjust `color` and `offset`. 

Basic usage:

```tsx
css`
  &:focus {
    ${useEuiFocusRing('outset', euiTheme.colors.primary)}
  }
`
```

You can also apply it un-scoped to `:focus` since outlines only apply to focus state anyway.

![image](https://user-images.githubusercontent.com/549577/166064525-c73c1ef1-c356-45d4-8c3c-f6213f0a3d8c.png)


### Global reset

The reset file has been updated to use the function directly so that we're only creating these styles once. It also fixed the current `offset` in the reset which was not get calculated correctly. The following screenshot compares the style output based on the 3 usages (none, without `:focus`, with `:focus`):

![image](https://user-images.githubusercontent.com/549577/166061404-9db6936a-4ea3-4cfc-b940-83e451c7da77.png)



### Checklist

- [x] Checked in both **light and dark** modes
- ~[ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- ~[ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
