### PR TITLE
[EuiBasicTable] Remove bottom border of table header cell

### DIFF
--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -78,7 +78,7 @@
 
 .euiTableHeaderCellCheckbox {
   @include euiTableCellCheckbox;
-  border-top: none;
+  border: none;
 }
 
 .euiTableRow {

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -36,7 +36,7 @@
   @include euiTableCell;
   @include euiTitle('xxs');
   font-weight: $euiFontWeightMedium;
-  border-top: none;
+  border: none;
 
   .euiTableHeaderButton {
     text-align: left;
@@ -146,10 +146,8 @@
   @include euiTableCellCheckbox;
 }
 
-// Must come after .euiTableRowCell selector for border to be removed
 .euiTableFooterCell {
   background-color: $euiColorLightestShade;
-  border-bottom: none;
 }
 
 /**

--- a/upcoming_changelogs/5914.md
+++ b/upcoming_changelogs/5914.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiInMemoryTable`'s loading state from shifting layout


### PR DESCRIPTION
### Fixes #4283 

Removes the bottom border of table headers so that it doesn't compete with the top border of cells. Everything should render exactly as it did, but now the loading state is properly aligned.



https://user-images.githubusercontent.com/549577/169591982-b6c72a72-359a-4ac8-8a0a-369f250a6984.mp4




### EuiInMemoryTable

<img width="1274" alt="image" src="https://user-images.githubusercontent.com/549577/169569493-8e262be5-4381-4a16-85d2-dc62d2953902.png">

### EuiBasicTable

<img width="1274" alt="image" src="https://user-images.githubusercontent.com/549577/169569358-3da84247-cbe5-4cd3-8dac-eb9facc87f3f.png">


### Empty state

<img width="1274" alt="image" src="https://user-images.githubusercontent.com/549577/169569210-c8013b2b-f0c3-4be6-9769-5029d08712dd.png">


### Checklist

- ~[ ] Checked in both **light and dark** modes~
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
