### PR TITLE
[EuiToolTip] Convert tests to RTL and export tooltip RTL helpers

### DIFF
--- a/scripts/jest/setup/mocks.js
+++ b/scripts/jest/setup/mocks.js
@@ -6,13 +6,8 @@ jest.mock('./../../../src/components/auto_sizer', () => {
 });
 
 jest.mock('./../../../src/components/observer/resize_observer', () => {
-  const rest = jest.requireActual(
-    './../../../src/components/observer/resize_observer'
-  );
-  const {
-    EuiResizeObserver,
-  } = require('./../../../src/components/observer/resize_observer/resize_observer.testenv');
-  return { ...rest, EuiResizeObserver };
+  const resizeObservers = require('./../../../src/components/observer/resize_observer/resize_observer.testenv');
+  return resizeObservers;
 });
 
 jest.mock('./../../../src/components/icon', () => {

--- a/scripts/jest/setup/mocks.js
+++ b/scripts/jest/setup/mocks.js
@@ -1,6 +1,18 @@
 jest.mock('./../../../src/components/auto_sizer', () => {
-  const { EuiAutoSizer } = require('./../../../src/components/auto_sizer/auto_sizer.testenv');
+  const {
+    EuiAutoSizer,
+  } = require('./../../../src/components/auto_sizer/auto_sizer.testenv');
   return { EuiAutoSizer };
+});
+
+jest.mock('./../../../src/components/observer/resize_observer', () => {
+  const rest = jest.requireActual(
+    './../../../src/components/observer/resize_observer'
+  );
+  const {
+    EuiResizeObserver,
+  } = require('./../../../src/components/observer/resize_observer/resize_observer.testenv');
+  return { ...rest, EuiResizeObserver };
 });
 
 jest.mock('./../../../src/components/icon', () => {

--- a/src/components/observer/resize_observer/resize_observer.testenv.tsx
+++ b/src/components/observer/resize_observer/resize_observer.testenv.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { useEffect, useState } from 'react';
+import { EuiResizeObserverProps } from './resize_observer';
+
+/**
+ * jsdom currently does not support ResizeObservers (@see https://github.com/jsdom/jsdom/issues/3368)
+ * To mimic RO init behavior (should call onResize on mount), we're providing the below testenv mock.
+ */
+export const EuiResizeObserver = ({
+  onResize,
+  children,
+}: EuiResizeObserverProps) => {
+  const [observedElement, setObservedElement] = useState<Element | null>(null);
+
+  useEffect(() => {
+    if (observedElement) {
+      const { width, height } = observedElement.getBoundingClientRect();
+      onResize({ width, height });
+    }
+  }, [observedElement, onResize]);
+
+  return children(setObservedElement);
+};

--- a/src/components/observer/resize_observer/resize_observer.testenv.tsx
+++ b/src/components/observer/resize_observer/resize_observer.testenv.tsx
@@ -9,10 +9,15 @@
 import { useEffect, useState } from 'react';
 import { EuiResizeObserverProps } from './resize_observer';
 
+// Re-export `hasResizeObserver` as-is
+export const hasResizeObserver =
+  typeof window !== 'undefined' && typeof window.ResizeObserver !== 'undefined';
+
 /**
  * jsdom currently does not support ResizeObservers (@see https://github.com/jsdom/jsdom/issues/3368)
- * To mimic RO init behavior (should call onResize on mount), we're providing the below testenv mock.
+ * To mimic RO init behavior (should call onResize on mount), we're providing the below testenv mocks.
  */
+
 export const EuiResizeObserver = ({
   onResize,
   children,
@@ -27,4 +32,20 @@ export const EuiResizeObserver = ({
   }, [observedElement, onResize]);
 
   return children(setObservedElement);
+};
+
+export const useResizeObserver = (
+  container: Element | null,
+  dimension?: 'width' | 'height'
+) => {
+  const [size, setSize] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    if (container != null) {
+      const { width, height } = container.getBoundingClientRect();
+      setSize({ width, height });
+    }
+  }, [container, dimension]);
+
+  return size;
 };

--- a/src/components/tool_tip/__snapshots__/tool_tip.test.tsx.snap
+++ b/src/components/tool_tip/__snapshots__/tool_tip.test.tsx.snap
@@ -1,23 +1,71 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiToolTip display prop renders block 1`] = `
-<span
-  class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
->
-  <button>
-    Trigger
-  </button>
-</span>
+<div>
+  <span
+    class="euiToolTipAnchor euiToolTipAnchor--displayBlock"
+  >
+    <button>
+      Trigger
+    </button>
+  </span>
+</div>
 `;
 
 exports[`EuiToolTip is rendered 1`] = `
-<span
-  class="euiToolTipAnchor"
->
-  <button>
-    Trigger
-  </button>
-</span>
+<body>
+  <div>
+    <span
+      class="euiToolTipAnchor"
+    >
+      <button>
+        Trigger
+      </button>
+    </span>
+  </div>
+</body>
 `;
 
-exports[`EuiToolTip shows tooltip on focus 1`] = `"<div data-euiportal=\\"true\\"><div class=\\"euiToolTipPopover euiToolTip euiToolTip--top testClass1 testClass2\\" style=\\"top: 50px; left: 50px; opacity: 0; visibility: hidden;\\" id=\\"id\\" role=\\"tooltip\\" aria-label=\\"aria-label\\" data-test-subj=\\"tooltip\\" position=\\"top\\"><div class=\\"euiToolTip__title\\">title</div><div class=\\"euiToolTip__arrow\\"></div><div>content</div></div></div>"`;
+exports[`EuiToolTip shows tooltip on mouseover and focus 1`] = `
+<body
+  class="euiBody-hasPortalContent"
+>
+  <div>
+    <span
+      class="euiToolTipAnchor"
+    >
+      <button
+        aria-describedby="id"
+        data-test-subj="trigger"
+      >
+        Trigger
+      </button>
+    </span>
+  </div>
+  <div
+    data-euiportal="true"
+  >
+    <div
+      aria-label="aria-label"
+      class="euiToolTipPopover euiToolTip euiToolTip--top testClass1 testClass2"
+      data-test-subj="test subject string"
+      id="id"
+      position="top"
+      role="tooltip"
+      style="top: 50px; left: 50px; opacity: 0; visibility: hidden;"
+    >
+      <div
+        class="euiToolTip__title"
+      >
+        title
+      </div>
+      <div
+        class="euiToolTip__arrow"
+      />
+      <div>
+        content
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/src/components/tool_tip/__snapshots__/tool_tip.test.tsx.snap
+++ b/src/components/tool_tip/__snapshots__/tool_tip.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`EuiToolTip shows tooltip on mouseover and focus 1`] = `
       id="id"
       position="top"
       role="tooltip"
-      style="top: 50px; left: 50px; opacity: 0; visibility: hidden;"
+      style="top: -16px; left: -10px;"
     >
       <div
         class="euiToolTip__title"
@@ -61,6 +61,7 @@ exports[`EuiToolTip shows tooltip on mouseover and focus 1`] = `
       </div>
       <div
         class="euiToolTip__arrow"
+        style="left: 4px; top: 0px;"
       />
       <div>
         content

--- a/src/components/tool_tip/__snapshots__/tool_tip.test.tsx.snap
+++ b/src/components/tool_tip/__snapshots__/tool_tip.test.tsx.snap
@@ -20,15 +20,4 @@ exports[`EuiToolTip is rendered 1`] = `
 </span>
 `;
 
-exports[`EuiToolTip shows tooltip on focus 1`] = `
-<span
-  class="euiToolTipAnchor"
->
-  <button
-    aria-describedby="id"
-    data-test-subj="trigger"
-  >
-    Trigger
-  </button>
-</span>
-`;
+exports[`EuiToolTip shows tooltip on focus 1`] = `"<div data-euiportal=\\"true\\"><div class=\\"euiToolTipPopover euiToolTip euiToolTip--top testClass1 testClass2\\" style=\\"top: 50px; left: 50px; opacity: 0; visibility: hidden;\\" id=\\"id\\" role=\\"tooltip\\" aria-label=\\"aria-label\\" data-test-subj=\\"tooltip\\" position=\\"top\\"><div class=\\"euiToolTip__title\\">title</div><div class=\\"euiToolTip__arrow\\"></div><div>content</div></div></div>"`;

--- a/src/components/tool_tip/tool_tip.test.tsx
+++ b/src/components/tool_tip/tool_tip.test.tsx
@@ -8,11 +8,7 @@
 
 import React from 'react';
 import { render, mount } from 'enzyme';
-import {
-  requiredProps,
-  findTestSubject,
-  takeMountedSnapshot,
-} from '../../test';
+import { requiredProps, findTestSubject } from '../../test';
 import { EuiToolTip } from './tool_tip';
 
 describe('EuiToolTip', () => {
@@ -29,15 +25,25 @@ describe('EuiToolTip', () => {
   test('shows tooltip on focus', () => {
     jest.useFakeTimers();
     const component = mount(
-      <EuiToolTip title="title" id="id" content="content" {...requiredProps}>
+      <EuiToolTip
+        title="title"
+        id="id"
+        content="content"
+        {...requiredProps}
+        data-test-subj="tooltip"
+      >
         <button data-test-subj="trigger">Trigger</button>
       </EuiToolTip>
     );
 
     const trigger = findTestSubject(component, 'trigger');
     trigger.simulate('focus');
-    jest.advanceTimersByTime(260); // wait for showToolTip setTimeout
-    expect(takeMountedSnapshot(component)).toMatchSnapshot();
+    jest.runAllTimers(); // wait for showToolTip setTimeout
+
+    expect(document.querySelector('[data-test-subj="tooltip"]')).not.toBeNull();
+    expect(document.body.innerHTML.toString()).toMatchSnapshot();
+
+    jest.useRealTimers();
   });
 
   test('display prop renders block', () => {

--- a/src/components/tool_tip/tool_tip.test.tsx
+++ b/src/components/tool_tip/tool_tip.test.tsx
@@ -7,22 +7,49 @@
  */
 
 import React from 'react';
-import { render, mount } from 'enzyme';
+import { mount } from 'enzyme';
+import { fireEvent } from '@testing-library/react';
+import {
+  render,
+  waitForEuiToolTipVisible,
+  waitForEuiToolTipHidden,
+} from '../../test/rtl';
 import { requiredProps, findTestSubject } from '../../test';
+
 import { EuiToolTip } from './tool_tip';
 
 describe('EuiToolTip', () => {
-  test('is rendered', () => {
-    const component = render(
+  it('is rendered', () => {
+    const { baseElement } = render(
       <EuiToolTip title="title" id="id" content="content" {...requiredProps}>
         <button>Trigger</button>
       </EuiToolTip>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(baseElement).toMatchSnapshot();
   });
 
-  test('shows tooltip on focus', () => {
+  it('shows tooltip on mouseover and focus', async () => {
+    const { baseElement, getByTestSubject } = render(
+      <EuiToolTip title="title" id="id" content="content" {...requiredProps}>
+        <button data-test-subj="trigger">Trigger</button>
+      </EuiToolTip>
+    );
+
+    fireEvent.mouseOver(getByTestSubject('trigger'));
+    await waitForEuiToolTipVisible();
+
+    expect(baseElement).toMatchSnapshot();
+
+    fireEvent.mouseOut(getByTestSubject('trigger'));
+    await waitForEuiToolTipHidden();
+
+    fireEvent.focus(getByTestSubject('trigger'));
+    await waitForEuiToolTipVisible();
+  });
+
+  // This is a legacy unit test to ensure tooltips/portal updates still play well with Enzyme
+  it('[enzyme] shows tooltip on focus', () => {
     jest.useFakeTimers();
     const component = mount(
       <EuiToolTip
@@ -41,13 +68,12 @@ describe('EuiToolTip', () => {
     jest.runAllTimers(); // wait for showToolTip setTimeout
 
     expect(document.querySelector('[data-test-subj="tooltip"]')).not.toBeNull();
-    expect(document.body.innerHTML.toString()).toMatchSnapshot();
 
     jest.useRealTimers();
   });
 
   test('display prop renders block', () => {
-    const component = render(
+    const { container } = render(
       <EuiToolTip
         title="title"
         id="id"
@@ -59,6 +85,6 @@ describe('EuiToolTip', () => {
       </EuiToolTip>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 });

--- a/src/components/tool_tip/tool_tip_popover.tsx
+++ b/src/components/tool_tip/tool_tip_popover.tsx
@@ -40,7 +40,6 @@ export class EuiToolTipPopover extends Component<Props> {
   componentDidMount() {
     document.body.classList.add('euiBody-hasPortalContent');
     window.addEventListener('resize', this.updateDimensions);
-    this.updateDimensions();
   }
 
   componentWillUnmount() {

--- a/src/components/tool_tip/tool_tip_popover.tsx
+++ b/src/components/tool_tip/tool_tip_popover.tsx
@@ -40,6 +40,7 @@ export class EuiToolTipPopover extends Component<Props> {
   componentDidMount() {
     document.body.classList.add('euiBody-hasPortalContent');
     window.addEventListener('resize', this.updateDimensions);
+    this.updateDimensions();
   }
 
   componentWillUnmount() {

--- a/src/test/rtl/component_helpers.ts
+++ b/src/test/rtl/component_helpers.ts
@@ -9,7 +9,7 @@
 import { waitFor } from '@testing-library/react';
 
 /**
- * Ensure the EuiPopover being tested is open/closed before contiuning
+ * Ensure the EuiPopover being tested is open/closed before continuing
  * Note: Because EuiPopover is portalled, we want to query `document`
  * instead of the `container` returned by RTL's render()
  */
@@ -23,4 +23,19 @@ export const waitForEuiPopoverClose = async () =>
   await waitFor(() => {
     const openPopover = document.querySelector('[data-popover-open]');
     expect(openPopover).toBeFalsy();
+  });
+
+/**
+ * Ensure the EuiToolTip being tested is open and visible before continuing
+ */
+export const waitForEuiToolTipVisible = async () =>
+  await waitFor(() => {
+    const tooltip = document.querySelector('.euiToolTipPopover');
+    expect(tooltip).toBeTruthy();
+  });
+
+export const waitForEuiToolTipHidden = async () =>
+  await waitFor(() => {
+    const tooltip = document.querySelector('.euiToolTipPopover');
+    expect(tooltip).toBeFalsy();
   });

--- a/src/test/rtl/component_helpers.ts
+++ b/src/test/rtl/component_helpers.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import '@testing-library/jest-dom';
 import { waitFor } from '@testing-library/react';
 
 /**
@@ -31,11 +32,11 @@ export const waitForEuiPopoverClose = async () =>
 export const waitForEuiToolTipVisible = async () =>
   await waitFor(() => {
     const tooltip = document.querySelector('.euiToolTipPopover');
-    expect(tooltip).toBeTruthy();
+    expect(tooltip).toBeVisible();
   });
 
 export const waitForEuiToolTipHidden = async () =>
   await waitFor(() => {
     const tooltip = document.querySelector('.euiToolTipPopover');
-    expect(tooltip).toBeFalsy();
+    expect(tooltip).toBeNull();
   });

--- a/upcoming_changelogs/6106.md
+++ b/upcoming_changelogs/6106.md
@@ -1,0 +1,1 @@
+- Added new React Testing Library EuiToolTip helpers, `waitForEuiToolTipVisible` and `waitForEuiToolTipClose`


### PR DESCRIPTION
### Summary

This PR:

- Improves our EuiToolTip tests to actually snapshot the rendered tooltip content
- Converts our tooltip tests to RTL while still maintaining a single Enzyme test for legacy/portal regression testing
- Exports new RTL `waitForEuiToolTipVisible` and `waitForEuiToolTipHidden` test helpers
- Closes https://github.com/elastic/eui/issues/6065

### Checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
