### PR TITLE
[Docs] typo correction of basic tables

### DIFF
--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -508,9 +508,9 @@ export class EuiBasicTable<T = any> extends Component<
       page: !currentCriteria.page
         ? undefined
         : {
-          index: 0,
-          size: currentCriteria.page.size,
-        },
+            index: 0,
+            size: currentCriteria.page.size,
+          },
       sort: {
         field: ((column as EuiTableFieldDataColumnType<T>).field ||
           column.name) as keyof T,
@@ -632,7 +632,7 @@ export class EuiBasicTable<T = any> extends Component<
       if (
         !(column as EuiTableFieldDataColumnType<T>).sortable ||
         (column as EuiTableFieldDataColumnType<T>)?.mobileOptions?.show ===
-        false
+          false
       ) {
         return;
       }
@@ -641,8 +641,9 @@ export class EuiBasicTable<T = any> extends Component<
 
       items.push({
         name: column.name,
-        key: `_data_s_${(column as EuiTableFieldDataColumnType<T>).field
-          }_${index}`,
+        key: `_data_s_${
+          (column as EuiTableFieldDataColumnType<T>).field
+        }_${index}`,
         onSort: this.resolveColumnOnSort(column),
         isSorted: !!sortDirection,
         isSortAscending: sortDirection
@@ -824,8 +825,9 @@ export class EuiBasicTable<T = any> extends Component<
             align={columnAlign}
             width={width}
             mobileOptions={mobileOptions}
-            data-test-subj={`tableHeaderCell_${typeof name === 'string' ? name : ''
-              }_${index}`}
+            data-test-subj={`tableHeaderCell_${
+              typeof name === 'string' ? name : ''
+            }_${index}`}
             description={description}
             {...sorting}
           >
@@ -948,7 +950,7 @@ export class EuiBasicTable<T = any> extends Component<
       const tableItemIndex =
         hasPagination(this.props) && this.props.pagination.pageSize > 0
           ? this.props.pagination.pageIndex * this.props.pagination.pageSize +
-          index
+            index
           : index;
       return this.renderItemRow(item, tableItemIndex);
     });
@@ -1011,10 +1013,10 @@ export class EuiBasicTable<T = any> extends Component<
     const selected = !selection
       ? false
       : this.state.selection &&
-      !!this.state.selection.find(
-        (selectedItem: T) =>
-          getItemId(selectedItem, itemIdCallback) === itemId
-      );
+        !!this.state.selection.find(
+          (selectedItem: T) =>
+            getItemId(selectedItem, itemIdCallback) === itemId
+        );
 
     let calculatedHasSelection;
     if (selection) {

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -199,7 +199,7 @@ interface BasicTableProps<T> extends Omit<EuiTableProps, 'onChange'> {
    */
   itemIdToExpandedRowMap?: ItemIdToExpandedRowMap;
   /**
-   * A list of objects to who in the table - an item per row
+   * A list of objects to appear in the table - an item per row
    */
   items: T[];
   /**
@@ -508,9 +508,9 @@ export class EuiBasicTable<T = any> extends Component<
       page: !currentCriteria.page
         ? undefined
         : {
-            index: 0,
-            size: currentCriteria.page.size,
-          },
+          index: 0,
+          size: currentCriteria.page.size,
+        },
       sort: {
         field: ((column as EuiTableFieldDataColumnType<T>).field ||
           column.name) as keyof T,
@@ -632,7 +632,7 @@ export class EuiBasicTable<T = any> extends Component<
       if (
         !(column as EuiTableFieldDataColumnType<T>).sortable ||
         (column as EuiTableFieldDataColumnType<T>)?.mobileOptions?.show ===
-          false
+        false
       ) {
         return;
       }
@@ -641,9 +641,8 @@ export class EuiBasicTable<T = any> extends Component<
 
       items.push({
         name: column.name,
-        key: `_data_s_${
-          (column as EuiTableFieldDataColumnType<T>).field
-        }_${index}`,
+        key: `_data_s_${(column as EuiTableFieldDataColumnType<T>).field
+          }_${index}`,
         onSort: this.resolveColumnOnSort(column),
         isSorted: !!sortDirection,
         isSortAscending: sortDirection
@@ -825,9 +824,8 @@ export class EuiBasicTable<T = any> extends Component<
             align={columnAlign}
             width={width}
             mobileOptions={mobileOptions}
-            data-test-subj={`tableHeaderCell_${
-              typeof name === 'string' ? name : ''
-            }_${index}`}
+            data-test-subj={`tableHeaderCell_${typeof name === 'string' ? name : ''
+              }_${index}`}
             description={description}
             {...sorting}
           >
@@ -950,7 +948,7 @@ export class EuiBasicTable<T = any> extends Component<
       const tableItemIndex =
         hasPagination(this.props) && this.props.pagination.pageSize > 0
           ? this.props.pagination.pageIndex * this.props.pagination.pageSize +
-            index
+          index
           : index;
       return this.renderItemRow(item, tableItemIndex);
     });
@@ -1013,10 +1011,10 @@ export class EuiBasicTable<T = any> extends Component<
     const selected = !selection
       ? false
       : this.state.selection &&
-        !!this.state.selection.find(
-          (selectedItem: T) =>
-            getItemId(selectedItem, itemIdCallback) === itemId
-        );
+      !!this.state.selection.find(
+        (selectedItem: T) =>
+          getItemId(selectedItem, itemIdCallback) === itemId
+      );
 
     let calculatedHasSelection;
     if (selection) {


### PR DESCRIPTION
### Summary

Address the following issues.
https://github.com/elastic/eui/issues/5874

### Checklist

- [ ] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
