### PR TITLE
[EuiContextMenu] Fix `panels.width` prop typing to accept all CSS width values

### DIFF
--- a/src-docs/src/views/context_menu/context_menu_example.js
+++ b/src-docs/src/views/context_menu/context_menu_example.js
@@ -9,6 +9,7 @@ import {
   EuiContextMenuItem,
   EuiContextMenuPanel,
 } from '../../../../src/components';
+import { EuiContextMenuPanelDescriptor } from '!!prop-loader!../../../../src/components/context_menu/context_menu';
 
 import ContextMenu from './context_menu';
 const contextMenuSource = require('!!raw-loader!./context_menu');
@@ -81,7 +82,12 @@ export const ContextMenuExample = {
           this example).
         </p>
       ),
-      props: { EuiContextMenu, EuiContextMenuPanel, EuiContextMenuItem },
+      props: {
+        EuiContextMenu,
+        EuiContextMenuPanelDescriptor,
+        EuiContextMenuPanel,
+        EuiContextMenuItem,
+      },
       snippet: contextMenuSnippet,
       demo: <ContextMenu />,
     },

--- a/src/components/context_menu/context_menu.tsx
+++ b/src/components/context_menu/context_menu.tsx
@@ -9,6 +9,7 @@
 import React, {
   Component,
   HTMLAttributes,
+  CSSProperties,
   ReactElement,
   ReactNode,
 } from 'react';
@@ -53,7 +54,7 @@ export interface EuiContextMenuPanelDescriptor {
   title?: ReactNode;
   items?: EuiContextMenuPanelItemDescriptor[];
   content?: ReactNode;
-  width?: number;
+  width?: CSSProperties['width'];
   initialFocusedItemIndex?: number;
   /**
    * Alters the size of the items and the title

--- a/upcoming_changelogs/6043.md
+++ b/upcoming_changelogs/6043.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiContextMenuPanelDescriptor`'s `width` prop type to correctly reflect that it allows all CSS width values, not just numbers


### PR DESCRIPTION
### Summary

closes https://github.com/elastic/eui/issues/5980

This resolves two issues in the linked thread:

- A consumer who wants to set `width: 100%;` CSS on a non-popover'ed `EuiContextMenu` (which can be accomplished by passing `width: '100%',` on each `panels[]` object) - our typing needed to be updated to allow for all CSS values of `width`, not just numbers
- Lack of prop documentation of the `panels` prop on `EuiContextMenu`

### Checklist

- [x] Props have proper **autodocs** ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~