### PR TITLE
[EuiDataGrid] Fix focus/scroll jump when initial data grid focus is not a keyboard tab

### DIFF
--- a/src/components/datagrid/data_grid.spec.tsx
+++ b/src/components/datagrid/data_grid.spec.tsx
@@ -295,9 +295,10 @@ describe('EuiDataGrid', () => {
 
         getGridData();
 
-        cy.get('[data-test-subj=euiDataGridBody]').focus();
-
         // first cell is non-interactive and non-expandable = focus cell
+        cy.get(
+          '[data-gridcell-column-index="0"][data-gridcell-row-index="0"]'
+        ).click();
         cy.focused()
           .should('have.attr', 'data-gridcell-column-index', '0')
           .should('have.attr', 'data-gridcell-row-index', '0');
@@ -336,9 +337,10 @@ describe('EuiDataGrid', () => {
 
         getGridData();
 
-        cy.get('[data-test-subj=euiDataGridBody]').focus();
-
         // first cell is non-interactive and non-expandable, enter should have no effect
+        cy.get(
+          '[data-gridcell-column-index="0"][data-gridcell-row-index="0"]'
+        ).click();
         cy.focused().type('{enter}');
         cy.focused()
           .should('have.attr', 'data-gridcell-column-index', '0')

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -2354,9 +2354,8 @@ describe('EuiDataGrid', () => {
 
       // enable the grid to accept focus
       act(() =>
-        component
-          .find('div [data-test-subj="euiDataGridBody"][onFocus]')
-          .props().onFocus!({} as React.FocusEvent)
+        component.find('div [data-test-subj="euiDataGridBody"]').props()
+          .onKeyUp!({ key: keys.TAB } as React.KeyboardEvent)
       );
       component.update();
 
@@ -2552,9 +2551,8 @@ describe('EuiDataGrid', () => {
 
       // enable the grid to accept focus
       act(() =>
-        component
-          .find('div [data-test-subj="euiDataGridBody"][onFocus]')
-          .props().onFocus!({} as React.FocusEvent)
+        component.find('div [data-test-subj="euiDataGridBody"]').props()
+          .onKeyUp!({ key: keys.TAB } as React.KeyboardEvent)
       );
       component.update();
 

--- a/src/components/datagrid/utils/focus.test.tsx
+++ b/src/components/datagrid/utils/focus.test.tsx
@@ -127,18 +127,18 @@ describe('useFocus', () => {
 
   describe('setIsFocusedCellInView / focusProps', () => {
     describe('when no focused child cell is in view', () => {
-      it('renders the grid with tabindex 0 and an onFocus event', () => {
+      it('renders the grid with tabindex 0 and an onKeyUp event', () => {
         const {
           return: { focusProps },
         } = testCustomHook(() => useFocus(mockArgs));
 
         expect(focusProps).toEqual({
           tabIndex: 0,
-          onFocus: expect.any(Function),
+          onKeyUp: expect.any(Function),
         });
       });
 
-      describe('onFocus event', () => {
+      describe('onKeyUp event', () => {
         const mockGrid = document.createElement('div');
         const someChild = mockGrid.appendChild(
           document.createElement('button')
@@ -147,27 +147,44 @@ describe('useFocus', () => {
         it('focuses into the first visible cell of the grid when the grid is directly tabbed to', () => {
           const {
             return: {
-              focusProps: { onFocus },
+              focusProps: { onKeyUp },
             },
             getUpdatedState,
           } = testCustomHook<ReturnValues>(() => useFocus(mockArgs));
 
           act(() =>
-            onFocus!({ target: mockGrid, currentTarget: mockGrid } as any)
+            onKeyUp!({
+              key: keys.TAB,
+              target: mockGrid,
+              currentTarget: mockGrid,
+            } as any)
           );
           expect(getUpdatedState().focusedCell).toEqual([0, -1]);
         });
 
-        it('does nothing if the focus event was not on the grid itself', () => {
+        it('does nothing if not a tab keyup, or if the event was not on the grid itself', () => {
           const {
             return: {
-              focusProps: { onFocus },
+              focusProps: { onKeyUp },
             },
             getUpdatedState,
           } = testCustomHook<ReturnValues>(() => useFocus(mockArgs));
 
           act(() =>
-            onFocus!({ target: someChild, currentTarget: mockGrid } as any)
+            onKeyUp!({
+              key: keys.ARROW_DOWN,
+              target: mockGrid,
+              currentTarget: mockGrid,
+            } as any)
+          );
+          expect(getUpdatedState().focusedCell).toEqual(undefined);
+
+          act(() =>
+            onKeyUp!({
+              key: keys.TAB,
+              target: someChild,
+              currentTarget: mockGrid,
+            } as any)
           );
           expect(getUpdatedState().focusedCell).toEqual(undefined);
         });

--- a/src/components/datagrid/utils/focus.ts
+++ b/src/components/datagrid/utils/focus.ts
@@ -35,7 +35,7 @@ export const DataGridFocusContext = createContext<DataGridFocusContextShape>({
   focusFirstVisibleInteractiveCell: () => {},
 });
 
-type FocusProps = Pick<HTMLAttributes<HTMLDivElement>, 'tabIndex' | 'onFocus'>;
+type FocusProps = Pick<HTMLAttributes<HTMLDivElement>, 'tabIndex' | 'onKeyUp'>;
 
 /**
  * Main focus context and overarching focus state management
@@ -114,13 +114,16 @@ export const useFocus = ({
           }
         : {
             tabIndex: 0,
-            onFocus: (e) => {
-              // if e.target (the source element of the `focus event`
-              // matches e.currentTarget (always the div with this onFocus listener)
-              // then the user has focused directly on the data grid wrapper (almost definitely by tabbing)
-              // so shift focus to the first visible and interactive cell within the grid
-              if (e.target === e.currentTarget) {
-                focusFirstVisibleInteractiveCell();
+            onKeyUp: (e: KeyboardEvent) => {
+              // Ensure we only manually focus into the grid via keyboard tab -
+              // mouse users can accidentally trigger focus by clicking on scrollbars
+              if (e.key === keys.TAB) {
+                // if e.target (the source element of the `focus event`) matches
+                // e.currentTarget (always the div with this onKeyUp listener)
+                // then the user has focused directly on the data grid wrapper
+                if (e.target === e.currentTarget) {
+                  focusFirstVisibleInteractiveCell();
+                }
               }
             },
           },

--- a/upcoming_changelogs/6018.md
+++ b/upcoming_changelogs/6018.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiDataGrid` focus/scroll jumping occurring when the first interaction the user had with the grid was the scrollbar(s)


### PR DESCRIPTION
### Summary

closes https://github.com/elastic/eui/issues/6008

### Before

![before](https://user-images.githubusercontent.com/549407/176772862-6fa3fe7e-c0a9-46cf-af1f-0815291113ad.gif)

### After

![after](https://user-images.githubusercontent.com/549407/176772879-ea212b8c-4623-45f6-b525-a39861cd48ff.gif)

### Checklist

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
