### PR TITLE
[Docs EuiPortal] Fix CodeSandbox demos

### DIFF
--- a/src-docs/src/views/portal/portal.js
+++ b/src-docs/src/views/portal/portal.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import { EuiPortal, EuiButton, EuiBottomBar } from '../../../../src/components';
 
-export const Portal = () => {
+export default () => {
   const [isPortalVisible, setIsPortalVisible] = useState(false);
 
   const togglePortal = () => {

--- a/src-docs/src/views/portal/portal_example.js
+++ b/src-docs/src/views/portal/portal_example.js
@@ -4,10 +4,10 @@ import { GuideSectionTypes } from '../../components';
 
 import { EuiCode, EuiPortal } from '../../../../src/components';
 
-import { Portal } from './portal';
+import Portal from './portal';
 const portalSource = require('!!raw-loader!./portal');
 
-import { PortalInsert } from './portal_insert';
+import PortalInsert from './portal_insert';
 const portalInsertSource = require('!!raw-loader!./portal_insert');
 
 export const PortalExample = {

--- a/src-docs/src/views/portal/portal_insert.js
+++ b/src-docs/src/views/portal/portal_insert.js
@@ -5,7 +5,7 @@ import { EuiSpacer } from '../../../../src/components/spacer/spacer';
 
 let buttonRef = null;
 
-export const PortalInsert = () => {
+export default () => {
   const [isPortalVisible, setIsPortalVisible] = useState(false);
 
   const setButtonRef = (node) => (buttonRef = node);


### PR DESCRIPTION
### Summary

This PR fixes the CodeSandbox demos in `/utilities/portal`.

### Before 

<img width="1437" alt="Screenshot 2022-07-19 at 17 36 50" src="https://user-images.githubusercontent.com/2750668/179803475-21e3c3ea-323e-491b-90f3-dbdb73f893ca.png">

 ### After
 
<img width="1430" alt="Screenshot 2022-07-19 at 17 37 15" src="https://user-images.githubusercontent.com/2750668/179803461-1bdf0cc9-a9c5-4588-89bd-356669891416.png">


### Checklist

- [ ] ~Checked in both **light and dark** modes~
- [ ] ~Checked in **mobile**~
- [ ] ~Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- [ ] ~Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] ~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] ~Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [ ] ~A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
