### PR TITLE
[Docs] Fix scrollToHash focus fighting

### DIFF
--- a/src-docs/src/components/guide_section/guide_section.tsx
+++ b/src-docs/src/components/guide_section/guide_section.tsx
@@ -197,14 +197,14 @@ export const GuideSection: FunctionComponent<GuideSectionProps> = ({
 
   return (
     <EuiPageSection
-      id={id}
       className={classNames('guideSection', className)}
       color={!isLargeBreakpoint ? 'transparent' : color || 'transparent'}
       paddingSize={nested ? 'none' : 'l'}
       restrictWidth
+      id={title ? undefined : id} // Prefer setting the ID on titles, if present
     >
       <EuiSpacer size={(color || title) && isLargeBreakpoint ? 'xxl' : 'xs'} />
-      <GuideSectionExampleText title={title} wrapText={wrapText}>
+      <GuideSectionExampleText title={title} id={id} wrapText={wrapText}>
         {text}
       </GuideSectionExampleText>
 

--- a/src-docs/src/components/guide_section/guide_section_parts/guide_section_text.tsx
+++ b/src-docs/src/components/guide_section/guide_section_parts/guide_section_text.tsx
@@ -7,12 +7,14 @@ export const LANGUAGES = ['javascript', 'html'] as const;
 
 type GuideSectionExampleText = {
   title?: ReactNode;
+  id?: string;
   children?: ReactNode;
   wrapText?: boolean;
 };
 
 export const GuideSectionExampleText: FunctionComponent<GuideSectionExampleText> = ({
   title,
+  id,
   children,
   wrapText = true,
 }) => {
@@ -22,7 +24,7 @@ export const GuideSectionExampleText: FunctionComponent<GuideSectionExampleText>
     titleNode = (
       <>
         <EuiTitle>
-          <h2>{title}</h2>
+          <h2 id={id}>{title}</h2>
         </EuiTitle>
         <EuiSpacer size="m" />
       </>

--- a/src-docs/src/index.js
+++ b/src-docs/src/index.js
@@ -16,7 +16,6 @@ import Routes from './routes';
 import themeLight from './theme_light.scss';
 import themeDark from './theme_dark.scss';
 import { ThemeProvider } from './components/with_theme/theme_context';
-import ScrollToHash from './components/scroll_to_hash';
 
 registerTheme('light', [themeLight]);
 registerTheme('dark', [themeDark]);
@@ -46,7 +45,6 @@ ReactDOM.render(
     <ThemeProvider>
       <AppContext>
         <Router history={history}>
-          <ScrollToHash />
           <Switch>
             {routes.map(
               ({ name, path, sections, isNew, component, from, to }) => {

--- a/src-docs/src/services/index.js
+++ b/src-docs/src/services/index.js
@@ -11,3 +11,5 @@ export { getPropsFromComponent } from './props/get_props';
 export { registerTheme, applyTheme } from './theme/theme';
 
 export { ExampleContext, useExitPath } from './routing/routing';
+
+export { useScrollToHash } from './routing/scroll_to_hash';

--- a/src-docs/src/services/routing/scroll_to_hash.ts
+++ b/src-docs/src/services/routing/scroll_to_hash.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { isTabbable } from 'tabbable';
 
-const HEADER_OFFSET = 48;
+const HEADER_OFFSET = 60;
 
 export const useScrollToHash = () => {
   const location = useLocation();

--- a/src-docs/src/services/routing/scroll_to_hash.ts
+++ b/src-docs/src/services/routing/scroll_to_hash.ts
@@ -1,8 +1,10 @@
-import { useEffect, useState, FunctionComponent } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { isTabbable } from 'tabbable';
 
-const ScrollToHash: FunctionComponent = () => {
+const HEADER_OFFSET = 48;
+
+export const useScrollToHash = () => {
   const location = useLocation();
 
   const [documentReadyState, setReadyState] = useState(document.readyState);
@@ -15,9 +17,10 @@ const ScrollToHash: FunctionComponent = () => {
 
   useEffect(() => {
     if (documentReadyState !== 'complete') return; // Wait for page to finish loading before scrolling
+
     const hash = location.hash.split('?')[0].replace('#', ''); // Remove any query params and the leading hash
     const element = document.getElementById(hash);
-    const headerOffset = 48;
+
     if (element) {
       // Focus element for keyboard and screen reader users
       if (!isTabbable(element)) {
@@ -31,7 +34,7 @@ const ScrollToHash: FunctionComponent = () => {
       }
       // Scroll to element
       window.scrollTo({
-        top: element.offsetTop - headerOffset,
+        top: element.offsetTop - HEADER_OFFSET,
         behavior: 'smooth',
       });
     } else {
@@ -42,7 +45,4 @@ const ScrollToHash: FunctionComponent = () => {
       });
     }
   }, [location, documentReadyState]);
-  return null;
 };
-
-export default ScrollToHash;

--- a/src-docs/src/services/routing/scroll_to_hash.ts
+++ b/src-docs/src/services/routing/scroll_to_hash.ts
@@ -19,7 +19,7 @@ export const useScrollToHash = () => {
     if (documentReadyState !== 'complete') return; // Wait for page to finish loading before scrolling
 
     const hash = location.hash.split('?')[0].replace('#', ''); // Remove any query params and the leading hash
-    const element = document.getElementById(hash);
+    const element = hash ? document.getElementById(hash) : null;
 
     if (element) {
       // Focus element for keyboard and screen reader users
@@ -30,8 +30,8 @@ export const useScrollToHash = () => {
           () => element.removeAttribute('tabindex'),
           { once: true }
         );
-        element.focus();
       }
+      element.focus({ preventScroll: true }); // Scrolling already handled below
       // Scroll to element
       window.scrollTo({
         top: element.offsetTop - HEADER_OFFSET,

--- a/src-docs/src/services/routing/scroll_to_hash.ts
+++ b/src-docs/src/services/routing/scroll_to_hash.ts
@@ -15,6 +15,11 @@ export const useScrollToHash = () => {
       document.removeEventListener('readystatechange', readyStateListener);
   }, []);
 
+  // Scroll back to top of page when going to a completely separate page
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [location.pathname]);
+
   useEffect(() => {
     if (documentReadyState !== 'complete') return; // Wait for page to finish loading before scrolling
 
@@ -22,20 +27,23 @@ export const useScrollToHash = () => {
     const element = hash ? document.getElementById(hash) : null;
 
     if (element) {
-      // Focus element for keyboard and screen reader users
-      if (!isTabbable(element)) {
-        element.tabIndex = -1;
-        element.addEventListener(
-          'blur',
-          () => element.removeAttribute('tabindex'),
-          { once: true }
-        );
-      }
-      element.focus({ preventScroll: true }); // Scrolling already handled below
-      // Scroll to element
-      window.scrollTo({
-        top: element.offsetTop - HEADER_OFFSET,
-        behavior: 'smooth',
+      // Wait a beat for layout to settle (especially when navigating to a hash of a new page)
+      requestAnimationFrame(() => {
+        // Focus element for keyboard and screen reader users
+        if (!isTabbable(element)) {
+          element.tabIndex = -1;
+          element.addEventListener(
+            'blur',
+            () => element.removeAttribute('tabindex'),
+            { once: true }
+          );
+        }
+        element.focus({ preventScroll: true }); // Scrolling already handled below
+        // Scroll to element
+        window.scrollTo({
+          top: element.offsetTop - HEADER_OFFSET,
+          behavior: 'smooth',
+        });
       });
     } else {
       // Scroll back to top of page
@@ -44,5 +52,5 @@ export const useScrollToHash = () => {
         top: 0,
       });
     }
-  }, [location, documentReadyState]);
+  }, [location.hash, documentReadyState]);
 };

--- a/src-docs/src/views/accessibility/screen_reader_live.tsx
+++ b/src-docs/src/views/accessibility/screen_reader_live.tsx
@@ -1,34 +1,37 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 
 import {
   EuiCode,
-  EuiFieldNumber,
-  EuiFormRow,
+  EuiButton,
   EuiScreenReaderLive,
   EuiSpacer,
   EuiText,
 } from '../../../../src/components';
 
 export default () => {
-  const [value, setValue] = useState(1);
+  const [screenReaderText, setScreenReaderText] = useState(
+    'You have no notifications.'
+  );
+  const startAnnouncements = useCallback(() => {
+    const randomNumber = Math.floor(Math.random() * 10) + 1;
+    setScreenReaderText(
+      `You have ${randomNumber} new notification${randomNumber > 1 ? 's' : ''}.`
+    );
+  }, []);
+
   return (
     <>
-      <EuiFormRow label="Current value">
-        <EuiFieldNumber
-          placeholder="Current value"
-          value={value}
-          onChange={(e) => setValue(Number(e.target.value))}
-          min={0}
-        />
-      </EuiFormRow>
+      <EuiButton onClick={startAnnouncements}>
+        Create screen reader announcement
+      </EuiButton>
       <EuiSpacer />
       <EuiText>
         <p>
           <em>Content announced by screen reader: </em>
-          <EuiCode>Current value: {value}</EuiCode>
+          <EuiCode>{screenReaderText}</EuiCode>
         </p>
         <EuiScreenReaderLive>
-          <p>Current value: {value}</p>
+          <p>{screenReaderText}</p>
         </EuiScreenReaderLive>
       </EuiText>
     </>

--- a/src-docs/src/views/app_view.js
+++ b/src-docs/src/views/app_view.js
@@ -1,9 +1,10 @@
 import PropTypes from 'prop-types';
-import React, { useContext, useEffect, useRef } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { toggleLocale as _toggleLocale } from '../actions';
 import { GuidePageChrome, ThemeContext, GuidePageHeader } from '../components';
 import { getLocale, getRoutes } from '../store';
+import { useScrollToHash } from '../services';
 
 import {
   EuiPageTemplate,
@@ -21,8 +22,6 @@ export const AppView = ({ children, currentRoute }) => {
   const locale = useSelector((state) => getLocale(state));
   const routes = useSelector((state) => getRoutes(state));
   const { theme } = useContext(ThemeContext);
-
-  const prevPath = useRef(currentRoute.path);
 
   useEffect(() => {
     const onKeydown = (event) => {
@@ -59,12 +58,7 @@ export const AppView = ({ children, currentRoute }) => {
     };
   }, []); // eslint-disable-line
 
-  useEffect(() => {
-    if (prevPath.current !== currentRoute.path) {
-      window.scrollTo(0, 0);
-      prevPath.current = currentRoute.path;
-    }
-  }, [currentRoute.path]);
+  useScrollToHash();
 
   return (
     <LinkWrapper>

--- a/src-docs/src/views/app_view.js
+++ b/src-docs/src/views/app_view.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useContext, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useLocation } from 'react-router-dom';
 import { toggleLocale as _toggleLocale } from '../actions';
 import { GuidePageChrome, ThemeContext, GuidePageHeader } from '../components';
 import { getLocale, getRoutes } from '../store';
@@ -59,11 +60,15 @@ export const AppView = ({ children, currentRoute }) => {
   }, []); // eslint-disable-line
 
   useScrollToHash();
+  const { hash } = useLocation();
 
   return (
     <LinkWrapper>
-      <EuiScreenReaderLive focusRegionOnTextChange>
-        {`${currentRoute.name} - Elastic UI Framework`}
+      {/* Do not focus the screen reader region or announce a page change
+      if navigating to directly to a hash - our scroll to hash logic takes
+      care of focusing the correct region and announcing the page */}
+      <EuiScreenReaderLive focusRegionOnTextChange={!hash}>
+        {`${hash ? '— ' : ''}${currentRoute.name} — Elastic UI Framework`}
       </EuiScreenReaderLive>
       <EuiSkipLink
         color="ghost"

--- a/src/components/accessibility/screen_reader_live/__snapshots__/screen_reader_live.test.tsx.snap
+++ b/src/components/accessibility/screen_reader_live/__snapshots__/screen_reader_live.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`EuiScreenReaderLive with a static configuration accepts \`aria-live\` 1
   <div
     aria-atomic="true"
     aria-hidden="true"
-    aria-live="assertive"
+    aria-live="off"
     role="status"
   />
   <div
@@ -52,7 +52,7 @@ exports[`EuiScreenReaderLive with a static configuration accepts \`role\` 1`] = 
   <div
     aria-atomic="true"
     aria-hidden="true"
-    aria-live="polite"
+    aria-live="off"
     role="log"
   />
   <div
@@ -74,7 +74,7 @@ exports[`EuiScreenReaderLive with a static configuration does not render screen 
   <div
     aria-atomic="true"
     aria-hidden="true"
-    aria-live="polite"
+    aria-live="off"
     role="status"
   />
   <div
@@ -92,7 +92,7 @@ exports[`EuiScreenReaderLive with a static configuration renders screen reader c
   <div
     aria-atomic="true"
     aria-hidden="true"
-    aria-live="polite"
+    aria-live="off"
     role="status"
   />
   <div
@@ -120,7 +120,7 @@ exports[`EuiScreenReaderLive with dynamic properties alternates rendering screen
     <div
       aria-atomic="true"
       aria-hidden="true"
-      aria-live="polite"
+      aria-live="off"
       role="status"
     />
     <div
@@ -149,7 +149,7 @@ exports[`EuiScreenReaderLive with dynamic properties initially renders screen re
     <div
       aria-atomic="true"
       aria-hidden="true"
-      aria-live="polite"
+      aria-live="off"
       role="status"
     />
     <div

--- a/src/components/accessibility/screen_reader_live/screen_reader_live.tsx
+++ b/src/components/accessibility/screen_reader_live/screen_reader_live.tsx
@@ -85,7 +85,7 @@ export const EuiScreenReaderLive: FunctionComponent<EuiScreenReaderLiveProps> = 
           // Setting `aria-hidden` and setting `aria-live` to "off" prevents
           // double announcements from VO when `focusRegionOnTextChange` is true
           aria-hidden={toggle ? undefined : 'true'}
-          aria-live={focusRegionOnTextChange ? 'off' : ariaLive}
+          aria-live={!toggle || focusRegionOnTextChange ? 'off' : ariaLive}
         >
           {isActive && toggle ? children : ''}
         </div>
@@ -93,7 +93,7 @@ export const EuiScreenReaderLive: FunctionComponent<EuiScreenReaderLiveProps> = 
           role={role}
           aria-atomic="true"
           aria-hidden={!toggle ? undefined : 'true'}
-          aria-live={focusRegionOnTextChange ? 'off' : ariaLive}
+          aria-live={toggle || focusRegionOnTextChange ? 'off' : ariaLive}
         >
           {isActive && !toggle ? children : ''}
         </div>

--- a/src/components/selectable/__snapshots__/selectable.test.tsx.snap
+++ b/src/components/selectable/__snapshots__/selectable.test.tsx.snap
@@ -341,7 +341,7 @@ exports[`EuiSelectable search value supports inheriting initialSearchValue from 
     <div
       aria-atomic="true"
       aria-hidden="true"
-      aria-live="polite"
+      aria-live="off"
       role="status"
     />
     <div

--- a/upcoming_changelogs/6133.md
+++ b/upcoming_changelogs/6133.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiScreenReaderLive` double announcements on VO when `focusRegionOnTextChange` is not set


### PR DESCRIPTION
### Summary

closes https://github.com/elastic/eui/issues/6115

I recommend [following along by commit](https://github.com/elastic/eui/pull/6133/commits), as this PR has several tweaks and an incidental `EuiScreenReaderLive` fix (required to get this PR working).

## QA scenarios:

### To a different page with a hash

This was the broken experience in #6115. Repro steps:

1. Search for, e.g. "humor" in the sidebar
2. Click the **third level** hash subsection in the sidebar
3. On production, this was not correctly scrolling to the hash section due to the `EuiScreenReaderLive` stealing focus

Fixed behavior: (**Note**: GitHub starts video auto-muted, unmute to hear VoiceOver narration)

https://user-images.githubusercontent.com/549407/184252511-0a6e7251-30a3-47ad-af03-2bd585e3760d.mov

NOTE: Safari + VO treats the polite non-focused live region correctly (waiting to read out focused header before reading out live region), but Firefox + VO does _not_ treat `aria-live=polite` correctly and tries to read out 2 things at once. FF is not correct here.

### From page to page (no hash)

Should be same as before:

https://user-images.githubusercontent.com/549407/184252766-8dcf5ef5-f0d8-4a4d-9bda-d3b916772468.mov

### Within same page (with/without hash)

Should be same as before:

https://user-images.githubusercontent.com/549407/184253079-b5d29318-dc96-4039-9996-9c6ecdcd0b66.mov

Note that scroll to hash behavior with VO open is different from scrolling without - VO appears to center the focused heading.

### Checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~