### PR TITLE
[EuiSkipLink] Add `overrideLinkBehavior` prop for SPA/hash routers

### DIFF
--- a/src-docs/src/views/app_view.js
+++ b/src-docs/src/views/app_view.js
@@ -72,7 +72,7 @@ export const AppView = ({ children, currentRoute }) => {
       <EuiSkipLink
         destinationId="start-of-content"
         position="fixed"
-        overrideAnchorBehavior
+        overrideLinkBehavior
       >
         Skip to content
       </EuiSkipLink>

--- a/src-docs/src/views/app_view.js
+++ b/src-docs/src/views/app_view.js
@@ -9,6 +9,7 @@ import {
   EuiErrorBoundary,
   EuiPage,
   EuiPageBody,
+  EuiSkipLink,
 } from '../../../src/components';
 
 import { keys } from '../../../src/services';
@@ -68,6 +69,13 @@ export const AppView = ({ children, currentRoute }) => {
 
   return (
     <LinkWrapper>
+      <EuiSkipLink
+        destinationId="start-of-content"
+        position="fixed"
+        overrideAnchorBehavior
+      >
+        Skip to content
+      </EuiSkipLink>
       <GuidePageHeader onToggleLocale={toggleLocale} selectedLocale={locale} />
       <EuiPage paddingSize="none">
         <EuiErrorBoundary>
@@ -79,7 +87,7 @@ export const AppView = ({ children, currentRoute }) => {
           />
         </EuiErrorBoundary>
 
-        <EuiPageBody paddingSize="none" panelled>
+        <EuiPageBody paddingSize="none" panelled id="start-of-content">
           {children({ theme })}
         </EuiPageBody>
       </EuiPage>

--- a/src/components/accessibility/skip_link/__snapshots__/skip_link.test.tsx.snap
+++ b/src/components/accessibility/skip_link/__snapshots__/skip_link.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`EuiSkipLink props position absolute is rendered 1`] = `
 
 exports[`EuiSkipLink props position fixed is rendered 1`] = `
 <a
-  class="euiButton euiButton--primary euiButton--small euiButton--fill euiScreenReaderOnly--showOnFocus euiSkipLink css-o3tocm-euiSkipLink-fixed"
+  class="euiButton euiButton--primary euiButton--small euiButton--fill euiScreenReaderOnly--showOnFocus euiSkipLink css-1c2hhvc-euiSkipLink-fixed"
   href="#somewhere"
   rel="noreferrer"
   tabindex="0"

--- a/src/components/accessibility/skip_link/skip_link.styles.ts
+++ b/src/components/accessibility/skip_link/skip_link.styles.ts
@@ -27,8 +27,9 @@ export const euiSkipLinkStyles = ({ euiTheme }: UseEuiTheme) => {
       }
     `,
     fixed: css`
+      position: fixed !important; // Needs to override euiScreenReaderOnly - prevents scroll jumping in Firefox
+
       &:focus {
-        position: fixed;
         inset-block-start: ${euiTheme.size.xs};
         inset-inline-start: ${euiTheme.size.xs};
         z-index: ${Number(euiTheme.levels.header) + 1};

--- a/src/components/accessibility/skip_link/skip_link.test.tsx
+++ b/src/components/accessibility/skip_link/skip_link.test.tsx
@@ -25,10 +25,10 @@ describe('EuiSkipLink', () => {
 
   describe('props', () => {
     test('overrideLinkBehavior prevents default link behavior and manually scrolls and focuses the destination', () => {
-      const scrollToSpy = jest.fn();
+      const scrollSpy = jest.fn();
       const focusSpy = jest.fn();
       jest.spyOn(document, 'getElementById').mockReturnValue({
-        scrollTo: scrollToSpy,
+        scrollIntoView: scrollSpy,
         focus: focusSpy,
       } as any);
 
@@ -40,7 +40,7 @@ describe('EuiSkipLink', () => {
       component.find('EuiButton').simulate('click', { preventDefault });
 
       expect(preventDefault).toHaveBeenCalled();
-      expect(scrollToSpy).toHaveBeenCalled();
+      expect(scrollSpy).toHaveBeenCalled();
       expect(focusSpy).toHaveBeenCalled();
     });
 

--- a/src/components/accessibility/skip_link/skip_link.test.tsx
+++ b/src/components/accessibility/skip_link/skip_link.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render, mount } from 'enzyme';
 import { requiredProps } from '../../../test';
 
 import { EuiSkipLink, POSITIONS } from './skip_link';
@@ -24,6 +24,26 @@ describe('EuiSkipLink', () => {
   });
 
   describe('props', () => {
+    test('overrideAnchorBehavior prevents default link behavior and manually scrolls and focuses the destination', () => {
+      const scrollToSpy = jest.fn();
+      const focusSpy = jest.fn();
+      jest.spyOn(document, 'getElementById').mockReturnValue({
+        scrollTo: scrollToSpy,
+        focus: focusSpy,
+      } as any);
+
+      const component = mount(
+        <EuiSkipLink destinationId="somewhere" overrideAnchorBehavior />
+      );
+
+      const preventDefault = jest.fn();
+      component.find('EuiButton').simulate('click', { preventDefault });
+
+      expect(preventDefault).toHaveBeenCalled();
+      expect(scrollToSpy).toHaveBeenCalled();
+      expect(focusSpy).toHaveBeenCalled();
+    });
+
     test('tabIndex is rendered', () => {
       const component = render(
         <EuiSkipLink destinationId="somewhere" tabIndex={-1} />

--- a/src/components/accessibility/skip_link/skip_link.test.tsx
+++ b/src/components/accessibility/skip_link/skip_link.test.tsx
@@ -24,7 +24,7 @@ describe('EuiSkipLink', () => {
   });
 
   describe('props', () => {
-    test('overrideAnchorBehavior prevents default link behavior and manually scrolls and focuses the destination', () => {
+    test('overrideLinkBehavior prevents default link behavior and manually scrolls and focuses the destination', () => {
       const scrollToSpy = jest.fn();
       const focusSpy = jest.fn();
       jest.spyOn(document, 'getElementById').mockReturnValue({
@@ -33,7 +33,7 @@ describe('EuiSkipLink', () => {
       } as any);
 
       const component = mount(
-        <EuiSkipLink destinationId="somewhere" overrideAnchorBehavior />
+        <EuiSkipLink destinationId="somewhere" overrideLinkBehavior />
       );
 
       const preventDefault = jest.fn();

--- a/src/components/accessibility/skip_link/skip_link.tsx
+++ b/src/components/accessibility/skip_link/skip_link.tsx
@@ -33,7 +33,7 @@ interface EuiSkipLinkInterface extends EuiButtonProps {
    * setting this flag to true will manually scroll to and focus the destination element
    * without changing the browser URL's hash
    */
-  overrideAnchorBehavior?: boolean;
+  overrideLinkBehavior?: boolean;
   /**
    * When position is fixed, this is forced to `0`
    */
@@ -58,7 +58,7 @@ export type EuiSkipLinkProps = ExclusiveUnion<propsForAnchor, propsForButton>;
 
 export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
   destinationId,
-  overrideAnchorBehavior,
+  overrideLinkBehavior,
   tabIndex,
   position = 'static',
   children,
@@ -82,7 +82,7 @@ export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
       href: `#${destinationId}`,
     };
   }
-  if (overrideAnchorBehavior) {
+  if (overrideLinkBehavior) {
     optionalProps = {
       ...optionalProps,
       onClick: (e: React.MouseEvent) => {

--- a/src/components/accessibility/skip_link/skip_link.tsx
+++ b/src/components/accessibility/skip_link/skip_link.tsx
@@ -29,6 +29,12 @@ interface EuiSkipLinkInterface extends EuiButtonProps {
    */
   destinationId: string;
   /**
+   * If default HTML anchor link behavior is not desired (e.g. for SPAs with hash routing),
+   * setting this flag to true will manually scroll to and focus the destination element
+   * without changing the browser URL's hash
+   */
+  overrideAnchorBehavior?: boolean;
+  /**
    * When position is fixed, this is forced to `0`
    */
   tabIndex?: number;
@@ -52,6 +58,7 @@ export type EuiSkipLinkProps = ExclusiveUnion<propsForAnchor, propsForButton>;
 
 export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
   destinationId,
+  overrideAnchorBehavior,
   tabIndex,
   position = 'static',
   children,
@@ -73,6 +80,21 @@ export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
   if (destinationId) {
     optionalProps = {
       href: `#${destinationId}`,
+    };
+  }
+  if (overrideAnchorBehavior) {
+    optionalProps = {
+      ...optionalProps,
+      onClick: (e: React.MouseEvent) => {
+        e.preventDefault();
+
+        const destinationEl = document.getElementById(destinationId);
+        if (!destinationEl) return;
+
+        destinationEl.scrollTo();
+        destinationEl.tabIndex = -1; // Ensure the destination content is focusable
+        destinationEl.focus({ preventScroll: true }); // Scrolling is already handled above, and focus's autoscroll behaves oddly around fixed headers
+      },
     };
   }
 

--- a/src/components/accessibility/skip_link/skip_link.tsx
+++ b/src/components/accessibility/skip_link/skip_link.tsx
@@ -91,7 +91,7 @@ export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
         const destinationEl = document.getElementById(destinationId);
         if (!destinationEl) return;
 
-        destinationEl.scrollTo();
+        destinationEl.scrollIntoView();
         destinationEl.tabIndex = -1; // Ensure the destination content is focusable
         destinationEl.focus({ preventScroll: true }); // Scrolling is already handled above, and focus's autoscroll behaves oddly around fixed headers
       },

--- a/upcoming_changelogs/5957.md
+++ b/upcoming_changelogs/5957.md
@@ -1,1 +1,1 @@
-- Added the `overrideAnchorBehavior` prop to `EuiSkipLink` for applications that use hash routers
+- Added the `overrideLinkBehavior` prop to `EuiSkipLink` for applications that use hash routers

--- a/upcoming_changelogs/5957.md
+++ b/upcoming_changelogs/5957.md
@@ -1,0 +1,1 @@
+- Added the `overrideAnchorBehavior` prop to `EuiSkipLink` for applications that use hash routers


### PR DESCRIPTION
### Summary

See Ryan's comment here: https://github.com/elastic/kibana/issues/38980#issuecomment-606114655

Default skip anchor links mess up hash routers, which both EUI's docs and Kibana uses. We need the ability to set a prop to override manual anchor link behavior by replicating it manually (scrolling to and focusing the destination node).

As a proof of concept, this PR also sets up skip links for our own EUI docs.

![screencap](https://user-images.githubusercontent.com/549407/172462729-f4744984-8c58-46e6-8c62-c2d280213b4d.gif)

### Checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~