### PR TITLE
[EuiDatePickerRange] Applying onFocus/OnBlur handlers to inner EuiDatePicker components

### DIFF
--- a/src/components/date_picker/date_picker_range.test.tsx
+++ b/src/components/date_picker/date_picker_range.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render, mount } from 'enzyme';
 import { requiredProps } from '../../test';
 
 import { EuiDatePickerRange } from './date_picker_range';
@@ -78,5 +78,52 @@ describe('EuiDatePickerRange', () => {
     );
 
     expect(component).toMatchSnapshot();
+  });
+
+  it('calls blur and focus handlers for date pickers while also triggering range control handlers', () => {
+    const rangeControlOnBlurMock = jest.fn();
+    const rangeControlOnFocusMock = jest.fn();
+    const startControlOnBlurMock = jest.fn();
+    const startControlOnFocusMock = jest.fn();
+    const endControlOnBlurMock = jest.fn();
+    const endControlOnFocusMock = jest.fn();
+
+    const component = mount(
+      <EuiDatePickerRange
+        onBlur={rangeControlOnBlurMock}
+        onFocus={rangeControlOnFocusMock}
+        startDateControl={
+          <EuiDatePicker
+            onBlur={startControlOnBlurMock}
+            onFocus={startControlOnFocusMock}
+          />
+        }
+        endDateControl={
+          <EuiDatePicker
+            onBlur={endControlOnBlurMock}
+            onFocus={endControlOnFocusMock}
+          />
+        }
+      />
+    );
+
+    const startControl = component.find('EuiDatePicker').at(0);
+    const endControl = component.find('EuiDatePicker').at(1);
+
+    startControl.props().onFocus?.({} as React.FocusEvent);
+    expect(startControlOnFocusMock).toHaveBeenCalledTimes(1);
+    expect(rangeControlOnFocusMock).toHaveBeenCalledTimes(1);
+
+    startControl.props().onBlur?.({} as React.FocusEvent);
+    expect(startControlOnBlurMock).toHaveBeenCalledTimes(1);
+    expect(rangeControlOnBlurMock).toHaveBeenCalledTimes(1);
+
+    endControl.props().onFocus?.({} as React.FocusEvent);
+    expect(endControlOnFocusMock).toHaveBeenCalledTimes(1);
+    expect(rangeControlOnFocusMock).toHaveBeenCalledTimes(2);
+
+    endControl.props().onBlur?.({} as React.FocusEvent);
+    expect(endControlOnBlurMock).toHaveBeenCalledTimes(1);
+    expect(rangeControlOnBlurMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/components/date_picker/date_picker_range.tsx
+++ b/src/components/date_picker/date_picker_range.tsx
@@ -7,6 +7,8 @@
  */
 
 import React, {
+  FocusEvent,
+  FocusEventHandler,
   Fragment,
   FunctionComponent,
   ReactNode,
@@ -18,7 +20,6 @@ import classNames from 'classnames';
 import { IconType, EuiIcon } from '../icon';
 import { CommonProps } from '../common';
 import { EuiDatePickerProps } from './date_picker';
-import over from 'lodash/over';
 
 export type EuiDatePickerRangeProps = CommonProps & {
   /**
@@ -69,12 +70,12 @@ export type EuiDatePickerRangeProps = CommonProps & {
   /**
    * Triggered whenever the start or end controls are blurred
    */
-  onBlur?: (...args: any[]) => void;
+  onBlur?: FocusEventHandler<HTMLInputElement>;
 
   /**
    * Triggered whenever the start or end controls are focused
    */
-  onFocus?: (...args: any[]) => void;
+  onFocus?: FocusEventHandler<HTMLInputElement>;
 };
 
 export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
@@ -120,8 +121,14 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
           'euiDatePickerRange__start',
           startDateControl.props.className
         ),
-        onBlur: over([startDateControl.props.onBlur, onBlur]),
-        onFocus: over([startDateControl.props.onFocus, onFocus]),
+        onBlur: (event: FocusEvent<HTMLInputElement>) => {
+          startDateControl.props?.onBlur?.(event);
+          onBlur?.(event);
+        },
+        onFocus: (event: FocusEvent<HTMLInputElement>) => {
+          startDateControl.props?.onFocus?.(event);
+          onFocus?.(event);
+        },
       }
     );
 
@@ -138,8 +145,14 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
           'euiDatePickerRange__end',
           endDateControl.props.className
         ),
-        onBlur: over([endDateControl.props.onBlur, onBlur]),
-        onFocus: over([endDateControl.props.onFocus, onFocus]),
+        onBlur: (event: FocusEvent<HTMLInputElement>) => {
+          endDateControl.props?.onBlur?.(event);
+          onBlur?.(event);
+        },
+        onFocus: (event: FocusEvent<HTMLInputElement>) => {
+          endDateControl.props?.onFocus?.(event);
+          onFocus?.(event);
+        },
       }
     );
   }

--- a/src/components/date_picker/date_picker_range.tsx
+++ b/src/components/date_picker/date_picker_range.tsx
@@ -18,6 +18,7 @@ import classNames from 'classnames';
 import { IconType, EuiIcon } from '../icon';
 import { CommonProps } from '../common';
 import { EuiDatePickerProps } from './date_picker';
+import over from 'lodash/over';
 
 export type EuiDatePickerRangeProps = CommonProps & {
   /**
@@ -60,7 +61,20 @@ export type EuiDatePickerRangeProps = CommonProps & {
    */
   readOnly?: boolean;
 
+  /**
+   * Passes through to each control
+   */
   fullWidth?: boolean;
+
+  /**
+   * Triggered whenever the start or end controls are blurred
+   */
+  onBlur?: (...args: any[]) => void;
+
+  /**
+   * Triggered whenever the start or end controls are focused
+   */
+  onFocus?: (...args: any[]) => void;
 };
 
 export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
@@ -74,6 +88,8 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
   readOnly,
   isInvalid,
   disabled,
+  onFocus,
+  onBlur,
   ...rest
 }) => {
   const classes = classNames(
@@ -104,6 +120,8 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
           'euiDatePickerRange__start',
           startDateControl.props.className
         ),
+        onBlur: over([startDateControl.props.onBlur, onBlur]),
+        onFocus: over([startDateControl.props.onFocus, onFocus]),
       }
     );
 
@@ -120,6 +138,8 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
           'euiDatePickerRange__end',
           endDateControl.props.className
         ),
+        onBlur: over([endDateControl.props.onBlur, onBlur]),
+        onFocus: over([endDateControl.props.onFocus, onFocus]),
       }
     );
   }

--- a/upcoming_changelogs/6136.md
+++ b/upcoming_changelogs/6136.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed `onBlur` and `onFocus` handlers from `EuiDatePickerRange` being incorrectly applied to wrapping element rather than the start/end control datepickers.
+


### PR DESCRIPTION
### Summary

Fixes #6128 which has a detailed description of the error and how to replicate it.

- Destructures `onBlur` and `onFocus` to ensure they're not scooped up by the rest parameter and fed to containing `div` element.
- Uses lodash's [over](https://lodash.com/docs/4.17.15#over) method to create handlers that will trigger callbacks for both `EuiDatePicker` and `EuiDatePickerRange`. It's worth noting that `over` gracefully handles array elements that aren't functions, and ignores them. This means we don't need to worry about any of the handlers not being defined.

_Note: I contemplated writing these tests in Cypress as I think ultimately it's a better, more user-centric test but the entirety of the date picker suite runs using Enzyme so I've opted for consistency here._

### Checklist

- [X] Checked in both **light and dark** modes
- [X] Checked in **mobile**
- [X] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [X] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] ~~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~~
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [X] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [X] Checked for **breaking changes** and labeled appropriately
- [X] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] ~~Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
