### PR TITLE
Reduce webpack dev server output

### DIFF
--- a/cypress/plugins/webpack.config.js
+++ b/cypress/plugins/webpack.config.js
@@ -8,7 +8,6 @@
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 
-const path = require('path');
 const webpack = require('webpack');
 
 const THEME_IMPORT = `'../../dist/eui_theme_${process.env.THEME}.css'`;
@@ -17,6 +16,8 @@ module.exports = {
   mode: 'development',
 
   devtool: 'cheap-module-source-map',
+
+  stats: 'minimal',
 
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.json'],
@@ -34,10 +35,7 @@ module.exports = {
       },
       {
         test: /\.css$/,
-        loaders: [
-          'style-loader',
-          'css-loader',
-        ],
+        loaders: ['style-loader', 'css-loader'],
         exclude: /node_modules/,
       },
       {
@@ -52,5 +50,5 @@ module.exports = {
     new webpack.DefinePlugin({
       THEME_IMPORT, // allow cypress/suport/index.js to require the correct css file
     }),
-  ]
+  ],
 };

--- a/src-docs/webpack.config.js
+++ b/src-docs/webpack.config.js
@@ -164,6 +164,8 @@ const webpackConfig = {
       }),
     ],
   },
+
+  stats: 'minimal',
 };
 
 // Inspired by `get-port-sync`, but propogates options


### PR DESCRIPTION
## Summary

Per @cchaos's request:

### Before (start + 1 recompile)
<details>
<summary>Click to expand</summary>

```
Constances-MBP:eui constance$ yarn start
yarn run v1.22.18
$ cross-env BABEL_MODULES=false webpack-dev-server --config=src-docs/webpack.config.js
ℹ ｢wds｣: Project is running at http://0.0.0.0:8030/
ℹ ｢wds｣: webpack output is served from /
ℹ ｢wds｣: Content not from webpack is served from src-docs/build
ℹ ｢wds｣: 404s will fallback to /index.html
ℹ ｢wdm｣: Hash: dd9f82cc8b17fe7139f5
Version: webpack 4.46.0
Time: 90541ms
Built at: 05/20/2022 2:04:36 PM
                                                                                Asset      Size                              Chunks                         Chunk Names
                                                                            bundle.js  48.8 MiB                              bundle  [emitted]              bundle
                                                                        bundle.js.map  28.4 MiB                              bundle  [emitted] [dev]        bundle
                                                                icon.accessibility.js  8.32 KiB                  icon.accessibility  [emitted]              icon.accessibility
[...] GitHub actually complained at me because the output exceeded their char limit so I snipped the icon output here
                                                                       icon.wrench.js  8.27 KiB                         icon.wrench  [emitted]              icon.wrench
                                                                   icon.wrench.js.map  1.82 KiB                         icon.wrench  [emitted] [dev]        icon.wrench
                     images/0a38c4b245644558189b9a8f72cb98d9-404_rainy_cloud_dark.png   242 KiB                                      [emitted] [immutable]  
                        images/272fd34bc8c628321e023f8c14c16592-no-results--light.svg   206 KiB                                      [emitted] [immutable]  
                                   images/34ab53549b7e99e6293e1ea5923f2fb1-tour_6.gif  1.07 MiB                                      [emitted] [immutable]  
                                images/3cff48417a937f302d88b845d65dd517-tour_1_do.svg  32.6 KiB                                      [emitted] [immutable]  
                         images/43da53199b8a847399ed0d29c549a850-no-results--dark.svg   206 KiB                                      [emitted] [immutable]  
                         images/5755e6a0170da3714612aa037d3c09c1-form-row--toggle.gif   162 KiB                                      [emitted] [immutable]  
                         images/6c9d81950af24f5df9e318c2d7adfb9a-button_placement.svg   8.6 KiB                                      [emitted] [immutable]  
                 images/71528e7dd5c72326c722ba250e02fe24-pagination_infinite_dont.svg   465 KiB                                      [emitted] [immutable]  
                   images/84b0f66164ebb9e032d613e5822a9b7f-pagination_infinite_do.svg   464 KiB                                      [emitted] [immutable]  
                              images/8a809ad8498577a7c49d7012e6eb0609-tour_1_dont.svg  53.7 KiB                                      [emitted] [immutable]  
                          images/a6015746d17b8f6f5ee37ecadc569e69-pie_slice_order.png   814 KiB                                      [emitted] [immutable]  
                       images/b3c1eeb7b88d879679052fc671214b0a-pagination_filters.gif   614 KiB                                      [emitted] [immutable]  
                             images/bb68cce79d5e28fcd85dce0eca39c112-illustration.svg   448 KiB                                      [emitted] [immutable]  
         images/ccf8bad5e356313fbd240deec3a9a6b6-illustration-eui-hero-500-shadow.svg  79.8 KiB                                      [emitted] [immutable]  
images/e029a98075967c92586b619fcb4334c3-illustration-eui-hero-500-darkmode-shadow.svg  80.4 KiB                                      [emitted] [immutable]  
                    images/fef171315512ddd39d1743089db9883f-404_rainy_cloud_light.png   234 KiB                                      [emitted] [immutable]  
                                    images/ff12cb327152f2b424b7bb4c71dc606a-icons.svg  63.2 KiB                                      [emitted] [immutable]  
                                                                           index.html  1.22 KiB                                      [emitted]              
Entrypoint bundle = bundle.js bundle.js.map
[1] multi (webpack)-dev-server/client?http://0.0.0.0:8030 (webpack)/hot/dev-server.js /Users/constance/Documents/eui/node_modules/@pmmmwh/react-refresh-webpack-plugin/client/ReactRefreshEntry.js /Users/constance/Documents/eui/node_modules/@pmmmwh/react-refresh-webpack-plugin/client/ErrorOverlayEntry.js?sockHost=0.0.0.0&sockPort=8030&sockProtocol=http ./index.js 76 bytes {bundle} [built]
[../../node_modules/@emotion/react/dist/emotion-react.browser.esm.js] /Users/constance/Documents/eui/node_modules/@emotion/react/dist/emotion-react.browser.esm.js 10.7 KiB {bundle} [built]
[../../node_modules/@pmmmwh/react-refresh-webpack-plugin/client/ErrorOverlayEntry.js?sockHost=0.0.0.0&sockPort=8030&sockProtocol=http] /Users/constance/Documents/eui/node_modules/@pmmmwh/react-refresh-webpack-plugin/client/ErrorOverlayEntry.js?sockHost=0.0.0.0&sockPort=8030&sockProtocol=http 2.94 KiB {bundle} [built]
[../../node_modules/@pmmmwh/react-refresh-webpack-plugin/client/ReactRefreshEntry.js] /Users/constance/Documents/eui/node_modules/@pmmmwh/react-refresh-webpack-plugin/client/ReactRefreshEntry.js 862 bytes {bundle} [built]
[../../node_modules/@pmmmwh/react-refresh-webpack-plugin/client/utils/errorEventHandlers.js] /Users/constance/Documents/eui/node_modules/@pmmmwh/react-refresh-webpack-plugin/client/utils/errorEventHandlers.js 3.02 KiB {bundle} [built]
[../../node_modules/@pmmmwh/react-refresh-webpack-plugin/client/utils/formatWebpackErrors.js] /Users/constance/Documents/eui/node_modules/@pmmmwh/react-refresh-webpack-plugin/client/utils/formatWebpackErrors.js 3.34 KiB {bundle} [built]
[../../node_modules/@pmmmwh/react-refresh-webpack-plugin/client/utils/patchUrl.js] /Users/constance/Documents/eui/node_modules/@pmmmwh/react-refresh-webpack-plugin/client/utils/patchUrl.js 1.17 KiB {bundle} [built]
[../../node_modules/@pmmmwh/react-refresh-webpack-plugin/client/utils/retry.js] /Users/constance/Documents/eui/node_modules/@pmmmwh/react-refresh-webpack-plugin/client/utils/retry.js 495 bytes {bundle} [built]
[../../node_modules/@pmmmwh/react-refresh-webpack-plugin/lib/runtime/RefreshUtils.js] /Users/constance/Documents/eui/node_modules/@pmmmwh/react-refresh-webpack-plugin/lib/runtime/RefreshUtils.js 8.11 KiB {bundle} [built]
[../../node_modules/@pmmmwh/react-refresh-webpack-plugin/overlay/index.js] /Users/constance/Documents/eui/node_modules/@pmmmwh/react-refresh-webpack-plugin/overlay/index.js 9.12 KiB {bundle} [built]
[../../node_modules/@pmmmwh/react-refresh-webpack-plugin/sockets/WDSSocket.js] /Users/constance/Documents/eui/node_modules/@pmmmwh/react-refresh-webpack-plugin/sockets/WDSSocket.js 1.15 KiB {bundle} [built]
[../../node_modules/core-js-pure/features/global-this.js] /Users/constance/Documents/eui/node_modules/core-js-pure/features/global-this.js 149 bytes {bundle} [built]
[../../node_modules/webpack-dev-server/client/index.js?http://0.0.0.0:8030] (webpack)-dev-server/client?http://0.0.0.0:8030 4.29 KiB {bundle} [built]
[../../node_modules/webpack/hot/dev-server.js] (webpack)/hot/dev-server.js 1.59 KiB {bundle} [built]
[./index.js] 5.98 KiB {bundle} [built]
    + 6482 hidden modules
Child HtmlWebpackCompiler:
     1 asset
    Entrypoint HtmlWebpackPlugin_0 = __child-HtmlWebpackPlugin_0
    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /Users/constance/Documents/eui/node_modules/html-webpack-plugin/lib/loader.js!./index.html 1.44 KiB {HtmlWebpackPlugin_0} [built]
ℹ ｢wdm｣: Compiled successfully.
ℹ ｢wdm｣: Compiling...
ℹ ｢wdm｣: Hash: 1ef6fc565180198631cc
Version: webpack 4.46.0
Time: 6907ms
Built at: 05/20/2022 2:23:31 PM
                                        Asset      Size  Chunks                               Chunk Names
    bundle.dd9f82cc8b17fe7139f5.hot-update.js  10.1 KiB  bundle  [emitted] [immutable] [hmr]  bundle
bundle.dd9f82cc8b17fe7139f5.hot-update.js.map   3.5 KiB  bundle  [emitted] [dev]              bundle
                                    bundle.js  48.8 MiB  bundle  [emitted]                    bundle
                                bundle.js.map  28.4 MiB  bundle  [emitted] [dev]              bundle
         dd9f82cc8b17fe7139f5.hot-update.json  48 bytes          [emitted] [immutable] [hmr]  
 + 907 hidden assets
Entrypoint bundle = bundle.js bundle.dd9f82cc8b17fe7139f5.hot-update.js bundle.js.map bundle.dd9f82cc8b17fe7139f5.hot-update.js.map
[../../node_modules/sass-vars-to-js-loader/index.js!../../src/themes/amsterdam/_colors_dark.scss] /Users/constance/Documents/eui/node_modules/sass-vars-to-js-loader!/Users/constance/Documents/eui/src/themes/amsterdam/_colors_dark.scss 4.92 KiB {bundle} [built]
[../../node_modules/sass-vars-to-js-loader/index.js!../../src/themes/amsterdam/_colors_light.scss] /Users/constance/Documents/eui/node_modules/sass-vars-to-js-loader!/Users/constance/Documents/eui/src/themes/amsterdam/_colors_light.scss 4.92 KiB {bundle} [built]
[./views/app_context.js] 4.26 KiB {bundle} [built]
    + 6494 hidden modules
ℹ ｢wdm｣: Compiled successfully.
```

</details>

### After (start + 1 recompile)
```
Constances-MBP:eui constance$ yarn start
yarn run v1.22.18
$ cross-env BABEL_MODULES=false webpack-dev-server --config=src-docs/webpack.config.js
ℹ ｢wds｣: Project is running at http://0.0.0.0:8030/
ℹ ｢wds｣: webpack output is served from /
ℹ ｢wds｣: Content not from webpack is served from src-docs/build
ℹ ｢wds｣: 404s will fallback to /index.html
ℹ ｢wdm｣:    6498 modules
ℹ ｢wdm｣: Compiled successfully.
ℹ ｢wdm｣: Compiling...
ℹ ｢wdm｣:    6498 modules
ℹ ｢wdm｣: Compiled successfully.
```

### Resources/documentation

- https://webpack.js.org/configuration/stats/ - we can configure `stats` more granuarly if we want to show more info that the `minimal` setting doesn't supply (personally I think this is pretty good though; errors and recompile state is really all I check the webpack logs for), e.g.
```
{
    hash: false,
    version: false,
    timings: false,
    assets: false,
    chunks: false,
    modules: false,
    reasons: false,
    children: false,
    source: false,
    errors: false,
    errorDetails: false,
    warnings: false,
    publicPath: false
}
```

- https://github.com/webpack/webpack/issues/1191 / https://stackoverflow.com/questions/30756804/webpack-silence-output

## Checklist

N/A, dev-only