### PR TITLE
[EuiTour] Fix positioning calculation issues caused by width style overrides

### DIFF
--- a/src-docs/src/views/datagrid/basics/datagrid.js
+++ b/src-docs/src/views/datagrid/basics/datagrid.js
@@ -33,6 +33,7 @@ import {
   EuiScreenReaderOnly,
   EuiText,
   EuiTitle,
+  EuiTourStep,
 } from '../../../../../src/components/';
 
 const gridRef = createRef();
@@ -410,8 +411,69 @@ export default () => {
     console.log(eventData);
   });
 
+  const [showTour, setShowTour] = useState(true);
+  const [showTour2, setShowTour2] = useState(false);
+  const nextStep = () => {
+    setShowTour(false);
+    setShowTour2(true);
+  };
+
   return (
     <DataContext.Provider value={raw_data}>
+      {showTour ? (
+        <EuiTourStep
+          anchor="[data-test-subj='dataGridColumnSelectorButton']"
+          isStepOpen
+          title="Test"
+          content={
+            <EuiText size="s">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed
+              fringilla quam in turpis blandit, eu ultricies nulla efficitur.
+            </EuiText>
+          }
+          step={1}
+          stepsTotal={2}
+          maxWidth={400}
+          onFinish={nextStep}
+          footerAction={
+            <EuiButtonEmpty
+              color="text"
+              flush="right"
+              size="xs"
+              onClick={nextStep}
+            >
+              Next
+            </EuiButtonEmpty>
+          }
+        />
+      ) : null}
+      {showTour2 ? (
+        <EuiTourStep
+          anchor="[data-test-subj='dataGridDisplaySelectorButton']"
+          isStepOpen
+          title="Test"
+          content={
+            <EuiText size="s">
+              Nunc ultricies egestas bibendum. Maecenas finibus enim at justo
+              elementum elementum.
+            </EuiText>
+          }
+          step={2}
+          stepsTotal={2}
+          maxWidth={400}
+          onFinish={() => setShowTour2(false)}
+          footerAction={
+            <EuiButtonEmpty
+              color="text"
+              flush="right"
+              size="xs"
+              onClick={() => setShowTour2(false)}
+            >
+              Dismiss
+            </EuiButtonEmpty>
+          }
+        />
+      ) : null}
       <EuiDataGrid
         aria-label="Data grid demo"
         columns={columns}

--- a/src/components/tour/__snapshots__/tour_step.test.tsx.snap
+++ b/src/components/tour/__snapshots__/tour_step.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`EuiTourStep can change the minWidth and maxWidth 1`] = `
       class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--left euiPopover__panel-isOpen euiTour testClass1 testClass2"
       data-popover-panel="true"
       role="dialog"
-      style="top: -22px; left: -26px; will-change: transform, opacity; max-width: 420px; min-width: 240px; z-index: 2000;"
+      style="top: -22px; left: -26px; will-change: transform, opacity; z-index: 2000;"
     >
       <div
         class="euiPopover__panelArrow euiPopover__panelArrow--left"
@@ -63,43 +63,47 @@ exports[`EuiTourStep can change the minWidth and maxWidth 1`] = `
       </div>
       <div>
         <div
-          class="euiPopoverTitle euiTourHeader"
-          id="generated-id"
-        >
-          <h2
-            class="euiTitle euiTourHeader__title css-1po7voc-euiTitle-xxs"
-          >
-            A demo
-          </h2>
-        </div>
-        <div
-          class="euiTour__content"
-        >
-          You are here
-        </div>
-        <div
-          class="euiPopoverFooter euiTourFooter"
+          style="min-width: 240px; max-width: 420px;"
         >
           <div
-            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow"
+            class="euiPopoverTitle euiTourHeader"
+            id="generated-id"
+          >
+            <h2
+              class="euiTitle euiTourHeader__title css-1po7voc-euiTitle-xxs"
+            >
+              A demo
+            </h2>
+          </div>
+          <div
+            class="euiTour__content"
+          >
+            You are here
+          </div>
+          <div
+            class="euiPopoverFooter euiTourFooter"
           >
             <div
-              class="euiFlexItem euiFlexItem--flexGrowZero"
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow"
             >
-              <button
-                class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
-                type="button"
+              <div
+                class="euiFlexItem euiFlexItem--flexGrowZero"
               >
-                <span
-                  class="euiButtonContent euiButtonEmpty__content"
+                <button
+                  class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                  type="button"
                 >
                   <span
-                    class="euiButtonEmpty__text"
+                    class="euiButtonContent euiButtonEmpty__content"
                   >
-                    Close tour
+                    <span
+                      class="euiButtonEmpty__text"
+                    >
+                      Close tour
+                    </span>
                   </span>
-                </span>
-              </button>
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -148,7 +152,7 @@ exports[`EuiTourStep can have subtitle 1`] = `
       class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--left euiPopover__panel-isOpen euiTour testClass1 testClass2"
       data-popover-panel="true"
       role="dialog"
-      style="top: -22px; left: -26px; will-change: transform, opacity; max-width: 600px; min-width: 300px; z-index: 2000;"
+      style="top: -22px; left: -26px; will-change: transform, opacity; z-index: 2000;"
     >
       <div
         class="euiPopover__panelArrow euiPopover__panelArrow--left"
@@ -161,48 +165,52 @@ exports[`EuiTourStep can have subtitle 1`] = `
       </div>
       <div>
         <div
-          class="euiPopoverTitle euiTourHeader"
-          id="generated-id"
-        >
-          <h2
-            class="euiTitle euiTourHeader__subtitle css-7xv8go-euiTitle-xxxs"
-          >
-            Subtitle
-          </h2>
-          <h3
-            class="euiTitle euiTourHeader__title css-1po7voc-euiTitle-xxs"
-          >
-            A demo
-          </h3>
-        </div>
-        <div
-          class="euiTour__content"
-        >
-          You are here
-        </div>
-        <div
-          class="euiPopoverFooter euiTourFooter"
+          style="min-width: 300px; max-width: 600px;"
         >
           <div
-            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow"
+            class="euiPopoverTitle euiTourHeader"
+            id="generated-id"
+          >
+            <h2
+              class="euiTitle euiTourHeader__subtitle css-7xv8go-euiTitle-xxxs"
+            >
+              Subtitle
+            </h2>
+            <h3
+              class="euiTitle euiTourHeader__title css-1po7voc-euiTitle-xxs"
+            >
+              A demo
+            </h3>
+          </div>
+          <div
+            class="euiTour__content"
+          >
+            You are here
+          </div>
+          <div
+            class="euiPopoverFooter euiTourFooter"
           >
             <div
-              class="euiFlexItem euiFlexItem--flexGrowZero"
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow"
             >
-              <button
-                class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
-                type="button"
+              <div
+                class="euiFlexItem euiFlexItem--flexGrowZero"
               >
-                <span
-                  class="euiButtonContent euiButtonEmpty__content"
+                <button
+                  class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                  type="button"
                 >
                   <span
-                    class="euiButtonEmpty__text"
+                    class="euiButtonContent euiButtonEmpty__content"
                   >
-                    Close tour
+                    <span
+                      class="euiButtonEmpty__text"
+                    >
+                      Close tour
+                    </span>
                   </span>
-                </span>
-              </button>
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -251,7 +259,7 @@ exports[`EuiTourStep can override the footer action 1`] = `
       class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--left euiPopover__panel-isOpen euiTour testClass1 testClass2"
       data-popover-panel="true"
       role="dialog"
-      style="top: -22px; left: -26px; will-change: transform, opacity; max-width: 600px; min-width: 300px; z-index: 2000;"
+      style="top: -22px; left: -26px; will-change: transform, opacity; z-index: 2000;"
     >
       <div
         class="euiPopover__panelArrow euiPopover__panelArrow--left"
@@ -264,32 +272,36 @@ exports[`EuiTourStep can override the footer action 1`] = `
       </div>
       <div>
         <div
-          class="euiPopoverTitle euiTourHeader"
-          id="generated-id"
-        >
-          <h2
-            class="euiTitle euiTourHeader__title css-1po7voc-euiTitle-xxs"
-          >
-            A demo
-          </h2>
-        </div>
-        <div
-          class="euiTour__content"
-        >
-          You are here
-        </div>
-        <div
-          class="euiPopoverFooter euiTourFooter"
+          style="min-width: 300px; max-width: 600px;"
         >
           <div
-            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow"
+            class="euiPopoverTitle euiTourHeader"
+            id="generated-id"
+          >
+            <h2
+              class="euiTitle euiTourHeader__title css-1po7voc-euiTitle-xxs"
+            >
+              A demo
+            </h2>
+          </div>
+          <div
+            class="euiTour__content"
+          >
+            You are here
+          </div>
+          <div
+            class="euiPopoverFooter euiTourFooter"
           >
             <div
-              class="euiFlexItem euiFlexItem--flexGrowZero"
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow"
             >
-              <button>
-                Test
-              </button>
+              <div
+                class="euiFlexItem euiFlexItem--flexGrowZero"
+              >
+                <button>
+                  Test
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -338,7 +350,7 @@ exports[`EuiTourStep can turn off the beacon 1`] = `
       class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--left euiPopover__panel-isOpen euiTour testClass1 testClass2"
       data-popover-panel="true"
       role="dialog"
-      style="top: -22px; left: -16px; will-change: transform, opacity; max-width: 600px; min-width: 300px; z-index: 2000;"
+      style="top: -22px; left: -16px; will-change: transform, opacity; z-index: 2000;"
     >
       <div
         class="euiPopover__panelArrow euiPopover__panelArrow--left"
@@ -346,43 +358,47 @@ exports[`EuiTourStep can turn off the beacon 1`] = `
       />
       <div>
         <div
-          class="euiPopoverTitle euiTourHeader"
-          id="generated-id"
-        >
-          <h2
-            class="euiTitle euiTourHeader__title css-1po7voc-euiTitle-xxs"
-          >
-            A demo
-          </h2>
-        </div>
-        <div
-          class="euiTour__content"
-        >
-          You are here
-        </div>
-        <div
-          class="euiPopoverFooter euiTourFooter"
+          style="min-width: 300px; max-width: 600px;"
         >
           <div
-            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow"
+            class="euiPopoverTitle euiTourHeader"
+            id="generated-id"
+          >
+            <h2
+              class="euiTitle euiTourHeader__title css-1po7voc-euiTitle-xxs"
+            >
+              A demo
+            </h2>
+          </div>
+          <div
+            class="euiTour__content"
+          >
+            You are here
+          </div>
+          <div
+            class="euiPopoverFooter euiTourFooter"
           >
             <div
-              class="euiFlexItem euiFlexItem--flexGrowZero"
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow"
             >
-              <button
-                class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
-                type="button"
+              <div
+                class="euiFlexItem euiFlexItem--flexGrowZero"
               >
-                <span
-                  class="euiButtonContent euiButtonEmpty__content"
+                <button
+                  class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                  type="button"
                 >
                   <span
-                    class="euiButtonEmpty__text"
+                    class="euiButtonContent euiButtonEmpty__content"
                   >
-                    Close tour
+                    <span
+                      class="euiButtonEmpty__text"
+                    >
+                      Close tour
+                    </span>
                   </span>
-                </span>
-              </button>
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -431,7 +447,7 @@ exports[`EuiTourStep is rendered 1`] = `
       class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--noShadow euiPopover__panel euiPopover__panel--left euiPopover__panel-isOpen euiTour testClass1 testClass2"
       data-popover-panel="true"
       role="dialog"
-      style="top: -22px; left: -26px; will-change: transform, opacity; max-width: 600px; min-width: 300px; z-index: 2000;"
+      style="top: -22px; left: -26px; will-change: transform, opacity; z-index: 2000;"
     >
       <div
         class="euiPopover__panelArrow euiPopover__panelArrow--left"
@@ -444,43 +460,47 @@ exports[`EuiTourStep is rendered 1`] = `
       </div>
       <div>
         <div
-          class="euiPopoverTitle euiTourHeader"
-          id="generated-id"
-        >
-          <h2
-            class="euiTitle euiTourHeader__title css-1po7voc-euiTitle-xxs"
-          >
-            A demo
-          </h2>
-        </div>
-        <div
-          class="euiTour__content"
-        >
-          You are here
-        </div>
-        <div
-          class="euiPopoverFooter euiTourFooter"
+          style="min-width: 300px; max-width: 600px;"
         >
           <div
-            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow"
+            class="euiPopoverTitle euiTourHeader"
+            id="generated-id"
+          >
+            <h2
+              class="euiTitle euiTourHeader__title css-1po7voc-euiTitle-xxs"
+            >
+              A demo
+            </h2>
+          </div>
+          <div
+            class="euiTour__content"
+          >
+            You are here
+          </div>
+          <div
+            class="euiPopoverFooter euiTourFooter"
           >
             <div
-              class="euiFlexItem euiFlexItem--flexGrowZero"
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow"
             >
-              <button
-                class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
-                type="button"
+              <div
+                class="euiFlexItem euiFlexItem--flexGrowZero"
               >
-                <span
-                  class="euiButtonContent euiButtonEmpty__content"
+                <button
+                  class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                  type="button"
                 >
                   <span
-                    class="euiButtonEmpty__text"
+                    class="euiButtonContent euiButtonEmpty__content"
                   >
-                    Close tour
+                    <span
+                      class="euiButtonEmpty__text"
+                    >
+                      Close tour
+                    </span>
                   </span>
-                </span>
-              </button>
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/tour/tour_step.tsx
+++ b/src/components/tour/tour_step.tsx
@@ -170,8 +170,6 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
     };
   }, [anchor]);
 
-  const newStyle: CSSProperties = { ...style, maxWidth, minWidth };
-
   const classes = classNames('euiTour', className);
 
   const finishButtonProps: EuiButtonEmptyProps = {
@@ -240,7 +238,7 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
     isOpen: isStepOpen,
     ownFocus: false,
     panelClassName: classes,
-    panelStyle: newStyle,
+    panelStyle: style,
     offset: hasBeacon ? 10 : 0,
     'aria-labelledby': titleId,
     arrowChildren: hasBeacon && <EuiBeacon className="euiTour__beacon" />,
@@ -248,7 +246,7 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
   };
 
   const layout = (
-    <>
+    <div style={{ minWidth, maxWidth }}>
       <EuiPopoverTitle className="euiTourHeader" id={titleId}>
         {subtitle && (
           <EuiTitle size="xxxs" className="euiTourHeader__subtitle">
@@ -261,7 +259,7 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
       </EuiPopoverTitle>
       <div className="euiTour__content">{content}</div>
       <EuiPopoverFooter className="euiTourFooter">{footer}</EuiPopoverFooter>
-    </>
+    </div>
   );
 
   if (!anchor && children) {

--- a/src/components/tour/tour_step.tsx
+++ b/src/components/tour/tour_step.tsx
@@ -100,11 +100,6 @@ export type EuiTourStepProps = CommonProps &
     stepsTotal: number;
 
     /**
-     * Optional, standard DOM `style` attribute. Passed to the EuiPopover panel.
-     */
-    style?: CSSProperties;
-
-    /**
      * Smaller title text that appears atop each step in the tour. The subtitle gets wrapped in the appropriate heading level.
      */
     subtitle?: ReactNode;
@@ -138,7 +133,6 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
   onFinish,
   step = 1,
   stepsTotal,
-  style,
   subtitle,
   title,
   decoration = 'beacon',
@@ -238,7 +232,6 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
     isOpen: isStepOpen,
     ownFocus: false,
     panelClassName: classes,
-    panelStyle: style,
     offset: hasBeacon ? 10 : 0,
     'aria-labelledby': titleId,
     arrowChildren: hasBeacon && <EuiBeacon className="euiTour__beacon" />,


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/5861
closes https://github.com/elastic/eui/issues/5731 (I'm relatively confident this is the same root problem)

QA can be performed on the [Data Grid example](http://localhost:8030/#/tabular-content/data-grid) (I was trying to recreate/repro the issue reported by a separate Kibana setup)

### Before
![before](https://user-images.githubusercontent.com/549407/168156848-00d16fb2-832d-4211-882e-425b13ec380d.gif)

### After
![after](https://user-images.githubusercontent.com/549407/168156853-42963be0-80d4-4fda-831d-d5d151428044.gif)

### Why was this bug happening?

Unfortunately, EuiPopover's popover positioning calculation does not elegantly handle overriding the width of the popover via either CSS or styling of `width`, `max-width`, or `min-width` **on the popover panel itself**. Instead, the "correct" (or non-bug-inducing-way) to manage a popover's width is to restrict it with a wrapper around the popover's contents (which is the change that this PR made).

I _could_ dive more deeply into EuiPopover's `popover_positioning` service to try and figure out how to work around this, but that seemed like a much more involved fix compared to this much simpler one, and since it hasn't come up before except for EuiTour, I figured there wasn't a super pressing need for it.

### Checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] ~Added or~ updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately