### PR TITLE
[EuiDataGrid] Update `virtualizationOptions` to respect `onItemsRendered` and `className`

### DIFF
--- a/src-docs/src/views/datagrid/_snippets.tsx
+++ b/src-docs/src/views/datagrid/_snippets.tsx
@@ -106,4 +106,21 @@ ref={dataGridRef}`,
     </Link>
   ),
   onColumnResize: 'onColumnResize={({columnId, width}) => {}}',
+  virtualizationOptions: `// Optional. For advanced control of the underlying react-window virtualization grid.
+virtualizationOptions={{
+  className: 'virtualizedGridClass',
+  style: {},
+  direction: 'ltr',
+  estimatedRowHeight: 50,
+  overscanColumnCount: 1,
+  overscanRowCount: 1,
+  initialScrollLeft: 0,
+  initialScrollTop: 0,
+  onScroll: () => {},
+  onItemsRendered: () => {},
+  itemKey: () => {},
+  outerElementType: 'div',
+}}
+// Properties not listed above are used by EuiDataGrid internals and cannot be overridden.
+`,
 };

--- a/src-docs/src/views/datagrid/basics/datagrid.js
+++ b/src-docs/src/views/datagrid/basics/datagrid.js
@@ -429,6 +429,9 @@ export default () => {
         }}
         onColumnResize={onColumnResize.current}
         ref={gridRef}
+        virtualizationOptions={{
+          onItemsRendered: (items) => console.log('onItemsRendered', items),
+        }}
       />
     </DataContext.Provider>
   );

--- a/src-docs/src/views/datagrid/basics/datagrid.js
+++ b/src-docs/src/views/datagrid/basics/datagrid.js
@@ -429,9 +429,6 @@ export default () => {
         }}
         onColumnResize={onColumnResize.current}
         ref={gridRef}
-        virtualizationOptions={{
-          onItemsRendered: (items) => console.log('onItemsRendered', items),
-        }}
       />
     </DataContext.Provider>
   );

--- a/src/components/datagrid/body/data_grid_body.test.tsx
+++ b/src/components/datagrid/body/data_grid_body.test.tsx
@@ -98,6 +98,22 @@ describe('EuiDataGridBody', () => {
     expect(component.find('[data-test-subj="footer"]')).toHaveLength(2);
   });
 
+  it('passes some virtualization options to the underlying react-window grid', () => {
+    const onItemsRendered = jest.fn();
+    const component = mount(
+      <EuiDataGridBody
+        {...requiredProps}
+        virtualizationOptions={{
+          initialScrollTop: 50,
+          className: 'test',
+          onItemsRendered,
+        }}
+      />
+    );
+    expect(component.find('.test').exists()).toBe(true);
+    expect(onItemsRendered).toHaveBeenCalled();
+  });
+
   // TODO: Test final height/weights in Cypress
 
   // TODO: Test tabbing in Cypress

--- a/src/components/datagrid/body/data_grid_body.tsx
+++ b/src/components/datagrid/body/data_grid_body.tsx
@@ -455,13 +455,17 @@ export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
       <Grid
         {...(virtualizationOptions ? virtualizationOptions : {})}
         ref={gridRef}
+        className={classNames(
+          'euiDataGrid__virtualized',
+          virtualizationOptions?.className
+        )}
         onItemsRendered={(itemsRendered) => {
           gridItemsRendered.current = itemsRendered;
+          virtualizationOptions?.onItemsRendered?.(itemsRendered);
         }}
         innerElementType={InnerElement}
         outerRef={outerGridRef}
         innerRef={innerGridRef}
-        className="euiDataGrid__virtualized"
         columnCount={visibleColCount}
         width={finalWidth}
         columnWidth={getColumnWidth}

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -305,7 +305,24 @@ export type CommonGridProps = CommonProps &
     /**
      * Allows customizing the underlying [react-window grid](https://react-window.vercel.app/#/api/VariableSizeGrid) props.
      */
-    virtualizationOptions?: Partial<VariableSizeGridProps>;
+    virtualizationOptions?: Partial<
+      Omit<
+        VariableSizeGridProps,
+        | 'children'
+        | 'itemData'
+        | 'height'
+        | 'width'
+        | 'rowCount'
+        | 'rowHeight'
+        | 'columnCount'
+        | 'columnWidth'
+        | 'ref'
+        | 'innerRef'
+        | 'outerRef'
+        | 'innerElementType'
+        | 'useIsScrolling'
+      >
+    >;
     /**
      * A #EuiDataGridRowHeightsOptions object that provides row heights options.
      * Allows configuring both default and specific heights of grid rows.
@@ -386,7 +403,7 @@ export interface EuiDataGridBodyProps {
   setVisibleColumns: EuiDataGridHeaderRowProps['setVisibleColumns'];
   switchColumnPos: EuiDataGridHeaderRowProps['switchColumnPos'];
   onColumnResize?: EuiDataGridOnColumnResizeHandler;
-  virtualizationOptions?: Partial<VariableSizeGridProps>;
+  virtualizationOptions?: EuiDataGridProps['virtualizationOptions'];
   rowHeightsOptions?: EuiDataGridRowHeightsOptions;
   isFullScreen: boolean;
   gridStyles: EuiDataGridStyle;

--- a/upcoming_changelogs/6019.md
+++ b/upcoming_changelogs/6019.md
@@ -1,0 +1,1 @@
+- `EuiDataGrid` now accepts a `virtualizationOptions.onItemsRendered` callback, as well as `virtualizationOptions.className`


### PR DESCRIPTION
### Summary

closes https://github.com/elastic/eui/issues/6002

This PR adds support for `virtualizationOptions.onItemsRendered` as well as `virtualizationOptions.className` (figured why not, since I was here). It also adds better documentation and type-checking for the `virtualizationOptions` prop.

<img width="1143" alt="" src="https://user-images.githubusercontent.com/549407/176781191-64e92a93-242b-4463-8886-fbe4472d54e8.png">

### Checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
- [x] Revert [REVERT ME] commits

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~