### PR TITLE
[EuiDataGrid] Fix buggy header cell display for sorted columns with no actions

### DIFF
--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -1064,11 +1064,11 @@ Array [
                   style="margin-right:0px"
                 />
                 <div
-                  class="euiPopover euiPopover--anchorDownCenter"
+                  class="euiPopover euiPopover--anchorDownCenter eui-fullWidth"
                   offset="7"
                 >
                   <div
-                    class="euiPopover__anchor euiDataGridHeaderCell__anchor"
+                    class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
                       class="euiDataGridHeaderCell__button"
@@ -1108,11 +1108,11 @@ Array [
                   style="margin-right:0px"
                 />
                 <div
-                  class="euiPopover euiPopover--anchorDownCenter"
+                  class="euiPopover euiPopover--anchorDownCenter eui-fullWidth"
                   offset="7"
                 >
                   <div
-                    class="euiPopover__anchor euiDataGridHeaderCell__anchor"
+                    class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
                       class="euiDataGridHeaderCell__button"
@@ -1505,11 +1505,11 @@ Array [
                   style="margin-right:0px"
                 />
                 <div
-                  class="euiPopover euiPopover--anchorDownCenter"
+                  class="euiPopover euiPopover--anchorDownCenter eui-fullWidth"
                   offset="7"
                 >
                   <div
-                    class="euiPopover__anchor euiDataGridHeaderCell__anchor"
+                    class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
                       class="euiDataGridHeaderCell__button"
@@ -1549,11 +1549,11 @@ Array [
                   style="margin-right:0px"
                 />
                 <div
-                  class="euiPopover euiPopover--anchorDownCenter"
+                  class="euiPopover euiPopover--anchorDownCenter eui-fullWidth"
                   offset="7"
                 >
                   <div
-                    class="euiPopover__anchor euiDataGridHeaderCell__anchor"
+                    class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
                       class="euiDataGridHeaderCell__button"
@@ -2243,11 +2243,11 @@ Array [
                   style="margin-right:0px"
                 />
                 <div
-                  class="euiPopover euiPopover--anchorDownCenter"
+                  class="euiPopover euiPopover--anchorDownCenter eui-fullWidth"
                   offset="7"
                 >
                   <div
-                    class="euiPopover__anchor euiDataGridHeaderCell__anchor"
+                    class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
                       class="euiDataGridHeaderCell__button"
@@ -2287,11 +2287,11 @@ Array [
                   style="margin-right:0px"
                 />
                 <div
-                  class="euiPopover euiPopover--anchorDownCenter"
+                  class="euiPopover euiPopover--anchorDownCenter eui-fullWidth"
                   offset="7"
                 >
                   <div
-                    class="euiPopover__anchor euiDataGridHeaderCell__anchor"
+                    class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
                       class="euiDataGridHeaderCell__button"
@@ -2664,11 +2664,11 @@ Array [
                   style="margin-right:0px"
                 />
                 <div
-                  class="euiPopover euiPopover--anchorDownCenter"
+                  class="euiPopover euiPopover--anchorDownCenter eui-fullWidth"
                   offset="7"
                 >
                   <div
-                    class="euiPopover__anchor euiDataGridHeaderCell__anchor"
+                    class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
                       class="euiDataGridHeaderCell__button"
@@ -2708,11 +2708,11 @@ Array [
                   style="margin-right:0px"
                 />
                 <div
-                  class="euiPopover euiPopover--anchorDownCenter"
+                  class="euiPopover euiPopover--anchorDownCenter eui-fullWidth"
                   offset="7"
                 >
                   <div
-                    class="euiPopover__anchor euiDataGridHeaderCell__anchor"
+                    class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
                       class="euiDataGridHeaderCell__button"

--- a/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
@@ -30,11 +30,11 @@ exports[`EuiDataGridBody renders 1`] = `
           style="margin-right:0px"
         />
         <div
-          class="euiPopover euiPopover--anchorDownCenter"
+          class="euiPopover euiPopover--anchorDownCenter eui-fullWidth"
           offset="7"
         >
           <div
-            class="euiPopover__anchor euiDataGridHeaderCell__anchor"
+            class="euiPopover__anchor eui-fullWidth"
           >
             <button
               class="euiDataGridHeaderCell__button"
@@ -74,11 +74,11 @@ exports[`EuiDataGridBody renders 1`] = `
           style="margin-right:0px"
         />
         <div
-          class="euiPopover euiPopover--anchorDownCenter"
+          class="euiPopover euiPopover--anchorDownCenter eui-fullWidth"
           offset="7"
         >
           <div
-            class="euiPopover__anchor euiDataGridHeaderCell__anchor"
+            class="euiPopover__anchor eui-fullWidth"
           >
             <button
               class="euiDataGridHeaderCell__button"

--- a/src/components/datagrid/body/header/__snapshots__/data_grid_header_cell.test.tsx.snap
+++ b/src/components/datagrid/body/header/__snapshots__/data_grid_header_cell.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`EuiDataGridHeaderCell renders 1`] = `
     setColumnWidth={[MockFunction]}
   />
   <EuiPopover
-    anchorClassName="euiDataGridHeaderCell__anchor"
+    anchorClassName="eui-fullWidth"
     anchorPosition="downCenter"
     button={
       <button
@@ -37,6 +37,7 @@ exports[`EuiDataGridHeaderCell renders 1`] = `
         />
       </button>
     }
+    className="eui-fullWidth"
     closePopover={[Function]}
     display="inlineBlock"
     hasArrow={true}

--- a/src/components/datagrid/body/header/_data_grid_header_row.scss
+++ b/src/components/datagrid/body/header/_data_grid_header_row.scss
@@ -16,11 +16,6 @@
   align-items: center;
   display: flex;
 
-  > * {
-    max-width: 100%;
-    width: 100%;
-  }
-
   &.euiDataGridHeaderCell--numeric {
     text-align: right;
   }

--- a/src/components/datagrid/body/header/data_grid_header_cell.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.tsx
@@ -149,7 +149,8 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
         </>
       ) : (
         <EuiPopover
-          anchorClassName="euiDataGridHeaderCell__anchor"
+          className="eui-fullWidth"
+          anchorClassName="eui-fullWidth"
           panelPaddingSize="none"
           offset={7}
           button={


### PR DESCRIPTION
## Summary

### Before
<img width="228" alt="" src="https://user-images.githubusercontent.com/549407/176730446-62f5823f-3313-41e9-b892-23cfeff45ab5.png">

### After
<img width="228" alt="" src="https://user-images.githubusercontent.com/549407/176730483-79833992-43ab-480a-b5be-4bfeac24ef14.png">

### Repro steps:

This bug only occurs on sorted header cells with actions disabled (i.e. no popover wrapper).

1. Go to https://eui.elastic.co/v60.1.0/#/tabular-content/data-grid
2. Click the "Sort fields" toolbar button
3. Sort by the "Version" field (any direction)
4. Notice the broken header cell display with only the arrow showing

### Cause

This bug appears to have been caused by the Emotion conversion of EuiIcon. Because Emotion CSS comes before our remaining Sass CSS, the width of the icon is being overridden by the `> * { width: 100%; }` CSS. This will in theory(?) fix itself once we're fully on Emotion, but since that's a whiles away, this fix solves the issue in the interim by removing the `> *` blanket selector and only applying our `.eui-fullWidth` CSS utilities to specific divs that we need it.

### Checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
