### PR TITLE
[EuiSelectableMessage] Fixed flex alignment

### DIFF
--- a/src/components/selectable/selectable_message/_selectable_message.scss
+++ b/src/components/selectable/selectable_message/_selectable_message.scss
@@ -6,6 +6,7 @@
   text-align: center;
   word-wrap: break-word; /* 1 */
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
 }


### PR DESCRIPTION
This component based it's layout on the fact that EuiText created a second wrapping element for `color`. Since we removed that element the flex layout was not targeting the actual (multiple) children vs the single text color div. In order to put the elements back into the direction, I had to add `flex-direction: column` directly.

It's most noticeable when showing the loading state of EuiSelectble.

**Before**
<img width="538" alt="Screen Shot 2022-06-13 at 13 36 17 PM" src="https://user-images.githubusercontent.com/549577/173415932-e1e42303-0f52-4263-9472-e74808fe07ad.png">



**After**
<img width="542" alt="Screen Shot 2022-06-13 at 13 36 11 PM" src="https://user-images.githubusercontent.com/549577/173415946-bba64fe8-f413-4719-a664-cbacb15ec26a.png">


### Checklist

- ~[ ] Checked in both **light and dark** modes~
- ~[ ] Checked in **mobile**~
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
