### PR TITLE
[Docs] Remove `euiTextColor` classes

### DIFF
--- a/src-docs/src/views/flyout/flyout_complicated.js
+++ b/src-docs/src/views/flyout/flyout_complicated.js
@@ -76,9 +76,7 @@ export default () => {
         <Fragment>
           <strong>Option one</strong>
           <EuiText size="s" color="subdued">
-            <p className="euiTextColor--subdued">
-              Has a short description giving more detail to the option.
-            </p>
+            <p>Has a short description giving more detail to the option.</p>
           </EuiText>
         </Fragment>
       ),
@@ -90,9 +88,7 @@ export default () => {
         <Fragment>
           <strong>Option two</strong>
           <EuiText size="s" color="subdued">
-            <p className="euiTextColor--subdued">
-              Has a short description giving more detail to the option.
-            </p>
+            <p>Has a short description giving more detail to the option.</p>
           </EuiText>
         </Fragment>
       ),
@@ -104,9 +100,7 @@ export default () => {
         <Fragment>
           <strong>Option three</strong>
           <EuiText size="s" color="subdued">
-            <p className="euiTextColor--subdued">
-              Has a short description giving more detail to the option.
-            </p>
+            <p>Has a short description giving more detail to the option.</p>
           </EuiText>
         </Fragment>
       ),

--- a/src-docs/src/views/modal/modal_form.js
+++ b/src-docs/src/views/modal/modal_form.js
@@ -42,9 +42,7 @@ export default () => {
         <Fragment>
           <strong>Option one</strong>
           <EuiText size="s" color="subdued">
-            <p className="euiTextColor--subdued">
-              Has a short description giving more detail to the option.
-            </p>
+            <p>Has a short description giving more detail to the option.</p>
           </EuiText>
         </Fragment>
       ),
@@ -56,9 +54,7 @@ export default () => {
         <Fragment>
           <strong>Option two</strong>
           <EuiText size="s" color="subdued">
-            <p className="euiTextColor--subdued">
-              Has a short description giving more detail to the option.
-            </p>
+            <p>Has a short description giving more detail to the option.</p>
           </EuiText>
         </Fragment>
       ),
@@ -70,9 +66,7 @@ export default () => {
         <Fragment>
           <strong>Option three</strong>
           <EuiText size="s" color="subdued">
-            <p className="euiTextColor--subdued">
-              Has a short description giving more detail to the option.
-            </p>
+            <p>Has a short description giving more detail to the option.</p>
           </EuiText>
         </Fragment>
       ),

--- a/src-docs/src/views/super_select/super_select_complex.js
+++ b/src-docs/src/views/super_select/super_select_complex.js
@@ -11,9 +11,7 @@ export default () => {
         <Fragment>
           <strong>Option one</strong>
           <EuiText size="s" color="subdued">
-            <p className="euiTextColor--subdued">
-              Has a short description giving more detail to the option.
-            </p>
+            <p>Has a short description giving more detail to the option.</p>
           </EuiText>
         </Fragment>
       ),
@@ -25,9 +23,7 @@ export default () => {
         <Fragment>
           <strong>Option two</strong>
           <EuiText size="s" color="subdued">
-            <p className="euiTextColor--subdued">
-              Has a short description giving more detail to the option.
-            </p>
+            <p>Has a short description giving more detail to the option.</p>
           </EuiText>
         </Fragment>
       ),
@@ -39,9 +35,7 @@ export default () => {
         <Fragment>
           <strong>Option three</strong>
           <EuiText size="s" color="subdued">
-            <p className="euiTextColor--subdued">
-              Has a short description giving more detail to the option.
-            </p>
+            <p>Has a short description giving more detail to the option.</p>
           </EuiText>
         </Fragment>
       ),


### PR DESCRIPTION
### Summary

`euiTextColor--subdued` does nothing in these cases; `EuiText` adds the appropriate styling. Found instances of this in Kibana and they were likely copy-pasted from these examples.
