### PR TITLE
Set min-width on header section items only when they are not empty

### DIFF
--- a/src/components/header/header_section/__snapshots__/header_section_item.test.tsx.snap
+++ b/src/components/header/header_section/__snapshots__/header_section_item.test.tsx.snap
@@ -3,22 +3,24 @@
 exports[`EuiHeaderSectionItem border defaults to left 1`] = `
 <div
   class="euiHeaderSectionItem euiHeaderSectionItem--borderLeft"
-/>
+>
+  <span>
+    Left is default
+  </span>
+</div>
 `;
 
 exports[`EuiHeaderSectionItem border renders right 1`] = `
 <div
   class="euiHeaderSectionItem euiHeaderSectionItem--borderRight"
-/>
+>
+  <span>
+    Right section
+  </span>
+</div>
 `;
 
-exports[`EuiHeaderSectionItem is rendered 1`] = `
-<div
-  aria-label="aria-label"
-  class="euiHeaderSectionItem euiHeaderSectionItem--borderLeft testClass1 testClass2"
-  data-test-subj="test subject string"
-/>
-`;
+exports[`EuiHeaderSectionItem is rendered 1`] = `null`;
 
 exports[`EuiHeaderSectionItem renders children 1`] = `
 <div

--- a/src/components/header/header_section/_header_section_item.scss
+++ b/src/components/header/header_section/_header_section_item.scss
@@ -31,7 +31,7 @@
 }
 
 @include euiBreakpoint('xs') {
-  .euiHeaderSectionItem {
+  .euiHeaderSectionItem:not(:empty) {
     min-width: $euiHeaderChildSize * .75;
   }
 

--- a/src/components/header/header_section/_header_section_item.scss
+++ b/src/components/header/header_section/_header_section_item.scss
@@ -31,7 +31,7 @@
 }
 
 @include euiBreakpoint('xs') {
-  .euiHeaderSectionItem:not(:empty) {
+  .euiHeaderSectionItem {
     min-width: $euiHeaderChildSize * .75;
   }
 

--- a/src/components/header/header_section/header_section_item.test.tsx
+++ b/src/components/header/header_section/header_section_item.test.tsx
@@ -31,13 +31,21 @@ describe('EuiHeaderSectionItem', () => {
 
   describe('border', () => {
     test('defaults to left', () => {
-      const component = render(<EuiHeaderSectionItem />);
+      const component = render(
+        <EuiHeaderSectionItem>
+          <span>Left is default</span>
+        </EuiHeaderSectionItem>
+      );
 
       expect(component).toMatchSnapshot();
     });
 
     test('renders right', () => {
-      const component = render(<EuiHeaderSectionItem border="right" />);
+      const component = render(
+        <EuiHeaderSectionItem border="right">
+          <span>Right section</span>
+        </EuiHeaderSectionItem>
+      );
 
       expect(component).toMatchSnapshot();
     });

--- a/src/components/header/header_section/header_section_item.tsx
+++ b/src/components/header/header_section/header_section_item.tsx
@@ -43,9 +43,10 @@ export const EuiHeaderSectionItem: FunctionComponent<EuiHeaderSectionItemProps> 
     className
   );
 
-  return (
+  // we check if there is any children and if not, we don't render anything
+  return children ? (
     <div className={classes} {...rest}>
       {children}
     </div>
-  );
+  ) : null;
 };

--- a/upcoming_changelogs/6158.md
+++ b/upcoming_changelogs/6158.md
@@ -1,3 +1,3 @@
 **Bug fixes**
 
-- Updated the header section item to have `min-width` only when non-empty
+- Updated the header section item to not render if empty

--- a/upcoming_changelogs/6158.md
+++ b/upcoming_changelogs/6158.md
@@ -1,3 +1,3 @@
 **Bug fixes**
 
-- Updated the header section item to not render if empty
+- Updated the `EuiHeaderSectionItem` to not render if empty

--- a/upcoming_changelogs/6158.md
+++ b/upcoming_changelogs/6158.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Updated the header section item to have `min-width` only when non-empty


### PR DESCRIPTION
### Summary

While working on the guided onboarding [project](https://github.com/elastic/kibana/issues/138557), I noticed that when a header section item is empty, it's still rendered with a `min-width` setting. Instead we only render this component, if it's not empty. 

#### Screenshot before
<img width="526" alt="Screenshot 2022-08-22 at 17 50 40" src="https://user-images.githubusercontent.com/6585477/186167114-4b3937cf-f67d-4a29-992c-6c7a137cad06.png">


### Checklist

- [ ] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
