### PR TITLE
Adding a callout for aria-label on EuiDraggable custom drag handles.

### DIFF
--- a/src-docs/src/views/drag_and_drop/drag_and_drop_example.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_example.js
@@ -217,10 +217,11 @@ export const DragAndDropExample = {
             iconType="accessibility"
             title={
               <>
-                Custom drag handles <strong>require</strong> an accessible
-                label. Add an <EuiCode>{'aria-label="Drag handle"'}</EuiCode>{' '}
-                attribute to your React component or HTML element that receives
-                Draggable <EuiCode>{'provided.dragHandleProps'}</EuiCode>.
+                <strong>Icon-only</strong> custom drag handles require an
+                accessible label. Add an{' '}
+                <EuiCode>{'aria-label="Drag handle"'}</EuiCode> attribute to
+                your React component or HTML element that receives
+                <EuiCode>{'provided.dragHandleProps'}</EuiCode>.
               </>
             }
           />

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_example.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_example.js
@@ -212,6 +212,18 @@ export const DragAndDropExample = {
             <EuiCode>provided.dragHandleProps</EuiCode> needs to be added to the
             intended handle element.
           </p>
+
+          <EuiCallOut
+            iconType="accessibility"
+            title={
+              <>
+                Custom drag handles <strong>require</strong> an accessible
+                label. Add an <EuiCode>{'aria-label="Drag handle"'}</EuiCode>{' '}
+                attribute to your React component or HTML element that receives
+                Draggable <EuiCode>{'provided.dragHandleProps'}</EuiCode>.
+              </>
+            }
+          />
         </React.Fragment>
       ),
       demo: <DragAndDropCustomHandle />,

--- a/upcoming_changelogs/5919.md
+++ b/upcoming_changelogs/5919.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Added accessibility documentation to `EuiDraggable` custom drag handles

--- a/upcoming_changelogs/5919.md
+++ b/upcoming_changelogs/5919.md
@@ -1,3 +1,0 @@
-**Bug fixes**
-
-- Added accessibility documentation to `EuiDraggable` custom drag handles


### PR DESCRIPTION
### Summary

Adding a callout to the `EuiDraggable` custom drag handles section that outlines adding an `aria-label` for accessibility.

Closes #5911 

---
<img width="1309" alt="Screen Shot 2022-05-20 at 3 46 01 PM" src="https://user-images.githubusercontent.com/934879/169608842-d6f159b0-9c8d-49ea-9b7a-afba66b9b0d8.png">


### Checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] ~~Props have proper **autodocs** and **[playground toggles]~~(https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] ~~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~~
- [ ] ~~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~~
- [ ] ~~Checked for **breaking changes** and labeled appropriately~~
- [ ] ~~Checked for **accessibility** including keyboard-only and screenreader modes~~
- [ ] ~~Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~~
- [ ] ~~A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~~
