### PR TITLE
Remove IE CSS utilities, mixins, and non-flex/sizing fallbacks

### DIFF
--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -262,7 +262,10 @@ interface BasicTableProps<T> extends Omit<EuiTableProps, 'onChange'> {
    */
   tableLayout?: 'fixed' | 'auto';
   /**
-   * Applied to table cells => Any cell using render function will set this to be false, leading to unnecessary word breaks. Apply textOnly: true in order to ensure it breaks properly
+   * Applied to table cells. Any cell using a render function will set this to be false.
+   *
+   * Creates a text wrapper around cell content that helps word break or truncate
+   * long text correctly.
    */
   textOnly?: boolean;
 }

--- a/src/components/basic_table/table_types.ts
+++ b/src/components/basic_table/table_types.ts
@@ -58,6 +58,10 @@ export interface EuiTableFieldDataColumnType<T>
    */
   sortable?: boolean | ((item: T) => Primitive);
   isExpander?: boolean;
+  /**
+   * Creates a text wrapper around cell content that helps word break or truncate
+   * long text correctly.
+   */
   textOnly?: boolean;
   /**
    * Defines the horizontal alignment of the column

--- a/src/components/card/card.styles.ts
+++ b/src/components/card/card.styles.ts
@@ -42,8 +42,7 @@ export const euiCardStyles = (
       euiCard: css`
         display: flex;
 
-        // Progressive enhancement where we apply the outline to the whole card
-        // when the internal text button has focus
+        // Apply the outline to the whole card when the internal text button has focus
         &:has([class*='euiCard__text'][class*='-interactive']:focus:focus-visible) {
           outline: ${euiTheme.focus.width} solid currentColor;
         }

--- a/src/components/datagrid/body/header/_data_grid_header_row.scss
+++ b/src/components/datagrid/body/header/_data_grid_header_row.scss
@@ -2,7 +2,7 @@
   display: flex;
   z-index: 3; // Needs to sit above the content and focused cells
   background: $euiColorEmptyShade;
-  position: sticky; // In IE11 this does not work, but doesn't cause a break.
+  position: sticky;
   top: 0;
 }
 

--- a/src/components/description_list/description_list_description.styles.ts
+++ b/src/components/description_list/description_list_description.styles.ts
@@ -22,7 +22,7 @@ export const euiDescriptionListDescriptionStyles = (
   const { euiTheme } = euiThemeContext;
 
   const columnDisplay = `
-    ${logicalCSS('width', '50%')} // Flex-basis doesn't work in IE with padding
+    ${logicalCSS('width', '50%')}
     ${logicalCSS('padding-left', euiTheme.size.s)}
     &:not(:first-of-type) {
       ${logicalCSS('margin-top', euiTheme.size.base)}

--- a/src/components/description_list/description_list_title.styles.ts
+++ b/src/components/description_list/description_list_title.styles.ts
@@ -21,7 +21,7 @@ export const euiDescriptionListTitleStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme, colorMode } = euiThemeContext;
 
   const columnDisplay = `
-    ${logicalCSS('width', '50%')} // Flex-basis doesn't work in IE with padding
+  ${logicalCSS('width', '50%')}
     ${logicalCSS('padding-right', euiTheme.size.s)}
   `;
   return {

--- a/src/components/filter_group/_filter_group.scss
+++ b/src/components/filter_group/_filter_group.scss
@@ -36,9 +36,11 @@
   display: flex;
 }
 
-// A fixed width is required in IE11 because of the shift in widths that can be caused
+// A fixed width is required because of the shift in widths that can be caused
 // by the loading animation that precedes the results.
 .euiFilterGroup__popoverPanel {
+  // Note for Emotion conversion: there are unfortunately 5+ direct
+  // usages of this className in Kibana that will need to be refactored
   width: $euiSize * 18;
 }
 

--- a/src/components/flex/_flex_group.scss
+++ b/src/components/flex/_flex_group.scss
@@ -9,10 +9,6 @@
   flex-grow: 1; /* 1 */
 
   .euiFlexItem {
-    @include internetExplorerOnly {
-      min-width: 1px;
-    }
-
     flex-grow: 1;
     flex-basis: 0%; /* 2 */
   }

--- a/src/components/flex/_flex_item.scss
+++ b/src/components/flex/_flex_item.scss
@@ -1,13 +1,7 @@
 /**
  * 1. Allow EuiPanels to expand to fill the item.
- * 2. IE11 hack forces inner content of flex items to respect a higher parent's width (mostly) and
- *    not cause weird wrapping issues.
  */
 .euiFlexItem {
-  @include internetExplorerOnly {
-    min-width: 1px; /* 2 */
-  }
-
   display: flex; /* 1 */
   flex-direction: column; /* 1 */
 

--- a/src/components/form/field_search/_field_search.scss
+++ b/src/components/form/field_search/_field_search.scss
@@ -1,7 +1,6 @@
 /*
  * 1. Fix for Safari to ensure that it renders like a normal text input
  *    and doesn't add extra spacing around text
- * 2. Remove the X clear button from input type search in Chrome and IE
 */
 
 .euiFieldSearch {
@@ -15,10 +14,6 @@
   &::-webkit-search-decoration,
   &::-webkit-search-cancel-button {
     -webkit-appearance: none;  /* 1, 2 */
-  }
-
-  &::-ms-clear {
-    display: none; /* 2 */
   }
 }
 

--- a/src/components/list_group/_list_group_item.scss
+++ b/src/components/list_group/_list_group_item.scss
@@ -7,21 +7,13 @@
   position: relative;
 
   &.euiListGroupItem-isActive,
-  &.euiListGroupItem-isClickable:hover {
-    background-color: $euiListGroupItemHoverBackground;
-  }
-
-  // Can't be grouped with above or else IE will ignore the whole group
+  &.euiListGroupItem-isClickable:hover,
   &.euiListGroupItem-isClickable:focus-within {
     background-color: $euiListGroupItemHoverBackground;
   }
 
   &.euiListGroupItem--ghost {
-    &.euiListGroupItem-isClickable:hover {
-      background-color: $euiListGroupItemHoverBackgroundGhost;
-    }
-
-    // Can't be grouped with above or else IE will ignore the whole group
+    &.euiListGroupItem-isClickable:hover,
     &.euiListGroupItem-isClickable:focus-within {
       background-color: $euiListGroupItemHoverBackgroundGhost;
     }

--- a/src/components/list_group/_list_group_item.scss
+++ b/src/components/list_group/_list_group_item.scss
@@ -46,20 +46,6 @@
   }
 }
 
-// IE doesn't support :focus-within
-@include internetExplorerOnly {
-  .euiListGroupItem__button:hover,
-  .euiListGroupItem__button:focus {
-    background-color: $euiListGroupItemHoverBackground;
-    border-radius: $euiBorderRadius;
-
-    .euiListGroupItem--ghost .euiListGroupItem__button:hover,
-    .euiListGroupItem--ghost .euiListGroupItem__button:focus {
-      background-color: $euiListGroupItemHoverBackgroundGhost;
-    }
-  }
-}
-
 .euiListGroupItem__text,
 .euiListGroupItem__button {
   line-height: $euiSizeL;

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -190,7 +190,6 @@
   overflow: visible;
   white-space: normal;
   //* 4 */ overflow-wrap is not supported on flex parents
-  word-break: break-all; // Fallback for FF and IE
   word-break: break-word;
 }
 

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -1,7 +1,3 @@
-/**
- * NOTE: table-layout: fixed causes a bug in IE11 and Edge (see #9929). It also prevents us from
- * specifying a column width, e.g. the checkbox column.
- */
 .euiTable {
   @include euiFontSizeS;
   @include euiNumberFormat;

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -37,9 +37,8 @@ interface EuiTableRowCellSharedPropsShape {
    */
   showOnHover?: boolean;
   /**
-   * Setting `textOnly` to `false` will break words unnecessarily on FF and
-   * IE.  To combat this problem on FF, wrap contents with the css utility
-   * `.eui-textBreakWord`.
+   * Creates a text wrapper around cell content that helps word break or truncate
+   * long text correctly.
    */
   textOnly?: boolean;
   /**

--- a/src/global_styling/mixins/__snapshots__/_typography.test.ts.snap
+++ b/src/global_styling/mixins/__snapshots__/_typography.test.ts.snap
@@ -198,8 +198,7 @@ exports[`euiNumberFormat returns a string of CSS text 1`] = `
 exports[`euiTextBreakWord returns a string of CSS text 1`] = `
 "
   overflow-wrap: break-word !important; // makes sure the long string will wrap and not bust out of the container
-  word-wrap: break-word !important; // spec says, they are literally just alternate names for each other but some browsers support one and not the other
-  word-break: break-word; // IE doesn't understand but that's ok
+  word-break: break-word;
 "
 `;
 

--- a/src/global_styling/mixins/_form.scss
+++ b/src/global_styling/mixins/_form.scss
@@ -78,10 +78,6 @@
   font-size: $euiFontSizeS;
   color: $euiTextColor;
 
-  @include internetExplorerOnly {
-    line-height: 1em; // fixes text alignment in IE
-  }
-
   // sass-lint:disable-block mixins-before-declarations
   @include euiPlaceholderPerBrowser {
     color: $euiFormControlPlaceholderText;

--- a/src/global_styling/mixins/_helpers.scss
+++ b/src/global_styling/mixins/_helpers.scss
@@ -112,14 +112,6 @@
   margin: -1px;
 }
 
-// Specifically target IE11, but not Edge.
-@mixin internetExplorerOnly {
-  // sass-lint:disable-block no-vendor-prefixes
-  @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
-    @content;
-  }
-}
-
 // Doesn't have reduced motion turned on
 @mixin euiCanAnimate {
   @media screen and (prefers-reduced-motion: no-preference) {

--- a/src/global_styling/mixins/_typography.scss
+++ b/src/global_styling/mixins/_typography.scss
@@ -127,8 +127,7 @@
 @mixin euiTextBreakWord {
   // https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/
   overflow-wrap: break-word !important; // makes sure the long string will wrap and not bust out of the container
-  word-wrap: break-word !important; // spec says, they are literally just alternate names for each other but some browsers support one and not the other
-  word-break: break-word; // IE doesn't understand but that's ok
+  word-break: break-word;
 }
 
 // Text truncation
@@ -138,8 +137,6 @@
 //
 // 1. Ensure that the node has a maximum width after which truncation can
 //    occur.
-// 2. Fix for IE 8/9 if `word-wrap: break-word` is in effect on ancestor
-//    nodes.
 
 @mixin euiTextTruncate {
   // sass-lint:disable-block no-important
@@ -147,7 +144,6 @@
   overflow: hidden !important;
   text-overflow: ellipsis !important;
   white-space: nowrap !important;
-  word-wrap: normal !important; // 2
 }
 
 @mixin euiNumberFormat {

--- a/src/global_styling/mixins/_typography.ts
+++ b/src/global_styling/mixins/_typography.ts
@@ -48,8 +48,7 @@ export const useEuiFontSize = (
  */
 export const euiTextBreakWord = () => `
   overflow-wrap: break-word !important; // makes sure the long string will wrap and not bust out of the container
-  word-wrap: break-word !important; // spec says, they are literally just alternate names for each other but some browsers support one and not the other
-  word-break: break-word; // IE doesn't understand but that's ok
+  word-break: break-word;
 `;
 
 /**

--- a/src/global_styling/utility/__snapshots__/utility.test.tsx.snap
+++ b/src/global_styling/utility/__snapshots__/utility.test.tsx.snap
@@ -39,8 +39,7 @@ exports[`global utility styles generates static global styles 1`] = `
 .eui-textInheritColor{color:inherit!important;}
 .eui-textBreakWord{
   overflow-wrap: break-word !important; // makes sure the long string will wrap and not bust out of the container
-  word-wrap: break-word !important; // spec says, they are literally just alternate names for each other but some browsers support one and not the other
-  word-break: break-word; // IE doesn't understand but that's ok
+  word-break: break-word;
 ;}
 .eui-textBreakAll{overflow-wrap:break-word!important;word-break:break-all!important;}
 .eui-textBreakNormal{overflow-wrap:normal!important;word-wrap:normal!important;word-break:normal!important;}

--- a/src/global_styling/utility/_index.scss
+++ b/src/global_styling/utility/_index.scss
@@ -1,2 +1,1 @@
 @import 'animations';
-@import 'utility';

--- a/src/global_styling/utility/_utility.scss
+++ b/src/global_styling/utility/_utility.scss
@@ -1,15 +1,2 @@
 // This file utilizes !importants on purpose
 // sass-lint:disable no-important
-
-/**
-  * IE doesn't properly wrap groups if it is within a flex-item of a flex-group.
-  * Adding the following styles to the flex-item that contains the wrapping group, will fix IE.
-  * https://github.com/philipwalton/flexbugs/issues/104
-  */
-.euiIEFlexWrapFix {
-  @include internetExplorerOnly {
-    flex-grow: 1;
-    flex-shrink: 1;
-    flex-basis: 0%;
-  }
-}

--- a/src/global_styling/utility/_utility.scss
+++ b/src/global_styling/utility/_utility.scss
@@ -1,2 +1,0 @@
-// This file utilizes !importants on purpose
-// sass-lint:disable no-important

--- a/upcoming_changelogs/6154.md
+++ b/upcoming_changelogs/6154.md
@@ -1,0 +1,3 @@
+**Breaking changes**
+
+- Removed `.euiIEFlexWrapFix` global className and `internetExplorerOnly()` Sass mixin, as IE is no longer a supported browser


### PR DESCRIPTION
### Summary

This PR is a follow-up to #6124, by removing the `_utility.scss` file completely (removing `.euiIEFlexWrapFix`) and removing the `internetExplorerOnly()` mixin.

This PR also removes several fairly innocuous IE fallbacks/workarounds. There are more in the codebase, but I decided to open multiple PRs rather than just one. The next PR will handle IE flex fallbacks/workarounds specifically, and a 3rd PR will handle IE fallbacks/workarounds in our JS code.

## Components to QA

- [x] .eui-textTruncate
- [x] EuiBasicTable (text word breaking and text truncation)
- [x] EuiCard
- [x] EuiFlex
- [x] EuiFieldSearch
- [x] EuiListGroup
- [x] EuiForm (line-height)

### Checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
