### PR TITLE
[Emotion] Fix `euiBreakpoint` behavior to match Sass mixin

### DIFF
--- a/scripts/jest/config.json
+++ b/scripts/jest/config.json
@@ -8,11 +8,11 @@
     "<rootDir>/packages/eslint-plugin"
   ],
   "collectCoverageFrom": [
-    "src/{components,services}/**/*.{ts,tsx,js,jsx}",
-    "!src/{components,services}/**/*.spec.{ts,tsx,js,jsx}",
-    "!src/{components,services}/**/*.testenv.{ts,tsx,js,jsx}",
-    "!src/{components,services}/index.ts",
-    "!src/{components,services}/**/*/index.ts",
+    "src/{components,services,global_styling}/**/*.{ts,tsx,js,jsx}",
+    "!src/{components,services,global_styling}/**/*.spec.{ts,tsx,js,jsx}",
+    "!src/{components,services,global_styling}/**/*.testenv.{ts,tsx,js,jsx}",
+    "!src/{components,services,global_styling}/index.ts",
+    "!src/{components,services,global_styling}/**/*/index.ts",
     "!src/components/date_picker/react-datepicker/**/*.{js,jsx}"
   ],
   "moduleNameMapper": {

--- a/src-docs/src/views/theme/breakpoints/_breakpoints_js.tsx
+++ b/src-docs/src/views/theme/breakpoints/_breakpoints_js.tsx
@@ -157,25 +157,28 @@ export default () => {
         example={
           <p
             css={css`
-              ${useEuiBreakpoint([0, 'm'])} {
+              ${useEuiBreakpoint(['xs', 's'])} {
                 color: ${euiTheme.colors.dangerText};
               }
-              ${useEuiBreakpoint(['m', 'xl'])} {
+              ${useEuiBreakpoint(['m'])} {
                 color: ${euiTheme.colors.warningText};
               }
-              ${useEuiBreakpoint(['xl', Infinity])} {
+              ${useEuiBreakpoint(['l', 'xl'])} {
                 color: ${euiTheme.colors.successText};
               }
             `}
           >
-            This text is red on screens narrower than `m`, yellow between `m` to
-            `xl` breakpoints, and green on screens wider than `xl`.
+            This text is red on small screens, yellow on medium screens, and
+            green on large screens.
           </p>
         }
-        snippet={`\${useEuiBreakpoint(['m', 'xl'])} {
+        snippet={`\${useEuiBreakpoint(['xs', 's'])} {
     color: red;
   }
-  \${useEuiBreakpoint(['xl', Infinity])} {
+  \${useEuiBreakpoint(['m'])} {
+    color: yellow;
+  }
+  \${useEuiBreakpoint(['l', 'xl'])} {
     color: green;
   }`}
         snippetLanguage="emotion"

--- a/src-docs/src/views/theme/breakpoints/_breakpoints_js.tsx
+++ b/src-docs/src/views/theme/breakpoints/_breakpoints_js.tsx
@@ -148,15 +148,18 @@ export default () => {
             </p>
             <p>
               You can also create media queries with a{' '}
-              <EuiCode>(min-width)</EuiCode> only or{' '}
-              <EuiCode>(max-width)</EuiCode> only by utilizing the{' '}
-              <EuiCode>0</EuiCode> and <EuiCode>Infinity</EuiCode> arguments.
+              <EuiCode>(max-width)</EuiCode> only or{' '}
+              <EuiCode>(min-width)</EuiCode> only by utilizing the{' '}
+              <EuiCode>xs</EuiCode> and <EuiCode>xl</EuiCode> arguments.
             </p>
           </>
         }
         example={
           <p
             css={css`
+              ${useEuiBreakpoint(['s', 'l'])} {
+                font-weight: ${euiTheme.font.weight.bold};
+              }
               ${useEuiBreakpoint(['xs', 's'])} {
                 color: ${euiTheme.colors.dangerText};
               }
@@ -168,11 +171,15 @@ export default () => {
               }
             `}
           >
-            This text is red on small screens, yellow on medium screens, and
-            green on large screens.
+            This text is bold on small to large screens, red on small and below
+            screens, yellow on medium screens, and green on large and above
+            screens.
           </p>
         }
-        snippet={`\${useEuiBreakpoint(['xs', 's'])} {
+        snippet={`\${useEuiBreakpoint(['s', 'l'])} {
+    font-weight: bold;
+  }
+  \${useEuiBreakpoint(['xs', 's'])} {
     color: red;
   }
   \${useEuiBreakpoint(['m'])} {

--- a/src/global_styling/mixins/__snapshots__/_responsive.test.ts.snap
+++ b/src/global_styling/mixins/__snapshots__/_responsive.test.ts.snap
@@ -1,53 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`useEuiBreakpoint 0 as a first argument should not render a min-width query (0 and l) 1`] = `"@media only screen and (max-width: 991px)"`;
+exports[`useEuiBreakpoint common breakpoint size arrays returns a media query for two element breakpoint combinations (l and xl) 1`] = `"@media only screen and (min-width: 992px)"`;
 
-exports[`useEuiBreakpoint 0 as a first argument should not render a min-width query (0 and m) 1`] = `"@media only screen and (max-width: 767px)"`;
+exports[`useEuiBreakpoint common breakpoint size arrays returns a media query for two element breakpoint combinations (m and l) 1`] = `"@media only screen and (min-width: 768px) and (max-width: 1199px)"`;
 
-exports[`useEuiBreakpoint 0 as a first argument should not render a min-width query (0 and s) 1`] = `"@media only screen and (max-width: 574px)"`;
+exports[`useEuiBreakpoint common breakpoint size arrays returns a media query for two element breakpoint combinations (m and xl) 1`] = `"@media only screen and (min-width: 768px)"`;
 
-exports[`useEuiBreakpoint 0 as a first argument should not render a min-width query (0 and xl) 1`] = `"@media only screen and (max-width: 1199px)"`;
+exports[`useEuiBreakpoint common breakpoint size arrays returns a media query for two element breakpoint combinations (s and l) 1`] = `"@media only screen and (min-width: 575px) and (max-width: 1199px)"`;
 
-exports[`useEuiBreakpoint 0 as a first argument should not render a min-width query (0 and xs) 1`] = `"@media only screen"`;
+exports[`useEuiBreakpoint common breakpoint size arrays returns a media query for two element breakpoint combinations (s and m) 1`] = `"@media only screen and (min-width: 575px) and (max-width: 991px)"`;
 
-exports[`useEuiBreakpoint Infinity as a last argument should not render a max-width query (l and Infinity) 1`] = `"@media only screen and (min-width: 992px)"`;
+exports[`useEuiBreakpoint common breakpoint size arrays returns a media query for two element breakpoint combinations (s and xl) 1`] = `"@media only screen and (min-width: 575px)"`;
 
-exports[`useEuiBreakpoint Infinity as a last argument should not render a max-width query (m and Infinity) 1`] = `"@media only screen and (min-width: 768px)"`;
+exports[`useEuiBreakpoint common breakpoint size arrays returns a media query for two element breakpoint combinations (xs and l) 1`] = `"@media only screen and (max-width: 1199px)"`;
 
-exports[`useEuiBreakpoint Infinity as a last argument should not render a max-width query (s and Infinity) 1`] = `"@media only screen and (min-width: 575px)"`;
+exports[`useEuiBreakpoint common breakpoint size arrays returns a media query for two element breakpoint combinations (xs and m) 1`] = `"@media only screen and (max-width: 991px)"`;
 
-exports[`useEuiBreakpoint Infinity as a last argument should not render a max-width query (xl and Infinity) 1`] = `"@media only screen and (min-width: 1200px)"`;
+exports[`useEuiBreakpoint common breakpoint size arrays returns a media query for two element breakpoint combinations (xs and s) 1`] = `"@media only screen and (max-width: 767px)"`;
 
-exports[`useEuiBreakpoint Infinity as a last argument should not render a max-width query (xs and Infinity) 1`] = `"@media only screen"`;
+exports[`useEuiBreakpoint common breakpoint size arrays returns a media query for two element breakpoint combinations (xs and xl) 1`] = `"@media only screen"`;
 
-exports[`useEuiBreakpoint breakpoint size arrays with more than 2 sizes should use the first and last items in the array 1`] = `"@media only screen and (min-width: 575px) and (max-width: 991px)"`;
+exports[`useEuiBreakpoint single breakpoint sizes (l) 1`] = `"@media only screen and (min-width: 992px) and (max-width: 1199px)"`;
 
-exports[`useEuiBreakpoint common breakpoint size arrays useEuiBreakpoint returns a media query for two element breakpoint combinations (l and xl) 1`] = `"@media only screen and (min-width: 992px) and (max-width: 1199px)"`;
+exports[`useEuiBreakpoint single breakpoint sizes (m) 1`] = `"@media only screen and (min-width: 768px) and (max-width: 991px)"`;
 
-exports[`useEuiBreakpoint common breakpoint size arrays useEuiBreakpoint returns a media query for two element breakpoint combinations (m and l) 1`] = `"@media only screen and (min-width: 768px) and (max-width: 991px)"`;
+exports[`useEuiBreakpoint single breakpoint sizes (s) 1`] = `"@media only screen and (min-width: 575px) and (max-width: 767px)"`;
 
-exports[`useEuiBreakpoint common breakpoint size arrays useEuiBreakpoint returns a media query for two element breakpoint combinations (m and xl) 1`] = `"@media only screen and (min-width: 768px) and (max-width: 1199px)"`;
+exports[`useEuiBreakpoint single breakpoint sizes (xl) 1`] = `"@media only screen and (min-width: 1200px)"`;
 
-exports[`useEuiBreakpoint common breakpoint size arrays useEuiBreakpoint returns a media query for two element breakpoint combinations (s and l) 1`] = `"@media only screen and (min-width: 575px) and (max-width: 991px)"`;
-
-exports[`useEuiBreakpoint common breakpoint size arrays useEuiBreakpoint returns a media query for two element breakpoint combinations (s and m) 1`] = `"@media only screen and (min-width: 575px) and (max-width: 767px)"`;
-
-exports[`useEuiBreakpoint common breakpoint size arrays useEuiBreakpoint returns a media query for two element breakpoint combinations (s and xl) 1`] = `"@media only screen and (min-width: 575px) and (max-width: 1199px)"`;
-
-exports[`useEuiBreakpoint common breakpoint size arrays useEuiBreakpoint returns a media query for two element breakpoint combinations (xs and l) 1`] = `"@media only screen and (max-width: 991px)"`;
-
-exports[`useEuiBreakpoint common breakpoint size arrays useEuiBreakpoint returns a media query for two element breakpoint combinations (xs and m) 1`] = `"@media only screen and (max-width: 767px)"`;
-
-exports[`useEuiBreakpoint common breakpoint size arrays useEuiBreakpoint returns a media query for two element breakpoint combinations (xs and s) 1`] = `"@media only screen and (max-width: 574px)"`;
-
-exports[`useEuiBreakpoint common breakpoint size arrays useEuiBreakpoint returns a media query for two element breakpoint combinations (xs and xl) 1`] = `"@media only screen and (max-width: 1199px)"`;
-
-exports[`useEuiBreakpoint single breakpoint sizes should infer the next breakpoint size as max-width l 1`] = `"@media only screen and (min-width: 992px) and (max-width: 1199px)"`;
-
-exports[`useEuiBreakpoint single breakpoint sizes should infer the next breakpoint size as max-width m 1`] = `"@media only screen and (min-width: 768px) and (max-width: 991px)"`;
-
-exports[`useEuiBreakpoint single breakpoint sizes should infer the next breakpoint size as max-width s 1`] = `"@media only screen and (min-width: 575px) and (max-width: 767px)"`;
-
-exports[`useEuiBreakpoint single breakpoint sizes should infer the next breakpoint size as max-width xl 1`] = `"@media only screen and (min-width: 1200px)"`;
-
-exports[`useEuiBreakpoint single breakpoint sizes should infer the next breakpoint size as max-width xs 1`] = `"@media only screen and (max-width: 574px)"`;
+exports[`useEuiBreakpoint single breakpoint sizes (xs) 1`] = `"@media only screen and (max-width: 574px)"`;

--- a/src/global_styling/mixins/_responsive.test.ts
+++ b/src/global_styling/mixins/_responsive.test.ts
@@ -25,7 +25,7 @@ describe('useEuiBreakpoint', () => {
     }
 
     test.each(possibleTwoElementBreakpointCombinations)(
-      'useEuiBreakpoint returns a media query for two element breakpoint combinations (%s and %s)',
+      'returns a media query for two element breakpoint combinations (%s and %s)',
       (minSize, maxSize) => {
         expect(
           testCustomHook(() =>
@@ -39,21 +39,11 @@ describe('useEuiBreakpoint', () => {
     );
   });
 
-  describe('0 as a first argument should not render a min-width query', () => {
+  describe('single breakpoint sizes', () => {
     EuiThemeBreakpoints.forEach((size) => {
-      test(`(0 and ${size})`, () => {
+      test(`(${size})`, () => {
         expect(
-          testCustomHook(() => useEuiBreakpoint([0, size])).return
-        ).toMatchSnapshot();
-      });
-    });
-  });
-
-  describe('Infinity as a last argument should not render a max-width query', () => {
-    EuiThemeBreakpoints.forEach((size) => {
-      test(`(${size} and Infinity)`, () => {
-        expect(
-          testCustomHook(() => useEuiBreakpoint([size, Infinity])).return
+          testCustomHook(() => useEuiBreakpoint([size])).return
         ).toMatchSnapshot();
       });
     });
@@ -63,130 +53,47 @@ describe('useEuiBreakpoint', () => {
     it('should use the first and last items in the array', () => {
       expect(
         testCustomHook(() => useEuiBreakpoint(['s', 'm', 'l'])).return
-      ).toMatchSnapshot();
+      ).toMatchInlineSnapshot(
+        '"@media only screen and (min-width: 575px) and (max-width: 1199px)"'
+      );
+    });
+
+    it('handles sorting the array if sizes are passed in the wrong order', () => {
+      expect(
+        testCustomHook(() => useEuiBreakpoint(['l', 's', 'm'])).return
+      ).toMatchInlineSnapshot(
+        '"@media only screen and (min-width: 575px) and (max-width: 1199px)"'
+      );
     });
   });
 
-  describe('single breakpoint sizes should infer the next breakpoint size as max-width', () => {
-    EuiThemeBreakpoints.forEach((size) => {
-      test(`${size}`, () => {
-        expect(
-          testCustomHook(() => useEuiBreakpoint([size])).return
-        ).toMatchSnapshot();
-      });
-    });
+  it('does not generate a min-width if the min size is xs', () => {
+    expect(
+      testCustomHook(() => useEuiBreakpoint(['xs', 'm'])).return
+    ).toMatchInlineSnapshot('"@media only screen and (max-width: 991px)"');
   });
 
-  describe('invalid arguments', () => {
+  it('skips generating a max-width if the max size is xl', () => {
+    expect(
+      testCustomHook(() => useEuiBreakpoint(['m', 'xl'])).return
+    ).toMatchInlineSnapshot('"@media only screen and (min-width: 768px)"');
+  });
+
+  describe('fallback behavior', () => {
     const fallbackOutput = '@media only screen';
 
-    const oldConsoleError = console.warn;
-    let consoleStub: jest.Mock;
-    beforeEach(() => {
-      console.warn = consoleStub = jest.fn();
-    });
-    afterEach(() => {
-      console.warn = oldConsoleError;
+    test('if at least one input is not passed', () => {
+      // @ts-expect-error Source has 0 element(s) but target requires 1
+      expect(testCustomHook(() => useEuiBreakpoint([])).return).toEqual(
+        fallbackOutput
+      );
     });
 
-    describe('invalid array sizes', () => {
-      afterEach(() => {
-        expect(consoleStub).toHaveBeenCalledTimes(1);
-        expect(consoleStub).toHaveBeenLastCalledWith(
-          'Pass more than one breakpoint size'
-        );
-      });
-
-      it('empty array', () => {
-        expect(testCustomHook(() => useEuiBreakpoint([])).return).toEqual(
-          fallbackOutput
-        );
-      });
-
-      it('invalid single non-breakpoint size', () => {
-        expect(testCustomHook(() => useEuiBreakpoint([0])).return).toEqual(
-          fallbackOutput
-        );
-      });
-
-      it('invalid single non-breakpoint size', () => {
-        expect(
-          testCustomHook(() => useEuiBreakpoint([Infinity])).return
-        ).toEqual(fallbackOutput);
-      });
-    });
-
-    describe('invalid breakpoint keys', () => {
-      afterEach(() => {
-        expect(consoleStub).toHaveBeenCalledTimes(2);
-        expect(consoleStub).toHaveBeenCalledWith(
-          'Invalid min-width breakpoint size passed'
-        );
-        expect(consoleStub).toHaveBeenCalledWith(
-          'Invalid max-width breakpoint size passed'
-        );
-      });
-
-      it('warns when invalid size key strings are passed', () => {
-        expect(
-          // @ts-expect-error deliberate incorrect type
-          testCustomHook(() => useEuiBreakpoint(['teeny-tiny', 'SUPERMASSIVE']))
-            .return
-        ).toEqual(fallbackOutput);
-      });
-
-      it('warns when invalid size numbers are passed', () => {
-        expect(
-          testCustomHook(() => useEuiBreakpoint([100, 400])).return // we might support this someday, but today is not that day
-        ).toEqual(fallbackOutput);
-      });
-
-      it('warns when 0 and Infinity are used in the wrong position', () => {
-        expect(
-          testCustomHook(() => useEuiBreakpoint([Infinity, 0])).return
-        ).toEqual(fallbackOutput);
-      });
-    });
-
-    describe('invalid breakpoint size order', () => {
-      afterEach(() => {
-        expect(consoleStub).toHaveBeenCalledTimes(1);
-        expect(consoleStub).toHaveBeenLastCalledWith(
-          'Invalid breakpoint sizes passed. The first size should be smaller than the last size'
-        );
-      });
-
-      it('warns if min breakpoint is not smaller than the max breakpoint', () => {
-        expect(
-          testCustomHook(() => useEuiBreakpoint(['xl', 'xs'])).return
-        ).toEqual(fallbackOutput);
-      });
-
-      it('warns if the min/max breakpoints are equal', () => {
-        expect(
-          testCustomHook(() => useEuiBreakpoint(['s', 's'])).return
-        ).toEqual(fallbackOutput);
-      });
-    });
-
-    describe('valid but funky breakpoint combos', () => {
-      afterEach(() => {
-        expect(consoleStub).not.toHaveBeenCalled();
-      });
-
-      test('0 and xs', () => {
-        // Since xs is (currently) already 0, this should output nothing
-        expect(
-          testCustomHook(() => useEuiBreakpoint([0, 'xs'])).return
-        ).toEqual(fallbackOutput);
-      });
-
-      test('xs and infinity', () => {
-        // Since xs is (currently) 0, there should be no min or max width
-        expect(
-          testCustomHook(() => useEuiBreakpoint(['xs', Infinity])).return
-        ).toEqual(fallbackOutput);
-      });
+    test('if at least one input is not passed', () => {
+      // @ts-expect-error Type "asdf" is not assignable to type "..."
+      expect(testCustomHook(() => useEuiBreakpoint(['asdf'])).return).toEqual(
+        fallbackOutput
+      );
     });
   });
 });

--- a/src/global_styling/mixins/_responsive.ts
+++ b/src/global_styling/mixins/_responsive.ts
@@ -32,8 +32,7 @@ export const euiBreakpoint = (
   const firstBreakpoint: _EuiThemeBreakpoint = orderedSizes[0];
   const minBreakpointSize = euiTheme.breakpoint[firstBreakpoint];
 
-  const lastBreakpoint: _EuiThemeBreakpoint =
-    orderedSizes.length > 1 ? orderedSizes[sizes.length - 1] : firstBreakpoint;
+  const lastBreakpoint: _EuiThemeBreakpoint = orderedSizes[sizes.length - 1];
   let maxBreakpointSize: number | undefined;
 
   // To get the correct screen range, we set the max-width

--- a/src/global_styling/mixins/_responsive.ts
+++ b/src/global_styling/mixins/_responsive.ts
@@ -13,7 +13,7 @@ import { EuiThemeBreakpoints, _EuiThemeBreakpoint } from '../variables';
  * Generates a CSS media query rule string based on the input breakpoint ranges.
  * Examples:
  * euiBreakpoint(['s']) becomes `@media only screen and (min-width: 575px) and (max-width: 767px)`
- * euiBreakpoint(['s', 'm']) becomes `@media only screen and (min-width: 575px) and (max-width: 991px)`
+ * euiBreakpoint(['s', 'l']) becomes `@media only screen and (min-width: 575px) and (max-width: 1199px)`
  *
  * Use the `xs` and `xl` sizes to generate media queries with only min/max-width.
  * Examples:
@@ -45,8 +45,8 @@ export const euiBreakpoint = (
 
   return [
     '@media only screen',
-    minBreakpointSize ? `(min-width: ${minBreakpointSize}px)` : false,
-    maxBreakpointSize ? `(max-width: ${maxBreakpointSize - 1}px)` : false,
+    minBreakpointSize ? `(min-width: ${minBreakpointSize}px)` : false, // If xs/0, don't render a min-width
+    maxBreakpointSize ? `(max-width: ${maxBreakpointSize - 1}px)` : false, // If xl/undefined, don't render a max-width
   ]
     .filter(Boolean)
     .join(' and ');

--- a/src/global_styling/mixins/_responsive.ts
+++ b/src/global_styling/mixins/_responsive.ts
@@ -9,11 +9,6 @@
 import { useEuiTheme, UseEuiTheme } from '../../services/theme/hooks';
 import { EuiThemeBreakpoints, _EuiThemeBreakpoint } from '../variables';
 
-const mediaQuery = '@media only screen';
-const getMinWidthQuery = (breakpoint: number) => `(min-width: ${breakpoint}px)`;
-const getMaxWidthQuery = (breakpoint: number) =>
-  `(max-width: ${breakpoint - 1}px)`;
-
 /**
  * Generates a CSS media query rule string based on the input breakpoint ranges.
  * Examples:
@@ -50,9 +45,9 @@ export const euiBreakpoint = (
   }
 
   return [
-    mediaQuery,
-    minBreakpointSize ? getMinWidthQuery(minBreakpointSize) : false,
-    maxBreakpointSize ? getMaxWidthQuery(maxBreakpointSize) : false,
+    '@media only screen',
+    minBreakpointSize ? `(min-width: ${minBreakpointSize}px)` : false,
+    maxBreakpointSize ? `(max-width: ${maxBreakpointSize - 1}px)` : false,
   ]
     .filter(Boolean)
     .join(' and ');

--- a/upcoming_changelogs/6057.md
+++ b/upcoming_changelogs/6057.md
@@ -1,3 +1,3 @@
 **CSS-in-JS conversions**
 
-- Converted `euiBreakpoint` mixin to Emotion. This new JS mixin has the enhanced option of generating `min-width` only and `max-width` only media queries.
+- Converted `euiBreakpoint` mixin to Emotion.


### PR DESCRIPTION
### Summary

It turns out I completely misunderstood how the Sass `euiBreakpoint` mixin worked!

1. Sass was capable of generating `min-width: {size} to infinity` without a max width media queries all along :upside_down_face: it just wasn't obvious because it was generating separate media queries (and accompanying CSS) for each screen size passed instead of a single media query, and `xl` was apparently the size that had no max-width set.
So, no need for new `0` or `Infinity` inputs, xs/xl essentially serve as those ranges.

2. The old JS mixin was treating input breakpoints as single one-dimensional points, while the Sass mixin treated input breakpoints as two-dimensional widths/screen sizes, i.e.
JS: `euiBreakpoint(['xs', 's'])` -> outputs `min-width of xs` and `max-width of s - 1px`
Sass: `euiBreakpoint(['xs', 's'])` -> outpoints `min-width of xs` and `max-width of m - 1px`

### What's in a name?

We chatted about the confusion around `euiBreakpoint` and how 2 different devs managed to confuse themselves about its behavior. For me personally, the issue is that I view a breakpoint as a single point and not a range, whereas the sizes passed to `euiBreakpoint` represent an entire screen/range ([example article](https://www.freecodecamp.org/news/the-100-correct-way-to-do-css-breakpoints-88d6a5ba1862/))

I proposed changing the name to `euiScreenSizes` to help clarify behavior, but after realizing point (1) above I opted instead to just leave things as-is to maintain consistency with all our other [breakpoint utils/services](https://elastic.github.io/eui/#/theming/breakpoints/values). If we do want to rename things in the future, we should probably opt to update all our helper names at once.

Unit tests and developer code documentation should hopefully help in the interim. 🤞 

### Checklist

- [x] Checked in **mobile**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~

No changelog needed, as the new Emotion mixin is not yet released.

<img src="https://media3.giphy.com/media/xFpT7lMV5Mkqq0E6YM/giphy.gif" alt="Animation of a penguin waving its arms and disappearing backwards into a hole in the ground, captioned 'You didn't see anything'">