### PR TITLE
Export theme-based shadows at global level

### DIFF
--- a/src-docs/src/views/theme/other/_shadow_js.tsx
+++ b/src-docs/src/views/theme/other/_shadow_js.tsx
@@ -11,14 +11,11 @@ import {
   transparentize,
   EuiDescribedFormGroup,
   EuiFormRow,
+  useEuiShadow,
+  useEuiShadowFlat,
 } from '../../../../../src';
 import { getPropsFromComponent } from '../../../services/props/get_props';
 import { getDescription } from '../../../services/props/get_description';
-
-import {
-  useEuiShadow,
-  useEuiShadowFlat,
-} from '../../../../../src/themes/amsterdam/global_styling/mixins/shadow';
 
 import { ThemeExample } from '../_components/_theme_example';
 import { ThemeValuesTable } from '../_components/_theme_values_table';

--- a/src/themes/amsterdam/index.ts
+++ b/src/themes/amsterdam/index.ts
@@ -6,9 +6,5 @@
  * Side Public License, v 1.
  */
 
-export type { EUI_THEME } from './themes';
-export { EUI_THEMES, isDefaultTheme } from './themes';
-
-export { AMSTERDAM_NAME_KEY, EuiThemeAmsterdam } from './amsterdam/theme';
-
-export * from './amsterdam';
+// Only globally export the mixins we allow consumers to re-use
+export * from './global_styling/mixins/shadow';

--- a/upcoming_changelogs/5970.md
+++ b/upcoming_changelogs/5970.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed export location of JS based shadow mixins


### PR DESCRIPTION
Somewhat a quick fix since only Sass files can be imported from `src` in the package, this PR also exports the shadows from the theme folder (but only the shadows). We may want to continue thinking about how we store these long-term.

### Checklist

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
