### PR TITLE
[EuiDataGrid] Fix sorting drag handle axe errors

### DIFF
--- a/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
@@ -267,6 +267,7 @@ exports[`useDataGridColumnSorting columnSorting renders a toolbar button/popover
                               </div>
                               <div
                                 aria-describedby="rbd-hidden-text-0-hidden-text-0"
+                                aria-label="Drag handle"
                                 class="euiFlexItem euiFlexItem--flexGrowZero"
                                 data-rbd-drag-handle-context-id="0"
                                 data-rbd-drag-handle-draggable-id="columnA"
@@ -274,19 +275,10 @@ exports[`useDataGridColumnSorting columnSorting renders a toolbar button/popover
                                 role="button"
                                 tabindex="0"
                               >
-                                <div
-                                  aria-describedby="rbd-hidden-text-0-hidden-text-0"
-                                  data-rbd-drag-handle-context-id="0"
-                                  data-rbd-drag-handle-draggable-id="columnA"
-                                  draggable="false"
-                                  role="button"
-                                  tabindex="0"
-                                >
-                                  <span
-                                    color="subdued"
-                                    data-euiicon-type="grab"
-                                  />
-                                </div>
+                                <span
+                                  color="subdued"
+                                  data-euiicon-type="grab"
+                                />
                               </div>
                             </div>
                           </div>
@@ -1204,6 +1196,7 @@ exports[`useDataGridColumnSorting columnSorting renders a toolbar button/popover
                                                                       </EuiFlexItem>
                                                                       <EuiFlexItem
                                                                         aria-describedby="rbd-hidden-text-0-hidden-text-0"
+                                                                        aria-label="Drag handle"
                                                                         data-rbd-drag-handle-context-id="0"
                                                                         data-rbd-drag-handle-draggable-id="columnA"
                                                                         draggable={false}
@@ -1214,6 +1207,7 @@ exports[`useDataGridColumnSorting columnSorting renders a toolbar button/popover
                                                                       >
                                                                         <div
                                                                           aria-describedby="rbd-hidden-text-0-hidden-text-0"
+                                                                          aria-label="Drag handle"
                                                                           className="euiFlexItem euiFlexItem--flexGrowZero"
                                                                           data-rbd-drag-handle-context-id="0"
                                                                           data-rbd-drag-handle-draggable-id="columnA"
@@ -1222,25 +1216,15 @@ exports[`useDataGridColumnSorting columnSorting renders a toolbar button/popover
                                                                           role="button"
                                                                           tabIndex={0}
                                                                         >
-                                                                          <div
-                                                                            aria-describedby="rbd-hidden-text-0-hidden-text-0"
-                                                                            data-rbd-drag-handle-context-id="0"
-                                                                            data-rbd-drag-handle-draggable-id="columnA"
-                                                                            draggable={false}
-                                                                            onDragStart={[Function]}
-                                                                            role="button"
-                                                                            tabIndex={0}
+                                                                          <EuiIcon
+                                                                            color="subdued"
+                                                                            type="grab"
                                                                           >
-                                                                            <EuiIcon
+                                                                            <span
                                                                               color="subdued"
-                                                                              type="grab"
-                                                                            >
-                                                                              <span
-                                                                                color="subdued"
-                                                                                data-euiicon-type="grab"
-                                                                              />
-                                                                            </EuiIcon>
-                                                                          </div>
+                                                                              data-euiicon-type="grab"
+                                                                            />
+                                                                          </EuiIcon>
                                                                         </div>
                                                                       </EuiFlexItem>
                                                                     </div>

--- a/src/components/datagrid/controls/__snapshots__/column_sorting_draggable.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_sorting_draggable.test.tsx.snap
@@ -142,14 +142,13 @@ exports[`EuiDataGridColumnSortingDraggable renders an EuiDraggable component of 
       </EuiI18n>
     </EuiFlexItem>
     <EuiFlexItem
+      aria-label="Drag handle"
       grow={false}
     >
-      <div>
-        <EuiIcon
-          color="subdued"
-          type="grab"
-        />
-      </div>
+      <EuiIcon
+        color="subdued"
+        type="grab"
+      />
     </EuiFlexItem>
   </EuiFlexGroup>
 </div>

--- a/src/components/datagrid/controls/column_sorting_draggable.tsx
+++ b/src/components/datagrid/controls/column_sorting_draggable.tsx
@@ -11,7 +11,7 @@ import { EuiScreenReaderOnly } from '../../accessibility';
 import { EuiButtonGroup, EuiButtonIcon } from '../../button';
 import { EuiDraggable } from '../../drag_and_drop';
 import { EuiFlexGroup, EuiFlexItem } from '../../flex';
-import { EuiI18n } from '../../i18n';
+import { EuiI18n, useEuiI18n } from '../../i18n';
 import { EuiIcon } from '../../icon';
 import { EuiText } from '../../text';
 import { EuiToken } from '../../token';
@@ -60,6 +60,11 @@ export const EuiDataGridColumnSortingDraggable: FunctionComponent<EuiDataGridCol
       'data-test-subj': `euiDataGridColumnSorting-sortColumn-${id}-desc`,
     },
   ];
+
+  const dragHandleAriaLabel = useEuiI18n(
+    'euiColumnSortingDraggable.dragHandleAriaLabel',
+    'Drag handle'
+  );
 
   return (
     <EuiDraggable draggableId={id} index={index} {...rest}>
@@ -154,10 +159,12 @@ export const EuiDataGridColumnSortingDraggable: FunctionComponent<EuiDataGridCol
                 )}
               </EuiI18n>
             </EuiFlexItem>
-            <EuiFlexItem grow={false} {...provided.dragHandleProps}>
-              <div {...provided.dragHandleProps}>
-                <EuiIcon type="grab" color="subdued" />
-              </div>
+            <EuiFlexItem
+              grow={false}
+              {...provided.dragHandleProps}
+              aria-label={dragHandleAriaLabel}
+            >
+              <EuiIcon type="grab" color="subdued" />
             </EuiFlexItem>
           </EuiFlexGroup>
         </div>

--- a/upcoming_changelogs/5916.md
+++ b/upcoming_changelogs/5916.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed accessibility errors with `EuiDataGrid`'s column sorting drag & drop handles


### PR DESCRIPTION
### Summary

closes https://github.com/elastic/eui/issues/5900
closes https://github.com/elastic/eui/issues/5912

- Fixes the drag handle props being repeated/nested unecessarily (probably a mistake)
- Fixes the drag handle missing an `aria-label` and triggering an axe error

### Checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
