### PR TITLE
[EuiDataGrid] Add `title` attribute to column header cell content

### DIFF
--- a/src-docs/src/views/datagrid/_snippets.tsx
+++ b/src-docs/src/views/datagrid/_snippets.tsx
@@ -8,15 +8,20 @@ inMemory={{ level: 'sorting' }}`,
   columns: `columns={[
   {
     id: 'A', // required
+    display: <>Column A <EuiIcon type="dot" /></>, // optional column header rendering
+    displayAsText: 'Column A', // column header as plain text
     initialWidth: 150, // starting width of 150px
     isResizable: false, // prevents the user from resizing width
-    actions: false, // no column header actions are displayed
     isExpandable: false, // doesn't allow clicking in to see the content in a popup
-    actions: { showMoveLeft: false, showMoveRight: false }, // doesn't show move actions in column header
+    isSortable: false, // prevents the user from sorting the data grid by this column
+    defaultSortDirection: 'asc', // sets the default sort direction
     schema: 'franchise', // custom schema later defined under schemaDetectors
+    actions: false, // no column header actions are displayed
+    actions: { showMoveLeft: false, showMoveRight: false }, // doesn't show move actions in column header
     cellActions: [ // provides one additional cell action that triggers an alert once clicked
       ({ Component }) => <Component iconType="heart" onClick={() => alert('test')}>Custom action</Component>,
     ],
+    visibleCellActions: 2, // configures the number of cell action buttons immediately visible on a cell
   },
 ]}`,
   columnVisibility: `columnVisibility={{

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -1057,6 +1057,7 @@ Array [
                 role="columnheader"
                 style="width:100px"
                 tabindex="-1"
+                title="A"
               >
                 <div
                   class="euiDataGridColumnResizer"
@@ -1100,6 +1101,7 @@ Array [
                 role="columnheader"
                 style="width:100px"
                 tabindex="-1"
+                title="B"
               >
                 <div
                   class="euiDataGridColumnResizer"
@@ -1496,6 +1498,7 @@ Array [
                 role="columnheader"
                 style="width:100px"
                 tabindex="-1"
+                title="A"
               >
                 <div
                   class="euiDataGridColumnResizer"
@@ -1539,6 +1542,7 @@ Array [
                 role="columnheader"
                 style="width:100px"
                 tabindex="-1"
+                title="B"
               >
                 <div
                   class="euiDataGridColumnResizer"
@@ -2232,6 +2236,7 @@ Array [
                 role="columnheader"
                 style="width:100px"
                 tabindex="-1"
+                title="A"
               >
                 <div
                   class="euiDataGridColumnResizer"
@@ -2275,6 +2280,7 @@ Array [
                 role="columnheader"
                 style="width:100px"
                 tabindex="-1"
+                title="B"
               >
                 <div
                   class="euiDataGridColumnResizer"
@@ -2651,6 +2657,7 @@ Array [
                 role="columnheader"
                 style="width:100px"
                 tabindex="-1"
+                title="A"
               >
                 <div
                   class="euiDataGridColumnResizer"
@@ -2694,6 +2701,7 @@ Array [
                 role="columnheader"
                 style="width:100px"
                 tabindex="-1"
+                title="B"
               >
                 <div
                   class="euiDataGridColumnResizer"

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -1057,7 +1057,6 @@ Array [
                 role="columnheader"
                 style="width:100px"
                 tabindex="-1"
-                title="A"
               >
                 <div
                   class="euiDataGridColumnResizer"
@@ -1076,6 +1075,7 @@ Array [
                     >
                       <div
                         class="euiDataGridHeaderCell__content"
+                        title="A"
                       >
                         A
                       </div>
@@ -1101,7 +1101,6 @@ Array [
                 role="columnheader"
                 style="width:100px"
                 tabindex="-1"
-                title="B"
               >
                 <div
                   class="euiDataGridColumnResizer"
@@ -1120,6 +1119,7 @@ Array [
                     >
                       <div
                         class="euiDataGridHeaderCell__content"
+                        title="B"
                       >
                         B
                       </div>
@@ -1498,7 +1498,6 @@ Array [
                 role="columnheader"
                 style="width:100px"
                 tabindex="-1"
-                title="A"
               >
                 <div
                   class="euiDataGridColumnResizer"
@@ -1517,6 +1516,7 @@ Array [
                     >
                       <div
                         class="euiDataGridHeaderCell__content"
+                        title="A"
                       >
                         A
                       </div>
@@ -1542,7 +1542,6 @@ Array [
                 role="columnheader"
                 style="width:100px"
                 tabindex="-1"
-                title="B"
               >
                 <div
                   class="euiDataGridColumnResizer"
@@ -1561,6 +1560,7 @@ Array [
                     >
                       <div
                         class="euiDataGridHeaderCell__content"
+                        title="B"
                       >
                         B
                       </div>
@@ -2236,7 +2236,6 @@ Array [
                 role="columnheader"
                 style="width:100px"
                 tabindex="-1"
-                title="A"
               >
                 <div
                   class="euiDataGridColumnResizer"
@@ -2255,6 +2254,7 @@ Array [
                     >
                       <div
                         class="euiDataGridHeaderCell__content"
+                        title="A"
                       >
                         Column A
                       </div>
@@ -2280,7 +2280,6 @@ Array [
                 role="columnheader"
                 style="width:100px"
                 tabindex="-1"
-                title="B"
               >
                 <div
                   class="euiDataGridColumnResizer"
@@ -2299,6 +2298,7 @@ Array [
                     >
                       <div
                         class="euiDataGridHeaderCell__content"
+                        title="B"
                       >
                         <div>
                           More Elements
@@ -2657,7 +2657,6 @@ Array [
                 role="columnheader"
                 style="width:100px"
                 tabindex="-1"
-                title="A"
               >
                 <div
                   class="euiDataGridColumnResizer"
@@ -2676,6 +2675,7 @@ Array [
                     >
                       <div
                         class="euiDataGridHeaderCell__content"
+                        title="A"
                       >
                         A
                       </div>
@@ -2701,7 +2701,6 @@ Array [
                 role="columnheader"
                 style="width:100px"
                 tabindex="-1"
-                title="B"
               >
                 <div
                   class="euiDataGridColumnResizer"
@@ -2720,6 +2719,7 @@ Array [
                     >
                       <div
                         class="euiDataGridHeaderCell__content"
+                        title="B"
                       >
                         B
                       </div>

--- a/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
@@ -23,7 +23,6 @@ exports[`EuiDataGridBody renders 1`] = `
         role="columnheader"
         style="width:100px"
         tabindex="-1"
-        title="columnA"
       >
         <div
           class="euiDataGridColumnResizer"
@@ -42,6 +41,7 @@ exports[`EuiDataGridBody renders 1`] = `
             >
               <div
                 class="euiDataGridHeaderCell__content"
+                title="columnA"
               >
                 columnA
               </div>
@@ -67,7 +67,6 @@ exports[`EuiDataGridBody renders 1`] = `
         role="columnheader"
         style="width:100px"
         tabindex="-1"
-        title="columnB"
       >
         <div
           class="euiDataGridColumnResizer"
@@ -86,6 +85,7 @@ exports[`EuiDataGridBody renders 1`] = `
             >
               <div
                 class="euiDataGridHeaderCell__content"
+                title="columnB"
               >
                 columnB
               </div>

--- a/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`EuiDataGridBody renders 1`] = `
         role="columnheader"
         style="width:100px"
         tabindex="-1"
+        title="columnA"
       >
         <div
           class="euiDataGridColumnResizer"
@@ -66,6 +67,7 @@ exports[`EuiDataGridBody renders 1`] = `
         role="columnheader"
         style="width:100px"
         tabindex="-1"
+        title="columnB"
       >
         <div
           class="euiDataGridColumnResizer"

--- a/src/components/datagrid/body/header/__snapshots__/data_grid_header_cell.test.tsx.snap
+++ b/src/components/datagrid/body/header/__snapshots__/data_grid_header_cell.test.tsx.snap
@@ -6,7 +6,6 @@ exports[`EuiDataGridHeaderCell renders 1`] = `
   headerIsInteractive={false}
   id="someColumn"
   index={0}
-  title="someColumn"
   width={50}
 >
   <EuiDataGridColumnResizer
@@ -24,6 +23,7 @@ exports[`EuiDataGridHeaderCell renders 1`] = `
       >
         <div
           className="euiDataGridHeaderCell__content"
+          title="someColumn"
         >
           someColumn
         </div>

--- a/src/components/datagrid/body/header/__snapshots__/data_grid_header_cell.test.tsx.snap
+++ b/src/components/datagrid/body/header/__snapshots__/data_grid_header_cell.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`EuiDataGridHeaderCell renders 1`] = `
   headerIsInteractive={false}
   id="someColumn"
   index={0}
+  title="someColumn"
   width={50}
 >
   <EuiDataGridColumnResizer

--- a/src/components/datagrid/body/header/data_grid_header_cell.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.tsx
@@ -122,7 +122,6 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
       width={width}
       headerIsInteractive={headerIsInteractive}
       className={classes}
-      title={displayAsText || id}
       {...ariaProps}
     >
       {column.isResizable !== false && width != null ? (
@@ -141,7 +140,10 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
       {!showColumnActions ? (
         <>
           {sortingArrow}
-          <div className="euiDataGridHeaderCell__content">
+          <div
+            className="euiDataGridHeaderCell__content"
+            title={displayAsText || id}
+          >
             {display || displayAsText || id}
           </div>
         </>
@@ -159,7 +161,10 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
               }}
             >
               {sortingArrow}
-              <div className="euiDataGridHeaderCell__content">
+              <div
+                className="euiDataGridHeaderCell__content"
+                title={displayAsText || id}
+              >
                 {display || displayAsText || id}
               </div>
               <EuiIcon

--- a/src/components/datagrid/body/header/data_grid_header_cell.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.tsx
@@ -122,6 +122,7 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
       width={width}
       headerIsInteractive={headerIsInteractive}
       className={classes}
+      title={displayAsText || id}
       {...ariaProps}
     >
       {column.isResizable !== false && width != null ? (

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -149,7 +149,6 @@ export interface EuiDataGridHeaderCellWrapperProps {
   headerIsInteractive: boolean;
   width?: number | null;
   className?: string;
-  title?: string;
 }
 
 export type EuiDataGridFooterRowProps = CommonProps &

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -149,6 +149,7 @@ export interface EuiDataGridHeaderCellWrapperProps {
   headerIsInteractive: boolean;
   width?: number | null;
   className?: string;
+  title?: string;
 }
 
 export type EuiDataGridFooterRowProps = CommonProps &

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -540,11 +540,16 @@ export interface EuiDataGridColumn {
    */
   display?: ReactNode;
   /**
-   * A Schema to use for the column.
-   * Built-in values are [`boolean`, `currency`, `datetime`, `numeric`, `json`] but can be expanded by defining your own #EuiDataGrid `schemaDetectors` (for in-memory detection).
-   * In general, it is advised to pass in a value here when you are sure of the schema ahead of time, so that you don't need to rely on the automatic detection.
+   * Display name as text for the column.
+   * This can be used to display a readable column name in column hiding/sorting, where `display` won't be used.
+   * This will also be used as a `title` attribute that will display on mouseover (useful if the display text is being truncated by the column width).
+   * If not passed, `id` will be shown as the column name.
    */
-  schema?: string;
+  displayAsText?: string;
+  /**
+   * Initial width (in pixels) of the column
+   */
+  initialWidth?: number;
   /**
    * Defaults to true, always true if cellActions are defined. Defines whether or not the column's cells can be expanded with a popup onClick / keydown.
    */
@@ -554,10 +559,6 @@ export interface EuiDataGridColumn {
    */
   isResizable?: boolean;
   /**
-   * Initial width (in pixels) of the column
-   */
-  initialWidth?: number;
-  /**
    * Whether this column is sortable
    */
   isSortable?: boolean;
@@ -566,9 +567,11 @@ export interface EuiDataGridColumn {
    */
   defaultSortDirection?: 'asc' | 'desc';
   /**
-   * Display name as text for column. This can be used to display column name in column selector and column sorting where `display` won't be used. If not used `id` will be shown as column name in column selector and column sorting.
+   * A Schema to use for the column.
+   * Built-in values are [`boolean`, `currency`, `datetime`, `numeric`, `json`] but can be expanded by defining your own #EuiDataGrid `schemaDetectors` (for in-memory detection).
+   * In general, it is advised to pass in a value here when you are sure of the schema ahead of time, so that you don't need to rely on the automatic detection.
    */
-  displayAsText?: string;
+  schema?: string;
   /**
    * Configuration of column actions. Set to false to disable or use #EuiDataGridColumnActions to configure the actions displayed in the header cell of the column.
    */

--- a/upcoming_changelogs/6013.md
+++ b/upcoming_changelogs/6013.md
@@ -1,0 +1,1 @@
+- Added a default `title` to `EuiDataGrid`'s column header cells, allowing header text to remain visible if truncated due to column widths

--- a/upcoming_changelogs/6013.md
+++ b/upcoming_changelogs/6013.md
@@ -1,1 +1,1 @@
-- Added a default `title` to `EuiDataGrid`'s column header cells, allowing header text to remain visible if truncated due to column widths
+- Added a default `title` to `EuiDataGrid`'s column headers, allowing header text to remain visible if truncated due to column widths


### PR DESCRIPTION
### Summary

closes https://github.com/elastic/eui/issues/6012

<img width="124" alt="" src="https://user-images.githubusercontent.com/549407/176499304-ca59fcef-4717-4046-b5f0-984078d2a40f.png">

This uses `displayAsText` by default, falling back to `id` (which means `title` should always be present).

### Checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Added or updated ~**[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~ snapshots
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~