### PR TITLE
Fix release script

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -51,12 +51,13 @@ if (args.dry_run) {
     execSync('npm run build', execOptions);
   }
 
+  let versionTarget;
 
   if (args.steps.indexOf('version') > -1) {
     const { changelogMap, changelog } = collateChangelogFiles();
 
     // prompt user for what type of version bump to make (major|minor|patch)
-    const versionTarget = await getVersionTypeFromChangelog(changelogMap);
+    versionTarget = await getVersionTypeFromChangelog(changelogMap);
 
     // build may have generated a new i18ntokens.json file, dirtying the git workspace
     // it's important to track those changes with this release, so determine the changes and write them


### PR DESCRIPTION
### Summary

Fixes https://github.com/elastic/eui/pull/6083 - I totally forgot / failed to notice that there's different steps in the release script JS, and `versionTarget` is instantiated inside a step and therefore unavailable to subsequent steps, causing an `undefined` error 😬 

### Checklist

N/A, internal only 