### PR TITLE
Track changes to json theme files during release

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -64,6 +64,7 @@ if (args.dry_run) {
     execSync(`npm run update-token-changelog -- ${versionTarget}`, execOptions);
 
     // similarly, the build may have generated new theme json tokens
+    // TODO: this can be removed when the Emotion conversion is complete and the theme JSON files no longer exist
     await commitThemeTokens();
 
     // Update CHANGELOG.md

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -59,7 +59,7 @@ if (args.dry_run) {
 
     // build may have generated a new i18ntokens.json file, dirtying the git workspace
     // it's important to track those changes with this release, so determine the changes and write them
-    // to i18ntokens_changelog.json, comitting both to the workspace before running `npm version`
+    // to i18ntokens_changelog.json, committing both to the workspace before running `npm version`
     execSync(`npm run update-token-changelog -- ${versionTarget}`, execOptions);
 
     // Update CHANGELOG.md


### PR DESCRIPTION
### Summary

The build's `compile-scss` step includes generating _eui_theme_light.json_ and _eui_theme_dark.json_ token/value maps. This dirties the git workspace and interrupts following actions during a release.

Testing:

* copy the new `commitThemeTokens` function into _scripts/test.js_ and call it in the script
* update [`$euiBreadcrumbSpacing`](https://github.com/elastic/eui/blob/main/src/components/breadcrumbs/_variables.scss#L1)'s definition
* run `yarn compile-scss`
* verify the json token files are dirty
* run `node scripts/test.js`
* verify the json files are no longer dirty, and that a new _update theme json tokens_ commit exists
