### PR TITLE
[Platform] Remove `eui.js` and `eui.min.js` distribution

### DIFF
--- a/scripts/compile-eui.js
+++ b/scripts/compile-eui.js
@@ -9,7 +9,7 @@ const dtsGenerator = require('dts-generator').default;
 const IGNORE_BUILD = ['**/webpack.config.js','**/*.d.ts'];
 const IGNORE_TESTS = ['**/*.test.js','**/*.test.ts','**/*.test.tsx','**/*.spec.tsx','**/test/internal/**/*.ts','**/test/internal/**/*.tsx','**/__mocks__/**'];
 const IGNORE_TESTENV = ['**/*.testenv.js','**/*.testenv.tsx','**/*.testenv.ts'];
-const IGNORE_PACKAGES = ['**/react-datepicker/test/**/*.js']
+const IGNORE_PACKAGES = ['**/react-datepicker/test/**/*.js', '**/themes/charts/themes.ts']
 
 function compileLib() {
   shell.mkdir('-p', 'lib/services', 'lib/test');
@@ -132,7 +132,7 @@ function compileBundle() {
 
   console.log('Building chart theme module...');
   execSync(
-    'webpack src/themes/charts/themes.ts -o dist/eui_charts_theme.js --output-library-target="commonjs" --config=src/webpack.config.js',
+    'webpack --output-library-target="commonjs" --config=src/themes/charts/webpack.config.js',
     {
       stdio: 'inherit',
     }

--- a/scripts/compile-eui.js
+++ b/scripts/compile-eui.js
@@ -110,24 +110,6 @@ function compileLib() {
 function compileBundle() {
   shell.mkdir('-p', 'dist');
 
-  console.log('Building bundle...');
-  execSync('webpack --config=src/webpack.config.js', {
-    stdio: 'inherit',
-    env: {
-      ...process.env,
-      BABEL_MODULES: false,
-    },
-  });
-
-  console.log('Building minified bundle...');
-  execSync('NODE_ENV=production NODE_OPTIONS=--max-old-space-size=4096 webpack --config=src/webpack.config.js', {
-    stdio: 'inherit',
-    env: {
-      ...process.env,
-      BABEL_MODULES: false,
-    },
-  });
-
   console.log('Building test utils .d.ts files...');
   ['lib/test', 'optimize/lib/test', 'es/test', 'optimize/es/test'].forEach((dir) => {
     dtsGenerator({

--- a/src/themes/charts/webpack.config.js
+++ b/src/themes/charts/webpack.config.js
@@ -24,14 +24,10 @@ const plugins = [
   }),
   // run TypeScript during webpack build
   new ForkTsCheckerWebpackPlugin({
-    typescript: { configFile: path.resolve(__dirname, '..', 'tsconfig.json') },
+    typescript: {
+      configFile: path.resolve(__dirname, '..', '..', '..', 'tsconfig.json'),
+    },
     async: false, // makes errors more visible, but potentially less performant
-  }),
-
-  // Force EuiIcon's dynamic imports to be included in the single eui.js build,
-  // instead of being split out into multiple files
-  new webpack.optimize.LimitChunkCountPlugin({
-    maxChunks: 1,
   }),
 ];
 
@@ -45,26 +41,18 @@ module.exports = {
   devtool: isProduction ? 'source-map' : 'cheap-module-source-map',
 
   entry: {
-    guide: './index.ts',
+    guide: './themes.ts',
   },
 
   context: __dirname,
 
   output: {
-    path: path.resolve(__dirname, '../dist'),
-    filename: `eui${isProduction ? '.min' : ''}.js`,
+    path: path.resolve(__dirname, '../../../dist'),
+    filename: `eui_charts_theme${isProduction ? '.min' : ''}.js`,
   },
 
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.json'],
-  },
-
-  // Specify where these libraries should be found
-  externals: {
-    moment: 'window.moment',
-    'prop-types': 'window.PropTypes',
-    react: 'window.React',
-    'react-dom': 'window.ReactDOM',
   },
 
   module: {
@@ -83,10 +71,6 @@ module.exports = {
           'sass-loader',
         ],
         exclude: /node_modules/,
-      },
-      {
-        test: /\.(woff|woff2|ttf|eot|ico|png|gif|jpg|jpeg)(\?|$)/,
-        loader: 'file-loader',
       },
     ],
     strictExportPresence: isProduction,


### PR DESCRIPTION
### Summary

Closes #5801 by ending the practice of distributing webpack bundles in `dist`.

The `eui_charts_theme` module still relies on the webpack config, so I've moved that into the `theme/charts` directory and removed superfluous configuration. The output is identical except for path names.
I also noticed that we were building `lib` and `es` versions of `theme/charts/theme` which is ignorant because it uses a webpack loader (not available during babel builds). So I've ignored that file during babel builds.
Eventually we can get rid of the `eui_charts_theme` module and ship the theme as part of the babel build(s), but that will require refactoring to not use the theme variable JSON file.

### Checklist

- [ ] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
