### PR TITLE
Fix some Emotion snapshots not being correctly converted to static classNames

### DIFF
--- a/src/components/health/__snapshots__/health.test.tsx.snap
+++ b/src/components/health/__snapshots__/health.test.tsx.snap
@@ -289,7 +289,7 @@ exports[`EuiHealth props textSize inherit is rendered 1`] = `
 
 exports[`EuiHealth props textSize m is rendered 1`] = `
 <div
-  class="euiHealth css-28ntf-euiHealth-m"
+  class="euiHealth emotion-euiHealth-m"
 >
   <div
     class="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"

--- a/src/components/loading/__snapshots__/loading_chart.test.tsx.snap
+++ b/src/components/loading/__snapshots__/loading_chart.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`EuiLoadingChart size xl is rendered 1`] = `
     class="emotion-euiLoadingChart__bar-xl"
   />
   <span
-    class="css-3rl1i-euiLoadingChart__bar-xl"
+    class="emotion-euiLoadingChart__bar-xl"
   />
   <span
     class="emotion-euiLoadingChart__bar-xl"

--- a/src/components/stat/__snapshots__/stat.test.tsx.snap
+++ b/src/components/stat/__snapshots__/stat.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`EuiStat props accent is rendered 1`] = `
   </div>
   <p
     aria-hidden="true"
-    class="euiTitle euiStat__title css-v0lnn-euiTitle-l-euiStat__title-accent"
+    class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-accent"
   >
     title
   </p>

--- a/src/test/emotion-prefix.ts
+++ b/src/test/emotion-prefix.ts
@@ -12,7 +12,7 @@ export const replaceEmotionPrefix = (selector: string) => {
   // Contains `eui[ComponentName] or `Eui[ComponentName]`.
   // Capture the component name (from above) and all variant additions until the end of the string.
   const euiMatch = selector.match(
-    /css-[\d\w]{6,}-(?<euiComponent>[eE]ui[A-Z][\d\w-]*$)/
+    /css-[\d\w]{5,}-(?<euiComponent>[eE]ui[A-Z][\d\w-]*$)/
   );
   // Use the captured group (`euiComponent`) if available and prepend with `emotion-`,
   // otherwise use the full selector.


### PR DESCRIPTION
### Summary

I only just noticed in a current Emotion PR that Emotion sometimes output 5 character hashes 🙈 

### Checklist

N/A, tests only. May affect Kibana/create snapshot churn for them down the road