### PR TITLE
[Docs] Fix link in CSS utility classes page

### DIFF
--- a/src-docs/src/views/utility_classes/utility_classes_example.js
+++ b/src-docs/src/views/utility_classes/utility_classes_example.js
@@ -23,7 +23,7 @@ export const UtilityClassesExample = {
       <EuiSpacer size="m" />
       <EuiCallOut title="Text utilities have moved" iconType="symlink">
         For text and typography specific utilities, go to the{' '}
-        <Link to="/utilities/text">Text documentation page</Link>.
+        <Link to="/theming/typography/utilities">Text documentation page</Link>.
       </EuiCallOut>
       <EuiSpacer size="m" />
       <EuiCallOut title="Responsive utilities have moved" iconType="symlink">


### PR DESCRIPTION
### Summary

This PR fixes a link on **CSS utility classes** page. The link `Text documentation page` was pointing to an old page resulting in a 404 error.

### Checklist

- [ ] ~Checked in both **light and dark** modes~
- [ ] ~Checked in **mobile**~
- [ ] ~Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- [ ] ~Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- [ ] ~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] ~Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [ ] ~A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
