### PR TITLE
[EuiSelectable] Fix searchable single selection selectables not correctly highlighting the checked option on initial render

### DIFF
--- a/src/components/selectable/selectable.test.tsx
+++ b/src/components/selectable/selectable.test.tsx
@@ -191,6 +191,20 @@ describe('EuiSelectable', () => {
       ).toEqual('second value');
     });
 
+    it('calls the searchProps.onChange callback on mount', () => {
+      const onChange = jest.fn();
+      mount(
+        <EuiSelectable
+          options={options}
+          searchable
+          searchProps={{ value: 'pandora', onChange }}
+        >
+          {(_, search) => <>{search}</>}
+        </EuiSelectable>
+      );
+      expect(onChange).toHaveBeenCalledWith('pandora', [options[2]]);
+    });
+
     it('defaults to an empty string if no value or defaultValue is passed from searchProps', () => {
       const component = render(
         <EuiSelectable

--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -295,7 +295,10 @@ export class EuiSelectable<T = {}> extends Component<
       return;
     }
 
-    if (!this.state.visibleOptions.length || this.state.activeOptionIndex) {
+    if (
+      !this.state.visibleOptions.length ||
+      this.state.activeOptionIndex != null
+    ) {
       return;
     }
 

--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -214,6 +214,7 @@ export class EuiSelectable<T = {}> extends Component<
       initialSearchValue,
       isPreFiltered
     );
+    searchProps?.onChange?.(initialSearchValue, visibleOptions);
 
     // ensure that the currently selected single option is active if it is in the visibleOptions
     const selectedOptions = options.filter((option) => option.checked);
@@ -436,9 +437,7 @@ export class EuiSelectable<T = {}> extends Component<
         }
       }
     );
-    if (this.props.searchProps && this.props.searchProps.onChange) {
-      this.props.searchProps.onChange(searchValue, visibleOptions);
-    }
+    this.props.searchProps?.onChange?.(searchValue, visibleOptions);
   };
 
   onContainerBlur = (e: React.FocusEvent) => {

--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -278,10 +278,6 @@ export class EuiSelectable<T = {}> extends Component<
     }
   }
 
-  hasActiveOption = () => {
-    return this.state.activeOptionIndex != null;
-  };
-
   onMouseDown = () => {
     // Bypass onFocus when a click event originates from this.containerRef.
     // Prevents onFocus from scrolling away from a clicked option and negating the selection event.

--- a/src/components/selectable/selectable_search/selectable_search.test.tsx
+++ b/src/components/selectable/selectable_search/selectable_search.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { render, mount, shallow } from 'enzyme';
+import { render, shallow } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
 
 import { EuiSelectableSearch } from './selectable_search';
@@ -48,11 +48,6 @@ describe('EuiSelectableSearch', () => {
       />
     );
     expect(component).toMatchSnapshot();
-  });
-
-  it('calls the onChange callback on mount', () => {
-    mount(<EuiSelectableSearch {...baseProps} value="w" />);
-    expect(onChange).toHaveBeenCalledWith('w', [{ label: 'world' }]);
   });
 
   it("calls the onChange callback when the EuiFieldSearch's change event fires", () => {

--- a/src/components/selectable/selectable_search/selectable_search.tsx
+++ b/src/components/selectable/selectable_search/selectable_search.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { useEffect, useCallback, ChangeEvent } from 'react';
+import React, { useCallback, ChangeEvent } from 'react';
 import classNames from 'classnames';
 import { CommonProps } from '../../common';
 import { EuiFieldSearch, EuiFieldSearchProps } from '../../form';
@@ -52,16 +52,6 @@ export const EuiSelectableSearch = <T,>({
   className,
   ...rest
 }: _EuiSelectableSearchProps<T>) => {
-  useEffect(() => {
-    const matchingOptions = getMatchingOptions<T>(
-      options,
-      value,
-      isPreFiltered
-    );
-    onChangeCallback(value, matchingOptions);
-    // Call on mount only
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
   const onChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       const searchValue = e.target.value;

--- a/upcoming_changelogs/6072.md
+++ b/upcoming_changelogs/6072.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed searchable single selection `EuiSelectable`s not correctly highlighting the checked option on initial render


### PR DESCRIPTION
## Summary

This PR also contains 2 other small fixes / cleanups (see commit history).

### Before

![before](https://user-images.githubusercontent.com/549407/180485889-251e3138-a4bf-48eb-b2b5-b5c13cc7c50b.gif)

### After
![after](https://user-images.githubusercontent.com/549407/180485893-bfcb9926-84a7-445a-930a-46044f1c140d.gif)

### Problem

`EuiSelectable.onSearchChange` was being called on mount by `EuiSelectableSearch`, which was setting `activeOptionIndex` to undefined:

https://github.com/elastic/eui/blob/eb493ffc41feb968602ebf5087694475e6a2d082/src/components/selectable/selectable.tsx#L423-L432

### Solution

Moving the `searchProps.onChange` callback to the `EuiSelectable`'s constructor (which calls `getMatchingOptions`/sets search state on mount anyway, so no need for `EuiSelectableSearch` to repeat it) fixes the issue and leaves the found `activeOptionIndex` from the constructor intact.

### Checklist

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~ Tested but no meaningful impact for these users - they have to tab into the Selectable which triggers the highlight in any case

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately