### PR TITLE
[EuiEmptyPrompt] Remove `grow` from EuiPanel

### DIFF
--- a/src/components/empty_prompt/__snapshots__/empty_prompt.test.tsx.snap
+++ b/src/components/empty_prompt/__snapshots__/empty_prompt.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiEmptyPrompt is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge testClass1 testClass2"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge testClass1 testClass2"
   data-test-subj="test subject string"
 >
   <div
@@ -56,7 +56,7 @@ exports[`EuiEmptyPrompt is rendered 1`] = `
 
 exports[`EuiEmptyPrompt props actions renders alone 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
 >
   <div
     class="euiEmptyPrompt__main"
@@ -79,7 +79,7 @@ exports[`EuiEmptyPrompt props actions renders alone 1`] = `
 
 exports[`EuiEmptyPrompt props actions renders an array 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
 >
   <div
     class="euiEmptyPrompt__main"
@@ -115,7 +115,7 @@ exports[`EuiEmptyPrompt props actions renders an array 1`] = `
 
 exports[`EuiEmptyPrompt props body renders alone 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
 >
   <div
     class="euiEmptyPrompt__main"
@@ -143,7 +143,7 @@ exports[`EuiEmptyPrompt props body renders alone 1`] = `
 
 exports[`EuiEmptyPrompt props color accent is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--accent euiPanel--noShadow euiPanel--noBorder euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--accent euiPanel--noShadow euiPanel--noBorder euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
 >
   <div
     class="euiEmptyPrompt__main"
@@ -161,7 +161,7 @@ exports[`EuiEmptyPrompt props color accent is rendered 1`] = `
 
 exports[`EuiEmptyPrompt props color danger is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--danger euiPanel--noShadow euiPanel--noBorder euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--danger euiPanel--noShadow euiPanel--noBorder euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
 >
   <div
     class="euiEmptyPrompt__main"
@@ -179,7 +179,7 @@ exports[`EuiEmptyPrompt props color danger is rendered 1`] = `
 
 exports[`EuiEmptyPrompt props color plain is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
 >
   <div
     class="euiEmptyPrompt__main"
@@ -197,7 +197,7 @@ exports[`EuiEmptyPrompt props color plain is rendered 1`] = `
 
 exports[`EuiEmptyPrompt props color primary is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--primary euiPanel--noShadow euiPanel--noBorder euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--primary euiPanel--noShadow euiPanel--noBorder euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
 >
   <div
     class="euiEmptyPrompt__main"
@@ -215,7 +215,7 @@ exports[`EuiEmptyPrompt props color primary is rendered 1`] = `
 
 exports[`EuiEmptyPrompt props color subdued is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--subdued euiPanel--noShadow euiPanel--noBorder euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--subdued euiPanel--noShadow euiPanel--noBorder euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
 >
   <div
     class="euiEmptyPrompt__main"
@@ -233,7 +233,7 @@ exports[`EuiEmptyPrompt props color subdued is rendered 1`] = `
 
 exports[`EuiEmptyPrompt props color success is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--success euiPanel--noShadow euiPanel--noBorder euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--success euiPanel--noShadow euiPanel--noBorder euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
 >
   <div
     class="euiEmptyPrompt__main"
@@ -251,7 +251,7 @@ exports[`EuiEmptyPrompt props color success is rendered 1`] = `
 
 exports[`EuiEmptyPrompt props color transparent is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
 >
   <div
     class="euiEmptyPrompt__main"
@@ -269,7 +269,7 @@ exports[`EuiEmptyPrompt props color transparent is rendered 1`] = `
 
 exports[`EuiEmptyPrompt props color warning is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--warning euiPanel--noShadow euiPanel--noBorder euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--warning euiPanel--noShadow euiPanel--noBorder euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
 >
   <div
     class="euiEmptyPrompt__main"
@@ -287,7 +287,7 @@ exports[`EuiEmptyPrompt props color warning is rendered 1`] = `
 
 exports[`EuiEmptyPrompt props footer renders alone 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
 >
   <div
     class="euiEmptyPrompt__main"
@@ -310,7 +310,7 @@ exports[`EuiEmptyPrompt props footer renders alone 1`] = `
 
 exports[`EuiEmptyPrompt props icon renders alone 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
 >
   <div
     class="euiEmptyPrompt__main"
@@ -335,7 +335,7 @@ exports[`EuiEmptyPrompt props icon renders alone 1`] = `
 
 exports[`EuiEmptyPrompt props iconType renders alone 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
 >
   <div
     class="euiEmptyPrompt__main"
@@ -361,7 +361,7 @@ exports[`EuiEmptyPrompt props iconType renders alone 1`] = `
 
 exports[`EuiEmptyPrompt props iconType renders with iconColor 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
 >
   <div
     class="euiEmptyPrompt__main"
@@ -387,7 +387,7 @@ exports[`EuiEmptyPrompt props iconType renders with iconColor 1`] = `
 
 exports[`EuiEmptyPrompt props layout renders alone 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiEmptyPrompt euiEmptyPrompt--horizontal euiEmptyPrompt--paddingLarge"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--horizontal euiEmptyPrompt--paddingLarge"
 >
   <div
     class="euiEmptyPrompt__main"
@@ -405,7 +405,7 @@ exports[`EuiEmptyPrompt props layout renders alone 1`] = `
 
 exports[`EuiEmptyPrompt props paddingSize l is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
 >
   <div
     class="euiEmptyPrompt__main"
@@ -423,7 +423,7 @@ exports[`EuiEmptyPrompt props paddingSize l is rendered 1`] = `
 
 exports[`EuiEmptyPrompt props paddingSize m is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingMedium"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingMedium"
 >
   <div
     class="euiEmptyPrompt__main"
@@ -441,7 +441,7 @@ exports[`EuiEmptyPrompt props paddingSize m is rendered 1`] = `
 
 exports[`EuiEmptyPrompt props paddingSize none is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiEmptyPrompt euiEmptyPrompt--vertical"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical"
 >
   <div
     class="euiEmptyPrompt__main"
@@ -459,7 +459,7 @@ exports[`EuiEmptyPrompt props paddingSize none is rendered 1`] = `
 
 exports[`EuiEmptyPrompt props paddingSize s is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingSmall"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingSmall"
 >
   <div
     class="euiEmptyPrompt__main"
@@ -477,7 +477,7 @@ exports[`EuiEmptyPrompt props paddingSize s is rendered 1`] = `
 
 exports[`EuiEmptyPrompt props styles are rendered 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
   style="background:yellow;min-width:200px;max-width:600px"
 >
   <div
@@ -496,7 +496,7 @@ exports[`EuiEmptyPrompt props styles are rendered 1`] = `
 
 exports[`EuiEmptyPrompt props title renders alone 1`] = `
 <div
-  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
+  class="euiPanel euiPanel--borderRadiusMedium euiPanel--transparent euiPanel--noShadow euiPanel--flexGrowZero euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge"
 >
   <div
     class="euiEmptyPrompt__main"

--- a/src/components/empty_prompt/empty_prompt.tsx
+++ b/src/components/empty_prompt/empty_prompt.tsx
@@ -176,6 +176,7 @@ export const EuiEmptyPrompt: FunctionComponent<EuiEmptyPromptProps> = ({
     color: color,
     paddingSize: 'none',
     hasBorder: hasBorder,
+    grow: false,
     ...rest,
   };
 

--- a/upcoming_changelogs/5907.md
+++ b/upcoming_changelogs/5907.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed height stretching of `EuiEmptyPrompt` by setting `grow=false` on the nested panel


### PR DESCRIPTION
### Summary

In Kibana, we're using the shared No Data View empty prompt in a lot more locations. Because EuiPanel comes with `grow=true` by default **and** the prop has been excluded from EuiEmptyPrompt, it's been difficult to override this behavior when the prompt is placed in `flex-direction: column` containers (which is a lot in Kibana). 


<img width="1628" alt="Screen Shot 2022-05-18 at 08 37 12 AM" src="https://user-images.githubusercontent.com/549577/169060124-fb771d62-6038-4832-a2f9-18344bb57d68.png">

I couldn't think of a scenario where we'd **want** the prompt to grow to fill it's container's height especially since the prompt's contents are centered in itself. So I just set `grow=false` directly in the component.

To test, you'll need to set `flex-direction: column` on a parent container.

**Before**
<img width="1237" alt="Screen Shot 2022-05-18 at 09 58 24 AM" src="https://user-images.githubusercontent.com/549577/169060062-83a7176a-7af8-4bce-b1fe-5cfbb131f967.png">


**After**
<img width="1232" alt="Screen Shot 2022-05-18 at 09 58 49 AM" src="https://user-images.githubusercontent.com/549577/169060091-dbcc3ea6-6181-4edd-b33e-3d7ffcf86834.png">


### Checklist

- ~[ ] Checked in both **light and dark** modes~
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
