### PR TITLE
[EuiDataGrid] Fix/improve screen reader accessibility for column headers

### DIFF
--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -1070,6 +1070,7 @@ Array [
                     class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
+                      aria-describedby="euiDataGridCellHeaderActions-A"
                       class="euiDataGridHeaderCell__button"
                     >
                       <div
@@ -1083,12 +1084,16 @@ Array [
                         color="text"
                         data-euiicon-type="arrowDown"
                         data-test-subj="dataGridHeaderCellActionButton-A"
-                      >
-                        Header actions
-                      </span>
+                      />
                     </button>
                   </div>
                 </div>
+                <p
+                  hidden=""
+                  id="euiDataGridCellHeader_generated-id_actions"
+                >
+                  Click to view column header actions
+                </p>
               </div>
               <div
                 class="euiDataGridHeaderCell"
@@ -1113,6 +1118,7 @@ Array [
                     class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
+                      aria-describedby="euiDataGridCellHeaderActions-B"
                       class="euiDataGridHeaderCell__button"
                     >
                       <div
@@ -1126,12 +1132,16 @@ Array [
                         color="text"
                         data-euiicon-type="arrowDown"
                         data-test-subj="dataGridHeaderCellActionButton-B"
-                      >
-                        Header actions
-                      </span>
+                      />
                     </button>
                   </div>
                 </div>
+                <p
+                  hidden=""
+                  id="euiDataGridCellHeader_generated-id_actions"
+                >
+                  Click to view column header actions
+                </p>
               </div>
             </div>
             <div
@@ -1509,6 +1519,7 @@ Array [
                     class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
+                      aria-describedby="euiDataGridCellHeaderActions-A"
                       class="euiDataGridHeaderCell__button"
                     >
                       <div
@@ -1522,12 +1533,16 @@ Array [
                         color="text"
                         data-euiicon-type="arrowDown"
                         data-test-subj="dataGridHeaderCellActionButton-A"
-                      >
-                        Header actions
-                      </span>
+                      />
                     </button>
                   </div>
                 </div>
+                <p
+                  hidden=""
+                  id="euiDataGridCellHeader_generated-id_actions"
+                >
+                  Click to view column header actions
+                </p>
               </div>
               <div
                 class="euiDataGridHeaderCell"
@@ -1552,6 +1567,7 @@ Array [
                     class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
+                      aria-describedby="euiDataGridCellHeaderActions-B"
                       class="euiDataGridHeaderCell__button"
                     >
                       <div
@@ -1565,12 +1581,16 @@ Array [
                         color="text"
                         data-euiicon-type="arrowDown"
                         data-test-subj="dataGridHeaderCellActionButton-B"
-                      >
-                        Header actions
-                      </span>
+                      />
                     </button>
                   </div>
                 </div>
+                <p
+                  hidden=""
+                  id="euiDataGridCellHeader_generated-id_actions"
+                >
+                  Click to view column header actions
+                </p>
               </div>
               <div
                 class="euiDataGridHeaderCell euiDataGridHeaderCell--controlColumn"
@@ -2245,6 +2265,7 @@ Array [
                     class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
+                      aria-describedby="euiDataGridCellHeaderActions-A"
                       class="euiDataGridHeaderCell__button"
                     >
                       <div
@@ -2258,12 +2279,16 @@ Array [
                         color="text"
                         data-euiicon-type="arrowDown"
                         data-test-subj="dataGridHeaderCellActionButton-A"
-                      >
-                        Header actions
-                      </span>
+                      />
                     </button>
                   </div>
                 </div>
+                <p
+                  hidden=""
+                  id="euiDataGridCellHeader_generated-id_actions"
+                >
+                  Click to view column header actions
+                </p>
               </div>
               <div
                 class="euiDataGridHeaderCell"
@@ -2288,6 +2313,7 @@ Array [
                     class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
+                      aria-describedby="euiDataGridCellHeaderActions-B"
                       class="euiDataGridHeaderCell__button"
                     >
                       <div
@@ -2303,12 +2329,16 @@ Array [
                         color="text"
                         data-euiicon-type="arrowDown"
                         data-test-subj="dataGridHeaderCellActionButton-B"
-                      >
-                        Header actions
-                      </span>
+                      />
                     </button>
                   </div>
                 </div>
+                <p
+                  hidden=""
+                  id="euiDataGridCellHeader_generated-id_actions"
+                >
+                  Click to view column header actions
+                </p>
               </div>
             </div>
             <div
@@ -2664,6 +2694,7 @@ Array [
                     class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
+                      aria-describedby="euiDataGridCellHeaderActions-A"
                       class="euiDataGridHeaderCell__button"
                     >
                       <div
@@ -2677,12 +2708,16 @@ Array [
                         color="text"
                         data-euiicon-type="arrowDown"
                         data-test-subj="dataGridHeaderCellActionButton-A"
-                      >
-                        Header actions
-                      </span>
+                      />
                     </button>
                   </div>
                 </div>
+                <p
+                  hidden=""
+                  id="euiDataGridCellHeader_generated-id_actions"
+                >
+                  Click to view column header actions
+                </p>
               </div>
               <div
                 class="euiDataGridHeaderCell"
@@ -2707,6 +2742,7 @@ Array [
                     class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
+                      aria-describedby="euiDataGridCellHeaderActions-B"
                       class="euiDataGridHeaderCell__button"
                     >
                       <div
@@ -2720,12 +2756,16 @@ Array [
                         color="text"
                         data-euiicon-type="arrowDown"
                         data-test-subj="dataGridHeaderCellActionButton-B"
-                      >
-                        Header actions
-                      </span>
+                      />
                     </button>
                   </div>
                 </div>
+                <p
+                  hidden=""
+                  id="euiDataGridCellHeader_generated-id_actions"
+                >
+                  Click to view column header actions
+                </p>
               </div>
             </div>
             <div

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -1070,7 +1070,7 @@ Array [
                     class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
-                      aria-describedby="euiDataGridCellHeaderActions-A"
+                      aria-describedby="euiDataGridCellHeader_generated-id_sorting euiDataGridCellHeader_generated-id_actions"
                       class="euiDataGridHeaderCell__button"
                     >
                       <div
@@ -1088,6 +1088,10 @@ Array [
                     </button>
                   </div>
                 </div>
+                <p
+                  hidden=""
+                  id="euiDataGridCellHeader_generated-id_sorting"
+                />
                 <p
                   hidden=""
                   id="euiDataGridCellHeader_generated-id_actions"
@@ -1118,7 +1122,7 @@ Array [
                     class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
-                      aria-describedby="euiDataGridCellHeaderActions-B"
+                      aria-describedby="euiDataGridCellHeader_generated-id_sorting euiDataGridCellHeader_generated-id_actions"
                       class="euiDataGridHeaderCell__button"
                     >
                       <div
@@ -1136,6 +1140,10 @@ Array [
                     </button>
                   </div>
                 </div>
+                <p
+                  hidden=""
+                  id="euiDataGridCellHeader_generated-id_sorting"
+                />
                 <p
                   hidden=""
                   id="euiDataGridCellHeader_generated-id_actions"
@@ -1519,7 +1527,7 @@ Array [
                     class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
-                      aria-describedby="euiDataGridCellHeaderActions-A"
+                      aria-describedby="euiDataGridCellHeader_generated-id_sorting euiDataGridCellHeader_generated-id_actions"
                       class="euiDataGridHeaderCell__button"
                     >
                       <div
@@ -1537,6 +1545,10 @@ Array [
                     </button>
                   </div>
                 </div>
+                <p
+                  hidden=""
+                  id="euiDataGridCellHeader_generated-id_sorting"
+                />
                 <p
                   hidden=""
                   id="euiDataGridCellHeader_generated-id_actions"
@@ -1567,7 +1579,7 @@ Array [
                     class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
-                      aria-describedby="euiDataGridCellHeaderActions-B"
+                      aria-describedby="euiDataGridCellHeader_generated-id_sorting euiDataGridCellHeader_generated-id_actions"
                       class="euiDataGridHeaderCell__button"
                     >
                       <div
@@ -1585,6 +1597,10 @@ Array [
                     </button>
                   </div>
                 </div>
+                <p
+                  hidden=""
+                  id="euiDataGridCellHeader_generated-id_sorting"
+                />
                 <p
                   hidden=""
                   id="euiDataGridCellHeader_generated-id_actions"
@@ -2265,7 +2281,7 @@ Array [
                     class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
-                      aria-describedby="euiDataGridCellHeaderActions-A"
+                      aria-describedby="euiDataGridCellHeader_generated-id_sorting euiDataGridCellHeader_generated-id_actions"
                       class="euiDataGridHeaderCell__button"
                     >
                       <div
@@ -2283,6 +2299,10 @@ Array [
                     </button>
                   </div>
                 </div>
+                <p
+                  hidden=""
+                  id="euiDataGridCellHeader_generated-id_sorting"
+                />
                 <p
                   hidden=""
                   id="euiDataGridCellHeader_generated-id_actions"
@@ -2313,7 +2333,7 @@ Array [
                     class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
-                      aria-describedby="euiDataGridCellHeaderActions-B"
+                      aria-describedby="euiDataGridCellHeader_generated-id_sorting euiDataGridCellHeader_generated-id_actions"
                       class="euiDataGridHeaderCell__button"
                     >
                       <div
@@ -2333,6 +2353,10 @@ Array [
                     </button>
                   </div>
                 </div>
+                <p
+                  hidden=""
+                  id="euiDataGridCellHeader_generated-id_sorting"
+                />
                 <p
                   hidden=""
                   id="euiDataGridCellHeader_generated-id_actions"
@@ -2694,7 +2718,7 @@ Array [
                     class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
-                      aria-describedby="euiDataGridCellHeaderActions-A"
+                      aria-describedby="euiDataGridCellHeader_generated-id_sorting euiDataGridCellHeader_generated-id_actions"
                       class="euiDataGridHeaderCell__button"
                     >
                       <div
@@ -2712,6 +2736,10 @@ Array [
                     </button>
                   </div>
                 </div>
+                <p
+                  hidden=""
+                  id="euiDataGridCellHeader_generated-id_sorting"
+                />
                 <p
                   hidden=""
                   id="euiDataGridCellHeader_generated-id_actions"
@@ -2742,7 +2770,7 @@ Array [
                     class="euiPopover__anchor eui-fullWidth"
                   >
                     <button
-                      aria-describedby="euiDataGridCellHeaderActions-B"
+                      aria-describedby="euiDataGridCellHeader_generated-id_sorting euiDataGridCellHeader_generated-id_actions"
                       class="euiDataGridHeaderCell__button"
                     >
                       <div
@@ -2760,6 +2788,10 @@ Array [
                     </button>
                   </div>
                 </div>
+                <p
+                  hidden=""
+                  id="euiDataGridCellHeader_generated-id_sorting"
+                />
                 <p
                   hidden=""
                   id="euiDataGridCellHeader_generated-id_actions"

--- a/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`EuiDataGridBody renders 1`] = `
             class="euiPopover__anchor eui-fullWidth"
           >
             <button
-              aria-describedby="euiDataGridCellHeaderActions-columnA"
+              aria-describedby="euiDataGridCellHeader_generated-id_sorting euiDataGridCellHeader_generated-id_actions"
               class="euiDataGridHeaderCell__button"
             >
               <div
@@ -54,6 +54,10 @@ exports[`EuiDataGridBody renders 1`] = `
             </button>
           </div>
         </div>
+        <p
+          hidden=""
+          id="euiDataGridCellHeader_generated-id_sorting"
+        />
         <p
           hidden=""
           id="euiDataGridCellHeader_generated-id_actions"
@@ -84,7 +88,7 @@ exports[`EuiDataGridBody renders 1`] = `
             class="euiPopover__anchor eui-fullWidth"
           >
             <button
-              aria-describedby="euiDataGridCellHeaderActions-columnB"
+              aria-describedby="euiDataGridCellHeader_generated-id_sorting euiDataGridCellHeader_generated-id_actions"
               class="euiDataGridHeaderCell__button"
             >
               <div
@@ -102,6 +106,10 @@ exports[`EuiDataGridBody renders 1`] = `
             </button>
           </div>
         </div>
+        <p
+          hidden=""
+          id="euiDataGridCellHeader_generated-id_sorting"
+        />
         <p
           hidden=""
           id="euiDataGridCellHeader_generated-id_actions"

--- a/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body.test.tsx.snap
@@ -36,6 +36,7 @@ exports[`EuiDataGridBody renders 1`] = `
             class="euiPopover__anchor eui-fullWidth"
           >
             <button
+              aria-describedby="euiDataGridCellHeaderActions-columnA"
               class="euiDataGridHeaderCell__button"
             >
               <div
@@ -49,12 +50,16 @@ exports[`EuiDataGridBody renders 1`] = `
                 color="text"
                 data-euiicon-type="arrowDown"
                 data-test-subj="dataGridHeaderCellActionButton-columnA"
-              >
-                Header actions
-              </span>
+              />
             </button>
           </div>
         </div>
+        <p
+          hidden=""
+          id="euiDataGridCellHeader_generated-id_actions"
+        >
+          Click to view column header actions
+        </p>
       </div>
       <div
         class="euiDataGridHeaderCell euiDataGridHeaderCell--string"
@@ -79,6 +84,7 @@ exports[`EuiDataGridBody renders 1`] = `
             class="euiPopover__anchor eui-fullWidth"
           >
             <button
+              aria-describedby="euiDataGridCellHeaderActions-columnB"
               class="euiDataGridHeaderCell__button"
             >
               <div
@@ -92,12 +98,16 @@ exports[`EuiDataGridBody renders 1`] = `
                 color="text"
                 data-euiicon-type="arrowDown"
                 data-test-subj="dataGridHeaderCellActionButton-columnB"
-              >
-                Header actions
-              </span>
+              />
             </button>
           </div>
         </div>
+        <p
+          hidden=""
+          id="euiDataGridCellHeader_generated-id_actions"
+        >
+          Click to view column header actions
+        </p>
       </div>
     </div>
     <div

--- a/src/components/datagrid/body/header/__snapshots__/data_grid_header_cell.test.tsx.snap
+++ b/src/components/datagrid/body/header/__snapshots__/data_grid_header_cell.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`EuiDataGridHeaderCell renders 1`] = `
     anchorPosition="downCenter"
     button={
       <button
-        aria-describedby="euiDataGridCellHeaderActions-someColumn"
+        aria-describedby="euiDataGridCellHeader_generated-id_sorting euiDataGridCellHeader_generated-id_actions"
         className="euiDataGridHeaderCell__button"
         onClick={[Function]}
       >
@@ -99,6 +99,10 @@ exports[`EuiDataGridHeaderCell renders 1`] = `
       }
     />
   </EuiPopover>
+  <p
+    hidden={true}
+    id="euiDataGridCellHeader_generated-id_sorting"
+  />
   <p
     hidden={true}
     id="euiDataGridCellHeader_generated-id_actions"

--- a/src/components/datagrid/body/header/__snapshots__/data_grid_header_cell.test.tsx.snap
+++ b/src/components/datagrid/body/header/__snapshots__/data_grid_header_cell.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`EuiDataGridHeaderCell renders 1`] = `
     anchorPosition="downCenter"
     button={
       <button
+        aria-describedby="euiDataGridCellHeaderActions-someColumn"
         className="euiDataGridHeaderCell__button"
         onClick={[Function]}
       >
@@ -28,7 +29,6 @@ exports[`EuiDataGridHeaderCell renders 1`] = `
           someColumn
         </div>
         <EuiIcon
-          aria-label="Header actions"
           className="euiDataGridHeaderCell__icon"
           color="text"
           data-test-subj="dataGridHeaderCellActionButton-someColumn"
@@ -99,5 +99,14 @@ exports[`EuiDataGridHeaderCell renders 1`] = `
       }
     />
   </EuiPopover>
+  <p
+    hidden={true}
+    id="euiDataGridCellHeader_generated-id_actions"
+  >
+    <EuiI18n
+      default="Click to view column header actions"
+      token="euiDataGridHeaderCell.headerActions"
+    />
+  </p>
 </EuiDataGridHeaderCellWrapper>
 `;

--- a/src/components/datagrid/body/header/data_grid_header_cell.test.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount, shallow, render } from 'enzyme';
 import { testCustomHook } from '../../../../test/internal';
 
 import { DataGridFocusContext } from '../../utils/focus';
@@ -83,7 +83,7 @@ describe('EuiDataGridHeaderCell', () => {
     describe('when multiple columns are being sorted', () => {
       it('renders sorting screen reader text text with a full list of sorted columns', () => {
         const {
-          return: { sortString },
+          return: { sortingScreenReaderText },
         } = testCustomHook(useSortingUtils, {
           sorting: {
             columns: [
@@ -94,8 +94,10 @@ describe('EuiDataGridHeaderCell', () => {
           id: 'A',
         });
 
-        expect(sortString).toMatchInlineSnapshot(
-          '"Sorted by A asc then Sorted by B desc"'
+        expect(
+          render(<p>{sortingScreenReaderText}</p>).text()
+        ).toMatchInlineSnapshot(
+          '"Sorted by A, ascending, then sorted by B, descending."'
         );
       });
     });

--- a/src/components/datagrid/body/header/data_grid_header_cell.test.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.test.tsx
@@ -10,13 +10,12 @@ import React from 'react';
 import { mount, shallow } from 'enzyme';
 import { testCustomHook } from '../../../../test/internal';
 
-import { EuiDataGridSorting } from '../../data_grid_types';
-import { DataGridSortingContext } from '../../utils/sorting';
 import { DataGridFocusContext } from '../../utils/focus';
 import { mockFocusContext } from '../../utils/__mocks__/focus_context';
 
 import {
   EuiDataGridHeaderCell,
+  useSortingUtils,
   usePopoverArrowNavigation,
 } from './data_grid_header_cell';
 
@@ -43,70 +42,61 @@ describe('EuiDataGridHeaderCell', () => {
   });
 
   describe('sorting', () => {
-    const sortingContext = {
-      onSort: jest.fn(),
-      columns: [],
-    } as EuiDataGridSorting;
-
-    const mountWithContext = (props = {}, sorting = {}) => {
-      return mount(
-        <DataGridSortingContext.Provider
-          value={{
-            sorting: { ...sortingContext, ...sorting },
-            sortedRowMap: [],
-            getCorrectRowIndex: jest.fn(),
-          }}
-        >
-          <EuiDataGridHeaderCell {...requiredProps} {...props} />
-        </DataGridSortingContext.Provider>
-      );
-    };
-
     describe('if the current column is being sorted', () => {
-      it('renders a ascending sort arrow', () => {
-        const component = mountWithContext(
-          { column: { id: 'test' } },
-          { columns: [{ id: 'test', direction: 'asc' }] }
+      it('renders an ascending sort arrow', () => {
+        const {
+          return: { sortingArrow },
+        } = testCustomHook(useSortingUtils, {
+          sorting: { columns: [{ id: 'test', direction: 'asc' }] },
+          id: 'test',
+        });
+        expect(shallow(sortingArrow).prop('data-euiicon-type')).toEqual(
+          'sortUp'
         );
-        const arrowIcon = component.find('EuiIcon').first();
-        expect(arrowIcon.prop('type')).toEqual('sortUp');
       });
 
       it('renders a descending sort arrow', () => {
-        const component = mountWithContext(
-          { column: { id: 'test' } },
-          { columns: [{ id: 'test', direction: 'desc' }] }
+        const {
+          return: { sortingArrow },
+        } = testCustomHook(useSortingUtils, {
+          sorting: { columns: [{ id: 'test', direction: 'desc' }] },
+          id: 'test',
+        });
+        expect(shallow(sortingArrow).prop('data-euiicon-type')).toEqual(
+          'sortDown'
         );
-        const arrowIcon = component.find('EuiIcon').first();
-        expect(arrowIcon.prop('type')).toEqual('sortDown');
       });
     });
 
     describe('if the current column is not being sorted', () => {
       it('does not render an arrow even if other columns are sorted', () => {
-        const component = mountWithContext(
-          { column: { id: 'test' } },
-          { columns: [{ id: 'other', direction: 'asc' }] }
-        );
-        expect(
-          component.find('.euiDataGridHeaderCell__sortingArrow')
-        ).toHaveLength(0);
+        const {
+          return: { sortingArrow },
+        } = testCustomHook(useSortingUtils, {
+          sorting: { columns: [{ id: 'other', direction: 'desc' }] },
+          id: 'test',
+        });
+        expect(sortingArrow).toBeNull();
       });
     });
 
     describe('when multiple columns are being sorted', () => {
-      it('renders EuiScreenReaderOnly text with a full list of sorted columns', () => {
-        const component = mountWithContext(
-          { column: { id: 'A' } },
-          {
+      it('renders sorting screen reader text text with a full list of sorted columns', () => {
+        const {
+          return: { sortString },
+        } = testCustomHook(useSortingUtils, {
+          sorting: {
             columns: [
               { id: 'A', direction: 'asc' },
               { id: 'B', direction: 'desc' },
             ],
-          }
-        );
+          },
+          id: 'A',
+        });
 
-        expect(component.find('EuiScreenReaderOnly')).toHaveLength(1);
+        expect(sortString).toMatchInlineSnapshot(
+          '"Sorted by A asc then Sorted by B desc"'
+        );
       });
     });
   });

--- a/src/components/datagrid/body/header/data_grid_header_cell.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.tsx
@@ -20,7 +20,7 @@ import { tabbable, FocusableElement } from 'tabbable';
 import { keys } from '../../../../services';
 import { useGeneratedHtmlId } from '../../../../services/accessibility';
 import { EuiScreenReaderOnly } from '../../../accessibility';
-import { useEuiI18n, EuiI18n } from '../../../i18n';
+import { EuiI18n } from '../../../i18n';
 import { EuiIcon } from '../../../icon';
 import { EuiListGroup } from '../../../list_group';
 import { EuiPopover } from '../../../popover';
@@ -53,15 +53,15 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
     [`euiDataGridHeaderCell--${columnType}`]: columnType,
   });
 
-  const actionButtonAriaLabel = useEuiI18n(
-    'euiDataGridHeaderCell.headerActions',
-    'Header actions'
-  );
   const ariaProps: {
     'aria-sort'?: AriaAttributes['aria-sort'];
     'aria-describedby'?: AriaAttributes['aria-describedby'];
   } = {};
   const screenReaderId = useGeneratedHtmlId();
+  const actionsAriaId = useGeneratedHtmlId({
+    prefix: 'euiDataGridCellHeader',
+    suffix: 'actions',
+  });
 
   const { setFocusedCell, focusFirstVisibleInteractiveCell } = useContext(
     DataGridFocusContext
@@ -153,46 +153,55 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
           </div>
         </>
       ) : (
-        <EuiPopover
-          className="eui-fullWidth"
-          anchorClassName="eui-fullWidth"
-          panelPaddingSize="none"
-          offset={7}
-          button={
-            <button
-              className="euiDataGridHeaderCell__button"
-              onClick={() => {
-                setFocusedCell([index, -1]);
-                setIsPopoverOpen((isPopoverOpen) => !isPopoverOpen);
-              }}
-            >
-              {sortingArrow}
-              <div
-                className="euiDataGridHeaderCell__content"
-                title={displayAsText || id}
+        <>
+          <EuiPopover
+            className="eui-fullWidth"
+            anchorClassName="eui-fullWidth"
+            panelPaddingSize="none"
+            offset={7}
+            button={
+              <button
+                className="euiDataGridHeaderCell__button"
+                onClick={() => {
+                  setFocusedCell([index, -1]);
+                  setIsPopoverOpen((isPopoverOpen) => !isPopoverOpen);
+                }}
+                aria-describedby={`euiDataGridCellHeaderActions-${id}`}
               >
-                {display || displayAsText || id}
-              </div>
-              <EuiIcon
-                className="euiDataGridHeaderCell__icon"
-                type="arrowDown"
-                size="s"
-                color="text"
-                aria-label={actionButtonAriaLabel}
-                data-test-subj={`dataGridHeaderCellActionButton-${id}`}
-              />
-            </button>
-          }
-          isOpen={isPopoverOpen}
-          closePopover={() => setIsPopoverOpen(false)}
-          {...popoverArrowNavigationProps}
-        >
-          <EuiListGroup
-            listItems={columnActions}
-            gutterSize="none"
-            data-test-subj={`dataGridHeaderCellActionGroup-${id}`}
-          />
-        </EuiPopover>
+                {sortingArrow}
+                <div
+                  className="euiDataGridHeaderCell__content"
+                  title={displayAsText || id}
+                >
+                  {display || displayAsText || id}
+                </div>
+                <EuiIcon
+                  className="euiDataGridHeaderCell__icon"
+                  type="arrowDown"
+                  size="s"
+                  color="text"
+                  data-test-subj={`dataGridHeaderCellActionButton-${id}`}
+                />
+              </button>
+            }
+            isOpen={isPopoverOpen}
+            closePopover={() => setIsPopoverOpen(false)}
+            {...popoverArrowNavigationProps}
+          >
+            <EuiListGroup
+              listItems={columnActions}
+              gutterSize="none"
+              data-test-subj={`dataGridHeaderCellActionGroup-${id}`}
+            />
+          </EuiPopover>
+
+          <p id={actionsAriaId} hidden>
+            <EuiI18n
+              token="euiDataGridHeaderCell.headerActions"
+              default="Click to view column header actions"
+            />
+          </p>
+        </>
       )}
     </EuiDataGridHeaderCellWrapper>
   );

--- a/src/components/datagrid/body/header/data_grid_header_cell.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.tsx
@@ -80,13 +80,14 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
 
   const showColumnActions = columnActions && columnActions.length > 0;
 
-  const {
-    sortingArrow,
-    ariaProps,
-    sortString,
-    screenReaderId,
-  } = useSortingUtils({ sorting, id });
-
+  const { sortingArrow, ariaProps, sortString } = useSortingUtils({
+    sorting,
+    id,
+  });
+  const sortingAriaId = useGeneratedHtmlId({
+    prefix: 'euiDataGridCellHeader',
+    suffix: 'sorting',
+  });
   const actionsAriaId = useGeneratedHtmlId({
     prefix: 'euiDataGridCellHeader',
     suffix: 'actions',
@@ -109,11 +110,6 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
         />
       ) : null}
 
-      {sortString && (
-        <EuiScreenReaderOnly>
-          <div id={screenReaderId}>{sortString}</div>
-        </EuiScreenReaderOnly>
-      )}
       {!showColumnActions ? (
         <>
           {sortingArrow}
@@ -123,6 +119,11 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
           >
             {display || displayAsText || id}
           </div>
+          {sortString && (
+            <EuiScreenReaderOnly>
+              <p>{sortString}</p>
+            </EuiScreenReaderOnly>
+          )}
         </>
       ) : (
         <>
@@ -138,7 +139,7 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
                   setFocusedCell([index, -1]);
                   setIsPopoverOpen((isPopoverOpen) => !isPopoverOpen);
                 }}
-                aria-describedby={`euiDataGridCellHeaderActions-${id}`}
+                aria-describedby={`${sortingAriaId} ${actionsAriaId}`}
               >
                 {sortingArrow}
                 <div
@@ -167,6 +168,9 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
             />
           </EuiPopover>
 
+          <p id={sortingAriaId} hidden>
+            {sortString}
+          </p>
           <p id={actionsAriaId} hidden>
             <EuiI18n
               token="euiDataGridHeaderCell.headerActions"
@@ -209,11 +213,9 @@ export const useSortingUtils = ({
   /**
    * ariaProps and sorting
    */
-  const screenReaderId = useGeneratedHtmlId();
 
   const ariaProps: {
     'aria-sort'?: AriaAttributes['aria-sort'];
-    'aria-describedby'?: AriaAttributes['aria-describedby'];
   } = {};
 
   let sortString;
@@ -235,12 +237,11 @@ export const useSortingUtils = ({
         sortString = sorting.columns
           .map((col) => `Sorted by ${col.id} ${col.direction}`)
           .join(' then ');
-        ariaProps['aria-describedby'] = screenReaderId;
       }
     }
   }
 
-  return { sortingArrow, ariaProps, sortString, screenReaderId };
+  return { sortingArrow, ariaProps, sortString };
 };
 
 /**

--- a/src/components/datagrid/data_grid.spec.tsx
+++ b/src/components/datagrid/data_grid.spec.tsx
@@ -621,14 +621,17 @@ function getGridData() {
   const rows = cy.get('[role=row]');
   return rows.then((rows) => {
     const headers: string[] = [];
-    const data = [];
+    const data: Array<{ [key: string]: string }> = [];
 
     // process header
     const headerRow = rows[0];
     const headerCells = headerRow.querySelectorAll('[role=columnheader]');
     for (let i = 0; i < headerCells.length; i++) {
       const headerCell = headerCells[i];
-      headers.push(headerCell.textContent ?? '');
+      const headerContent = headerCell.querySelector(
+        '.euiDataGridHeaderCell__content'
+      )?.textContent;
+      headers.push(headerContent ?? '');
     }
 
     // process data rows

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -645,64 +645,6 @@ describe('EuiDataGrid', () => {
       `);
     });
 
-    it('renders correct aria attributes on column headers', () => {
-      const component = mount(
-        <EuiDataGrid
-          {...requiredProps}
-          columns={[{ id: 'A' }, { id: 'B' }]}
-          columnVisibility={{
-            visibleColumns: ['A', 'B'],
-            setVisibleColumns: () => {},
-          }}
-          rowCount={1}
-          renderCellValue={() => 'value'}
-        />
-      );
-
-      // no columns are sorted, expect no aria-sort or aria-describedby attributes
-      expect(component.find('[role="columnheader"][aria-sort]').length).toBe(0);
-      expect(
-        component.find('[role="columnheader"][aria-describedby]').length
-      ).toBe(0);
-
-      // sort on one column
-      component.setProps({
-        sorting: { columns: [{ id: 'A', direction: 'asc' }], onSort: () => {} },
-      });
-
-      // expect A column to have aria-sort, expect no aria-describedby
-      expect(component.find('[role="columnheader"][aria-sort]').length).toBe(1);
-      expect(
-        component.find(
-          '[role="columnheader"][aria-sort="ascending"][data-test-subj="dataGridHeaderCell-A"]'
-        ).length
-      ).toBe(1);
-      expect(
-        component.find('[role="columnheader"][aria-describedby]').length
-      ).toBe(0);
-
-      // sort on both columns
-      component.setProps({
-        sorting: {
-          columns: [
-            { id: 'A', direction: 'asc' },
-            { id: 'B', direction: 'desc' },
-          ],
-          onSort: () => {},
-        },
-      });
-
-      // expect no aria-sort, both columns have aria-describedby
-      expect(component.find('[role="columnheader"][aria-sort]').length).toBe(0);
-      expect(
-        component.find('[role="columnheader"][aria-describedby]').length
-      ).toBe(2);
-      expect(
-        component.find('[role="columnheader"][aria-describedby="generated-id"]')
-          .length
-      ).toBe(2);
-    });
-
     it('renders additional toolbar controls', () => {
       const component = render(
         <EuiDataGrid

--- a/upcoming_changelogs/6034.md
+++ b/upcoming_changelogs/6034.md
@@ -1,0 +1,1 @@
+- Improved screen reader accessibility for `EuiDataGrid` column headers


### PR DESCRIPTION
### Summary

closes https://github.com/elastic/eui/issues/5333

**Fixes:**
- Column headers with actions were not correctly announcing their sorting status to screen readers
- Multi-sort SR announcements were not being correctly i18n'd

**Improvements:**
- Column headers without actions now report multi-sort announcements _after_ the column title, not before
- Multi-sorts now have better punctuation and general verbal flow
- The SR text for column headers with actions is more explicit/provides more guidance (`Click to view header actions`) and additionally also comes after a pause instead of being mashed together with the column title
- When using screen reader navigation/browsing to navigate grid cells, SRs would previously announce the column title as `{Title} Header Actions`. Thanks to switching to `aria-describedby`, SRs now only announce the column title.
  - * Note - screen reader navigation in EuiDataGrid is slightly janky and not super recommended (see [this comment](https://github.com/elastic/eui/pull/6033#discussion_r915235756)), but this was a minor enhancement to add for relatively low effort, so I figured why not
  - * Note - unfortunately this is not the case for column headers with no actions - since `describedby` does not work for those cells and they're using SR only text, the extra text comes along for the ride

### Screencap

Note: GitHub auto-mutes videos, you'll have to unmute to hear VO.

https://user-images.githubusercontent.com/549407/177714962-cf5e15e4-af7e-4f12-a698-b530fcf37395.mp4

### Checklist

- [x] Checked in ~**Chrome**~, **Safari**, ~**Edge**~, and **Firefox**
  - NOTE: Firefox does not announce `aria-sort` while Safari does
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~