### PR TITLE
[EuiPageTemplate] Fix `data-fixed-headers` usage

### DIFF
--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -98,17 +98,14 @@ export const EuiHeader: FunctionComponent<EuiHeaderProps> = ({
       // Increment fixed header counter for each fixed header
       euiHeaderFixedCounter++;
       document.body.classList.add('euiBody--headerIsFixed');
-      document.body.setAttribute(
-        'data-fixed-headers',
-        String(euiHeaderFixedCounter)
-      );
+      document.body.dataset.fixedHeaders = String(euiHeaderFixedCounter);
 
       return () => {
         // Both decrement the fixed counter AND then check if there are none
         if (--euiHeaderFixedCounter === 0) {
           // If there are none, THEN remove class
           document.body.classList.remove('euiBody--headerIsFixed');
-          document.body.removeAttribute('data-fixed-headers');
+          delete document.body.dataset.fixedHeaders;
         }
       };
     }

--- a/src/components/page/page_sidebar/page_sidebar.tsx
+++ b/src/components/page/page_sidebar/page_sidebar.tsx
@@ -82,7 +82,9 @@ export const EuiPageSidebar: FunctionComponent<EuiPageSidebarProps> = ({
 
   useEffect(() => {
     if (sticky) {
-      const euiHeaderFixedCounter = Number(document.body.dataset.fixedHeaders);
+      const euiHeaderFixedCounter = Number(
+        document.body.dataset.fixedHeaders ?? 0
+      );
 
       const offset =
         typeof sticky === 'object'

--- a/src/components/page_template/page_template.tsx
+++ b/src/components/page_template/page_template.tsx
@@ -179,7 +179,6 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
   const _minHeight = grow ? `max(${minHeight}, 100vh)` : minHeight;
 
   const classes = classNames('euiPageTemplate', className);
-  console.log(offset);
   const pageStyle = {
     ...logicalStyle('min-height', _minHeight),
     ...logicalStyle('padding-top', offset),

--- a/src/components/page_template/page_template.tsx
+++ b/src/components/page_template/page_template.tsx
@@ -108,7 +108,9 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
 
   useEffect(() => {
     if (_offset === undefined) {
-      const euiHeaderFixedCounter = Number(document.body.dataset.fixedHeaders);
+      const euiHeaderFixedCounter = Number(
+        document.body.dataset.fixedHeaders ?? 0
+      );
       setOffset(euiTheme.base * 3 * euiHeaderFixedCounter);
     }
   }, [_offset, euiTheme.base]);
@@ -177,6 +179,7 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
   const _minHeight = grow ? `max(${minHeight}, 100vh)` : minHeight;
 
   const classes = classNames('euiPageTemplate', className);
+  console.log(offset);
   const pageStyle = {
     ...logicalStyle('min-height', _minHeight),
     ...logicalStyle('padding-top', offset),

--- a/upcoming_changelogs/6140.md
+++ b/upcoming_changelogs/6140.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed missing `data-fixed-headers` property in some layout configurations using `EuiPageTemplate`.
+


### PR DESCRIPTION
### Summary

Related to #5768
Closes #6138

`EuiPageTemplate` expects the `data-fixed-headers` attribute is to exist, but the attribute is only managed by `EuiHeader`. The fix is to have a fallback value for when `EuiHeader` is not in use. Also updated the method by which the attribute is managed (`setAttribute` to `dataset`).

For verification, you'll need something other than the docs site. I used CRA with the `build-pack` output and the simple [`App.tsx` from the issue](https://github.com/elastic/eui/issues/6138#issue-1338189645).


### Checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Checked for **breaking changes** and labeled appropriately
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
