### PR TITLE
[EuiTableBody] Add `children` prop to `EuiTableBody`

### DIFF
--- a/src/components/table/table_body.tsx
+++ b/src/components/table/table_body.tsx
@@ -6,11 +6,12 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, Ref } from 'react';
+import React, { FunctionComponent, ReactNode, Ref } from 'react';
 import { CommonProps } from '../common';
 
 export type EuiTableBodyProps = CommonProps & {
   bodyRef?: Ref<HTMLTableSectionElement>;
+  children?: ReactNode;
 };
 
 export const EuiTableBody: FunctionComponent<EuiTableBodyProps> = ({


### PR DESCRIPTION
### Summary

This PR adds the missing `children` property to `EuiTableBody`. After upgrading to React 18, I started getting the following error in my project:

`TS2559: Type '{ children: Element[]; }' has no properties in common with type 'IntrinsicAttributes & CommonProps & { bodyRef?: Ref<HTMLTableSectionElement> | undefined; }'.`

I guess this issue is caused by the same reason as [this SO question](https://stackoverflow.com/questions/71817106/type-children-element-has-no-properties-in-common-with-type-intrinsicat). I'm not sure if this is the appropriate fix for this issue, but I think it makes sense, considering that `EuiTableHeader`, which doesn't give the above error, [has the `children` property](https://github.com/elastic/eui/blob/91b416dcd51e116edb2cb4a2cac4c306512e28c7/src/components/table/table_header.tsx#L18).

### Checklist

- [ ] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
