### PR TITLE
[EuiDataGrid] Improve `aria` row counts and indices for screen reader users

### DIFF
--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -1029,6 +1029,7 @@ Array [
       </div>
       <div
         aria-label="aria-label"
+        aria-rowcount="3"
         class="euiDataGrid__content"
         data-test-subj="euiDataGridBody"
         id="generated-id"
@@ -1135,6 +1136,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="0"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
@@ -1166,6 +1168,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="0"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
@@ -1197,6 +1200,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="1"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
@@ -1228,6 +1232,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="1"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
@@ -1259,6 +1264,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="2"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
@@ -1290,6 +1296,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="2"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
@@ -1449,6 +1456,7 @@ Array [
       </div>
       <div
         aria-label="aria-label"
+        aria-rowcount="3"
         class="euiDataGrid__content"
         data-test-subj="euiDataGridBody"
         id="generated-id"
@@ -1593,6 +1601,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="0"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn euiDataGridRowCell--controlColumn"
               data-gridcell-column-id="leading"
               data-gridcell-column-index="0"
@@ -1643,6 +1652,7 @@ Array [
               />
             </div>
             <div
+              aria-rowindex="0"
               class="euiDataGridRowCell"
               data-gridcell-column-id="A"
               data-gridcell-column-index="1"
@@ -1674,6 +1684,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="0"
               class="euiDataGridRowCell"
               data-gridcell-column-id="B"
               data-gridcell-column-index="2"
@@ -1705,6 +1716,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="0"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn euiDataGridRowCell--controlColumn"
               data-gridcell-column-id="trailing"
               data-gridcell-column-index="3"
@@ -1755,6 +1767,7 @@ Array [
               />
             </div>
             <div
+              aria-rowindex="1"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn euiDataGridRowCell--controlColumn"
               data-gridcell-column-id="leading"
               data-gridcell-column-index="0"
@@ -1805,6 +1818,7 @@ Array [
               />
             </div>
             <div
+              aria-rowindex="1"
               class="euiDataGridRowCell"
               data-gridcell-column-id="A"
               data-gridcell-column-index="1"
@@ -1836,6 +1850,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="1"
               class="euiDataGridRowCell"
               data-gridcell-column-id="B"
               data-gridcell-column-index="2"
@@ -1867,6 +1882,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="1"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn euiDataGridRowCell--controlColumn"
               data-gridcell-column-id="trailing"
               data-gridcell-column-index="3"
@@ -1917,6 +1933,7 @@ Array [
               />
             </div>
             <div
+              aria-rowindex="2"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn euiDataGridRowCell--controlColumn"
               data-gridcell-column-id="leading"
               data-gridcell-column-index="0"
@@ -1967,6 +1984,7 @@ Array [
               />
             </div>
             <div
+              aria-rowindex="2"
               class="euiDataGridRowCell"
               data-gridcell-column-id="A"
               data-gridcell-column-index="1"
@@ -1998,6 +2016,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="2"
               class="euiDataGridRowCell"
               data-gridcell-column-id="B"
               data-gridcell-column-index="2"
@@ -2029,6 +2048,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="2"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn euiDataGridRowCell--controlColumn"
               data-gridcell-column-id="trailing"
               data-gridcell-column-index="3"
@@ -2204,6 +2224,7 @@ Array [
       </div>
       <div
         aria-label="aria-label"
+        aria-rowcount="3"
         class="euiDataGrid__content"
         data-test-subj="euiDataGridBody"
         id="generated-id"
@@ -2312,6 +2333,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="0"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
@@ -2343,6 +2365,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="0"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
@@ -2374,6 +2397,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="1"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
@@ -2405,6 +2429,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="1"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
@@ -2436,6 +2461,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="2"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
@@ -2467,6 +2493,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="2"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
@@ -2623,6 +2650,7 @@ Array [
       </div>
       <div
         aria-label="aria-label"
+        aria-rowcount="3"
         class="euiDataGrid__content"
         data-test-subj="euiDataGridBody"
         id="generated-id"
@@ -2729,6 +2757,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="0"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
@@ -2760,6 +2789,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="0"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
@@ -2791,6 +2821,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="1"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
@@ -2822,6 +2853,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="1"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
@@ -2853,6 +2885,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="2"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
@@ -2884,6 +2917,7 @@ Array [
               </div>
             </div>
             <div
+              aria-rowindex="2"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -1162,7 +1162,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 1; Column: 1
+                    - Row 1, Column 1 (A)
                   </p>
                 </div>
               </div>
@@ -1194,7 +1194,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 1; Column: 2
+                    - Row 1, Column 2 (B)
                   </p>
                 </div>
               </div>
@@ -1226,7 +1226,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 2; Column: 1
+                    - Row 2, Column 1 (A)
                   </p>
                 </div>
               </div>
@@ -1258,7 +1258,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 2; Column: 2
+                    - Row 2, Column 2 (B)
                   </p>
                 </div>
               </div>
@@ -1290,7 +1290,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 3; Column: 1
+                    - Row 3, Column 1 (A)
                   </p>
                 </div>
               </div>
@@ -1322,7 +1322,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 3; Column: 2
+                    - Row 3, Column 2 (B)
                   </p>
                 </div>
               </div>
@@ -1640,7 +1640,7 @@ Array [
                     <p
                       class="emotion-euiScreenReaderOnly"
                     >
-                      Row: 1; Column: 1
+                      - Row 1, Column 1 (leading)
                     </p>
                   </div>
                 </div>
@@ -1678,7 +1678,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 1; Column: 2
+                    - Row 1, Column 2 (A)
                   </p>
                 </div>
               </div>
@@ -1710,7 +1710,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 1; Column: 3
+                    - Row 1, Column 3 (B)
                   </p>
                 </div>
               </div>
@@ -1755,7 +1755,7 @@ Array [
                     <p
                       class="emotion-euiScreenReaderOnly"
                     >
-                      Row: 1; Column: 4
+                      - Row 1, Column 4 (trailing)
                     </p>
                   </div>
                 </div>
@@ -1806,7 +1806,7 @@ Array [
                     <p
                       class="emotion-euiScreenReaderOnly"
                     >
-                      Row: 2; Column: 1
+                      - Row 2, Column 1 (leading)
                     </p>
                   </div>
                 </div>
@@ -1844,7 +1844,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 2; Column: 2
+                    - Row 2, Column 2 (A)
                   </p>
                 </div>
               </div>
@@ -1876,7 +1876,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 2; Column: 3
+                    - Row 2, Column 3 (B)
                   </p>
                 </div>
               </div>
@@ -1921,7 +1921,7 @@ Array [
                     <p
                       class="emotion-euiScreenReaderOnly"
                     >
-                      Row: 2; Column: 4
+                      - Row 2, Column 4 (trailing)
                     </p>
                   </div>
                 </div>
@@ -1972,7 +1972,7 @@ Array [
                     <p
                       class="emotion-euiScreenReaderOnly"
                     >
-                      Row: 3; Column: 1
+                      - Row 3, Column 1 (leading)
                     </p>
                   </div>
                 </div>
@@ -2010,7 +2010,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 3; Column: 2
+                    - Row 3, Column 2 (A)
                   </p>
                 </div>
               </div>
@@ -2042,7 +2042,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 3; Column: 3
+                    - Row 3, Column 3 (B)
                   </p>
                 </div>
               </div>
@@ -2087,7 +2087,7 @@ Array [
                     <p
                       class="emotion-euiScreenReaderOnly"
                     >
-                      Row: 3; Column: 4
+                      - Row 3, Column 4 (trailing)
                     </p>
                   </div>
                 </div>
@@ -2359,7 +2359,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 1; Column: 1
+                    - Row 1, Column 1 (A)
                   </p>
                 </div>
               </div>
@@ -2391,7 +2391,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 1; Column: 2
+                    - Row 1, Column 2 (B)
                   </p>
                 </div>
               </div>
@@ -2423,7 +2423,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 2; Column: 1
+                    - Row 2, Column 1 (A)
                   </p>
                 </div>
               </div>
@@ -2455,7 +2455,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 2; Column: 2
+                    - Row 2, Column 2 (B)
                   </p>
                 </div>
               </div>
@@ -2487,7 +2487,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 3; Column: 1
+                    - Row 3, Column 1 (A)
                   </p>
                 </div>
               </div>
@@ -2519,7 +2519,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 3; Column: 2
+                    - Row 3, Column 2 (B)
                   </p>
                 </div>
               </div>
@@ -2783,7 +2783,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 1; Column: 1
+                    - Row 1, Column 1 (A)
                   </p>
                 </div>
               </div>
@@ -2815,7 +2815,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 1; Column: 2
+                    - Row 1, Column 2 (B)
                   </p>
                 </div>
               </div>
@@ -2847,7 +2847,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 2; Column: 1
+                    - Row 2, Column 1 (A)
                   </p>
                 </div>
               </div>
@@ -2879,7 +2879,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 2; Column: 2
+                    - Row 2, Column 2 (B)
                   </p>
                 </div>
               </div>
@@ -2911,7 +2911,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 3; Column: 1
+                    - Row 3, Column 1 (A)
                   </p>
                 </div>
               </div>
@@ -2943,7 +2943,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    Row: 3; Column: 2
+                    - Row 3, Column 2 (B)
                   </p>
                 </div>
               </div>

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -1136,7 +1136,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="0"
+              aria-rowindex="1"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
@@ -1168,7 +1168,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="0"
+              aria-rowindex="1"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
@@ -1200,7 +1200,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="1"
+              aria-rowindex="2"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
@@ -1232,7 +1232,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="1"
+              aria-rowindex="2"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
@@ -1264,7 +1264,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="2"
+              aria-rowindex="3"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
@@ -1296,7 +1296,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="2"
+              aria-rowindex="3"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
@@ -1601,7 +1601,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="0"
+              aria-rowindex="1"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn euiDataGridRowCell--controlColumn"
               data-gridcell-column-id="leading"
               data-gridcell-column-index="0"
@@ -1652,7 +1652,7 @@ Array [
               />
             </div>
             <div
-              aria-rowindex="0"
+              aria-rowindex="1"
               class="euiDataGridRowCell"
               data-gridcell-column-id="A"
               data-gridcell-column-index="1"
@@ -1684,7 +1684,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="0"
+              aria-rowindex="1"
               class="euiDataGridRowCell"
               data-gridcell-column-id="B"
               data-gridcell-column-index="2"
@@ -1716,7 +1716,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="0"
+              aria-rowindex="1"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn euiDataGridRowCell--controlColumn"
               data-gridcell-column-id="trailing"
               data-gridcell-column-index="3"
@@ -1767,7 +1767,7 @@ Array [
               />
             </div>
             <div
-              aria-rowindex="1"
+              aria-rowindex="2"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn euiDataGridRowCell--controlColumn"
               data-gridcell-column-id="leading"
               data-gridcell-column-index="0"
@@ -1818,7 +1818,7 @@ Array [
               />
             </div>
             <div
-              aria-rowindex="1"
+              aria-rowindex="2"
               class="euiDataGridRowCell"
               data-gridcell-column-id="A"
               data-gridcell-column-index="1"
@@ -1850,7 +1850,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="1"
+              aria-rowindex="2"
               class="euiDataGridRowCell"
               data-gridcell-column-id="B"
               data-gridcell-column-index="2"
@@ -1882,7 +1882,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="1"
+              aria-rowindex="2"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn euiDataGridRowCell--controlColumn"
               data-gridcell-column-id="trailing"
               data-gridcell-column-index="3"
@@ -1933,7 +1933,7 @@ Array [
               />
             </div>
             <div
-              aria-rowindex="2"
+              aria-rowindex="3"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn euiDataGridRowCell--controlColumn"
               data-gridcell-column-id="leading"
               data-gridcell-column-index="0"
@@ -1984,7 +1984,7 @@ Array [
               />
             </div>
             <div
-              aria-rowindex="2"
+              aria-rowindex="3"
               class="euiDataGridRowCell"
               data-gridcell-column-id="A"
               data-gridcell-column-index="1"
@@ -2016,7 +2016,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="2"
+              aria-rowindex="3"
               class="euiDataGridRowCell"
               data-gridcell-column-id="B"
               data-gridcell-column-index="2"
@@ -2048,7 +2048,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="2"
+              aria-rowindex="3"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn euiDataGridRowCell--controlColumn"
               data-gridcell-column-id="trailing"
               data-gridcell-column-index="3"
@@ -2333,7 +2333,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="0"
+              aria-rowindex="1"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
@@ -2365,7 +2365,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="0"
+              aria-rowindex="1"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
@@ -2397,7 +2397,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="1"
+              aria-rowindex="2"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
@@ -2429,7 +2429,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="1"
+              aria-rowindex="2"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
@@ -2461,7 +2461,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="2"
+              aria-rowindex="3"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
@@ -2493,7 +2493,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="2"
+              aria-rowindex="3"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
@@ -2757,7 +2757,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="0"
+              aria-rowindex="1"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
@@ -2789,7 +2789,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="0"
+              aria-rowindex="1"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
@@ -2821,7 +2821,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="1"
+              aria-rowindex="2"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
@@ -2853,7 +2853,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="1"
+              aria-rowindex="2"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
@@ -2885,7 +2885,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="2"
+              aria-rowindex="3"
               class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
@@ -2917,7 +2917,7 @@ Array [
               </div>
             </div>
             <div
-              aria-rowindex="2"
+              aria-rowindex="3"
               class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -1162,7 +1162,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 1, Column 1 (A)
+                    - A, column 1, row 1
                   </p>
                 </div>
               </div>
@@ -1194,7 +1194,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 1, Column 2 (B)
+                    - B, column 2, row 1
                   </p>
                 </div>
               </div>
@@ -1226,7 +1226,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 2, Column 1 (A)
+                    - A, column 1, row 2
                   </p>
                 </div>
               </div>
@@ -1258,7 +1258,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 2, Column 2 (B)
+                    - B, column 2, row 2
                   </p>
                 </div>
               </div>
@@ -1290,7 +1290,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 3, Column 1 (A)
+                    - A, column 1, row 3
                   </p>
                 </div>
               </div>
@@ -1322,7 +1322,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 3, Column 2 (B)
+                    - B, column 2, row 3
                   </p>
                 </div>
               </div>
@@ -1640,7 +1640,7 @@ Array [
                     <p
                       class="emotion-euiScreenReaderOnly"
                     >
-                      - Row 1, Column 1 (leading)
+                      - leading, column 1, row 1
                     </p>
                   </div>
                 </div>
@@ -1678,7 +1678,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 1, Column 2 (A)
+                    - A, column 2, row 1
                   </p>
                 </div>
               </div>
@@ -1710,7 +1710,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 1, Column 3 (B)
+                    - B, column 3, row 1
                   </p>
                 </div>
               </div>
@@ -1755,7 +1755,7 @@ Array [
                     <p
                       class="emotion-euiScreenReaderOnly"
                     >
-                      - Row 1, Column 4 (trailing)
+                      - trailing, column 4, row 1
                     </p>
                   </div>
                 </div>
@@ -1806,7 +1806,7 @@ Array [
                     <p
                       class="emotion-euiScreenReaderOnly"
                     >
-                      - Row 2, Column 1 (leading)
+                      - leading, column 1, row 2
                     </p>
                   </div>
                 </div>
@@ -1844,7 +1844,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 2, Column 2 (A)
+                    - A, column 2, row 2
                   </p>
                 </div>
               </div>
@@ -1876,7 +1876,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 2, Column 3 (B)
+                    - B, column 3, row 2
                   </p>
                 </div>
               </div>
@@ -1921,7 +1921,7 @@ Array [
                     <p
                       class="emotion-euiScreenReaderOnly"
                     >
-                      - Row 2, Column 4 (trailing)
+                      - trailing, column 4, row 2
                     </p>
                   </div>
                 </div>
@@ -1972,7 +1972,7 @@ Array [
                     <p
                       class="emotion-euiScreenReaderOnly"
                     >
-                      - Row 3, Column 1 (leading)
+                      - leading, column 1, row 3
                     </p>
                   </div>
                 </div>
@@ -2010,7 +2010,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 3, Column 2 (A)
+                    - A, column 2, row 3
                   </p>
                 </div>
               </div>
@@ -2042,7 +2042,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 3, Column 3 (B)
+                    - B, column 3, row 3
                   </p>
                 </div>
               </div>
@@ -2087,7 +2087,7 @@ Array [
                     <p
                       class="emotion-euiScreenReaderOnly"
                     >
-                      - Row 3, Column 4 (trailing)
+                      - trailing, column 4, row 3
                     </p>
                   </div>
                 </div>
@@ -2359,7 +2359,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 1, Column 1 (A)
+                    - A, column 1, row 1
                   </p>
                 </div>
               </div>
@@ -2391,7 +2391,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 1, Column 2 (B)
+                    - B, column 2, row 1
                   </p>
                 </div>
               </div>
@@ -2423,7 +2423,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 2, Column 1 (A)
+                    - A, column 1, row 2
                   </p>
                 </div>
               </div>
@@ -2455,7 +2455,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 2, Column 2 (B)
+                    - B, column 2, row 2
                   </p>
                 </div>
               </div>
@@ -2487,7 +2487,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 3, Column 1 (A)
+                    - A, column 1, row 3
                   </p>
                 </div>
               </div>
@@ -2519,7 +2519,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 3, Column 2 (B)
+                    - B, column 2, row 3
                   </p>
                 </div>
               </div>
@@ -2783,7 +2783,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 1, Column 1 (A)
+                    - A, column 1, row 1
                   </p>
                 </div>
               </div>
@@ -2815,7 +2815,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 1, Column 2 (B)
+                    - B, column 2, row 1
                   </p>
                 </div>
               </div>
@@ -2847,7 +2847,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 2, Column 1 (A)
+                    - A, column 1, row 2
                   </p>
                 </div>
               </div>
@@ -2879,7 +2879,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 2, Column 2 (B)
+                    - B, column 2, row 2
                   </p>
                 </div>
               </div>
@@ -2911,7 +2911,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 3, Column 1 (A)
+                    - A, column 1, row 3
                   </p>
                 </div>
               </div>
@@ -2943,7 +2943,7 @@ Array [
                   <p
                     class="emotion-euiScreenReaderOnly"
                   >
-                    - Row 3, Column 2 (B)
+                    - B, column 2, row 3
                   </p>
                 </div>
               </div>

--- a/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`EuiDataGridBody renders 1`] = `
           <p
             class="emotion-euiScreenReaderOnly"
           >
-            Row: 1; Column: 1
+            - Row 1, Column 1 (columnA)
           </p>
         </div>
       </div>
@@ -163,7 +163,7 @@ exports[`EuiDataGridBody renders 1`] = `
           <p
             class="emotion-euiScreenReaderOnly"
           >
-            Row: 1; Column: 2
+            - Row 1, Column 2 (columnB)
           </p>
         </div>
       </div>

--- a/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`EuiDataGridBody renders 1`] = `
       </div>
     </div>
     <div
-      aria-rowindex="0"
+      aria-rowindex="1"
       class="euiDataGridRowCell euiDataGridRowCell--boolean euiDataGridRowCell--firstColumn"
       data-gridcell-column-id="columnA"
       data-gridcell-column-index="0"
@@ -135,7 +135,7 @@ exports[`EuiDataGridBody renders 1`] = `
       </div>
     </div>
     <div
-      aria-rowindex="0"
+      aria-rowindex="1"
       class="euiDataGridRowCell euiDataGridRowCell--string euiDataGridRowCell--lastColumn"
       data-gridcell-column-id="columnB"
       data-gridcell-column-index="1"

--- a/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
@@ -101,6 +101,7 @@ exports[`EuiDataGridBody renders 1`] = `
       </div>
     </div>
     <div
+      aria-rowindex="0"
       class="euiDataGridRowCell euiDataGridRowCell--boolean euiDataGridRowCell--firstColumn"
       data-gridcell-column-id="columnA"
       data-gridcell-column-index="0"
@@ -134,6 +135,7 @@ exports[`EuiDataGridBody renders 1`] = `
       </div>
     </div>
     <div
+      aria-rowindex="0"
       class="euiDataGridRowCell euiDataGridRowCell--string euiDataGridRowCell--lastColumn"
       data-gridcell-column-id="columnB"
       data-gridcell-column-index="1"

--- a/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`EuiDataGridBody renders 1`] = `
           <p
             class="emotion-euiScreenReaderOnly"
           >
-            - Row 1, Column 1 (columnA)
+            - columnA, column 1, row 1
           </p>
         </div>
       </div>
@@ -163,7 +163,7 @@ exports[`EuiDataGridBody renders 1`] = `
           <p
             class="emotion-euiScreenReaderOnly"
           >
-            - Row 1, Column 2 (columnB)
+            - columnB, column 2, row 1
           </p>
         </div>
       </div>

--- a/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
@@ -38,6 +38,7 @@ Array [
 
 exports[`EuiDataGridCell renders 1`] = `
 <div
+  aria-rowindex="0"
   class="euiDataGridRowCell"
   data-gridcell-column-id="someColumn"
   data-gridcell-column-index="0"

--- a/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`EuiDataGridCell renders 1`] = `
       <p
         class="emotion-euiScreenReaderOnly"
       >
-        - Row 1, Column 1 (someColumn)
+        - someColumn, column 1, row 1
       </p>
     </div>
   </div>

--- a/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
@@ -38,7 +38,7 @@ Array [
 
 exports[`EuiDataGridCell renders 1`] = `
 <div
-  aria-rowindex="0"
+  aria-rowindex="1"
   class="euiDataGridRowCell"
   data-gridcell-column-id="someColumn"
   data-gridcell-column-index="0"

--- a/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`EuiDataGridCell renders 1`] = `
       <p
         class="emotion-euiScreenReaderOnly"
       >
-        Row: 1; Column: 1
+        - Row 1, Column 1 (someColumn)
       </p>
     </div>
   </div>

--- a/src/components/datagrid/body/data_grid_body.tsx
+++ b/src/components/datagrid/body/data_grid_body.tsx
@@ -68,6 +68,7 @@ export const Cell: FunctionComponent<GridChildComponentProps> = ({
     rowHeightsOptions,
     rowHeightUtils,
     rowManager,
+    pagination,
   } = data;
   const popoverContext = useContext(DataGridCellPopoverContext);
   const { headerRowHeight } = useContext(DataGridWrapperRowsContext);
@@ -118,6 +119,7 @@ export const Cell: FunctionComponent<GridChildComponentProps> = ({
     setRowHeight: isFirstColumn ? setRowHeight : undefined,
     rowManager,
     popoverContext,
+    pagination,
   };
 
   if (isLeadingControlColumn) {
@@ -487,6 +489,7 @@ export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
           rowHeightsOptions,
           rowHeightUtils,
           rowManager,
+          pagination,
         }}
         rowCount={
           IS_JEST_ENVIRONMENT || headerRowHeight > 0 ? visibleRowCount : 0

--- a/src/components/datagrid/body/data_grid_cell.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell.test.tsx
@@ -48,6 +48,23 @@ describe('EuiDataGridCell', () => {
     expect(component).toMatchSnapshot();
   });
 
+  it("renders the cell's `aria-rowindex` correctly when paginated on a different page", () => {
+    const component = mount(
+      <EuiDataGridCell
+        {...requiredProps}
+        pagination={{
+          pageIndex: 3,
+          pageSize: 20,
+          onChangePage: () => {},
+          onChangeItemsPerPage: () => {},
+        }}
+      />
+    );
+    expect(
+      component.find('[data-test-subj="dataGridRowCell"]').prop('aria-rowindex')
+    ).toEqual(61);
+  });
+
   it('renders cell actions', () => {
     const component = mount(
       <EuiDataGridCell

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -686,6 +686,7 @@ export class EuiDataGridCell extends Component<
     const content = (
       <div
         role="gridcell"
+        aria-rowindex={this.props.rowIndex}
         tabIndex={
           this.state.isFocused && !this.state.disableCellTabIndex ? 0 : -1
         }

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -22,7 +22,7 @@ import { tabbable } from 'tabbable';
 import { keys } from '../../../services';
 import { EuiScreenReaderOnly } from '../../accessibility';
 import { EuiFocusTrap } from '../../focus_trap';
-import { useEuiI18n } from '../../i18n';
+import { EuiI18n } from '../../i18n';
 import { hasResizeObserver } from '../../observer/resize_observer/resize_observer';
 import { DataGridFocusContext } from '../utils/focus';
 import {
@@ -46,6 +46,7 @@ const EuiDataGridCellContent: FunctionComponent<
     setCellContentsRef: EuiDataGridCell['setCellContentsRef'];
     isExpanded: boolean;
     isDefinedHeight: boolean;
+    ariaRowIndex: number;
   }
 > = memo(
   ({
@@ -55,6 +56,7 @@ const EuiDataGridCellContent: FunctionComponent<
     rowHeightsOptions,
     rowIndex,
     colIndex,
+    ariaRowIndex,
     rowHeightUtils,
     isDefinedHeight,
     ...rest
@@ -63,12 +65,6 @@ const EuiDataGridCellContent: FunctionComponent<
     const CellElement = renderCellValue as JSXElementConstructor<
       EuiDataGridCellValueElementProps
     >;
-
-    const positionText = useEuiI18n(
-      'euiDataGridCell.position',
-      'Row: {row}; Column: {col}',
-      { row: rowIndex + 1, col: colIndex + 1 }
-    );
 
     return (
       <>
@@ -96,7 +92,18 @@ const EuiDataGridCellContent: FunctionComponent<
           />
         </div>
         <EuiScreenReaderOnly>
-          <p>{positionText}</p>
+          <p>
+            {'- '}
+            <EuiI18n
+              token="euiDataGridCell.position"
+              default="Row {row}, Column {col} ({columnId})"
+              values={{
+                row: ariaRowIndex,
+                col: colIndex + 1,
+                columnId: column?.displayAsText || rest.columnId,
+              }}
+            />
+          </p>
         </EuiScreenReaderOnly>
       </>
     );
@@ -640,6 +647,7 @@ export class EuiDataGridCell extends Component<
       rowHeightsOptions,
       rowHeightUtils,
       isDefinedHeight,
+      ariaRowIndex,
     };
 
     const anchorClass = 'euiDataGridRowCell__expandFlex';

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -518,6 +518,7 @@ export class EuiDataGridCell extends Component<
       rowHeightUtils,
       rowHeightsOptions,
       rowManager,
+      pagination,
       ...rest
     } = this.props;
     const { rowIndex, visibleRowIndex, colIndex } = rest;
@@ -538,6 +539,10 @@ export class EuiDataGridCell extends Component<
       },
       className
     );
+
+    const ariaRowIndex = pagination
+      ? visibleRowIndex + 1 + pagination.pageSize * pagination.pageIndex
+      : visibleRowIndex + 1;
 
     const {
       isExpandable: _, // Not a valid DOM property, so needs to be destructured out
@@ -686,7 +691,7 @@ export class EuiDataGridCell extends Component<
     const content = (
       <div
         role="gridcell"
-        aria-rowindex={this.props.rowIndex}
+        aria-rowindex={ariaRowIndex}
         tabIndex={
           this.state.isFocused && !this.state.disableCellTabIndex ? 0 : -1
         }

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -96,11 +96,11 @@ const EuiDataGridCellContent: FunctionComponent<
             {'- '}
             <EuiI18n
               token="euiDataGridCell.position"
-              default="Row {row}, Column {col} ({columnId})"
+              default="{columnId}, column {col}, row {row}"
               values={{
-                row: ariaRowIndex,
-                col: colIndex + 1,
                 columnId: column?.displayAsText || rest.columnId,
+                col: colIndex + 1,
+                row: ariaRowIndex,
               }}
             />
           </p>

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -542,6 +542,7 @@ describe('EuiDataGrid', () => {
       ).toMatchInlineSnapshot(`
         Array [
           Object {
+            "aria-rowindex": 0,
             "className": "euiDataGridRowCell euiDataGridRowCell--firstColumn customClass",
             "data-gridcell-column-id": "A",
             "data-gridcell-column-index": 0,
@@ -567,6 +568,7 @@ describe('EuiDataGrid', () => {
             "tabIndex": -1,
           },
           Object {
+            "aria-rowindex": 0,
             "className": "euiDataGridRowCell euiDataGridRowCell--lastColumn customClass",
             "data-gridcell-column-id": "B",
             "data-gridcell-column-index": 1,
@@ -592,6 +594,7 @@ describe('EuiDataGrid', () => {
             "tabIndex": -1,
           },
           Object {
+            "aria-rowindex": 1,
             "className": "euiDataGridRowCell euiDataGridRowCell--firstColumn customClass",
             "data-gridcell-column-id": "A",
             "data-gridcell-column-index": 0,
@@ -617,6 +620,7 @@ describe('EuiDataGrid', () => {
             "tabIndex": -1,
           },
           Object {
+            "aria-rowindex": 1,
             "className": "euiDataGridRowCell euiDataGridRowCell--lastColumn customClass",
             "data-gridcell-column-id": "B",
             "data-gridcell-column-index": 1,

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -542,7 +542,7 @@ describe('EuiDataGrid', () => {
       ).toMatchInlineSnapshot(`
         Array [
           Object {
-            "aria-rowindex": 0,
+            "aria-rowindex": 1,
             "className": "euiDataGridRowCell euiDataGridRowCell--firstColumn customClass",
             "data-gridcell-column-id": "A",
             "data-gridcell-column-index": 0,
@@ -568,7 +568,7 @@ describe('EuiDataGrid', () => {
             "tabIndex": -1,
           },
           Object {
-            "aria-rowindex": 0,
+            "aria-rowindex": 1,
             "className": "euiDataGridRowCell euiDataGridRowCell--lastColumn customClass",
             "data-gridcell-column-id": "B",
             "data-gridcell-column-index": 1,
@@ -594,7 +594,7 @@ describe('EuiDataGrid', () => {
             "tabIndex": -1,
           },
           Object {
-            "aria-rowindex": 1,
+            "aria-rowindex": 2,
             "className": "euiDataGridRowCell euiDataGridRowCell--firstColumn customClass",
             "data-gridcell-column-id": "A",
             "data-gridcell-column-index": 0,
@@ -620,7 +620,7 @@ describe('EuiDataGrid', () => {
             "tabIndex": -1,
           },
           Object {
-            "aria-rowindex": 1,
+            "aria-rowindex": 2,
             "className": "euiDataGridRowCell euiDataGridRowCell--lastColumn customClass",
             "data-gridcell-column-id": "B",
             "data-gridcell-column-index": 1,

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -420,6 +420,7 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
                   data-test-subj="euiDataGridBody"
                   className="euiDataGrid__content"
                   role="grid"
+                  aria-rowcount={rowCount}
                   id={gridId}
                   {...wrappingDivFocusProps} // re: above jsx-a11y - tabIndex is handled by these props, but the linter isn't smart enough to know that
                   {...gridAriaProps}

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -513,6 +513,7 @@ export interface EuiDataGridCellProps {
   rowHeightsOptions?: EuiDataGridRowHeightsOptions;
   rowHeightUtils?: RowHeightUtils;
   rowManager?: EuiDataGridRowManager;
+  pagination?: EuiDataGridPaginationProps;
 }
 
 export interface EuiDataGridCellState {

--- a/upcoming_changelogs/6033.md
+++ b/upcoming_changelogs/6033.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed `EuiDataGrid`'s row count/indices announced to screen readers when virtualized
+- Fixed `EuiDataGrid`'s current cell row/column position announced to screen readers when sorted and paginated, and also improved column identification and announcement cadence


### PR DESCRIPTION
### Summary

Please see inline code comments below that highlight changes & include screen reader before/after screencaps.

### Checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
