### PR TITLE
[EuiText] Fixes custom `styles` 

### DIFF
--- a/src-docs/src/views/popover/popover_panel_class_name.js
+++ b/src-docs/src/views/popover/popover_panel_class_name.js
@@ -24,7 +24,7 @@ export default () => {
       closePopover={closePopover}
       panelClassName="guideDemo__textLines"
     >
-      <EuiText color="danger" style={{ width: 100 }}>
+      <EuiText style={{ width: 100 }}>
         <p>This has a custom class that applies some grid lines.</p>
       </EuiText>
     </EuiPopover>

--- a/src-docs/src/views/popover/popover_panel_class_name.js
+++ b/src-docs/src/views/popover/popover_panel_class_name.js
@@ -24,7 +24,7 @@ export default () => {
       closePopover={closePopover}
       panelClassName="guideDemo__textLines"
     >
-      <EuiText style={{ width: 100 }}>
+      <EuiText color="danger" style={{ width: 100 }}>
         <p>This has a custom class that applies some grid lines.</p>
       </EuiText>
     </EuiPopover>

--- a/src/components/text/__snapshots__/text.test.tsx.snap
+++ b/src/components/text/__snapshots__/text.test.tsx.snap
@@ -35,3 +35,16 @@ exports[`EuiText props grow false 1`] = `
   </p>
 </div>
 `;
+
+exports[`EuiText props style 1`] = `
+<div
+  aria-label="aria-label"
+  class="euiText testClass1 testClass2 css-1rhs9x7-euiText-m-euiTextColor-customColor"
+  data-test-subj="test subject string"
+  style="background-color:#000;color:#fff"
+>
+  <p>
+    Content
+  </p>
+</div>
+`;

--- a/src/components/text/__snapshots__/text_align.test.tsx.snap
+++ b/src/components/text/__snapshots__/text_align.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`EuiTextAlign is rendered 1`] = `
 />
 `;
 
-exports[`EuiTextAlign props cloneElement 1`] = `
+exports[`EuiTextAlign props cloneElement cloneElement 1`] = `
 <p
   class="css-1sr0rpv-euiTextAlign-left"
 >

--- a/src/components/text/__snapshots__/text_color.test.tsx.snap
+++ b/src/components/text/__snapshots__/text_color.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`EuiTextColor is rendered 1`] = `
 />
 `;
 
-exports[`EuiTextColor props cloneElement 1`] = `
+exports[`EuiTextColor props cloneElement is rendered 1`] = `
 <p
   class="css-1jfxl0s-euiTextColor-default"
 >

--- a/src/components/text/text.test.tsx
+++ b/src/components/text/text.test.tsx
@@ -48,5 +48,19 @@ describe('EuiText', () => {
 
       expect(component).toMatchSnapshot();
     });
+
+    test('style', () => {
+      const component = render(
+        <EuiText
+          {...requiredProps}
+          color="#fff"
+          style={{ backgroundColor: '#000' }}
+        >
+          <p>Content</p>
+        </EuiText>
+      );
+
+      expect(component).toMatchSnapshot();
+    });
   });
 });

--- a/src/components/text/text.tsx
+++ b/src/components/text/text.tsx
@@ -41,7 +41,6 @@ export const EuiText: FunctionComponent<EuiTextProps> = ({
   textAlign,
   children,
   className,
-  style,
   ...rest
 }) => {
   const euiTheme = useEuiTheme();
@@ -62,7 +61,7 @@ export const EuiText: FunctionComponent<EuiTextProps> = ({
 
   if (color) {
     text = (
-      <EuiTextColor color={color} style={style} cloneElement>
+      <EuiTextColor color={color} cloneElement>
         {text}
       </EuiTextColor>
     );

--- a/src/components/text/text_align.test.tsx
+++ b/src/components/text/text_align.test.tsx
@@ -20,7 +20,11 @@ describe('EuiTextAlign', () => {
     expect(component).toMatchSnapshot();
   });
 
-  shouldRenderCustomStyles(<EuiTextAlign textAlign="right" />);
+  shouldRenderCustomStyles(
+    <EuiTextAlign textAlign="right">
+      <p>Content</p>
+    </EuiTextAlign>
+  );
 
   describe('props', () => {
     describe('direction', () => {

--- a/src/components/text/text_align.test.tsx
+++ b/src/components/text/text_align.test.tsx
@@ -33,14 +33,18 @@ describe('EuiTextAlign', () => {
       });
     });
 
-    test('cloneElement', () => {
-      const component = render(
-        <EuiTextAlign cloneElement>
-          <p>Content</p>
-        </EuiTextAlign>
-      );
+    describe('cloneElement', () => {
+      test('cloneElement', () => {
+        const component = render(
+          <EuiTextAlign cloneElement>
+            <p>Content</p>
+          </EuiTextAlign>
+        );
 
-      expect(component).toMatchSnapshot();
+        expect(component).toMatchSnapshot();
+      });
+
+      shouldRenderCustomStyles(<EuiTextAlign cloneElement textAlign="right" />);
     });
   });
 });

--- a/src/components/text/text_align.tsx
+++ b/src/components/text/text_align.tsx
@@ -6,7 +6,11 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, HTMLAttributes } from 'react';
+import React, {
+  FunctionComponent,
+  HTMLAttributes,
+  isValidElement,
+} from 'react';
 import { CommonProps } from '../common';
 import { cloneElementWithCss } from '../../services/theme/clone_element';
 
@@ -36,7 +40,7 @@ export const EuiTextAlign: FunctionComponent<EuiTextAlignProps> = ({
 
   const props = { css: cssStyles, ...rest };
 
-  if (cloneElement) {
+  if (isValidElement(children) && cloneElement) {
     return cloneElementWithCss(children, props);
   } else {
     return <div {...props}>{children}</div>;

--- a/src/components/text/text_color.test.tsx
+++ b/src/components/text/text_color.test.tsx
@@ -45,14 +45,18 @@ describe('EuiTextColor', () => {
       });
     });
 
-    test('cloneElement', () => {
-      const component = render(
-        <EuiTextColor cloneElement>
-          <p>Content</p>
-        </EuiTextColor>
-      );
+    describe('cloneElement', () => {
+      test('is rendered', () => {
+        const component = render(
+          <EuiTextColor cloneElement>
+            <p>Content</p>
+          </EuiTextColor>
+        );
 
-      expect(component).toMatchSnapshot();
+        expect(component).toMatchSnapshot();
+      });
+
+      shouldRenderCustomStyles(<EuiTextColor cloneElement color="#fff" />);
     });
   });
 });

--- a/src/components/text/text_color.test.tsx
+++ b/src/components/text/text_color.test.tsx
@@ -56,7 +56,11 @@ describe('EuiTextColor', () => {
         expect(component).toMatchSnapshot();
       });
 
-      shouldRenderCustomStyles(<EuiTextColor cloneElement color="#fff" />);
+      shouldRenderCustomStyles(
+        <EuiTextColor cloneElement color="#fff">
+          <p>Content</p>
+        </EuiTextColor>
+      );
     });
   });
 });

--- a/src/components/text/text_color.tsx
+++ b/src/components/text/text_color.tsx
@@ -66,7 +66,6 @@ export const EuiTextColor: FunctionComponent<EuiTextColorProps> = ({
     styles.euiTextColor,
     isNamedColor ? styles[color as TextColor] : styles.customColor,
   ];
-  const childrenStyle = isValidElement(children) ? children.props.style : {};
 
   // We're checking if is a custom color.
   // If it is a custom color we set the `color` of the `.euiTextColor` div to that custom color.
@@ -74,15 +73,15 @@ export const EuiTextColor: FunctionComponent<EuiTextColorProps> = ({
   const euiTextStyle = !isNamedColor
     ? {
         color: color,
-        ...childrenStyle,
         ...style,
       }
-    : { ...childrenStyle, ...style };
+    : { ...style };
 
   const props = { css: cssStyles, style: euiTextStyle, ...rest };
 
   if (isValidElement(children) && cloneElement) {
-    return cloneElementWithCss(children, props);
+    const childrenStyle = { ...children.props.style, ...euiTextStyle };
+    return cloneElementWithCss(children, { ...props, style: childrenStyle });
   } else {
     const Component = component;
     return <Component {...props}>{children}</Component>;

--- a/src/components/text/text_color.tsx
+++ b/src/components/text/text_color.tsx
@@ -6,7 +6,12 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, HTMLAttributes, CSSProperties } from 'react';
+import React, {
+  FunctionComponent,
+  HTMLAttributes,
+  CSSProperties,
+  isValidElement,
+} from 'react';
 import { CommonProps } from '../common';
 import { cloneElementWithCss } from '../../services/theme/clone_element';
 
@@ -61,6 +66,7 @@ export const EuiTextColor: FunctionComponent<EuiTextColorProps> = ({
     styles.euiTextColor,
     isNamedColor ? styles[color as TextColor] : styles.customColor,
   ];
+  const childrenStyle = isValidElement(children) ? children.props.style : {};
 
   // We're checking if is a custom color.
   // If it is a custom color we set the `color` of the `.euiTextColor` div to that custom color.
@@ -68,13 +74,14 @@ export const EuiTextColor: FunctionComponent<EuiTextColorProps> = ({
   const euiTextStyle = !isNamedColor
     ? {
         color: color,
+        ...childrenStyle,
         ...style,
       }
-    : { ...style };
+    : { ...childrenStyle, ...style };
 
   const props = { css: cssStyles, style: euiTextStyle, ...rest };
 
-  if (cloneElement) {
+  if (isValidElement(children) && cloneElement) {
     return cloneElementWithCss(children, props);
   } else {
     const Component = component;

--- a/upcoming_changelogs/5960.md
+++ b/upcoming_changelogs/5960.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed custom styles from being overridden in `EuiText` and `EuiTextColor`
+


### PR DESCRIPTION
### The problem:

The new cloning mechanism doesn't respect the custom `style` attribute.

<img width="560" alt="Screen Shot 2022-06-08 at 10 22 11 AM" src="https://user-images.githubusercontent.com/549577/172643727-0c00f85b-a703-44d0-9fc9-6ab95ae86145.png">


### The solution:

**Fixed for EuiText**
<img width="899" alt="Screen Shot 2022-06-08 at 10 21 21 AM" src="https://user-images.githubusercontent.com/549577/172643839-4bcc925c-db24-4937-bc49-0157e66c7488.png">


### Checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
