### PR TITLE
[DOCS] Adding a11y documentation for disabled elements

### DIFF
--- a/src-docs/src/views/guidelines/accessibility.js
+++ b/src-docs/src/views/guidelines/accessibility.js
@@ -517,10 +517,27 @@ export default {
         <>
           <EuiText grow={false}>
             <p>
-              If you disable elements using the <EuiCode language="html" size="s">disabled</EuiCode> attribute or pass the <EuiCode language="js">isDisabled</EuiCode> prop to the <EuiLink href="http://localhost:8030/#/layout/accordion#disabled-state">EuiAccordion</EuiLink> component, you must ensure there are no nested hover/focus interactions like tooltips.
+              If you disable elements by adding the HTML{' '}
+              <EuiCode language="html" size="s">
+                disabled
+              </EuiCode>{' '}
+              attribute or passing the{' '}
+              <EuiCode language="js">isDisabled</EuiCode> prop to the{' '}
+              <EuiLink href="http://localhost:8030/#/layout/accordion#disabled-state">
+                EuiAccordion
+              </EuiLink>{' '}
+              component, you must ensure there are no nested hover/focus
+              interactions like tooltips.
             </p>
             <p>
-              Browsers remove disabled buttons from the normal tab order. This means keyboard users cannot tab to those buttons and activate the nested focus behavior.
+              Browsers remove disabled elements from the tab order. This means
+              keyboard users cannot tab to those elements or activate nested
+              focus behaviors.
+            </p>
+            <p>
+              If you disable a button or form element, you need to provide clear
+              instructions to users how to correct errors or remove the disabled
+              state.
             </p>
           </EuiText>
           <EuiSpacer />

--- a/src-docs/src/views/guidelines/accessibility.js
+++ b/src-docs/src/views/guidelines/accessibility.js
@@ -511,6 +511,39 @@ export default {
       ),
     },
     {
+      title: 'Disabled elements',
+      wrapText: false,
+      text: (
+        <>
+          <EuiText grow={false}>
+            <p>
+              If you disable elements using the <EuiCode language="html" size="s">disabled</EuiCode> attribute or pass the <EuiCode language="js">isDisabled</EuiCode> prop to the <EuiLink href="http://localhost:8030/#/layout/accordion#disabled-state">EuiAccordion</EuiLink> component, you must ensure there are no nested hover/focus interactions like tooltips.
+            </p>
+            <p>
+              Browsers remove disabled buttons from the normal tab order. This means keyboard users cannot tab to those buttons and activate the nested focus behavior.
+            </p>
+          </EuiText>
+          <EuiSpacer />
+          <EuiText size="s" grow={false}>
+            <h3>Further reading</h3>
+            <ul aria-labelledby="disabled-elements further-reading">
+              <li>
+                <EuiLink href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex">
+                  MDN: Tabindex
+                </EuiLink>
+              </li>
+              <li>
+                <EuiLink href="https://www.w3.org/TR/2014/REC-html5-20141028/disabled-elements.html#disabled-elements">
+                  W3C: Disabled elements
+                </EuiLink>
+              </li>
+            </ul>
+          </EuiText>
+          <EuiHorizontalRule />
+        </>
+      ),
+    },
+    {
       title: 'Naming',
       wrapText: false,
       text: (

--- a/src-docs/src/views/guidelines/accessibility.js
+++ b/src-docs/src/views/guidelines/accessibility.js
@@ -515,20 +515,7 @@ export default {
       wrapText: false,
       text: (
         <>
-          <EuiText grow={false}>
-            <p>
-              If you disable elements by adding the HTML{' '}
-              <EuiCode language="html" size="s">
-                disabled
-              </EuiCode>{' '}
-              attribute or passing the{' '}
-              <EuiCode language="js">isDisabled</EuiCode> prop to the{' '}
-              <EuiLink href="http://localhost:8030/#/layout/accordion#disabled-state">
-                EuiAccordion
-              </EuiLink>{' '}
-              component, you must ensure there are no nested hover/focus
-              interactions like tooltips.
-            </p>
+          <EuiText>
             <p>
               Browsers remove disabled elements from the tab order. This means
               keyboard users cannot tab to those elements or activate nested
@@ -539,9 +526,17 @@ export default {
               instructions to users how to correct errors or remove the disabled
               state.
             </p>
+            <p>
+              When you add the HTML <EuiCode language="html">disabled</EuiCode>{' '}
+              attribute to an element, you must remove tooltips or other focus
+              interactions. You must also remove focus interactions if you pass
+              the <EuiCode language="js">isDisabled</EuiCode> prop to components
+              like{' '}
+              <Link to="/layout/accordion#disabled-state">EuiAccordion</Link>.
+            </p>
           </EuiText>
           <EuiSpacer />
-          <EuiText size="s" grow={false}>
+          <EuiText size="s">
             <h3>Further reading</h3>
             <ul aria-labelledby="disabled-elements further-reading">
               <li>


### PR DESCRIPTION
### Summary

I added a section to our `Accessibility` documentation for disabled elements. It mentions specifically adding the `disabled` attribute or passing `isDisabled` to EuiAccordion and users' responsibility to not include focus interactions.

### Checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**