### PR TITLE
[EuiDataGrid] Add keyboard shortcuts reference

### DIFF
--- a/src-docs/src/views/accessibility/screen_reader_focus.tsx
+++ b/src-docs/src/views/accessibility/screen_reader_focus.tsx
@@ -4,6 +4,8 @@ import {
   EuiScreenReaderOnly,
   EuiText,
   EuiLink,
+  EuiToolTip,
+  EuiButtonIcon,
 } from '../../../../src/components';
 
 export default () => (
@@ -12,6 +14,16 @@ export default () => (
       This link is visible to all on focus:{' '}
       <EuiScreenReaderOnly showOnFocus>
         <EuiLink href="#/utilities/accessibility">Link text</EuiLink>
+      </EuiScreenReaderOnly>
+    </p>
+    <p>
+      This tooltip + button is visible on focus within:{' '}
+      <EuiScreenReaderOnly showOnFocus>
+        <span>
+          <EuiToolTip content="Information">
+            <EuiButtonIcon iconType="iInCircle" aria-label="Information" />
+          </EuiToolTip>
+        </span>
       </EuiScreenReaderOnly>
     </p>
   </EuiText>

--- a/src-docs/src/views/datagrid/_snippets.tsx
+++ b/src-docs/src/views/datagrid/_snippets.tsx
@@ -70,6 +70,7 @@ inMemory={{ level: 'sorting' }}`,
   showColumnSelector: false,
   showDisplaySelector: false,
   showSortSelector: false,
+  showKeyboardShortcuts: false,
   showFullScreenSelector: false,
   additionalControls: {
     left: <EuiButtonEmpty size="xs" />,

--- a/src-docs/src/views/datagrid/toolbar/_grid.js
+++ b/src-docs/src/views/datagrid/toolbar/_grid.js
@@ -48,6 +48,7 @@ const DataGridStyle = ({
   showColumnSelector,
   showSortSelector,
   showDisplaySelector,
+  showKeyboardShortcuts,
   showFullScreenSelector,
   allowDensity,
   allowRowHeight,
@@ -114,6 +115,7 @@ const DataGridStyle = ({
     showColumnSelector: toggleColumnSelector,
     showSortSelector: showSortSelector,
     showDisplaySelector: toggleDisplaySelector,
+    showKeyboardShortcuts: showKeyboardShortcuts,
     showFullScreenSelector: showFullScreenSelector,
   };
 

--- a/src-docs/src/views/datagrid/toolbar/visibility.js
+++ b/src-docs/src/views/datagrid/toolbar/visibility.js
@@ -49,6 +49,7 @@ const DataGrid = () => {
   const [showColumnSelector, setShowColumnSelector] = useState(true);
   const [allowHideColumns, setAllowHideColumns] = useState(true);
   const [allowOrderingColumns, setAllowOrderingColumns] = useState(true);
+  const [showKeyboardShortcuts, setShowKeyboardShortcuts] = useState(true);
   const [showFullScreenSelector, setShowFullScreenSelector] = useState(true);
   const [toolbarType, setToolbarType] = useState('true');
 
@@ -74,6 +75,10 @@ const DataGrid = () => {
   };
   const onAllowRowHeightChange = (optionId) => {
     setAllowRowHeight(optionId === 'true');
+  };
+
+  const onShowKeyboardShortcutsChange = (optionId) => {
+    setShowKeyboardShortcuts(optionId === 'true');
   };
 
   const onShowFullScreenSelectorChange = (optionId) => {
@@ -233,6 +238,13 @@ const DataGrid = () => {
               )}
 
               <li>
+                {createItem('Show keyboard shortcuts', {
+                  idSelected: showKeyboardShortcuts.toString(),
+                  onChange: onShowKeyboardShortcutsChange,
+                })}
+              </li>
+
+              <li>
                 {createItem('Show full screen', {
                   idSelected: showFullScreenSelector.toString(),
                   onChange: onShowFullScreenSelectorChange,
@@ -250,6 +262,7 @@ const DataGrid = () => {
         showColumnSelector={showColumnSelector}
         showSortSelector={showSortSelector}
         showDisplaySelector={showDisplaySelector}
+        showKeyboardShortcuts={showKeyboardShortcuts}
         showFullScreenSelector={showFullScreenSelector}
         allowDensity={allowDensity}
         allowRowHeight={allowRowHeight}

--- a/src/components/accessibility/screen_reader_only/screen_reader_only.styles.ts
+++ b/src/components/accessibility/screen_reader_only/screen_reader_only.styles.ts
@@ -38,7 +38,7 @@ export const euiScreenReaderOnlyStyles = (showOnFocus?: boolean) => ({
   euiScreenReaderOnly: showOnFocus
     ? css`
         // The :active selector is necessary for Safari which removes :focus when a button is pressed
-        &:not(:focus):not(:active) {
+        &:not(:focus):not(:active):not(:focus-within) {
           ${euiScreenReaderOnly()}
         }
       `

--- a/src/components/accessibility/screen_reader_only/screen_reader_only.tsx
+++ b/src/components/accessibility/screen_reader_only/screen_reader_only.tsx
@@ -19,7 +19,7 @@ export interface EuiScreenReaderOnlyProps {
   children: ReactElement;
 
   /**
-   * For keyboard navigation, force content to display visually upon focus.
+   * For keyboard navigation, force content to display visually upon focus/focus-within.
    */
   showOnFocus?: boolean;
   className?: string;

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -476,7 +476,7 @@ Array [
     >
       <div
         class="euiDataGrid__controls"
-        data-test-sub="dataGridControls"
+        data-test-subj="dataGridControls"
       >
         <div
           class="euiDataGrid__leftControls"
@@ -517,6 +517,32 @@ Array [
         <div
           class="euiDataGrid__rightControls"
         >
+          <div
+            class="euiPopover emotion-euiPopover"
+            data-test-subj="dataGridKeyboardShortcutsPopover"
+          >
+            <div
+              class="euiPopover__anchor css-16vtueo-render"
+            >
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+              >
+                <button
+                  aria-label="Keyboard shortcuts"
+                  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
+                  data-test-subj="dataGridKeyboardShortcutsButton"
+                  type="button"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="euiButtonIcon__icon"
+                    color="inherit"
+                    data-euiicon-type="keyboard"
+                  />
+                </button>
+              </span>
+            </div>
+          </div>
           <div
             class="euiPopover emotion-euiPopover"
             data-test-subj="dataGridDisplaySelectorPopover"
@@ -921,7 +947,7 @@ Array [
     >
       <div
         class="euiDataGrid__controls"
-        data-test-sub="dataGridControls"
+        data-test-subj="dataGridControls"
       >
         <div
           class="euiDataGrid__leftControls"
@@ -962,6 +988,32 @@ Array [
         <div
           class="euiDataGrid__rightControls"
         >
+          <div
+            class="euiPopover emotion-euiPopover"
+            data-test-subj="dataGridKeyboardShortcutsPopover"
+          >
+            <div
+              class="euiPopover__anchor css-16vtueo-render"
+            >
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+              >
+                <button
+                  aria-label="Keyboard shortcuts"
+                  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
+                  data-test-subj="dataGridKeyboardShortcutsButton"
+                  type="button"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="euiButtonIcon__icon"
+                    color="inherit"
+                    data-euiicon-type="keyboard"
+                  />
+                </button>
+              </span>
+            </div>
+          </div>
           <div
             class="euiPopover emotion-euiPopover"
             data-test-subj="dataGridDisplaySelectorPopover"
@@ -1710,7 +1762,7 @@ Array [
     >
       <div
         class="euiDataGrid__controls"
-        data-test-sub="dataGridControls"
+        data-test-subj="dataGridControls"
       >
         <div
           class="euiDataGrid__leftControls"
@@ -1748,6 +1800,32 @@ Array [
         <div
           class="euiDataGrid__rightControls"
         >
+          <div
+            class="euiPopover emotion-euiPopover"
+            data-test-subj="dataGridKeyboardShortcutsPopover"
+          >
+            <div
+              class="euiPopover__anchor css-16vtueo-render"
+            >
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+              >
+                <button
+                  aria-label="Keyboard shortcuts"
+                  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
+                  data-test-subj="dataGridKeyboardShortcutsButton"
+                  type="button"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="euiButtonIcon__icon"
+                    color="inherit"
+                    data-euiicon-type="keyboard"
+                  />
+                </button>
+              </span>
+            </div>
+          </div>
           <div
             class="euiPopover emotion-euiPopover"
             data-test-subj="dataGridDisplaySelectorPopover"
@@ -2154,7 +2232,7 @@ Array [
     >
       <div
         class="euiDataGrid__controls"
-        data-test-sub="dataGridControls"
+        data-test-subj="dataGridControls"
       >
         <div
           class="euiDataGrid__leftControls"
@@ -2192,6 +2270,32 @@ Array [
         <div
           class="euiDataGrid__rightControls"
         >
+          <div
+            class="euiPopover emotion-euiPopover"
+            data-test-subj="dataGridKeyboardShortcutsPopover"
+          >
+            <div
+              class="euiPopover__anchor css-16vtueo-render"
+            >
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+              >
+                <button
+                  aria-label="Keyboard shortcuts"
+                  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
+                  data-test-subj="dataGridKeyboardShortcutsButton"
+                  type="button"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="euiButtonIcon__icon"
+                    color="inherit"
+                    data-euiicon-type="keyboard"
+                  />
+                </button>
+              </span>
+            </div>
+          </div>
           <div
             class="euiPopover emotion-euiPopover"
             data-test-subj="dataGridDisplaySelectorPopover"

--- a/src/components/datagrid/_index.scss
+++ b/src/components/datagrid/_index.scss
@@ -9,3 +9,4 @@
 @import 'controls/data_grid_column_selector';
 @import 'controls/data_grid_column_sorting';
 @import 'controls/data_grid_display';
+@import 'controls/data_grid_keyboard_shortcuts';

--- a/src/components/datagrid/controls/__snapshots__/keyboard_shortcuts.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/keyboard_shortcuts.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`useDataGridKeyboardShortcuts returns a popover containing a list of key
               <dd
                 class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
               >
-                Moves focus one cell up.
+                Move one cell up
               </dd>
               <dt
                 class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
@@ -116,7 +116,7 @@ exports[`useDataGridKeyboardShortcuts returns a popover containing a list of key
               <dd
                 class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
               >
-                Moves focus one cell down.
+                Move one cell down
               </dd>
               <dt
                 class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
@@ -128,7 +128,7 @@ exports[`useDataGridKeyboardShortcuts returns a popover containing a list of key
               <dd
                 class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
               >
-                Moves focus one cell to the right.
+                Move one cell right
               </dd>
               <dt
                 class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
@@ -140,7 +140,7 @@ exports[`useDataGridKeyboardShortcuts returns a popover containing a list of key
               <dd
                 class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
               >
-                Moves focus one cell to the left.
+                Move one cell left
               </dd>
               <dt
                 class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
@@ -152,7 +152,7 @@ exports[`useDataGridKeyboardShortcuts returns a popover containing a list of key
               <dd
                 class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
               >
-                Moves focus to the first cell in the current row.
+                Move to the first cell of the current row
               </dd>
               <dt
                 class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
@@ -164,7 +164,7 @@ exports[`useDataGridKeyboardShortcuts returns a popover containing a list of key
               <dd
                 class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
               >
-                Moves focus to the last cell in the current row.
+                Move to the last cell of the current row
               </dd>
               <dt
                 class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
@@ -180,7 +180,7 @@ exports[`useDataGridKeyboardShortcuts returns a popover containing a list of key
               <dd
                 class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
               >
-                Moves focus to the first cell in the first row.
+                Move to the first cell of the current page
               </dd>
               <dt
                 class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
@@ -196,7 +196,7 @@ exports[`useDataGridKeyboardShortcuts returns a popover containing a list of key
               <dd
                 class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
               >
-                Moves focus to the last cell in the last row.
+                Move to the last cell of the current page
               </dd>
               <dt
                 class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
@@ -208,7 +208,7 @@ exports[`useDataGridKeyboardShortcuts returns a popover containing a list of key
               <dd
                 class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
               >
-                Paginates to the last row of the previous page.
+                Go to the last row of the previous page
               </dd>
               <dt
                 class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
@@ -220,7 +220,7 @@ exports[`useDataGridKeyboardShortcuts returns a popover containing a list of key
               <dd
                 class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
               >
-                Paginates to the first row of the next page.
+                Go to the first row of the next page
               </dd>
               <dt
                 class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
@@ -232,7 +232,7 @@ exports[`useDataGridKeyboardShortcuts returns a popover containing a list of key
               <dd
                 class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
               >
-                Opens cell expansion popover for interactive cells.
+                Open cell details and actions
               </dd>
               <dt
                 class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
@@ -244,7 +244,7 @@ exports[`useDataGridKeyboardShortcuts returns a popover containing a list of key
               <dd
                 class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
               >
-                Closes any open popovers.
+                Close cell details and actions
               </dd>
             </dl>
           </div>

--- a/src/components/datagrid/controls/__snapshots__/keyboard_shortcuts.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/keyboard_shortcuts.test.tsx.snap
@@ -1,0 +1,263 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useDataGridKeyboardShortcuts returns a popover containing a list of keyboard shortcuts 1`] = `
+<body>
+  <div
+    aria-hidden="true"
+    data-aria-hidden="true"
+  >
+    <div
+      class="euiPopover euiPopover-isOpen emotion-euiPopover"
+      data-test-subj="dataGridKeyboardShortcutsPopover"
+    >
+      <div
+        class="euiPopover__anchor css-16vtueo-render"
+      >
+        <span
+          class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+        >
+          <button
+            aria-label="Keyboard shortcuts"
+            class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
+            data-test-subj="dataGridKeyboardShortcutsButton"
+            type="button"
+          >
+            <span
+              aria-hidden="true"
+              class="euiButtonIcon__icon"
+              color="inherit"
+              data-euiicon-type="keyboard"
+            />
+          </button>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    data-euiportal="true"
+  >
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="1"
+    />
+    <div
+      data-focus-lock-disabled="false"
+    >
+      <div
+        aria-describedby="generated-id"
+        aria-live="off"
+        aria-modal="true"
+        class="euiPanel euiPanel--plain euiPanel--paddingMedium euiPopover__panel emotion-euiPanel-grow-m-m-plain-euiPopover__panel-isOpen-bottom"
+        data-autofocus="true"
+        data-popover-open="true"
+        data-popover-panel="true"
+        role="dialog"
+        style="top: 16px; left: -22px; z-index: 2000;"
+        tabindex="0"
+      >
+        <div
+          class="emotion-euiPopoverArrow-bottom"
+          data-popover-arrow="bottom"
+          style="left: 10px; top: 0px;"
+        />
+        <p
+          class="emotion-euiScreenReaderOnly"
+          id="generated-id"
+        >
+          You are in a dialog. To close this dialog, hit escape.
+        </p>
+        <div>
+          <div
+            class="euiPopoverTitle emotion-euiPopoverTitle-m-s"
+          >
+            <h2
+              id="generated-id"
+            >
+              Keyboard shortcuts
+            </h2>
+          </div>
+          <div
+            class="euiText euiDataGrid__keyboardShortcuts emotion-euiText-xs"
+          >
+            <dl
+              aria-labelledby="generated-id"
+              class="euiDescriptionList emotion-euiDescriptionList-column-center"
+              data-type="column"
+            >
+              <dt
+                class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
+              >
+                <kbd>
+                  Up arrow
+                </kbd>
+              </dt>
+              <dd
+                class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
+              >
+                Moves focus one cell up.
+              </dd>
+              <dt
+                class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
+              >
+                <kbd>
+                  Down arrow
+                </kbd>
+              </dt>
+              <dd
+                class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
+              >
+                Moves focus one cell down.
+              </dd>
+              <dt
+                class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
+              >
+                <kbd>
+                  Right arrow
+                </kbd>
+              </dt>
+              <dd
+                class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
+              >
+                Moves focus one cell to the right.
+              </dd>
+              <dt
+                class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
+              >
+                <kbd>
+                  Left arrow
+                </kbd>
+              </dt>
+              <dd
+                class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
+              >
+                Moves focus one cell to the left.
+              </dd>
+              <dt
+                class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
+              >
+                <kbd>
+                  Home
+                </kbd>
+              </dt>
+              <dd
+                class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
+              >
+                Moves focus to the first cell in the current row.
+              </dd>
+              <dt
+                class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
+              >
+                <kbd>
+                  End
+                </kbd>
+              </dt>
+              <dd
+                class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
+              >
+                Moves focus to the last cell in the current row.
+              </dd>
+              <dt
+                class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
+              >
+                <kbd>
+                  Ctrl
+                </kbd>
+                 
+                <kbd>
+                  Home
+                </kbd>
+              </dt>
+              <dd
+                class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
+              >
+                Moves focus to the first cell in the first row.
+              </dd>
+              <dt
+                class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
+              >
+                <kbd>
+                  Ctrl
+                </kbd>
+                 
+                <kbd>
+                  End
+                </kbd>
+              </dt>
+              <dd
+                class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
+              >
+                Moves focus to the last cell in the last row.
+              </dd>
+              <dt
+                class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
+              >
+                <kbd>
+                  Page Up
+                </kbd>
+              </dt>
+              <dd
+                class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
+              >
+                Paginates to the last row of the previous page.
+              </dd>
+              <dt
+                class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
+              >
+                <kbd>
+                  Page Down
+                </kbd>
+              </dt>
+              <dd
+                class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
+              >
+                Paginates to the first row of the next page.
+              </dd>
+              <dt
+                class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
+              >
+                <kbd>
+                  Enter
+                </kbd>
+              </dt>
+              <dd
+                class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
+              >
+                Opens cell expansion popover for interactive cells.
+              </dd>
+              <dt
+                class="euiDescriptionList__title emotion-euiDescriptionList__title-column-s-compressed-right"
+              >
+                <kbd>
+                  Escape
+                </kbd>
+              </dt>
+              <dd
+                class="euiDescriptionList__description emotion-euiDescriptionList__description-column-normal-left-s"
+              >
+                Closes any open popovers.
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;

--- a/src/components/datagrid/controls/_data_grid_keyboard_shortcuts.scss
+++ b/src/components/datagrid/controls/_data_grid_keyboard_shortcuts.scss
@@ -1,5 +1,9 @@
-.euiDataGrid__keyboardShortcutsPopoverPanel {
-  width: $euiSizeXXL * 12;
+.euiDataGrid__keyboardShortcuts {
+  display: block;
+  max-inline-size: $euiSizeXXL * 12;
+  max-block-size: 80vh;
+  overflow-y: auto;
+  overflow-block: auto;
 
   .euiDescriptionList {
     .euiDescriptionList__title {

--- a/src/components/datagrid/controls/_data_grid_keyboard_shortcuts.scss
+++ b/src/components/datagrid/controls/_data_grid_keyboard_shortcuts.scss
@@ -1,6 +1,6 @@
 .euiDataGrid__keyboardShortcuts {
   display: block;
-  max-inline-size: $euiSizeXXL * 12;
+  max-inline-size: $euiSizeXXL * 10;
   max-block-size: 80vh;
   overflow-y: auto;
   overflow-block: auto;

--- a/src/components/datagrid/controls/_data_grid_keyboard_shortcuts.scss
+++ b/src/components/datagrid/controls/_data_grid_keyboard_shortcuts.scss
@@ -1,0 +1,17 @@
+.euiDataGrid__keyboardShortcutsPopoverPanel {
+  width: $euiSizeXXL * 12;
+
+  .euiDescriptionList.euiDescriptionList--column { // Specificity override
+    .euiDescriptionList__title {
+      width: 25%;
+    }
+
+    .euiDescriptionList__description {
+      width: 75%;
+    }
+
+    & > *:not(:first-of-type) {
+      margin-top: $euiSizeS;
+    }
+  }
+}

--- a/src/components/datagrid/controls/_data_grid_keyboard_shortcuts.scss
+++ b/src/components/datagrid/controls/_data_grid_keyboard_shortcuts.scss
@@ -1,17 +1,13 @@
 .euiDataGrid__keyboardShortcutsPopoverPanel {
   width: $euiSizeXXL * 12;
 
-  .euiDescriptionList.euiDescriptionList--column { // Specificity override
+  .euiDescriptionList {
     .euiDescriptionList__title {
       width: 25%;
     }
 
     .euiDescriptionList__description {
       width: 75%;
-    }
-
-    & > *:not(:first-of-type) {
-      margin-top: $euiSizeS;
     }
   }
 }

--- a/src/components/datagrid/controls/data_grid_toolbar.test.tsx
+++ b/src/components/datagrid/controls/data_grid_toolbar.test.tsx
@@ -23,6 +23,7 @@ describe('EuiDataGridToolbar', () => {
     isFullScreen: false,
     fullScreenSelector: <div>mock fullscreen selector</div>,
     displaySelector: <div>mock style selector</div>,
+    keyboardShortcuts: <div>mock keyboard shortcuts</div>,
     columnSelector: <div>mock column selector</div>,
     columnSorting: <div>mock column sorting</div>,
   };
@@ -33,7 +34,7 @@ describe('EuiDataGridToolbar', () => {
     expect(component).toMatchInlineSnapshot(`
       <div
         className="euiDataGrid__controls"
-        data-test-sub="dataGridControls"
+        data-test-subj="dataGridControls"
       >
         <div
           className="euiDataGrid__leftControls"
@@ -48,6 +49,9 @@ describe('EuiDataGridToolbar', () => {
         <div
           className="euiDataGrid__rightControls"
         >
+          <div>
+            mock keyboard shortcuts
+          </div>
           <div>
             mock style selector
           </div>
@@ -67,14 +71,24 @@ describe('EuiDataGridToolbar', () => {
     expect(component).toMatchInlineSnapshot(`
       <div
         className="euiDataGrid__controls"
-        data-test-sub="dataGridControls"
+        data-test-subj="dataGridControls"
       >
         <div
           className="euiDataGrid__leftControls"
         />
         <div
           className="euiDataGrid__rightControls"
-        />
+        >
+          <EuiScreenReaderOnly
+            showOnFocus={true}
+          >
+            <span>
+              <div>
+                mock keyboard shortcuts
+              </div>
+            </span>
+          </EuiScreenReaderOnly>
+        </div>
       </div>
     `);
   });
@@ -99,7 +113,7 @@ describe('EuiDataGridToolbar', () => {
     expect(component).toMatchInlineSnapshot(`
       <div
         className="euiDataGrid__controls"
-        data-test-sub="dataGridControls"
+        data-test-subj="dataGridControls"
       >
         <div
           className="euiDataGrid__leftControls"
@@ -113,6 +127,9 @@ describe('EuiDataGridToolbar', () => {
         >
           <div>
             world
+          </div>
+          <div>
+            mock keyboard shortcuts
           </div>
         </div>
       </div>

--- a/src/components/datagrid/controls/data_grid_toolbar.tsx
+++ b/src/components/datagrid/controls/data_grid_toolbar.tsx
@@ -60,12 +60,6 @@ export const EuiDataGridToolbar = ({
         {renderAdditionalControls(toolbarVisibility, 'right')}
         {checkOrDefaultToolBarDisplayOptions(
           toolbarVisibility,
-          'showDisplaySelector'
-        )
-          ? displaySelector
-          : null}
-        {checkOrDefaultToolBarDisplayOptions(
-          toolbarVisibility,
           'showKeyboardShortcuts'
         ) ? (
           keyboardShortcuts
@@ -74,6 +68,12 @@ export const EuiDataGridToolbar = ({
             <span>{keyboardShortcuts}</span>
           </EuiScreenReaderOnly>
         )}
+        {checkOrDefaultToolBarDisplayOptions(
+          toolbarVisibility,
+          'showDisplaySelector'
+        )
+          ? displaySelector
+          : null}
         {checkOrDefaultToolBarDisplayOptions(
           toolbarVisibility,
           'showFullScreenSelector'

--- a/src/components/datagrid/controls/data_grid_toolbar.tsx
+++ b/src/components/datagrid/controls/data_grid_toolbar.tsx
@@ -14,6 +14,7 @@ import {
   EuiDataGridToolBarAdditionalControlsOptions,
   EuiDataGridToolBarAdditionalControlsLeftOptions,
 } from '../data_grid_types';
+import { EuiScreenReaderOnly } from '../../accessibility';
 import { IS_JEST_ENVIRONMENT } from '../../../utils';
 
 // When below this number the grid only shows the right control icon buttons
@@ -25,6 +26,7 @@ export const EuiDataGridToolbar = ({
   toolbarVisibility,
   isFullScreen,
   fullScreenSelector,
+  keyboardShortcuts,
   displaySelector,
   columnSelector,
   columnSorting,
@@ -35,7 +37,7 @@ export const EuiDataGridToolbar = ({
     : gridWidth > minSizeForControls || isFullScreen;
 
   return (
-    <div className="euiDataGrid__controls" data-test-sub="dataGridControls">
+    <div className="euiDataGrid__controls" data-test-subj="dataGridControls">
       {hasRoomForGridControls && (
         <div className="euiDataGrid__leftControls">
           {renderAdditionalControls(toolbarVisibility, 'left.prepend')}
@@ -62,6 +64,16 @@ export const EuiDataGridToolbar = ({
         )
           ? displaySelector
           : null}
+        {checkOrDefaultToolBarDisplayOptions(
+          toolbarVisibility,
+          'showKeyboardShortcuts'
+        ) ? (
+          keyboardShortcuts
+        ) : (
+          <EuiScreenReaderOnly showOnFocus>
+            <span>{keyboardShortcuts}</span>
+          </EuiScreenReaderOnly>
+        )}
         {checkOrDefaultToolBarDisplayOptions(
           toolbarVisibility,
           'showFullScreenSelector'

--- a/src/components/datagrid/controls/index.ts
+++ b/src/components/datagrid/controls/index.ts
@@ -9,6 +9,7 @@
 export { useDataGridColumnSelector } from './column_selector';
 export { useDataGridColumnSorting } from './column_sorting';
 export { useDataGridDisplaySelector, startingStyles } from './display_selector';
+export { useDataGridKeyboardShortcuts } from './keyboard_shortcuts';
 export { useDataGridFullScreenSelector } from './fullscreen_selector';
 export {
   checkOrDefaultToolBarDisplayOptions,

--- a/src/components/datagrid/controls/keyboard_shortcuts.test.tsx
+++ b/src/components/datagrid/controls/keyboard_shortcuts.test.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react-hooks';
+import { render, waitForEuiPopoverOpen } from '../../../test/rtl';
+import { useDataGridKeyboardShortcuts } from './keyboard_shortcuts';
+
+describe('useDataGridKeyboardShortcuts', () => {
+  it('returns a popover containing a list of keyboard shortcuts', async () => {
+    const { result } = renderHook(() => useDataGridKeyboardShortcuts());
+    const { baseElement, getByTestSubject, rerender } = render(
+      <>{result.current.keyboardShortcuts}</>
+    );
+
+    act(() => getByTestSubject('dataGridKeyboardShortcutsButton').click());
+    rerender(<>{result.current.keyboardShortcuts}</>);
+    await waitForEuiPopoverOpen();
+
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/src/components/datagrid/controls/keyboard_shortcuts.tsx
+++ b/src/components/datagrid/controls/keyboard_shortcuts.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { useState, useMemo, ReactNode } from 'react';
+import { EuiButtonIcon } from '../../button';
+import { EuiToolTip } from '../../tool_tip';
+import { EuiPopover } from '../../popover';
+import { EuiDescriptionList } from '../../description_list';
+import { EuiBadge } from '../../badge';
+import { useEuiI18n } from '../../i18n';
+
+export const useDataGridKeyboardShortcuts = (): {
+  keyboardShortcuts: ReactNode;
+} => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const buttonLabel = useEuiI18n(
+    'euiKeyboardShortcuts.label',
+    'Keyboard shortcuts'
+  );
+
+  const keyboardShortcuts = useMemo(
+    () => (
+      <EuiPopover
+        data-test-subj="dataGridKeyboardShortcutsPopover"
+        isOpen={isOpen}
+        closePopover={() => setIsOpen(false)}
+        anchorPosition="downRight"
+        panelClassName="euiDataGrid__keyboardShortcutsPopoverPanel"
+        button={
+          <EuiToolTip content={buttonLabel} delay="long">
+            <EuiButtonIcon
+              size="xs"
+              iconType="iInCircle" // TODO
+              color="text"
+              data-test-subj="dataGridKeyboardShortcutsButton"
+              onClick={() => setIsOpen(!isOpen)}
+              aria-label={buttonLabel}
+            />
+          </EuiToolTip>
+        }
+      >
+        <EuiDescriptionList
+          type="column"
+          align="center"
+          compressed
+          listItems={[
+            {
+              title: <EuiBadge>Up arrow</EuiBadge>,
+              description: 'Moves focus one cell down.',
+            },
+            {
+              title: <EuiBadge>Down arrow</EuiBadge>,
+              description: 'Moves focus one cell up.',
+            },
+            {
+              title: <EuiBadge>Right arrow</EuiBadge>,
+              description: 'Moves focus one cell to the right.',
+            },
+            {
+              title: <EuiBadge>Left arrow</EuiBadge>,
+              description: 'Moves focus one cell to the left.',
+            },
+            {
+              title: <EuiBadge>Home</EuiBadge>,
+              description: 'Moves focus to the first cell in the current row.',
+            },
+            {
+              title: <EuiBadge>End</EuiBadge>,
+              description: 'Moves focus to the last cell in the current row.',
+            },
+            {
+              title: (
+                <>
+                  <EuiBadge>Ctrl</EuiBadge>
+                  <EuiBadge>Home</EuiBadge>
+                </>
+              ),
+              description: 'Moves focus to the first cell in the first row.',
+            },
+            {
+              title: (
+                <>
+                  <EuiBadge>Ctrl</EuiBadge>
+                  <EuiBadge>End</EuiBadge>
+                </>
+              ),
+              description: 'Moves focus to the last cell in the last row.',
+            },
+            {
+              title: <EuiBadge>Page Up</EuiBadge>,
+              description: 'Paginates to the last row of the previous page.',
+            },
+            {
+              title: <EuiBadge>Page Down</EuiBadge>,
+              description: 'Paginates to the first row of the next page.',
+            },
+            {
+              title: <EuiBadge>Enter</EuiBadge>,
+              description:
+                'Opens cell expansion popover for interactive cells.',
+            },
+            {
+              title: <EuiBadge>Escape</EuiBadge>,
+              description: 'Closes any open popovers.',
+            },
+          ]}
+        />
+      </EuiPopover>
+    ),
+    [isOpen, buttonLabel]
+  );
+
+  return { keyboardShortcuts };
+};

--- a/src/components/datagrid/controls/keyboard_shortcuts.tsx
+++ b/src/components/datagrid/controls/keyboard_shortcuts.tsx
@@ -67,7 +67,7 @@ export const useDataGridKeyboardShortcuts = (): {
                 description: (
                   <EuiI18n
                     token="euiKeyboardShortcuts.upArrowDescription"
-                    default="Moves focus one cell up."
+                    default="Move one cell up"
                   />
                 ),
               },
@@ -83,7 +83,7 @@ export const useDataGridKeyboardShortcuts = (): {
                 description: (
                   <EuiI18n
                     token="euiKeyboardShortcuts.downArrowDescription"
-                    default="Moves focus one cell down."
+                    default="Move one cell down"
                   />
                 ),
               },
@@ -99,7 +99,7 @@ export const useDataGridKeyboardShortcuts = (): {
                 description: (
                   <EuiI18n
                     token="euiKeyboardShortcuts.rightArrowDescription"
-                    default="Moves focus one cell to the right."
+                    default="Move one cell right"
                   />
                 ),
               },
@@ -115,7 +115,7 @@ export const useDataGridKeyboardShortcuts = (): {
                 description: (
                   <EuiI18n
                     token="euiKeyboardShortcuts.leftArrowDescription"
-                    default="Moves focus one cell to the left."
+                    default="Move one cell left"
                   />
                 ),
               },
@@ -131,7 +131,7 @@ export const useDataGridKeyboardShortcuts = (): {
                 description: (
                   <EuiI18n
                     token="euiKeyboardShortcuts.homeDescription"
-                    default="Moves focus to the first cell in the current row."
+                    default="Move to the first cell of the current row"
                   />
                 ),
               },
@@ -147,7 +147,7 @@ export const useDataGridKeyboardShortcuts = (): {
                 description: (
                   <EuiI18n
                     token="euiKeyboardShortcuts.endDescription"
-                    default="Moves focus to the last cell in the current row."
+                    default="Move to the last cell of the current row"
                   />
                 ),
               },
@@ -171,7 +171,7 @@ export const useDataGridKeyboardShortcuts = (): {
                 description: (
                   <EuiI18n
                     token="euiKeyboardShortcuts.ctrlHomeDescription"
-                    default="Moves focus to the first cell in the first row."
+                    default="Move to the first cell of the current page"
                   />
                 ),
               },
@@ -195,7 +195,7 @@ export const useDataGridKeyboardShortcuts = (): {
                 description: (
                   <EuiI18n
                     token="euiKeyboardShortcuts.ctrlEndDescription"
-                    default="Moves focus to the last cell in the last row."
+                    default="Move to the last cell of the current page"
                   />
                 ),
               },
@@ -211,7 +211,7 @@ export const useDataGridKeyboardShortcuts = (): {
                 description: (
                   <EuiI18n
                     token="euiKeyboardShortcuts.pageUpDescription"
-                    default="Paginates to the last row of the previous page."
+                    default="Go to the last row of the previous page"
                   />
                 ),
               },
@@ -227,7 +227,7 @@ export const useDataGridKeyboardShortcuts = (): {
                 description: (
                   <EuiI18n
                     token="euiKeyboardShortcuts.pageDownDescription"
-                    default="Paginates to the first row of the next page."
+                    default="Go to the first row of the next page"
                   />
                 ),
               },
@@ -243,7 +243,7 @@ export const useDataGridKeyboardShortcuts = (): {
                 description: (
                   <EuiI18n
                     token="euiKeyboardShortcuts.enterDescription"
-                    default="Opens cell expansion popover for interactive cells."
+                    default="Open cell details and actions"
                   />
                 ),
               },
@@ -259,7 +259,7 @@ export const useDataGridKeyboardShortcuts = (): {
                 description: (
                   <EuiI18n
                     token="euiKeyboardShortcuts.escapeDescription"
-                    default="Closes any open popovers."
+                    default="Close cell details and actions"
                   />
                 ),
               },

--- a/src/components/datagrid/controls/keyboard_shortcuts.tsx
+++ b/src/components/datagrid/controls/keyboard_shortcuts.tsx
@@ -54,6 +54,7 @@ export const useDataGridKeyboardShortcuts = (): {
             type="column"
             align="center"
             compressed
+            gutterSize="s"
             listItems={[
               {
                 title: <kbd>Up arrow</kbd>,

--- a/src/components/datagrid/controls/keyboard_shortcuts.tsx
+++ b/src/components/datagrid/controls/keyboard_shortcuts.tsx
@@ -31,7 +31,6 @@ export const useDataGridKeyboardShortcuts = (): {
         isOpen={isOpen}
         closePopover={() => setIsOpen(false)}
         anchorPosition="downRight"
-        panelClassName="euiDataGrid__keyboardShortcutsPopoverPanel"
         button={
           <EuiToolTip content={title} delay="long">
             <EuiButtonIcon
@@ -48,7 +47,7 @@ export const useDataGridKeyboardShortcuts = (): {
         <EuiPopoverTitle paddingSize="s">
           <h2 id={titleId}>{title}</h2>
         </EuiPopoverTitle>
-        <EuiText size="xs">
+        <EuiText className="euiDataGrid__keyboardShortcuts" size="xs">
           <EuiDescriptionList
             aria-labelledby={titleId}
             type="column"

--- a/src/components/datagrid/controls/keyboard_shortcuts.tsx
+++ b/src/components/datagrid/controls/keyboard_shortcuts.tsx
@@ -9,7 +9,7 @@
 import React, { useState, useMemo, ReactNode } from 'react';
 import { EuiButtonIcon } from '../../button';
 import { EuiToolTip } from '../../tool_tip';
-import { EuiPopover } from '../../popover';
+import { EuiPopover, EuiPopoverTitle } from '../../popover';
 import { EuiDescriptionList } from '../../description_list';
 import { EuiText } from '../../text';
 import { useEuiI18n } from '../../i18n';
@@ -19,10 +19,7 @@ export const useDataGridKeyboardShortcuts = (): {
 } => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const buttonLabel = useEuiI18n(
-    'euiKeyboardShortcuts.label',
-    'Keyboard shortcuts'
-  );
+  const title = useEuiI18n('euiKeyboardShortcuts.title', 'Keyboard shortcuts');
 
   const keyboardShortcuts = useMemo(
     () => (
@@ -33,18 +30,19 @@ export const useDataGridKeyboardShortcuts = (): {
         anchorPosition="downRight"
         panelClassName="euiDataGrid__keyboardShortcutsPopoverPanel"
         button={
-          <EuiToolTip content={buttonLabel} delay="long">
+          <EuiToolTip content={title} delay="long">
             <EuiButtonIcon
               size="xs"
               iconType="keyboard"
               color="text"
               data-test-subj="dataGridKeyboardShortcutsButton"
               onClick={() => setIsOpen(!isOpen)}
-              aria-label={buttonLabel}
+              aria-label={title}
             />
           </EuiToolTip>
         }
       >
+        <EuiPopoverTitle paddingSize="s">{title}</EuiPopoverTitle>
         <EuiText size="xs">
           <EuiDescriptionList
             type="column"
@@ -114,7 +112,7 @@ export const useDataGridKeyboardShortcuts = (): {
         </EuiText>
       </EuiPopover>
     ),
-    [isOpen, buttonLabel]
+    [isOpen, title]
   );
 
   return { keyboardShortcuts };

--- a/src/components/datagrid/controls/keyboard_shortcuts.tsx
+++ b/src/components/datagrid/controls/keyboard_shortcuts.tsx
@@ -11,7 +11,7 @@ import { EuiButtonIcon } from '../../button';
 import { EuiToolTip } from '../../tool_tip';
 import { EuiPopover } from '../../popover';
 import { EuiDescriptionList } from '../../description_list';
-import { EuiBadge } from '../../badge';
+import { EuiText } from '../../text';
 import { useEuiI18n } from '../../i18n';
 
 export const useDataGridKeyboardShortcuts = (): {
@@ -36,7 +36,7 @@ export const useDataGridKeyboardShortcuts = (): {
           <EuiToolTip content={buttonLabel} delay="long">
             <EuiButtonIcon
               size="xs"
-              iconType="iInCircle" // TODO
+              iconType="keyboard"
               color="text"
               data-test-subj="dataGridKeyboardShortcutsButton"
               onClick={() => setIsOpen(!isOpen)}
@@ -45,72 +45,73 @@ export const useDataGridKeyboardShortcuts = (): {
           </EuiToolTip>
         }
       >
-        <EuiDescriptionList
-          type="column"
-          align="center"
-          compressed
-          listItems={[
-            {
-              title: <EuiBadge>Up arrow</EuiBadge>,
-              description: 'Moves focus one cell down.',
-            },
-            {
-              title: <EuiBadge>Down arrow</EuiBadge>,
-              description: 'Moves focus one cell up.',
-            },
-            {
-              title: <EuiBadge>Right arrow</EuiBadge>,
-              description: 'Moves focus one cell to the right.',
-            },
-            {
-              title: <EuiBadge>Left arrow</EuiBadge>,
-              description: 'Moves focus one cell to the left.',
-            },
-            {
-              title: <EuiBadge>Home</EuiBadge>,
-              description: 'Moves focus to the first cell in the current row.',
-            },
-            {
-              title: <EuiBadge>End</EuiBadge>,
-              description: 'Moves focus to the last cell in the current row.',
-            },
-            {
-              title: (
-                <>
-                  <EuiBadge>Ctrl</EuiBadge>
-                  <EuiBadge>Home</EuiBadge>
-                </>
-              ),
-              description: 'Moves focus to the first cell in the first row.',
-            },
-            {
-              title: (
-                <>
-                  <EuiBadge>Ctrl</EuiBadge>
-                  <EuiBadge>End</EuiBadge>
-                </>
-              ),
-              description: 'Moves focus to the last cell in the last row.',
-            },
-            {
-              title: <EuiBadge>Page Up</EuiBadge>,
-              description: 'Paginates to the last row of the previous page.',
-            },
-            {
-              title: <EuiBadge>Page Down</EuiBadge>,
-              description: 'Paginates to the first row of the next page.',
-            },
-            {
-              title: <EuiBadge>Enter</EuiBadge>,
-              description:
-                'Opens cell expansion popover for interactive cells.',
-            },
-            {
-              title: <EuiBadge>Escape</EuiBadge>,
-              description: 'Closes any open popovers.',
-            },
-          ]}
-        />
+        <EuiText size="xs">
+          <EuiDescriptionList
+            type="column"
+            align="center"
+            compressed
+            listItems={[
+              {
+                title: <kbd>Up arrow</kbd>,
+                description: 'Moves focus one cell down.',
+              },
+              {
+                title: <kbd>Down arrow</kbd>,
+                description: 'Moves focus one cell up.',
+              },
+              {
+                title: <kbd>Right arrow</kbd>,
+                description: 'Moves focus one cell to the right.',
+              },
+              {
+                title: <kbd>Left arrow</kbd>,
+                description: 'Moves focus one cell to the left.',
+              },
+              {
+                title: <kbd>Home</kbd>,
+                description:
+                  'Moves focus to the first cell in the current row.',
+              },
+              {
+                title: <kbd>End</kbd>,
+                description: 'Moves focus to the last cell in the current row.',
+              },
+              {
+                title: (
+                  <>
+                    <kbd>Ctrl</kbd> <kbd>Home</kbd>
+                  </>
+                ),
+                description: 'Moves focus to the first cell in the first row.',
+              },
+              {
+                title: (
+                  <>
+                    <kbd>Ctrl</kbd> <kbd>End</kbd>
+                  </>
+                ),
+                description: 'Moves focus to the last cell in the last row.',
+              },
+              {
+                title: <kbd>Page Up</kbd>,
+                description: 'Paginates to the last row of the previous page.',
+              },
+              {
+                title: <kbd>Page Down</kbd>,
+                description: 'Paginates to the first row of the next page.',
+              },
+              {
+                title: <kbd>Enter</kbd>,
+                description:
+                  'Opens cell expansion popover for interactive cells.',
+              },
+              {
+                title: <kbd>Escape</kbd>,
+                description: 'Closes any open popovers.',
+              },
+            ]}
+          />
+        </EuiText>
       </EuiPopover>
     ),
     [isOpen, buttonLabel]

--- a/src/components/datagrid/controls/keyboard_shortcuts.tsx
+++ b/src/components/datagrid/controls/keyboard_shortcuts.tsx
@@ -14,7 +14,7 @@ import { EuiToolTip } from '../../tool_tip';
 import { EuiPopover, EuiPopoverTitle } from '../../popover';
 import { EuiDescriptionList } from '../../description_list';
 import { EuiText } from '../../text';
-import { useEuiI18n } from '../../i18n';
+import { useEuiI18n, EuiI18n } from '../../i18n';
 
 export const useDataGridKeyboardShortcuts = (): {
   keyboardShortcuts: ReactNode;
@@ -56,62 +56,212 @@ export const useDataGridKeyboardShortcuts = (): {
             gutterSize="s"
             listItems={[
               {
-                title: <kbd>Up arrow</kbd>,
-                description: 'Moves focus one cell down.',
+                title: (
+                  <kbd>
+                    <EuiI18n
+                      token="euiKeyboardShortcuts.upArrowTitle"
+                      default="Up arrow"
+                    />
+                  </kbd>
+                ),
+                description: (
+                  <EuiI18n
+                    token="euiKeyboardShortcuts.upArrowDescription"
+                    default="Moves focus one cell up."
+                  />
+                ),
               },
               {
-                title: <kbd>Down arrow</kbd>,
-                description: 'Moves focus one cell up.',
+                title: (
+                  <kbd>
+                    <EuiI18n
+                      token="euiKeyboardShortcuts.downArrowTitle"
+                      default="Down arrow"
+                    />
+                  </kbd>
+                ),
+                description: (
+                  <EuiI18n
+                    token="euiKeyboardShortcuts.downArrowDescription"
+                    default="Moves focus one cell down."
+                  />
+                ),
               },
               {
-                title: <kbd>Right arrow</kbd>,
-                description: 'Moves focus one cell to the right.',
+                title: (
+                  <kbd>
+                    <EuiI18n
+                      token="euiKeyboardShortcuts.rightArrowTitle"
+                      default="Right arrow"
+                    />
+                  </kbd>
+                ),
+                description: (
+                  <EuiI18n
+                    token="euiKeyboardShortcuts.rightArrowDescription"
+                    default="Moves focus one cell to the right."
+                  />
+                ),
               },
               {
-                title: <kbd>Left arrow</kbd>,
-                description: 'Moves focus one cell to the left.',
+                title: (
+                  <kbd>
+                    <EuiI18n
+                      token="euiKeyboardShortcuts.leftArrowTitle"
+                      default="Left arrow"
+                    />
+                  </kbd>
+                ),
+                description: (
+                  <EuiI18n
+                    token="euiKeyboardShortcuts.leftArrowDescription"
+                    default="Moves focus one cell to the left."
+                  />
+                ),
               },
               {
-                title: <kbd>Home</kbd>,
-                description:
-                  'Moves focus to the first cell in the current row.',
+                title: (
+                  <kbd>
+                    <EuiI18n
+                      token="euiKeyboardShortcuts.homeTitle"
+                      default="Home"
+                    />
+                  </kbd>
+                ),
+                description: (
+                  <EuiI18n
+                    token="euiKeyboardShortcuts.homeDescription"
+                    default="Moves focus to the first cell in the current row."
+                  />
+                ),
               },
               {
-                title: <kbd>End</kbd>,
-                description: 'Moves focus to the last cell in the current row.',
+                title: (
+                  <kbd>
+                    <EuiI18n
+                      token="euiKeyboardShortcuts.endTitle"
+                      default="End"
+                    />
+                  </kbd>
+                ),
+                description: (
+                  <EuiI18n
+                    token="euiKeyboardShortcuts.endDescription"
+                    default="Moves focus to the last cell in the current row."
+                  />
+                ),
               },
               {
                 title: (
                   <>
-                    <kbd>Ctrl</kbd> <kbd>Home</kbd>
+                    <kbd>
+                      <EuiI18n
+                        token="euiKeyboardShortcuts.ctrl"
+                        default="Ctrl"
+                      />
+                    </kbd>{' '}
+                    <kbd>
+                      <EuiI18n
+                        token="euiKeyboardShortcuts.homeTitle"
+                        default="Home"
+                      />
+                    </kbd>
                   </>
                 ),
-                description: 'Moves focus to the first cell in the first row.',
+                description: (
+                  <EuiI18n
+                    token="euiKeyboardShortcuts.ctrlHomeDescription"
+                    default="Moves focus to the first cell in the first row."
+                  />
+                ),
               },
               {
                 title: (
                   <>
-                    <kbd>Ctrl</kbd> <kbd>End</kbd>
+                    <kbd>
+                      <EuiI18n
+                        token="euiKeyboardShortcuts.ctrl"
+                        default="Ctrl"
+                      />
+                    </kbd>{' '}
+                    <kbd>
+                      <EuiI18n
+                        token="euiKeyboardShortcuts.endTitle"
+                        default="End"
+                      />
+                    </kbd>
                   </>
                 ),
-                description: 'Moves focus to the last cell in the last row.',
+                description: (
+                  <EuiI18n
+                    token="euiKeyboardShortcuts.ctrlEndDescription"
+                    default="Moves focus to the last cell in the last row."
+                  />
+                ),
               },
               {
-                title: <kbd>Page Up</kbd>,
-                description: 'Paginates to the last row of the previous page.',
+                title: (
+                  <kbd>
+                    <EuiI18n
+                      token="euiKeyboardShortcuts.pageUpTitle"
+                      default="Page Up"
+                    />
+                  </kbd>
+                ),
+                description: (
+                  <EuiI18n
+                    token="euiKeyboardShortcuts.pageUpDescription"
+                    default="Paginates to the last row of the previous page."
+                  />
+                ),
               },
               {
-                title: <kbd>Page Down</kbd>,
-                description: 'Paginates to the first row of the next page.',
+                title: (
+                  <kbd>
+                    <EuiI18n
+                      token="euiKeyboardShortcuts.pageDownTitle"
+                      default="Page Down"
+                    />
+                  </kbd>
+                ),
+                description: (
+                  <EuiI18n
+                    token="euiKeyboardShortcuts.pageDownDescription"
+                    default="Paginates to the first row of the next page."
+                  />
+                ),
               },
               {
-                title: <kbd>Enter</kbd>,
-                description:
-                  'Opens cell expansion popover for interactive cells.',
+                title: (
+                  <kbd>
+                    <EuiI18n
+                      token="euiKeyboardShortcuts.enterTitle"
+                      default="Enter"
+                    />
+                  </kbd>
+                ),
+                description: (
+                  <EuiI18n
+                    token="euiKeyboardShortcuts.enterDescription"
+                    default="Opens cell expansion popover for interactive cells."
+                  />
+                ),
               },
               {
-                title: <kbd>Escape</kbd>,
-                description: 'Closes any open popovers.',
+                title: (
+                  <kbd>
+                    <EuiI18n
+                      token="euiKeyboardShortcuts.escapeTitle"
+                      default="Escape"
+                    />
+                  </kbd>
+                ),
+                description: (
+                  <EuiI18n
+                    token="euiKeyboardShortcuts.escapeDescription"
+                    default="Closes any open popovers."
+                  />
+                ),
               },
             ]}
           />

--- a/src/components/datagrid/controls/keyboard_shortcuts.tsx
+++ b/src/components/datagrid/controls/keyboard_shortcuts.tsx
@@ -7,6 +7,8 @@
  */
 
 import React, { useState, useMemo, ReactNode } from 'react';
+
+import { useGeneratedHtmlId } from '../../../services';
 import { EuiButtonIcon } from '../../button';
 import { EuiToolTip } from '../../tool_tip';
 import { EuiPopover, EuiPopoverTitle } from '../../popover';
@@ -20,6 +22,7 @@ export const useDataGridKeyboardShortcuts = (): {
   const [isOpen, setIsOpen] = useState(false);
 
   const title = useEuiI18n('euiKeyboardShortcuts.title', 'Keyboard shortcuts');
+  const titleId = useGeneratedHtmlId();
 
   const keyboardShortcuts = useMemo(
     () => (
@@ -42,9 +45,12 @@ export const useDataGridKeyboardShortcuts = (): {
           </EuiToolTip>
         }
       >
-        <EuiPopoverTitle paddingSize="s">{title}</EuiPopoverTitle>
+        <EuiPopoverTitle paddingSize="s">
+          <h2 id={titleId}>{title}</h2>
+        </EuiPopoverTitle>
         <EuiText size="xs">
           <EuiDescriptionList
+            aria-labelledby={titleId}
             type="column"
             align="center"
             compressed
@@ -112,7 +118,7 @@ export const useDataGridKeyboardShortcuts = (): {
         </EuiText>
       </EuiPopover>
     ),
-    [isOpen, title]
+    [isOpen, title, titleId]
   );
 
   return { keyboardShortcuts };

--- a/src/components/datagrid/data_grid.spec.tsx
+++ b/src/components/datagrid/data_grid.spec.tsx
@@ -271,6 +271,12 @@ describe('EuiDataGrid', () => {
         cy.focused().should(
           'have.attr',
           'data-test-subj',
+          'dataGridKeyboardShortcutsButton'
+        );
+        cy.realPress('Tab');
+        cy.focused().should(
+          'have.attr',
+          'data-test-subj',
           'dataGridDisplaySelectorButton'
         );
         cy.realPress('Tab');

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -24,6 +24,7 @@ import {
   useDataGridDisplaySelector,
   startingStyles,
   useDataGridFullScreenSelector,
+  useDataGridKeyboardShortcuts,
   checkOrDefaultToolBarDisplayOptions,
   EuiDataGridToolbar,
 } from './controls';
@@ -271,9 +272,11 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
     const { cellPopoverContext, cellPopover } = useCellPopover();
 
     /**
-     * Toolbar & fullscreen
+     * Toolbar, keyboard shortcuts, & fullscreen
      */
     const showToolbar = !!toolbarVisibility;
+
+    const { keyboardShortcuts } = useDataGridKeyboardShortcuts();
 
     const {
       isFullScreen,
@@ -384,6 +387,7 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
                     toolbarVisibility={toolbarVisibility}
                     isFullScreen={isFullScreen}
                     fullScreenSelector={fullScreenSelector}
+                    keyboardShortcuts={keyboardShortcuts}
                     displaySelector={displaySelector}
                     columnSelector={columnSelector}
                     columnSorting={columnSorting}

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -39,6 +39,7 @@ export interface EuiDataGridToolbarProps {
   toolbarVisibility: boolean | EuiDataGridToolBarVisibilityOptions;
   isFullScreen: boolean;
   fullScreenSelector: ReactNode;
+  keyboardShortcuts: ReactNode;
   displaySelector: ReactNode;
   columnSelector: ReactNode;
   columnSorting: ReactNode;
@@ -779,6 +780,11 @@ export interface EuiDataGridToolBarVisibilityOptions {
    * Allows the ability for the user to sort rows based upon column values
    */
   showSortSelector?: boolean;
+  /**
+   * Displays a popover listing all keyboard controls and shortcuts for the data grid.
+   * If set to `false`, the toggle will be visually hidden, but still focusable by keyboard and screen reader users.
+   */
+  showKeyboardShortcuts?: boolean;
   /**
    * Allows user to be able to fullscreen the data grid. If set to `false` make sure your grid fits within a large enough panel to still show the other controls.
    */

--- a/src/components/datagrid/utils/scrolling.spec.tsx
+++ b/src/components/datagrid/utils/scrolling.spec.tsx
@@ -37,7 +37,7 @@ describe('useScroll', () => {
   describe('cell focus', () => {
     it('fully scrolls cells into view (accounting for sticky headers, rows, and scrollbars)', () => {
       cy.realMount(<EuiDataGrid {...baseProps} />);
-      cy.repeatRealPress('Tab', 3);
+      cy.repeatRealPress('Tab', 4);
       cy.realPress('ArrowDown');
 
       cy.realPress('End');

--- a/upcoming_changelogs/6036.md
+++ b/upcoming_changelogs/6036.md
@@ -1,0 +1,2 @@
+- Added a keyboard shortcuts popover to `EuiDataGrid`'s toolbar. This can be visually hidden via `toolbarVisibility.showKeyboardShortcuts`, but will always remain accessible to keyboard and screen reader users.
+- `EuiScreenReaderOnly`'s `showOnFocus` prop now also shows on focus within its children


### PR DESCRIPTION
### Summary

closes https://github.com/elastic/eui/issues/2482, see also https://github.com/elastic/kibana/issues/90515 for reference

This PR adds a keyboard shortcuts popover to the EuiDataGrid toolbar. The primary target audience of this functionality is non-sighted screen reader users who otherwise have no indication of how to interact with the data grid.

<img width="1108" alt="" src="https://user-images.githubusercontent.com/549407/200432830-48d5863a-f96b-41ba-8dc8-503a6f0607dc.png">

### Checklist

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~

- [x] Checked in **mobile**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
