### PR TITLE
Add scroll anchor row option

### DIFF
--- a/src-docs/src/views/datagrid/_snippets.tsx
+++ b/src-docs/src/views/datagrid/_snippets.tsx
@@ -97,6 +97,7 @@ inMemory={{ level: 'sorting' }}`,
     4: 200, // row at index 4 will adjust the height to 200px
     6: 'auto', // row at index 6 will automatically adjust the height
   },
+  scrollAnchorRow: 'start', // compensate for layout shift when auto-sized rows are scrolled into view
 }}`,
   ref: `// Optional. For advanced control of internal data grid state, passes back an object of imperative API methods
 ref={dataGridRef}`,

--- a/src-docs/src/views/datagrid/styling/datagrid_height_options_example.js
+++ b/src-docs/src/views/datagrid/styling/datagrid_height_options_example.js
@@ -169,6 +169,42 @@ export const dataGridRowHeightOptionsExample = {
                   </li>
                 </ul>
               </li>
+              <li>
+                <EuiCode>scrollAnchorRow</EuiCode>
+                <ul>
+                  <li>
+                    Optional indicator of the row that should be used as an
+                    anchor for vertical layout shift compensation.
+                  </li>
+                  <li>
+                    Can be set to the default <EuiCode>undefined</EuiCode>,
+                    <EuiCode>&quot;start&quot;</EuiCode>, or
+                    <EuiCode>&quot;center&quot;</EuiCode>.
+                  </li>
+                  <li>
+                    If set to <EuiCode>&quot;start&quot;</EuiCode>, the topmost
+                    visible row will monitor for unexpected changes to its
+                    vertical position and try to compensate for these by
+                    scrolling the grid scroll container such that the topmost
+                    row position remains stable.
+                  </li>
+                  <li>
+                    If set to <EuiCode>&quot;center&quot;</EuiCode>, the middle
+                    visible row will monitor for unexpected changes to its
+                    vertical position and try to compensate for these by
+                    scrolling the grid scroll container such that the middle row
+                    position remains stable.
+                  </li>
+                  <li>
+                    This is particularly useful when the grid contains
+                    <EuiCode>auto</EuiCode> sized rows. Since these rows are
+                    measured as they appear in the overscan, they can cause
+                    surprising shifts of the vertical position of all following
+                    rows when their measure height is different from the
+                    estimated height.
+                  </li>
+                </ul>
+              </li>
             </ul>
           </EuiText>
           <EuiSpacer />

--- a/src/components/datagrid/body/data_grid_body.test.tsx
+++ b/src/components/datagrid/body/data_grid_body.test.tsx
@@ -21,9 +21,15 @@ describe('EuiDataGridBody', () => {
       resetAfterRowIndex: jest.fn(),
     } as any,
   };
+  const outerGridElementRef = { current: null };
   const gridItemsRendered = { current: null };
   const rerenderGridBodyRef = { current: null };
-  const rowHeightUtils = new RowHeightUtils(gridRef, rerenderGridBodyRef);
+  const rowHeightUtils = new RowHeightUtils(
+    gridRef,
+    outerGridElementRef,
+    gridItemsRendered,
+    rerenderGridBodyRef
+  );
 
   const requiredProps = {
     headerIsInteractive: true,

--- a/src/components/datagrid/body/data_grid_body.tsx
+++ b/src/components/datagrid/body/data_grid_body.tsx
@@ -389,6 +389,8 @@ export const EuiDataGridBody: FunctionComponent<EuiDataGridBodyProps> = (
    */
   const rowHeightUtils = useRowHeightUtils({
     gridRef,
+    outerGridElementRef: outerGridRef,
+    gridItemsRenderedRef: gridItemsRendered,
     gridStyles,
     columns,
     rowHeightsOptions,

--- a/src/components/datagrid/body/data_grid_cell.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell.test.tsx
@@ -18,6 +18,8 @@ import { EuiDataGridCell } from './data_grid_cell';
 describe('EuiDataGridCell', () => {
   const mockRowHeightUtils = new RowHeightUtils(
     { current: null },
+    { current: null },
+    { current: null },
     { current: null }
   );
 

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -299,6 +299,21 @@ export class EuiDataGridCell extends Component<
     }
 
     if (
+      this.props.colIndex === 0 && // once per row
+      this.props.columnId === prevProps.columnId && // if this is still the same column
+      this.props.rowIndex === prevProps.rowIndex && // if this is still the same row
+      this.props.style?.top !== prevProps.style?.top // if the top position has changed
+    ) {
+      const previousTop = parseFloat(prevProps.style?.top as string);
+      const currentTop = parseFloat(this.props.style?.top as string);
+      this.props.rowHeightUtils?.compensateForLayoutShift(
+        this.props.rowIndex,
+        currentTop - previousTop,
+        this.props.rowHeightsOptions?.scrollAnchorRow
+      );
+    }
+
+    if (
       this.props.popoverContext.popoverIsOpen !==
         prevProps.popoverContext.popoverIsOpen ||
       this.props.popoverContext.cellLocation !==

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -890,6 +890,8 @@ export type EuiDataGridOnColumnResizeHandler = (
   data: EuiDataGridOnColumnResizeData
 ) => void;
 
+export type EuiDataGridScrollAnchorRow = 'start' | 'center' | undefined;
+
 export type EuiDataGridRowHeightOption =
   | number
   | 'auto'
@@ -916,6 +918,12 @@ export interface EuiDataGridRowHeightsOptions {
    * Can be used for, e.g. storing user `rowHeightsOptions` in a local storage object.
    */
   onChange?: (rowHeightsOptions: EuiDataGridRowHeightsOptions) => void;
+  /**
+   * When set to 'start' or 'center' the topmost or middle visible row will try
+   * to compensate for changes in their top offsets by adjust the grid's scroll
+   * position.
+   */
+  scrollAnchorRow?: EuiDataGridScrollAnchorRow;
 }
 
 export interface EuiDataGridRowManager {

--- a/src/components/datagrid/utils/__mocks__/row_heights.ts
+++ b/src/components/datagrid/utils/__mocks__/row_heights.ts
@@ -39,6 +39,7 @@ export const RowHeightUtils = jest
       isRowHeightOverride: jest.fn(rowHeightUtils.isRowHeightOverride),
       resetRow: jest.fn(),
       resetGrid: jest.fn(),
+      compensateForLayoutShift: jest.fn(),
     };
 
     return (rowHeightUtilsMock as any) as ActualRowHeightUtils;

--- a/src/components/datagrid/utils/row_heights.test.ts
+++ b/src/components/datagrid/utils/row_heights.test.ts
@@ -27,8 +27,15 @@ describe('RowHeightUtils', () => {
       scrollToItem: jest.fn(),
     },
   };
+  const outerGridElementRef = { current: null };
+  const gridItemsRenderedRef = { current: null };
   const rerenderGridBodyRef = { current: jest.fn() };
-  const rowHeightUtils = new RowHeightUtils(gridRef, rerenderGridBodyRef);
+  const rowHeightUtils = new RowHeightUtils(
+    gridRef,
+    outerGridElementRef,
+    gridItemsRenderedRef,
+    rerenderGridBodyRef
+  );
 
   beforeEach(() => {
     jest.useFakeTimers();

--- a/src/components/datagrid/utils/row_heights.test.ts
+++ b/src/components/datagrid/utils/row_heights.test.ts
@@ -429,6 +429,118 @@ describe('RowHeightUtils', () => {
         });
       });
     });
+
+    describe('layout shift compensation', () => {
+      it('can compensate vertical shifts of the start anchor row', () => {
+        const rowHeightUtils = new RowHeightUtils(
+          gridRef,
+          {
+            current: {
+              scrollTop: 100,
+            } as any,
+          },
+          {
+            current: {
+              overscanRowStartIndex: 1,
+              overscanRowStopIndex: 12,
+              overscanColumnStartIndex: 0,
+              overscanColumnStopIndex: 1,
+              visibleRowStartIndex: 2,
+              visibleRowStopIndex: 11,
+              visibleColumnStartIndex: 0,
+              visibleColumnStopIndex: 1,
+            },
+          },
+          rerenderGridBodyRef
+        );
+
+        // the center row shifted by 10 pixels
+        rowHeightUtils.compensateForLayoutShift(4, 10, 'start');
+
+        // no scrolling should have taken place
+        expect(gridRef.current?.scrollTo).toHaveBeenCalledTimes(0);
+
+        // the anchor row shifted by 23 pixels
+        rowHeightUtils.compensateForLayoutShift(2, 23, 'start');
+
+        // the grid should have scrolled accordingly
+        expect(gridRef.current?.scrollTo).toHaveBeenCalledWith(
+          expect.objectContaining({
+            scrollTop: 123,
+          })
+        );
+      });
+
+      it('can compensate vertical shifts of the center anchor row', () => {
+        const rowHeightUtils = new RowHeightUtils(
+          gridRef,
+          {
+            current: {
+              scrollTop: 100,
+            } as any,
+          },
+          {
+            current: {
+              overscanRowStartIndex: 1,
+              overscanRowStopIndex: 12,
+              overscanColumnStartIndex: 0,
+              overscanColumnStopIndex: 1,
+              visibleRowStartIndex: 2,
+              visibleRowStopIndex: 11,
+              visibleColumnStartIndex: 0,
+              visibleColumnStopIndex: 1,
+            },
+          },
+          rerenderGridBodyRef
+        );
+
+        // the topmost visible row shifted by 10 pixels
+        rowHeightUtils.compensateForLayoutShift(2, 10, 'center');
+
+        // no scrolling should have taken place
+        expect(gridRef.current?.scrollTo).toHaveBeenCalledTimes(0);
+
+        // the anchor row shifted by 23 pixels
+        rowHeightUtils.compensateForLayoutShift(4, 23, 'center');
+
+        // the grid should have scrolled accordingly
+        expect(gridRef.current?.scrollTo).toHaveBeenCalledWith(
+          expect.objectContaining({
+            scrollTop: 123,
+          })
+        );
+      });
+
+      it("doesn't compensate vertical shifts when no anchor row is specified", () => {
+        const rowHeightUtils = new RowHeightUtils(
+          gridRef,
+          {
+            current: {
+              scrollTop: 100,
+            } as any,
+          },
+          {
+            current: {
+              overscanRowStartIndex: 1,
+              overscanRowStopIndex: 12,
+              overscanColumnStartIndex: 0,
+              overscanColumnStopIndex: 1,
+              visibleRowStartIndex: 2,
+              visibleRowStopIndex: 11,
+              visibleColumnStartIndex: 0,
+              visibleColumnStopIndex: 1,
+            },
+          },
+          rerenderGridBodyRef
+        );
+
+        // the topmost visible row shifted by 23 pixels, but no anchor has been specified
+        rowHeightUtils.compensateForLayoutShift(2, 23, undefined);
+
+        // no scrolling should have taken place
+        expect(gridRef.current?.scrollTo).toHaveBeenCalledTimes(0);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
## :spiral_notepad: Summary

This adds a mechanism to the `EuiDataGrid` to compensate for vertical layout shifts when rows above the currently visible ones change their height. This often happens when the row heights are `"auto"`-measured and new rows are rendered in the overscan area. By specifying a `scrollAnchorRow: 'start'`, the grid will try to scroll to keep the vertical position of the topmost visible row stable in the viewport. This behavior is opt-in.

closes #6024 

## :art: Previews

## Checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- ~Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~ (no visible changes)
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
