### PR TITLE
[EuiBetaBadge] Change `LabelAsString` from  interface to type

### DIFF
--- a/src/components/badge/beta_badge/beta_badge.tsx
+++ b/src/components/badge/beta_badge/beta_badge.tsx
@@ -78,6 +78,8 @@ type LabelAsNode = ExclusiveUnion<
   label: ReactNode;
 };
 
+// Must be `type` instead of `interface`
+// https://github.com/elastic/eui/issues/6085
 type LabelAsString = {
   /**
    * One word label like "Beta" or "Lab"

--- a/src/components/badge/beta_badge/beta_badge.tsx
+++ b/src/components/badge/beta_badge/beta_badge.tsx
@@ -78,12 +78,12 @@ type LabelAsNode = ExclusiveUnion<
   label: ReactNode;
 };
 
-interface LabelAsString {
+type LabelAsString = {
   /**
    * One word label like "Beta" or "Lab"
    */
   label: string;
-}
+};
 
 type BadgeProps = {
   /**


### PR DESCRIPTION
### Summary

Fixes #6085, which highlights that sometimes `ExclusiveUnion` does weird things. When using `type` the interface will be accessible as part of the eventual export, but not when using `interface`.

**Local testing:**

* In Kibana, add `export const BetaBadgeTest = EuiBetaBadge;` to `x-pack/plugins/infra/public/components/beta_badge.tsx`
* Confirm a type error about `LabelAsString`
* In EUI, run `node scripts/dtsgenerator.js`
* Copy the resuting `eui.d.ts` and paste into Kibana's `eui.d.ts`
* Confirm the type error is resolved

~### Checklist~
