### PR TITLE
[EuiProgress docs] Removing callout and other fixes

### DIFF
--- a/src-docs/src/views/progress/progress_example.js
+++ b/src-docs/src/views/progress/progress_example.js
@@ -159,25 +159,13 @@ export const ProgressExample = {
             <EuiCode>color</EuiCode>. You can pass any value from our basic
             color set or from our visualization palette (<EuiCode>vis0</EuiCode>{' '}
             through <EuiCode>vis9</EuiCode>). To learn more about color usage,
-            go to the <Link to="/guidelines/colors">Color guidelines</Link>{' '}
-            page.
+            go to the <Link to="/theming/colors/values">Colors</Link> page.
           </p>
           <p>
             Additionally, you can pass any valid color string like a hex value
-            or named color.
+            or named color. Each <EuiCode>valueText</EuiCode> renders with a
+            high contrast version of the color.
           </p>
-          <EuiCallOut
-            title="Note about using custom colors"
-            iconType="accessibility"
-            color="warning"
-          >
-            <p>
-              Usually, we calculate a high contrast color for{' '}
-              <EuiCode>valueText</EuiCode> based on <EuiCode>color</EuiCode>.
-              This is not possible when using a custom color. In such cases,{' '}
-              <EuiCode>valueText</EuiCode> will just use the custom color.
-            </p>
-          </EuiCallOut>
         </>
       ),
       demo: <ProgressColors />,
@@ -196,9 +184,7 @@ export const ProgressExample = {
           <p>
             Determinate progress bar can be used as simple bar charts. Use them
             with the <EuiCode>label</EuiCode> and <EuiCode>valueText</EuiCode>{' '}
-            props to show the data corresponding to each bar. The{' '}
-            <EuiCode>valueText</EuiCode> renders as the same color as the{' '}
-            <strong>EuiProgress</strong>.
+            props to show the data corresponding to each bar.
           </p>
           <p>
             Setting <EuiCode language="ts">{'valueText={true}'}</EuiCode> will

--- a/src-docs/src/views/theme/color/_color_js.tsx
+++ b/src-docs/src/views/theme/color/_color_js.tsx
@@ -100,7 +100,7 @@ export const TextJS: FunctionComponent<ThemeRowType> = ({ description }) => {
               If your background color is anything other than or darker than the{' '}
               <EuiCode>body</EuiCode> color, you will want to re-calculate the
               high contrast version by using the{' '}
-              <Link to="/utilities/color-functions">
+              <Link to="/theming/colors/utilities">
                 <EuiCode>makeHighContrastColor(foreground)(background)</EuiCode>
               </Link>{' '}
               method.

--- a/src-docs/src/views/theme/color/_color_sass.tsx
+++ b/src-docs/src/views/theme/color/_color_sass.tsx
@@ -74,7 +74,7 @@ export const TextSass: FunctionComponent<ThemeRowType> = ({ description }) => {
               If your background color is anything other than or darker than the{' '}
               <EuiCode>$euiPageBackgroundColor</EuiCode>, you will want to
               re-calculate the high contrast version by using the{' '}
-              <Link to="/utilities/color-functions">
+              <Link to="/theming/colors/utilities">
                 <EuiCode>
                   @include makeHighContrastColor($foreground, $background)
                 </EuiCode>

--- a/src-docs/src/views/theme/color/tokens.tsx
+++ b/src-docs/src/views/theme/color/tokens.tsx
@@ -97,7 +97,7 @@ export default () => {
         </p>
         <p>
           For all available color functions see the{' '}
-          <Link to="/utilities/color-functions">Color Utilities page</Link>.
+          <Link to="/theming/colors/utilities">Colors Utilities page</Link>.
         </p>
       </>
     );


### PR DESCRIPTION
### Summary

Just a follow-up on #5986:

### Removed the following callout that is no longer valid:

<img width="667" alt="Screenshot 2022-06-23 at 19 15 09" src="https://user-images.githubusercontent.com/2750668/175366951-4df644cd-6f13-4eb6-a99e-4dcac158d945.png">

### Added info about the `valueText` which renders with a high contrast version of the color

<img width="813" alt="Screenshot 2022-06-23 at 19 20 25" src="https://user-images.githubusercontent.com/2750668/175367943-93381d44-09c0-4645-8d51-b2ecb0d57da6.png">

### Also fixed a link that was pointing to an old page.


### Checklist

- [ ] ~Checked in both **light and dark** modes~
- [ ] ~Checked in **mobile**~
- [ ] ~Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- [ ] ~Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- [ ] ~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] ~Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [ ] ~A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
