### PR TITLE
Turn off Emotion source mapping

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -17,7 +17,8 @@ module.exports = {
       "@emotion/babel-preset-css-prop",
       {
         "autoLabel": "always",
-        "labelFormat": "[local]"
+        "labelFormat": "[local]",
+        "sourceMap": false,
       },
     ],
   ],


### PR DESCRIPTION
### Summary

Encountered a scenario where Emotion source mapping was adding 65kb to a 8kb file. Furthermore, we don't get the real benefit of source mapping because of out TypeScript compilation step (same problem we see with devtool sourcing). 

~### Checklist~
