### PR TITLE
[Emotion] Convert `EuiPortal`

### DIFF
--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -32,7 +32,6 @@
 @import 'pagination/index';
 @import 'panel/index';
 @import 'page/index'; // Page needs to come after Panel for cascade specificity
-@import 'portal/index';
 @import 'tree_view/index';
 @import 'resizable_container/index';
 @import 'side_nav/index';

--- a/src/components/portal/_index.scss
+++ b/src/components/portal/_index.scss
@@ -1,1 +1,0 @@
-@import 'portal';

--- a/src/components/portal/_portal.scss
+++ b/src/components/portal/_portal.scss
@@ -1,6 +1,0 @@
-/**
- * 1. Portal content is absolutely positioned (e.g. tooltips, popovers, flyouts).
- */
-.euiBody-hasPortalContent {
-  position: relative; /* 1 */
-}

--- a/src/global_styling/reset/global_styles.tsx
+++ b/src/global_styling/reset/global_styles.tsx
@@ -105,6 +105,12 @@ export const EuiGlobalStyles = ({}: EuiGlobalStylesProps) => {
         text-decoration: none;
       }
     }
+
+    // A few EUI components (e.g. tooltip, combobox) use a portal to render content outside of the DOM hierarchy.
+    // The portal content is absolutely positioned relative to the body.
+    .euiBody-hasPortalContent {
+      position: relative;
+    }
   `;
 
   return <Global styles={styles} />;


### PR DESCRIPTION
### Summary

This PR converts `EuiPortal` to Emotion. 

I moved the styles that used to live in `src/components/portal/_portal.scss` to the `src/global_styling/reset/global_styles.tsx` because. 

Not sure how we want to handle global styles that can be used in multiple components. But happy to discuss.


### Checklist

- [ ] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
