### PR TITLE
[EuiAspectRatio] Fix incorrectly inherited height and ignored `style` prop

### DIFF
--- a/src/components/aspect_ratio/__snapshots__/aspect_ratio.test.tsx.snap
+++ b/src/components/aspect_ratio/__snapshots__/aspect_ratio.test.tsx.snap
@@ -16,6 +16,21 @@ exports[`EuiAspectRatio is rendered 1`] = `
 />
 `;
 
+
+exports[`EuiAspectRatio allows overriding with custom styles 1`] = `
+<iframe
+  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen=""
+  class="euiAspectRatio"
+  frameborder="0"
+  height="315"
+  src="https://www.youtube.com/embed/yJarWSLRM24"
+  style="aspect-ratio:9 / 4;height:300px;width:100%;margin:2em"
+  title="Elastic is a search company"
+  width="560"
+/>
+`;
+
 exports[`EuiAspectRatio props maxWidth is rendered 1`] = `
 <iframe
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"

--- a/src/components/aspect_ratio/__snapshots__/aspect_ratio.test.tsx.snap
+++ b/src/components/aspect_ratio/__snapshots__/aspect_ratio.test.tsx.snap
@@ -17,21 +17,17 @@ exports[`EuiAspectRatio is rendered 1`] = `
 `;
 
 exports[`EuiAspectRatio props maxWidth is rendered 1`] = `
-<div
-  style="max-width:500px"
->
-  <iframe
-    allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-    allowfullscreen=""
-    aria-label="aria-label"
-    class="euiAspectRatio testClass1 testClass2"
-    data-test-subj="test subject string"
-    frameborder="0"
-    height="315"
-    src="https://www.youtube.com/embed/yJarWSLRM24"
-    style="aspect-ratio:9 / 16;height:auto;width:100%"
-    title="Elastic is a search company"
-    width="560"
-  />
-</div>
+<iframe
+  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen=""
+  aria-label="aria-label"
+  class="euiAspectRatio testClass1 testClass2"
+  data-test-subj="test subject string"
+  frameborder="0"
+  height="315"
+  src="https://www.youtube.com/embed/yJarWSLRM24"
+  style="aspect-ratio:9 / 16;height:auto;width:100%;max-width:500px"
+  title="Elastic is a search company"
+  width="560"
+/>
 `;

--- a/src/components/aspect_ratio/__snapshots__/aspect_ratio.test.tsx.snap
+++ b/src/components/aspect_ratio/__snapshots__/aspect_ratio.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`EuiAspectRatio is rendered 1`] = `
   frameborder="0"
   height="315"
   src="https://www.youtube.com/embed/yJarWSLRM24"
-  style="aspect-ratio:9 / 4;height:100%;width:100%"
+  style="aspect-ratio:9 / 4;height:auto;width:100%"
   title="Elastic is a search company"
   width="560"
 />
@@ -29,7 +29,7 @@ exports[`EuiAspectRatio props maxWidth is rendered 1`] = `
     frameborder="0"
     height="315"
     src="https://www.youtube.com/embed/yJarWSLRM24"
-    style="aspect-ratio:9 / 16;height:100%;width:100%"
+    style="aspect-ratio:9 / 16;height:auto;width:100%"
     title="Elastic is a search company"
     width="560"
   />

--- a/src/components/aspect_ratio/aspect_ratio.test.tsx
+++ b/src/components/aspect_ratio/aspect_ratio.test.tsx
@@ -31,6 +31,28 @@ describe('EuiAspectRatio', () => {
     expect(component).toMatchSnapshot();
   });
 
+  test('allows overriding with custom styles', () => {
+    const component = render(
+      <EuiAspectRatio
+        height={4}
+        width={9}
+        style={{ margin: '2em', height: '300px' }}
+      >
+        <iframe
+          title="Elastic is a search company"
+          width="560"
+          height="315"
+          src="https://www.youtube.com/embed/yJarWSLRM24"
+          frameBorder="0"
+          allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+        />
+      </EuiAspectRatio>
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
   describe('props', () => {
     describe('maxWidth', () => {
       test('is rendered', () => {

--- a/src/components/aspect_ratio/aspect_ratio.tsx
+++ b/src/components/aspect_ratio/aspect_ratio.tsx
@@ -46,6 +46,7 @@ export const EuiAspectRatio: FunctionComponent<EuiAspectRatioProps> = ({
     aspectRatio: `${width} / ${height}`,
     height: 'auto',
     width: '100%',
+    maxWidth,
   };
 
   const props = {
@@ -54,13 +55,5 @@ export const EuiAspectRatio: FunctionComponent<EuiAspectRatioProps> = ({
     ...rest,
   };
 
-  const content = React.cloneElement(children, props);
-  let contentwithoptionalwrap = content;
-  if (maxWidth) {
-    contentwithoptionalwrap = (
-      <div style={{ maxWidth: maxWidth }}>{content}</div>
-    );
-  }
-
-  return contentwithoptionalwrap;
+  return React.cloneElement(children, props);
 };

--- a/src/components/aspect_ratio/aspect_ratio.tsx
+++ b/src/components/aspect_ratio/aspect_ratio.tsx
@@ -38,6 +38,7 @@ export const EuiAspectRatio: FunctionComponent<EuiAspectRatioProps> = ({
   height,
   width,
   maxWidth,
+  style,
   ...rest
 }) => {
   const classes = classNames('euiAspectRatio', className);
@@ -47,6 +48,7 @@ export const EuiAspectRatio: FunctionComponent<EuiAspectRatioProps> = ({
     height: 'auto',
     width: '100%',
     maxWidth,
+    ...style,
   };
 
   const props = {

--- a/src/components/aspect_ratio/aspect_ratio.tsx
+++ b/src/components/aspect_ratio/aspect_ratio.tsx
@@ -44,7 +44,7 @@ export const EuiAspectRatio: FunctionComponent<EuiAspectRatioProps> = ({
 
   const euiAspectRatioStyle = {
     aspectRatio: `${width} / ${height}`,
-    height: '100%',
+    height: 'auto',
     width: '100%',
   };
 

--- a/upcoming_changelogs/6141.md
+++ b/upcoming_changelogs/6141.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed `EuiAspectRatio` sometimes incorrectly inheriting its height from parent containers as opposed to from its aspect ratio
+- Fixed `EuiAspectRatio` to allow custom `style`s to be passed by consumers


### PR DESCRIPTION
## Summary

The video on https://elastic.github.io/eui/#/guidelines/accessibility was not working correctly due to the `height: 100%` set (which was attempting to inherit height from the parent div which had a `flex-direction: column;` set).

If we're using the `aspect-ratio` css (see #5818), we shouldn't be using `height: 100%` - we should be using `height: auto` due to setting `width: 100%`, the same way an img tag gets treated essentially.

I also noticed 2 more things while adding this fix:

1. Any custom `style`s getting set by the consumer were not correctly being spread, and
2. The `div` wrapper for `max-width` is also unnecessary if we're using the `aspect-ratio` CSS property: because it now behaves the same way as an img tag, the max-width can be set directly on the iframe.

### Before

<img width="771" alt="" src="https://user-images.githubusercontent.com/549407/184684633-a9ef1032-7f99-4a04-9926-d982046b49f4.png">

### After

<img width="776" alt="" src="https://user-images.githubusercontent.com/549407/184684640-1abaa1fe-a893-418f-981f-68a96cf5c89a.png">

## QA

- [x] https://eui.elastic.co/pr_6141/#/guidelines/accessibility displays correctly on desktop views
- [x] https://eui.elastic.co/pr_6141/#/display/aspect-ratio works as before

### Checklist

- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~