### PR TITLE
[EuiText] Add `kbd` styles

### DIFF
--- a/src-docs/src/views/text/text.js
+++ b/src-docs/src/views/text/text.js
@@ -118,6 +118,14 @@ export default () => (
         <dt>Release date</dt>
         <dd>2002</dd>
       </dl>
+
+      <p>
+        Press <kbd>Ctrl</kbd> + <kbd>C</kbd> to copy text (Windows).
+      </p>
+
+      <p>
+        Press <kbd>Cmd</kbd> + <kbd>C</kbd> to copy text (Mac OS).
+      </p>
     </EuiText>
   </div>
 );

--- a/src/components/text/__snapshots__/text.styles.test.ts.snap
+++ b/src/components/text/__snapshots__/text.styles.test.ts.snap
@@ -124,6 +124,20 @@ exports[`euiTextStyles sizes m 1`] = `
     code:not(.euiCode):not(.euiCodeBlock__code)  {
       font-size: .9em; // 90% of parent font size
     }
+
+    
+    
+   
+  // when the size is 'm' the 'kbd' element get a line bellow the text
+    kbd::after {
+        content: '';
+        display: inline-block;
+        border-bottom: 1px solid #343741;
+        position: absolute;
+        bottom: 2px;
+        left: 0;
+        width: 100%;
+      }
   ;;label:m;"
 `;
 
@@ -251,6 +265,9 @@ exports[`euiTextStyles sizes relative 1`] = `
     code:not(.euiCode):not(.euiCodeBlock__code)  {
       font-size: .9em; // 90% of parent font size
     }
+
+    
+    
   ;;label:relative;"
 `;
 
@@ -378,6 +395,9 @@ exports[`euiTextStyles sizes s 1`] = `
     code:not(.euiCode):not(.euiCodeBlock__code)  {
       font-size: .9em; // 90% of parent font size
     }
+
+    
+    
   ;;label:s;"
 `;
 
@@ -505,5 +525,8 @@ exports[`euiTextStyles sizes xs 1`] = `
     code:not(.euiCode):not(.euiCodeBlock__code)  {
       font-size: .9em; // 90% of parent font size
     }
+
+    
+    
   ;;label:xs;"
 `;

--- a/src/components/text/__snapshots__/text.styles.test.ts.snap
+++ b/src/components/text/__snapshots__/text.styles.test.ts.snap
@@ -124,26 +124,22 @@ exports[`euiTextStyles sizes m 1`] = `
     code:not(.euiCode):not(.euiCodeBlock__code)  {
       font-size: .9em; // 90% of parent font size
     }
-
     
-    
-   
-    // when the size is 'm' the 'kbd' element gets a line between the text and the border-bottom
     kbd {
-        padding-block-end: 4px;;
-        // ensures when only one character the shape looks like a square
-        min-inline-size: 24px;; 
-        text-align: center;
-      }
-      
-      kbd::after {
-        content: '';
-        border-bottom: 1px solid #343741;
-        position: absolute;
-        bottom: 2px;
-        left: 0;
-        width: 100%;
-      }
+      padding-block-end: 4px;
+      // ensures when only one character the shape looks like a square
+      min-inline-size: 24px;
+      text-align: center;
+    }
+    
+    kbd::after {
+      content: '';
+      border-bottom: 1px solid #343741;
+      position: absolute;
+      bottom: 2px;
+      left: 0;
+      width: 100%;
+    }
   ;;label:m;"
 `;
 
@@ -271,8 +267,6 @@ exports[`euiTextStyles sizes relative 1`] = `
     code:not(.euiCode):not(.euiCodeBlock__code)  {
       font-size: .9em; // 90% of parent font size
     }
-
-    
     
   ;;label:relative;"
 `;
@@ -401,8 +395,6 @@ exports[`euiTextStyles sizes s 1`] = `
     code:not(.euiCode):not(.euiCodeBlock__code)  {
       font-size: .9em; // 90% of parent font size
     }
-
-    
     
   ;;label:s;"
 `;
@@ -531,8 +523,6 @@ exports[`euiTextStyles sizes xs 1`] = `
     code:not(.euiCode):not(.euiCodeBlock__code)  {
       font-size: .9em; // 90% of parent font size
     }
-
-    
     
   ;;label:xs;"
 `;

--- a/src/components/text/__snapshots__/text.styles.test.ts.snap
+++ b/src/components/text/__snapshots__/text.styles.test.ts.snap
@@ -128,10 +128,16 @@ exports[`euiTextStyles sizes m 1`] = `
     
     
    
-  // when the size is 'm' the 'kbd' element get a line bellow the text
-    kbd::after {
+    // when the size is 'm' the 'kbd' element gets a line between the text and the border-bottom
+    kbd {
+        padding-block-end: 4px;;
+        // ensures when only one character the shape looks like a square
+        min-inline-size: 24px;; 
+        text-align: center;
+      }
+      
+      kbd::after {
         content: '';
-        display: inline-block;
         border-bottom: 1px solid #343741;
         position: absolute;
         bottom: 2px;

--- a/src/components/text/text.styles.ts
+++ b/src/components/text/text.styles.ts
@@ -182,6 +182,34 @@ const euiScaleText = (
     code:not(.euiCode):not(.euiCodeBlock__code)  {
       font-size: .9em; // 90% of parent font size
     }
+
+    
+    
+  `;
+};
+
+// Internal utility for EuiText ornaments
+const euiGetTextOrnaments = (
+  euiThemeContext: UseEuiTheme,
+  options: _FontScaleOptions
+) => {
+  const { euiTheme } = euiThemeContext;
+  const { customScale } = options;
+
+  return `
+  // when the size is 'm' the 'kbd' element get a line bellow the text
+    ${
+      customScale === 'm' &&
+      `kbd::after {
+        content: '';
+        display: inline-block;
+        border-bottom: 1px solid ${euiTheme.colors.text};
+        position: absolute;
+        bottom: ${euiTheme.size.xxs};
+        left: 0;
+        width: 100%;
+      }`
+    }
   `;
 };
 
@@ -303,6 +331,13 @@ export const euiTextStyles = (euiThemeContext: UseEuiTheme) => {
       > :last-child {
         margin-bottom: 0 !important;
       }
+
+      kbd {
+        position: relative;
+        ${logicalCSS('padding-horizontal', euiTheme.size.xs)}
+        border: 1px solid ${euiTheme.colors.text};
+        border-radius: calc(${euiTheme.border.radius.small} / 2);
+      }
     `,
     constrainedWidth: css`
       max-width: ${euiTextConstrainedMaxWidth};
@@ -311,6 +346,10 @@ export const euiTextStyles = (euiThemeContext: UseEuiTheme) => {
     m: css`
       ${euiScaleText(euiThemeContext, {
         measurement: 'rem',
+        customScale: 'm',
+      })}
+
+      ${euiGetTextOrnaments(euiThemeContext, {
         customScale: 'm',
       })}
     `,

--- a/src/components/text/text.styles.ts
+++ b/src/components/text/text.styles.ts
@@ -197,12 +197,18 @@ const euiGetTextOrnaments = (
   const { customScale } = options;
 
   return `
-  // when the size is 'm' the 'kbd' element get a line bellow the text
+    // when the size is 'm' the 'kbd' element gets a line between the text and the border-bottom
     ${
       customScale === 'm' &&
-      `kbd::after {
+      `kbd {
+        ${logicalCSS('padding-bottom', euiTheme.size.xs)};
+        // ensures when only one character the shape looks like a square
+        ${logicalCSS('min-width', euiTheme.size.l)}; 
+        text-align: center;
+      }
+      
+      kbd::after {
         content: '';
-        display: inline-block;
         border-bottom: 1px solid ${euiTheme.colors.text};
         position: absolute;
         bottom: ${euiTheme.size.xxs};
@@ -334,7 +340,10 @@ export const euiTextStyles = (euiThemeContext: UseEuiTheme) => {
 
       kbd {
         position: relative;
-        ${logicalCSS('padding-horizontal', euiTheme.size.xs)}
+        display: inline-block;
+        ${logicalCSS('padding-vertical', euiTheme.size.xxs)};
+        ${logicalCSS('padding-horizontal', euiTheme.size.xs)};
+        line-height: 1;
         border: 1px solid ${euiTheme.colors.text};
         border-radius: calc(${euiTheme.border.radius.small} / 2);
       }

--- a/src/components/text/text.styles.ts
+++ b/src/components/text/text.styles.ts
@@ -188,7 +188,7 @@ const euiScaleText = (
   `;
 };
 
-// Internal utility for EuiText ornaments
+// Internal utility for getting EuiText ornaments based on options
 const euiGetTextOrnaments = (
   euiThemeContext: UseEuiTheme,
   options: _FontScaleOptions

--- a/src/components/text/text.styles.ts
+++ b/src/components/text/text.styles.ts
@@ -182,39 +182,28 @@ const euiScaleText = (
     code:not(.euiCode):not(.euiCodeBlock__code)  {
       font-size: .9em; // 90% of parent font size
     }
-
-    
-    
-  `;
-};
-
-// Internal utility for getting EuiText ornaments based on options
-const euiGetTextOrnaments = (
-  euiThemeContext: UseEuiTheme,
-  options: _FontScaleOptions
-) => {
-  const { euiTheme } = euiThemeContext;
-  const { customScale } = options;
-
-  return `
-    // when the size is 'm' the 'kbd' element gets a line between the text and the border-bottom
     ${
-      customScale === 'm' &&
-      `kbd {
-        ${logicalCSS('padding-bottom', euiTheme.size.xs)};
-        // ensures when only one character the shape looks like a square
-        ${logicalCSS('min-width', euiTheme.size.l)}; 
-        text-align: center;
-      }
-      
-      kbd::after {
-        content: '';
-        border-bottom: 1px solid ${euiTheme.colors.text};
-        position: absolute;
-        bottom: ${euiTheme.size.xxs};
-        left: 0;
-        width: 100%;
-      }`
+      // when textSize is 'm', the 'kbd' element gets a line between the text and the border-bottom
+      _customScale === 'm'
+        ? `
+    kbd {
+      ${logicalCSS('padding-bottom', euiTheme.size.xs)}
+      // ensures when only one character the shape looks like a square
+      ${logicalCSS('min-width', euiTheme.size.l)}
+      text-align: center;
+    }
+    
+    kbd::after {
+      content: '';
+      border-bottom: ${euiTheme.border.width.thin} solid ${
+            euiTheme.colors.text
+          };
+      position: absolute;
+      bottom: ${euiTheme.size.xxs};
+      left: 0;
+      width: 100%;
+    }`
+        : ''
     }
   `;
 };
@@ -341,10 +330,10 @@ export const euiTextStyles = (euiThemeContext: UseEuiTheme) => {
       kbd {
         position: relative;
         display: inline-block;
-        ${logicalCSS('padding-vertical', euiTheme.size.xxs)};
-        ${logicalCSS('padding-horizontal', euiTheme.size.xs)};
+        ${logicalCSS('padding-vertical', euiTheme.size.xxs)}
+        ${logicalCSS('padding-horizontal', euiTheme.size.xs)}
         line-height: 1;
-        border: 1px solid ${euiTheme.colors.text};
+        border: ${euiTheme.border.width.thin} solid ${euiTheme.colors.text};
         border-radius: calc(${euiTheme.border.radius.small} / 2);
       }
     `,
@@ -355,10 +344,6 @@ export const euiTextStyles = (euiThemeContext: UseEuiTheme) => {
     m: css`
       ${euiScaleText(euiThemeContext, {
         measurement: 'rem',
-        customScale: 'm',
-      })}
-
-      ${euiGetTextOrnaments(euiThemeContext, {
         customScale: 'm',
       })}
     `,

--- a/upcoming_changelogs/6049.md
+++ b/upcoming_changelogs/6049.md
@@ -1,0 +1,1 @@
+- Added styles for `kbd`'s within `EuiText`


### PR DESCRIPTION
## Summary

Closes #5016.

This PR adds styles for `kbd`'s within `EuiText`.

- This can be tested locally by replacing the file `src-docs/src/views/text/text.js` with the content from: https://gist.github.com/miukimiu/ed2274e98af630f46013fd767b4a9799. 
- Or just use the playground in https://eui.elastic.co/pr_6049/#/display/text.

## `kbd` within different `EuiText` sizes:

<img width="531" alt="kbd@2x" src="https://user-images.githubusercontent.com/2750668/178785273-397b36cd-4e1d-49e9-8c33-a6d9c3290f64.png">


## Code vs Figma

The implementation differs a little bit from Figma because of the way the font is rendered.

<img width="248" alt="code vs figma@2x" src="https://user-images.githubusercontent.com/2750668/178785849-7bf5a7d0-3c2f-48df-9ecf-3616e9967978.png">


### Checklist

- [x] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
