### PR TITLE
Add new auto-close cron job for `answered` label

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -33,7 +33,7 @@ jobs:
           remove-stale-when-updated: true
           enable-statistics: true
           debug-only: false
-  answered: # automatically close issues labeled as 'answered' if there was no response in 7 days
+  answered: # automatically close issues labeled as 'answered' if there was no response in 3 days
     permissions:
       issues: write
     runs-on: ubuntu-latest
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/stale@v3
         with:
           days-before-stale: -1 # the label should be manually applied
-          days-before-close: 7
+          days-before-close: 3
           only-issue-labels: 'answered'
           stale-issue-label: 'answered'
           remove-stale-when-updated: true

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -46,7 +46,7 @@ jobs:
           stale-issue-label: 'answered'
           remove-stale-when-updated: true
           stale-issue-message: ''
-          close-issue-message: '👋 This issue hasn''t seen activity in 7 days, so we''re automatically closing this issue as answered. Please leave a comment if that''s not the case, or if you have any remaining questions or issues.'
+          close-issue-message: '👋 This issue hasn''t seen activity in 3 days, so we''re automatically closing this issue as answered. Please leave a comment if that''s not the case, or if you have any remaining questions or issues.'
           operations-per-run: 1000
           enable-statistics: true
           debug-only: false

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -33,3 +33,20 @@ jobs:
           remove-stale-when-updated: true
           enable-statistics: true
           debug-only: false
+  answered: # automatically close issues labeled as 'answered' if there was no response in 7 days
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          days-before-stale: -1 # the label should be manually applied
+          days-before-close: 7
+          only-issue-labels: 'answered'
+          stale-issue-label: 'answered'
+          remove-stale-when-updated: true
+          stale-issue-message: ''
+          close-issue-message: '👋 This issue hasn''t seen activity in 7 days, so we''re automatically closing this issue as answered. Please leave a comment if that''s not the case, or if you have any remaining questions or issues.'
+          operations-per-run: 1000
+          enable-statistics: true
+          debug-only: false


### PR DESCRIPTION
### Summary

Adds another job to our [GitHub Stale Action](https://github.com/actions/stale) that auto-closes all issues (not PRs) marked as `answered` within 7 days. Should hopefully close certain issues faster than the stale bot normally does.

### Checklist

N/A, internal GitHub only change

Issue to test on: https://github.com/elastic/eui/issues/6020