### PR TITLE
[docs] Increased support for TS types -> props table/docgen

### DIFF
--- a/scripts/loaders/prop-loader.js
+++ b/scripts/loaders/prop-loader.js
@@ -106,24 +106,71 @@ module.exports = function(fileSource) {
   if (types.length > 0) {
     types.map(member => {
       const displayName = member.name.escapedText;
+
       const props = {};
-      const generatedTypes = [];
+      const type = checker.getTypeAtLocation(member);
       if (member.type && member.type.types) {
+        // this is a composite type, e.g. type A = B | C
+        const generatedTypes = [];
+
         member.type.types.map(member => {
           const type = checker.getTypeAtLocation(member);
           const stringType = checker.typeToString(type);
           generatedTypes.push(stringType);
         });
+
+        props[displayName] = {
+          name: displayName,
+          type: {
+            name: generatedTypes.toString(),
+          },
+        };
+      } else if (type?.symbol?.members) {
+        // this type has direct members, e.g. type A = { value: string }
+        type.symbol.members.forEach(
+          ({ escapedName, valueDeclaration }) => {
+            if (valueDeclaration == undefined) {
+              // nothing to read from
+              return;
+            }
+            const typeString = checker.typeToString(checker.getTypeAtLocation(valueDeclaration))
+
+            const description = member.jsDoc ? member.jsDoc[0].comment : '';
+            const propName = escapedName;
+
+            generatedType = {
+              name: 'enum',
+              raw: typeString,
+              value: typeString,
+            };
+
+            props[propName] = setPropInfo(
+              {
+                name: typeString,
+              },
+              propName,
+              !valueDeclaration?.questionToken,
+              description
+            );
+          }
+        );
+      } else {
+        // unknown, but let's pass through TS's take on it
+        const propType = checker.getTypeAtLocation(member.type);
+        if (propType.types) {
+          props[displayName] = {
+            name: displayName,
+            type: {
+              name: checker.typeToString(propType),
+            },
+          };
+        }
       }
-      props[displayName] = {
-        name: displayName,
-        type: {
-          name: generatedTypes.toString(),
-        },
-      };
+
       docsInfo.push(generateDocInfo(displayName, props));
     });
   }
+
   /**
    * Append all the types and interfaces to the file as objects.
    */


### PR DESCRIPTION
### Summary

This started by looking at why `EuiPopoverPanelProps` were not showing in the props table in #5977. Turns out the code for TS->docgen was limited to a very specific type def. This PR adds support for basic `type`s and a fallback to use whatever TS gives us in other cases.

It doesn't solve `EuiPopoverPanelProps` in a great way,

<img width="987" alt="Screen Shot 2022-06-24 at 2 05 10 PM" src="https://user-images.githubusercontent.com/313125/175663495-1a3036de-3787-462d-b065-4b48e7bd1a92.png">

but at least it shows up now and aligns with how other complex types are displayed. The basic `type` handling does include meaningful details,

```typescript
type FooProps = {
  foo: string;
  bar?: number;
}
```

<img width="985" alt="Screen Shot 2022-06-24 at 2 05 05 PM" src="https://user-images.githubusercontent.com/313125/175663631-55048550-c055-427c-9f64-694ebff4139b.png">

### Checklist

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
