### PR TITLE
Create a status component and use it in EUI Docs to announce page loads to screen readers

### DIFF
--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -8,6 +8,7 @@ import {
   EuiSideNav,
   EuiPageSideBar,
   EuiText,
+  EuiScreenReaderOnly,
 } from '../../../../src/components';
 
 import { EuiHighlight } from '../../../../src/components/highlight';
@@ -127,7 +128,16 @@ export class GuidePageChrome extends Component {
 
       return {
         id: sectionHref,
-        name: isCurrentlyOpenSubSection ? <strong>{name}</strong> : name,
+        name: isCurrentlyOpenSubSection ? (
+          <strong>{name}</strong>
+        ) : (
+          <>
+            {name}
+            <EuiScreenReaderOnly>
+              <span> - same page</span>
+            </EuiScreenReaderOnly>
+          </>
+        ),
         href: sectionHref,
         className: isCurrentlyOpenSubSection
           ? 'guideSideNav__item--openSubTitle'

--- a/src-docs/src/views/accessibility/accessibility_example.js
+++ b/src-docs/src/views/accessibility/accessibility_example.js
@@ -201,12 +201,15 @@ export const AccessibilityExample = {
             block is at the top of the HTML source order.
           </p>
           <p>
+            To learn more about the <EuiCode>status</EuiCode> role make sure to
+            read the{' '}
             <EuiLink
               href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role"
               external
             >
-              ARIA role status guidelines
+              ARIA guidelines
             </EuiLink>
+            .
           </p>
         </>
       ),

--- a/src-docs/src/views/accessibility/accessibility_example.js
+++ b/src-docs/src/views/accessibility/accessibility_example.js
@@ -9,18 +9,26 @@ import {
   EuiSkipLink,
   EuiScreenReaderLive,
   EuiScreenReaderOnly,
+  EuiScreenReaderStatus,
   EuiSpacer,
 } from '../../../../src';
 
 import ScreenReaderLive from './screen_reader_live';
 import ScreenReaderOnly from './screen_reader';
 import ScreenReaderFocus from './screen_reader_focus';
+import ScreenReaderStatus from './screen_reader_status';
 import SkipLink from './skip_link';
 import StylesHelpers from './styles_helpers';
 
 const screenReaderLiveSource = require('!!raw-loader!./screen_reader_live');
 const screenReaderOnlySource = require('!!raw-loader!./screen_reader');
+
 const screenReaderFocusSource = require('!!raw-loader!./screen_reader_focus');
+const screenReaderStatusSource = require('!!raw-loader!./screen_reader_status');
+const screenReaderStatusSnippet = [
+  '<EuiScreenReaderStatus statusMessage="User-defined message" />',
+  '<EuiScreenReaderStatus statusMessage="User-defined message" shouldReceiveFocus />',
+];
 
 const skipLinkSource = require('!!raw-loader!./skip_link');
 const skipLinkSnippet = [
@@ -127,7 +135,7 @@ export const AccessibilityExample = {
       text: (
         <>
           <p>
-            Using <EuiCode>EuiScreenReaderLive</EuiCode> to announce dynamic
+            Use <EuiCode>EuiScreenReaderLive</EuiCode> to announce dynamic
             content, such as status changes based on user interaction.
           </p>
           <p>
@@ -155,6 +163,58 @@ export const AccessibilityExample = {
         EuiScreenReaderLive,
       },
       demo: <ScreenReaderLive />,
+    },
+    {
+      title: 'Screen reader status',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: screenReaderStatusSource,
+        },
+      ],
+      text: (
+        <>
+          <p>
+            Use <EuiCode>EuiScreenReaderStatus</EuiCode> to announce status
+            changes such as content being loaded or client-side route changes.
+          </p>
+          <p>
+            The configurable <EuiCode>statusMessage</EuiCode> and{' '}
+            <EuiCode>shouldReceiveFocus</EuiCode> props default to{' '}
+            <EuiCode>document.title</EuiCode> and <EuiCode>false</EuiCode>{' '}
+            respectively.
+          </p>
+          <p>
+            Most users will want to pass a string to{' '}
+            <EuiCode>statusMessage</EuiCode>. This will add a non-focusable
+            status block to the page. This status will be read by screen readers
+            when there is a natural pause.
+          </p>
+          <p>
+            Passing <EuiCode>shouldReceiveFocus</EuiCode> sets keyboard focus on
+            the status block when
+            <EuiCode>EuiScreenReaderStatus</EuiCode> mounts, or the{' '}
+            <EuiCode>statusMessage</EuiCode> prop updates. Passing{' '}
+            <EuiCode>shouldReceiveFocus</EuiCode> also removes the live region.
+            This is useful for announcing client-side route changes to screen
+            readers and should <strong>only</strong> be used when the status
+            block is at the top of the HTML source order.
+          </p>
+          <p>
+            <EuiLink
+              href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role"
+              external
+            >
+              ARIA role status guidelines
+            </EuiLink>
+          </p>
+        </>
+      ),
+      props: {
+        EuiScreenReaderStatus,
+      },
+      snippet: screenReaderStatusSnippet,
+      demo: <ScreenReaderStatus />,
     },
     {
       title: 'Skip link',

--- a/src-docs/src/views/accessibility/screen_reader_status.tsx
+++ b/src-docs/src/views/accessibility/screen_reader_status.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { EuiScreenReaderStatus, EuiText } from '../../../../src/components';
+
+export default () => (
+  <EuiText>
+    <p>This is the first paragraph. It is visible to all.</p>
+    <EuiScreenReaderStatus statusMessage="User-defined status message" />
+    <p>
+      This is the third paragraph. If you turn on a screen reader, there is a
+      status message between the paragraphs.
+    </p>
+  </EuiText>
+);

--- a/src-docs/src/views/app_view.js
+++ b/src-docs/src/views/app_view.js
@@ -71,7 +71,8 @@ export const AppView = ({ children, currentRoute }) => {
   return (
     <LinkWrapper>
       <EuiScreenReaderStatus
-        pageTitle={`${currentRoute.name} - Elastic UI Framework`}
+        statusMessage={`${currentRoute.name} - Elastic UI Framework`}
+        shouldReceiveFocus
       />
       <EuiSkipLink
         destinationId="start-of-content"

--- a/src-docs/src/views/app_view.js
+++ b/src-docs/src/views/app_view.js
@@ -11,6 +11,7 @@ import {
   EuiPageBody,
   EuiSkipLink,
 } from '../../../src/components';
+import { EuiScreenReaderStatus } from '../../../src/components/accessibility/screen_reader_status';
 
 import { keys } from '../../../src/services';
 
@@ -69,6 +70,9 @@ export const AppView = ({ children, currentRoute }) => {
 
   return (
     <LinkWrapper>
+      <EuiScreenReaderStatus
+        pageTitle={`${currentRoute.name} - Elastic UI Framework`}
+      />
       <EuiSkipLink
         destinationId="start-of-content"
         position="fixed"

--- a/src/components/accessibility/index.ts
+++ b/src/components/accessibility/index.ts
@@ -12,3 +12,5 @@ export { EuiScreenReaderOnly, euiScreenReaderOnly } from './screen_reader_only';
 export type { EuiScreenReaderOnlyProps } from './screen_reader_only';
 export { EuiSkipLink } from './skip_link';
 export type { EuiSkipLinkProps } from './skip_link';
+export { EuiScreenReaderStatus } from './screen_reader_status';
+export type { EuiScreenReaderStatusProps } from './screen_reader_status';

--- a/src/components/accessibility/screen_reader_status/__snapshots__/screen_reader_status.test.tsx.snap
+++ b/src/components/accessibility/screen_reader_status/__snapshots__/screen_reader_status.test.tsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiScreenReaderStatus it renders 1`] = `
+<div
+  class="euiScreenReaderOnly"
+  role="status"
+  tabindex="-1"
+/>
+`;
+
+exports[`EuiScreenReaderStatus it sets pageTitle using document title 1`] = `
+<EuiScreenReaderStatus>
+  <EuiScreenReaderOnly>
+    <div
+      className="euiScreenReaderOnly"
+      role="status"
+      tabIndex={-1}
+    >
+      Default title
+    </div>
+  </EuiScreenReaderOnly>
+</EuiScreenReaderStatus>
+`;
+
+exports[`EuiScreenReaderStatus it sets pageTitle using passed prop 1`] = `
+<EuiScreenReaderStatus
+  pageTitle="User-defined title"
+>
+  <EuiScreenReaderOnly>
+    <div
+      className="euiScreenReaderOnly"
+      role="status"
+      tabIndex={-1}
+    >
+      User-defined title
+    </div>
+  </EuiScreenReaderOnly>
+</EuiScreenReaderStatus>
+`;

--- a/src/components/accessibility/screen_reader_status/__snapshots__/screen_reader_status.test.tsx.snap
+++ b/src/components/accessibility/screen_reader_status/__snapshots__/screen_reader_status.test.tsx.snap
@@ -2,19 +2,19 @@
 
 exports[`EuiScreenReaderStatus it renders 1`] = `
 <div
+  aria-live="polite"
   class="euiScreenReaderOnly"
   role="status"
-  tabindex="-1"
 />
 `;
 
-exports[`EuiScreenReaderStatus it sets pageTitle using document title 1`] = `
+exports[`EuiScreenReaderStatus it sets \`statusMessage\` using document title 1`] = `
 <EuiScreenReaderStatus>
   <EuiScreenReaderOnly>
     <div
+      aria-live="polite"
       className="euiScreenReaderOnly"
       role="status"
-      tabIndex={-1}
     >
       Default title
     </div>
@@ -22,12 +22,30 @@ exports[`EuiScreenReaderStatus it sets pageTitle using document title 1`] = `
 </EuiScreenReaderStatus>
 `;
 
-exports[`EuiScreenReaderStatus it sets pageTitle using passed prop 1`] = `
+exports[`EuiScreenReaderStatus it sets \`statusMessage\` with user defined string 1`] = `
 <EuiScreenReaderStatus
-  pageTitle="User-defined title"
+  statusMessage="User-defined title"
 >
   <EuiScreenReaderOnly>
     <div
+      aria-live="polite"
+      className="euiScreenReaderOnly"
+      role="status"
+    >
+      User-defined title
+    </div>
+  </EuiScreenReaderOnly>
+</EuiScreenReaderStatus>
+`;
+
+exports[`EuiScreenReaderStatus it sets aria-live and tabindex correctly when \`shouldReceiveFocus\` is passed 1`] = `
+<EuiScreenReaderStatus
+  shouldReceiveFocus={true}
+  statusMessage="User-defined title"
+>
+  <EuiScreenReaderOnly>
+    <div
+      aria-live="off"
       className="euiScreenReaderOnly"
       role="status"
       tabIndex={-1}

--- a/src/components/accessibility/screen_reader_status/index.ts
+++ b/src/components/accessibility/screen_reader_status/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export type { EuiScreenReaderStatusProps } from './screen_reader_status';
+export { EuiScreenReaderStatus } from './screen_reader_status';

--- a/src/components/accessibility/screen_reader_status/screen_reader_status.test.tsx
+++ b/src/components/accessibility/screen_reader_status/screen_reader_status.test.tsx
@@ -17,25 +17,68 @@ describe('EuiScreenReaderStatus', () => {
     expect(component).toMatchSnapshot();
   });
 
-  test('it sets pageTitle using document title', () => {
+  test('it sets `statusMessage` using document title', () => {
     document.title = 'Default title';
     const component = mount(<EuiScreenReaderStatus />);
     expect(component).toMatchSnapshot();
   });
 
-  test('it sets pageTitle using passed prop', () => {
+  test('it sets `statusMessage` with user defined string', () => {
     const component = mount(
-      <EuiScreenReaderStatus pageTitle="User-defined title" />
+      <EuiScreenReaderStatus statusMessage="User-defined title" />
     );
     expect(component).toMatchSnapshot();
   });
 
-  test('it sets focus correctly', () => {
+  test('it sets aria-live and tabindex correctly when `shouldReceiveFocus` is passed', () => {
     const component = mount(
-      <EuiScreenReaderStatus pageTitle="User-defined title" />
+      <EuiScreenReaderStatus
+        statusMessage="User-defined title"
+        shouldReceiveFocus
+      />
+    );
+    expect(component).toMatchSnapshot();
+  });
+
+  test('it creates a non-focusable live region by default', () => {
+    const component = mount(
+      <EuiScreenReaderStatus statusMessage="User-defined title" />
+    );
+    const statusDiv = component.find('div');
+    expect(statusDiv.prop('tabindex')).toBe(undefined);
+    expect(statusDiv.prop('aria-live')).toBe('polite');
+    expect(statusDiv.text()).toBe('User-defined title');
+  });
+
+  test('it creates a focusable region when `shouldReceiveFocus` is passed', () => {
+    const component = mount(
+      <EuiScreenReaderStatus
+        statusMessage="User-defined title"
+        shouldReceiveFocus
+      />
+    );
+    const statusDiv = component.find('div');
+    expect(statusDiv.prop('tabIndex')).toBe(-1);
+    expect(statusDiv.prop('aria-live')).toBe('off');
+    expect(statusDiv.text()).toBe('User-defined title');
+  });
+
+  test('it does not set focus by default', () => {
+    const component = mount(
+      <EuiScreenReaderStatus statusMessage="User-defined title" />
+    );
+    const statusDiv = component.find('div');
+    expect(statusDiv.is(':focus')).toBe(false);
+  });
+
+  test('it sets focus when `shouldReceiveFocus` is passed', () => {
+    const component = mount(
+      <EuiScreenReaderStatus
+        statusMessage="User-defined title"
+        shouldReceiveFocus
+      />
     );
     const statusDiv = component.find('div');
     expect(statusDiv.is(':focus')).toBe(true);
-    expect(statusDiv.text()).toBe('User-defined title');
   });
 });

--- a/src/components/accessibility/screen_reader_status/screen_reader_status.test.tsx
+++ b/src/components/accessibility/screen_reader_status/screen_reader_status.test.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { mount, render } from 'enzyme';
+
+import { EuiScreenReaderStatus } from './screen_reader_status';
+
+describe('EuiScreenReaderStatus', () => {
+  test('it renders', () => {
+    const component = render(<EuiScreenReaderStatus />);
+    expect(component).toMatchSnapshot();
+  });
+
+  test('it sets pageTitle using document title', () => {
+    document.title = 'Default title';
+    const component = mount(<EuiScreenReaderStatus />);
+    expect(component).toMatchSnapshot();
+  });
+
+  test('it sets pageTitle using passed prop', () => {
+    const component = mount(
+      <EuiScreenReaderStatus pageTitle="User-defined title" />
+    );
+    expect(component).toMatchSnapshot();
+  });
+
+  test('it sets focus correctly', () => {
+    const component = mount(
+      <EuiScreenReaderStatus pageTitle="User-defined title" />
+    );
+    const statusDiv = component.find('div');
+    expect(statusDiv.is(':focus')).toBe(true);
+    expect(statusDiv.text()).toBe('User-defined title');
+  });
+});

--- a/src/components/accessibility/screen_reader_status/screen_reader_status.tsx
+++ b/src/components/accessibility/screen_reader_status/screen_reader_status.tsx
@@ -10,30 +10,49 @@ import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
 import { EuiScreenReaderOnly } from '../screen_reader_only';
 
 export interface EuiScreenReaderStatusProps {
-  pageTitle?: string;
+  /**
+   * Set a custom status message to be announced to screen readers.
+   * Defaults to `document.title` and will announce client-side route change.
+   */
+  statusMessage?: string;
+  /**
+   * Focuses the status message when set to true. Should only be used if
+   * the status message is at the top of the HTML source order AND the
+   * status message is being updated on client-side route change.
+   *
+   * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role
+   */
+  shouldReceiveFocus?: boolean;
 }
 
 export const EuiScreenReaderStatus: FunctionComponent<EuiScreenReaderStatusProps> = ({
-  pageTitle = document.title,
+  statusMessage = document.title,
+  shouldReceiveFocus = false,
 }) => {
-  const [pageTitleState, setPageTitleState] = useState('');
+  const [statusMessageState, setStatusMessageState] = useState('');
   const statusRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (statusRef.current !== null) {
-      setPageTitleState(pageTitle);
+    setStatusMessageState(statusMessage);
+
+    if (statusRef.current !== null && shouldReceiveFocus) {
       statusRef.current.focus();
     }
 
     return () => {
-      setPageTitleState('');
+      setStatusMessageState('');
     };
-  }, [pageTitle]);
+  }, [statusMessage, shouldReceiveFocus]);
 
   return (
     <EuiScreenReaderOnly>
-      <div ref={statusRef} role="status" tabIndex={-1}>
-        {pageTitleState}
+      <div
+        aria-live={shouldReceiveFocus ? 'off' : 'polite'}
+        ref={statusRef}
+        role="status"
+        tabIndex={shouldReceiveFocus ? -1 : undefined}
+      >
+        {statusMessageState}
       </div>
     </EuiScreenReaderOnly>
   );

--- a/src/components/accessibility/screen_reader_status/screen_reader_status.tsx
+++ b/src/components/accessibility/screen_reader_status/screen_reader_status.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
+import { EuiScreenReaderOnly } from '../screen_reader_only';
+
+export interface EuiScreenReaderStatusProps {
+  pageTitle?: string;
+}
+
+export const EuiScreenReaderStatus: FunctionComponent<EuiScreenReaderStatusProps> = ({
+  pageTitle = document.title,
+}) => {
+  const [pageTitleState, setPageTitleState] = useState('');
+  const statusRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (statusRef.current !== null) {
+      setPageTitleState(pageTitle);
+      statusRef.current.focus();
+    }
+
+    return () => {
+      setPageTitleState('');
+    };
+  }, [pageTitle]);
+
+  return (
+    <EuiScreenReaderOnly>
+      <div ref={statusRef} role="status" tabIndex={-1}>
+        {pageTitleState}
+      </div>
+    </EuiScreenReaderOnly>
+  );
+};

--- a/src/components/accessibility/screen_reader_status/screen_reader_status.tsx
+++ b/src/components/accessibility/screen_reader_status/screen_reader_status.tsx
@@ -16,11 +16,7 @@ export interface EuiScreenReaderStatusProps {
    */
   statusMessage?: string;
   /**
-   * Focuses the status message when set to true. Should only be used if
-   * the status message is at the top of the HTML source order AND the
-   * status message is being updated on client-side route change.
-   *
-   * See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role
+   * Focuses the status message and removes the live region when set to true.
    */
   shouldReceiveFocus?: boolean;
 }

--- a/src/components/accessibility/skip_link/__snapshots__/skip_link.test.tsx.snap
+++ b/src/components/accessibility/skip_link/__snapshots__/skip_link.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiSkipLink is rendered 1`] = `
 <a
   aria-label="aria-label"
-  class="euiButton euiButton--primary euiButton--small euiButton--fill euiScreenReaderOnly--showOnFocus euiSkipLink testClass1 testClass2 emotion-euiSkipLink"
+  class="euiButton euiButton--ghost euiButton--small euiButton--fill euiScreenReaderOnly--showOnFocus euiSkipLink testClass1 testClass2 emotion-euiSkipLink"
   data-test-subj="test subject string"
   href="#somewhere"
   rel="noreferrer"
@@ -22,7 +22,7 @@ exports[`EuiSkipLink is rendered 1`] = `
 
 exports[`EuiSkipLink props onClick is rendered 1`] = `
 <a
-  class="euiButton euiButton--primary euiButton--small euiButton--fill euiScreenReaderOnly--showOnFocus euiSkipLink emotion-euiSkipLink"
+  class="euiButton euiButton--ghost euiButton--small euiButton--fill euiScreenReaderOnly--showOnFocus euiSkipLink emotion-euiSkipLink"
   href="#somewhere"
   rel="noreferrer"
 >
@@ -38,7 +38,7 @@ exports[`EuiSkipLink props onClick is rendered 1`] = `
 
 exports[`EuiSkipLink props position absolute is rendered 1`] = `
 <a
-  class="euiButton euiButton--primary euiButton--small euiButton--fill euiScreenReaderOnly--showOnFocus euiSkipLink emotion-euiSkipLink-absolute"
+  class="euiButton euiButton--ghost euiButton--small euiButton--fill euiScreenReaderOnly--showOnFocus euiSkipLink emotion-euiSkipLink-absolute"
   href="#somewhere"
   rel="noreferrer"
 >
@@ -54,7 +54,7 @@ exports[`EuiSkipLink props position absolute is rendered 1`] = `
 
 exports[`EuiSkipLink props position fixed is rendered 1`] = `
 <a
-  class="euiButton euiButton--primary euiButton--small euiButton--fill euiScreenReaderOnly--showOnFocus euiSkipLink emotion-euiSkipLink-fixed"
+  class="euiButton euiButton--ghost euiButton--small euiButton--fill euiScreenReaderOnly--showOnFocus euiSkipLink emotion-euiSkipLink-fixed"
   href="#somewhere"
   rel="noreferrer"
   tabindex="0"
@@ -71,7 +71,7 @@ exports[`EuiSkipLink props position fixed is rendered 1`] = `
 
 exports[`EuiSkipLink props position static is rendered 1`] = `
 <a
-  class="euiButton euiButton--primary euiButton--small euiButton--fill euiScreenReaderOnly--showOnFocus euiSkipLink emotion-euiSkipLink"
+  class="euiButton euiButton--ghost euiButton--small euiButton--fill euiScreenReaderOnly--showOnFocus euiSkipLink emotion-euiSkipLink"
   href="#somewhere"
   rel="noreferrer"
 >
@@ -87,7 +87,7 @@ exports[`EuiSkipLink props position static is rendered 1`] = `
 
 exports[`EuiSkipLink props tabIndex is rendered 1`] = `
 <a
-  class="euiButton euiButton--primary euiButton--small euiButton--fill euiScreenReaderOnly--showOnFocus euiSkipLink emotion-euiSkipLink"
+  class="euiButton euiButton--ghost euiButton--small euiButton--fill euiScreenReaderOnly--showOnFocus euiSkipLink emotion-euiSkipLink"
   href="#somewhere"
   rel="noreferrer"
   tabindex="-1"

--- a/src/components/accessibility/skip_link/skip_link.tsx
+++ b/src/components/accessibility/skip_link/skip_link.tsx
@@ -103,6 +103,7 @@ export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
       <EuiButton
         css={cssStyles}
         className={classes}
+        color="ghost"
         tabIndex={position === 'fixed' ? 0 : tabIndex}
         size="s"
         fill

--- a/upcoming_changelogs/5991.md
+++ b/upcoming_changelogs/5991.md
@@ -1,0 +1,1 @@
+- Added `EuiScreenReaderStatus` and patched into EUI Docs views


### PR DESCRIPTION
### Summary

Adding an `EuiScreenReaderStatus` component to announce changes to screen readers without **requiring** keyboard focus. The component allows focus to be controlled, so we can use it as a consistent announcement for SPA route changes.

Tested for screen reader usability:
* MacOS Monterey + Safari + VoiceOver
* MacOS Monterey + Firefox + VoiceOver
* Reached out to @barlowm for additional screen reader testing

### Checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
