### PR TITLE
[EuiComment] Revert `username` prop to accept a `ReactNode`

### DIFF
--- a/src-docs/src/views/comment/comment.tsx
+++ b/src-docs/src/views/comment/comment.tsx
@@ -28,6 +28,7 @@ export default () => (
   <EuiCommentList>
     <EuiComment
       username="janed"
+      timelineIconAriaLabel="Jane Doe"
       event="added a comment"
       actions={copyAction}
       timestamp="on Jan 1, 2020"

--- a/src-docs/src/views/comment/comment.tsx
+++ b/src-docs/src/views/comment/comment.tsx
@@ -28,7 +28,7 @@ export default () => (
   <EuiCommentList>
     <EuiComment
       username="janed"
-      timelineIconAriaLabel="Jane Doe"
+      timelineAvatarAriaLabel="Jane Doe"
       event="added a comment"
       actions={copyAction}
       timestamp="on Jan 1, 2020"

--- a/src-docs/src/views/comment/comment_actions.tsx
+++ b/src-docs/src/views/comment/comment_actions.tsx
@@ -121,6 +121,7 @@ export default () => {
       <EuiCommentList aria-label="Actions">
         <EuiComment
           username="janed"
+          timelineIconAriaLabel="Jane Doe"
           event="added a comment"
           actions={customActions}
           timestamp="on Jan 1, 2020"
@@ -129,6 +130,7 @@ export default () => {
         </EuiComment>
         <EuiComment
           username="system"
+          timelineIconAriaLabel="System"
           timelineIcon="dot"
           event={
             <>

--- a/src-docs/src/views/comment/comment_actions.tsx
+++ b/src-docs/src/views/comment/comment_actions.tsx
@@ -121,7 +121,7 @@ export default () => {
       <EuiCommentList aria-label="Actions">
         <EuiComment
           username="janed"
-          timelineIconAriaLabel="Jane Doe"
+          timelineAvatarAriaLabel="Jane Doe"
           event="added a comment"
           actions={customActions}
           timestamp="on Jan 1, 2020"
@@ -130,8 +130,8 @@ export default () => {
         </EuiComment>
         <EuiComment
           username="system"
-          timelineIconAriaLabel="System"
-          timelineIcon="dot"
+          timelineAvatarAriaLabel="System"
+          timelineAvatar="dot"
           event={
             <>
               pushed a new incident <EuiLink>malware detection</EuiLink>

--- a/src-docs/src/views/comment/comment_avatar.tsx
+++ b/src-docs/src/views/comment/comment_avatar.tsx
@@ -9,7 +9,11 @@ import {
 
 export default () => (
   <EuiCommentList aria-label="An example with different timeline icons">
-    <EuiComment username="andred" event="is using a default avatar">
+    <EuiComment
+      username="andred"
+      timelineIconAriaLabel="Andre Diaz"
+      event="is using a default avatar"
+    >
       <EuiText size="s">
         <p>
           The avatar initials is generated from the <EuiCode>username</EuiCode>{' '}
@@ -20,6 +24,7 @@ export default () => (
 
     <EuiComment
       username="system"
+      timelineIconAriaLabel="System"
       timelineIcon="dot"
       event={
         <>
@@ -31,6 +36,7 @@ export default () => (
 
     <EuiComment
       username="cat"
+      timelineIconAriaLabel="Beatiful cat"
       event="is using a custom avatar"
       timelineIcon={
         <EuiAvatar

--- a/src-docs/src/views/comment/comment_avatar.tsx
+++ b/src-docs/src/views/comment/comment_avatar.tsx
@@ -11,7 +11,7 @@ export default () => (
   <EuiCommentList aria-label="An example with different timeline icons">
     <EuiComment
       username="andred"
-      timelineIconAriaLabel="Andre Diaz"
+      timelineAvatarAriaLabel="Andre Diaz"
       event="is using a default avatar"
     >
       <EuiText size="s">
@@ -24,21 +24,21 @@ export default () => (
 
     <EuiComment
       username="system"
-      timelineIconAriaLabel="System"
-      timelineIcon="dot"
+      timelineAvatarAriaLabel="System"
+      timelineAvatar="dot"
       event={
         <>
-          The <EuiCode>timelineIcon</EuiCode> is using a <EuiCode>dot</EuiCode>{' '}
-          icon.
+          The <EuiCode>timelineAvatar</EuiCode> is using a{' '}
+          <EuiCode>dot</EuiCode> icon.
         </>
       }
     />
 
     <EuiComment
       username="cat"
-      timelineIconAriaLabel="Beatiful cat"
+      timelineAvatarAriaLabel="Beatiful cat"
       event="is using a custom avatar"
-      timelineIcon={
+      timelineAvatar={
         <EuiAvatar
           name="cat"
           imageUrl="https://source.unsplash.com/64x64/?cat"
@@ -47,7 +47,7 @@ export default () => (
     >
       <EuiText size="s">
         <p>
-          The <EuiCode>timelineIcon</EuiCode> is using a custom{' '}
+          The <EuiCode>timelineAvatar</EuiCode> is using a custom{' '}
           <strong>EuiAvatar</strong>.
         </p>
       </EuiText>

--- a/src-docs/src/views/comment/comment_example.js
+++ b/src-docs/src/views/comment/comment_example.js
@@ -96,10 +96,10 @@ export const CommentListExample = {
             For accessibility, it is highly recommended to provide a descriptive{' '}
             <EuiCode>aria-label</EuiCode> or the ID of an external label to the{' '}
             <EuiCode>aria-labelledby</EuiCode> prop of the{' '}
-            <strong>EuiCommentList</strong>. Every <strong>EuiComment</strong>{' '}
-            should have a <EuiCode>timelineIconAriaLabel</EuiCode> when a{' '}
-            <EuiCode>timelineIcon</EuiCode> is passed as an{' '}
-            <EuiCode>IconType</EuiCode>.
+            <strong>EuiCommentList</strong>. A{' '}
+            <EuiCode>timelineIconAriaLabel</EuiCode> should be provided for
+            every <strong>EuiComment</strong> with or without a{' '}
+            <EuiCode>timelineIcon</EuiCode> as <EuiCode>IconType</EuiCode>.
           </>
         }
       />

--- a/src-docs/src/views/comment/comment_example.js
+++ b/src-docs/src/views/comment/comment_example.js
@@ -96,7 +96,10 @@ export const CommentListExample = {
             For accessibility, it is highly recommended to provide a descriptive{' '}
             <EuiCode>aria-label</EuiCode> or the ID of an external label to the{' '}
             <EuiCode>aria-labelledby</EuiCode> prop of the{' '}
-            <strong>EuiCommentList</strong>.
+            <strong>EuiCommentList</strong>. Every <strong>EuiComment</strong>{' '}
+            should have a <EuiCode>timelineIconAriaLabel</EuiCode> when a{' '}
+            <EuiCode>timelineIcon</EuiCode> is passed as an{' '}
+            <EuiCode>IconType</EuiCode>.
           </>
         }
       />

--- a/src-docs/src/views/comment/comment_example.js
+++ b/src-docs/src/views/comment/comment_example.js
@@ -52,11 +52,11 @@ const commentAvatarSnippet = [
 </EuiCommentList>
 `,
   `<EuiCommentList aria-label="Timeline icon example">
-  <EuiComment timelineIcon="tag" username="janed" />
+  <EuiComment timelineAvatar="tag" username="janed" />
 </EuiCommentList>
 `,
   `<EuiCommentList aria-label="Timeline icon example">
-  <EuiComment timelineIcon={avatar} username="janed">
+  <EuiComment timelineAvatar={avatar} username="janed">
     {body}
   </EuiComment>
 </EuiCommentList>
@@ -97,9 +97,9 @@ export const CommentListExample = {
             <EuiCode>aria-label</EuiCode> or the ID of an external label to the{' '}
             <EuiCode>aria-labelledby</EuiCode> prop of the{' '}
             <strong>EuiCommentList</strong>. A{' '}
-            <EuiCode>timelineIconAriaLabel</EuiCode> should be provided for
+            <EuiCode>timelineAvatarAriaLabel</EuiCode> should be provided for
             every <strong>EuiComment</strong> with or without a{' '}
-            <EuiCode>timelineIcon</EuiCode> as <EuiCode>IconType</EuiCode>.
+            <EuiCode>timelineAvatar</EuiCode> as <EuiCode>IconType</EuiCode>.
           </>
         }
       />
@@ -148,7 +148,7 @@ export const CommentListExample = {
           <EuiText>
             <ol style={{ listStyleType: 'upper-alpha' }}>
               <li>
-                <EuiCode>timelineIcon</EuiCode>: Shows an icon that should
+                <EuiCode>timelineAvatar</EuiCode>: Shows an icon that should
                 indicate who is the author of the comment. To customize, pass a{' '}
                 <EuiCode>string</EuiCode> as a{' '}
                 <EuiCode>EuiIcon[&apos;type&apos;]</EuiCode> or a{' '}
@@ -210,7 +210,7 @@ export const CommentListExample = {
       playground: commentConfig,
     },
     {
-      title: 'Timeline icon',
+      title: 'Timeline avatar',
       source: [
         {
           type: GuideSectionTypes.JS,
@@ -223,28 +223,24 @@ export const CommentListExample = {
           <ul>
             <li>
               By default, each <strong>EuiComment</strong> shows an avatar with
-              the initial letter of the <EuiCode>username</EuiCode>. It also
-              uses the <EuiCode>username</EuiCode> for the avatar title
-              attribute.
+              the <EuiCode>userAvatar</EuiCode> icon. A{' '}
+              <EuiCode>timelineAvatarAriaLabel</EuiCode>
+              should be provided when using this default option.
             </li>
             <li>
-              If your <strong>EuiComment</strong> doesn&apos;t have a{' '}
-              <EuiCode>username</EuiCode>, or if you don&apos;t want to use it
-              for generating the title attribute and initials you can use the{' '}
-              <EuiCode>timelineIcon</EuiCode> prop instead.
-            </li>
-            <li>
-              You can also show an icon by passing to the{' '}
-              <EuiCode>timelineIcon</EuiCode> any of the icon types that{' '}
+              You can customize your avatar by passing to the{' '}
+              <EuiCode>timelineAvatar</EuiCode> any of the icon types that{' '}
               <Link to="/display/icons">
                 <strong>EuiIcon</strong>
               </Link>{' '}
               supports. The icon will show inside a <EuiCode>subdued</EuiCode>{' '}
               avatar. Consider this option when showing a system update.
+              Providing a <EuiCode>timelineAvatarAriaLabel</EuiCode> is
+              recommended.
             </li>
             <li>
               You can further customize the timeline icon by passing to the{' '}
-              <EuiCode>timelineIcon</EuiCode> a{' '}
+              <EuiCode>timelineAvatar</EuiCode> a{' '}
               <Link to="/display/avatar">
                 <strong>EuiAvatar</strong>
               </Link>

--- a/src-docs/src/views/comment/comment_example.js
+++ b/src-docs/src/views/comment/comment_example.js
@@ -155,8 +155,10 @@ export const CommentListExample = {
                 <Link to="/display/avatar">
                   <strong>EuiAvatar</strong>
                 </Link>
-                . If no avatar is provided, it will default to an avatar with a{' '}
-                <EuiCode>userAvatar</EuiCode> icon.
+                . Use in conjunction with{' '}
+                <EuiCode>timelineAvatarAriaLabel</EuiCode> to pass an aria label
+                to the avatar. If no avatar is provided, it will default to an
+                avatar with a <EuiCode>userAvatar</EuiCode> icon.
               </li>
               <li>
                 <EuiCode>eventIcon</EuiCode>: Icon that shows before the

--- a/src-docs/src/views/comment/comment_example.js
+++ b/src-docs/src/views/comment/comment_example.js
@@ -148,17 +148,15 @@ export const CommentListExample = {
           <EuiText>
             <ol style={{ listStyleType: 'upper-alpha' }}>
               <li>
-                <EuiCode>timelineAvatar</EuiCode>: Shows an icon that should
+                <EuiCode>timelineAvatar</EuiCode>: Shows an avatar that should
                 indicate who is the author of the comment. To customize, pass a{' '}
                 <EuiCode>string</EuiCode> as a{' '}
-                <EuiCode>EuiIcon[&apos;type&apos;]</EuiCode> or a{' '}
-                <EuiCode>ReactNode</EuiCode>, preferably a{' '}
+                <EuiCode>EuiIcon[&apos;type&apos;]</EuiCode> or a a{' '}
                 <Link to="/display/avatar">
                   <strong>EuiAvatar</strong>
                 </Link>
-                . If no icon is provided, it will default to the{' '}
-                <EuiCode>username</EuiCode>
-                &apos;s initials.
+                . If no avatar is provided, it will default to an avatar with a{' '}
+                <EuiCode>userAvatar</EuiCode> icon.
               </li>
               <li>
                 <EuiCode>eventIcon</EuiCode>: Icon that shows before the

--- a/src-docs/src/views/comment/comment_flexible.tsx
+++ b/src-docs/src/views/comment/comment_flexible.tsx
@@ -49,6 +49,7 @@ const eventWithMultipleTags = (
 const commentsData: EuiCommentListProps['comments'] = [
   {
     username: 'janed',
+    timelineIconAriaLabel: 'Jane Doe',
     event: 'added a comment',
     timestamp: 'on Jan 1, 2020',
     children: body,
@@ -56,6 +57,7 @@ const commentsData: EuiCommentListProps['comments'] = [
   },
   {
     username: 'luisg',
+    timelineIconAriaLabel: 'Luis G',
     event: eventWithMultipleTags,
     timestamp: '22 hours ago',
     eventIcon: 'tag',
@@ -64,6 +66,7 @@ const commentsData: EuiCommentListProps['comments'] = [
   },
   {
     username: 'system',
+    timelineIconAriaLabel: 'System',
     timelineIcon: 'dot',
     event: 'pushed a new incident',
     timestamp: '20 hours ago',
@@ -71,6 +74,7 @@ const commentsData: EuiCommentListProps['comments'] = [
   },
   {
     username: 'pancho1',
+    timelineIconAriaLabel: 'Pancho Pérez',
     children: (
       <EuiTextArea
         fullWidth

--- a/src-docs/src/views/comment/comment_flexible.tsx
+++ b/src-docs/src/views/comment/comment_flexible.tsx
@@ -49,7 +49,7 @@ const eventWithMultipleTags = (
 const commentsData: EuiCommentListProps['comments'] = [
   {
     username: 'janed',
-    timelineIconAriaLabel: 'Jane Doe',
+    timelineAvatarAriaLabel: 'Jane Doe',
     event: 'added a comment',
     timestamp: 'on Jan 1, 2020',
     children: body,
@@ -57,7 +57,7 @@ const commentsData: EuiCommentListProps['comments'] = [
   },
   {
     username: 'luisg',
-    timelineIconAriaLabel: 'Luis G',
+    timelineAvatarAriaLabel: 'Luis G',
     event: eventWithMultipleTags,
     timestamp: '22 hours ago',
     eventIcon: 'tag',
@@ -66,15 +66,15 @@ const commentsData: EuiCommentListProps['comments'] = [
   },
   {
     username: 'system',
-    timelineIconAriaLabel: 'System',
-    timelineIcon: 'dot',
+    timelineAvatarAriaLabel: 'System',
+    timelineAvatar: 'dot',
     event: 'pushed a new incident',
     timestamp: '20 hours ago',
     eventColor: 'danger',
   },
   {
     username: 'pancho1',
-    timelineIconAriaLabel: 'Pancho Pérez',
+    timelineAvatarAriaLabel: 'Pancho Pérez',
     children: (
       <EuiTextArea
         fullWidth

--- a/src-docs/src/views/comment/comment_list.tsx
+++ b/src-docs/src/views/comment/comment_list.tsx
@@ -57,7 +57,7 @@ const longBody = (
 const comments: EuiCommentProps[] = [
   {
     username: 'janed',
-    timelineIconAriaLabel: 'Jane Doe',
+    timelineAvatarAriaLabel: 'Jane Doe',
     event: 'added a comment',
     timestamp: 'on Jan 1, 2020',
     children: body,
@@ -65,14 +65,14 @@ const comments: EuiCommentProps[] = [
   },
   {
     username: 'juanab',
-    timelineIconAriaLabel: 'Juana Barros',
+    timelineAvatarAriaLabel: 'Juana Barros',
     actions: copyAction,
     event: 'pushed incident X0Z235',
     timestamp: 'on Jan 3, 2020',
   },
   {
     username: 'pancho1',
-    timelineIconAriaLabel: 'Pancho Pérez',
+    timelineAvatarAriaLabel: 'Pancho Pérez',
     event: 'edited case',
     timestamp: 'on Jan 9, 2020',
     eventIcon: 'pencil',
@@ -80,7 +80,7 @@ const comments: EuiCommentProps[] = [
   },
   {
     username: 'pedror',
-    timelineIconAriaLabel: 'Pedro Rodriguez',
+    timelineAvatarAriaLabel: 'Pedro Rodriguez',
     actions: copyAction,
     event: complexEvent,
     timestamp: 'on Jan 11, 2020',
@@ -89,7 +89,7 @@ const comments: EuiCommentProps[] = [
   },
   {
     username: 'elohar',
-    timelineIconAriaLabel: 'Elohar Jackson',
+    timelineAvatarAriaLabel: 'Elohar Jackson',
     event: 'added a comment',
     timestamp: 'on Jan 14, 2020',
     children: longBody,

--- a/src-docs/src/views/comment/comment_list.tsx
+++ b/src-docs/src/views/comment/comment_list.tsx
@@ -57,6 +57,7 @@ const longBody = (
 const comments: EuiCommentProps[] = [
   {
     username: 'janed',
+    timelineIconAriaLabel: 'Jane Doe',
     event: 'added a comment',
     timestamp: 'on Jan 1, 2020',
     children: body,
@@ -64,12 +65,14 @@ const comments: EuiCommentProps[] = [
   },
   {
     username: 'juanab',
+    timelineIconAriaLabel: 'Juana Barros',
     actions: copyAction,
     event: 'pushed incident X0Z235',
     timestamp: 'on Jan 3, 2020',
   },
   {
     username: 'pancho1',
+    timelineIconAriaLabel: 'Pancho Pérez',
     event: 'edited case',
     timestamp: 'on Jan 9, 2020',
     eventIcon: 'pencil',
@@ -77,6 +80,7 @@ const comments: EuiCommentProps[] = [
   },
   {
     username: 'pedror',
+    timelineIconAriaLabel: 'Pedro Rodriguez',
     actions: copyAction,
     event: complexEvent,
     timestamp: 'on Jan 11, 2020',
@@ -85,7 +89,7 @@ const comments: EuiCommentProps[] = [
   },
   {
     username: 'elohar',
-
+    timelineIconAriaLabel: 'Elohar Jackson',
     event: 'added a comment',
     timestamp: 'on Jan 14, 2020',
     children: longBody,

--- a/src-docs/src/views/comment/comment_props.tsx
+++ b/src-docs/src/views/comment/comment_props.tsx
@@ -55,7 +55,7 @@ export default ({ snippet }: { snippet: ReactNode }) => {
       style={{ maxWidth: '540px' }}
     >
       <EuiCommentList>
-        <EuiComment username="Avatar">
+        <EuiComment username="avatar" timelineIconAriaLabel="Avatar">
           <div
             css={css`
               border-radius: ${euiTheme.border.radius.small};

--- a/src-docs/src/views/comment/comment_props.tsx
+++ b/src-docs/src/views/comment/comment_props.tsx
@@ -55,7 +55,7 @@ export default ({ snippet }: { snippet: ReactNode }) => {
       style={{ maxWidth: '540px' }}
     >
       <EuiCommentList>
-        <EuiComment username="avatar" timelineIconAriaLabel="Avatar">
+        <EuiComment username="avatar" timelineAvatarAriaLabel="Avatar">
           <div
             css={css`
               border-radius: ${euiTheme.border.radius.small};

--- a/src-docs/src/views/comment/comment_system.tsx
+++ b/src-docs/src/views/comment/comment_system.tsx
@@ -57,7 +57,7 @@ const UserActionUsername = ({
 const initialComments: EuiCommentProps[] = [
   {
     username: <UserActionUsername username="emma" fullname="Emma Watson" />,
-    timelineIcon: <EuiAvatar name="emma" />,
+    timelineAvatar: <EuiAvatar name="emma" />,
     event: 'added a comment',
     timestamp: 'on 3rd March 2022',
     children: (
@@ -69,7 +69,7 @@ const initialComments: EuiCommentProps[] = [
   },
   {
     username: <UserActionUsername username="emma" fullname="Emma Watson" />,
-    timelineIcon: <EuiAvatar name="emma" />,
+    timelineAvatar: <EuiAvatar name="emma" />,
     event: complexEvent,
     timestamp: 'on 3rd March 2022',
     eventIcon: 'tag',
@@ -77,15 +77,15 @@ const initialComments: EuiCommentProps[] = [
   },
   {
     username: 'system',
-    timelineIcon: 'dot',
-    timelineIconAriaLabel: 'System',
+    timelineAvatar: 'dot',
+    timelineAvatarAriaLabel: 'System',
     event: 'pushed a new incident',
     timestamp: 'on 4th March 2022',
     eventColor: 'danger',
   },
   {
     username: <UserActionUsername username="tiago" fullname="Tiago Pontes" />,
-    timelineIcon: <EuiAvatar name="tiago" />,
+    timelineAvatar: <EuiAvatar name="tiago" />,
     event: 'added a comment',
     timestamp: 'on 4th March 2022',
     actions: actionButton,
@@ -98,7 +98,7 @@ const initialComments: EuiCommentProps[] = [
   },
   {
     username: <UserActionUsername username="emma" fullname="Emma Watson" />,
-    timelineIcon: <EuiAvatar name="emma" />,
+    timelineAvatar: <EuiAvatar name="emma" />,
     event: (
       <>
         marked case as <EuiBadge color="warning">In progress</EuiBadge>
@@ -143,7 +143,7 @@ export default () => {
           username: (
             <UserActionUsername username="emma" fullname="Emma Watson" />
           ),
-          timelineIcon: <EuiAvatar name="emma" />,
+          timelineAvatar: <EuiAvatar name="emma" />,
           event: 'added a comment',
           timestamp: `on ${date}`,
           actions: actionButton,
@@ -167,7 +167,10 @@ export default () => {
     <>
       <EuiCommentList aria-label="Comment system example">
         {commentsList}
-        <EuiComment username="juana" timelineIcon={<EuiAvatar name="juana" />}>
+        <EuiComment
+          username="juana"
+          timelineAvatar={<EuiAvatar name="juana" />}
+        >
           <EuiMarkdownEditor
             aria-label="Markdown editor"
             aria-describedby={errorElementId.current}

--- a/src-docs/src/views/comment/comment_system.tsx
+++ b/src-docs/src/views/comment/comment_system.tsx
@@ -12,6 +12,8 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiButton,
+  EuiToolTip,
+  EuiAvatar,
 } from '../../../../src/components';
 
 const actionButton = (
@@ -38,9 +40,28 @@ const complexEvent = (
   </EuiFlexGroup>
 );
 
+const UserActionUsername = ({
+  username,
+  fullname,
+}: {
+  username: string;
+  fullname: string;
+}) => {
+  return (
+    <EuiToolTip
+      position="top"
+      content={<p>{fullname}</p>}
+      data-test-subj="user-action-username-tooltip"
+    >
+      <strong>{username}</strong>
+    </EuiToolTip>
+  );
+};
+
 const initialComments: EuiCommentProps[] = [
   {
-    username: 'emma',
+    username: <UserActionUsername username="emma" fullname="Emma Watson" />,
+    timelineIcon: <EuiAvatar name="emma" />,
     event: 'added a comment',
     timestamp: 'on 3rd March 2022',
     children: (
@@ -51,7 +72,8 @@ const initialComments: EuiCommentProps[] = [
     actions: actionButton,
   },
   {
-    username: 'emma',
+    username: <UserActionUsername username="emma" fullname="Emma Watson" />,
+    timelineIcon: <EuiAvatar name="emma" />,
     event: complexEvent,
     timestamp: 'on 3rd March 2022',
     eventIcon: 'tag',
@@ -59,13 +81,14 @@ const initialComments: EuiCommentProps[] = [
   },
   {
     username: 'system',
-    timelineIcon: 'dot',
+    timelineIcon: <EuiAvatar name="system" iconType="dot" />,
     event: 'pushed a new incident',
     timestamp: 'on 4th March 2022',
     eventColor: 'danger',
   },
   {
-    username: 'tiago',
+    username: <UserActionUsername username="tiago" fullname="Tiago Pontes" />,
+    timelineIcon: <EuiAvatar name="tiago" />,
     event: 'added a comment',
     timestamp: 'on 4th March 2022',
     actions: actionButton,
@@ -77,7 +100,8 @@ const initialComments: EuiCommentProps[] = [
     ),
   },
   {
-    username: 'emma',
+    username: <UserActionUsername username="emma" fullname="Emma Watson" />,
+    timelineIcon: <EuiAvatar name="emma" />,
     event: (
       <>
         marked case as <EuiBadge color="warning">In progress</EuiBadge>
@@ -119,7 +143,10 @@ export default () => {
       setComments([
         ...comments,
         {
-          username: 'emma',
+          username: (
+            <UserActionUsername username="emma" fullname="Emma Watson" />
+          ),
+          timelineIcon: <EuiAvatar name="emma" />,
           event: 'added a comment',
           timestamp: `on ${date}`,
           actions: actionButton,
@@ -143,7 +170,7 @@ export default () => {
     <>
       <EuiCommentList aria-label="Comment system example">
         {commentsList}
-        <EuiComment username="juana">
+        <EuiComment username="juana" timelineIcon={<EuiAvatar name="juana" />}>
           <EuiMarkdownEditor
             aria-label="Markdown editor"
             aria-describedby={errorElementId.current}

--- a/src-docs/src/views/comment/comment_system.tsx
+++ b/src-docs/src/views/comment/comment_system.tsx
@@ -77,7 +77,8 @@ const initialComments: EuiCommentProps[] = [
   },
   {
     username: 'system',
-    timelineIcon: <EuiAvatar name="system" iconType="dot" />,
+    timelineIcon: 'dot',
+    timelineIconAriaLabel: 'System',
     event: 'pushed a new incident',
     timestamp: 'on 4th March 2022',
     eventColor: 'danger',

--- a/src-docs/src/views/comment/comment_system.tsx
+++ b/src-docs/src/views/comment/comment_system.tsx
@@ -48,11 +48,7 @@ const UserActionUsername = ({
   fullname: string;
 }) => {
   return (
-    <EuiToolTip
-      position="top"
-      content={<p>{fullname}</p>}
-      data-test-subj="user-action-username-tooltip"
-    >
+    <EuiToolTip position="top" content={<p>{fullname}</p>}>
       <strong>{username}</strong>
     </EuiToolTip>
   );

--- a/src-docs/src/views/copy/copy_to_clipboard.js
+++ b/src-docs/src/views/copy/copy_to_clipboard.js
@@ -34,8 +34,8 @@ export default () => {
   return (
     <EuiCommentList aria-label="Copy to clipboard example">
       <EuiComment
-        component="div"
         username="Gusteau"
+        timelineIconAriaLabel="Gusteau"
         event="added a comment"
         actions={
           <EuiToolTip

--- a/src-docs/src/views/copy/copy_to_clipboard.js
+++ b/src-docs/src/views/copy/copy_to_clipboard.js
@@ -35,7 +35,7 @@ export default () => {
     <EuiCommentList aria-label="Copy to clipboard example">
       <EuiComment
         username="Gusteau"
-        timelineIconAriaLabel="Gusteau"
+        timelineAvatarAriaLabel="Gusteau"
         event="added a comment"
         actions={
           <EuiToolTip

--- a/src/components/avatar/__snapshots__/avatar.test.tsx.snap
+++ b/src/components/avatar/__snapshots__/avatar.test.tsx.snap
@@ -106,9 +106,7 @@ exports[`EuiAvatar props iconType and iconColor as null is rendered 1`] = `
   <span
     class="euiAvatar__icon"
     data-euiicon-type="bolt"
-  >
-    name
-  </span>
+  />
 </div>
 `;
 
@@ -124,9 +122,7 @@ exports[`EuiAvatar props iconType and iconColor is rendered 1`] = `
     class="euiAvatar__icon"
     color="primary"
     data-euiicon-type="bolt"
-  >
-    name
-  </span>
+  />
 </div>
 `;
 
@@ -142,9 +138,7 @@ exports[`EuiAvatar props iconType and iconSize is rendered 1`] = `
     class="euiAvatar__icon"
     color="#000000"
     data-euiicon-type="bolt"
-  >
-    name
-  </span>
+  />
 </div>
 `;
 
@@ -160,9 +154,7 @@ exports[`EuiAvatar props iconType is rendered 1`] = `
     class="euiAvatar__icon"
     color="#000000"
     data-euiicon-type="bolt"
-  >
-    name
-  </span>
+  />
 </div>
 `;
 

--- a/src/components/avatar/avatar.tsx
+++ b/src/components/avatar/avatar.tsx
@@ -179,7 +179,6 @@ export const EuiAvatar: FunctionComponent<EuiAvatarProps> = ({
         className="euiAvatar__icon"
         size={iconSize || size}
         type={iconType}
-        aria-label={name}
         color={iconCustomColor === null ? undefined : iconCustomColor}
       />
     );

--- a/src/components/comment_list/__snapshots__/comment.test.tsx.snap
+++ b/src/components/comment_list/__snapshots__/comment.test.tsx.snap
@@ -13,17 +13,15 @@ exports[`EuiComment is rendered 1`] = `
       class="emotion-euiTimelineItemIcon__content"
     >
       <div
-        aria-label="someuser"
-        class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user"
+        aria-label=""
+        class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user-subdued"
         role="img"
-        style="background-color:#c47c6c;color:#000000"
-        title="someuser"
+        title=""
       >
         <span
-          aria-hidden="true"
-        >
-          s
-        </span>
+          class="euiAvatar__icon"
+          data-euiicon-type="userAvatar"
+        />
       </div>
     </div>
   </div>
@@ -48,17 +46,15 @@ exports[`EuiComment props event is rendered 1`] = `
       class="emotion-euiTimelineItemIcon__content"
     >
       <div
-        aria-label="someuser"
-        class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user"
+        aria-label=""
+        class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user-subdued"
         role="img"
-        style="background-color:#c47c6c;color:#000000"
-        title="someuser"
+        title=""
       >
         <span
-          aria-hidden="true"
-        >
-          s
-        </span>
+          class="euiAvatar__icon"
+          data-euiicon-type="userAvatar"
+        />
       </div>
     </div>
   </div>
@@ -110,17 +106,15 @@ exports[`EuiComment props timestamp is rendered 1`] = `
       class="emotion-euiTimelineItemIcon__content"
     >
       <div
-        aria-label="someuser"
-        class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user"
+        aria-label=""
+        class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user-subdued"
         role="img"
-        style="background-color:#c47c6c;color:#000000"
-        title="someuser"
+        title=""
       >
         <span
-          aria-hidden="true"
-        >
-          s
-        </span>
+          class="euiAvatar__icon"
+          data-euiicon-type="userAvatar"
+        />
       </div>
     </div>
   </div>
@@ -174,17 +168,15 @@ exports[`EuiComment renders a body 1`] = `
       class="emotion-euiTimelineItemIcon__content"
     >
       <div
-        aria-label="someuser"
-        class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user"
+        aria-label=""
+        class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user-subdued"
         role="img"
-        style="background-color:#c47c6c;color:#000000"
-        title="someuser"
+        title=""
       >
         <span
-          aria-hidden="true"
-        >
-          s
-        </span>
+          class="euiAvatar__icon"
+          data-euiicon-type="userAvatar"
+        />
       </div>
     </div>
   </div>
@@ -217,17 +209,15 @@ exports[`EuiComment renders a timeline icon 1`] = `
       class="emotion-euiTimelineItemIcon__content"
     >
       <div
-        aria-label="someuser"
+        aria-label=""
         class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user-subdued"
         role="img"
-        title="someuser"
+        title=""
       >
         <span
           class="euiAvatar__icon"
           data-euiicon-type="dot"
-        >
-          someuser
-        </span>
+        />
       </div>
     </div>
   </div>

--- a/src/components/comment_list/__snapshots__/comment_event.test.tsx.snap
+++ b/src/components/comment_list/__snapshots__/comment_event.test.tsx.snap
@@ -79,9 +79,7 @@ exports[`EuiCommentEvent props eventIcon and eventIconAriaLabel are rendered 1`]
             <span
               class="euiAvatar__icon"
               data-euiicon-type="pencil"
-            >
-              edit
-            </span>
+            />
           </div>
           <div
             class="emotion-euiCommentEvent__headerUsername"

--- a/src/components/comment_list/__snapshots__/comment_list.test.tsx.snap
+++ b/src/components/comment_list/__snapshots__/comment_list.test.tsx.snap
@@ -17,17 +17,15 @@ exports[`EuiCommentList is rendered 1`] = `
         class="emotion-euiTimelineItemIcon__content"
       >
         <div
-          aria-label="janed"
-          class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user"
+          aria-label=""
+          class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user-subdued"
           role="img"
-          style="background-color:#f1d86f;color:#000000"
-          title="janed"
+          title=""
         >
           <span
-            aria-hidden="true"
-          >
-            j
-          </span>
+            class="euiAvatar__icon"
+            data-euiicon-type="userAvatar"
+          />
         </div>
       </div>
     </div>
@@ -57,17 +55,15 @@ exports[`EuiCommentList props gutterSize l is rendered 1`] = `
         class="emotion-euiTimelineItemIcon__content"
       >
         <div
-          aria-label="janed"
-          class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user"
+          aria-label=""
+          class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user-subdued"
           role="img"
-          style="background-color:#f1d86f;color:#000000"
-          title="janed"
+          title=""
         >
           <span
-            aria-hidden="true"
-          >
-            j
-          </span>
+            class="euiAvatar__icon"
+            data-euiicon-type="userAvatar"
+          />
         </div>
       </div>
     </div>
@@ -97,17 +93,15 @@ exports[`EuiCommentList props gutterSize m is rendered 1`] = `
         class="emotion-euiTimelineItemIcon__content"
       >
         <div
-          aria-label="janed"
-          class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user"
+          aria-label=""
+          class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user-subdued"
           role="img"
-          style="background-color:#f1d86f;color:#000000"
-          title="janed"
+          title=""
         >
           <span
-            aria-hidden="true"
-          >
-            j
-          </span>
+            class="euiAvatar__icon"
+            data-euiicon-type="userAvatar"
+          />
         </div>
       </div>
     </div>
@@ -137,17 +131,15 @@ exports[`EuiCommentList props gutterSize xl is rendered 1`] = `
         class="emotion-euiTimelineItemIcon__content"
       >
         <div
-          aria-label="janed"
-          class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user"
+          aria-label=""
+          class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user-subdued"
           role="img"
-          style="background-color:#f1d86f;color:#000000"
-          title="janed"
+          title=""
         >
           <span
-            aria-hidden="true"
-          >
-            j
-          </span>
+            class="euiAvatar__icon"
+            data-euiicon-type="userAvatar"
+          />
         </div>
       </div>
     </div>

--- a/src/components/comment_list/__snapshots__/comment_timeline.test.tsx.snap
+++ b/src/components/comment_list/__snapshots__/comment_timeline.test.tsx.snap
@@ -1,33 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiCommentTimeline props timelineIcon is rendered 1`] = `
+exports[`EuiCommentTimeline props timelineIcon defaults to a avatar with a \`userAvatar\` icon 1`] = `
 <div
-  aria-label="someuser"
+  aria-label=""
   class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user-subdued"
   role="img"
-  title="someuser"
+  title=""
 >
   <span
     class="euiAvatar__icon"
-    data-euiicon-type="dot"
+    data-euiicon-type="userAvatar"
+  />
+</div>
+`;
+
+exports[`EuiCommentTimeline props timelineIcon is rendered with a ReactNode 1`] = `
+<div
+  aria-label="username"
+  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-m-user-subdued"
+  role="img"
+  title="username"
+>
+  <span
+    class="euiAvatar__icon"
+    data-euiicon-type="userAvatar"
   >
-    someuser
+    username
   </span>
 </div>
 `;
 
-exports[`EuiCommentTimeline props username is rendered 1`] = `
+exports[`EuiCommentTimeline props timelineIcon is rendered with a string 1`] = `
 <div
-  aria-label="someuser"
+  aria-label=""
   class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user-subdued"
   role="img"
-  title="someuser"
+  title=""
 >
   <span
     class="euiAvatar__icon"
-    data-euiicon-type="avatar dot"
-  >
-    someuser
-  </span>
+    data-euiicon-type="dot"
+  />
 </div>
 `;

--- a/src/components/comment_list/__snapshots__/comment_timeline.test.tsx.snap
+++ b/src/components/comment_list/__snapshots__/comment_timeline.test.tsx.snap
@@ -24,9 +24,7 @@ exports[`EuiCommentTimeline props timelineIcon is rendered with a ReactNode 1`] 
   <span
     class="euiAvatar__icon"
     data-euiicon-type="userAvatar"
-  >
-    username
-  </span>
+  />
 </div>
 `;
 
@@ -54,8 +52,6 @@ exports[`EuiCommentTimeline props timelineIcon is rendered with timelineIconAria
   <span
     class="euiAvatar__icon"
     data-euiicon-type="dot"
-  >
-    timelineIconAriaLabel
-  </span>
+  />
 </div>
 `;

--- a/src/components/comment_list/__snapshots__/comment_timeline.test.tsx.snap
+++ b/src/components/comment_list/__snapshots__/comment_timeline.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiCommentTimeline props timelineIcon defaults to a avatar with a \`userAvatar\` icon 1`] = `
+exports[`EuiCommentTimeline props timelineAvatar defaults to an avatar with a \`userAvatar\` icon 1`] = `
 <div
   aria-label=""
   class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user-subdued"
@@ -14,7 +14,7 @@ exports[`EuiCommentTimeline props timelineIcon defaults to a avatar with a \`use
 </div>
 `;
 
-exports[`EuiCommentTimeline props timelineIcon is rendered with a ReactNode 1`] = `
+exports[`EuiCommentTimeline props timelineAvatar is rendered with a ReactNode 1`] = `
 <div
   aria-label="username"
   class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-m-user-subdued"
@@ -28,7 +28,7 @@ exports[`EuiCommentTimeline props timelineIcon is rendered with a ReactNode 1`] 
 </div>
 `;
 
-exports[`EuiCommentTimeline props timelineIcon is rendered with a string 1`] = `
+exports[`EuiCommentTimeline props timelineAvatar is rendered with a string 1`] = `
 <div
   aria-label=""
   class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user-subdued"
@@ -42,12 +42,12 @@ exports[`EuiCommentTimeline props timelineIcon is rendered with a string 1`] = `
 </div>
 `;
 
-exports[`EuiCommentTimeline props timelineIcon is rendered with timelineIconAriaLabel 1`] = `
+exports[`EuiCommentTimeline props timelineAvatar is rendered with timelineAvatarAriaLabel 1`] = `
 <div
-  aria-label="timelineIconAriaLabel"
+  aria-label="timelineAvatarAriaLabel"
   class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user-subdued"
   role="img"
-  title="timelineIconAriaLabel"
+  title="timelineAvatarAriaLabel"
 >
   <span
     class="euiAvatar__icon"

--- a/src/components/comment_list/__snapshots__/comment_timeline.test.tsx.snap
+++ b/src/components/comment_list/__snapshots__/comment_timeline.test.tsx.snap
@@ -43,3 +43,19 @@ exports[`EuiCommentTimeline props timelineIcon is rendered with a string 1`] = `
   />
 </div>
 `;
+
+exports[`EuiCommentTimeline props timelineIcon is rendered with timelineIconAriaLabel 1`] = `
+<div
+  aria-label="timelineIconAriaLabel"
+  class="euiAvatar euiAvatar--m euiAvatar--user euiCommentAvatar emotion-euiAvatar-m-user-subdued"
+  role="img"
+  title="timelineIconAriaLabel"
+>
+  <span
+    class="euiAvatar__icon"
+    data-euiicon-type="dot"
+  >
+    timelineIconAriaLabel
+  </span>
+</div>
+`;

--- a/src/components/comment_list/comment.test.tsx
+++ b/src/components/comment_list/comment.test.tsx
@@ -60,7 +60,7 @@ describe('EuiComment', () => {
 
   test('renders a timeline icon', () => {
     const component = render(
-      <EuiComment username="someuser" timelineIcon="dot">
+      <EuiComment username="someuser" timelineAvatar="dot">
         <p>This is the body.</p>
       </EuiComment>
     );

--- a/src/components/comment_list/comment.tsx
+++ b/src/components/comment_list/comment.tsx
@@ -36,9 +36,8 @@ export const EuiComment: FunctionComponent<EuiCommentProps> = ({
 
   const isTypeUpdate = !children;
   const verticalAlign = isTypeUpdate ? 'center' : 'top';
-  const mainIcon = (
-    <EuiCommentTimeline username={username} timelineIcon={timelineIcon} />
-  );
+
+  const mainIcon = <EuiCommentTimeline timelineIcon={timelineIcon} />;
 
   return (
     <EuiTimelineItem

--- a/src/components/comment_list/comment.tsx
+++ b/src/components/comment_list/comment.tsx
@@ -26,8 +26,8 @@ export const EuiComment: FunctionComponent<EuiCommentProps> = ({
   event,
   actions,
   timestamp,
-  timelineIcon,
-  timelineIconAriaLabel,
+  timelineAvatar,
+  timelineAvatarAriaLabel,
   eventColor,
   eventIcon,
   eventIconAriaLabel,
@@ -40,8 +40,8 @@ export const EuiComment: FunctionComponent<EuiCommentProps> = ({
 
   const mainIcon = (
     <EuiCommentTimeline
-      timelineIcon={timelineIcon}
-      timelineIconAriaLabel={timelineIconAriaLabel}
+      timelineAvatar={timelineAvatar}
+      timelineAvatarAriaLabel={timelineAvatarAriaLabel}
     />
   );
 

--- a/src/components/comment_list/comment.tsx
+++ b/src/components/comment_list/comment.tsx
@@ -27,6 +27,7 @@ export const EuiComment: FunctionComponent<EuiCommentProps> = ({
   actions,
   timestamp,
   timelineIcon,
+  timelineIconAriaLabel,
   eventColor,
   eventIcon,
   eventIconAriaLabel,
@@ -37,7 +38,12 @@ export const EuiComment: FunctionComponent<EuiCommentProps> = ({
   const isTypeUpdate = !children;
   const verticalAlign = isTypeUpdate ? 'center' : 'top';
 
-  const mainIcon = <EuiCommentTimeline timelineIcon={timelineIcon} />;
+  const mainIcon = (
+    <EuiCommentTimeline
+      timelineIcon={timelineIcon}
+      timelineIconAriaLabel={timelineIconAriaLabel}
+    />
+  );
 
   return (
     <EuiTimelineItem

--- a/src/components/comment_list/comment_event.tsx
+++ b/src/components/comment_list/comment_event.tsx
@@ -23,7 +23,7 @@ export interface EuiCommentEventProps extends CommonProps {
   /**
    * Author of the comment.
    */
-  username: string;
+  username: ReactNode;
   /**
    * Time of occurrence of the event. Its format is set on the consumer's side
    */

--- a/src/components/comment_list/comment_timeline.test.tsx
+++ b/src/components/comment_list/comment_timeline.test.tsx
@@ -28,7 +28,26 @@ describe('EuiCommentTimeline', () => {
 
       it('is rendered with a ReactNode', () => {
         const component = render(
-          <EuiAvatar name="username" iconType="userAvatar" color="subdued" />
+          <EuiCommentTimeline
+            timelineIcon={
+              <EuiAvatar
+                name="username"
+                iconType="userAvatar"
+                color="subdued"
+              />
+            }
+          />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+
+      it('is rendered with timelineIconAriaLabel', () => {
+        const component = render(
+          <EuiCommentTimeline
+            timelineIcon="dot"
+            timelineIconAriaLabel="timelineIconAriaLabel"
+          />
         );
 
         expect(component).toMatchSnapshot();

--- a/src/components/comment_list/comment_timeline.test.tsx
+++ b/src/components/comment_list/comment_timeline.test.tsx
@@ -13,15 +13,15 @@ import { EuiAvatar } from '../avatar';
 
 describe('EuiCommentTimeline', () => {
   describe('props', () => {
-    describe('timelineIcon', () => {
-      it('defaults to a avatar with a `userAvatar` icon', () => {
+    describe('timelineAvatar', () => {
+      it('defaults to an avatar with a `userAvatar` icon', () => {
         const component = render(<EuiCommentTimeline />);
 
         expect(component).toMatchSnapshot();
       });
 
       it('is rendered with a string', () => {
-        const component = render(<EuiCommentTimeline timelineIcon="dot" />);
+        const component = render(<EuiCommentTimeline timelineAvatar="dot" />);
 
         expect(component).toMatchSnapshot();
       });
@@ -29,7 +29,7 @@ describe('EuiCommentTimeline', () => {
       it('is rendered with a ReactNode', () => {
         const component = render(
           <EuiCommentTimeline
-            timelineIcon={
+            timelineAvatar={
               <EuiAvatar
                 name="username"
                 iconType="userAvatar"
@@ -42,11 +42,11 @@ describe('EuiCommentTimeline', () => {
         expect(component).toMatchSnapshot();
       });
 
-      it('is rendered with timelineIconAriaLabel', () => {
+      it('is rendered with timelineAvatarAriaLabel', () => {
         const component = render(
           <EuiCommentTimeline
-            timelineIcon="dot"
-            timelineIconAriaLabel="timelineIconAriaLabel"
+            timelineAvatar="dot"
+            timelineAvatarAriaLabel="timelineAvatarAriaLabel"
           />
         );
 

--- a/src/components/comment_list/comment_timeline.test.tsx
+++ b/src/components/comment_list/comment_timeline.test.tsx
@@ -9,23 +9,26 @@
 import React from 'react';
 import { render } from 'enzyme';
 import { EuiCommentTimeline } from './comment_timeline';
+import { EuiAvatar } from '../avatar';
 
 describe('EuiCommentTimeline', () => {
   describe('props', () => {
-    describe('username', () => {
-      it('is rendered', () => {
-        const component = render(
-          <EuiCommentTimeline username="someuser" timelineIcon="avatar dot" />
-        );
+    describe('timelineIcon', () => {
+      it('defaults to a avatar with a `userAvatar` icon', () => {
+        const component = render(<EuiCommentTimeline />);
 
         expect(component).toMatchSnapshot();
       });
-    });
 
-    describe('timelineIcon', () => {
-      it('is rendered', () => {
+      it('is rendered with a string', () => {
+        const component = render(<EuiCommentTimeline timelineIcon="dot" />);
+
+        expect(component).toMatchSnapshot();
+      });
+
+      it('is rendered with a ReactNode', () => {
         const component = render(
-          <EuiCommentTimeline username="someuser" timelineIcon="dot" />
+          <EuiAvatar name="username" iconType="userAvatar" color="subdued" />
         );
 
         expect(component).toMatchSnapshot();

--- a/src/components/comment_list/comment_timeline.tsx
+++ b/src/components/comment_list/comment_timeline.tsx
@@ -49,7 +49,7 @@ export const EuiCommentTimeline: FunctionComponent<EuiCommentTimelineProps> = ({
     iconRender = (
       <EuiAvatar
         className={avatarClassName}
-        name={timelineIconAriaLabel ? timelineIconAriaLabel : ''}
+        name={timelineIconAriaLabel || ''}
         iconType="userAvatar"
         color="subdued"
       />

--- a/src/components/comment_list/comment_timeline.tsx
+++ b/src/components/comment_list/comment_timeline.tsx
@@ -38,7 +38,7 @@ export const EuiCommentTimeline: FunctionComponent<EuiCommentTimelineProps> = ({
     iconRender = (
       <EuiAvatar
         className={avatarClassName}
-        name={timelineIconAriaLabel ? timelineIconAriaLabel : ''}
+        name={timelineIconAriaLabel || ''}
         iconType={timelineIcon}
         color="subdued"
       />

--- a/src/components/comment_list/comment_timeline.tsx
+++ b/src/components/comment_list/comment_timeline.tsx
@@ -19,7 +19,7 @@ export interface EuiCommentTimelineProps extends CommonProps {
   timelineIcon?: ReactNode | EuiAvatarProps['iconType'];
 
   /**
-   * Specify an `aria-label` for the `timelineIcon` when passed as an `IconType` or when nothing is passed.
+   * Specify an `aria-label` and `title` for the `timelineIcon` when passed as an `IconType` or when nothing is passed.
    * If no `aria-label` is passed we assume the icon is purely decorative.
    */
   timelineIconAriaLabel?: string;

--- a/src/components/comment_list/comment_timeline.tsx
+++ b/src/components/comment_list/comment_timeline.tsx
@@ -9,41 +9,43 @@
 import React, { FunctionComponent, ReactNode } from 'react';
 import { CommonProps } from '../common';
 import { EuiAvatar, EuiAvatarProps } from '../avatar';
-import { EuiCommentEventProps } from './comment_event';
 
 export interface EuiCommentTimelineProps extends CommonProps {
   /**
-   * Main icon that accompanies the comment. Should indicate who is the author of the comment. To customize, pass a `string` as an `EuiIcon['type']` or any `ReactNode`. If no icon is provided, it  will default to the `username`'s initials.
+   * Main icon that accompanies the comment. Should indicate who is the author of the comment. To customize, pass a `string` as an `EuiIcon['type']` or any `ReactNode`. If no icon is provided, it  will default to a avatar with a `userAvatar` icon.
    */
   timelineIcon?: ReactNode | EuiAvatarProps['iconType'];
-
-  username: EuiCommentEventProps['username'];
 }
 
 export const EuiCommentTimeline: FunctionComponent<EuiCommentTimelineProps> = ({
   timelineIcon,
-  username,
 }) => {
   let iconRender;
 
   const avatarClassName = 'euiCommentAvatar';
 
   const iconIsString = typeof timelineIcon === 'string';
-  const iconIsNode = typeof timelineIcon === 'object';
 
   if (iconIsString) {
     iconRender = (
       <EuiAvatar
         className={avatarClassName}
-        name={username}
+        name=""
         iconType={timelineIcon}
         color="subdued"
       />
     );
-  } else if (iconIsNode) {
+  } else if (timelineIcon) {
     iconRender = timelineIcon;
   } else {
-    iconRender = <EuiAvatar className={avatarClassName} name={username} />;
+    iconRender = (
+      <EuiAvatar
+        className={avatarClassName}
+        name=""
+        iconType="userAvatar"
+        color="subdued"
+      />
+    );
   }
 
   return <>{iconRender}</>;

--- a/src/components/comment_list/comment_timeline.tsx
+++ b/src/components/comment_list/comment_timeline.tsx
@@ -12,25 +12,33 @@ import { EuiAvatar, EuiAvatarProps } from '../avatar';
 
 export interface EuiCommentTimelineProps extends CommonProps {
   /**
-   * Main icon that accompanies the comment. Should indicate who is the author of the comment. To customize, pass a `string` as an `EuiIcon['type']` or any `ReactNode`. If no icon is provided, it  will default to a avatar with a `userAvatar` icon.
+   * Main avatar that accompanies the comment. Should indicate who is the author of the comment.
+   * Any `ReactNode`, but preferably `EuiAvatar`, or a `string` as an `EuiIcon['type']`.
+   * If no `timelineIcon` is passed, the `userAvatar` icon will be used as the avatar.
    */
   timelineIcon?: ReactNode | EuiAvatarProps['iconType'];
+
+  /**
+   * Specify an `aria-label` for the `timelineIcon` when passed as an `IconType` or when nothing is passed.
+   * If no `aria-label` is passed we assume the icon is purely decorative.
+   */
+  timelineIconAriaLabel?: string;
 }
 
 export const EuiCommentTimeline: FunctionComponent<EuiCommentTimelineProps> = ({
   timelineIcon,
+  timelineIconAriaLabel,
 }) => {
   let iconRender;
 
   const avatarClassName = 'euiCommentAvatar';
-
   const iconIsString = typeof timelineIcon === 'string';
 
   if (iconIsString) {
     iconRender = (
       <EuiAvatar
         className={avatarClassName}
-        name=""
+        name={timelineIconAriaLabel ? timelineIconAriaLabel : ''}
         iconType={timelineIcon}
         color="subdued"
       />
@@ -41,7 +49,7 @@ export const EuiCommentTimeline: FunctionComponent<EuiCommentTimelineProps> = ({
     iconRender = (
       <EuiAvatar
         className={avatarClassName}
-        name=""
+        name={timelineIconAriaLabel ? timelineIconAriaLabel : ''}
         iconType="userAvatar"
         color="subdued"
       />

--- a/src/components/comment_list/comment_timeline.tsx
+++ b/src/components/comment_list/comment_timeline.tsx
@@ -13,43 +13,43 @@ import { EuiAvatar, EuiAvatarProps } from '../avatar';
 export interface EuiCommentTimelineProps extends CommonProps {
   /**
    * Main avatar that accompanies the comment. Should indicate who is the author of the comment.
-   * Any `ReactNode`, but preferably `EuiAvatar`, or a `string` as an `EuiIcon['type']`.
-   * If no `timelineIcon` is passed, the `userAvatar` icon will be used as the avatar.
+   * Any `ReactNode`, but preferably `EuiAvatar`, or a `string` as an `EuiAvatarProps['iconType']`.
+   * If no `timelineAvatar` is passed, the `userAvatar` icon will be used as the avatar.
    */
-  timelineIcon?: ReactNode | EuiAvatarProps['iconType'];
+  timelineAvatar?: ReactNode | EuiAvatarProps['iconType'];
 
   /**
-   * Specify an `aria-label` and `title` for the `timelineIcon` when passed as an `IconType` or when nothing is passed.
-   * If no `aria-label` is passed we assume the icon is purely decorative.
+   * Specify an `aria-label` and `title` for the `timelineAvatar` when passed as an `IconType` or when nothing is passed.
+   * If no `timelineAvatarAriaLabel` is passed we assume the avatar is purely decorative.
    */
-  timelineIconAriaLabel?: string;
+  timelineAvatarAriaLabel?: string;
 }
 
 export const EuiCommentTimeline: FunctionComponent<EuiCommentTimelineProps> = ({
-  timelineIcon,
-  timelineIconAriaLabel,
+  timelineAvatar,
+  timelineAvatarAriaLabel,
 }) => {
   let iconRender;
 
   const avatarClassName = 'euiCommentAvatar';
-  const iconIsString = typeof timelineIcon === 'string';
+  const iconIsString = typeof timelineAvatar === 'string';
 
   if (iconIsString) {
     iconRender = (
       <EuiAvatar
         className={avatarClassName}
-        name={timelineIconAriaLabel || ''}
-        iconType={timelineIcon}
+        name={timelineAvatarAriaLabel || ''}
+        iconType={timelineAvatar}
         color="subdued"
       />
     );
-  } else if (timelineIcon) {
-    iconRender = timelineIcon;
+  } else if (timelineAvatar) {
+    iconRender = timelineAvatar;
   } else {
     iconRender = (
       <EuiAvatar
         className={avatarClassName}
-        name={timelineIconAriaLabel || ''}
+        name={timelineAvatarAriaLabel || ''}
         iconType="userAvatar"
         color="subdued"
       />

--- a/src/components/timeline/__snapshots__/timeline.test.tsx.snap
+++ b/src/components/timeline/__snapshots__/timeline.test.tsx.snap
@@ -23,9 +23,7 @@ exports[`EuiTimeline is rendered with items 1`] = `
           <span
             class="euiAvatar__icon"
             data-euiicon-type="email"
-          >
-            email
-          </span>
+          />
         </div>
       </div>
     </div>
@@ -99,9 +97,7 @@ exports[`EuiTimeline props gutterSize l is rendered 1`] = `
           <span
             class="euiAvatar__icon"
             data-euiicon-type="email"
-          >
-            email
-          </span>
+          />
         </div>
       </div>
     </div>
@@ -175,9 +171,7 @@ exports[`EuiTimeline props gutterSize m is rendered 1`] = `
           <span
             class="euiAvatar__icon"
             data-euiicon-type="email"
-          >
-            email
-          </span>
+          />
         </div>
       </div>
     </div>
@@ -251,9 +245,7 @@ exports[`EuiTimeline props gutterSize xl is rendered 1`] = `
           <span
             class="euiAvatar__icon"
             data-euiicon-type="email"
-          >
-            email
-          </span>
+          />
         </div>
       </div>
     </div>

--- a/src/components/timeline/__snapshots__/timeline_item.test.tsx.snap
+++ b/src/components/timeline/__snapshots__/timeline_item.test.tsx.snap
@@ -52,9 +52,7 @@ exports[`EuiTimelineItem props EuiAvatar is passed as an icon 1`] = `
         <span
           class="euiAvatar__icon"
           data-euiicon-type="dot"
-        >
-          dot
-        </span>
+        />
       </div>
     </div>
   </div>
@@ -87,9 +85,7 @@ exports[`EuiTimelineItem props iconAriaLabel is rendered 1`] = `
         <span
           class="euiAvatar__icon"
           data-euiicon-type="dot"
-        >
-          icon aria label
-        </span>
+        />
       </div>
     </div>
   </div>

--- a/upcoming_changelogs/6071.md
+++ b/upcoming_changelogs/6071.md
@@ -1,0 +1,5 @@
+- Removed the nested `aria-label` on the `EuiAvatar` icon to simplify a11y
+
+**Bug fixes**
+
+- Reverted the change `EuiCommentEvent.username` type from `ReactNode` to `string`

--- a/upcoming_changelogs/6071.md
+++ b/upcoming_changelogs/6071.md
@@ -1,5 +1,10 @@
 - Removed the nested `aria-label` on the `EuiAvatar` icon to simplify a11y
+- Added `timelineAvatarAriaLabel` to `EuiComment`
 
 **Bug fixes**
 
 - Reverted the change `EuiCommentEvent.username` type from `ReactNode` to `string`
+
+**Breaking changes**
+
+- Renamed `timelineIcon` on `EuiComment` to `timelineAvatar`


### PR DESCRIPTION
### Summary

This PR reverts the **EuiComment**'s `username` prop to accept a `ReactNode` instead of a `string`. 

Not having the `username` as a string makes it impossible to have a `timelineIcon` defaulting to the `username`'s initials. So the `timelineAvatar` now defaults to an avatar with a `userAvatar` icon.

<img width="1606" alt="username-prop@2x" src="https://user-images.githubusercontent.com/2750668/180435367-35b78c82-f5c3-4e22-a1dc-cb49729338de.png">

### Updated "A comment system" example

This example reflects more on the current implementation for **Cases**:

<img width="567" alt="Screenshot 2022-07-22 at 13 13 32" src="https://user-images.githubusercontent.com/2750668/180437164-2846eb54-97e4-42b0-8fb5-96ec30c933db.png">

Consumers can now pass a `ReactNode` to show the username with a tooltip and or avatar. As they doing in **Cases**

<img width="1169" alt="username-components@2x" src="https://user-images.githubusercontent.com/2750668/180437368-c74ce936-b2b1-41e1-aa29-e56af5a6c331.png">


### `aria-label` for each `EuiCommment.timelineIcon`

One of the reasons I was trying to have the `username` as a `string` is that I could pass the username as a name to the `timelineAvatar` Having the username reverted to a `ReactNode` turns this impossible.

For this reason, I created a new prop called `timelineAvatarAriaLabel`  that should be passed for each `EuiCommment` when a `timelineAvatar` is passed as an `IconType`:

<img width="1002" alt="Screenshot 2022-07-26 at 13 41 52" src="https://user-images.githubusercontent.com/2750668/181017689-c1aa5474-1b91-4945-b149-dc447bbf0696.png">


A sentence was added to the callout to reflect the above changes:

<img width="1226" alt="Screenshot 2022-07-26 at 14 29 18" src="https://user-images.githubusercontent.com/2750668/181017879-f7cad74d-2a81-4f52-bf50-d1eb9c80b139.png">


### Checklist

- [x] Checked in both **light and dark** modes
- ~[ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- ~[ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- ~[ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
