### PR TITLE
[EuiText] Fix `className` not correctly inheriting when both `color` and `textAlign` are passed

### DIFF
--- a/src/components/text/__snapshots__/text.test.tsx.snap
+++ b/src/components/text/__snapshots__/text.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`EuiText is rendered 1`] = `
 exports[`EuiText props color & align 1`] = `
 <div
   aria-label="aria-label"
-  class="emotion-euiText-m-euiTextColor-danger-euiTextAlign-center"
+  class="euiText testClass1 testClass2 emotion-euiText-m-euiTextColor-danger-euiTextAlign-center"
   data-test-subj="test subject string"
 >
   <p>

--- a/src/components/text/text.test.tsx
+++ b/src/components/text/text.test.tsx
@@ -25,6 +25,8 @@ describe('EuiText', () => {
   });
 
   shouldRenderCustomStyles(<EuiText size="s" color="#fff" />);
+  shouldRenderCustomStyles(<EuiText size="xs" textAlign="left" />);
+  shouldRenderCustomStyles(<EuiText textAlign="center" color="success" />);
 
   describe('props', () => {
     describe('grow', () => {

--- a/src/components/text/text.tsx
+++ b/src/components/text/text.tsx
@@ -61,7 +61,7 @@ export const EuiText: FunctionComponent<EuiTextProps> = ({
 
   if (color) {
     text = (
-      <EuiTextColor color={color} cloneElement>
+      <EuiTextColor color={color} className={classes} cloneElement>
         {text}
       </EuiTextColor>
     );
@@ -69,7 +69,7 @@ export const EuiText: FunctionComponent<EuiTextProps> = ({
 
   if (textAlign) {
     text = (
-      <EuiTextAlign textAlign={textAlign} cloneElement>
+      <EuiTextAlign textAlign={textAlign} className={classes} cloneElement>
         {text}
       </EuiTextAlign>
     );

--- a/upcoming_changelogs/6027.md
+++ b/upcoming_changelogs/6027.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiText` not correctly inheriting `className`s when both the `color` and `textAlign` props were passed


### PR DESCRIPTION
### Summary

closes https://github.com/elastic/eui/issues/6023

Even our own `euiText` className wasn't being correctly inherited. Apologies for missing this 😬 

Before:
<img width="636" alt="" src="https://user-images.githubusercontent.com/549407/177391784-22d418f7-e957-4e03-9700-98e62af16c46.png">

After:
<img width="588" alt="" src="https://user-images.githubusercontent.com/549407/177391842-8d1b78d5-7495-484d-8085-a9429c35d359.png">


### Checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
