### PR TITLE
[Docs] Better docs for color mode

### DIFF
--- a/src-docs/src/views/theme/color_mode/color_mode_example.js
+++ b/src-docs/src/views/theme/color_mode/color_mode_example.js
@@ -42,8 +42,8 @@ export const ColorModeExample = {
             the current color mode.
           </p>
           <p>
-            When nesting or overriding <strong>EuiThemeProvider</strong> bear in mind
-            that the{' '}
+            When nesting or overriding <strong>EuiThemeProvider</strong> bear in
+            mind that the{' '}
             <Link to="/display/text">
               <strong>EuiText</strong>
             </Link>{' '}

--- a/src-docs/src/views/theme/color_mode/color_mode_example.js
+++ b/src-docs/src/views/theme/color_mode/color_mode_example.js
@@ -42,7 +42,7 @@ export const ColorModeExample = {
             the current color mode.
           </p>
           <p>
-            When having a nested <strong>EuiThemeProvider</strong> bear in mind
+            When nesting or overriding <strong>EuiThemeProvider</strong> bear in mind
             that the{' '}
             <Link to="/display/text">
               <strong>EuiText</strong>

--- a/src-docs/src/views/theme/color_mode/color_mode_example.js
+++ b/src-docs/src/views/theme/color_mode/color_mode_example.js
@@ -51,7 +51,7 @@ export const ColorModeExample = {
             component. This is why you should change the color of{' '}
             <strong>EuiText</strong> to <EuiCode>{'"default"'}</EuiCode> when
             you want it to correctly adapt to the <EuiCode>colorMode</EuiCode>{' '}
-            of its directly parent <strong>EuiThemeProvider</strong>.
+            of the nested <strong>EuiThemeProvider</strong>.
           </p>
           <p>
             <Link to="/display/icons">

--- a/src-docs/src/views/theme/color_mode/color_mode_example.js
+++ b/src-docs/src/views/theme/color_mode/color_mode_example.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 import { GuideSectionTypes } from '../../../components';
 
@@ -36,6 +37,27 @@ export const ColorModeExample = {
             <EuiCode>{'"light"'}</EuiCode>, <EuiCode>{'"dark"'}</EuiCode>, or{' '}
             <EuiCode>{'"inverse"'}</EuiCode> which sets it to the opposite of
             the current color mode.
+          </p>
+          <p>
+            When having a nested <strong>EuiThemeProvider</strong> bear in mind
+            that the{' '}
+            <Link to="/display/text">
+              <strong>EuiText</strong>
+            </Link>{' '}
+            inherits the color that is set in the global styles or a parent
+            component. This is why you should change the color of{' '}
+            <strong>EuiText</strong> to <EuiCode>{'"default"'}</EuiCode> when
+            you want it to correctly adapt to the <EuiCode>colorMode</EuiCode>{' '}
+            of its directly parent <strong>EuiThemeProvider</strong>.
+          </p>
+          <p>
+            <Link to="/display/icons">
+              <strong>EuiIcon</strong>
+            </Link>{' '}
+            behaves similarly. By default, it gets the color of its parent
+            component. Thus, you can override the color to{' '}
+            <EuiCode>{'"text"'}</EuiCode> or wrap it in a{' '}
+            <strong>EuiText</strong> to inherit its color.
           </p>
         </>
       ),

--- a/src-docs/src/views/theme/color_mode/color_mode_example.js
+++ b/src-docs/src/views/theme/color_mode/color_mode_example.js
@@ -11,6 +11,9 @@ import Intro from './_color_mode_intro';
 import Inverse from './inverse';
 const InverseSource = require('!!raw-loader!./inverse');
 
+import InverseComplex from './inverse_complex';
+const InverseComplexSource = require('!!raw-loader!./inverse_complex');
+
 export const ColorModeExample = {
   title: 'Color mode',
   notice: <ThemeNotice />,
@@ -62,6 +65,23 @@ export const ColorModeExample = {
         </>
       ),
       demo: <Inverse />,
+    },
+    {
+      title: 'Using color tokens in a specific color mode',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: InverseComplexSource,
+        },
+      ],
+      text: (
+        <p>
+          The following example demonstrates how you can use color tokens in any
+          of the color modes: <EuiCode>{'"light"'}</EuiCode>,{' '}
+          <EuiCode>{'"dark"'}</EuiCode>, or <EuiCode>{'"inverse"'}</EuiCode>.
+        </p>
+      ),
+      demo: <InverseComplex />,
     },
   ],
 };

--- a/src-docs/src/views/theme/color_mode/inverse.tsx
+++ b/src-docs/src/views/theme/color_mode/inverse.tsx
@@ -8,6 +8,7 @@ import {
   EuiButtonGroup,
   EuiPanel,
   EuiThemeColorMode,
+  EuiHorizontalRule,
 } from '../../../../../src';
 
 const Box: FunctionComponent<{ children: ReactNode }> = ({ children }) => {
@@ -85,25 +86,23 @@ export default () => {
         </EuiPanel>
       </EuiThemeProvider>
 
+      <EuiHorizontalRule />
+
+      <EuiButtonGroup
+        legend="Change color mode"
+        options={boxColorButtons}
+        idSelected={boxColorModeSelected}
+        onChange={(id) => onChange(id as EuiThemeColorMode)}
+      />
+
       <EuiSpacer />
 
-      <EuiPanel hasShadow={false} color="subdued">
-        <EuiButtonGroup
-          legend="Change color mode"
-          options={boxColorButtons}
-          idSelected={boxColorModeSelected}
-          onChange={(id) => onChange(id as EuiThemeColorMode)}
-        />
-
-        <EuiSpacer />
-
-        <EuiThemeProvider colorMode={boxColorModeSelected}>
-          <Box>
-            <EuiIcon type="faceHappy" /> The colors of this box is in{' '}
-            <strong>{boxColorModeSelected}</strong> color mode
-          </Box>
-        </EuiThemeProvider>
-      </EuiPanel>
+      <EuiThemeProvider colorMode={boxColorModeSelected}>
+        <Box>
+          <EuiIcon type="faceHappy" /> The colors of this box is in{' '}
+          <strong>{boxColorModeSelected}</strong> color mode
+        </Box>
+      </EuiThemeProvider>
     </div>
   );
 };

--- a/src-docs/src/views/theme/color_mode/inverse.tsx
+++ b/src-docs/src/views/theme/color_mode/inverse.tsx
@@ -1,13 +1,55 @@
-import React from 'react';
+import React, { FunctionComponent, ReactNode, useState } from 'react';
 import {
   EuiIcon,
   EuiSpacer,
-  EuiPanel,
   EuiText,
   EuiThemeProvider,
+  useEuiTheme,
+  EuiButtonGroup,
+  EuiPanel,
+  EuiThemeColorMode,
 } from '../../../../../src';
 
+const Box: FunctionComponent<{ children: ReactNode }> = ({ children }) => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <EuiText
+      css={{
+        background: euiTheme.colors.lightShade,
+        padding: euiTheme.size.xl,
+        color: euiTheme.colors.text,
+      }}
+    >
+      <p>{children}</p>
+    </EuiText>
+  );
+};
+
 export default () => {
+  const boxColorButtons = [
+    {
+      id: 'light',
+      label: 'Light',
+    },
+    {
+      id: 'dark',
+      label: 'Dark',
+    },
+    {
+      id: 'inverse',
+      label: 'Inverse',
+    },
+  ];
+
+  const [boxColorModeSelected, setBoxColorMode] = useState<EuiThemeColorMode>(
+    'light'
+  );
+
+  const onChange = (colorMode: EuiThemeColorMode) => {
+    setBoxColorMode(colorMode);
+  };
+
   return (
     <div>
       <EuiThemeProvider colorMode="light">
@@ -42,6 +84,26 @@ export default () => {
           </EuiText>
         </EuiPanel>
       </EuiThemeProvider>
+
+      <EuiSpacer />
+
+      <EuiPanel hasShadow={false} color="subdued">
+        <EuiButtonGroup
+          legend="Change color mode"
+          options={boxColorButtons}
+          idSelected={boxColorModeSelected}
+          onChange={(id) => onChange(id as EuiThemeColorMode)}
+        />
+
+        <EuiSpacer />
+
+        <EuiThemeProvider colorMode={boxColorModeSelected}>
+          <Box>
+            <EuiIcon type="faceHappy" /> The colors of this box is in{' '}
+            <strong>{boxColorModeSelected}</strong> color mode
+          </Box>
+        </EuiThemeProvider>
+      </EuiPanel>
     </div>
   );
 };

--- a/src-docs/src/views/theme/color_mode/inverse.tsx
+++ b/src-docs/src/views/theme/color_mode/inverse.tsx
@@ -1,50 +1,46 @@
-import React, { FunctionComponent, ReactNode } from 'react';
+import React from 'react';
 import {
   EuiIcon,
   EuiSpacer,
+  EuiPanel,
   EuiText,
   EuiThemeProvider,
-  useEuiTheme,
 } from '../../../../../src';
-
-const Box: FunctionComponent<{ children: ReactNode }> = ({ children }) => {
-  const { euiTheme } = useEuiTheme();
-
-  return (
-    <EuiText
-      css={{
-        background: euiTheme.colors.lightShade,
-        padding: euiTheme.size.xl,
-        color: euiTheme.colors.text,
-      }}
-    >
-      <p>{children}</p>
-    </EuiText>
-  );
-};
 
 export default () => {
   return (
     <div>
       <EuiThemeProvider colorMode="light">
-        <Box>
-          <EuiIcon type="faceHappy" /> The colors of this box are will always be
-          in <strong>light</strong> mode
-        </Box>
+        <EuiPanel>
+          <EuiText color="default">
+            <p>
+              <EuiIcon type="faceHappy" /> The colors of this panel will always
+              be in <strong>light</strong> mode
+            </p>
+          </EuiText>
+        </EuiPanel>
       </EuiThemeProvider>
       <EuiSpacer />
       <EuiThemeProvider colorMode="dark">
-        <Box>
-          <EuiIcon type="faceHappy" /> The colors of this box are will always be
-          in <strong>dark</strong> mode
-        </Box>
+        <EuiPanel>
+          <EuiText color="default">
+            <p>
+              <EuiIcon type="faceHappy" /> The colors of this panel will always
+              be in <strong>dark</strong> mode
+            </p>
+          </EuiText>
+        </EuiPanel>
       </EuiThemeProvider>
       <EuiSpacer />
       <EuiThemeProvider colorMode="inverse">
-        <Box>
-          <EuiIcon type="faceHappy" /> The colors of this box are the opposite (
-          <strong>inverse</strong>) of the current color mode
-        </Box>
+        <EuiPanel>
+          <EuiText color="default">
+            <p>
+              <EuiIcon type="faceHappy" /> The colors of this panel are the
+              opposite (<strong>inverse</strong>) of the current color mode
+            </p>
+          </EuiText>
+        </EuiPanel>
       </EuiThemeProvider>
     </div>
   );

--- a/src-docs/src/views/theme/color_mode/inverse.tsx
+++ b/src-docs/src/views/theme/color_mode/inverse.tsx
@@ -1,58 +1,15 @@
-import React, { FunctionComponent, ReactNode, useState } from 'react';
+import React from 'react';
 import {
   EuiIcon,
   EuiSpacer,
   EuiText,
   EuiThemeProvider,
-  useEuiTheme,
-  EuiButtonGroup,
   EuiPanel,
-  EuiThemeColorMode,
-  EuiHorizontalRule,
 } from '../../../../../src';
 
-const Box: FunctionComponent<{ children: ReactNode }> = ({ children }) => {
-  const { euiTheme } = useEuiTheme();
-
-  return (
-    <EuiText
-      css={{
-        background: euiTheme.colors.lightShade,
-        padding: euiTheme.size.xl,
-        color: euiTheme.colors.text,
-      }}
-    >
-      <p>{children}</p>
-    </EuiText>
-  );
-};
-
 export default () => {
-  const boxColorButtons = [
-    {
-      id: 'light',
-      label: 'Light',
-    },
-    {
-      id: 'dark',
-      label: 'Dark',
-    },
-    {
-      id: 'inverse',
-      label: 'Inverse',
-    },
-  ];
-
-  const [boxColorModeSelected, setBoxColorMode] = useState<EuiThemeColorMode>(
-    'light'
-  );
-
-  const onChange = (colorMode: EuiThemeColorMode) => {
-    setBoxColorMode(colorMode);
-  };
-
   return (
-    <div>
+    <>
       <EuiThemeProvider colorMode="light">
         <EuiPanel>
           <EuiText color="default">
@@ -85,24 +42,6 @@ export default () => {
           </EuiText>
         </EuiPanel>
       </EuiThemeProvider>
-
-      <EuiHorizontalRule />
-
-      <EuiButtonGroup
-        legend="Change color mode"
-        options={boxColorButtons}
-        idSelected={boxColorModeSelected}
-        onChange={(id) => onChange(id as EuiThemeColorMode)}
-      />
-
-      <EuiSpacer />
-
-      <EuiThemeProvider colorMode={boxColorModeSelected}>
-        <Box>
-          <EuiIcon type="faceHappy" /> The colors of this box is in{' '}
-          <strong>{boxColorModeSelected}</strong> color mode
-        </Box>
-      </EuiThemeProvider>
-    </div>
+    </>
   );
 };

--- a/src-docs/src/views/theme/color_mode/inverse_complex.tsx
+++ b/src-docs/src/views/theme/color_mode/inverse_complex.tsx
@@ -1,0 +1,71 @@
+import React, { FunctionComponent, ReactNode, useState } from 'react';
+import {
+  EuiIcon,
+  EuiSpacer,
+  EuiText,
+  EuiThemeProvider,
+  useEuiTheme,
+  EuiButtonGroup,
+  EuiThemeColorMode,
+} from '../../../../../src';
+
+const Box: FunctionComponent<{ children: ReactNode }> = ({ children }) => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <EuiText
+      css={{
+        background: euiTheme.colors.lightShade,
+        padding: euiTheme.size.xl,
+        color: euiTheme.colors.text,
+      }}
+    >
+      <p>{children}</p>
+    </EuiText>
+  );
+};
+
+export default () => {
+  const boxColorButtons = [
+    {
+      id: 'light',
+      label: 'Light',
+    },
+    {
+      id: 'dark',
+      label: 'Dark',
+    },
+    {
+      id: 'inverse',
+      label: 'Inverse',
+    },
+  ];
+
+  const [boxColorModeSelected, setBoxColorMode] = useState<EuiThemeColorMode>(
+    'light'
+  );
+
+  const onChange = (colorMode: EuiThemeColorMode) => {
+    setBoxColorMode(colorMode);
+  };
+
+  return (
+    <>
+      <EuiButtonGroup
+        legend="Change color mode"
+        options={boxColorButtons}
+        idSelected={boxColorModeSelected}
+        onChange={(id) => onChange(id as EuiThemeColorMode)}
+      />
+
+      <EuiSpacer />
+
+      <EuiThemeProvider colorMode={boxColorModeSelected}>
+        <Box>
+          <EuiIcon type="faceHappy" /> The colors of this box is in{' '}
+          <strong>{boxColorModeSelected}</strong> color mode
+        </Box>
+      </EuiThemeProvider>
+    </>
+  );
+};


### PR DESCRIPTION
### Summary

Closes #6123.

This PR adds better docs in  https://eui.elastic.co/pr_6155/#/theming/color-mode to show how to use components like **EuiText** and **EuiIcon** in a specific color mode. 

<img width="788" alt="Screenshot 2022-08-23 at 10 36 35" src="https://user-images.githubusercontent.com/2750668/186125498-24930fca-4b51-4d7b-b0eb-89763b40379f.png">

The last example shows how to use color variables.

<img width="781" alt="Screenshot 2022-08-23 at 10 36 40" src="https://user-images.githubusercontent.com/2750668/186125522-41a560f8-2717-47d6-9ded-b14a86216fc7.png">


- [x] Checked in both **light and dark** modes
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
