### PR TITLE
Attempt to squash flaky date Jest test

### DIFF
--- a/src/components/search_bar/query/date_format.test.ts
+++ b/src/components/search_bar/query/date_format.test.ts
@@ -127,7 +127,7 @@ describe('date format', () => {
       expect(dateGranularity(parsed)).toBe(Granularity.DAY);
     });
 
-    const sunday = moment(now).subtract(now.day(), 'days');
+    const sunday = moment().day('Sunday');
     ['Sun', 'Sunday'].forEach((time) => {
       const parsed = dateFormat.parse(time);
       expect(parsed.utcOffset()).toBe(0);


### PR DESCRIPTION
### Summary

In my EuiText Emotion PR, my machine ended up running a lot of tests due to downstream affected components and I saw the following flakey Jest failure more than 5 times while working on the conversion:

```
FAIL src/components/search_bar/query/date_format.test.ts
  ● date format › parse - day granularity

    expect(received).toBe(expected) // Object.is equality

    Expected: 8
    Received: 7

      133 |       expect(parsed.utcOffset()).toBe(0);
      134 |       expect(parsed.year()).toBe(sunday.year());
    > 135 |       expect(parsed.month()).toBe(sunday.month());
```

I'm honestly not clear why this is happening (greebles?) but I think it's because the previous code was looking to last Sunday whereas the new code finds this week's Sunday (https://momentjscom.readthedocs.io/en/latest/moment/02-get-set/06-day/) 🤷 TBH it might not really fully squash the flakiness but if CI passes it at least isn't making it worse.

### Checklist

N/A, internal only. Should be fine if CI passes