### PR TITLE
[eui.d.ts] Exclude all of `src/test`

### DIFF
--- a/scripts/dtsgenerator.js
+++ b/scripts/dtsgenerator.js
@@ -37,7 +37,7 @@ const generator = dtsGenerator({
     '**/*.mock.{ts,tsx}',
     '**/__mocks__/*',
     'src/themes/charts/*', // A separate d.ts file is generated for the charts theme file
-    'src/test/*', // A separate d.ts file is generated for test utils
+    'src/test/**/*', // A separate d.ts file is generated for test utils
     'src-docs/**/*', // Don't include src-docs
   ],
   resolveModuleId(params) {

--- a/scripts/dtsgenerator.js
+++ b/scripts/dtsgenerator.js
@@ -37,7 +37,7 @@ const generator = dtsGenerator({
     '**/*.mock.{ts,tsx}',
     '**/__mocks__/*',
     'src/themes/charts/*', // A separate d.ts file is generated for the charts theme file
-    'src/test/**/*', // Aeparate d.ts files are generated for test utils
+    'src/test/**/*', // Separate d.ts files are generated for test utils
     'src-docs/**/*', // Don't include src-docs
   ],
   resolveModuleId(params) {

--- a/scripts/dtsgenerator.js
+++ b/scripts/dtsgenerator.js
@@ -37,7 +37,7 @@ const generator = dtsGenerator({
     '**/*.mock.{ts,tsx}',
     '**/__mocks__/*',
     'src/themes/charts/*', // A separate d.ts file is generated for the charts theme file
-    'src/test/**/*', // A separate d.ts file is generated for test utils
+    'src/test/**/*', // Aeparate d.ts files are generated for test utils
     'src-docs/**/*', // Don't include src-docs
   ],
   resolveModuleId(params) {

--- a/upcoming_changelogs/6142.md
+++ b/upcoming_changelogs/6142.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed `eui.d.ts` containing `@testing-library` type definitions
+


### PR DESCRIPTION
### Summary

Required for https://github.com/elastic/kibana/pull/138837

The exclude glob pattern for the `d.ts` generator script was not accounting for nested directories with TS files. The result was that `src/test/rtl/` and `src/test/internal/` files and types were included in `eui.d.ts` (like, specifically the ones we _don't_ want to include 🙈) and in turn included problematic types from RTL that interfere with other testing lib type definitions.

Verification:
* Checkout the `v62.2.1` tag
* `yarn`
* Generate a new `eui.d.ts` 
* Drop that `eui.d.ts` in the [Kibana upgrade branch](https://github.com/elastic/kibana/pull/138837)
* Type errors related to `this` in, say `test/functional/apps/console/_autocomplete.ts` should be resolved

### Checklist

- [x] Checked for **breaking changes** and labeled appropriately
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
