### PR TITLE
[EuiText] Fix multiple missing CSS logical properties

### DIFF
--- a/src/components/text/__snapshots__/text.styles.test.ts.snap
+++ b/src/components/text/__snapshots__/text.styles.test.ts.snap
@@ -134,11 +134,11 @@ exports[`euiTextStyles sizes m 1`] = `
     
     kbd::after {
       content: '';
-      border-bottom: 1px solid #343741;
+      border-block-end: 1px solid #343741;
       position: absolute;
-      bottom: 2px;
-      left: 0;
-      width: 100%;
+      inset-block-end: 2px;
+      inset-inline-start: 0;
+      inline-size: 100%;
     }
   ;;label:m;"
 `;

--- a/src/components/text/text.styles.ts
+++ b/src/components/text/text.styles.ts
@@ -10,6 +10,7 @@ import { css } from '@emotion/react';
 import { UseEuiTheme } from '../../services';
 import {
   logicalCSS,
+  logicalTextAlignCSS,
   euiFontSize,
   euiBackgroundColor,
   _FontScaleOptions,
@@ -190,7 +191,7 @@ const euiScaleText = (
       ${logicalCSS('padding-bottom', euiTheme.size.xs)}
       // ensures when only one character the shape looks like a square
       ${logicalCSS('min-width', euiTheme.size.l)}
-      text-align: center;
+      ${logicalTextAlignCSS('center')}
     }
     
     kbd::after {
@@ -243,7 +244,7 @@ export const euiTextStyles = (euiThemeContext: UseEuiTheme) => {
 
       blockquote:not(.euiMarkdownFormat__blockquote) {
         position: relative;
-        text-align: center;
+        ${logicalTextAlignCSS('center')}
         ${logicalCSS('margin-horizontal', 'auto')}
         font-family: ${euiTheme.font.familySerif};
         font-style: italic;

--- a/src/components/text/text.styles.ts
+++ b/src/components/text/text.styles.ts
@@ -195,13 +195,14 @@ const euiScaleText = (
     
     kbd::after {
       content: '';
-      border-bottom: ${euiTheme.border.width.thin} solid ${
-            euiTheme.colors.text
-          };
+      ${logicalCSS(
+        'border-bottom',
+        `${euiTheme.border.width.thin} solid ${euiTheme.colors.text}`
+      )}
       position: absolute;
-      bottom: ${euiTheme.size.xxs};
-      left: 0;
-      width: 100%;
+      ${logicalCSS('bottom', euiTheme.size.xxs)}
+      ${logicalCSS('left', 0)}
+      ${logicalCSS('width', '100%')}
     }`
         : ''
     }
@@ -249,26 +250,26 @@ export const euiTextStyles = (euiThemeContext: UseEuiTheme) => {
         letter-spacing: normal;
 
         p:last-child {
-          margin-bottom: 0;
+          ${logicalCSS('margin-bottom', '0')}
         }
 
         &:before,
         &:after {
           position: absolute;
           content: '';
-          height: ${euiTheme.border.width.thick};
-          width: 50%;
-          right: 0;
-          transform: translateX(-50%);
+          ${logicalCSS('height', euiTheme.border.width.thick)}
+          ${logicalCSS('width', '50%')}
+          ${logicalCSS('left', '25%')}
+          ${logicalCSS('right', '25%')}
           background: ${euiTheme.colors.darkShade};
         }
 
         &:before {
-          top: 0;
+          ${logicalCSS('top', '0')}
         }
 
         &:after {
-          bottom: 0;
+          ${logicalCSS('bottom', '0')}
         }
       }
 
@@ -324,7 +325,7 @@ export const euiTextStyles = (euiThemeContext: UseEuiTheme) => {
       }
 
       > :last-child {
-        margin-bottom: 0 !important;
+        ${logicalCSS('margin-bottom', '0 !important')}
       }
 
       kbd {
@@ -338,7 +339,7 @@ export const euiTextStyles = (euiThemeContext: UseEuiTheme) => {
       }
     `,
     constrainedWidth: css`
-      max-width: ${euiTextConstrainedMaxWidth};
+      ${logicalCSS('max-width', euiTextConstrainedMaxWidth)}
     `,
     // Sizes
     m: css`

--- a/upcoming_changelogs/6059.md
+++ b/upcoming_changelogs/6059.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed multiple missing CSS logical properties within `EuiText` children


### PR DESCRIPTION
## Summary

I missed converting a few of these properties in #5895 and #6049 🙈 

### Before
<img width="300" alt="" src="https://user-images.githubusercontent.com/549407/179581507-300b3966-b47f-44e2-af5d-d729c7025806.png"> <img width="300" alt="" src="https://user-images.githubusercontent.com/549407/179581501-6c508762-7844-4bc6-bf4d-f6981e7a7b36.png">

### After
<img width="300" alt="" src="https://user-images.githubusercontent.com/549407/179581345-668f59da-8971-4b07-b282-bbfcb7c60f3d.png"> <img width="300" alt="" src="https://user-images.githubusercontent.com/549407/179581349-fcbdb8be-301a-4d13-bba0-9e3554bd973d.png">

### Checklist

- [x] Checked in `direction: rtl` and `writing-mode: vertical-rl`
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately