### PR TITLE
Tweak release script prompt

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -84,7 +84,7 @@ if (args.dry_run) {
 
   if (args.steps.indexOf('publish') > -1) {
     // prompt user for npm 2FA
-    const otp = await getOneTimePassword();
+    const otp = await getOneTimePassword(versionTarget);
 
     // publish new version to npm
     execSync(`npm publish --otp=${otp}`, execOptions);
@@ -226,9 +226,8 @@ async function promptUserForVersionType() {
   });
 }
 
-async function getOneTimePassword() {
-  const version = require('../package.json').version
-  console.log(chalk.magenta(`Preparing to publish @elastic/eui@${version} to npm registry`));
+async function getOneTimePassword(versionTarget) {
+  console.log(chalk.magenta(`Preparing to publish @elastic/eui@${versionTarget} to npm registry`));
   console.log('');
   console.log(chalk.magenta('The @elastic organization requires membership and 2FA to publish'));
 


### PR DESCRIPTION
### Summary

I noticed while doing a patch release today that the prompt copy is off:

<img width="514" alt="" src="https://user-images.githubusercontent.com/549407/181360787-d967197b-bd2c-48ca-bbed-98ae9615cddf.png">

The version in pink should be 62.0.1, not 62.0.0. Not a huge deal, but reduces some confusion / a tiny moment of 'oh no did choose the wrong release type'.

### Checklist

N/A, internal only