### PR TITLE
[EuiCollapsibleNavGroup] Fix TypeScript error with `title` definition

### DIFF
--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.tsx
@@ -90,7 +90,7 @@ type GroupAsDiv = EuiCollapsibleNavGroupInterface & {
    * with the option to add an iconType
    */
   title?: ReactNode;
-} & HTMLAttributes<HTMLDivElement>;
+} & Omit<HTMLAttributes<HTMLDivElement>, 'title'>;
 
 export type EuiCollapsibleNavGroupProps = ExclusiveUnion<
   GroupAsAccordion,

--- a/upcoming_changelogs/5935.md
+++ b/upcoming_changelogs/5935.md
@@ -1,1 +1,3 @@
+**Bug fixes**
+
 Fixed `EuiCollapsibleNavGroup` TypeScript error where `title` definition was being overridden by an extended `div` element

--- a/upcoming_changelogs/5935.md
+++ b/upcoming_changelogs/5935.md
@@ -1,0 +1,1 @@
+Fixed `EuiCollapsibleNavGroup` TypeScript error where `title` definition was being overridden by an extended `div` element


### PR DESCRIPTION
### Summary

This PR fixes a TypeScript error in  `EuiCollapsibleNavGroup` where `title` definition was being overridden by an extended `div` element.

### Checklist

- ~[ ] Checked in both **light and dark** modes~
- ~[ ] Checked in **mobile**~
- ~[ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
