### PR TITLE
[EuiImage] Fix empty `figcaption`s and non-centered EuiEmptyPrompt images

### DIFF
--- a/src/components/empty_prompt/_empty_prompt.scss
+++ b/src/components/empty_prompt/_empty_prompt.scss
@@ -12,6 +12,7 @@
     > * {
       flex-shrink: 1;
       max-width: convertToRem(360px);
+      margin-inline: auto;
     }
   }
 

--- a/src/components/empty_prompt/_empty_prompt.scss
+++ b/src/components/empty_prompt/_empty_prompt.scss
@@ -12,7 +12,6 @@
     > * {
       flex-shrink: 1;
       max-width: convertToRem(360px);
-      margin-inline: auto;
     }
   }
 

--- a/src/components/image/__snapshots__/image.test.tsx.snap
+++ b/src/components/image/__snapshots__/image.test.tsx.snap
@@ -11,9 +11,6 @@ exports[`EuiImage is rendered 1`] = `
     data-test-subj="test subject string"
     src="/cat.jpg"
   />
-  <figcaption
-    class="emotion-euiImageCaption"
-  />
 </figure>
 `;
 
@@ -47,9 +44,6 @@ exports[`EuiImage props allowFullScreen 1`] = `
       />
     </div>
   </button>
-  <figcaption
-    class="emotion-euiImageCaption"
-  />
 </figure>
 `;
 
@@ -85,9 +79,6 @@ exports[`EuiImage props float 1`] = `
     data-test-subj="test subject string"
     src="/cat.jpg"
   />
-  <figcaption
-    class="emotion-euiImageCaption"
-  />
 </figure>
 `;
 
@@ -121,9 +112,6 @@ exports[`EuiImage props fullScreenIconColor 1`] = `
       />
     </div>
   </button>
-  <figcaption
-    class="emotion-euiImageCaption"
-  />
 </figure>
 `;
 
@@ -157,9 +145,6 @@ exports[`EuiImage props hasShadow 1`] = `
       />
     </div>
   </button>
-  <figcaption
-    class="emotion-euiImageCaption"
-  />
 </figure>
 `;
 
@@ -173,9 +158,6 @@ exports[`EuiImage props margin 1`] = `
     class="euiImage testClass1 testClass2 emotion-euiImage-original"
     data-test-subj="test subject string"
     src="/cat.jpg"
-  />
-  <figcaption
-    class="emotion-euiImageCaption"
   />
 </figure>
 `;
@@ -192,9 +174,6 @@ exports[`EuiImage props size 1`] = `
     src="/cat.jpg"
     style="max-width:50px;max-height:50px"
   />
-  <figcaption
-    class="emotion-euiImageCaption"
-  />
 </figure>
 `;
 
@@ -207,9 +186,6 @@ exports[`EuiImage props src vs url src 1`] = `
     class="euiImage emotion-euiImage-original"
     src="/dog.jpg"
   />
-  <figcaption
-    class="emotion-euiImageCaption"
-  />
 </figure>
 `;
 
@@ -221,9 +197,6 @@ exports[`EuiImage props src vs url url 1`] = `
     alt=""
     class="euiImage emotion-euiImage-original"
     src="/dog.jpg"
-  />
-  <figcaption
-    class="emotion-euiImageCaption"
   />
 </figure>
 `;

--- a/src/components/image/image_caption.tsx
+++ b/src/components/image/image_caption.tsx
@@ -22,11 +22,11 @@ export const EuiImageCaption = forwardRef<HTMLDivElement, EuiImageCaptionProps>(
       isOnOverlayMask && styles.isOnOverlayMask,
     ];
 
-    return (
+    return caption ? (
       <figcaption ref={ref} css={cssStyles}>
         {caption}
       </figcaption>
-    );
+    ) : null;
   }
 );
 

--- a/src/components/image/image_wrapper.styles.ts
+++ b/src/components/image/image_wrapper.styles.ts
@@ -20,7 +20,7 @@ export const euiImageWrapperStyles = (euiThemeContext: UseEuiTheme) => {
   return {
     // Base
     euiImageWrapper: css`
-      display: table; // inline-block causes margins not to correctly collapse
+      display: inline-block;
       ${logicalCSS('max-width', '100%')}
       ${logicalTextAlignCSS('center')}; // Aligns both caption and image
       line-height: 0; // Fixes cropping when image is resized by forcing its height to be determined by the image not line-height

--- a/upcoming_changelogs/6081.md
+++ b/upcoming_changelogs/6081.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed `EuiImage` rendering empty captions 
+- Fixed `EuiEmptyPrompt` rendering non-centered `EuiImage`s in the `icon` prop

--- a/upcoming_changelogs/6081.md
+++ b/upcoming_changelogs/6081.md
@@ -1,4 +1,4 @@
 **Bug fixes**
 
 - Fixed `EuiImage` rendering empty captions 
-- Fixed `EuiEmptyPrompt` rendering non-centered `EuiImage`s in the `icon` prop
+- Fixed `EuiImage` not respecting `text-align` on parents


### PR DESCRIPTION
### Summary

closes https://github.com/elastic/eui/issues/6080

### Checklist

- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
