### PR TITLE
Fix maximum call stack error for large combobox option groups

### DIFF
--- a/src/components/combo_box/combo_box.test.tsx
+++ b/src/components/combo_box/combo_box.test.tsx
@@ -16,6 +16,7 @@ import {
 import { comboBoxKeys } from '../../services';
 
 import { EuiComboBox, EuiComboBoxProps } from './combo_box';
+import type { EuiComboBoxOptionOption } from './types';
 
 jest.mock('../portal', () => ({
   EuiPortal: ({ children }: { children: ReactNode }) => children,
@@ -65,6 +66,17 @@ describe('EuiComboBox', () => {
     const component = render(<EuiComboBox {...requiredProps} />);
 
     expect(component).toMatchSnapshot();
+  });
+
+  test('supports thousands of options in an options group', () => {
+    // tests for a regression: RangeError: Maximum call stack size exceeded
+    // https://mathiasbynens.be/demo/javascript-argument-count
+    const options: EuiComboBoxOptionOption[] = [{ label: 'test', options: [] }];
+    for (let i = 0; i < 250000; i++) {
+      options[0].options?.push({ label: `option ${i}` });
+    }
+
+    mount(<EuiComboBox {...requiredProps} options={options} />);
   });
 });
 

--- a/src/components/combo_box/matching_options.ts
+++ b/src/components/combo_box/matching_options.ts
@@ -17,7 +17,7 @@ export const flattenOptionGroups = <T>(
       optionOrGroup: EuiComboBoxOptionOption<T>
     ) => {
       if (optionOrGroup.options) {
-        options.push(...optionOrGroup.options);
+        options = options.concat(optionOrGroup.options);
       } else {
         options.push(optionOrGroup);
       }
@@ -84,7 +84,7 @@ export const getMatchingOptions = <T>(
   sortMatchesBy: string
 ) => {
   const normalizedSearchValue = searchValue.trim().toLowerCase();
-  const matchingOptions: Array<EuiComboBoxOptionOption<T>> = [];
+  let matchingOptions: Array<EuiComboBoxOptionOption<T>> = [];
 
   options.forEach((option) => {
     if (option.options) {
@@ -107,7 +107,8 @@ export const getMatchingOptions = <T>(
           isGroupLabelOption: true,
         });
         // Add matching options for group
-        matchingOptions.push(...matchingOptionsForGroup);
+        // use concat over spreading to support large arrays - https://mathiasbynens.be/demo/javascript-argument-count
+        matchingOptions = matchingOptions.concat(matchingOptionsForGroup);
       }
     } else {
       collectMatchingOption(

--- a/upcoming_changelogs/5976.md
+++ b/upcoming_changelogs/5976.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed a maximum call stack error in `EuiComboBox` when an option group contains hundreds of thousands of options 


### PR DESCRIPTION
### Summary

Fixes an issue that has come up twice in Kibana support. The issue is that the spread operation,

```
matchingOptions.push(...matchingOptionsForGroup);
````

was transpiled to

```
matchingOptions.push.apply(matchingOptions, matchingOptionsForGroup);
```

which overflowed the call stack size when matchingOptionsForGroup array was too large (see https://mathiasbynens.be/demo/javascript-argument-count). The fix is to use the `concat` method to merge the two arrays. Also had to update a second instance in _matching_options.ts_ with the same change.

### Checklist

~- [ ] Checked in both **light and dark** modes~
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
