### PR TITLE
[EuiSelectable] Export `EuiSelectableSearchableProps` type

### DIFF
--- a/src/components/selectable/index.ts
+++ b/src/components/selectable/index.ts
@@ -8,6 +8,7 @@
 
 export type {
   EuiSelectableProps,
+  EuiSelectableSearchableProps,
   EuiSelectableSearchableSearchProps,
 } from './selectable';
 export { EuiSelectable } from './selectable';

--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -56,7 +56,7 @@ type EuiSelectableOptionsListPropsWithDefaults = RequiredEuiSelectableOptionsLis
 // modifications remain in alignment.
 //
 // `searchProps` can only be specified when `searchable` is true
-type EuiSelectableSearchableProps<T> = ExclusiveUnion<
+export type EuiSelectableSearchableProps<T> = ExclusiveUnion<
   {
     searchable: false;
   },


### PR DESCRIPTION
### Summary

A recently highlighted use case for `EuiSelectable` had `searchable` dependent on some variable. This is fine, but the underlying type could not correctly infer the value of `searchProps` and would cause errors. The workaround was to construct an object of type `EuiSelectableSearchableProps` so that the values could be correctly parsed. Unfortunately the type was not available as a top-level export, though.

```tsx
const searchableProps: EuiSelectableSearchableProps<{}> = someTruthyProp
  ? {
      searchable: true,
      searchProps: {
        placeholder: 'Placeholder',
        compressed: true,
        isClearable: true,
        id: 'id',
      },
    }
  : {
      searchable: false,
    };

return (
    <EuiSelectable
      aria-label="Basic example"
      options={options}
      onChange={(newOptions) => setOptions(newOptions)}
      {...searchableProps}
    >
      {(list) => list}
    </EuiSelectable>
  );
};



```

~### Checklist~
