### PR TITLE
[Docs] Fix scroll to hash behavior

### DIFF
--- a/src-docs/src/components/scroll_to_hash.tsx
+++ b/src-docs/src/components/scroll_to_hash.tsx
@@ -16,7 +16,7 @@ const ScrollToHash: FunctionComponent = () => {
     if (documentReadyState !== 'complete') return; // Wait for page to finish loading before scrolling
     const hash = location.hash.split('?')[0].replace('#', ''); // Remove any query params and the leading hash
     const element = document.getElementById(hash);
-    const headerOffset = 72;
+    const headerOffset = 48;
     if (element) {
       window.scrollTo({
         top: element.offsetTop - headerOffset,

--- a/src-docs/src/components/scroll_to_hash.tsx
+++ b/src-docs/src/components/scroll_to_hash.tsx
@@ -1,9 +1,19 @@
-import { useEffect, FunctionComponent } from 'react';
+import { useEffect, useState, FunctionComponent } from 'react';
 import { useLocation } from 'react-router-dom';
 
 const ScrollToHash: FunctionComponent = () => {
   const location = useLocation();
+
+  const [documentReadyState, setReadyState] = useState(document.readyState);
   useEffect(() => {
+    const readyStateListener = () => setReadyState(document.readyState);
+    document.addEventListener('readystatechange', readyStateListener);
+    return () =>
+      document.removeEventListener('readystatechange', readyStateListener);
+  }, []);
+
+  useEffect(() => {
+    if (documentReadyState !== 'complete') return; // Wait for page to finish loading before scrolling
     const hash = location.hash.split('?')[0].replace('#', ''); // Remove any query params and the leading hash
     const element = document.getElementById(hash);
     const headerOffset = 72;
@@ -18,7 +28,7 @@ const ScrollToHash: FunctionComponent = () => {
         top: 0,
       });
     }
-  }, [location]);
+  }, [location, documentReadyState]);
   return null;
 };
 


### PR DESCRIPTION
### Summary

From @miukimiu 

> I noticed on our site when the page load (the first time) the scroll-to functionality doesn't work as expected: https://elastic.github.io/eui/#/tabular-content/data-grid-cells-popovers#focus. It should scroll to the Focus section.

This PR adds a document readystate check to ensure DOM is done loading/shifting before scrolling to a hash section.

It also tweaks the header offset slightly account for new section spacing added in #5887

### Checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

Other items are probably N/A as an internal only change