### PR TITLE
[Emotion] Use default cache for consumers who do not pass a cache to EuiProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,6 +252,7 @@
   "peerDependencies": {
     "@elastic/datemath": "^5.0.2",
     "@emotion/react": "11.x",
+    "@emotion/cache": "11.x",
     "@types/react": "^16.9 || ^17.0",
     "@types/react-dom": "^16.9 || ^17.0",
     "moment": "^2.13.0",

--- a/src-docs/src/views/app_context.js
+++ b/src-docs/src/views/app_context.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
 import { Helmet } from 'react-helmet';
 import { useSelector } from 'react-redux';
-// import createCache from '@emotion/cache';
+import createCache from '@emotion/cache';
 import { ThemeContext } from '../components';
 import { translateUsingPseudoLocale } from '../services';
 import { getLocale } from '../store';
@@ -17,15 +17,15 @@ import favicon16Dev from '../images/favicon/dev/favicon-16x16.png';
 import favicon32Dev from '../images/favicon/dev/favicon-32x32.png';
 import favicon96Dev from '../images/favicon/dev/favicon-96x96.png';
 
-// const generalEmotionCache = createCache({
-//   key: 'css',
-//   container: document.querySelector('meta[name="emotion-styles"]'),
-// });
-// generalEmotionCache.compat = true;
-// const utilityCache = createCache({
-//   key: 'util',
-//   container: document.querySelector('meta[name="emotion-styles-utility"]'),
-// });
+const generalEmotionCache = createCache({
+  key: 'css',
+  container: document.querySelector('meta[name="emotion-styles"]'),
+});
+generalEmotionCache.compat = true;
+const utilityCache = createCache({
+  key: 'util',
+  container: document.querySelector('meta[name="emotion-styles-utility"]'),
+});
 
 export const AppContext = ({ children }) => {
   const { theme } = useContext(ThemeContext);
@@ -45,10 +45,10 @@ export const AppContext = ({ children }) => {
 
   return (
     <EuiProvider
-      // cache={{
-      //   default: generalEmotionCache,
-      //   utility: utilityCache,
-      // }}
+      cache={{
+        default: generalEmotionCache,
+        utility: utilityCache,
+      }}
       theme={EUI_THEMES.find((t) => t.value === theme)?.provider}
       colorMode={theme.includes('light') ? 'light' : 'dark'}
     >

--- a/src-docs/src/views/app_context.js
+++ b/src-docs/src/views/app_context.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
 import { Helmet } from 'react-helmet';
 import { useSelector } from 'react-redux';
-import createCache from '@emotion/cache';
+// import createCache from '@emotion/cache';
 import { ThemeContext } from '../components';
 import { translateUsingPseudoLocale } from '../services';
 import { getLocale } from '../store';
@@ -17,15 +17,15 @@ import favicon16Dev from '../images/favicon/dev/favicon-16x16.png';
 import favicon32Dev from '../images/favicon/dev/favicon-32x32.png';
 import favicon96Dev from '../images/favicon/dev/favicon-96x96.png';
 
-const generalEmotionCache = createCache({
-  key: 'css',
-  container: document.querySelector('meta[name="emotion-styles"]'),
-});
-generalEmotionCache.compat = true;
-const utilityCache = createCache({
-  key: 'util',
-  container: document.querySelector('meta[name="emotion-styles-utility"]'),
-});
+// const generalEmotionCache = createCache({
+//   key: 'css',
+//   container: document.querySelector('meta[name="emotion-styles"]'),
+// });
+// generalEmotionCache.compat = true;
+// const utilityCache = createCache({
+//   key: 'util',
+//   container: document.querySelector('meta[name="emotion-styles-utility"]'),
+// });
 
 export const AppContext = ({ children }) => {
   const { theme } = useContext(ThemeContext);
@@ -45,10 +45,10 @@ export const AppContext = ({ children }) => {
 
   return (
     <EuiProvider
-      cache={{
-        default: generalEmotionCache,
-        utility: utilityCache,
-      }}
+      // cache={{
+      //   default: generalEmotionCache,
+      //   utility: utilityCache,
+      // }}
       theme={EUI_THEMES.find((t) => t.value === theme)?.provider}
       colorMode={theme.includes('light') ? 'light' : 'dark'}
     >

--- a/src-docs/src/views/guidelines/getting_started/getting_started.js
+++ b/src-docs/src/views/guidelines/getting_started/getting_started.js
@@ -43,7 +43,7 @@ export const GettingStarted = {
           <EuiSpacer />
           <EuiCodeBlock language="bash" isCopyable fontSize="m">
             {
-              'yarn add @elastic/eui @elastic/datemath @emotion/react moment prop-types'
+              'yarn add @elastic/eui @elastic/datemath @emotion/react @emotion/cache moment prop-types'
             }
           </EuiCodeBlock>
           <EuiSpacer />

--- a/src/components/provider/cache/__snapshots__/cache_provider.test.tsx.snap
+++ b/src/components/provider/cache/__snapshots__/cache_provider.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiProvider adds CacheProvider from Emotion when configured with a cache 1`] = `
+exports[`EuiProvider customizes CacheProvider when configured with a cache 1`] = `
 <ContextProvider
   value={
     Object {
@@ -28,10 +28,31 @@ exports[`EuiProvider adds CacheProvider from Emotion when configured with a cach
 </ContextProvider>
 `;
 
-exports[`EuiProvider does not add CacheProvider from Emotion when configured without a cache 1`] = `
-<Fragment>
+exports[`EuiProvider provides a default cache from Emotion when configured without a cache 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "compat": true,
+      "insert": [Function],
+      "inserted": Object {},
+      "key": "css",
+      "nonce": undefined,
+      "registered": Object {},
+      "sheet": StyleSheet {
+        "_insertTag": [Function],
+        "before": null,
+        "container": <head />,
+        "ctr": 0,
+        "insertionPoint": undefined,
+        "isSpeedy": false,
+        "key": "css",
+        "nonce": undefined,
+        "prepend": undefined,
+        "tags": Array [],
+      },
+    }
+  }
+>
   <div />
-</Fragment>
+</ContextProvider>
 `;
-
-exports[`EuiProvider renders a Fragment when no children are provided 1`] = `<Fragment />`;

--- a/src/components/provider/cache/cache_provider.test.tsx
+++ b/src/components/provider/cache/cache_provider.test.tsx
@@ -16,7 +16,8 @@ describe('EuiProvider', () => {
   const cache = createCache({
     key: 'testing',
   });
-  it('adds CacheProvider from Emotion when configured with a cache', () => {
+
+  it('customizes CacheProvider when configured with a cache', () => {
     const component = shallow(
       <EuiCacheProvider cache={cache}>
         <div />
@@ -24,9 +25,10 @@ describe('EuiProvider', () => {
     );
 
     expect(component).toMatchSnapshot();
+    expect(component.prop('value').key).toEqual('testing');
   });
 
-  it('does not add CacheProvider from Emotion when configured without a cache', () => {
+  it('provides a default cache from Emotion when configured without a cache', () => {
     const component = shallow(
       <EuiCacheProvider>
         <div />
@@ -34,11 +36,7 @@ describe('EuiProvider', () => {
     );
 
     expect(component).toMatchSnapshot();
-  });
-
-  it('renders a Fragment when no children are provided', () => {
-    const component = shallow(<EuiCacheProvider cache={cache} />);
-
-    expect(component).toMatchSnapshot();
+    expect(component.prop('value').key).toEqual('css');
+    expect(component.prop('value').compat).toEqual(true);
   });
 });

--- a/src/components/provider/cache/cache_provider.tsx
+++ b/src/components/provider/cache/cache_provider.tsx
@@ -7,20 +7,19 @@
  */
 
 import React, { PropsWithChildren } from 'react';
-import { EmotionCache } from '@emotion/cache';
+import createCache, { EmotionCache } from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 
+const defaultCache = createCache({ key: 'css' });
+defaultCache.compat = true;
+
 export interface EuiCacheProviderProps {
-  cache?: false | EmotionCache;
+  cache?: EmotionCache;
 }
 
 export const EuiCacheProvider = ({
-  cache,
+  cache = defaultCache,
   children,
-}: PropsWithChildren<EuiCacheProviderProps>) => {
-  return children && cache ? (
-    <CacheProvider value={cache}>{children}</CacheProvider>
-  ) : (
-    <>{children}</>
-  );
-};
+}: PropsWithChildren<EuiCacheProviderProps>) => (
+  <CacheProvider value={cache}>{children}</CacheProvider>
+);

--- a/upcoming_changelogs/6126.md
+++ b/upcoming_changelogs/6126.md
@@ -1,3 +1,7 @@
 **Bug fixes**
 
 - Fixed `:first-child/:nth-child` console warnings for consumers not passing in a `cache` to `EuiProvider`
+
+**Breaking changes**
+
+- `@emotion/cache` is now a required peer dependency, alongside `@emotion/react`

--- a/upcoming_changelogs/6126.md
+++ b/upcoming_changelogs/6126.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `:first-child/:nth-child` console warnings for consumers not passing in a `cache` to `EuiProvider`

--- a/wiki/consuming.md
+++ b/wiki/consuming.md
@@ -11,7 +11,7 @@ yarn add @elastic/eui
 Note that EUI has [several `peerDependencies` requirements](package.json) that will also need to be installed if starting with a blank project.
 
 ```bash
-yarn add @elastic/eui @elastic/datemath @emotion/react moment prop-types
+yarn add @elastic/eui @elastic/datemath @emotion/react @emotion/cache moment prop-types
 ```
 
 ## Requirements and dependencies


### PR DESCRIPTION
### Summary

closes https://github.com/elastic/eui/issues/6113

#5920 did not account for consumers who do not pass a cache tag to `<EuiProvider>`. This PR fixes the first-child/nth-child console warnings for that scenario, ~using the "Option 3" method recommended by https://github.com/emotion-js/emotion/issues/1105#issuecomment-557726922~ by creating our own default cache.

### Checklist

- [x] Revert [REVERT ME] commit
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~