### PR TITLE
[EuiText] Updated `euiTextContrainedMaxWidth` Value

### DIFF
--- a/src/components/text/text.styles.ts
+++ b/src/components/text/text.styles.ts
@@ -22,7 +22,7 @@ import { euiTitle } from '../title/title.styles';
 /**
  * TODO: Make this a global value so it can be set by theme?
  */
-export const euiTextConstrainedMaxWidth = 'max(64ch, 75%)';
+export const euiTextConstrainedMaxWidth = '36em';
 
 /**
  * Mixins
@@ -340,7 +340,7 @@ export const euiTextStyles = (euiThemeContext: UseEuiTheme) => {
       }
     `,
     constrainedWidth: css`
-      ${logicalCSS('max-width', euiTextConstrainedMaxWidth)}
+      max-width: ${euiTextConstrainedMaxWidth};
     `,
     // Sizes
     m: css`

--- a/upcoming_changelogs/6146.md
+++ b/upcoming_changelogs/6146.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Updated `euiTextContrainedMaxWidth` to ensure text content fits doesn't extend the bounds of the screen


### PR DESCRIPTION
### Summary

Resolved a bug with `EuiText` that caused `EuiPopover` to have a length that extended beyond the width of the screen when the popover contains a lot of text. In #5977, `euiTextConstrainedMaxWidth` was converted with a max-width of `max(64ch, 75%)` as opposed to `36rem`.
 
I've also opted for using the native CSS `max-width` property instead of the `logicalCSS` function with `max-width` as a parameter because it is converted to `max-inline-size` which was not respected by the popover.

**Before**
![83BA5EF5-A430-4701-A946-D188769E7A98](https://user-images.githubusercontent.com/40739624/185252337-d8296357-7884-43a6-bfd8-75230b9a36b1.jpeg)

**After**
![image](https://user-images.githubusercontent.com/40739624/185252377-a77232a0-e26a-4b30-a68a-0b06268ccba8.png)

### Checklist

~- [ ] Checked in both **light and dark** modes~
- [x] Checked in **mobile**
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
