### PR TITLE
[EuiComboBox] Center enter badge in option

### DIFF
--- a/src/components/combo_box/combo_box_options_list/_combo_box_option.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_option.scss
@@ -38,7 +38,7 @@
   }
 
   .euiComboBoxOption__enterBadge {
-    align-self: flex-start;
+    align-self: center;
     margin-left: $euiSizeXS;
   }
 }

--- a/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
@@ -12,6 +12,7 @@
   }
 
   .euiFilterSelectItem__content {
+    // sass-lint:disable no-important
     margin-block: 0 !important;
   }
 }

--- a/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
@@ -10,6 +10,10 @@
   &.euiPopover__panel-isAttached.euiComboBoxOptionsList--top { /* 1 */
     @include euiBottomShadowFlat;
   }
+
+  .euiFilterSelectItem__content {
+    margin-block: 0 !important;
+  }
 }
 
 .euiComboBoxOptionsList__empty {

--- a/upcoming_changelogs/5890.md
+++ b/upcoming_changelogs/5890.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiComboBox` by centering the enter badge in the list options.


### PR DESCRIPTION
### Summary

This PR centers the enter badge in the Combo Box option, by setting `align-self` to `center`, instead of `flex-start`. Because centering the badge would actually cause the badge to not be centered with smaller `rowHeight`s, I also increased the default `rowHeight` to be `34`.

This is the badge with a default `rowHeight` of `29`, after setting `align-self` to `center`:

![Screenshot 2022-05-10 at 12 40 08](https://user-images.githubusercontent.com/83580976/167648094-c4e4903e-2a91-45ef-8f6a-c5317487412b.png)

I believe this can be caused by the margin being set to `-4` for the EuiFlexGroup: 

![Screenshot 2022-05-10 at 12 39 54](https://user-images.githubusercontent.com/83580976/167648562-385bc68a-7283-4dfe-ad75-9f948d0c2fe6.png)

This is the badge after changing the default `rowHeight` to `34`:

![Screenshot 2022-05-10 at 12 41 23](https://user-images.githubusercontent.com/83580976/167648945-4f81df85-7090-4a15-a34c-245e3935414f.png)

Closes https://github.com/elastic/eui/issues/5873

### Checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
