### PR TITLE
Update README to document M1 Apple devices support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ To install and use the correct node version with `nvm`:
 nvm install
 ```
 
+> **Notes:** if you are running on an **M1 Apple device**, you might want to the following
+> - downgrade to node v14 (`lts/fermium` aka `v14.19.3` works)
+> - make sure that you're running your terminal in Rosetta mode
+    >  - select the `Terminal` application in the Finder (Applications -> Utilities)
+>  - right-click and select `Get Info` then check the `Open using Rosetta` check-box
+>  - close the window and restart your Terminal
+
 ### Documentation
 
 You can run the documentation locally at [http://localhost:8030/](http://localhost:8030/) by running the following.


### PR DESCRIPTION
### Summary

This PR adds a small section in the root README file to indicates the steps to take when trying to `yarn` and `yarn start` on an M1 Apple device. From [a discussion on Slack](https://elastic.slack.com/archives/C7QC1JV6F/p1652280124572909) we need to make sure the Terminal app is running in Rosetta mode, as well as downgrading the version of node (to version `14`).

_Notes: I'm on week 3 at Elastic and this is my second PR. Please do not hesitate to close it if this PR is not desired, or if it isn't following the proper standards. I also could not find any guidance on how to format the commit message, so hopefully what I did is OK!_