### PR TITLE
[CSS-in-JS] Simplify shadow parameters

### DIFF
--- a/src-docs/src/views/theme/other/_shadow_js.tsx
+++ b/src-docs/src/views/theme/other/_shadow_js.tsx
@@ -15,7 +15,6 @@ import {
 import { getPropsFromComponent } from '../../../services/props/get_props';
 import { getDescription } from '../../../services/props/get_description';
 
-// TODO: Update imports
 import {
   useEuiShadow,
   useEuiShadowFlat,

--- a/src/components/bottom_bar/bottom_bar.styles.ts
+++ b/src/components/bottom_bar/bottom_bar.styles.ts
@@ -23,34 +23,38 @@ const euiBottomBarAppear = keyframes`
   }
 `;
 
-export const euiBottomBarStyles = ({ euiTheme, colorMode }: UseEuiTheme) => ({
-  // Base
-  // Text color needs to be reapplied to properly scope the forced `colorMode`
-  euiBottomBar: css`
-    ${euiShadowFlat(euiTheme, undefined, colorMode)};
-    background: ${shade(euiTheme.colors.lightestShade, 0.5)};
-    color: ${euiTheme.colors.text};
-    ${euiCanAnimate} {
-      animation: ${euiBottomBarAppear} ${euiTheme.animation.slow}
-        ${euiTheme.animation.resistance};
-    }
-  `,
-  static: css``,
-  fixed: css`
-    z-index: ${Number(euiTheme.levels.header) - 2};
-  `,
-  sticky: css`
-    z-index: ${Number(euiTheme.levels.header) - 2};
-  `,
-  // Padding
-  s: css`
-    padding: ${euiTheme.size.s};
-  `,
-  m: css`
-    padding: ${euiTheme.size.base};
-  `,
-  l: css`
-    padding: ${euiTheme.size.l};
-  `,
-  none: '',
-});
+export const euiBottomBarStyles = (_euiTheme: UseEuiTheme) => {
+  const { euiTheme } = _euiTheme;
+
+  return {
+    // Base
+    // Text color needs to be reapplied to properly scope the forced `colorMode`
+    euiBottomBar: css`
+      ${euiShadowFlat(_euiTheme)};
+      background: ${shade(euiTheme.colors.lightestShade, 0.5)};
+      color: ${euiTheme.colors.text};
+      ${euiCanAnimate} {
+        animation: ${euiBottomBarAppear} ${euiTheme.animation.slow}
+          ${euiTheme.animation.resistance};
+      }
+    `,
+    static: css``,
+    fixed: css`
+      z-index: ${Number(euiTheme.levels.header) - 2};
+    `,
+    sticky: css`
+      z-index: ${Number(euiTheme.levels.header) - 2};
+    `,
+    // Padding
+    s: css`
+      padding: ${euiTheme.size.s};
+    `,
+    m: css`
+      padding: ${euiTheme.size.base};
+    `,
+    l: css`
+      padding: ${euiTheme.size.l};
+    `,
+    none: '',
+  };
+};

--- a/src/themes/amsterdam/global_styling/mixins/shadow.ts
+++ b/src/themes/amsterdam/global_styling/mixins/shadow.ts
@@ -8,7 +8,6 @@
 
 import { useEuiTheme, UseEuiTheme } from '../../../../services/theme';
 import { getShadowColor } from '../functions';
-import { createStyleHookFromMixin } from '../../../../global_styling/utils';
 import {
   _EuiThemeShadowSize,
   _EuiThemeShadowCustomColor,
@@ -22,11 +21,12 @@ export interface EuiShadowCustomColor {
  * euiSlightShadow
  */
 export const euiShadowXSmall = (
-  { colors }: UseEuiTheme['euiTheme'],
-  { color: _color }: _EuiThemeShadowCustomColor = {},
-  colorMode: UseEuiTheme['colorMode']
+  _euiTheme: UseEuiTheme,
+  { color: _color }: _EuiThemeShadowCustomColor = {}
 ) => {
-  const color = _color || colors.shadow;
+  const { euiTheme, colorMode } = _euiTheme;
+
+  const color = _color || euiTheme.colors.shadow;
   return `
 box-shadow:
   0 .8px .8px ${getShadowColor(color, 0.04, colorMode)},
@@ -38,11 +38,12 @@ box-shadow:
  * bottomShadowSmall
  */
 export const euiShadowSmall = (
-  { colors }: UseEuiTheme['euiTheme'],
-  { color: _color }: _EuiThemeShadowCustomColor = {},
-  colorMode: UseEuiTheme['colorMode']
+  _euiTheme: UseEuiTheme,
+  { color: _color }: _EuiThemeShadowCustomColor = {}
 ) => {
-  const color = _color || colors.shadow;
+  const { euiTheme, colorMode } = _euiTheme;
+
+  const color = _color || euiTheme.colors.shadow;
   return `
 box-shadow:
   0 .7px 1.4px ${getShadowColor(color, 0.07, colorMode)},
@@ -55,11 +56,12 @@ box-shadow:
  * bottomShadowMedium
  */
 export const euiShadowMedium = (
-  { colors }: UseEuiTheme['euiTheme'],
-  { color: _color }: _EuiThemeShadowCustomColor = {},
-  colorMode: UseEuiTheme['colorMode']
+  _euiTheme: UseEuiTheme,
+  { color: _color }: _EuiThemeShadowCustomColor = {}
 ) => {
-  const color = _color || colors.shadow;
+  const { euiTheme, colorMode } = _euiTheme;
+
+  const color = _color || euiTheme.colors.shadow;
   return `
 box-shadow:
   0 .9px 4px -1px ${getShadowColor(color, 0.08, colorMode)},
@@ -73,12 +75,12 @@ box-shadow:
  * bottomShadow
  */
 export const euiShadowLarge = (
-  { colors }: UseEuiTheme['euiTheme'],
-  { color: _color }: _EuiThemeShadowCustomColor = {},
-  colorMode: UseEuiTheme['colorMode']
+  _euiTheme: UseEuiTheme,
+  { color: _color }: _EuiThemeShadowCustomColor = {}
 ) => {
-  const color = _color || colors.shadow;
+  const { euiTheme, colorMode } = _euiTheme;
 
+  const color = _color || euiTheme.colors.shadow;
   return `
 box-shadow:
   0 1px 5px ${getShadowColor(color, 0.1, colorMode)},
@@ -95,12 +97,12 @@ export interface EuiShadowXLarge extends _EuiThemeShadowCustomColor {
   reverse?: boolean;
 }
 export const euiShadowXLarge = (
-  { colors }: UseEuiTheme['euiTheme'],
-  { color: _color, reverse }: EuiShadowXLarge = {},
-  colorMode: UseEuiTheme['colorMode']
+  _euiTheme: UseEuiTheme,
+  { color: _color, reverse }: EuiShadowXLarge = {}
 ) => {
-  const color = _color || colors.shadow;
+  const { euiTheme, colorMode } = _euiTheme;
 
+  const color = _color || euiTheme.colors.shadow;
   return `
 box-shadow:
   0 ${reverse ? '-' : ''}2.7px 9px ${getShadowColor(color, 0.13, colorMode)},
@@ -114,11 +116,12 @@ box-shadow:
  * TODO: I think this is only used by panels/cards in the Amsterdam theme, move there
  */
 export const euiSlightShadowHover = (
-  { colors }: UseEuiTheme['euiTheme'],
-  { color: _color }: _EuiThemeShadowCustomColor = {},
-  colorMode: UseEuiTheme['colorMode']
+  _euiTheme: UseEuiTheme,
+  { color: _color }: _EuiThemeShadowCustomColor = {}
 ) => {
-  const color = _color || colors.shadow;
+  const { euiTheme, colorMode } = _euiTheme;
+
+  const color = _color || euiTheme.colors.shadow;
   return `
 box-shadow:
   0 1px 5px ${getShadowColor(color, 0.1, colorMode)},
@@ -127,9 +130,12 @@ box-shadow:
   0 23px 35px ${getShadowColor(color, 0.05, colorMode)};
 `;
 };
-export const useEuiSlightShadowHover = createStyleHookFromMixin(
-  euiSlightShadowHover
-);
+export const useEuiSlightShadowHover = (
+  color?: _EuiThemeShadowCustomColor['color']
+) => {
+  const euiTheme = useEuiTheme();
+  return euiSlightShadowHover(euiTheme, { color });
+};
 
 /**
  * bottomShadowFlat
@@ -138,52 +144,54 @@ export const useEuiSlightShadowHover = createStyleHookFromMixin(
  * Useful for popovers that drop UP rather than DOWN.
  */
 export const euiShadowFlat = (
-  { colors }: UseEuiTheme['euiTheme'],
-  color: _EuiThemeShadowCustomColor['color'] = undefined,
-  colorMode: UseEuiTheme['colorMode']
+  _euiTheme: UseEuiTheme,
+  { color: _color }: _EuiThemeShadowCustomColor = {}
 ) => {
-  const _color = color || colors.shadow;
+  const { euiTheme, colorMode } = _euiTheme;
+
+  const color = _color || euiTheme.colors.shadow;
   return `
 box-shadow:
-  0 0 .8px ${getShadowColor(_color, 0.06, colorMode)},
-  0 0 2px ${getShadowColor(_color, 0.04, colorMode)},
-  0 0 5px ${getShadowColor(_color, 0.04, colorMode)},
-  0 0 17px ${getShadowColor(_color, 0.03, colorMode)};
+  0 0 .8px ${getShadowColor(color, 0.06, colorMode)},
+  0 0 2px ${getShadowColor(color, 0.04, colorMode)},
+  0 0 5px ${getShadowColor(color, 0.04, colorMode)},
+  0 0 17px ${getShadowColor(color, 0.03, colorMode)};
 `;
 };
-export const useEuiShadowFlat = createStyleHookFromMixin(euiShadowFlat);
+export const useEuiShadowFlat = (
+  color?: _EuiThemeShadowCustomColor['color']
+) => {
+  const euiTheme = useEuiTheme();
+  return euiShadowFlat(euiTheme, { color });
+};
 
-// One hook to rule them all
-interface EuiShadowStyles {
-  size?: _EuiThemeShadowSize;
-  color?: _EuiThemeShadowCustomColor['color'];
-}
 export const euiShadow = (
-  euiTheme: UseEuiTheme['euiTheme'],
-  { size = 'l', color = undefined }: EuiShadowStyles = {},
-  colorMode: UseEuiTheme['colorMode']
+  euiTheme: UseEuiTheme,
+  size: _EuiThemeShadowSize = 'l',
+  { color }: _EuiThemeShadowCustomColor = {}
 ) => {
   switch (size) {
     case 'xs':
-      return euiShadowXSmall(euiTheme, { color }, colorMode);
+      return euiShadowXSmall(euiTheme, { color });
     case 's':
-      return euiShadowSmall(euiTheme, { color }, colorMode);
+      return euiShadowSmall(euiTheme, { color });
     case 'm':
-      return euiShadowMedium(euiTheme, { color }, colorMode);
+      return euiShadowMedium(euiTheme, { color });
     case 'l':
-      return euiShadowLarge(euiTheme, { color }, colorMode);
+      return euiShadowLarge(euiTheme, { color });
     case 'xl':
-      return euiShadowXLarge(euiTheme, { color }, colorMode);
+      return euiShadowXLarge(euiTheme, { color });
 
     default:
       console.warn('Please provide a valid size option to useEuiShadow');
       return '';
   }
 };
+
 export const useEuiShadow = (
-  size: EuiShadowStyles['size'] = 'l',
-  color?: EuiShadowStyles['color']
+  size: _EuiThemeShadowSize = 'l',
+  color?: _EuiThemeShadowCustomColor['color']
 ) => {
-  const { euiTheme, colorMode } = useEuiTheme();
-  return euiShadow(euiTheme, { size, color }, colorMode);
+  const euiTheme = useEuiTheme();
+  return euiShadow(euiTheme, size, { color });
 };


### PR DESCRIPTION
Based on a comment I made in #5891 : 

> So @constancecchen and I just ran into a similar issue with the font-sizing functions. We came up with what we think is a nice pattern we could re-use here.
> 
> * All **required** parameters are directly passed, while any optional ones are in the final parameter as a single object.
> * If the function requires the use of any part of `euiTheme` it takes the whole `UseEuiTheme`, and always comes first
> 
> ```tsx
> const euiMixin(
>   euiTheme: UseEuiTheme;
>   required: PropertyThatIsRequired;
>   {
>     optionalKey1?: something;
>     optionalKey2?: something;
>   }
> ) => {}
> ```

I've converted the shadow mixins to use this pattern. I think it simplifies them a lot.

_I'm not considering this a breaking change since we just released these and under the Beta flag._

### Checklist

- [ ] Checked in both **light and dark** modes
- ~[ ] Checked in **mobile**~
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
