### PR TITLE
[EuiDescriptionList] Export subcomponent prop interfaces

### DIFF
--- a/src/components/description_list/description_list_description.tsx
+++ b/src/components/description_list/description_list_description.tsx
@@ -13,7 +13,8 @@ import { useEuiTheme } from '../../services';
 import { euiDescriptionListDescriptionStyles } from './description_list_description.styles';
 import { EuiDescriptionListContext } from './description_list_context';
 
-interface EuiDescriptionListDescriptionProps
+// Export required for correct inference by HOCs
+export interface EuiDescriptionListDescriptionProps
   extends CommonProps,
     HTMLAttributes<HTMLElement> {}
 

--- a/src/components/description_list/description_list_title.tsx
+++ b/src/components/description_list/description_list_title.tsx
@@ -13,7 +13,8 @@ import { useEuiTheme } from '../../services';
 import { euiDescriptionListTitleStyles } from './description_list_title.styles';
 import { EuiDescriptionListContext } from './description_list_context';
 
-interface EuiDescriptionListTitleProps
+// Export required for correct inference by HOCs
+export interface EuiDescriptionListTitleProps
   extends CommonProps,
     HTMLAttributes<HTMLElement> {}
 


### PR DESCRIPTION
### Summary

Required for https://github.com/elastic/kibana/pull/138837

Instances of `EuiDescriptionListDescription` and `EuiDescriptionListTitle` are styled with `styled-components` and the prop type cannot be correctly accessed because the interface is not exported.

> Exported variable 'MonListTitle' has or is using name 'EuiDescriptionListTitleProps' from external module "@elastic/eui/src/components/description_list/description_list_title" but cannot be named.

Local export resolves the problem

~### Checklist~
