### PR TITLE
[Feature] Converting EuiPageTemplate to use ReactContext instead of cloneChildren

### DIFF
--- a/src-docs/src/views/page_template/page_template.tsx
+++ b/src-docs/src/views/page_template/page_template.tsx
@@ -35,7 +35,11 @@ export default ({
       offset={offset}
       grow={grow}
     >
-      <EuiPageTemplate.Section color="subdued" bottomBorder="extended">
+      <EuiPageTemplate.Section
+        grow={false}
+        color="subdued"
+        bottomBorder="extended"
+      >
         <EuiText textAlign="center">
           <strong>
             Stack EuiPageTemplate sections and headers to create your custom

--- a/src-docs/src/views/page_template/page_template_bottom_bar.tsx
+++ b/src-docs/src/views/page_template/page_template_bottom_bar.tsx
@@ -43,7 +43,6 @@ export default ({
       {bottomBar && (
         <EuiPageTemplate.BottomBar>{bottomBar}</EuiPageTemplate.BottomBar>
       )}
-      <EuiPageTemplate.Section grow>{content}</EuiPageTemplate.Section>
     </EuiPageTemplate>
   );
 };

--- a/src-docs/src/views/page_template/page_template_bottom_bar.tsx
+++ b/src-docs/src/views/page_template/page_template_bottom_bar.tsx
@@ -43,6 +43,7 @@ export default ({
       {bottomBar && (
         <EuiPageTemplate.BottomBar>{bottomBar}</EuiPageTemplate.BottomBar>
       )}
+      <EuiPageTemplate.Section grow>{content}</EuiPageTemplate.Section>
     </EuiPageTemplate>
   );
 };

--- a/src-docs/src/views/page_template/page_template_example.js
+++ b/src-docs/src/views/page_template/page_template_example.js
@@ -116,30 +116,7 @@ export const PageTemplateExample = {
             </p>
           </EuiText>
           <EuiSpacer />
-          <EuiCallOut
-            iconType="alert"
-            color="warning"
-            title="Only direct children declared in the same component scope will be recognized."
-          >
-            <p>
-              If you declare your page contents in a different file, even when
-              using the namespaced components, the{' '}
-              <strong>EuiPageTemplate</strong> cannot determine the component
-              type because of the added layer of obfuscation. In these
-              instances, you will want to use{' '}
-              <Link to="/layout/page-header">
-                <strong>EuiPageHeader</strong>
-              </Link>{' '}
-              and{' '}
-              <Link to="/layout/page-components#page-sections">
-                <strong>EuiPageSection</strong>
-              </Link>{' '}
-              components directly, and pass the appropriate props to those
-              components.
-            </p>
-          </EuiCallOut>
-          <EuiSpacer />
-          <EuiText>
+          <EuiCallOut color="primary">
             <p>
               If you have a fixed position{' '}
               <Link to="/layout/header#fixed-header">headers</Link>, the
@@ -149,7 +126,7 @@ export const PageTemplateExample = {
               can pass <EuiCode>0</EuiCode> in as the manual{' '}
               <EuiCode>offset</EuiCode>.
             </p>
-          </EuiText>
+          </EuiCallOut>
           <PageDemo
             slug="full-page"
             toggle={{
@@ -217,6 +194,18 @@ export const PageTemplateExample = {
               <EuiCode language="tsx">{'borderBottom="extended"'}</EuiCode>.
             </p>
           </EuiText>
+          <EuiSpacer />
+          <EuiCallOut
+            iconType="alert"
+            color="warning"
+            title="Sidebars must be direct children declared in the same component."
+          >
+            <p>
+              In order for the template configurations to properly account for
+              the existence of a sidebar, it needs to clone the element which
+              can only be performed on direct children.
+            </p>
+          </EuiCallOut>
           <PageDemo
             slug="sidebar"
             toggle={{
@@ -293,7 +282,7 @@ export const PageTemplateExample = {
             color="warning"
             title={
               <>
-                For proper alignment in case of short content, at least on{' '}
+                For proper alignment in case of short content, at least one{' '}
                 <strong>EuiPageTemplate.Section</strong> must have{' '}
                 <EuiCode>{'grow={true}'}</EuiCode>.
               </>

--- a/src-docs/src/views/page_template/page_template_sidebar.tsx
+++ b/src-docs/src/views/page_template/page_template_sidebar.tsx
@@ -45,7 +45,7 @@ export default ({
       {header && (
         <EuiPageTemplate.Header {...header} rightSideItems={[button]} />
       )}
-      <EuiPageTemplate.Section bottomBorder={bottomBorder}>
+      <EuiPageTemplate.Section grow={false} bottomBorder={bottomBorder}>
         <EuiText textAlign="center">
           <strong>
             Stack EuiPageTemplate sections and headers to create your custom

--- a/src/components/bottom_bar/bottom_bar.tsx
+++ b/src/components/bottom_bar/bottom_bar.tsx
@@ -19,7 +19,7 @@ import { EuiScreenReaderOnly } from '../accessibility';
 import { CommonProps, ExclusiveUnion } from '../common';
 import { EuiI18n } from '../i18n';
 import { useResizeObserver } from '../observer/resize_observer';
-import { EuiPortal } from '../portal';
+import { EuiPortal, EuiPortalProps } from '../portal';
 import { euiBottomBarStyles } from './bottom_bar.styles';
 import { EuiThemeProvider } from '../../services/theme/provider';
 
@@ -45,7 +45,7 @@ type _BottomBarExclusivePositions = ExclusiveUnion<
      * Whether to wrap in an EuiPortal which appends the component to the body element.
      * Only works if `position` is `fixed`.
      */
-    usePortal?: boolean;
+    usePortal?: boolean | EuiPortalProps;
     /**
      * Whether the component should apply padding on the document body element to afford for its own displacement height.
      * Only works if `usePortal` is true and `position` is `fixed`.
@@ -224,7 +224,13 @@ const _EuiBottomBar = forwardRef<
       </>
     );
 
-    return usePortal ? <EuiPortal>{bar}</EuiPortal> : bar;
+    return usePortal ? (
+      <EuiPortal {...(typeof usePortal !== 'boolean' ? usePortal : undefined)}>
+        {bar}
+      </EuiPortal>
+    ) : (
+      bar
+    );
   }
 );
 

--- a/src/components/page_template/__snapshots__/page_template.test.tsx.snap
+++ b/src/components/page_template/__snapshots__/page_template.test.tsx.snap
@@ -8,7 +8,11 @@ exports[`_EuiPageSidebar _EuiPageInnerProps is rendered 1`] = `
 >
   <main
     class="css-6kpn8r-euiPageInner-left"
-  />
+  >
+    <div
+      id="testID"
+    />
+  </main>
 </div>
 `;
 
@@ -19,7 +23,11 @@ exports[`_EuiPageSidebar _EuiPageOuterProps is rendered 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  />
+  >
+    <div
+      id="testID"
+    />
+  </main>
 </div>
 `;
 
@@ -30,7 +38,11 @@ exports[`_EuiPageSidebar bottomBorder is rendered as extended 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  />
+  >
+    <div
+      id="testID"
+    />
+  </main>
 </div>
 `;
 
@@ -41,7 +53,11 @@ exports[`_EuiPageSidebar bottomBorder is rendered as true 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  />
+  >
+    <div
+      id="testID"
+    />
+  </main>
 </div>
 `;
 
@@ -54,7 +70,11 @@ exports[`_EuiPageSidebar is rendered 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  />
+  >
+    <div
+      id="testID"
+    />
+  </main>
 </div>
 `;
 
@@ -65,7 +85,11 @@ exports[`_EuiPageSidebar minHeight is rendered 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  />
+  >
+    <div
+      id="testID"
+    />
+  </main>
 </div>
 `;
 
@@ -76,7 +100,11 @@ exports[`_EuiPageSidebar offset is rendered 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  />
+  >
+    <div
+      id="testID"
+    />
+  </main>
 </div>
 `;
 
@@ -87,7 +115,11 @@ exports[`_EuiPageSidebar paddingSize l is rendered 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  />
+  >
+    <div
+      id="testID"
+    />
+  </main>
 </div>
 `;
 
@@ -98,7 +130,11 @@ exports[`_EuiPageSidebar paddingSize m is rendered 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  />
+  >
+    <div
+      id="testID"
+    />
+  </main>
 </div>
 `;
 
@@ -109,7 +145,11 @@ exports[`_EuiPageSidebar paddingSize none is rendered 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  />
+  >
+    <div
+      id="testID"
+    />
+  </main>
 </div>
 `;
 
@@ -120,7 +160,11 @@ exports[`_EuiPageSidebar paddingSize s is rendered 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  />
+  >
+    <div
+      id="testID"
+    />
+  </main>
 </div>
 `;
 
@@ -131,7 +175,11 @@ exports[`_EuiPageSidebar paddingSize xl is rendered 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  />
+  >
+    <div
+      id="testID"
+    />
+  </main>
 </div>
 `;
 
@@ -142,7 +190,11 @@ exports[`_EuiPageSidebar paddingSize xs is rendered 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  />
+  >
+    <div
+      id="testID"
+    />
+  </main>
 </div>
 `;
 
@@ -153,7 +205,11 @@ exports[`_EuiPageSidebar restrict width can be set to a custom number 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  />
+  >
+    <div
+      id="testID"
+    />
+  </main>
 </div>
 `;
 
@@ -164,7 +220,11 @@ exports[`_EuiPageSidebar restrict width can be set to a custom value and measure
 >
   <main
     class="css-nq554q-euiPageInner"
-  />
+  >
+    <div
+      id="testID"
+    />
+  </main>
 </div>
 `;
 
@@ -175,6 +235,10 @@ exports[`_EuiPageSidebar restrict width can be set to a default 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  />
+  >
+    <div
+      id="testID"
+    />
+  </main>
 </div>
 `;

--- a/src/components/page_template/__snapshots__/page_template.test.tsx.snap
+++ b/src/components/page_template/__snapshots__/page_template.test.tsx.snap
@@ -8,11 +8,8 @@ exports[`_EuiPageSidebar _EuiPageInnerProps is rendered 1`] = `
 >
   <main
     class="css-6kpn8r-euiPageInner-left"
-  >
-    <div
-      id="testID"
-    />
-  </main>
+    id="EuiPageTemplateInner_generated-id"
+  />
 </div>
 `;
 
@@ -23,11 +20,8 @@ exports[`_EuiPageSidebar _EuiPageOuterProps is rendered 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  >
-    <div
-      id="testID"
-    />
-  </main>
+    id="EuiPageTemplateInner_generated-id"
+  />
 </div>
 `;
 
@@ -38,11 +32,8 @@ exports[`_EuiPageSidebar bottomBorder is rendered as extended 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  >
-    <div
-      id="testID"
-    />
-  </main>
+    id="EuiPageTemplateInner_generated-id"
+  />
 </div>
 `;
 
@@ -53,11 +44,8 @@ exports[`_EuiPageSidebar bottomBorder is rendered as true 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  >
-    <div
-      id="testID"
-    />
-  </main>
+    id="EuiPageTemplateInner_generated-id"
+  />
 </div>
 `;
 
@@ -70,11 +58,8 @@ exports[`_EuiPageSidebar is rendered 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  >
-    <div
-      id="testID"
-    />
-  </main>
+    id="EuiPageTemplateInner_generated-id"
+  />
 </div>
 `;
 
@@ -85,11 +70,8 @@ exports[`_EuiPageSidebar minHeight is rendered 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  >
-    <div
-      id="testID"
-    />
-  </main>
+    id="EuiPageTemplateInner_generated-id"
+  />
 </div>
 `;
 
@@ -100,11 +82,8 @@ exports[`_EuiPageSidebar offset is rendered 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  >
-    <div
-      id="testID"
-    />
-  </main>
+    id="EuiPageTemplateInner_generated-id"
+  />
 </div>
 `;
 
@@ -115,11 +94,8 @@ exports[`_EuiPageSidebar paddingSize l is rendered 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  >
-    <div
-      id="testID"
-    />
-  </main>
+    id="EuiPageTemplateInner_generated-id"
+  />
 </div>
 `;
 
@@ -130,11 +106,8 @@ exports[`_EuiPageSidebar paddingSize m is rendered 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  >
-    <div
-      id="testID"
-    />
-  </main>
+    id="EuiPageTemplateInner_generated-id"
+  />
 </div>
 `;
 
@@ -145,11 +118,8 @@ exports[`_EuiPageSidebar paddingSize none is rendered 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  >
-    <div
-      id="testID"
-    />
-  </main>
+    id="EuiPageTemplateInner_generated-id"
+  />
 </div>
 `;
 
@@ -160,11 +130,8 @@ exports[`_EuiPageSidebar paddingSize s is rendered 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  >
-    <div
-      id="testID"
-    />
-  </main>
+    id="EuiPageTemplateInner_generated-id"
+  />
 </div>
 `;
 
@@ -175,11 +142,8 @@ exports[`_EuiPageSidebar paddingSize xl is rendered 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  >
-    <div
-      id="testID"
-    />
-  </main>
+    id="EuiPageTemplateInner_generated-id"
+  />
 </div>
 `;
 
@@ -190,11 +154,8 @@ exports[`_EuiPageSidebar paddingSize xs is rendered 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  >
-    <div
-      id="testID"
-    />
-  </main>
+    id="EuiPageTemplateInner_generated-id"
+  />
 </div>
 `;
 
@@ -205,11 +166,8 @@ exports[`_EuiPageSidebar restrict width can be set to a custom number 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  >
-    <div
-      id="testID"
-    />
-  </main>
+    id="EuiPageTemplateInner_generated-id"
+  />
 </div>
 `;
 
@@ -220,11 +178,8 @@ exports[`_EuiPageSidebar restrict width can be set to a custom value and measure
 >
   <main
     class="css-nq554q-euiPageInner"
-  >
-    <div
-      id="testID"
-    />
-  </main>
+    id="EuiPageTemplateInner_generated-id"
+  />
 </div>
 `;
 
@@ -235,10 +190,7 @@ exports[`_EuiPageSidebar restrict width can be set to a default 1`] = `
 >
   <main
     class="css-nq554q-euiPageInner"
-  >
-    <div
-      id="testID"
-    />
-  </main>
+    id="EuiPageTemplateInner_generated-id"
+  />
 </div>
 `;

--- a/src/components/page_template/bottom_bar/page_bottom_bar.tsx
+++ b/src/components/page_template/bottom_bar/page_bottom_bar.tsx
@@ -7,11 +7,11 @@
  */
 
 import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { findElementBySelectorOrRef } from '../../../services';
 import { EuiBottomBar, EuiBottomBarProps } from '../../bottom_bar';
 import { EuiPageSection, EuiPageSectionProps } from '../../page/page_section';
 import { _EuiPageRestrictWidth } from '../../page/_restrict_width';
-import { EuiPortal } from '../../portal';
 
 export interface _EuiPageBottomBarProps
   extends Pick<EuiPageSectionProps, 'paddingSize'>,
@@ -44,29 +44,22 @@ export const _EuiPageBottomBar: FunctionComponent<_EuiPageBottomBarProps> = ({
     };
   }, [sibling]);
 
-  return (
-    <EuiPortal
-      insert={
-        hasValidAnchor && siblingNode.current
-          ? {
-              sibling: siblingNode.current,
-              position: 'after',
-            }
-          : undefined
-      }
+  const bar = (
+    <EuiBottomBar
+      paddingSize={'none'}
+      position="sticky"
+      style={{ flexShrink: 0, ...style }}
+      // Using unknown here because of the possible conflict with overriding props and position `sticky`
+      {...(rest as unknown)}
     >
-      <EuiBottomBar
-        paddingSize={'none'}
-        position="sticky"
-        style={{ flexShrink: 0, ...style }}
-        // Using unknown here because of the possible conflict with overriding props and position `sticky`
-        {...(rest as unknown)}
-      >
-        {/* Wrapping the contents with EuiPageContentBody allows us to match the restrictWidth to keep the contents aligned */}
-        <EuiPageSection paddingSize={paddingSize} restrictWidth={restrictWidth}>
-          {children}
-        </EuiPageSection>
-      </EuiBottomBar>
-    </EuiPortal>
+      {/* Wrapping the contents with EuiPageContentBody allows us to match the restrictWidth to keep the contents aligned */}
+      <EuiPageSection paddingSize={paddingSize} restrictWidth={restrictWidth}>
+        {children}
+      </EuiPageSection>
+    </EuiBottomBar>
   );
+
+  return hasValidAnchor && siblingNode.current
+    ? createPortal(bar, siblingNode.current)
+    : bar;
 };

--- a/src/components/page_template/bottom_bar/page_bottom_bar.tsx
+++ b/src/components/page_template/bottom_bar/page_bottom_bar.tsx
@@ -17,32 +17,37 @@ export interface _EuiPageBottomBarProps
   extends Pick<EuiPageSectionProps, 'paddingSize'>,
     _EuiPageRestrictWidth,
     Omit<EuiBottomBarProps, 'paddingSize'> {
-  sibling?: string;
+  /**
+   * The reference id of the element to insert into
+   */
+  parent?: string;
 }
 
 export const _EuiPageBottomBar: FunctionComponent<_EuiPageBottomBarProps> = ({
   children,
   paddingSize,
   restrictWidth,
-  sibling,
+  parent,
   style,
   ...rest
 }) => {
+  // In order for the bottom bar to be placed at the end of the content,
+  // it must know what parent element to insert into
   const [hasValidAnchor, setHasValidAnchor] = useState<boolean>(false);
   const animationFrameId = useRef<number>();
-  const siblingNode = useRef<HTMLElement | null>(null);
+  const parentNode = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     animationFrameId.current = window.requestAnimationFrame(() => {
-      siblingNode.current = findElementBySelectorOrRef(sibling);
-      setHasValidAnchor(siblingNode.current ? true : false);
+      parentNode.current = findElementBySelectorOrRef(parent);
+      setHasValidAnchor(parentNode.current ? true : false);
     });
 
     return () => {
       animationFrameId.current &&
         window.cancelAnimationFrame(animationFrameId.current);
     };
-  }, [sibling]);
+  }, [parent]);
 
   const bar = (
     <EuiBottomBar
@@ -59,7 +64,7 @@ export const _EuiPageBottomBar: FunctionComponent<_EuiPageBottomBarProps> = ({
     </EuiBottomBar>
   );
 
-  return hasValidAnchor && siblingNode.current
-    ? createPortal(bar, siblingNode.current)
+  return hasValidAnchor && parentNode.current
+    ? createPortal(bar, parentNode.current)
     : bar;
 };

--- a/src/components/page_template/bottom_bar/page_bottom_bar.tsx
+++ b/src/components/page_template/bottom_bar/page_bottom_bar.tsx
@@ -11,6 +11,7 @@ import { findElementBySelectorOrRef } from '../../../services';
 import { EuiBottomBar, EuiBottomBarProps } from '../../bottom_bar';
 import { EuiPageSection, EuiPageSectionProps } from '../../page/page_section';
 import { _EuiPageRestrictWidth } from '../../page/_restrict_width';
+import { EuiPortal } from '../../portal';
 
 export interface _EuiPageBottomBarProps
   extends Pick<EuiPageSectionProps, 'paddingSize'>,
@@ -44,26 +45,28 @@ export const _EuiPageBottomBar: FunctionComponent<_EuiPageBottomBarProps> = ({
   }, [sibling]);
 
   return (
-    <EuiBottomBar
-      paddingSize={'none'}
-      position="sticky"
-      style={{ flexShrink: 0, ...style }}
-      usePortal={
+    <EuiPortal
+      insert={
         hasValidAnchor && siblingNode.current
           ? {
-              // @ts-expect-error Doesn't work anyway
               sibling: siblingNode.current,
               position: 'after',
             }
-          : false
+          : undefined
       }
-      // Using unknown here because of the possible conflict with overriding props and position `sticky`
-      {...(rest as unknown)}
     >
-      {/* Wrapping the contents with EuiPageContentBody allows us to match the restrictWidth to keep the contents aligned */}
-      <EuiPageSection paddingSize={paddingSize} restrictWidth={restrictWidth}>
-        {children}
-      </EuiPageSection>
-    </EuiBottomBar>
+      <EuiBottomBar
+        paddingSize={'none'}
+        position="sticky"
+        style={{ flexShrink: 0, ...style }}
+        // Using unknown here because of the possible conflict with overriding props and position `sticky`
+        {...(rest as unknown)}
+      >
+        {/* Wrapping the contents with EuiPageContentBody allows us to match the restrictWidth to keep the contents aligned */}
+        <EuiPageSection paddingSize={paddingSize} restrictWidth={restrictWidth}>
+          {children}
+        </EuiPageSection>
+      </EuiBottomBar>
+    </EuiPortal>
   );
 };

--- a/src/components/page_template/page_template.tsx
+++ b/src/components/page_template/page_template.tsx
@@ -35,7 +35,7 @@ import {
 } from '../page';
 import { _EuiPageRestrictWidth } from '../page/_restrict_width';
 import { _EuiPageBottomBorder } from '../page/_bottom_border';
-import { useEuiTheme } from '../../services';
+import { useEuiTheme, useGeneratedHtmlId } from '../../services';
 import { logicalStyle } from '../../global_styling';
 
 export const TemplateContext = createContext({
@@ -93,6 +93,9 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
   const [offset, setOffset] = useState(_offset);
   const templateContext = useContext(TemplateContext);
 
+  // Used as a target to insert the bottom bar component
+  const pageInnerId = useGeneratedHtmlId({ prefix: 'EuiPageTemplateInner' });
+
   useEffect(() => {
     if (_offset === undefined) {
       const euiHeaderFixedCounter = Number(document.body.dataset.fixedHeaders);
@@ -133,7 +136,7 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
   const getBottomBarProps = () => ({
     restrictWidth,
     paddingSize,
-    sibling: '#testID',
+    sibling: pageInnerId,
   });
 
   const innerPanelled = () =>
@@ -145,13 +148,13 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
   React.Children.toArray(children).forEach((child, index) => {
     if (!React.isValidElement(child)) return; // Skip non-components
 
-    // All content types can have their props overridden by appending the child props spread at the end
     switch (child.type) {
       case EuiPageSidebar:
         sidebar.push(
           React.cloneElement(child, {
             key: `sidebar${index}`,
             ...getSideBarProps(),
+            // Allow their props overridden by appending the child props spread at the end
             ...child.props,
           })
         );
@@ -190,12 +193,12 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
         {sidebar}
 
         <EuiPageInner
+          id={pageInnerId}
           border={innerBordered()}
           panelled={innerPanelled()}
           responsive={responsive}
         >
           {sections}
-          <div id="testID" />
         </EuiPageInner>
       </EuiPageOuter>
     </TemplateContext.Provider>
@@ -222,10 +225,9 @@ const _EuiPageEmptyPrompt: FunctionComponent<_EuiPageEmptyPromptProps> = (
   return <EuiPageEmptyPrompt {...templateContext.emptyPrompt} {...props} />;
 };
 
-const _EuiPageBottomBar: FunctionComponent<Omit<
-  _EuiPageBottomBarProps,
-  'sibling'
->> = (props) => {
+const _EuiPageBottomBar: FunctionComponent<_EuiPageBottomBarProps> = (
+  props
+) => {
   const { bottomBar } = useContext(TemplateContext);
 
   return <EuiPageBottomBar {...bottomBar} {...props} />;

--- a/src/components/page_template/page_template.tsx
+++ b/src/components/page_template/page_template.tsx
@@ -130,7 +130,6 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
   const getSideBarProps = () => ({
     paddingSize,
     responsive,
-    sticky: { offset: _offset },
   });
 
   const getBottomBarProps = () => ({

--- a/src/components/page_template/page_template.tsx
+++ b/src/components/page_template/page_template.tsx
@@ -135,7 +135,7 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
   const getBottomBarProps = () => ({
     restrictWidth,
     paddingSize,
-    sibling: pageInnerId,
+    parent: pageInnerId,
   });
 
   const innerPanelled = () =>

--- a/src/components/page_template/page_template.tsx
+++ b/src/components/page_template/page_template.tsx
@@ -135,7 +135,7 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
   const getBottomBarProps = () => ({
     restrictWidth,
     paddingSize,
-    parent: pageInnerId,
+    parent: `#${pageInnerId}`,
   });
 
   const innerPanelled = () =>


### PR DESCRIPTION
### Summary

Since most of Kibana's usages wildly separate the content from the template, the cloning method was not going to work as it required the children to be direct descendents without any file obfuscation.

So instead, I'm creating a template context in order to pass through the top-level props like padding and restricted width. 

The exception of which is the sidebar. This needs to be a direct child because the presence of this exact element determines the configuration. I've noted this in the docs.

The bottom bar now uses `createPortal` to insert itself at the right place.

### Checklist

- ~[ ] Checked in both **light and dark** modes~
- ~[ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- ~[ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
- 
