### PR TITLE
[EuiSelectable] Fix keyboard events not persisting to onChange callbacks

### DIFF
--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -358,6 +358,7 @@ export class EuiSelectable<T = {}> extends Component<
         event.preventDefault();
         event.stopPropagation();
         if (this.state.activeOptionIndex != null && optionsList) {
+          event.persist(); // NOTE: This is needed for React v16 backwards compatibility
           optionsList.onAddOrRemoveOption(
             this.state.visibleOptions[this.state.activeOptionIndex],
             event

--- a/upcoming_changelogs/6045.md
+++ b/upcoming_changelogs/6045.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiSelectable` onChange keyboard events not being correctly passed back on React v16


### PR DESCRIPTION
### Summary

🤦 I completely missed this in #6026. Just throw my body in the trash

### Checklist

- [x] Tested against React v16
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
