### PR TITLE
[EuiSkipLink] Improve `overrideLinkBehavior` UX

### DIFF
--- a/src/components/accessibility/skip_link/skip_link.spec.tsx
+++ b/src/components/accessibility/skip_link/skip_link.spec.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../../cypress/support"/>
+
+import React from 'react';
+import { EuiSkipLink } from './';
+
+describe('EuiSkipLink', () => {
+  describe('overrideLinkBehavior', () => {
+    describe('focus/tab behavior', () => {
+      it('manually focuses the target element', () => {
+        cy.realMount(
+          <div>
+            <EuiSkipLink
+              destinationId="start-of-content"
+              overrideLinkBehavior
+            />
+            <main id="start-of-content">Hello world</main>
+          </div>
+        );
+
+        cy.realPress('Tab');
+        cy.focused().should('have.class', 'euiSkipLink');
+
+        cy.realPress('Enter');
+        cy.focused().should('have.id', 'start-of-content');
+      });
+
+      it('removes the manual tabindex on the target element after the user moves away from it', () => {
+        cy.realMount(
+          <div>
+            <EuiSkipLink
+              destinationId="start-of-content"
+              overrideLinkBehavior
+            />
+            <main id="start-of-content">
+              Hello world
+              <button id="button">Next focus</button>
+            </main>
+          </div>
+        );
+        cy.realPress('Tab');
+        cy.realPress('Enter');
+
+        cy.focused()
+          .should('have.id', 'start-of-content')
+          .should('have.attr', 'tabindex', '-1');
+
+        cy.realPress('Tab');
+
+        cy.focused().should('have.id', 'button');
+        cy.get('#start-of-content').should('not.have.attr', 'tabindex');
+      });
+
+      it('does not add tabindex -1 to target elements that are already tabbable', () => {
+        cy.realMount(
+          <div>
+            <EuiSkipLink destinationId="button" overrideLinkBehavior />
+            <button id="button">Button</button>
+
+            <EuiSkipLink destinationId="negativeOne" overrideLinkBehavior />
+            <div id="negativeOne" tabIndex={0}>
+              tabIndex -1
+            </div>
+          </div>
+        );
+
+        cy.realPress('Tab');
+        cy.realPress('Enter');
+        cy.focused()
+          .should('have.id', 'button')
+          .should('not.have.attr', 'tabindex', '-1');
+
+        cy.realPress('Tab');
+        cy.realPress('Enter');
+        cy.focused()
+          .should('have.id', 'negativeOne')
+          .should('have.attr', 'tabindex', '0');
+      });
+    });
+  });
+});

--- a/src/components/accessibility/skip_link/skip_link.spec.tsx
+++ b/src/components/accessibility/skip_link/skip_link.spec.tsx
@@ -84,5 +84,65 @@ describe('EuiSkipLink', () => {
           .should('have.attr', 'tabindex', '0');
       });
     });
+
+    describe('scroll behavior', () => {
+      it('should scroll down to the target element if it is out of the viewport', () => {
+        cy.realMount(
+          <div style={{ height: '1500px', paddingTop: '1400px' }}>
+            <EuiSkipLink
+              position="fixed"
+              destinationId="start-of-content"
+              overrideLinkBehavior
+            />
+            <main id="start-of-content">Hello world</main>
+          </div>
+        );
+        cy.window().its('scrollY').should('equal', 0);
+
+        cy.realPress('Tab');
+        cy.realPress('Enter');
+
+        cy.window().its('scrollY').should('not.equal', 0);
+      });
+
+      it('should scroll back up to the top of the target element if the user scrolled down past it', () => {
+        cy.realMount(
+          <div style={{ height: '1500px' }}>
+            <EuiSkipLink
+              position="fixed"
+              destinationId="start-of-content"
+              overrideLinkBehavior
+            />
+            <main id="start-of-content">Hello world</main>
+          </div>
+        );
+        cy.scrollTo('bottom');
+        cy.window().its('scrollY').should('not.equal', 0);
+
+        cy.realPress('Tab');
+        cy.realPress('Enter');
+
+        cy.window().its('scrollY').should('equal', 1); // Not sure why this isn't 0 - might be a Chrome thing
+      });
+
+      it('should not scroll if the element is already visible in the viewport', () => {
+        cy.realMount(
+          <div style={{ height: '1500px', paddingTop: '100px' }}>
+            <EuiSkipLink
+              position="fixed"
+              destinationId="start-of-content"
+              overrideLinkBehavior
+            />
+            <main id="start-of-content">Hello world</main>
+          </div>
+        );
+        cy.window().its('scrollY').should('equal', 0);
+
+        cy.realPress('Tab');
+        cy.realPress('Enter');
+
+        cy.window().its('scrollY').should('equal', 0);
+      });
+    });
   });
 });

--- a/src/components/accessibility/skip_link/skip_link.test.tsx
+++ b/src/components/accessibility/skip_link/skip_link.test.tsx
@@ -25,12 +25,12 @@ describe('EuiSkipLink', () => {
 
   describe('props', () => {
     test('overrideLinkBehavior prevents default link behavior and manually scrolls and focuses the destination', () => {
+      const mockElement = document.createElement('main');
       const scrollSpy = jest.fn();
+      mockElement.scrollIntoView = scrollSpy;
       const focusSpy = jest.fn();
-      jest.spyOn(document, 'getElementById').mockReturnValue({
-        scrollIntoView: scrollSpy,
-        focus: focusSpy,
-      } as any);
+      mockElement.focus = focusSpy;
+      jest.spyOn(document, 'getElementById').mockReturnValue(mockElement);
 
       const component = mount(
         <EuiSkipLink destinationId="somewhere" overrideLinkBehavior />

--- a/src/components/accessibility/skip_link/skip_link.test.tsx
+++ b/src/components/accessibility/skip_link/skip_link.test.tsx
@@ -24,24 +24,39 @@ describe('EuiSkipLink', () => {
   });
 
   describe('props', () => {
-    test('overrideLinkBehavior prevents default link behavior and manually scrolls and focuses the destination', () => {
+    describe('overrideLinkBehavior', () => {
       const mockElement = document.createElement('main');
-      const scrollSpy = jest.fn();
-      mockElement.scrollIntoView = scrollSpy;
-      const focusSpy = jest.fn();
-      mockElement.focus = focusSpy;
       jest.spyOn(document, 'getElementById').mockReturnValue(mockElement);
 
-      const component = mount(
-        <EuiSkipLink destinationId="somewhere" overrideLinkBehavior />
-      );
+      it('prevents default link behavior and manually focuses the destination', () => {
+        const focusSpy = jest.fn();
+        mockElement.focus = focusSpy;
 
-      const preventDefault = jest.fn();
-      component.find('EuiButton').simulate('click', { preventDefault });
+        const component = mount(
+          <EuiSkipLink destinationId="somewhere" overrideLinkBehavior />
+        );
 
-      expect(preventDefault).toHaveBeenCalled();
-      expect(scrollSpy).toHaveBeenCalled();
-      expect(focusSpy).toHaveBeenCalled();
+        const preventDefault = jest.fn();
+        component.find('EuiButton').simulate('click', { preventDefault });
+
+        expect(preventDefault).toHaveBeenCalled();
+        expect(focusSpy).toHaveBeenCalled();
+      });
+
+      it('only scrolls to the destination if out of view', () => {
+        const scrollSpy = jest.fn();
+        mockElement.scrollIntoView = scrollSpy;
+
+        const component = mount(
+          <EuiSkipLink destinationId="somewhere" overrideLinkBehavior />
+        );
+        component.find('EuiButton').simulate('click');
+        expect(scrollSpy).not.toHaveBeenCalled();
+
+        mockElement.getBoundingClientRect = () => ({ top: 1000 } as any);
+        component.find('EuiButton').simulate('click');
+        expect(scrollSpy).toHaveBeenCalled();
+      });
     });
 
     test('tabIndex is rendered', () => {

--- a/src/components/accessibility/skip_link/skip_link.tsx
+++ b/src/components/accessibility/skip_link/skip_link.tsx
@@ -114,7 +114,7 @@ export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
           );
         }
 
-        destinationEl.focus({ preventScroll: true }); // Scrolling is already handled above, and focus autoscroll behaves oddly on Chrome due to the fixed header
+        destinationEl.focus({ preventScroll: true }); // Scrolling is already handled above, and focus autoscroll behaves oddly on Chrome around fixed headers
       },
     };
   }

--- a/src/components/accessibility/skip_link/skip_link.tsx
+++ b/src/components/accessibility/skip_link/skip_link.tsx
@@ -8,6 +8,7 @@
 
 import React, { FunctionComponent, Ref } from 'react';
 import classNames from 'classnames';
+import { isTabbable } from 'tabbable';
 import { useEuiTheme } from '../../../services';
 import { EuiButton, EuiButtonProps } from '../../button/button';
 import { PropsForAnchor, PropsForButton, ExclusiveUnion } from '../../common';
@@ -92,7 +93,19 @@ export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
         if (!destinationEl) return;
 
         destinationEl.scrollIntoView();
-        destinationEl.tabIndex = -1; // Ensure the destination content is focusable
+
+        // Ensure the destination content is focusable
+        if (!isTabbable(destinationEl)) {
+          destinationEl.tabIndex = -1;
+          destinationEl.addEventListener(
+            'blur',
+            () => {
+              destinationEl.removeAttribute('tabindex');
+            },
+            { once: true }
+          );
+        }
+
         destinationEl.focus({ preventScroll: true }); // Scrolling is already handled above, and focus's autoscroll behaves oddly around fixed headers
       },
     };

--- a/src/components/accessibility/skip_link/skip_link.tsx
+++ b/src/components/accessibility/skip_link/skip_link.tsx
@@ -107,9 +107,7 @@ export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
           destinationEl.tabIndex = -1;
           destinationEl.addEventListener(
             'blur',
-            () => {
-              destinationEl.removeAttribute('tabindex');
-            },
+            () => destinationEl.removeAttribute('tabindex'),
             { once: true }
           );
         }

--- a/src/components/accessibility/skip_link/skip_link.tsx
+++ b/src/components/accessibility/skip_link/skip_link.tsx
@@ -92,7 +92,15 @@ export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
         const destinationEl = document.getElementById(destinationId);
         if (!destinationEl) return;
 
-        destinationEl.scrollIntoView();
+        // Scroll to the top of the destination content only if it's ~mostly out of view
+        const destinationY = destinationEl.getBoundingClientRect().top;
+        const halfOfViewportHeight = window.innerHeight / 2;
+        if (
+          destinationY >= halfOfViewportHeight ||
+          window.scrollY >= destinationY + halfOfViewportHeight
+        ) {
+          destinationEl.scrollIntoView();
+        }
 
         // Ensure the destination content is focusable
         if (!isTabbable(destinationEl)) {
@@ -106,7 +114,7 @@ export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
           );
         }
 
-        destinationEl.focus({ preventScroll: true }); // Scrolling is already handled above, and focus's autoscroll behaves oddly around fixed headers
+        destinationEl.focus({ preventScroll: true }); // Scrolling is already handled above, and focus autoscroll behaves oddly on Chrome due to the fixed header
       },
     };
   }

--- a/upcoming_changelogs/5996.md
+++ b/upcoming_changelogs/5996.md
@@ -1,0 +1,1 @@
+- Enhanced `EuiSkipLink`'s `overrideLinkBehavior` scroll and focus UX


### PR DESCRIPTION
## Summary

### Before:

![before](https://user-images.githubusercontent.com/549407/175406260-17d21bc7-513a-4016-a734-3a14cb03a420.gif)

Note: Scroll jump + how black focus outline remains after clicking on the container

### After:

![after](https://user-images.githubusercontent.com/549407/175405887-290b5c48-9b6f-430b-8224-137d5caffeaa.gif)

## Checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~