### PR TITLE
[Emotion][Theming] Add support for added custom theme breakpoints

### DIFF
--- a/src-docs/src/views/theme/_props.tsx
+++ b/src-docs/src/views/theme/_props.tsx
@@ -82,11 +82,9 @@ export const EuiThemeAnimationEasing: FunctionComponent<_EuiThemeAnimationEasing
   <div />
 );
 
-import { _EuiThemeBreakpoints } from '../../../../src/global_styling/variables/breakpoint';
-
-export const EuiThemeBreakpoints: FunctionComponent<_EuiThemeBreakpoints> = () => (
-  <div />
-);
+export const euiThemeBreakpointType = {
+  custom: { origin: { type: { name: 'number' } } },
+};
 
 import { _EuiThemeLevels } from '../../../../src/global_styling/variables/levels';
 

--- a/src-docs/src/views/theme/breakpoints/_breakpoints_js.tsx
+++ b/src-docs/src/views/theme/breakpoints/_breakpoints_js.tsx
@@ -3,15 +3,14 @@ import { css } from '@emotion/react';
 import {
   EuiIcon,
   EuiCode,
-  EuiThemeBreakpoints,
   useEuiBreakpoint,
   useCurrentEuiBreakpoint,
   useIsWithinBreakpoints,
   useEuiTheme,
 } from '../../../../../src';
+import { sortMapBySmallToLargeValues } from '../../../../../src/services/breakpoint/_sorting';
 
-import { EuiThemeBreakpoints as _EuiThemeBreakpoints } from '../_props';
-import { getPropsFromComponent } from '../../../services/props/get_props';
+import { euiThemeBreakpointType } from '../_props';
 import { ThemeExample } from '../_components/_theme_example';
 import { ThemeValuesTable } from '../_components/_theme_values_table';
 
@@ -135,42 +134,96 @@ export default () => {
   );
 };
 
+export const CUSTOM_BREAKPOINTS = {
+  xxs: 0,
+  xs: 250,
+  s: 500,
+  m: 1000,
+  l: 1500,
+  xl: 2000,
+  xxl: 2500,
+};
+export const CustomBreakpointsJS = () => {
+  const currentBreakpoint = useCurrentEuiBreakpoint();
+
+  return (
+    <ThemeExample
+      title={<code>EuiProvider</code>}
+      type="theme"
+      description={
+        <>
+          <p>
+            Theme breakpoints can be overriden or added via{' '}
+            <EuiCode>EuiProvider</EuiCode>&apos;s <EuiCode>modify</EuiCode>{' '}
+            prop.
+          </p>
+          <p>
+            Excluding a default breakpoint key in your{' '}
+            <EuiCode>breakpoint</EuiCode> override will use the EUI default
+            value for that size as a fallback.
+          </p>
+        </>
+      }
+      example={
+        <p>
+          Current custom breakpoint: <strong>{currentBreakpoint}</strong>
+        </p>
+      }
+      snippet={`<EuiProvider
+  modify={{
+    breakpoint: {
+      xxs: 0,
+      xs: 250,
+      s: 500,
+      m: 1000,
+      l: 1500,
+      xl: 2000,
+      xxl: 2500,
+    },
+  }}
+>
+  <App />
+</EuiProvider>
+`}
+      snippetLanguage="js"
+    />
+  );
+};
+
 export const BreakpointValuesJS = () => {
   const {
     euiTheme: { breakpoint },
   } = useEuiTheme();
-  const breakpointTypes = getPropsFromComponent(_EuiThemeBreakpoints);
+  const breakpoints = Object.keys(sortMapBySmallToLargeValues(breakpoint));
   const currentBreakpoint = useCurrentEuiBreakpoint();
 
   return (
-    <>
-      <ThemeValuesTable
-        items={EuiThemeBreakpoints.map((size) => {
-          return {
-            id: size,
-            token: `breakpoint.${size}`,
-            type: breakpointTypes[size],
-            value: breakpoint[size],
-          };
-        })}
-        valueColumnProps={{
-          title: 'Min width',
-        }}
-        sampleColumnProps={{
-          title: 'Current',
-          width: '80px',
-        }}
-        render={(item) => {
-          if (item.id === currentBreakpoint)
-            return (
-              <EuiIcon
-                title="Current window size is within this breakpoint"
-                type="checkInCircleFilled"
-                color="success"
-              />
-            );
-        }}
-      />
-    </>
+    <ThemeValuesTable
+      items={breakpoints.map((size) => {
+        return {
+          id: size,
+          token: `breakpoint.${size}`,
+          type: euiThemeBreakpointType,
+          value: breakpoint[size],
+        };
+      })}
+      valueColumnProps={{
+        title: 'Min width',
+      }}
+      sampleColumnProps={{
+        title: 'Current',
+        width: '80px',
+      }}
+      render={(item) => {
+        if (item.id === currentBreakpoint)
+          return (
+            <EuiIcon
+              title="Current window size is within this breakpoint"
+              type="checkInCircleFilled"
+              color="success"
+            />
+          );
+      }}
+    />
   );
 };

--- a/src-docs/src/views/theme/breakpoints/breakpoints.tsx
+++ b/src-docs/src/views/theme/breakpoints/breakpoints.tsx
@@ -1,14 +1,19 @@
 import React, { useContext, useMemo } from 'react';
-import { EuiSpacer, EuiText } from '../../../../../src';
+import { EuiSpacer, EuiText, EuiProvider } from '../../../../../src';
 
 import { GuideSection } from '../../../components/guide_section/guide_section';
 import { ThemeContext } from '../../../components/with_theme';
 
-import JSContent, { BreakpointValuesJS } from './_breakpoints_js';
+import JSContent, {
+  BreakpointValuesJS,
+  CustomBreakpointsJS,
+  CUSTOM_BREAKPOINTS,
+} from './_breakpoints_js';
 import SassContent, { BreakpointValuesSass } from './_breakpoints_sass';
 
 export const breakpointSections = [
   { title: 'Default values', id: 'default-values' },
+  { title: 'Custom values', id: 'custom-values' },
 ];
 
 export default () => {
@@ -30,9 +35,7 @@ export default () => {
     <>
       <GuideSection color="subdued">
         <EuiText grow={false}>
-          <h2
-            id={`${breakpointSections[0].id}`}
-          >{`${breakpointSections[0].title}`}</h2>
+          <h2 id={breakpointSections[0].id}>{breakpointSections[0].title}</h2>
           <p>
             If you want to align your custom responsive styles with EUI&apos;s
             breakpoints, or when using components that accept our named
@@ -46,6 +49,29 @@ export default () => {
       </GuideSection>
 
       <GuideSection color="transparent">{valuesContent}</GuideSection>
+
+      {currentLanguage.includes('js') && (
+        <EuiProvider modify={{ breakpoint: CUSTOM_BREAKPOINTS }}>
+          <GuideSection color="subdued">
+            <EuiText grow={false}>
+              <h2 id={breakpointSections[1].id}>
+                {breakpointSections[1].title}
+              </h2>
+              <p>
+                EUI&apos;s theme breakpoints can be overridden and extended.
+                However, the default sizes (<strong>xl</strong> through{' '}
+                <strong>xs</strong>) will always be present and cannot be
+                removed.
+              </p>
+            </EuiText>
+            <EuiSpacer size="xl" />
+
+            <CustomBreakpointsJS />
+          </GuideSection>
+
+          <GuideSection color="transparent">{valuesContent}</GuideSection>
+        </EuiProvider>
+      )}
     </>
   );
 };

--- a/src-docs/src/views/theme/customizing/_breakpoints.js
+++ b/src-docs/src/views/theme/customizing/_breakpoints.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+import { Link } from 'react-router-dom';
 
 import {
   EuiText,
@@ -7,24 +8,25 @@ import {
   EuiPanel,
   EuiTitle,
 } from '../../../../../src';
+import { sortMapBySmallToLargeValues } from '../../../../../src/services/breakpoint/_sorting';
 
-import { getPropsFromComponent } from '../../../services/props/get_props';
 import { useDebouncedUpdate } from '../hooks';
-
+import { euiThemeBreakpointType } from '../_props';
 import { ThemeValue } from './_values';
 
-import { EuiThemeBreakpoints } from '../_props';
-
 export default ({ onThemeUpdate }) => {
-  const { euiTheme } = useEuiTheme();
-  const breakpoint = euiTheme.breakpoint;
+  const {
+    euiTheme: { breakpoint },
+  } = useEuiTheme();
+  const breakpoints = useMemo(() => {
+    return sortMapBySmallToLargeValues(breakpoint);
+  }, [breakpoint]);
+
   const [breakpointClone, updateBreakpoint] = useDebouncedUpdate({
     property: 'breakpoint',
     value: breakpoint,
     onUpdate: onThemeUpdate,
   });
-
-  const breakpointTypes = getPropsFromComponent(EuiThemeBreakpoints);
 
   return (
     <div>
@@ -43,18 +45,22 @@ export default ({ onThemeUpdate }) => {
           <p>
             This default set of breakpoint tokens specify the{' '}
             <strong>minimum</strong> window size and are used throughout EUI.
-            You can always customize or add more keys as needed.
+            You can{' '}
+            <Link to="/theming/breakpoints/values#custom-values">
+              customize sizes or add more keys
+            </Link>{' '}
+            as needed, but you cannot remove the default keys.
           </p>
         </EuiText>
 
         <EuiSpacer />
 
-        {Object.keys(breakpointTypes).map((prop) => {
+        {Object.keys(breakpoints).map((prop) => {
           return (
             <ThemeValue
               key={prop}
               property="breakpoint"
-              type={breakpointTypes[prop]}
+              type={euiThemeBreakpointType}
               name={prop}
               value={breakpointClone[prop]}
               onUpdate={(value) => updateBreakpoint(prop, value)}

--- a/src/global_styling/mixins/_responsive.test.ts
+++ b/src/global_styling/mixins/_responsive.test.ts
@@ -8,7 +8,7 @@
 
 import { testCustomHook } from '../../test/internal';
 import { EuiThemeBreakpoints, _EuiThemeBreakpoint } from '../variables';
-import { useEuiBreakpoint } from './_responsive';
+import { useEuiBreakpoint, euiBreakpoint } from './_responsive';
 
 describe('useEuiBreakpoint', () => {
   describe('common breakpoint size arrays', () => {
@@ -94,5 +94,36 @@ describe('useEuiBreakpoint', () => {
         fallbackOutput
       );
     });
+  });
+});
+
+describe('euiBreakpoint & custom theme breakpoints', () => {
+  const CUSTOM_BREAKPOINTS = {
+    xxl: 700,
+    xl: 600,
+    l: 500,
+    m: 400,
+    s: 300,
+    xs: 200,
+    xxs: 100,
+  };
+  const mockEuiTheme: any = { euiTheme: { breakpoint: CUSTOM_BREAKPOINTS } };
+
+  it('correctly inherits the breakpoint size override', () => {
+    expect(euiBreakpoint(mockEuiTheme, ['s', 'l'])).toMatchInlineSnapshot(
+      '"@media only screen and (min-width: 300px) and (max-width: 599px)"'
+    );
+  });
+
+  it('correctly infers the largest breakpoint and does not render a max-width if passed', () => {
+    expect(euiBreakpoint(mockEuiTheme, ['xl', 'xxl'])).toMatchInlineSnapshot(
+      '"@media only screen and (min-width: 600px)"'
+    );
+  });
+
+  it('correctly uses the smallest breakpoint for a min-width if it is not set to 0', () => {
+    expect(euiBreakpoint(mockEuiTheme, ['xxs', 'xs'])).toMatchInlineSnapshot(
+      '"@media only screen and (min-width: 100px) and (max-width: 299px)"'
+    );
   });
 });

--- a/src/global_styling/mixins/_responsive.test.ts
+++ b/src/global_styling/mixins/_responsive.test.ts
@@ -89,8 +89,7 @@ describe('useEuiBreakpoint', () => {
       );
     });
 
-    test('if an invalid breakpoint size is passed', () => {
-      // @ts-expect-error Type "asdf" is not assignable to type "..."
+    test('if a breakpoint key without a corresponding value is passed', () => {
       expect(testCustomHook(() => useEuiBreakpoint(['asdf'])).return).toEqual(
         fallbackOutput
       );

--- a/src/global_styling/mixins/_responsive.ts
+++ b/src/global_styling/mixins/_responsive.ts
@@ -6,17 +6,20 @@
  * Side Public License, v 1.
  */
 
+import { sortMapBySmallToLargeValues } from '../../services/breakpoint/_sorting';
 import { useEuiTheme, UseEuiTheme } from '../../services/theme/hooks';
-import { EuiThemeBreakpoints, _EuiThemeBreakpoint } from '../variables';
+import { _EuiThemeBreakpoint } from '../variables';
 
 /**
  * Generates a CSS media query rule string based on the input breakpoint ranges.
- * Examples:
+ * Examples with default theme breakpoints:
+ *
  * euiBreakpoint(['s']) becomes `@media only screen and (min-width: 575px) and (max-width: 767px)`
  * euiBreakpoint(['s', 'l']) becomes `@media only screen and (min-width: 575px) and (max-width: 1199px)`
  *
- * Use the `xs` and `xl` sizes to generate media queries with only min/max-width.
- * Examples:
+ * Use the smallest and largest sizes to generate media queries with only min/max-width.
+ * Examples with default theme breakpoints:
+ *
  * euiBreakpoint(['xs', 'm']) becomes `@media only screen and (max-width: 991px)`
  * euiBreakpoint(['l', 'xl']) becomes `@media only screen and (min-width: 992px)`
  */
@@ -24,29 +27,33 @@ export const euiBreakpoint = (
   { euiTheme }: UseEuiTheme,
   sizes: [_EuiThemeBreakpoint, ..._EuiThemeBreakpoint[]]
 ) => {
-  // Ensure the array is in the correct ascending size order
-  const orderedSizes = sizes.sort(
-    (a, b) => EuiThemeBreakpoints.indexOf(a) - EuiThemeBreakpoints.indexOf(b)
+  // Ensure we inherit any theme breakpoint overrides & sort by small to large
+  const orderedBreakpoints = Object.keys(
+    sortMapBySmallToLargeValues(euiTheme.breakpoint)
   );
 
-  const firstBreakpoint: _EuiThemeBreakpoint = orderedSizes[0];
+  // Ensure the sizes array is in the correct ascending size order
+  const orderedSizes = sizes.sort(
+    (a, b) => orderedBreakpoints.indexOf(a) - orderedBreakpoints.indexOf(b)
+  );
+
+  const firstBreakpoint = orderedSizes[0];
   const minBreakpointSize = euiTheme.breakpoint[firstBreakpoint];
 
-  const lastBreakpoint: _EuiThemeBreakpoint = orderedSizes[sizes.length - 1];
+  const lastBreakpoint = orderedSizes[sizes.length - 1];
   let maxBreakpointSize: number | undefined;
 
-  // To get the correct screen range, we set the max-width
-  // to the next breakpoint size in the sizes array
-  if (lastBreakpoint !== 'xl') {
-    const nextBreakpoint = EuiThemeBreakpoints.indexOf(lastBreakpoint) + 1;
-    maxBreakpointSize =
-      euiTheme.breakpoint[EuiThemeBreakpoints[nextBreakpoint]];
+  // To get the correct screen range, we set the max-width to the next breakpoint
+  // size in the sizes array (unless the size is already the largest breakpoint)
+  if (lastBreakpoint !== orderedBreakpoints[orderedBreakpoints.length - 1]) {
+    const nextBreakpoint = orderedBreakpoints.indexOf(lastBreakpoint) + 1;
+    maxBreakpointSize = euiTheme.breakpoint[orderedBreakpoints[nextBreakpoint]];
   }
 
   return [
     '@media only screen',
-    minBreakpointSize ? `(min-width: ${minBreakpointSize}px)` : false, // If xs/0, don't render a min-width
-    maxBreakpointSize ? `(max-width: ${maxBreakpointSize - 1}px)` : false, // If xl/undefined, don't render a max-width
+    minBreakpointSize ? `(min-width: ${minBreakpointSize}px)` : false, // If 0, don't render a min-width
+    maxBreakpointSize ? `(max-width: ${maxBreakpointSize - 1}px)` : false, // If undefined, don't render a max-width
   ]
     .filter(Boolean)
     .join(' and ');

--- a/src/global_styling/variables/breakpoint.ts
+++ b/src/global_styling/variables/breakpoint.ts
@@ -8,11 +8,9 @@
 
 export const EuiThemeBreakpoints = ['xs', 's', 'm', 'l', 'xl'] as const;
 
-export type _EuiThemeBreakpoint = typeof EuiThemeBreakpoints[number];
+// This type cannot be a string enum / must be a generic string
+// in case consumers add custom breakpoint sizes, such as xxl or xxs
+export type _EuiThemeBreakpoint = string;
 
-export type _EuiThemeBreakpoints = {
-  /**
-   * Set the minimum window width at which to start to the breakpoint
-   */
-  [key in _EuiThemeBreakpoint]: number;
-};
+// Set the minimum window width at which to start to the breakpoint
+export type _EuiThemeBreakpoints = Record<_EuiThemeBreakpoint, number>;

--- a/src/services/breakpoint/_sorting.test.ts
+++ b/src/services/breakpoint/_sorting.test.ts
@@ -6,7 +6,10 @@
  * Side Public License, v 1.
  */
 
-import { sortMapByLargeToSmallValues } from './_sorting';
+import {
+  sortMapByLargeToSmallValues,
+  sortMapBySmallToLargeValues,
+} from './_sorting';
 
 describe('sortMapByLargeToSmallValues', () => {
   it('sorts an object by its values from largest to smallest', () => {
@@ -20,6 +23,22 @@ describe('sortMapByLargeToSmallValues', () => {
       large: 30,
       medium: 10,
       small: 5,
+    });
+  });
+});
+
+describe('sortMapBySmallToLargeValues', () => {
+  it('sorts an object by its values from small to largest', () => {
+    expect(
+      sortMapBySmallToLargeValues({
+        large: 100,
+        medium: 10,
+        small: 1,
+      })
+    ).toEqual({
+      small: 1,
+      medium: 10,
+      large: 100,
     });
   });
 });

--- a/src/services/breakpoint/_sorting.test.ts
+++ b/src/services/breakpoint/_sorting.test.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { sortMapByLargeToSmallValues } from './_sorting';
+
+describe('sortMapByLargeToSmallValues', () => {
+  it('sorts an object by its values from largest to smallest', () => {
+    expect(
+      sortMapByLargeToSmallValues({
+        medium: 10,
+        large: 30,
+        small: 5,
+      })
+    ).toEqual({
+      large: 30,
+      medium: 10,
+      small: 5,
+    });
+  });
+});

--- a/src/services/breakpoint/_sorting.ts
+++ b/src/services/breakpoint/_sorting.ts
@@ -14,3 +14,10 @@ export const sortMapByLargeToSmallValues = (
   Object.fromEntries(
     Object.entries(breakpointsMap).sort(([, a], [, b]) => b - a)
   );
+
+export const sortMapBySmallToLargeValues = (
+  breakpointsMap: _EuiThemeBreakpoints
+) =>
+  Object.fromEntries(
+    Object.entries(breakpointsMap).sort(([, a], [, b]) => a - b)
+  );

--- a/src/services/breakpoint/_sorting.ts
+++ b/src/services/breakpoint/_sorting.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { _EuiThemeBreakpoints } from '../../global_styling/variables/breakpoint';
+
+export const sortMapByLargeToSmallValues = (
+  breakpointsMap: _EuiThemeBreakpoints
+) =>
+  Object.fromEntries(
+    Object.entries(breakpointsMap).sort(([, a], [, b]) => b - a)
+  );

--- a/src/services/breakpoint/breakpoint.ts
+++ b/src/services/breakpoint/breakpoint.ts
@@ -19,6 +19,8 @@ export type EuiBreakpoints = _EuiThemeBreakpoints;
 export const BREAKPOINTS = breakpoint;
 export const BREAKPOINT_KEYS = keysOf(BREAKPOINTS);
 
+import { sortMapByLargeToSmallValues } from './_sorting';
+
 /**
  * Given the current `width` and an object of `EuiBreakpoints`,
  * this function returns the string that is the name of the breakpoint key
@@ -32,8 +34,13 @@ export function getBreakpoint(
   width: number,
   breakpoints: EuiBreakpoints = BREAKPOINTS
 ): EuiBreakpointSize | undefined {
+  // Ensure the breakpoints map is sorted from largest value to smallest
+  const sortedBreakpoints: EuiBreakpoints = sortMapByLargeToSmallValues(
+    breakpoints
+  );
+
   // Find the breakpoint (key) whose value is <= windowWidth starting with largest first
-  return BREAKPOINT_KEYS.find((key) => breakpoints[key] <= width);
+  return keysOf(sortedBreakpoints).find((key) => breakpoints[key] <= width);
 }
 
 /**

--- a/src/services/breakpoint/currentEuiBreakpoint.spec.tsx
+++ b/src/services/breakpoint/currentEuiBreakpoint.spec.tsx
@@ -72,11 +72,13 @@ describe('useCurrentEuiBreakpoint', () => {
         <EuiProvider
           modify={{
             breakpoint: {
-              xs: 0,
+              xxs: 0,
+              xs: 250,
               s: 500,
               m: 1000,
               l: 1500,
               xl: 2000,
+              xxl: 2500,
             },
           }}
         >
@@ -87,8 +89,13 @@ describe('useCurrentEuiBreakpoint', () => {
     });
 
     describe('returns the correct custom breakpoint based on window width', () => {
-      it('xs', () => {
+      it('custom xxs breakpoint', () => {
         cy.viewport(100, 600);
+        cy.get('[data-test-subj]').should('have.text', 'xxs');
+      });
+
+      it('xs', () => {
+        cy.viewport(300, 600);
         cy.get('[data-test-subj]').should('have.text', 'xs');
       });
 
@@ -110,6 +117,11 @@ describe('useCurrentEuiBreakpoint', () => {
       it('xl', () => {
         cy.viewport(2000, 600);
         cy.get('[data-test-subj]').should('have.text', 'xl');
+      });
+
+      it('custom xxl breakpoint', () => {
+        cy.viewport(2500, 600);
+        cy.get('[data-test-subj]').should('have.text', 'xxl');
       });
     });
   });

--- a/upcoming_changelogs/6111.md
+++ b/upcoming_changelogs/6111.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed JS breakpoint hooks (`useCurrentEuiBreakpoint`, `useIsWithinBreakpoints`, and `euiBreakpoint`) to correctly handle custom theme breakpoint keys


### PR DESCRIPTION
### Summary

Despite our CSS-in-JS documentation noting it as such, our current EuiProvider does not actually support extra keys being added to our `breakpoint` map, e.g. `xxl`, `xxxl`, `xxs`, etc.

This is primarily because our `getBreakpoint` logic (which depended on the map being statically ordered from largest to smallest) was no longer in order when dynamic values were added. If our `breakpoint` maps can be anything, we need to dynamically order them as we get them to obtain the behavior we want.

## QA:

http://localhost:8030/#/theming/breakpoints/values#custom-values (TODO: replace w/ staging link)

![screencap](https://user-images.githubusercontent.com/549407/182944173-edbff220-732b-4bc7-884b-594f05ff91d7.gif)

### Checklist

- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~