### PR TITLE
[EuiGlobalToastList] Persistent toasts disappear immediately #5945

### DIFF
--- a/src/services/time/timer.test.ts
+++ b/src/services/time/timer.test.ts
@@ -13,11 +13,16 @@ describe('Timer', () => {
     test('counts down until time elapses and calls callback', (done) => {
       const callbackSpy = jest.fn();
       new Timer(callbackSpy, 5);
-
       setTimeout(() => {
         expect(callbackSpy).toBeCalled();
         done();
       }, 8);
+    });
+    test('creates no timeout for Infinity value', (done) => {
+      const callbackSpy = jest.fn();
+      new Timer(callbackSpy, Infinity);
+      expect(callbackSpy).not.toBeCalled();
+      done();
     });
   });
 

--- a/src/services/time/timer.ts
+++ b/src/services/time/timer.ts
@@ -15,7 +15,8 @@ export class Timer {
   timeRemaining: number | undefined;
 
   constructor(callback: () => void, timeMs: number) {
-    this.id = setTimeout(this.finish, timeMs);
+    // No need to set timeout for Infinity timeMs.
+    this.id = timeMs !== Infinity ? setTimeout(this.finish, timeMs) : undefined;
     this.callback = callback;
     this.finishTime = Date.now() + timeMs;
     this.timeRemaining = undefined;

--- a/upcoming_changelogs/5954.md
+++ b/upcoming_changelogs/5954.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed the issue of toasts disappear immediately when given Infinity value in `EuiGlobalToastList` component.
+

--- a/upcoming_changelogs/5954.md
+++ b/upcoming_changelogs/5954.md
@@ -1,4 +1,4 @@
 **Bug fixes**
 
-- Fixed the issue of toasts disappear immediately when given Infinity value in `EuiGlobalToastList` component.
+- Fixed `EuiGlobalToastList`/`EuiToast`s disappearing immediately when given an Infinity timeout
 


### PR DESCRIPTION
### Summary

closes https://github.com/elastic/eui/issues/5945

Fixes the toast disappear immediately issue.

### Checklist

- [x] Checked this fix by providing Infinity to `toastLifeTimeMs` prop. No time out is getting set for Infinity.
- [x] Checked this fix by providing value other than Infinity. Timeout is getting set as expected.
- [x] Added A [changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog) entry for this bugfix
