### PR TITLE
[EuiForm] Enable `ref` Prop for EuiForm

### DIFF
--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -7,11 +7,11 @@
  */
 
 import React, {
-  FunctionComponent,
   ReactNode,
   HTMLAttributes,
   FormHTMLAttributes,
   useCallback,
+  forwardRef,
 } from 'react';
 import classNames from 'classnames';
 import { EuiCallOut } from '../call_out';
@@ -35,67 +35,78 @@ export type EuiFormProps = CommonProps &
     invalidCallout?: 'above' | 'none';
   };
 
-export const EuiForm: FunctionComponent<EuiFormProps> = ({
-  children,
-  className,
-  isInvalid,
-  error,
-  component = 'div',
-  invalidCallout = 'above',
-  ...rest
-}) => {
-  const handleFocus = useCallback((node) => {
-    node?.focus();
-  }, []);
+export const EuiForm = forwardRef<HTMLElement, EuiFormProps>(
+  (
+    {
+      children,
+      className,
+      isInvalid,
+      error,
+      component = 'div',
+      invalidCallout = 'above',
+      ...rest
+    },
+    ref
+  ) => {
+    const handleFocus = useCallback((node) => {
+      node?.focus();
+    }, []);
 
-  const classes = classNames('euiForm', className);
+    const classes = classNames('euiForm', className);
 
-  let optionalErrors: JSX.Element | null = null;
+    let optionalErrors: JSX.Element | null = null;
 
-  if (error) {
-    const errorTexts = Array.isArray(error) ? error : [error];
-    optionalErrors = (
-      <ul>
-        {errorTexts.map((error, index) => (
-          <li className="euiForm__error" key={index}>
-            {error}
-          </li>
-        ))}
-      </ul>
-    );
-  }
+    if (error) {
+      const errorTexts = Array.isArray(error) ? error : [error];
+      optionalErrors = (
+        <ul>
+          {errorTexts.map((error, index) => (
+            <li className="euiForm__error" key={index}>
+              {error}
+            </li>
+          ))}
+        </ul>
+      );
+    }
 
-  let optionalErrorAlert;
+    let optionalErrorAlert;
 
-  if (isInvalid && invalidCallout === 'above') {
-    optionalErrorAlert = (
-      <EuiI18n
-        token="euiForm.addressFormErrors"
-        default="Please address the highlighted errors."
+    if (isInvalid && invalidCallout === 'above') {
+      optionalErrorAlert = (
+        <EuiI18n
+          token="euiForm.addressFormErrors"
+          default="Please address the highlighted errors."
+        >
+          {(addressFormErrors: string) => (
+            <EuiCallOut
+              tabIndex={-1}
+              ref={handleFocus}
+              className="euiForm__errors"
+              title={addressFormErrors}
+              color="danger"
+              role="alert"
+              aria-live="assertive"
+            >
+              {optionalErrors}
+            </EuiCallOut>
+          )}
+        </EuiI18n>
+      );
+    }
+
+    const Element = component;
+
+    return (
+      <Element
+        // @ts-ignore Element is a <div> or <form>, but TypeScript wants to support both
+        ref={ref}
+        className={classes}
+        {...(rest as HTMLAttributes<HTMLElement>)}
       >
-        {(addressFormErrors: string) => (
-          <EuiCallOut
-            tabIndex={-1}
-            ref={handleFocus}
-            className="euiForm__errors"
-            title={addressFormErrors}
-            color="danger"
-            role="alert"
-            aria-live="assertive"
-          >
-            {optionalErrors}
-          </EuiCallOut>
-        )}
-      </EuiI18n>
+        {optionalErrorAlert}
+        {children}
+      </Element>
     );
   }
-
-  const Element = component;
-
-  return (
-    <Element className={classes} {...(rest as HTMLAttributes<HTMLElement>)}>
-      {optionalErrorAlert}
-      {children}
-    </Element>
-  );
-};
+);
+EuiForm.displayName = 'EuiForm';

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -98,7 +98,7 @@ export const EuiForm = forwardRef<HTMLElement, EuiFormProps>(
 
     return (
       <Element
-        // @ts-ignore Element is a <div> or <form>, but TypeScript wants to support both
+        // @ts-expect-error Element is a <div> or <form>, but TypeScript wants to support both
         ref={ref}
         className={classes}
         {...(rest as HTMLAttributes<HTMLElement>)}

--- a/upcoming_changelogs/5866.md
+++ b/upcoming_changelogs/5866.md
@@ -1,0 +1,1 @@
+- Updated `EuiForm` to use `forwardRef`


### PR DESCRIPTION
### Summary
Fixes #5465 

This PR has updated `EuiForm` to use the `ref` prop. No visual changes in this PR.

### Checklist

- ~[ ] Checked in both **light and dark** modes~
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- [x] Checked for **breaking changes** and labeled appropriately
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
