### PR TITLE
[Docs] Moved google fonts import to `<head>`

### DIFF
--- a/src-docs/src/components/codesandbox/link.js
+++ b/src-docs/src/components/codesandbox/link.js
@@ -182,6 +182,7 @@ ReactDOM.render(
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:slnt,wght@-10,300..700;0,300..700&family=Roboto+Mono:ital,wght@0,400..700;1,400..700&display=swap" rel="stylesheet" />
   <meta name="emotion-styles">
 </head>
 <body>

--- a/src-docs/src/theme_dark.scss
+++ b/src-docs/src/theme_dark.scss
@@ -1,6 +1,3 @@
-// sass-lint:disable no-url-domains, no-url-protocols
-@import url('https://fonts.googleapis.com/css2?family=Inter:slnt,wght@-10,300..700;0,300..700&family=Roboto+Mono:ital,wght@0,400..700;1,400..700&display=swap');
-
 @import '../../src/themes/amsterdam/theme_dark';
 @import './components/index';
 @import './services/playground/index';

--- a/src-docs/src/theme_light.scss
+++ b/src-docs/src/theme_light.scss
@@ -1,6 +1,3 @@
-// sass-lint:disable no-url-domains, no-url-protocols
-@import url('https://fonts.googleapis.com/css2?family=Inter:slnt,wght@-10,300..700;0,300..700&family=Roboto+Mono:ital,wght@0,400..700;1,400..700&display=swap');
-
 @import '../../src/themes/amsterdam/theme_light';
 @import './components/index';
 @import './services/playground/index';

--- a/src-docs/src/views/app_context.js
+++ b/src-docs/src/views/app_context.js
@@ -63,6 +63,12 @@ export const AppContext = ({ children }) => {
           href={isLocalDev ? favicon96Dev : favicon96Prod}
           sizes="96x96"
         />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:slnt,wght@-10,300..700;0,300..700&family=Roboto+Mono:ital,wght@0,400..700;1,400..700&display=swap"
+          rel="stylesheet"
+        />
       </Helmet>
       <EuiContext i18n={i18n}>{children}</EuiContext>
     </EuiProvider>

--- a/src-docs/src/views/guidelines/getting_started/getting_started.js
+++ b/src-docs/src/views/guidelines/getting_started/getting_started.js
@@ -144,9 +144,10 @@ export const GettingStarted = {
           <EuiSpacer />
 
           <EuiCodeBlock language="scss" isCopyable fontSize="m">
-            {
-              "@import url('https://fonts.googleapis.com/css2?family=Inter:ital,wght@300;400;500;600;700&family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap');"
-            }
+            {`<link
+  href="https://fonts.googleapis.com/css2?family=Inter:ital,wght@300;400;500;600;700&family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap"
+  rel="stylesheet"
+/>`}
           </EuiCodeBlock>
           <EuiSpacer />
           <EuiText grow={false}>
@@ -157,9 +158,10 @@ export const GettingStarted = {
           </EuiText>
           <EuiSpacer />
           <EuiCodeBlock language="scss" isCopyable fontSize="m">
-            {
-              "@import url('https://fonts.googleapis.com/css2?family=Inter:ital,wght@-10,300..700;0,300..700&family=Roboto+Mono:ital,wght@0,400..700;1,400..700&display=swap');"
-            }
+            {`<link
+  href="https://fonts.googleapis.com/css2?family=Inter:slnt,wght@-10,300..700;0,300..700&family=Roboto+Mono:ital,wght@0,400..700;1,400..700&display=swap"
+  rel="stylesheet"
+/>`}
           </EuiCodeBlock>
 
           <EuiSpacer />


### PR DESCRIPTION
### Summary

Fixes Chrome hanging on loading. I also updated the Getting Started docs to mention this `<link />` method instead of through Sass imports as well as added the link to the codesandbox setup.

### Checklist

- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
