### PR TITLE
[Emotion] Squash :first-child/:nth-child errors

### DIFF
--- a/scripts/jest/setup/throw_on_console_error.js
+++ b/scripts/jest/setup/throw_on_console_error.js
@@ -1,5 +1,18 @@
 // Fail if a test ends up `console.error`-ing, e.g. if React logs because of a
 // failed prop types check.
-console.error = message => {
+console.error = (message) => {
+  // @see https://github.com/emotion-js/emotion/issues/1105
+  // This error that Emotion throws doesn't apply to Jest, so
+  // we're just going to straight up ignore the first/nth-child warning
+  if (
+    typeof message === 'string' &&
+    message.includes('The pseudo class') &&
+    message.includes(
+      'is potentially unsafe when doing server-side rendering. Try changing it to'
+    )
+  ) {
+    return;
+  }
+
   throw new Error(message);
 };

--- a/src-docs/src/components/codesandbox/link.js
+++ b/src-docs/src/components/codesandbox/link.js
@@ -167,6 +167,7 @@ const cache = createCache({
   key: 'codesandbox',
   container: document.querySelector('meta[name="emotion-styles"]'),
 });
+cache.compat = true;
 
 ReactDOM.render(
   <EuiProvider cache={cache} ${providerProps}>

--- a/src-docs/src/views/app_context.js
+++ b/src-docs/src/views/app_context.js
@@ -21,6 +21,7 @@ const emotionCache = createCache({
   key: 'eui-docs',
   container: document.querySelector('meta[name="emotion-styles"]'),
 });
+emotionCache.compat = true;
 
 export const AppContext = ({ children }) => {
   const { theme } = useContext(ThemeContext);

--- a/src-docs/src/views/provider/provider_styles.tsx
+++ b/src-docs/src/views/provider/provider_styles.tsx
@@ -32,6 +32,7 @@ const cache = createCache({
   key: 'myApp',
   container: document.querySelector('meta[name="emotion-style-insert"]'),
 });
+cache.compat = true;
 
 <EuiProvider${colorMode === 'DARK' ? ' colorMode="dark"' : ''} cache={cache}'>
   {/* Content */}


### PR DESCRIPTION
### Summary

Emotion throws a bunch of errors for the `:first-child` and `:nth-child` selectors for SSR reasons: https://github.com/emotion-js/emotion/issues/1105

This PR silences those errors on Jest (db0b25a80f87a8443cbe12743253b38c336c2b9d, see https://github.com/emotion-js/emotion/issues/1105#issuecomment-1029920343) which absolutely do not need them, and also silences them in the browser (1378d1ae2ba91e7bd56d1f6d75e88454f122308c, https://github.com/emotion-js/emotion/issues/1105#issuecomment-557726922 - dev-recommended option)

### Checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples

No changelog as _technically_ this does not affect any source code