### PR TITLE
Document EuiAccordion disabled state

### DIFF
--- a/src-docs/src/views/accordion/accordion_disabled.tsx
+++ b/src-docs/src/views/accordion/accordion_disabled.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { EuiAccordion, EuiFieldText, EuiFormRow, EuiSpacer } from '../../../../src/components';
+import { useGeneratedHtmlId } from '../../../../src/services';
+
+export default () => {
+  const disabledAccordionId = useGeneratedHtmlId({ prefix: 'disabledAccordion' });
+
+  return (
+    <div>
+<EuiAccordion
+  id={disabledAccordionId}
+  buttonContent="Security settings"
+  arrowProps={{ disabled: true }}
+  buttonProps={{ disabled: true }}
+  initialIsOpen={true}
+>
+        <EuiSpacer size="s" />
+        <EuiFormRow
+          label="Password"
+          isInvalid={true}
+          error={[
+            "You must enter your password to save these changes.",
+          ]}
+        >
+          <EuiFieldText name="text" isInvalid={true} />
+        </EuiFormRow>
+      </EuiAccordion>
+    </div>
+  );
+};

--- a/src-docs/src/views/accordion/accordion_example.js
+++ b/src-docs/src/views/accordion/accordion_example.js
@@ -89,6 +89,9 @@ const accordionIsLoadingSnippet = [
 import AccordionButtonElement from './accordion_buttonElement';
 const accordionButtonElementSource = require('!!raw-loader!./accordion_buttonElement');
 
+import AccordionDisabled from './accordion_disabled';
+const accordionDisabledSource = require('!!raw-loader!./accordion_disabled');
+
 export const AccordionExample = {
   title: 'Accordion',
   intro: (
@@ -419,6 +422,41 @@ export const AccordionExample = {
   paddingSize="l">
   <!-- Content to show when expanded -->
 </EuiAccordion>`,
+    },
+    {
+      title: 'Disabled',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: accordionDisabledSource,
+        },
+      ],
+      text: (
+        <>
+          <p>
+            In some cases you might want to prevent the user from closing the
+            <strong>EuiAccordion</strong>. For example, if a form field is
+            displaying an error, opening the accordion and preventing its
+            closure until the error has been addressed will help the user
+            find and fix the error.
+          </p>
+          <p>
+            The <EuiCode>arrowProps</EuiCode>, <EuiCode>buttonProps</EuiCode>,
+            and <EuiCode>initialIsOpen</EuiCode> props can be used together
+            to achieve this state.
+          </p>
+        </>
+      ),
+      demo: <AccordionDisabled />,
+      playground: accordionConfig,
+      props: { EuiAccordion },
+      snippet: `<EuiAccordion
+  id={accordionId1}
+  buttonContent="Clickable title"
+  >
+    <!-- Content to show when expanded -->
+</EuiAccordion>
+`,
     },
   ],
 };


### PR DESCRIPTION
### Summary

![image](https://user-images.githubusercontent.com/1238659/181595663-71b731e3-3f73-4afa-a7f4-04629e6bb034.png)

I'm anticipating the need to disable an accordion in https://github.com/elastic/kibana/issues/137464 and found that this state seems to be supported by the existing props, but isn't documented. I added some documentation for this state and would love some guidance on whether this is indeed supported with the existing props, and if so how to improve the docs for it.

There are a couple weird things about this state that makes me suspect we didn't intend to support it originally.

**Incomplete hover state.** The hover state for the `.euiAccordionForm__button` class doesn't take into account a disabled state, so even though you can't click it, it still looks clickable when you hover.

**TS errors.** There are TS errors when I pass `arrowProps` and `buttonProps` like this:

```tsx
<EuiAccordion
  id={disabledAccordionId}
  buttonContent="Security settings"
  arrowProps={{ disabled: true }}
  buttonProps={{ disabled: true }}
  initialIsOpen={true}
>
```

`arrowProps` error:
```
src-docs/src/views/accordion/accordion_disabled.tsx:14:23 - error TS2322: Type '{ disabled: true; }' is not assignable to type 'Partial<Omit<EuiButtonIconProps, "aria-labelledby" | "onClick" | "iconType">>'.
  Object literal may only specify known properties, but 'disabled' does not exist in type 'Partial<Omit<EuiButtonIconProps, "aria-labelledby" | "onClick" | "iconType">>'. Did you mean to write 'isDisabled'?
```

`buttonProps` error:
```
src-docs/src/views/accordion/accordion_disabled.tsx:15:24 - error TS2322: Type '{ disabled: true; }' is not assignable to type 'CommonProps & HTMLAttributes<HTMLElement>'.
  Object literal may only specify known properties, and 'disabled' does not exist in type 'CommonProps & HTMLAttributes<HTMLElement>'.
```

### Checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [ ] ~Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- [ ] ~Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- [ ] ~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] ~Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [ ] ~A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
