### PR TITLE
[EuiPanel] Add missing `Emotion`styles when panel render as `button`

### DIFF
--- a/src/components/panel/__snapshots__/panel.test.tsx.snap
+++ b/src/components/panel/__snapshots__/panel.test.tsx.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[` 1`] = `
+<button
+  aria-label="aria-label"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium testClass1 testClass2 emotion-euiPanel-grow-m-m-plain-hasShadow-isClickable"
+  data-test-subj="test subject string"
+/>
+`;
+
 exports[`EuiPanel is rendered 1`] = `
 <div
   aria-label="aria-label"

--- a/src/components/panel/panel.test.tsx
+++ b/src/components/panel/panel.test.tsx
@@ -81,5 +81,13 @@ describe('EuiPanel', () => {
         });
       });
     });
+
+    describe('onClick', () => {
+      const component = render(
+        <EuiPanel {...requiredProps} onClick={jest.fn()} />
+      );
+
+      expect(component).toMatchSnapshot();
+    });
   });
 });

--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -140,6 +140,7 @@ export const EuiPanel: FunctionComponent<EuiPanelProps> = ({
       <button
         ref={panelRef as Ref<HTMLButtonElement>}
         className={classes}
+        css={cssStyles}
         {...(rest as ButtonHTMLAttributes<HTMLButtonElement>)}
       >
         {children}


### PR DESCRIPTION
### Summary

Fixes #6009.

This PR fixes an issue with `EuiPanel` where the `Emotion` styles were not being passed when it was rendered as a button.

### Checklist

- [ ] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
