### PR TITLE
[CollapsedItemActions] Account for `null` ref object

### DIFF
--- a/src-docs/src/views/tables/actions/actions.js
+++ b/src-docs/src/views/tables/actions/actions.js
@@ -3,7 +3,6 @@ import { formatDate } from '../../../../../src/services/format';
 import { createDataStore } from '../data_store';
 
 import {
-  EuiAccordion,
   EuiBasicTable,
   EuiLink,
   EuiHealth,
@@ -318,19 +317,17 @@ export const Table = () => {
 
       <EuiSpacer size="l" />
 
-      <EuiAccordion id={'accordionId1'} buttonContent="Clickable title">
-        <EuiBasicTable
-          tableCaption="Demo of EuiBasicTable with actions"
-          items={pageOfItems}
-          itemId="id"
-          columns={columns}
-          pagination={pagination}
-          sorting={sorting}
-          selection={selection}
-          hasActions={customAction ? false : true}
-          onChange={onTableChange}
-        />
-      </EuiAccordion>
+      <EuiBasicTable
+        tableCaption="Demo of EuiBasicTable with actions"
+        items={pageOfItems}
+        itemId="id"
+        columns={columns}
+        pagination={pagination}
+        sorting={sorting}
+        selection={selection}
+        hasActions={customAction ? false : true}
+        onChange={onTableChange}
+      />
     </Fragment>
   );
 };

--- a/src-docs/src/views/tables/actions/actions.js
+++ b/src-docs/src/views/tables/actions/actions.js
@@ -3,6 +3,7 @@ import { formatDate } from '../../../../../src/services/format';
 import { createDataStore } from '../data_store';
 
 import {
+  EuiAccordion,
   EuiBasicTable,
   EuiLink,
   EuiHealth,
@@ -317,17 +318,19 @@ export const Table = () => {
 
       <EuiSpacer size="l" />
 
-      <EuiBasicTable
-        tableCaption="Demo of EuiBasicTable with actions"
-        items={pageOfItems}
-        itemId="id"
-        columns={columns}
-        pagination={pagination}
-        sorting={sorting}
-        selection={selection}
-        hasActions={customAction ? false : true}
-        onChange={onTableChange}
-      />
+      <EuiAccordion id={'accordionId1'} buttonContent="Clickable title">
+        <EuiBasicTable
+          tableCaption="Demo of EuiBasicTable with actions"
+          items={pageOfItems}
+          itemId="id"
+          columns={columns}
+          pagination={pagination}
+          sorting={sorting}
+          selection={selection}
+          hasActions={customAction ? false : true}
+          onChange={onTableChange}
+        />
+      </EuiAccordion>
     </Fragment>
   );
 };

--- a/src/components/basic_table/collapsed_item_actions.tsx
+++ b/src/components/basic_table/collapsed_item_actions.tsx
@@ -67,10 +67,11 @@ export class CollapsedItemActions<T> extends Component<
     });
   };
 
-  registerPopoverDiv = (popoverDiv: HTMLDivElement) => {
+  registerPopoverDiv = (popoverDiv: HTMLDivElement | null) => {
     if (!this.popoverDiv) {
       this.popoverDiv = popoverDiv;
-      this.popoverDiv.addEventListener('focusout', this.onPopoverBlur);
+      this.popoverDiv &&
+        this.popoverDiv.addEventListener('focusout', this.onPopoverBlur);
     }
   };
 

--- a/upcoming_changelogs/6145.md
+++ b/upcoming_changelogs/6145.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed `CollapsedItemActions` ref callback not accounting for `null` value
+


### PR DESCRIPTION
### Summary

The `registerPopoverDiv` callback was not accounting for `null` as a possible return value.
In the scenerio where `popoverDiv` is `null` and `this.popoverDiv` is not defined, we would attempt to add an event listener to `null`, which results in a type error.

Solution is to update the type and logic to account for `null`

### Checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Checked for **breaking changes** and labeled appropriately
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
