### PR TITLE
[BUG]: Adding `role=marquee` to `EuiFilterButton`

### DIFF
--- a/src/components/filter_group/__snapshots__/filter_button.test.tsx.snap
+++ b/src/components/filter_group/__snapshots__/filter_button.test.tsx.snap
@@ -141,6 +141,7 @@ exports[`EuiFilterButton props numActiveFilters and hasActiveFilters is rendered
       <span
         aria-label="5 active filters"
         class="euiNotificationBadge euiFilterButton__notification"
+        role="marquee"
       >
         5
       </span>
@@ -166,6 +167,7 @@ exports[`EuiFilterButton props numFilters is rendered 1`] = `
       <span
         aria-label="5 available filters"
         class="euiNotificationBadge euiNotificationBadge--subdued euiFilterButton__notification"
+        role="marquee"
       >
         5
       </span>
@@ -231,6 +233,7 @@ exports[`EuiFilterButton renders zero properly 1`] = `
       <span
         aria-label="0 available filters"
         class="euiNotificationBadge euiNotificationBadge--subdued euiFilterButton__notification"
+        role="marquee"
       >
         0
       </span>

--- a/src/components/filter_group/filter_button.tsx
+++ b/src/components/filter_group/filter_button.tsx
@@ -104,6 +104,7 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
       className="euiFilterButton__notification"
       aria-label={hasActiveFilters ? activeBadgeLabel : availableBadgeLabel}
       color={isDisabled || !hasActiveFilters ? 'subdued' : 'accent'}
+      role="marquee" // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/marquee_role
     >
       {badgeCount}
     </EuiNotificationBadge>

--- a/upcoming_changelogs/6076.md
+++ b/upcoming_changelogs/6076.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiFilterButton` missing role attribute

--- a/upcoming_changelogs/6076.md
+++ b/upcoming_changelogs/6076.md
@@ -1,3 +1,3 @@
 **Bug fixes**
 
-- Fixed `EuiFilterButton` missing role attribute
+- Fixed an `EuiFilterButton` accessibility error


### PR DESCRIPTION
### Summary

@Heenawter reported an axe violation in EUI issue #6011 for the `EuiFilterButton` component. I solved this issue by adding a role of "marquee" to the badge inside the button. This felt like the correct role [based on MDN documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/marquee_role) and will be non-breaking change.

Closes #6011 

### Checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] ~~Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] ~~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] ~~Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
