### PR TITLE
[EuiCommentEvent] Restore child classNames removed in Emotion conversion

### DIFF
--- a/src/components/comment_list/__snapshots__/comment.test.tsx.snap
+++ b/src/components/comment_list/__snapshots__/comment.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`EuiComment is rendered 1`] = `
   >
     <div
       class="euiCommentEvent emotion-euiCommentEvent-custom"
+      data-type="custom"
     />
   </div>
 </li>
@@ -63,26 +64,27 @@ exports[`EuiComment props event is rendered 1`] = `
   >
     <div
       class="euiCommentEvent emotion-euiCommentEvent-update"
+      data-type="update"
     >
       <div
-        class="emotion-euiCommentEvent__header"
+        class="euiCommentEvent__header emotion-euiCommentEvent__header"
       >
         <div
-          class="euiPanel euiPanel--transparent emotion-euiPanel-grow-m-transparent-euiCommentEvent__headerPanel"
+          class="euiPanel euiPanel--transparent emotion-euiPanel-grow-m-transparent"
         >
           <div
-            class="emotion-euiCommentEvent__headerMain"
+            class="euiCommentEvent__headerMain emotion-euiCommentEvent__headerMain"
           >
             <div
-              class="emotion-euiCommentEvent__headerData"
+              class="euiCommentEvent__headerData emotion-euiCommentEvent__headerData"
             >
               <div
-                class="emotion-euiCommentEvent__headerUsername"
+                class="euiCommentEvent__headerUsername emotion-euiCommentEvent__headerUsername"
               >
                 someuser
               </div>
               <div
-                class="emotion-euiCommentEvent__headerEvent"
+                class="euiCommentEvent__headerEvent emotion-euiCommentEvent__headerEvent"
               >
                 commented
               </div>
@@ -123,26 +125,27 @@ exports[`EuiComment props timestamp is rendered 1`] = `
   >
     <div
       class="euiCommentEvent emotion-euiCommentEvent-update"
+      data-type="update"
     >
       <div
-        class="emotion-euiCommentEvent__header"
+        class="euiCommentEvent__header emotion-euiCommentEvent__header"
       >
         <div
-          class="euiPanel euiPanel--transparent emotion-euiPanel-grow-m-transparent-euiCommentEvent__headerPanel"
+          class="euiPanel euiPanel--transparent emotion-euiPanel-grow-m-transparent"
         >
           <div
-            class="emotion-euiCommentEvent__headerMain"
+            class="euiCommentEvent__headerMain emotion-euiCommentEvent__headerMain"
           >
             <div
-              class="emotion-euiCommentEvent__headerData"
+              class="euiCommentEvent__headerData emotion-euiCommentEvent__headerData"
             >
               <div
-                class="emotion-euiCommentEvent__headerUsername"
+                class="euiCommentEvent__headerUsername emotion-euiCommentEvent__headerUsername"
               >
                 someuser
               </div>
               <div
-                class="emotion-euiCommentEvent__headerTimestamp"
+                class="euiCommentEvent__headerTimestamp"
               >
                 <time>
                   21 days ago
@@ -185,9 +188,10 @@ exports[`EuiComment renders a body 1`] = `
   >
     <div
       class="euiCommentEvent emotion-euiCommentEvent-custom"
+      data-type="custom"
     >
       <div
-        class="emotion-euiCommentEvent__body-custom"
+        class="euiCommentEvent__body emotion-euiCommentEvent__body-custom"
       >
         <p>
           This is the body.
@@ -226,9 +230,10 @@ exports[`EuiComment renders a timeline icon 1`] = `
   >
     <div
       class="euiCommentEvent emotion-euiCommentEvent-custom"
+      data-type="custom"
     >
       <div
-        class="emotion-euiCommentEvent__body-custom"
+        class="euiCommentEvent__body emotion-euiCommentEvent__body-custom"
       >
         <p>
           This is the body.

--- a/src/components/comment_list/__snapshots__/comment_event.test.tsx.snap
+++ b/src/components/comment_list/__snapshots__/comment_event.test.tsx.snap
@@ -3,9 +3,10 @@
 exports[`EuiCommentEvent is rendered with custom content 1`] = `
 <div
   class="euiCommentEvent testClass1 testClass2 emotion-euiCommentEvent-custom"
+  data-type="custom"
 >
   <div
-    class="emotion-euiCommentEvent__body-custom"
+    class="euiCommentEvent__body emotion-euiCommentEvent__body-custom"
   >
     <p>
       Some custom content
@@ -17,26 +18,27 @@ exports[`EuiCommentEvent is rendered with custom content 1`] = `
 exports[`EuiCommentEvent props event is rendered 1`] = `
 <div
   class="euiCommentEvent emotion-euiCommentEvent-update"
+  data-type="update"
 >
   <div
-    class="emotion-euiCommentEvent__header"
+    class="euiCommentEvent__header emotion-euiCommentEvent__header"
   >
     <div
-      class="euiPanel euiPanel--transparent emotion-euiPanel-grow-m-transparent-euiCommentEvent__headerPanel"
+      class="euiPanel euiPanel--transparent emotion-euiPanel-grow-m-transparent"
     >
       <div
-        class="emotion-euiCommentEvent__headerMain"
+        class="euiCommentEvent__headerMain emotion-euiCommentEvent__headerMain"
       >
         <div
-          class="emotion-euiCommentEvent__headerData"
+          class="euiCommentEvent__headerData emotion-euiCommentEvent__headerData"
         >
           <div
-            class="emotion-euiCommentEvent__headerUsername"
+            class="euiCommentEvent__headerUsername emotion-euiCommentEvent__headerUsername"
           >
             someuser
           </div>
           <div
-            class="emotion-euiCommentEvent__headerEvent"
+            class="euiCommentEvent__headerEvent emotion-euiCommentEvent__headerEvent"
           >
             commented
           </div>
@@ -50,29 +52,31 @@ exports[`EuiCommentEvent props event is rendered 1`] = `
 exports[`EuiCommentEvent props eventColor is rendered 1`] = `
 <div
   class="euiCommentEvent emotion-euiCommentEvent-custom"
+  data-type="custom"
 />
 `;
 
 exports[`EuiCommentEvent props eventIcon and eventIconAriaLabel are rendered 1`] = `
 <div
   class="euiCommentEvent emotion-euiCommentEvent-update"
+  data-type="update"
 >
   <div
-    class="emotion-euiCommentEvent__header"
+    class="euiCommentEvent__header emotion-euiCommentEvent__header"
   >
     <div
-      class="euiPanel euiPanel--transparent emotion-euiPanel-grow-m-transparent-euiCommentEvent__headerPanel"
+      class="euiPanel euiPanel--transparent emotion-euiPanel-grow-m-transparent"
     >
       <div
-        class="emotion-euiCommentEvent__headerMain"
+        class="euiCommentEvent__headerMain emotion-euiCommentEvent__headerMain"
       >
         <div
-          class="emotion-euiCommentEvent__headerData"
+          class="euiCommentEvent__headerData emotion-euiCommentEvent__headerData"
         >
           <div
             aria-hidden="false"
             aria-label="edit"
-            class="euiAvatar euiAvatar--s euiAvatar--user emotion-euiAvatar-s-user-subdued-euiCommentEvent__headerEventIcon"
+            class="euiAvatar euiAvatar--s euiAvatar--user euiCommentEvent__headerEventIcon emotion-euiAvatar-s-user-subdued-euiCommentEvent__headerEventIcon"
             role="img"
             title="edit"
           >
@@ -82,7 +86,7 @@ exports[`EuiCommentEvent props eventIcon and eventIconAriaLabel are rendered 1`]
             />
           </div>
           <div
-            class="emotion-euiCommentEvent__headerUsername"
+            class="euiCommentEvent__headerUsername emotion-euiCommentEvent__headerUsername"
           >
             someuser
           </div>
@@ -96,26 +100,27 @@ exports[`EuiCommentEvent props eventIcon and eventIconAriaLabel are rendered 1`]
 exports[`EuiCommentEvent props timestamp is rendered 1`] = `
 <div
   class="euiCommentEvent emotion-euiCommentEvent-update"
+  data-type="update"
 >
   <div
-    class="emotion-euiCommentEvent__header"
+    class="euiCommentEvent__header emotion-euiCommentEvent__header"
   >
     <div
-      class="euiPanel euiPanel--transparent emotion-euiPanel-grow-m-transparent-euiCommentEvent__headerPanel"
+      class="euiPanel euiPanel--transparent emotion-euiPanel-grow-m-transparent"
     >
       <div
-        class="emotion-euiCommentEvent__headerMain"
+        class="euiCommentEvent__headerMain emotion-euiCommentEvent__headerMain"
       >
         <div
-          class="emotion-euiCommentEvent__headerData"
+          class="euiCommentEvent__headerData emotion-euiCommentEvent__headerData"
         >
           <div
-            class="emotion-euiCommentEvent__headerUsername"
+            class="euiCommentEvent__headerUsername emotion-euiCommentEvent__headerUsername"
           >
             someuser
           </div>
           <div
-            class="emotion-euiCommentEvent__headerTimestamp"
+            class="euiCommentEvent__headerTimestamp"
           >
             <time>
               21 days ago

--- a/src/components/comment_list/__snapshots__/comment_list.test.tsx.snap
+++ b/src/components/comment_list/__snapshots__/comment_list.test.tsx.snap
@@ -34,6 +34,7 @@ exports[`EuiCommentList is rendered 1`] = `
     >
       <div
         class="euiCommentEvent emotion-euiCommentEvent-custom"
+        data-type="custom"
       />
     </div>
   </li>
@@ -72,6 +73,7 @@ exports[`EuiCommentList props gutterSize l is rendered 1`] = `
     >
       <div
         class="euiCommentEvent emotion-euiCommentEvent-custom"
+        data-type="custom"
       />
     </div>
   </li>
@@ -110,6 +112,7 @@ exports[`EuiCommentList props gutterSize m is rendered 1`] = `
     >
       <div
         class="euiCommentEvent emotion-euiCommentEvent-custom"
+        data-type="custom"
       />
     </div>
   </li>
@@ -148,6 +151,7 @@ exports[`EuiCommentList props gutterSize xl is rendered 1`] = `
     >
       <div
         class="euiCommentEvent emotion-euiCommentEvent-custom"
+        data-type="custom"
       />
     </div>
   </li>

--- a/src/components/comment_list/comment_event.styles.ts
+++ b/src/components/comment_list/comment_event.styles.ts
@@ -25,7 +25,17 @@ export const euiCommentEventStyles = ({ euiTheme }: UseEuiTheme) => ({
 
 export const euiCommentEventHeaderStyles = ({ euiTheme }: UseEuiTheme) => ({
   euiCommentEvent__header: css``,
-  euiCommentEvent__headerPanel: css``,
+  // types
+  regular: css`
+    background: ${euiTheme.colors.lightestShade};
+    border-bottom: ${euiTheme.border.thin};
+    padding: ${euiTheme.size.s};
+  `,
+  // variants
+  hasEventColor: css`
+    padding: 0;
+  `,
+  // Children
   euiCommentEvent__headerMain: css`
     display: flex;
     flex: 1;
@@ -51,21 +61,10 @@ export const euiCommentEventHeaderStyles = ({ euiTheme }: UseEuiTheme) => ({
     white-space: pre-wrap;
     flex-wrap: wrap;
   `,
-  euiCommentEvent__headerTimestamp: css``,
   euiCommentEvent__headerActions: css`
     display: flex;
     flex-wrap: wrap;
     gap: ${euiTheme.size.xs};
-  `,
-  // types
-  regular: css`
-    background: ${euiTheme.colors.lightestShade};
-    border-bottom: ${euiTheme.border.thin};
-    padding: ${euiTheme.size.s};
-  `,
-  // variants
-  hasEventColor: css`
-    padding: 0;
   `,
 });
 

--- a/src/components/comment_list/comment_event.tsx
+++ b/src/components/comment_list/comment_event.tsx
@@ -188,14 +188,10 @@ export const EuiCommentEvent: FunctionComponent<EuiCommentEventProps> = ({
   );
 
   return (
-    <Element className={classes} css={cssStyles}>
+    <Element className={classes} css={cssStyles} data-type={type}>
       {hasEventElements && eventHeader}
 
-      {children && (
-        <div className="euiCommentEvent__body" css={cssBodyStyles}>
-          {children}
-        </div>
-      )}
+      {children && <div css={cssBodyStyles}>{children}</div>}
     </Element>
   );
 };

--- a/src/components/comment_list/comment_event.tsx
+++ b/src/components/comment_list/comment_event.tsx
@@ -115,68 +115,73 @@ export const EuiCommentEvent: FunctionComponent<EuiCommentEventProps> = ({
     ? { color: finalEventColor, paddingSize: 's' }
     : { color: 'transparent', paddingSize: 'none' };
 
-  const eventHeader = (
-    <HeaderElement className="euiCommentEvent__header" css={cssHeaderStyles}>
-      <EuiPanel {...(panelProps as EuiPanelProps)}>
-        <div
-          className="euiCommentEvent__headerMain"
-          css={headerStyles.euiCommentEvent__headerMain}
-        >
-          <div
-            className="euiCommentEvent__headerData"
-            css={headerStyles.euiCommentEvent__headerData}
-          >
-            {eventIcon && (
-              <EuiAvatar
-                className="euiCommentEvent__headerEventIcon"
-                css={headerStyles.euiCommentEvent__headerEventIcon}
-                size="s"
-                iconType={eventIcon}
-                name={eventIconAriaLabel ? eventIconAriaLabel : ''}
-                color="subdued"
-                aria-hidden={!eventIconAriaLabel}
-              />
-            )}
-            {username && (
-              <div
-                className="euiCommentEvent__headerUsername"
-                css={headerStyles.euiCommentEvent__headerUsername}
-              >
-                {username}
-              </div>
-            )}
-            {event && (
-              <div
-                className="euiCommentEvent__headerEvent"
-                css={headerStyles.euiCommentEvent__headerEvent}
-              >
-                {event}
-              </div>
-            )}
-            {timestamp && (
-              <div className="euiCommentEvent__headerTimestamp">
-                <time>{timestamp}</time>
-              </div>
-            )}
-          </div>
-          {actions && (
-            <div
-              className="euiCommentEvent__headerActions"
-              css={headerStyles.euiCommentEvent__headerActions}
-            >
-              {actions}
-            </div>
-          )}
-        </div>
-      </EuiPanel>
-    </HeaderElement>
-  );
-
   return (
     <Element className={classes} css={cssStyles} data-type={type}>
-      {hasEventElements && eventHeader}
+      {hasEventElements && (
+        <HeaderElement
+          className="euiCommentEvent__header"
+          css={cssHeaderStyles}
+        >
+          <EuiPanel {...(panelProps as EuiPanelProps)}>
+            <div
+              className="euiCommentEvent__headerMain"
+              css={headerStyles.euiCommentEvent__headerMain}
+            >
+              <div
+                className="euiCommentEvent__headerData"
+                css={headerStyles.euiCommentEvent__headerData}
+              >
+                {eventIcon && (
+                  <EuiAvatar
+                    className="euiCommentEvent__headerEventIcon"
+                    css={headerStyles.euiCommentEvent__headerEventIcon}
+                    size="s"
+                    iconType={eventIcon}
+                    name={eventIconAriaLabel ? eventIconAriaLabel : ''}
+                    color="subdued"
+                    aria-hidden={!eventIconAriaLabel}
+                  />
+                )}
+                {username && (
+                  <div
+                    className="euiCommentEvent__headerUsername"
+                    css={headerStyles.euiCommentEvent__headerUsername}
+                  >
+                    {username}
+                  </div>
+                )}
+                {event && (
+                  <div
+                    className="euiCommentEvent__headerEvent"
+                    css={headerStyles.euiCommentEvent__headerEvent}
+                  >
+                    {event}
+                  </div>
+                )}
+                {timestamp && (
+                  <div className="euiCommentEvent__headerTimestamp">
+                    <time>{timestamp}</time>
+                  </div>
+                )}
+              </div>
+              {actions && (
+                <div
+                  className="euiCommentEvent__headerActions"
+                  css={headerStyles.euiCommentEvent__headerActions}
+                >
+                  {actions}
+                </div>
+              )}
+            </div>
+          </EuiPanel>
+        </HeaderElement>
+      )}
 
-      {children && <div css={cssBodyStyles}>{children}</div>}
+      {children && (
+        <div className="euiCommentEvent__body" css={cssBodyStyles}>
+          {children}
+        </div>
+      )}
     </Element>
   );
 };

--- a/src/components/comment_list/comment_event.tsx
+++ b/src/components/comment_list/comment_event.tsx
@@ -98,13 +98,10 @@ export const EuiCommentEvent: FunctionComponent<EuiCommentEventProps> = ({
     eventColor && headerStyles.hasEventColor,
     isTypeRegular && headerStyles.regular,
   ];
-  const cssHeaderPanelStyles = headerStyles.euiCommentEvent__headerPanel;
   const cssHeaderEventIconStyles =
     headerStyles.euiCommentEvent__headerEventIcon;
   const cssHeaderUsernameStyles = headerStyles.euiCommentEvent__headerUsername;
   const cssHeaderEventStyles = headerStyles.euiCommentEvent__headerEvent;
-  const cssHeaderTimestampStyles =
-    headerStyles.euiCommentEvent__headerTimestamp;
   const cssHeaderMainStyles = headerStyles.euiCommentEvent__headerMain;
   const cssHeaderDataStyles = headerStyles.euiCommentEvent__headerData;
   const cssHeaderActionsStyles = headerStyles.euiCommentEvent__headerActions;
@@ -128,7 +125,7 @@ export const EuiCommentEvent: FunctionComponent<EuiCommentEventProps> = ({
 
   const eventHeader = (
     <HeaderElement className="euiCommentEvent__header" css={cssHeaderStyles}>
-      <EuiPanel {...(panelProps as EuiPanelProps)} css={cssHeaderPanelStyles}>
+      <EuiPanel {...(panelProps as EuiPanelProps)}>
         <div className="euiCommentEvent__headerMain" css={cssHeaderMainStyles}>
           <div
             className="euiCommentEvent__headerData"
@@ -165,10 +162,7 @@ export const EuiCommentEvent: FunctionComponent<EuiCommentEventProps> = ({
             )}
 
             {timestamp && (
-              <div
-                className="euiCommentEvent__headerTimestamp"
-                css={cssHeaderTimestampStyles}
-              >
+              <div className="euiCommentEvent__headerTimestamp">
                 <time>{timestamp}</time>
               </div>
             )}

--- a/src/components/comment_list/comment_event.tsx
+++ b/src/components/comment_list/comment_event.tsx
@@ -127,12 +127,16 @@ export const EuiCommentEvent: FunctionComponent<EuiCommentEventProps> = ({
     : { color: 'transparent', paddingSize: 'none' };
 
   const eventHeader = (
-    <HeaderElement css={cssHeaderStyles}>
+    <HeaderElement className="euiCommentEvent__header" css={cssHeaderStyles}>
       <EuiPanel {...(panelProps as EuiPanelProps)} css={cssHeaderPanelStyles}>
-        <div css={cssHeaderMainStyles}>
-          <div css={cssHeaderDataStyles}>
+        <div className="euiCommentEvent__headerMain" css={cssHeaderMainStyles}>
+          <div
+            className="euiCommentEvent__headerData"
+            css={cssHeaderDataStyles}
+          >
             {eventIcon && (
               <EuiAvatar
+                className="euiCommentEvent__headerEventIcon"
                 css={cssHeaderEventIconStyles}
                 size="s"
                 iconType={eventIcon}
@@ -142,18 +146,42 @@ export const EuiCommentEvent: FunctionComponent<EuiCommentEventProps> = ({
               />
             )}
 
-            {username && <div css={cssHeaderUsernameStyles}>{username}</div>}
+            {username && (
+              <div
+                className="euiCommentEvent__headerUsername"
+                css={cssHeaderUsernameStyles}
+              >
+                {username}
+              </div>
+            )}
 
-            {event && <div css={cssHeaderEventStyles}>{event}</div>}
+            {event && (
+              <div
+                className="euiCommentEvent__headerEvent"
+                css={cssHeaderEventStyles}
+              >
+                {event}
+              </div>
+            )}
 
             {timestamp && (
-              <div css={cssHeaderTimestampStyles}>
+              <div
+                className="euiCommentEvent__headerTimestamp"
+                css={cssHeaderTimestampStyles}
+              >
                 <time>{timestamp}</time>
               </div>
             )}
           </div>
 
-          {actions && <div css={cssHeaderActionsStyles}>{actions}</div>}
+          {actions && (
+            <div
+              className="euiCommentEvent__headerActions"
+              css={cssHeaderActionsStyles}
+            >
+              {actions}
+            </div>
+          )}
         </div>
       </EuiPanel>
     </HeaderElement>
@@ -163,7 +191,11 @@ export const EuiCommentEvent: FunctionComponent<EuiCommentEventProps> = ({
     <Element className={classes} css={cssStyles}>
       {hasEventElements && eventHeader}
 
-      {children && <div css={cssBodyStyles}>{children}</div>}
+      {children && (
+        <div className="euiCommentEvent__body" css={cssBodyStyles}>
+          {children}
+        </div>
+      )}
     </Element>
   );
 };

--- a/src/components/comment_list/comment_event.tsx
+++ b/src/components/comment_list/comment_event.tsx
@@ -98,16 +98,8 @@ export const EuiCommentEvent: FunctionComponent<EuiCommentEventProps> = ({
     eventColor && headerStyles.hasEventColor,
     isTypeRegular && headerStyles.regular,
   ];
-  const cssHeaderEventIconStyles =
-    headerStyles.euiCommentEvent__headerEventIcon;
-  const cssHeaderUsernameStyles = headerStyles.euiCommentEvent__headerUsername;
-  const cssHeaderEventStyles = headerStyles.euiCommentEvent__headerEvent;
-  const cssHeaderMainStyles = headerStyles.euiCommentEvent__headerMain;
-  const cssHeaderDataStyles = headerStyles.euiCommentEvent__headerData;
-  const cssHeaderActionsStyles = headerStyles.euiCommentEvent__headerActions;
 
   const bodyStyles = euiCommentEventBodyStyles(euiTheme);
-
   const cssBodyStyles = [bodyStyles.euiCommentEvent__body, bodyStyles[type]];
 
   const isFigure = isTypeRegular;
@@ -126,15 +118,18 @@ export const EuiCommentEvent: FunctionComponent<EuiCommentEventProps> = ({
   const eventHeader = (
     <HeaderElement className="euiCommentEvent__header" css={cssHeaderStyles}>
       <EuiPanel {...(panelProps as EuiPanelProps)}>
-        <div className="euiCommentEvent__headerMain" css={cssHeaderMainStyles}>
+        <div
+          className="euiCommentEvent__headerMain"
+          css={headerStyles.euiCommentEvent__headerMain}
+        >
           <div
             className="euiCommentEvent__headerData"
-            css={cssHeaderDataStyles}
+            css={headerStyles.euiCommentEvent__headerData}
           >
             {eventIcon && (
               <EuiAvatar
                 className="euiCommentEvent__headerEventIcon"
-                css={cssHeaderEventIconStyles}
+                css={headerStyles.euiCommentEvent__headerEventIcon}
                 size="s"
                 iconType={eventIcon}
                 name={eventIconAriaLabel ? eventIconAriaLabel : ''}
@@ -142,36 +137,32 @@ export const EuiCommentEvent: FunctionComponent<EuiCommentEventProps> = ({
                 aria-hidden={!eventIconAriaLabel}
               />
             )}
-
             {username && (
               <div
                 className="euiCommentEvent__headerUsername"
-                css={cssHeaderUsernameStyles}
+                css={headerStyles.euiCommentEvent__headerUsername}
               >
                 {username}
               </div>
             )}
-
             {event && (
               <div
                 className="euiCommentEvent__headerEvent"
-                css={cssHeaderEventStyles}
+                css={headerStyles.euiCommentEvent__headerEvent}
               >
                 {event}
               </div>
             )}
-
             {timestamp && (
               <div className="euiCommentEvent__headerTimestamp">
                 <time>{timestamp}</time>
               </div>
             )}
           </div>
-
           {actions && (
             <div
               className="euiCommentEvent__headerActions"
-              css={cssHeaderActionsStyles}
+              css={headerStyles.euiCommentEvent__headerActions}
             >
               {actions}
             </div>

--- a/upcoming_changelogs/6089.md
+++ b/upcoming_changelogs/6089.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Restored non-Emotion classNames to `EuiCommentEvent`'s children


### PR DESCRIPTION
### Summary

Several Kibana tests and CSS overrides were targeting these classNames: https://github.com/elastic/kibana/pull/136865/commits/1bdae6b56507a78de66f7250d5e99ddaaec9e514

After some team discussion on Slack, we've decided that for the Emotion conversion, we're generally opting to **not** remove `__child` classNames (especially on DOM elements that aren't customizable via consumers/props). They serve as useful hooks/markers for consumers to use.

Modifier `--` classNames, especially maps, are fair game to be removed especially if replaced by a `data-` attribute (I've added one here for event types), but should be checked in Kibana first for usage.

### Notes

While I was here I did some minor code cleanup. The first 2 commits (+ snapshots) are the only required changes

### Checklist

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
