### PR TITLE
[EuiSelectable] EuiSelectable's onChange prop not passing a full event back on React v16

### DIFF
--- a/src/components/selectable/selectable_list/selectable_list.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.tsx
@@ -278,6 +278,7 @@ export class EuiSelectableList<T> extends Component<EuiSelectableListProps<T>> {
           setActiveOptionIndex(index);
         }}
         onClick={(event) => {
+          event.persist(); // NOTE: This is needed for React v16 backwards compatibility
           this.onAddOrRemoveOption(option, event);
         }}
         ref={ref ? ref.bind(null, index) : undefined}

--- a/upcoming_changelogs/6026.md
+++ b/upcoming_changelogs/6026.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed EuiSelectable's `onChange` callback not passing back a persisted event on React 16


### PR DESCRIPTION
### Summary

@jeramysoucy alerted us that the 2nd `event` arg on EuiSelectable's `onChange` callback (added in https://github.com/elastic/eui/pull/5926) is not working in Kibana. This is due to Kibana being on React v16 and EUI being on React v17 (see https://reactjs.org/docs/legacy-event-pooling.html).

I tested a built version of this branch against local Kibana and can confirm event types, shiftKey, nativeEvent data etc. are now correctly coming through:

<img width="801" alt="" src="https://user-images.githubusercontent.com/549407/177384511-5da76a75-befc-49fd-bf5d-3f33ab4a825b.png">

### Checklist

- [x] `yarn build-pack` Kibana test
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
